### PR TITLE
fix(googlechat): handle non-MESSAGE Workspace Add-on event payloads

### DIFF
--- a/extensions/googlechat/src/monitor-webhook.test.ts
+++ b/extensions/googlechat/src/monitor-webhook.test.ts
@@ -402,6 +402,96 @@ describe("googlechat monitor webhook", () => {
     expect(res.statusCode).toBe(401);
     expect(res.body).toBe("unauthorized");
   });
+
+  it("accepts add-on payloads with addedToSpacePayload (#13856)", async () => {
+    const target = {
+      account: {
+        accountId: "default",
+        config: { appPrincipal: "chat-app" },
+      },
+      runtime: { error: vi.fn() },
+      statusSink: vi.fn(),
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    };
+    installSimplePipeline([target]);
+    readJsonWebhookBodyOrReject.mockResolvedValue({
+      ok: true,
+      value: {
+        commonEventObject: { hostApp: "CHAT" },
+        authorizationEventObject: { systemIdToken: "addon-token" },
+        chat: {
+          eventTime: "2026-03-22T00:00:00.000Z",
+          user: { name: "users/123" },
+          // No messagePayload — this is the variant that used to 400.
+          addedToSpacePayload: {
+            space: { name: "spaces/AAA", type: "ROOM" },
+          },
+        },
+      },
+    });
+    resolveWebhookTargetWithAuthOrReject.mockImplementation(async ({ isMatch, targets }) => {
+      for (const target of targets) {
+        if (await isMatch(target)) return target;
+      }
+      return null;
+    });
+    verifyGoogleChatRequest.mockResolvedValue({ ok: true });
+    const { processEvent, res } = await runWebhookHandler();
+
+    // Before the fix this would 400 because eventType was hardcoded to "MESSAGE"
+    // and addedToSpacePayload has no `message` field, failing the MESSAGE-shape guard.
+    expect(processEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "ADDED_TO_SPACE",
+        space: { name: "spaces/AAA", type: "ROOM" },
+      }),
+      target,
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("prefers explicit rawObj.type over derived type", async () => {
+    const target = {
+      account: {
+        accountId: "default",
+        config: { appPrincipal: "chat-app" },
+      },
+      runtime: { error: vi.fn() },
+      statusSink: vi.fn(),
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    };
+    installSimplePipeline([target]);
+    readJsonWebhookBodyOrReject.mockResolvedValue({
+      ok: true,
+      value: {
+        type: "REMOVED_FROM_SPACE",
+        commonEventObject: { hostApp: "CHAT" },
+        authorizationEventObject: { systemIdToken: "addon-token" },
+        chat: {
+          eventTime: "2026-03-22T00:00:00.000Z",
+          user: { name: "users/123" },
+          removedFromSpacePayload: {
+            space: { name: "spaces/AAA", type: "ROOM" },
+          },
+        },
+      },
+    });
+    resolveWebhookTargetWithAuthOrReject.mockImplementation(async ({ isMatch, targets }) => {
+      for (const target of targets) {
+        if (await isMatch(target)) return target;
+      }
+      return null;
+    });
+    verifyGoogleChatRequest.mockResolvedValue({ ok: true });
+    const { processEvent, res } = await runWebhookHandler();
+    expect(processEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "REMOVED_FROM_SPACE" }),
+      target,
+    );
+    expect(res.statusCode).toBe(200);
+  });
 });
 
 describe("warnAppPrincipalMisconfiguration", () => {

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -50,26 +50,69 @@ function parseGoogleChatInboundPayload(
   let addOnBearerToken = "";
 
   // Transform Google Workspace Add-on format to standard Chat API format.
+  //
+  // The add-on framework wraps the chat event inside `rawObj.chat.<eventKind>Payload`
+  // (per https://developers.google.com/workspace/add-ons/chat/event-objects) and does
+  // NOT include a top-level `type` field. The event kind must be inferred from which
+  // `chat.*Payload` is populated. Prior to this fix, the code only handled
+  // `messagePayload` and hardcoded `type: "MESSAGE"`, which:
+  //   1) Dropped non-MESSAGE event kinds (ADDED_TO_SPACE, REMOVED_FROM_SPACE,
+  //      APP_COMMAND, etc.) — they hit the eventType-is-string guard below and 400'd.
+  //   2) For non-MESSAGE kinds that did slip through (because we still set
+  //      type=MESSAGE), the downstream `event.message` validation would 400 since
+  //      e.g. addedToSpacePayload has no `message` field.
+  // Reports: openclaw/openclaw#13856 (space events not received), #35095, #57386.
   const rawObj = raw as {
+    type?: string;
+    eventTime?: string;
     commonEventObject?: { hostApp?: string };
     chat?: {
       messagePayload?: { space?: GoogleChatSpace; message?: GoogleChatMessage };
+      addedToSpacePayload?: { space?: GoogleChatSpace };
+      removedFromSpacePayload?: { space?: GoogleChatSpace };
+      appCommandPayload?: { space?: GoogleChatSpace; message?: GoogleChatMessage };
+      buttonClickedPayload?: { space?: GoogleChatSpace; message?: GoogleChatMessage };
+      cardClickedPayload?: { space?: GoogleChatSpace; message?: GoogleChatMessage };
       user?: GoogleChatUser;
       eventTime?: string;
     };
     authorizationEventObject?: { systemIdToken?: string };
   };
 
-  if (rawObj.commonEventObject?.hostApp === "CHAT" && rawObj.chat?.messagePayload) {
+  if (rawObj.commonEventObject?.hostApp === "CHAT" && rawObj.chat) {
     const chat = rawObj.chat;
-    const messagePayload = chat.messagePayload;
-    eventPayload = {
-      type: "MESSAGE",
-      space: messagePayload?.space,
-      message: messagePayload?.message,
-      user: chat.user,
-      eventTime: chat.eventTime,
-    };
+    let payload:
+      | { space?: GoogleChatSpace; message?: GoogleChatMessage }
+      | undefined;
+    let derivedType: string | undefined;
+    if (chat.messagePayload) {
+      payload = chat.messagePayload;
+      derivedType = "MESSAGE";
+    } else if (chat.addedToSpacePayload) {
+      payload = chat.addedToSpacePayload;
+      derivedType = "ADDED_TO_SPACE";
+    } else if (chat.removedFromSpacePayload) {
+      payload = chat.removedFromSpacePayload;
+      derivedType = "REMOVED_FROM_SPACE";
+    } else if (chat.appCommandPayload) {
+      payload = chat.appCommandPayload;
+      derivedType = "APP_COMMAND";
+    } else if (chat.buttonClickedPayload) {
+      payload = chat.buttonClickedPayload;
+      derivedType = "CARD_CLICKED";
+    } else if (chat.cardClickedPayload) {
+      payload = chat.cardClickedPayload;
+      derivedType = "CARD_CLICKED";
+    }
+    if (payload) {
+      eventPayload = {
+        type: typeof rawObj.type === "string" ? rawObj.type : derivedType,
+        space: payload.space,
+        message: payload.message,
+        user: chat.user,
+        eventTime: chat.eventTime ?? rawObj.eventTime,
+      };
+    }
     addOnBearerToken =
       typeof rawObj.authorizationEventObject?.systemIdToken === "string"
         ? rawObj.authorizationEventObject.systemIdToken.trim()
@@ -79,12 +122,41 @@ function parseGoogleChatInboundPayload(
   const event = eventPayload as GoogleChatEvent;
   const eventType = event.type ?? (eventPayload as { eventType?: string }).eventType;
   if (typeof eventType !== "string") {
+    // Diagnostic — silent 400s are how this bug stayed in production unnoticed.
+    // Operators have to grep journalctl/stderr to discover why Google's framework
+    // got HTTP 400 from our endpoint; structured log makes that obvious.
+    try {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[googlechat] parseGoogleChatInboundPayload 400 eventType-missing ${JSON.stringify({
+          rootKeys: Object.keys(rawObj),
+          hasChat: Boolean(rawObj.chat),
+          chatKeys: rawObj.chat ? Object.keys(rawObj.chat) : null,
+          hostApp: rawObj.commonEventObject?.hostApp,
+        })}`,
+      );
+    } catch {
+      /* logging best-effort */
+    }
     res.statusCode = 400;
     res.end("invalid payload");
     return { ok: false };
   }
 
   if (!event.space || typeof event.space !== "object" || Array.isArray(event.space)) {
+    try {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[googlechat] parseGoogleChatInboundPayload 400 space-missing ${JSON.stringify({
+          eventType,
+          rootKeys: Object.keys(rawObj),
+          hasChat: Boolean(rawObj.chat),
+          chatKeys: rawObj.chat ? Object.keys(rawObj.chat) : null,
+        })}`,
+      );
+    } catch {
+      /* logging best-effort */
+    }
     res.statusCode = 400;
     res.end("invalid payload");
     return { ok: false };
@@ -92,6 +164,18 @@ function parseGoogleChatInboundPayload(
 
   if (eventType === "MESSAGE") {
     if (!event.message || typeof event.message !== "object" || Array.isArray(event.message)) {
+      try {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[googlechat] parseGoogleChatInboundPayload 400 message-missing ${JSON.stringify({
+            rootKeys: Object.keys(rawObj),
+            hasChat: Boolean(rawObj.chat),
+            chatKeys: rawObj.chat ? Object.keys(rawObj.chat) : null,
+          })}`,
+        );
+      } catch {
+        /* logging best-effort */
+      }
       res.statusCode = 400;
       res.end("invalid payload");
       return { ok: false };


### PR DESCRIPTION
## Summary

Closes #13856.

`parseGoogleChatInboundPayload` only handled `chat.messagePayload` and hardcoded `type: "MESSAGE"`. Per [Workspace Add-on Chat docs](https://developers.google.com/workspace/add-ons/chat/event-objects), event kind is signaled by which `chat.<kind>Payload` field is populated, and the framework does **not** include a top-level `type` field.

Effect: `ADDED_TO_SPACE`, `REMOVED_FROM_SPACE`, `APP_COMMAND`, `CARD_CLICKED` events silently 400'd. Empirically observed: this puts Google's add-on framework into back-off that eventually stops `MESSAGE` delivery too, matching #13856's symptom (DMs work, space events never arrive).

## Changes

- Broaden the extractor to handle all known `chat.<kind>Payload` variants.
- Derive `event.type` from which payload variant is populated; prefer `rawObj.type` when the host sets one explicitly.
- Add `console.warn` diagnostics on every 400 return path. Silent 400s are how this bug stayed in production unnoticed — operators had to grep journalctl with no signal pointing them at the parser. Structured logs surface `rootKeys`, `chatKeys`, `hostApp` so the next regression is obvious.

## Test plan

- [x] Added test: `addedToSpacePayload` accepted (previously 400'd)
- [x] Added test: explicit `rawObj.type` overrides derived type
- [x] Existing `messagePayload` happy-path test still passes
- [x] Manual smoke test against a live deployment: DM, group @-mention, ADDED_TO_SPACE all flow through the agent without 400s

## Related issues

- #13856 (canonical, space events not received)
- #35095, #53888, #57386 (downstream symptoms of the same parser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)