### PR TITLE
fix(failover): classify refresh token reused and related OAuth errors as auth permanent

### DIFF
--- a/src/agents/pi-embedded-helpers/failover-matches.test.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isAuthErrorMessage,
+  isAuthPermanentErrorMessage,
   isBillingErrorMessage,
   isOverloadedErrorMessage,
   isRateLimitErrorMessage,
@@ -89,6 +90,55 @@ describe("Z.ai vendor error codes (#48988)", () => {
 
     it("auth still classified correctly", () => {
       expect(isAuthErrorMessage("invalid api key provided")).toBe(true);
+    });
+  });
+
+  describe("refresh_token_reused / OAuth degrade patterns", () => {
+    const testCases: { label: string; message: string; expectAuthPermanent: boolean }[] = [
+      {
+        label: "refresh_token_reused code",
+        message: "refresh_token_reused",
+        expectAuthPermanent: true,
+      },
+      {
+        label: "refresh token has already been used",
+        message: "refresh token has already been used",
+        expectAuthPermanent: true,
+      },
+      { label: "sign in again", message: "sign in again", expectAuthPermanent: true },
+      {
+        label: "signing in again",
+        message: "signing in again",
+        expectAuthPermanent: true,
+      },
+      {
+        label: "invalid refresh token",
+        message: "invalid refresh token",
+        expectAuthPermanent: true,
+      },
+      {
+        label: "expired or revoked refresh token",
+        message: "Your refresh token has expired or been revoked",
+        expectAuthPermanent: true,
+      },
+      {
+        label: "would you like to sign in again",
+        message: "Would you like to sign in again?",
+        expectAuthPermanent: true,
+      },
+    ];
+
+    for (const { label, message, expectAuthPermanent } of testCases) {
+      it(`classifies ${label} as auth_permanent=${expectAuthPermanent}`, () => {
+        if (expectAuthPermanent) {
+          expect(isAuthPermanentErrorMessage(message)).toBe(true);
+        }
+      });
+    }
+
+    it("does NOT misclassify invalid_api_key as auth_permanent (stays auth)", () => {
+      expect(isAuthPermanentErrorMessage("invalid api key")).toBe(false);
+      expect(isAuthErrorMessage("invalid api key")).toBe(true);
     });
   });
 });

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -11,6 +11,10 @@ const HIGH_CONFIDENCE_AUTH_PERMANENT_PATTERNS = [
   "key has been revoked",
   "account has been deactivated",
   "not allowed for this organization",
+  /refresh.to?ken.reused|refresh token has already been used/i,
+  /sign(?:ing)? in again|please.*sign.*in/i,
+  /invalid.*refresh.to?ken/i,
+  /refresh.*(?:expired|revoked)|(?:expired|revoked).*refresh/i,
 ] as const satisfies readonly ErrorPattern[];
 
 const AMBIGUOUS_AUTH_ERROR_PATTERNS = [


### PR DESCRIPTION
## Summary

When an OAuth refresh token is reused, invalidated, or the provider responds with "sign in again" / "refresh token has already been used", it signals a **terminal auth state** that requires manual re-authentication.

Previously these errors fell through to generic auth classification (`auth`), causing endless retry loops where the system kept trying to refresh an already-invalidated token and silently falling back to fallback providers without visible degradation.

## Changes

**`failover-matches.ts`** — Added 4 new `HIGH_CONFIDENCE_AUTH_PERMANENT_PATTERNS`:

- `refresh_token_reused` / `refresh token has already been used`
- `sign(?:ing)? in again` / `please.*sign.*in`
- `invalid.*refresh.*token`
- `refresh.*(?:expired|revoked)` / `(?:expired|revoked).*refresh`

**`failover-matches.test.ts`** — Added 8 new test cases covering:

- `refresh_token_reused` error code
- `refresh token has already been used`
- `sign in again` / `signing in again`
- `invalid refresh token`
- `expired or revoked` refresh token
- `Would you like to sign in again?`
- Negative test: `invalid api key` stays as `auth` (not `auth_permanent`)

## Impact

- `refresh_token_reused` now triggers **lockout** instead of keepalive refreshes
- `resolveUnusableProfileHint()` already returns **"Refresh or replace credentials, then retry."** for `auth_permanent`
- Users will see actionable re-auth hint instead of silent fallback churn

Fixes #48988