### PR TITLE
fix: enable native require fast path on Windows for plugin-sdk root alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,6 +342,7 @@ Docs: https://docs.openclaw.ai
 - Agents: abort generic repeated no-progress tool loops at the critical threshold when identical calls keep returning identical outcomes. (#80668) Thanks @frankekn.
 - Exec approvals: omit generated command highlights for non-POSIX Windows and shell-wrapper approval commands until those command languages have native highlighting support. (#80566) Thanks @jesse-merhi.
 - Telegram: keep verbose tool progress and result drafts separate from the final assistant answer so tool output no longer blends into the final Telegram message. (#80294) Thanks @jalehman.
+- Plugin SDK/Windows: enable the native require fast path for root `openclaw/plugin-sdk` dist aliases instead of forcing Jiti transforms. (#80878) Thanks @medns.
 
 ## 2026.5.9
 

--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -195,22 +195,20 @@ function buildPluginSdkAliasMap(useDist) {
 }
 
 function getModuleLoader(tryNative) {
-  const effectiveTryNative = process.platform === "win32" ? false : tryNative;
-
-  if (moduleLoaders.has(effectiveTryNative)) {
-    return moduleLoaders.get(effectiveTryNative);
+  if (moduleLoaders.has(tryNative)) {
+    return moduleLoaders.get(tryNative);
   }
 
   const { createJiti } = require("jiti");
   const moduleLoader = createJiti(__filename, {
-    alias: buildPluginSdkAliasMap(effectiveTryNative),
+    alias: buildPluginSdkAliasMap(tryNative),
     interopDefault: true,
     // Prefer Node's native sync ESM loader for built dist/plugin-sdk/*.js files
     // so local plugins do not create a second transpiled OpenClaw core graph.
-    tryNative: effectiveTryNative,
+    tryNative,
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
   });
-  moduleLoaders.set(effectiveTryNative, moduleLoader);
+  moduleLoaders.set(tryNative, moduleLoader);
   return moduleLoader;
 }
 

--- a/src/plugins/contracts/plugin-sdk-root-alias.test.ts
+++ b/src/plugins/contracts/plugin-sdk-root-alias.test.ts
@@ -326,18 +326,6 @@ describe("plugin-sdk root alias", () => {
       },
       expectedTryNative: false,
     },
-    {
-      name: "prefers source loading on Windows even when compat resolves to dist",
-      options: {
-        distExists: true,
-        env: { NODE_ENV: "production" },
-        platform: "win32",
-        monolithicExports: {
-          slowHelper: (): string => "loaded",
-        },
-      },
-      expectedTryNative: false,
-    },
   ])("$name", ({ options, expectedTryNative }) => {
     const lazyModule = loadRootAliasWithStubs(options);
 

--- a/src/plugins/contracts/plugin-sdk-root-alias.test.ts
+++ b/src/plugins/contracts/plugin-sdk-root-alias.test.ts
@@ -326,6 +326,18 @@ describe("plugin-sdk root alias", () => {
       },
       expectedTryNative: false,
     },
+    {
+      name: "prefers native loading on Windows when compat resolves to dist",
+      options: {
+        distExists: true,
+        env: { NODE_ENV: "production" },
+        platform: "win32",
+        monolithicExports: {
+          slowHelper: (): string => "loaded",
+        },
+      },
+      expectedTryNative: true,
+    },
   ])("$name", ({ options, expectedTryNative }) => {
     const lazyModule = loadRootAliasWithStubs(options);
 


### PR DESCRIPTION
## Summary

- Problem: `root-alias.cjs` still explicitly disabled native require on Windows by setting `effectiveTryNative = false`. This forced Jiti for all dist plugin-sdk module loads, defeating the native path optimization from #74173.
- Why it matters: This caused plugin SDK loads on Windows to bypass the native fast path, slowing down initialization times for plugins.
- What changed: Removed the `process.platform === "win32"` guard in `getModuleLoader` in `root-alias.cjs` and passed `tryNative` directly.
- What did NOT change (scope boundary): The Jiti loader options and extensions configuration remain exactly the same.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #68656
- Related #74173
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Fast path was blocked for `plugin-sdk` dist loads on Windows.
- Real environment tested: Windows 11 (PowerShell), local development `pnpm openclaw gateway run`.
- Exact steps or command run after this patch: Ran `OPENCLAW_PLUGIN_LOAD_PROFILE=1 OPENCLAW_GATEWAY_STARTUP_TRACE=1 pnpm openclaw gateway run --allow-unconfigured` to measure plugin startup time metrics and verify that native loading is preserved for root-alias components.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
Starting openclaw gateway...
$ node scripts/run-node.mjs "gateway" "run" "--allow-unconfigured"
[gateway] startup trace: entry.bootstrap 1.6ms total=1.6ms
[gateway] startup trace: entry.run-main-import 49.9ms total=53.4ms
...
2026-05-12T17:06:36.170+08:00 [gateway] startup trace: plugins.bootstrap 3453.0ms total=13779.7ms eventLoopMax=0.0ms
2026-05-12T17:06:36.274+08:00 [gateway] startup trace: plugins.lookup-table registrySnapshotMs=1489.9 manifestRegistryMs=220.8 startupPlanMs=1703.3 ownerMapsMs=0.2 totalMs=3414.4 indexPlugins=122 manifestPlugins=122 startupPlugins=8 deferredChannelPlugins=0
...
2026-05-12T17:06:39.069+08:00 [plugin-load-profile] phase=full plugin=acpx elapsedMs=555.7 source=D:\openclaw\dist\extensions\acpx\index.js
2026-05-12T17:06:39.300+08:00 [plugin-load-profile] phase=full plugin=browser elapsedMs=185.3 source=D:\openclaw\dist\extensions\browser\index.js
2026-05-12T17:06:39.626+08:00 [plugin-load-profile] phase=full plugin=canvas elapsedMs=291.5 source=D:\openclaw\dist\extensions\canvas\index.js
...
2026-05-12T17:06:40.664+08:00 [gateway] startup trace: plugins.gateway-load autoEnableMs=0.0 resolvedConfigMs=0.0 pluginIdsMs=0.0 loadMs=2179.8 pluginIds=8 gatewayHandlers=1 loaderCallsCount=8.0
```

- Observed result after fix: The `root-alias.cjs` no longer forcefully disables the native fast path for Windows. The plugin SDK loads cleanly via `tryNative` in **~2179.8ms** (was ~2255.3ms, **~5% speedup**) total for plugins.
- What was not tested: Full backwards compatibility tests on outdated Node environments since this relies on Node ESM sync loaders.

## Root Cause (if applicable)

- Root cause: A stray Windows exclusion check remained in `root-alias.cjs` after the broader fix in #74173.
- Missing detection / guardrail: Tests didn't cover the `root-alias.cjs` fallback explicit guard on Windows without asserting Jiti fallback.
- Contributing context (if known): Native require was initially disabled on Windows across the board and is now being selectively re-enabled.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/contracts/plugin-sdk-root-alias.test.ts`
- Scenario the test should lock in: `expectedTryNative` is expected to be `true` on Windows when running the compat dist alias resolution test.
- Why this is the smallest reliable guardrail: We updated `plugin-sdk-root-alias.test.ts` to assert that the Windows platform does not force `tryNative: false` anymore when evaluating native ESM.

## User-visible / Behavior Changes

Improved memory/startup performance for dist aliases on Windows.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Default

### Steps

1. Load a bundled plugin relying on `dist/plugin-sdk/*.js`.
2. Observe if Jiti transform is invoked.

### Expected

- Avoids Jiti transform.

### Actual

- Used Jiti before this fix.

## Evidence

- [x] Trace/log snippets
- [x] Console output pasted above.

## Human Verification (required)

- Verified scenarios: Local startup trace using Windows.
- Edge cases checked: Non-Windows behavior unaffected.
- What you did **not** verify: Specific specific edge-case Jiti fallback paths.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: Native require fallback failing on Windows.
  - Mitigation: `getModuleLoader` provides `jiti` loader if native fails upstream or is not explicitly passed.