### PR TITLE
fix(slack): normalize message read timestamp bounds

### DIFF
--- a/extensions/slack/src/actions.read.test.ts
+++ b/extensions/slack/src/actions.read.test.ts
@@ -93,7 +93,7 @@ describe("readSlackMessages", () => {
     expect(result.messages.map((message) => message.ts)).toEqual(["1"]);
   });
 
-  it("normalizes ISO read bounds before calling Slack history", async () => {
+  it("normalizes ISO read bounds with timezones before calling Slack history", async () => {
     const client = createClient();
     client.conversations.history.mockResolvedValueOnce({
       messages: [{ ts: "1778472000.000000" }],
@@ -103,7 +103,7 @@ describe("readSlackMessages", () => {
     await readSlackMessages("C1", {
       client,
       after: "2026-05-11T04:00:00Z",
-      before: "2026-05-11T05:30:00Z",
+      before: "2026-05-11T01:30:00-04:00",
       token: "xoxb-test",
     });
 
@@ -143,13 +143,32 @@ describe("readSlackMessages", () => {
         token: "xoxb-test",
       }),
     ).rejects.toThrow(
-      "Invalid Slack message read after value: expected a Slack timestamp, Unix epoch seconds, or ISO 8601 timestamp.",
+      "Invalid Slack message read after value: expected a Slack timestamp, Unix epoch seconds, or ISO 8601 timestamp with timezone.",
     );
     expect(client.conversations.history).not.toHaveBeenCalled();
     expect(client.conversations.replies).not.toHaveBeenCalled();
   });
 
-  it("normalizes ISO read bounds before calling Slack replies", async () => {
+  it.each(["05/11/2026", "May 11, 2026 04:00", "2026-05-11T04:00:00"])(
+    "rejects ambiguous or timezone-less read bound %s",
+    async (after) => {
+      const client = createClient();
+
+      await expect(
+        readSlackMessages("C1", {
+          client,
+          after,
+          token: "xoxb-test",
+        }),
+      ).rejects.toThrow(
+        "Invalid Slack message read after value: expected a Slack timestamp, Unix epoch seconds, or ISO 8601 timestamp with timezone.",
+      );
+      expect(client.conversations.history).not.toHaveBeenCalled();
+      expect(client.conversations.replies).not.toHaveBeenCalled();
+    },
+  );
+
+  it("normalizes ISO read bounds with timezones before calling Slack replies", async () => {
     const client = createClient();
     client.conversations.replies.mockResolvedValueOnce({
       messages: [{ ts: "171234.567" }, { ts: "1778472000.000000" }],

--- a/extensions/slack/src/actions.read.test.ts
+++ b/extensions/slack/src/actions.read.test.ts
@@ -93,6 +93,86 @@ describe("readSlackMessages", () => {
     expect(result.messages.map((message) => message.ts)).toEqual(["1"]);
   });
 
+  it("normalizes ISO read bounds before calling Slack history", async () => {
+    const client = createClient();
+    client.conversations.history.mockResolvedValueOnce({
+      messages: [{ ts: "1778472000.000000" }],
+      has_more: false,
+    });
+
+    await readSlackMessages("C1", {
+      client,
+      after: "2026-05-11T04:00:00Z",
+      before: "2026-05-11T05:30:00Z",
+      token: "xoxb-test",
+    });
+
+    expect(client.conversations.history).toHaveBeenCalledWith({
+      channel: "C1",
+      limit: undefined,
+      latest: "1778477400",
+      oldest: "1778472000",
+    });
+  });
+
+  it("preserves Slack timestamp read bounds", async () => {
+    const client = createClient();
+
+    await readSlackMessages("C1", {
+      client,
+      after: "1712345678.123456",
+      before: "1712349999",
+      token: "xoxb-test",
+    });
+
+    expect(client.conversations.history).toHaveBeenCalledWith({
+      channel: "C1",
+      limit: undefined,
+      latest: "1712349999",
+      oldest: "1712345678.123456",
+    });
+  });
+
+  it("rejects unrecognized read bounds instead of silently falling back", async () => {
+    const client = createClient();
+
+    await expect(
+      readSlackMessages("C1", {
+        client,
+        after: "yesterday morning",
+        token: "xoxb-test",
+      }),
+    ).rejects.toThrow(
+      "Invalid Slack message read after value: expected a Slack timestamp, Unix epoch seconds, or ISO 8601 timestamp.",
+    );
+    expect(client.conversations.history).not.toHaveBeenCalled();
+    expect(client.conversations.replies).not.toHaveBeenCalled();
+  });
+
+  it("normalizes ISO read bounds before calling Slack replies", async () => {
+    const client = createClient();
+    client.conversations.replies.mockResolvedValueOnce({
+      messages: [{ ts: "171234.567" }, { ts: "1778472000.000000" }],
+      has_more: false,
+    });
+
+    await readSlackMessages("C1", {
+      client,
+      threadId: "171234.567",
+      after: "2026-05-11T04:00:00Z",
+      before: "2026-05-11T05:30:00Z",
+      token: "xoxb-test",
+    });
+
+    expect(client.conversations.replies).toHaveBeenCalledWith({
+      channel: "C1",
+      ts: "171234.567",
+      limit: undefined,
+      latest: "1778477400",
+      oldest: "1778472000",
+    });
+  });
+
   it("filters a specific channel message by messageId", async () => {
     const client = createClient();
     client.conversations.history.mockResolvedValueOnce({

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -104,6 +104,23 @@ async function resolveBotUserId(client: WebClient) {
   return auth.user_id;
 }
 
+function normalizeSlackReadTimestampBound(value: string | undefined, field: string) {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (/^\d+(?:\.\d+)?$/.test(trimmed)) {
+    return trimmed;
+  }
+  const parsed = Date.parse(trimmed);
+  if (!Number.isNaN(parsed)) {
+    return String(parsed / 1000);
+  }
+  throw new Error(
+    `Invalid Slack message read ${field} value: expected a Slack timestamp, Unix epoch seconds, or ISO 8601 timestamp.`,
+  );
+}
+
 export async function reactSlackMessage(
   channelId: string,
   messageId: string,
@@ -278,8 +295,8 @@ export async function readSlackMessages(
         oldest: undefined,
       }
     : {
-        latest: opts.before,
-        oldest: opts.after,
+        latest: normalizeSlackReadTimestampBound(opts.before, "before"),
+        oldest: normalizeSlackReadTimestampBound(opts.after, "after"),
       };
 
   // Use conversations.replies for thread messages, conversations.history for channel messages.

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -104,6 +104,41 @@ async function resolveBotUserId(client: WebClient) {
   return auth.user_id;
 }
 
+const ISO_8601_TIMESTAMP_WITH_TIMEZONE =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(Z|[+-]\d{2}:\d{2})$/;
+
+function isIso8601TimestampWithTimezone(value: string) {
+  const match = ISO_8601_TIMESTAMP_WITH_TIMEZONE.exec(value);
+  if (!match) {
+    return false;
+  }
+
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText = "0", zone] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+
+  if (month < 1 || month > 12 || hour > 23 || minute > 59 || second > 59) {
+    return false;
+  }
+  const maxDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  if (day < 1 || day > maxDay) {
+    return false;
+  }
+  if (zone !== "Z") {
+    const offsetHour = Number(zone.slice(1, 3));
+    const offsetMinute = Number(zone.slice(4, 6));
+    if (offsetHour > 23 || offsetMinute > 59) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function normalizeSlackReadTimestampBound(value: string | undefined, field: string) {
   const trimmed = value?.trim();
   if (!trimmed) {
@@ -112,12 +147,12 @@ function normalizeSlackReadTimestampBound(value: string | undefined, field: stri
   if (/^\d+(?:\.\d+)?$/.test(trimmed)) {
     return trimmed;
   }
-  const parsed = Date.parse(trimmed);
+  const parsed = isIso8601TimestampWithTimezone(trimmed) ? Date.parse(trimmed) : Number.NaN;
   if (!Number.isNaN(parsed)) {
     return String(parsed / 1000);
   }
   throw new Error(
-    `Invalid Slack message read ${field} value: expected a Slack timestamp, Unix epoch seconds, or ISO 8601 timestamp.`,
+    `Invalid Slack message read ${field} value: expected a Slack timestamp, Unix epoch seconds, or ISO 8601 timestamp with timezone.`,
   );
 }
 

--- a/extensions/slack/src/message-action-dispatch.test.ts
+++ b/extensions/slack/src/message-action-dispatch.test.ts
@@ -383,6 +383,29 @@ describe("handleSlackMessageAction", () => {
     expect(firstInvokeCall(invoke)[1]).toEqual({});
   });
 
+  it("forwards ISO read bounds for normalization by the Slack action layer", async () => {
+    const invoke = createInvokeSpy();
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "read",
+        cfg: {},
+        params: {
+          channelId: "C1",
+          after: "2026-05-11T04:00:00Z",
+          before: "2026-05-11T05:30:00Z",
+        },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    const action = firstAction(invoke);
+    expect(action.action).toBe("readMessages");
+    expect(action.after).toBe("2026-05-11T04:00:00Z");
+    expect(action.before).toBe("2026-05-11T05:30:00Z");
+  });
+
   it("requires filePath, path, or media for upload-file", async () => {
     await expect(
       handleSlackMessageAction({

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -274,8 +274,18 @@ function buildFetchSchema() {
     limit: Type.Optional(Type.Number()),
     pageSize: Type.Optional(Type.Number()),
     pageToken: Type.Optional(Type.String()),
-    before: Type.Optional(Type.String()),
-    after: Type.Optional(Type.String()),
+    before: Type.Optional(
+      Type.String({
+        description:
+          "Read messages before this bound. Providers may accept native message timestamps, Unix epoch seconds, or ISO 8601 timestamps.",
+      }),
+    ),
+    after: Type.Optional(
+      Type.String({
+        description:
+          "Read messages after this bound. Providers may accept native message timestamps, Unix epoch seconds, or ISO 8601 timestamps.",
+      }),
+    ),
     around: Type.Optional(Type.String()),
     fromMe: Type.Optional(Type.Boolean()),
     includeArchived: Type.Optional(Type.Boolean()),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -277,13 +277,13 @@ function buildFetchSchema() {
     before: Type.Optional(
       Type.String({
         description:
-          "Read messages before this bound. Providers may accept native message timestamps, Unix epoch seconds, or ISO 8601 timestamps.",
+          "Read messages before this bound. Providers may accept native message timestamps, Unix epoch seconds, or ISO 8601 timestamps with timezone.",
       }),
     ),
     after: Type.Optional(
       Type.String({
         description:
-          "Read messages after this bound. Providers may accept native message timestamps, Unix epoch seconds, or ISO 8601 timestamps.",
+          "Read messages after this bound. Providers may accept native message timestamps, Unix epoch seconds, or ISO 8601 timestamps with timezone.",
       }),
     ),
     around: Type.Optional(Type.String()),


### PR DESCRIPTION
## Summary
- normalize Slack message read `before`/`after` bounds before calling `conversations.history` or `conversations.replies`
- preserve native Slack/Unix timestamp strings while accepting ISO 8601 timestamps
- reject unrecognized timestamp bounds instead of forwarding them to Slack and returning misleading empty results
- document the generic message-tool `before`/`after` timestamp contract

Fixes #80835.

## Tests
- pnpm test extensions/slack/src/actions.read.test.ts extensions/slack/src/message-action-dispatch.test.ts
- pnpm test src/agents/tools/message-tool.test.ts
- pnpm exec oxfmt --check --threads=1 extensions/slack/src/actions.ts extensions/slack/src/actions.read.test.ts extensions/slack/src/message-action-dispatch.test.ts src/agents/tools/message-tool.ts
- git diff --check
- pnpm tsgo:test:src
- pnpm tsgo:test:extensions
