### PR TITLE
fix(matrix): stop runtime npm install from parent-derived cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Matrix: stop running `npm install`/`pnpm install` at runtime from a parent-derived plugin path; missing Matrix runtime dependencies now fail with repair guidance instead of mutating the wrong `node_modules` tree. Fixes #80758. (#80876) Thanks @kinjitakabe.
 - CLI/media: render terminal QR codes with full-block characters by default so the bundled `qrcode` terminal renderer does not emit a pathologically dense ANSI final row in compact half-block mode that breaks scanning in some terminals. Fixes #77820. Thanks @KrasimirKralev.
 - Agents/compaction: read post-compaction AGENTS.md refresh context from the queued run workspace instead of the runner process cwd, so CLI-backed follow-up turns re-inject the correct workspace startup rules after compaction. Fixes #70541. (#75532) Thanks @vyctorbrzezowski.
 - Agents/read tool: treat positive offsets beyond EOF as empty ranges instead of surfacing the upstream read error, so stale pagination cursors no longer crash tool calls while unrelated read failures still fail loud. Fixes #62466. (#75536) Thanks @vyctorbrzezowski.

--- a/extensions/matrix/src/matrix/deps.test.ts
+++ b/extensions/matrix/src/matrix/deps.test.ts
@@ -173,12 +173,8 @@ describe("ensureMatrixSdkInstalled", () => {
       throw new Error("Cannot find module");
     });
     await expect(ensureMatrixSdkInstalled({ resolveFn })).rejects.toThrow(
-      /matrix-js-sdk.*@matrix-org\/matrix-sdk-crypto-nodejs.*@matrix-org\/matrix-sdk-crypto-wasm/s,
+      /Matrix plugin dependencies are missing: matrix-js-sdk, @matrix-org\/matrix-sdk-crypto-nodejs, @matrix-org\/matrix-sdk-crypto-wasm\. Repair this plugin with `openclaw plugins update matrix` or run `openclaw doctor --fix`\./,
     );
-    await expect(ensureMatrixSdkInstalled({ resolveFn })).rejects.toThrow(
-      /openclaw plugins update matrix/,
-    );
-    await expect(ensureMatrixSdkInstalled({ resolveFn })).rejects.toThrow(/openclaw doctor --fix/);
   });
 
   it("lists only the packages that fail to resolve", async () => {

--- a/extensions/matrix/src/matrix/deps.test.ts
+++ b/extensions/matrix/src/matrix/deps.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { ensureMatrixCryptoRuntime } from "./deps.js";
+import { ensureMatrixCryptoRuntime, ensureMatrixSdkInstalled } from "./deps.js";
 
 const logStub = vi.fn();
 
@@ -158,5 +158,49 @@ describe("ensureMatrixCryptoRuntime", () => {
     expect(logStub).toHaveBeenCalledWith(
       "matrix: removed incomplete native crypto runtime (16 bytes); it will be downloaded again",
     );
+  });
+});
+
+describe("ensureMatrixSdkInstalled", () => {
+  it("returns without error when all required packages resolve", async () => {
+    const resolveFn = vi.fn((_id: string) => "/fake/path");
+    await expect(ensureMatrixSdkInstalled({ resolveFn })).resolves.toBeUndefined();
+    expect(resolveFn).toHaveBeenCalled();
+  });
+
+  it("throws actionable repair error listing every missing package", async () => {
+    const resolveFn = vi.fn((_id: string) => {
+      throw new Error("Cannot find module");
+    });
+    await expect(ensureMatrixSdkInstalled({ resolveFn })).rejects.toThrow(
+      /matrix-js-sdk.*@matrix-org\/matrix-sdk-crypto-nodejs.*@matrix-org\/matrix-sdk-crypto-wasm/s,
+    );
+    await expect(ensureMatrixSdkInstalled({ resolveFn })).rejects.toThrow(
+      /openclaw plugins update matrix/,
+    );
+    await expect(ensureMatrixSdkInstalled({ resolveFn })).rejects.toThrow(/openclaw doctor --fix/);
+  });
+
+  it("lists only the packages that fail to resolve", async () => {
+    const resolveFn = vi.fn((id: string) => {
+      if (id === "@matrix-org/matrix-sdk-crypto-wasm") {
+        throw new Error("Cannot find module");
+      }
+      return "/fake/path";
+    });
+    await expect(ensureMatrixSdkInstalled({ resolveFn })).rejects.toThrow(
+      /Matrix plugin dependencies are missing: @matrix-org\/matrix-sdk-crypto-wasm\./,
+    );
+  });
+
+  it("does not invoke the install confirm prompt when packages are missing (regression: #80758)", async () => {
+    const confirm = vi.fn(async () => true);
+    const resolveFn = vi.fn((_id: string) => {
+      throw new Error("Cannot find module");
+    });
+    await expect(ensureMatrixSdkInstalled({ resolveFn, confirm })).rejects.toThrow(
+      /Matrix plugin dependencies are missing/,
+    );
+    expect(confirm).not.toHaveBeenCalled();
   });
 });

--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -2,7 +2,6 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 
@@ -26,12 +25,12 @@ type MatrixCryptoRuntimeDeps = {
   log?: (message: string) => void;
 };
 
-function resolveMissingMatrixPackages(): string[] {
+function resolveMissingMatrixPackages(resolveFn?: (id: string) => string): string[] {
   try {
-    const req = createRequire(import.meta.url);
+    const resolve = resolveFn ?? defaultResolveFn;
     return REQUIRED_MATRIX_PACKAGES.filter((pkg) => {
       try {
-        req.resolve(pkg);
+        resolve(pkg);
         return false;
       } catch {
         return true;
@@ -46,9 +45,12 @@ export function isMatrixSdkAvailable(): boolean {
   return resolveMissingMatrixPackages().length === 0;
 }
 
-function resolvePluginRoot(): string {
-  const currentDir = path.dirname(fileURLToPath(import.meta.url));
-  return path.resolve(currentDir, "..", "..");
+function buildMatrixDepsMissingMessage(missing: string[]): string {
+  const packages = missing.length > 0 ? missing.join(", ") : REQUIRED_MATRIX_PACKAGES.join(", ");
+  return [
+    `Matrix plugin dependencies are missing: ${packages}.`,
+    "Repair this plugin with `openclaw plugins update matrix` or run `openclaw doctor --fix`.",
+  ].join(" ");
 }
 
 type CommandResult = {
@@ -299,47 +301,14 @@ async function ensureMatrixCryptoRuntimeOnce(params: MatrixCryptoRuntimeDeps): P
   requireFn("@matrix-org/matrix-sdk-crypto-nodejs");
 }
 
-export async function ensureMatrixSdkInstalled(params: {
-  runtime: RuntimeEnv;
+export async function ensureMatrixSdkInstalled(params?: {
+  runtime?: RuntimeEnv;
   confirm?: (message: string) => Promise<boolean>;
+  resolveFn?: (id: string) => string;
 }): Promise<void> {
-  if (isMatrixSdkAvailable()) {
+  const missing = resolveMissingMatrixPackages(params?.resolveFn);
+  if (missing.length === 0) {
     return;
   }
-  const confirm = params.confirm;
-  if (confirm) {
-    const ok = await confirm(
-      "Matrix requires matrix-js-sdk, @matrix-org/matrix-sdk-crypto-nodejs, and @matrix-org/matrix-sdk-crypto-wasm. Install now?",
-    );
-    if (!ok) {
-      throw new Error(
-        "Matrix requires matrix-js-sdk, @matrix-org/matrix-sdk-crypto-nodejs, and @matrix-org/matrix-sdk-crypto-wasm (install dependencies first).",
-      );
-    }
-  }
-
-  const root = resolvePluginRoot();
-  const command = fs.existsSync(path.join(root, "pnpm-lock.yaml"))
-    ? ["pnpm", "install"]
-    : ["npm", "install", "--omit=dev", "--silent"];
-  params.runtime.log?.(`matrix: installing dependencies via ${command[0]} (${root})…`);
-  const result = await runFixedCommandWithTimeout({
-    argv: command,
-    cwd: root,
-    timeoutMs: 300_000,
-    env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
-  });
-  if (result.code !== 0) {
-    throw new Error(
-      result.stderr.trim() || result.stdout.trim() || "Matrix dependency install failed.",
-    );
-  }
-  if (!isMatrixSdkAvailable()) {
-    const missing = resolveMissingMatrixPackages();
-    throw new Error(
-      missing.length > 0
-        ? `Matrix dependency install completed but required packages are still missing: ${missing.join(", ")}`
-        : "Matrix dependency install completed but Matrix dependencies are still missing.",
-    );
-  }
+  throw new Error(buildMatrixDepsMissingMessage(missing));
 }

--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -26,19 +26,15 @@ type MatrixCryptoRuntimeDeps = {
 };
 
 function resolveMissingMatrixPackages(resolveFn?: (id: string) => string): string[] {
-  try {
-    const resolve = resolveFn ?? defaultResolveFn;
-    return REQUIRED_MATRIX_PACKAGES.filter((pkg) => {
-      try {
-        resolve(pkg);
-        return false;
-      } catch {
-        return true;
-      }
-    });
-  } catch {
-    return [...REQUIRED_MATRIX_PACKAGES];
-  }
+  const resolve = resolveFn ?? defaultResolveFn;
+  return REQUIRED_MATRIX_PACKAGES.filter((pkg) => {
+    try {
+      resolve(pkg);
+      return false;
+    } catch {
+      return true;
+    }
+  });
 }
 
 export function isMatrixSdkAvailable(): boolean {
@@ -46,9 +42,8 @@ export function isMatrixSdkAvailable(): boolean {
 }
 
 function buildMatrixDepsMissingMessage(missing: string[]): string {
-  const packages = missing.length > 0 ? missing.join(", ") : REQUIRED_MATRIX_PACKAGES.join(", ");
   return [
-    `Matrix plugin dependencies are missing: ${packages}.`,
+    `Matrix plugin dependencies are missing: ${missing.join(", ")}.`,
     "Repair this plugin with `openclaw plugins update matrix` or run `openclaw doctor --fix`.",
   ].join(" ");
 }


### PR DESCRIPTION
## Summary

`extensions/matrix/src/matrix/deps.ts:ensureMatrixSdkInstalled` derived its install `cwd` via fixed two-segment traversal from `import.meta.url` and spawned `npm install` (or `pnpm install`) when Matrix runtime packages were missing. The derived path was a `node_modules` scope directory under either:

- the legacy bundled layout: `<global-prefix>/lib/node_modules` — could delete unrelated global CLIs, including OpenClaw itself
- the externalized plugin layout: `<openclaw-config>/npm/node_modules/@openclaw` — npm walks up to the managed root and prunes undeclared siblings in the same scope

The fix makes `ensureMatrixSdkInstalled` a pure availability check. If any of `matrix-js-sdk`, `@matrix-org/matrix-sdk-crypto-nodejs`, or `@matrix-org/matrix-sdk-crypto-wasm` fails to resolve, it throws an actionable error directing the operator at the supported repair commands (`openclaw plugins update matrix`, `openclaw doctor --fix`).

Aligns with `extensions/AGENTS.md`: _"Runtime never installs deps; install/update/doctor are repair points."_

Fixes #80758.

## Root cause

`extensions/matrix/src/matrix/deps.ts:49-52` and `:321-336` on current `main`:

```ts
function resolvePluginRoot(): string {
  const currentDir = path.dirname(fileURLToPath(import.meta.url));
  return path.resolve(currentDir, "..", "..");
}
// ...
const root = resolvePluginRoot();
const command = fs.existsSync(path.join(root, "pnpm-lock.yaml"))
  ? ["pnpm", "install"]
  : ["npm", "install", "--omit=dev", "--silent"];
const result = await runFixedCommandWithTimeout({ argv: command, cwd: root, ... });
```

Path-shape-dependent `cwd` + package-manager mutation at runtime startup.

## What changed (scope boundary)

- `extensions/matrix/src/matrix/deps.ts`
  - Deleted `resolvePluginRoot()` and the `npm install` / `pnpm install` spawn block.
  - Replaced `ensureMatrixSdkInstalled` body with a pure availability check that throws `buildMatrixDepsMissingMessage(missing)`.
  - Added `resolveFn` test seam to `resolveMissingMatrixPackages` and `ensureMatrixSdkInstalled`, mirroring the existing `ensureMatrixCryptoRuntime` injection pattern.
  - Dropped the now-unused `fileURLToPath` import.
- `extensions/matrix/src/matrix/deps.test.ts`
  - 4 new tests for `ensureMatrixSdkInstalled`.

## What did NOT change (scope boundary)

- `ensureMatrixCryptoRuntime` (the separate, safer `download-lib.js` script execution at `deps.ts:267-300`) is intentionally untouched — it runs `node`, not a package manager, in the bundled package's own directory.
- The exported signature of `ensureMatrixSdkInstalled` is backwards-compatible. `params.runtime` and `params.confirm` are still accepted but ignored — no caller changes needed.
- `runtime-api.ts` public surface (`ensureMatrixSdkInstalled`, `isMatrixSdkAvailable`) is unchanged.
- No core (`src/**`) changes. No cross-extension changes.

## Regression test plan

`extensions/matrix/src/matrix/deps.test.ts` — new `describe("ensureMatrixSdkInstalled")` block with cases:

1. Returns when all required packages resolve.
2. Throws an actionable error listing every missing package, with both repair hints.
3. Lists only the packages that fail to resolve.
4. Does not invoke the install confirm prompt when packages are missing (regression for #80758).

## Real behavior proof

**Behavior or issue addressed**: Missing Matrix runtime packages no longer start `npm install` or `pnpm install` from a parent-derived `node_modules` path; the runtime fails with repair guidance instead.

**Real environment tested**: Local OpenClaw checkout at PR head `0887c3a4d6`, using the production export from `extensions/matrix/src/matrix/deps.ts` with `@matrix-org/matrix-sdk-crypto-wasm` temporarily masked from both the PR worktree and parent checkout dependency roots to force the missing-package path.

**Exact steps or command run after this patch**:

```bash
node --import tsx --input-type=module - <<'JS'
import { ensureMatrixSdkInstalled, isMatrixSdkAvailable } from "./extensions/matrix/src/matrix/deps.ts";

console.log("isMatrixSdkAvailable():", isMatrixSdkAvailable());
try {
  await ensureMatrixSdkInstalled();
  console.log("UNEXPECTED: returned without throwing");
} catch (error) {
  console.log("THROWN ERROR MESSAGE:");
  console.log(error instanceof Error ? error.message : String(error));
}
JS
```

**Evidence after fix**:

```text
isMatrixSdkAvailable(): false
THROWN ERROR MESSAGE:
Matrix plugin dependencies are missing: @matrix-org/matrix-sdk-crypto-wasm. Repair this plugin with `openclaw plugins update matrix` or run `openclaw doctor --fix`.
```

**Observed result after fix**: The production `ensureMatrixSdkInstalled()` path throws the repair error before any package-manager command can run. The pre-fix path computed `<openclaw-config>/npm/node_modules/@openclaw` or `<global-prefix>/lib/node_modules` and passed that as the `cwd` for `npm install`/`pnpm install`; this branch is deleted.

**What was not tested**: End-to-end `openclaw plugins install @openclaw/matrix` was not rerun because this fix removes runtime install behavior rather than changing plugin install/update. `ensureMatrixCryptoRuntime` is intentionally out of scope and remains covered by the existing tests.

Supplemental checks:

```text
OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test extensions/matrix/src/matrix/deps.test.ts
Test Files  1 passed (1)
Tests       8 passed (8)

OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test extensions/matrix/src/onboarding.test.ts
Test Files  1 passed (1)
Tests       14 passed (14)

node_modules/oxfmt/bin/oxfmt --check --threads=1 extensions/matrix/src/matrix/deps.ts extensions/matrix/src/matrix/deps.test.ts CHANGELOG.md
All matched files use the correct format.
```

## User-visible behavior change

Before: missing Matrix runtime packages triggered an automatic `npm install` from a path-derived `cwd`, which could mutate `node_modules` trees that OpenClaw did not own.

After: missing Matrix runtime packages produce:

```
Matrix plugin dependencies are missing: <packages>. Repair this plugin with `openclaw plugins update matrix` or run `openclaw doctor --fix`.
```

No package-manager process is started. Operators run the documented repair path.

## Security impact

Removes an unbounded `node_modules` mutation that could prune undeclared sibling packages or, under the legacy bundled layout, delete global CLIs. No new privileged code paths.


