### PR TITLE
Fix Discord gzip response parsing

### DIFF
--- a/extensions/discord/src/actions/runtime.messaging.messages.ts
+++ b/extensions/discord/src/actions/runtime.messaging.messages.ts
@@ -250,8 +250,7 @@ export async function handleDiscordMessageManagementAction(ctx: DiscordMessaging
       if (!results || typeof results !== "object") {
         return jsonResult({ ok: true, results });
       }
-      const resultsRecord = results as Record<string, unknown>;
-      const messages = resultsRecord.messages;
+      const messages = results.messages;
       const normalizedMessages = Array.isArray(messages)
         ? messages.map((group) =>
             Array.isArray(group) ? group.map((msg) => ctx.normalizeMessage(msg)) : group,
@@ -260,7 +259,7 @@ export async function handleDiscordMessageManagementAction(ctx: DiscordMessaging
       return jsonResult({
         ok: true,
         results: {
-          ...resultsRecord,
+          ...results,
           messages: normalizedMessages,
         },
       });

--- a/extensions/discord/src/internal/rest.test.ts
+++ b/extensions/discord/src/internal/rest.test.ts
@@ -784,6 +784,25 @@ describe("RequestClient", () => {
     ]);
   });
 
+  it("bounds gzip-compressed REST response bodies after decompression", async () => {
+    const body = gzipSync(Buffer.from(JSON.stringify({ data: "x".repeat(8 * 1024 * 1024) })));
+    const client = new RequestClient("test-token", {
+      queueRequests: false,
+      fetch: async () =>
+        new Response(body, {
+          status: 200,
+          headers: {
+            "Content-Encoding": "gzip",
+            "Content-Type": "application/json",
+          },
+        }),
+    });
+
+    await expect(client.get("/channels/c1/messages")).rejects.toThrow(
+      /Discord REST response body exceeds 8388608 bytes/,
+    );
+  });
+
   it("does not double-decompress responses fetch has already decoded", async () => {
     const client = new RequestClient("test-token", {
       queueRequests: false,

--- a/extensions/discord/src/internal/rest.test.ts
+++ b/extensions/discord/src/internal/rest.test.ts
@@ -1,5 +1,6 @@
 // Discord tests cover rest plugin behavior.
 import { createServer, type Server } from "node:http";
+import { gzipSync } from "node:zlib";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { fetch as undiciFetch } from "undici";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -762,6 +763,44 @@ describe("RequestClient", () => {
     const client = new RequestClient("test-token", { fetch: fetchSpy, queueRequests: false });
 
     await expect(client.get("/channels/c1")).resolves.toEqual({ id: "channel", name: "general" });
+  });
+
+  it("parses raw gzip-compressed JSON response bodies", async () => {
+    const body = gzipSync(Buffer.from(JSON.stringify([{ id: "m1", content: "hello" }])));
+    const client = new RequestClient("test-token", {
+      queueRequests: false,
+      fetch: async () =>
+        new Response(body, {
+          status: 200,
+          headers: {
+            "Content-Encoding": "gzip",
+            "Content-Type": "application/json",
+          },
+        }),
+    });
+
+    await expect(client.get("/channels/c1/messages")).resolves.toEqual([
+      { id: "m1", content: "hello" },
+    ]);
+  });
+
+  it("does not double-decompress responses fetch has already decoded", async () => {
+    const client = new RequestClient("test-token", {
+      queueRequests: false,
+      fetch: async () =>
+        new Response(JSON.stringify({ id: "m1", content: "hello" }), {
+          status: 200,
+          headers: {
+            "Content-Encoding": "gzip",
+            "Content-Type": "application/json",
+          },
+        }),
+    });
+
+    await expect(client.get("/channels/c1/messages/m1")).resolves.toEqual({
+      id: "m1",
+      content: "hello",
+    });
   });
 
   it("serializes message multipart uploads with payload_json", () => {

--- a/extensions/discord/src/internal/rest.ts
+++ b/extensions/discord/src/internal/rest.ts
@@ -1,6 +1,7 @@
 // Discord plugin module implements rest behavior.
 import { randomBytes } from "node:crypto";
 import { inspect } from "node:util";
+import { gunzipSync } from "node:zlib";
 import {
   clampTimerTimeoutMs,
   parseFiniteNumber,
@@ -105,7 +106,7 @@ async function readResponseBodyText(response: Response, idleTimeoutMs: number): 
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`Discord REST response stalled: no data received for ${chunkTimeoutMs}ms`),
   });
-  return buffer.toString("utf8");
+  return decodeResponseBody(buffer);
 }
 
 function coerceResponseBody(raw: string): unknown {
@@ -117,6 +118,16 @@ function coerceResponseBody(raw: string): unknown {
   } catch {
     return raw;
   }
+}
+
+function decodeResponseBody(buffer: Buffer): string {
+  if (!buffer.byteLength) {
+    return "";
+  }
+  if (buffer[0] === 0x1f && buffer[1] === 0x8b) {
+    return gunzipSync(buffer).toString("utf8");
+  }
+  return buffer.toString("utf8");
 }
 
 function escapeMultipartQuotedValue(value: string): string {

--- a/extensions/discord/src/internal/rest.ts
+++ b/extensions/discord/src/internal/rest.ts
@@ -95,6 +95,7 @@ const defaultLaneOptions: Record<RestRequestPriority, { staleAfterMs?: number; w
 // (bulk message/member fetches stay in the low hundreds of KB) so a controlled
 // or hijacked endpoint cannot flood the body into an unbounded buffer (OOM).
 const DISCORD_REST_RESPONSE_BODY_MAX_BYTES = 8 * 1024 * 1024;
+const GZIP_MAGIC = [0x1f, 0x8b] as const;
 
 async function readResponseBodyText(response: Response, idleTimeoutMs: number): Promise<string> {
   const buffer = await readResponseWithLimit(response, DISCORD_REST_RESPONSE_BODY_MAX_BYTES, {
@@ -124,7 +125,7 @@ function decodeResponseBody(buffer: Buffer): string {
   if (!buffer.byteLength) {
     return "";
   }
-  if (buffer[0] === 0x1f && buffer[1] === 0x8b) {
+  if (buffer[0] === GZIP_MAGIC[0] && buffer[1] === GZIP_MAGIC[1]) {
     return gunzipSync(buffer).toString("utf8");
   }
   return buffer.toString("utf8");

--- a/extensions/discord/src/internal/rest.ts
+++ b/extensions/discord/src/internal/rest.ts
@@ -97,13 +97,16 @@ const defaultLaneOptions: Record<RestRequestPriority, { staleAfterMs?: number; w
 const DISCORD_REST_RESPONSE_BODY_MAX_BYTES = 8 * 1024 * 1024;
 const GZIP_MAGIC = [0x1f, 0x8b] as const;
 
+function createResponseBodyOverflowError(size: number | "decompressed output"): Error {
+  return new Error(
+    `Discord REST response body exceeds ${DISCORD_REST_RESPONSE_BODY_MAX_BYTES} bytes (received ${size})`,
+  );
+}
+
 async function readResponseBodyText(response: Response, idleTimeoutMs: number): Promise<string> {
   const buffer = await readResponseWithLimit(response, DISCORD_REST_RESPONSE_BODY_MAX_BYTES, {
     chunkTimeoutMs: idleTimeoutMs,
-    onOverflow: ({ size }) =>
-      new Error(
-        `Discord REST response body exceeds ${DISCORD_REST_RESPONSE_BODY_MAX_BYTES} bytes (received ${size})`,
-      ),
+    onOverflow: ({ size }) => createResponseBodyOverflowError(size),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`Discord REST response stalled: no data received for ${chunkTimeoutMs}ms`),
   });
@@ -126,9 +129,26 @@ function decodeResponseBody(buffer: Buffer): string {
     return "";
   }
   if (buffer[0] === GZIP_MAGIC[0] && buffer[1] === GZIP_MAGIC[1]) {
-    return gunzipSync(buffer).toString("utf8");
+    try {
+      return gunzipSync(buffer, {
+        maxOutputLength: DISCORD_REST_RESPONSE_BODY_MAX_BYTES,
+      }).toString("utf8");
+    } catch (err: unknown) {
+      if (isZlibMaxOutputLengthError(err)) {
+        throw createResponseBodyOverflowError("decompressed output");
+      }
+      throw err;
+    }
   }
   return buffer.toString("utf8");
+}
+
+function isZlibMaxOutputLengthError(err: unknown): boolean {
+  return (
+    err instanceof RangeError &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "ERR_BUFFER_TOO_LARGE"
+  );
 }
 
 function escapeMultipartQuotedValue(value: string): string {

--- a/extensions/discord/src/send.messages.test.ts
+++ b/extensions/discord/src/send.messages.test.ts
@@ -43,6 +43,14 @@ describe("readMessagesDiscord", () => {
     expect(result).toEqual(messages);
     expect(restMock.get).toHaveBeenCalledWith("/channels/C1/messages", { limit: 5 });
   });
+
+  it("throws a clear error when Discord returns a non-array message read response", async () => {
+    restMock.get.mockResolvedValueOnce("\u001f\ufffd\u0008raw gzip bytes");
+
+    await expect(readMessagesDiscord("C1", {}, { cfg: {} as never })).rejects.toThrow(
+      "Unexpected Discord response for message read: expected array.",
+    );
+  });
 });
 
 describe("searchMessagesDiscord", () => {
@@ -56,5 +64,13 @@ describe("searchMessagesDiscord", () => {
     );
 
     expect(result).toEqual(results);
+  });
+
+  it("throws a clear error when Discord returns a non-object search response", async () => {
+    restMock.get.mockResolvedValueOnce("\u001f\ufffd\u0008raw gzip bytes");
+
+    await expect(
+      searchMessagesDiscord({ guildId: "G1", content: "test" }, { cfg: {} as never }),
+    ).rejects.toThrow("Unexpected Discord response for message search: expected object.");
   });
 });

--- a/extensions/discord/src/send.messages.ts
+++ b/extensions/discord/src/send.messages.ts
@@ -30,6 +30,20 @@ function formatDiscordThreadInitialMessageError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function assertDiscordResponseArray<T>(value: unknown, label: string): T[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Unexpected Discord response for ${label}: expected array.`);
+  }
+  return value as T[];
+}
+
+function assertDiscordResponseObject(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Unexpected Discord response for ${label}: expected object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
 export class DiscordThreadInitialMessageError extends Error {
   readonly initialMessageError: string;
   readonly thread: APIChannel;
@@ -69,7 +83,10 @@ export async function readMessagesDiscord(
   if (messageQuery.around) {
     params.around = messageQuery.around;
   }
-  return await listChannelMessages(rest, channelId, params);
+  return assertDiscordResponseArray<APIMessage>(
+    await listChannelMessages(rest, channelId, params),
+    "message read",
+  );
 }
 
 export async function fetchMessageDiscord(
@@ -226,5 +243,8 @@ export async function searchMessagesDiscord(query: DiscordSearchQuery, opts: Dis
     const limit = Math.min(Math.max(Math.floor(query.limit), 1), 25);
     params.set("limit", String(limit));
   }
-  return await searchGuildMessages(rest, query.guildId, params);
+  return assertDiscordResponseObject(
+    await searchGuildMessages(rest, query.guildId, params),
+    "message search",
+  );
 }


### PR DESCRIPTION
## Summary

- Problem: Discord `message read` and `search` could receive raw gzip bytes and surface compressed binary instead of parsed JSON.
- Why it matters: callers expect parsed Discord API data; compressed bytes break message read/search workflows before normalization.
- What changed: the Discord REST client now defensively decodes raw gzip response bodies, and message read/search add response-shape guards with clear errors.
- What did NOT change (scope boundary): no Discord endpoint behavior, auth, request params, or network call shape changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80764
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: raw gzipped Discord REST response bodies now decode into JSON before `message read` / `search` callers see them.
- Real environment tested: local OpenClaw checkout running the real Discord `RequestClient`, `readMessagesDiscord`, and `searchMessagesDiscord` code paths against a local HTTP endpoint that returns raw gzipped response bytes.
- Exact steps or command run after this patch: `node --import tsx` with a local HTTP endpoint serving gzipped JSON bytes to the real Discord REST client.
- Evidence after fix: copied terminal output from the runtime proof:

```text
[proof-server] GET /api/v10/channels/proof-channel/messages?limit=1 -> raw gzip bytes=77
[proof-server] GET /api/v10/guilds/proof-guild/messages/search?content=decoded&limit=1 -> raw gzip bytes=101
{
  "readContent": "decoded read gzip",
  "searchContent": "decoded search gzip"
}
```

- Observed result after fix: both read and search returned decoded JSON content from raw gzip bytes.
- What was not tested: live Discord API credentials/account flow.
- Before evidence: the same raw-gzip response shape is the issue shape that previously surfaced compressed binary instead of parsed JSON.

## Root Cause (if applicable)

- Root cause: the Discord REST client relied on `response.text()`, but some runtimes can expose the raw gzipped body bytes instead of decoded text.
- Missing detection / guardrail: there was no coverage for raw gzipped Discord JSON response bodies, and read/search did not validate the response shape before returning data.
- Contributing context (if known): unknown.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/internal/rest.test.ts`, `extensions/discord/src/send.messages.test.ts`
- Scenario the test should lock in: raw gzip-compressed JSON parses correctly; already-decoded text remains unchanged; read/search reject invalid response shapes clearly.
- Why this is the smallest reliable guardrail: the bug is in REST response decoding and the immediate message API contracts.
- Existing test that already covers this (if any): none for gzipped raw bodies.

## User-visible / Behavior Changes

Discord message read/search responses that arrive gzip-compressed now return parsed JSON instead of compressed binary text. Invalid response shapes now report a clear error.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo via pnpm / Node
- Model/provider: N/A
- Integration/channel (if any): Discord extension
- Relevant config (redacted): none

### Steps

1. Serve gzipped JSON bytes from a local HTTP endpoint without relying on Discord credentials.
2. Point the real Discord `RequestClient` at that endpoint.
3. Call `readMessagesDiscord` and `searchMessagesDiscord` through the normal Discord helper functions.

### Expected

- Response bodies are parsed as JSON and invalid response shapes fail clearly.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification passed:

```text
pnpm vitest run extensions/discord/src/internal/rest.test.ts extensions/discord/src/actions/runtime.test.ts extensions/discord/src/send.messages.test.ts -- --reporter=verbose
Test Files  3 passed
Tests       76 passed
```

Additional checks passed:

```text
git diff --check
pnpm exec oxfmt --check extensions/discord/src/internal/rest.ts extensions/discord/src/internal/rest.test.ts extensions/discord/src/send.messages.ts extensions/discord/src/send.messages.test.ts extensions/discord/src/actions/runtime.messaging.messages.ts
CI=1 pnpm check:changed
```

## Human Verification (required)

- Verified scenarios: raw gzip decode path, already-decoded body path, read response array guard, search response object guard, changed-file type/lint checks.
- Edge cases checked: empty body, already-decoded JSON text, invalid read/search response shapes.
- What you did **not** verify: live Discord API account flow.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: manually decompressing could double-decompress in fetch implementations that already decode gzip.
  - Mitigation: decode only when the raw body starts with gzip magic bytes and add a regression test for already-decoded bodies.

