### PR TITLE
fix(image): stop 1ms timeout collapse after deadline exhaustion

### DIFF
--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -687,6 +687,60 @@ describe("describeImageWithModel", () => {
     expect(completeMock).not.toHaveBeenCalled();
   });
 
+  it("fails with deadline exceeded when retry starts after budget is exhausted", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5.4-mini",
+        input: ["text", "image"],
+        baseUrl: "https://api.openai.com/v1",
+      })),
+    });
+    completeMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            vi.setSystemTime(new Date("2026-01-01T00:00:00.030Z"));
+            resolve({
+              role: "assistant",
+              api: "openai-responses",
+              provider: "openai",
+              model: "gpt-5.4-mini",
+              stopReason: "stop",
+              timestamp: Date.now(),
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "internal image reasoning",
+                  thinkingSignature: "reasoning_content",
+                },
+              ],
+            });
+          }, 1);
+        }),
+    );
+
+    const result = describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 25,
+    });
+
+    const assertion = expect(result).rejects.toThrow("image description deadline exceeded");
+    await vi.advanceTimersByTimeAsync(1);
+    await assertion;
+    expect(completeMock).toHaveBeenCalledTimes(1);
+  });
+
   it("normalizes deprecated google flash ids before lookup and keeps profile auth selection", async () => {
     const findMock = vi.fn((provider: string, modelId: string) => {
       expect(provider).toBe("google");

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -281,21 +281,27 @@ function resolveImageDescriptionTimeoutMs(timeoutMs: number | undefined, started
   if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return undefined;
   }
-  return Math.max(1, Math.floor(timeoutMs - (Date.now() - startedAtMs)));
+  const remainingMs = Math.floor(timeoutMs - (Date.now() - startedAtMs));
+  return remainingMs > 0 ? remainingMs : 0;
 }
 
 async function withImageDescriptionTimeout<T>(params: {
-  task: Promise<T>;
+  task: () => Promise<T>;
   timeoutMs: number | undefined;
   controller: AbortController;
 }): Promise<T> {
   if (params.timeoutMs === undefined) {
-    return await params.task;
+    return await params.task();
+  }
+  if (params.timeoutMs <= 0) {
+    params.controller.abort();
+    throw new Error("image description deadline exceeded");
   }
   let timeout: NodeJS.Timeout | undefined;
   try {
+    const taskPromise = params.task();
     return await Promise.race([
-      params.task,
+      taskPromise,
       new Promise<never>((_, reject) => {
         timeout = setTimeout(() => {
           params.controller.abort();
@@ -324,7 +330,7 @@ async function describeImagesWithModelInternal(
     const resolved = await withImageDescriptionTimeout({
       controller,
       timeoutMs: resolveImageDescriptionTimeoutMs(params.timeoutMs, startedAtMs),
-      task: resolveImageRuntime(params),
+      task: () => resolveImageRuntime(params),
     });
     apiKey = resolved.apiKey;
     model = resolved.model;
@@ -371,13 +377,14 @@ async function describeImagesWithModelInternal(
     return await withImageDescriptionTimeout({
       controller,
       timeoutMs,
-      task: complete(model, context, {
-        apiKey,
-        maxTokens,
-        signal: controller.signal,
-        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-        ...(payloadHandler ? { onPayload: payloadHandler } : {}),
-      }),
+      task: () =>
+        complete(model, context, {
+          apiKey,
+          maxTokens,
+          signal: controller.signal,
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+          ...(payloadHandler ? { onPayload: payloadHandler } : {}),
+        }),
     });
   };
 


### PR DESCRIPTION
## Summary
Fixes #80771 by preventing exhausted image-description timeout budgets from collapsing into repeated 1ms retries.

## What changed
- Updated resolveImageDescriptionTimeoutMs to return 0 when the remaining budget is exhausted instead of clamping to 1.
- Updated withImageDescriptionTimeout to:
  - accept a lazy task callback (`task: () => Promise<T>`),
  - fail fast with `image description deadline exceeded` when `timeoutMs <= 0`,
  - avoid starting new provider calls after the budget is already exhausted.
- Added regression coverage in src/media-understanding/image.test.ts for the exhausted-budget retry path.

## Why
Previously, after the shared deadline budget was consumed, retries could keep running with timeoutMs=1, producing repeated `image description timed out after 1ms` failures and retry churn.

## Validation
- pnpm test src/media-understanding/image.test.ts src/agents/tools/image-tool.test.ts
