### PR TITLE
fix(gateway): wire max_completion_tokens/max_tokens through openai-http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/OpenAI HTTP: honor `max_completion_tokens` and `max_tokens` on inbound `/v1/chat/completions` requests so client-provided token caps reach the upstream provider via `streamParams.maxTokens`, with `max_completion_tokens` taking precedence when both are sent.
 - Models/OpenAI CLI auth: make `openclaw models auth login --provider openai` start the ChatGPT/Codex account login by default, while `--method api-key` remains the explicit OpenAI API-key setup path.
 - Google/Gemini: normalize retired Gemini 3 Pro Preview ids in provider catalog rows when API-key onboarding only reapplies the agent default, so emitted config keeps testing `google/gemini-3.1-pro-preview`.
 - Docs/subagents: document `agents.defaults.subagents.announceTimeoutMs` in the sub-agent and configuration references. (#75509) Thanks @akrimm702.

--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -201,6 +201,10 @@ Set `stream: true` to receive Server-Sent Events (SSE):
 - `tool_choice`: `"auto"`, `"none"`
 - `messages[*].role: "tool"` follow-up turns
 - `messages[*].tool_call_id` for binding tool results back to a prior tool call
+- `max_completion_tokens`: number; per-call cap for total completion tokens (reasoning tokens included). Current OpenAI Chat Completions field name; preferred when both `max_completion_tokens` and `max_tokens` are sent.
+- `max_tokens`: number; legacy alias accepted for backwards compatibility. Ignored when `max_completion_tokens` is also present.
+
+When either field is set, the value is forwarded to the upstream provider via the agent stream-param channel. The actual wire field name sent to the upstream provider is chosen by the provider transport: `max_completion_tokens` for OpenAI-family endpoints, and `max_tokens` for providers that only accept the legacy name (such as Mistral and Chutes).
 
 ### Unsupported variants
 

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -1273,6 +1273,67 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     }
   });
 
+  it("forwards inbound max_completion_tokens and max_tokens into streamParams", async () => {
+    const port = enabledPort;
+    const mockAgentOnce = (payloads: Array<{ text: string }>) => {
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({ payloads } as never);
+    };
+    const getFirstAgentMaxTokens = () => {
+      const opts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0];
+      return (opts as { streamParams?: { maxTokens?: number } } | undefined)?.streamParams
+        ?.maxTokens;
+    };
+
+    {
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        max_completion_tokens: 256,
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getFirstAgentMaxTokens()).toBe(256);
+      await res.text();
+    }
+
+    {
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        max_tokens: 128,
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getFirstAgentMaxTokens()).toBe(128);
+      await res.text();
+    }
+
+    {
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        max_completion_tokens: 64,
+        max_tokens: 999,
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getFirstAgentMaxTokens()).toBe(64);
+      await res.text();
+    }
+
+    {
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getFirstAgentMaxTokens()).toBeUndefined();
+      await res.text();
+    }
+  });
+
   it("returns 429 for repeated failed auth when gateway.auth.rateLimit is configured", async () => {
     testState.gatewayAuth = {
       mode: "token",

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -73,6 +73,8 @@ type OpenAiChatCompletionRequest = {
   tool_choice?: unknown;
   messages?: unknown;
   user?: unknown;
+  max_tokens?: unknown;
+  max_completion_tokens?: unknown;
 };
 
 const DEFAULT_OPENAI_CHAT_COMPLETIONS_BODY_BYTES = 20 * 1024 * 1024;
@@ -132,6 +134,7 @@ function buildAgentCommandInput(params: {
   messageChannel: string;
   senderIsOwner: boolean;
   abortSignal?: AbortSignal;
+  streamParams?: { maxTokens?: number };
 }) {
   return {
     message: params.prompt.message,
@@ -147,6 +150,7 @@ function buildAgentCommandInput(params: {
     senderIsOwner: params.senderIsOwner,
     allowModelOverride: true as const,
     abortSignal: params.abortSignal,
+    streamParams: params.streamParams,
   };
 }
 
@@ -813,6 +817,13 @@ export async function handleOpenAiHttpRequest(
   const streamIncludeUsage = stream && resolveIncludeUsageForStreaming(payload);
   const model = typeof payload.model === "string" ? payload.model : "openclaw";
   const user = typeof payload.user === "string" ? payload.user : undefined;
+  const maxTokens =
+    typeof payload.max_completion_tokens === "number"
+      ? payload.max_completion_tokens
+      : typeof payload.max_tokens === "number"
+        ? payload.max_tokens
+        : undefined;
+  const streamParams = maxTokens !== undefined ? { maxTokens } : undefined;
 
   const { agentId, sessionKey, messageChannel } = resolveGatewayRequestContext({
     req,
@@ -897,6 +908,7 @@ export async function handleOpenAiHttpRequest(
     messageChannel,
     abortSignal: abortController.signal,
     senderIsOwner,
+    streamParams,
   });
 
   if (!stream) {


### PR DESCRIPTION
## Summary

Wire `max_completion_tokens` and `max_tokens` from inbound `/v1/chat/completions` requests through to `streamParams.maxTokens`, so client-supplied per-call token caps actually reach the upstream provider.

- Adds parsing for both fields in `src/gateway/openai-http.ts`, with `max_completion_tokens` taking precedence when both are present (matches OpenAI's current Chat Completions guidance).
- Threads `streamParams` through `buildAgentCommandInput()` into `agentCommandFromIngress`. No changes needed downstream: `src/agents/openai-completions-compat.ts:70-87` + `src/agents/openai-transport-stream.ts:2338-2345` already pick the correct wire field name (`max_tokens` for Mistral/Chutes, `max_completion_tokens` for OpenAI-family) per upstream provider.
- Mirrors the existing Responses-side wiring at `src/gateway/openresponses-http.ts:676-679`.

Fixes #80866.

## Verification

- `pnpm test src/gateway/openai-http.test.ts` → 13/13 passing (1 new `it` with 4 sub-cases: `max_completion_tokens` only, `max_tokens` only, both-present precedence, neither-present sentinel; no regression in the 12 existing cases).
- `pnpm check:changed` → exit 0 (typecheck core + core tests via tsgo, oxlint 0/0, import cycles 0, all gateway guards green).
- `codex review --base main` → no discrete correctness issues; transport chain (`AgentCommandIngressOpts` → `AgentCommandOpts.streamParams` → `agentCommandInternal`) confirmed wired.
- Docs: `docs/gateway/openai-http-api.md` updated to document both fields and explain the inbound vs. wire field-name relationship.
- Changelog: single-line entry added under `## Unreleased` → `### Changes`.


## Real behavior proof

- **Behavior or issue addressed**: Inbound OpenAI-compatible `/v1/chat/completions` requests that set `max_completion_tokens` now carry that per-call token cap through the Gateway and agent runtime to the upstream provider request.
- **Real environment tested**: Local OpenClaw Gateway process from this branch (`node scripts/run-node.mjs gateway run`) on macOS, isolated `OPENCLAW_CONFIG_PATH`/`OPENCLAW_STATE_DIR`, token auth enabled, `gateway.http.endpoints.chatCompletions.enabled: true`, and a local OpenAI-compatible provider process (`scripts/e2e/mock-openai-server.mjs`) recording the actual upstream `/v1/chat/completions` request body.
- **Exact steps or command run after this patch**: Started the local provider recorder, started `node scripts/run-node.mjs gateway run --port 18992 --bind loopback`, confirmed `GET /v1/models`, then sent `curl -fsS http://127.0.0.1:18992/v1/chat/completions -H 'Authorization: Bearer <redacted>' -H 'Content-Type: application/json' -d '{"model":"openclaw/default","stream":false,"max_completion_tokens":13,"messages":[{"role":"user","content":"Return OPENCLAW_PROOF_80867_OK exactly."}]}'`.
- **Evidence after fix**: Terminal capture from the after-fix run:

```text
GET /v1/models -> openclaw, openclaw/default

POST /v1/chat/completions with max_completion_tokens=13 ->
{
  "id": "chatcmpl_6c3c39d3-6eef-49aa-ad55-d876af8c4bba",
  "object": "chat.completion",
  "content": "OPENCLAW_PROOF_80867_OK",
  "finish_reason": "stop",
  "usage": {
    "prompt_tokens": 0,
    "completion_tokens": 0,
    "total_tokens": 0
  }
}

Upstream /v1/chat/completions body observed by mock provider ->
{
  "path": "/v1/chat/completions",
  "model": "gpt-5.5",
  "max_completion_tokens": 13,
  "max_tokens": null,
  "stream": true,
  "messageCount": 2
}

Gateway startup evidence ->
2026-05-12T12:47:26.117+08:00 [gateway] http server listening (9 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 1.2s)
2026-05-12T12:47:26.199+08:00 [gateway] ready

Proof result: PASS - inbound max_completion_tokens reached upstream provider as token cap 13.
```

- **Observed result after fix**: The real Gateway endpoint returned a successful OpenAI-compatible chat completion, and the recorded upstream provider request body contained `max_completion_tokens: 13` with `max_tokens: null`, proving the inbound cap reached the provider transport.
- **What was not tested**: No live cloud OpenAI API key was available in `~/.profile`, so this proof used a local OpenAI-compatible provider recorder instead of a paid external provider. The provider transport path and HTTP request body were still exercised through a real Gateway process.
