### PR TITLE
test: update embedded Pi exec summary assertion

### DIFF
--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
@@ -203,8 +203,8 @@ describe("subscribeEmbeddedPiSession", () => {
 
     expect(onToolResult).toHaveBeenCalledTimes(1);
     const summary = onToolResult.mock.calls[0][0];
-    expect(summary.text).toContain("Exec");
     expect(summary.text).toContain("pty");
+    expect(summary.text).toContain("`claude`");
 
     toolHarness.emit({
       type: "tool_execution_end",


### PR DESCRIPTION
## Summary
- update the embedded Pi verbose exec summary test to match the current compact exec display contract
- assert the PTY flag plus command identity instead of the stale literal `Exec` label

Fixes #80430

## Real behavior proof
- **Behavior or issue addressed**: The embedded Pi verbose exec-summary test no longer asserts the stale literal `Exec` label. It now checks the current user-facing summary contract reported in #80430: PTY flag plus command identity.
- **Real environment tested**: Local OpenClaw checkout on Linux arm64, branch `thiago-quick-openclaw`, after applying commit `14c0c12a2`.
- **Exact steps or command run after this patch**: `git show --unified=6 -- src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts && git diff --check HEAD~1..HEAD`
- **Evidence after fix**: Copied live terminal output from the patched checkout:

```text
commit 14c0c12a2 test: update embedded Pi exec summary assertion

@@ -200,14 +200,14 @@ describe("subscribeEmbeddedPiSession", () => {
     await Promise.resolve();

     expect(onToolResult).toHaveBeenCalledTimes(1);
     const summary = onToolResult.mock.calls[0][0];
-    expect(summary.text).toContain("Exec");
     expect(summary.text).toContain("pty");
+    expect(summary.text).toContain("`claude`");

     toolHarness.emit({
       type: "tool_execution_end",
       toolName: "exec",
       toolCallId: "tool-exec-1",
```

- **Observed result after fix**: The stale `Exec` assertion is gone, while the test still verifies the real summary content that matters for the current compact exec display: `pty` and `` `claude` ``. `git diff --check HEAD~1..HEAD` completed without whitespace errors.
- **What was not tested**: The focused Vitest target could not run in this local checkout because this environment cannot resolve the workspace package `@openclaw/fs-safe/config` / pnpm wants to reinstall `node_modules`. CI should run the canonical workspace validation.

## Validation
- `git diff --check HEAD~1..HEAD`
- attempted focused test locally, but this checkout cannot run it because the workspace dependency `@openclaw/fs-safe/config` is missing / pnpm wants to reinstall node_modules in this environment; leaving full validation to CI

## Risk
- test-only change; no runtime behavior changes
