### PR TITLE
fix(nvidia): load featured model catalog

### DIFF
--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -62,7 +62,19 @@ openclaw onboard --auth-choice nvidia-api-key --nvidia-api-key "nvapi-..."
 }
 ```
 
-## Built-in catalog
+## Featured catalog
+
+When OpenClaw can load the NVIDIA provider runtime, it fetches NVIDIA's public
+featured-model catalog from
+`https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json` and
+caches the ranked result for 24 hours. New featured models from build.nvidia.com
+therefore appear in setup and model-selection surfaces without waiting for an
+OpenClaw release.
+
+If that public catalog is unavailable or malformed, OpenClaw falls back to the
+bundled catalog below.
+
+## Bundled fallback catalog
 
 | Model ref                                  | Name                         | Context | Max output |
 | ------------------------------------------ | ---------------------------- | ------- | ---------- |
@@ -80,8 +92,9 @@ openclaw onboard --auth-choice nvidia-api-key --nvidia-api-key "nvapi-..."
   </Accordion>
 
   <Accordion title="Catalog and pricing">
-    The bundled catalog is static. Costs default to `0` in source since NVIDIA
-    currently offers free API access for the listed models.
+    OpenClaw prefers NVIDIA's public featured-model catalog and caches it for 24
+    hours. The bundled fallback catalog is static. Costs default to `0` in source
+    since NVIDIA currently offers free API access for the listed models.
   </Accordion>
 
   <Accordion title="OpenAI-compatible endpoint">

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -64,24 +64,27 @@ openclaw onboard --auth-choice nvidia-api-key --nvidia-api-key "nvapi-..."
 
 ## Featured catalog
 
-When OpenClaw can load the NVIDIA provider runtime, it fetches NVIDIA's public
-featured-model catalog from
+When an NVIDIA API key is configured, OpenClaw setup and model-selection paths
+try NVIDIA's public featured-model catalog from
 `https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json` and
 caches the ranked result for 24 hours. New featured models from build.nvidia.com
 therefore appear in setup and model-selection surfaces without waiting for an
 OpenClaw release.
 
-If that public catalog is unavailable or malformed, OpenClaw falls back to the
-bundled catalog below.
+The fetch uses a fixed HTTPS host policy for `assets.ngc.nvidia.com`. If no
+NVIDIA API key is configured, or if that public catalog is unavailable or
+malformed, OpenClaw falls back to the bundled catalog below.
 
 ## Bundled fallback catalog
 
-| Model ref                                  | Name                         | Context | Max output |
-| ------------------------------------------ | ---------------------------- | ------- | ---------- |
-| `nvidia/nvidia/nemotron-3-super-120b-a12b` | NVIDIA Nemotron 3 Super 120B | 262,144 | 8,192      |
-| `nvidia/moonshotai/kimi-k2.5`              | Kimi K2.5                    | 262,144 | 8,192      |
-| `nvidia/minimaxai/minimax-m2.7`            | Minimax M2.7                 | 196,608 | 8,192      |
-| `nvidia/z-ai/glm-5.1`                      | GLM 5.1                      | 202,752 | 8,192      |
+| Model ref                                  | Name                         | Context | Max output | Notes                             |
+| ------------------------------------------ | ---------------------------- | ------- | ---------- | --------------------------------- |
+| `nvidia/nvidia/nemotron-3-super-120b-a12b` | NVIDIA Nemotron 3 Super 120B | 262,144 | 8,192      | Featured fallback                 |
+| `nvidia/moonshotai/kimi-k2.5`              | Kimi K2.5                    | 262,144 | 8,192      | Featured fallback                 |
+| `nvidia/minimaxai/minimax-m2.7`            | Minimax M2.7                 | 196,608 | 8,192      | Featured fallback                 |
+| `nvidia/z-ai/glm-5.1`                      | GLM 5.1                      | 202,752 | 8,192      | Featured fallback                 |
+| `nvidia/minimaxai/minimax-m2.5`            | MiniMax M2.5                 | 196,608 | 8,192      | Deprecated, upgrade compatibility |
+| `nvidia/z-ai/glm5`                         | GLM-5                        | 202,752 | 8,192      | Deprecated, upgrade compatibility |
 
 ## Advanced configuration
 
@@ -92,9 +95,11 @@ bundled catalog below.
   </Accordion>
 
   <Accordion title="Catalog and pricing">
-    OpenClaw prefers NVIDIA's public featured-model catalog and caches it for 24
-    hours. The bundled fallback catalog is static. Costs default to `0` in source
-    since NVIDIA currently offers free API access for the listed models.
+    OpenClaw prefers NVIDIA's public featured-model catalog when NVIDIA auth is
+    configured and caches it for 24 hours. The bundled fallback catalog is static
+    and keeps deprecated shipped refs for upgrade compatibility. Costs default to
+    `0` in source since NVIDIA currently offers free API access for the listed
+    models.
   </Accordion>
 
   <Accordion title="OpenAI-compatible endpoint">

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -80,8 +80,8 @@ bundled catalog below.
 | ------------------------------------------ | ---------------------------- | ------- | ---------- |
 | `nvidia/nvidia/nemotron-3-super-120b-a12b` | NVIDIA Nemotron 3 Super 120B | 262,144 | 8,192      |
 | `nvidia/moonshotai/kimi-k2.5`              | Kimi K2.5                    | 262,144 | 8,192      |
-| `nvidia/minimaxai/minimax-m2.5`            | Minimax M2.5                 | 196,608 | 8,192      |
-| `nvidia/z-ai/glm5`                         | GLM 5                        | 202,752 | 8,192      |
+| `nvidia/minimaxai/minimax-m2.7`            | Minimax M2.7                 | 196,608 | 8,192      |
+| `nvidia/z-ai/glm-5.1`                      | GLM 5.1                      | 202,752 | 8,192      |
 
 ## Advanced configuration
 

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -245,14 +245,7 @@ describe("nvidia provider hooks", () => {
 
     const entries = await provider.augmentModelCatalog?.(buildAugmentCatalogContext("nvapi-test"));
 
-    expect(entries?.map((entry) => entry.id)).toEqual([
-      "minimaxai/minimax-m2.7",
-      "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.5",
-      "z-ai/glm-5.1",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
-    ]);
+    expect(entries?.map((entry) => entry.id)).toEqual(["minimaxai/minimax-m2.7"]);
   });
 
   it("opts into literal provider-prefix preservation", async () => {
@@ -307,11 +300,16 @@ describe("nvidia provider hooks", () => {
     const liveRows = await catalogProvider?.liveCatalog?.(buildCatalogContext("nvapi-test"));
     expect(liveRows?.map((entry) => `${entry.source}:${entry.provider}/${entry.model}`)).toEqual([
       "live:nvidia/minimaxai/minimax-m2.7",
-      "live:nvidia/nvidia/nemotron-3-super-120b-a12b",
-      "live:nvidia/moonshotai/kimi-k2.5",
-      "live:nvidia/z-ai/glm-5.1",
-      "live:nvidia/minimaxai/minimax-m2.5",
-      "live:nvidia/z-ai/glm5",
     ]);
+  });
+
+  it("keeps static rows out of the live catalog when the featured catalog is unavailable", async () => {
+    mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
+    const { registeredModelCatalogProviders } = registerNvidiaPluginApi();
+    const catalogProvider = registeredModelCatalogProviders[0];
+
+    await expect(
+      catalogProvider?.liveCatalog?.(buildCatalogContext("nvapi-test")),
+    ).resolves.toEqual([]);
   });
 });

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -47,6 +47,37 @@ function mockFeaturedCatalogResponse(payload: unknown, status = 200) {
   });
 }
 
+function registerNvidiaPluginApi() {
+  const registeredProviders: string[] = [];
+  const registeredModelCatalogProviders: RegisteredModelCatalogProvider[] = [];
+
+  plugin.register(
+    createTestPluginApi({
+      registerProvider(provider: { id: string }) {
+        registeredProviders.push(provider.id);
+      },
+      registerModelCatalogProvider(provider) {
+        registeredModelCatalogProviders.push(provider);
+      },
+    }),
+  );
+
+  return { registeredProviders, registeredModelCatalogProviders };
+}
+
+function buildCatalogContext(apiKey?: string) {
+  return {
+    config: {},
+    env: process.env,
+    resolveProviderApiKey: () => ({ apiKey }),
+    resolveProviderAuth: () => ({
+      apiKey,
+      mode: apiKey ? ("api_key" as const) : ("none" as const),
+      source: apiKey ? ("env" as const) : ("none" as const),
+    }),
+  };
+}
+
 describe("nvidia provider hooks", () => {
   it("registers the nvidia provider with correct metadata", async () => {
     const provider = await registerNvidiaProvider();
@@ -209,23 +240,48 @@ describe("nvidia provider hooks", () => {
   });
 
   it("registers nvidia provider through the plugin api", () => {
-    const registeredProviders: string[] = [];
-    const registeredModelCatalogProviders: RegisteredModelCatalogProvider[] = [];
-
-    plugin.register(
-      createTestPluginApi({
-        registerProvider(provider: { id: string }) {
-          registeredProviders.push(provider.id);
-        },
-        registerModelCatalogProvider(provider) {
-          registeredModelCatalogProviders.push(provider);
-        },
-      }),
-    );
+    const { registeredProviders, registeredModelCatalogProviders } = registerNvidiaPluginApi();
 
     expect(registeredProviders).toStrictEqual(["nvidia"]);
     expect(registeredModelCatalogProviders.map((provider) => provider.provider)).toStrictEqual([
       "nvidia",
+    ]);
+  });
+
+  it("registers static and live nvidia model catalog rows", async () => {
+    mockFeaturedCatalogResponse({
+      "featured-models": [
+        {
+          model: "minimaxai/minimax-m2.7",
+          "model-name": "Minimax M2.7",
+          context: 196608,
+          "max-output": 8192,
+        },
+      ],
+    });
+    const { registeredModelCatalogProviders } = registerNvidiaPluginApi();
+    const catalogProvider = registeredModelCatalogProviders[0];
+
+    expect(catalogProvider?.provider).toBe("nvidia");
+    expect(catalogProvider?.kinds).toStrictEqual(["text"]);
+
+    const staticRows = await catalogProvider?.staticCatalog?.(buildCatalogContext());
+    expect(staticRows?.map((entry) => `${entry.source}:${entry.provider}/${entry.model}`)).toEqual([
+      "static:nvidia/nvidia/nemotron-3-super-120b-a12b",
+      "static:nvidia/moonshotai/kimi-k2.5",
+      "static:nvidia/minimaxai/minimax-m2.5",
+      "static:nvidia/z-ai/glm5",
+    ]);
+
+    await expect(catalogProvider?.liveCatalog?.(buildCatalogContext())).resolves.toEqual([]);
+
+    const liveRows = await catalogProvider?.liveCatalog?.(buildCatalogContext("nvapi-test"));
+    expect(liveRows?.map((entry) => `${entry.source}:${entry.provider}/${entry.model}`)).toEqual([
+      "live:nvidia/minimaxai/minimax-m2.7",
+      "live:nvidia/nvidia/nemotron-3-super-120b-a12b",
+      "live:nvidia/moonshotai/kimi-k2.5",
+      "live:nvidia/minimaxai/minimax-m2.5",
+      "live:nvidia/z-ai/glm5",
     ]);
   });
 });

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -203,8 +203,8 @@ describe("nvidia provider hooks", () => {
     expect(entries?.map((entry) => entry.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "minimaxai/minimax-m2.7",
+      "z-ai/glm-5.1",
     ]);
     expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
@@ -219,8 +219,8 @@ describe("nvidia provider hooks", () => {
     expect(entries?.map((entry) => entry.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "minimaxai/minimax-m2.7",
+      "z-ai/glm-5.1",
     ]);
     expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1);
@@ -245,8 +245,7 @@ describe("nvidia provider hooks", () => {
       "minimaxai/minimax-m2.7",
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "z-ai/glm-5.1",
     ]);
   });
 
@@ -291,8 +290,8 @@ describe("nvidia provider hooks", () => {
     expect(staticRows?.map((entry) => `${entry.source}:${entry.provider}/${entry.model}`)).toEqual([
       "static:nvidia/nvidia/nemotron-3-super-120b-a12b",
       "static:nvidia/moonshotai/kimi-k2.5",
-      "static:nvidia/minimaxai/minimax-m2.5",
-      "static:nvidia/z-ai/glm5",
+      "static:nvidia/minimaxai/minimax-m2.7",
+      "static:nvidia/z-ai/glm-5.1",
     ]);
 
     await expect(catalogProvider?.liveCatalog?.(buildCatalogContext())).resolves.toEqual([]);
@@ -302,8 +301,7 @@ describe("nvidia provider hooks", () => {
       "live:nvidia/minimaxai/minimax-m2.7",
       "live:nvidia/nvidia/nemotron-3-super-120b-a12b",
       "live:nvidia/moonshotai/kimi-k2.5",
-      "live:nvidia/minimaxai/minimax-m2.5",
-      "live:nvidia/z-ai/glm5",
+      "live:nvidia/z-ai/glm-5.1",
     ]);
   });
 });

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -78,6 +78,18 @@ function buildCatalogContext(apiKey?: string) {
   };
 }
 
+function buildAugmentCatalogContext(apiKey?: string) {
+  const env = { ...process.env };
+  if (!apiKey) {
+    delete env.NVIDIA_API_KEY;
+  }
+  return {
+    ...buildCatalogContext(apiKey),
+    env,
+    entries: [],
+  };
+}
+
 describe("nvidia provider hooks", () => {
   it("registers the nvidia provider with correct metadata", async () => {
     const provider = await registerNvidiaProvider();
@@ -183,14 +195,10 @@ describe("nvidia provider hooks", () => {
     expect(provider.wrapStreamFn).toBeUndefined();
   });
 
-  it("surfaces the bundled NVIDIA models when featured catalog fetch fails", async () => {
-    mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
+  it("surfaces the bundled NVIDIA models without fetching when no NVIDIA API token is available", async () => {
     const provider = await registerNvidiaProvider();
 
-    const entries = await provider.augmentModelCatalog?.({
-      env: process.env,
-      entries: [],
-    });
+    const entries = await provider.augmentModelCatalog?.(buildAugmentCatalogContext());
 
     expect(entries?.map((entry) => entry.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
@@ -199,6 +207,23 @@ describe("nvidia provider hooks", () => {
       "z-ai/glm5",
     ]);
     expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the bundled NVIDIA models when authenticated featured catalog fetch fails", async () => {
+    mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
+    const provider = await registerNvidiaProvider();
+
+    const entries = await provider.augmentModelCatalog?.(buildAugmentCatalogContext("nvapi-test"));
+
+    expect(entries?.map((entry) => entry.id)).toEqual([
+      "nvidia/nemotron-3-super-120b-a12b",
+      "moonshotai/kimi-k2.5",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
+    ]);
+    expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces live featured NVIDIA models via augmentModelCatalog", async () => {
@@ -214,12 +239,15 @@ describe("nvidia provider hooks", () => {
     });
     const provider = await registerNvidiaProvider();
 
-    const entries = await provider.augmentModelCatalog?.({
-      env: process.env,
-      entries: [],
-    });
+    const entries = await provider.augmentModelCatalog?.(buildAugmentCatalogContext("nvapi-test"));
 
-    expect(entries?.map((entry) => entry.id)).toEqual(["minimaxai/minimax-m2.7"]);
+    expect(entries?.map((entry) => entry.id)).toEqual([
+      "minimaxai/minimax-m2.7",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "moonshotai/kimi-k2.5",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
+    ]);
   });
 
   it("opts into literal provider-prefix preservation", async () => {
@@ -272,6 +300,10 @@ describe("nvidia provider hooks", () => {
     const liveRows = await catalogProvider?.liveCatalog?.(buildCatalogContext("nvapi-test"));
     expect(liveRows?.map((entry) => `${entry.source}:${entry.provider}/${entry.model}`)).toEqual([
       "live:nvidia/minimaxai/minimax-m2.7",
+      "live:nvidia/nvidia/nemotron-3-super-120b-a12b",
+      "live:nvidia/moonshotai/kimi-k2.5",
+      "live:nvidia/minimaxai/minimax-m2.5",
+      "live:nvidia/z-ai/glm5",
     ]);
   });
 });

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -205,6 +205,8 @@ describe("nvidia provider hooks", () => {
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
       "z-ai/glm-5.1",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
     ]);
     expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
@@ -221,6 +223,8 @@ describe("nvidia provider hooks", () => {
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
       "z-ai/glm-5.1",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
     ]);
     expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1);
@@ -246,6 +250,8 @@ describe("nvidia provider hooks", () => {
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
       "z-ai/glm-5.1",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
     ]);
   });
 
@@ -292,6 +298,8 @@ describe("nvidia provider hooks", () => {
       "static:nvidia/moonshotai/kimi-k2.5",
       "static:nvidia/minimaxai/minimax-m2.7",
       "static:nvidia/z-ai/glm-5.1",
+      "static:nvidia/minimaxai/minimax-m2.5",
+      "static:nvidia/z-ai/glm5",
     ]);
 
     await expect(catalogProvider?.liveCatalog?.(buildCatalogContext())).resolves.toEqual([]);
@@ -302,6 +310,8 @@ describe("nvidia provider hooks", () => {
       "live:nvidia/nvidia/nemotron-3-super-120b-a12b",
       "live:nvidia/moonshotai/kimi-k2.5",
       "live:nvidia/z-ai/glm-5.1",
+      "live:nvidia/minimaxai/minimax-m2.5",
+      "live:nvidia/z-ai/glm5",
     ]);
   });
 });

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -4,8 +4,18 @@ import {
   registerSingleProviderPlugin,
   resolveProviderPluginChoice,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
+import { clearNvidiaFeaturedModelCacheForTests } from "./provider-catalog.js";
+
+const ssrfRuntimeMocks = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+  ssrfPolicyFromHttpBaseUrlAllowedHostname: vi.fn((baseUrl: string) => ({
+    allowedHostnames: [new URL(baseUrl).hostname],
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ssrfRuntimeMocks);
 
 type NvidiaManifest = {
   providerAuthChoices?: Array<Record<string, unknown>>;
@@ -22,6 +32,19 @@ function readManifest(): NvidiaManifest {
 
 async function registerNvidiaProvider() {
   return registerSingleProviderPlugin(plugin);
+}
+
+afterEach(() => {
+  clearNvidiaFeaturedModelCacheForTests();
+  ssrfRuntimeMocks.fetchWithSsrFGuard.mockReset();
+  ssrfRuntimeMocks.ssrfPolicyFromHttpBaseUrlAllowedHostname.mockClear();
+});
+
+function mockFeaturedCatalogResponse(payload: unknown, status = 200) {
+  ssrfRuntimeMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+    response: Response.json(payload, { status }),
+    release: vi.fn(),
+  });
 }
 
 describe("nvidia provider hooks", () => {
@@ -129,7 +152,8 @@ describe("nvidia provider hooks", () => {
     expect(provider.wrapStreamFn).toBeUndefined();
   });
 
-  it("surfaces the bundled NVIDIA models via augmentModelCatalog", async () => {
+  it("surfaces the bundled NVIDIA models when featured catalog fetch fails", async () => {
+    mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
     const provider = await registerNvidiaProvider();
 
     const entries = await provider.augmentModelCatalog?.({
@@ -144,6 +168,33 @@ describe("nvidia provider hooks", () => {
       "z-ai/glm5",
     ]);
     expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);
+  });
+
+  it("surfaces live featured NVIDIA models via augmentModelCatalog", async () => {
+    mockFeaturedCatalogResponse({
+      "featured-models": [
+        {
+          model: "minimaxai/minimax-m2.7",
+          "model-name": "Minimax M2.7",
+          context: 196608,
+          "max-output": 8192,
+        },
+      ],
+    });
+    const provider = await registerNvidiaProvider();
+
+    const entries = await provider.augmentModelCatalog?.({
+      env: process.env,
+      entries: [],
+    });
+
+    expect(entries?.map((entry) => entry.id)).toEqual([
+      "minimaxai/minimax-m2.7",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "moonshotai/kimi-k2.5",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
+    ]);
   });
 
   it("opts into literal provider-prefix preservation", async () => {

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -219,13 +219,7 @@ describe("nvidia provider hooks", () => {
       entries: [],
     });
 
-    expect(entries?.map((entry) => entry.id)).toEqual([
-      "minimaxai/minimax-m2.7",
-      "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
-    ]);
+    expect(entries?.map((entry) => entry.id)).toEqual(["minimaxai/minimax-m2.7"]);
   });
 
   it("opts into literal provider-prefix preservation", async () => {
@@ -278,10 +272,6 @@ describe("nvidia provider hooks", () => {
     const liveRows = await catalogProvider?.liveCatalog?.(buildCatalogContext("nvapi-test"));
     expect(liveRows?.map((entry) => `${entry.source}:${entry.provider}/${entry.model}`)).toEqual([
       "live:nvidia/minimaxai/minimax-m2.7",
-      "live:nvidia/nvidia/nemotron-3-super-120b-a12b",
-      "live:nvidia/moonshotai/kimi-k2.5",
-      "live:nvidia/minimaxai/minimax-m2.5",
-      "live:nvidia/z-ai/glm5",
     ]);
   });
 });

--- a/extensions/nvidia/index.ts
+++ b/extensions/nvidia/index.ts
@@ -1,11 +1,12 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyNvidiaConfig, NVIDIA_DEFAULT_MODEL_REF } from "./onboard.js";
-import { buildNvidiaProvider } from "./provider-catalog.js";
+import { buildLiveNvidiaProvider, buildNvidiaProvider } from "./provider-catalog.js";
 
 const PROVIDER_ID = "nvidia";
 
-function buildNvidiaCatalogModels() {
-  return buildNvidiaProvider().models.map((model) => ({
+async function buildNvidiaCatalogModels() {
+  const provider = await buildLiveNvidiaProvider();
+  return provider.models.map((model) => ({
     provider: PROVIDER_ID,
     id: model.id,
     name: model.name ?? model.id,
@@ -38,7 +39,8 @@ export default defineSingleProviderPluginEntry({
       },
     ],
     catalog: {
-      buildProvider: buildNvidiaProvider,
+      buildProvider: buildLiveNvidiaProvider,
+      buildStaticProvider: buildNvidiaProvider,
     },
     augmentModelCatalog: buildNvidiaCatalogModels,
     wizard: {

--- a/extensions/nvidia/index.ts
+++ b/extensions/nvidia/index.ts
@@ -1,6 +1,10 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyNvidiaConfig, NVIDIA_DEFAULT_MODEL_REF } from "./onboard.js";
-import { buildLiveNvidiaProvider, buildNvidiaProvider } from "./provider-catalog.js";
+import {
+  buildLiveNvidiaProvider,
+  buildNvidiaProvider,
+  buildSelectableLiveNvidiaProvider,
+} from "./provider-catalog.js";
 
 const PROVIDER_ID = "nvidia";
 
@@ -51,7 +55,7 @@ export default defineSingleProviderPluginEntry({
       },
     ],
     catalog: {
-      buildProvider: buildLiveNvidiaProvider,
+      buildProvider: buildSelectableLiveNvidiaProvider,
       buildStaticProvider: buildNvidiaProvider,
     },
     augmentModelCatalog: buildNvidiaCatalogModels,

--- a/extensions/nvidia/index.ts
+++ b/extensions/nvidia/index.ts
@@ -4,8 +4,20 @@ import { buildLiveNvidiaProvider, buildNvidiaProvider } from "./provider-catalog
 
 const PROVIDER_ID = "nvidia";
 
-async function buildNvidiaCatalogModels() {
-  const provider = await buildLiveNvidiaProvider();
+function hasNvidiaApiToken(ctx: {
+  env: NodeJS.ProcessEnv;
+  resolveProviderApiKey?: (providerId?: string) => { apiKey: string | undefined };
+}) {
+  return Boolean(
+    ctx.resolveProviderApiKey?.(PROVIDER_ID).apiKey?.trim() || ctx.env.NVIDIA_API_KEY?.trim(),
+  );
+}
+
+async function buildNvidiaCatalogModels(ctx: {
+  env: NodeJS.ProcessEnv;
+  resolveProviderApiKey?: (providerId?: string) => { apiKey: string | undefined };
+}) {
+  const provider = hasNvidiaApiToken(ctx) ? await buildLiveNvidiaProvider() : buildNvidiaProvider();
   return provider.models.map((model) => ({
     provider: PROVIDER_ID,
     id: model.id,

--- a/extensions/nvidia/onboard.test.ts
+++ b/extensions/nvidia/onboard.test.ts
@@ -19,6 +19,8 @@ describe("nvidia onboard", () => {
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
       "z-ai/glm-5.1",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
     ]);
     // Config stores the canonical form; the picker label shows the literal
     // form via preserveLiteralProviderPrefix.
@@ -44,6 +46,8 @@ describe("nvidia onboard", () => {
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
       "z-ai/glm-5.1",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
     ]);
   });
 });

--- a/extensions/nvidia/onboard.test.ts
+++ b/extensions/nvidia/onboard.test.ts
@@ -17,8 +17,8 @@ describe("nvidia onboard", () => {
     expect(provider.models.map((model) => model.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "minimaxai/minimax-m2.7",
+      "z-ai/glm-5.1",
     ]);
     // Config stores the canonical form; the picker label shows the literal
     // form via preserveLiteralProviderPrefix.
@@ -42,8 +42,8 @@ describe("nvidia onboard", () => {
       "nvidia/custom-model",
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "minimaxai/minimax-m2.7",
+      "z-ai/glm-5.1",
     ]);
   });
 });

--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -88,6 +88,44 @@
             "compat": {
               "requiresStringContent": true
             }
+          },
+          {
+            "id": "minimaxai/minimax-m2.5",
+            "name": "MiniMax M2.5",
+            "input": ["text"],
+            "contextWindow": 196608,
+            "maxTokens": 8192,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "requiresStringContent": true
+            },
+            "status": "deprecated",
+            "statusReason": "Shipped compatibility row; use minimaxai/minimax-m2.7 for new NVIDIA setups.",
+            "replacedBy": "minimaxai/minimax-m2.7"
+          },
+          {
+            "id": "z-ai/glm5",
+            "name": "GLM-5",
+            "input": ["text"],
+            "contextWindow": 202752,
+            "maxTokens": 8192,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "requiresStringContent": true
+            },
+            "status": "deprecated",
+            "statusReason": "Shipped compatibility row; use z-ai/glm-5.1 for new NVIDIA setups.",
+            "replacedBy": "z-ai/glm-5.1"
           }
         ]
       }

--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -58,8 +58,8 @@
             }
           },
           {
-            "id": "minimaxai/minimax-m2.5",
-            "name": "MiniMax M2.5",
+            "id": "minimaxai/minimax-m2.7",
+            "name": "Minimax M2.7",
             "input": ["text"],
             "contextWindow": 196608,
             "maxTokens": 8192,
@@ -74,8 +74,8 @@
             }
           },
           {
-            "id": "z-ai/glm5",
-            "name": "GLM-5",
+            "id": "z-ai/glm-5.1",
+            "name": "GLM 5.1",
             "input": ["text"],
             "contextWindow": 202752,
             "maxTokens": 8192,

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -71,6 +71,9 @@ describe("nvidia provider catalog", () => {
     expect(provider.models.map((model) => model.id)).toEqual([
       "z-ai/glm-5.1",
       "nvidia/nemotron-3-super-120b-a12b",
+      "moonshotai/kimi-k2.5",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
     ]);
     expect(provider.models[0]).toMatchObject({
       name: "GLM 5.1",
@@ -128,7 +131,13 @@ describe("nvidia provider catalog", () => {
 
     const provider = await buildLiveNvidiaProvider();
 
-    expect(provider.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m2.7"]);
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "minimaxai/minimax-m2.7",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "moonshotai/kimi-k2.5",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
+    ]);
   });
 
   it("caches the featured catalog for repeated provider builds", async () => {

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -71,9 +71,6 @@ describe("nvidia provider catalog", () => {
     expect(provider.models.map((model) => model.id)).toEqual([
       "z-ai/glm-5.1",
       "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
     ]);
     expect(provider.models[0]).toMatchObject({
       name: "GLM 5.1",
@@ -86,6 +83,7 @@ describe("nvidia provider catalog", () => {
       timeoutMs: 10_000,
       requireHttps: true,
       policy: { allowedHostnames: ["assets.ngc.nvidia.com"] },
+      lookupFn: expect.any(Function),
       auditContext: "nvidia-featured-model-catalog",
     });
     expect(release).toHaveBeenCalledOnce();
@@ -130,13 +128,7 @@ describe("nvidia provider catalog", () => {
 
     const provider = await buildLiveNvidiaProvider();
 
-    expect(provider.models.map((model) => model.id)).toEqual([
-      "minimaxai/minimax-m2.7",
-      "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
-    ]);
+    expect(provider.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m2.7"]);
   });
 
   it("caches the featured catalog for repeated provider builds", async () => {

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -1,5 +1,34 @@
-import { describe, expect, it } from "vitest";
-import { buildNvidiaProvider } from "./provider-catalog.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildLiveNvidiaProvider,
+  buildNvidiaProvider,
+  clearNvidiaFeaturedModelCacheForTests,
+  NVIDIA_FEATURED_MODELS_URL,
+} from "./provider-catalog.js";
+
+const ssrfRuntimeMocks = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+  ssrfPolicyFromHttpBaseUrlAllowedHostname: vi.fn((baseUrl: string) => ({
+    allowedHostnames: [new URL(baseUrl).hostname],
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ssrfRuntimeMocks);
+
+afterEach(() => {
+  clearNvidiaFeaturedModelCacheForTests();
+  ssrfRuntimeMocks.fetchWithSsrFGuard.mockReset();
+  ssrfRuntimeMocks.ssrfPolicyFromHttpBaseUrlAllowedHostname.mockClear();
+});
+
+function mockFeaturedCatalogResponse(payload: unknown, status = 200) {
+  const release = vi.fn();
+  ssrfRuntimeMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+    response: Response.json(payload, { status }),
+    release,
+  });
+  return release;
+}
 
 describe("nvidia provider catalog", () => {
   it("builds the bundled NVIDIA provider defaults", () => {
@@ -17,5 +46,114 @@ describe("nvidia provider catalog", () => {
     expect(provider.models.filter((model) => model.compat?.requiresStringContent !== true)).toEqual(
       [],
     );
+  });
+
+  it("promotes ranked models from NVIDIA's featured catalog", async () => {
+    const release = mockFeaturedCatalogResponse({
+      "featured-models": [
+        {
+          model: "z-ai/glm-5.1",
+          "model-name": "GLM 5.1",
+          context: 202752,
+          "max-output": 8192,
+        },
+        {
+          model: "nemotron-3-super-120b-a12b",
+          "model-name": "Nemotron 3 Super 120B",
+          context: 262144,
+          "max-output": 8192,
+        },
+      ],
+    });
+
+    const provider = await buildLiveNvidiaProvider();
+
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "z-ai/glm-5.1",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "moonshotai/kimi-k2.5",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
+    ]);
+    expect(provider.models[0]).toMatchObject({
+      name: "GLM 5.1",
+      contextWindow: 202752,
+      maxTokens: 8192,
+      compat: { requiresStringContent: true },
+    });
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledWith({
+      url: NVIDIA_FEATURED_MODELS_URL,
+      timeoutMs: 2500,
+      requireHttps: true,
+      policy: { allowedHostnames: ["assets.ngc.nvidia.com"] },
+      auditContext: "nvidia-featured-model-catalog",
+    });
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the bundled catalog when the featured catalog is unavailable", async () => {
+    mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
+
+    const provider = await buildLiveNvidiaProvider();
+
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-super-120b-a12b",
+      "moonshotai/kimi-k2.5",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
+    ]);
+  });
+
+  it("ignores malformed featured catalog rows and keeps valid entries", async () => {
+    mockFeaturedCatalogResponse({
+      "featured-models": [
+        {
+          model: "bad model id",
+          "model-name": "Bad",
+          context: 1000,
+          "max-output": 1000,
+        },
+        {
+          model: "minimaxai/minimax-m2.7",
+          "model-name": "Minimax M2.7",
+          context: 196608,
+          "max-output": 8192,
+        },
+        {
+          model: "oversized-context",
+          "model-name": "Oversized Context",
+          context: 10_000_001,
+          "max-output": 8192,
+        },
+      ],
+    });
+
+    const provider = await buildLiveNvidiaProvider();
+
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "minimaxai/minimax-m2.7",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "moonshotai/kimi-k2.5",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
+    ]);
+  });
+
+  it("caches the featured catalog for repeated provider builds", async () => {
+    mockFeaturedCatalogResponse({
+      "featured-models": [
+        {
+          model: "minimaxai/minimax-m2.7",
+          "model-name": "Minimax M2.7",
+          context: 196608,
+          "max-output": 8192,
+        },
+      ],
+    });
+
+    await buildLiveNvidiaProvider();
+    await buildLiveNvidiaProvider();
+
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -40,8 +40,8 @@ describe("nvidia provider catalog", () => {
     expect(provider.models.map((model) => model.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "minimaxai/minimax-m2.7",
+      "z-ai/glm-5.1",
     ]);
     expect(provider.models.filter((model) => model.compat?.requiresStringContent !== true)).toEqual(
       [],
@@ -72,8 +72,7 @@ describe("nvidia provider catalog", () => {
       "z-ai/glm-5.1",
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "minimaxai/minimax-m2.7",
     ]);
     expect(provider.models[0]).toMatchObject({
       name: "GLM 5.1",
@@ -100,8 +99,8 @@ describe("nvidia provider catalog", () => {
     expect(provider.models.map((model) => model.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "minimaxai/minimax-m2.7",
+      "z-ai/glm-5.1",
     ]);
   });
 
@@ -135,8 +134,7 @@ describe("nvidia provider catalog", () => {
       "minimaxai/minimax-m2.7",
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
+      "z-ai/glm-5.1",
     ]);
   });
 

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -83,7 +83,7 @@ describe("nvidia provider catalog", () => {
     });
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledWith({
       url: NVIDIA_FEATURED_MODELS_URL,
-      timeoutMs: 2500,
+      timeoutMs: 10_000,
       requireHttps: true,
       policy: { allowedHostnames: ["assets.ngc.nvidia.com"] },
       auditContext: "nvidia-featured-model-catalog",

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -42,6 +42,8 @@ describe("nvidia provider catalog", () => {
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
       "z-ai/glm-5.1",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
     ]);
     expect(provider.models.filter((model) => model.compat?.requiresStringContent !== true)).toEqual(
       [],
@@ -73,6 +75,8 @@ describe("nvidia provider catalog", () => {
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
     ]);
     expect(provider.models[0]).toMatchObject({
       name: "GLM 5.1",
@@ -101,7 +105,17 @@ describe("nvidia provider catalog", () => {
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
       "z-ai/glm-5.1",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
     ]);
+  });
+
+  it("retains shipped NVIDIA model refs as bundled fallback compatibility rows", () => {
+    const provider = buildNvidiaProvider();
+
+    expect(provider.models.map((model) => model.id)).toEqual(
+      expect.arrayContaining(["minimaxai/minimax-m2.5", "z-ai/glm5"]),
+    );
   });
 
   it("ignores malformed featured catalog rows and keeps valid entries", async () => {
@@ -135,6 +149,8 @@ describe("nvidia provider catalog", () => {
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
       "z-ai/glm-5.1",
+      "minimaxai/minimax-m2.5",
+      "z-ai/glm5",
     ]);
   });
 

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildLiveNvidiaProvider,
   buildNvidiaProvider,
+  buildSelectableLiveNvidiaProvider,
   clearNvidiaFeaturedModelCacheForTests,
   NVIDIA_FEATURED_MODELS_URL,
 } from "./provider-catalog.js";
@@ -73,10 +74,6 @@ describe("nvidia provider catalog", () => {
     expect(provider.models.map((model) => model.id)).toEqual([
       "z-ai/glm-5.1",
       "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.5",
-      "minimaxai/minimax-m2.7",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
     ]);
     expect(provider.models[0]).toMatchObject({
       name: "GLM 5.1",
@@ -118,6 +115,40 @@ describe("nvidia provider catalog", () => {
     );
   });
 
+  it("uses only selectable live catalog rows when the featured catalog returns models", async () => {
+    mockFeaturedCatalogResponse({
+      "featured-models": [
+        {
+          model: "z-ai/glm-5.1",
+          "model-name": "GLM 5.1",
+          context: 202752,
+          "max-output": 8192,
+        },
+        {
+          model: "nemotron-3-super-120b-a12b",
+          "model-name": "Nemotron 3 Super 120B",
+          context: 262144,
+          "max-output": 8192,
+        },
+      ],
+    });
+
+    const provider = await buildSelectableLiveNvidiaProvider();
+
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "z-ai/glm-5.1",
+      "nvidia/nemotron-3-super-120b-a12b",
+    ]);
+  });
+
+  it("returns no selectable live rows when the featured catalog is unavailable", async () => {
+    mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
+
+    const provider = await buildSelectableLiveNvidiaProvider();
+
+    expect(provider.models.map((model) => model.id)).toEqual([]);
+  });
+
   it("ignores malformed featured catalog rows and keeps valid entries", async () => {
     mockFeaturedCatalogResponse({
       "featured-models": [
@@ -144,14 +175,7 @@ describe("nvidia provider catalog", () => {
 
     const provider = await buildLiveNvidiaProvider();
 
-    expect(provider.models.map((model) => model.id)).toEqual([
-      "minimaxai/minimax-m2.7",
-      "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.5",
-      "z-ai/glm-5.1",
-      "minimaxai/minimax-m2.5",
-      "z-ai/glm5",
-    ]);
+    expect(provider.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m2.7"]);
   });
 
   it("caches the featured catalog for repeated provider builds", async () => {

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -1,3 +1,4 @@
+import { lookup as dnsLookup } from "node:dns/promises";
 import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type {
   ModelDefinitionConfig,
@@ -5,6 +6,7 @@ import type {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   fetchWithSsrFGuard,
+  type LookupFn,
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
 } from "openclaw/plugin-sdk/ssrf-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
@@ -42,6 +44,24 @@ let featuredModelCache:
   | undefined;
 let featuredModelRequest: Promise<ModelDefinitionConfig[] | null> | undefined;
 
+type DnsLookupOptions = {
+  all?: boolean;
+  family?: number;
+  hints?: number;
+  order?: "ipv4first" | "ipv6first" | "verbatim";
+  verbatim?: boolean;
+};
+
+const lookupNvidiaFeaturedModelHostname = (async (
+  hostname: string,
+  options?: number | DnsLookupOptions,
+) => {
+  if (typeof options === "object" && options !== null) {
+    return await dnsLookup(hostname, { ...options, family: 4 });
+  }
+  return await dnsLookup(hostname, { family: 4 });
+}) as LookupFn;
+
 export function buildNvidiaProvider(): ModelProviderConfig {
   return {
     ...buildManifestModelProviderConfig({
@@ -60,7 +80,7 @@ export async function buildLiveNvidiaProvider(): Promise<ModelProviderConfig> {
   }
   return {
     ...provider,
-    models: mergeFeaturedModels(featuredModels, provider.models),
+    models: featuredModels,
   };
 }
 
@@ -96,6 +116,10 @@ async function fetchNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | nu
       timeoutMs: FEATURED_MODEL_FETCH_TIMEOUT_MS,
       requireHttps: true,
       policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(NVIDIA_FEATURED_MODELS_URL),
+      // The featured catalog is an NVIDIA-owned CloudFront URL. Some resolvers
+      // stall for seconds on the default all-family lookup; IPv4 pinning keeps
+      // the guarded fixed-host fetch on the fast path.
+      lookupFn: lookupNvidiaFeaturedModelHostname,
       auditContext: "nvidia-featured-model-catalog",
     });
     try {
@@ -176,23 +200,6 @@ function normalizeFeaturedModelName(name: string): string {
     return "";
   }
   return trimmed;
-}
-
-function mergeFeaturedModels(
-  featuredModels: ModelDefinitionConfig[],
-  fallbackModels: ModelDefinitionConfig[],
-): ModelDefinitionConfig[] {
-  const seen = new Set<string>();
-  const merged: ModelDefinitionConfig[] = [];
-  for (const model of [...featuredModels, ...fallbackModels]) {
-    const key = model.id.toLowerCase();
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    merged.push(model);
-  }
-  return merged;
 }
 
 function isBoundedPositiveInteger(value: unknown, max: number): value is number {

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -80,13 +80,30 @@ export async function buildLiveNvidiaProvider(): Promise<ModelProviderConfig> {
   }
   return {
     ...provider,
-    models: featuredModels,
+    models: mergeFeaturedModels(featuredModels, provider.models),
   };
 }
 
 export function clearNvidiaFeaturedModelCacheForTests() {
   featuredModelCache = undefined;
   featuredModelRequest = undefined;
+}
+
+function mergeFeaturedModels(
+  featuredModels: ModelDefinitionConfig[],
+  fallbackModels: ModelDefinitionConfig[],
+): ModelDefinitionConfig[] {
+  const seen = new Set<string>();
+  const merged: ModelDefinitionConfig[] = [];
+  for (const model of [...featuredModels, ...fallbackModels]) {
+    const key = model.id.trim().toLowerCase();
+    if (!key || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(model);
+  }
+  return merged;
 }
 
 async function loadNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | null> {

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -80,30 +80,28 @@ export async function buildLiveNvidiaProvider(): Promise<ModelProviderConfig> {
   }
   return {
     ...provider,
-    models: mergeFeaturedModels(featuredModels, provider.models),
+    models: featuredModels,
+  };
+}
+
+export async function buildSelectableLiveNvidiaProvider(): Promise<ModelProviderConfig> {
+  const provider = buildNvidiaProvider();
+  const featuredModels = await loadNvidiaFeaturedModels();
+  if (!featuredModels || featuredModels.length === 0) {
+    return {
+      ...provider,
+      models: [],
+    };
+  }
+  return {
+    ...provider,
+    models: featuredModels,
   };
 }
 
 export function clearNvidiaFeaturedModelCacheForTests() {
   featuredModelCache = undefined;
   featuredModelRequest = undefined;
-}
-
-function mergeFeaturedModels(
-  featuredModels: ModelDefinitionConfig[],
-  fallbackModels: ModelDefinitionConfig[],
-): ModelDefinitionConfig[] {
-  const seen = new Set<string>();
-  const merged: ModelDefinitionConfig[] = [];
-  for (const model of [...featuredModels, ...fallbackModels]) {
-    const key = model.id.trim().toLowerCase();
-    if (!key || seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    merged.push(model);
-  }
-  return merged;
 }
 
 async function loadNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | null> {

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -1,8 +1,46 @@
 import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
-import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedHostname,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 export const NVIDIA_DEFAULT_MODEL_ID = "nvidia/nemotron-3-super-120b-a12b";
+export const NVIDIA_FEATURED_MODELS_URL =
+  "https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json";
+
+const FEATURED_MODEL_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FEATURED_MODEL_FETCH_TIMEOUT_MS = 2500;
+const FEATURED_MODEL_MAX_ROWS = 32;
+const FEATURED_MODEL_MAX_ID_LENGTH = 200;
+const FEATURED_MODEL_MAX_NAME_LENGTH = 200;
+const FEATURED_MODEL_MAX_CONTEXT_WINDOW = 10_000_000;
+const FEATURED_MODEL_MAX_OUTPUT_TOKENS = 1_000_000;
+const FEATURED_MODEL_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+} as const;
+
+type NvidiaFeaturedModel = {
+  model: string;
+  "model-name": string;
+  context: number;
+  "max-output": number;
+};
+
+let featuredModelCache:
+  | {
+      expiresAtMs: number;
+      models: ModelDefinitionConfig[];
+    }
+  | undefined;
+let featuredModelRequest: Promise<ModelDefinitionConfig[] | null> | undefined;
 
 export function buildNvidiaProvider(): ModelProviderConfig {
   return {
@@ -12,4 +50,179 @@ export function buildNvidiaProvider(): ModelProviderConfig {
     }),
     apiKey: "NVIDIA_API_KEY",
   };
+}
+
+export async function buildLiveNvidiaProvider(): Promise<ModelProviderConfig> {
+  const provider = buildNvidiaProvider();
+  const featuredModels = await loadNvidiaFeaturedModels();
+  if (!featuredModels || featuredModels.length === 0) {
+    return provider;
+  }
+  return {
+    ...provider,
+    models: mergeFeaturedModels(featuredModels, provider.models),
+  };
+}
+
+export function clearNvidiaFeaturedModelCacheForTests() {
+  featuredModelCache = undefined;
+  featuredModelRequest = undefined;
+}
+
+async function loadNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | null> {
+  const now = Date.now();
+  if (featuredModelCache && featuredModelCache.expiresAtMs > now) {
+    return featuredModelCache.models;
+  }
+  featuredModelRequest ??= fetchNvidiaFeaturedModels();
+  try {
+    const models = await featuredModelRequest;
+    if (models && models.length > 0) {
+      featuredModelCache = {
+        expiresAtMs: now + FEATURED_MODEL_CACHE_TTL_MS,
+        models,
+      };
+    }
+    return models;
+  } finally {
+    featuredModelRequest = undefined;
+  }
+}
+
+async function fetchNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | null> {
+  try {
+    const { response, release } = await fetchWithSsrFGuard({
+      url: NVIDIA_FEATURED_MODELS_URL,
+      timeoutMs: FEATURED_MODEL_FETCH_TIMEOUT_MS,
+      requireHttps: true,
+      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(NVIDIA_FEATURED_MODELS_URL),
+      auditContext: "nvidia-featured-model-catalog",
+    });
+    try {
+      if (!response.ok) {
+        return null;
+      }
+      return parseNvidiaFeaturedModels(await response.json());
+    } finally {
+      await release();
+    }
+  } catch {
+    return null;
+  }
+}
+
+function parseNvidiaFeaturedModels(payload: unknown): ModelDefinitionConfig[] | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const rows = (payload as { "featured-models"?: unknown })["featured-models"];
+  if (!Array.isArray(rows)) {
+    return null;
+  }
+  const models = rows
+    .slice(0, FEATURED_MODEL_MAX_ROWS)
+    .map(parseNvidiaFeaturedModel)
+    .filter((model) => model !== null);
+  return models.length > 0 ? models : null;
+}
+
+function parseNvidiaFeaturedModel(row: unknown): ModelDefinitionConfig | null {
+  if (!row || typeof row !== "object") {
+    return null;
+  }
+  const entry = row as Partial<NvidiaFeaturedModel>;
+  if (
+    typeof entry.model !== "string" ||
+    typeof entry["model-name"] !== "string" ||
+    !isBoundedPositiveInteger(entry.context, FEATURED_MODEL_MAX_CONTEXT_WINDOW) ||
+    !isBoundedPositiveInteger(entry["max-output"], FEATURED_MODEL_MAX_OUTPUT_TOKENS)
+  ) {
+    return null;
+  }
+  const id = normalizeNvidiaFeaturedModelId(entry.model);
+  const name = normalizeFeaturedModelName(entry["model-name"]);
+  if (!id || !name) {
+    return null;
+  }
+  return {
+    id,
+    name,
+    reasoning: false,
+    input: ["text"],
+    contextWindow: entry.context,
+    maxTokens: entry["max-output"],
+    cost: { ...FEATURED_MODEL_COST },
+    compat: {
+      requiresStringContent: true,
+    },
+  };
+}
+
+function normalizeNvidiaFeaturedModelId(model: string): string {
+  const trimmed = model.trim();
+  if (
+    !trimmed ||
+    trimmed.length > FEATURED_MODEL_MAX_ID_LENGTH ||
+    hasWhitespaceOrControlCharacter(trimmed)
+  ) {
+    return "";
+  }
+  return trimmed.includes("/") ? trimmed : `nvidia/${trimmed}`;
+}
+
+function normalizeFeaturedModelName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed || trimmed.length > FEATURED_MODEL_MAX_NAME_LENGTH || hasControlCharacter(trimmed)) {
+    return "";
+  }
+  return trimmed;
+}
+
+function mergeFeaturedModels(
+  featuredModels: ModelDefinitionConfig[],
+  fallbackModels: ModelDefinitionConfig[],
+): ModelDefinitionConfig[] {
+  const seen = new Set<string>();
+  const merged: ModelDefinitionConfig[] = [];
+  for (const model of [...featuredModels, ...fallbackModels]) {
+    const key = model.id.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(model);
+  }
+  return merged;
+}
+
+function isBoundedPositiveInteger(value: unknown, max: number): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= max;
+}
+
+function hasWhitespaceOrControlCharacter(value: string): boolean {
+  for (const char of value) {
+    if (isAsciiWhitespaceOrControlCharacter(char)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (const char of value) {
+    if (isControlCharacter(char)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isControlCharacter(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return code <= 31 || code === 127;
+}
+
+function isAsciiWhitespaceOrControlCharacter(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return code <= 32 || code === 127;
 }

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -14,7 +14,7 @@ export const NVIDIA_FEATURED_MODELS_URL =
   "https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json";
 
 const FEATURED_MODEL_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-const FEATURED_MODEL_FETCH_TIMEOUT_MS = 2500;
+const FEATURED_MODEL_FETCH_TIMEOUT_MS = 10_000;
 const FEATURED_MODEL_MAX_ROWS = 32;
 const FEATURED_MODEL_MAX_ID_LENGTH = 200;
 const FEATURED_MODEL_MAX_NAME_LENGTH = 200;

--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -48,6 +48,7 @@ export async function resolveVisibleModelCatalog(params: {
   catalog: ModelCatalogEntry[];
   defaultProvider: string;
   defaultModel?: string;
+  agentDir?: string;
   agentId?: string;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
@@ -68,6 +69,7 @@ export async function resolveVisibleModelCatalog(params: {
       createProviderAuthChecker({
         cfg: params.cfg,
         workspaceDir: params.workspaceDir,
+        agentDir: params.agentDir,
         agentId: params.agentId,
         env: params.env,
         allowPluginSyntheticAuth: params.runtimeAuthDiscovery,

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -18,6 +18,7 @@ import {
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { resolveDefaultAgentDir } from "./agent-scope.js";
+import { ensureAuthProfileStoreWithoutExternalProfiles } from "./auth-profiles.js";
 import { modelSupportsInput as modelCatalogEntrySupportsInput } from "./model-catalog-lookup.js";
 import type { ModelCatalogEntry, ModelInputType } from "./model-catalog.types.js";
 import {
@@ -68,6 +69,9 @@ let importAgentDiscovery = defaultImportAgentDiscovery;
 const modelSuppressionLoader = createLazyImportLoader(
   () => import("./model-suppression.runtime.js"),
 );
+const providerApiKeyResolverLoader = createLazyImportLoader(
+  () => import("./models-config.providers.secrets.js"),
+);
 
 function shouldLogModelCatalogTiming(): boolean {
   return process.env.OPENCLAW_DEBUG_INGRESS_TIMING === "1";
@@ -75,6 +79,10 @@ function shouldLogModelCatalogTiming(): boolean {
 
 function loadModelSuppression() {
   return modelSuppressionLoader.load();
+}
+
+function loadProviderApiKeyResolver() {
+  return providerApiKeyResolverLoader.load();
 }
 
 export function resetModelCatalogCache() {
@@ -540,6 +548,20 @@ export async function loadModelCatalog(params?: {
       );
       logStage("manifest-models-merged", `entries=${models.length}`);
       if (!readOnly) {
+        const { createProviderApiKeyResolver } = await loadProviderApiKeyResolver();
+        let authStore: ReturnType<typeof ensureAuthProfileStoreWithoutExternalProfiles> | undefined;
+        const resolveProviderApiKeyForProvider = createProviderApiKeyResolver(
+          process.env,
+          () =>
+            (authStore ??= ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+              allowKeychainPrompt: false,
+            })),
+          cfg,
+        );
+        const resolveProviderApiKey = (providerId?: string) =>
+          providerId?.trim()
+            ? resolveProviderApiKeyForProvider(providerId)
+            : { apiKey: undefined, discoveryApiKey: undefined };
         const supplemental = await augmentModelCatalogWithProviderPlugins({
           config: cfg,
           env: process.env,
@@ -547,6 +569,7 @@ export async function loadModelCatalog(params?: {
             config: cfg,
             agentDir,
             env: process.env,
+            resolveProviderApiKey,
             entries: [...models],
           },
         });

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -260,6 +260,28 @@ describe("prepared provider auth state", () => {
     );
   });
 
+  it("uses an explicit agent auth store directory for provider auth checks", async () => {
+    const cfg = {} as OpenClawConfig;
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(false);
+    authProfilesMocks.listProfilesForProvider.mockReturnValueOnce([{} as never]);
+
+    const hasAuth = createProviderAuthChecker({
+      cfg,
+      agentDir: "/state/agents/worker/agent",
+      discoverExternalCliAuth: false,
+    });
+
+    await expect(hasAuth("nvidia")).resolves.toBe(true);
+    expect(authProfilesMocks.ensureAuthProfileStoreWithoutExternalProfiles).toHaveBeenCalledWith(
+      "/state/agents/worker/agent",
+      { allowKeychainPrompt: false },
+    );
+    expect(authProfilesMocks.listProfilesForProvider).toHaveBeenCalledWith(
+      expect.anything(),
+      "nvidia",
+    );
+  });
+
   it("hasAuthForModelProvider uses the prepared answer for equivalent runtime config clones", async () => {
     const cfg = { gateway: { port: 18789 } } as OpenClawConfig;
     const clonedCfg = structuredClone(cfg);

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -145,6 +145,7 @@ export async function hasAuthForModelProvider(params: {
   provider: string;
   cfg?: OpenClawConfig;
   workspaceDir?: string;
+  agentDir?: string;
   agentId?: string;
   env?: NodeJS.ProcessEnv;
   store?: AuthProfileStore;
@@ -176,10 +177,15 @@ export async function hasAuthForModelProvider(params: {
     preparedState !== null && params.cfg
       ? resolveAgentWorkspaceDir(params.cfg, preparedState.agentId)
       : null;
+  const expectedAgentDir =
+    preparedState !== null && params.cfg
+      ? resolveAgentDir(params.cfg, preparedState.agentId)
+      : null;
   const matchesWarmedScope =
     preparedState !== null &&
     configFingerprint === preparedState.configFingerprint &&
     workspaceDir === expectedWorkspaceDir &&
+    (params.agentDir === undefined || params.agentDir === expectedAgentDir) &&
     params.discoverExternalCliAuth !== false &&
     params.allowPluginSyntheticAuth !== false &&
     params.env === undefined &&
@@ -204,7 +210,10 @@ export async function hasAuthForModelProvider(params: {
     return true;
   }
   const slowPathAgentDir =
-    params.agentId && params.cfg ? resolveAgentDir(params.cfg, params.agentId) : undefined;
+    params.agentDir ??
+    (params.agentId && params.cfg
+      ? resolveAgentDir(params.cfg, params.agentId, params.env)
+      : undefined);
   const store =
     params.store ??
     (params.discoverExternalCliAuth === false
@@ -223,6 +232,7 @@ export async function hasAuthForModelProvider(params: {
 export function createProviderAuthChecker(params: {
   cfg?: OpenClawConfig;
   workspaceDir?: string;
+  agentDir?: string;
   agentId?: string;
   env?: NodeJS.ProcessEnv;
   allowPluginSyntheticAuth?: boolean;
@@ -240,6 +250,7 @@ export function createProviderAuthChecker(params: {
       provider: key,
       cfg: params.cfg,
       workspaceDir: params.workspaceDir,
+      agentDir: params.agentDir,
       agentId: params.agentId,
       env: params.env,
       allowPluginSyntheticAuth: params.allowPluginSyntheticAuth,

--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -218,6 +218,7 @@ function promptModelAllowlistOptions(index = 0) {
         loadCatalog?: boolean;
         message?: string;
         preferredProvider?: string;
+        providerScopedCatalog?: boolean;
       }
     | undefined;
 }
@@ -528,6 +529,7 @@ describe("promptAuthConfig", () => {
 
     expect(promptModelAllowlistOptions()?.preferredProvider).toBe("github-copilot");
     expect(promptModelAllowlistOptions()?.loadCatalog).toBe(true);
+    expect(promptModelAllowlistOptions()?.providerScopedCatalog).toBe(false);
   });
 
   it("loads configured provider models after Ollama Cloud + Local and Cloud only setup", async () => {
@@ -559,6 +561,7 @@ describe("promptAuthConfig", () => {
     const allowlistOptions = promptModelAllowlistOptions();
     expect(allowlistOptions?.preferredProvider).toBe("ollama");
     expect(allowlistOptions?.loadCatalog).toBe(true);
+    expect(allowlistOptions?.providerScopedCatalog).toBe(true);
   });
 
   it("loads plugin catalog when the selected provider allowlist requires it", async () => {
@@ -600,6 +603,7 @@ describe("promptAuthConfig", () => {
     const allowlistOptions = promptModelAllowlistOptions();
     expect(allowlistOptions?.preferredProvider).toBe("github-copilot");
     expect(allowlistOptions?.loadCatalog).toBe(true);
+    expect(allowlistOptions?.providerScopedCatalog).toBe(true);
   });
 
   it("loads catalog when the selected provider has manifest catalog rows", async () => {
@@ -639,6 +643,7 @@ describe("promptAuthConfig", () => {
     const call = promptModelAllowlistOptions();
     expect(call?.preferredProvider).toBe("github-copilot");
     expect(call?.loadCatalog).toBe(true);
+    expect(call?.providerScopedCatalog).toBe(true);
   });
 
   it("lets skip-auth model browsing scope the allowlist to the selected model provider", async () => {

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -262,6 +262,16 @@ export async function promptAuthConfig(
     });
     const promptProvider =
       modelPrompt?.provider ?? preferredProvider ?? resolveSingleConfiguredProvider(next);
+    const hasPromptProviderConfiguredModels = hasConfiguredProviderModels(next, promptProvider);
+    const hasPromptProviderStaticManifestRows = hasStaticManifestCatalogRows(next, promptProvider);
+    const shouldLoadModelCatalog =
+      modelPrompt?.loadCatalog ??
+      (hasPromptProviderConfiguredModels || hasPromptProviderStaticManifestRows);
+    const useProviderScopedCatalog = Boolean(
+      promptProvider &&
+        shouldLoadModelCatalog &&
+        (modelPrompt?.loadCatalog === true || hasPromptProviderConfiguredModels),
+    );
     const allowlistSelection = await promptModelAllowlist({
       config: next,
       prompter,
@@ -271,10 +281,8 @@ export async function promptAuthConfig(
       initialSelections: modelPrompt?.initialSelections,
       message: modelPrompt?.message,
       preferredProvider: promptProvider,
-      loadCatalog:
-        modelPrompt?.loadCatalog ??
-        (hasConfiguredProviderModels(next, promptProvider) ||
-          hasStaticManifestCatalogRows(next, promptProvider)),
+      providerScopedCatalog: useProviderScopedCatalog,
+      loadCatalog: shouldLoadModelCatalog,
     });
     if (allowlistSelection.models) {
       next = applyModelFallbacksFromSelection(next, allowlistSelection.models, {

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testing as cliBackendsTesting } from "../agents/cli-backends.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { NormalizedModelCatalogRow } from "../model-catalog/index.js";
 import {
@@ -20,6 +21,21 @@ const loadStaticManifestCatalogRowsForList = vi.hoisted(() =>
 );
 vi.mock("./models/list.manifest-catalog.js", () => ({
   loadStaticManifestCatalogRowsForList,
+}));
+
+const loadPreferredProviderPickerCatalog = vi.hoisted(() =>
+  vi.fn<
+    (_params: {
+      cfg: OpenClawConfig;
+      preferredProvider: string;
+      agentDir?: string;
+      workspaceDir?: string;
+      env?: NodeJS.ProcessEnv;
+    }) => Promise<ModelCatalogEntry[]>
+  >(async () => []),
+);
+vi.mock("../flows/model-picker.provider-catalog.js", () => ({
+  loadPreferredProviderPickerCatalog,
 }));
 
 const ensureAuthProfileStore = vi.hoisted(() =>
@@ -290,6 +306,7 @@ beforeEach(() => {
     }),
   });
   loadStaticManifestCatalogRowsForList.mockReturnValue([]);
+  loadPreferredProviderPickerCatalog.mockResolvedValue([]);
   listProfilesForProvider.mockReturnValue([]);
   resolveEnvApiKey.mockImplementation((_provider: string) => ({
     apiKey: "test-key",
@@ -680,8 +697,55 @@ describe("promptDefaultModel", () => {
     ]);
   });
 
-  it("loads the full model catalog when the user chooses to browse", async () => {
+  it("loads the full model catalog when browsing without a preferred provider", async () => {
     loadModelCatalog.mockResolvedValue([
+      {
+        provider: "openai-codex",
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+      },
+      {
+        provider: "openai-codex",
+        id: "gpt-5.5-pro",
+        name: "GPT-5.5 Pro",
+      },
+    ]);
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("__browse__")
+      .mockImplementationOnce(async (params) => {
+        const option = params.options.find(
+          (entry: { value: string }) => entry.value === "openai-codex/gpt-5.5-pro",
+        );
+        return option?.value ?? params.initialValue;
+      });
+    const prompter = makePrompter({ select });
+    const config = {
+      agents: {
+        defaults: {
+          model: "openai-codex/gpt-5.5",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await promptDefaultModel({
+      config,
+      prompter,
+      allowKeep: true,
+      includeManual: true,
+      ignoreAllowlist: true,
+      browseCatalogOnDemand: true,
+    });
+
+    expect(result.model).toBe("openai-codex/gpt-5.5-pro");
+    expect(loadModelCatalog).toHaveBeenCalledOnce();
+    expect(loadPreferredProviderPickerCatalog).not.toHaveBeenCalled();
+    expect(select).toHaveBeenCalledTimes(2);
+    expect(select.mock.calls[1]?.[0]?.searchable).toBe(true);
+  });
+
+  it("loads the preferred provider catalog when the user chooses to browse", async () => {
+    loadPreferredProviderPickerCatalog.mockResolvedValue([
       {
         provider: "openai-codex",
         id: "gpt-5.5",
@@ -722,9 +786,102 @@ describe("promptDefaultModel", () => {
     });
 
     expect(result.model).toBe("openai-codex/gpt-5.5-pro");
-    expect(loadModelCatalog).toHaveBeenCalledOnce();
+    expect(loadPreferredProviderPickerCatalog).toHaveBeenCalledWith({
+      cfg: config,
+      preferredProvider: "openai-codex",
+      agentDir: expect.stringContaining("agents/main/agent"),
+    });
+    expect(loadModelCatalog).not.toHaveBeenCalled();
     expect(select).toHaveBeenCalledTimes(2);
     expect(select.mock.calls[1]?.[0]?.searchable).toBe(true);
+  });
+
+  it("scopes on-demand preferred-provider loads before the first model prompt", async () => {
+    loadPreferredProviderPickerCatalog.mockResolvedValue([
+      {
+        provider: "nvidia",
+        id: "nvidia/nemotron-3-super-120b-a12b",
+        name: "NVIDIA Nemotron 3 Super 120B",
+      },
+      {
+        provider: "nvidia",
+        id: "moonshotai/kimi-k2.5",
+        name: "Kimi K2.5",
+      },
+    ]);
+    const select = vi.fn(async (params) => params.options[0]?.value as never);
+    const prompter = makePrompter({ select });
+    const config = {
+      agents: {
+        defaults: {
+          model: "nvidia/nemotron-3-super-120b-a12b",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await promptDefaultModel({
+      config,
+      prompter,
+      allowKeep: false,
+      includeManual: false,
+      ignoreAllowlist: true,
+      preferredProvider: "nvidia",
+      browseCatalogOnDemand: true,
+    });
+
+    expect(result.model).toBe("nvidia/nemotron-3-super-120b-a12b");
+    expect(loadPreferredProviderPickerCatalog).toHaveBeenCalledWith({
+      cfg: config,
+      preferredProvider: "nvidia",
+      agentDir: expect.stringContaining("agents/main/agent"),
+    });
+    expect(loadModelCatalog).not.toHaveBeenCalled();
+    expect(optionValues(pickerOptions(select as MockCallSource))).toEqual([
+      "nvidia/nemotron-3-super-120b-a12b",
+      "nvidia/moonshotai/kimi-k2.5",
+    ]);
+  });
+
+  it("uses the configured default agent dir for provider-scoped catalog auth", async () => {
+    loadPreferredProviderPickerCatalog.mockResolvedValue([
+      {
+        provider: "nvidia",
+        id: "z-ai/glm-5.1",
+        name: "GLM 5.1",
+      },
+    ]);
+    const select = vi.fn(async (params) => params.options[0]?.value as never);
+    const prompter = makePrompter({ select });
+    const env = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: "/tmp/openclaw-picker-state",
+    };
+    const config = {
+      agents: {
+        list: [{ id: "worker", default: true }],
+        defaults: {
+          model: "nvidia/nemotron-3-super-120b-a12b",
+        },
+      },
+    } as OpenClawConfig;
+
+    await promptDefaultModel({
+      config,
+      prompter,
+      allowKeep: false,
+      includeManual: false,
+      ignoreAllowlist: true,
+      preferredProvider: "nvidia",
+      browseCatalogOnDemand: true,
+      env,
+    });
+
+    expect(loadPreferredProviderPickerCatalog).toHaveBeenCalledWith({
+      cfg: config,
+      preferredProvider: "nvidia",
+      agentDir: "/tmp/openclaw-picker-state/agents/worker/agent",
+      env,
+    });
   });
 
   it("supports configuring vLLM during setup", async () => {

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -209,6 +209,25 @@ function configuredTextModel(id: string, name: string) {
   };
 }
 
+function manifestTextRow(
+  provider: string,
+  id: string,
+  name: string,
+  status: NormalizedModelCatalogRow["status"] = "available",
+): NormalizedModelCatalogRow {
+  return {
+    provider,
+    id,
+    name,
+    ref: `${provider}/${id}`,
+    mergeKey: `${provider}:${id}`,
+    source: "manifest",
+    input: ["text"],
+    reasoning: false,
+    status,
+  };
+}
+
 type MockCallSource = {
   mock: {
     calls: ReadonlyArray<ReadonlyArray<unknown>>;
@@ -591,6 +610,53 @@ describe("promptDefaultModel", () => {
     );
   });
 
+  it("does not double-prefix non-literal NVIDIA vendor model labels", async () => {
+    loadModelCatalog.mockResolvedValue([
+      {
+        provider: "nvidia",
+        id: "nvidia/nemotron-3-super-120b-a12b",
+        name: "Nemotron",
+      },
+      {
+        provider: "nvidia",
+        id: "minimaxai/minimax-m2.7",
+        name: "MiniMax M2.7",
+      },
+      {
+        provider: "nvidia",
+        id: "z-ai/glm-5.1",
+        name: "GLM 5.1",
+      },
+    ]);
+    resolvePluginProviders.mockReturnValue([
+      {
+        id: "nvidia",
+        preserveLiteralProviderPrefix: true,
+      },
+    ] as never);
+
+    const select = vi.fn(async (params) => params.initialValue as never);
+    const prompter = makePrompter({ select });
+
+    await promptDefaultModel({
+      config: { agents: { defaults: {} } } as OpenClawConfig,
+      prompter,
+      allowKeep: false,
+      includeManual: false,
+      ignoreAllowlist: true,
+      preferredProvider: "nvidia",
+    });
+
+    const options = pickerOptions(select as MockCallSource);
+    expect(requireOption(options, "nvidia/nemotron-3-super-120b-a12b").label).toBe(
+      "nvidia/nvidia/nemotron-3-super-120b-a12b",
+    );
+    expect(requireOption(options, "nvidia/minimaxai/minimax-m2.7").label).toBe(
+      "nvidia/minimaxai/minimax-m2.7",
+    );
+    expect(requireOption(options, "nvidia/z-ai/glm-5.1").label).toBe("nvidia/z-ai/glm-5.1");
+  });
+
   it("shows literal double-prefix keep label before browsing provider catalogs", async () => {
     resolvePluginProviders.mockReturnValue([
       {
@@ -796,42 +862,6 @@ describe("promptDefaultModel", () => {
     expect(select.mock.calls[1]?.[0]?.searchable).toBe(true);
   });
 
-  it("uses static manifest rows for a preferred provider without on-demand browsing", async () => {
-    loadStaticManifestCatalogRowsForList.mockReturnValue([
-      {
-        provider: "github-copilot",
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        ref: "github-copilot/gpt-5.4",
-        mergeKey: "github-copilot:gpt-5.4",
-        source: "manifest",
-        input: ["text"],
-        reasoning: true,
-        status: "available",
-      },
-    ]);
-    const select = vi.fn(async (params) => params.options[0]?.value as never);
-    const prompter = makePrompter({ select });
-    const config = { agents: { defaults: {} } } as OpenClawConfig;
-
-    const result = await promptDefaultModel({
-      config,
-      prompter,
-      allowKeep: false,
-      includeManual: false,
-      ignoreAllowlist: true,
-      preferredProvider: "github-copilot",
-    });
-
-    expect(result.model).toBe("github-copilot/gpt-5.4");
-    expect(loadStaticManifestCatalogRowsForList).toHaveBeenCalledWith({
-      cfg: config,
-      providerFilter: "github-copilot",
-    });
-    expect(loadModelCatalog).not.toHaveBeenCalled();
-    expect(loadPreferredProviderPickerCatalog).not.toHaveBeenCalled();
-  });
-
   it("scopes on-demand preferred-provider loads before the first model prompt", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
       {
@@ -875,6 +905,121 @@ describe("promptDefaultModel", () => {
     expect(optionValues(pickerOptions(select as MockCallSource))).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
       "nvidia/moonshotai/kimi-k2.5",
+    ]);
+  });
+
+  it("keeps on-demand NVIDIA vendor labels single-prefixed after browsing", async () => {
+    loadPreferredProviderPickerCatalog.mockResolvedValue([
+      {
+        provider: "nvidia",
+        id: "nvidia/nemotron-3-super-120b-a12b",
+        name: "NVIDIA Nemotron 3 Super 120B",
+      },
+      {
+        provider: "nvidia",
+        id: "minimaxai/minimax-m2.7",
+        name: "MiniMax M2.7",
+      },
+      {
+        provider: "nvidia",
+        id: "z-ai/glm-5.1",
+        name: "GLM 5.1",
+      },
+    ]);
+    resolvePluginProviders.mockReturnValue([
+      {
+        id: "nvidia",
+        preserveLiteralProviderPrefix: true,
+      },
+    ] as never);
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("__browse__")
+      .mockResolvedValueOnce("nvidia/nemotron-3-super-120b-a12b");
+    const prompter = makePrompter({ select });
+
+    await promptDefaultModel({
+      config: {
+        agents: {
+          defaults: {
+            model: "nvidia/nemotron-3-super-120b-a12b",
+          },
+        },
+      } as OpenClawConfig,
+      prompter,
+      allowKeep: true,
+      includeManual: true,
+      ignoreAllowlist: true,
+      preferredProvider: "nvidia",
+      browseCatalogOnDemand: true,
+    });
+
+    const options = pickerOptions(select as MockCallSource, 1);
+    expect(requireOption(options, "nvidia/nemotron-3-super-120b-a12b").label).toBe(
+      "nvidia/nvidia/nemotron-3-super-120b-a12b",
+    );
+    expect(requireOption(options, "nvidia/minimaxai/minimax-m2.7").label).toBe(
+      "nvidia/minimaxai/minimax-m2.7",
+    );
+    expect(requireOption(options, "nvidia/z-ai/glm-5.1").label).toBe("nvidia/z-ai/glm-5.1");
+  });
+
+  it("omits local NVIDIA static fallback rows when browsing live provider rows", async () => {
+    loadPreferredProviderPickerCatalog.mockResolvedValue([
+      {
+        provider: "nvidia",
+        id: "nvidia/nemotron-3-super-120b-a12b",
+        name: "NVIDIA Nemotron 3 Super 120B",
+      },
+      {
+        provider: "nvidia",
+        id: "minimaxai/minimax-m2.7",
+        name: "MiniMax M2.7",
+      },
+      {
+        provider: "nvidia",
+        id: "z-ai/glm-5.1",
+        name: "GLM 5.1",
+      },
+    ]);
+    loadStaticManifestCatalogRowsForList.mockReturnValue([
+      manifestTextRow("nvidia", "minimaxai/minimax-m2.5", "MiniMax M2.5", "deprecated"),
+      manifestTextRow("nvidia", "z-ai/glm5", "GLM5", "deprecated"),
+    ]);
+    resolvePluginProviders.mockReturnValue([
+      {
+        id: "nvidia",
+        preserveLiteralProviderPrefix: true,
+      },
+    ] as never);
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("__browse__")
+      .mockResolvedValueOnce("nvidia/nemotron-3-super-120b-a12b");
+    const prompter = makePrompter({ select });
+
+    await promptDefaultModel({
+      config: {
+        agents: {
+          defaults: {
+            model: "nvidia/nemotron-3-super-120b-a12b",
+          },
+        },
+      } as OpenClawConfig,
+      prompter,
+      allowKeep: true,
+      includeManual: true,
+      ignoreAllowlist: true,
+      preferredProvider: "nvidia",
+      browseCatalogOnDemand: true,
+    });
+
+    expect(optionValues(pickerOptions(select as MockCallSource, 1))).toEqual([
+      "__keep__",
+      "__manual__",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "nvidia/minimaxai/minimax-m2.7",
+      "nvidia/z-ai/glm-5.1",
     ]);
   });
 
@@ -1325,6 +1470,283 @@ describe("promptModelAllowlist", () => {
       models: ["ollama/kimi-k2.5:cloud", "ollama/gpt-oss:20b-cloud"],
       scopeKeys: ["ollama/kimi-k2.5:cloud", "ollama/gpt-oss:20b-cloud"],
     });
+  });
+
+  it("keeps live preferred-provider rows before configured fallback supplements", async () => {
+    loadPreferredProviderPickerCatalog.mockResolvedValue([
+      {
+        provider: "nvidia",
+        id: "minimaxai/minimax-m2.7",
+        name: "MiniMax M2.7",
+      },
+      {
+        provider: "nvidia",
+        id: "nvidia/nemotron-3-super-120b-a12b",
+        name: "Nemotron 3 Super",
+      },
+    ]);
+
+    const multiselect = createSelectAllMultiselect();
+    const prompter = makePrompter({ multiselect });
+    const config = {
+      models: {
+        providers: {
+          nvidia: {
+            api: "openai-completions",
+            baseUrl: "https://integrate.api.nvidia.com/v1",
+            models: [
+              configuredTextModel("nvidia/nemotron-3-super-120b-a12b", "Bundled Nemotron 3 Super"),
+              configuredTextModel("moonshotai/kimi-k2.5", "Bundled Kimi K2.5"),
+              configuredTextModel("minimaxai/minimax-m2.7", "Bundled MiniMax M2.7"),
+              configuredTextModel("z-ai/glm5", "Bundled GLM5"),
+            ],
+          },
+        },
+      },
+      agents: { defaults: {} },
+    } as OpenClawConfig;
+
+    const result = await promptModelAllowlist({
+      config,
+      prompter,
+      preferredProvider: "nvidia",
+      loadCatalog: true,
+    });
+
+    const values = optionValues(pickerOptions(multiselect as MockCallSource));
+    expect(values).toEqual([
+      "nvidia/minimaxai/minimax-m2.7",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "nvidia/moonshotai/kimi-k2.5",
+      "nvidia/z-ai/glm5",
+    ]);
+    expect(result.scopeKeys).toEqual(values);
+  });
+
+  it("keeps provider-scoped live rows authoritative over configured provider supplements", async () => {
+    loadPreferredProviderPickerCatalog.mockResolvedValue([
+      {
+        provider: "nvidia",
+        id: "nvidia/nemotron-3-super-120b-a12b",
+        name: "Nemotron 3 Super",
+      },
+      {
+        provider: "nvidia",
+        id: "z-ai/glm-5.1",
+        name: "GLM 5.1",
+      },
+      {
+        provider: "nvidia",
+        id: "minimaxai/minimax-m2.7",
+        name: "MiniMax M2.7",
+      },
+      {
+        provider: "nvidia",
+        id: "moonshotai/kimi-k2.5",
+        name: "Kimi K2.5",
+      },
+      {
+        provider: "nvidia",
+        id: "minimaxai/minimax-m2.5",
+        name: "MiniMax M2.5",
+      },
+      {
+        provider: "nvidia",
+        id: "z-ai/glm5",
+        name: "GLM5",
+      },
+    ]);
+    loadStaticManifestCatalogRowsForList.mockReturnValue([
+      manifestTextRow("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Bundled Nemotron 3 Super"),
+      manifestTextRow("nvidia", "moonshotai/kimi-k2.5", "Bundled Kimi K2.5"),
+      manifestTextRow("nvidia", "minimaxai/minimax-m2.7", "Bundled MiniMax M2.7"),
+      manifestTextRow("nvidia", "z-ai/glm-5.1", "Bundled GLM 5.1"),
+      manifestTextRow("nvidia", "minimaxai/minimax-m2.5", "Bundled MiniMax M2.5", "deprecated"),
+      manifestTextRow("nvidia", "z-ai/glm5", "Bundled GLM5", "deprecated"),
+    ]);
+
+    const multiselect = createSelectAllMultiselect();
+    const prompter = makePrompter({ multiselect });
+    const config = {
+      models: {
+        providers: {
+          nvidia: {
+            api: "openai-completions",
+            baseUrl: "https://integrate.api.nvidia.com/v1",
+            models: [
+              configuredTextModel("nvidia/nemotron-3-super-120b-a12b", "Bundled Nemotron 3 Super"),
+              configuredTextModel("moonshotai/kimi-k2.5", "Bundled Kimi K2.5"),
+              configuredTextModel("minimaxai/minimax-m2.7", "Bundled MiniMax M2.7"),
+              configuredTextModel("z-ai/glm-5.1", "Bundled GLM 5.1"),
+              configuredTextModel("minimaxai/minimax-m2.5", "Bundled MiniMax M2.5"),
+              configuredTextModel("z-ai/glm5", "Bundled GLM5"),
+            ],
+          },
+        },
+      },
+      agents: { defaults: {} },
+    } as OpenClawConfig;
+
+    const result = await promptModelAllowlist({
+      config,
+      prompter,
+      preferredProvider: "nvidia",
+      loadCatalog: true,
+      providerScopedCatalog: true,
+    });
+
+    const values = optionValues(pickerOptions(multiselect as MockCallSource));
+    expect(values).toEqual([
+      "nvidia/nemotron-3-super-120b-a12b",
+      "nvidia/z-ai/glm-5.1",
+      "nvidia/minimaxai/minimax-m2.7",
+      "nvidia/moonshotai/kimi-k2.5",
+    ]);
+    expect(result.scopeKeys).toEqual(values);
+    expect(loadModelCatalog).not.toHaveBeenCalled();
+  });
+
+  it("keeps custom configured rows after provider-scoped live rows", async () => {
+    loadPreferredProviderPickerCatalog.mockResolvedValue([
+      {
+        provider: "nvidia",
+        id: "nvidia/nemotron-3-super-120b-a12b",
+        name: "Nemotron 3 Super",
+      },
+      {
+        provider: "nvidia",
+        id: "z-ai/glm-5.1",
+        name: "GLM 5.1",
+      },
+    ]);
+    loadStaticManifestCatalogRowsForList.mockReturnValue([
+      manifestTextRow("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Bundled Nemotron 3 Super"),
+      manifestTextRow("nvidia", "z-ai/glm-5.1", "Bundled GLM 5.1"),
+      manifestTextRow("nvidia", "z-ai/glm5", "Bundled GLM5", "deprecated"),
+    ]);
+
+    const multiselect = createSelectAllMultiselect();
+    const prompter = makePrompter({ multiselect });
+    const config = {
+      models: {
+        providers: {
+          nvidia: {
+            api: "openai-completions",
+            baseUrl: "https://integrate.api.nvidia.com/v1",
+            models: [
+              configuredTextModel("nvidia/nemotron-3-super-120b-a12b", "Bundled Nemotron 3 Super"),
+              configuredTextModel("z-ai/glm5", "Configured GLM5 fallback"),
+              configuredTextModel("private/custom-nvidia", "Private NVIDIA model"),
+            ],
+          },
+        },
+      },
+      agents: { defaults: {} },
+    } as OpenClawConfig;
+
+    const result = await promptModelAllowlist({
+      config,
+      prompter,
+      preferredProvider: "nvidia",
+      loadCatalog: true,
+      providerScopedCatalog: true,
+    });
+
+    const values = optionValues(pickerOptions(multiselect as MockCallSource));
+    expect(values).toEqual([
+      "nvidia/nemotron-3-super-120b-a12b",
+      "nvidia/z-ai/glm-5.1",
+      "nvidia/private/custom-nvidia",
+    ]);
+    expect(result.scopeKeys).toEqual(values);
+  });
+
+  it("does not re-add configured static rows after filtering deprecated live rows", async () => {
+    loadPreferredProviderPickerCatalog.mockResolvedValue([
+      {
+        provider: "nvidia",
+        id: "minimaxai/minimax-m2.5",
+        name: "MiniMax M2.5",
+      },
+      {
+        provider: "nvidia",
+        id: "z-ai/glm5",
+        name: "GLM5",
+      },
+    ]);
+    loadStaticManifestCatalogRowsForList.mockReturnValue([
+      manifestTextRow("nvidia", "minimaxai/minimax-m2.5", "Bundled MiniMax M2.5", "deprecated"),
+      manifestTextRow("nvidia", "z-ai/glm5", "Bundled GLM5", "deprecated"),
+    ]);
+
+    const multiselect = createSelectAllMultiselect();
+    const prompter = makePrompter({ multiselect });
+    const config = {
+      models: {
+        providers: {
+          nvidia: {
+            api: "openai-completions",
+            baseUrl: "https://integrate.api.nvidia.com/v1",
+            models: [
+              configuredTextModel("minimaxai/minimax-m2.5", "Configured MiniMax M2.5"),
+              configuredTextModel("z-ai/glm5", "Configured GLM5"),
+              configuredTextModel("private/custom-nvidia", "Private NVIDIA model"),
+            ],
+          },
+        },
+      },
+      agents: { defaults: {} },
+    } as OpenClawConfig;
+
+    const result = await promptModelAllowlist({
+      config,
+      prompter,
+      preferredProvider: "nvidia",
+      loadCatalog: true,
+      providerScopedCatalog: true,
+    });
+
+    const values = optionValues(pickerOptions(multiselect as MockCallSource));
+    expect(values).toEqual(["nvidia/private/custom-nvidia"]);
+    expect(result.scopeKeys).toEqual(values);
+  });
+
+  it("uses configured provider rows when a provider-scoped live catalog is unavailable", async () => {
+    loadStaticManifestCatalogRowsForList.mockReturnValue([
+      manifestTextRow("nvidia", "z-ai/glm5", "Bundled GLM5", "deprecated"),
+    ]);
+
+    const multiselect = createSelectAllMultiselect();
+    const prompter = makePrompter({ multiselect });
+    const config = {
+      models: {
+        providers: {
+          nvidia: {
+            api: "openai-completions",
+            baseUrl: "https://integrate.api.nvidia.com/v1",
+            models: [
+              configuredTextModel("custom-nvidia-model", "Custom NVIDIA model"),
+              configuredTextModel("z-ai/glm5", "Configured GLM5 fallback"),
+            ],
+          },
+        },
+      },
+      agents: { defaults: {} },
+    } as OpenClawConfig;
+
+    const result = await promptModelAllowlist({
+      config,
+      prompter,
+      preferredProvider: "nvidia",
+      loadCatalog: true,
+      providerScopedCatalog: true,
+    });
+
+    const values = optionValues(pickerOptions(multiselect as MockCallSource));
+    expect(values).toEqual(["nvidia/custom-nvidia-model", "nvidia/z-ai/glm5"]);
+    expect(result.scopeKeys).toEqual(values);
+    expect(loadStaticManifestCatalogRowsForList).not.toHaveBeenCalled();
+    expect(loadModelCatalog).not.toHaveBeenCalled();
   });
 
   it("keeps local no-key provider models visible in allowlist choices", async () => {

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -796,6 +796,42 @@ describe("promptDefaultModel", () => {
     expect(select.mock.calls[1]?.[0]?.searchable).toBe(true);
   });
 
+  it("uses static manifest rows for a preferred provider without on-demand browsing", async () => {
+    loadStaticManifestCatalogRowsForList.mockReturnValue([
+      {
+        provider: "github-copilot",
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        ref: "github-copilot/gpt-5.4",
+        mergeKey: "github-copilot:gpt-5.4",
+        source: "manifest",
+        input: ["text"],
+        reasoning: true,
+        status: "available",
+      },
+    ]);
+    const select = vi.fn(async (params) => params.options[0]?.value as never);
+    const prompter = makePrompter({ select });
+    const config = { agents: { defaults: {} } } as OpenClawConfig;
+
+    const result = await promptDefaultModel({
+      config,
+      prompter,
+      allowKeep: false,
+      includeManual: false,
+      ignoreAllowlist: true,
+      preferredProvider: "github-copilot",
+    });
+
+    expect(result.model).toBe("github-copilot/gpt-5.4");
+    expect(loadStaticManifestCatalogRowsForList).toHaveBeenCalledWith({
+      cfg: config,
+      providerFilter: "github-copilot",
+    });
+    expect(loadModelCatalog).not.toHaveBeenCalled();
+    expect(loadPreferredProviderPickerCatalog).not.toHaveBeenCalled();
+  });
+
   it("scopes on-demand preferred-provider loads before the first model prompt", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
       {

--- a/src/flows/model-picker.provider-catalog.test.ts
+++ b/src/flows/model-picker.provider-catalog.test.ts
@@ -1,159 +1,143 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { loadPreferredProviderPickerCatalog } from "./model-picker.provider-catalog.js";
+import type { ProviderPlugin } from "../plugins/types.js";
 
-const providerCatalogMocks = vi.hoisted(() => ({
-  resolveProviderCatalogPluginIdsForFilter: vi.fn(),
-}));
-
-vi.mock("../commands/models/list.provider-catalog.js", () => providerCatalogMocks);
+function textModel(id: string, name: string): ModelDefinitionConfig {
+  return {
+    id,
+    name,
+    reasoning: false,
+    input: ["text"],
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow: 128_000,
+    maxTokens: 8_192,
+  };
+}
 
 const providerDiscoveryMocks = vi.hoisted(() => ({
-  groupPluginDiscoveryProvidersByOrder: vi.fn((providers: unknown[]) => ({
-    simple: providers,
-    profile: [],
-    paired: [],
-    late: [],
-  })),
+  resolveRuntimePluginDiscoveryProviders: vi.fn<() => Promise<ProviderPlugin[]>>(),
+  runProviderCatalog: vi.fn(
+    async ({ provider, ...ctx }: { provider: ProviderPlugin } & Record<string, unknown>) =>
+      provider.catalog?.run(ctx as never),
+  ),
   normalizePluginDiscoveryResult: vi.fn(
     ({
       provider,
       result,
     }: {
-      provider: { id: string; aliases?: string[]; hookAliases?: string[] };
-      result: unknown;
+      provider: ProviderPlugin;
+      result:
+        | { provider: { models?: unknown[] } }
+        | { providers: Record<string, { models?: unknown[] }> }
+        | null
+        | undefined;
     }) => {
-      if (!result || typeof result !== "object") {
+      if (!result) {
         return {};
       }
       if ("provider" in result) {
-        const rows: Record<string, unknown> = {};
-        for (const providerId of [
-          provider.id,
-          ...(provider.aliases ?? []),
-          ...(provider.hookAliases ?? []),
-        ]) {
-          const normalized = providerId.trim().toLowerCase();
-          if (normalized) {
-            rows[normalized] = result.provider;
-          }
-        }
-        return rows;
+        return { [provider.id]: result.provider };
       }
-      if ("providers" in result && result.providers && typeof result.providers === "object") {
-        return result.providers;
-      }
-      return {};
+      return result.providers;
     },
   ),
-  resolveRuntimePluginDiscoveryProviders: vi.fn(),
-  runProviderCatalog: vi.fn(),
-}));
-
-vi.mock("../plugins/provider-discovery.js", () => providerDiscoveryMocks);
-
-const authProfileMocks = vi.hoisted(() => ({
-  ensureAuthProfileStoreWithoutExternalProfiles: vi.fn(() => ({
-    version: 1,
-    profiles: {},
+  groupPluginDiscoveryProvidersByOrder: vi.fn((providers: ProviderPlugin[]) => ({
+    simple: providers,
+    profile: [],
+    paired: [],
+    late: [],
   })),
 }));
 
-vi.mock("../agents/auth-profiles.js", () => authProfileMocks);
+const providersRuntimeMocks = vi.hoisted(() => ({
+  resolvePluginProviders: vi.fn<() => ProviderPlugin[]>(),
+}));
 
-const providerSecretMocks = vi.hoisted(() => {
-  const resolveProviderApiKey = vi.fn(() => ({
-    apiKey: undefined,
-    discoveryApiKey: undefined,
-  }));
-  const resolveProviderAuth = vi.fn(() => undefined);
-  return {
-    createProviderApiKeyResolver: vi.fn(() => resolveProviderApiKey),
-    createProviderAuthResolver: vi.fn(() => resolveProviderAuth),
-    resolveProviderApiKey,
-    resolveProviderAuth,
-  };
-});
+const providerCatalogListMocks = vi.hoisted(() => ({
+  resolveProviderCatalogPluginIdsForFilter: vi.fn(async () => ["nvidia"]),
+}));
 
-vi.mock("../agents/models-config.providers.secrets.js", () => providerSecretMocks);
+vi.mock("../plugins/provider-discovery.js", () => providerDiscoveryMocks);
+vi.mock("../plugins/providers.runtime.js", () => providersRuntimeMocks);
+vi.mock("../commands/models/list.provider-catalog.js", () => providerCatalogListMocks);
+vi.mock("../agents/auth-profiles.js", () => ({
+  ensureAuthProfileStoreWithoutExternalProfiles: vi.fn(() => ({ profiles: {} })),
+}));
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  providerCatalogMocks.resolveProviderCatalogPluginIdsForFilter.mockResolvedValue(["openai"]);
-  providerDiscoveryMocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([
-    {
-      id: "openai",
-      aliases: ["openai-codex"],
-      hookAliases: ["codex"],
-      envVars: [],
-    },
-  ]);
-});
+const { loadPreferredProviderPickerCatalog } = await import("./model-picker.provider-catalog.js");
 
 describe("loadPreferredProviderPickerCatalog", () => {
-  it("keeps canonical catalog rows when the preferred provider matches an alias", async () => {
-    providerDiscoveryMocks.runProviderCatalog.mockResolvedValue({
-      provider: {
-        models: [
-          {
-            id: "gpt-5.5",
-            name: "GPT-5.5",
-            reasoning: true,
-            input: ["text"],
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads the full live provider when manifest static discovery masks the runtime catalog", async () => {
+    const manifestStaticProvider = {
+      id: "nvidia",
+      label: "nvidia",
+      auth: [],
+      staticCatalog: {
+        run: async () => ({
+          provider: {
+            baseUrl: "https://static.invalid/v1",
+            models: [textModel("minimaxai/minimax-m2.5", "Static MiniMax M2.5")],
           },
-        ],
+        }),
       },
-    });
+    } satisfies ProviderPlugin;
+    const liveProvider = {
+      id: "nvidia",
+      label: "NVIDIA",
+      envVars: ["NVIDIA_API_KEY"],
+      auth: [],
+      catalog: {
+        run: async (ctx) => {
+          expect(ctx.resolveProviderApiKey("nvidia")).toEqual({
+            apiKey: "nvapi-test",
+            discoveryApiKey: "nvapi-test",
+          });
+          return {
+            provider: {
+              baseUrl: "https://integrate.api.nvidia.com/v1",
+              models: [
+                textModel("nvidia/nemotron-3-super-120b-a12b", "Nemotron"),
+                textModel("minimaxai/minimax-m2.7", "MiniMax M2.7"),
+              ],
+            },
+          };
+        },
+      },
+    } satisfies ProviderPlugin;
+    providerDiscoveryMocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([
+      manifestStaticProvider,
+    ]);
+    providersRuntimeMocks.resolvePluginProviders.mockReturnValue([liveProvider]);
 
     const rows = await loadPreferredProviderPickerCatalog({
       cfg: {} as OpenClawConfig,
-      preferredProvider: "openai-codex",
-      agentDir: "/tmp/openclaw-test-agent",
-      env: {},
+      preferredProvider: "nvidia",
+      env: { NVIDIA_API_KEY: "nvapi-test" },
     });
 
-    expect(rows).toEqual([
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-        reasoning: true,
-        input: ["text"],
-      },
+    expect(rows.map((entry) => `${entry.provider}/${entry.id}`)).toEqual([
+      "nvidia/nvidia/nemotron-3-super-120b-a12b",
+      "nvidia/minimaxai/minimax-m2.7",
     ]);
-    expect(providerDiscoveryMocks.runProviderCatalog).toHaveBeenCalledOnce();
-  });
-
-  it("passes the environment API key value to provider catalog hooks", async () => {
-    providerDiscoveryMocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([
-      {
-        id: "openai",
-        aliases: ["openai-codex"],
-        hookAliases: [],
-        envVars: ["OPENAI_API_KEY"],
-      },
-    ]);
-    providerDiscoveryMocks.runProviderCatalog.mockImplementationOnce(async (params) => {
-      expect(params.resolveProviderApiKey("openai")).toEqual({
-        apiKey: "sk-test",
-        discoveryApiKey: "sk-test",
-      });
-      return {
-        provider: {
-          models: [],
-        },
-      };
+    expect(rows.map((entry) => entry.id)).not.toContain("minimaxai/minimax-m2.5");
+    expect(providersRuntimeMocks.resolvePluginProviders).toHaveBeenCalledWith({
+      config: {},
+      env: { NVIDIA_API_KEY: "nvapi-test" },
+      onlyPluginIds: ["nvidia"],
+      includeUntrustedWorkspacePlugins: false,
+      mode: "setup",
+      activate: false,
+      cache: false,
     });
-
-    await loadPreferredProviderPickerCatalog({
-      cfg: {} as OpenClawConfig,
-      preferredProvider: "openai-codex",
-      agentDir: "/tmp/openclaw-test-agent",
-      env: {
-        OPENAI_API_KEY: "sk-test",
-      },
-    });
-
-    expect(providerDiscoveryMocks.runProviderCatalog).toHaveBeenCalledOnce();
   });
 });

--- a/src/flows/model-picker.provider-catalog.test.ts
+++ b/src/flows/model-picker.provider-catalog.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadPreferredProviderPickerCatalog } from "./model-picker.provider-catalog.js";
+
+const providerCatalogMocks = vi.hoisted(() => ({
+  resolveProviderCatalogPluginIdsForFilter: vi.fn(),
+}));
+
+vi.mock("../commands/models/list.provider-catalog.js", () => providerCatalogMocks);
+
+const providerDiscoveryMocks = vi.hoisted(() => ({
+  groupPluginDiscoveryProvidersByOrder: vi.fn((providers: unknown[]) => ({
+    simple: providers,
+    profile: [],
+    paired: [],
+    late: [],
+  })),
+  normalizePluginDiscoveryResult: vi.fn(
+    ({
+      provider,
+      result,
+    }: {
+      provider: { id: string; aliases?: string[]; hookAliases?: string[] };
+      result: unknown;
+    }) => {
+      if (!result || typeof result !== "object") {
+        return {};
+      }
+      if ("provider" in result) {
+        const rows: Record<string, unknown> = {};
+        for (const providerId of [
+          provider.id,
+          ...(provider.aliases ?? []),
+          ...(provider.hookAliases ?? []),
+        ]) {
+          const normalized = providerId.trim().toLowerCase();
+          if (normalized) {
+            rows[normalized] = result.provider;
+          }
+        }
+        return rows;
+      }
+      if ("providers" in result && result.providers && typeof result.providers === "object") {
+        return result.providers;
+      }
+      return {};
+    },
+  ),
+  resolveRuntimePluginDiscoveryProviders: vi.fn(),
+  runProviderCatalog: vi.fn(),
+}));
+
+vi.mock("../plugins/provider-discovery.js", () => providerDiscoveryMocks);
+
+const authProfileMocks = vi.hoisted(() => ({
+  ensureAuthProfileStoreWithoutExternalProfiles: vi.fn(() => ({
+    version: 1,
+    profiles: {},
+  })),
+}));
+
+vi.mock("../agents/auth-profiles.js", () => authProfileMocks);
+
+const providerSecretMocks = vi.hoisted(() => {
+  const resolveProviderApiKey = vi.fn(() => ({
+    apiKey: undefined,
+    discoveryApiKey: undefined,
+  }));
+  const resolveProviderAuth = vi.fn(() => undefined);
+  return {
+    createProviderApiKeyResolver: vi.fn(() => resolveProviderApiKey),
+    createProviderAuthResolver: vi.fn(() => resolveProviderAuth),
+    resolveProviderApiKey,
+    resolveProviderAuth,
+  };
+});
+
+vi.mock("../agents/models-config.providers.secrets.js", () => providerSecretMocks);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providerCatalogMocks.resolveProviderCatalogPluginIdsForFilter.mockResolvedValue(["openai"]);
+  providerDiscoveryMocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([
+    {
+      id: "openai",
+      aliases: ["openai-codex"],
+      hookAliases: ["codex"],
+      envVars: [],
+    },
+  ]);
+});
+
+describe("loadPreferredProviderPickerCatalog", () => {
+  it("keeps canonical catalog rows when the preferred provider matches an alias", async () => {
+    providerDiscoveryMocks.runProviderCatalog.mockResolvedValue({
+      provider: {
+        models: [
+          {
+            id: "gpt-5.5",
+            name: "GPT-5.5",
+            reasoning: true,
+            input: ["text"],
+          },
+        ],
+      },
+    });
+
+    const rows = await loadPreferredProviderPickerCatalog({
+      cfg: {} as OpenClawConfig,
+      preferredProvider: "openai-codex",
+      agentDir: "/tmp/openclaw-test-agent",
+      env: {},
+    });
+
+    expect(rows).toEqual([
+      {
+        provider: "openai",
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        reasoning: true,
+        input: ["text"],
+      },
+    ]);
+    expect(providerDiscoveryMocks.runProviderCatalog).toHaveBeenCalledOnce();
+  });
+
+  it("passes the environment API key value to provider catalog hooks", async () => {
+    providerDiscoveryMocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([
+      {
+        id: "openai",
+        aliases: ["openai-codex"],
+        hookAliases: [],
+        envVars: ["OPENAI_API_KEY"],
+      },
+    ]);
+    providerDiscoveryMocks.runProviderCatalog.mockImplementationOnce(async (params) => {
+      expect(params.resolveProviderApiKey("openai")).toEqual({
+        apiKey: "sk-test",
+        discoveryApiKey: "sk-test",
+      });
+      return {
+        provider: {
+          models: [],
+        },
+      };
+    });
+
+    await loadPreferredProviderPickerCatalog({
+      cfg: {} as OpenClawConfig,
+      preferredProvider: "openai-codex",
+      agentDir: "/tmp/openclaw-test-agent",
+      env: {
+        OPENAI_API_KEY: "sk-test",
+      },
+    });
+
+    expect(providerDiscoveryMocks.runProviderCatalog).toHaveBeenCalledOnce();
+  });
+});

--- a/src/flows/model-picker.provider-catalog.ts
+++ b/src/flows/model-picker.provider-catalog.ts
@@ -44,6 +44,52 @@ function providerAuthIds(provider: ProviderPlugin): string[] {
     .filter(Boolean);
 }
 
+function hasLiveProviderCatalog(provider: ProviderPlugin): boolean {
+  return (
+    typeof provider.catalog?.run === "function" || typeof provider.discovery?.run === "function"
+  );
+}
+
+async function resolvePreferredProviderLiveCatalogProviders(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  onlyPluginIds: string[];
+  providerFilter: string;
+  workspaceDir?: string;
+}): Promise<ProviderPlugin[]> {
+  const providers = (
+    await resolveRuntimePluginDiscoveryProviders({
+      config: params.cfg,
+      env: params.env,
+      onlyPluginIds: params.onlyPluginIds,
+      includeUntrustedWorkspacePlugins: false,
+      ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+    })
+  ).filter((provider) =>
+    providerMatchesFilter({ provider, providerFilter: params.providerFilter }),
+  );
+  const liveProviders = providers.filter(hasLiveProviderCatalog);
+  if (liveProviders.length > 0) {
+    return liveProviders;
+  }
+
+  const { resolvePluginProviders } = await import("../plugins/providers.runtime.js");
+  return resolvePluginProviders({
+    config: params.cfg,
+    env: params.env,
+    onlyPluginIds: params.onlyPluginIds,
+    includeUntrustedWorkspacePlugins: false,
+    mode: "setup",
+    activate: false,
+    cache: false,
+    ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+  }).filter(
+    (provider) =>
+      providerMatchesFilter({ provider, providerFilter: params.providerFilter }) &&
+      hasLiveProviderCatalog(provider),
+  );
+}
+
 function resolveProviderEnvApiKey(
   provider: ProviderPlugin,
   env: NodeJS.ProcessEnv,
@@ -113,15 +159,13 @@ export async function loadPreferredProviderPickerCatalog(params: {
     return [];
   }
 
-  const providers = (
-    await resolveRuntimePluginDiscoveryProviders({
-      config: params.cfg,
-      env,
-      onlyPluginIds,
-      includeUntrustedWorkspacePlugins: false,
-      ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
-    })
-  ).filter((provider) => providerMatchesFilter({ provider, providerFilter }));
+  const providers = await resolvePreferredProviderLiveCatalogProviders({
+    cfg: params.cfg,
+    env,
+    onlyPluginIds,
+    providerFilter,
+    ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+  });
   if (providers.length === 0) {
     return [];
   }
@@ -172,32 +216,24 @@ export async function loadPreferredProviderPickerCatalog(params: {
       }
 
       const normalized = normalizePluginDiscoveryResult({ provider, result });
-      const canonicalProviderId = normalizeProviderId(provider.id);
-      const acceptedProviderIds = new Set(providerAuthIds(provider));
-      const canonicalProviderConfig = canonicalProviderId
-        ? normalized[canonicalProviderId]
-        : undefined;
-      const providerConfig = Array.isArray(canonicalProviderConfig?.models)
-        ? canonicalProviderConfig
-        : [...acceptedProviderIds]
-            .map((providerId) => normalized[providerId])
-            .find((candidate) => Array.isArray(candidate?.models));
-      const outputProviderId = canonicalProviderId || providerFilter;
-      if (!providerConfig || !Array.isArray(providerConfig.models)) {
-        continue;
-      }
-      for (const model of providerConfig.models) {
-        const entry = modelFromProviderCatalog({
-          provider: outputProviderId,
-          providerConfig,
-          model,
-        });
-        const key = `${entry.provider}/${entry.id}`;
-        if (seen.has(key)) {
+      for (const [providerIdRaw, providerConfig] of Object.entries(normalized)) {
+        const providerId = normalizeProviderId(providerIdRaw);
+        if (providerId !== providerFilter || !Array.isArray(providerConfig.models)) {
           continue;
         }
-        seen.add(key);
-        rows.push(entry);
+        for (const model of providerConfig.models) {
+          const entry = modelFromProviderCatalog({
+            provider: providerId,
+            providerConfig,
+            model,
+          });
+          const key = `${entry.provider}/${entry.id}`;
+          if (seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          rows.push(entry);
+        }
       }
     }
   }

--- a/src/flows/model-picker.provider-catalog.ts
+++ b/src/flows/model-picker.provider-catalog.ts
@@ -1,0 +1,198 @@
+import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
+import { ensureAuthProfileStoreWithoutExternalProfiles } from "../agents/auth-profiles.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import { normalizeConfiguredProviderCatalogModelId } from "../agents/model-ref-shared.js";
+import {
+  createProviderApiKeyResolver,
+  createProviderAuthResolver,
+} from "../agents/models-config.providers.secrets.js";
+import { normalizeProviderId } from "../agents/provider-id.js";
+import { resolveProviderCatalogPluginIdsForFilter } from "../commands/models/list.provider-catalog.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  groupPluginDiscoveryProvidersByOrder,
+  normalizePluginDiscoveryResult,
+  resolveRuntimePluginDiscoveryProviders,
+  runProviderCatalog,
+} from "../plugins/provider-discovery.js";
+import type { ProviderPlugin } from "../plugins/types.js";
+
+const log = createSubsystemLogger("model-picker-provider-catalog");
+const DISCOVERY_ORDERS = ["simple", "profile", "paired", "late"] as const;
+
+function providerMatchesFilter(params: {
+  provider: Pick<ProviderPlugin, "id" | "aliases" | "hookAliases">;
+  providerFilter: string;
+}): boolean {
+  return [
+    params.provider.id,
+    ...(params.provider.aliases ?? []),
+    ...(params.provider.hookAliases ?? []),
+  ].some((providerId) => normalizeProviderId(providerId) === params.providerFilter);
+}
+
+function positiveNumber(value: number | undefined): number | undefined {
+  return typeof value === "number" && value > 0 ? value : undefined;
+}
+
+function providerAuthIds(provider: ProviderPlugin): string[] {
+  return [provider.id, ...(provider.aliases ?? []), ...(provider.hookAliases ?? [])]
+    .map(normalizeProviderId)
+    .filter(Boolean);
+}
+
+function resolveProviderEnvApiKey(
+  provider: ProviderPlugin,
+  env: NodeJS.ProcessEnv,
+):
+  | {
+      apiKey: string;
+      discoveryApiKey?: string;
+    }
+  | undefined {
+  for (const envVar of provider.envVars ?? []) {
+    const normalized = envVar.trim();
+    const value = env[normalized]?.trim();
+    if (normalized && value) {
+      return {
+        apiKey: normalized,
+        discoveryApiKey: value,
+      };
+    }
+  }
+  return undefined;
+}
+
+function modelFromProviderCatalog(params: {
+  provider: string;
+  providerConfig: ModelProviderConfig;
+  model: ModelDefinitionConfig;
+}): ModelCatalogEntry {
+  const id = normalizeConfiguredProviderCatalogModelId(params.provider, params.model.id);
+  const contextWindow =
+    positiveNumber(params.model.contextWindow) ??
+    positiveNumber(params.providerConfig.contextWindow);
+  const contextTokens =
+    positiveNumber(params.model.contextTokens) ??
+    positiveNumber(params.providerConfig.contextTokens);
+  return {
+    id,
+    name: params.model.name || id,
+    provider: params.provider,
+    ...(contextWindow !== undefined ? { contextWindow } : {}),
+    ...(contextTokens !== undefined ? { contextTokens } : {}),
+    reasoning: params.model.reasoning,
+    input: params.model.input,
+    ...(params.model.compat ? { compat: params.model.compat } : {}),
+  };
+}
+
+export async function loadPreferredProviderPickerCatalog(params: {
+  cfg: OpenClawConfig;
+  preferredProvider: string;
+  agentDir?: string;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<ModelCatalogEntry[]> {
+  const env = params.env ?? process.env;
+  const agentDir = params.agentDir ?? resolveDefaultAgentDir(params.cfg, env);
+  const providerFilter = normalizeProviderId(params.preferredProvider);
+  if (!providerFilter) {
+    return [];
+  }
+
+  const onlyPluginIds = await resolveProviderCatalogPluginIdsForFilter({
+    cfg: params.cfg,
+    env,
+    providerFilter,
+  });
+  if (!onlyPluginIds || onlyPluginIds.length === 0) {
+    return [];
+  }
+
+  const providers = (
+    await resolveRuntimePluginDiscoveryProviders({
+      config: params.cfg,
+      env,
+      onlyPluginIds,
+      includeUntrustedWorkspacePlugins: false,
+      ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+    })
+  ).filter((provider) => providerMatchesFilter({ provider, providerFilter }));
+  if (providers.length === 0) {
+    return [];
+  }
+
+  let authStore: ReturnType<typeof ensureAuthProfileStoreWithoutExternalProfiles> | undefined;
+  const getAuthStore = () =>
+    (authStore ??= ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+      allowKeychainPrompt: false,
+    }));
+  const resolveProviderApiKey = createProviderApiKeyResolver(env, getAuthStore, params.cfg);
+  const resolveProviderAuth = createProviderAuthResolver(env, getAuthStore, params.cfg);
+  const resolveFastProviderApiKey = (provider: ProviderPlugin, providerId = provider.id) => {
+    const normalizedProviderId = normalizeProviderId(providerId);
+    if (providerAuthIds(provider).includes(normalizedProviderId)) {
+      const fromEnv = resolveProviderEnvApiKey(provider, env);
+      if (fromEnv) {
+        return fromEnv;
+      }
+    }
+    return resolveProviderApiKey(providerId);
+  };
+  const byOrder = groupPluginDiscoveryProvidersByOrder(providers);
+  const rows: ModelCatalogEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const order of DISCOVERY_ORDERS) {
+    for (const provider of byOrder[order]) {
+      let result: Awaited<ReturnType<typeof runProviderCatalog>>;
+      const resolveCatalogProviderApiKey = (providerId?: string) =>
+        resolveFastProviderApiKey(provider, providerId?.trim() || provider.id);
+      const resolveCatalogProviderAuth = (
+        providerId?: string,
+        options?: { oauthMarker?: string },
+      ) => resolveProviderAuth(providerId?.trim() || provider.id, options);
+      try {
+        result = await runProviderCatalog({
+          provider,
+          config: params.cfg,
+          env,
+          resolveProviderApiKey: resolveCatalogProviderApiKey,
+          resolveProviderAuth: resolveCatalogProviderAuth,
+          agentDir,
+          ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+        });
+      } catch (error) {
+        log.warn(`provider catalog failed for ${provider.id}: ${formatErrorMessage(error)}`);
+        continue;
+      }
+
+      const normalized = normalizePluginDiscoveryResult({ provider, result });
+      for (const [providerIdRaw, providerConfig] of Object.entries(normalized)) {
+        const providerId = normalizeProviderId(providerIdRaw);
+        if (providerId !== providerFilter || !Array.isArray(providerConfig.models)) {
+          continue;
+        }
+        for (const model of providerConfig.models) {
+          const entry = modelFromProviderCatalog({
+            provider: providerId,
+            providerConfig,
+            model,
+          });
+          const key = `${entry.provider}/${entry.id}`;
+          if (seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          rows.push(entry);
+        }
+      }
+    }
+  }
+
+  return rows;
+}

--- a/src/flows/model-picker.provider-catalog.ts
+++ b/src/flows/model-picker.provider-catalog.ts
@@ -58,7 +58,7 @@ function resolveProviderEnvApiKey(
     const value = env[normalized]?.trim();
     if (normalized && value) {
       return {
-        apiKey: normalized,
+        apiKey: value,
         discoveryApiKey: value,
       };
     }
@@ -172,24 +172,32 @@ export async function loadPreferredProviderPickerCatalog(params: {
       }
 
       const normalized = normalizePluginDiscoveryResult({ provider, result });
-      for (const [providerIdRaw, providerConfig] of Object.entries(normalized)) {
-        const providerId = normalizeProviderId(providerIdRaw);
-        if (providerId !== providerFilter || !Array.isArray(providerConfig.models)) {
+      const canonicalProviderId = normalizeProviderId(provider.id);
+      const acceptedProviderIds = new Set(providerAuthIds(provider));
+      const canonicalProviderConfig = canonicalProviderId
+        ? normalized[canonicalProviderId]
+        : undefined;
+      const providerConfig = Array.isArray(canonicalProviderConfig?.models)
+        ? canonicalProviderConfig
+        : [...acceptedProviderIds]
+            .map((providerId) => normalized[providerId])
+            .find((candidate) => Array.isArray(candidate?.models));
+      const outputProviderId = canonicalProviderId || providerFilter;
+      if (!providerConfig || !Array.isArray(providerConfig.models)) {
+        continue;
+      }
+      for (const model of providerConfig.models) {
+        const entry = modelFromProviderCatalog({
+          provider: outputProviderId,
+          providerConfig,
+          model,
+        });
+        const key = `${entry.provider}/${entry.id}`;
+        if (seen.has(key)) {
           continue;
         }
-        for (const model of providerConfig.models) {
-          const entry = modelFromProviderCatalog({
-            provider: providerId,
-            providerConfig,
-            model,
-          });
-          const key = `${entry.provider}/${entry.id}`;
-          if (seen.has(key)) {
-            continue;
-          }
-          seen.add(key);
-          rows.push(entry);
-        }
+        seen.add(key);
+        rows.push(entry);
       }
     }
   }

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -1,3 +1,4 @@
+import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveVisibleModelCatalog } from "../agents/model-catalog-visibility.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
@@ -32,6 +33,7 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { sortUniqueStrings } from "../shared/string-normalization.js";
 import { t } from "../wizard/i18n/index.js";
 import type { WizardPrompter, WizardSelectOption } from "../wizard/prompts.js";
+import { loadPreferredProviderPickerCatalog } from "./model-picker.provider-catalog.js";
 
 export { applyPrimaryModel } from "../plugins/provider-model-primary.js";
 
@@ -52,6 +54,14 @@ function formatKeepCurrentModelLabel(params: {
   return params.configuredRaw
     ? t("wizard.model.keepCurrent", { value: params.configuredLabel })
     : t("wizard.model.keepCurrentDefault", { value: params.resolvedKey });
+}
+
+function resolvePickerAgentDir(params: {
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  return params.agentDir ?? resolveDefaultAgentDir(params.cfg, params.env ?? process.env);
 }
 
 export type PromptDefaultModelParams = {
@@ -109,18 +119,55 @@ function toPickerCatalogEntry(
 
 function loadPickerModelCatalog(
   cfg: OpenClawConfig,
-  opts: { preferredProvider?: string } = {},
+  opts: {
+    preferredProvider?: string;
+    preferLiveProviderCatalog?: boolean;
+    providerScoped?: boolean;
+    agentDir?: string;
+    workspaceDir?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
 ): ReturnType<typeof loadModelCatalog> {
   if (cfg.models?.mode === "replace") {
     return Promise.resolve(buildConfiguredModelCatalog({ cfg }));
   }
   if (opts.preferredProvider) {
+    if (opts.preferLiveProviderCatalog) {
+      return loadPreferredProviderPickerCatalog({
+        cfg,
+        preferredProvider: opts.preferredProvider,
+        ...(opts.agentDir !== undefined ? { agentDir: opts.agentDir } : {}),
+        ...(opts.workspaceDir !== undefined ? { workspaceDir: opts.workspaceDir } : {}),
+        ...(opts.env !== undefined ? { env: opts.env } : {}),
+      }).then((providerCatalog) => {
+        if (providerCatalog.length > 0) {
+          return providerCatalog;
+        }
+        const manifestRows = loadStaticManifestCatalogRowsForList({
+          cfg,
+          providerFilter: opts.preferredProvider,
+          ...(opts.env !== undefined ? { env: opts.env } : {}),
+        });
+        if (manifestRows.length > 0) {
+          return manifestRows.map(toPickerCatalogEntry);
+        }
+        return opts.providerScoped
+          ? []
+          : loadModelCatalog({
+              config: cfg,
+            });
+      });
+    }
     const manifestRows = loadStaticManifestCatalogRowsForList({
       cfg,
       providerFilter: opts.preferredProvider,
+      ...(opts.env !== undefined ? { env: opts.env } : {}),
     });
     if (manifestRows.length > 0) {
       return Promise.resolve(manifestRows.map(toPickerCatalogEntry));
+    }
+    if (opts.providerScoped) {
+      return Promise.resolve([]);
     }
   }
   return loadModelCatalog({
@@ -564,6 +611,11 @@ export async function promptDefaultModel(
   params: PromptDefaultModelParams,
 ): Promise<PromptDefaultModelResult> {
   const cfg = params.config;
+  const pickerAgentDir = resolvePickerAgentDir({
+    cfg,
+    ...(params.agentDir !== undefined ? { agentDir: params.agentDir } : {}),
+    ...(params.env !== undefined ? { env: params.env } : {}),
+  });
   const allowKeep = params.allowKeep ?? true;
   const includeManual = params.includeManual ?? true;
   const includeProviderPluginSetups = params.includeProviderPluginSetups ?? false;
@@ -705,7 +757,15 @@ export async function promptDefaultModel(
   const catalogProgress = params.prompter.progress(t("wizard.model.loadingModels"));
   let catalog: Awaited<ReturnType<typeof loadModelCatalog>>;
   try {
-    catalog = await loadPickerModelCatalog(cfg, { preferredProvider });
+    const providerScopedCatalog = browseCatalogOnDemand && preferredProvider;
+    catalog = await loadPickerModelCatalog(cfg, {
+      preferredProvider: providerScopedCatalog ? preferredProvider : undefined,
+      preferLiveProviderCatalog: Boolean(providerScopedCatalog),
+      providerScoped: Boolean(providerScopedCatalog),
+      agentDir: pickerAgentDir,
+      ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+      ...(params.env !== undefined ? { env: params.env } : {}),
+    });
   } finally {
     catalogProgress.stop();
   }
@@ -728,6 +788,7 @@ export async function promptDefaultModel(
         catalog,
         defaultProvider: DEFAULT_PROVIDER,
         defaultModel: resolved.model,
+        agentDir: pickerAgentDir,
         workspaceDir: params.workspaceDir,
         env: params.env,
       });
@@ -774,6 +835,7 @@ export async function promptDefaultModel(
   const hasAuth = createProviderAuthChecker({
     cfg,
     workspaceDir: params.workspaceDir,
+    agentDir: pickerAgentDir,
     env: params.env,
   });
   const literalPrefixProviders = await resolveCachedLiteralPrefixProviders();
@@ -895,6 +957,11 @@ export async function promptModelAllowlist(params: {
   loadCatalog?: boolean;
 }): Promise<PromptModelAllowlistResult> {
   const cfg = params.config;
+  const pickerAgentDir = resolvePickerAgentDir({
+    cfg,
+    ...(params.agentDir !== undefined ? { agentDir: params.agentDir } : {}),
+    ...(params.env !== undefined ? { env: params.env } : {}),
+  });
   const existingKeys = resolveConfiguredModelKeys(cfg);
   const configuredRaw = resolveConfiguredModelRaw(cfg);
   const allowedKeys = normalizeModelKeys(params.allowedKeys ?? []);
@@ -937,10 +1004,18 @@ export async function promptModelAllowlist(params: {
     fallbackKeys.length > 0 ||
     (params.initialSelections?.length ?? 0) > 0 ||
     configuredRaw.length > 0;
+  const hasAuth = createProviderAuthChecker({
+    cfg,
+    workspaceDir: params.workspaceDir,
+    agentDir: pickerAgentDir,
+    env: params.env,
+  });
   const matchesPreferredProvider = preferredProvider
     ? createPreferredProviderMatcher({
         preferredProvider,
         cfg,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
       })
     : undefined;
   const loadCatalog = params.loadCatalog ?? true;
@@ -965,11 +1040,6 @@ export async function promptModelAllowlist(params: {
     const initialKeys = normalizeModelKeys(initialSeeds.filter((key) => scopeKeySet.has(key)));
     const options: WizardSelectOption[] = [];
     const seen = new Set<string>();
-    const hasAuth = createProviderAuthChecker({
-      cfg,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-    });
     for (const key of scopeKeys) {
       await addModelKeySelectOption({
         key,
@@ -1012,7 +1082,13 @@ export async function promptModelAllowlist(params: {
   const allowlistProgress = params.prompter.progress(t("wizard.model.loadingModels"));
   let catalog: Awaited<ReturnType<typeof loadModelCatalog>>;
   try {
-    catalog = await loadPickerModelCatalog(cfg, { preferredProvider });
+    catalog = await loadPickerModelCatalog(cfg, {
+      preferredProvider,
+      preferLiveProviderCatalog: Boolean(preferredProvider),
+      agentDir: pickerAgentDir,
+      ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+      ...(params.env !== undefined ? { env: params.env } : {}),
+    });
   } finally {
     allowlistProgress.stop();
   }
@@ -1072,11 +1148,6 @@ export async function promptModelAllowlist(params: {
     preferredProvider && allowedCatalog.some((entry) => matchesPreferredProvider?.(entry.provider))
       ? allowedCatalog.filter((entry) => matchesPreferredProvider?.(entry.provider))
       : allowedCatalog;
-  const hasAuth = createProviderAuthChecker({
-    cfg,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-  });
 
   const scopeKeys = allowedKeySet
     ? allowedKeys

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -759,7 +759,7 @@ export async function promptDefaultModel(
   try {
     const providerScopedCatalog = browseCatalogOnDemand && preferredProvider;
     catalog = await loadPickerModelCatalog(cfg, {
-      preferredProvider: providerScopedCatalog ? preferredProvider : undefined,
+      preferredProvider,
       preferLiveProviderCatalog: Boolean(providerScopedCatalog),
       providerScoped: Boolean(providerScopedCatalog),
       agentDir: pickerAgentDir,

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -56,6 +56,21 @@ function formatKeepCurrentModelLabel(params: {
     : t("wizard.model.keepCurrentDefault", { value: params.resolvedKey });
 }
 
+function formatModelRefLabel(params: {
+  provider: string;
+  model: string;
+  key: string;
+  literalPrefixProviders: Set<string>;
+}): string {
+  const providerId = normalizeProviderId(params.provider);
+  const modelId = params.model.trim().toLowerCase();
+  return providerId &&
+    params.literalPrefixProviders.has(providerId) &&
+    modelId.startsWith(`${providerId}/`)
+    ? formatLiteralProviderPrefixedModelRef(params.provider, params.key)
+    : params.key;
+}
+
 function resolvePickerAgentDir(params: {
   cfg: OpenClawConfig;
   agentDir?: string;
@@ -123,6 +138,7 @@ function loadPickerModelCatalog(
     preferredProvider?: string;
     preferLiveProviderCatalog?: boolean;
     providerScoped?: boolean;
+    allowStaticFallbackCatalog?: boolean;
     agentDir?: string;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
@@ -143,13 +159,15 @@ function loadPickerModelCatalog(
         if (providerCatalog.length > 0) {
           return providerCatalog;
         }
-        const manifestRows = loadStaticManifestCatalogRowsForList({
-          cfg,
-          providerFilter: opts.preferredProvider,
-          ...(opts.env !== undefined ? { env: opts.env } : {}),
-        });
-        if (manifestRows.length > 0) {
-          return manifestRows.map(toPickerCatalogEntry);
+        if (opts.allowStaticFallbackCatalog !== false) {
+          const manifestRows = loadStaticManifestCatalogRowsForList({
+            cfg,
+            providerFilter: opts.preferredProvider,
+            ...(opts.env !== undefined ? { env: opts.env } : {}),
+          });
+          if (manifestRows.length > 0) {
+            return manifestRows.map(toPickerCatalogEntry);
+          }
         }
         return opts.providerScoped
           ? []
@@ -320,9 +338,12 @@ async function addModelSelectOption(params: {
   if (!(await params.hasAuth(normalizedRef.provider))) {
     return;
   }
-  const label = params.literalPrefixProviders.has(normalizeProviderId(normalizedRef.provider))
-    ? formatLiteralProviderPrefixedModelRef(normalizedRef.provider, key)
-    : key;
+  const label = formatModelRefLabel({
+    provider: normalizedRef.provider,
+    model: normalizedRef.model,
+    key,
+    literalPrefixProviders: params.literalPrefixProviders,
+  });
   params.options.push({
     value: key,
     label,
@@ -653,9 +674,12 @@ export async function promptDefaultModel(
       return configuredRaw || resolvedKey;
     }
     const literalPrefixProviders = await resolveCachedLiteralPrefixProviders();
-    return literalPrefixProviders.has(providerId)
-      ? formatLiteralProviderPrefixedModelRef(resolved.provider, resolvedKey)
-      : configuredRaw || resolvedKey;
+    return formatModelRefLabel({
+      provider: resolved.provider,
+      model: resolved.model,
+      key: configuredRaw || resolvedKey,
+      literalPrefixProviders,
+    });
   };
 
   if (
@@ -759,7 +783,7 @@ export async function promptDefaultModel(
   try {
     const providerScopedCatalog = browseCatalogOnDemand && preferredProvider;
     catalog = await loadPickerModelCatalog(cfg, {
-      preferredProvider,
+      preferredProvider: providerScopedCatalog ? preferredProvider : undefined,
       preferLiveProviderCatalog: Boolean(providerScopedCatalog),
       providerScoped: Boolean(providerScopedCatalog),
       agentDir: pickerAgentDir,
@@ -843,9 +867,12 @@ export async function promptDefaultModel(
   // Show the literal form (e.g. nvidia/nvidia/...) in the "Keep current" label
   // for providers that set preserveLiteralProviderPrefix, so the user sees the
   // same ref they'll pick from the catalog rows. Config itself stays canonical.
-  const configuredLabel = literalPrefixProviders.has(normalizeProviderId(resolved.provider))
-    ? formatLiteralProviderPrefixedModelRef(resolved.provider, resolvedKey)
-    : configuredRaw || resolvedKey;
+  const configuredLabel = formatModelRefLabel({
+    provider: resolved.provider,
+    model: resolved.model,
+    key: configuredRaw || resolvedKey,
+    literalPrefixProviders,
+  });
 
   const options: WizardSelectOption[] = [];
   if (allowKeep) {
@@ -955,6 +982,7 @@ export async function promptModelAllowlist(params: {
   initialSelections?: string[];
   preferredProvider?: string;
   loadCatalog?: boolean;
+  providerScopedCatalog?: boolean;
 }): Promise<PromptModelAllowlistResult> {
   const cfg = params.config;
   const pickerAgentDir = resolvePickerAgentDir({
@@ -1085,6 +1113,8 @@ export async function promptModelAllowlist(params: {
     catalog = await loadPickerModelCatalog(cfg, {
       preferredProvider,
       preferLiveProviderCatalog: Boolean(preferredProvider),
+      providerScoped: Boolean(preferredProvider && params.providerScopedCatalog),
+      allowStaticFallbackCatalog: !params.providerScopedCatalog,
       agentDir: pickerAgentDir,
       ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
       ...(params.env !== undefined ? { env: params.env } : {}),
@@ -1092,17 +1122,55 @@ export async function promptModelAllowlist(params: {
   } finally {
     allowlistProgress.stop();
   }
+  let providerStaticCatalogRows:
+    | ReturnType<typeof loadStaticManifestCatalogRowsForList>
+    | undefined;
+  const loadProviderStaticCatalogRows = () =>
+    (providerStaticCatalogRows ??= preferredProvider
+      ? loadStaticManifestCatalogRowsForList({
+          cfg,
+          providerFilter: preferredProvider,
+          ...(params.env !== undefined ? { env: params.env } : {}),
+        })
+      : []);
+  const providerScopedCatalogLoaded = Boolean(
+    preferredProvider && params.providerScopedCatalog && catalog.length > 0,
+  );
+  if (providerScopedCatalogLoaded) {
+    const deprecatedStaticKeys = new Set(
+      loadProviderStaticCatalogRows()
+        .filter((entry) => entry.status === "deprecated")
+        .map((entry) => modelKey(entry.provider, entry.id)),
+    );
+    if (deprecatedStaticKeys.size > 0) {
+      catalog = catalog.filter(
+        (entry) => !deprecatedStaticKeys.has(modelKey(entry.provider, entry.id)),
+      );
+    }
+  }
   if (preferredProvider) {
-    const configuredCatalog = buildConfiguredModelCatalog({ cfg }).filter(
+    let configuredCatalog = buildConfiguredModelCatalog({ cfg }).filter(
       (entry) => matchesPreferredProvider?.(entry.provider) === true,
     );
-    const configuredKeys = new Set(
-      configuredCatalog.map((entry) => modelKey(entry.provider, entry.id)),
-    );
-    catalog = [
-      ...configuredCatalog,
-      ...catalog.filter((entry) => !configuredKeys.has(modelKey(entry.provider, entry.id))),
-    ];
+    if (providerScopedCatalogLoaded && configuredCatalog.length > 0) {
+      const staticKeys = new Set(
+        loadProviderStaticCatalogRows().map((entry) => modelKey(entry.provider, entry.id)),
+      );
+      configuredCatalog = configuredCatalog.filter(
+        (entry) => !staticKeys.has(modelKey(entry.provider, entry.id)),
+      );
+    }
+    const catalogKeys = new Set(catalog.map((entry) => modelKey(entry.provider, entry.id)));
+    const mergedCatalog = [...catalog];
+    for (const entry of configuredCatalog) {
+      const key = modelKey(entry.provider, entry.id);
+      if (catalogKeys.has(key)) {
+        continue;
+      }
+      catalogKeys.add(key);
+      mergedCatalog.push(entry);
+    }
+    catalog = mergedCatalog;
   }
   if (catalog.length === 0 && allowedKeys.length === 0) {
     const noCatalogInitialKeys =

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1092,6 +1092,7 @@ export type ProviderAugmentModelCatalogContext = {
   agentDir?: string;
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
+  resolveProviderApiKey?: ProviderCatalogContext["resolveProviderApiKey"];
   entries: ModelCatalogEntry[];
 };
 


### PR DESCRIPTION
## Summary

- Loads NVIDIA's public featured-model catalog in the NVIDIA provider runtime and falls back to the bundled manifest catalog when the feed is unavailable.
- Keeps NVIDIA setup and model-picker surfaces current without changing existing auth or config defaults.

## Changes

- Added a guarded HTTPS fetch for the featured catalog with hostname policy, a 10s timeout for the guarded pinned-dispatcher path, successful-result caching, row bounds, schema validation, and duplicate merging.
- Registered the live NVIDIA catalog with the existing static provider catalog as the offline fallback.
- Updated NVIDIA provider tests and docs, including the canonical normalized model-id expectation in onboarding coverage.

## Real behavior proof

**Behavior or issue addressed:** NVIDIA setup/model-picker catalog loading can consume NVIDIA's public featured-model feed and merge live ranked rows with the bundled fallback catalog.

**Real environment tested:** Local OpenClaw checkout at branch `79431`, commit `90b56ad407`, Node `v22.22.2`, Linux container, no NVIDIA API key required because the featured catalog endpoint is public.

**Exact steps or command run after this patch:** Ran the provider runtime against the live NVIDIA featured catalog endpoint:

  ```bash
  corepack pnpm exec tsx -e 'import { buildLiveNvidiaProvider } from "./extensions/nvidia/provider-catalog.ts"; void (async () => { const started = Date.now(); const provider = await buildLiveNvidiaProvider(); console.log(JSON.stringify({ elapsedMs: Date.now() - started, modelCount: provider.models.length, firstModels: provider.models.slice(0, 4).map((model) => ({ id: model.id, name: model.name, contextWindow: model.contextWindow, maxTokens: model.maxTokens })) }, null, 2)); })();'
  ```

**Evidence after fix:** Terminal output from the exact-head local runtime command:

  ```json
  {
    "elapsedMs": 5281,
    "modelCount": 6,
    "firstModels": [
      {
        "id": "nvidia/nemotron-3-super-120b-a12b",
        "name": "Nemotron 3 Super 120B",
        "contextWindow": 262144,
        "maxTokens": 8192
      },
      {
        "id": "z-ai/glm-5.1",
        "name": "GLM 5.1",
        "contextWindow": 202752,
        "maxTokens": 8192
      },
      {
        "id": "minimaxai/minimax-m2.7",
        "name": "Minimax M2.7",
        "contextWindow": 196608,
        "maxTokens": 8192
      },
      {
        "id": "moonshotai/kimi-k2.5",
        "name": "Kimi K2.5",
        "contextWindow": 262144,
        "maxTokens": 8192
      }
    ]
  }
  ```

**Observed result after fix:** The provider runtime fetched NVIDIA's current public featured feed, promoted live rows such as `z-ai/glm-5.1` and `minimaxai/minimax-m2.7`, and merged them ahead of bundled fallback rows.

**What was not tested:** Full interactive onboarding with a real NVIDIA API key was not tested; the changed provider catalog runtime path does not require the key.

## Validation

- `corepack pnpm test -- extensions/nvidia/provider-catalog.test.ts extensions/nvidia/index.test.ts extensions/nvidia/onboard.test.ts`
- `corepack pnpm check:changed -- --base upstream/main docs/providers/nvidia.md extensions/nvidia/index.test.ts extensions/nvidia/index.ts extensions/nvidia/onboard.test.ts extensions/nvidia/provider-catalog.test.ts extensions/nvidia/provider-catalog.ts`
- `corepack pnpm exec tsx -e 'import { buildLiveNvidiaProvider } from "./extensions/nvidia/provider-catalog.ts"; void (async () => { const started = Date.now(); const provider = await buildLiveNvidiaProvider(); console.log(JSON.stringify({ elapsedMs: Date.now() - started, modelCount: provider.models.length, firstModels: provider.models.slice(0, 4).map((model) => ({ id: model.id, name: model.name, contextWindow: model.contextWindow, maxTokens: model.maxTokens })) }, null, 2)); })();'`

## Notes

- Related: #79431
- Incorporates the safe provider-owned live catalog approach from #79482; @CaptainTimon is credited as co-author on the first commit.
- No `CHANGELOG.md` update per maintainer instruction.
- Project board update is blocked in this environment because the GitHub token lacks `read:project` scope.
