### PR TITLE
docs: clarify PR workflow gitcrawl fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,8 @@ Skills own workflows; root owns hard policy and routing.
 
 ## GitHub / PRs
 
-- Use `$openclaw-pr-maintainer` immediately for maintainer-side OpenClaw issue/PR URLs/numbers, review, triage, duplicate search, close, labels, landing, comments, or maintainer evidence. Contributor PR creation/refresh follows the requested contributor workflow; a linked issue/PR alone does not require maintainer archive tooling.
-- PR refs: `gh pr view/diff` or `gh api`, not web search. Use REST `gh api` when structured `gh pr view --json` hits CLI GraphQL/project-field failures. Prefer `gitcrawl` for maintainer triage/discovery and optional local `gh` caching; unavailable `gitcrawl` is a quiet live-`gh` fallback, not contributor setup. Verify live with `gh` before mutation.
+- Use `$openclaw-pr-maintainer` immediately for maintainer-side OpenClaw issue/PR review, triage, duplicates, labels, comments, close, land, or evidence. Contributor PR creation/refresh follows the requested contributor workflow; linked refs alone do not require maintainer archive tooling.
+- PR refs: `gh pr view/diff` or `gh api`, not web search. Prefer `gitcrawl` for maintainer discovery; missing/stale `gitcrawl` falls through to live `gh`, not contributor setup. Verify live with `gh` before mutation.
 - Bare issue/PR URL/number means review/report in chat. Suggest comment/close/merge when appropriate; mutate only when asked.
 - No unsolicited PR comments/reviews/labels/retitles/rebases/fixups/landing. Exception: close/duplicate action that needs a reason comment after explicit close/sweep/landing request.
 - PR review answer: bug/behavior, URL(s), affected surface, best-fix judgment, evidence from code/tests/CI/current or shipped behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,8 @@ Skills own workflows; root owns hard policy and routing.
 
 ## GitHub / PRs
 
-- Use `$openclaw-pr-maintainer` immediately for OpenClaw issue/PR URLs/numbers, review, triage, duplicate search, close, labels, landing, comments, or maintainer evidence.
-- PR refs: `gh pr view/diff`, not web search. Prefer `gitcrawl` for local candidate discovery; verify live with `gh` before mutation.
+- Use `$openclaw-pr-maintainer` immediately for maintainer-side OpenClaw issue/PR URLs/numbers, review, triage, duplicate search, close, labels, landing, comments, or maintainer evidence. Contributor PR creation/refresh follows the requested contributor workflow; a linked issue/PR alone does not require maintainer archive tooling.
+- PR refs: `gh pr view/diff` or `gh api`, not web search. Use REST `gh api` when structured `gh pr view --json` hits CLI GraphQL/project-field failures. Prefer `gitcrawl` for maintainer triage/discovery and optional local `gh` caching; unavailable `gitcrawl` is a quiet live-`gh` fallback, not contributor setup. Verify live with `gh` before mutation.
 - Bare issue/PR URL/number means review/report in chat. Suggest comment/close/merge when appropriate; mutate only when asked.
 - No unsolicited PR comments/reviews/labels/retitles/rebases/fixups/landing. Exception: close/duplicate action that needs a reason comment after explicit close/sweep/landing request.
 - PR review answer: bug/behavior, URL(s), affected surface, best-fix judgment, evidence from code/tests/CI/current or shipped behavior.


### PR DESCRIPTION
## Summary

- Problem: OpenClaw root PR routing made contributor PR work inherit maintainer-only archive discovery expectations when a linked issue or PR was present.
- Why it matters: Contributors should be able to create and refresh focused PRs with live `gh`/`gh api`; `gitcrawl` should improve maintainer/agent triage but not become required contributor setup.
- What changed: Clarified that `$openclaw-pr-maintainer` is for maintainer-side PR/issue work, added `gh api` as an accepted PR read path, and documented quiet live-`gh` fallback when `gitcrawl` is unavailable.
- What did NOT change (scope boundary): No runtime code, tests, workflow automation, labels, or GitHub mutation policy changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Agent-facing repository instructions for OpenClaw PR/issue and contributor PR workflows.
- Real environment tested: Local OpenClaw checkout at `147db477075c9e8124eb4b7ed657ee7440f7d6a9`.
- Exact steps or command run after this patch: `git diff --name-only origin/main...HEAD`; `git diff --check HEAD~1..HEAD`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal capture:
  ```text
  $ git diff --name-only origin/main...HEAD
  AGENTS.md
  $ git diff --check HEAD~1..HEAD
  $ echo $?
  0
  ```
- Observed result after fix: The AGENTS.md Markdown diff has no whitespace errors and only the intended root policy lines changed.
- What was not tested: Runtime behavior, because this is an AGENTS.md instruction-only change.
- Before evidence (optional but encouraged): Previous wording required `$openclaw-pr-maintainer` for all OpenClaw PR/issue URLs and only mentioned `gh pr view/diff` plus `gitcrawl` preference.

## Root Cause (if applicable)

- Root cause: Root routing collapsed maintainer-side PR/issue triage and contributor PR creation/refresh into the same instruction path.
- Missing detection / guardrail: No explicit carve-out said missing `gitcrawl` should be a quiet live-`gh` fallback for contributor workflow.
- Contributing context (if known): `gitcrawl` is useful for maintainer triage/discovery and optional agent-side `gh` caching, but its absence should not block contributor PR work.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `AGENTS.md`.
- Scenario the test should lock in: N/A; this is operator guidance, not executable behavior.
- Why this is the smallest reliable guardrail: The root instruction text is the behavior contract for agents.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: Instruction-only change; `git diff --check` is the relevant local validation.

## User-visible / Behavior Changes

None for OpenClaw runtime. Agent contributors should see quieter fallback behavior and less confusion around `gitcrawl` setup.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Local checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Inspect `AGENTS.md` GitHub / PRs section.
2. Run `git diff --check HEAD~1..HEAD`.
3. Run `codex review --base origin/main`.

### Expected

- Root guidance distinguishes maintainer-side PR/issue triage from contributor PR creation/refresh.
- Markdown diff check passes.
- Local Codex review reports no actionable findings.

### Actual

- Root guidance now includes the contributor workflow carve-out, `gh api` PR reads, and quiet missing/stale-`gitcrawl` fallback.
- `git diff --name-only origin/main...HEAD` printed only `AGENTS.md`.
- `git diff --check HEAD~1..HEAD` passed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
$ git diff --name-only origin/main...HEAD
AGENTS.md
$ git diff --check HEAD~1..HEAD
$ echo $?
0
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Checked the final diff and confirmed only `AGENTS.md` changed.
- Edge cases checked: The maintainer workflow remains required for maintainer-side review/triage/duplicate/landing work; contributor PR creation/refresh is the only carve-out.
- What you did **not** verify: Runtime flows, because this PR changes only agent instructions.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.

