### PR TITLE
fix(install): don't abort install.ps1 when git writes to stderr

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -568,8 +568,13 @@ function Install-OpenClawFromGit {
     }
 
     if (-not $SkipUpdate) {
-        if (-not (git -C $RepoDir status --porcelain 2>$null)) {
-            git -C $RepoDir pull --rebase 2>$null
+        # PowerShell 7+ surfaces native-command stderr as terminating errors when
+        # $ErrorActionPreference=Stop, so git's normal "From <url>" progress line
+        # would abort the script. Swallow failures here — pull is best-effort.
+        $dirty = $null
+        try { $dirty = git -C $RepoDir status --porcelain 2>$null } catch {}
+        if (-not $dirty) {
+            try { git -C $RepoDir pull --rebase 2>$null } catch {}
         } else {
             Write-Host "[!] Repo is dirty; skipping git pull" -ForegroundColor Yellow
         }


### PR DESCRIPTION
## Summary

`scripts/install.ps1` aborts immediately after the initial `git clone` when invoked under PowerShell 7+ with `-InstallMethod git`, before `pnpm install` / `pnpm build` ever run.

Reproduced on Windows 11 ARM, PowerShell 7.x:

```
powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1 -InstallMethod git -GitDir C:\openclaw
...
Resolving deltas: 100% (...), done.
git : From https://github.com/openclaw/openclaw
At ...\scripts\install.ps1:572 char:13
+             git -C $RepoDir pull --rebase 2>$null
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (From https://...:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
```

## Cause

Line 15 sets `$ErrorActionPreference = "Stop"`. PowerShell 7+ extends that to native commands (via `$PSNativeCommandUseErrorActionPreference`, default `$true` since 7.3), so any stderr output from a native command becomes a terminating error. `git pull --rebase` writes its routine "From `<url>`" progress line to stderr by design — the existing `2>$null` suppresses the *display* but the error record is still produced and aborts the script.

PowerShell 5.1 doesn't hit this, which is why the script worked before.

## Fix

Wrap the git status / pull calls in `try {} catch {}` so the pull stays best-effort, matching the existing intent (the `2>$null` redirects show the author already wanted to ignore git's chatter here. The dirty-check is also wrapped defensively.

## Test plan

- [x] Repro on Windows 11 ARM + PowerShell 7.x: installer aborts after clone, before Scope: all 127 workspace projects
Already up to date
Done in 179ms using pnpm v11.0.8
- [ ] Verify with this patch: installer proceeds through Scope: all 127 workspace projects
Already up to date
Done in 170ms using pnpm v11.0.8 → vite v8.0.11 building client environment for production...
[2Ktransforming...✓ 861 modules transformed.
rendering chunks...
computing gzip size...
../dist/control-ui/index.html                                   10.13 kB │ gzip:   3.00 kB
../dist/control-ui/assets/index-D6MC3CBQ.css                   306.29 kB │ gzip:  49.13 kB
../dist/control-ui/assets/preview-Bpt_pTk6.js                    0.18 kB │ gzip:   0.17 kB │ map:     0.36 kB
../dist/control-ui/assets/directive-Dk4hInuL.js                  0.36 kB │ gzip:   0.27 kB │ map:     1.03 kB
../dist/control-ui/assets/channel-config-extras-Dju2-QGs.js      0.57 kB │ gzip:   0.37 kB │ map:     2.25 kB
../dist/control-ui/assets/directive-helpers-CIaUdxG8.js          0.75 kB │ gzip:   0.47 kB │ map:     2.35 kB
../dist/control-ui/assets/push-subscription-D6jbvmm4.js          1.50 kB │ gzip:   0.75 kB │ map:     6.14 kB
../dist/control-ui/assets/skills-shared-BAgIhWaY.js              1.51 kB │ gzip:   0.70 kB │ map:     4.49 kB
../dist/control-ui/assets/instances-tM6XPIKG.js                  2.91 kB │ gzip:   1.06 kB │ map:     5.96 kB
../dist/control-ui/assets/logs-8432hc5M.js                       3.13 kB │ gzip:   1.15 kB │ map:     6.63 kB
../dist/control-ui/assets/debug-CSe2yO2_.js                      4.60 kB │ gzip:   1.26 kB │ map:     8.30 kB
../dist/control-ui/assets/skills-Dz07ESHw.js                    14.03 kB │ gzip:   3.53 kB │ map:    26.85 kB
../dist/control-ui/assets/format-CMbyKmU8.js                    14.05 kB │ gzip:   5.26 kB │ map:    67.45 kB
../dist/control-ui/assets/nodes-yohW-koz.js                     23.59 kB │ gzip:   5.57 kB │ map:    59.09 kB
../dist/control-ui/assets/channels-BokN7BVf.js                  24.80 kB │ gzip:   5.19 kB │ map:    66.27 kB
../dist/control-ui/assets/sessions-v0IpWfqX.js                  25.29 kB │ gzip:   6.11 kB │ map:    59.50 kB
../dist/control-ui/assets/zh-CN-k2iC1jsr.js                     39.02 kB │ gzip:  16.27 kB │ map:    66.46 kB
../dist/control-ui/assets/zh-TW-jqscHalj.js                     39.82 kB │ gzip:  16.64 kB │ map:    67.34 kB
../dist/control-ui/assets/id-CtLgIaVk.js                        41.29 kB │ gzip:  15.31 kB │ map:    69.51 kB
../dist/control-ui/assets/nl-YrNnK4XC.js                        42.18 kB │ gzip:  15.76 kB │ map:    70.46 kB
../dist/control-ui/assets/pt-BR-Ct9ro-pC.js                     43.32 kB │ gzip:  16.01 kB │ map:    71.61 kB
../dist/control-ui/assets/it-DeJD-vjp.js                        43.70 kB │ gzip:  15.87 kB │ map:    72.11 kB
../dist/control-ui/assets/pl-CE45ZwLk.js                        43.76 kB │ gzip:  16.78 kB │ map:    72.10 kB
../dist/control-ui/assets/tr-9jXFBP9y.js                        44.11 kB │ gzip:  16.45 kB │ map:    72.42 kB
../dist/control-ui/assets/de-DZHwaZiY.js                        44.42 kB │ gzip:  16.58 kB │ map:    72.84 kB
../dist/control-ui/assets/es-CbGQXmSa.js                        44.70 kB │ gzip:  16.35 kB │ map:    73.08 kB
../dist/control-ui/assets/ko-CVptHCgP.js                        44.74 kB │ gzip:  16.72 kB │ map:    72.62 kB
../dist/control-ui/assets/fr-6KM1oVGz.js                        45.70 kB │ gzip:  16.46 kB │ map:    74.16 kB
../dist/control-ui/assets/vi-DEegzekp.js                        48.55 kB │ gzip:  16.31 kB │ map:    76.70 kB
../dist/control-ui/assets/ja-JP-DL7_lPp7.js                     50.68 kB │ gzip:  17.60 kB │ map:    78.73 kB
../dist/control-ui/assets/cron-BhX25mq6.js                      50.87 kB │ gzip:   8.93 kB │ map:    98.98 kB
../dist/control-ui/assets/ar-Ao_nx4te.js                        55.24 kB │ gzip:  17.40 kB │ map:    83.26 kB
../dist/control-ui/assets/fa-DbMx-20g.js                        58.31 kB │ gzip:  17.50 kB │ map:    86.51 kB
../dist/control-ui/assets/string-coerce-B303fUwC.js             59.32 kB │ gzip:  22.48 kB │ map:   117.86 kB
../dist/control-ui/assets/uk-UkeMzlU3.js                        61.31 kB │ gzip:  18.69 kB │ map:    89.63 kB
../dist/control-ui/assets/th-Backb2Cu.js                        72.24 kB │ gzip:  17.88 kB │ map:   100.11 kB
../dist/control-ui/assets/agents-BFQXIrPd.js                    99.63 kB │ gzip:  26.15 kB │ map:   239.15 kB
../dist/control-ui/assets/index-CUs_YBp3.js                  1,080.16 kB │ gzip: 306.67 kB │ map: 3,560.64 kB

✓ built in 570ms → [canvas] build: node scripts/bundle-a2ui.mjs
A2UI bundle up to date; skipping.
CLI bootstrap import guard passed.
OK: All 4 required plugin-sdk exports verified.
[canvas] copy: node scripts/copy-a2ui.mjs
[copy-hook-metadata] Copied 5 hook metadata files. and writes 
- [ ] Verify still works on PowerShell 5.1 (no behavior change there)
- [ ] Verify dirty-checkout path still prints 
EOF
)