### PR TITLE
[auth-profiles] avoid repeated terminal OAuth refresh retries

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -74,7 +74,7 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
         return null;
       }
       let oauthCredential = credential;
-      if ((oauthCredential.expires ?? 0) <= Date.now()) {
+      if (params.forceOAuthRefresh || (oauthCredential.expires ?? 0) <= Date.now()) {
         const refreshed = await providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin({
           provider: oauthCredential.provider,
           context: oauthCredential,
@@ -1095,6 +1095,42 @@ describe("bridgeCodexAppServerStartOptions", () => {
         chatgptAccountId: "account-789",
         chatgptPlanType: null,
       });
+      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("refresh-token");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a persisted OAuth expiry when a forced app-server refresh fails", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const expires = Date.now() + 60_000;
+    oauthMocks.refreshOpenAICodexToken.mockRejectedValueOnce(new Error("invalid_grant"));
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai-codex:work",
+        credential: {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "current-access-token",
+          refresh: "refresh-token",
+          expires,
+          accountId: "account-123",
+          email: "codex@example.test",
+        },
+      });
+
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai-codex:work",
+        }),
+      ).rejects.toThrow("invalid_grant");
+
+      const profile = expectOAuthProfile(
+        loadAuthProfileStoreForSecretsRuntime(agentDir).profiles["openai-codex:work"],
+      );
+      expect(profile?.expires).toBe(expires);
       expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("refresh-token");
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -11,7 +11,6 @@ import {
   resolveApiKeyForProfile,
   resolveDefaultAgentDir,
   resolvePersistedAuthProfileOwnerAgentDir,
-  saveAuthProfileStore,
   type AuthProfileCredential,
   type AuthProfileStore,
   type OAuthCredential,
@@ -470,7 +469,6 @@ async function resolveOAuthCredentialForCodexAppServer(
     isCodexAppServerAuthProvider(ownerCredential.provider, params.config)
       ? ownerCredential
       : undefined;
-  const credentialForOwner = persistedOAuthCredential ?? overlaidOAuthCredential ?? credential;
   if (params.forceRefresh && !persistedOAuthCredential && overlaidOAuthCredential) {
     const refreshedRuntimeCredential = await refreshOAuthCredentialForRuntime({
       credential: overlaidOAuthCredential,
@@ -481,14 +479,11 @@ async function resolveOAuthCredentialForCodexAppServer(
     store.profiles[profileId] = refreshedRuntimeCredential;
     return refreshedRuntimeCredential;
   }
-  if (params.forceRefresh && persistedOAuthCredential) {
-    store.profiles[profileId] = { ...credentialForOwner, expires: 0 };
-    saveAuthProfileStore(store, ownerAgentDir);
-  }
   const resolved = await resolveApiKeyForProfile({
     store,
     profileId,
     agentDir: ownerAgentDir,
+    forceOAuthRefresh: params.forceRefresh,
   });
   const refreshed = loadAuthProfileStoreForSecretsRuntime(ownerAgentDir).profiles[profileId];
   const storedCredential = store.profiles[profileId];

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -401,7 +401,58 @@ describe("createOAuthManager", () => {
     expect(refreshCredential).toHaveBeenCalledTimes(1);
   });
 
-  it("retries after the cached refresh-failure credential snapshot changes", async () => {
+  it("propagates forced refresh failures instead of reusing unchanged stored OAuth access", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-manager-forced-refresh-"));
+    tempDirs.push(tempRoot);
+    process.env.OPENCLAW_STATE_DIR = tempRoot;
+    const agentDir = path.join(tempRoot, "agents", "main", "agent");
+    process.env.OPENCLAW_AGENT_DIR = agentDir;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    await fs.mkdir(agentDir, { recursive: true });
+
+    const profileId = "openai-codex:default";
+    const credential = createCredential({
+      access: "current-access",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+    });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: credential,
+        },
+      },
+      agentDir,
+      { filterExternalAuthProfiles: false },
+    );
+
+    const refreshCredential = vi.fn(async () => {
+      throw new Error("invalid_grant");
+    });
+    const manager = createOAuthManager({
+      buildApiKey: async (_provider, value) => value.access,
+      refreshCredential,
+      readBootstrapCredential: () => null,
+      isRefreshTokenReusedError: () => false,
+      shouldCacheRefreshFailure: () => true,
+    });
+
+    await expect(
+      manager.resolveOAuthAccess({
+        store: ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+          allowKeychainPrompt: false,
+        }),
+        profileId,
+        credential,
+        agentDir,
+        forceRefresh: true,
+      }),
+    ).rejects.toThrow("invalid_grant");
+    expect(refreshCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries after refresh-relevant credential metadata changes", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-manager-failure-cache-"));
     tempDirs.push(tempRoot);
     process.env.OPENCLAW_STATE_DIR = tempRoot;
@@ -415,6 +466,7 @@ describe("createOAuthManager", () => {
       access: "stale-access",
       refresh: "stale-refresh",
       expires: Date.now() - 60_000,
+      clientId: "stale-client-id",
     });
     saveAuthProfileStore(
       {
@@ -454,16 +506,17 @@ describe("createOAuthManager", () => {
       }),
     ).rejects.toThrow("invalid_grant");
 
-    const rotatedCredential = createCredential({
-      access: "rotated-stale-access",
-      refresh: "rotated-stale-refresh",
-      expires: Date.now() - 30_000,
+    const correctedCredential = createCredential({
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires: staleCredential.expires,
+      clientId: "corrected-client-id",
     });
     saveAuthProfileStore(
       {
         version: 1,
         profiles: {
-          [profileId]: rotatedCredential,
+          [profileId]: correctedCredential,
         },
       },
       agentDir,
@@ -476,7 +529,7 @@ describe("createOAuthManager", () => {
           allowKeychainPrompt: false,
         }),
         profileId,
-        credential: rotatedCredential,
+        credential: correctedCredential,
         agentDir,
       }),
     ).resolves.toMatchObject({

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -172,6 +172,7 @@ describe("createOAuthManager", () => {
       refreshCredential: vi.fn(async () => null),
       readBootstrapCredential: () => null,
       isRefreshTokenReusedError: () => false,
+      shouldCacheRefreshFailure: () => false,
     });
 
     const result = await manager.resolveOAuthAccess({
@@ -263,6 +264,7 @@ describe("createOAuthManager", () => {
       refreshCredential,
       readBootstrapCredential: () => null,
       isRefreshTokenReusedError: () => false,
+      shouldCacheRefreshFailure: () => false,
     });
 
     const result = await manager.resolveOAuthAccess({
@@ -329,6 +331,7 @@ describe("createOAuthManager", () => {
           expires: Date.now() - 30_000,
         }),
       isRefreshTokenReusedError: () => false,
+      shouldCacheRefreshFailure: () => false,
     });
 
     const result = await manager.resolveOAuthAccess({
@@ -345,5 +348,144 @@ describe("createOAuthManager", () => {
     expect(result.credential.provider).toBe("minimax-portal");
     expect(result.credential.access).toBe("rotated-access");
     expect(result.credential.refresh).toBe("rotated-refresh");
+  });
+
+  it("reuses cached terminal refresh failures for an unchanged OAuth credential snapshot", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-manager-failure-cache-"));
+    tempDirs.push(tempRoot);
+    process.env.OPENCLAW_STATE_DIR = tempRoot;
+    const agentDir = path.join(tempRoot, "agents", "main", "agent");
+    process.env.OPENCLAW_AGENT_DIR = agentDir;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    await fs.mkdir(agentDir, { recursive: true });
+
+    const profileId = "openai-codex:default";
+    const credential = createCredential({
+      access: "expired-access",
+      refresh: "expired-refresh",
+      expires: Date.now() - 60_000,
+    });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: credential,
+        },
+      },
+      agentDir,
+      { filterExternalAuthProfiles: false },
+    );
+
+    const refreshCredential = vi.fn(async () => {
+      throw new Error("invalid_grant");
+    });
+    const manager = createOAuthManager({
+      buildApiKey: async (_provider, value) => value.access,
+      refreshCredential,
+      readBootstrapCredential: () => null,
+      isRefreshTokenReusedError: () => false,
+      shouldCacheRefreshFailure: () => true,
+    });
+    const resolveAccess = () =>
+      manager.resolveOAuthAccess({
+        store: ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+          allowKeychainPrompt: false,
+        }),
+        profileId,
+        credential,
+        agentDir,
+      });
+
+    await expect(resolveAccess()).rejects.toThrow("invalid_grant");
+    await expect(resolveAccess()).rejects.toThrow("invalid_grant");
+    expect(refreshCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries after the cached refresh-failure credential snapshot changes", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-manager-failure-cache-"));
+    tempDirs.push(tempRoot);
+    process.env.OPENCLAW_STATE_DIR = tempRoot;
+    const agentDir = path.join(tempRoot, "agents", "main", "agent");
+    process.env.OPENCLAW_AGENT_DIR = agentDir;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    await fs.mkdir(agentDir, { recursive: true });
+
+    const profileId = "openai-codex:default";
+    const staleCredential = createCredential({
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires: Date.now() - 60_000,
+    });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: staleCredential,
+        },
+      },
+      agentDir,
+      { filterExternalAuthProfiles: false },
+    );
+
+    const refreshCredential = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("invalid_grant"))
+      .mockResolvedValueOnce({
+        access: "fresh-access",
+        refresh: "fresh-refresh",
+        expires: Date.now() + 60_000,
+      });
+    const manager = createOAuthManager({
+      buildApiKey: async (_provider, value) => value.access,
+      refreshCredential,
+      readBootstrapCredential: () => null,
+      isRefreshTokenReusedError: () => false,
+      shouldCacheRefreshFailure: () => true,
+    });
+
+    await expect(
+      manager.resolveOAuthAccess({
+        store: ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+          allowKeychainPrompt: false,
+        }),
+        profileId,
+        credential: staleCredential,
+        agentDir,
+      }),
+    ).rejects.toThrow("invalid_grant");
+
+    const rotatedCredential = createCredential({
+      access: "rotated-stale-access",
+      refresh: "rotated-stale-refresh",
+      expires: Date.now() - 30_000,
+    });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: rotatedCredential,
+        },
+      },
+      agentDir,
+      { filterExternalAuthProfiles: false },
+    );
+
+    await expect(
+      manager.resolveOAuthAccess({
+        store: ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+          allowKeychainPrompt: false,
+        }),
+        profileId,
+        credential: rotatedCredential,
+        agentDir,
+      }),
+    ).resolves.toMatchObject({
+      apiKey: "fresh-access",
+      credential: {
+        access: "fresh-access",
+        refresh: "fresh-refresh",
+      },
+    });
+    expect(refreshCredential).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -268,7 +268,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
 
   function refreshFailureCredentialFingerprint(credential: OAuthCredential): string {
     return JSON.stringify(
-      Object.entries(credential).sort(([left], [right]) => left.localeCompare(right)),
+      Object.entries(credential).toSorted(([left], [right]) => left.localeCompare(right)),
     );
   }
 
@@ -276,7 +276,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     provider: string;
     profileId: string;
     credential: OAuthCredential;
-  }): unknown | null {
+  }): { error: unknown } | null {
     const key = refreshQueueKey(params.provider, params.profileId);
     const cached = cachedRefreshFailures.get(key);
     if (!cached) {
@@ -286,7 +286,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       cachedRefreshFailures.delete(key);
       return null;
     }
-    return cached.error;
+    return { error: cached.error };
   }
 
   function rememberRefreshFailure(params: {
@@ -485,7 +485,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             credential: credentialToRefresh,
           });
           if (cachedFailure) {
-            throw cachedFailure;
+            throw cachedFailure.error;
           }
 
           let refreshedCredentials: OAuthCredential | null;

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -46,6 +46,7 @@ export type OAuthManagerAdapter = {
     credential: OAuthCredential;
   }) => OAuthCredential | null;
   isRefreshTokenReusedError: (error: unknown) => boolean;
+  shouldCacheRefreshFailure: (error: unknown) => boolean;
 };
 
 export type ResolvedOAuthAccess = {
@@ -253,9 +254,53 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   }
 
   const refreshQueues = new Map<string, Promise<unknown>>();
+  const cachedRefreshFailures = new Map<
+    string,
+    {
+      credential: Pick<OAuthCredential, "access" | "refresh" | "expires">;
+      error: unknown;
+    }
+  >();
 
   function refreshQueueKey(provider: string, profileId: string): string {
     return `${provider}\u0000${profileId}`;
+  }
+
+  function getCachedRefreshFailure(params: {
+    provider: string;
+    profileId: string;
+    credential: Pick<OAuthCredential, "access" | "refresh" | "expires">;
+  }): unknown | null {
+    const key = refreshQueueKey(params.provider, params.profileId);
+    const cached = cachedRefreshFailures.get(key);
+    if (!cached) {
+      return null;
+    }
+    if (hasOAuthCredentialChanged(cached.credential, params.credential)) {
+      cachedRefreshFailures.delete(key);
+      return null;
+    }
+    return cached.error;
+  }
+
+  function rememberRefreshFailure(params: {
+    provider: string;
+    profileId: string;
+    credential: Pick<OAuthCredential, "access" | "refresh" | "expires">;
+    error: unknown;
+  }): void {
+    cachedRefreshFailures.set(refreshQueueKey(params.provider, params.profileId), {
+      credential: {
+        access: params.credential.access,
+        refresh: params.credential.refresh,
+        expires: params.credential.expires,
+      },
+      error: params.error,
+    });
+  }
+
+  function clearCachedRefreshFailure(provider: string, profileId: string): void {
+    cachedRefreshFailures.delete(refreshQueueKey(provider, profileId));
   }
 
   async function withRefreshCallTimeout<T>(
@@ -324,6 +369,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     provider: string;
     agentDir?: string;
     cfg?: OpenClawConfig;
+    forceRefresh?: boolean;
   }): Promise<ResolvedOAuthAccess | null> {
     const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir(params);
     const authPath = resolveAuthStorePath(ownerAgentDir);
@@ -340,7 +386,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           }
           let credentialToRefresh = cred;
 
-          if (hasUsableOAuthCredential(cred)) {
+          if (!params.forceRefresh && hasUsableOAuthCredential(cred)) {
             return {
               apiKey: await adapter.buildApiKey(cred.provider, cred, {
                 cfg: params.cfg,
@@ -431,23 +477,46 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             }
           }
 
-          const refreshedCredentials = await withRefreshCallTimeout(
-            `refreshOAuthCredential(${cred.provider})`,
-            OAUTH_REFRESH_CALL_TIMEOUT_MS,
-            async () => {
-              const refreshed = await adapter.refreshCredential(credentialToRefresh);
-              return refreshed
-                ? ({
-                    ...credentialToRefresh,
-                    ...refreshed,
-                    type: "oauth",
-                  } satisfies OAuthCredential)
-                : null;
-            },
-          );
+          const cachedFailure = getCachedRefreshFailure({
+            provider: credentialToRefresh.provider,
+            profileId: params.profileId,
+            credential: credentialToRefresh,
+          });
+          if (cachedFailure) {
+            throw cachedFailure;
+          }
+
+          let refreshedCredentials: OAuthCredential | null;
+          try {
+            refreshedCredentials = await withRefreshCallTimeout(
+              `refreshOAuthCredential(${cred.provider})`,
+              OAUTH_REFRESH_CALL_TIMEOUT_MS,
+              async () => {
+                const refreshed = await adapter.refreshCredential(credentialToRefresh);
+                return refreshed
+                  ? ({
+                      ...credentialToRefresh,
+                      ...refreshed,
+                      type: "oauth",
+                    } satisfies OAuthCredential)
+                  : null;
+              },
+            );
+          } catch (error) {
+            if (adapter.shouldCacheRefreshFailure(error)) {
+              rememberRefreshFailure({
+                provider: credentialToRefresh.provider,
+                profileId: params.profileId,
+                credential: credentialToRefresh,
+                error,
+              });
+            }
+            throw error;
+          }
           if (!refreshedCredentials) {
             return null;
           }
+          clearCachedRefreshFailure(credentialToRefresh.provider, params.profileId);
           store.profiles[params.profileId] = refreshedCredentials;
           saveAuthProfileStore(store, ownerAgentDir);
           if (ownerAgentDir) {
@@ -485,6 +554,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     provider: string;
     agentDir?: string;
     cfg?: OpenClawConfig;
+    forceRefresh?: boolean;
   }): Promise<ResolvedOAuthAccess | null> {
     const key = refreshQueueKey(params.provider, params.profileId);
     const prev = refreshQueues.get(key) ?? Promise.resolve();
@@ -510,6 +580,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     credential: OAuthCredential;
     agentDir?: string;
     cfg?: OpenClawConfig;
+    forceRefresh?: boolean;
   }): Promise<ResolvedOAuthAccess | null> {
     const adoptedCredential =
       adoptNewerMainOAuthCredential({
@@ -524,7 +595,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       readBootstrapCredential: adapter.readBootstrapCredential,
     });
 
-    if (hasUsableOAuthCredential(effectiveCredential)) {
+    if (!params.forceRefresh && hasUsableOAuthCredential(effectiveCredential)) {
       return {
         apiKey: await adapter.buildApiKey(effectiveCredential.provider, effectiveCredential, {
           cfg: params.cfg,
@@ -540,6 +611,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         provider: params.credential.provider,
         agentDir: params.agentDir,
         cfg: params.cfg,
+        forceRefresh: params.forceRefresh,
       });
       return refreshed;
     } catch (error) {
@@ -582,6 +654,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             provider: params.credential.provider,
             agentDir: params.agentDir,
             cfg: params.cfg,
+            forceRefresh: params.forceRefresh,
           });
           if (retried) {
             return retried;
@@ -632,6 +705,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
 
   function resetRefreshQueuesForTest(): void {
     refreshQueues.clear();
+    cachedRefreshFailures.clear();
   }
 
   return {

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { withFileLock } from "../../infra/file-lock.js";
@@ -267,9 +268,10 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   }
 
   function refreshFailureCredentialFingerprint(credential: OAuthCredential): string {
-    return JSON.stringify(
+    const serializedCredential = JSON.stringify(
       Object.entries(credential).toSorted(([left], [right]) => left.localeCompare(right)),
     );
+    return createHash("sha256").update(serializedCredential).digest("hex");
   }
 
   function getCachedRefreshFailure(params: {

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -257,7 +257,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   const cachedRefreshFailures = new Map<
     string,
     {
-      credential: Pick<OAuthCredential, "access" | "refresh" | "expires">;
+      credentialFingerprint: string;
       error: unknown;
     }
   >();
@@ -266,17 +266,23 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     return `${provider}\u0000${profileId}`;
   }
 
+  function refreshFailureCredentialFingerprint(credential: OAuthCredential): string {
+    return JSON.stringify(
+      Object.entries(credential).sort(([left], [right]) => left.localeCompare(right)),
+    );
+  }
+
   function getCachedRefreshFailure(params: {
     provider: string;
     profileId: string;
-    credential: Pick<OAuthCredential, "access" | "refresh" | "expires">;
+    credential: OAuthCredential;
   }): unknown | null {
     const key = refreshQueueKey(params.provider, params.profileId);
     const cached = cachedRefreshFailures.get(key);
     if (!cached) {
       return null;
     }
-    if (hasOAuthCredentialChanged(cached.credential, params.credential)) {
+    if (cached.credentialFingerprint !== refreshFailureCredentialFingerprint(params.credential)) {
       cachedRefreshFailures.delete(key);
       return null;
     }
@@ -286,15 +292,11 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   function rememberRefreshFailure(params: {
     provider: string;
     profileId: string;
-    credential: Pick<OAuthCredential, "access" | "refresh" | "expires">;
+    credential: OAuthCredential;
     error: unknown;
   }): void {
     cachedRefreshFailures.set(refreshQueueKey(params.provider, params.profileId), {
-      credential: {
-        access: params.credential.access,
-        refresh: params.credential.refresh,
-        expires: params.credential.expires,
-      },
+      credentialFingerprint: refreshFailureCredentialFingerprint(params.credential),
       error: params.error,
     });
   }
@@ -617,7 +619,11 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     } catch (error) {
       const refreshedStore = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir);
       const refreshed = refreshedStore.profiles[params.profileId];
-      if (refreshed?.type === "oauth" && hasUsableOAuthCredential(refreshed)) {
+      if (
+        refreshed?.type === "oauth" &&
+        hasUsableOAuthCredential(refreshed) &&
+        (!params.forceRefresh || hasOAuthCredentialChanged(params.credential, refreshed))
+      ) {
         return {
           apiKey: await adapter.buildApiKey(refreshed.provider, refreshed, {
             cfg: params.cfg,

--- a/src/agents/auth-profiles/oauth-refresh-error.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-error.test.ts
@@ -140,6 +140,11 @@ describe("shouldCacheOAuthRefreshFailure", () => {
   it("matches terminal refresh failures without caching transient ones", () => {
     expect(shouldCacheOAuthRefreshFailure(new Error("invalid_grant"))).toBe(true);
     expect(shouldCacheOAuthRefreshFailure(new Error("expired or revoked"))).toBe(true);
+    expect(
+      shouldCacheOAuthRefreshFailure(
+        new Error("Your refresh token has already been used to generate a new access token."),
+      ),
+    ).toBe(true);
     expect(shouldCacheOAuthRefreshFailure(new Error("network timeout"))).toBe(false);
     expect(shouldCacheOAuthRefreshFailure(new Error("HTTP 500 Internal Server Error"))).toBe(false);
   });

--- a/src/agents/auth-profiles/oauth-refresh-error.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-error.test.ts
@@ -4,7 +4,7 @@ import {
   randomAsciiString as randomJunk,
   randomlyCased,
 } from "./oauth-test-utils.js";
-import { isRefreshTokenReusedError } from "./oauth.js";
+import { isRefreshTokenReusedError, shouldCacheOAuthRefreshFailure } from "./oauth.js";
 
 // Direct tests for the refresh_token_reused classifier. This is the gate that
 // triggers the retry/adoption recovery path; a false negative here means we
@@ -133,5 +133,14 @@ describe("isRefreshTokenReusedError", () => {
         expect(isRefreshTokenReusedError(new Error(msg))).toBe(false);
       }
     });
+  });
+});
+
+describe("shouldCacheOAuthRefreshFailure", () => {
+  it("matches terminal refresh failures without caching transient ones", () => {
+    expect(shouldCacheOAuthRefreshFailure(new Error("invalid_grant"))).toBe(true);
+    expect(shouldCacheOAuthRefreshFailure(new Error("expired or revoked"))).toBe(true);
+    expect(shouldCacheOAuthRefreshFailure(new Error("network timeout"))).toBe(false);
+    expect(shouldCacheOAuthRefreshFailure(new Error("HTTP 500 Internal Server Error"))).toBe(false);
   });
 });

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -130,7 +130,10 @@ export function isRefreshTokenReusedError(error: unknown): boolean {
 }
 
 export function shouldCacheOAuthRefreshFailure(error: unknown): boolean {
-  return classifyOAuthRefreshFailureReason(extractErrorMessage(error)) !== null;
+  return (
+    isRefreshTokenReusedError(error) ||
+    classifyOAuthRefreshFailureReason(extractErrorMessage(error)) !== null
+  );
 }
 
 type ResolveApiKeyForProfileParams = {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -21,6 +21,7 @@ import { resolveTokenExpiryState } from "./credential-state.js";
 import { formatAuthDoctorHint } from "./doctor.js";
 import { readManagedExternalCliCredential } from "./external-cli-sync.js";
 import { createOAuthManager, OAuthManagerRefreshError } from "./oauth-manager.js";
+import { classifyOAuthRefreshFailureReason } from "./oauth-refresh-failure.js";
 import { assertNoOAuthSecretRefPolicyViolations } from "./policy.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
 import { loadAuthProfileStoreForSecretsRuntime } from "./store.js";
@@ -128,11 +129,16 @@ export function isRefreshTokenReusedError(error: unknown): boolean {
   );
 }
 
+export function shouldCacheOAuthRefreshFailure(error: unknown): boolean {
+  return classifyOAuthRefreshFailureReason(extractErrorMessage(error)) !== null;
+}
+
 type ResolveApiKeyForProfileParams = {
   cfg?: OpenClawConfig;
   store: AuthProfileStore;
   profileId: string;
   agentDir?: string;
+  forceOAuthRefresh?: boolean;
 };
 
 type SecretDefaults = NonNullable<OpenClawConfig["secrets"]>["defaults"];
@@ -184,6 +190,7 @@ const oauthManager = createOAuthManager({
       credential,
     }),
   isRefreshTokenReusedError,
+  shouldCacheRefreshFailure: shouldCacheOAuthRefreshFailure,
 });
 
 export function resetOAuthRefreshQueuesForTest(): void {
@@ -215,6 +222,7 @@ async function tryResolveOAuthProfile(
     credential: cred,
     agentDir: params.agentDir,
     cfg,
+    forceRefresh: params.forceOAuthRefresh,
   });
   if (!resolved) {
     return null;
@@ -354,6 +362,7 @@ export async function resolveApiKeyForProfile(
       profileId,
       credential: cred,
       cfg,
+      forceRefresh: params.forceOAuthRefresh,
     });
     if (!resolved) {
       return null;


### PR DESCRIPTION
## Summary
- Cache terminal OAuth refresh failures per credential fingerprint so unchanged bad credentials do not keep reissuing refresh requests.
- Thread an explicit force-refresh flag through OAuth resolution instead of durably persisting `expires: 0` for Codex app-server refreshes.
- Preserve forced-refresh failure semantics and allow retries when refresh-relevant credential metadata changes.

## Verification
- `pnpm lint:core`
- `pnpm tsgo:prod`
- `pnpm test src/agents/auth-profiles/oauth-manager.test.ts src/agents/auth-profiles/oauth-refresh-error.test.ts extensions/codex/src/app-server/auth-bridge.test.ts`
- Local Codex review via the PR readiness loop backend: clean on head `bf13d3ef5968a5e87fc4558f3c5366cb0b46ac80`

## Real behavior proof
- **Behavior or issue addressed**: Terminal OAuth refresh failures are cached for unchanged stored credentials, and forced refresh failures continue to surface instead of falling back to the unchanged stored access token.
- **Real environment tested**: Local OpenClaw checkout on this branch with Node running the real `createOAuthManager` plus persisted auth-profile store path from `src/agents/auth-profiles/store.ts`.
- **Exact steps or command run after this patch**: Executed a live local probe with `node --import tsx --input-type=module -e "..."` that wrote a temp auth-profile store, invoked the real OAuth manager twice against an `invalid_grant` refresh failure, then invoked a forced refresh against a still-usable stored credential.
- **Evidence after fix**: Console output from the live Node probe:
  ```json
  {
    "repeatedScenarioRefreshCalls": 1,
    "repeatedTerminalFailuresSurfaced": [true, true],
    "forceScenarioAdditionalRefreshCalls": 1,
    "forcedRefreshFailurePropagated": true
  }
  ```
- **Observed result after fix**: Two identical terminal refresh attempts surfaced the same failure while issuing only one refresh call total; the forced-refresh path made one explicit refresh attempt and propagated the failure instead of reusing the unchanged stored access token.
- **What was not tested**: A browser OAuth login followed by a real upstream provider refresh-token round trip.