### PR TITLE
docs: resolve contradiction on browser wait --load networkidle support

### DIFF
--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -276,7 +276,7 @@ Current existing-session limits:
 - `hover`, `scrollintoview`, `drag`, `select`, `fill`, and `evaluate` reject
   per-call timeout overrides
 - `select` supports one value only
-- `wait --load networkidle` is not supported
+- `wait --load networkidle` is not supported (for existing-session profiles only — the managed `openclaw` profile supports it)
 - file uploads require `--ref` / `--input-ref`, do not support CSS
   `--element`, and currently support one file at a time
 - dialog hooks do not support `--timeout`

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -292,14 +292,14 @@ You can wait on more than just time/text:
 
 - Wait for URL (globs supported by Playwright):
   - `openclaw browser wait --url "**/dash"`
-- Wait for load state:
+- Wait for load state (managed `openclaw` profile only):
   - `openclaw browser wait --load networkidle`
 - Wait for a JS predicate:
   - `openclaw browser wait --fn "window.ready===true"`
 - Wait for a selector to become visible:
   - `openclaw browser wait "#main"`
 
-These can be combined:
+These can be combined (requires a managed `openclaw` profile — `--load networkidle` is not supported for existing-session profiles):
 
 ```bash
 openclaw browser wait "#main" \

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -646,7 +646,7 @@ Compared to the managed `openclaw` profile, existing-session drivers are more co
 
 - **Screenshots** - page captures and `--ref` element captures work; CSS `--element` selectors do not. `--full-page` cannot combine with `--ref` or `--element`. Playwright is not required for page or ref-based element screenshots.
 - **Actions** - `click`, `type`, `hover`, `scrollIntoView`, `drag`, and `select` require snapshot refs (no CSS selectors). `click-coords` clicks visible viewport coordinates and does not require a snapshot ref. `click` is left-button only. `type` does not support `slowly=true`; use `fill` or `press`. `press` does not support `delayMs`. `type`, `hover`, `scrollIntoView`, `drag`, `select`, `fill`, and `evaluate` do not support per-call timeouts. `select` accepts a single value.
-- **Wait / upload / dialog** - `wait --url` supports exact, substring, and glob patterns; `wait --load networkidle` is not supported. Upload hooks require `ref` or `inputRef`, one file at a time, no CSS `element`. Dialog hooks do not support timeout overrides.
+- **Wait / upload / dialog** - `wait --url` supports exact, substring, and glob patterns; `wait --load networkidle` is not supported (managed `openclaw` profiles support `--load networkidle`). Upload hooks require `ref` or `inputRef`, one file at a time, no CSS `element`. Dialog hooks do not support timeout overrides.
 - **Managed-only features** - batch actions, PDF export, download interception, and `responsebody` still require the managed browser path.
 
 </Accordion>


### PR DESCRIPTION
## Summary

Fixes #80587.

browser-control.md showed `--load networkidle` without qualifier, while browser.md (within existing-session accordion) said it is not supported. The code confirms: `networkidle` is supported for managed openclaw profiles but rejected for existing-session profiles (enforced in `existing-session-limits.ts` and `agent.act.ts`).

## Changes

- **browser-control.md**: add qualifier notes clarifying managed-only scope
- **browser.md**: add note that managed profiles DO support `--load networkidle`
- **cli/browser.md**: add qualifier to existing-session limit bullet

Closes #80587