### PR TITLE
fix(devices): always route stale-approve operator to openclaw devices list

### DIFF
--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -188,6 +188,45 @@ function buildFallbackStateMismatchError(details: ConnectPairingRequiredDetails)
   );
 }
 
+async function buildStaleApproveRequestIdError(
+  _opts: DevicesRpcOpts,
+  staleRequestId: string,
+): Promise<Error> {
+  const lines = [
+    `Pairing requestId "${staleRequestId}" is not in the local pending state.`,
+    "It may have been superseded by a fresh request during the gateway dial, expired (5-minute TTL), or never been created in this profile.",
+  ];
+  try {
+    const list = await listDevicePairing();
+    const otherPending = (list.pending ?? []).filter(
+      (entry) => normalizeOptionalString(entry.requestId) && entry.requestId !== staleRequestId,
+    );
+    // The freshest pending entry is not necessarily the replacement for the
+    // stale id — TTL prune or profile/state mismatch can leave an unrelated
+    // request as the only visible one, and a multi-device profile can mix
+    // requests from agents the operator did not type the command for. Always
+    // route the operator through `openclaw devices list` so they can verify
+    // the deviceId and scopes before approving anything, instead of printing
+    // a direct rerun the operator might copy uncritically.
+    if (otherPending.length === 0) {
+      lines.push(
+        "No other pending requests are visible in this profile. List pending requests with: openclaw devices list",
+      );
+    } else {
+      const count = otherPending.length;
+      const label = count === 1 ? "request is" : "requests are";
+      lines.push(
+        `${count} other pending ${label} visible in this profile. Inspect device id and requested scopes before approving:`,
+        "  openclaw devices list",
+      );
+    }
+  } catch {
+    // diagnostic-only — never replace the primary failure mode with a
+    // local-state read error
+  }
+  return new Error(lines.join("\n"));
+}
+
 function assertLocalFallbackMatchesGatewayRequest(
   details: ConnectPairingRequiredDetails,
   list: DevicePairingList,
@@ -318,7 +357,17 @@ async function approvePairingWithFallback(
       if (gatewayRequestId && gatewayRequestId === requestId) {
         throw buildFallbackStateMismatchError(fallback.details);
       }
-      return null;
+      // The user-supplied requestId is not in local pending state and the
+      // gateway error did not surface a distinct alternative. The most common
+      // cause is supersession: the gateway dial just replaced the pending
+      // entry (`reconcilePendingPairingRequests` builds a fresh requestId
+      // when the incoming scope set diverges from the stored one — see
+      // `src/infra/device-pairing.ts:533-570`). Other causes are the 5-minute
+      // TTL prune (`PENDING_TTL_MS` in device-pairing.ts:132) or invoking
+      // approve under a different profile/state-dir. Surface the current
+      // local pending state so the operator has actionable diagnosis
+      // instead of the bare "unknown requestId" emitted by the caller.
+      throw await buildStaleApproveRequestIdError(opts, requestId);
     }
     if (approved.status === "forbidden") {
       throw new Error(formatDevicePairingForbiddenMessage(approved), { cause: error });

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -1310,6 +1310,99 @@ describe("devices cli local fallback", () => {
     ).rejects.toThrow("pairing required");
     expect(listDevicePairing).not.toHaveBeenCalled();
   });
+
+  it("routes the operator to `openclaw devices list` when a single other pending request is visible", async () => {
+    // The gateway close error omits a requestId, so the existing
+    // gateway-vs-user mismatch guard in `approvePairingWithFallback` does
+    // not fire. The supplied requestId is absent from local pending
+    // (superseded by the dial, pruned by the TTL, or never created in
+    // this profile), so the fallback previously returned null and the
+    // caller printed only "unknown requestId". The new diagnostic must
+    // identify the stale id, never suggest a direct rerun (the one
+    // visible alternative can belong to another device when TTL prune
+    // or profile mismatch is the cause), and route the operator to
+    // `openclaw devices list`. Two `callGateway` rejections cover
+    // `device.pair.list` (scope precheck) and `device.pair.approve`
+    // (the main call).
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    listDevicePairing.mockResolvedValue({
+      pending: [
+        {
+          requestId: "req-other",
+          deviceId: "device-1",
+          publicKey: "pk",
+          ts: 5_000,
+        },
+      ],
+      paired: [],
+    });
+
+    await expect(runDevicesApprove(["req-stale"])).rejects.toThrow(
+      /req-stale.*is not in the local pending state/s,
+    );
+
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    await expect(runDevicesApprove(["req-stale"])).rejects.toThrow(
+      /1 other pending request is visible.*openclaw devices list/s,
+    );
+
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    await expect(runDevicesApprove(["req-stale"])).rejects.not.toThrow(/Rerun:/);
+  });
+
+  it("falls back without a fresh requestId hint when no pending entries are visible locally", async () => {
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    listDevicePairing.mockResolvedValue({ pending: [], paired: [] });
+
+    await expect(runDevicesApprove(["req-stale"])).rejects.toThrow(
+      /No other pending requests are visible/,
+    );
+  });
+
+  it("does not suggest a direct rerun when multiple pending requests are visible", async () => {
+    // With more than one other pending request in the profile, the
+    // freshest may belong to a different device — picking it for the
+    // operator could approve an unrelated request. Assert the diagnostic
+    // routes the operator to `openclaw devices list` for explicit
+    // inspection instead of printing a `Rerun:` command.
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    listDevicePairing.mockResolvedValue({
+      pending: [
+        {
+          requestId: "req-other-a",
+          deviceId: "device-2",
+          publicKey: "pk2",
+          ts: 4_000,
+        },
+        {
+          requestId: "req-other-b",
+          deviceId: "device-3",
+          publicKey: "pk3",
+          ts: 5_000,
+        },
+      ],
+      paired: [],
+    });
+
+    await expect(runDevicesApprove(["req-stale"])).rejects.toThrow(
+      /2 other pending requests are visible.*openclaw devices list/s,
+    );
+
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    await expect(runDevicesApprove(["req-stale"])).rejects.not.toThrow(/Rerun:/);
+  });
 });
 
 describe("devices cli list", () => {

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -630,23 +630,26 @@ describe("devices cli local fallback", () => {
     expect(listDevicePairing).not.toHaveBeenCalled();
   });
 
-  it("surfaces the freshest pending requestId when the supplied id is no longer in local state", async () => {
+  it("routes the operator to `openclaw devices list` when a single other pending request is visible", async () => {
     // The gateway close error omits a requestId, so the existing
     // gateway-vs-user mismatch guard in `approvePairingWithFallback` does
     // not fire. The supplied requestId is absent from local pending
-    // (superseded by the dial or expired by the TTL), so the fallback
-    // previously returned null and the caller printed only
-    // "unknown requestId". Assert the new error names the fresh pending
-    // request and offers an exact rerun command. Two `callGateway`
-    // rejections cover `device.pair.list` (scope precheck) and
-    // `device.pair.approve` (the main call).
+    // (superseded by the dial, pruned by the TTL, or never created in
+    // this profile), so the fallback previously returned null and the
+    // caller printed only "unknown requestId". The new diagnostic must
+    // identify the stale id, never suggest a direct rerun (the one
+    // visible alternative can belong to another device when TTL prune
+    // or profile mismatch is the cause), and route the operator to
+    // `openclaw devices list`. Two `callGateway` rejections cover
+    // `device.pair.list` (scope precheck) and `device.pair.approve`
+    // (the main call).
     rejectGatewayForLocalFallback("pairing required");
     rejectGatewayForLocalFallback("pairing required");
     approveDevicePairing.mockResolvedValueOnce(undefined);
     listDevicePairing.mockResolvedValue({
       pending: [
         {
-          requestId: "req-fresh",
+          requestId: "req-other",
           deviceId: "device-1",
           publicKey: "pk",
           ts: 5_000,
@@ -663,8 +666,13 @@ describe("devices cli local fallback", () => {
     rejectGatewayForLocalFallback("pairing required");
     approveDevicePairing.mockResolvedValueOnce(undefined);
     await expect(runDevicesApprove(["req-stale"])).rejects.toThrow(
-      /Rerun: openclaw devices approve req-fresh/,
+      /1 other pending request is visible.*openclaw devices list/s,
     );
+
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    await expect(runDevicesApprove(["req-stale"])).rejects.not.toThrow(/Rerun:/);
   });
 
   it("falls back without a fresh requestId hint when no pending entries are visible locally", async () => {
@@ -676,6 +684,43 @@ describe("devices cli local fallback", () => {
     await expect(runDevicesApprove(["req-stale"])).rejects.toThrow(
       /No other pending requests are visible/,
     );
+  });
+
+  it("does not suggest a direct rerun when multiple pending requests are visible", async () => {
+    // With more than one other pending request in the profile, the
+    // freshest may belong to a different device — picking it for the
+    // operator could approve an unrelated request. Assert the diagnostic
+    // routes the operator to `openclaw devices list` for explicit
+    // inspection instead of printing a `Rerun:` command.
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    listDevicePairing.mockResolvedValue({
+      pending: [
+        {
+          requestId: "req-other-a",
+          deviceId: "device-2",
+          publicKey: "pk2",
+          ts: 4_000,
+        },
+        {
+          requestId: "req-other-b",
+          deviceId: "device-3",
+          publicKey: "pk3",
+          ts: 5_000,
+        },
+      ],
+      paired: [],
+    });
+
+    await expect(runDevicesApprove(["req-stale"])).rejects.toThrow(
+      /2 other pending requests are visible.*openclaw devices list/s,
+    );
+
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    await expect(runDevicesApprove(["req-stale"])).rejects.not.toThrow(/Rerun:/);
   });
 });
 

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -466,9 +466,18 @@ describe("devices cli clear", () => {
     await runDevicesCommand(["clear", "--yes", "--pending"]);
 
     expectGatewayCall(0, { method: "device.pair.list" });
-    expectGatewayCall(1, { method: "device.pair.remove", params: { deviceId: "device-1" } });
-    expectGatewayCall(2, { method: "device.pair.remove", params: { deviceId: "device-2" } });
-    expectGatewayCall(3, { method: "device.pair.reject", params: { requestId: "req-1" } });
+    expectGatewayCall(1, {
+      method: "device.pair.remove",
+      params: { deviceId: "device-1" },
+    });
+    expectGatewayCall(2, {
+      method: "device.pair.remove",
+      params: { deviceId: "device-2" },
+    });
+    expectGatewayCall(3, {
+      method: "device.pair.reject",
+      params: { requestId: "req-1" },
+    });
   });
 });
 
@@ -572,7 +581,14 @@ describe("devices cli local fallback", () => {
   it("refuses local fallback when the gateway request is absent from local pairing state", async () => {
     rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-profile)");
     listDevicePairing.mockResolvedValueOnce({
-      pending: [{ requestId: "req-default", deviceId: "device-1", publicKey: "pk", ts: 1 }],
+      pending: [
+        {
+          requestId: "req-default",
+          deviceId: "device-1",
+          publicKey: "pk",
+          ts: 1,
+        },
+      ],
       paired: [],
     });
     summarizeDeviceTokens.mockReturnValue(undefined);
@@ -612,6 +628,54 @@ describe("devices cli local fallback", () => {
       runDevicesCommand(["list", "--json", "--url", "ws://127.0.0.1:18789"]),
     ).rejects.toThrow("pairing required");
     expect(listDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the freshest pending requestId when the supplied id is no longer in local state", async () => {
+    // The gateway close error omits a requestId, so the existing
+    // gateway-vs-user mismatch guard in `approvePairingWithFallback` does
+    // not fire. The supplied requestId is absent from local pending
+    // (superseded by the dial or expired by the TTL), so the fallback
+    // previously returned null and the caller printed only
+    // "unknown requestId". Assert the new error names the fresh pending
+    // request and offers an exact rerun command. Two `callGateway`
+    // rejections cover `device.pair.list` (scope precheck) and
+    // `device.pair.approve` (the main call).
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    listDevicePairing.mockResolvedValue({
+      pending: [
+        {
+          requestId: "req-fresh",
+          deviceId: "device-1",
+          publicKey: "pk",
+          ts: 5_000,
+        },
+      ],
+      paired: [],
+    });
+
+    await expect(runDevicesApprove(["req-stale"])).rejects.toThrow(
+      /req-stale.*is not in the local pending state/s,
+    );
+
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    await expect(runDevicesApprove(["req-stale"])).rejects.toThrow(
+      /Rerun: openclaw devices approve req-fresh/,
+    );
+  });
+
+  it("falls back without a fresh requestId hint when no pending entries are visible locally", async () => {
+    rejectGatewayForLocalFallback("pairing required");
+    rejectGatewayForLocalFallback("pairing required");
+    approveDevicePairing.mockResolvedValueOnce(undefined);
+    listDevicePairing.mockResolvedValue({ pending: [], paired: [] });
+
+    await expect(runDevicesApprove(["req-stale"])).rejects.toThrow(
+      /No other pending requests are visible/,
+    );
   });
 });
 

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -186,6 +186,34 @@ function buildFallbackStateMismatchError(details: ConnectPairingRequiredDetails)
   );
 }
 
+async function buildStaleApproveRequestIdError(
+  opts: DevicesRpcOpts,
+  staleRequestId: string,
+): Promise<Error> {
+  const lines = [
+    `Pairing requestId "${staleRequestId}" is not in the local pending state.`,
+    "It may have been superseded by a fresh request during the gateway dial, expired (5-minute TTL), or never been created in this profile.",
+  ];
+  try {
+    const list = await listDevicePairing();
+    const latest = selectLatestPendingRequest(list.pending);
+    if (latest?.requestId && latest.requestId !== staleRequestId) {
+      lines.push(
+        `Most recent pending request in this profile: ${latest.requestId}.`,
+        `Rerun: ${buildExplicitApproveCommand(opts, latest.requestId)}`,
+      );
+    } else {
+      lines.push(
+        "No other pending requests are visible in this profile. List pending requests with: openclaw devices list",
+      );
+    }
+  } catch {
+    // diagnostic-only — never replace the primary failure mode with a
+    // local-state read error
+  }
+  return new Error(lines.join("\n"));
+}
+
 function assertLocalFallbackMatchesGatewayRequest(
   details: ConnectPairingRequiredDetails,
   list: DevicePairingList,
@@ -269,10 +297,22 @@ async function approvePairingWithFallback(
       if (gatewayRequestId && gatewayRequestId === requestId) {
         throw buildFallbackStateMismatchError(fallback.details);
       }
-      return null;
+      // The user-supplied requestId is not in local pending state and the
+      // gateway error did not surface a distinct alternative. The most common
+      // cause is supersession: the gateway dial just replaced the pending
+      // entry (`reconcilePendingPairingRequests` builds a fresh requestId
+      // when the incoming scope set diverges from the stored one — see
+      // `src/infra/device-pairing.ts:533-570`). Other causes are the 5-minute
+      // TTL prune (`PENDING_TTL_MS` in device-pairing.ts:132) or invoking
+      // approve under a different profile/state-dir. Surface the current
+      // local pending entry so the operator has a concrete rerun command
+      // instead of the bare "unknown requestId" emitted by the caller.
+      throw await buildStaleApproveRequestIdError(opts, requestId);
     }
     if (approved.status === "forbidden") {
-      throw new Error(formatDevicePairingForbiddenMessage(approved), { cause: error });
+      throw new Error(formatDevicePairingForbiddenMessage(approved), {
+        cause: error,
+      });
     }
     if (opts.json !== true) {
       defaultRuntime.log(theme.warn(FALLBACK_NOTICE));
@@ -542,8 +582,18 @@ export function registerDevicesCli(program: Command) {
               columns: [
                 { key: "Request", header: "Request", minWidth: 10 },
                 { key: "Device", header: "Device", minWidth: 16, flex: true },
-                { key: "Requested", header: "Requested", minWidth: 20, flex: true },
-                { key: "Approved", header: "Approved", minWidth: 20, flex: true },
+                {
+                  key: "Requested",
+                  header: "Requested",
+                  minWidth: 20,
+                  flex: true,
+                },
+                {
+                  key: "Approved",
+                  header: "Approved",
+                  minWidth: 20,
+                  flex: true,
+                },
                 { key: "Age", header: "Age", minWidth: 8 },
                 { key: "Status", header: "Status", minWidth: 12 },
               ],
@@ -617,7 +667,9 @@ export function registerDevicesCli(program: Command) {
           defaultRuntime.exit(1);
           return;
         }
-        const result = await callGatewayCli("device.pair.remove", opts, { deviceId: trimmed });
+        const result = await callGatewayCli("device.pair.remove", opts, {
+          deviceId: trimmed,
+        });
         if (opts.json) {
           defaultRuntime.writeJson(result);
           return;
@@ -788,7 +840,9 @@ export function registerDevicesCli(program: Command) {
       .description("Reject a pending device pairing request")
       .argument("<requestId>", "Pending request id")
       .action(async (requestId: string, opts: DevicesRpcOpts) => {
-        const result = await callGatewayCli("device.pair.reject", opts, { requestId });
+        const result = await callGatewayCli("device.pair.reject", opts, {
+          requestId,
+        });
         if (opts.json) {
           defaultRuntime.writeJson(result);
           return;

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -187,7 +187,7 @@ function buildFallbackStateMismatchError(details: ConnectPairingRequiredDetails)
 }
 
 async function buildStaleApproveRequestIdError(
-  opts: DevicesRpcOpts,
+  _opts: DevicesRpcOpts,
   staleRequestId: string,
 ): Promise<Error> {
   const lines = [
@@ -196,15 +196,26 @@ async function buildStaleApproveRequestIdError(
   ];
   try {
     const list = await listDevicePairing();
-    const latest = selectLatestPendingRequest(list.pending);
-    if (latest?.requestId && latest.requestId !== staleRequestId) {
-      lines.push(
-        `Most recent pending request in this profile: ${latest.requestId}.`,
-        `Rerun: ${buildExplicitApproveCommand(opts, latest.requestId)}`,
-      );
-    } else {
+    const otherPending = (list.pending ?? []).filter(
+      (entry) => normalizeOptionalString(entry.requestId) && entry.requestId !== staleRequestId,
+    );
+    // The freshest pending entry is not necessarily the replacement for the
+    // stale id — TTL prune or profile/state mismatch can leave an unrelated
+    // request as the only visible one, and a multi-device profile can mix
+    // requests from agents the operator did not type the command for. Always
+    // route the operator through `openclaw devices list` so they can verify
+    // the deviceId and scopes before approving anything, instead of printing
+    // a direct rerun the operator might copy uncritically.
+    if (otherPending.length === 0) {
       lines.push(
         "No other pending requests are visible in this profile. List pending requests with: openclaw devices list",
+      );
+    } else {
+      const count = otherPending.length;
+      const label = count === 1 ? "request is" : "requests are";
+      lines.push(
+        `${count} other pending ${label} visible in this profile. Inspect device id and requested scopes before approving:`,
+        "  openclaw devices list",
       );
     }
   } catch {


### PR DESCRIPTION
> AI-assisted: drafted with Claude (Opus 4.7). Bug surfaced by the agent
> while operating an OpenClaw 2026.5.7 ECS Fargate deployment in production;
> full transcript available on request.

> **Update (rebased 2026-05-14):** Post-refactor in `fe25ed214e` ("refactor(cli): lazy-load devices runtime"), the
> approve fallback code moved from `src/cli/devices-cli.ts` to `src/cli/devices-cli.runtime.ts`. This PR's fix
> now applies in the new file; the bug (`return null` silent path → bare `unknown requestId` caller log) is
> still present on main and the diff/tests remain the same shape, just at the new file location.

## Summary

`openclaw devices approve <requestId>` on a loopback gateway has a local
file fallback path (`src/cli/devices-cli.runtime.ts:220-271` (post-refactor; was `src/cli/devices-cli.ts:280-358`)) that approves
directly against `~/.openclaw/devices/{pending.json,paired.json}` when
the CLI cannot dial the gateway as an admin. The fallback compares the
user-supplied `requestId` against `requestId` extracted from the
gateway's pairing-required close error. Three branches today:

1. Gateway error names a different requestId → throw
   `FALLBACK_STATE_MISMATCH_MESSAGE` with `Missing requestId: <gatewayId>`.
   Actionable. ✅
2. Gateway error names the same requestId, but local pending lacks it
   → throw the same state-mismatch error. Actionable. ✅
3. Gateway error names **no** requestId, and local pending lacks the
   user-supplied id → silent `return null`. The caller at the caller line in the runtime file
   only logs `defaultRuntime.error("unknown requestId")`. ❌

Branch 3 fires whenever the gateway emits a `not-paired` close
(`buildPairingConnectErrorMessage` in
`src/gateway/protocol/connect-error-details.ts:275-281` returns the
bare `"pairing required"` string without a parenthetical) **and** the
user-supplied requestId is no longer in `pending.json`. The most common
reason for that disappearance is *supersession*: the gateway dial just
called `requestDevicePairing` → `reconcilePendingPairingRequests` →
`canRefreshSingle` returned false because the incoming and existing
scope sets diverge (`samePendingApprovalSnapshot` requires exact set
equality, `src/infra/device-pairing.ts:314-331`), so the reconciler
**replaced** the entry with a fresh `requestId`. Other causes: the 5
minute TTL (`PENDING_TTL_MS` at `src/infra/device-pairing.ts:132`) or
running approve under a different `OPENCLAW_PROFILE`/`OPENCLAW_STATE_DIR`.

The operator is left with `unknown requestId` and no pointer to the
current pending state or what to do next.

## Reproduction (before)

ECS Fargate container running `ghcr.io/openclaw/openclaw:2026.5.7`,
Linux x86_64, loopback gateway, paired operator device with only
`operator.read`. Generated a pending request via
`openclaw devices approve --latest` preview (which builds a
scope-upgrade request for the full `CLI_DEFAULT_OPERATOR_SCOPES` set),
then ran the explicit approve:

```text
$ openclaw devices approve 11e7be5a-a243-4855-9439-ccc9291449ba --json
gateway connect failed: GatewayClientRequestError: scope upgrade pending approval (requestId: 1dce2124-3c2d-4fa6-98f9-77ccf1e422d1)
gateway connect failed: GatewayClientRequestError: scope upgrade pending approval (requestId: 34a9feb9-847c-48d7-8a42-057c4d3dab82)
unknown requestId
```

`11e7be5a` was the user-supplied id from the preview. The dial built a
new pending whose scope set was a narrower subset of the user-supplied
one (just `operator.pairing` to call `device.pair.approve`); the
reconciler replaced rather than refreshed and `11e7be5a` was gone by
the time the fallback ran. The operator has no way to discover from
this output that the current pending entry exists locally.

## Fix

Replace the silent `return null` with a thrown `Error` whose message
includes:

- the user-supplied (stale) requestId
- a one-line list of plausible causes (supersession during dial, TTL
  prune, profile mismatch)
- a count of other pending entries visible in this profile
- a routing line: `openclaw devices list`

The diagnostic **never prints a direct `Rerun: openclaw devices approve <id>`
command**, even when only one other pending entry is visible. Three
plausible causes (TTL prune, profile/state mismatch, multi-device
profile churn) can each produce a single visible pending that is
unrelated to the operator's intent. The earlier ClawSweeper review
(`P2: Single pending request can be unrelated`) called this out
explicitly. Routing through `openclaw devices list` forces the
operator to verify deviceId + requested scopes before approving,
matching the existing implicit-approve `--latest` flow which is also
preview-only.

No behavior change to the approval semantics in any branch. The other
two error paths (mismatched gatewayRequestId, gatewayRequestId matches
but pending missing) keep the existing `buildFallbackStateMismatchError`
text; only the previously silent `return null` path now throws an
actionable error.

## After

### No other pending entries

```text
$ openclaw devices approve req-stale --json
[openclaw] Reason: Pairing requestId "req-stale" is not in the local pending state.
It may have been superseded by a fresh request during the gateway dial, expired (5-minute TTL), or never been created in this profile.
No other pending requests are visible in this profile. List pending requests with: openclaw devices list
```

### One other pending entry (still routes to `list` — could be unrelated)

```text
$ openclaw devices approve 11111111-1111-1111-1111-111111111111 --json
[openclaw] Reason: Pairing requestId "11111111-1111-1111-1111-111111111111" is not in the local pending state.
It may have been superseded by a fresh request during the gateway dial, expired (5-minute TTL), or never been created in this profile.
1 other pending request is visible in this profile. Inspect device id and requested scopes before approving:
  openclaw devices list
```

### Multiple other pending entries

```text
$ openclaw devices approve 11111111-1111-1111-1111-111111111111 --json
[openclaw] Reason: Pairing requestId "11111111-1111-1111-1111-111111111111" is not in the local pending state.
It may have been superseded by a fresh request during the gateway dial, expired (5-minute TTL), or never been created in this profile.
4 other pending requests are visible in this profile. Inspect device id and requested scopes before approving:
  openclaw devices list
```

## Tests

Extends `src/cli/devices-cli.test.ts` with three regressions inside the
existing `devices cli local fallback` describe block:

- *"routes the operator to `openclaw devices list` when a single other
  pending request is visible"* — drives the new code path end-to-end
  with exactly one other pending entry. Both `device.pair.list` (the
  precheck scope resolver) and `device.pair.approve` reject with a
  bare `pairing required` message (no requestId),
  `approveDevicePairing` returns `undefined` for the supplied id, and
  a freshly mocked `listDevicePairing` is the only way to surface the
  alternative. Asserts the rejected error contains the
  `1 other pending request is visible` line + the `openclaw devices list`
  routing, **and** asserts the error does NOT contain a `Rerun:` line.
- *"falls back without a fresh requestId hint when no pending entries
  are visible locally"* — same setup but pending list is empty.
  Asserts the error switches to `No other pending requests are visible`.
- *"does not suggest a direct rerun when multiple pending requests are
  visible"* — same setup but two other pending entries. Asserts the
  error routes to `openclaw devices list` AND does not contain a
  `Rerun:` line.

```text
$ pnpm test src/cli/devices-cli.test.ts
Test Files  1 passed (1)
Tests       32 passed (32)

$ pnpm check:changed
[exit 0]

$ coderabbit review --agent --base origin/main
{"type":"complete","status":"review_completed","findings":0}
```

No changes to `CHANGELOG.md` per contributor convention.

## Why the CLI layer and not the dial/reconciler

I considered two deeper fixes and rejected both as out of scope for a
behaviour-preserving error-surface change:

1. **Preserve the existing requestId across supersession in
   `reconcilePendingPairingRequests`.** `samePendingApprovalSnapshot`
   gating refresh on exact scope-set equality is intentional — the
   replacement branch already merges scopes upward
   (`src/infra/device-pairing.ts:546-558`), so the new pending covers
   the user's intent; only the identifier changes. Allowing refresh on
   superset/subset relationships would change persisted-state
   semantics on every cron's connect handshake, well beyond the bug
   this addresses.
2. **Auto-redirect approval to the gateway-supplied alternative.**
   `approve <id>` is a contract the operator typed explicitly;
   silently approving a different id under the same command would
   surprise scripts and audit trails. The CLI's existing pattern (the
   mismatched-id branch at devices-cli.ts:311-313) chooses error over
   redirect, and this PR keeps that posture. The diagnostic always
   routes through `openclaw devices list` so the operator chooses
   explicitly after seeing deviceId + scopes.

## Why not auto-suggest the single visible pending entry

ClawSweeper flagged this on the first revision of this PR
(`P2: Single pending request can be unrelated`). Earlier revisions of
this fix attempted to print
`Rerun: openclaw devices approve <id>` whenever exactly one alternative
pending request was visible. Counter-examples:

- **TTL prune.** `PENDING_TTL_MS = 5 minutes`. If the operator's stale
  id expired and a different agent (with a different deviceId)
  subsequently created a pending request, the local profile shows one
  pending entry — but it is not the replacement for the stale request.
- **Profile/state-dir mismatch.** The CLI may be looking at a
  different `OPENCLAW_STATE_DIR` than the gateway. The one visible
  local pending request is local-only and unrelated to the gateway's
  current view.
- **Multi-device profile.** Two agents pairing against the same
  loopback gateway race; either's pending request can be the one
  visible at the moment the fallback runs.

Routing through `openclaw devices list` for the operator to inspect
deviceId + requested scopes before approving is the same safety the
existing `--latest`/implicit-approve preview flow uses
(`src/cli/devices-cli.ts:703+`).

## Real Behavior Proof

**Behavior or issue addressed:** `openclaw devices approve <id>` on a
loopback gateway returns the bare error `unknown requestId` whenever
the supplied requestId is missing from local `pending.json` and the
gateway's close error did not carry a requestId in its parenthetical.
The operator has no way to discover from this output that other
pending entries exist or what to do next.

**Real environment tested:**
1. Original bug: live ECS Fargate container running
   `ghcr.io/openclaw/openclaw:2026.5.7` on Linux x86_64, loopback
   gateway with `auth.mode: "token"`, accessed via
   `aws ecs execute-command`. Captured `unknown requestId` from the
   patched-CLI repro path.
2. Patched verification: built the patched CLI from this branch
   (`pnpm build`) and ran it against a local `openclaw gateway --dev`
   instance with an isolated `OPENCLAW_STATE_DIR=/tmp/openclaw-pr-evidence`
   on macOS arm64 (Node 22.18.0).

**Steps run after the patch:**

Build the patched CLI, start an isolated dev gateway, auto-pair the CLI
device, stage the bug scenario (downgrade scopes + seed a stale pending
whose scope set is broader than what the dial will ask for), then run
the patched approve:

```sh
cd ~/Projects/public/openclaw
pnpm build

OPENCLAW_STATE_DIR=/tmp/openclaw-pr-evidence \
  node ./openclaw.mjs gateway --dev --port 18789 --auth none --bind loopback &

OPENCLAW_STATE_DIR=/tmp/openclaw-pr-evidence \
  node ./openclaw.mjs devices list --token "$TOKEN" --timeout 3000

OPENCLAW_STATE_DIR=/tmp/openclaw-pr-evidence \
  node ./openclaw.mjs devices approve 11111111-1111-1111-1111-111111111111 \
    --token "$TOKEN" --timeout 3000 --json
```

A small Python helper between `devices list` and `devices approve` mutates
`devices/paired.json` (downgrade scopes to `operator.read`) and
`devices/pending.json` (insert the stale id with the broader scope set);
omitted here for brevity.

**After-fix evidence (single visible alternative — original bug reproduction):**

```text
[openclaw] Reason: Pairing requestId "11111111-1111-1111-1111-111111111111" is not in the local pending state.
It may have been superseded by a fresh request during the gateway dial, expired (5-minute TTL), or never been created in this profile.
1 other pending request is visible in this profile. Inspect device id and requested scopes before approving:
  openclaw devices list
```

**After-fix evidence (multi-pending case — staged with 4 fake pending entries from different deviceIds):**

```text
[openclaw] Reason: Pairing requestId "11111111-1111-1111-1111-111111111111" is not in the local pending state.
It may have been superseded by a fresh request during the gateway dial, expired (5-minute TTL), or never been created in this profile.
4 other pending requests are visible in this profile. Inspect device id and requested scopes before approving:
  openclaw devices list
```

**After-fix evidence (no other pending case — also covered by unit regression):**

```text
[openclaw] Reason: Pairing requestId "<id>" is not in the local pending state.
It may have been superseded by a fresh request during the gateway dial, expired (5-minute TTL), or never been created in this profile.
No other pending requests are visible in this profile. List pending requests with: openclaw devices list
```

**Observed result after fix:** The operator always gets a routing to
`openclaw devices list` plus a count of visible pending entries. They
never get a direct `Rerun:` command that could approve an unrelated
device's request. The original ECS-Fargate bug scenario matches the
single-visible-alternative case (after `--latest`-preview-driven
supersession), with the operator now seeing the actionable diagnostic
instead of the dead-end `unknown requestId`.

**What was not tested:** I did not rebuild the OpenClaw container
image with this patch and redeploy it onto the original ECS Fargate
task. The local dev-gateway reproduction stages the exact failure
path (`reconcilePendingPairingRequests` replacing the user-supplied
pending entry during the gateway dial, then the local fallback
running with no matching id), and the patched CLI is the actual
binary built from this branch's commits. A maintainer who wants live
ECS confirmation can stage the patched image, run the two-command
repro above, and read the new error text.


