### PR TITLE
fix(compaction): make overflow tuning configurable

### DIFF
--- a/src/agents/pi-embedded-runner/compaction-runtime-config.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-config.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { AgentCompactionConfig } from "../../config/types.agent-defaults.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  DEFAULT_MAX_OVERFLOW_COMPACTION_ATTEMPTS,
+  DEFAULT_PREEMPTIVE_OVERFLOW_RATIO,
+  resolveMaxOverflowCompactionAttempts,
+  resolvePreemptiveOverflowRatio,
+} from "./compaction-runtime-config.js";
+
+function cfg(compaction: AgentCompactionConfig): OpenClawConfig {
+  return { agents: { defaults: { compaction } } };
+}
+
+describe("Pi compaction runtime config", () => {
+  it("uses defaults when overflow knobs are unset", () => {
+    expect(resolveMaxOverflowCompactionAttempts()).toBe(DEFAULT_MAX_OVERFLOW_COMPACTION_ATTEMPTS);
+    expect(resolvePreemptiveOverflowRatio()).toBe(DEFAULT_PREEMPTIVE_OVERFLOW_RATIO);
+  });
+
+  it("resolves configured overflow compaction attempts", () => {
+    expect(resolveMaxOverflowCompactionAttempts(cfg({ maxOverflowAttempts: 1 }))).toBe(1);
+    expect(resolveMaxOverflowCompactionAttempts(cfg({ maxOverflowAttempts: 0 }))).toBe(0);
+    expect(resolveMaxOverflowCompactionAttempts(cfg({ maxOverflowAttempts: 2.9 }))).toBe(2);
+  });
+
+  it("falls back for invalid overflow compaction attempts", () => {
+    expect(resolveMaxOverflowCompactionAttempts(cfg({ maxOverflowAttempts: -1 }))).toBe(
+      DEFAULT_MAX_OVERFLOW_COMPACTION_ATTEMPTS,
+    );
+  });
+
+  it("resolves configured preemptive overflow ratio", () => {
+    expect(resolvePreemptiveOverflowRatio(cfg({ preemptiveOverflowRatio: 0.7 }))).toBe(0.7);
+  });
+
+  it("falls back for invalid preemptive overflow ratio values", () => {
+    expect(resolvePreemptiveOverflowRatio(cfg({ preemptiveOverflowRatio: 0 }))).toBe(
+      DEFAULT_PREEMPTIVE_OVERFLOW_RATIO,
+    );
+    expect(resolvePreemptiveOverflowRatio(cfg({ preemptiveOverflowRatio: 1 }))).toBe(
+      DEFAULT_PREEMPTIVE_OVERFLOW_RATIO,
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/compaction-runtime-config.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-config.ts
@@ -1,0 +1,24 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+export const DEFAULT_PREEMPTIVE_OVERFLOW_RATIO = 0.9;
+export const DEFAULT_MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function resolvePreemptiveOverflowRatio(config?: OpenClawConfig): number {
+  const configured = asFiniteNumber(config?.agents?.defaults?.compaction?.preemptiveOverflowRatio);
+  if (configured === undefined || configured <= 0 || configured >= 1) {
+    return DEFAULT_PREEMPTIVE_OVERFLOW_RATIO;
+  }
+  return configured;
+}
+
+export function resolveMaxOverflowCompactionAttempts(config?: OpenClawConfig): number {
+  const configured = asFiniteNumber(config?.agents?.defaults?.compaction?.maxOverflowAttempts);
+  if (configured === undefined || configured < 0) {
+    return DEFAULT_MAX_OVERFLOW_COMPACTION_ATTEMPTS;
+  }
+  return Math.floor(configured);
+}

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -93,6 +93,7 @@ import { resolveToolLoopDetectionConfig } from "../tool-loop-detection-config.js
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import { runPostCompactionSideEffects } from "./compaction-hooks.js";
+import { resolveMaxOverflowCompactionAttempts } from "./compaction-runtime-config.js";
 import { buildEmbeddedCompactionRuntimeContext } from "./compaction-runtime-context.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
 import { runContextEngineMaintenance } from "./context-engine-maintenance.js";
@@ -893,7 +894,7 @@ export async function runEmbeddedPiAgent(
       const maxEmptyResponseRetryAttempts = DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT;
 
       const MAX_TIMEOUT_COMPACTION_ATTEMPTS = 2;
-      const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
+      const MAX_OVERFLOW_COMPACTION_ATTEMPTS = resolveMaxOverflowCompactionAttempts(params.config);
       const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
       let overflowCompactionAttempts = 0;
       let toolResultTruncationAttempted = false;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -191,6 +191,7 @@ import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
+import { resolvePreemptiveOverflowRatio } from "../compaction-runtime-config.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { runContextEngineMaintenance } from "../context-engine-maintenance.js";
 import { applyFinalEffectiveToolPolicy } from "../effective-tool-policy.js";
@@ -1963,6 +1964,7 @@ export async function runEmbeddedAttempt(
         removeToolResultContextGuard = installToolResultContextGuard({
           agent: activeSession.agent,
           contextWindowTokens: contextTokenBudgetForGuard,
+          preemptiveOverflowRatio: resolvePreemptiveOverflowRatio(params.config),
           ...(midTurnPrecheckEnabled
             ? {
                 midTurnPrecheck: {

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
+import { DEFAULT_PREEMPTIVE_OVERFLOW_RATIO } from "./compaction-runtime-config.js";
 import {
   CONTEXT_LIMIT_TRUNCATION_NOTICE,
   formatContextLimitTruncationNotice,
@@ -20,7 +21,6 @@ import {
 } from "./tool-result-char-estimator.js";
 
 const SINGLE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
-const PREEMPTIVE_OVERFLOW_RATIO = 0.9;
 
 export const PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE =
   "Context overflow: estimated context size exceeds safe threshold during tool loop.";
@@ -359,11 +359,19 @@ export function installToolResultContextGuard(params: {
   agent: GuardableAgent;
   contextWindowTokens: number;
   midTurnPrecheck?: MidTurnPrecheckOptions;
+  preemptiveOverflowRatio?: number;
 }): () => void {
   const contextWindowTokens = Math.max(1, Math.floor(params.contextWindowTokens));
+  const preemptiveOverflowRatio =
+    typeof params.preemptiveOverflowRatio === "number" &&
+    Number.isFinite(params.preemptiveOverflowRatio) &&
+    params.preemptiveOverflowRatio > 0 &&
+    params.preemptiveOverflowRatio < 1
+      ? params.preemptiveOverflowRatio
+      : DEFAULT_PREEMPTIVE_OVERFLOW_RATIO;
   const maxContextChars = Math.max(
     1_024,
-    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * PREEMPTIVE_OVERFLOW_RATIO),
+    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * preemptiveOverflowRatio),
   );
   const maxSingleToolResultChars = Math.max(
     1_024,

--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -75,6 +75,16 @@ describe("config compaction settings", () => {
     expect(compaction?.reserveTokensFloor).toBe(9000);
   });
 
+  it("preserves overflow runtime knob values during materialization", () => {
+    const compaction = materializeCompactionConfig({
+      preemptiveOverflowRatio: 0.7,
+      maxOverflowAttempts: 1,
+    });
+
+    expect(compaction?.preemptiveOverflowRatio).toBe(0.7);
+    expect(compaction?.maxOverflowAttempts).toBe(1);
+  });
+
   it("preserves recent turn safeguard values during materialization", () => {
     const compaction = materializeCompactionConfig({
       mode: "safeguard",

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -399,6 +399,8 @@ const TARGET_KEYS = [
   "agents.defaults.compaction.keepRecentTokens",
   "agents.defaults.compaction.reserveTokensFloor",
   "agents.defaults.compaction.maxHistoryShare",
+  "agents.defaults.compaction.preemptiveOverflowRatio",
+  "agents.defaults.compaction.maxOverflowAttempts",
   "agents.defaults.compaction.identifierPolicy",
   "agents.defaults.compaction.identifierInstructions",
   "agents.defaults.compaction.recentTurnsPreserve",
@@ -850,6 +852,13 @@ describe("config help copy quality", () => {
 
     const historyShare = FIELD_HELP["agents.defaults.compaction.maxHistoryShare"];
     expect(/0\\.1-0\\.9|fraction|share/i.test(historyShare)).toBe(true);
+
+    expect(FIELD_HELP["agents.defaults.compaction.preemptiveOverflowRatio"]).toMatch(
+      /overflow.*ratio.*default:\s*0\.9/i,
+    );
+    expect(FIELD_HELP["agents.defaults.compaction.maxOverflowAttempts"]).toMatch(
+      /maximum.*overflow.*default:\s*3/i,
+    );
 
     const identifierPolicy = FIELD_HELP["agents.defaults.compaction.identifierPolicy"];
     expect(identifierPolicy.includes('"strict"')).toBe(true);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1392,6 +1392,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Minimum floor enforced for reserveTokens in Pi compaction paths (0 disables the floor guard). Use a non-zero floor to avoid over-aggressive compression under fluctuating token estimates.",
   "agents.defaults.compaction.maxHistoryShare":
     "Maximum fraction of total context budget allowed for retained history after compaction (range 0.1-0.9). Use lower shares for more generation headroom or higher shares for deeper historical continuity.",
+  "agents.defaults.compaction.preemptiveOverflowRatio":
+    "Soft context-overflow threshold ratio for Pi tool-loop preemptive checks (range 0-1 exclusive, default: 0.9). Lower this to compact earlier with more headroom; raise it to preserve more context before compaction.",
+  "agents.defaults.compaction.maxOverflowAttempts":
+    "Maximum automatic compaction retries after Pi context-overflow errors (default: 3). Lower this to fail faster and avoid repeated billable summarization calls; set 0 to skip overflow retry compaction.",
   "agents.defaults.compaction.identifierPolicy":
     'Identifier-preservation policy for compaction summaries: "strict" prepends built-in opaque-identifier retention guidance (default), "off" disables this prefix, and "custom" uses identifierInstructions. Keep "strict" unless you have a specific compatibility need.',
   "agents.defaults.compaction.identifierInstructions":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -639,6 +639,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.keepRecentTokens": "Compaction Keep Recent Tokens",
   "agents.defaults.compaction.reserveTokensFloor": "Compaction Reserve Token Floor",
   "agents.defaults.compaction.maxHistoryShare": "Compaction Max History Share",
+  "agents.defaults.compaction.preemptiveOverflowRatio": "Compaction Preemptive Overflow Ratio",
+  "agents.defaults.compaction.maxOverflowAttempts": "Compaction Max Overflow Attempts",
   "agents.defaults.compaction.identifierPolicy": "Compaction Identifier Policy",
   "agents.defaults.compaction.identifierInstructions": "Compaction Identifier Instructions",
   "agents.defaults.compaction.recentTurnsPreserve": "Compaction Preserve Recent Turns",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -479,6 +479,10 @@ export type AgentCompactionConfig = {
   reserveTokensFloor?: number;
   /** Max share of context window for history during safeguard pruning (0.1–0.9, default 0.5). */
   maxHistoryShare?: number;
+  /** Soft context-overflow threshold ratio for Pi tool-loop preemptive checks (0–1 exclusive, default 0.9). */
+  preemptiveOverflowRatio?: number;
+  /** Maximum automatic compaction retries after Pi context-overflow errors (default 3). */
+  maxOverflowAttempts?: number;
   /** Additional compaction-summary instructions that can preserve language or persona continuity. */
   customInstructions?: string;
   /** Preserve this many most-recent user/assistant turns verbatim in compaction summary context. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -178,6 +178,8 @@ export const AgentDefaultsSchema = z
         keepRecentTokens: z.number().int().positive().optional(),
         reserveTokensFloor: z.number().int().nonnegative().optional(),
         maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
+        preemptiveOverflowRatio: z.number().gt(0).lt(1).optional(),
+        maxOverflowAttempts: z.number().int().nonnegative().optional(),
         customInstructions: z.string().optional(),
         identifierPolicy: z
           .union([z.literal("strict"), z.literal("off"), z.literal("custom")])


### PR DESCRIPTION
## Summary

- add `agents.defaults.compaction.preemptiveOverflowRatio` for Pi tool-loop preemptive overflow threshold tuning
- add `agents.defaults.compaction.maxOverflowAttempts` for Pi overflow compaction retry tuning
- preserve current defaults (`0.9` ratio, `3` overflow retries) and document schema labels/help text

Fixes #80638
Fixes #80639

## Real behavior proof

- **Behavior or issue addressed:** Pi compaction overflow tuning is now configurable instead of hardcoded: configured values are accepted by the config schema and used by runtime resolver helpers, while unset config preserves the old defaults.
- **Real environment tested:** Harry's Mac mini, Darwin 25.4.0 arm64, Node v22.22.0, local OpenClaw checkout on branch `fix/80638-80639-compaction-knobs`.
- **Exact steps or command run after this patch:**

```bash
node --import tsx - <<'EOF'
import { resolveMaxOverflowCompactionAttempts, resolvePreemptiveOverflowRatio } from './src/agents/pi-embedded-runner/compaction-runtime-config.ts';
import { AgentDefaultsSchema } from './src/config/zod-schema.agent-defaults.ts';

const config = { agents: { defaults: { compaction: { preemptiveOverflowRatio: 0.72, maxOverflowAttempts: 1 } } } };
const parsed = AgentDefaultsSchema.parse(config.agents.defaults);
console.log('runtime preemptiveOverflowRatio:', resolvePreemptiveOverflowRatio(config));
console.log('runtime maxOverflowAttempts:', resolveMaxOverflowCompactionAttempts(config));
console.log('schema preserved preemptiveOverflowRatio:', parsed.compaction?.preemptiveOverflowRatio);
console.log('schema preserved maxOverflowAttempts:', parsed.compaction?.maxOverflowAttempts);
console.log('default preemptiveOverflowRatio:', resolvePreemptiveOverflowRatio({}));
console.log('default maxOverflowAttempts:', resolveMaxOverflowCompactionAttempts({}));
EOF
```

- **Evidence after fix:** terminal output from the real local checkout:

```text
runtime preemptiveOverflowRatio: 0.72
runtime maxOverflowAttempts: 1
schema preserved preemptiveOverflowRatio: 0.72
schema preserved maxOverflowAttempts: 1
default preemptiveOverflowRatio: 0.9
default maxOverflowAttempts: 3
```

- **Observed result after fix:** Configured values (`0.72`, `1`) are parsed and resolved at runtime; default behavior remains `0.9` and `3` when unset.
- **What was not tested:** A live long-running overflow failure against a paid provider; validation used the real config/runtime code paths directly.

## Validation

- `node scripts/test-projects.mjs src/agents/pi-embedded-runner/compaction-runtime-config.test.ts src/config/config.compaction-settings.test.ts src/config/schema.help.quality.test.ts`
- `pnpm -s config:schema:check`
- `pnpm -s check:test-types`
