### PR TITLE
fix(docker): avoid external Dockerfile frontend pull

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.7
-
 # Opt-in plugin dependencies at build time (space- or comma-separated directory names).
 # Example: docker build --build-arg OPENCLAW_EXTENSIONS="diagnostics-otel,matrix" .
 #

--- a/scripts/docker/sandbox/Dockerfile
+++ b/scripts/docker/sandbox/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.7
-
 FROM debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -7,6 +7,7 @@ import YAML from "yaml";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
+const dockerSetupDockerfilePaths = ["Dockerfile", "scripts/docker/sandbox/Dockerfile"] as const;
 const pnpmWorkspacePath = join(repoRoot, "pnpm-workspace.yaml");
 
 function collapseDockerContinuations(dockerfile: string): string {
@@ -14,6 +15,13 @@ function collapseDockerContinuations(dockerfile: string): string {
 }
 
 describe("Dockerfile", () => {
+  it("does not force an external Dockerfile frontend pull", async () => {
+    for (const path of dockerSetupDockerfilePaths) {
+      const dockerfile = await readFile(join(repoRoot, path), "utf8");
+      expect(dockerfile, path).not.toMatch(/^#\s*syntax=/m);
+    }
+  });
+
   it("uses full bookworm for build stages and slim bookworm for runtime", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     expect(dockerfile).toContain(


### PR DESCRIPTION
## Summary

- Remove the root Dockerfile `# syntax=docker/dockerfile:1.7` parser directive so Docker setup no longer requires a pre-build pull of the external Dockerfile frontend from Docker Hub.
- Keep BuildKit enabled through the existing Docker build helper; the Dockerfile still uses BuildKit `RUN --mount` features, but now relies on the bundled frontend.
- Add a focused regression test so the root Dockerfile does not reintroduce an external `# syntax=` frontend pull.

## Linked Issue

Closes #80580

## Real behavior proof

- Behavior or issue addressed: Root `Dockerfile` no longer forces BuildKit to pull the external `docker/dockerfile:1.7` frontend before the build, avoiding the WSL/Docker Hub timeout path reported in #80580.
- Real environment tested: Blacksmith Testbox Linux, Docker BuildKit enabled, Testbox `tbx_01krd47qpd4gpbb6gwwh9szfmj`.
- Exact steps or command run after this patch:

  ```sh
  env DOCKER_BUILDKIT=1 docker build --target workspace-deps \
    -t openclaw-dockerfile-syntax-smoke \
    -f Dockerfile .
  ```

- Evidence after fix: Copied live Testbox terminal output from the Docker BuildKit smoke:

  ```text
  CRABBOX_PHASE:docker-smoke
  #0 building with "default" instance using docker driver
  #1 [internal] load build definition from Dockerfile
  ...
  #7 exporting to image
  #7 writing image sha256:03c7180feb30e5be92c7d30f67f542d26eab9f136785c29c3f2f13a6bb4d6121 done
  #7 naming to docker.io/library/openclaw-dockerfile-syntax-smoke done
  #7 DONE 0.0s
  blacksmith run summary sync=delegated command=52.649s total=54.644s exit=0
  ```

- Observed result after fix: The patched root `Dockerfile` loaded without any `docker/dockerfile:1.7` frontend pull, the `workspace-deps` stage executed successfully with BuildKit `RUN --mount=type=bind`, and Docker exported `docker.io/library/openclaw-dockerfile-syntax-smoke`.
- What was not tested: I did not run the reporter's exact Windows 11 + WSL Ubuntu 22.04 host. The Testbox proof covers the Docker BuildKit frontend resolution path that failed before the build in the report.

## Verification

```sh
pnpm test src/dockerfile.test.ts src/docker-build-cache.test.ts test/scripts/docker-build-helper.test.ts
pnpm test src/docker-setup.e2e.test.ts
pnpm exec oxfmt --check --threads=1 src/dockerfile.test.ts
git diff --check origin/main..HEAD
```
