### PR TITLE
fix(config): reject auto-managed meta.lastTouched* paths in config set/unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - memory-wiki: require write scope for Obsidian search [AI]. (#80904) Thanks @pgondhi987.
 - Build: skip copied metadata for bundled plugins that are excluded from build entries, preventing update/status rebuilds from advertising missing QQ Bot runtime files. (#80925)
 - Control UI/sessions: nest subagent sessions under their parent session in the session picker dropdown using a visual `└─ ` prefix, making the parent-child relationship clear. Fixes #77628. (#78623) Thanks @chinar-amrutkar.
+- fix(config): reject auto-managed meta.lastTouched\* paths in config set/unset (#80856). Thanks @ai-hpc
 - Auto-reply: surface a visible error when the configured model backend fails and fallback produces no visible reply, while preserving intentional silent turns and side-effect-only deliveries. (#80917) Thanks @dutifulbob.
 - Agents/exec: skip redundant heartbeat wake-ups for subagent session exec completions, preventing spurious LLM invocations on parent sessions. Fixes #66748. (#66749) Thanks @ggzeng.
 - Provider streams: keep OpenAI-compatible SSE and JSON fallback streams draining across split chunks and fail Azure Responses streams with a bounded first-event diagnostic instead of stalling. Refs #80926. (#80927) Thanks @galiniliev and @CaptainTimon.

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -496,6 +496,116 @@ describe("config cli", () => {
       expectErrorIncludes("openclaw plugins update <plugin-id>");
     });
 
+    it("rejects auto-managed meta.lastTouchedVersion config updates (#80849)", async () => {
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "meta.lastTouchedVersion",
+          "BOGUS-NOT-A-VERSION",
+          "--dry-run",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("meta.lastTouchedVersion");
+      expectErrorIncludes("auto-managed");
+    });
+
+    it("rejects auto-managed meta.lastTouchedAt config updates (#80849)", async () => {
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "meta.lastTouchedAt",
+          "1999-01-01T00:00:00.000Z",
+          "--dry-run",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("meta.lastTouchedAt");
+      expectErrorIncludes("auto-managed");
+    });
+
+    it("rejects auto-managed meta paths via config unset (#80849)", async () => {
+      await expect(runConfigCommand(["config", "unset", "meta.lastTouchedAt"])).rejects.toThrow(
+        "__exit__:1",
+      );
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("meta.lastTouchedAt");
+      expectErrorIncludes("auto-managed");
+    });
+
+    it("rejects parent meta path mutations when payload merges an auto-managed child (#80849)", async () => {
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "meta",
+          '{"lastTouchedVersion":"BOGUS-NOT-A-VERSION"}',
+          "--strict-json",
+          "--merge",
+          "--dry-run",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("meta.lastTouchedVersion");
+      expectErrorIncludes("auto-managed");
+    });
+
+    it("rejects parent meta path replacement that would clobber auto-managed children (#80849)", async () => {
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "meta",
+          '{"lastTouchedAt":"1999-01-01T00:00:00.000Z"}',
+          "--strict-json",
+          "--replace",
+          "--dry-run",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("meta.lastTouchedAt");
+      expectErrorIncludes("auto-managed");
+    });
+
+    it("rejects config unset meta because deleting the parent removes auto-managed children (#80849)", async () => {
+      await expect(runConfigCommand(["config", "unset", "meta"])).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("meta.lastTouchedVersion");
+      expectErrorIncludes("auto-managed");
+    });
+
+    it("does not auto-managed-reject parent meta merges that leave the managed children alone (#80849)", async () => {
+      // The merge payload only references a non-auto-managed key; the auto-managed
+      // guard MUST NOT fire — otherwise a future schema-valid sibling of
+      // meta.lastTouched* would be collateral-rejected. Downstream layers (schema
+      // validator, etc.) may still legitimately reject this; we only care that the
+      // rejection was NOT from our auto-managed guard.
+      setSnapshot({}, {});
+      try {
+        await runConfigCommand([
+          "config",
+          "set",
+          "meta",
+          '{"unrelated":"x"}',
+          "--strict-json",
+          "--merge",
+          "--dry-run",
+        ]);
+      } catch {
+        // Tolerated: any downstream rejection. Inspected below.
+      }
+      const errorMessages = mockError.mock.calls.map((call) => String(call[0])).join("\n");
+      expect(errorMessages).not.toContain("auto-managed");
+    });
+
     it("rejects protected model map replacement unless explicitly requested", async () => {
       const resolved: OpenClawConfig = {
         agents: {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -155,6 +155,11 @@ function normalizeConfigMutationExplicitSetPath(path: PathSegment[]): PathSegmen
 const GATEWAY_AUTH_MODE_PATH: PathSegment[] = ["gateway", "auth", "mode"];
 const SECRET_PROVIDER_PATH_PREFIX: PathSegment[] = ["secrets", "providers"];
 const PLUGIN_INSTALL_RECORD_PATH_PREFIX: PathSegment[] = ["plugins", "installs"];
+// Re-stamped on every write by stampConfigVersion (src/config/io.ts); user input never persists.
+const AUTO_MANAGED_META_PATHS: ReadonlyArray<ReadonlyArray<PathSegment>> = [
+  ["meta", "lastTouchedVersion"],
+  ["meta", "lastTouchedAt"],
+];
 const CONFIG_SET_EXAMPLE_VALUE = formatCliCommand(
   "openclaw config set gateway.port 19001 --strict-json",
 );
@@ -1371,6 +1376,106 @@ function formatPluginInstallConfigSetError(): string {
   ].join("\n");
 }
 
+function isAutoManagedMetaPath(path: ReadonlyArray<PathSegment>): boolean {
+  return AUTO_MANAGED_META_PATHS.some((managedPath) => pathStartsWith(path, managedPath));
+}
+
+function valueHasAutoManagedChild(value: unknown, childPath: ReadonlyArray<PathSegment>): boolean {
+  let cursor: unknown = value;
+  for (const segment of childPath) {
+    if (cursor === null || typeof cursor !== "object" || Array.isArray(cursor)) {
+      return false;
+    }
+    if (typeof segment !== "string") {
+      return false;
+    }
+    const record = cursor as Record<string, unknown>;
+    if (!Object.prototype.hasOwnProperty.call(record, segment)) {
+      return false;
+    }
+    cursor = record[segment];
+  }
+  return cursor !== undefined;
+}
+
+function operationClobbersAncestorChild(
+  operation: ConfigSetOperation,
+  managedPath: ReadonlyArray<PathSegment>,
+  options: { merge?: boolean },
+): boolean {
+  if (operation.mutation === "delete") {
+    return true;
+  }
+  const childPath = managedPath.slice(operation.requestedPath.length);
+  const isMerge =
+    operation.mutation === "merge" || (Boolean(options.merge) && operation.mutation !== "replace");
+  if (isMerge) {
+    return valueHasAutoManagedChild(operation.value, childPath);
+  }
+  // Default set/replace at an ancestor path clobbers every descendant including
+  // the auto-managed leaf, even when the payload doesn't name it.
+  return true;
+}
+
+function findAutoManagedMetaTargets(
+  operations: ReadonlyArray<ConfigSetOperation>,
+  options: { merge?: boolean } = {},
+): readonly PathSegment[][] {
+  const matches: PathSegment[][] = [];
+  const seen = new Set<string>();
+  const record = (path: ReadonlyArray<PathSegment>): void => {
+    const segments = [...path];
+    const key = toDotPath(segments);
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    matches.push(segments);
+  };
+  for (const operation of operations) {
+    if (isAutoManagedMetaPath(operation.requestedPath)) {
+      record(operation.requestedPath);
+      continue;
+    }
+    for (const managedPath of AUTO_MANAGED_META_PATHS) {
+      if (operation.requestedPath.length >= managedPath.length) {
+        continue;
+      }
+      if (!pathStartsWith(managedPath, operation.requestedPath)) {
+        continue;
+      }
+      if (operationClobbersAncestorChild(operation, managedPath, options)) {
+        record(managedPath);
+      }
+    }
+  }
+  return matches;
+}
+
+function findAutoManagedMetaUnsetTargets(
+  path: ReadonlyArray<PathSegment>,
+): readonly PathSegment[][] {
+  return findAutoManagedMetaTargets([
+    {
+      inputMode: "json",
+      requestedPath: [...path],
+      setPath: [...path],
+      value: undefined,
+      mutation: "delete",
+    },
+  ]);
+}
+
+function formatAutoManagedMetaError(paths: readonly PathSegment[][]): string {
+  const targets = paths.map((path) => toDotPath(path));
+  const subject = targets.length === 1 ? targets[0] : targets.join(", ");
+  return [
+    `${subject} is auto-managed by OpenClaw and cannot be edited; the value would be overwritten on the next config write.`,
+    "",
+    "These fields are stamped on every config write to record the OpenClaw version and timestamp that produced the file.",
+  ].join("\n");
+}
+
 function collectDryRunSchemaErrors(params: {
   config: OpenClawConfig;
   operations: ReadonlyArray<ConfigSetOperation>;
@@ -1451,6 +1556,12 @@ async function runConfigOperations(params: {
     )
   ) {
     throw new Error(formatPluginInstallConfigSetError());
+  }
+  const autoManagedMetaTargets = findAutoManagedMetaTargets(operations, {
+    merge: options.merge,
+  });
+  if (autoManagedMetaTargets.length > 0) {
+    throw new Error(formatAutoManagedMetaError(autoManagedMetaTargets));
   }
   const snapshot = await loadValidConfig(runtime);
   // Use snapshot.resolved (config after $include and ${ENV} resolution, but BEFORE runtime defaults)
@@ -1767,6 +1878,10 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
   const runtime = opts.runtime ?? defaultRuntime;
   try {
     const parsedPath = parseRequiredPath(opts.path);
+    const autoManagedUnsetTargets = findAutoManagedMetaUnsetTargets(parsedPath);
+    if (autoManagedUnsetTargets.length > 0) {
+      throw new Error(formatAutoManagedMetaError(autoManagedUnsetTargets));
+    }
     const snapshot = await loadValidConfig(runtime);
     // Use snapshot.resolved (config after $include and ${ENV} resolution, but BEFORE runtime defaults)
     // instead of snapshot.config (runtime-merged with defaults).

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import type { Command } from "commander";
 import JSON5 from "json5";
 import { readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
+import { AUTO_MANAGED_CONFIG_META_PATHS } from "../config/io.meta.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
 import {
   normalizeAgentModelMapForConfig,
@@ -155,11 +156,6 @@ function normalizeConfigMutationExplicitSetPath(path: PathSegment[]): PathSegmen
 const GATEWAY_AUTH_MODE_PATH: PathSegment[] = ["gateway", "auth", "mode"];
 const SECRET_PROVIDER_PATH_PREFIX: PathSegment[] = ["secrets", "providers"];
 const PLUGIN_INSTALL_RECORD_PATH_PREFIX: PathSegment[] = ["plugins", "installs"];
-// Re-stamped on every write by stampConfigVersion (src/config/io.ts); user input never persists.
-const AUTO_MANAGED_META_PATHS: ReadonlyArray<ReadonlyArray<PathSegment>> = [
-  ["meta", "lastTouchedVersion"],
-  ["meta", "lastTouchedAt"],
-];
 const CONFIG_SET_EXAMPLE_VALUE = formatCliCommand(
   "openclaw config set gateway.port 19001 --strict-json",
 );
@@ -1377,7 +1373,7 @@ function formatPluginInstallConfigSetError(): string {
 }
 
 function isAutoManagedMetaPath(path: ReadonlyArray<PathSegment>): boolean {
-  return AUTO_MANAGED_META_PATHS.some((managedPath) => pathStartsWith(path, managedPath));
+  return AUTO_MANAGED_CONFIG_META_PATHS.some((managedPath) => pathStartsWith(path, managedPath));
 }
 
 function valueHasAutoManagedChild(value: unknown, childPath: ReadonlyArray<PathSegment>): boolean {
@@ -1437,7 +1433,7 @@ function findAutoManagedMetaTargets(
       record(operation.requestedPath);
       continue;
     }
-    for (const managedPath of AUTO_MANAGED_META_PATHS) {
+    for (const managedPath of AUTO_MANAGED_CONFIG_META_PATHS) {
       if (operation.requestedPath.length >= managedPath.length) {
         continue;
       }

--- a/src/config/io.meta.test.ts
+++ b/src/config/io.meta.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { AUTO_MANAGED_CONFIG_META_PATHS, stampConfigWriteMetadata } from "./io.meta.js";
+
+describe("config write metadata stamping", () => {
+  it("stamps every declared auto-managed meta path", () => {
+    const stamped = stampConfigWriteMetadata({});
+
+    expect(AUTO_MANAGED_CONFIG_META_PATHS).toEqual([
+      ["meta", "lastTouchedVersion"],
+      ["meta", "lastTouchedAt"],
+    ]);
+
+    for (const [parent, field] of AUTO_MANAGED_CONFIG_META_PATHS) {
+      expect(parent).toBe("meta");
+      expect(typeof stamped.meta?.[field]).toBe("string");
+    }
+  });
+});

--- a/src/config/io.meta.ts
+++ b/src/config/io.meta.ts
@@ -1,0 +1,26 @@
+import { VERSION } from "../version.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+
+export const AUTO_MANAGED_CONFIG_META_FIELDS = {
+  lastTouchedVersion: "lastTouchedVersion",
+  lastTouchedAt: "lastTouchedAt",
+} as const;
+
+export const AUTO_MANAGED_CONFIG_META_PATHS = [
+  ["meta", AUTO_MANAGED_CONFIG_META_FIELDS.lastTouchedVersion],
+  ["meta", AUTO_MANAGED_CONFIG_META_FIELDS.lastTouchedAt],
+] as const;
+
+export function stampConfigWriteMetadata(
+  cfg: OpenClawConfig,
+  now: string = new Date().toISOString(),
+): OpenClawConfig {
+  return {
+    ...cfg,
+    meta: {
+      ...cfg.meta,
+      [AUTO_MANAGED_CONFIG_META_FIELDS.lastTouchedVersion]: VERSION,
+      [AUTO_MANAGED_CONFIG_META_FIELDS.lastTouchedAt]: now,
+    },
+  };
+}

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -52,6 +52,7 @@ import {
 } from "./io.audit.js";
 import { persistBoundedClobberedConfigSnapshot } from "./io.clobber-snapshot.js";
 import { throwInvalidConfig } from "./io.invalid-config.js";
+import { stampConfigWriteMetadata } from "./io.meta.js";
 import {
   promoteConfigSnapshotToLastKnownGood as promoteConfigSnapshotToLastKnownGoodWithDeps,
   recoverConfigFromLastKnownGood as recoverConfigFromLastKnownGoodWithDeps,
@@ -895,15 +896,7 @@ function warnOnConfigMiskeys(raw: unknown, logger: Pick<typeof console, "warn">)
 }
 
 function stampConfigVersion(cfg: OpenClawConfig): OpenClawConfig {
-  const now = new Date().toISOString();
-  return {
-    ...cfg,
-    meta: {
-      ...cfg.meta,
-      lastTouchedVersion: VERSION,
-      lastTouchedAt: now,
-    },
-  };
+  return stampConfigWriteMetadata(cfg);
 }
 
 function warnIfConfigFromFuture(cfg: OpenClawConfig, logger: Pick<typeof console, "warn">): void {


### PR DESCRIPTION
## Summary

- Problem: `openclaw config set meta.lastTouchedVersion <value>` and `openclaw config set meta.lastTouchedAt <value>` print `Updated meta.lastTouched…. Restart the gateway to apply.` and produce a new config sha256, but the on-disk value is **never** the user's value — `stampConfigVersion` at `src/config/io.ts:897-908` is called unconditionally at `src/config/io.ts:2114` and re-stamps both fields with the current package `VERSION` and a fresh ISO timestamp on every write. The `config set` and `config unset` CLI handlers don't gate against these auto-managed paths, so the success indicator is decoupled from whether the user's value actually persisted.
- Why it matters: silent data loss with false success. Same defect class as the closed `#79856` (`config set returns success while discarding values that match schema defaults`), but a distinct code path that `#79856`'s fix (`#80106`) did not touch. The schema help (`src/config/schema.help.ts:6-7`) already documents these fields as auto-managed; the CLI just doesn't honor that contract.
- What changed: in `src/cli/config-cli.ts`, declare a new `AUTO_MANAGED_META_PATHS` constant covering `meta.lastTouchedVersion` and `meta.lastTouchedAt`, and add three helpers (`isAutoManagedMetaPath`, `findAutoManagedMetaTargets`, `formatAutoManagedMetaError`). Wire an early-throw check into both write entry points: `runConfigOperations` (covers `openclaw config set` value mode, `openclaw config patch`, `openclaw config set --batch-file`, JSON-merge mode, and the batch-mode `delete` operation) and `runConfigUnset` (covers `openclaw config unset`). Mirrors the existing precedent for `plugins.installs` at `src/cli/config-cli.ts:1453`. The error message names the rejected path and explains that the value would be overwritten on the next write.
- What did NOT change (scope boundary):
  - `stampConfigVersion` itself. Auto-stamping is intentional behavior; the fix is to surface the contract at the CLI boundary, not to disable the stamp.
  - The `meta` parent path. Setting `meta` wholesale (e.g. `openclaw config set meta '{"foo":"bar"}'` via `--strict-json`) is not rejected because schema validation already gates unknown sub-keys. Only the two leaf-or-deeper paths that `stampConfigVersion` actually overrides are rejected.
  - `wizard.lastRun*` fields. Despite the "auto-set" wording in schema help, those are stamped only when the setup wizard *runs* (`applyWizardMetadata` in `src/commands/onboard-helpers.ts:112`), not on every write. A user `config set` of `wizard.lastRunCommand` legitimately persists until the next wizard run, so including these would break correct behavior.
  - `config patch` / `config set` runtime semantics for non-auto-managed paths. No existing behavior changes outside the two rejected paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80849
- Related #79856
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw config set meta.lastTouchedVersion <value>` and `openclaw config set meta.lastTouchedAt <value>` print `Updated …` and produce a new config sha256, but the on-disk value is always the auto-stamped value from `stampConfigVersion`, not the user's input.
- Real environment tested: Ubuntu 24.04, openclaw `v2026.5.10-beta.1` (commit `033ecc944d`), Node 22.22.2, against `~/.openclaw/openclaw.json` carrying a populated `meta` block.
- Exact steps or command run after this patch:
  1. Apply this PR locally and build (`pnpm install && pnpm build`).
  2. Run the following two commands against a config with an existing `meta` block:
     ```
     pnpm openclaw config set meta.lastTouchedVersion 'BOGUS-NOT-A-VERSION'
     pnpm openclaw config set meta.lastTouchedAt       '1999-01-01T00:00:00.000Z'
     ```
  3. Run the equivalent `unset` commands to confirm symmetric rejection:
     ```
     pnpm openclaw config unset meta.lastTouchedVersion
     pnpm openclaw config unset meta.lastTouchedAt
     ```
  4. Verify on-disk state is unchanged and that `stampConfigVersion` continues to populate both fields on legitimate writes (e.g. `pnpm openclaw config set gateway.port 19002`).
- Evidence after fix: live terminal capture of the four commands above (and a legitimate `gateway.port` write to prove unrelated paths still write correctly) on the patched branch will be attached as a follow-up comment on this PR. The before-fix capture from `v2026.5.10-beta.1` is included below.
- Observed result after fix: each `config set` / `config unset` invocation against `meta.lastTouchedVersion` or `meta.lastTouchedAt` exits non-zero with the auto-managed error message, no `Updated …` line is printed, no new sha256 is produced, and the config file is untouched. A subsequent `config set` against an unrelated path (e.g. `gateway.port`) still succeeds and `stampConfigVersion` continues to refresh both `meta.lastTouchedVersion` and `meta.lastTouchedAt` on that legitimate write.
- What was not tested:
  - JSON-merge mode where the user passes a nested object at a higher level (e.g. `config set meta '{"lastTouchedVersion":"X"}'` with `--strict-json`). The current fix only inspects the operation's `requestedPath`, not the value tree. The `meta` parent path is intentionally out of scope (see Summary).
  - Programmatic callers of `replaceConfigFile` outside the `config` CLI surface. The bug surfaces specifically through `config set` / `config patch` / `config unset`; other writers don't expose user-controlled `meta.lastTouched*` input.
- Before evidence (optional but encouraged): real `pnpm openclaw config set` run on `v2026.5.10-beta.1` (commit `033ecc944d`) showing the silent-override defect:

  ```
  BEFORE disk: "lastTouchedVersion": "2026.5.10-beta.1"

  $ pnpm openclaw config set meta.lastTouchedVersion 'BOGUS-NOT-A-VERSION'
  Config overwrite: /home/orin/.openclaw/openclaw.json (sha256 1492da9bb89… -> 43873cf614…, backup=/home/orin/.openclaw/openclaw.json.bak)
  Updated meta.lastTouchedVersion. Restart the gateway to apply.

  AFTER disk:  "lastTouchedVersion": "2026.5.10-beta.1"
  AFTER via 'config get meta.lastTouchedVersion':
  2026.5.10-beta.1

  BEFORE disk: "lastTouchedAt": "2026-05-12T00:59:11.762Z"

  $ pnpm openclaw config set meta.lastTouchedAt '1999-01-01T00:00:00.000Z'
  Config overwrite: /home/orin/.openclaw/openclaw.json (sha256 43873cf614… -> fc132f02b4…, backup=/home/orin/.openclaw/openclaw.json.bak)
  Updated meta.lastTouchedAt. Restart the gateway to apply.

  AFTER disk:  "lastTouchedAt": "2026-05-12T00:59:42.441Z"
  ```

## Root Cause (if applicable)

- Root cause: `stampConfigVersion` at `src/config/io.ts:897-908` always overwrites `meta.lastTouchedVersion` (with the package `VERSION` constant) and `meta.lastTouchedAt` (with the current ISO timestamp) via a key spread that sequences `...cfg.meta` before the two explicit overrides. It is called unconditionally at `src/config/io.ts:2114` on every config-write pipeline, including the path used by `openclaw config set`. The CLI handler in `src/cli/config-cli.ts` printed `Updated …` based on the fact that *a* write happened (sha256 changed because `lastTouchedAt` was re-stamped), not whether the user's intended write was persisted.
- Missing detection / guardrail: no test or runtime check asserted that user-supplied values for the documented auto-managed `meta.*` paths actually persisted. The earlier `#79856` regression (default-equal silent drop) was fixed by `#80106` with the `explicitSetPaths` mechanism, but that mechanism operates inside the write pipeline *before* `stampConfigVersion` runs and so cannot protect against the auto-stamp override.
- Contributing context: the adjacent `plugins.installs` rejection (`src/cli/config-cli.ts:1448-1454`) already establishes the precedent of rejecting auto-managed paths at the CLI boundary instead of trying to make the write path preserve user input.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/cli/config-cli.test.ts`
- Scenario the test should lock in:
  - `openclaw config set meta.lastTouchedVersion <value>` exits non-zero with an auto-managed error and writes nothing.
  - `openclaw config set meta.lastTouchedAt <value>` exits non-zero with an auto-managed error and writes nothing.
  - `openclaw config unset meta.lastTouchedAt` exits non-zero with an auto-managed error and writes nothing.
- Why this is the smallest reliable guardrail: it pins the CLI-boundary contract for the two paths `stampConfigVersion` re-stamps, on both the write code path (`runConfigOperations`) and the unset code path (`runConfigUnset`).
- Existing test that already covers this: none — `#80106`'s regression tests cover the `explicitSetPaths` mechanism (default-equal drop) but not the auto-stamp override class.
- If no new test is added, why not: N/A; three regression tests are added in this PR, all tagged `(#80849)`.

## User-visible / Behavior Changes

- `openclaw config set meta.lastTouchedVersion <value>`, `openclaw config set meta.lastTouchedAt <value>`, and `openclaw config unset` against either path now exit with a clear error explaining the field is auto-managed, instead of printing `Updated …` and silently dropping the value. Legitimate writes to other paths are unchanged; `stampConfigVersion` continues to refresh both `meta.lastTouched*` fields on every successful write.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 22.22.2 (local)
- Model/provider: Not applicable
- Integration/channel (if any): Not applicable
- Relevant config (redacted): any populated `~/.openclaw/openclaw.json` with an existing `meta` block.

### Steps

1. On the current main / patched branch, run `pnpm openclaw config set meta.lastTouchedVersion 'BOGUS-NOT-A-VERSION'`.
2. Run `pnpm openclaw config set meta.lastTouchedAt '1999-01-01T00:00:00.000Z'`.
3. Run `pnpm openclaw config unset meta.lastTouchedAt`.
4. Run `pnpm openclaw config set gateway.port 19002` to confirm unrelated writes still succeed and `stampConfigVersion` still refreshes both `meta.lastTouched*` fields on legitimate writes.

### Expected

- Steps 1–3 each exit non-zero with the auto-managed error; no `Updated …` line; config file untouched.
- Step 4 exits 0, writes the new `gateway.port`, and refreshes `meta.lastTouchedVersion` and `meta.lastTouchedAt` as part of the legitimate write.

### Actual

- Before this PR: steps 1–3 each printed `Updated …` and a new sha256, while the on-disk `meta.lastTouched*` values were the auto-stamped values rather than the user's input (see Before evidence above).
- After this PR: steps 1–3 are rejected with the auto-managed error and zero disk writes. Step 4 behaves identically to today.

## Evidence

- [x] Failing test/log before + passing after — three new vitest assertions in `src/cli/config-cli.test.ts` cover `set meta.lastTouchedVersion`, `set meta.lastTouchedAt`, and `unset meta.lastTouchedAt`.
- [x] Trace/log snippets — see the verbatim `v2026.5.10-beta.1` capture above.
- [ ] Screenshot/recording — after-fix CLI capture will be added as a follow-up comment on this PR.
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/cli/config-cli.test.ts` — 79 tests pass, including the three new regression tests for #80849.
  - `pnpm test src/cli/config-cli.integration.test.ts` — 5 integration tests pass.
- Edge cases checked:
  - `runConfigOperations` covers `config set` value mode, `config patch`, `config set --batch-file` JSON mode, JSON-merge mode, and the batch `delete` operation — all funnel through the same early-throw check.
  - `runConfigUnset` is a separate code path not routed through `runConfigOperations`, hence its own guard with the same helper.
  - Operations whose `requestedPath` *extends* an auto-managed path (e.g. a deeper key under `meta.lastTouchedVersion`) are also rejected via `pathStartsWith`, matching the precedent set by `plugins.installs`.
  - Operations that *do not* touch the auto-managed paths are unaffected — the early-throw fires only when at least one operation's `requestedPath` starts with one of the two registered auto-managed paths.
- What I did not verify:
  - JSON-merge mode where the user provides a nested object at a higher path (e.g. `config set meta '{"lastTouchedVersion":"X"}'` with `--strict-json --merge`). The current fix inspects `requestedPath`, not the value tree, so a deeply-nested override of an auto-managed leaf via a parent-path merge is not blocked. The `meta` parent is intentionally out of scope (see Summary).
  - Behavior under `config set --batch-file` with mixed operations (some auto-managed, some not) — the early-throw rejects the whole batch as soon as one operation matches, matching the `plugins.installs` precedent.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes (rejecting values that already never persisted on disk; no scripted workflow can have relied on the dropped value).
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A scripted workflow may currently call `openclaw config set meta.lastTouchedVersion …` expecting silent success (even though the value was always dropped). Those scripts would now fail with a non-zero exit.
  - Mitigation: the script was already broken — the documented and observed behavior was a silent override. Surfacing the error gives operators a real signal to remove the dead call. The error message names the path and explains the auto-managed semantics.
- Risk: A future field added to `stampConfigVersion` is forgotten in `AUTO_MANAGED_META_PATHS` and re-introduces the silent-override class for the new field.
  - Mitigation: the constant is colocated with the rejection check and the precedent comment points at `src/config/io.ts`. A linked follow-up could add a contract test asserting that every field stamped by `stampConfigVersion` is registered in `AUTO_MANAGED_META_PATHS`; out of scope for this PR.
