### PR TITLE
fix(doctor): render legacy migration panel as preview when --fix is not passed

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -2612,6 +2612,51 @@ describe("doctor config flow", () => {
     }
   });
 
+  it("titles the legacy migration panel as a preview when --fix is not passed (#80817)", async () => {
+    const noteSpy = resetTerminalNoteMock();
+    try {
+      await runDoctorConfigWithInput({
+        config: {
+          heartbeat: {
+            model: "anthropic/claude-3-5-haiku-20241022",
+            every: "30m",
+          },
+        },
+        run: loadAndMaybeMigrateDoctorConfig,
+      });
+      const changeTitles = noteSpy.mock.calls.map(([, title]) => title);
+      expect(changeTitles).toContain("Doctor changes preview");
+      expect(changeTitles).not.toContain("Doctor changes");
+      const previewPanel = noteSpy.mock.calls.find(
+        ([, title]) => title === "Doctor changes preview",
+      );
+      expect(previewPanel?.[0]).toContain("Moved heartbeat to");
+    } finally {
+      noteSpy.mockClear();
+    }
+  });
+
+  it("titles the legacy migration panel as applied when --fix is passed (#80817)", async () => {
+    const noteSpy = resetTerminalNoteMock();
+    try {
+      await runDoctorConfigWithInput({
+        repair: true,
+        config: {
+          heartbeat: {
+            model: "anthropic/claude-3-5-haiku-20241022",
+            every: "30m",
+          },
+        },
+        run: loadAndMaybeMigrateDoctorConfig,
+      });
+      const changeTitles = noteSpy.mock.calls.map(([, title]) => title);
+      expect(changeTitles).toContain("Doctor changes");
+      expect(changeTitles).not.toContain("Doctor changes preview");
+    } finally {
+      noteSpy.mockClear();
+    }
+  });
+
   it("recovers from stale googlechat top-level allowFrom by repairing dm.allowFrom", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -64,6 +64,22 @@ function collectConfiguredChannelIds(cfg: OpenClawConfig): string[] {
   return Object.keys(channels).filter((channelId) => channelId !== "defaults");
 }
 
+// Past-tense "Removed X" lines must not appear under a "Doctor changes" panel
+// when the run did not write to disk; retitle to signal the preview state.
+function emitDoctorChangesPanel(
+  changeLines: ReadonlyArray<string>,
+  shouldRepair: boolean,
+  options: { sanitize?: boolean } = {},
+): void {
+  if (changeLines.length === 0) {
+    return;
+  }
+  const body = changeLines.join("\n");
+  const message = options.sanitize ? sanitizeDoctorNote(body) : body;
+  const title = shouldRepair ? "Doctor changes" : "Doctor changes preview";
+  note(message, title);
+}
+
 export async function loadAndMaybeMigrateDoctorConfig(params: {
   options: DoctorOptions;
   confirm: (p: { message: string; initialValue: boolean }) => Promise<boolean>;
@@ -123,9 +139,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   if (legacyIssueLines.length > 0) {
     note(legacyIssueLines.join("\n"), "Legacy config keys detected");
   }
-  if (legacyStep.changeLines.length > 0) {
-    note(legacyStep.changeLines.join("\n"), "Doctor changes");
-  }
+  emitDoctorChangesPanel(legacyStep.changeLines, shouldRepair);
   if (hasLegacyInternalHookHandlers(snapshot.parsed)) {
     note(
       [
@@ -143,7 +157,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
 
   const normalized = normalizeCompatibilityConfigValues(candidate);
   if (normalized.changes.length > 0) {
-    note(normalized.changes.join("\n"), "Doctor changes");
+    emitDoctorChangesPanel(normalized.changes, shouldRepair);
     ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
       state: { cfg, candidate, pendingChanges, fixHints },
       mutation: normalized,
@@ -155,7 +169,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   const { applyPluginAutoEnable } = await import("../config/plugin-auto-enable.js");
   const autoEnable = applyPluginAutoEnable({ config: candidate, env: process.env });
   if (autoEnable.changes.length > 0) {
-    note(autoEnable.changes.join("\n"), "Doctor changes");
+    emitDoctorChangesPanel(autoEnable.changes, shouldRepair);
     ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
       state: { cfg, candidate, pendingChanges, fixHints },
       mutation: autoEnable,
@@ -202,7 +216,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       if (staleCleanup.changes.length === 0) {
         continue;
       }
-      note(sanitizeDoctorNote(staleCleanup.changes.join("\n")), "Doctor changes");
+      emitDoctorChangesPanel(staleCleanup.changes, shouldRepair, { sanitize: true });
       ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
         state: { cfg, candidate, pendingChanges, fixHints },
         mutation: staleCleanup,


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` (without `--fix`) emitted three contradictory panels in one run on a config carrying the legacy `agents.defaults.agentRuntime` key: `Legacy config keys detected` said the key was still ignored and the user must run `--fix`, `Doctor changes` said past-tense *"Removed agents.defaults.agentRuntime"* as if migration had happened, and the final `Doctor` panel hinted again to run `--fix`. After the read-only run, the on-disk config was unchanged.
- Why it matters: A user reading top-to-bottom cannot tell whether the legacy key was already migrated or still pending. Past-tense `Removed X` is the source-of-truth signal that the write happened, so this is the panel that misleads — and it appears in the same run as the panels that say the key is still pending.
- What changed: In `src/commands/doctor-config-flow.ts`, `loadAndMaybeMigrateDoctorConfig` now picks the `Doctor changes` panel title based on `shouldRepair`. When `shouldRepair` is false, the four `Doctor changes` emit sites in this function (legacy migration step, normalized compatibility, plugin auto-enable, channel stale cleanup) render under the title `Doctor changes preview`. This mirrors the existing precedent for the unknown-config-key emission a few lines below, which already conditionally titled the panel as `"Unknown config keys"` in preview mode.
- What did NOT change (scope boundary):
  - Migration semantics. `applyLegacyCompatibilityStep` and `migrateLegacyConfig` still return the same `changeLines` and same in-memory mutations. The only thing that differs in preview mode is the panel title.
  - The `Doctor changes` emit sites in other doctor command files (`doctor-health-contributions.ts`, `doctor-auth-flat-profiles.ts`, `doctor-state-integrity.ts`, `doctor-skills.ts`, `doctor-config-preflight.ts`, `doctor-memory-search.ts`, `doctor-cron.ts`, `doctor-sandbox.ts`, `doctor-plugin-manifests.ts`, `doctor-workspace.ts`, and the shared `emit-notes.ts` helper). The issue called out the same systemic pattern there but did not reproduce it; those sites can be addressed in follow-up PRs if maintainers want a uniform preview convention.
  - Final fix-hint panel and the `Legacy config keys detected` panel — both already render the correct pending-state language and are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80817
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw doctor` (without `--fix`) renders past-tense `◇ Doctor changes: Removed agents.defaults.agentRuntime` even though nothing has been written to disk, contradicting the same run's `◇ Legacy config keys detected` panel and final `◇ Doctor` hint.
- Real environment tested: Ubuntu 24.04, openclaw `v2026.5.10-beta.1` (commit `9c7e67b0f8`), Node 22.22.2, against a `~/.openclaw/openclaw.json` containing only the legacy `agents.defaults.agentRuntime` key (full config quoted in the Repro section below).
- Exact steps or command run after this patch:
  1. Apply this PR locally and build (`pnpm install && pnpm build`).
  2. Save the config below as `~/.openclaw/openclaw.json` (config-only repro; no provider/channel needed):
     ```json
     { "agents": { "defaults": { "agentRuntime": { "id": "claude-cli" } } } }
     ```
  3. Run `pnpm openclaw doctor` (read-only, without `--fix`) and observe the panel sequence around the legacy key.
  4. Run `pnpm openclaw doctor --fix` against the same config and observe that the panel reverts to `◇ Doctor changes`.
- Evidence after fix: Live terminal capture of `pnpm openclaw doctor` (no `--fix`) on the patched branch, showing the legacy migration panel rendered as `◇ Doctor changes preview` instead of `◇ Doctor changes`, paired with the matching `pnpm openclaw doctor --fix` run showing `◇ Doctor changes`, will be attached as a follow-up comment on this PR. Before-fix terminal capture (real `pnpm openclaw doctor` run on `v2026.5.10-beta.1` against the same config, demonstrating the contradiction) is included in the **Before evidence** field below.
- Observed result after fix: On the patched branch, `pnpm openclaw doctor` (no `--fix`) emits the legacy migration block under `◇ Doctor changes preview ───…` instead of `◇ Doctor changes ───…`. The body of the panel (`Removed agents.defaults.agentRuntime; runtime is now provider/model scoped.`) is unchanged, but it now reads as a preview, consistent with the `◇ Legacy config keys detected` panel and the final `◇ Doctor` `--fix` hint in the same run. `pnpm openclaw doctor --fix` emits the panel as `◇ Doctor changes ───…` (unchanged path). The on-disk config is still untouched in the no-`--fix` run.
- What was not tested:
  - The other `Doctor changes` emit sites listed in the scope boundary — those did not reproduce in this issue and are explicitly out of scope.
  - The partial-validity branch (`legacyMigrationPartiallyValid`) in `applyLegacyCompatibilityStep`; behavior is identical at the source level (same `changeLines` array, same call site) but no separate CLI run was performed for that specific shape.
- Before evidence (optional but encouraged): Real `pnpm openclaw doctor` run on `v2026.5.10-beta.1` (commit `9c7e67b0f8`) against the config quoted above. The three contradictory panels appear in order:

  ```
  ◇  Legacy config keys detected ───────────────────────────────────────╮
  │                                                                     │
  │  - agents.defaults.agentRuntime: agents.defaults.agentRuntime is    │
  │    ignored; set models.providers.<provider>.agentRuntime or a       │
  │    model-scoped agentRuntime instead. Run "openclaw doctor --fix".  │
  │                                                                     │
  ├─────────────────────────────────────────────────────────────────────╯

  ◇  Doctor changes ──────────────────────────────────────────────────────╮
  │                                                                       │
  │  Removed agents.defaults.agentRuntime; runtime is now provider/model  │
  │  scoped.                                                              │
  │                                                                       │
  ├───────────────────────────────────────────────────────────────────────╯

  ◇  Doctor ─────────────────────────────────────────────────────╮
  │                                                              │
  │  Run "openclaw doctor --fix" to migrate legacy config keys.  │
  │                                                              │
  ├──────────────────────────────────────────────────────────────╯
  ```

## Root Cause (if applicable)

- Root cause: `src/commands/doctor-config-flow.ts` line 124-127 (pre-patch) and the three sibling emit sites at lines 143, 155, 202 titled the panel with the hardcoded string `"Doctor changes"` regardless of `shouldRepair`. The migration generator in `legacy-config-migrations.runtime.agents.ts:212` produces past-tense `"Removed X"` lines that correctly describe an applied change. When those past-tense lines render under a `Doctor changes` title in a no-write run, they read as if the change happened.
- Missing detection / guardrail: There was no test asserting which panel title is used when `shouldRepair` is false. Existing legacy-config tests asserted the `Legacy config keys detected` and final `Doctor` panels, but never the title of the migration changes panel.
- Contributing context: The adjacent `applyUnknownConfigKeyStep` emission at line 271 already used the correct pattern: `note(lines, shouldRepair ? "Doctor changes" : "Unknown config keys")`. The legacy migration emission predates that conditional and was not updated alongside it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/commands/doctor-config-flow.test.ts`
- Scenario the test should lock in:
  - When `shouldRepair` is false and the migration produces change lines, the panel title is `Doctor changes preview` and `Doctor changes` is not emitted.
  - When `shouldRepair` is true and the migration produces change lines, the panel title is `Doctor changes` and `Doctor changes preview` is not emitted.
- Why this is the smallest reliable guardrail: it pins the contract between `shouldRepair` and the panel title at the only call sites that emit migration-derived past-tense text.
- Existing test that already covers this: none — see Root Cause above.
- If no new test is added, why not: N/A; two regression tests are added in this PR, tagged with `(#80817)`.

## User-visible / Behavior Changes

- `openclaw doctor` (no `--fix`) now shows migration change lines under a `◇ Doctor changes preview` panel instead of `◇ Doctor changes`. Body text is unchanged. `openclaw doctor --fix` is unchanged.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 22.22.2 (local)
- Model/provider: Not applicable
- Integration/channel (if any): Not applicable
- Relevant config (redacted):

  ```json
  {
    "agents": {
      "defaults": {
        "agentRuntime": { "id": "claude-cli" }
      }
    }
  }
  ```

### Steps

1. Save the config above as `~/.openclaw/openclaw.json`.
2. Run `pnpm openclaw doctor` (no `--fix`).
3. Observe the panel title of the legacy migration changes block.
4. Run `pnpm openclaw doctor --fix` and observe the title for the applied run.

### Expected

- Step 3 emits a `◇ Doctor changes preview` panel.
- Step 4 emits a `◇ Doctor changes` panel.

### Actual

- Before this PR: step 3 emitted `◇ Doctor changes` with past-tense body, contradicting the same run's `Legacy config keys detected` panel (full capture in the Real behavior proof section above).
- After this PR: step 3 emits `◇ Doctor changes preview`; step 4 unchanged.

## Evidence

- [x] Failing test/log before + passing after — two new vitest assertions in `doctor-config-flow.test.ts` lock in the panel-title contract for both `shouldRepair` branches.
- [x] Trace/log snippets — see the verbatim `v2026.5.10-beta.1` panels quoted above.
- [ ] Screenshot/recording — after-fix CLI capture will be added as a PR comment.
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/commands/doctor-config-flow.test.ts` — 34 tests pass including the two new regression tests for #80817 (preview title without `--fix`; applied title with `--fix`).
  - `pnpm test src/commands/doctor/shared/config-flow-steps.test.ts src/commands/doctor/emit-notes.test.ts` — 14 tests pass.
  - `pnpm check:changed` — green (oxlint, tsgo, import cycles, runtime sidecar loader guard, conflict markers, changelog attributions, plugin-sdk wildcard re-exports, duplicate scan target coverage).
  - `pnpm exec oxfmt --check` on the two touched files — formatted.
- Edge cases checked:
  - `repair: true` path still titles `Doctor changes`.
  - Existing test `sanitizes config-derived doctor warnings and changes before logging` (which filters on `title === "Doctor changes"`) uses `repair: true`, so its filter still matches after the fix.
  - The mocked migration in the test file emits realistic `Moved heartbeat to ...` change lines, so the regression tests run the same code path that produces the reported `Removed agents.defaults.agentRuntime` line.
- What I did not verify:
  - The same systemic pattern at the other `Doctor changes` emit sites listed in the scope boundary — those are out of scope for this PR.
  - Behavior under partial-validity (`legacyMigrationPartiallyValid`) was not specifically exercised by the regression tests, though the unchanged `applyLegacyCompatibilityStep` keeps emitting the same `changeLines` array.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Tooling, snapshots, or external automation that parses doctor stdout may be matching on the literal `Doctor changes` panel title and could miss the `Doctor changes preview` panel in non-repair runs.
  - Mitigation: Body content (the change lines themselves) is unchanged. The new title is a superset matcher (`Doctor changes preview` contains `Doctor changes`), so substring-based consumers continue to match; only exact-equality consumers would need to handle the preview variant.
