### PR TITLE
fix(codex): gate migration on app readiness

### DIFF
--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -22,6 +22,7 @@ openclaw migrate claude --dry-run
 openclaw migrate codex --dry-run
 openclaw migrate codex --skill gog-vault77-google-workspace
 openclaw migrate codex --plugin google-calendar --dry-run
+openclaw migrate codex --plugin google-calendar --verify-plugin-apps --dry-run
 openclaw migrate hermes --dry-run
 openclaw migrate hermes
 openclaw migrate apply codex --yes --skill gog-vault77-google-workspace
@@ -58,6 +59,9 @@ openclaw onboard --import-from hermes --import-source ~/.hermes
 </ParamField>
 <ParamField path="--plugin <name>" type="string">
   Select one Codex plugin install item by plugin name or item id. Repeat the flag to migrate multiple Codex plugins. When omitted, interactive Codex migrations show a native Codex plugin checkbox selector and non-interactive migrations keep all planned plugins. This only applies to source-installed `openai-curated` Codex plugins discovered by the Codex app-server inventory.
+</ParamField>
+<ParamField path="--verify-plugin-apps" type="boolean">
+  Codex only. Force a fresh source Codex app-server `app/list` traversal before planning native plugin activation. Off by default to keep migration planning fast.
 </ParamField>
 <ParamField path="--no-backup" type="boolean">
   Skip the pre-apply backup. Requires `--force` when local OpenClaw state exists.
@@ -157,13 +161,20 @@ openclaw migrate apply codex --yes --plugin google-calendar
   OpenClaw agent workspace when you want per-agent ownership.
 - Source-installed `openai-curated` Codex plugins discovered through Codex
   app-server `plugin/list`. Planning reads `plugin/read` for each enabled
-  installed plugin. App-backed plugins are migratable only when the source Codex
-  app-server account is logged in with ChatGPT subscription auth and a fresh
-  source `app/list` snapshot reports every owned app as present, enabled, and
-  accessible. Disabled plugins, unreadable plugin details, subscription-gated
-  source accounts, missing apps, disabled apps, inaccessible apps, and source app
-  inventory failures become manual skipped items with typed reasons instead of
-  target config entries.
+  installed plugin. App-backed plugins require the source Codex app-server
+  account response to be a ChatGPT subscription account; non-ChatGPT or missing
+  account responses are skipped with `codex_subscription_required`. By default,
+  migration does not call source `app/list`, so app-backed plugins that pass the
+  account gate are planned without source app accessibility verification, and
+  account lookup transport failures skip with `codex_account_unavailable`. Pass
+  `--verify-plugin-apps` when you want migration to force a fresh source
+  `app/list` snapshot and require every owned app to be present, enabled, and
+  accessible before planning native activation. In that mode, account lookup
+  transport failures fall through to source app inventory verification. Disabled
+  plugins, unreadable plugin details, subscription-gated source accounts, and,
+  when verification is requested, missing apps, disabled apps, inaccessible
+  apps, or source app inventory failures become manual skipped items with typed
+  reasons instead of target config entries.
   Apply calls app-server `plugin/install` for each selected eligible plugin,
   even if the target app-server already reports that plugin as installed and
   enabled. Migrated Codex plugins are usable only in sessions that select the
@@ -174,9 +185,10 @@ openclaw migrate apply codex --yes --plugin google-calendar
 
 Codex `config.toml`, native `hooks/hooks.json`, non-curated marketplaces, cached
 plugin bundles that are not source-installed curated plugins, and source-installed
-plugins that fail the source subscription or app-inventory gates are not activated
-automatically. They are copied or reported in the migration report for manual
-review.
+plugins that fail the source subscription gate are not activated automatically.
+When `--verify-plugin-apps` is set, plugins that fail the source app-inventory
+gate are also skipped. They are copied or reported in the migration report for
+manual review.
 
 For migrated source-installed curated plugins, apply writes:
 
@@ -187,11 +199,12 @@ For migrated source-installed curated plugins, apply writes:
   `pluginName` for each selected plugin
 
 Migration never writes `plugins["*"]` and never stores local marketplace cache
-paths. Source-side subscription and app-inventory failures are reported on manual
-items with typed reasons such as `codex_subscription_required`,
-`app_inaccessible`, `app_disabled`, `app_missing`, `plugin_disabled`,
-`plugin_read_unavailable`, or `app_inventory_unavailable`; those plugins are not
-written to target config.
+paths. Source-side subscription failures are reported on manual items with typed
+reasons such as `codex_subscription_required`, `codex_account_unavailable`,
+`plugin_disabled`, or `plugin_read_unavailable`. With `--verify-plugin-apps`,
+source app-inventory failures can also appear as `app_inaccessible`,
+`app_disabled`, `app_missing`, or `app_inventory_unavailable`. Skipped plugins
+are not written to target config.
 Target-side auth-required installs are reported on the affected plugin item with
 `status: "skipped"`, `reason: "auth_required"`, and sanitized app identifiers.
 Their explicit config entries are written disabled until you reauthorize and

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -170,11 +170,13 @@ openclaw migrate apply codex --yes --plugin google-calendar
   `--verify-plugin-apps` when you want migration to force a fresh source
   `app/list` snapshot and require every owned app to be present, enabled, and
   accessible before planning native activation. In that mode, account lookup
-  transport failures fall through to source app inventory verification. Disabled
-  plugins, unreadable plugin details, subscription-gated source accounts, and,
-  when verification is requested, missing apps, disabled apps, inaccessible
-  apps, or source app inventory failures become manual skipped items with typed
-  reasons instead of target config entries.
+  transport failures fall through to source app inventory verification. The
+  source app inventory snapshot is kept in memory for the current process; it
+  is not written to migration output or target config. Disabled plugins,
+  unreadable plugin details, subscription-gated source accounts, and, when
+  verification is requested, missing apps, disabled apps, inaccessible apps, or
+  source app inventory failures become manual skipped items with typed reasons
+  instead of target config entries.
   Apply calls app-server `plugin/install` for each selected eligible plugin,
   even if the target app-server already reports that plugin as installed and
   enabled. Migrated Codex plugins are usable only in sessions that select the

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -156,16 +156,23 @@ openclaw migrate apply codex --yes --plugin google-calendar
 - Personal AgentSkills under `$HOME/.agents/skills`, copied into the current
   OpenClaw agent workspace when you want per-agent ownership.
 - Source-installed `openai-curated` Codex plugins discovered through Codex
-  app-server `plugin/list`. Apply calls app-server `plugin/install` for each
-  selected plugin, even if the target app-server already reports that plugin as
-  installed and enabled. Migrated Codex plugins are usable only in sessions that
-  select the native Codex harness; they are not exposed to Pi, normal OpenAI
-  provider runs, ACP conversation bindings, or other harnesses.
+  app-server `plugin/list`. Planning reads `plugin/read` for each enabled
+  installed plugin. App-backed plugins are migratable only when a fresh source
+  `app/list` snapshot reports every owned app as present, enabled, accessible,
+  and not needing auth. Disabled plugins, unreadable plugin details, missing
+  apps, disabled apps, inaccessible apps, auth-required apps, and source app
+  inventory failures become manual skipped items with typed reasons instead of
+  target config entries. Apply calls app-server `plugin/install` for each
+  selected eligible plugin, even if the target app-server already reports that
+  plugin as installed and enabled. Migrated Codex plugins are usable only in
+  sessions that select the native Codex harness; they are not exposed to Pi,
+  normal OpenAI provider runs, ACP conversation bindings, or other harnesses.
 
 ### Manual-review Codex state
 
-Codex `config.toml`, native `hooks/hooks.json`, non-curated marketplaces, and
-cached plugin bundles that are not source-installed curated plugins are not
+Codex `config.toml`, native `hooks/hooks.json`, non-curated marketplaces,
+cached plugin bundles that are not source-installed curated plugins, and
+source-installed plugins that fail the source app-readiness gate are not
 activated automatically. They are copied or reported in the migration report for
 manual review.
 
@@ -178,7 +185,11 @@ For migrated source-installed curated plugins, apply writes:
   `pluginName` for each selected plugin
 
 Migration never writes `plugins["*"]` and never stores local marketplace cache
-paths. Auth-required installs are reported on the affected plugin item with
+paths. Source-side app-readiness failures are reported on manual items with
+typed reasons such as `app_inaccessible`, `app_disabled`, `app_missing`,
+`app_auth_required`, `plugin_disabled`, `plugin_read_unavailable`, or
+`app_inventory_unavailable`; those plugins are not written to target config.
+Target-side auth-required installs are reported on the affected plugin item with
 `status: "skipped"`, `reason: "auth_required"`, and sanitized app identifiers.
 Their explicit config entries are written disabled until you reauthorize and
 enable them. Other install failures are item-scoped `error` results.

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -158,15 +158,15 @@ openclaw migrate apply codex --yes --plugin google-calendar
 - Source-installed `openai-curated` Codex plugins discovered through Codex
   app-server `plugin/list`. Planning reads `plugin/read` for each enabled
   installed plugin. App-backed plugins are migratable only when a fresh source
-  `app/list` snapshot reports every owned app as present, enabled, accessible,
-  and not needing auth. Disabled plugins, unreadable plugin details, missing
-  apps, disabled apps, inaccessible apps, auth-required apps, and source app
-  inventory failures become manual skipped items with typed reasons instead of
-  target config entries. Apply calls app-server `plugin/install` for each
-  selected eligible plugin, even if the target app-server already reports that
-  plugin as installed and enabled. Migrated Codex plugins are usable only in
-  sessions that select the native Codex harness; they are not exposed to Pi,
-  normal OpenAI provider runs, ACP conversation bindings, or other harnesses.
+  `app/list` snapshot reports every owned app as present, enabled, and
+  accessible. Disabled plugins, unreadable plugin details, missing apps,
+  disabled apps, inaccessible apps, and source app inventory failures become
+  manual skipped items with typed reasons instead of target config entries.
+  Apply calls app-server `plugin/install` for each selected eligible plugin,
+  even if the target app-server already reports that plugin as installed and
+  enabled. Migrated Codex plugins are usable only in sessions that select the
+  native Codex harness; they are not exposed to Pi, normal OpenAI provider runs,
+  ACP conversation bindings, or other harnesses.
 
 ### Manual-review Codex state
 

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -157,11 +157,13 @@ openclaw migrate apply codex --yes --plugin google-calendar
   OpenClaw agent workspace when you want per-agent ownership.
 - Source-installed `openai-curated` Codex plugins discovered through Codex
   app-server `plugin/list`. Planning reads `plugin/read` for each enabled
-  installed plugin. App-backed plugins are migratable only when a fresh source
-  `app/list` snapshot reports every owned app as present, enabled, and
-  accessible. Disabled plugins, unreadable plugin details, missing apps,
-  disabled apps, inaccessible apps, and source app inventory failures become
-  manual skipped items with typed reasons instead of target config entries.
+  installed plugin. App-backed plugins are migratable only when the source Codex
+  app-server account is logged in with ChatGPT subscription auth and a fresh
+  source `app/list` snapshot reports every owned app as present, enabled, and
+  accessible. Disabled plugins, unreadable plugin details, subscription-gated
+  source accounts, missing apps, disabled apps, inaccessible apps, and source app
+  inventory failures become manual skipped items with typed reasons instead of
+  target config entries.
   Apply calls app-server `plugin/install` for each selected eligible plugin,
   even if the target app-server already reports that plugin as installed and
   enabled. Migrated Codex plugins are usable only in sessions that select the
@@ -170,11 +172,11 @@ openclaw migrate apply codex --yes --plugin google-calendar
 
 ### Manual-review Codex state
 
-Codex `config.toml`, native `hooks/hooks.json`, non-curated marketplaces,
-cached plugin bundles that are not source-installed curated plugins, and
-source-installed plugins that fail the source app-readiness gate are not
-activated automatically. They are copied or reported in the migration report for
-manual review.
+Codex `config.toml`, native `hooks/hooks.json`, non-curated marketplaces, cached
+plugin bundles that are not source-installed curated plugins, and source-installed
+plugins that fail the source subscription or app-inventory gates are not activated
+automatically. They are copied or reported in the migration report for manual
+review.
 
 For migrated source-installed curated plugins, apply writes:
 
@@ -185,10 +187,11 @@ For migrated source-installed curated plugins, apply writes:
   `pluginName` for each selected plugin
 
 Migration never writes `plugins["*"]` and never stores local marketplace cache
-paths. Source-side app-readiness failures are reported on manual items with
-typed reasons such as `app_inaccessible`, `app_disabled`, `app_missing`,
-`plugin_disabled`, `plugin_read_unavailable`, or `app_inventory_unavailable`;
-those plugins are not written to target config.
+paths. Source-side subscription and app-inventory failures are reported on manual
+items with typed reasons such as `codex_subscription_required`,
+`app_inaccessible`, `app_disabled`, `app_missing`, `plugin_disabled`,
+`plugin_read_unavailable`, or `app_inventory_unavailable`; those plugins are not
+written to target config.
 Target-side auth-required installs are reported on the affected plugin item with
 `status: "skipped"`, `reason: "auth_required"`, and sanitized app identifiers.
 Their explicit config entries are written disabled until you reauthorize and

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -187,8 +187,8 @@ For migrated source-installed curated plugins, apply writes:
 Migration never writes `plugins["*"]` and never stores local marketplace cache
 paths. Source-side app-readiness failures are reported on manual items with
 typed reasons such as `app_inaccessible`, `app_disabled`, `app_missing`,
-`app_auth_required`, `plugin_disabled`, `plugin_read_unavailable`, or
-`app_inventory_unavailable`; those plugins are not written to target config.
+`plugin_disabled`, `plugin_read_unavailable`, or `app_inventory_unavailable`;
+those plugins are not written to target config.
 Target-side auth-required installs are reported on the affected plugin item with
 `status: "skipped"`, `reason: "auth_required"`, and sanitized app identifiers.
 Their explicit config entries are written disabled until you reauthorize and

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -135,7 +135,18 @@ V1 is intentionally narrow:
 ## App inventory and ownership
 
 OpenClaw reads Codex app inventory through app-server `app/list`, caches it for
-one hour, and refreshes stale or missing entries asynchronously.
+one hour, and refreshes stale or missing entries asynchronously. The cache is
+in memory only; restarting the CLI or gateway drops it, and OpenClaw rebuilds it
+from the next `app/list` read.
+
+Migration and runtime use separate cache keys:
+
+- Source migration verification uses the source Codex home and source app-server
+  start options. This runs only when `--verify-plugin-apps` is set, and it
+  forces a fresh source `app/list` traversal for that planning run.
+- Target runtime setup uses the target agent's Codex app-server identity when it
+  builds the Codex thread app config. Plugin activation invalidates that target
+  cache key and then force-refreshes it after `plugin/install`.
 
 A plugin app is exposed only when OpenClaw can map it back to the migrated
 plugin through stable ownership:

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -88,12 +88,13 @@ The integration has three separate states:
   for the active account and can be mapped to the migrated plugin identity.
 
 Migration is the durable install/eligibility step. During planning, OpenClaw
-reads source Codex `plugin/read` details and takes a fresh source `app/list`
-snapshot. App-backed source plugins are eligible only when every owned app is
-present, enabled, and accessible in that fresh source snapshot. Runtime app
-inventory is the target-session accessibility check after migration. Codex
-harness session setup then computes a restrictive thread app config for the
-enabled and accessible plugin apps.
+reads source Codex `plugin/read` details, checks that the source Codex app-server
+account is logged in with ChatGPT subscription auth, and takes a fresh source
+`app/list` snapshot. App-backed source plugins are eligible only when the
+subscription check passes and every owned app is present, enabled, and accessible
+in that fresh source snapshot. Runtime app inventory is the target-session
+accessibility check after migration. Codex harness session setup then computes a
+restrictive thread app config for the enabled and accessible plugin apps.
 
 Thread app config is computed when OpenClaw establishes a Codex harness session
 or replaces a stale Codex thread binding. It is not recomputed on every turn.
@@ -104,9 +105,10 @@ V1 is intentionally narrow:
 
 - Only `openai-curated` plugins that were already installed in the source Codex
   app-server inventory are migration-eligible.
-- App-backed source plugins must pass the migration-time app-readiness gate.
-  Inaccessible, disabled, missing, unreadable, or stale source app state is
-  reported as a skipped manual item instead of an enabled config entry.
+- App-backed source plugins must pass the migration-time subscription and
+  app-inventory gates. Subscription-gated accounts plus inaccessible, disabled,
+  missing, unreadable, or stale source app state are reported as skipped manual
+  items instead of enabled config entries.
 - Migration writes explicit plugin identities with `marketplaceName` and
   `pluginName`; it does not write local `marketplacePath` cache paths.
 - `codexPlugins.enabled` is the global enablement switch.
@@ -170,8 +172,13 @@ reauthorize and enable it.
 
 **`app_inaccessible`, `app_disabled`, or `app_missing`:**
 migration did not install the plugin because the source Codex app inventory did
-not show all owned apps as ready. Reauthorize or enable the app in Codex, then
-rerun migration.
+not show all owned apps as present, enabled, and accessible. Reauthorize or
+enable the app in Codex, then rerun migration.
+
+**`codex_subscription_required`:** migration did not install the app-backed
+plugin because the source Codex app-server account was not logged in with a
+ChatGPT subscription account. Log in to the Codex app with subscription auth,
+then rerun migration.
 
 **`marketplace_missing` or `plugin_missing`:** the target Codex app-server
 cannot see the expected `openai-curated` marketplace or plugin. Rerun migration

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -39,6 +39,13 @@ Preview migration from the source Codex home:
 openclaw migrate codex --dry-run
 ```
 
+Use strict source app verification when you want migration to check source app
+accessibility before planning native plugin activation:
+
+```bash
+openclaw migrate codex --dry-run --verify-plugin-apps
+```
+
 Apply the migration when the plan looks right:
 
 ```bash
@@ -88,13 +95,19 @@ The integration has three separate states:
   for the active account and can be mapped to the migrated plugin identity.
 
 Migration is the durable install/eligibility step. During planning, OpenClaw
-reads source Codex `plugin/read` details, checks that the source Codex app-server
-account is logged in with ChatGPT subscription auth, and takes a fresh source
-`app/list` snapshot. App-backed source plugins are eligible only when the
-subscription check passes and every owned app is present, enabled, and accessible
-in that fresh source snapshot. Runtime app inventory is the target-session
-accessibility check after migration. Codex harness session setup then computes a
-restrictive thread app config for the enabled and accessible plugin apps.
+reads source Codex `plugin/read` details and checks that the source Codex
+app-server account response is a ChatGPT subscription account. Non-ChatGPT or
+missing account responses skip app-backed plugins with
+`codex_subscription_required`. By default, migration does not call source
+`app/list`; app-backed source plugins that pass the account gate are planned
+without source app accessibility verification, and account lookup transport
+failures skip with `codex_account_unavailable`. With `--verify-plugin-apps`,
+migration takes a fresh source `app/list` snapshot and requires every owned app
+to be present, enabled, and accessible before planning native activation. In
+that mode, account lookup transport failures fall through to the source
+app-inventory gate. Runtime app inventory is the target-session accessibility
+check after migration. Codex harness session setup then computes a restrictive
+thread app config for the enabled and accessible plugin apps.
 
 Thread app config is computed when OpenClaw establishes a Codex harness session
 or replaces a stale Codex thread binding. It is not recomputed on every turn.
@@ -105,10 +118,12 @@ V1 is intentionally narrow:
 
 - Only `openai-curated` plugins that were already installed in the source Codex
   app-server inventory are migration-eligible.
-- App-backed source plugins must pass the migration-time subscription and
-  app-inventory gates. Subscription-gated accounts plus inaccessible, disabled,
-  missing, unreadable, or stale source app state are reported as skipped manual
-  items instead of enabled config entries.
+- App-backed source plugins must pass the migration-time subscription gate.
+  `--verify-plugin-apps` adds the source app-inventory gate. Subscription-gated
+  accounts plus, in verification mode, inaccessible, disabled, missing source
+  apps or source app-inventory refresh failures are reported as skipped manual
+  items instead of enabled config entries. Unreadable plugin details are skipped
+  before the source app-inventory gate.
 - Migration writes explicit plugin identities with `marketplaceName` and
   `pluginName`; it does not write local `marketplacePath` cache paths.
 - `codexPlugins.enabled` is the global enablement switch.
@@ -172,13 +187,24 @@ reauthorize and enable it.
 
 **`app_inaccessible`, `app_disabled`, or `app_missing`:**
 migration did not install the plugin because the source Codex app inventory did
-not show all owned apps as present, enabled, and accessible. Reauthorize or
-enable the app in Codex, then rerun migration.
+not show all owned apps as present, enabled, and accessible while
+`--verify-plugin-apps` was set. Reauthorize or enable the app in Codex, then
+rerun migration with `--verify-plugin-apps`.
+
+**`app_inventory_unavailable`:** migration did not install the plugin because
+strict source app verification was requested and source Codex app inventory
+refresh failed. Fix source Codex app-server access or retry without
+`--verify-plugin-apps` if you accept the faster account-gated plan.
 
 **`codex_subscription_required`:** migration did not install the app-backed
 plugin because the source Codex app-server account was not logged in with a
 ChatGPT subscription account. Log in to the Codex app with subscription auth,
 then rerun migration.
+
+**`codex_account_unavailable`:** migration did not install the app-backed plugin
+because the source Codex app-server account could not be read. Fix source Codex
+app-server auth or rerun with `--verify-plugin-apps` if you want source app
+inventory to decide eligibility when account lookup fails.
 
 **`marketplace_missing` or `plugin_missing`:** the target Codex app-server
 cannot see the expected `openai-curated` marketplace or plugin. Rerun migration

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -87,9 +87,13 @@ The integration has three separate states:
 - Accessible: Codex app-server confirms the plugin's app entries are available
   for the active account and can be mapped to the migrated plugin identity.
 
-Migration is the durable install/eligibility step. Runtime app inventory is the
-accessibility check. Codex harness session setup then computes a restrictive
-thread app config for the enabled and accessible plugin apps.
+Migration is the durable install/eligibility step. During planning, OpenClaw
+reads source Codex `plugin/read` details and takes a fresh source `app/list`
+snapshot. App-backed source plugins are eligible only when every owned app is
+present, enabled, accessible, and not auth-required in that fresh source
+snapshot. Runtime app inventory is the target-session accessibility check after
+migration. Codex harness session setup then computes a restrictive thread app
+config for the enabled and accessible plugin apps.
 
 Thread app config is computed when OpenClaw establishes a Codex harness session
 or replaces a stale Codex thread binding. It is not recomputed on every turn.
@@ -100,6 +104,10 @@ V1 is intentionally narrow:
 
 - Only `openai-curated` plugins that were already installed in the source Codex
   app-server inventory are migration-eligible.
+- App-backed source plugins must pass the migration-time app-readiness gate.
+  Inaccessible, disabled, missing, auth-required, unreadable, or stale source
+  app state is reported as a skipped manual item instead of an enabled config
+  entry.
 - Migration writes explicit plugin identities with `marketplaceName` and
   `pluginName`; it does not write local `marketplacePath` cache paths.
 - `codexPlugins.enabled` is the global enablement switch.
@@ -160,6 +168,11 @@ plugins, while unsafe schemas and ambiguous ownership still fail closed:
 **`auth_required`:** migration installed the plugin, but one of its apps still
 needs authentication. The explicit plugin entry is written disabled until you
 reauthorize and enable it.
+
+**`app_inaccessible`, `app_disabled`, `app_missing`, or `app_auth_required`:**
+migration did not install the plugin because the source Codex app inventory did
+not show all owned apps as ready. Reauthorize or enable the app in Codex, then
+rerun migration.
 
 **`marketplace_missing` or `plugin_missing`:** the target Codex app-server
 cannot see the expected `openai-curated` marketplace or plugin. Rerun migration

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -90,10 +90,10 @@ The integration has three separate states:
 Migration is the durable install/eligibility step. During planning, OpenClaw
 reads source Codex `plugin/read` details and takes a fresh source `app/list`
 snapshot. App-backed source plugins are eligible only when every owned app is
-present, enabled, accessible, and not auth-required in that fresh source
-snapshot. Runtime app inventory is the target-session accessibility check after
-migration. Codex harness session setup then computes a restrictive thread app
-config for the enabled and accessible plugin apps.
+present, enabled, and accessible in that fresh source snapshot. Runtime app
+inventory is the target-session accessibility check after migration. Codex
+harness session setup then computes a restrictive thread app config for the
+enabled and accessible plugin apps.
 
 Thread app config is computed when OpenClaw establishes a Codex harness session
 or replaces a stale Codex thread binding. It is not recomputed on every turn.
@@ -105,9 +105,8 @@ V1 is intentionally narrow:
 - Only `openai-curated` plugins that were already installed in the source Codex
   app-server inventory are migration-eligible.
 - App-backed source plugins must pass the migration-time app-readiness gate.
-  Inaccessible, disabled, missing, auth-required, unreadable, or stale source
-  app state is reported as a skipped manual item instead of an enabled config
-  entry.
+  Inaccessible, disabled, missing, unreadable, or stale source app state is
+  reported as a skipped manual item instead of an enabled config entry.
 - Migration writes explicit plugin identities with `marketplaceName` and
   `pluginName`; it does not write local `marketplacePath` cache paths.
 - `codexPlugins.enabled` is the global enablement switch.

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -168,7 +168,7 @@ plugins, while unsafe schemas and ambiguous ownership still fail closed:
 needs authentication. The explicit plugin entry is written disabled until you
 reauthorize and enable it.
 
-**`app_inaccessible`, `app_disabled`, `app_missing`, or `app_auth_required`:**
+**`app_inaccessible`, `app_disabled`, or `app_missing`:**
 migration did not install the plugin because the source Codex app inventory did
 not show all owned apps as ready. Reauthorize or enable the app in Codex, then
 rerun migration.

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -550,6 +550,25 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
+  it("leaves native app-server auth untouched when auth bridging is disabled", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const request = vi.fn(async () => ({ requiresOpenaiAuth: true }));
+    try {
+      vi.stubEnv("OPENAI_API_KEY", "env-api-key");
+
+      await applyCodexAppServerAuthProfile({
+        client: { request } as never,
+        agentDir,
+        authProfileId: null,
+        startOptions: createStartOptions(),
+      });
+
+      expect(request).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("applies a normal OpenAI API-key profile as a Codex app-server backup", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const request = vi.fn(async () => ({ type: "apiKey" }));

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -42,7 +42,7 @@ type AuthProfileOrderConfig = Parameters<typeof resolveAuthProfileOrder>[0]["cfg
 export async function bridgeCodexAppServerStartOptions(params: {
   startOptions: CodexAppServerStartOptions;
   agentDir: string;
-  authProfileId?: string;
+  authProfileId?: string | null;
   config?: AuthProfileOrderConfig;
 }): Promise<CodexAppServerStartOptions> {
   if (params.startOptions.transport !== "stdio") {
@@ -52,6 +52,9 @@ export async function bridgeCodexAppServerStartOptions(params: {
     params.startOptions,
     params.agentDir,
   );
+  if (params.authProfileId === null) {
+    return isolatedStartOptions;
+  }
   const store = ensureCodexAppServerAuthProfileStore({
     agentDir: params.agentDir,
     authProfileId: params.authProfileId,
@@ -291,10 +294,13 @@ function withoutClearedCodexIsolationEnv(clearEnv: string[] | undefined): string
 export async function applyCodexAppServerAuthProfile(params: {
   client: CodexAppServerClient;
   agentDir: string;
-  authProfileId?: string;
+  authProfileId?: string | null;
   startOptions?: CodexAppServerStartOptions;
   config?: AuthProfileOrderConfig;
 }): Promise<void> {
+  if (params.authProfileId === null) {
+    return;
+  }
   const loginParams = await resolveCodexAppServerAuthProfileLoginParams({
     agentDir: params.agentDir,
     authProfileId: params.authProfileId,

--- a/extensions/codex/src/app-server/plugin-app-cache-key.ts
+++ b/extensions/codex/src/app-server/plugin-app-cache-key.ts
@@ -1,0 +1,74 @@
+import { createHash } from "node:crypto";
+import {
+  buildCodexAppInventoryCacheKey,
+  type CodexAppInventoryCacheKeyInput,
+} from "./app-inventory-cache.js";
+import { resolveCodexAppServerHomeDir } from "./auth-bridge.js";
+import type { CodexAppServerRuntimeOptions, CodexAppServerStartOptions } from "./config.js";
+
+export type CodexPluginAppCacheKeyParams = Omit<
+  CodexAppInventoryCacheKeyInput,
+  "codexHome" | "endpoint"
+> & {
+  appServer: Pick<CodexAppServerRuntimeOptions, "start">;
+  agentDir?: string;
+};
+
+export function buildCodexPluginAppCacheKey(params: CodexPluginAppCacheKeyParams): string {
+  return buildCodexAppInventoryCacheKey({
+    codexHome: resolveCodexPluginAppCacheCodexHome(params.appServer, params.agentDir),
+    endpoint: resolveCodexPluginAppCacheEndpoint(params.appServer),
+    authProfileId: params.authProfileId,
+    accountId: params.accountId,
+    envApiKeyFingerprint: params.envApiKeyFingerprint,
+    appServerVersion: params.appServerVersion,
+  });
+}
+
+export function resolveCodexPluginAppCacheEndpoint(
+  appServer: Pick<CodexAppServerRuntimeOptions, "start">,
+): string {
+  return JSON.stringify({
+    transport: appServer.start.transport,
+    command: appServer.start.command,
+    args: appServer.start.args,
+    url: appServer.start.url ?? null,
+    credentialFingerprint: fingerprintCodexPluginAppCacheCredentials(appServer.start),
+  });
+}
+
+export function resolveCodexPluginAppCacheCodexHome(
+  appServer: Pick<CodexAppServerRuntimeOptions, "start">,
+  agentDir?: string,
+): string | undefined {
+  const configuredCodexHome = appServer.start.env?.CODEX_HOME?.trim();
+  if (configuredCodexHome) {
+    return configuredCodexHome;
+  }
+  return appServer.start.transport === "stdio" && agentDir
+    ? resolveCodexAppServerHomeDir(agentDir)
+    : undefined;
+}
+
+function fingerprintCodexPluginAppCacheCredentials(
+  startOptions: CodexAppServerStartOptions,
+): string | null {
+  const authToken = startOptions.authToken ?? "";
+  const headers = Object.entries(startOptions.headers)
+    .map(([key, value]) => [key.toLowerCase(), value] as const)
+    .toSorted(([left], [right]) => left.localeCompare(right));
+  if (!authToken && headers.length === 0) {
+    return null;
+  }
+  const hash = createHash("sha256");
+  hash.update("openclaw:codex:plugin-app-cache-credentials:v1");
+  hash.update("\0");
+  hash.update(authToken);
+  for (const [key, value] of headers) {
+    hash.update("\0");
+    hash.update(key);
+    hash.update("\0");
+    hash.update(value);
+  }
+  return `sha256:${hash.digest("hex")}`;
+}

--- a/extensions/codex/src/app-server/request.ts
+++ b/extensions/codex/src/app-server/request.ts
@@ -17,7 +17,7 @@ export async function requestCodexAppServerJson<M extends CodexAppServerRequestM
   requestParams: CodexAppServerRequestParams<M>;
   timeoutMs?: number;
   startOptions?: CodexAppServerStartOptions;
-  authProfileId?: string;
+  authProfileId?: string | null;
   agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
   isolated?: boolean;
@@ -27,7 +27,7 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
   requestParams?: unknown;
   timeoutMs?: number;
   startOptions?: CodexAppServerStartOptions;
-  authProfileId?: string;
+  authProfileId?: string | null;
   agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
   isolated?: boolean;
@@ -37,7 +37,7 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
   requestParams?: unknown;
   timeoutMs?: number;
   startOptions?: CodexAppServerStartOptions;
-  authProfileId?: string;
+  authProfileId?: string | null;
   agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
   isolated?: boolean;

--- a/extensions/codex/src/app-server/request.ts
+++ b/extensions/codex/src/app-server/request.ts
@@ -18,6 +18,7 @@ export async function requestCodexAppServerJson<M extends CodexAppServerRequestM
   timeoutMs?: number;
   startOptions?: CodexAppServerStartOptions;
   authProfileId?: string;
+  agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
   isolated?: boolean;
 }): Promise<CodexAppServerRequestResult<M>>;
@@ -27,6 +28,7 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
   timeoutMs?: number;
   startOptions?: CodexAppServerStartOptions;
   authProfileId?: string;
+  agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
   isolated?: boolean;
 }): Promise<T>;
@@ -36,6 +38,7 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
   timeoutMs?: number;
   startOptions?: CodexAppServerStartOptions;
   authProfileId?: string;
+  agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
   isolated?: boolean;
 }): Promise<T> {
@@ -48,6 +51,7 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
         startOptions: params.startOptions,
         timeoutMs,
         authProfileId: params.authProfileId,
+        agentDir: params.agentDir,
         config: params.config,
       });
       try {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -25,20 +25,18 @@ function queueActiveRunMessageForTest(
   return queueAgentHarnessMessage(...args);
 }
 import { CODEX_GPT5_BEHAVIOR_CONTRACT } from "../../prompt-overlay.js";
-import {
-  buildCodexAppInventoryCacheKey,
-  defaultCodexAppInventoryCache,
-} from "./app-inventory-cache.js";
-import {
-  resolveCodexAppServerEnvApiKeyCacheKey,
-  resolveCodexAppServerHomeDir,
-} from "./auth-bridge.js";
+import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
+import { resolveCodexAppServerEnvApiKeyCacheKey } from "./auth-bridge.js";
 import { readCodexPluginConfig, resolveCodexAppServerRuntimeOptions } from "./config.js";
 import {
   CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
   createCodexDynamicToolBridge,
 } from "./dynamic-tools.js";
 import * as elicitationBridge from "./elicitation-bridge.js";
+import {
+  buildCodexPluginAppCacheKey,
+  resolveCodexPluginAppCacheEndpoint,
+} from "./plugin-app-cache-key.js";
 import type { CodexServerNotification } from "./protocol.js";
 import { rememberCodexRateLimits, resetCodexRateLimitCacheForTests } from "./rate-limit-cache.js";
 import { runCodexAppServerAttempt, __testing } from "./run-attempt.js";
@@ -3210,9 +3208,9 @@ describe("runCodexAppServerAttempt", () => {
     });
     defaultCodexAppInventoryCache.clear();
     await defaultCodexAppInventoryCache.refreshNow({
-      key: buildCodexAppInventoryCacheKey({
-        codexHome: resolveCodexAppServerHomeDir(agentDir),
-        endpoint: __testing.resolveCodexPluginAppCacheEndpoint(appServer),
+      key: buildCodexPluginAppCacheKey({
+        appServer,
+        agentDir,
       }),
       request: async () => ({
         data: [
@@ -3412,9 +3410,9 @@ describe("runCodexAppServerAttempt", () => {
     });
     defaultCodexAppInventoryCache.clear();
     await defaultCodexAppInventoryCache.refreshNow({
-      key: buildCodexAppInventoryCacheKey({
-        codexHome: resolveCodexAppServerHomeDir(agentDir),
-        endpoint: __testing.resolveCodexPluginAppCacheEndpoint(appServer),
+      key: buildCodexPluginAppCacheKey({
+        appServer,
+        agentDir,
         authProfileId,
         accountId: "account-work",
       }),
@@ -3553,9 +3551,9 @@ describe("runCodexAppServerAttempt", () => {
     });
     defaultCodexAppInventoryCache.clear();
     await defaultCodexAppInventoryCache.refreshNow({
-      key: buildCodexAppInventoryCacheKey({
-        codexHome: resolveCodexAppServerHomeDir(agentDir),
-        endpoint: __testing.resolveCodexPluginAppCacheEndpoint(appServer),
+      key: buildCodexPluginAppCacheKey({
+        appServer,
+        agentDir,
         envApiKeyFingerprint: resolveCodexAppServerEnvApiKeyCacheKey({
           startOptions: appServer.start,
           baseEnv: { CODEX_API_KEY: "old-codex-env-key" },
@@ -4723,7 +4721,7 @@ describe("runCodexAppServerAttempt", () => {
   });
 
   it("keys plugin app inventory by websocket credentials without exposing them", () => {
-    const first = __testing.resolveCodexPluginAppCacheEndpoint({
+    const first = resolveCodexPluginAppCacheEndpoint({
       start: {
         transport: "websocket",
         command: "codex",
@@ -4732,13 +4730,8 @@ describe("runCodexAppServerAttempt", () => {
         authToken: "token-first",
         headers: { Authorization: "Bearer first" },
       },
-      requestTimeoutMs: 60_000,
-      turnCompletionIdleTimeoutMs: 5,
-      approvalPolicy: "never",
-      approvalsReviewer: "user",
-      sandbox: "workspace-write",
     });
-    const second = __testing.resolveCodexPluginAppCacheEndpoint({
+    const second = resolveCodexPluginAppCacheEndpoint({
       start: {
         transport: "websocket",
         command: "codex",
@@ -4747,11 +4740,6 @@ describe("runCodexAppServerAttempt", () => {
         authToken: "token-second",
         headers: { Authorization: "Bearer second" },
       },
-      requestTimeoutMs: 60_000,
-      turnCompletionIdleTimeoutMs: 5,
-      approvalPolicy: "never",
-      approvalsReviewer: "user",
-      sandbox: "workspace-write",
     });
 
     expect(first).not.toEqual(second);

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -41,16 +41,12 @@ import {
 import { markAuthProfileBlockedUntil, resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { pathExists } from "openclaw/plugin-sdk/security-runtime";
-import {
-  buildCodexAppInventoryCacheKey,
-  defaultCodexAppInventoryCache,
-} from "./app-inventory-cache.js";
+import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
 import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
 import {
   refreshCodexAppServerAuthTokens,
   resolveCodexAppServerAuthAccountCacheKey,
   resolveCodexAppServerEnvApiKeyCacheKey,
-  resolveCodexAppServerHomeDir,
   resolveCodexAppServerAuthProfileId,
   resolveCodexAppServerAuthProfileIdForAgent,
 } from "./auth-bridge.js";
@@ -87,6 +83,7 @@ import {
   buildCodexNativeHookRelayConfig,
   CODEX_NATIVE_HOOK_RELAY_EVENTS,
 } from "./native-hook-relay.js";
+import { buildCodexPluginAppCacheKey } from "./plugin-app-cache-key.js";
 import {
   buildCodexPluginThreadConfig,
   buildCodexPluginThreadConfigInputFingerprint,
@@ -390,50 +387,6 @@ function toCodexTextInput(text: string): CodexUserInput {
   return { type: "text", text, text_elements: [] };
 }
 
-function resolveCodexPluginAppCacheEndpoint(appServer: CodexAppServerRuntimeOptions): string {
-  return JSON.stringify({
-    transport: appServer.start.transport,
-    command: appServer.start.command,
-    args: appServer.start.args,
-    url: appServer.start.url ?? null,
-    credentialFingerprint: fingerprintCodexPluginAppCacheCredentials(appServer.start),
-  });
-}
-
-function fingerprintCodexPluginAppCacheCredentials(
-  startOptions: CodexAppServerRuntimeOptions["start"],
-): string | null {
-  const authToken = startOptions.authToken ?? "";
-  const headers = Object.entries(startOptions.headers)
-    .map(([key, value]) => [key.toLowerCase(), value] as const)
-    .toSorted(([left], [right]) => left.localeCompare(right));
-  if (!authToken && headers.length === 0) {
-    return null;
-  }
-  const hash = createHash("sha256");
-  hash.update("openclaw:codex:plugin-app-cache-credentials:v1");
-  hash.update("\0");
-  hash.update(authToken);
-  for (const [key, value] of headers) {
-    hash.update("\0");
-    hash.update(key);
-    hash.update("\0");
-    hash.update(value);
-  }
-  return `sha256:${hash.digest("hex")}`;
-}
-
-function resolveCodexPluginAppCacheCodexHome(
-  appServer: CodexAppServerRuntimeOptions,
-  agentDir: string,
-): string | undefined {
-  const configuredCodexHome = appServer.start.env?.CODEX_HOME?.trim();
-  if (configuredCodexHome) {
-    return configuredCodexHome;
-  }
-  return appServer.start.transport === "stdio" ? resolveCodexAppServerHomeDir(agentDir) : undefined;
-}
-
 function restrictCodexAppServerSandboxForOpenClawSandbox(
   appServer: CodexAppServerRuntimeOptions,
   sandbox: Awaited<ReturnType<typeof resolveSandboxContext>>,
@@ -732,9 +685,9 @@ export async function runCodexAppServerAttempt(
         : undefined;
     const threadConfig = nativeHookRelayConfig;
     const pluginThreadConfigEnabled = shouldBuildCodexPluginThreadConfig(pluginConfig);
-    const pluginAppCacheKey = buildCodexAppInventoryCacheKey({
-      codexHome: resolveCodexPluginAppCacheCodexHome(appServer, agentDir),
-      endpoint: resolveCodexPluginAppCacheEndpoint(appServer),
+    const pluginAppCacheKey = buildCodexPluginAppCacheKey({
+      appServer,
+      agentDir,
       authProfileId: startupAuthProfileId,
       accountId: startupAuthAccountCacheKey,
       envApiKeyFingerprint: startupEnvApiKeyCacheKey,
@@ -2978,7 +2931,6 @@ export const __testing = {
   filterToolsForVisionInputs,
   handleDynamicToolCallWithTimeout,
   resolveDynamicToolCallTimeoutMs,
-  resolveCodexPluginAppCacheEndpoint,
   restrictCodexAppServerSandboxForOpenClawSandbox,
   resolveOpenClawCodingToolsSessionKeys,
   shouldForceMessageTool,

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -39,6 +39,7 @@ let listCodexAppServerModels: typeof import("./models.js").listCodexAppServerMod
 let clearSharedCodexAppServerClient: typeof import("./shared-client.js").clearSharedCodexAppServerClient;
 let clearSharedCodexAppServerClientIfCurrent: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrent;
 let createIsolatedCodexAppServerClient: typeof import("./shared-client.js").createIsolatedCodexAppServerClient;
+let getSharedCodexAppServerClient: typeof import("./shared-client.js").getSharedCodexAppServerClient;
 let resetSharedCodexAppServerClientForTests: typeof import("./shared-client.js").resetSharedCodexAppServerClientForTests;
 
 async function sendInitializeResult(
@@ -63,6 +64,7 @@ describe("shared Codex app-server client", () => {
       clearSharedCodexAppServerClient,
       clearSharedCodexAppServerClientIfCurrent,
       createIsolatedCodexAppServerClient,
+      getSharedCodexAppServerClient,
       resetSharedCodexAppServerClientForTests,
     } = await import("./shared-client.js"));
   });
@@ -149,6 +151,39 @@ describe("shared Codex app-server client", () => {
     expect(bridgeCall?.authProfileId).toBe("openai-codex:work");
     const [applyCall] = mocks.applyCodexAppServerAuthProfile.mock.calls[0] ?? [];
     expect(applyCall?.authProfileId).toBe("openai-codex:work");
+  });
+
+  it("skips target auth resolution when native source auth is requested", async () => {
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+    const config = { auth: { order: { "openai-codex": ["openai-codex:target"] } } };
+
+    const clientPromise = getSharedCodexAppServerClient({
+      timeoutMs: 1000,
+      authProfileId: null,
+      agentDir: "/tmp/openclaw-target-agent",
+      config,
+    });
+    await sendInitializeResult(harness, "openclaw/0.125.0 (macOS; test)");
+
+    await expect(clientPromise).resolves.toBe(harness.client);
+    expect(mocks.resolveCodexAppServerAuthProfileIdForAgent).not.toHaveBeenCalled();
+    const [bridgeCall] = mocks.bridgeCodexAppServerStartOptions.mock.calls[0] ?? [];
+    expect(bridgeCall).toEqual(
+      expect.objectContaining({
+        agentDir: "/tmp/openclaw-target-agent",
+        authProfileId: null,
+        config,
+      }),
+    );
+    const [applyCall] = mocks.applyCodexAppServerAuthProfile.mock.calls[0] ?? [];
+    expect(applyCall).toEqual(
+      expect.objectContaining({
+        agentDir: "/tmp/openclaw-target-agent",
+        authProfileId: null,
+        config,
+      }),
+    );
   });
 
   it("resolves the configured implicit auth profile before sharing a client", async () => {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -39,7 +39,8 @@ export async function getSharedCodexAppServerClient(options?: {
   const state = getSharedCodexAppServerClientState();
   const agentDir = options?.agentDir ?? resolveDefaultAgentDir(options?.config ?? {});
   const usesNativeAuth = options?.authProfileId === null;
-  const requestedAuthProfileId = usesNativeAuth ? undefined : options?.authProfileId;
+  const requestedAuthProfileId =
+    options?.authProfileId === null ? undefined : options?.authProfileId;
   const authProfileId = usesNativeAuth
     ? undefined
     : resolveCodexAppServerAuthProfileIdForAgent({
@@ -110,7 +111,8 @@ export async function createIsolatedCodexAppServerClient(options?: {
 }): Promise<CodexAppServerClient> {
   const agentDir = options?.agentDir ?? resolveDefaultAgentDir(options?.config ?? {});
   const usesNativeAuth = options?.authProfileId === null;
-  const requestedAuthProfileId = usesNativeAuth ? undefined : options?.authProfileId;
+  const requestedAuthProfileId =
+    options?.authProfileId === null ? undefined : options?.authProfileId;
   const authProfileId = usesNativeAuth
     ? undefined
     : resolveCodexAppServerAuthProfileIdForAgent({

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -32,29 +32,33 @@ function getSharedCodexAppServerClientState(): SharedCodexAppServerClientState {
 export async function getSharedCodexAppServerClient(options?: {
   startOptions?: CodexAppServerStartOptions;
   timeoutMs?: number;
-  authProfileId?: string;
+  authProfileId?: string | null;
   agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
 }): Promise<CodexAppServerClient> {
   const state = getSharedCodexAppServerClientState();
   const agentDir = options?.agentDir ?? resolveDefaultAgentDir(options?.config ?? {});
-  const authProfileId = resolveCodexAppServerAuthProfileIdForAgent({
-    authProfileId: options?.authProfileId,
-    agentDir,
-    config: options?.config,
-  });
+  const usesNativeAuth = options?.authProfileId === null;
+  const requestedAuthProfileId = usesNativeAuth ? undefined : options?.authProfileId;
+  const authProfileId = usesNativeAuth
+    ? undefined
+    : resolveCodexAppServerAuthProfileIdForAgent({
+        authProfileId: requestedAuthProfileId,
+        agentDir,
+        config: options?.config,
+      });
   const requestedStartOptions =
     options?.startOptions ?? resolveCodexAppServerRuntimeOptions().start;
   const managedStartOptions = await resolveManagedCodexAppServerStartOptions(requestedStartOptions);
   const startOptions = await bridgeCodexAppServerStartOptions({
     startOptions: managedStartOptions,
     agentDir,
-    authProfileId,
+    authProfileId: usesNativeAuth ? null : authProfileId,
     config: options?.config,
   });
   const key = codexAppServerStartOptionsKey(startOptions, {
     authProfileId,
-    agentDir,
+    agentDir: usesNativeAuth ? undefined : agentDir,
   });
   if (state.key && state.key !== key) {
     clearSharedCodexAppServerClient();
@@ -71,7 +75,7 @@ export async function getSharedCodexAppServerClient(options?: {
         await applyCodexAppServerAuthProfile({
           client,
           agentDir,
-          authProfileId,
+          authProfileId: usesNativeAuth ? null : authProfileId,
           startOptions,
           config: options?.config,
         });
@@ -100,23 +104,27 @@ export async function getSharedCodexAppServerClient(options?: {
 export async function createIsolatedCodexAppServerClient(options?: {
   startOptions?: CodexAppServerStartOptions;
   timeoutMs?: number;
-  authProfileId?: string;
+  authProfileId?: string | null;
   agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
 }): Promise<CodexAppServerClient> {
   const agentDir = options?.agentDir ?? resolveDefaultAgentDir(options?.config ?? {});
-  const authProfileId = resolveCodexAppServerAuthProfileIdForAgent({
-    authProfileId: options?.authProfileId,
-    agentDir,
-    config: options?.config,
-  });
+  const usesNativeAuth = options?.authProfileId === null;
+  const requestedAuthProfileId = usesNativeAuth ? undefined : options?.authProfileId;
+  const authProfileId = usesNativeAuth
+    ? undefined
+    : resolveCodexAppServerAuthProfileIdForAgent({
+        authProfileId: requestedAuthProfileId,
+        agentDir,
+        config: options?.config,
+      });
   const requestedStartOptions =
     options?.startOptions ?? resolveCodexAppServerRuntimeOptions().start;
   const managedStartOptions = await resolveManagedCodexAppServerStartOptions(requestedStartOptions);
   const startOptions = await bridgeCodexAppServerStartOptions({
     startOptions: managedStartOptions,
     agentDir,
-    authProfileId,
+    authProfileId: usesNativeAuth ? null : authProfileId,
     config: options?.config,
   });
   const client = CodexAppServerClient.start(startOptions);
@@ -126,7 +134,7 @@ export async function createIsolatedCodexAppServerClient(options?: {
     await applyCodexAppServerAuthProfile({
       client,
       agentDir,
-      authProfileId,
+      authProfileId: usesNativeAuth ? null : authProfileId,
       startOptions,
       config: options?.config,
     });

--- a/extensions/codex/src/migration/apply.ts
+++ b/extensions/codex/src/migration/apply.ts
@@ -22,13 +22,21 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { defaultCodexAppInventoryCache } from "../app-server/app-inventory-cache.js";
 import {
+  resolveCodexAppServerAuthAccountCacheKey,
+  resolveCodexAppServerAuthProfileIdForAgent,
+  resolveCodexAppServerEnvApiKeyCacheKey,
+} from "../app-server/auth-bridge.js";
+import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
+  readCodexPluginConfig,
+  resolveCodexAppServerRuntimeOptions,
   type ResolvedCodexPluginPolicy,
 } from "../app-server/config.js";
 import {
   ensureCodexPluginActivation,
   type CodexPluginActivationResult,
 } from "../app-server/plugin-activation.js";
+import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
 import type { v2 } from "../app-server/protocol.js";
 import { requestCodexAppServerJson } from "../app-server/request.js";
 import { buildCodexMigrationPlan } from "./plan.js";
@@ -40,6 +48,7 @@ import {
   readCodexPluginMigrationConfigEntry,
   type CodexPluginMigrationConfigEntry,
 } from "./plan.js";
+import { resolveCodexMigrationTargets } from "./targets.js";
 
 const CODEX_PLUGIN_AUTH_REQUIRED_REASON = "auth_required";
 const CODEX_PLUGIN_NOT_SELECTED_REASON = "not selected for migration";
@@ -104,6 +113,8 @@ async function applyCodexPluginInstallItem(
     };
   }
   try {
+    const appCacheKey = await buildTargetCodexPluginAppCacheKey(ctx);
+    const appServer = resolveTargetCodexAppServer(ctx);
     const result = await ensureCodexPluginActivation({
       identity: policy,
       installEvenIfActive: true,
@@ -112,10 +123,13 @@ async function applyCodexPluginInstallItem(
           method,
           requestParams,
           timeoutMs: 60_000,
+          startOptions: appServer.start,
+          agentDir: resolveCodexMigrationTargets(ctx).agentDir,
           config: ctx.config,
         }),
+      appCache: defaultCodexAppInventoryCache,
+      appCacheKey,
     });
-    defaultCodexAppInventoryCache.clear();
     const baseDetails = {
       ...item.details,
       code: result.reason,
@@ -160,6 +174,38 @@ async function applyCodexPluginInstallItem(
       },
     };
   }
+}
+
+function resolveTargetCodexAppServer(ctx: MigrationProviderContext) {
+  return resolveCodexAppServerRuntimeOptions({
+    pluginConfig: readCodexPluginConfig(ctx.config),
+  });
+}
+
+async function buildTargetCodexPluginAppCacheKey(ctx: MigrationProviderContext): Promise<string> {
+  const targets = resolveCodexMigrationTargets(ctx);
+  const appServer = resolveTargetCodexAppServer(ctx);
+  const authProfileId = resolveCodexAppServerAuthProfileIdForAgent({
+    agentDir: targets.agentDir,
+    config: ctx.config,
+  });
+  const accountId = await resolveCodexAppServerAuthAccountCacheKey({
+    authProfileId,
+    agentDir: targets.agentDir,
+    config: ctx.config,
+  });
+  const envApiKeyFingerprint = authProfileId
+    ? undefined
+    : resolveCodexAppServerEnvApiKeyCacheKey({
+        startOptions: appServer.start,
+      });
+  return buildCodexPluginAppCacheKey({
+    appServer,
+    agentDir: targets.agentDir,
+    authProfileId,
+    accountId,
+    envApiKeyFingerprint,
+  });
 }
 
 async function applyCodexPluginConfigItem(

--- a/extensions/codex/src/migration/plan.ts
+++ b/extensions/codex/src/migration/plan.ts
@@ -15,6 +15,7 @@ import type {
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "../app-server/config.js";
 import { exists, sanitizeName } from "./helpers.js";
 import {
+  codexPluginMigrationSubscriptionWarning,
   discoverCodexSource,
   hasCodexSource,
   type CodexPluginAppReadinessCode,
@@ -420,15 +421,23 @@ export async function buildCodexMigrationPlan(
           "Conflicts were found. Re-run with --overwrite to replace conflicting migration targets after item-level backups.",
         ]
       : []),
-    ...(source.plugins.length > 0
+    ...(source.plugins.some((plugin) => plugin.migratable)
       ? [
           "Codex source-installed openai-curated plugins are planned for native activation; cached plugin bundles remain manual-review only.",
         ]
+      : []),
+    ...(source.plugins.some((plugin) => plugin.sourceKind === "cache")
+      ? ["Codex cached plugin bundles remain manual-review only."]
       : []),
     ...(source.pluginDiscoveryError
       ? [
           `Codex app-server plugin inventory discovery failed: ${source.pluginDiscoveryError}. Cached plugin bundles, if any, are advisory only.`,
         ]
+      : []),
+    ...(source.plugins.some(
+      (plugin) => plugin.appReadiness?.reason === "codex_subscription_required",
+    )
+      ? [codexPluginMigrationSubscriptionWarning()]
       : []),
     ...(source.archivePaths.length > 0
       ? [

--- a/extensions/codex/src/migration/plan.ts
+++ b/extensions/codex/src/migration/plan.ts
@@ -18,7 +18,6 @@ import {
   codexPluginMigrationSubscriptionWarning,
   discoverCodexSource,
   hasCodexSource,
-  type CodexPluginAppReadinessCode,
   type CodexPluginSource,
   type CodexSkillSource,
 } from "./source.js";
@@ -42,11 +41,11 @@ export type CodexPluginMigrationConfigEntry = {
   enabled: boolean;
 };
 
-type CodexPluginAppReadinessSkipDetails = {
-  code: CodexPluginAppReadinessCode;
+type CodexPluginMigrationBlockSkipDetails = {
   pluginName: string;
   marketplaceName: typeof CODEX_PLUGINS_MARKETPLACE_NAME;
-  apps: NonNullable<CodexPluginSource["appReadiness"]>["apps"];
+  apps?: NonNullable<CodexPluginSource["migrationBlock"]>["apps"];
+  error?: string;
 };
 
 function uniqueSkillName(skill: CodexSkillSource, counts: Map<string, number>): string {
@@ -189,12 +188,12 @@ function buildPluginItems(
     }
 
     manualIndex += 1;
-    if (plugin.appReadiness?.reason && plugin.pluginName) {
-      const details: CodexPluginAppReadinessSkipDetails = {
-        code: plugin.appReadiness.reason,
+    if (plugin.migrationBlock && plugin.pluginName) {
+      const details: CodexPluginMigrationBlockSkipDetails = {
         pluginName: plugin.pluginName,
         marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-        apps: plugin.appReadiness.apps,
+        ...(plugin.migrationBlock.apps ? { apps: plugin.migrationBlock.apps } : {}),
+        ...(plugin.migrationBlock.error ? { error: plugin.migrationBlock.error } : {}),
       };
       items.push(
         createMigrationItem({
@@ -203,7 +202,7 @@ function buildPluginItems(
           action: "manual",
           source: plugin.source,
           status: "skipped",
-          reason: details.code,
+          reason: plugin.migrationBlock.code,
           message:
             plugin.message ??
             `Codex native plugin "${plugin.name}" was found but not activated automatically.`,
@@ -380,7 +379,7 @@ export async function buildCodexMigrationPlan(
   const targets = resolveCodexMigrationTargets(ctx);
   const source = await discoverCodexSource({
     input: ctx.source,
-    evaluatePluginAppReadiness: true,
+    evaluatePluginMigrationEligibility: true,
   });
   if (!hasCodexSource(source)) {
     throw new Error(
@@ -435,7 +434,7 @@ export async function buildCodexMigrationPlan(
         ]
       : []),
     ...(source.plugins.some(
-      (plugin) => plugin.appReadiness?.reason === "codex_subscription_required",
+      (plugin) => plugin.migrationBlock?.code === "codex_subscription_required",
     )
       ? [codexPluginMigrationSubscriptionWarning()]
       : []),

--- a/extensions/codex/src/migration/plan.ts
+++ b/extensions/codex/src/migration/plan.ts
@@ -34,6 +34,7 @@ const CODEX_PLUGIN_NATIVE_CONFIG_PATH = [
   "codexPlugins",
 ] as const;
 const MIGRATION_REASON_PLUGIN_EXISTS = "plugin exists";
+const CODEX_PLUGIN_SOURCE_APP_VERIFICATION_UNVERIFIED = "not_run";
 
 export type CodexPluginMigrationConfigEntry = {
   configKey: string;
@@ -181,6 +182,9 @@ function buildPluginItems(
             pluginName: plugin.pluginName,
             sourceInstalled: plugin.installed === true,
             sourceEnabled: plugin.enabled === true,
+            ...(plugin.apps && plugin.apps.length > 0 && !shouldVerifyPluginApps(ctx)
+              ? { sourceAppVerification: CODEX_PLUGIN_SOURCE_APP_VERIFICATION_UNVERIFIED }
+              : {}),
           },
         }),
       );
@@ -224,6 +228,10 @@ function buildPluginItems(
     );
   }
   return items;
+}
+
+function shouldVerifyPluginApps(ctx: MigrationProviderContext): boolean {
+  return ctx.providerOptions?.verifyPluginApps === true;
 }
 
 export function readCodexPluginMigrationConfigEntry(
@@ -380,6 +388,7 @@ export async function buildCodexMigrationPlan(
   const source = await discoverCodexSource({
     input: ctx.source,
     evaluatePluginMigrationEligibility: true,
+    verifyPluginApps: shouldVerifyPluginApps(ctx),
   });
   if (!hasCodexSource(source)) {
     throw new Error(
@@ -423,6 +432,13 @@ export async function buildCodexMigrationPlan(
     ...(source.plugins.some((plugin) => plugin.migratable)
       ? [
           "Codex source-installed openai-curated plugins are planned for native activation; cached plugin bundles remain manual-review only.",
+        ]
+      : []),
+    ...(source.plugins.some(
+      (plugin) => plugin.migratable && plugin.apps && plugin.apps.length > 0,
+    ) && !shouldVerifyPluginApps(ctx)
+      ? [
+          "Codex app-backed plugins were planned without source app accessibility verification. Re-run with --verify-plugin-apps to force a fresh source app/list check before planning native plugin activation.",
         ]
       : []),
     ...(source.plugins.some((plugin) => plugin.sourceKind === "cache")

--- a/extensions/codex/src/migration/plan.ts
+++ b/extensions/codex/src/migration/plan.ts
@@ -17,6 +17,7 @@ import { exists, sanitizeName } from "./helpers.js";
 import {
   discoverCodexSource,
   hasCodexSource,
+  type CodexPluginAppReadinessCode,
   type CodexPluginSource,
   type CodexSkillSource,
 } from "./source.js";
@@ -38,6 +39,13 @@ export type CodexPluginMigrationConfigEntry = {
   configKey: string;
   pluginName: string;
   enabled: boolean;
+};
+
+type CodexPluginAppReadinessSkipDetails = {
+  code: CodexPluginAppReadinessCode;
+  pluginName: string;
+  marketplaceName: typeof CODEX_PLUGINS_MARKETPLACE_NAME;
+  apps: NonNullable<CodexPluginSource["appReadiness"]>["apps"];
 };
 
 function uniqueSkillName(skill: CodexSkillSource, counts: Map<string, number>): string {
@@ -180,6 +188,29 @@ function buildPluginItems(
     }
 
     manualIndex += 1;
+    if (plugin.appReadiness?.reason && plugin.pluginName) {
+      const details: CodexPluginAppReadinessSkipDetails = {
+        code: plugin.appReadiness.reason,
+        pluginName: plugin.pluginName,
+        marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+        apps: plugin.appReadiness.apps,
+      };
+      items.push(
+        createMigrationItem({
+          id: `plugin:${sanitizeName(plugin.name) || sanitizeName(path.basename(plugin.source))}:${manualIndex}`,
+          kind: "manual",
+          action: "manual",
+          source: plugin.source,
+          status: "skipped",
+          reason: details.code,
+          message:
+            plugin.message ??
+            `Codex native plugin "${plugin.name}" was found but not activated automatically.`,
+          details: { ...details },
+        }),
+      );
+      continue;
+    }
     items.push(
       createMigrationManualItem({
         id: `plugin:${sanitizeName(plugin.name) || sanitizeName(path.basename(plugin.source))}:${manualIndex}`,
@@ -345,13 +376,18 @@ function buildPluginConfigItem(
 export async function buildCodexMigrationPlan(
   ctx: MigrationProviderContext,
 ): Promise<MigrationPlan> {
-  const source = await discoverCodexSource(ctx.source);
+  const targets = resolveCodexMigrationTargets(ctx);
+  const source = await discoverCodexSource({
+    input: ctx.source,
+    config: ctx.config,
+    agentDir: targets.agentDir,
+    evaluatePluginAppReadiness: true,
+  });
   if (!hasCodexSource(source)) {
     throw new Error(
       `Codex state was not found at ${source.root}. Pass --from <path> if it lives elsewhere.`,
     );
   }
-  const targets = resolveCodexMigrationTargets(ctx);
   const items: MigrationItem[] = [];
   items.push(
     ...(await buildSkillItems({

--- a/extensions/codex/src/migration/plan.ts
+++ b/extensions/codex/src/migration/plan.ts
@@ -379,8 +379,6 @@ export async function buildCodexMigrationPlan(
   const targets = resolveCodexMigrationTargets(ctx);
   const source = await discoverCodexSource({
     input: ctx.source,
-    config: ctx.config,
-    agentDir: targets.agentDir,
     evaluatePluginAppReadiness: true,
   });
   if (!hasCodexSource(source)) {

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -40,6 +40,7 @@ function makeContext(params: {
   stateDir: string;
   workspaceDir: string;
   overwrite?: boolean;
+  verifyPluginApps?: boolean;
   reportDir?: string;
   config?: MigrationProviderContext["config"];
   runtime?: MigrationProviderContext["runtime"];
@@ -58,6 +59,7 @@ function makeContext(params: {
     source: params.source,
     stateDir: params.stateDir,
     overwrite: params.overwrite,
+    providerOptions: params.verifyPluginApps ? { verifyPluginApps: true } : undefined,
     reportDir: params.reportDir,
     logger,
   };
@@ -174,6 +176,7 @@ describe("buildCodexMigrationProvider", () => {
         source: fixture.codexHome,
         stateDir: fixture.stateDir,
         workspaceDir: fixture.workspaceDir,
+        verifyPluginApps: true,
       }),
     );
 
@@ -230,6 +233,7 @@ describe("buildCodexMigrationProvider", () => {
         source: fixture.codexHome,
         stateDir: fixture.stateDir,
         workspaceDir: fixture.workspaceDir,
+        verifyPluginApps: true,
       }),
     );
 
@@ -296,6 +300,7 @@ describe("buildCodexMigrationProvider", () => {
         source: fixture.codexHome,
         stateDir: fixture.stateDir,
         workspaceDir: fixture.workspaceDir,
+        verifyPluginApps: true,
       }),
     );
 
@@ -324,6 +329,52 @@ describe("buildCodexMigrationProvider", () => {
     ]);
     expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
       1,
+    );
+  });
+
+  it("plans app-backed plugins without source app/list by default", async () => {
+    const fixture = await createCodexFixture();
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("gmail", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("gmail", [pluginApp("app-gmail", { name: "Gmail", needsAuth: true })]);
+      }
+      if (method === "account/read") {
+        return chatGptAccount();
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider();
+
+    const plan = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    expectRecordFields(findItem(plan.items, "plugin:gmail"), {
+      kind: "plugin",
+      action: "install",
+      status: "planned",
+    });
+    expectRecordFields(findItem(plan.items, "config:codex-plugins"), {
+      kind: "config",
+      action: "merge",
+      status: "planned",
+    });
+    expect(plan.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "Codex app-backed plugins were planned without source app accessibility verification",
+        ),
+      ]),
+    );
+    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
+      0,
     );
   });
 
@@ -428,7 +479,7 @@ describe("buildCodexMigrationProvider", () => {
     );
   });
 
-  it("falls through to app inventory when source account read fails", async () => {
+  it("falls through to app inventory when source account read fails and app verification is requested", async () => {
     const fixture = await createCodexFixture();
     appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
       if (method === "plugin/list") {
@@ -452,6 +503,7 @@ describe("buildCodexMigrationProvider", () => {
         source: fixture.codexHome,
         stateDir: fixture.stateDir,
         workspaceDir: fixture.workspaceDir,
+        verifyPluginApps: true,
       }),
     );
 
@@ -462,6 +514,45 @@ describe("buildCodexMigrationProvider", () => {
     });
     expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
       1,
+    );
+  });
+
+  it("skips app-backed plugins by default when source account read fails", async () => {
+    const fixture = await createCodexFixture();
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("gmail", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("gmail", [pluginApp("app-gmail", { name: "Gmail", needsAuth: true })]);
+      }
+      if (method === "account/read") {
+        throw new Error("account unavailable");
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider();
+
+    const plan = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    expect(plan.items.some((item) => item.id === "plugin:gmail")).toBe(false);
+    expect(plan.items.some((item) => item.id === "config:codex-plugins")).toBe(false);
+    const manualItem = findItemByReason(plan.items, "codex_account_unavailable");
+    expectRecordFields(manualItem, {
+      kind: "manual",
+      action: "manual",
+      reason: "codex_account_unavailable",
+      status: "skipped",
+    });
+    expectRecordFields(manualItem.details, { error: "account unavailable" });
+    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
+      0,
     );
   });
 
@@ -491,6 +582,7 @@ describe("buildCodexMigrationProvider", () => {
         source: fixture.codexHome,
         stateDir: fixture.stateDir,
         workspaceDir: fixture.workspaceDir,
+        verifyPluginApps: true,
         config: {
           agents: {
             defaults: {
@@ -558,6 +650,7 @@ describe("buildCodexMigrationProvider", () => {
         source: fixture.codexHome,
         stateDir: fixture.stateDir,
         workspaceDir: fixture.workspaceDir,
+        verifyPluginApps: true,
       }),
     );
 
@@ -622,6 +715,7 @@ describe("buildCodexMigrationProvider", () => {
         source: fixture.codexHome,
         stateDir: fixture.stateDir,
         workspaceDir: fixture.workspaceDir,
+        verifyPluginApps: true,
       }),
     );
 
@@ -656,6 +750,7 @@ describe("buildCodexMigrationProvider", () => {
         source: fixture.codexHome,
         stateDir: fixture.stateDir,
         workspaceDir: fixture.workspaceDir,
+        verifyPluginApps: true,
       }),
     );
 
@@ -697,6 +792,7 @@ describe("buildCodexMigrationProvider", () => {
         source: fixture.codexHome,
         stateDir: fixture.stateDir,
         workspaceDir: fixture.workspaceDir,
+        verifyPluginApps: true,
       }),
     );
 
@@ -734,6 +830,7 @@ describe("buildCodexMigrationProvider", () => {
         source: fixture.codexHome,
         stateDir: fixture.stateDir,
         workspaceDir: fixture.workspaceDir,
+        verifyPluginApps: true,
       }),
     );
 

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defaultCodexAppInventoryCache } from "../app-server/app-inventory-cache.js";
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "../app-server/config.js";
 import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
-import type { v2 } from "../app-server/protocol.js";
+import type { CodexGetAccountResponse, v2 } from "../app-server/protocol.js";
 import { buildCodexMigrationProvider } from "./provider.js";
 
 const appServerRequest = vi.hoisted(() => vi.fn());
@@ -273,6 +273,9 @@ describe("buildCodexMigrationProvider", () => {
             pluginApp("asdk_app_readwise", { name: "Readwise", needsAuth: false }),
           ]);
         }
+        if (method === "account/read") {
+          return chatGptAccount();
+        }
         if (method === "app/list") {
           expectRecordFields(requestParams, { forceRefetch: true });
           return appsList([
@@ -325,6 +328,70 @@ describe("buildCodexMigrationProvider", () => {
     );
   });
 
+  it("warns and skips app-backed plugins when source Codex account is not ChatGPT subscription auth", async () => {
+    const fixture = await createCodexFixture();
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("gmail", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("gmail", [pluginApp("app-gmail", { name: "Gmail", needsAuth: true })]);
+      }
+      if (method === "account/read") {
+        return {
+          account: { type: "apiKey" },
+          requiresOpenaiAuth: true,
+        } satisfies CodexGetAccountResponse;
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider();
+
+    const plan = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    expect(plan.items.some((item) => item.id === "plugin:gmail")).toBe(false);
+    expect(plan.items.some((item) => item.id === "config:codex-plugins")).toBe(false);
+    const manualItem = findItemByReason(plan.items, "codex_subscription_required");
+    expectRecordFields(manualItem, {
+      kind: "manual",
+      action: "manual",
+      status: "skipped",
+      reason: "codex_subscription_required",
+    });
+    const details = expectRecordFields(manualItem.details, {
+      code: "codex_subscription_required",
+      pluginName: "gmail",
+      marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+    });
+    expect(details.apps).toEqual([
+      {
+        id: "app-gmail",
+        name: "Gmail",
+        status: "auth_required",
+        needsAuth: true,
+      },
+    ]);
+    expect(plan.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "Codex app-backed plugin migration requires the Codex app-server source account",
+        ),
+      ]),
+    );
+    expect(plan.warnings).not.toEqual(
+      expect.arrayContaining([expect.stringContaining("planned for native activation")]),
+    );
+    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
+      0,
+    );
+  });
+
   it("reads source plugin readiness with native source auth instead of target agent auth", async () => {
     const fixture = await createCodexFixture();
     appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
@@ -335,6 +402,9 @@ describe("buildCodexMigrationProvider", () => {
         return pluginRead("google-calendar", [
           pluginApp("app-google-calendar", { name: "Google Calendar", needsAuth: false }),
         ]);
+      }
+      if (method === "account/read") {
+        return chatGptAccount();
       }
       if (method === "app/list") {
         return appsList([appInfo("app-google-calendar")]);
@@ -363,7 +433,7 @@ describe("buildCodexMigrationProvider", () => {
       }),
     );
 
-    expect(appServerRequest).toHaveBeenCalledTimes(3);
+    expect(appServerRequest).toHaveBeenCalledTimes(4);
     for (const [arg] of appServerRequest.mock.calls) {
       expect(arg).toEqual(
         expect.objectContaining({
@@ -393,6 +463,9 @@ describe("buildCodexMigrationProvider", () => {
           pluginApp("asdk_app_readwise", { name: "Readwise", needsAuth: false }),
           pluginApp("asdk_app_reader", { name: "Reader", needsAuth: false }),
         ]);
+      }
+      if (method === "account/read") {
+        return chatGptAccount();
       }
       if (method === "app/list") {
         return appsList([
@@ -460,6 +533,9 @@ describe("buildCodexMigrationProvider", () => {
         if (method === "plugin/read") {
           const pluginName = (requestParams as v2.PluginReadParams).pluginName;
           return pluginRead(pluginName, [pluginApp(`app-${pluginName}`)]);
+        }
+        if (method === "account/read") {
+          return chatGptAccount();
         }
         if (method === "app/list") {
           expectRecordFields(requestParams, { forceRefetch: true });
@@ -535,6 +611,9 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "plugin/read") {
         return pluginRead("readwise", [pluginApp("asdk_app_readwise", { name: "Readwise" })]);
       }
+      if (method === "account/read") {
+        return chatGptAccount();
+      }
       if (method === "app/list") {
         throw new Error("app inventory unavailable");
       }
@@ -568,6 +647,9 @@ describe("buildCodexMigrationProvider", () => {
           pluginApp("ready-app", { name: "Ready App", needsAuth: false }),
           pluginApp("auth-app", { name: "Auth App", needsAuth: true }),
         ]);
+      }
+      if (method === "account/read") {
+        return chatGptAccount();
       }
       if (method === "app/list") {
         return appsList([appInfo("ready-app"), appInfo("auth-app")]);
@@ -1244,6 +1326,13 @@ function appInfo(id: string, overrides: Partial<v2.AppInfo> = {}): v2.AppInfo {
 
 function appsList(apps: v2.AppInfo[]): v2.AppsListResponse {
   return { data: apps, nextCursor: null };
+}
+
+function chatGptAccount(): CodexGetAccountResponse {
+  return {
+    account: { type: "chatgpt", email: "codex@example.test", planType: "plus" },
+    requiresOpenaiAuth: false,
+  };
 }
 
 function pluginSummary(id: string, overrides: Partial<v2.PluginSummary> = {}): v2.PluginSummary {

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -3,7 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import type { MigrationProviderContext } from "openclaw/plugin-sdk/plugin-entry";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultCodexAppInventoryCache } from "../app-server/app-inventory-cache.js";
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "../app-server/config.js";
+import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
 import type { v2 } from "../app-server/protocol.js";
 import { buildCodexMigrationProvider } from "./provider.js";
 
@@ -69,6 +71,14 @@ function findItem(items: readonly { id?: string }[], id: string) {
   return item as Record<string, unknown>;
 }
 
+function findItemByReason(items: readonly { reason?: string }[], reason: string) {
+  const item = items.find((entry) => entry.reason === reason);
+  if (!item) {
+    throw new Error(`Expected migration item reason ${reason}`);
+  }
+  return item as Record<string, unknown>;
+}
+
 function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
   if (!record || typeof record !== "object") {
     throw new Error("Expected record");
@@ -122,9 +132,28 @@ async function createCodexFixture(): Promise<{
   return { root, homeDir, codexHome, stateDir, workspaceDir };
 }
 
+function sourceAppCacheKey(fixture: { codexHome: string }): string {
+  return buildCodexPluginAppCacheKey({
+    appServer: {
+      start: {
+        transport: "stdio",
+        command: "codex",
+        commandSource: "config",
+        args: ["app-server", "--listen", "stdio://"],
+        headers: {},
+        env: {
+          CODEX_HOME: fixture.codexHome,
+          HOME: path.dirname(fixture.codexHome),
+        },
+      },
+    },
+  });
+}
+
 afterEach(async () => {
   vi.unstubAllEnvs();
   appServerRequest.mockReset();
+  defaultCodexAppInventoryCache.clear();
   for (const root of tempRoots) {
     await fs.rm(root, { recursive: true, force: true });
   }
@@ -185,9 +214,15 @@ describe("buildCodexMigrationProvider", () => {
 
   it("plans source-installed curated plugins without installing during dry-run", async () => {
     const fixture = await createCodexFixture();
-    appServerRequest.mockResolvedValueOnce(
-      pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]),
-    );
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("google-calendar");
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
     const provider = buildCodexMigrationProvider();
 
     const plan = await provider.plan(
@@ -198,7 +233,7 @@ describe("buildCodexMigrationProvider", () => {
       }),
     );
 
-    expect(appServerRequest).toHaveBeenCalledTimes(1);
+    expect(appServerRequest).toHaveBeenCalledTimes(2);
     expectRecordFields(mockCallArg(appServerRequest), {
       method: "plugin/list",
       requestParams: { cwds: [] },
@@ -224,6 +259,302 @@ describe("buildCodexMigrationProvider", () => {
       action: "merge",
       status: "planned",
     });
+  });
+
+  it("skips source-installed plugins whose owned apps are inaccessible", async () => {
+    const fixture = await createCodexFixture();
+    appServerRequest.mockImplementation(
+      async ({ method, requestParams }: { method: string; requestParams?: unknown }) => {
+        if (method === "plugin/list") {
+          return pluginList([pluginSummary("readwise", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read") {
+          return pluginRead("readwise", [
+            pluginApp("asdk_app_readwise", { name: "Readwise", needsAuth: false }),
+          ]);
+        }
+        if (method === "app/list") {
+          expectRecordFields(requestParams, { forceRefetch: true });
+          return appsList([
+            appInfo("asdk_app_readwise", {
+              name: "Readwise",
+              isAccessible: false,
+              isEnabled: true,
+            }),
+          ]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    );
+    const provider = buildCodexMigrationProvider();
+
+    const plan = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    expect(plan.items.some((item) => item.id === "plugin:readwise")).toBe(false);
+    expect(plan.items.some((item) => item.id === "config:codex-plugins")).toBe(false);
+    const manualItem = findItemByReason(plan.items, "app_inaccessible");
+    expectRecordFields(manualItem, {
+      kind: "manual",
+      action: "manual",
+      status: "skipped",
+      reason: "app_inaccessible",
+    });
+    const details = expectRecordFields(manualItem.details, {
+      code: "app_inaccessible",
+      pluginName: "readwise",
+      marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+    });
+    expect(details.apps).toEqual([
+      {
+        id: "asdk_app_readwise",
+        name: "Readwise",
+        status: "inaccessible",
+        isAccessible: false,
+        isEnabled: true,
+        needsAuth: false,
+      },
+    ]);
+    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
+      1,
+    );
+  });
+
+  it("reports inaccessible before missing when multiple owned apps are blocked", async () => {
+    const fixture = await createCodexFixture();
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("readwise", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("readwise", [
+          pluginApp("asdk_app_readwise", { name: "Readwise", needsAuth: false }),
+          pluginApp("asdk_app_reader", { name: "Reader", needsAuth: false }),
+        ]);
+      }
+      if (method === "app/list") {
+        return appsList([
+          appInfo("asdk_app_readwise", {
+            name: "Readwise",
+            isAccessible: false,
+            isEnabled: true,
+          }),
+        ]);
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider();
+
+    const plan = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    const manualItem = findItemByReason(plan.items, "app_inaccessible");
+    expectRecordFields(manualItem, {
+      reason: "app_inaccessible",
+      status: "skipped",
+    });
+    const details = expectRecordFields(manualItem.details, {
+      code: "app_inaccessible",
+      pluginName: "readwise",
+      marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+    });
+    expect(details.apps).toEqual([
+      {
+        id: "asdk_app_reader",
+        name: "Reader",
+        status: "missing",
+        needsAuth: false,
+      },
+      {
+        id: "asdk_app_readwise",
+        name: "Readwise",
+        status: "inaccessible",
+        isAccessible: false,
+        isEnabled: true,
+        needsAuth: false,
+      },
+    ]);
+  });
+
+  it("force-refreshes source app inventory once for app-backed plugins sharing a cache key", async () => {
+    const fixture = await createCodexFixture();
+    await defaultCodexAppInventoryCache.refreshNow({
+      key: sourceAppCacheKey(fixture),
+      request: async () => appsList([appInfo("app-google-calendar", { isAccessible: false })]),
+    });
+    appServerRequest.mockImplementation(
+      async ({ method, requestParams }: { method: string; requestParams?: unknown }) => {
+        if (method === "plugin/list") {
+          return pluginList([
+            pluginSummary("google-calendar", { installed: true, enabled: true }),
+            pluginSummary("gmail", { installed: true, enabled: true }),
+          ]);
+        }
+        if (method === "plugin/read") {
+          const pluginName = (requestParams as v2.PluginReadParams).pluginName;
+          return pluginRead(pluginName, [pluginApp(`app-${pluginName}`)]);
+        }
+        if (method === "app/list") {
+          expectRecordFields(requestParams, { forceRefetch: true });
+          return appsList([appInfo("app-google-calendar"), appInfo("app-gmail")]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    );
+    const provider = buildCodexMigrationProvider();
+
+    const plan = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    expectRecordFields(findItem(plan.items, "plugin:google-calendar"), { status: "planned" });
+    expectRecordFields(findItem(plan.items, "plugin:gmail"), { status: "planned" });
+    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
+      1,
+    );
+  });
+
+  it("fails closed for disabled plugins and plugin/read failures", async () => {
+    const fixture = await createCodexFixture();
+    appServerRequest.mockImplementation(
+      async ({ method, requestParams }: { method: string; requestParams?: unknown }) => {
+        if (method === "plugin/list") {
+          return pluginList([
+            pluginSummary("readwise", { installed: true, enabled: false }),
+            pluginSummary("gmail", { installed: true, enabled: true }),
+          ]);
+        }
+        if (method === "plugin/read") {
+          expectRecordFields(requestParams, { pluginName: "gmail" });
+          throw new Error("detail unavailable");
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    );
+    const provider = buildCodexMigrationProvider();
+
+    const plan = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    expectRecordFields(findItemByReason(plan.items, "plugin_disabled"), {
+      reason: "plugin_disabled",
+      status: "skipped",
+    });
+    expectRecordFields(findItemByReason(plan.items, "plugin_read_unavailable"), {
+      reason: "plugin_read_unavailable",
+      status: "skipped",
+    });
+    expect(plan.items.some((item) => item.id === "config:codex-plugins")).toBe(false);
+    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
+      0,
+    );
+  });
+
+  it("fails closed when app inventory refresh fails for app-backed plugins", async () => {
+    const fixture = await createCodexFixture();
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("readwise", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("readwise", [pluginApp("asdk_app_readwise", { name: "Readwise" })]);
+      }
+      if (method === "app/list") {
+        throw new Error("app inventory unavailable");
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider();
+
+    const plan = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    expectRecordFields(findItemByReason(plan.items, "app_inventory_unavailable"), {
+      reason: "app_inventory_unavailable",
+      status: "skipped",
+    });
+    expect(plan.items.some((item) => item.id === "plugin:readwise")).toBe(false);
+  });
+
+  it("blocks auth-required and mixed multi-app readiness while preserving per-app details", async () => {
+    const fixture = await createCodexFixture();
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("reader", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("reader", [
+          pluginApp("ready-app", { name: "Ready App", needsAuth: false }),
+          pluginApp("auth-app", { name: "Auth App", needsAuth: true }),
+        ]);
+      }
+      if (method === "app/list") {
+        return appsList([appInfo("ready-app"), appInfo("auth-app")]);
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider();
+
+    const plan = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    const manualItem = findItemByReason(plan.items, "app_auth_required");
+    expectRecordFields(manualItem, {
+      reason: "app_auth_required",
+      status: "skipped",
+    });
+    const details = expectRecordFields(manualItem.details, {
+      code: "app_auth_required",
+      pluginName: "reader",
+      marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+    });
+    expect(details.apps).toEqual([
+      {
+        id: "auth-app",
+        name: "Auth App",
+        status: "auth_required",
+        isAccessible: true,
+        isEnabled: true,
+        needsAuth: true,
+      },
+      {
+        id: "ready-app",
+        name: "Ready App",
+        status: "ready",
+        isAccessible: true,
+        isEnabled: true,
+        needsAuth: false,
+      },
+    ]);
   });
 
   it("copies planned skills and archives native config during apply", async () => {
@@ -275,6 +606,9 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "plugin/list") {
         return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
       }
+      if (method === "plugin/read") {
+        return pluginRead("google-calendar");
+      }
       if (method === "plugin/install") {
         return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
       }
@@ -286,6 +620,9 @@ describe("buildCodexMigrationProvider", () => {
       }
       if (method === "config/mcpServer/reload") {
         return {};
+      }
+      if (method === "app/list") {
+        return appsList([]);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -375,6 +712,9 @@ describe("buildCodexMigrationProvider", () => {
           pluginSummary("gmail", { installed: true, enabled: true }),
         ]);
       }
+      if (method === "plugin/read") {
+        return pluginRead("google-calendar");
+      }
       throw new Error(`unexpected request ${method}`);
     });
     const provider = buildCodexMigrationProvider();
@@ -415,6 +755,9 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "plugin/list") {
         return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
       }
+      if (method === "plugin/read") {
+        return pluginRead("google-calendar");
+      }
       if (method === "plugin/install") {
         return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
       }
@@ -426,6 +769,9 @@ describe("buildCodexMigrationProvider", () => {
       }
       if (method === "config/mcpServer/reload") {
         return {};
+      }
+      if (method === "app/list") {
+        return appsList([]);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -449,6 +795,11 @@ describe("buildCodexMigrationProvider", () => {
 
   it("merges migrated plugin config with existing Codex plugins when entries do not conflict", async () => {
     const fixture = await createCodexFixture();
+    const sourceKey = sourceAppCacheKey(fixture);
+    await defaultCodexAppInventoryCache.refreshNow({
+      key: sourceKey,
+      request: async () => appsList([appInfo("source-only-app")]),
+    });
     const configState: MigrationProviderContext["config"] = {
       plugins: {
         entries: {
@@ -476,6 +827,9 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "plugin/list") {
         return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
       }
+      if (method === "plugin/read") {
+        return pluginRead("google-calendar");
+      }
       if (method === "plugin/install") {
         return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
       }
@@ -487,6 +841,9 @@ describe("buildCodexMigrationProvider", () => {
       }
       if (method === "config/mcpServer/reload") {
         return {};
+      }
+      if (method === "app/list") {
+        return appsList([]);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -504,6 +861,14 @@ describe("buildCodexMigrationProvider", () => {
     );
 
     expectRecordFields(findItem(result.items, "config:codex-plugins"), { status: "migrated" });
+    const sourceCacheRead = defaultCodexAppInventoryCache.read({
+      key: sourceKey,
+      request: async () => {
+        throw new Error("source app cache was cleared");
+      },
+    });
+    expect(sourceCacheRead.state).toBe("fresh");
+    expect(sourceCacheRead.snapshot?.apps.map((app) => app.id)).toEqual(["source-only-app"]);
     expect(configState.plugins?.entries?.codex?.config?.codexPlugins).toEqual({
       allow_destructive_actions: true,
       plugins: {
@@ -545,6 +910,9 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "plugin/list") {
         return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
       }
+      if (method === "plugin/read") {
+        return pluginRead("google-calendar");
+      }
       if (method === "plugin/install") {
         return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
       }
@@ -556,6 +924,9 @@ describe("buildCodexMigrationProvider", () => {
       }
       if (method === "config/mcpServer/reload") {
         return {};
+      }
+      if (method === "app/list") {
+        return appsList([]);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -596,6 +967,9 @@ describe("buildCodexMigrationProvider", () => {
       if (method === "plugin/list") {
         return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
       }
+      if (method === "plugin/read") {
+        return pluginRead("google-calendar");
+      }
       if (method === "plugin/install") {
         return {
           authPolicy: "ON_USE",
@@ -618,6 +992,9 @@ describe("buildCodexMigrationProvider", () => {
       }
       if (method === "config/mcpServer/reload") {
         return {};
+      }
+      if (method === "app/list") {
+        return appsList([]);
       }
       throw new Error(`unexpected request ${method}`);
     });
@@ -670,6 +1047,9 @@ describe("buildCodexMigrationProvider", () => {
     appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
       if (method === "plugin/list") {
         return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("google-calendar");
       }
       if (method === "plugin/install") {
         throw new Error("install failed");
@@ -775,6 +1155,54 @@ function pluginList(plugins: v2.PluginSummary[]): v2.PluginListResponse {
     marketplaceLoadErrors: [],
     featuredPluginIds: [],
   };
+}
+
+function pluginRead(pluginName: string, apps: v2.AppSummary[] = []): v2.PluginReadResponse {
+  return {
+    plugin: {
+      marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+      marketplacePath: "/marketplaces/openai-curated",
+      summary: pluginSummary(pluginName, { installed: true, enabled: true }),
+      description: null,
+      skills: [],
+      apps,
+      mcpServers: [],
+    },
+  };
+}
+
+function pluginApp(id: string, overrides: Partial<v2.AppSummary> = {}): v2.AppSummary {
+  return {
+    id,
+    name: id,
+    description: null,
+    installUrl: null,
+    needsAuth: false,
+    ...overrides,
+  };
+}
+
+function appInfo(id: string, overrides: Partial<v2.AppInfo> = {}): v2.AppInfo {
+  return {
+    id,
+    name: id,
+    description: null,
+    logoUrl: null,
+    logoUrlDark: null,
+    distributionChannel: null,
+    branding: null,
+    appMetadata: null,
+    labels: null,
+    installUrl: null,
+    isAccessible: true,
+    isEnabled: true,
+    pluginDisplayNames: [],
+    ...overrides,
+  };
+}
+
+function appsList(apps: v2.AppInfo[]): v2.AppsListResponse {
+  return { data: apps, nextCursor: null };
 }
 
 function pluginSummary(id: string, overrides: Partial<v2.PluginSummary> = {}): v2.PluginSummary {

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -368,6 +368,7 @@ describe("buildCodexMigrationProvider", () => {
       expect(arg).toEqual(
         expect.objectContaining({
           authProfileId: null,
+          isolated: true,
           startOptions: expect.objectContaining({
             env: {
               CODEX_HOME: fixture.codexHome,

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -309,15 +309,14 @@ describe("buildCodexMigrationProvider", () => {
       reason: "app_inaccessible",
     });
     const details = expectRecordFields(manualItem.details, {
-      code: "app_inaccessible",
       pluginName: "readwise",
       marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
     });
+    expect(details).not.toHaveProperty("code");
     expect(details.apps).toEqual([
       {
         id: "asdk_app_readwise",
         name: "Readwise",
-        status: "inaccessible",
         isAccessible: false,
         isEnabled: true,
         needsAuth: false,
@@ -365,15 +364,14 @@ describe("buildCodexMigrationProvider", () => {
       reason: "codex_subscription_required",
     });
     const details = expectRecordFields(manualItem.details, {
-      code: "codex_subscription_required",
       pluginName: "gmail",
       marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
     });
+    expect(details).not.toHaveProperty("code");
     expect(details.apps).toEqual([
       {
         id: "app-gmail",
         name: "Gmail",
-        status: "auth_required",
         needsAuth: true,
       },
     ]);
@@ -389,6 +387,81 @@ describe("buildCodexMigrationProvider", () => {
     );
     expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
       0,
+    );
+  });
+
+  it("warns and skips app-backed plugins when source Codex account is missing", async () => {
+    const fixture = await createCodexFixture();
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("gmail", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("gmail", [pluginApp("app-gmail", { name: "Gmail", needsAuth: true })]);
+      }
+      if (method === "account/read") {
+        return {
+          account: null,
+          requiresOpenaiAuth: true,
+        } satisfies CodexGetAccountResponse;
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider();
+
+    const plan = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    expect(plan.items.some((item) => item.id === "plugin:gmail")).toBe(false);
+    expect(plan.items.some((item) => item.id === "config:codex-plugins")).toBe(false);
+    expectRecordFields(findItemByReason(plan.items, "codex_subscription_required"), {
+      reason: "codex_subscription_required",
+      status: "skipped",
+    });
+    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
+      0,
+    );
+  });
+
+  it("falls through to app inventory when source account read fails", async () => {
+    const fixture = await createCodexFixture();
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("gmail", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("gmail", [pluginApp("app-gmail", { name: "Gmail", needsAuth: true })]);
+      }
+      if (method === "account/read") {
+        throw new Error("account unavailable");
+      }
+      if (method === "app/list") {
+        return appsList([appInfo("app-gmail")]);
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider();
+
+    const plan = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+      }),
+    );
+
+    expectRecordFields(findItem(plan.items, "plugin:gmail"), {
+      kind: "plugin",
+      action: "install",
+      status: "planned",
+    });
+    expect(appServerRequest.mock.calls.filter(([arg]) => arg.method === "app/list")).toHaveLength(
+      1,
     );
   });
 
@@ -494,21 +567,19 @@ describe("buildCodexMigrationProvider", () => {
       status: "skipped",
     });
     const details = expectRecordFields(manualItem.details, {
-      code: "app_inaccessible",
       pluginName: "readwise",
       marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
     });
+    expect(details).not.toHaveProperty("code");
     expect(details.apps).toEqual([
       {
         id: "asdk_app_reader",
         name: "Reader",
-        status: "missing",
         needsAuth: false,
       },
       {
         id: "asdk_app_readwise",
         name: "Readwise",
-        status: "inaccessible",
         isAccessible: false,
         isEnabled: true,
         needsAuth: false,
@@ -677,7 +748,6 @@ describe("buildCodexMigrationProvider", () => {
       pluginName: "reader",
       marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
     });
-    expect(plan.items.some((item) => item.reason === "app_auth_required")).toBe(false);
   });
 
   it("copies planned skills and archives native config during apply", async () => {

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -325,6 +325,62 @@ describe("buildCodexMigrationProvider", () => {
     );
   });
 
+  it("reads source plugin readiness with native source auth instead of target agent auth", async () => {
+    const fixture = await createCodexFixture();
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginRead("google-calendar", [
+          pluginApp("app-google-calendar", { name: "Google Calendar", needsAuth: false }),
+        ]);
+      }
+      if (method === "app/list") {
+        return appsList([appInfo("app-google-calendar")]);
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider();
+
+    await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+        config: {
+          agents: {
+            defaults: {
+              workspace: fixture.workspaceDir,
+            },
+          },
+          auth: {
+            order: {
+              "openai-codex": ["openai-codex:target"],
+            },
+          },
+        } as MigrationProviderContext["config"],
+      }),
+    );
+
+    expect(appServerRequest).toHaveBeenCalledTimes(3);
+    for (const [arg] of appServerRequest.mock.calls) {
+      expect(arg).toEqual(
+        expect.objectContaining({
+          authProfileId: null,
+          startOptions: expect.objectContaining({
+            env: {
+              CODEX_HOME: fixture.codexHome,
+              HOME: path.dirname(fixture.codexHome),
+            },
+          }),
+        }),
+      );
+      expect(arg).not.toHaveProperty("agentDir");
+      expect(arg).not.toHaveProperty("config");
+    }
+  });
+
   it("reports inaccessible before missing when multiple owned apps are blocked", async () => {
     const fixture = await createCodexFixture();
     appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
@@ -500,7 +556,7 @@ describe("buildCodexMigrationProvider", () => {
     expect(plan.items.some((item) => item.id === "plugin:readwise")).toBe(false);
   });
 
-  it("blocks auth-required and mixed multi-app readiness while preserving per-app details", async () => {
+  it("treats auth-required source apps as ready when app inventory says they are accessible", async () => {
     const fixture = await createCodexFixture();
     appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
       if (method === "plugin/list") {
@@ -527,34 +583,18 @@ describe("buildCodexMigrationProvider", () => {
       }),
     );
 
-    const manualItem = findItemByReason(plan.items, "app_auth_required");
-    expectRecordFields(manualItem, {
-      reason: "app_auth_required",
-      status: "skipped",
+    const pluginItem = findItem(plan.items, "plugin:reader");
+    expectRecordFields(pluginItem, {
+      kind: "plugin",
+      action: "install",
+      status: "planned",
     });
-    const details = expectRecordFields(manualItem.details, {
-      code: "app_auth_required",
+    expectRecordFields(pluginItem.details, {
+      configKey: "reader",
       pluginName: "reader",
       marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
     });
-    expect(details.apps).toEqual([
-      {
-        id: "auth-app",
-        name: "Auth App",
-        status: "auth_required",
-        isAccessible: true,
-        isEnabled: true,
-        needsAuth: true,
-      },
-      {
-        id: "ready-app",
-        name: "Ready App",
-        status: "ready",
-        isAccessible: true,
-        isEnabled: true,
-        needsAuth: false,
-      },
-    ]);
+    expect(plan.items.some((item) => item.reason === "app_auth_required")).toBe(false);
   });
 
   it("copies planned skills and archives native config during apply", async () => {

--- a/extensions/codex/src/migration/provider.ts
+++ b/extensions/codex/src/migration/provider.ts
@@ -6,7 +6,6 @@ import type {
 import { applyCodexMigrationPlan } from "./apply.js";
 import { buildCodexMigrationPlan } from "./plan.js";
 import { discoverCodexSource, hasCodexSource } from "./source.js";
-import { resolveCodexMigrationTargets } from "./targets.js";
 
 export function buildCodexMigrationProvider(
   params: {
@@ -19,11 +18,8 @@ export function buildCodexMigrationProvider(
     description:
       "Inventory and promote Codex CLI skills while keeping Codex native plugins and hooks explicit.",
     async detect(ctx) {
-      const targets = resolveCodexMigrationTargets(ctx);
       const source = await discoverCodexSource({
         input: ctx.source,
-        config: ctx.config,
-        agentDir: targets.agentDir,
       });
       const found = hasCodexSource(source);
       return {

--- a/extensions/codex/src/migration/provider.ts
+++ b/extensions/codex/src/migration/provider.ts
@@ -6,6 +6,7 @@ import type {
 import { applyCodexMigrationPlan } from "./apply.js";
 import { buildCodexMigrationPlan } from "./plan.js";
 import { discoverCodexSource, hasCodexSource } from "./source.js";
+import { resolveCodexMigrationTargets } from "./targets.js";
 
 export function buildCodexMigrationProvider(
   params: {
@@ -18,7 +19,12 @@ export function buildCodexMigrationProvider(
     description:
       "Inventory and promote Codex CLI skills while keeping Codex native plugins and hooks explicit.",
     async detect(ctx) {
-      const source = await discoverCodexSource(ctx.source);
+      const targets = resolveCodexMigrationTargets(ctx);
+      const source = await discoverCodexSource({
+        input: ctx.source,
+        config: ctx.config,
+        agentDir: targets.agentDir,
+      });
       const found = hasCodexSource(source);
       return {
         found,

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -12,7 +12,7 @@ import {
   pluginReadParams,
   type CodexPluginMarketplaceRef,
 } from "../app-server/plugin-inventory.js";
-import type { v2 } from "../app-server/protocol.js";
+import type { CodexGetAccountResponse, v2 } from "../app-server/protocol.js";
 import { requestCodexAppServerJson } from "../app-server/request.js";
 import {
   exists,
@@ -62,6 +62,7 @@ export type CodexPluginAppReadinessCode =
   | "app_disabled"
   | "app_missing"
   | "app_auth_required"
+  | "codex_subscription_required"
   | "app_readiness_unknown"
   | "plugin_read_unavailable"
   | "app_inventory_unavailable";
@@ -385,6 +386,23 @@ async function withPluginAppReadiness(params: {
     return evaluated;
   }
 
+  const sourceAccount = await readSourceCodexAccount(params.requestOptions).catch(() => undefined);
+  if (sourceAccount && sourceAccount !== "chatgpt") {
+    for (const { plugin } of pending) {
+      plugin.appReadiness = {
+        status: "auth_required",
+        reason: "codex_subscription_required",
+        apps:
+          plugin.appReadiness?.apps.map((app) => ({
+            ...app,
+            status: "auth_required",
+          })) ?? [],
+      };
+      plugin.message = codexSubscriptionRequiredMessage(plugin);
+    }
+    return evaluated;
+  }
+
   const snapshot = await refreshSourceAppInventory(params.requestOptions).catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
     for (const { plugin } of pending) {
@@ -424,6 +442,24 @@ async function withPluginAppReadiness(params: {
   }
 
   return evaluated;
+}
+
+async function readSourceCodexAccount(
+  options: SourceAppServerRequestOptions,
+): Promise<"chatgpt" | "non_chatgpt" | "missing"> {
+  const response = await requestSourceCodexAppServerJson<CodexGetAccountResponse>(options, {
+    method: "account/read",
+    requestParams: { refreshToken: false },
+  });
+  if (
+    !response.account ||
+    typeof response.account !== "object" ||
+    Array.isArray(response.account)
+  ) {
+    return "missing";
+  }
+  const type = response.account.type;
+  return type === "chatgpt" ? "chatgpt" : "non_chatgpt";
 }
 
 async function readPluginDetail(
@@ -536,6 +572,14 @@ function appReadinessMessage(
     apps[0];
   const appLabel = blocking ? ` app "${blocking.name}"` : " an owned app";
   return `Codex plugin "${plugin.pluginName ?? plugin.name}" owns${appLabel} but the source app inventory reports it is ${blocking?.status ?? "unknown"}; authenticate or enable the app in Codex before migrating it to OpenClaw.`;
+}
+
+export function codexPluginMigrationSubscriptionWarning(): string {
+  return "Codex app-backed plugin migration requires the Codex app-server source account to be logged in with a ChatGPT subscription account. Log in to the Codex app with subscription auth; OpenClaw auth or API-key auth does not satisfy Codex app connector access.";
+}
+
+function codexSubscriptionRequiredMessage(plugin: CodexPluginSource): string {
+  return `Codex plugin "${plugin.pluginName ?? plugin.name}" owns apps, but ${codexPluginMigrationSubscriptionWarning()}`;
 }
 
 function pluginNameFromSummary(summary: v2.PluginSummary): string | undefined {

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -42,52 +42,31 @@ export type CodexPluginSource = {
   pluginName?: string;
   installed?: boolean;
   enabled?: boolean;
-  appReadiness?: CodexPluginAppReadiness;
+  migrationBlock?: CodexPluginMigrationBlock;
   message?: string;
 };
 
-export type CodexPluginAppReadinessStatus =
-  | "not_app_backed"
-  | "ready"
-  | "inaccessible"
-  | "missing"
-  | "disabled"
+export type CodexPluginMigrationBlockCode =
   | "plugin_disabled"
-  | "auth_required"
-  | "unknown";
-
-export type CodexPluginAppReadinessCode =
-  | "plugin_disabled"
+  | "codex_subscription_required"
+  | "plugin_read_unavailable"
+  | "app_inventory_unavailable"
   | "app_inaccessible"
   | "app_disabled"
-  | "app_missing"
-  | "app_auth_required"
-  | "codex_subscription_required"
-  | "app_readiness_unknown"
-  | "plugin_read_unavailable"
-  | "app_inventory_unavailable";
+  | "app_missing";
 
-export type CodexPluginAppReadinessAppStatus =
-  | "ready"
-  | "inaccessible"
-  | "missing"
-  | "disabled"
-  | "auth_required"
-  | "unknown";
-
-export type CodexPluginAppReadinessApp = {
+export type CodexPluginMigrationAppFact = {
   id: string;
   name: string;
-  status: CodexPluginAppReadinessAppStatus;
+  needsAuth?: boolean;
   isAccessible?: boolean;
   isEnabled?: boolean;
-  needsAuth?: boolean;
 };
 
-export type CodexPluginAppReadiness = {
-  status: CodexPluginAppReadinessStatus;
-  reason?: CodexPluginAppReadinessCode;
-  apps: CodexPluginAppReadinessApp[];
+export type CodexPluginMigrationBlock = {
+  code: CodexPluginMigrationBlockCode;
+  apps?: CodexPluginMigrationAppFact[];
+  error?: string;
 };
 
 type CodexArchiveSource = {
@@ -113,7 +92,7 @@ type CodexSource = {
 
 type CodexSourceDiscoveryOptions = {
   input?: string;
-  evaluatePluginAppReadiness?: boolean;
+  evaluatePluginMigrationEligibility?: boolean;
 };
 
 type SourceAppServerRequestOptions = {
@@ -238,15 +217,15 @@ async function discoverInstalledCuratedPlugins(
       .filter((plugin) => plugin.installed)
       .map((plugin) => buildInstalledPluginSource(plugin))
       .filter((plugin): plugin is CodexPluginSource => plugin !== undefined);
-    const withReadiness =
-      options.evaluatePluginAppReadiness === true
-        ? await withPluginAppReadiness({
+    const withEligibility =
+      options.evaluatePluginMigrationEligibility === true
+        ? await withPluginMigrationEligibility({
             plugins,
             marketplace: marketplaceRef(marketplace),
             requestOptions,
           })
         : plugins;
-    const sorted = withReadiness.toSorted((a, b) =>
+    const sorted = withEligibility.toSorted((a, b) =>
       (a.pluginName ?? a.name).localeCompare(b.pluginName ?? b.name),
     );
     return { plugins: sorted };
@@ -314,12 +293,12 @@ function marketplaceRef(marketplace: v2.PluginMarketplaceEntry): CodexPluginMark
   };
 }
 
-async function withPluginAppReadiness(params: {
+async function withPluginMigrationEligibility(params: {
   plugins: CodexPluginSource[];
   marketplace: CodexPluginMarketplaceRef;
   requestOptions: SourceAppServerRequestOptions;
 }): Promise<CodexPluginSource[]> {
-  const pending: Array<{ plugin: CodexPluginSource; detail: v2.PluginDetail }> = [];
+  const pending: Array<{ plugin: CodexPluginSource; apps: CodexPluginMigrationAppFact[] }> = [];
   const evaluated: CodexPluginSource[] = [];
 
   for (const plugin of params.plugins) {
@@ -327,11 +306,7 @@ async function withPluginAppReadiness(params: {
       evaluated.push({
         ...plugin,
         migratable: false,
-        appReadiness: {
-          status: "plugin_disabled",
-          reason: "plugin_disabled",
-          apps: [],
-        },
+        migrationBlock: { code: "plugin_disabled" },
         message: `Codex plugin "${plugin.pluginName ?? plugin.name}" is installed in Codex but disabled; enable it in Codex before migrating it to OpenClaw.`,
       });
       continue;
@@ -342,11 +317,7 @@ async function withPluginAppReadiness(params: {
       evaluated.push({
         ...plugin,
         migratable: false,
-        appReadiness: {
-          status: "unknown",
-          reason: "plugin_read_unavailable",
-          apps: [],
-        },
+        migrationBlock: { code: "plugin_read_unavailable", error: detail.error },
         message: `Codex plugin "${plugin.pluginName ?? plugin.name}" detail could not be read: ${detail.error}`,
       });
       continue;
@@ -356,30 +327,14 @@ async function withPluginAppReadiness(params: {
       evaluated.push({
         ...plugin,
         migratable: true,
-        appReadiness: {
-          status: "not_app_backed",
-          apps: [],
-        },
       });
       continue;
     }
 
-    const appBackedPlugin: CodexPluginSource = {
-      ...plugin,
-      migratable: false,
-      appReadiness: {
-        status: "unknown",
-        reason: "app_readiness_unknown",
-        apps: detail.detail.apps.map((app) => ({
-          id: app.id,
-          name: app.name,
-          status: "unknown" as const,
-          needsAuth: app.needsAuth,
-        })),
-      },
-    };
-    evaluated.push(appBackedPlugin);
-    pending.push({ plugin: appBackedPlugin, detail: detail.detail });
+    const apps = detail.detail.apps
+      .map(sourcePluginAppFact)
+      .toSorted((left, right) => left.id.localeCompare(right.id));
+    pending.push({ plugin, apps });
   }
 
   if (pending.length === 0) {
@@ -388,34 +343,30 @@ async function withPluginAppReadiness(params: {
 
   const sourceAccount = await readSourceCodexAccount(params.requestOptions).catch(() => undefined);
   if (sourceAccount && sourceAccount !== "chatgpt") {
-    for (const { plugin } of pending) {
-      plugin.appReadiness = {
-        status: "auth_required",
-        reason: "codex_subscription_required",
-        apps:
-          plugin.appReadiness?.apps.map((app) => ({
-            ...app,
-            status: "auth_required",
-          })) ?? [],
-      };
-      plugin.message = codexSubscriptionRequiredMessage(plugin);
+    for (const { plugin, apps } of pending) {
+      evaluated.push({
+        ...plugin,
+        migratable: false,
+        migrationBlock: { code: "codex_subscription_required", apps },
+        message: codexSubscriptionRequiredMessage(plugin),
+      });
     }
     return evaluated;
   }
 
   const snapshot = await refreshSourceAppInventory(params.requestOptions).catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
-    for (const { plugin } of pending) {
-      plugin.appReadiness = {
-        status: "unknown",
-        reason: "app_inventory_unavailable",
-        apps:
-          plugin.appReadiness?.apps.map((app) => ({
-            ...app,
-            status: "unknown",
-          })) ?? [],
-      };
-      plugin.message = `Codex plugin "${plugin.pluginName ?? plugin.name}" owns apps, but source app inventory could not be read: ${message}`;
+    for (const { plugin, apps } of pending) {
+      evaluated.push({
+        ...plugin,
+        migratable: false,
+        migrationBlock: {
+          code: "app_inventory_unavailable",
+          apps,
+          error: message,
+        },
+        message: `Codex plugin "${plugin.pluginName ?? plugin.name}" owns apps, but source app inventory could not be read: ${message}`,
+      });
     }
     return undefined;
   });
@@ -424,21 +375,21 @@ async function withPluginAppReadiness(params: {
   }
 
   const appInfoById = new Map(snapshot.apps.map((app) => [app.id, app] as const));
-  for (const { plugin, detail } of pending) {
-    const apps = detail.apps
-      .map((app) => sourceAppReadiness(app, appInfoById.get(app.id)))
+  for (const { plugin, apps: declaredApps } of pending) {
+    const apps = declaredApps
+      .map((app) => sourcePluginAppFactWithInventory(app, appInfoById.get(app.id)))
       .toSorted((left, right) => left.id.localeCompare(right.id));
-    const status = summarizeAppReadiness(apps);
-    const ready = status === "ready";
-    plugin.migratable = ready;
-    plugin.appReadiness = {
-      status,
-      ...(ready ? {} : { reason: readinessCode(status) }),
-      apps,
-    };
-    if (!ready) {
-      plugin.message = appReadinessMessage(plugin, apps, status);
+    const blockCode = migrationBlockCodeForApps(apps);
+    if (!blockCode) {
+      evaluated.push({ ...plugin, migratable: true });
+      continue;
     }
+    evaluated.push({
+      ...plugin,
+      migratable: false,
+      migrationBlock: { code: blockCode, apps },
+      message: appInventoryBlockMessage(plugin, apps, blockCode),
+    });
   }
 
   return evaluated;
@@ -496,82 +447,60 @@ async function refreshSourceAppInventory(
   });
 }
 
-function sourceAppReadiness(
-  app: v2.AppSummary,
-  info: v2.AppInfo | undefined,
-): CodexPluginAppReadinessApp {
-  if (!info) {
-    return {
-      id: app.id,
-      name: app.name,
-      status: "missing",
-      needsAuth: app.needsAuth,
-    };
-  }
-  const status: CodexPluginAppReadinessAppStatus = !info.isAccessible
-    ? "inaccessible"
-    : !info.isEnabled
-      ? "disabled"
-      : "ready";
+function sourcePluginAppFact(app: v2.AppSummary): CodexPluginMigrationAppFact {
   return {
     id: app.id,
     name: app.name,
-    status,
-    isAccessible: info.isAccessible,
-    isEnabled: info.isEnabled,
     needsAuth: app.needsAuth,
   };
 }
 
-function summarizeAppReadiness(
-  apps: readonly CodexPluginAppReadinessApp[],
-): CodexPluginAppReadinessStatus {
-  if (apps.some((app) => app.status === "inaccessible")) {
-    return "inaccessible";
+function sourcePluginAppFactWithInventory(
+  app: CodexPluginMigrationAppFact,
+  info: v2.AppInfo | undefined,
+): CodexPluginMigrationAppFact {
+  if (!info) {
+    return app;
   }
-  if (apps.some((app) => app.status === "disabled")) {
-    return "disabled";
-  }
-  if (apps.some((app) => app.status === "missing")) {
-    return "missing";
-  }
-  if (apps.some((app) => app.status === "auth_required")) {
-    return "auth_required";
-  }
-  if (apps.some((app) => app.status === "unknown")) {
-    return "unknown";
-  }
-  return "ready";
+  return {
+    ...app,
+    isAccessible: info.isAccessible,
+    isEnabled: info.isEnabled,
+  };
 }
 
-function readinessCode(status: CodexPluginAppReadinessStatus): CodexPluginAppReadinessCode {
-  switch (status) {
-    case "inaccessible":
-      return "app_inaccessible";
-    case "disabled":
-      return "app_disabled";
-    case "missing":
-      return "app_missing";
-    case "auth_required":
-      return "app_auth_required";
-    case "plugin_disabled":
-      return "plugin_disabled";
-    default:
-      return "app_readiness_unknown";
+function migrationBlockCodeForApps(
+  apps: readonly CodexPluginMigrationAppFact[],
+): CodexPluginMigrationBlockCode | undefined {
+  if (apps.some((app) => app.isAccessible === false)) {
+    return "app_inaccessible";
   }
+  if (apps.some((app) => app.isEnabled === false)) {
+    return "app_disabled";
+  }
+  if (apps.some((app) => app.isAccessible === undefined || app.isEnabled === undefined)) {
+    return "app_missing";
+  }
+  return undefined;
 }
 
-function appReadinessMessage(
+function appInventoryBlockMessage(
   plugin: CodexPluginSource,
-  apps: readonly CodexPluginAppReadinessApp[],
-  status: CodexPluginAppReadinessStatus,
+  apps: readonly CodexPluginMigrationAppFact[],
+  code: CodexPluginMigrationBlockCode,
 ): string {
+  const status =
+    code === "app_inaccessible" ? "inaccessible" : code === "app_disabled" ? "disabled" : "missing";
   const blocking =
-    apps.find((app) => app.status === status) ??
-    apps.find((app) => app.status !== "ready") ??
-    apps[0];
+    apps.find((app) =>
+      code === "app_inaccessible"
+        ? app.isAccessible === false
+        : code === "app_disabled"
+          ? app.isEnabled === false
+          : app.isAccessible === undefined || app.isEnabled === undefined,
+    ) ?? apps[0];
   const appLabel = blocking ? ` app "${blocking.name}"` : " an owned app";
-  return `Codex plugin "${plugin.pluginName ?? plugin.name}" owns${appLabel} but the source app inventory reports it is ${blocking?.status ?? "unknown"}; authenticate or enable the app in Codex before migrating it to OpenClaw.`;
+  return `Codex plugin "${plugin.pluginName ?? plugin.name}" owns${appLabel} but the source app inventory reports it is ${status}; authenticate or enable the app in Codex before migrating it to OpenClaw.`;
 }
 
 export function codexPluginMigrationSubscriptionWarning(): string {

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -284,6 +284,7 @@ async function requestSourceCodexAppServerJson<T>(
     timeoutMs: 60_000,
     startOptions: options.startOptions,
     authProfileId: null,
+    isolated: true,
   });
 }
 

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -42,6 +42,7 @@ export type CodexPluginSource = {
   pluginName?: string;
   installed?: boolean;
   enabled?: boolean;
+  apps?: CodexPluginMigrationAppFact[];
   migrationBlock?: CodexPluginMigrationBlock;
   message?: string;
 };
@@ -49,6 +50,7 @@ export type CodexPluginSource = {
 export type CodexPluginMigrationBlockCode =
   | "plugin_disabled"
   | "codex_subscription_required"
+  | "codex_account_unavailable"
   | "plugin_read_unavailable"
   | "app_inventory_unavailable"
   | "app_inaccessible"
@@ -93,6 +95,7 @@ type CodexSource = {
 type CodexSourceDiscoveryOptions = {
   input?: string;
   evaluatePluginMigrationEligibility?: boolean;
+  verifyPluginApps?: boolean;
 };
 
 type SourceAppServerRequestOptions = {
@@ -223,6 +226,7 @@ async function discoverInstalledCuratedPlugins(
             plugins,
             marketplace: marketplaceRef(marketplace),
             requestOptions,
+            verifyPluginApps: options.verifyPluginApps === true,
           })
         : plugins;
     const sorted = withEligibility.toSorted((a, b) =>
@@ -297,6 +301,7 @@ async function withPluginMigrationEligibility(params: {
   plugins: CodexPluginSource[];
   marketplace: CodexPluginMarketplaceRef;
   requestOptions: SourceAppServerRequestOptions;
+  verifyPluginApps: boolean;
 }): Promise<CodexPluginSource[]> {
   const pending: Array<{ plugin: CodexPluginSource; apps: CodexPluginMigrationAppFact[] }> = [];
   const evaluated: CodexPluginSource[] = [];
@@ -341,7 +346,23 @@ async function withPluginMigrationEligibility(params: {
     return evaluated;
   }
 
-  const sourceAccount = await readSourceCodexAccount(params.requestOptions).catch(() => undefined);
+  let sourceAccount: Awaited<ReturnType<typeof readSourceCodexAccount>> | undefined;
+  try {
+    sourceAccount = await readSourceCodexAccount(params.requestOptions);
+  } catch (error) {
+    if (!params.verifyPluginApps) {
+      const message = error instanceof Error ? error.message : String(error);
+      for (const { plugin, apps } of pending) {
+        evaluated.push({
+          ...plugin,
+          migratable: false,
+          migrationBlock: { code: "codex_account_unavailable", apps, error: message },
+          message: `Codex plugin "${plugin.pluginName ?? plugin.name}" owns apps, but the source Codex app-server account could not be read: ${message}`,
+        });
+      }
+      return evaluated;
+    }
+  }
   if (sourceAccount && sourceAccount !== "chatgpt") {
     for (const { plugin, apps } of pending) {
       evaluated.push({
@@ -349,6 +370,17 @@ async function withPluginMigrationEligibility(params: {
         migratable: false,
         migrationBlock: { code: "codex_subscription_required", apps },
         message: codexSubscriptionRequiredMessage(plugin),
+      });
+    }
+    return evaluated;
+  }
+
+  if (!params.verifyPluginApps) {
+    for (const { plugin, apps } of pending) {
+      evaluated.push({
+        ...plugin,
+        apps,
+        migratable: true,
       });
     }
     return evaluated;
@@ -381,7 +413,7 @@ async function withPluginMigrationEligibility(params: {
       .toSorted((left, right) => left.id.localeCompare(right.id));
     const blockCode = migrationBlockCodeForApps(apps);
     if (!blockCode) {
-      evaluated.push({ ...plugin, migratable: true });
+      evaluated.push({ ...plugin, apps, migratable: true });
       continue;
     }
     evaluated.push({

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -1,16 +1,10 @@
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { MigrationProviderContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
   defaultCodexAppInventoryCache,
   type CodexAppInventoryRequest,
 } from "../app-server/app-inventory-cache.js";
-import {
-  resolveCodexAppServerAuthAccountCacheKey,
-  resolveCodexAppServerAuthProfileIdForAgent,
-  resolveCodexAppServerEnvApiKeyCacheKey,
-} from "../app-server/auth-bridge.js";
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "../app-server/config.js";
 import type { CodexAppServerStartOptions } from "../app-server/config.js";
 import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
@@ -118,15 +112,11 @@ type CodexSource = {
 
 type CodexSourceDiscoveryOptions = {
   input?: string;
-  config?: MigrationProviderContext["config"];
-  agentDir?: string;
   evaluatePluginAppReadiness?: boolean;
 };
 
 type SourceAppServerRequestOptions = {
   startOptions: CodexAppServerStartOptions;
-  config?: MigrationProviderContext["config"];
-  agentDir?: string;
 };
 
 type PluginReadResult =
@@ -228,7 +218,7 @@ async function discoverInstalledCuratedPlugins(
   error?: string;
 }> {
   const startOptions = sourceCodexAppServerStartOptions(codexHome);
-  const requestOptions = { startOptions, config: options.config, agentDir: options.agentDir };
+  const requestOptions = { startOptions };
   try {
     const response = await requestSourceCodexAppServerJson<v2.PluginListResponse>(requestOptions, {
       method: "plugin/list",
@@ -293,8 +283,7 @@ async function requestSourceCodexAppServerJson<T>(
     requestParams: params.requestParams,
     timeoutMs: 60_000,
     startOptions: options.startOptions,
-    agentDir: options.agentDir,
-    config: options.config,
+    authProfileId: null,
   });
 }
 
@@ -455,26 +444,8 @@ async function readPluginDetail(
 async function refreshSourceAppInventory(
   options: SourceAppServerRequestOptions,
 ): Promise<Awaited<ReturnType<typeof defaultCodexAppInventoryCache.refreshNow>>> {
-  const authProfileId = resolveCodexAppServerAuthProfileIdForAgent({
-    agentDir: options.agentDir,
-    config: options.config,
-  });
-  const accountId = await resolveCodexAppServerAuthAccountCacheKey({
-    authProfileId,
-    agentDir: options.agentDir,
-    config: options.config,
-  });
-  const envApiKeyFingerprint = authProfileId
-    ? undefined
-    : resolveCodexAppServerEnvApiKeyCacheKey({
-        startOptions: options.startOptions,
-      });
   const key = buildCodexPluginAppCacheKey({
     appServer: { start: options.startOptions },
-    agentDir: options.agentDir,
-    authProfileId,
-    accountId,
-    envApiKeyFingerprint,
   });
   const request: CodexAppInventoryRequest = async (method, requestParams) =>
     await requestSourceCodexAppServerJson<v2.AppsListResponse>(options, {
@@ -504,9 +475,7 @@ function sourceAppReadiness(
     ? "inaccessible"
     : !info.isEnabled
       ? "disabled"
-      : app.needsAuth
-        ? "auth_required"
-        : "ready";
+      : "ready";
   return {
     id: app.id,
     name: app.name,

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -1,7 +1,23 @@
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { MigrationProviderContext } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  defaultCodexAppInventoryCache,
+  type CodexAppInventoryRequest,
+} from "../app-server/app-inventory-cache.js";
+import {
+  resolveCodexAppServerAuthAccountCacheKey,
+  resolveCodexAppServerAuthProfileIdForAgent,
+  resolveCodexAppServerEnvApiKeyCacheKey,
+} from "../app-server/auth-bridge.js";
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "../app-server/config.js";
+import type { CodexAppServerStartOptions } from "../app-server/config.js";
+import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
+import {
+  pluginReadParams,
+  type CodexPluginMarketplaceRef,
+} from "../app-server/plugin-inventory.js";
 import type { v2 } from "../app-server/protocol.js";
 import { requestCodexAppServerJson } from "../app-server/request.js";
 import {
@@ -32,7 +48,51 @@ export type CodexPluginSource = {
   pluginName?: string;
   installed?: boolean;
   enabled?: boolean;
+  appReadiness?: CodexPluginAppReadiness;
   message?: string;
+};
+
+export type CodexPluginAppReadinessStatus =
+  | "not_app_backed"
+  | "ready"
+  | "inaccessible"
+  | "missing"
+  | "disabled"
+  | "plugin_disabled"
+  | "auth_required"
+  | "unknown";
+
+export type CodexPluginAppReadinessCode =
+  | "plugin_disabled"
+  | "app_inaccessible"
+  | "app_disabled"
+  | "app_missing"
+  | "app_auth_required"
+  | "app_readiness_unknown"
+  | "plugin_read_unavailable"
+  | "app_inventory_unavailable";
+
+export type CodexPluginAppReadinessAppStatus =
+  | "ready"
+  | "inaccessible"
+  | "missing"
+  | "disabled"
+  | "auth_required"
+  | "unknown";
+
+export type CodexPluginAppReadinessApp = {
+  id: string;
+  name: string;
+  status: CodexPluginAppReadinessAppStatus;
+  isAccessible?: boolean;
+  isEnabled?: boolean;
+  needsAuth?: boolean;
+};
+
+export type CodexPluginAppReadiness = {
+  status: CodexPluginAppReadinessStatus;
+  reason?: CodexPluginAppReadinessCode;
+  apps: CodexPluginAppReadinessApp[];
 };
 
 type CodexArchiveSource = {
@@ -55,6 +115,29 @@ type CodexSource = {
   pluginDiscoveryError?: string;
   archivePaths: CodexArchiveSource[];
 };
+
+type CodexSourceDiscoveryOptions = {
+  input?: string;
+  config?: MigrationProviderContext["config"];
+  agentDir?: string;
+  evaluatePluginAppReadiness?: boolean;
+};
+
+type SourceAppServerRequestOptions = {
+  startOptions: CodexAppServerStartOptions;
+  config?: MigrationProviderContext["config"];
+  agentDir?: string;
+};
+
+type PluginReadResult =
+  | {
+      ok: true;
+      detail: v2.PluginDetail;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
 
 function defaultCodexHome(): string {
   return resolveHomePath(process.env.CODEX_HOME?.trim() || "~/.codex");
@@ -137,27 +220,19 @@ async function discoverPluginDirs(codexHome: string): Promise<CodexPluginSource[
   return [...discovered.values()].toSorted((a, b) => a.source.localeCompare(b.source));
 }
 
-async function discoverInstalledCuratedPlugins(codexHome: string): Promise<{
+async function discoverInstalledCuratedPlugins(
+  codexHome: string,
+  options: CodexSourceDiscoveryOptions = {},
+): Promise<{
   plugins: CodexPluginSource[];
   error?: string;
 }> {
+  const startOptions = sourceCodexAppServerStartOptions(codexHome);
+  const requestOptions = { startOptions, config: options.config, agentDir: options.agentDir };
   try {
-    const response = await requestCodexAppServerJson<v2.PluginListResponse>({
+    const response = await requestSourceCodexAppServerJson<v2.PluginListResponse>(requestOptions, {
       method: "plugin/list",
       requestParams: { cwds: [] } satisfies v2.PluginListParams,
-      timeoutMs: 60_000,
-      isolated: true,
-      startOptions: {
-        transport: "stdio",
-        command: "codex",
-        commandSource: "config",
-        args: ["app-server", "--listen", "stdio://"],
-        headers: {},
-        env: {
-          CODEX_HOME: codexHome,
-          HOME: path.dirname(codexHome),
-        },
-      },
     });
     const marketplace = response.marketplaces.find(
       (entry) => entry.name === CODEX_PLUGINS_MARKETPLACE_NAME,
@@ -170,31 +245,327 @@ async function discoverInstalledCuratedPlugins(codexHome: string): Promise<{
     }
     const plugins = marketplace.plugins
       .filter((plugin) => plugin.installed)
-      .map((plugin): CodexPluginSource | undefined => {
-        const pluginName = pluginNameFromSummary(plugin);
-        if (!pluginName) {
-          return undefined;
-        }
-        return {
-          name: plugin.name,
-          pluginName,
-          marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-          source: `${CODEX_PLUGINS_MARKETPLACE_NAME}/${pluginName}`,
-          sourceKind: "app-server",
-          migratable: true,
-          installed: plugin.installed,
-          enabled: plugin.enabled,
-        };
-      })
-      .filter((plugin): plugin is CodexPluginSource => plugin !== undefined)
-      .toSorted((a, b) => (a.pluginName ?? a.name).localeCompare(b.pluginName ?? b.name));
-    return { plugins };
+      .map((plugin) => buildInstalledPluginSource(plugin))
+      .filter((plugin): plugin is CodexPluginSource => plugin !== undefined);
+    const withReadiness =
+      options.evaluatePluginAppReadiness === true
+        ? await withPluginAppReadiness({
+            plugins,
+            marketplace: marketplaceRef(marketplace),
+            requestOptions,
+          })
+        : plugins;
+    const sorted = withReadiness.toSorted((a, b) =>
+      (a.pluginName ?? a.name).localeCompare(b.pluginName ?? b.name),
+    );
+    return { plugins: sorted };
   } catch (error) {
     return {
       plugins: [],
       error: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+function sourceCodexAppServerStartOptions(codexHome: string): CodexAppServerStartOptions {
+  return {
+    transport: "stdio",
+    command: "codex",
+    commandSource: "config",
+    args: ["app-server", "--listen", "stdio://"],
+    headers: {},
+    env: {
+      CODEX_HOME: codexHome,
+      HOME: path.dirname(codexHome),
+    },
+  };
+}
+
+async function requestSourceCodexAppServerJson<T>(
+  options: SourceAppServerRequestOptions,
+  params: {
+    method: string;
+    requestParams?: unknown;
+  },
+): Promise<T> {
+  return await requestCodexAppServerJson<T>({
+    method: params.method,
+    requestParams: params.requestParams,
+    timeoutMs: 60_000,
+    startOptions: options.startOptions,
+    agentDir: options.agentDir,
+    config: options.config,
+  });
+}
+
+function buildInstalledPluginSource(plugin: v2.PluginSummary): CodexPluginSource | undefined {
+  const pluginName = pluginNameFromSummary(plugin);
+  if (!pluginName) {
+    return undefined;
+  }
+  return {
+    name: plugin.name,
+    pluginName,
+    marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+    source: `${CODEX_PLUGINS_MARKETPLACE_NAME}/${pluginName}`,
+    sourceKind: "app-server",
+    migratable: true,
+    installed: plugin.installed,
+    enabled: plugin.enabled,
+  };
+}
+
+function marketplaceRef(marketplace: v2.PluginMarketplaceEntry): CodexPluginMarketplaceRef {
+  return {
+    name: CODEX_PLUGINS_MARKETPLACE_NAME,
+    ...(marketplace.path ? { path: marketplace.path } : {}),
+    ...(!marketplace.path ? { remoteMarketplaceName: marketplace.name } : {}),
+  };
+}
+
+async function withPluginAppReadiness(params: {
+  plugins: CodexPluginSource[];
+  marketplace: CodexPluginMarketplaceRef;
+  requestOptions: SourceAppServerRequestOptions;
+}): Promise<CodexPluginSource[]> {
+  const pending: Array<{ plugin: CodexPluginSource; detail: v2.PluginDetail }> = [];
+  const evaluated: CodexPluginSource[] = [];
+
+  for (const plugin of params.plugins) {
+    if (plugin.enabled !== true) {
+      evaluated.push({
+        ...plugin,
+        migratable: false,
+        appReadiness: {
+          status: "plugin_disabled",
+          reason: "plugin_disabled",
+          apps: [],
+        },
+        message: `Codex plugin "${plugin.pluginName ?? plugin.name}" is installed in Codex but disabled; enable it in Codex before migrating it to OpenClaw.`,
+      });
+      continue;
+    }
+
+    const detail = await readPluginDetail(params.requestOptions, params.marketplace, plugin);
+    if (!detail.ok) {
+      evaluated.push({
+        ...plugin,
+        migratable: false,
+        appReadiness: {
+          status: "unknown",
+          reason: "plugin_read_unavailable",
+          apps: [],
+        },
+        message: `Codex plugin "${plugin.pluginName ?? plugin.name}" detail could not be read: ${detail.error}`,
+      });
+      continue;
+    }
+
+    if (detail.detail.apps.length === 0) {
+      evaluated.push({
+        ...plugin,
+        migratable: true,
+        appReadiness: {
+          status: "not_app_backed",
+          apps: [],
+        },
+      });
+      continue;
+    }
+
+    const appBackedPlugin: CodexPluginSource = {
+      ...plugin,
+      migratable: false,
+      appReadiness: {
+        status: "unknown",
+        reason: "app_readiness_unknown",
+        apps: detail.detail.apps.map((app) => ({
+          id: app.id,
+          name: app.name,
+          status: "unknown" as const,
+          needsAuth: app.needsAuth,
+        })),
+      },
+    };
+    evaluated.push(appBackedPlugin);
+    pending.push({ plugin: appBackedPlugin, detail: detail.detail });
+  }
+
+  if (pending.length === 0) {
+    return evaluated;
+  }
+
+  const snapshot = await refreshSourceAppInventory(params.requestOptions).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    for (const { plugin } of pending) {
+      plugin.appReadiness = {
+        status: "unknown",
+        reason: "app_inventory_unavailable",
+        apps:
+          plugin.appReadiness?.apps.map((app) => ({
+            ...app,
+            status: "unknown",
+          })) ?? [],
+      };
+      plugin.message = `Codex plugin "${plugin.pluginName ?? plugin.name}" owns apps, but source app inventory could not be read: ${message}`;
+    }
+    return undefined;
+  });
+  if (!snapshot) {
+    return evaluated;
+  }
+
+  const appInfoById = new Map(snapshot.apps.map((app) => [app.id, app] as const));
+  for (const { plugin, detail } of pending) {
+    const apps = detail.apps
+      .map((app) => sourceAppReadiness(app, appInfoById.get(app.id)))
+      .toSorted((left, right) => left.id.localeCompare(right.id));
+    const status = summarizeAppReadiness(apps);
+    const ready = status === "ready";
+    plugin.migratable = ready;
+    plugin.appReadiness = {
+      status,
+      ...(ready ? {} : { reason: readinessCode(status) }),
+      apps,
+    };
+    if (!ready) {
+      plugin.message = appReadinessMessage(plugin, apps, status);
+    }
+  }
+
+  return evaluated;
+}
+
+async function readPluginDetail(
+  options: SourceAppServerRequestOptions,
+  marketplace: CodexPluginMarketplaceRef,
+  plugin: CodexPluginSource,
+): Promise<PluginReadResult> {
+  try {
+    const response = await requestSourceCodexAppServerJson<v2.PluginReadResponse>(options, {
+      method: "plugin/read",
+      requestParams: pluginReadParams(marketplace, plugin.pluginName ?? plugin.name),
+    });
+    return { ok: true, detail: response.plugin };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function refreshSourceAppInventory(
+  options: SourceAppServerRequestOptions,
+): Promise<Awaited<ReturnType<typeof defaultCodexAppInventoryCache.refreshNow>>> {
+  const authProfileId = resolveCodexAppServerAuthProfileIdForAgent({
+    agentDir: options.agentDir,
+    config: options.config,
+  });
+  const accountId = await resolveCodexAppServerAuthAccountCacheKey({
+    authProfileId,
+    agentDir: options.agentDir,
+    config: options.config,
+  });
+  const envApiKeyFingerprint = authProfileId
+    ? undefined
+    : resolveCodexAppServerEnvApiKeyCacheKey({
+        startOptions: options.startOptions,
+      });
+  const key = buildCodexPluginAppCacheKey({
+    appServer: { start: options.startOptions },
+    agentDir: options.agentDir,
+    authProfileId,
+    accountId,
+    envApiKeyFingerprint,
+  });
+  const request: CodexAppInventoryRequest = async (method, requestParams) =>
+    await requestSourceCodexAppServerJson<v2.AppsListResponse>(options, {
+      method,
+      requestParams,
+    });
+  return await defaultCodexAppInventoryCache.refreshNow({
+    key,
+    request,
+    forceRefetch: true,
+  });
+}
+
+function sourceAppReadiness(
+  app: v2.AppSummary,
+  info: v2.AppInfo | undefined,
+): CodexPluginAppReadinessApp {
+  if (!info) {
+    return {
+      id: app.id,
+      name: app.name,
+      status: "missing",
+      needsAuth: app.needsAuth,
+    };
+  }
+  const status: CodexPluginAppReadinessAppStatus = !info.isAccessible
+    ? "inaccessible"
+    : !info.isEnabled
+      ? "disabled"
+      : app.needsAuth
+        ? "auth_required"
+        : "ready";
+  return {
+    id: app.id,
+    name: app.name,
+    status,
+    isAccessible: info.isAccessible,
+    isEnabled: info.isEnabled,
+    needsAuth: app.needsAuth,
+  };
+}
+
+function summarizeAppReadiness(
+  apps: readonly CodexPluginAppReadinessApp[],
+): CodexPluginAppReadinessStatus {
+  if (apps.some((app) => app.status === "inaccessible")) {
+    return "inaccessible";
+  }
+  if (apps.some((app) => app.status === "disabled")) {
+    return "disabled";
+  }
+  if (apps.some((app) => app.status === "missing")) {
+    return "missing";
+  }
+  if (apps.some((app) => app.status === "auth_required")) {
+    return "auth_required";
+  }
+  if (apps.some((app) => app.status === "unknown")) {
+    return "unknown";
+  }
+  return "ready";
+}
+
+function readinessCode(status: CodexPluginAppReadinessStatus): CodexPluginAppReadinessCode {
+  switch (status) {
+    case "inaccessible":
+      return "app_inaccessible";
+    case "disabled":
+      return "app_disabled";
+    case "missing":
+      return "app_missing";
+    case "auth_required":
+      return "app_auth_required";
+    case "plugin_disabled":
+      return "plugin_disabled";
+    default:
+      return "app_readiness_unknown";
+  }
+}
+
+function appReadinessMessage(
+  plugin: CodexPluginSource,
+  apps: readonly CodexPluginAppReadinessApp[],
+  status: CodexPluginAppReadinessStatus,
+): string {
+  const blocking =
+    apps.find((app) => app.status === status) ??
+    apps.find((app) => app.status !== "ready") ??
+    apps[0];
+  const appLabel = blocking ? ` app "${blocking.name}"` : " an owned app";
+  return `Codex plugin "${plugin.pluginName ?? plugin.name}" owns${appLabel} but the source app inventory reports it is ${blocking?.status ?? "unknown"}; authenticate or enable the app in Codex before migrating it to OpenClaw.`;
 }
 
 function pluginNameFromSummary(summary: v2.PluginSummary): string | undefined {
@@ -216,8 +587,14 @@ function pluginNameFromSummary(summary: v2.PluginSummary): string | undefined {
   return undefined;
 }
 
-export async function discoverCodexSource(input?: string): Promise<CodexSource> {
-  const codexHome = resolveHomePath(input?.trim() || defaultCodexHome());
+export async function discoverCodexSource(
+  inputOrOptions?: string | CodexSourceDiscoveryOptions,
+): Promise<CodexSource> {
+  const options =
+    typeof inputOrOptions === "string" || inputOrOptions === undefined
+      ? { input: inputOrOptions }
+      : inputOrOptions;
+  const codexHome = resolveHomePath(options.input?.trim() || defaultCodexHome());
   const codexSkillsDir = path.join(codexHome, "skills");
   const agentsSkillsDir = personalAgentsSkillsDir();
   const configPath = path.join(codexHome, "config.toml");
@@ -231,7 +608,7 @@ export async function discoverCodexSource(input?: string): Promise<CodexSource> 
     root: agentsSkillsDir,
     sourceLabel: "personal AgentSkill",
   });
-  const sourcePluginDiscovery = await discoverInstalledCuratedPlugins(codexHome);
+  const sourcePluginDiscovery = await discoverInstalledCuratedPlugins(codexHome, options);
   const sourcePluginNames = new Set(
     sourcePluginDiscovery.plugins.flatMap((plugin) =>
       plugin.pluginName ? [plugin.pluginName] : [],

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -1,7 +1,23 @@
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { MigrationProviderContext } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  defaultCodexAppInventoryCache,
+  type CodexAppInventoryRequest,
+} from "../app-server/app-inventory-cache.js";
+import {
+  resolveCodexAppServerAuthAccountCacheKey,
+  resolveCodexAppServerAuthProfileIdForAgent,
+  resolveCodexAppServerEnvApiKeyCacheKey,
+} from "../app-server/auth-bridge.js";
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "../app-server/config.js";
+import type { CodexAppServerStartOptions } from "../app-server/config.js";
+import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
+import {
+  pluginReadParams,
+  type CodexPluginMarketplaceRef,
+} from "../app-server/plugin-inventory.js";
 import type { v2 } from "../app-server/protocol.js";
 import { requestCodexAppServerJson } from "../app-server/request.js";
 import {
@@ -32,7 +48,51 @@ export type CodexPluginSource = {
   pluginName?: string;
   installed?: boolean;
   enabled?: boolean;
+  appReadiness?: CodexPluginAppReadiness;
   message?: string;
+};
+
+export type CodexPluginAppReadinessStatus =
+  | "not_app_backed"
+  | "ready"
+  | "inaccessible"
+  | "missing"
+  | "disabled"
+  | "plugin_disabled"
+  | "auth_required"
+  | "unknown";
+
+export type CodexPluginAppReadinessCode =
+  | "plugin_disabled"
+  | "app_inaccessible"
+  | "app_disabled"
+  | "app_missing"
+  | "app_auth_required"
+  | "app_readiness_unknown"
+  | "plugin_read_unavailable"
+  | "app_inventory_unavailable";
+
+export type CodexPluginAppReadinessAppStatus =
+  | "ready"
+  | "inaccessible"
+  | "missing"
+  | "disabled"
+  | "auth_required"
+  | "unknown";
+
+export type CodexPluginAppReadinessApp = {
+  id: string;
+  name: string;
+  status: CodexPluginAppReadinessAppStatus;
+  isAccessible?: boolean;
+  isEnabled?: boolean;
+  needsAuth?: boolean;
+};
+
+export type CodexPluginAppReadiness = {
+  status: CodexPluginAppReadinessStatus;
+  reason?: CodexPluginAppReadinessCode;
+  apps: CodexPluginAppReadinessApp[];
 };
 
 type CodexArchiveSource = {
@@ -55,6 +115,29 @@ type CodexSource = {
   pluginDiscoveryError?: string;
   archivePaths: CodexArchiveSource[];
 };
+
+type CodexSourceDiscoveryOptions = {
+  input?: string;
+  config?: MigrationProviderContext["config"];
+  agentDir?: string;
+  evaluatePluginAppReadiness?: boolean;
+};
+
+type SourceAppServerRequestOptions = {
+  startOptions: CodexAppServerStartOptions;
+  config?: MigrationProviderContext["config"];
+  agentDir?: string;
+};
+
+type PluginReadResult =
+  | {
+      ok: true;
+      detail: v2.PluginDetail;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
 
 function defaultCodexHome(): string {
   return resolveHomePath(process.env.CODEX_HOME?.trim() || "~/.codex");
@@ -137,26 +220,19 @@ async function discoverPluginDirs(codexHome: string): Promise<CodexPluginSource[
   return [...discovered.values()].toSorted((a, b) => a.source.localeCompare(b.source));
 }
 
-async function discoverInstalledCuratedPlugins(codexHome: string): Promise<{
+async function discoverInstalledCuratedPlugins(
+  codexHome: string,
+  options: CodexSourceDiscoveryOptions = {},
+): Promise<{
   plugins: CodexPluginSource[];
   error?: string;
 }> {
+  const startOptions = sourceCodexAppServerStartOptions(codexHome);
+  const requestOptions = { startOptions, config: options.config, agentDir: options.agentDir };
   try {
-    const response = await requestCodexAppServerJson<v2.PluginListResponse>({
+    const response = await requestSourceCodexAppServerJson<v2.PluginListResponse>(requestOptions, {
       method: "plugin/list",
       requestParams: { cwds: [] } satisfies v2.PluginListParams,
-      timeoutMs: 60_000,
-      startOptions: {
-        transport: "stdio",
-        command: "codex",
-        commandSource: "config",
-        args: ["app-server", "--listen", "stdio://"],
-        headers: {},
-        env: {
-          CODEX_HOME: codexHome,
-          HOME: path.dirname(codexHome),
-        },
-      },
     });
     const marketplace = response.marketplaces.find(
       (entry) => entry.name === CODEX_PLUGINS_MARKETPLACE_NAME,
@@ -169,31 +245,327 @@ async function discoverInstalledCuratedPlugins(codexHome: string): Promise<{
     }
     const plugins = marketplace.plugins
       .filter((plugin) => plugin.installed)
-      .map((plugin): CodexPluginSource | undefined => {
-        const pluginName = pluginNameFromSummary(plugin);
-        if (!pluginName) {
-          return undefined;
-        }
-        return {
-          name: plugin.name,
-          pluginName,
-          marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-          source: `${CODEX_PLUGINS_MARKETPLACE_NAME}/${pluginName}`,
-          sourceKind: "app-server",
-          migratable: true,
-          installed: plugin.installed,
-          enabled: plugin.enabled,
-        };
-      })
-      .filter((plugin): plugin is CodexPluginSource => plugin !== undefined)
-      .toSorted((a, b) => (a.pluginName ?? a.name).localeCompare(b.pluginName ?? b.name));
-    return { plugins };
+      .map((plugin) => buildInstalledPluginSource(plugin))
+      .filter((plugin): plugin is CodexPluginSource => plugin !== undefined);
+    const withReadiness =
+      options.evaluatePluginAppReadiness === true
+        ? await withPluginAppReadiness({
+            plugins,
+            marketplace: marketplaceRef(marketplace),
+            requestOptions,
+          })
+        : plugins;
+    const sorted = withReadiness.toSorted((a, b) =>
+      (a.pluginName ?? a.name).localeCompare(b.pluginName ?? b.name),
+    );
+    return { plugins: sorted };
   } catch (error) {
     return {
       plugins: [],
       error: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+function sourceCodexAppServerStartOptions(codexHome: string): CodexAppServerStartOptions {
+  return {
+    transport: "stdio",
+    command: "codex",
+    commandSource: "config",
+    args: ["app-server", "--listen", "stdio://"],
+    headers: {},
+    env: {
+      CODEX_HOME: codexHome,
+      HOME: path.dirname(codexHome),
+    },
+  };
+}
+
+async function requestSourceCodexAppServerJson<T>(
+  options: SourceAppServerRequestOptions,
+  params: {
+    method: string;
+    requestParams?: unknown;
+  },
+): Promise<T> {
+  return await requestCodexAppServerJson<T>({
+    method: params.method,
+    requestParams: params.requestParams,
+    timeoutMs: 60_000,
+    startOptions: options.startOptions,
+    agentDir: options.agentDir,
+    config: options.config,
+  });
+}
+
+function buildInstalledPluginSource(plugin: v2.PluginSummary): CodexPluginSource | undefined {
+  const pluginName = pluginNameFromSummary(plugin);
+  if (!pluginName) {
+    return undefined;
+  }
+  return {
+    name: plugin.name,
+    pluginName,
+    marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+    source: `${CODEX_PLUGINS_MARKETPLACE_NAME}/${pluginName}`,
+    sourceKind: "app-server",
+    migratable: true,
+    installed: plugin.installed,
+    enabled: plugin.enabled,
+  };
+}
+
+function marketplaceRef(marketplace: v2.PluginMarketplaceEntry): CodexPluginMarketplaceRef {
+  return {
+    name: CODEX_PLUGINS_MARKETPLACE_NAME,
+    ...(marketplace.path ? { path: marketplace.path } : {}),
+    ...(!marketplace.path ? { remoteMarketplaceName: marketplace.name } : {}),
+  };
+}
+
+async function withPluginAppReadiness(params: {
+  plugins: CodexPluginSource[];
+  marketplace: CodexPluginMarketplaceRef;
+  requestOptions: SourceAppServerRequestOptions;
+}): Promise<CodexPluginSource[]> {
+  const pending: Array<{ plugin: CodexPluginSource; detail: v2.PluginDetail }> = [];
+  const evaluated: CodexPluginSource[] = [];
+
+  for (const plugin of params.plugins) {
+    if (plugin.enabled !== true) {
+      evaluated.push({
+        ...plugin,
+        migratable: false,
+        appReadiness: {
+          status: "plugin_disabled",
+          reason: "plugin_disabled",
+          apps: [],
+        },
+        message: `Codex plugin "${plugin.pluginName ?? plugin.name}" is installed in Codex but disabled; enable it in Codex before migrating it to OpenClaw.`,
+      });
+      continue;
+    }
+
+    const detail = await readPluginDetail(params.requestOptions, params.marketplace, plugin);
+    if (!detail.ok) {
+      evaluated.push({
+        ...plugin,
+        migratable: false,
+        appReadiness: {
+          status: "unknown",
+          reason: "plugin_read_unavailable",
+          apps: [],
+        },
+        message: `Codex plugin "${plugin.pluginName ?? plugin.name}" detail could not be read: ${detail.error}`,
+      });
+      continue;
+    }
+
+    if (detail.detail.apps.length === 0) {
+      evaluated.push({
+        ...plugin,
+        migratable: true,
+        appReadiness: {
+          status: "not_app_backed",
+          apps: [],
+        },
+      });
+      continue;
+    }
+
+    const appBackedPlugin: CodexPluginSource = {
+      ...plugin,
+      migratable: false,
+      appReadiness: {
+        status: "unknown",
+        reason: "app_readiness_unknown",
+        apps: detail.detail.apps.map((app) => ({
+          id: app.id,
+          name: app.name,
+          status: "unknown" as const,
+          needsAuth: app.needsAuth,
+        })),
+      },
+    };
+    evaluated.push(appBackedPlugin);
+    pending.push({ plugin: appBackedPlugin, detail: detail.detail });
+  }
+
+  if (pending.length === 0) {
+    return evaluated;
+  }
+
+  const snapshot = await refreshSourceAppInventory(params.requestOptions).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    for (const { plugin } of pending) {
+      plugin.appReadiness = {
+        status: "unknown",
+        reason: "app_inventory_unavailable",
+        apps:
+          plugin.appReadiness?.apps.map((app) => ({
+            ...app,
+            status: "unknown",
+          })) ?? [],
+      };
+      plugin.message = `Codex plugin "${plugin.pluginName ?? plugin.name}" owns apps, but source app inventory could not be read: ${message}`;
+    }
+    return undefined;
+  });
+  if (!snapshot) {
+    return evaluated;
+  }
+
+  const appInfoById = new Map(snapshot.apps.map((app) => [app.id, app] as const));
+  for (const { plugin, detail } of pending) {
+    const apps = detail.apps
+      .map((app) => sourceAppReadiness(app, appInfoById.get(app.id)))
+      .toSorted((left, right) => left.id.localeCompare(right.id));
+    const status = summarizeAppReadiness(apps);
+    const ready = status === "ready";
+    plugin.migratable = ready;
+    plugin.appReadiness = {
+      status,
+      ...(ready ? {} : { reason: readinessCode(status) }),
+      apps,
+    };
+    if (!ready) {
+      plugin.message = appReadinessMessage(plugin, apps, status);
+    }
+  }
+
+  return evaluated;
+}
+
+async function readPluginDetail(
+  options: SourceAppServerRequestOptions,
+  marketplace: CodexPluginMarketplaceRef,
+  plugin: CodexPluginSource,
+): Promise<PluginReadResult> {
+  try {
+    const response = await requestSourceCodexAppServerJson<v2.PluginReadResponse>(options, {
+      method: "plugin/read",
+      requestParams: pluginReadParams(marketplace, plugin.pluginName ?? plugin.name),
+    });
+    return { ok: true, detail: response.plugin };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function refreshSourceAppInventory(
+  options: SourceAppServerRequestOptions,
+): Promise<Awaited<ReturnType<typeof defaultCodexAppInventoryCache.refreshNow>>> {
+  const authProfileId = resolveCodexAppServerAuthProfileIdForAgent({
+    agentDir: options.agentDir,
+    config: options.config,
+  });
+  const accountId = await resolveCodexAppServerAuthAccountCacheKey({
+    authProfileId,
+    agentDir: options.agentDir,
+    config: options.config,
+  });
+  const envApiKeyFingerprint = authProfileId
+    ? undefined
+    : resolveCodexAppServerEnvApiKeyCacheKey({
+        startOptions: options.startOptions,
+      });
+  const key = buildCodexPluginAppCacheKey({
+    appServer: { start: options.startOptions },
+    agentDir: options.agentDir,
+    authProfileId,
+    accountId,
+    envApiKeyFingerprint,
+  });
+  const request: CodexAppInventoryRequest = async (method, requestParams) =>
+    await requestSourceCodexAppServerJson<v2.AppsListResponse>(options, {
+      method,
+      requestParams,
+    });
+  return await defaultCodexAppInventoryCache.refreshNow({
+    key,
+    request,
+    forceRefetch: true,
+  });
+}
+
+function sourceAppReadiness(
+  app: v2.AppSummary,
+  info: v2.AppInfo | undefined,
+): CodexPluginAppReadinessApp {
+  if (!info) {
+    return {
+      id: app.id,
+      name: app.name,
+      status: "missing",
+      needsAuth: app.needsAuth,
+    };
+  }
+  const status: CodexPluginAppReadinessAppStatus = !info.isAccessible
+    ? "inaccessible"
+    : !info.isEnabled
+      ? "disabled"
+      : app.needsAuth
+        ? "auth_required"
+        : "ready";
+  return {
+    id: app.id,
+    name: app.name,
+    status,
+    isAccessible: info.isAccessible,
+    isEnabled: info.isEnabled,
+    needsAuth: app.needsAuth,
+  };
+}
+
+function summarizeAppReadiness(
+  apps: readonly CodexPluginAppReadinessApp[],
+): CodexPluginAppReadinessStatus {
+  if (apps.some((app) => app.status === "inaccessible")) {
+    return "inaccessible";
+  }
+  if (apps.some((app) => app.status === "disabled")) {
+    return "disabled";
+  }
+  if (apps.some((app) => app.status === "missing")) {
+    return "missing";
+  }
+  if (apps.some((app) => app.status === "auth_required")) {
+    return "auth_required";
+  }
+  if (apps.some((app) => app.status === "unknown")) {
+    return "unknown";
+  }
+  return "ready";
+}
+
+function readinessCode(status: CodexPluginAppReadinessStatus): CodexPluginAppReadinessCode {
+  switch (status) {
+    case "inaccessible":
+      return "app_inaccessible";
+    case "disabled":
+      return "app_disabled";
+    case "missing":
+      return "app_missing";
+    case "auth_required":
+      return "app_auth_required";
+    case "plugin_disabled":
+      return "plugin_disabled";
+    default:
+      return "app_readiness_unknown";
+  }
+}
+
+function appReadinessMessage(
+  plugin: CodexPluginSource,
+  apps: readonly CodexPluginAppReadinessApp[],
+  status: CodexPluginAppReadinessStatus,
+): string {
+  const blocking =
+    apps.find((app) => app.status === status) ??
+    apps.find((app) => app.status !== "ready") ??
+    apps[0];
+  const appLabel = blocking ? ` app "${blocking.name}"` : " an owned app";
+  return `Codex plugin "${plugin.pluginName ?? plugin.name}" owns${appLabel} but the source app inventory reports it is ${blocking?.status ?? "unknown"}; authenticate or enable the app in Codex before migrating it to OpenClaw.`;
 }
 
 function pluginNameFromSummary(summary: v2.PluginSummary): string | undefined {
@@ -215,8 +587,14 @@ function pluginNameFromSummary(summary: v2.PluginSummary): string | undefined {
   return undefined;
 }
 
-export async function discoverCodexSource(input?: string): Promise<CodexSource> {
-  const codexHome = resolveHomePath(input?.trim() || defaultCodexHome());
+export async function discoverCodexSource(
+  inputOrOptions?: string | CodexSourceDiscoveryOptions,
+): Promise<CodexSource> {
+  const options =
+    typeof inputOrOptions === "string" || inputOrOptions === undefined
+      ? { input: inputOrOptions }
+      : inputOrOptions;
+  const codexHome = resolveHomePath(options.input?.trim() || defaultCodexHome());
   const codexSkillsDir = path.join(codexHome, "skills");
   const agentsSkillsDir = personalAgentsSkillsDir();
   const configPath = path.join(codexHome, "config.toml");
@@ -230,7 +608,7 @@ export async function discoverCodexSource(input?: string): Promise<CodexSource> 
     root: agentsSkillsDir,
     sourceLabel: "personal AgentSkill",
   });
-  const sourcePluginDiscovery = await discoverInstalledCuratedPlugins(codexHome);
+  const sourcePluginDiscovery = await discoverInstalledCuratedPlugins(codexHome, options);
   const sourcePluginNames = new Set(
     sourcePluginDiscovery.plugins.flatMap((plugin) =>
       plugin.pluginName ? [plugin.pluginName] : [],

--- a/src/cli/program/register.migrate.ts
+++ b/src/cli/program/register.migrate.ts
@@ -56,42 +56,62 @@ function addMigrationPluginOption(command: Command): Command {
   );
 }
 
+function addVerifyPluginAppsOption(command: Command): Command {
+  return command.option(
+    "--verify-plugin-apps",
+    "Codex only: verify source plugin app accessibility with app/list before planning native plugin activation",
+    false,
+  );
+}
+
 function addMigrationOptions(command: Command): Command {
-  return addMigrationPluginOption(
-    addMigrationSkillOption(
-      command
-        .option("--from <path>", "Source directory to migrate from")
-        .option("--include-secrets", "Import supported credentials and secrets", false)
-        .option("--overwrite", "Overwrite conflicting target files after item-level backups", false)
-        .option("--json", "Output JSON", false),
+  return addVerifyPluginAppsOption(
+    addMigrationPluginOption(
+      addMigrationSkillOption(
+        command
+          .option("--from <path>", "Source directory to migrate from")
+          .option("--include-secrets", "Import supported credentials and secrets", false)
+          .option(
+            "--overwrite",
+            "Overwrite conflicting target files after item-level backups",
+            false,
+          )
+          .option("--json", "Output JSON", false),
+      ),
     ),
   );
 }
 
+function readVerifyPluginApps(value: unknown): boolean {
+  return value === true;
+}
+
 export function registerMigrateCommand(program: Command) {
-  const migrate = program
-    .command("migrate")
-    .description("Import state from another agent system")
-    .argument("[provider]", "Migration provider id, for example hermes")
-    .option("--from <path>", "Source directory to migrate from")
-    .option("--include-secrets", "Import supported credentials and secrets", false)
-    .option("--overwrite", "Overwrite conflicting target files after item-level backups", false)
-    .option("--dry-run", "Preview only; do not apply changes", false)
-    .option("--yes", "Apply without prompting after preview", false)
-    .option(
-      "--skill <name>",
-      "Select one skill to migrate by name or item id; repeat for multiple skills",
-      collectMigrationSkill,
-    )
-    .option(
-      "--plugin <name>",
-      "Select one Codex plugin to migrate by name or item id; repeat for multiple plugins",
-      collectMigrationPlugin,
-    )
-    .option("--backup-output <path>", "Pre-migration backup archive path or directory")
-    .option("--no-backup", "Skip the pre-migration OpenClaw backup")
-    .option("--force", "Allow dangerous options such as --no-backup", false)
-    .option("--json", "Output JSON", false)
+  const migrate = addVerifyPluginAppsOption(
+    program
+      .command("migrate")
+      .description("Import state from another agent system")
+      .argument("[provider]", "Migration provider id, for example hermes")
+      .option("--from <path>", "Source directory to migrate from")
+      .option("--include-secrets", "Import supported credentials and secrets", false)
+      .option("--overwrite", "Overwrite conflicting target files after item-level backups", false)
+      .option("--dry-run", "Preview only; do not apply changes", false)
+      .option("--yes", "Apply without prompting after preview", false)
+      .option(
+        "--skill <name>",
+        "Select one skill to migrate by name or item id; repeat for multiple skills",
+        collectMigrationSkill,
+      )
+      .option(
+        "--plugin <name>",
+        "Select one Codex plugin to migrate by name or item id; repeat for multiple plugins",
+        collectMigrationPlugin,
+      )
+      .option("--backup-output <path>", "Pre-migration backup archive path or directory")
+      .option("--no-backup", "Skip the pre-migration OpenClaw backup")
+      .option("--force", "Allow dangerous options such as --no-backup", false)
+      .option("--json", "Output JSON", false),
+  )
     .addHelpText(
       "after",
       () =>
@@ -118,6 +138,7 @@ export function registerMigrateCommand(program: Command) {
           overwrite: Boolean(opts.overwrite),
           skills: readMigrationSkills(opts.skill),
           plugins: readMigrationPlugins(opts.plugin),
+          verifyPluginApps: readVerifyPluginApps(opts.verifyPluginApps),
           dryRun: Boolean(opts.dryRun),
           yes: Boolean(opts.yes),
           backupOutput: opts.backupOutput as string | undefined,
@@ -151,6 +172,7 @@ export function registerMigrateCommand(program: Command) {
         overwrite: Boolean(opts.overwrite),
         skills: readMigrationSkills(opts.skill),
         plugins: readMigrationPlugins(opts.plugin),
+        verifyPluginApps: readVerifyPluginApps(opts.verifyPluginApps),
         json: Boolean(opts.json),
       });
     });
@@ -172,6 +194,7 @@ export function registerMigrateCommand(program: Command) {
           overwrite: Boolean(opts.overwrite),
           skills: readMigrationSkills(opts.skill),
           plugins: readMigrationPlugins(opts.plugin),
+          verifyPluginApps: readVerifyPluginApps(opts.verifyPluginApps),
           yes: Boolean(opts.yes),
           backupOutput: opts.backupOutput as string | undefined,
           noBackup: opts.backup === false,

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -1416,19 +1416,22 @@ describe("migrateApplyCommand", () => {
     const warning =
       "Codex app-backed plugins were planned without source app accessibility verification.";
     const base = codexPluginPlan();
+    const items = [...base.items];
+    const gmailIndex = items.findIndex((item) => item.id === "plugin:gmail");
+    const gmailItem = items[gmailIndex];
+    if (!gmailItem) {
+      throw new Error("Expected gmail plugin item");
+    }
+    items[gmailIndex] = {
+      ...gmailItem,
+      details: {
+        ...gmailItem.details,
+        sourceAppVerification: "not_run",
+      },
+    };
     const planned = codexPluginPlan({
       warnings: [warning],
-      items: base.items.map((item) =>
-        item.id === "plugin:gmail"
-          ? {
-              ...item,
-              details: {
-                ...item.details,
-                sourceAppVerification: "not_run",
-              },
-            }
-          : item,
-      ),
+      items,
     });
     const logs: string[] = [];
     const jsonRuntime: RuntimeEnv = {

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -56,7 +56,8 @@ const {
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
 } = await import("./migrate/selection.js");
-const { migrateApplyCommand, migrateDefaultCommand } = await import("./migrate.js");
+const { migrateApplyCommand, migrateDefaultCommand, migratePlanCommand } =
+  await import("./migrate.js");
 
 function plan(overrides: Partial<MigrationPlan> = {}): MigrationPlan {
   return {
@@ -246,6 +247,81 @@ describe("migrateApplyCommand", () => {
       "requires --yes",
     );
     expect(mocks.provider.plan).not.toHaveBeenCalled();
+  });
+
+  it("rejects --verify-plugin-apps for non-Codex providers", async () => {
+    await expect(
+      migrateApplyCommand(runtime, { provider: "hermes", yes: true, verifyPluginApps: true }),
+    ).rejects.toThrow("--verify-plugin-apps is only supported for Codex migrations");
+    expect(mocks.provider.plan).not.toHaveBeenCalled();
+    expect(mocks.provider.apply).not.toHaveBeenCalled();
+  });
+
+  it("rejects --verify-plugin-apps for non-Codex default and plan paths", async () => {
+    await expect(
+      migrateDefaultCommand(runtime, { provider: "hermes", verifyPluginApps: true }),
+    ).rejects.toThrow("--verify-plugin-apps is only supported for Codex migrations");
+    await expect(
+      migratePlanCommand(runtime, { provider: "hermes", verifyPluginApps: true }),
+    ).rejects.toThrow("--verify-plugin-apps is only supported for Codex migrations");
+    expect(mocks.provider.plan).not.toHaveBeenCalled();
+    expect(mocks.provider.apply).not.toHaveBeenCalled();
+  });
+
+  it("passes --verify-plugin-apps into Codex migration planning", async () => {
+    const planned = codexPluginPlan();
+    mocks.provider.plan.mockImplementation(async (ctx) => {
+      expect(ctx.providerOptions).toEqual({ verifyPluginApps: true });
+      return planned;
+    });
+
+    const result = await migrateDefaultCommand(runtime, {
+      provider: "codex",
+      dryRun: true,
+      verifyPluginApps: true,
+    });
+
+    expect(result).toBe(planned);
+    expect(mocks.provider.plan).toHaveBeenCalledTimes(1);
+    expect(mocks.provider.apply).not.toHaveBeenCalled();
+  });
+
+  it("passes --verify-plugin-apps into Codex plan command", async () => {
+    const planned = codexPluginPlan();
+    mocks.provider.plan.mockImplementation(async (ctx) => {
+      expect(ctx.providerOptions).toEqual({ verifyPluginApps: true });
+      return planned;
+    });
+
+    const result = await migratePlanCommand(runtime, {
+      provider: "codex",
+      verifyPluginApps: true,
+    });
+
+    expect(result).toBe(planned);
+    expect(mocks.provider.plan).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes --verify-plugin-apps into Codex apply planning and apply contexts", async () => {
+    const planned = codexPluginPlan();
+    const applied: MigrationApplyResult = {
+      ...planned,
+      summary: { ...planned.summary, planned: 0, migrated: planned.summary.planned },
+      items: planned.items.map((item) => ({ ...item, status: "migrated" as const })),
+    };
+    mocks.provider.plan.mockImplementation(async (ctx) => {
+      expect(ctx.providerOptions).toEqual({ verifyPluginApps: true });
+      return planned;
+    });
+    mocks.provider.apply.mockImplementation(async (ctx) => {
+      expect(ctx.providerOptions).toEqual({ verifyPluginApps: true });
+      return applied;
+    });
+
+    await migrateApplyCommand(runtime, { provider: "codex", yes: true, verifyPluginApps: true });
+
+    expect(mocks.provider.plan).toHaveBeenCalledTimes(1);
+    expect(mocks.provider.apply).toHaveBeenCalledTimes(1);
   });
 
   it("previews and prompts before interactive apply without --yes", async () => {
@@ -1305,5 +1381,72 @@ describe("migrateApplyCommand", () => {
     expect(logPayload.summary?.planned).toBe(1);
     expect(mocks.provider.apply).not.toHaveBeenCalled();
     expect(mocks.backupCreateCommand).not.toHaveBeenCalled();
+  });
+
+  it("includes Codex app verification warnings in JSON dry-run output", async () => {
+    const warning =
+      "Codex app-backed plugins were planned without source app accessibility verification.";
+    const planned = codexPluginPlan({ warnings: [warning] });
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const jsonRuntime: RuntimeEnv = {
+      ...runtime,
+      log(message) {
+        logs.push(String(message));
+      },
+      error(message) {
+        errors.push(String(message));
+      },
+    };
+    mocks.provider.plan.mockResolvedValue(planned);
+
+    await migrateDefaultCommand(jsonRuntime, {
+      provider: "codex",
+      dryRun: true,
+      json: true,
+    });
+
+    expect(logs).toHaveLength(1);
+    expect(errors).toEqual([]);
+    const logPayload = JSON.parse(logs[0] ?? "{}") as { warnings?: unknown };
+    expect(logPayload.warnings).toEqual([warning]);
+  });
+
+  it("drops Codex app verification warning after plugin selection excludes app-backed items", async () => {
+    const warning =
+      "Codex app-backed plugins were planned without source app accessibility verification.";
+    const base = codexPluginPlan();
+    const planned = codexPluginPlan({
+      warnings: [warning],
+      items: base.items.map((item) =>
+        item.id === "plugin:gmail"
+          ? {
+              ...item,
+              details: {
+                ...item.details,
+                sourceAppVerification: "not_run",
+              },
+            }
+          : item,
+      ),
+    });
+    const logs: string[] = [];
+    const jsonRuntime: RuntimeEnv = {
+      ...runtime,
+      log(message) {
+        logs.push(String(message));
+      },
+    };
+    mocks.provider.plan.mockResolvedValue(planned);
+
+    await migrateDefaultCommand(jsonRuntime, {
+      provider: "codex",
+      plugins: ["google-calendar"],
+      dryRun: true,
+      json: true,
+    });
+
+    const logPayload = JSON.parse(logs[0] ?? "{}") as { warnings?: unknown };
+    expect(logPayload.warnings).toBeUndefined();
   });
 });

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -777,7 +777,7 @@ describe("migrateApplyCommand", () => {
           action: "manual",
           status: "skipped",
           reason: "codex_subscription_required",
-          details: { code: "codex_subscription_required", pluginName: "gmail" },
+          details: { pluginName: "gmail" },
         },
       ],
       warnings: [warning],

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -751,6 +751,54 @@ describe("migrateApplyCommand", () => {
     expect(itemsById.get("plugin:google-calendar")?.reason).toBe("not selected for migration");
   });
 
+  it("explains skipped plugin selection when Codex subscription auth is required", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const skillPlan = codexSkillPlan();
+    const warning =
+      "Codex app-backed plugin migration requires the Codex app-server source account to be logged in with a ChatGPT subscription account.";
+    const planned = codexSkillPlan({
+      summary: {
+        total: skillPlan.items.length + 1,
+        planned: skillPlan.summary.planned,
+        migrated: 0,
+        skipped: 1,
+        conflicts: 0,
+        errors: 0,
+        sensitive: 0,
+      },
+      items: [
+        ...skillPlan.items,
+        {
+          id: "plugin:gmail:1",
+          kind: "manual",
+          action: "manual",
+          status: "skipped",
+          reason: "codex_subscription_required",
+          details: { code: "codex_subscription_required", pluginName: "gmail" },
+        },
+      ],
+      warnings: [warning],
+    });
+    mocks.provider.plan.mockResolvedValue(planned);
+    mocks.multiselect.mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP]);
+
+    const result = await migrateDefaultCommand(runtime, { provider: "codex" });
+
+    expect(result.summary.planned).toBe(1);
+    expect(result.summary.skipped).toBe(3);
+    expect(mocks.multiselect).toHaveBeenCalledTimes(1);
+    expect(mocks.promptYesNo).not.toHaveBeenCalled();
+    expect(mocks.provider.apply).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith("Codex skill migration skipped for now.");
+    expect(runtime.log).toHaveBeenCalledWith(warning);
+    expect(runtime.log).toHaveBeenCalledWith(
+      "No Codex skills selected; native Codex plugins are not eligible for migration in this run.",
+    );
+  });
+
   it("does not apply archive-only Codex migration work after Toggle all off", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -44,11 +44,52 @@ import type {
 
 export type { MigrateApplyOptions, MigrateCommonOptions, MigrateDefaultOptions };
 
-function selectMigrationItems(plan: MigrationPlan, opts: MigrateCommonOptions): MigrationPlan {
-  return applyMigrationPluginSelection(
-    applyMigrationSkillSelection(plan, opts.skills),
-    opts.plugins,
+const CODEX_UNVERIFIED_APP_BACKED_PLUGIN_WARNING =
+  "Codex app-backed plugins were planned without source app accessibility verification.";
+
+function isPlannedUnverifiedCodexAppPlugin(item: MigrationPlan["items"][number]): boolean {
+  return (
+    item.kind === "plugin" &&
+    item.action === "install" &&
+    item.status === "planned" &&
+    item.details?.sourceAppVerification === "not_run"
   );
+}
+
+function filterSelectionScopedWarnings(
+  plan: MigrationPlan,
+  opts: MigrateCommonOptions,
+): MigrationPlan {
+  if (
+    opts.plugins === undefined ||
+    plan.providerId !== "codex" ||
+    !plan.warnings?.some((warning) =>
+      warning.includes(CODEX_UNVERIFIED_APP_BACKED_PLUGIN_WARNING),
+    ) ||
+    plan.items.some(isPlannedUnverifiedCodexAppPlugin)
+  ) {
+    return plan;
+  }
+  const warnings = plan.warnings.filter(
+    (warning) => !warning.includes(CODEX_UNVERIFIED_APP_BACKED_PLUGIN_WARNING),
+  );
+  return {
+    ...plan,
+    ...(warnings.length > 0 ? { warnings } : { warnings: undefined }),
+  };
+}
+
+function selectMigrationItems(plan: MigrationPlan, opts: MigrateCommonOptions): MigrationPlan {
+  return filterSelectionScopedWarnings(
+    applyMigrationPluginSelection(applyMigrationSkillSelection(plan, opts.skills), opts.plugins),
+    opts,
+  );
+}
+
+function assertVerifyPluginAppsProvider(providerId: string, opts: MigrateCommonOptions): void {
+  if (opts.verifyPluginApps && providerId !== "codex") {
+    throw new Error("--verify-plugin-apps is only supported for Codex migrations.");
+  }
 }
 
 async function promptCodexMigrationSkillSelection(
@@ -268,6 +309,7 @@ export async function migratePlanCommand(
       `Migration provider is required. Run ${formatCliCommand("openclaw migrate list")} to choose one.`,
     );
   }
+  assertVerifyPluginAppsProvider(providerId, opts);
   const plan = selectMigrationItems(
     await createMigrationPlan(runtime, { ...opts, provider: providerId }),
     opts,
@@ -298,6 +340,7 @@ export async function migrateApplyCommand(
       `Migration provider is required. Run ${formatCliCommand("openclaw migrate list")} to choose one.`,
     );
   }
+  assertVerifyPluginAppsProvider(providerId, opts);
   if (opts.noBackup && !opts.force) {
     throw new Error("--no-backup requires --force because it skips the automatic rollback copy.");
   }
@@ -361,6 +404,7 @@ export async function migrateDefaultCommand(
       items: [],
     };
   }
+  assertVerifyPluginAppsProvider(providerId, opts);
   const plan =
     opts.json && opts.yes && !opts.dryRun
       ? selectMigrationItems(

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -202,7 +202,34 @@ function shouldSkipCodexApplyAfterInteractiveSelection(plan: MigrationPlan): boo
   return plan.providerId === "codex" && !hasSelectedCodexMigrationWork(plan);
 }
 
-function logNoCodexSelection(runtime: RuntimeEnv): void {
+function hasCodexSubscriptionRequiredPlugin(plan: MigrationPlan): boolean {
+  if (plan.providerId !== "codex") {
+    return false;
+  }
+  return plan.items.some(
+    (item) =>
+      item.reason === "codex_subscription_required" ||
+      item.details?.code === "codex_subscription_required",
+  );
+}
+
+function readCodexSubscriptionWarning(plan: MigrationPlan): string | undefined {
+  return plan.warnings?.find((warning) =>
+    warning.includes("Codex app-backed plugin migration requires"),
+  );
+}
+
+function logNoCodexSelection(runtime: RuntimeEnv, plan: MigrationPlan): void {
+  if (hasCodexSubscriptionRequiredPlugin(plan)) {
+    const warning = readCodexSubscriptionWarning(plan);
+    if (warning) {
+      runtime.log(warning);
+    }
+    runtime.log(
+      "No Codex skills selected; native Codex plugins are not eligible for migration in this run.",
+    );
+    return;
+  }
   runtime.log("No Codex skills or native Codex plugins selected for migration.");
 }
 
@@ -298,7 +325,7 @@ export async function migrateApplyCommand(
       return plan;
     }
     if (shouldSkipCodexApplyAfterInteractiveSelection(selectedPlan)) {
-      logNoCodexSelection(runtime);
+      logNoCodexSelection(runtime, selectedPlan);
       return selectedPlan;
     }
     const ok = await promptYesNo("Apply this migration now?", false);
@@ -365,7 +392,7 @@ export async function migrateDefaultCommand(
       return plan;
     }
     if (shouldSkipCodexApplyAfterInteractiveSelection(selectedPlan)) {
-      logNoCodexSelection(runtime);
+      logNoCodexSelection(runtime, selectedPlan);
       return selectedPlan;
     }
     const ok = await promptYesNo("Apply this migration now?", false);

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -206,11 +206,7 @@ function hasCodexSubscriptionRequiredPlugin(plan: MigrationPlan): boolean {
   if (plan.providerId !== "codex") {
     return false;
   }
-  return plan.items.some(
-    (item) =>
-      item.reason === "codex_subscription_required" ||
-      item.details?.code === "codex_subscription_required",
-  );
+  return plan.items.some((item) => item.reason === "codex_subscription_required");
 }
 
 function readCodexSubscriptionWarning(plan: MigrationPlan): string | undefined {

--- a/src/commands/migrate/apply.ts
+++ b/src/commands/migrate/apply.ts
@@ -5,6 +5,7 @@ import type { RuntimeEnv } from "../../runtime.js";
 import { backupCreateCommand } from "../backup.js";
 import { buildMigrationContext, buildMigrationReportDir } from "./context.js";
 import { assertApplySucceeded, assertConflictFreePlan, writeApplyResult } from "./output.js";
+import { buildMigrationProviderOptions } from "./providers.js";
 import { applyMigrationPluginSelection, applyMigrationSkillSelection } from "./selection.js";
 import type { MigrateApplyOptions } from "./types.js";
 
@@ -55,6 +56,7 @@ export async function runMigrationApply(params: {
         source: params.opts.source,
         includeSecrets: params.opts.includeSecrets,
         overwrite: params.opts.overwrite,
+        providerOptions: buildMigrationProviderOptions(params.opts),
         runtime: params.runtime,
         json: params.opts.json,
       }),
@@ -74,6 +76,7 @@ export async function runMigrationApply(params: {
     source: params.opts.source,
     includeSecrets: params.opts.includeSecrets,
     overwrite: params.opts.overwrite,
+    providerOptions: buildMigrationProviderOptions(params.opts),
     runtime: params.runtime,
     backupPath,
     reportDir,

--- a/src/commands/migrate/context.ts
+++ b/src/commands/migrate/context.ts
@@ -31,6 +31,7 @@ export function buildMigrationContext(params: {
   source?: string;
   includeSecrets?: boolean;
   overwrite?: boolean;
+  providerOptions?: Record<string, unknown>;
   backupPath?: string;
   runtime: RuntimeEnv;
   reportDir?: string;
@@ -44,6 +45,7 @@ export function buildMigrationContext(params: {
     source: params.source,
     includeSecrets: Boolean(params.includeSecrets),
     overwrite: Boolean(params.overwrite),
+    providerOptions: params.providerOptions,
     backupPath: params.backupPath,
     reportDir: params.reportDir,
     logger: createMigrationLogger(params.runtime, { json: params.json }),

--- a/src/commands/migrate/providers.ts
+++ b/src/commands/migrate/providers.ts
@@ -24,15 +24,28 @@ export function resolveMigrationProvider(providerId: string): MigrationProviderP
   return provider;
 }
 
+export function buildMigrationProviderOptions(
+  opts: MigrateCommonOptions,
+): Record<string, unknown> | undefined {
+  if (opts.provider === "codex" && opts.verifyPluginApps === true) {
+    return { verifyPluginApps: true };
+  }
+  return undefined;
+}
+
 export async function createMigrationPlan(
   runtime: RuntimeEnv,
   opts: MigrateCommonOptions & { provider: string },
 ): Promise<MigrationPlan> {
+  if (opts.verifyPluginApps && opts.provider !== "codex") {
+    throw new Error("--verify-plugin-apps is only supported for Codex migrations.");
+  }
   const provider = resolveMigrationProvider(opts.provider);
   const ctx = buildMigrationContext({
     source: opts.source,
     includeSecrets: opts.includeSecrets,
     overwrite: opts.overwrite,
+    providerOptions: buildMigrationProviderOptions(opts),
     runtime,
     json: opts.json,
   });

--- a/src/commands/migrate/types.ts
+++ b/src/commands/migrate/types.ts
@@ -7,6 +7,7 @@ export type MigrateCommonOptions = {
   overwrite?: boolean;
   skills?: string[];
   plugins?: string[];
+  verifyPluginApps?: boolean;
   json?: boolean;
 };
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2423,6 +2423,7 @@ export type MigrationProviderContext = {
   source?: string;
   includeSecrets?: boolean;
   overwrite?: boolean;
+  providerOptions?: Record<string, unknown>;
   backupPath?: string;
   reportDir?: string;
   signal?: AbortSignal;


### PR DESCRIPTION
## Summary

- Gate Codex plugin migration on source `plugin/read` plus a fresh source `app/list` readiness snapshot so unavailable app-backed plugins become manual skipped items instead of migrated config.
- Preserve source/destination auth isolation during source readiness discovery: source `plugin/list`, `plugin/read`, and `app/list` run against the source Codex home with native source auth and isolated app-server probes.
- Reuse the shared Codex plugin app cache key for runtime, source migration refreshes, and target apply invalidation; apply now invalidates only the target app inventory cache key.

## Verification

- `pnpm test extensions/codex/src/migration/provider.test.ts extensions/codex/src/app-server/auth-bridge.test.ts extensions/codex/src/app-server/shared-client.test.ts`
- `pnpm test extensions/codex/src/migration/provider.test.ts` after the latest docs-only follow-up
- `git diff --check`
- Live copied-profile dry-run: `pnpm openclaw --profile codex-migration-readiness migrate codex --dry-run --json --from $HOME/.codex`
- Live native-source-auth dry-run: `pnpm openclaw --profile codex-migration-readiness-native migrate codex --dry-run --json --from $HOME/.codex`

## Real behavior proof

Behavior addressed: Codex migration source readiness now uses isolated source Codex app-server probes instead of logging that source app-server into the destination OpenClaw auth profile, and app-backed plugins are only planned when the fresh source app inventory reports their backing apps as available.

Real environment tested: Local OpenClaw checkout on macOS. Live migration dry-runs were run at PR head `d803b8c50e3638643694b0a273443c6369bae6e5`; latest PR head `404cb5c03564b837a6d33c67c0410c5ea602ccd2` is a docs-only follow-up validated with the focused provider test and `git diff --check`. The `codex-migration-readiness` profile is a copied dev OpenClaw auth profile. The `codex-migration-readiness-native` profile is the same copied setup with OpenClaw auth removed so the source Codex app server uses native `$HOME/.codex` auth.

Exact steps or command run after the patch: Ran the focused Vitest files, then ran both migration dry-runs with `--dry-run --json` against `$HOME/.codex`; after the latest docs-only follow-up, reran `pnpm test extensions/codex/src/migration/provider.test.ts` and `git diff --check`.

Evidence after fix:

```text
$ pnpm test extensions/codex/src/migration/provider.test.ts extensions/codex/src/app-server/auth-bridge.test.ts extensions/codex/src/app-server/shared-client.test.ts
Test Files  3 passed (3)
Tests  64 passed (64)

$ pnpm openclaw --profile codex-migration-readiness migrate codex --dry-run --json --from $HOME/.codex
returncode=0 timedOut=false stdoutBytes=46563 stderrBytes=1027
summary total=99 planned=88 skipped=11 errors=0
plugin:gmail:7            gmail            skipped app_missing
plugin:google-calendar:8  google-calendar  skipped app_missing
plugin:readwise:11        readwise         skipped app_missing
stderr did not contain refresh_token_reused

$ pnpm openclaw --profile codex-migration-readiness-native migrate codex --dry-run --json --from $HOME/.codex
returncode=0 timedOut=false stdoutBytes=46570 stderrBytes=1034
summary total=99 planned=88 skipped=11 errors=0
plugin:gmail:7            gmail            skipped app_missing
plugin:google-calendar:8  google-calendar  skipped app_missing
plugin:readwise:11        readwise         skipped app_missing
stderr did not contain refresh_token_reused

$ pnpm test extensions/codex/src/migration/provider.test.ts
Test Files  1 passed (1)
Tests  18 passed (18)

$ git diff --check
No whitespace errors reported.
```

Observed result after fix: The copied dev-auth profile run no longer fails source plugin inventory with Codex OAuth `refresh_token_reused`, and both dry-runs exit cleanly after emitting complete migration plans. In the current live Codex app inventory snapshot, Gmail, Google Calendar, and Readwise app ids are all reported missing, so migration leaves them as manual skipped items instead of planning plugin activation.

What was not tested: No apply/write migration was run; both live runs were dry-runs only.
