### PR TITLE
docs: clarify changelog ownership

### DIFF
--- a/.agents/skills/clawsweeper/SKILL.md
+++ b/.agents/skills/clawsweeper/SKILL.md
@@ -257,7 +257,7 @@ loop. The router:
   checks are green, GitHub says mergeable, no human-review label is present,
   the PR is not draft, and both merge gates are open.
 
-Missing changelog is not a review finding or merge blocker. If repairing a user-facing change, add/update changelog automatically when practical; never ask or block solely on it.
+Missing changelog is not a review finding or merge blocker. Contributor PR authors should not be asked to add `CHANGELOG.md` entries. When doing maintainer-authorized repair for a user-facing change, add/update changelog automatically when practical; never ask or block solely on it.
 
 If ClawSweeper passes while merge gates are closed, it labels
 `clawsweeper:merge-ready` and comments instead of merging. `@clawsweeper stop`

--- a/.agents/skills/openclaw-pr-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-pr-maintainer/SKILL.md
@@ -114,7 +114,7 @@ Issue triage is review/prove/patch-local by default:
 
 Do not batch unrelated issue fixes into one commit. Do not publish, comment, close, or label during the review/prove phase.
 
-Missing changelog is not a PR review finding or merge blocker. If landing/fixing a user-visible change, add/update changelog automatically when practical; never ask or block solely on it.
+Missing changelog is not a PR review finding or merge blocker. Contributor PR authors should not be asked to add `CHANGELOG.md` entries. When doing maintainer-authorized landing/fixing for a user-visible change, add/update changelog automatically when practical; never ask or block solely on it.
 
 Only list candidates that pass all gates:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Skills own workflows; root owns hard policy and routing.
 - No unsolicited PR comments/reviews/labels/retitles/rebases/fixups/landing. Exception: close/duplicate action that needs a reason comment after explicit close/sweep/landing request.
 - PR review answer: bug/behavior, URL(s), affected surface, best-fix judgment, evidence from code/tests/CI/current or shipped behavior.
 - Issue/PR final answer: last line is the full GitHub URL.
-- Changelog: PR landings/fixes need one unless pure test/internal. Do not mention missing changelog as a review finding; Codex handles it during fix/landing.
+- Maintainer changelog: PR landings/fixes need one unless pure test/internal. Do not mention missing changelog as a review finding; do not ask contributor PR authors to add it. Codex handles it during fix/landing.
 - PR verification: before merge, post exact local commands, CI/Testbox run IDs, before/after proof when used, and known proof gaps.
 - Issue fixed on `main` with proof: comment proof + commit/PR, then close.
 - After landing or requested close/sweep: search duplicates; comment proof + canonical commit/PR/release before closing.
@@ -116,7 +116,7 @@ Skills own workflows; root owns hard policy and routing.
 - Codex harness upgrade (`extensions/codex/package.json` `@openai/codex`): refresh `docs/plugins/codex-harness.md` model snapshot from the new harness `model/list`.
 - Docs final answers: include relevant full `https://docs.openclaw.ai/...` URL(s). If issue/PR work too, GitHub URL last.
 - Changelog entries: active version `### Changes`/`### Fixes`; single-line bullets only.
-- Contributor PR authors should not edit `CHANGELOG.md`; maintainer/AI adds entries during landing/merge.
+- Contributor PR authors and their agents should not edit `CHANGELOG.md` unless a maintainer explicitly asks. Maintainers or authorized landing agents add entries during landing/merge.
 - Contributor-facing changelog entries thank credited human `@author`. Never thank bots, `@openclaw`, `@clawsweeper`, or `@steipete`; if unknown, omit thanks.
 
 ## Git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ For coordinated change sets that genuinely need more than 20 PRs, join the **#cl
 
 - Test locally with your OpenClaw instance
 - External PRs must include a filled **Real behavior proof** section in the PR body. Show the real setup you tested, the exact command or steps you ran after the patch, after-fix evidence, the observed result, and anything you did not test. Screenshots, recordings, terminal screenshots, console output, copied live output, linked artifacts, and redacted runtime logs all count. Unit tests, mocks, snapshots, lint, typechecks, and CI are useful but do not satisfy this requirement by themselves. Maintainers may apply `proof: override` only when the proof gate should not apply.
-- Do not edit `CHANGELOG.md` in contributor PRs. Maintainers or ClawSweeper add the changelog entry when landing user-facing changes.
+- Do not edit `CHANGELOG.md` in contributor PRs unless a maintainer explicitly asks. Maintainers or ClawSweeper add the changelog entry when landing user-facing changes.
 - Run tests: `pnpm build && pnpm check && pnpm test`
 - For iterative local commits, `scripts/committer --fast "message" <files...>` passes `FAST_COMMIT=1` through to the pre-commit hook so it skips the repo-wide `pnpm check`. Only use it when you've already run equivalent targeted validation for the touched surface.
 - For extension/plugin changes, run the fast local lane first:

--- a/scripts/pr-lib/changelog.sh
+++ b/scripts/pr-lib/changelog.sh
@@ -194,7 +194,7 @@ validate_changelog_entry_for_pr() {
   local with_pr
   with_pr=$(printf '%s\n' "$added_lines" | rg -in "$pr_pattern" || true)
   if [ -z "$with_pr" ]; then
-    echo "CHANGELOG.md update must reference PR #$pr (for example, (#$pr))."
+    echo "Maintainer changelog update must reference PR #$pr (for example, (#$pr))."
     exit 1
   fi
 
@@ -332,7 +332,7 @@ END {
     local with_pr_and_thanks
     with_pr_and_thanks=$(printf '%s\n' "$added_lines" | rg -in "$pr_pattern" | rg -i "thanks @$contrib" || true)
     if [ -z "$with_pr_and_thanks" ]; then
-      echo "CHANGELOG.md update must include both PR #$pr and thanks @$contrib on the changelog entry line."
+      echo "Maintainer changelog update must include both PR #$pr and thanks @$contrib on the changelog entry line."
       exit 1
     fi
     echo "changelog validated: found PR #$pr + thanks @$contrib"

--- a/scripts/pr-lib/common.sh
+++ b/scripts/pr-lib/common.sh
@@ -29,7 +29,7 @@ path_is_testish() {
 path_is_maintainer_workflow_only() {
   local path="$1"
   case "$path" in
-    .agents/*|scripts/pr|scripts/pr-*|docs/subagent.md)
+    .agents/*|scripts/pr|scripts/pr-*|scripts/pr-lib/*|docs/subagent.md)
       return 0
       ;;
   esac

--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -54,7 +54,7 @@ prepare_gates() {
   fi
 
   if [ "$changelog_required" = "true" ] && [ "$has_changelog_update" = "false" ]; then
-    echo "Missing changelog update. Add CHANGELOG.md changes."
+    echo "Missing maintainer changelog update. Maintainer prep must add CHANGELOG.md changes before landing; contributor PR authors should not add it unless explicitly asked."
     exit 1
   fi
 


### PR DESCRIPTION
## Summary

- Clarify that contributor PR authors and their agents should not edit `CHANGELOG.md` unless a maintainer explicitly asks.
- Narrow maintainer-facing changelog guidance in OpenClaw agent skills and PR prep output so changelog entries are framed as a landing/repair responsibility.
- Classify `scripts/pr-lib/*` as maintainer workflow internals for the PR changelog-required gate.

## Verification

- `pnpm docs:list`
- `git diff --check`
- `bash -n scripts/pr-lib/common.sh scripts/pr-lib/changelog.sh scripts/pr-lib/gates.sh`
- `bash -lc 'source scripts/pr-lib/common.sh; if changelog_required_for_changed_files "scripts/pr-lib/gates.sh"; then echo required; else echo not_required; fi'` -> `not_required`
- `pnpm check:changed`

No `CHANGELOG.md` entry: this is contributor/maintainer workflow documentation and internal PR tooling guidance, not a user-facing product change.
