### PR TITLE
Fix native hook relay startup readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - fix(memory-wiki): require admin scope for ingest [AI]. (#80897) Thanks @pgondhi987.
 - memory-wiki: require write scope for Obsidian search [AI]. (#80904) Thanks @pgondhi987.
 - Build: skip copied metadata for bundled plugins that are excluded from build entries, preventing update/status rebuilds from advertising missing QQ Bot runtime files. (#80925)
+- Codex app-server: wait briefly for startup native hook relay bridge registration, preserve fallback timeout budget, and report precise bridge/gateway diagnostics when the relay is unavailable.
 - Control UI/sessions: nest subagent sessions under their parent session in the session picker dropdown using a visual `└─ ` prefix, making the parent-child relationship clear. Fixes #77628. (#78623) Thanks @chinar-amrutkar.
 
 ### Changes

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -60,14 +60,14 @@ describe("native hook relay CLI", () => {
     }
   });
 
-  it("reserves timeout budget for gateway fallback and fail-closed output", async () => {
+  it("caps absent bridge polling while reserving fallback and fail-closed budget", async () => {
     expect(
       cliTesting.calculateNativeHookRelayBridgeRegistrationTimeoutMs({
         startedAt: 1_000,
         timeoutMs: 5_000,
         now: 1_000,
       }),
-    ).toBe(3_750);
+    ).toBe(250);
     expect(
       cliTesting.calculateNativeHookRelayDirectBridgeTimeoutMs({
         startedAt: 1_000,

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -114,12 +114,18 @@ describe("native hook relay CLI", () => {
     expect(stdout.text()).toBe("");
     expect(stderr.text()).toBe("");
     expect(callGateway).not.toHaveBeenCalled();
-    expect(invokeNativeHookRelayBridge).toHaveBeenCalledWith(
+    const firstCall = (
+      invokeNativeHookRelayBridge.mock.calls as unknown as Array<
+        [{ registrationTimeoutMs: number; timeoutMs: number }]
+      >
+    )[0]?.[0];
+    expect(firstCall).toEqual(
       expect.objectContaining({
         registrationTimeoutMs: 90,
-        timeoutMs: 114,
       }),
     );
+    expect(firstCall?.timeoutMs).toBeGreaterThanOrEqual(100);
+    expect(firstCall?.timeoutMs).toBeLessThanOrEqual(114);
   });
 
   it("uses the remaining timeout budget when the bridge is absent", async () => {

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -2,6 +2,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import { __testing, registerNativeHookRelay } from "../agents/harness/native-hook-relay.js";
 import {
+  __testing as cliTesting,
   createReadableTextStream,
   createWritableTextBuffer,
   runNativeHookRelayCli,
@@ -57,6 +58,113 @@ describe("native hook relay CLI", () => {
       relay?.unregister();
       __testing.clearNativeHookRelaysForTests();
     }
+  });
+
+  it("reserves timeout budget for gateway fallback and fail-closed output", async () => {
+    expect(
+      cliTesting.calculateNativeHookRelayBridgeRegistrationTimeoutMs({
+        startedAt: 1_000,
+        timeoutMs: 5_000,
+        now: 1_000,
+      }),
+    ).toBe(3_750);
+    expect(
+      cliTesting.calculateNativeHookRelayDirectBridgeTimeoutMs({
+        startedAt: 1_000,
+        timeoutMs: 5_000,
+        now: 1_000,
+      }),
+    ).toBe(4_750);
+    expect(
+      cliTesting.calculateNativeHookRelayGatewayFallbackTimeoutMs({
+        startedAt: 1_000,
+        timeoutMs: 5_000,
+        now: 4_750,
+      }),
+    ).toBe(1_000);
+    expect(cliTesting.calculateNativeHookRelayResponseReserveMs(5_000)).toBe(250);
+  });
+
+  it("keeps reachable direct bridge invocation on the remaining hook budget", async () => {
+    const callGateway = vi.fn();
+    const invokeNativeHookRelayBridge = vi.fn(async () => {
+      await delay(95);
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    const exitCode = await runNativeHookRelayCli(
+      {
+        provider: "codex",
+        relayId: "relay-slow-direct-bridge",
+        event: "pre_tool_use",
+        timeout: "120",
+      },
+      {
+        stdin: createReadableTextStream("{}"),
+        stdout,
+        stderr,
+        callGateway: callGateway as never,
+        invokeNativeHookRelayBridge: invokeNativeHookRelayBridge as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout.text()).toBe("");
+    expect(stderr.text()).toBe("");
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(invokeNativeHookRelayBridge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registrationTimeoutMs: 90,
+        timeoutMs: 114,
+      }),
+    );
+  });
+
+  it("uses the remaining timeout budget when the bridge is absent", async () => {
+    __testing.clearNativeHookRelaysForTests();
+    const callGateway = vi.fn(async () => {
+      throw new Error("gateway closed");
+    });
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    const exitCode = await runNativeHookRelayCli(
+      {
+        provider: "codex",
+        relayId: "relay-missing-bridge-budget",
+        event: "pre_tool_use",
+        timeout: "120",
+      },
+      {
+        stdin: createReadableTextStream("{}"),
+        stdout,
+        stderr,
+        callGateway: callGateway as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: expect.any(Number),
+      }),
+    );
+    const firstCall = (callGateway.mock.calls as unknown[][])[0]?.[0] as
+      | { timeoutMs: number }
+      | undefined;
+    expect(firstCall).toBeDefined();
+    expect(firstCall?.timeoutMs).toBeGreaterThanOrEqual(1);
+    expect(firstCall?.timeoutMs).toBeLessThan(120);
+    expect(JSON.parse(stdout.text())).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: expect.stringContaining("Native hook relay unavailable"),
+      },
+    });
+    expect(stderr.text()).toContain("native hook relay unavailable");
   });
 
   it("reads Codex hook JSON from stdin and forwards it to the gateway relay", async () => {

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -1,4 +1,6 @@
+import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
+import { __testing, registerNativeHookRelay } from "../agents/harness/native-hook-relay.js";
 import {
   createReadableTextStream,
   createWritableTextBuffer,
@@ -6,6 +8,57 @@ import {
 } from "./native-hook-relay-cli.js";
 
 describe("native hook relay CLI", () => {
+  it("waits for a direct relay bridge that becomes ready after startup", async () => {
+    __testing.clearNativeHookRelaysForTests();
+    const relayId = "relay-startup-readiness";
+    const callGateway = vi.fn();
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+    let relay: ReturnType<typeof registerNativeHookRelay> | undefined;
+
+    const registerLater = delay(150).then(() => {
+      relay = registerNativeHookRelay({
+        provider: "codex",
+        relayId,
+        sessionId: "session-startup-readiness",
+        runId: "run-startup-readiness",
+        allowedEvents: ["pre_tool_use"],
+      });
+    });
+
+    try {
+      const exitCode = await runNativeHookRelayCli(
+        {
+          provider: "codex",
+          relayId,
+          event: "pre_tool_use",
+          timeout: "1000",
+        },
+        {
+          stdin: createReadableTextStream(
+            JSON.stringify({
+              hook_event_name: "PreToolUse",
+              tool_name: "Bash",
+              tool_input: { command: "pnpm test" },
+            }),
+          ),
+          stdout,
+          stderr,
+          callGateway: callGateway as never,
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stdout.text()).toBe("");
+      expect(stderr.text()).toBe("");
+      expect(callGateway).not.toHaveBeenCalled();
+    } finally {
+      await registerLater;
+      relay?.unregister();
+      __testing.clearNativeHookRelaysForTests();
+    }
+  });
+
   it("reads Codex hook JSON from stdin and forwards it to the gateway relay", async () => {
     const callGateway = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
     const stdout = createWritableTextBuffer();
@@ -16,7 +69,7 @@ describe("native hook relay CLI", () => {
         provider: "codex",
         relayId: "relay-1",
         event: "pre_tool_use",
-        timeout: "1234",
+        timeout: "1",
       },
       {
         stdin: createReadableTextStream(
@@ -47,7 +100,7 @@ describe("native hook relay CLI", () => {
           tool_input: { command: "pnpm test" },
         },
       },
-      timeoutMs: 1234,
+      timeoutMs: 1,
       scopes: ["operator.admin"],
     });
   });
@@ -58,7 +111,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "permission_request" },
+      { provider: "codex", relayId: "relay-1", event: "permission_request", timeout: "1" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -77,7 +130,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      { provider: "codex", relayId: "relay-1", event: "pre_tool_use", timeout: "1" },
       {
         stdin: createReadableTextStream("{nope"),
         stderr,
@@ -95,7 +148,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "post_tool_use" },
+      { provider: "codex", relayId: "relay-1", event: "post_tool_use", timeout: "1" },
       {
         stdin: createReadableTextStream("x".repeat(1024 * 1024 + 1)),
         stderr,
@@ -116,7 +169,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      { provider: "codex", relayId: "relay-1", event: "pre_tool_use", timeout: "1" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -130,10 +183,13 @@ describe("native hook relay CLI", () => {
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "deny",
-        permissionDecisionReason: "Native hook relay unavailable",
+        permissionDecisionReason: expect.stringContaining("Native hook relay unavailable"),
       },
     });
     expect(stderr.text()).toContain("native hook relay unavailable");
+    expect(stderr.text()).toContain("bridgeRegistry=");
+    expect(stderr.text()).toContain("gateway=gateway closed");
+    expect(stderr.text()).toContain("remediation=restart the active OpenClaw agent run");
   });
 
   it("fails closed for PermissionRequest when the gateway relay is unavailable", async () => {
@@ -144,7 +200,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "permission_request" },
+      { provider: "codex", relayId: "relay-1", event: "permission_request", timeout: "1" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -159,10 +215,12 @@ describe("native hook relay CLI", () => {
         hookEventName: "PermissionRequest",
         decision: {
           behavior: "deny",
-          message: "Native hook relay unavailable",
+          message: expect.stringContaining("Native hook relay unavailable"),
         },
       },
     });
+    expect(stderr.text()).toContain("bridgeRegistry=");
+    expect(stderr.text()).toContain("gateway=gateway closed");
   });
 
   it("keeps PostToolUse unavailable handling observational", async () => {
@@ -173,7 +231,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "post_tool_use" },
+      { provider: "codex", relayId: "relay-1", event: "post_tool_use", timeout: "1" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -195,7 +253,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "before_agent_finalize" },
+      { provider: "codex", relayId: "relay-1", event: "before_agent_finalize", timeout: "1" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -74,7 +74,7 @@ describe("native hook relay CLI", () => {
         timeoutMs: 5_000,
         now: 1_000,
       }),
-    ).toBe(4_750);
+    ).toBe(3_750);
     expect(
       cliTesting.calculateNativeHookRelayGatewayFallbackTimeoutMs({
         startedAt: 1_000,
@@ -83,6 +83,56 @@ describe("native hook relay CLI", () => {
       }),
     ).toBe(1_000);
     expect(cliTesting.calculateNativeHookRelayResponseReserveMs(5_000)).toBe(250);
+  });
+
+  it("reserves gateway fallback budget after stale bridge retries", async () => {
+    const dateNow = vi.spyOn(Date, "now");
+    let now = 10_000;
+    dateNow.mockImplementation(() => now);
+    const staleBridgeError = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1"), {
+      code: "ECONNREFUSED",
+    });
+    const invokeNativeHookRelayBridge = vi.fn(async (params: { timeoutMs: number }) => {
+      now += params.timeoutMs;
+      throw staleBridgeError;
+    });
+    const callGateway = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    try {
+      const exitCode = await runNativeHookRelayCli(
+        {
+          provider: "codex",
+          relayId: "relay-stale-bridge-budget",
+          event: "pre_tool_use",
+          timeout: "5000",
+        },
+        {
+          stdin: createReadableTextStream("{}"),
+          stdout,
+          stderr,
+          callGateway: callGateway as never,
+          invokeNativeHookRelayBridge: invokeNativeHookRelayBridge as never,
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stdout.text()).toBe("");
+      expect(stderr.text()).toBe("");
+      expect(invokeNativeHookRelayBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeoutMs: 3_750,
+        }),
+      );
+      expect(callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeoutMs: 1_000,
+        }),
+      );
+    } finally {
+      dateNow.mockRestore();
+    }
   });
 
   it("keeps reachable direct bridge invocation on the remaining hook budget", async () => {

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -13,6 +13,7 @@ import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
 const MAX_NATIVE_HOOK_STDIN_BYTES = 1024 * 1024;
 const NATIVE_HOOK_DIRECT_BRIDGE_TIMEOUT_FRACTION = 0.75;
 const NATIVE_HOOK_RESPONSE_RESERVE_FRACTION = 0.05;
+const MAX_NATIVE_HOOK_BRIDGE_REGISTRATION_WAIT_MS = 250;
 const MAX_NATIVE_HOOK_RESPONSE_RESERVE_MS = 250;
 
 export type NativeHookRelayCliOptions = {
@@ -156,6 +157,7 @@ function calculateNativeHookRelayBridgeRegistrationTimeoutMs(params: {
     1,
     Math.min(
       Math.floor(params.timeoutMs * NATIVE_HOOK_DIRECT_BRIDGE_TIMEOUT_FRACTION),
+      MAX_NATIVE_HOOK_BRIDGE_REGISTRATION_WAIT_MS,
       remainingBeforeResponse,
     ),
   );

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -1,3 +1,6 @@
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { Readable, Writable } from "node:stream";
 import {
   invokeNativeHookRelayBridge,
@@ -34,6 +37,7 @@ export async function runNativeHookRelayCli(
   const provider = readRequiredOption(opts.provider, "provider");
   const relayId = readRequiredOption(opts.relayId, "relay-id");
   const event = readRequiredOption(opts.event, "event");
+  const timeoutMs = normalizeTimeoutMs(opts.timeout);
 
   let rawPayload: unknown;
   try {
@@ -44,19 +48,21 @@ export async function runNativeHookRelayCli(
     return 1;
   }
 
+  let bridgeError: unknown;
   try {
     const response = await invokeNativeHookRelayBridge({
       provider,
       relayId,
       event,
       rawPayload,
-      registrationTimeoutMs: 100,
-      timeoutMs: normalizeTimeoutMs(opts.timeout),
+      registrationTimeoutMs: timeoutMs,
+      timeoutMs,
     });
     writeText(stdout, response.stdout);
     writeText(stderr, response.stderr);
     return response.exitCode;
-  } catch {
+  } catch (error) {
+    bridgeError = error;
     // Fall through to the gateway path for embedded/local gateway cases and
     // older registrations that predate the direct relay bridge.
   }
@@ -65,18 +71,25 @@ export async function runNativeHookRelayCli(
     const response = await callGatewayFn<NativeHookRelayProcessResponse>({
       method: "nativeHook.invoke",
       params: { provider, relayId, event, rawPayload },
-      timeoutMs: normalizeTimeoutMs(opts.timeout),
+      timeoutMs,
       scopes: [ADMIN_SCOPE],
     });
     writeText(stdout, response.stdout);
     writeText(stderr, response.stderr);
     return response.exitCode;
   } catch (error) {
-    writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
+    const message = formatNativeHookRelayUnavailableDiagnostic({
+      provider,
+      relayId,
+      event,
+      bridgeError,
+      gatewayError: error,
+    });
+    writeText(stderr, formatRelayCliError("native hook relay unavailable", message));
     const response = renderNativeHookRelayUnavailableResponse({
       provider,
       event,
-      message: "Native hook relay unavailable",
+      message,
     });
     writeText(stdout, response.stdout);
     writeText(stderr, response.stderr);
@@ -119,6 +132,53 @@ function writeText(stream: NodeJS.WritableStream, value: string | undefined): vo
 function formatRelayCliError(prefix: string, error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return `${prefix}: ${message}\n`;
+}
+
+function formatNativeHookRelayUnavailableDiagnostic(params: {
+  provider: string;
+  relayId: string;
+  event: string;
+  bridgeError: unknown;
+  gatewayError: unknown;
+}): string {
+  return [
+    "Native hook relay unavailable",
+    "owner=OpenClaw gateway native-hook-relay",
+    `provider=${params.provider}`,
+    `event=${params.event}`,
+    `relayId=${params.relayId}`,
+    `bridgeRegistry=${nativeHookRelayBridgeRegistryPath(params.relayId)}`,
+    `bridge=${formatRelayDiagnosticError(params.bridgeError)}`,
+    `gateway=${formatRelayDiagnosticError(params.gatewayError)}`,
+    "remediation=restart the active OpenClaw agent run so native hook commands are regenerated; if every run reports this, restart the OpenClaw gateway",
+  ].join("; ");
+}
+
+function formatRelayDiagnosticError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return sanitizeRelayDiagnostic(error.message);
+  }
+  if (typeof error === "string" && error.trim()) {
+    return sanitizeRelayDiagnostic(error);
+  }
+  return "unknown";
+}
+
+function sanitizeRelayDiagnostic(value: string): string {
+  return value.replace(/\s+/g, " ").trim().slice(0, 500);
+}
+
+function nativeHookRelayBridgeRegistryPath(relayId: string): string {
+  const uid = typeof process.getuid === "function" ? process.getuid() : "nouid";
+  return path.join(
+    tmpdir(),
+    `openclaw-native-hook-relays-${uid}`,
+    `${nativeHookRelayBridgeKey(relayId)}.json`,
+  );
+}
+
+function nativeHookRelayBridgeKey(relayId: string): string {
+  return createHash("sha256").update(relayId).digest("hex").slice(0, 32);
 }
 
 export function createReadableTextStream(text: string): NodeJS.ReadableStream {

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -11,6 +11,9 @@ import { callGateway } from "../gateway/call.js";
 import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
 
 const MAX_NATIVE_HOOK_STDIN_BYTES = 1024 * 1024;
+const NATIVE_HOOK_DIRECT_BRIDGE_TIMEOUT_FRACTION = 0.75;
+const NATIVE_HOOK_RESPONSE_RESERVE_FRACTION = 0.05;
+const MAX_NATIVE_HOOK_RESPONSE_RESERVE_MS = 250;
 
 export type NativeHookRelayCliOptions = {
   provider?: string;
@@ -24,6 +27,7 @@ type NativeHookRelayCliDeps = {
   stdout?: NodeJS.WritableStream;
   stderr?: NodeJS.WritableStream;
   callGateway?: typeof callGateway;
+  invokeNativeHookRelayBridge?: typeof invokeNativeHookRelayBridge;
 };
 
 export async function runNativeHookRelayCli(
@@ -34,10 +38,13 @@ export async function runNativeHookRelayCli(
   const stdout = deps.stdout ?? process.stdout;
   const stderr = deps.stderr ?? process.stderr;
   const callGatewayFn = deps.callGateway ?? callGateway;
+  const invokeNativeHookRelayBridgeFn =
+    deps.invokeNativeHookRelayBridge ?? invokeNativeHookRelayBridge;
   const provider = readRequiredOption(opts.provider, "provider");
   const relayId = readRequiredOption(opts.relayId, "relay-id");
   const event = readRequiredOption(opts.event, "event");
   const timeoutMs = normalizeTimeoutMs(opts.timeout);
+  const startedAt = Date.now();
 
   let rawPayload: unknown;
   try {
@@ -50,13 +57,21 @@ export async function runNativeHookRelayCli(
 
   let bridgeError: unknown;
   try {
-    const response = await invokeNativeHookRelayBridge({
+    const bridgeRegistrationTimeoutMs = calculateNativeHookRelayBridgeRegistrationTimeoutMs({
+      startedAt,
+      timeoutMs,
+    });
+    const bridgeTimeoutMs = calculateNativeHookRelayDirectBridgeTimeoutMs({
+      startedAt,
+      timeoutMs,
+    });
+    const response = await invokeNativeHookRelayBridgeFn({
       provider,
       relayId,
       event,
       rawPayload,
-      registrationTimeoutMs: timeoutMs,
-      timeoutMs,
+      registrationTimeoutMs: bridgeRegistrationTimeoutMs,
+      timeoutMs: bridgeTimeoutMs,
     });
     writeText(stdout, response.stdout);
     writeText(stderr, response.stderr);
@@ -68,10 +83,14 @@ export async function runNativeHookRelayCli(
   }
 
   try {
+    const gatewayTimeoutMs = calculateNativeHookRelayGatewayFallbackTimeoutMs({
+      startedAt,
+      timeoutMs,
+    });
     const response = await callGatewayFn<NativeHookRelayProcessResponse>({
       method: "nativeHook.invoke",
       params: { provider, relayId, event, rawPayload },
-      timeoutMs,
+      timeoutMs: gatewayTimeoutMs,
       scopes: [ADMIN_SCOPE],
     });
     writeText(stdout, response.stdout);
@@ -121,6 +140,63 @@ async function readStreamText(stream: NodeJS.ReadableStream, maxBytes: number): 
 function normalizeTimeoutMs(value: string | undefined): number {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 5_000;
+}
+
+function calculateNativeHookRelayBridgeRegistrationTimeoutMs(params: {
+  startedAt: number;
+  timeoutMs: number;
+  now?: number;
+}): number {
+  const elapsedMs = Math.max(0, (params.now ?? Date.now()) - params.startedAt);
+  const remainingBeforeResponse = Math.max(
+    1,
+    params.timeoutMs - elapsedMs - calculateNativeHookRelayResponseReserveMs(params.timeoutMs),
+  );
+  return Math.max(
+    1,
+    Math.min(
+      Math.floor(params.timeoutMs * NATIVE_HOOK_DIRECT_BRIDGE_TIMEOUT_FRACTION),
+      remainingBeforeResponse,
+    ),
+  );
+}
+
+function calculateNativeHookRelayDirectBridgeTimeoutMs(params: {
+  startedAt: number;
+  timeoutMs: number;
+  now?: number;
+}): number {
+  return calculateNativeHookRelayRemainingTimeoutMs(params);
+}
+
+function calculateNativeHookRelayGatewayFallbackTimeoutMs(params: {
+  startedAt: number;
+  timeoutMs: number;
+  now?: number;
+}): number {
+  return calculateNativeHookRelayRemainingTimeoutMs(params);
+}
+
+function calculateNativeHookRelayRemainingTimeoutMs(params: {
+  startedAt: number;
+  timeoutMs: number;
+  now?: number;
+}): number {
+  const elapsedMs = Math.max(0, (params.now ?? Date.now()) - params.startedAt);
+  return Math.max(
+    1,
+    params.timeoutMs - elapsedMs - calculateNativeHookRelayResponseReserveMs(params.timeoutMs),
+  );
+}
+
+function calculateNativeHookRelayResponseReserveMs(timeoutMs: number): number {
+  if (timeoutMs <= 20) {
+    return 0;
+  }
+  return Math.min(
+    MAX_NATIVE_HOOK_RESPONSE_RESERVE_MS,
+    Math.max(1, Math.floor(timeoutMs * NATIVE_HOOK_RESPONSE_RESERVE_FRACTION)),
+  );
 }
 
 function writeText(stream: NodeJS.WritableStream, value: string | undefined): void {
@@ -197,3 +273,10 @@ export function createWritableTextBuffer(): NodeJS.WritableStream & { text: () =
     text: () => Buffer.concat(chunks).toString("utf8"),
   });
 }
+
+export const __testing = {
+  calculateNativeHookRelayBridgeRegistrationTimeoutMs,
+  calculateNativeHookRelayDirectBridgeTimeoutMs,
+  calculateNativeHookRelayGatewayFallbackTimeoutMs,
+  calculateNativeHookRelayResponseReserveMs,
+};

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -13,6 +13,7 @@ import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
 const MAX_NATIVE_HOOK_STDIN_BYTES = 1024 * 1024;
 const NATIVE_HOOK_DIRECT_BRIDGE_TIMEOUT_FRACTION = 0.75;
 const NATIVE_HOOK_RESPONSE_RESERVE_FRACTION = 0.05;
+const MIN_NATIVE_HOOK_DIRECT_BRIDGE_TIMEOUT_MS = 100;
 const MAX_NATIVE_HOOK_BRIDGE_REGISTRATION_WAIT_MS = 250;
 const MAX_NATIVE_HOOK_RESPONSE_RESERVE_MS = 250;
 
@@ -168,7 +169,12 @@ function calculateNativeHookRelayDirectBridgeTimeoutMs(params: {
   timeoutMs: number;
   now?: number;
 }): number {
-  return calculateNativeHookRelayRemainingTimeoutMs(params);
+  const remainingTimeoutMs = calculateNativeHookRelayRemainingTimeoutMs(params);
+  const directBridgeBudgetMs = Math.max(
+    MIN_NATIVE_HOOK_DIRECT_BRIDGE_TIMEOUT_MS,
+    Math.floor(params.timeoutMs * NATIVE_HOOK_DIRECT_BRIDGE_TIMEOUT_FRACTION),
+  );
+  return Math.max(1, Math.min(remainingTimeoutMs, directBridgeBudgetMs));
 }
 
 function calculateNativeHookRelayGatewayFallbackTimeoutMs(params: {


### PR DESCRIPTION
## Summary

- wait briefly for newly registered native hook relay bridge records before falling back to gateway RPC
- cap absent direct-bridge registry polling so fallback-only environments do not wait for most of the hook timeout
- reserve timeout budget so stale direct bridge retries still leave time for gateway fallback and fail-closed response output
- replace the vague unavailable response with diagnostics that name the owner, provider/event/relay id, bridge registry path, bridge error, gateway error, and remediation path
- add a changelog entry for the Codex app-server native hook relay fix

## Root Cause

Native hook commands could execute before the direct relay bridge registry record was written, or after the bridge disappeared. The CLI immediately treated the startup race as unavailable, while the first budgeted repair let a truly absent bridge wait too long before gateway fallback. A later stale bridge record review found that retryable socket errors could consume nearly all direct-bridge time and starve the gateway fallback. This patch keeps a bounded startup-readiness wait for delayed bridge registration, caps the no-registry poll at 250 ms, caps direct bridge attempts to reserve fallback budget, and still reserves budget for provider-compatible fail-closed output.

## Real behavior proof

Behavior or issue addressed: Native hook relay startup readiness and missing-relay fallback behavior for OpenClaw hook command execution.

Real environment tested: Installed local OpenClaw runtime on Nikita's macOS machine, using `/opt/homebrew/lib/node_modules/openclaw/dist/native-hook-relay-Dd9iHtsW.js` and the installed `openclaw` CLI after applying the matching local hot patch.

Exact steps or command run after this patch:

```text
node /Users/borodutch/.openclaw/workspace/scripts/openclaw_native_hook_relay_regression.mjs
openclaw hooks relay --provider codex --relay-id missing-ocl-kaneo-18-fallback-cap-smoke --event pre_tool_use --timeout 500 < /dev/null
```

Evidence after fix:

```text
$ node /Users/borodutch/.openclaw/workspace/scripts/openclaw_native_hook_relay_regression.mjs
{"ok":true,"relayId":"ocl-kaneo-18-83806-1778568082583","modulePath":"/opt/homebrew/lib/node_modules/openclaw/dist/native-hook-relay-Dd9iHtsW.js","initialExpiresAtMs":1778568082783,"refreshedExpiresAtMs":1778611282617,"registryPath":"/var/folders/zy/dzlc3wv10sl2c_ztl6bk3s4h0000gn/T/openclaw-native-hook-relays-501/0fe9da188b9072262c0743b2d7e04b37.json"}
```

```text
$ openclaw hooks relay --provider codex --relay-id missing-ocl-kaneo-18-fallback-cap-smoke --event pre_tool_use --timeout 500 < /dev/null
native hook relay unavailable: Native hook relay unavailable; owner=OpenClaw gateway native-hook-relay; provider=codex; event=pre_tool_use; relayId=missing-ocl-kaneo-18-fallback-cap-smoke; bridgeRegistry=/var/folders/zy/dzlc3wv10sl2c_ztl6bk3s4h0000gn/T/openclaw-native-hook-relays-501/293b7cef338f499e3444b3ff557bc0ec.json; bridge=native hook relay bridge not found; gateway=native hook relay not found; remediation=restart the active OpenClaw agent run so native hook commands are regenerated; if every run reports this, restart the OpenClaw gateway
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Native hook relay unavailable; owner=OpenClaw gateway native-hook-relay; provider=codex; event=pre_tool_use; relayId=missing-ocl-kaneo-18-fallback-cap-smoke; bridgeRegistry=/var/folders/zy/dzlc3wv10sl2c_ztl6bk3s4h0000gn/T/openclaw-native-hook-relays-501/293b7cef338f499e3444b3ff557bc0ec.json; bridge=native hook relay bridge not found; gateway=native hook relay not found; remediation=restart the active OpenClaw agent run so native hook commands are regenerated; if every run reports this, restart the OpenClaw gateway"}}
```

Observed result after fix: The delayed bridge regression returns `ok: true`, showing live bridge invocation still works after the old short TTL window. The missing-relay command fails closed with provider-compatible PreToolUse deny JSON and a specific owner/bridge/gateway/remediation diagnostic instead of the vague unavailable message.

What was not tested: No additional gaps.

Installed-runtime backup before the latest hot patch: `/Users/borodutch/.openclaw/backups/hooks-cli-COudtXtI.js.pre-ocl-kaneo-18-fallback-cap-20260512T064053Z`.

## Testing

- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/cli/native-hook-relay-cli.test.ts src/agents/harness/native-hook-relay.test.ts` - passed on head `6500fcd448`, 2 Vitest shards / 56 tests
- `pnpm check:changed` - passed on head `6500fcd448`
- `gh pr checks 80860 --repo openclaw/openclaw` - passed on head `6500fcd448`; current required checks are green, with only workflow-rule skips and an old cancelled duplicate proof run superseded by the passing `Real behavior proof`

## Automation note

The Kaneo contract expects a `symphony` PR label. This repository currently has no `symphony` label, and this token cannot create labels on `openclaw/openclaw` (`gh label create symphony` returned GitHub 404; `gh pr edit --add-label symphony` returns `'symphony' not found`), so the label is blocked by repository permissions/metadata.
