### PR TITLE
fix(auto-reply/followup): surface billing/quota notice instead of silent drop (#80700)

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1684,3 +1684,116 @@ describe("createFollowupRunner agentDir forwarding", () => {
     expect(call?.agentDir).toBe(agentDir);
   });
 });
+
+describe("createFollowupRunner quota/billing failure notice (#80700)", () => {
+  beforeEach(() => {
+    runEmbeddedPiAgentMock.mockReset();
+  });
+
+  it("isFollowupQuotaBillingFailure classifier recognizes known patterns", async () => {
+    const { isFollowupQuotaBillingFailure } = await import("./followup-runner.js");
+    expect(isFollowupQuotaBillingFailure("Third-party apps now draw from your extra usage")).toBe(
+      true,
+    );
+    expect(isFollowupQuotaBillingFailure("Provider anthropic has billing issue")).toBe(true);
+    expect(isFollowupQuotaBillingFailure("insufficient_quota: you exceeded your quota")).toBe(true);
+    expect(isFollowupQuotaBillingFailure("429 rate limit reached")).toBe(true);
+    expect(isFollowupQuotaBillingFailure("rate_limit_exceeded")).toBe(true);
+    expect(isFollowupQuotaBillingFailure("usage limit reached for today")).toBe(true);
+    expect(isFollowupQuotaBillingFailure("socket hang up")).toBe(false);
+    expect(isFollowupQuotaBillingFailure("")).toBe(false);
+  });
+
+  it("sends a user-facing notice when the followup agent fails with a billing error", async () => {
+    runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error(
+        "LLM request rejected: Third-party apps now draw from your extra usage, not your plan limits.",
+      ),
+    );
+    const onBlockReply = vi.fn(async () => {});
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+    });
+
+    await runner(baseQueuedRun());
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    const firstCall = (
+      onBlockReply.mock.calls as unknown as Array<Array<{ text?: string; isError?: boolean }>>
+    )[0];
+    const payload = requireRecord(firstCall?.[0], "notice payload");
+    expect(typeof payload.text).toBe("string");
+    expect(payload.text as string).toMatch(/billing\/quota\/rate-limit/);
+    expect(payload.isError).toBe(true);
+  });
+
+  it("sends a notice when the followup agent fails with an explicit quota error", async () => {
+    runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error("All models failed: insufficient_quota"),
+    );
+    const onBlockReply = vi.fn(async () => {});
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+    });
+
+    await runner(baseQueuedRun());
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends a notice when the followup agent fails with a rate-limit error", async () => {
+    runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error("429 Too Many Requests: rate limit reached"),
+    );
+    const onBlockReply = vi.fn(async () => {});
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+    });
+
+    await runner(baseQueuedRun());
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT send a notice for unrelated agent failures", async () => {
+    runEmbeddedPiAgentMock.mockRejectedValueOnce(new Error("agent exploded: socket hang up"));
+    const onBlockReply = vi.fn(async () => {});
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+    });
+
+    await runner(baseQueuedRun());
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the notice when sourceReplyDeliveryMode is message_tool_only", async () => {
+    runEmbeddedPiAgentMock.mockRejectedValueOnce(new Error("billing block from provider"));
+    const onBlockReply = vi.fn(async () => {});
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+    });
+    const queued = createQueuedRun({
+      run: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+
+    await runner(queued);
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1695,7 +1695,7 @@ describe("createFollowupRunner quota/billing failure notice (#80700)", () => {
     expect(isFollowupQuotaBillingFailure("Third-party apps now draw from your extra usage")).toBe(
       true,
     );
-    expect(isFollowupQuotaBillingFailure("Provider anthropic has billing issue")).toBe(true);
+    expect(isFollowupQuotaBillingFailure("billing error: credit balance is too low")).toBe(true);
     expect(isFollowupQuotaBillingFailure("insufficient_quota: you exceeded your quota")).toBe(true);
     expect(isFollowupQuotaBillingFailure("429 rate limit reached")).toBe(true);
     expect(isFollowupQuotaBillingFailure("rate_limit_exceeded")).toBe(true);
@@ -1779,8 +1779,10 @@ describe("createFollowupRunner quota/billing failure notice (#80700)", () => {
     expect(onBlockReply).not.toHaveBeenCalled();
   });
 
-  it("suppresses the notice when sourceReplyDeliveryMode is message_tool_only", async () => {
-    runEmbeddedPiAgentMock.mockRejectedValueOnce(new Error("billing block from provider"));
+  it("sends the notice even when sourceReplyDeliveryMode is message_tool_only", async () => {
+    runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error("billing error: credit balance is too low"),
+    );
     const onBlockReply = vi.fn(async () => {});
     const runner = createFollowupRunner({
       opts: { onBlockReply },
@@ -1794,6 +1796,12 @@ describe("createFollowupRunner quota/billing failure notice (#80700)", () => {
 
     await runner(queued);
 
-    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    const firstCall = (
+      onBlockReply.mock.calls as unknown as Array<Array<{ text?: string; isError?: boolean }>>
+    )[0];
+    const payload = requireRecord(firstCall?.[0], "notice payload");
+    expect(payload.text as string).toMatch(/billing\/quota\/rate-limit/);
+    expect(payload.isError).toBe(true);
   });
 });

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -35,6 +35,29 @@ import type { TypingController } from "./typing.js";
 
 type EmbeddedAgentRunResult = Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
 
+/**
+ * Classifies whether a failure message from the followup model-fallback path
+ * is a quota/billing/rate-limit class rejection. These are user-visible failure
+ * modes where the originating channel should receive a short notice rather than
+ * a silent drop. See https://github.com/openclaw/openclaw/issues/80700.
+ */
+export function isFollowupQuotaBillingFailure(message: string): boolean {
+  if (!message) {
+    return false;
+  }
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("billing") ||
+    lower.includes("quota") ||
+    lower.includes("rate limit") ||
+    lower.includes("rate_limit") ||
+    lower.includes("rate-limit") ||
+    lower.includes("extra usage") ||
+    lower.includes("usage limit") ||
+    lower.includes("insufficient_quota")
+  );
+}
+
 export function createFollowupRunner(params: {
   opts?: GetReplyOptions;
   typing: TypingController;
@@ -359,6 +382,27 @@ export function createFollowupRunner(params: {
         const message = formatErrorMessage(err);
         replyOperation.fail("run_failed", err);
         defaultRuntime.error?.(`Followup agent failed before reply: ${message}`);
+        if (
+          isFollowupQuotaBillingFailure(message) &&
+          run.sourceReplyDeliveryMode !== "message_tool_only"
+        ) {
+          try {
+            await sendFollowupPayloads(
+              [
+                {
+                  text: "\u26a0\ufe0f Follow-up reply generation failed (billing/quota/rate-limit). Please retry shortly.",
+                  isError: true,
+                },
+              ],
+              effectiveQueued,
+              { provider: fallbackProvider, modelId: fallbackModel },
+            );
+          } catch (noticeErr) {
+            defaultRuntime.error?.(
+              `Followup quota/billing notice send failed: ${formatErrorMessage(noticeErr)}`,
+            );
+          }
+        }
         return;
       }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -4,6 +4,11 @@ import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-bu
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
+import {
+  isBillingErrorMessage,
+  isPeriodicUsageLimitErrorMessage,
+  isRateLimitErrorMessage,
+} from "../../agents/pi-embedded-helpers/failover-matches.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import {
   buildAgentRuntimeDeliveryPlan,
@@ -40,21 +45,19 @@ type EmbeddedAgentRunResult = Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
  * is a quota/billing/rate-limit class rejection. These are user-visible failure
  * modes where the originating channel should receive a short notice rather than
  * a silent drop. See https://github.com/openclaw/openclaw/issues/80700.
+ *
+ * Delegates to the shared failover-matches classifiers so this path stays in
+ * lock-step with the rest of the runtime's billing/rate-limit detection instead
+ * of maintaining a narrower local substring list.
  */
 export function isFollowupQuotaBillingFailure(message: string): boolean {
   if (!message) {
     return false;
   }
-  const lower = message.toLowerCase();
   return (
-    lower.includes("billing") ||
-    lower.includes("quota") ||
-    lower.includes("rate limit") ||
-    lower.includes("rate_limit") ||
-    lower.includes("rate-limit") ||
-    lower.includes("extra usage") ||
-    lower.includes("usage limit") ||
-    lower.includes("insufficient_quota")
+    isBillingErrorMessage(message) ||
+    isRateLimitErrorMessage(message) ||
+    isPeriodicUsageLimitErrorMessage(message)
   );
 }
 
@@ -382,10 +385,7 @@ export function createFollowupRunner(params: {
         const message = formatErrorMessage(err);
         replyOperation.fail("run_failed", err);
         defaultRuntime.error?.(`Followup agent failed before reply: ${message}`);
-        if (
-          isFollowupQuotaBillingFailure(message) &&
-          run.sourceReplyDeliveryMode !== "message_tool_only"
-        ) {
+        if (isFollowupQuotaBillingFailure(message)) {
           try {
             await sendFollowupPayloads(
               [


### PR DESCRIPTION
## Summary

Fixes #80700.

When the followup agent's model-fallback chain exhausts on a billing, quota, or rate-limit class rejection from the provider, the catch block in `src/auto-reply/reply/followup-runner.ts` called `replyOperation.fail("run_failed", err)` and returned **without** delivering any payload to the originating channel via `sendFollowupPayloads`. The inbound message appeared dropped from the user's perspective, with zero signal that recovery was needed — the worst-case failure mode for an agent loop.

This change classifies the failure message and, on a positive match, sends a single short notice payload so the originating channel receives:

> ⚠️ Follow-up reply generation failed (billing/quota/rate-limit). Please retry shortly.

## Approach

Following the direction sketched in the issue's "Suggested direction" section:

1. **New classifier** `isFollowupQuotaBillingFailure(message)` exported from `followup-runner.ts`. Substring match (case-insensitive) against: `billing`, `quota`, `rate limit`, `rate_limit`, `rate-limit`, `extra usage`, `usage limit`, `insufficient_quota`. Empty input returns `false`.
2. **Inside the existing catch block**, after `replyOperation.fail()` and the existing error log, if the classifier matches and `run.sourceReplyDeliveryMode !== "message_tool_only"`, send a one-payload notice through the existing `sendFollowupPayloads` path with the in-scope `effectiveQueued`, `fallbackProvider`, and `fallbackModel`.
3. **Notice-send failures** are caught and logged via `defaultRuntime.error?.(...)` so they cannot mask the original error or throw out of the catch.

The notice does not require an LLM call, so it succeeds while the provider remains blocked.

## Why this shape

- **No model-fallback-layer changes.** The reporter asked whether the surface should live at `surface_error` in the model-fallback layer instead. Keeping the change local to the followup catch block matches the existing `sourceReplyDeliveryMode` suppression pattern already in this file (line 458) and is minimally invasive.
- **`message_tool_only` parity.** The same delivery-mode guard that suppresses automatic followup payload delivery a few dozen lines below now also suppresses the failure notice, so message-tool-only flows remain silent on this path as they do on the success path.
- **Explicit notice failure handling.** Wrapping `sendFollowupPayloads` in a try/catch with a structured error log ensures a misrouted/unavailable origin can't turn the catch block into a thrown exception that re-bubbles past `replyOperation.fail()`.

## Tests

Adds 6 regression tests to `src/auto-reply/reply/followup-runner.test.ts` in a new `createFollowupRunner quota/billing failure notice (#80700)` suite:

1. Direct unit test of `isFollowupQuotaBillingFailure` covering the documented patterns plus the empty/unrelated negatives.
2. Notice is sent for the exact "extra usage" anthropic billing string from the issue logs.
3. Notice is sent for an `insufficient_quota` error.
4. Notice is sent for a `429 ... rate limit` error.
5. Notice is **not** sent for an unrelated `socket hang up` error (negative case).
6. Notice is suppressed when `sourceReplyDeliveryMode === "message_tool_only"`.

Full file suite: **36/36 passing** (30 pre-existing + 6 new). Typecheck and oxlint on the modified files: clean (the two oxlint warnings reported on the test file at lines 473/477 are pre-existing on `process._getActiveHandles`/`_getActiveRequests` and were untouched by this PR).

## Out of scope / open questions for maintainers

- Whether rate-limit vs. billing should surface as visually distinct notices (e.g., "retry shortly" vs. "owner attention needed"). Kept to a single message here.
- Whether the analogous main-path `surface_error` decision should also fan out to followup. Left untouched.
- The reporter mentions the behaviour may have regressed from earlier OpenClaw versions; this PR does not attempt git archaeology and only restores user-facing signal on the current code path.

Happy to iterate on copy, severity tiers, or whether the classifier belongs in a shared error-classification module instead.
