### PR TITLE
fix(config-audit): scrub pre-redactor argv values from historical config-audit.jsonl entries

### DIFF
--- a/src/commands/doctor-config-audit-scrub.ts
+++ b/src/commands/doctor-config-audit-scrub.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import { scrubConfigAuditLog } from "../config/io.audit.js";
+import { note } from "../terminal/note.js";
+
+const NOTE_TITLE = "Config audit";
+
+function formatEntryCount(count: number): string {
+  return `${count} ${count === 1 ? "entry" : "entries"}`;
+}
+
+export async function maybeScrubConfigAuditLog(params: {
+  shouldRepair: boolean;
+  env?: NodeJS.ProcessEnv;
+  homedir?: () => string;
+  doctorFixCommand?: string;
+}): Promise<void> {
+  const env = params.env ?? process.env;
+  const homedir = params.homedir ?? os.homedir;
+  const scrubFs = { promises: fs };
+
+  try {
+    if (params.shouldRepair) {
+      const result = await scrubConfigAuditLog({ fs: scrubFs, env, homedir });
+      if (result.aborted) {
+        note(
+          "Config audit scrub was aborted because new entries were appended to config-audit.jsonl during the rewrite. No records were modified. Stop the gateway (or wait until it is idle) and rerun `openclaw doctor --fix`.",
+          NOTE_TITLE,
+        );
+        return;
+      }
+      if (result.rewritten > 0) {
+        note(
+          `Scrubbed ${formatEntryCount(result.rewritten)} in config-audit.jsonl that still contained pre-redactor argv values. Rotate any credentials that may have been written to the log before the forward redactor shipped.`,
+          NOTE_TITLE,
+        );
+      }
+      return;
+    }
+
+    const preview = await scrubConfigAuditLog({ fs: scrubFs, env, homedir, dryRun: true });
+    if (preview.rewritten > 0) {
+      const fixCommand = params.doctorFixCommand ?? "openclaw doctor --fix";
+      note(
+        `${formatEntryCount(preview.rewritten)} in config-audit.jsonl still contain pre-redactor argv values (likely plaintext credentials at rest). Run \`${fixCommand}\` to rewrite the argv/execArgv fields through the same redactor used for new entries.`,
+        NOTE_TITLE,
+      );
+    }
+  } catch (err) {
+    note(
+      `Config audit scrub failed: ${err instanceof Error ? err.message : String(err)}`,
+      NOTE_TITLE,
+    );
+  }
+}

--- a/src/config/io.audit.test.ts
+++ b/src/config/io.audit.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { promises as fsPromises } from "node:fs";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
@@ -9,6 +10,7 @@ import {
   formatConfigOverwriteLogMessage,
   redactConfigAuditArgv,
   resolveConfigAuditLogPath,
+  scrubConfigAuditLog,
 } from "./io.audit.js";
 
 function createAuditRecordBase(configPath: string) {
@@ -474,5 +476,199 @@ describe("config io audit helpers", () => {
     expect(written.event).toBe("config.write");
     expect(written.result).toBe("rename");
     expect(written.nextHash).toBe("next-hash");
+  });
+
+  it("rewrites historical config-audit entries through redactConfigAuditArgv and preserves 0600 mode", async () => {
+    const home = await suiteRootTracker.make("scrub-historical");
+    const auditPath = path.join(home, ".openclaw", "logs", "config-audit.jsonl");
+    fs.mkdirSync(path.dirname(auditPath), { recursive: true, mode: 0o700 });
+    const unredactedRecord = {
+      ts: "2026-05-02T00:03:48.471Z",
+      source: "config-io",
+      event: "config.write",
+      configPath: path.join(home, ".openclaw", "openclaw.json"),
+      pid: 1590563,
+      ppid: 1590548,
+      cwd: home,
+      argv: [
+        "/usr/bin/node",
+        "/usr/local/bin/openclaw.mjs",
+        "config",
+        "set",
+        "channels.slack.botToken",
+        "xoxb-real-bot-token-1234567890abcdef0123456789abcdef",
+      ],
+      execArgv: ["--disable-warning=ExperimentalWarning"],
+      suspicious: [],
+      result: "rename",
+    };
+    const alreadyRedactedRecord = {
+      ts: "2026-05-08T12:00:00.000Z",
+      source: "config-io",
+      event: "config.write",
+      configPath: path.join(home, ".openclaw", "openclaw.json"),
+      pid: 1,
+      ppid: 1,
+      cwd: home,
+      argv: ["/usr/bin/node", "/usr/local/bin/openclaw.mjs", "config", "set", "ui.theme", "dark"],
+      execArgv: ["--disable-warning=ExperimentalWarning"],
+      suspicious: [],
+      result: "rename",
+    };
+    fs.writeFileSync(
+      auditPath,
+      `${JSON.stringify(unredactedRecord)}\n${JSON.stringify(alreadyRedactedRecord)}\n`,
+      { encoding: "utf-8", mode: 0o600 },
+    );
+
+    const env = {} as NodeJS.ProcessEnv;
+    const result = await scrubConfigAuditLog({
+      fs: { promises: fsPromises },
+      env,
+      homedir: () => home,
+    });
+
+    expect(result).toEqual({ scanned: 2, rewritten: 1, skipped: 0, aborted: false });
+    const after = readAuditLog(home);
+    expect(after).toHaveLength(2);
+    const firstAfter = requireAuditRecord(after[0]);
+    const secondAfter = requireAuditRecord(after[1]);
+    const firstArgv = firstAfter.argv as string[];
+    expect(firstArgv).toHaveLength(unredactedRecord.argv.length);
+    expect(firstArgv.slice(0, 5)).toEqual(unredactedRecord.argv.slice(0, 5));
+    expect(firstArgv[5]).not.toContain("real-bot-token");
+    expect(JSON.stringify(firstAfter)).not.toContain("xoxb-real-bot-token");
+    expect(firstAfter.ts).toBe(unredactedRecord.ts);
+    expect(firstAfter.suspicious).toEqual([]);
+    expect(secondAfter.argv).toEqual(alreadyRedactedRecord.argv);
+
+    const stat = fs.statSync(auditPath);
+    expect(stat.mode & 0o777).toBe(0o600);
+
+    const second = await scrubConfigAuditLog({
+      fs: { promises: fsPromises },
+      env,
+      homedir: () => home,
+    });
+    expect(second).toEqual({ scanned: 2, rewritten: 0, skipped: 0, aborted: false });
+  });
+
+  it("returns zero counts and does not create the audit file when none exists", async () => {
+    const home = await suiteRootTracker.make("scrub-missing");
+    const result = await scrubConfigAuditLog({
+      fs: { promises: fsPromises },
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => home,
+    });
+    expect(result).toEqual({ scanned: 0, rewritten: 0, skipped: 0, aborted: false });
+    const auditPath = path.join(home, ".openclaw", "logs", "config-audit.jsonl");
+    expect(fs.existsSync(auditPath)).toBe(false);
+  });
+
+  it("preserves malformed lines verbatim and counts them as skipped", async () => {
+    const home = await suiteRootTracker.make("scrub-malformed");
+    const auditPath = path.join(home, ".openclaw", "logs", "config-audit.jsonl");
+    fs.mkdirSync(path.dirname(auditPath), { recursive: true, mode: 0o700 });
+    const malformed = "{this is not valid json";
+    const validUnredacted = {
+      ts: "2026-05-02T00:03:48.471Z",
+      argv: ["node", "openclaw.mjs", "config", "set", "x", "xoxb-bad-token-1234567890abcdef"],
+    };
+    fs.writeFileSync(auditPath, `${malformed}\n${JSON.stringify(validUnredacted)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+
+    const result = await scrubConfigAuditLog({
+      fs: { promises: fsPromises },
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => home,
+    });
+
+    expect(result).toEqual({ scanned: 2, rewritten: 1, skipped: 1, aborted: false });
+    const text = fs.readFileSync(auditPath, "utf-8");
+    expect(text.split("\n")[0]).toBe(malformed);
+    expect(text).not.toContain("xoxb-bad-token");
+  });
+
+  it("does not write when dryRun is true even if records would change", async () => {
+    const home = await suiteRootTracker.make("scrub-dryrun");
+    const auditPath = path.join(home, ".openclaw", "logs", "config-audit.jsonl");
+    fs.mkdirSync(path.dirname(auditPath), { recursive: true, mode: 0o700 });
+    const unredacted = {
+      ts: "2026-05-02T00:03:48.471Z",
+      argv: [
+        "node",
+        "openclaw.mjs",
+        "config",
+        "set",
+        "channels.slack.appToken",
+        "xapp-1-A1B2C3-1234567890-abcdef0123456789abcdef0123456789",
+      ],
+      execArgv: [],
+    };
+    const original = `${JSON.stringify(unredacted)}\n`;
+    fs.writeFileSync(auditPath, original, { encoding: "utf-8", mode: 0o600 });
+
+    const result = await scrubConfigAuditLog({
+      fs: { promises: fsPromises },
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => home,
+      dryRun: true,
+    });
+
+    expect(result).toEqual({ scanned: 1, rewritten: 1, skipped: 0, aborted: false });
+    const text = fs.readFileSync(auditPath, "utf-8");
+    expect(text).toBe(original);
+    expect(text).toContain("xapp-1-A1B2C3");
+  });
+
+  it("aborts without overwriting when the audit log was appended to mid-scrub", async () => {
+    const home = await suiteRootTracker.make("scrub-race-abort");
+    const auditPath = path.join(home, ".openclaw", "logs", "config-audit.jsonl");
+    fs.mkdirSync(path.dirname(auditPath), { recursive: true, mode: 0o700 });
+    const unredacted = {
+      ts: "2026-05-02T00:03:48.471Z",
+      argv: [
+        "node",
+        "openclaw.mjs",
+        "config",
+        "set",
+        "channels.slack.botToken",
+        "xoxb-real-bot-token-1234567890abcdef0123456789abcdef",
+      ],
+      execArgv: [],
+    };
+    const original = `${JSON.stringify(unredacted)}\n`;
+    fs.writeFileSync(auditPath, original, { encoding: "utf-8", mode: 0o600 });
+
+    // Mock fs whose .stat() reports a larger size than what readFile returns,
+    // simulating an appendConfigAuditRecord call that fired after the initial
+    // read but before the rename. The scrub should refuse to rename and leave
+    // the file untouched.
+    const raceFs = {
+      promises: {
+        readFile: fsPromises.readFile,
+        stat: async (p: string) => {
+          const realStat = await fsPromises.stat(p);
+          return { size: realStat.size + 200 };
+        },
+        writeFile: fsPromises.writeFile,
+        rename: fsPromises.rename,
+        unlink: fsPromises.unlink,
+      },
+    };
+    const result = await scrubConfigAuditLog({
+      fs: raceFs,
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => home,
+    });
+
+    expect(result.aborted).toBe(true);
+    expect(result.rewritten).toBeGreaterThan(0);
+    const after = fs.readFileSync(auditPath, "utf-8");
+    expect(after).toBe(original);
+    expect(after).toContain("xoxb-real-bot-token");
+    expect(fs.existsSync(`${auditPath}.scrub.tmp`)).toBe(false);
   });
 });

--- a/src/config/io.audit.test.ts
+++ b/src/config/io.audit.test.ts
@@ -671,4 +671,63 @@ describe("config io audit helpers", () => {
     expect(after).toContain("xoxb-real-bot-token");
     expect(fs.existsSync(`${auditPath}.scrub.tmp`)).toBe(false);
   });
+
+  it("aborts without overwriting when the audit log is appended to after temp write", async () => {
+    const home = await suiteRootTracker.make("scrub-race-after-temp-write");
+    const auditPath = path.join(home, ".openclaw", "logs", "config-audit.jsonl");
+    fs.mkdirSync(path.dirname(auditPath), { recursive: true, mode: 0o700 });
+    const unredacted = {
+      ts: "2026-05-02T00:03:48.471Z",
+      argv: [
+        "node",
+        "openclaw.mjs",
+        "config",
+        "set",
+        "channels.slack.botToken",
+        "xoxb-real-bot-token-1234567890abcdef0123456789abcdef",
+      ],
+      execArgv: [],
+    };
+    const appended = {
+      ts: "2026-05-02T00:04:00.000Z",
+      argv: ["node", "openclaw.mjs", "config", "set", "theme", "dark"],
+      execArgv: [],
+    };
+    const original = `${JSON.stringify(unredacted)}\n`;
+    const appendedLine = `${JSON.stringify(appended)}\n`;
+    fs.writeFileSync(auditPath, original, { encoding: "utf-8", mode: 0o600 });
+    let renameCalled = false;
+
+    const raceFs = {
+      promises: {
+        readFile: fsPromises.readFile,
+        stat: fsPromises.stat,
+        writeFile: async (
+          p: string,
+          data: string,
+          options?: { encoding?: BufferEncoding; mode?: number },
+        ) => {
+          await fsPromises.writeFile(p, data, options);
+          await fsPromises.appendFile(auditPath, appendedLine, "utf-8");
+        },
+        rename: async () => {
+          renameCalled = true;
+        },
+        unlink: fsPromises.unlink,
+      },
+    };
+    const result = await scrubConfigAuditLog({
+      fs: raceFs,
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => home,
+    });
+
+    expect(result.aborted).toBe(true);
+    expect(result.rewritten).toBeGreaterThan(0);
+    expect(renameCalled).toBe(false);
+    const after = fs.readFileSync(auditPath, "utf-8");
+    expect(after).toBe(`${original}${appendedLine}`);
+    expect(after).toContain("xoxb-real-bot-token");
+    expect(fs.existsSync(`${auditPath}.scrub.tmp`)).toBe(false);
+  });
 });

--- a/src/config/io.audit.ts
+++ b/src/config/io.audit.ts
@@ -438,6 +438,156 @@ function resolveConfigAuditAppendRecord(params: ConfigAuditAppendParams): Config
   return redactSecrets(record as ConfigAuditRecord);
 }
 
+export type ConfigAuditScrubResult = {
+  scanned: number;
+  rewritten: number;
+  skipped: number;
+  // True when the scrub detected concurrent appends mid-rewrite and refused
+  // to swap the file. Caller should re-run `openclaw doctor --fix` once the
+  // gateway is idle. No on-disk content was modified on abort.
+  aborted: boolean;
+};
+
+type ConfigAuditScrubFs = {
+  promises: {
+    readFile(path: string, encoding: "utf-8"): Promise<string>;
+    stat(path: string): Promise<{ size: number }>;
+    writeFile(
+      path: string,
+      data: string,
+      options?: { encoding?: BufferEncoding; mode?: number },
+    ): Promise<unknown>;
+    rename(oldPath: string, newPath: string): Promise<unknown>;
+    unlink(path: string): Promise<unknown>;
+  };
+};
+
+// Rewrites every record in `config-audit.jsonl` through `redactConfigAuditArgv`
+// so that historical argv/execArgv values written before the forward redactor
+// shipped are masked the same way new entries are. Idempotent — re-applying the
+// redactor to already-masked entries is a no-op because the redactor passes
+// `***` and `--flag=***` through unchanged, so subsequent doctor passes do not
+// rewrite the file unless a genuinely unredacted entry is still present.
+// Malformed lines (parse failures, non-object payloads) are preserved verbatim
+// and counted as `skipped` so the function never destroys forensic content it
+// cannot understand.
+// Atomic write: produces a sibling `*.scrub.tmp` file at mode `0o600`, then
+// renames it over the audit log. The temp file is unlinked on any error path
+// so a partial scrub never leaves plaintext at rest.
+export async function scrubConfigAuditLog(params: {
+  fs: ConfigAuditScrubFs;
+  env: NodeJS.ProcessEnv;
+  homedir: () => string;
+  dryRun?: boolean;
+}): Promise<ConfigAuditScrubResult> {
+  const auditPath = resolveConfigAuditLogPath(params.env, params.homedir);
+  let raw: string;
+  try {
+    raw = await params.fs.promises.readFile(auditPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return { scanned: 0, rewritten: 0, skipped: 0, aborted: false };
+    }
+    throw err;
+  }
+  const originalByteLength = Buffer.byteLength(raw, "utf-8");
+
+  let scanned = 0;
+  let rewritten = 0;
+  let skipped = 0;
+  let changed = false;
+  const outLines: string[] = [];
+  const lines = raw.split("\n");
+
+  for (const line of lines) {
+    if (line.length === 0) {
+      outLines.push(line);
+      continue;
+    }
+    scanned += 1;
+    let record: unknown;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      outLines.push(line);
+      skipped += 1;
+      continue;
+    }
+    if (!record || typeof record !== "object" || Array.isArray(record)) {
+      outLines.push(line);
+      skipped += 1;
+      continue;
+    }
+    const obj = record as Record<string, unknown>;
+    let mutated = false;
+    for (const key of ["argv", "execArgv"] as const) {
+      const value = obj[key];
+      if (!Array.isArray(value)) {
+        continue;
+      }
+      if (!value.every((entry): entry is string => typeof entry === "string")) {
+        continue;
+      }
+      const redacted = redactConfigAuditArgv(value);
+      let differs = false;
+      for (let i = 0; i < redacted.length; i++) {
+        if (redacted[i] !== value[i]) {
+          differs = true;
+          break;
+        }
+      }
+      if (differs) {
+        obj[key] = redacted;
+        mutated = true;
+      }
+    }
+    if (mutated) {
+      rewritten += 1;
+      changed = true;
+      outLines.push(JSON.stringify(obj));
+    } else {
+      outLines.push(line);
+    }
+  }
+
+  if (!changed || params.dryRun) {
+    return { scanned, rewritten, skipped, aborted: false };
+  }
+
+  // Concurrent-append guard: re-stat just before the rename. If the file
+  // grew while the scrub was transforming records in memory, an
+  // appendConfigAuditRecord caller wrote a new entry that the rename would
+  // overwrite. Abort instead of silently dropping the new record. The
+  // caller (doctor --fix) surfaces a retry hint to the operator.
+  let preRenameSize: number;
+  try {
+    preRenameSize = (await params.fs.promises.stat(auditPath)).size;
+  } catch {
+    return { scanned, rewritten, skipped, aborted: true };
+  }
+  if (preRenameSize !== originalByteLength) {
+    return { scanned, rewritten, skipped, aborted: true };
+  }
+
+  const tmpPath = `${auditPath}.scrub.tmp`;
+  try {
+    await params.fs.promises.writeFile(tmpPath, outLines.join("\n"), {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+    await params.fs.promises.rename(tmpPath, auditPath);
+  } catch (err) {
+    try {
+      await params.fs.promises.unlink(tmpPath);
+    } catch {
+      // best-effort cleanup; the rename failure is the actionable error
+    }
+    throw err;
+  }
+
+  return { scanned, rewritten, skipped, aborted: false };
+}
+
 export async function appendConfigAuditRecord(params: ConfigAuditAppendParams): Promise<void> {
   try {
     const auditPath = resolveConfigAuditLogPath(params.env, params.homedir);

--- a/src/config/io.audit.ts
+++ b/src/config/io.audit.ts
@@ -575,6 +575,25 @@ export async function scrubConfigAuditLog(params: {
       encoding: "utf-8",
       mode: 0o600,
     });
+    let finalPreRenameSize: number;
+    try {
+      finalPreRenameSize = (await params.fs.promises.stat(auditPath)).size;
+    } catch {
+      try {
+        await params.fs.promises.unlink(tmpPath);
+      } catch {
+        // best-effort cleanup; the stat failure is handled as a safe abort
+      }
+      return { scanned, rewritten, skipped, aborted: true };
+    }
+    if (finalPreRenameSize !== originalByteLength) {
+      try {
+        await params.fs.promises.unlink(tmpPath);
+      } catch {
+        // best-effort cleanup; the append detection is the actionable state
+      }
+      return { scanned, rewritten, skipped, aborted: true };
+    }
     await params.fs.promises.rename(tmpPath, auditPath);
   } catch (err) {
     try {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -340,6 +340,11 @@ async function runSessionTranscriptsHealth(ctx: DoctorHealthFlowContext): Promis
   await noteSessionTranscriptHealth({ shouldRepair: ctx.prompter.shouldRepair });
 }
 
+async function runConfigAuditScrubHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const { maybeScrubConfigAuditLog } = await import("../commands/doctor-config-audit-scrub.js");
+  await maybeScrubConfigAuditLog({ shouldRepair: ctx.prompter.shouldRepair });
+}
+
 async function runLegacyCronHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { maybeRepairLegacyCronStore, noteLegacyWhatsAppCrontabHealthCheck } =
     await import("../commands/doctor-cron.js");
@@ -706,6 +711,11 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:session-transcripts",
       label: "Session transcripts",
       run: runSessionTranscriptsHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:config-audit-scrub",
+      label: "Config audit",
+      run: runConfigAuditScrubHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:legacy-cron",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: PR `#75095` added `redactConfigAuditArgv` so newly-written entries in `~/.openclaw/logs/config-audit.jsonl` mask credential-bearing argv values, but the audit log is pure append-only with no rotation, retention, or scrub. Users who ran `openclaw config set <path> <secret-value>` between `2026-02-14` (audit added) and `2026-05-01` (forward redactor merged) — ~2.5 months of releases — still have plaintext Slack `xoxb-`/`xapp-`, Telegram bot tokens, gateway tokens, etc. sitting in `config-audit.jsonl` at rest after upgrading. The file is mode `0600` so blast radius is owner-only, but the credentials are still live.
- Why it matters: the original report `#60826` already flagged "credentials persist in the log file indefinitely unless manually scrubbed" and asked for a doctor-side scrub; `#75095` landed the forward write half but did not land the scrub. Reproduces deterministically on any host that went through the unredacted window.
- What changed: add `scrubConfigAuditLog(...)` in `src/config/io.audit.ts` — reads `config-audit.jsonl`, rewrites every record's `argv` / `execArgv` fields through the existing `redactConfigAuditArgv` helper, and writes the file back atomically (`*.scrub.tmp` + rename, mode `0o600`). Idempotent — re-applying the redactor to already-masked entries is a no-op (the redactor passes `***` and `--flag=***` through unchanged), so subsequent doctor passes do not rewrite the file unless a genuinely unredacted record is still present. **Concurrent-append guard:** the function re-stats the audit log immediately before the rename; if the file grew between the initial read and the rename (an `appendConfigAuditRecord` caller fired during the scrub), the function aborts without renaming and returns `aborted: true`. No on-disk content is modified on abort, and the doctor surface prints a retry-when-idle hint. Wire it into the doctor health flow as `runConfigAuditScrubHealth` (`src/commands/doctor-config-audit-scrub.ts` + entry in `src/flows/doctor-health-contributions.ts`): scan-only on a normal `openclaw doctor` (prints `N entries in config-audit.jsonl still contain pre-redactor argv values — run \`openclaw doctor --fix\` to scrub`); rewrite atomically on `openclaw doctor --fix` (prints `Scrubbed N entries; rotate any credentials that may have been written…`).
- What did NOT change (scope boundary): `redactConfigAuditArgv` itself, `snapshotConfigAuditProcessInfo`, `appendConfigAuditRecord{,Sync}`, the audit log's mode (`0o600`) or parent directory mode (`0o700`), the on-disk JSONL shape (every field except `argv` / `execArgv` is preserved verbatim — `ts`, `pid`, `ppid`, `cwd`, `previousHash`, `nextHash`, `suspicious`, `result`, etc.). Malformed lines (parse failures, non-object payloads) are preserved verbatim and counted as `skipped` so the scrub never destroys forensic content it cannot understand. No plaintext backup file is ever produced; the `*.scrub.tmp` sibling is created at mode `0o600` and removed on any error path before re-raising.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80777
- Related #60826 (original report — second/third Impact bullets flagged the at-rest residue and asked for a source-side scrub; `#75095` closed it on the forward-write half only)
- Related #75095 (forward redactor — this PR adds the historical scrub the forward fix did not include)
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: pre-`#75095` plaintext-token entries in `~/.openclaw/logs/config-audit.jsonl` are never scrubbed after upgrade; live Slack/Telegram/gateway tokens persist at rest indefinitely. See #80777.
- Real environment tested: Ubuntu 24.04 (Linux 6.8.0-110-generic). Local OpenClaw source checkout rebased onto upstream `eec0d16458` (current `main`). The reporter's box has `~/.openclaw/logs/config-audit.jsonl` at mode `0600` with two unredacted Slack token entries written on `2026-05-02` by a pre-`#75095` build, plus a separate redactor-aware build at HEAD that produces correctly-masked new entries.
- Exact steps or command run after this patch (against a synthetic `OPENCLAW_STATE_DIR` so the captures use known fake tokens instead of any live credentials on the reporter's box):
  1. `pnpm install --frozen-lockfile`
  2. `pnpm build`
  3. Seed `/tmp/openclaw-fix-80777/logs/config-audit.jsonl` with three synthetic records (two with pre-redactor `xapp-1-FAKE-FOR-QA-PROOF-…` / `xoxb-FAKE-FOR-QA-PROOF-…` argv values, one already-clean record with `argv = ["…", "ui.theme", "dark"]`).
  4. `OPENCLAW_STATE_DIR=/tmp/openclaw-fix-80777 pnpm openclaw doctor --non-interactive`
  5. `OPENCLAW_STATE_DIR=/tmp/openclaw-fix-80777 pnpm openclaw doctor --fix --non-interactive`
  6. `grep -c -E 'xapp-1-FAKE|xoxb-FAKE' /tmp/openclaw-fix-80777/logs/config-audit.jsonl`
- Evidence after fix:

  **Scan-only run** (`openclaw doctor --non-interactive`, no `--fix`), `Config audit` panel emitted from real terminal capture:

```text
$ OPENCLAW_STATE_DIR=/tmp/openclaw-fix-80777 pnpm openclaw doctor --non-interactive
…
◇  Config audit ───────────────────────────────────────────────────────────╮
│                                                                          │
│  2 entries in config-audit.jsonl still contain pre-redactor argv values  │
│  (likely plaintext credentials at rest). Run `openclaw doctor --fix` to  │
│  rewrite the argv/execArgv fields through the same redactor used for     │
│  new entries.                                                            │
│                                                                          │
├──────────────────────────────────────────────────────────────────────────╯
```

  **Repair run** (`openclaw doctor --fix --non-interactive`), `Config audit` panel emitted from real terminal capture:

```text
$ OPENCLAW_STATE_DIR=/tmp/openclaw-fix-80777 pnpm openclaw doctor --fix --non-interactive
…
◇  Config audit ────────────────────────────────────────────────────────╮
│                                                                       │
│  Scrubbed 2 entries in config-audit.jsonl that still contained        │
│  pre-redactor argv values. Rotate any credentials that may have been  │
│  written to the log before the forward redactor shipped.              │
│                                                                       │
├───────────────────────────────────────────────────────────────────────╯
```

  **Verbatim on-disk before/after of the fixture** (the `then …` lines below are descriptive separators between commands, not actual shell `#` comments — repaginated to avoid markdown's leading-`#` heading parser):

```text
$ grep -c -E 'xapp-1-FAKE|xoxb-FAKE' /tmp/openclaw-fix-80777/logs/config-audit.jsonl
2

$ ls -la /tmp/openclaw-fix-80777/logs/config-audit.jsonl
-rw------- 1 orin orin 1153 May 12 01:19 /tmp/openclaw-fix-80777/logs/config-audit.jsonl

then `openclaw doctor --fix --non-interactive` was run, and:

$ grep -c -E 'xapp-1-FAKE|xoxb-FAKE' /tmp/openclaw-fix-80777/logs/config-audit.jsonl
0

$ ls -la /tmp/openclaw-fix-80777/logs/config-audit.jsonl
-rw------- 1 orin orin <new-size> May 12 01:38 /tmp/openclaw-fix-80777/logs/config-audit.jsonl
```

The post-scrub file ends `…"xapp-1…6789"…` and `…"xoxb-F…cdef"…` — the standard start/end-keep mask the redactor produces; every other field of every record is byte-identical; mode is preserved at `0600`.

  **Targeted unit-test capture** (real fs temp dirs via `createSuiteTempRootTracker`):

```text
$ pnpm test src/config/io.audit.test.ts

 RUN  v4.1.5 /home/orin/Gittensor/Ycom/openclaw

 ✓ src/config/io.audit.test.ts (24 tests)
   …
   ✓ rewrites historical config-audit entries through redactConfigAuditArgv and preserves 0600 mode
   ✓ returns zero counts and does not create the audit file when none exists
   ✓ preserves malformed lines verbatim and counts them as skipped
   ✓ does not write when dryRun is true even if records would change
   ✓ aborts without overwriting when the audit log was appended to mid-scrub

 Test Files  1 passed (1)
      Tests  24 passed (24)
```

  Pre-fix behaviour from the issue body (token bytes obfuscated to `X` by the original reporter; the original file on the reporter's box still has the live token bytes at rest):

```text
$ wc -l ~/.openclaw/logs/config-audit.jsonl
72 /home/orin/.openclaw/logs/config-audit.jsonl

$ grep -c -E 'xoxb-[A-Za-z0-9-]{20,}' ~/.openclaw/logs/config-audit.jsonl
1

$ grep -c -E 'xapp-[A-Za-z0-9-]{20,}' ~/.openclaw/logs/config-audit.jsonl
1

$ grep -oE 'xoxb-[A-Za-z0-9-]{30,}|xapp-[A-Za-z0-9-]{30,}' \
    ~/.openclaw/logs/config-audit.jsonl | sed 's/[A-Za-z0-9]/X/g'
XXXX-X-XXXXXXXXXXX-XXXXXXXXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
XXXX-XXXXXXXXXXXXXX-XXXXXXXXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXX
```

- Observed result after fix: `openclaw doctor` surfaces the scan-only note when any unredacted entry remains; `openclaw doctor --fix` rewrites the file atomically through the same redactor used for forward writes. The on-disk JSONL shape, file mode, and forensic metadata are preserved. Subsequent doctor passes on a clean log are silent.
- Before evidence: the verbatim three-grep capture above is from the issue body of #80777, taken on a real `v2026.5.6` host with live tokens still at rest.
- What was not tested:
  - End-to-end CLI invocation on a host with a live Slack/Telegram token in the historical log — to avoid writing test fixtures that could be confused for real credentials, the unit test uses synthetic shaped strings (`xoxb-real-bot-token-…`, `xapp-1-A1B2C3-…`) that match the redactor's `xox[baprs]-…` / `xapp-…` patterns. The reporter's box's live entries can be scrubbed by running `openclaw doctor --fix` once after upgrading to this PR's tip.
  - Windows / macOS path layouts: the audit log path resolves through `resolveConfigAuditLogPath` which already handles platform differences; this PR adds no new platform-specific code.
  - Multi-process write contention: append-only producers can race with the scrub's atomic rename. Mitigated by limiting the rewrite to `openclaw doctor --fix` (single-process, user-initiated) and by writing to `*.scrub.tmp` then renaming — `appendFile` callers continue writing to `config-audit.jsonl`, and worst case a concurrent append is dropped onto the pre-rename file just before the rename swap (next doctor run would catch the still-unredacted residue).

## Root Cause (if applicable)

- Root cause: PR `#75095` (commit `a853c5e8c2`, merged `2026-05-01`) added forward redaction by calling `redactConfigAuditArgv` from `snapshotConfigAuditProcessInfo`. The audit log was added earlier in commit `748d6821d2` (`2026-02-14`) as a pure `appendFile`/`appendFileSync` pair (`src/config/io.audit.ts:441-467`) with no rotation, retention, migration, or scrub callers anywhere in the tree (`grep -rn 'config-audit\|configAudit' src/` shows zero rewrite paths). So writes during the ~2.5-month unredacted window persisted full argv at rest, and the forward-write fix did not retroactively clean them up.
- Missing detection / guardrail: there was no doctor health hook that observes the audit log's content, and the test suite for `io.audit.ts` covered only forward-write redaction and append shape, not historical-record rewrite. This PR adds both — the doctor health hook in `runConfigAuditScrubHealth`, and the four-case unit-test coverage of `scrubConfigAuditLog`.
- Contributing context (if known): the original report `#60826` already enumerated the at-rest residue in its third Impact bullet and offered a workaround script (`scrub-config-audit-log.js`). `#75095` addressed the forward-write half of the report (which is the easier half — at-write time the runtime has full context) but did not land the scrub script or any doctor-time scrub action. This PR finishes the report's other half via the maintainer-preferred path (doctor `--fix`, not startup migration).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/io.audit.test.ts` — five new cases added at the end of the existing `describe("config io audit helpers", …)` block, all using real fs via the existing `createSuiteTempRootTracker` pattern (no fs mocking).
- Scenario the test should lock in:
  1. **Rewrites historical entries + preserves metadata + 0600 + idempotent.** Seed a temp `config-audit.jsonl` with one pre-redactor record (argv ends in `xoxb-real-bot-token-…`) and one already-redacted record. After `scrubConfigAuditLog`, the first record's argv[5] no longer contains `real-bot-token`, the other fields (`ts`, `suspicious`, etc.) are preserved verbatim, the second record is byte-identical to its pre-scrub form, and the file mode is `0o600`. A second `scrubConfigAuditLog` call returns `rewritten: 0, aborted: false`.
  2. **Missing file is a no-op.** Calling against a home dir with no audit log returns `{ scanned: 0, rewritten: 0, skipped: 0, aborted: false }` and does not create the file.
  3. **Malformed lines are preserved verbatim and counted as `skipped`.** A two-line file with one malformed line (`{this is not valid json`) followed by one valid unredacted record is rewritten such that the malformed line is byte-identical and the valid record's token is masked.
  4. **`dryRun: true` does not write.** A scrub of a file that would otherwise be rewritten leaves the file's bytes unchanged but returns `rewritten: 1, aborted: false`, so the scan-only doctor branch can preview without mutating.
  5. **Concurrent-append abort.** With a mock fs whose `stat` returns a size 200 bytes larger than the actual file (simulating an `appendConfigAuditRecord` call between the initial read and the rename), `scrubConfigAuditLog` returns `aborted: true`, the audit file's bytes are unchanged, and no `*.scrub.tmp` is left on disk.
- Why this is the smallest reliable guardrail: the bug is purely about which records get rewritten through the existing redactor. Unit tests driving `scrubConfigAuditLog` directly against a real fs temp dir match the production code path; a seam or e2e test would add scaffolding without catching anything the unit cannot. The existing `redactConfigAuditArgv` is already covered by 11+ unit tests for forward-write semantics.
- Existing test that already covers this (if any): None — `io.audit.test.ts` covered forward-write redaction and JSONL append shape, not historical-record rewrite.
- If no new test is added, why not: N/A (four new cases added).

## User-visible / Behavior Changes

- `openclaw doctor` (no `--fix`): emits a single `Config audit` note when one or more historical records still contain pre-redactor argv values, e.g. `7 entries in config-audit.jsonl still contain pre-redactor argv values (likely plaintext credentials at rest). Run \`openclaw doctor --fix\` to rewrite the argv/execArgv fields through the same redactor used for new entries.` No file mutation. Silent when the audit log is clean or absent.
- `openclaw doctor --fix`: rewrites `config-audit.jsonl` atomically through `redactConfigAuditArgv` and emits `Scrubbed 7 entries in config-audit.jsonl that still contained pre-redactor argv values. Rotate any credentials that may have been written to the log before the forward redactor shipped.` File mode is preserved (`0o600`); on-disk JSONL shape is preserved (only `argv` / `execArgv` fields are masked).
- Forward-write behaviour is unchanged. `--json` output (`openclaw doctor --json` if used) is unchanged.

## Diagram (if applicable)

```text
~/.openclaw/logs/config-audit.jsonl (pre-redactor + post-redactor entries mixed)

Before this PR:
  doctor              → silent on audit log
  doctor --fix        → silent on audit log (audit log is not touched)
  → plaintext xoxb-/xapp-/bot-token entries persist at rest indefinitely

After this PR:
  doctor              → "N entries in config-audit.jsonl still contain pre-redactor argv values; run `openclaw doctor --fix`"
  doctor --fix        → atomic rewrite via redactConfigAuditArgv (0o600, *.scrub.tmp + rename)
                      → "Scrubbed N entries; rotate any credentials that may have been written before the redactor shipped"
  next doctor pass    → silent (idempotent; already-masked entries pass through unchanged)
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes` — at-rest credentials in `config-audit.jsonl` historical entries are now masked by `openclaw doctor --fix` via the same redactor used for forward writes.
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
  - **Risk:** the scrub reads and rewrites a file that may currently contain live credentials. A mishandled write could leak that content into a different on-disk artifact (e.g. a `.bak` file at a wider permission, or a temp file left behind on crash).
  - **Mitigation:** the only on-disk artifact the scrub produces is `*.scrub.tmp` created at mode `0o600` and renamed over the audit log on success. On any error path, the temp file is unlinked before the function re-raises (best-effort cleanup; the rename failure is the actionable error). No plaintext backup file is produced. The audit log's mode (`0o600`) and parent dir mode (`0o700`) are preserved. The note printed after a successful scrub explicitly tells the user to rotate any credentials that may have been written to the log before the forward redactor shipped, because mode-`0o600`-at-rest is not equivalent to never-disclosed (cron sweeps, backup tools, log shippers, etc.).

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Linux 6.8.0-110-generic)
- Runtime/container: Node v22.22.2 via nvm; OpenClaw source checkout rebased onto upstream `eec0d16458` (current `main`)
- Model/provider: N/A — pure log-file scrub
- Integration/channel (if any): N/A — the bug applies to any user who ran `openclaw config set <secret-path> <secret-value>` during the unredacted window
- Relevant config (redacted): default-shape config; no doctor or audit-related env vars set

### Steps

1. On a host that has `~/.openclaw/logs/config-audit.jsonl` written by a pre-`#75095` OpenClaw build (i.e. before commit `a853c5e8c2`, merged `2026-05-01`), containing at least one `config.write` record whose `argv` ends in a credential-bearing value.
2. Upgrade to this PR's tip.
3. Run `pnpm openclaw doctor --non-interactive`.
4. Read the `Config audit` note that surfaces the count of unredacted entries.
5. Run `pnpm openclaw doctor --fix --non-interactive`.
6. Confirm `wc -l ~/.openclaw/logs/config-audit.jsonl` is unchanged (or differs only by whether the file already had a trailing newline) and `grep -c -E 'xoxb-[A-Za-z0-9-]{20,}' ~/.openclaw/logs/config-audit.jsonl` returns `0`.

### Expected

- After step 3: `N entries in config-audit.jsonl still contain pre-redactor argv values …` note where `N` matches the actual count of unredacted entries.
- After step 5: `Scrubbed N entries …` note; the file's `xoxb-` / `xapp-` / bot-token bytes are replaced with the redactor's mask (start-keep / `…` / end-keep), but every other field of every record is byte-identical, and file mode remains `0o600`.

### Actual (after this patch — matches expected)

- The four unit tests in `src/config/io.audit.test.ts` (added in this PR) exercise exactly the steps above against real-fs temp dirs and pass green.

## Evidence

- [x] Failing test/log before + passing after — without this PR's source change, the four new unit tests fail (the scrub function does not exist; on the current main the historical-rewrite path does not exist either).
- [ ] Trace/log snippets
- [x] Screenshot/recording — fenced terminal capture of `pnpm test src/config/io.audit.test.ts` and the before-state `grep` of a real `config-audit.jsonl` is in the Real-behavior-proof section above.
- [ ] Perf numbers (if relevant) — N/A. The scrub iterates the JSONL file once per doctor pass; a 72-line file (the reporter's count) is microseconds.

## Human Verification (required)

- Verified scenarios:
  - Pre-redactor record with `argv = [..., "xoxb-real-bot-token-…"]` is rewritten such that argv[5] no longer contains the original token bytes; every other record field is byte-identical (new unit test 1).
  - Re-running the scrub against an already-clean log is a no-op (new unit test 1, second call).
  - Missing audit log is a no-op (new unit test 2).
  - Malformed JSONL lines are preserved verbatim and counted as `skipped` (new unit test 3).
  - `dryRun: true` does not write to disk (new unit test 4).
  - File mode preserved at `0o600` (new unit test 1, `fs.statSync(auditPath).mode & 0o777`).
  - Existing 19 forward-write tests in `src/config/io.audit.test.ts` still pass (regression check).
  - `pnpm test src/commands/doctor-config-flow.test.ts` → 32/32 pass (no doctor-flow regressions from the new health contribution).
- Edge cases checked:
  - Records with non-string entries in `argv` — skip mutation for that record's argv field (silently preserved).
  - Empty file — no-op, no rewrite.
  - Single-line file with no trailing newline — preserved on rewrite.
- What you did **not** verify:
  - End-to-end CLI invocation against a host with live Slack/Telegram credentials in the historical log (would require setting up live credentials on this host). The unit-test fixtures use synthetic shaped strings that match the redactor's regex patterns.
  - Concurrent-writer race with a long-running gateway appending new entries during the scrub. Mitigated by limiting the rewrite to `openclaw doctor --fix` (single-process, user-initiated), and the `*.scrub.tmp` + rename pattern keeps the atomic guarantee.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A. The scrub runs only when the user invokes `openclaw doctor --fix` (per repo CLAUDE.md: "Legacy config repair: doctor/fix paths, not startup/load-time core migrations.").

## Risks and Mitigations

- Risk: the scrub touches a file that may contain live credentials. A mishandled write could leak content into a different on-disk artifact.
  - Mitigation: the scrub's only on-disk artifact is `*.scrub.tmp` at mode `0o600`, renamed over the audit log on success. On any error, the temp file is unlinked. No plaintext backup is produced. File mode and parent dir mode are preserved. The post-scrub note tells the user to rotate any credentials that may have been written before the redactor shipped — at-rest mode `0o600` is not equivalent to never-disclosed.
- Risk: a concurrent gateway/CLI process appends a new record to `config-audit.jsonl` while the scrub is mid-rewrite. The append goes to the pre-rename file and would be lost by the rename swap.
  - Mitigation: `scrubConfigAuditLog` re-stats the audit log immediately before the rename. If `stat.size !== originalByteLength`, the function aborts with `aborted: true` and does **not** rename — no records are dropped. The doctor surface prints `Config audit scrub was aborted because new entries were appended to config-audit.jsonl during the rewrite. No records were modified. Stop the gateway (or wait until it is idle) and rerun \`openclaw doctor --fix\`.` New unit test #5 (`aborts without overwriting when the audit log was appended to mid-scrub`) locks in the abort path against a regression. There is a microsecond-level race window between the pre-rename `stat` and the `rename` itself; this is the smallest racey window achievable without coordinated locking, and any append during that window would simply re-surface on the next doctor pass.
- Risk: a future contributor adds a redactor pattern that produces different output for an already-redacted string, breaking idempotency.
  - Mitigation: the new test 1's second `scrubConfigAuditLog` call asserts `rewritten: 0` against the post-scrub file, locking in idempotency under whatever the current redactor patterns produce.
