### PR TITLE
Require device key proof for bootstrap token binding [AI]

### DIFF
--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1411,6 +1411,92 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  test("does not revive revoked operator token through unbound bootstrap handoff", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { approveDevicePairing, getPairedDevice, requestDevicePairing, revokeDeviceToken } =
+      await import("../infra/device-pairing.js");
+    const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
+    const { server, port, prevToken } = await startControlUiServer("secret");
+
+    const { identityPath, identity } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-revoked-token-",
+    );
+    const client = {
+      id: "openclaw-ios",
+      version: "2026.3.30",
+      platform: "iOS 26.3.1",
+      mode: "node",
+      deviceFamily: "iPhone",
+    };
+    const bootstrapOperatorScopes = [
+      "operator.approvals",
+      "operator.read",
+      "operator.talk.secrets",
+      "operator.write",
+    ];
+
+    try {
+      const seededRequest = await requestDevicePairing({
+        deviceId: identity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+        role: "node",
+        roles: ["node", "operator"],
+        scopes: bootstrapOperatorScopes,
+        clientId: client.id,
+        clientMode: client.mode,
+        platform: client.platform,
+        deviceFamily: client.deviceFamily,
+      });
+      await expect(
+        approveDevicePairing(seededRequest.request.requestId, {
+          callerScopes: bootstrapOperatorScopes,
+        }),
+      ).resolves.toMatchObject({
+        status: "approved",
+      });
+      await expect(
+        revokeDeviceToken({
+          deviceId: identity.deviceId,
+          role: "operator",
+        }),
+      ).resolves.toEqual(expect.objectContaining({ ok: true }));
+      const pairedBefore = await getPairedDevice(identity.deviceId);
+      const revokedOperatorToken = pairedBefore?.tokens?.operator;
+      expect(typeof revokedOperatorToken?.revokedAtMs).toBe("number");
+
+      const issued = await issueDeviceBootstrapToken();
+      const wsBootstrap = await openWs(port);
+      const initial = await connectReq(wsBootstrap, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client,
+        deviceIdentityPath: identityPath,
+      });
+      expect(initial.ok).toBe(true);
+      const payload = initial.payload as
+        | {
+            auth?: {
+              deviceTokens?: Array<{
+                role?: string;
+              }>;
+            };
+          }
+        | undefined;
+      expect(payload?.auth?.deviceTokens?.some((entry) => entry.role === "operator") ?? false).toBe(
+        false,
+      );
+      const pairedAfter = await getPairedDevice(identity.deviceId);
+      expect(pairedAfter?.tokens?.operator?.token).toBe(revokedOperatorToken?.token);
+      expect(pairedAfter?.tokens?.operator?.revokedAtMs).toBe(revokedOperatorToken?.revokedAtMs);
+      wsBootstrap.close();
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("requires approval for bootstrap-auth role upgrades on already-paired devices", async () => {
     const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
     const { approveDevicePairing, getPairedDevice, listDevicePairing, requestDevicePairing } =

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -998,7 +998,7 @@ export function registerControlUiAndPairingSuite(): void {
 
     try {
       const issued = await issueDeviceBootstrapToken();
-      const wsBootstrap = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      const wsBootstrap = await openWs(port);
       const initial = await connectReq(wsBootstrap, {
         skipDefaultAuth: true,
         bootstrapToken: issued.token,
@@ -1032,7 +1032,7 @@ export function registerControlUiAndPairingSuite(): void {
         wsBootstrap.close();
       });
 
-      const wsRetry = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      const wsRetry = await openWs(port);
       const retry = await connectReq(wsRetry, {
         skipDefaultAuth: true,
         bootstrapToken: issued.token,

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1131,6 +1131,7 @@ export function registerControlUiAndPairingSuite(): void {
         "operator.talk.secrets",
         "operator.write",
       ]);
+      expectArrayExcludes(operatorBootstrapScopes, ["operator.admin", "operator.pairing"]);
 
       const paired = await getPairedDevice(identity.deviceId);
       expectArrayIncludes(paired?.roles, ["node", "operator"]);
@@ -1166,6 +1167,89 @@ export function registerControlUiAndPairingSuite(): void {
       await expect(getDeviceBootstrapTokenProfile({ token: issued.token })).resolves.toBeNull();
       wsApproved.close();
     } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
+  test("does not consume bootstrap token when node reconcile fails before hello-ok", async () => {
+    const { getDeviceBootstrapTokenProfile, issueDeviceBootstrapToken } =
+      await import("../infra/device-bootstrap.js");
+    const { approveDevicePairing, listDevicePairing } = await import("../infra/device-pairing.js");
+    const reconcileModule = await import("./node-connect-reconcile.js");
+    const reconcileSpy = vi
+      .spyOn(reconcileModule, "reconcileNodePairingOnConnect")
+      .mockRejectedValueOnce(new Error("boom"));
+    const { server, port, prevToken } = await startControlUiServer("secret");
+
+    const { identityPath, identity, client } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-reconcile-fail-",
+    );
+    const nodeClient = {
+      ...client,
+      id: "openclaw-android",
+      mode: "node",
+    };
+
+    try {
+      const issued = await issueDeviceBootstrapToken({
+        profile: {
+          roles: ["node"],
+          scopes: [],
+        },
+      });
+      const wsPending = await openWs(port);
+      const pendingConnect = await connectReq(wsPending, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client: nodeClient,
+        deviceIdentityPath: identityPath,
+      });
+      expect(pendingConnect.ok).toBe(false);
+      const pending = (await listDevicePairing()).pending.filter(
+        (entry) => entry.deviceId === identity.deviceId,
+      );
+      expect(pending).toHaveLength(1);
+      await expect(
+        approveDevicePairing(pending[0]?.requestId ?? "", {
+          callerScopes: ["operator.pairing"],
+        }),
+      ).resolves.toMatchObject({ status: "approved" });
+      wsPending.close();
+
+      const wsFail = await openWs(port);
+      await expect(
+        connectReq(wsFail, {
+          skipDefaultAuth: true,
+          bootstrapToken: issued.token,
+          role: "node",
+          scopes: [],
+          client: nodeClient,
+          deviceIdentityPath: identityPath,
+          timeoutMs: 500,
+        }),
+      ).rejects.toThrow();
+      await expect(waitForWsClose(wsFail, 5_000)).resolves.toBe(true);
+      await expect(getDeviceBootstrapTokenProfile({ token: issued.token })).resolves.toEqual({
+        roles: ["node"],
+        scopes: [],
+      });
+
+      const wsRetry = await openWs(port);
+      const retry = await connectReq(wsRetry, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client: nodeClient,
+        deviceIdentityPath: identityPath,
+      });
+      expect(retry.ok).toBe(true);
+      wsRetry.close();
+    } finally {
+      reconcileSpy.mockRestore();
       await server.close();
       restoreGatewayToken(prevToken);
     }

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1240,6 +1240,80 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  test("does not expose broader operator token through bootstrap handoff", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { approveDevicePairing, getPairedDevice, requestDevicePairing } =
+      await import("../infra/device-pairing.js");
+    const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
+    const { server, port, prevToken } = await startControlUiServer("secret");
+
+    const { identityPath, identity } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-admin-token-",
+    );
+    const client = {
+      id: "openclaw-ios",
+      version: "2026.3.30",
+      platform: "iOS 26.3.1",
+      mode: "node",
+      deviceFamily: "iPhone",
+    };
+
+    try {
+      const seededRequest = await requestDevicePairing({
+        deviceId: identity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+        role: "node",
+        roles: ["node", "operator"],
+        scopes: ["operator.admin"],
+        clientId: client.id,
+        clientMode: client.mode,
+        platform: client.platform,
+        deviceFamily: client.deviceFamily,
+      });
+      await expect(
+        approveDevicePairing(seededRequest.request.requestId, {
+          callerScopes: ["operator.admin"],
+        }),
+      ).resolves.toMatchObject({
+        status: "approved",
+      });
+      const pairedBefore = await getPairedDevice(identity.deviceId);
+      expect(pairedBefore?.tokens?.operator?.scopes).toEqual(["operator.admin"]);
+
+      const issued = await issueDeviceBootstrapToken();
+      const wsBootstrap = await openWs(port);
+      const initial = await connectReq(wsBootstrap, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client,
+        deviceIdentityPath: identityPath,
+      });
+      expect(initial.ok).toBe(true);
+      const payload = initial.payload as
+        | {
+            auth?: {
+              deviceTokens?: Array<{
+                role?: string;
+                scopes?: string[];
+              }>;
+            };
+          }
+        | undefined;
+      expect(payload?.auth?.deviceTokens?.some((entry) => entry.role === "operator") ?? false).toBe(
+        false,
+      );
+      const pairedAfter = await getPairedDevice(identity.deviceId);
+      expect(pairedAfter?.tokens?.operator?.token).toBe(pairedBefore?.tokens?.operator?.token);
+      expect(pairedAfter?.tokens?.operator?.scopes).toEqual(["operator.admin"]);
+      wsBootstrap.close();
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("requires approval for bootstrap-auth role upgrades on already-paired devices", async () => {
     const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
     const { approveDevicePairing, getPairedDevice, listDevicePairing, requestDevicePairing } =

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -981,8 +981,10 @@ export function registerControlUiAndPairingSuite(): void {
   });
 
   test("requires approval for fresh node bootstrap pairing from setup code", async () => {
-    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
-    const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
+    const { getDeviceBootstrapTokenProfile, issueDeviceBootstrapToken } =
+      await import("../infra/device-bootstrap.js");
+    const { approveDevicePairing, getPairedDevice, listDevicePairing, verifyDeviceToken } =
+      await import("../infra/device-pairing.js");
     const { server, port, prevToken } = await startControlUiServer("secret");
 
     const { identityPath, identity } = await createOperatorIdentityFixture(
@@ -1050,6 +1052,94 @@ export function registerControlUiAndPairingSuite(): void {
       expect(retryPending).toHaveLength(1);
       expect(await getPairedDevice(identity.deviceId)).toBeNull();
       wsRetry.close();
+
+      const requestId = retryPending[0]?.requestId;
+      expect(typeof requestId).toBe("string");
+      if (!requestId) {
+        throw new Error("expected pending bootstrap pairing request");
+      }
+      await expect(approveDevicePairing(requestId, { callerScopes: [] })).resolves.toMatchObject({
+        status: "approved",
+      });
+
+      const wsApproved = await openWs(port);
+      const approved = await connectReq(wsApproved, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client,
+        deviceIdentityPath: identityPath,
+      });
+      expect(approved.ok).toBe(true);
+      const approvedPayload = approved.payload as
+        | {
+            type?: string;
+            auth?: {
+              deviceToken?: string;
+              role?: string;
+              scopes?: string[];
+              deviceTokens?: Array<{
+                deviceToken?: string;
+                role?: string;
+                scopes?: string[];
+              }>;
+            };
+          }
+        | undefined;
+      expect(approvedPayload?.type).toBe("hello-ok");
+      const issuedDeviceToken = approvedPayload?.auth?.deviceToken;
+      const issuedOperatorToken = approvedPayload?.auth?.deviceTokens?.find(
+        (entry) => entry.role === "operator",
+      )?.deviceToken;
+      if (!issuedDeviceToken || !issuedOperatorToken) {
+        throw new Error("expected bootstrap node and operator device tokens");
+      }
+      expect(approvedPayload?.auth?.role).toBe("node");
+      expect(approvedPayload?.auth?.scopes ?? []).toEqual([]);
+      const operatorBootstrapScopes = approvedPayload?.auth?.deviceTokens?.find(
+        (entry) => entry.role === "operator",
+      )?.scopes;
+      expectArrayIncludes(operatorBootstrapScopes, [
+        "operator.approvals",
+        "operator.read",
+        "operator.talk.secrets",
+        "operator.write",
+      ]);
+
+      const paired = await getPairedDevice(identity.deviceId);
+      expectArrayIncludes(paired?.roles, ["node", "operator"]);
+      expectArrayIncludes(paired?.approvedScopes, [
+        "operator.approvals",
+        "operator.read",
+        "operator.talk.secrets",
+        "operator.write",
+      ]);
+      expect(paired?.tokens?.node?.token).toBe(issuedDeviceToken);
+      expect(paired?.tokens?.operator?.token).toBe(issuedOperatorToken);
+      await expect(
+        verifyDeviceToken({
+          deviceId: identity.deviceId,
+          token: issuedDeviceToken,
+          role: "node",
+          scopes: [],
+        }),
+      ).resolves.toEqual({ ok: true });
+      await expect(
+        verifyDeviceToken({
+          deviceId: identity.deviceId,
+          token: issuedOperatorToken,
+          role: "operator",
+          scopes: [
+            "operator.approvals",
+            "operator.read",
+            "operator.talk.secrets",
+            "operator.write",
+          ],
+        }),
+      ).resolves.toEqual({ ok: true });
+      await expect(getDeviceBootstrapTokenProfile({ token: issued.token })).resolves.toBeNull();
+      wsApproved.close();
     } finally {
       await server.close();
       restoreGatewayToken(prevToken);

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1362,7 +1362,11 @@ export function registerControlUiAndPairingSuite(): void {
         status: "approved",
       });
       const pairedBefore = await getPairedDevice(identity.deviceId);
-      expect(pairedBefore?.tokens?.operator?.scopes).toEqual(["operator.admin"]);
+      expect(pairedBefore?.tokens?.operator?.scopes).toEqual([
+        "operator.admin",
+        "operator.read",
+        "operator.write",
+      ]);
 
       const issued = await issueDeviceBootstrapToken();
       const wsBootstrap = await openWs(port);
@@ -1390,7 +1394,7 @@ export function registerControlUiAndPairingSuite(): void {
       );
       const pairedAfter = await getPairedDevice(identity.deviceId);
       expect(pairedAfter?.tokens?.operator?.token).toBe(pairedBefore?.tokens?.operator?.token);
-      expect(pairedAfter?.tokens?.operator?.scopes).toEqual(["operator.admin"]);
+      expect(pairedAfter?.tokens?.operator?.scopes).toEqual(pairedBefore?.tokens?.operator?.scopes);
       wsBootstrap.close();
     } finally {
       await server.close();

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -980,12 +980,9 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
-  test("auto-approves fresh node bootstrap pairing from qr setup code", async () => {
-    const { issueDeviceBootstrapToken, verifyDeviceBootstrapToken } =
-      await import("../infra/device-bootstrap.js");
-    const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
-    const { getPairedDevice, listDevicePairing, verifyDeviceToken } =
-      await import("../infra/device-pairing.js");
+  test("requires approval for fresh node bootstrap pairing from setup code", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
     const { server, port, prevToken } = await startControlUiServer("secret");
 
     const { identityPath, identity } = await createOperatorIdentityFixture(
@@ -1010,69 +1007,21 @@ export function registerControlUiAndPairingSuite(): void {
         client,
         deviceIdentityPath: identityPath,
       });
-      expect(initial.ok).toBe(true);
-      const initialPayload = initial.payload as
-        | {
-            type?: string;
-            auth?: {
-              deviceToken?: string;
-              role?: string;
-              scopes?: string[];
-              deviceTokens?: Array<{
-                deviceToken?: string;
-                role?: string;
-                scopes?: string[];
-              }>;
-            };
-          }
-        | undefined;
-      expect(initialPayload?.type).toBe("hello-ok");
-      const issuedDeviceToken = initialPayload?.auth?.deviceToken;
-      const issuedOperatorToken = initialPayload?.auth?.deviceTokens?.find(
-        (entry) => entry.role === "operator",
-      )?.deviceToken;
-      if (!issuedDeviceToken || !issuedOperatorToken) {
-        throw new Error("expected issued device and operator tokens");
-      }
-      expect(initialPayload?.auth?.role).toBe("node");
-      expect(initialPayload?.auth?.scopes ?? []).toEqual([]);
-      expect(initialPayload?.auth?.deviceTokens?.some((entry) => entry.role === "node")).toBe(
-        false,
+      expect(initial.ok).toBe(false);
+      expect(initial.error?.message ?? "").toContain("pairing required");
+      expect((initial.error?.details as { code?: string } | undefined)?.code).toBe(
+        ConnectErrorDetailCodes.PAIRING_REQUIRED,
       );
-      const operatorBootstrapScopes = initialPayload?.auth?.deviceTokens?.find(
-        (entry) => entry.role === "operator",
-      )?.scopes;
-      expectArrayIncludes(operatorBootstrapScopes, [
-        "operator.approvals",
-        "operator.read",
-        "operator.talk.secrets",
-        "operator.write",
-      ]);
-      expectArrayExcludes(operatorBootstrapScopes, [
-        "node.camera",
-        "node.display",
-        "node.exec",
-        "node.voice",
-      ]);
-      expectArrayExcludes(operatorBootstrapScopes, ["operator.admin", "operator.pairing"]);
 
       const afterBootstrap = await listDevicePairing();
-      expect(
-        afterBootstrap.pending.filter((entry) => entry.deviceId === identity.deviceId),
-      ).toEqual([]);
-      const paired = await getPairedDevice(identity.deviceId);
-      expectArrayIncludes(paired?.roles, ["node", "operator"]);
-      expectArrayIncludes(paired?.approvedScopes, [
-        "operator.approvals",
-        "operator.read",
-        "operator.talk.secrets",
-        "operator.write",
-      ]);
-      expect(paired?.tokens?.node?.token).toBe(issuedDeviceToken);
-      expect(paired?.tokens?.operator?.token).toBe(issuedOperatorToken);
-      if (!issuedDeviceToken || !issuedOperatorToken) {
-        throw new Error("expected hello-ok auth.deviceTokens for bootstrap onboarding");
-      }
+      const pending = afterBootstrap.pending.filter(
+        (entry) => entry.deviceId === identity.deviceId,
+      );
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.role).toBe("node");
+      expect(pending[0]?.scopes).toEqual([]);
+      expect(pending[0]?.silent).toBe(false);
+      expect(await getPairedDevice(identity.deviceId)).toBeNull();
 
       await new Promise<void>((resolve) => {
         if (wsBootstrap.readyState === WebSocket.CLOSED) {
@@ -1083,124 +1032,25 @@ export function registerControlUiAndPairingSuite(): void {
         wsBootstrap.close();
       });
 
-      const wsReplay = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
-      const replay = await connectReq(wsReplay, {
-        skipDefaultAuth: true,
-        bootstrapToken: issued.token,
-        role: "node",
-        scopes: [],
-        client,
-        deviceIdentityPath: identityPath,
-      });
-      expect(replay.ok).toBe(false);
-      expect((replay.error?.details as { code?: string } | undefined)?.code).toBe(
-        ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID,
-      );
-      wsReplay.close();
-
-      const wsReconnect = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
-      const reconnect = await connectReq(wsReconnect, {
-        skipDefaultAuth: true,
-        deviceToken: issuedDeviceToken,
-        role: "node",
-        scopes: [],
-        client,
-        deviceIdentityPath: identityPath,
-      });
-      expect(reconnect.ok).toBe(true);
-      wsReconnect.close();
-
-      await expect(
-        verifyDeviceBootstrapToken({
-          token: issued.token,
-          deviceId: identity.deviceId,
-          publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
-          role: "node",
-          scopes: [],
-        }),
-      ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
-
-      await expect(
-        verifyDeviceToken({
-          deviceId: identity.deviceId,
-          token: issuedDeviceToken,
-          role: "node",
-          scopes: [],
-        }),
-      ).resolves.toEqual({ ok: true });
-      await expect(
-        verifyDeviceToken({
-          deviceId: identity.deviceId,
-          token: issuedOperatorToken,
-          role: "operator",
-          scopes: [
-            "operator.approvals",
-            "operator.read",
-            "operator.talk.secrets",
-            "operator.write",
-          ],
-        }),
-      ).resolves.toEqual({ ok: true });
-    } finally {
-      await server.close();
-      restoreGatewayToken(prevToken);
-    }
-  });
-
-  test("does not consume bootstrap token when node reconcile fails before hello-ok", async () => {
-    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
-    const reconcileModule = await import("./node-connect-reconcile.js");
-    const reconcileSpy = vi
-      .spyOn(reconcileModule, "reconcileNodePairingOnConnect")
-      .mockRejectedValueOnce(new Error("boom"));
-    const { server, port, prevToken } = await startControlUiServer("secret");
-
-    const { identityPath, client } = await createOperatorIdentityFixture(
-      "openclaw-bootstrap-reconcile-fail-",
-    );
-    const nodeClient = {
-      ...client,
-      id: "openclaw-android",
-      mode: "node",
-    };
-
-    try {
-      const issued = await issueDeviceBootstrapToken({
-        profile: {
-          roles: ["node"],
-          scopes: [],
-        },
-      });
-
-      const wsFail = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
-      await expect(
-        connectReq(wsFail, {
-          skipDefaultAuth: true,
-          bootstrapToken: issued.token,
-          role: "node",
-          scopes: [],
-          client: nodeClient,
-          deviceIdentityPath: identityPath,
-          timeoutMs: 500,
-        }),
-      ).rejects.toThrow();
-      // The full agentic shard can saturate the event loop enough that the
-      // server-side close after a pre-hello failure arrives later than 1s.
-      await expect(waitForWsClose(wsFail, 5_000)).resolves.toBe(true);
-
       const wsRetry = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
       const retry = await connectReq(wsRetry, {
         skipDefaultAuth: true,
         bootstrapToken: issued.token,
         role: "node",
         scopes: [],
-        client: nodeClient,
+        client,
         deviceIdentityPath: identityPath,
       });
-      expect(retry.ok).toBe(true);
+      expect(retry.ok).toBe(false);
+      expect(retry.error?.message ?? "").toContain("pairing required");
+      const afterRetry = await listDevicePairing();
+      const retryPending = afterRetry.pending.filter(
+        (entry) => entry.deviceId === identity.deviceId,
+      );
+      expect(retryPending).toHaveLength(1);
+      expect(await getPairedDevice(identity.deviceId)).toBeNull();
       wsRetry.close();
     } finally {
-      reconcileSpy.mockRestore();
       await server.close();
       restoreGatewayToken(prevToken);
     }

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1028,6 +1028,10 @@ export function registerControlUiAndPairingSuite(): void {
         "operator.talk.secrets",
         "operator.write",
       ]);
+      expect(pending[0]?.bootstrapProfile).toEqual({
+        roles: ["node", "operator"],
+        scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+      });
       expect(pending[0]?.silent).toBe(false);
       expect(await getPairedDevice(identity.deviceId)).toBeNull();
 
@@ -1063,6 +1067,10 @@ export function registerControlUiAndPairingSuite(): void {
         "operator.talk.secrets",
         "operator.write",
       ]);
+      expect(retryPending[0]?.bootstrapProfile).toEqual({
+        roles: ["node", "operator"],
+        scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+      });
       expect(await getPairedDevice(identity.deviceId)).toBeNull();
       wsRetry.close();
 
@@ -1073,12 +1081,7 @@ export function registerControlUiAndPairingSuite(): void {
       }
       await expect(
         approveDevicePairing(requestId, {
-          callerScopes: [
-            "operator.approvals",
-            "operator.read",
-            "operator.talk.secrets",
-            "operator.write",
-          ],
+          callerScopes: ["operator.pairing"],
         }),
       ).resolves.toMatchObject({
         status: "approved",

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1021,7 +1021,13 @@ export function registerControlUiAndPairingSuite(): void {
       );
       expect(pending).toHaveLength(1);
       expect(pending[0]?.role).toBe("node");
-      expect(pending[0]?.scopes).toEqual([]);
+      expectArrayIncludes(pending[0]?.roles, ["node", "operator"]);
+      expectArrayIncludes(pending[0]?.scopes, [
+        "operator.approvals",
+        "operator.read",
+        "operator.talk.secrets",
+        "operator.write",
+      ]);
       expect(pending[0]?.silent).toBe(false);
       expect(await getPairedDevice(identity.deviceId)).toBeNull();
 
@@ -1050,6 +1056,13 @@ export function registerControlUiAndPairingSuite(): void {
         (entry) => entry.deviceId === identity.deviceId,
       );
       expect(retryPending).toHaveLength(1);
+      expectArrayIncludes(retryPending[0]?.roles, ["node", "operator"]);
+      expectArrayIncludes(retryPending[0]?.scopes, [
+        "operator.approvals",
+        "operator.read",
+        "operator.talk.secrets",
+        "operator.write",
+      ]);
       expect(await getPairedDevice(identity.deviceId)).toBeNull();
       wsRetry.close();
 
@@ -1058,7 +1071,16 @@ export function registerControlUiAndPairingSuite(): void {
       if (!requestId) {
         throw new Error("expected pending bootstrap pairing request");
       }
-      await expect(approveDevicePairing(requestId, { callerScopes: [] })).resolves.toMatchObject({
+      await expect(
+        approveDevicePairing(requestId, {
+          callerScopes: [
+            "operator.approvals",
+            "operator.read",
+            "operator.talk.secrets",
+            "operator.write",
+          ],
+        }),
+      ).resolves.toMatchObject({
         status: "approved",
       });
 
@@ -1140,6 +1162,75 @@ export function registerControlUiAndPairingSuite(): void {
       ).resolves.toEqual({ ok: true });
       await expect(getDeviceBootstrapTokenProfile({ token: issued.token })).resolves.toBeNull();
       wsApproved.close();
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
+  test("does not hand off operator token for existing node-only bootstrap auth", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { approveDevicePairing, getPairedDevice, requestDevicePairing } =
+      await import("../infra/device-pairing.js");
+    const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
+    const { server, port, prevToken } = await startControlUiServer("secret");
+
+    const { identityPath, identity } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-node-only-",
+    );
+    const client = {
+      id: "openclaw-ios",
+      version: "2026.3.30",
+      platform: "iOS 26.3.1",
+      mode: "node",
+      deviceFamily: "iPhone",
+    };
+
+    try {
+      const seededRequest = await requestDevicePairing({
+        deviceId: identity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+        role: "node",
+        scopes: [],
+        clientId: client.id,
+        clientMode: client.mode,
+        platform: client.platform,
+        deviceFamily: client.deviceFamily,
+      });
+      await expect(
+        approveDevicePairing(seededRequest.request.requestId, { callerScopes: [] }),
+      ).resolves.toMatchObject({
+        status: "approved",
+      });
+
+      const issued = await issueDeviceBootstrapToken();
+      const wsBootstrap = await openWs(port);
+      const initial = await connectReq(wsBootstrap, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client,
+        deviceIdentityPath: identityPath,
+      });
+      expect(initial.ok).toBe(true);
+      const payload = initial.payload as
+        | {
+            auth?: {
+              deviceTokens?: Array<{
+                role?: string;
+              }>;
+            };
+          }
+        | undefined;
+      expect(payload?.auth?.deviceTokens?.some((entry) => entry.role === "operator") ?? false).toBe(
+        false,
+      );
+      const paired = await getPairedDevice(identity.deviceId);
+      expectArrayIncludes(paired?.roles, ["node"]);
+      expectArrayExcludes(paired?.roles, ["operator"]);
+      expect(paired?.tokens?.operator).toBeUndefined();
+      wsBootstrap.close();
     } finally {
       await server.close();
       restoreGatewayToken(prevToken);

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -981,8 +981,11 @@ export function registerControlUiAndPairingSuite(): void {
   });
 
   test("requires approval for fresh node bootstrap pairing from setup code", async () => {
-    const { getDeviceBootstrapTokenProfile, issueDeviceBootstrapToken } =
-      await import("../infra/device-bootstrap.js");
+    const {
+      getDeviceBootstrapTokenProfile,
+      issueDeviceBootstrapToken,
+      resolveDeviceBootstrapTokenBindingId,
+    } = await import("../infra/device-bootstrap.js");
     const { approveDevicePairing, getPairedDevice, listDevicePairing, verifyDeviceToken } =
       await import("../infra/device-pairing.js");
     const { server, port, prevToken } = await startControlUiServer("secret");
@@ -1032,6 +1035,9 @@ export function registerControlUiAndPairingSuite(): void {
         roles: ["node", "operator"],
         scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
       });
+      expect(pending[0]?.bootstrapTokenBindingId).toBe(
+        resolveDeviceBootstrapTokenBindingId(issued.token),
+      );
       expect(pending[0]?.silent).toBe(false);
       expect(await getPairedDevice(identity.deviceId)).toBeNull();
 
@@ -1071,6 +1077,9 @@ export function registerControlUiAndPairingSuite(): void {
         roles: ["node", "operator"],
         scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
       });
+      expect(retryPending[0]?.bootstrapTokenBindingId).toBe(
+        resolveDeviceBootstrapTokenBindingId(issued.token),
+      );
       expect(await getPairedDevice(identity.deviceId)).toBeNull();
       wsRetry.close();
 

--- a/src/gateway/server/ws-connection/auth-context.test.ts
+++ b/src/gateway/server/ws-connection/auth-context.test.ts
@@ -200,6 +200,36 @@ describe("resolveConnectAuthDecision", () => {
     expect(verifyDeviceToken).not.toHaveBeenCalled();
   });
 
+  it("passes public key proof into bootstrap token verification", async () => {
+    const publicKeyProof = { payload: "challenge-payload", signature: "signature" };
+    const verifyBootstrapToken = vi.fn<VerifyBootstrapTokenFn>(async () => ({ ok: true }));
+    const verifyDeviceToken = vi.fn<VerifyDeviceTokenFn>(async () => ({ ok: true }));
+    await resolveConnectAuthDecision({
+      state: createBaseState({
+        bootstrapTokenCandidate: "bootstrap-token",
+        deviceTokenCandidate: undefined,
+        deviceTokenCandidateSource: undefined,
+      }),
+      hasDeviceIdentity: true,
+      deviceId: "dev-1",
+      publicKey: "pub-1",
+      publicKeyProof,
+      role: "node",
+      scopes: [],
+      verifyBootstrapToken,
+      verifyDeviceToken,
+    });
+
+    expect(verifyBootstrapToken).toHaveBeenCalledWith({
+      deviceId: "dev-1",
+      publicKey: "pub-1",
+      publicKeyProof,
+      token: "bootstrap-token",
+      role: "node",
+      scopes: [],
+    });
+  });
+
   it("reports invalid bootstrap tokens when no device token fallback is available", async () => {
     const verifyBootstrapToken = vi.fn<VerifyBootstrapTokenFn>(async () => ({
       ok: false,

--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage } from "node:http";
+import type { DeviceBootstrapPublicKeyProof } from "../../../infra/device-bootstrap.js";
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
@@ -151,6 +152,7 @@ export async function resolveConnectAuthDecision(params: {
   hasDeviceIdentity: boolean;
   deviceId?: string;
   publicKey?: string;
+  publicKeyProof?: DeviceBootstrapPublicKeyProof;
   role: string;
   scopes: string[];
   rateLimiter?: AuthRateLimiter;
@@ -158,6 +160,7 @@ export async function resolveConnectAuthDecision(params: {
   verifyBootstrapToken: (params: {
     deviceId: string;
     publicKey: string;
+    publicKeyProof?: DeviceBootstrapPublicKeyProof;
     token: string;
     role: string;
     scopes: string[];
@@ -178,6 +181,7 @@ export async function resolveConnectAuthDecision(params: {
     const tokenCheck = await params.verifyBootstrapToken({
       deviceId: params.deviceId,
       publicKey: params.publicKey,
+      publicKeyProof: params.publicKeyProof,
       token: bootstrapTokenCandidate,
       role: params.role,
       scopes: params.scopes,

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -303,7 +303,7 @@ function buildUnauthorizedHandshakeContext(params: {
   };
 }
 
-export function resolveDeviceSignaturePayloadVersion(params: {
+export function resolveDeviceSignaturePayload(params: {
   device: {
     id: string;
     signature: string;
@@ -314,7 +314,7 @@ export function resolveDeviceSignaturePayloadVersion(params: {
   scopes: string[];
   signedAtMs: number;
   nonce: string;
-}): "v3" | "v2" | null {
+}): { version: "v3" | "v2"; payload: string } | null {
   const signatureToken = resolveSignatureToken(params.connectParams);
   const basePayload = {
     deviceId: params.device.id,
@@ -332,14 +332,20 @@ export function resolveDeviceSignaturePayloadVersion(params: {
     deviceFamily: params.connectParams.client.deviceFamily,
   });
   if (verifyDeviceSignature(params.device.publicKey, payloadV3, params.device.signature)) {
-    return "v3";
+    return { version: "v3", payload: payloadV3 };
   }
 
   const payloadV2 = buildDeviceAuthPayload(basePayload);
   if (verifyDeviceSignature(params.device.publicKey, payloadV2, params.device.signature)) {
-    return "v2";
+    return { version: "v2", payload: payloadV2 };
   }
   return null;
+}
+
+export function resolveDeviceSignaturePayloadVersion(
+  params: Parameters<typeof resolveDeviceSignaturePayload>[0],
+): "v3" | "v2" | null {
+  return resolveDeviceSignaturePayload(params)?.version ?? null;
 }
 
 function resolveAuthProvidedKind(

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -342,12 +342,6 @@ export function resolveDeviceSignaturePayload(params: {
   return null;
 }
 
-export function resolveDeviceSignaturePayloadVersion(
-  params: Parameters<typeof resolveDeviceSignaturePayload>[0],
-): "v3" | "v2" | null {
-  return resolveDeviceSignaturePayload(params)?.version ?? null;
-}
-
 function resolveAuthProvidedKind(
   connectAuth: HandshakeConnectAuth | null | undefined,
 ): AuthProvidedKind {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import type { RawData, WebSocket } from "ws";
 import { getRuntimeConfig } from "../../../config/io.js";
 import {
+  getBoundDeviceBootstrapProfile,
   getDeviceBootstrapTokenProfile,
   redeemDeviceBootstrapTokenProfile,
   resolveDeviceBootstrapTokenBindingId,
@@ -1296,8 +1297,14 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           role === "node" &&
           hasServerApprovedDeviceTokenBaseline &&
           authMethod === "bootstrap-token" &&
-          issuedBootstrapProfile
-            ? issuedBootstrapProfile
+          issuedBootstrapProfile &&
+          bootstrapTokenCandidate &&
+          devicePublicKey
+            ? await getBoundDeviceBootstrapProfile({
+                token: bootstrapTokenCandidate,
+                deviceId: device.id,
+                publicKey: devicePublicKey,
+              })
             : null;
         let bootstrapHandoffComplete = false;
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -133,7 +133,7 @@ import {
   shouldSkipControlUiPairing,
 } from "./connect-policy.js";
 import {
-  resolveDeviceSignaturePayloadVersion,
+  resolveDeviceSignaturePayload,
   resolveHandshakeBrowserSecurityContext,
   resolvePairingLocality,
   resolveUnauthorizedHandshakeContext,
@@ -597,6 +597,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         const deviceRaw = connectParams.device;
         let devicePublicKey: string | null = null;
         let deviceAuthPayloadVersion: "v2" | "v3" | null = null;
+        let deviceBootstrapPublicKeyProof: { payload: string; signature: string } | undefined;
         const hasTokenAuth = Boolean(connectParams.auth?.token);
         const hasPasswordAuth = Boolean(connectParams.auth?.password);
         const hasSharedAuth = hasTokenAuth || hasPasswordAuth;
@@ -808,7 +809,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           }
           const rejectDeviceSignatureInvalid = () =>
             rejectDeviceAuthInvalid("device-signature", "device signature invalid");
-          const payloadVersion = resolveDeviceSignaturePayloadVersion({
+          const payloadMatch = resolveDeviceSignaturePayload({
             device,
             connectParams,
             role,
@@ -816,11 +817,15 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             signedAtMs: signedAt,
             nonce: providedNonce,
           });
-          if (!payloadVersion) {
+          if (!payloadMatch) {
             rejectDeviceSignatureInvalid();
             return;
           }
-          deviceAuthPayloadVersion = payloadVersion;
+          deviceAuthPayloadVersion = payloadMatch.version;
+          deviceBootstrapPublicKeyProof = {
+            payload: payloadMatch.payload,
+            signature: device.signature,
+          };
           devicePublicKey = normalizeDevicePublicKeyBase64Url(device.publicKey);
           if (!devicePublicKey) {
             rejectDeviceAuthInvalid("device-public-key", "device public key invalid");
@@ -842,14 +847,23 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           hasDeviceIdentity: Boolean(device),
           deviceId: device?.id,
           publicKey: device?.publicKey,
+          publicKeyProof: deviceBootstrapPublicKeyProof,
           role,
           scopes,
           rateLimiter: authRateLimiter,
           clientIp: browserRateLimitClientIp,
-          verifyBootstrapToken: async ({ deviceId, publicKey, token, role, scopes }) =>
+          verifyBootstrapToken: async ({
+            deviceId,
+            publicKey,
+            publicKeyProof,
+            token,
+            role,
+            scopes,
+          }) =>
             await verifyDeviceBootstrapToken({
               deviceId,
               publicKey,
+              publicKeyProof,
               token,
               role,
               scopes,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -14,7 +14,6 @@ import {
 } from "../../../infra/device-identity.js";
 import {
   approveDevicePairing,
-  ensureBootstrapDeviceProfile,
   ensureDeviceToken,
   getPairedDevice,
   hasEffectivePairedDeviceRole,
@@ -43,6 +42,7 @@ import { logRejectedLargePayload } from "../../../logging/diagnostic-payload.js"
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import {
   resolveBootstrapProfileScopesForRole,
+  resolveBootstrapProfileScopesForRoles,
   type DeviceBootstrapProfile,
 } from "../../../shared/device-bootstrap-profile.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
@@ -1031,10 +1031,29 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                 autoApproveCidrs: configSnapshot.gateway?.nodes?.pairing?.autoApproveCidrs,
               },
             );
+            const bootstrapPairingProfile =
+              authMethod === "bootstrap-token" &&
+              reason === "not-paired" &&
+              role === "node" &&
+              scopes.length === 0 &&
+              !existingPairedDevice &&
+              issuedBootstrapProfile
+                ? issuedBootstrapProfile
+                : null;
+            const bootstrapPairingRoles = bootstrapPairingProfile?.roles;
+            const bootstrapPairingScopes = bootstrapPairingProfile
+              ? resolveBootstrapProfileScopesForRoles(
+                  bootstrapPairingProfile.roles,
+                  bootstrapPairingProfile.scopes,
+                )
+              : undefined;
             const pairing = await requestDevicePairing({
               deviceId: device.id,
               publicKey: devicePublicKey,
               ...clientPairingMetadata,
+              ...(bootstrapPairingProfile
+                ? { roles: bootstrapPairingRoles, scopes: bootstrapPairingScopes }
+                : {}),
               silent:
                 reason === "scope-upgrade" || authMethod === "bootstrap-token"
                   ? false
@@ -1253,24 +1272,15 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           }
         }
 
-        let handoffBootstrapProfile: DeviceBootstrapProfile | null = null;
-        if (
+        const handoffBootstrapProfile: DeviceBootstrapProfile | null =
           device &&
-          devicePublicKey &&
           role === "node" &&
           hasServerApprovedDeviceTokenBaseline &&
           authMethod === "bootstrap-token" &&
           issuedBootstrapProfile
-        ) {
-          const seeded = await ensureBootstrapDeviceProfile({
-            deviceId: device.id,
-            publicKey: devicePublicKey,
-            profile: issuedBootstrapProfile,
-          });
-          if (seeded) {
-            handoffBootstrapProfile = issuedBootstrapProfile;
-          }
-        }
+            ? issuedBootstrapProfile
+            : null;
+        let bootstrapHandoffComplete = false;
 
         const deviceToken =
           device && hasServerApprovedDeviceTokenBaseline
@@ -1291,6 +1301,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           });
         }
         if (device && handoffBootstrapProfile) {
+          let issuedAllBootstrapRoles = true;
           for (const bootstrapRole of handoffBootstrapProfile.roles) {
             if (bootstrapDeviceTokens.some((entry) => entry.role === bootstrapRole)) {
               continue;
@@ -1308,6 +1319,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               scopes: bootstrapRoleScopes,
             });
             if (!extraToken) {
+              issuedAllBootstrapRoles = false;
               continue;
             }
             bootstrapDeviceTokens.push({
@@ -1317,6 +1329,11 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               issuedAtMs: extraToken.rotatedAtMs ?? extraToken.createdAtMs,
             });
           }
+          bootstrapHandoffComplete =
+            issuedAllBootstrapRoles &&
+            handoffBootstrapProfile.roles.every((bootstrapRole) =>
+              bootstrapDeviceTokens.some((entry) => entry.role === bootstrapRole),
+            );
         }
         if (role === "node") {
           const reconciliation = await reconcileNodePairingOnConnect({
@@ -1552,7 +1569,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         }
         if (authMethod === "bootstrap-token" && bootstrapTokenCandidate && device) {
           try {
-            if (handoffBootstrapProfile) {
+            if (handoffBootstrapProfile && bootstrapHandoffComplete) {
               const revoked = await revokeDeviceBootstrapToken({
                 token: bootstrapTokenCandidate,
               });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -153,6 +153,14 @@ function firstHeaderValue(value: string | string[] | undefined): string | undefi
   return Array.isArray(value) ? value[0] : value;
 }
 
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  const rightSet = new Set(right);
+  return left.every((value) => rightSet.has(value));
+}
+
 function resolveTrustedProxyControlUiScopes(params: {
   requestedScopes: string[];
   upgradeReq: IncomingMessage;
@@ -1323,6 +1331,10 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               scopes: bootstrapRoleScopes,
             });
             if (!extraToken) {
+              issuedAllBootstrapRoles = false;
+              continue;
+            }
+            if (!sameStringSet(extraToken.scopes, bootstrapRoleScopes)) {
               issuedAllBootstrapRoles = false;
               continue;
             }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -5,6 +5,7 @@ import { getRuntimeConfig } from "../../../config/io.js";
 import {
   getDeviceBootstrapTokenProfile,
   redeemDeviceBootstrapTokenProfile,
+  resolveDeviceBootstrapTokenBindingId,
   revokeDeviceBootstrapToken,
   verifyDeviceBootstrapToken,
 } from "../../../infra/device-bootstrap.js";
@@ -1064,6 +1065,12 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                     roles: bootstrapPairingRoles,
                     scopes: bootstrapPairingScopes,
                     bootstrapProfile: bootstrapPairingProfile,
+                    ...(bootstrapTokenCandidate
+                      ? {
+                          bootstrapTokenBindingId:
+                            resolveDeviceBootstrapTokenBindingId(bootstrapTokenCandidate),
+                        }
+                      : {}),
                   }
                 : {}),
               silent:

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import type { RawData, WebSocket } from "ws";
 import { getRuntimeConfig } from "../../../config/io.js";
 import {
-  getBoundDeviceBootstrapProfile,
   getDeviceBootstrapTokenProfile,
   redeemDeviceBootstrapTokenProfile,
   revokeDeviceBootstrapToken,
@@ -14,7 +13,6 @@ import {
   normalizeDevicePublicKeyBase64Url,
 } from "../../../infra/device-identity.js";
 import {
-  approveBootstrapDevicePairing,
   approveDevicePairing,
   ensureDeviceToken,
   getPairedDevice,
@@ -42,10 +40,6 @@ import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { rawDataToString } from "../../../infra/ws.js";
 import { logRejectedLargePayload } from "../../../logging/diagnostic-payload.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
-import {
-  resolveBootstrapProfileScopesForRole,
-  type DeviceBootstrapProfile,
-} from "../../../shared/device-bootstrap-profile.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import {
   isBrowserOperatorUiClient,
@@ -859,15 +853,16 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             token,
             role,
             scopes,
-          }) =>
-            await verifyDeviceBootstrapToken({
+          }) => {
+            return await verifyDeviceBootstrapToken({
               deviceId,
               publicKey,
               publicKeyProof,
               token,
               role,
               scopes,
-            }),
+            });
+          },
           verifyDeviceToken,
         }));
         pairingLocality = resolvePairingLocality({
@@ -914,8 +909,6 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           authMethod === "bootstrap-token" && bootstrapTokenCandidate
             ? await getDeviceBootstrapTokenProfile({ token: bootstrapTokenCandidate })
             : null;
-        let boundBootstrapProfile: DeviceBootstrapProfile | null = null;
-        let handoffBootstrapProfile: DeviceBootstrapProfile | null = null;
 
         const trustedProxyAuthOk = isTrustedProxyControlUiOperatorAuth({
           isControlUi,
@@ -1011,21 +1004,6 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                 allowedScopes: pairedScopes,
               });
             };
-            if (
-              boundBootstrapProfile === null &&
-              authMethod === "bootstrap-token" &&
-              reason === "not-paired" &&
-              role === "node" &&
-              scopes.length === 0 &&
-              !existingPairedDevice &&
-              bootstrapTokenCandidate
-            ) {
-              boundBootstrapProfile = await getBoundDeviceBootstrapProfile({
-                token: bootstrapTokenCandidate,
-                deviceId: device.id,
-                publicKey: devicePublicKey,
-              });
-            }
             const allowSilentLocalPairing = shouldAllowSilentLocalPairing({
               locality: pairingLocality,
               hasBrowserOriginHeader,
@@ -1048,30 +1026,14 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                 autoApproveCidrs: configSnapshot.gateway?.nodes?.pairing?.autoApproveCidrs,
               },
             );
-            const allowSilentBootstrapPairing =
-              authMethod === "bootstrap-token" &&
-              reason === "not-paired" &&
-              role === "node" &&
-              scopes.length === 0 &&
-              !existingPairedDevice &&
-              boundBootstrapProfile !== null;
-            const bootstrapProfileForSilentApproval = allowSilentBootstrapPairing
-              ? boundBootstrapProfile
-              : null;
-            const bootstrapPairingRoles = bootstrapProfileForSilentApproval
-              ? Array.from(new Set([role, ...bootstrapProfileForSilentApproval.roles]))
-              : undefined;
             const pairing = await requestDevicePairing({
               deviceId: device.id,
               publicKey: devicePublicKey,
               ...clientPairingMetadata,
-              ...(bootstrapPairingRoles ? { roles: bootstrapPairingRoles } : {}),
               silent:
                 reason === "scope-upgrade"
                   ? false
-                  : allowSilentLocalPairing ||
-                    allowSilentBootstrapPairing ||
-                    allowSilentTrustedCidrsNodePairing,
+                  : allowSilentLocalPairing || allowSilentTrustedCidrsNodePairing,
             });
             const context = buildRequestContext();
             let approved: Awaited<ReturnType<typeof approveDevicePairing>> | undefined;
@@ -1092,18 +1054,10 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               return replacementPending?.requestId;
             };
             if (pairing.request.silent === true) {
-              approved = bootstrapProfileForSilentApproval
-                ? await approveBootstrapDevicePairing(
-                    pairing.request.requestId,
-                    bootstrapProfileForSilentApproval,
-                  )
-                : await approveDevicePairing(pairing.request.requestId, {
-                    callerScopes: scopes,
-                  });
+              approved = await approveDevicePairing(pairing.request.requestId, {
+                callerScopes: scopes,
+              });
               if (approved?.status === "approved") {
-                if (bootstrapProfileForSilentApproval) {
-                  handoffBootstrapProfile = bootstrapProfileForSilentApproval;
-                }
                 logGateway.info(
                   `device pairing auto-approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,
                 );
@@ -1312,36 +1266,6 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             issuedAtMs: deviceToken.rotatedAtMs ?? deviceToken.createdAtMs,
           });
         }
-        if (device && handoffBootstrapProfile) {
-          const bootstrapProfileForHello = handoffBootstrapProfile as DeviceBootstrapProfile;
-          for (const bootstrapRole of bootstrapProfileForHello.roles) {
-            if (bootstrapDeviceTokens.some((entry) => entry.role === bootstrapRole)) {
-              continue;
-            }
-            const bootstrapRoleScopes =
-              bootstrapRole === "operator"
-                ? resolveBootstrapProfileScopesForRole(
-                    bootstrapRole,
-                    bootstrapProfileForHello.scopes,
-                  )
-                : [];
-            const extraToken = await ensureDeviceToken({
-              deviceId: device.id,
-              role: bootstrapRole,
-              scopes: bootstrapRoleScopes,
-            });
-            if (!extraToken) {
-              continue;
-            }
-            bootstrapDeviceTokens.push({
-              deviceToken: extraToken.token,
-              role: extraToken.role,
-              scopes: extraToken.scopes,
-              issuedAtMs: extraToken.rotatedAtMs ?? extraToken.createdAtMs,
-            });
-          }
-        }
-
         if (role === "node") {
           const reconciliation = await reconcileNodePairingOnConnect({
             cfg: getRuntimeConfig(),
@@ -1576,16 +1500,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         }
         if (authMethod === "bootstrap-token" && bootstrapTokenCandidate && device) {
           try {
-            if (handoffBootstrapProfile) {
-              const revoked = await revokeDeviceBootstrapToken({
-                token: bootstrapTokenCandidate,
-              });
-              if (!revoked.removed) {
-                logGateway.warn(
-                  `bootstrap token revoke skipped after device-token handoff device=${device.id}`,
-                );
-              }
-            } else if (issuedBootstrapProfile) {
+            if (issuedBootstrapProfile) {
               const redemption = await redeemDeviceBootstrapTokenProfile({
                 token: bootstrapTokenCandidate,
                 role,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1031,7 +1031,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               publicKey: devicePublicKey,
               ...clientPairingMetadata,
               silent:
-                reason === "scope-upgrade"
+                reason === "scope-upgrade" || authMethod === "bootstrap-token"
                   ? false
                   : allowSilentLocalPairing || allowSilentTrustedCidrsNodePairing,
             });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1052,7 +1052,11 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               publicKey: devicePublicKey,
               ...clientPairingMetadata,
               ...(bootstrapPairingProfile
-                ? { roles: bootstrapPairingRoles, scopes: bootstrapPairingScopes }
+                ? {
+                    roles: bootstrapPairingRoles,
+                    scopes: bootstrapPairingScopes,
+                    bootstrapProfile: bootstrapPairingProfile,
+                  }
                 : {}),
               silent:
                 reason === "scope-upgrade" || authMethod === "bootstrap-token"

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../infra/device-identity.js";
 import {
   approveDevicePairing,
+  ensureBootstrapDeviceProfile,
   ensureDeviceToken,
   getPairedDevice,
   hasEffectivePairedDeviceRole,
@@ -40,6 +41,10 @@ import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { rawDataToString } from "../../../infra/ws.js";
 import { logRejectedLargePayload } from "../../../logging/diagnostic-payload.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
+import {
+  resolveBootstrapProfileScopesForRole,
+  type DeviceBootstrapProfile,
+} from "../../../shared/device-bootstrap-profile.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import {
   isBrowserOperatorUiClient,
@@ -1248,6 +1253,25 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           }
         }
 
+        let handoffBootstrapProfile: DeviceBootstrapProfile | null = null;
+        if (
+          device &&
+          devicePublicKey &&
+          role === "node" &&
+          hasServerApprovedDeviceTokenBaseline &&
+          authMethod === "bootstrap-token" &&
+          issuedBootstrapProfile
+        ) {
+          const seeded = await ensureBootstrapDeviceProfile({
+            deviceId: device.id,
+            publicKey: devicePublicKey,
+            profile: issuedBootstrapProfile,
+          });
+          if (seeded) {
+            handoffBootstrapProfile = issuedBootstrapProfile;
+          }
+        }
+
         const deviceToken =
           device && hasServerApprovedDeviceTokenBaseline
             ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
@@ -1265,6 +1289,34 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             scopes: deviceToken.scopes,
             issuedAtMs: deviceToken.rotatedAtMs ?? deviceToken.createdAtMs,
           });
+        }
+        if (device && handoffBootstrapProfile) {
+          for (const bootstrapRole of handoffBootstrapProfile.roles) {
+            if (bootstrapDeviceTokens.some((entry) => entry.role === bootstrapRole)) {
+              continue;
+            }
+            const bootstrapRoleScopes =
+              bootstrapRole === "operator"
+                ? resolveBootstrapProfileScopesForRole(
+                    bootstrapRole,
+                    handoffBootstrapProfile.scopes,
+                  )
+                : [];
+            const extraToken = await ensureDeviceToken({
+              deviceId: device.id,
+              role: bootstrapRole,
+              scopes: bootstrapRoleScopes,
+            });
+            if (!extraToken) {
+              continue;
+            }
+            bootstrapDeviceTokens.push({
+              deviceToken: extraToken.token,
+              role: extraToken.role,
+              scopes: extraToken.scopes,
+              issuedAtMs: extraToken.rotatedAtMs ?? extraToken.createdAtMs,
+            });
+          }
         }
         if (role === "node") {
           const reconciliation = await reconcileNodePairingOnConnect({
@@ -1500,7 +1552,16 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         }
         if (authMethod === "bootstrap-token" && bootstrapTokenCandidate && device) {
           try {
-            if (issuedBootstrapProfile) {
+            if (handoffBootstrapProfile) {
+              const revoked = await revokeDeviceBootstrapToken({
+                token: bootstrapTokenCandidate,
+              });
+              if (!revoked.removed) {
+                logGateway.warn(
+                  `bootstrap token revoke skipped after device-token handoff device=${device.id}`,
+                );
+              }
+            } else if (issuedBootstrapProfile) {
               const redemption = await redeemDeviceBootstrapTokenProfile({
                 token: bootstrapTokenCandidate,
                 role,

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -14,7 +14,12 @@ import {
   revokeDeviceBootstrapToken,
   verifyDeviceBootstrapToken,
 } from "./device-bootstrap.js";
-import { loadOrCreateDeviceIdentity, publicKeyRawBase64UrlFromPem } from "./device-identity.js";
+import {
+  loadOrCreateDeviceIdentity,
+  publicKeyRawBase64UrlFromPem,
+  signDevicePayload,
+  type DeviceIdentity,
+} from "./device-identity.js";
 
 const tempDirs = createTrackedTempDirs();
 const createTempDir = () => tempDirs.make("openclaw-device-bootstrap-test-");
@@ -28,15 +33,26 @@ async function verifyBootstrapToken(
   token: string,
   overrides: Partial<Parameters<typeof verifyDeviceBootstrapToken>[0]> = {},
 ) {
+  const defaultIdentity = loadOrCreateDeviceIdentity(path.join(baseDir, "default-device.json"));
+  const publicKeyProof = createPublicKeyProof(defaultIdentity);
   return await verifyDeviceBootstrapToken({
     token,
-    deviceId: "device-123",
-    publicKey: "public-key-123",
+    deviceId: defaultIdentity.deviceId,
+    publicKey: publicKeyRawBase64UrlFromPem(defaultIdentity.publicKeyPem),
+    publicKeyProof,
     role: "node",
     scopes: [],
     baseDir,
     ...overrides,
   });
+}
+
+function createPublicKeyProof(identity: DeviceIdentity): { payload: string; signature: string } {
+  const payload = `openclaw-device-bootstrap-test:${identity.deviceId}`;
+  return {
+    payload,
+    signature: signDevicePayload(identity.privateKeyPem, payload),
+  };
 }
 
 afterEach(async () => {
@@ -78,6 +94,7 @@ describe("device bootstrap tokens", () => {
 
   it("verifies valid bootstrap tokens and binds them to the first device identity", async () => {
     const baseDir = await createTempDir();
+    const identity = loadOrCreateDeviceIdentity(path.join(baseDir, "default-device.json"));
     const issued = await issueDeviceBootstrapToken({ baseDir });
 
     await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
@@ -93,8 +110,55 @@ describe("device bootstrap tokens", () => {
       }
     >;
     expect(parsed[issued.token]?.token).toBe(issued.token);
-    expect(parsed[issued.token]?.deviceId).toBe("device-123");
-    expect(parsed[issued.token]?.publicKey).toBe("public-key-123");
+    expect(parsed[issued.token]?.deviceId).toBe(identity.deviceId);
+    expect(parsed[issued.token]?.publicKey).toBe(
+      publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+    );
+  });
+
+  it("requires public key proof before binding a bootstrap token", async () => {
+    const baseDir = await createTempDir();
+    const identity = loadOrCreateDeviceIdentity(path.join(baseDir, "default-device.json"));
+    const issued = await issueDeviceBootstrapToken({ baseDir });
+
+    await expect(
+      verifyDeviceBootstrapToken({
+        token: issued.token,
+        deviceId: identity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+        role: "node",
+        scopes: [],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
+
+    const raw = await fs.readFile(resolveBootstrapPath(baseDir), "utf8");
+    const parsed = JSON.parse(raw) as Record<string, { deviceId?: string; publicKey?: string }>;
+    expect(parsed[issued.token]?.deviceId).toBeUndefined();
+    expect(parsed[issued.token]?.publicKey).toBeUndefined();
+  });
+
+  it("rejects public key proof from a different device identity", async () => {
+    const baseDir = await createTempDir();
+    const identity = loadOrCreateDeviceIdentity(path.join(baseDir, "default-device.json"));
+    const otherIdentity = loadOrCreateDeviceIdentity(path.join(baseDir, "other-device.json"));
+    const issued = await issueDeviceBootstrapToken({ baseDir });
+
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        deviceId: identity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+        publicKeyProof: createPublicKeyProof(otherIdentity),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
+
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        deviceId: identity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+        publicKeyProof: createPublicKeyProof(identity),
+      }),
+    ).resolves.toEqual({ ok: true });
   });
 
   it("loads the issued bootstrap profile for a valid token", async () => {
@@ -199,6 +263,7 @@ describe("device bootstrap tokens", () => {
 
   it("verifies bootstrap tokens by the persisted map key and binds them", async () => {
     const baseDir = await createTempDir();
+    const identity = loadOrCreateDeviceIdentity(path.join(baseDir, "default-device.json"));
     const issued = await issueDeviceBootstrapToken({ baseDir });
     const issuedAtMs = Date.now();
     const bootstrapPath = path.join(baseDir, "devices", "bootstrap.json");
@@ -235,8 +300,10 @@ describe("device bootstrap tokens", () => {
       { token: string; deviceId?: string; publicKey?: string }
     >;
     expect(parsed["legacy-key"]?.token).toBe(issued.token);
-    expect(parsed["legacy-key"]?.deviceId).toBe("device-123");
-    expect(parsed["legacy-key"]?.publicKey).toBe("public-key-123");
+    expect(parsed["legacy-key"]?.deviceId).toBe(identity.deviceId);
+    expect(parsed["legacy-key"]?.publicKey).toBe(
+      publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+    );
   });
 
   it("keeps the token when required verification fields are blank", async () => {
@@ -414,6 +481,7 @@ describe("device bootstrap tokens", () => {
 
   it("accepts trimmed bootstrap tokens and binds them", async () => {
     const baseDir = await createTempDir();
+    const identity = loadOrCreateDeviceIdentity(path.join(baseDir, "default-device.json"));
     const issued = await issueDeviceBootstrapToken({ baseDir });
 
     await expect(verifyBootstrapToken(baseDir, `  ${issued.token}  `)).resolves.toEqual({
@@ -422,7 +490,7 @@ describe("device bootstrap tokens", () => {
 
     const raw = await fs.readFile(resolveBootstrapPath(baseDir), "utf8");
     const parsed = JSON.parse(raw) as Record<string, { deviceId?: string }>;
-    expect(parsed[issued.token]?.deviceId).toBe("device-123");
+    expect(parsed[issued.token]?.deviceId).toBe(identity.deviceId);
   });
 
   it("rejects blank or unknown tokens", async () => {
@@ -473,12 +541,14 @@ describe("device bootstrap tokens", () => {
       verifyBootstrapToken(baseDir, issued.token, {
         deviceId: identity.deviceId,
         publicKey: identity.publicKeyPem,
+        publicKeyProof: createPublicKeyProof(identity),
       }),
     ).resolves.toEqual({ ok: true });
     await expect(
       verifyBootstrapToken(baseDir, issued.token, {
         deviceId: identity.deviceId,
         publicKey: rawPublicKey,
+        publicKeyProof: createPublicKeyProof(identity),
       }),
     ).resolves.toEqual({ ok: true });
     await expect(
@@ -496,13 +566,15 @@ describe("device bootstrap tokens", () => {
 
   it("rejects a second device identity after the first verification binds the token", async () => {
     const baseDir = await createTempDir();
+    const secondIdentity = loadOrCreateDeviceIdentity(path.join(baseDir, "second-device.json"));
     const issued = await issueDeviceBootstrapToken({ baseDir });
 
     await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
     await expect(
       verifyBootstrapToken(baseDir, issued.token, {
-        deviceId: "device-456",
-        publicKey: "public-key-456",
+        deviceId: secondIdentity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(secondIdentity.publicKeyPem),
+        publicKeyProof: createPublicKeyProof(secondIdentity),
       }),
     ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
   });

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -161,6 +161,25 @@ describe("device bootstrap tokens", () => {
     ).resolves.toEqual({ ok: true });
   });
 
+  it("rejects a mismatched device id before binding a bootstrap token", async () => {
+    const baseDir = await createTempDir();
+    const identity = loadOrCreateDeviceIdentity(path.join(baseDir, "default-device.json"));
+    const issued = await issueDeviceBootstrapToken({ baseDir });
+
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        deviceId: "not-the-derived-device-id",
+        publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+        publicKeyProof: createPublicKeyProof(identity),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
+
+    const raw = await fs.readFile(resolveBootstrapPath(baseDir), "utf8");
+    const parsed = JSON.parse(raw) as Record<string, { deviceId?: string; publicKey?: string }>;
+    expect(parsed[issued.token]?.deviceId).toBeUndefined();
+    expect(parsed[issued.token]?.publicKey).toBeUndefined();
+  });
+
   it("loads the issued bootstrap profile for a valid token", async () => {
     const baseDir = await createTempDir();
     const issued = await issueDeviceBootstrapToken({ baseDir });

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -4,12 +4,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
+  bindDeviceBootstrapToken,
   clearDeviceBootstrapTokens,
   DEVICE_BOOTSTRAP_TOKEN_TTL_MS,
   getBoundDeviceBootstrapProfile,
   getDeviceBootstrapTokenProfile,
   issueDeviceBootstrapToken,
   redeemDeviceBootstrapTokenProfile,
+  resolveDeviceBootstrapTokenBindingId,
   restoreDeviceBootstrapToken,
   revokeDeviceBootstrapToken,
   verifyDeviceBootstrapToken,
@@ -92,9 +94,8 @@ describe("device bootstrap tokens", () => {
     });
   });
 
-  it("verifies valid bootstrap tokens and binds them to the first device identity", async () => {
+  it("verifies valid bootstrap tokens without binding before approval", async () => {
     const baseDir = await createTempDir();
-    const identity = loadOrCreateDeviceIdentity(path.join(baseDir, "default-device.json"));
     const issued = await issueDeviceBootstrapToken({ baseDir });
 
     await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
@@ -110,10 +111,53 @@ describe("device bootstrap tokens", () => {
       }
     >;
     expect(parsed[issued.token]?.token).toBe(issued.token);
-    expect(parsed[issued.token]?.deviceId).toBe(identity.deviceId);
-    expect(parsed[issued.token]?.publicKey).toBe(
-      publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
-    );
+    expect(parsed[issued.token]?.deviceId).toBeUndefined();
+    expect(parsed[issued.token]?.publicKey).toBeUndefined();
+  });
+
+  it("binds bootstrap tokens only after approval selects the device identity", async () => {
+    const baseDir = await createTempDir();
+    const firstIdentity = loadOrCreateDeviceIdentity(path.join(baseDir, "first-device.json"));
+    const secondIdentity = loadOrCreateDeviceIdentity(path.join(baseDir, "second-device.json"));
+    const issued = await issueDeviceBootstrapToken({ baseDir });
+
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        deviceId: firstIdentity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(firstIdentity.publicKeyPem),
+        publicKeyProof: createPublicKeyProof(firstIdentity),
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        deviceId: secondIdentity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(secondIdentity.publicKeyPem),
+        publicKeyProof: createPublicKeyProof(secondIdentity),
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(
+      bindDeviceBootstrapToken({
+        baseDir,
+        tokenBindingId: resolveDeviceBootstrapTokenBindingId(issued.token),
+        deviceId: secondIdentity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(secondIdentity.publicKeyPem),
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        deviceId: firstIdentity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(firstIdentity.publicKeyPem),
+        publicKeyProof: createPublicKeyProof(firstIdentity),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        deviceId: secondIdentity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(secondIdentity.publicKeyPem),
+        publicKeyProof: createPublicKeyProof(secondIdentity),
+      }),
+    ).resolves.toEqual({ ok: true });
   });
 
   it("requires public key proof before binding a bootstrap token", async () => {
@@ -280,9 +324,8 @@ describe("device bootstrap tokens", () => {
     await expect(verifyBootstrapToken(baseDir, second.token)).resolves.toEqual({ ok: true });
   });
 
-  it("verifies bootstrap tokens by the persisted map key and binds them", async () => {
+  it("verifies bootstrap tokens by the persisted map key", async () => {
     const baseDir = await createTempDir();
-    const identity = loadOrCreateDeviceIdentity(path.join(baseDir, "default-device.json"));
     const issued = await issueDeviceBootstrapToken({ baseDir });
     const issuedAtMs = Date.now();
     const bootstrapPath = path.join(baseDir, "devices", "bootstrap.json");
@@ -319,10 +362,8 @@ describe("device bootstrap tokens", () => {
       { token: string; deviceId?: string; publicKey?: string }
     >;
     expect(parsed["legacy-key"]?.token).toBe(issued.token);
-    expect(parsed["legacy-key"]?.deviceId).toBe(identity.deviceId);
-    expect(parsed["legacy-key"]?.publicKey).toBe(
-      publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
-    );
+    expect(parsed["legacy-key"]?.deviceId).toBeUndefined();
+    expect(parsed["legacy-key"]?.publicKey).toBeUndefined();
   });
 
   it("keeps the token when required verification fields are blank", async () => {
@@ -498,9 +539,8 @@ describe("device bootstrap tokens", () => {
     });
   });
 
-  it("accepts trimmed bootstrap tokens and binds them", async () => {
+  it("accepts trimmed bootstrap tokens without binding them", async () => {
     const baseDir = await createTempDir();
-    const identity = loadOrCreateDeviceIdentity(path.join(baseDir, "default-device.json"));
     const issued = await issueDeviceBootstrapToken({ baseDir });
 
     await expect(verifyBootstrapToken(baseDir, `  ${issued.token}  `)).resolves.toEqual({
@@ -509,7 +549,7 @@ describe("device bootstrap tokens", () => {
 
     const raw = await fs.readFile(resolveBootstrapPath(baseDir), "utf8");
     const parsed = JSON.parse(raw) as Record<string, { deviceId?: string }>;
-    expect(parsed[issued.token]?.deviceId).toBe(identity.deviceId);
+    expect(parsed[issued.token]?.deviceId).toBeUndefined();
   });
 
   it("rejects blank or unknown tokens", async () => {
@@ -564,6 +604,14 @@ describe("device bootstrap tokens", () => {
       }),
     ).resolves.toEqual({ ok: true });
     await expect(
+      bindDeviceBootstrapToken({
+        baseDir,
+        tokenBindingId: resolveDeviceBootstrapTokenBindingId(issued.token),
+        deviceId: identity.deviceId,
+        publicKey: rawPublicKey,
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
       verifyBootstrapToken(baseDir, issued.token, {
         deviceId: identity.deviceId,
         publicKey: rawPublicKey,
@@ -583,12 +631,27 @@ describe("device bootstrap tokens", () => {
     });
   });
 
-  it("rejects a second device identity after the first verification binds the token", async () => {
+  it("rejects a second device identity after approval binds the token", async () => {
     const baseDir = await createTempDir();
+    const firstIdentity = loadOrCreateDeviceIdentity(path.join(baseDir, "first-device.json"));
     const secondIdentity = loadOrCreateDeviceIdentity(path.join(baseDir, "second-device.json"));
     const issued = await issueDeviceBootstrapToken({ baseDir });
 
-    await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        deviceId: firstIdentity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(firstIdentity.publicKeyPem),
+        publicKeyProof: createPublicKeyProof(firstIdentity),
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      bindDeviceBootstrapToken({
+        baseDir,
+        tokenBindingId: resolveDeviceBootstrapTokenBindingId(issued.token),
+        deviceId: firstIdentity.deviceId,
+        publicKey: publicKeyRawBase64UrlFromPem(firstIdentity.publicKeyPem),
+      }),
+    ).resolves.toEqual({ ok: true });
     await expect(
       verifyBootstrapToken(baseDir, issued.token, {
         deviceId: secondIdentity.deviceId,

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -9,7 +9,11 @@ import {
   type DeviceBootstrapProfileInput,
 } from "../shared/device-bootstrap-profile.js";
 import { roleScopesAllow } from "../shared/operator-scope-compat.js";
-import { normalizeDevicePublicKeyBase64Url } from "./device-identity.js";
+import {
+  deriveDeviceIdFromPublicKey,
+  normalizeDevicePublicKeyBase64Url,
+  verifyDeviceSignature,
+} from "./device-identity.js";
 import { resolvePairingPaths } from "./pairing-files.js";
 import { createAsyncLock, pruneExpiredPending, tryReadJson, writeJson } from "./pairing-files.js";
 import { generatePairingToken, verifyPairingToken } from "./pairing-token.js";
@@ -27,6 +31,11 @@ export type DeviceBootstrapTokenRecord = {
   scopes?: string[];
   issuedAtMs: number;
   lastUsedAtMs?: number;
+};
+
+export type DeviceBootstrapPublicKeyProof = {
+  payload: string;
+  signature: string;
 };
 
 type DeviceBootstrapStateFile = Record<string, DeviceBootstrapTokenRecord>;
@@ -155,6 +164,19 @@ function normalizeBootstrapPublicKey(publicKey: string): string {
     return normalizeDevicePublicKeyBase64Url(trimmed) ?? trimmed;
   }
   return trimmed;
+}
+
+function verifyBootstrapPublicKeyProof(params: {
+  publicKey: string;
+  proof?: DeviceBootstrapPublicKeyProof;
+}): boolean {
+  const payload = params.proof?.payload ?? "";
+  const signature = params.proof?.signature.trim() ?? "";
+  return (
+    payload.trim().length > 0 &&
+    !!signature &&
+    verifyDeviceSignature(params.publicKey, payload, signature)
+  );
 }
 
 async function loadState(baseDir?: string): Promise<DeviceBootstrapStateFile> {
@@ -331,6 +353,7 @@ export async function verifyDeviceBootstrapToken(params: {
   token: string;
   deviceId: string;
   publicKey: string;
+  publicKeyProof?: DeviceBootstrapPublicKeyProof;
   role: string;
   scopes: readonly string[];
   baseDir?: string;
@@ -353,6 +376,12 @@ export async function verifyDeviceBootstrapToken(params: {
     const publicKey = normalizeBootstrapPublicKey(params.publicKey);
     const role = params.role.trim();
     if (!deviceId || !publicKey || !role) {
+      return { ok: false, reason: "bootstrap_token_invalid" };
+    }
+    if (deriveDeviceIdFromPublicKey(publicKey) !== deviceId) {
+      return { ok: false, reason: "bootstrap_token_invalid" };
+    }
+    if (!verifyBootstrapPublicKeyProof({ publicKey, proof: params.publicKeyProof })) {
       return { ok: false, reason: "bootstrap_token_invalid" };
     }
     const allowedProfile = resolvePersistedBootstrapProfile(record);
@@ -405,7 +434,8 @@ export async function verifyDeviceBootstrapToken(params: {
  * Reads the already-bound bootstrap profile for a verified device identity.
  *
  * Call this only after `verifyDeviceBootstrapToken()` has returned `{ ok: true }`
- * for the same `token` / `deviceId` / `publicKey` tuple in the current handshake.
+ * for the same `token` / `deviceId` / `publicKey` tuple and public-key proof
+ * in the current handshake.
  */
 export async function getBoundDeviceBootstrapProfile(params: {
   token: string;

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import path from "node:path";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
@@ -37,6 +38,10 @@ export type DeviceBootstrapPublicKeyProof = {
   payload: string;
   signature: string;
 };
+
+export function resolveDeviceBootstrapTokenBindingId(token: string): string {
+  return crypto.createHash("sha256").update(token.trim()).digest("hex");
+}
 
 type DeviceBootstrapStateFile = Record<string, DeviceBootstrapTokenRecord>;
 
@@ -418,9 +423,47 @@ export async function verifyDeviceBootstrapToken(params: {
       return { ok: true };
     }
 
+    return { ok: true };
+  });
+}
+
+export async function bindDeviceBootstrapToken(params: {
+  tokenBindingId: string;
+  deviceId: string;
+  publicKey: string;
+  baseDir?: string;
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  return await withLock(async () => {
+    const tokenBindingId = params.tokenBindingId.trim();
+    if (!tokenBindingId) {
+      return { ok: false, reason: "bootstrap_token_invalid" };
+    }
+    const state = await loadState(params.baseDir);
+    const found = Object.entries(state).find(
+      ([, candidate]) => resolveDeviceBootstrapTokenBindingId(candidate.token) === tokenBindingId,
+    );
+    if (!found) {
+      return { ok: false, reason: "bootstrap_token_invalid" };
+    }
+    const [tokenKey, record] = found;
+    const deviceId = params.deviceId.trim();
+    const publicKey = normalizeBootstrapPublicKey(params.publicKey);
+    if (!deviceId || !publicKey || deriveDeviceIdFromPublicKey(publicKey) !== deviceId) {
+      return { ok: false, reason: "bootstrap_token_invalid" };
+    }
+    const boundDeviceId = record.deviceId?.trim();
+    const boundPublicKey =
+      typeof record.publicKey === "string"
+        ? normalizeBootstrapPublicKey(record.publicKey)
+        : undefined;
+    if (boundDeviceId || boundPublicKey) {
+      if (boundDeviceId !== deviceId || boundPublicKey !== publicKey) {
+        return { ok: false, reason: "bootstrap_token_invalid" };
+      }
+    }
     state[tokenKey] = {
       ...record,
-      profile: allowedProfile,
+      profile: resolvePersistedBootstrapProfile(record),
       deviceId,
       publicKey,
       lastUsedAtMs: Date.now(),
@@ -431,11 +474,11 @@ export async function verifyDeviceBootstrapToken(params: {
 }
 
 /**
- * Reads the already-bound bootstrap profile for a verified device identity.
+ * Reads the bootstrap profile after approval has bound the token to a device.
  *
  * Call this only after `verifyDeviceBootstrapToken()` has returned `{ ok: true }`
- * for the same `token` / `deviceId` / `publicKey` tuple and public-key proof
- * in the current handshake.
+ * for the same `token` / `deviceId` / `publicKey` tuple and the pairing
+ * approval path has called `bindDeviceBootstrapToken()`.
  */
 export async function getBoundDeviceBootstrapProfile(params: {
   token: string;

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -1,8 +1,14 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { PAIRING_SETUP_BOOTSTRAP_PROFILE } from "../shared/device-bootstrap-profile.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { issueDeviceBootstrapToken, verifyDeviceBootstrapToken } from "./device-bootstrap.js";
+import {
+  loadOrCreateDeviceIdentity,
+  publicKeyRawBase64UrlFromPem,
+  signDevicePayload,
+} from "./device-identity.js";
 import {
   approveBootstrapDevicePairing,
   approveDevicePairing,
@@ -587,6 +593,13 @@ describe("device pairing tokens", () => {
 
   test("rejects bootstrap token replay before pending scope escalation can be approved", async () => {
     const baseDir = await makeDevicePairingDir();
+    const identity = loadOrCreateDeviceIdentity(path.join(baseDir, "device.json"));
+    const publicKey = publicKeyRawBase64UrlFromPem(identity.publicKeyPem);
+    const proofPayload = `openclaw-device-pairing-test:${identity.deviceId}`;
+    const publicKeyProof = {
+      payload: proofPayload,
+      signature: signDevicePayload(identity.privateKeyPem, proofPayload),
+    };
     const issued = await issueDeviceBootstrapToken({
       baseDir,
       roles: ["operator"],
@@ -596,8 +609,9 @@ describe("device pairing tokens", () => {
     await expect(
       verifyDeviceBootstrapToken({
         token: issued.token,
-        deviceId: "device-1",
-        publicKey: "public-key-1",
+        deviceId: identity.deviceId,
+        publicKey,
+        publicKeyProof,
         role: "operator",
         scopes: ["operator.read"],
         baseDir,
@@ -606,8 +620,8 @@ describe("device pairing tokens", () => {
 
     const first = await requestDevicePairing(
       {
-        deviceId: "device-1",
-        publicKey: "public-key-1",
+        deviceId: identity.deviceId,
+        publicKey,
         role: "operator",
         scopes: ["operator.read"],
       },
@@ -617,8 +631,9 @@ describe("device pairing tokens", () => {
     await expect(
       verifyDeviceBootstrapToken({
         token: issued.token,
-        deviceId: "device-1",
-        publicKey: "public-key-1",
+        deviceId: identity.deviceId,
+        publicKey,
+        publicKeyProof,
         role: "operator",
         scopes: ["operator.admin"],
         baseDir,
@@ -630,7 +645,7 @@ describe("device pairing tokens", () => {
       { callerScopes: ["operator.read"] },
       baseDir,
     );
-    const paired = await getPairedDevice("device-1", baseDir);
+    const paired = await getPairedDevice(identity.deviceId, baseDir);
     expect(paired?.scopes).toEqual(["operator.read"]);
     expect(paired?.approvedScopes).toEqual(["operator.read"]);
     expect(paired?.tokens?.operator?.scopes).toEqual(["operator.read"]);

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -1036,6 +1036,38 @@ describe("device pairing tokens", () => {
     );
   });
 
+  test("bootstrap-marked pairing requires pairing approval scope", async () => {
+    const baseDir = await makeDevicePairingDir();
+    const request = await requestDevicePairing(
+      {
+        deviceId: "bootstrap-device-approval-scope",
+        publicKey: "bootstrap-public-key-approval-scope",
+        role: "node",
+        roles: ["node", "operator"],
+        scopes: PAIRING_SETUP_BOOTSTRAP_PROFILE.scopes,
+        bootstrapProfile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
+      },
+      baseDir,
+    );
+
+    await expect(
+      approveDevicePairing(request.request.requestId, { callerScopes: [] }, baseDir),
+    ).resolves.toEqual({
+      status: "forbidden",
+      reason: "caller-missing-scope",
+      scope: "operator.pairing",
+    });
+    await expect(getPairedDevice("bootstrap-device-approval-scope", baseDir)).resolves.toBeNull();
+
+    await expect(
+      approveDevicePairing(
+        request.request.requestId,
+        { callerScopes: ["operator.pairing"] },
+        baseDir,
+      ),
+    ).resolves.toEqual(expect.objectContaining({ status: "approved" }));
+  });
+
   test("bootstrap-issued operator tokens accept handoff scopes and reject admin or pairing", async () => {
     const baseDir = await makeDevicePairingDir();
     const request = await requestDevicePairing(

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -3,7 +3,11 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { PAIRING_SETUP_BOOTSTRAP_PROFILE } from "../shared/device-bootstrap-profile.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
-import { issueDeviceBootstrapToken, verifyDeviceBootstrapToken } from "./device-bootstrap.js";
+import {
+  issueDeviceBootstrapToken,
+  resolveDeviceBootstrapTokenBindingId,
+  verifyDeviceBootstrapToken,
+} from "./device-bootstrap.js";
 import {
   loadOrCreateDeviceIdentity,
   publicKeyRawBase64UrlFromPem,
@@ -1066,6 +1070,95 @@ describe("device pairing tokens", () => {
         baseDir,
       ),
     ).resolves.toEqual(expect.objectContaining({ status: "approved" }));
+  });
+
+  test("bootstrap-marked pairing binds the token only after approval", async () => {
+    const baseDir = await makeDevicePairingDir();
+    const firstIdentity = loadOrCreateDeviceIdentity(path.join(baseDir, "first-device.json"));
+    const secondIdentity = loadOrCreateDeviceIdentity(path.join(baseDir, "second-device.json"));
+    const firstPublicKey = publicKeyRawBase64UrlFromPem(firstIdentity.publicKeyPem);
+    const secondPublicKey = publicKeyRawBase64UrlFromPem(secondIdentity.publicKeyPem);
+    const firstPayload = `openclaw-device-pairing-test:${firstIdentity.deviceId}`;
+    const secondPayload = `openclaw-device-pairing-test:${secondIdentity.deviceId}`;
+    const issued = await issueDeviceBootstrapToken({ baseDir });
+
+    await expect(
+      verifyDeviceBootstrapToken({
+        token: issued.token,
+        deviceId: firstIdentity.deviceId,
+        publicKey: firstPublicKey,
+        publicKeyProof: {
+          payload: firstPayload,
+          signature: signDevicePayload(firstIdentity.privateKeyPem, firstPayload),
+        },
+        role: "node",
+        scopes: [],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      verifyDeviceBootstrapToken({
+        token: issued.token,
+        deviceId: secondIdentity.deviceId,
+        publicKey: secondPublicKey,
+        publicKeyProof: {
+          payload: secondPayload,
+          signature: signDevicePayload(secondIdentity.privateKeyPem, secondPayload),
+        },
+        role: "node",
+        scopes: [],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    const request = await requestDevicePairing(
+      {
+        deviceId: firstIdentity.deviceId,
+        publicKey: firstPublicKey,
+        role: "node",
+        roles: PAIRING_SETUP_BOOTSTRAP_PROFILE.roles,
+        scopes: PAIRING_SETUP_BOOTSTRAP_PROFILE.scopes,
+        bootstrapProfile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
+        bootstrapTokenBindingId: resolveDeviceBootstrapTokenBindingId(issued.token),
+      },
+      baseDir,
+    );
+
+    await expect(
+      approveDevicePairing(
+        request.request.requestId,
+        { callerScopes: ["operator.pairing"] },
+        baseDir,
+      ),
+    ).resolves.toEqual(expect.objectContaining({ status: "approved" }));
+    await expect(
+      verifyDeviceBootstrapToken({
+        token: issued.token,
+        deviceId: firstIdentity.deviceId,
+        publicKey: firstPublicKey,
+        publicKeyProof: {
+          payload: firstPayload,
+          signature: signDevicePayload(firstIdentity.privateKeyPem, firstPayload),
+        },
+        role: "node",
+        scopes: [],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      verifyDeviceBootstrapToken({
+        token: issued.token,
+        deviceId: secondIdentity.deviceId,
+        publicKey: secondPublicKey,
+        publicKeyProof: {
+          payload: secondPayload,
+          signature: signDevicePayload(secondIdentity.privateKeyPem, secondPayload),
+        },
+        role: "node",
+        scopes: [],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
   });
 
   test("bootstrap-issued operator tokens accept handoff scopes and reject admin or pairing", async () => {

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -781,65 +781,6 @@ export async function approveBootstrapDevicePairing(
   });
 }
 
-export async function ensureBootstrapDeviceProfile(params: {
-  deviceId: string;
-  publicKey: string;
-  profile: DeviceBootstrapProfile;
-  baseDir?: string;
-}): Promise<PairedDevice | null> {
-  return await withLock(async () => {
-    const state = await loadState(params.baseDir);
-    const deviceId = normalizeDeviceId(params.deviceId);
-    const publicKey = params.publicKey.trim();
-    if (!deviceId || !publicKey) {
-      return null;
-    }
-    const existing = state.pairedByDeviceId[deviceId];
-    if (!existing || existing.publicKey !== publicKey) {
-      return null;
-    }
-    const approvedRoles = mergeRoles(params.profile.roles) ?? [];
-    if (approvedRoles.length === 0) {
-      return null;
-    }
-    const approvedScopes = resolveBootstrapProfileScopesForRoles(
-      approvedRoles,
-      params.profile.scopes,
-    );
-    const roles = mergeRoles(existing.roles, existing.role, approvedRoles);
-    const nextApprovedScopes = mergeScopes(
-      existing.approvedScopes ?? existing.scopes,
-      approvedScopes,
-    );
-    const tokens = cloneDeviceTokens(existing);
-    const now = Date.now();
-    for (const roleForToken of approvedRoles) {
-      const existingToken = tokens[roleForToken];
-      const tokenScopes =
-        roleForToken === OPERATOR_ROLE
-          ? resolveBootstrapProfileScopesForRole(roleForToken, approvedScopes)
-          : [];
-      tokens[roleForToken] = buildDeviceAuthToken({
-        role: roleForToken,
-        scopes: tokenScopes,
-        existing: existingToken,
-        now,
-        ...(existingToken ? { rotatedAtMs: now } : {}),
-      });
-    }
-    const device: PairedDevice = {
-      ...existing,
-      roles,
-      scopes: nextApprovedScopes ?? [],
-      approvedScopes: nextApprovedScopes ?? [],
-      tokens,
-    };
-    state.pairedByDeviceId[device.deviceId] = device;
-    await persistState(state, params.baseDir, "paired");
-    return device;
-  });
-}
-
 export async function rejectDevicePairing(
   requestId: string,
   baseDir?: string,

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -615,7 +615,14 @@ export async function approveDevicePairing(
     if (!pending) {
       return null;
     }
-    if (pending.bootstrapProfile && callerCanApproveBootstrapProfile(options?.callerScopes)) {
+    if (pending.bootstrapProfile) {
+      if (!callerCanApproveBootstrapProfile(options?.callerScopes)) {
+        return {
+          status: "forbidden",
+          reason: "caller-missing-scope",
+          scope: OPERATOR_PAIRING_SCOPE,
+        };
+      }
       const approved = approveBootstrapDevicePairingInState({
         state,
         requestId,

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -781,6 +781,65 @@ export async function approveBootstrapDevicePairing(
   });
 }
 
+export async function ensureBootstrapDeviceProfile(params: {
+  deviceId: string;
+  publicKey: string;
+  profile: DeviceBootstrapProfile;
+  baseDir?: string;
+}): Promise<PairedDevice | null> {
+  return await withLock(async () => {
+    const state = await loadState(params.baseDir);
+    const deviceId = normalizeDeviceId(params.deviceId);
+    const publicKey = params.publicKey.trim();
+    if (!deviceId || !publicKey) {
+      return null;
+    }
+    const existing = state.pairedByDeviceId[deviceId];
+    if (!existing || existing.publicKey !== publicKey) {
+      return null;
+    }
+    const approvedRoles = mergeRoles(params.profile.roles) ?? [];
+    if (approvedRoles.length === 0) {
+      return null;
+    }
+    const approvedScopes = resolveBootstrapProfileScopesForRoles(
+      approvedRoles,
+      params.profile.scopes,
+    );
+    const roles = mergeRoles(existing.roles, existing.role, approvedRoles);
+    const nextApprovedScopes = mergeScopes(
+      existing.approvedScopes ?? existing.scopes,
+      approvedScopes,
+    );
+    const tokens = cloneDeviceTokens(existing);
+    const now = Date.now();
+    for (const roleForToken of approvedRoles) {
+      const existingToken = tokens[roleForToken];
+      const tokenScopes =
+        roleForToken === OPERATOR_ROLE
+          ? resolveBootstrapProfileScopesForRole(roleForToken, approvedScopes)
+          : [];
+      tokens[roleForToken] = buildDeviceAuthToken({
+        role: roleForToken,
+        scopes: tokenScopes,
+        existing: existingToken,
+        now,
+        ...(existingToken ? { rotatedAtMs: now } : {}),
+      });
+    }
+    const device: PairedDevice = {
+      ...existing,
+      roles,
+      scopes: nextApprovedScopes ?? [],
+      approvedScopes: nextApprovedScopes ?? [],
+      tokens,
+    };
+    state.pairedByDeviceId[device.deviceId] = device;
+    await persistState(state, params.baseDir, "paired");
+    return device;
+  });
+}
+
 export async function rejectDevicePairing(
   requestId: string,
   baseDir?: string,

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -10,6 +10,7 @@ import {
   resolveScopeOutsideRequestedRoles,
   roleScopesAllow,
 } from "../shared/operator-scope-compat.js";
+import { bindDeviceBootstrapToken } from "./device-bootstrap.js";
 import {
   createAsyncLock,
   pruneExpiredPending,
@@ -35,6 +36,7 @@ export type DevicePairingPendingRequest = {
   roles?: string[];
   scopes?: string[];
   bootstrapProfile?: DeviceBootstrapProfile;
+  bootstrapTokenBindingId?: string;
   remoteIp?: string;
   silent?: boolean;
   isRepair?: boolean;
@@ -111,7 +113,8 @@ export type DevicePairingForbiddenReason =
   | "caller-missing-scope"
   | "scope-outside-requested-roles"
   | "bootstrap-role-not-allowed"
-  | "bootstrap-scope-not-allowed";
+  | "bootstrap-scope-not-allowed"
+  | "bootstrap-token-binding-mismatch";
 
 export type DevicePairingForbiddenResult = {
   status: "forbidden";
@@ -150,6 +153,8 @@ export function formatDevicePairingForbiddenMessage(result: DevicePairingForbidd
       return `bootstrap profile does not allow role: ${result.role ?? "unknown"}`;
     case "bootstrap-scope-not-allowed":
       return `bootstrap profile does not allow scope: ${result.scope ?? "unknown"}`;
+    case "bootstrap-token-binding-mismatch":
+      return "bootstrap token is bound to a different device";
   }
   throw new Error("Unsupported device pairing forbidden reason");
 }
@@ -339,6 +344,9 @@ function samePendingApprovalSnapshot(
   ) {
     return false;
   }
+  if (existing.bootstrapTokenBindingId !== incoming.bootstrapTokenBindingId) {
+    return false;
+  }
   return true;
 }
 
@@ -356,6 +364,7 @@ function refreshPendingDevicePairingRequest(
     clientId: incoming.clientId ?? existing.clientId,
     clientMode: incoming.clientMode ?? existing.clientMode,
     bootstrapProfile: incoming.bootstrapProfile ?? existing.bootstrapProfile,
+    bootstrapTokenBindingId: incoming.bootstrapTokenBindingId ?? existing.bootstrapTokenBindingId,
     remoteIp: incoming.remoteIp ?? existing.remoteIp,
     // If either request is interactive, keep the pending request visible for approval.
     silent: Boolean(existing.silent && incoming.silent),
@@ -396,6 +405,7 @@ function buildPendingDevicePairingRequest(params: {
     roles: mergeRoles(params.req.roles, role),
     scopes: mergeScopes(params.req.scopes),
     bootstrapProfile: params.req.bootstrapProfile,
+    bootstrapTokenBindingId: params.req.bootstrapTokenBindingId,
     remoteIp: params.req.remoteIp,
     silent: params.req.silent,
     isRepair: params.isRepair,
@@ -407,6 +417,22 @@ function callerCanApproveBootstrapProfile(callerScopes: readonly string[] | unde
   return Boolean(
     callerScopes?.includes(OPERATOR_PAIRING_SCOPE) || callerScopes?.includes(OPERATOR_ADMIN_SCOPE),
   );
+}
+
+async function bindBootstrapTokenForPending(
+  pending: DevicePairingPendingRequest,
+  baseDir: string | undefined,
+): Promise<DevicePairingForbiddenResult | null> {
+  if (!pending.bootstrapTokenBindingId) {
+    return null;
+  }
+  const bound = await bindDeviceBootstrapToken({
+    tokenBindingId: pending.bootstrapTokenBindingId,
+    deviceId: pending.deviceId,
+    publicKey: pending.publicKey,
+    baseDir,
+  });
+  return bound.ok ? null : { status: "forbidden", reason: "bootstrap-token-binding-mismatch" };
 }
 
 function newToken() {
@@ -568,6 +594,9 @@ export async function requestDevicePairing(
           ...existing.map((pending) => pending.scopes),
           incoming.scopes,
         );
+        const bootstrapProfile = incoming.bootstrapProfile ?? latestPending?.bootstrapProfile;
+        const bootstrapTokenBindingId =
+          incoming.bootstrapTokenBindingId ?? latestPending?.bootstrapTokenBindingId;
         return buildPendingDevicePairingRequest({
           deviceId,
           isRepair,
@@ -576,6 +605,8 @@ export async function requestDevicePairing(
             role: normalizeRole(incoming.role) ?? latestPending?.role,
             roles: mergedRoles,
             scopes: mergedScopes,
+            bootstrapProfile,
+            bootstrapTokenBindingId,
             // Preserve interactive visibility when superseding pending requests:
             // if any previous pending request was interactive, keep this one interactive.
             silent: resolveSupersededPendingSilent({
@@ -630,6 +661,10 @@ export async function approveDevicePairing(
         bootstrapProfile: pending.bootstrapProfile,
       });
       if (approved.status === "approved") {
+        const bindingFailure = await bindBootstrapTokenForPending(pending, baseDir);
+        if (bindingFailure) {
+          return bindingFailure;
+        }
         await persistState(state, baseDir, "both");
       }
       return approved;
@@ -832,6 +867,10 @@ export async function approveBootstrapDevicePairing(
       bootstrapProfile,
     });
     if (approved.status === "approved") {
+      const bindingFailure = await bindBootstrapTokenForPending(pending, baseDir);
+      if (bindingFailure) {
+        return bindingFailure;
+      }
       await persistState(state, baseDir, "both");
     }
     return approved;

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -34,6 +34,7 @@ export type DevicePairingPendingRequest = {
   role?: string;
   roles?: string[];
   scopes?: string[];
+  bootstrapProfile?: DeviceBootstrapProfile;
   remoteIp?: string;
   silent?: boolean;
   isRepair?: boolean;
@@ -131,6 +132,8 @@ type DevicePairingStateFile = {
 
 const PENDING_TTL_MS = 5 * 60 * 1000;
 const OPERATOR_ROLE = "operator";
+const OPERATOR_ADMIN_SCOPE = "operator.admin";
+const OPERATOR_PAIRING_SCOPE = "operator.pairing";
 const OPERATOR_SCOPE_PREFIX = "operator.";
 
 const withLock = createAsyncLock();
@@ -327,6 +330,15 @@ function samePendingApprovalSnapshot(
   ) {
     return false;
   }
+  if (
+    !sameStringSet(
+      existing.bootstrapProfile?.roles ?? [],
+      incoming.bootstrapProfile?.roles ?? [],
+    ) ||
+    !sameStringSet(existing.bootstrapProfile?.scopes ?? [], incoming.bootstrapProfile?.scopes ?? [])
+  ) {
+    return false;
+  }
   return true;
 }
 
@@ -343,6 +355,7 @@ function refreshPendingDevicePairingRequest(
     deviceFamily: incoming.deviceFamily ?? existing.deviceFamily,
     clientId: incoming.clientId ?? existing.clientId,
     clientMode: incoming.clientMode ?? existing.clientMode,
+    bootstrapProfile: incoming.bootstrapProfile ?? existing.bootstrapProfile,
     remoteIp: incoming.remoteIp ?? existing.remoteIp,
     // If either request is interactive, keep the pending request visible for approval.
     silent: Boolean(existing.silent && incoming.silent),
@@ -382,11 +395,18 @@ function buildPendingDevicePairingRequest(params: {
     role,
     roles: mergeRoles(params.req.roles, role),
     scopes: mergeScopes(params.req.scopes),
+    bootstrapProfile: params.req.bootstrapProfile,
     remoteIp: params.req.remoteIp,
     silent: params.req.silent,
     isRepair: params.isRepair,
     ts: Date.now(),
   };
+}
+
+function callerCanApproveBootstrapProfile(callerScopes: readonly string[] | undefined): boolean {
+  return Boolean(
+    callerScopes?.includes(OPERATOR_PAIRING_SCOPE) || callerScopes?.includes(OPERATOR_ADMIN_SCOPE),
+  );
 }
 
 function newToken() {
@@ -595,6 +615,18 @@ export async function approveDevicePairing(
     if (!pending) {
       return null;
     }
+    if (pending.bootstrapProfile && callerCanApproveBootstrapProfile(options?.callerScopes)) {
+      const approved = approveBootstrapDevicePairingInState({
+        state,
+        requestId,
+        pending,
+        bootstrapProfile: pending.bootstrapProfile,
+      });
+      if (approved.status === "approved") {
+        await persistState(state, baseDir, "both");
+      }
+      return approved;
+    }
     const requestedRoles = mergeRoles(pending.roles, pending.role) ?? [];
     const requestedScopes = normalizeDeviceAuthScopes(pending.scopes);
     const roleMismatchScope = resolveScopeOutsideRequestedRoles({
@@ -687,6 +719,91 @@ export async function approveDevicePairing(
   });
 }
 
+function approveBootstrapDevicePairingInState(params: {
+  state: DevicePairingStateFile;
+  requestId: string;
+  pending: DevicePairingPendingRequest;
+  bootstrapProfile: DeviceBootstrapProfile;
+}): Exclude<ApproveDevicePairingResult, null> {
+  const { state, requestId, pending, bootstrapProfile } = params;
+  const approvedRoles = mergeRoles(bootstrapProfile.roles) ?? [];
+  const approvedScopes = resolveBootstrapProfileScopesForRoles(
+    approvedRoles,
+    bootstrapProfile.scopes,
+  );
+  const requestedRoles = resolveRequestedRoles(pending);
+  const missingRole = requestedRoles.find((role) => !approvedRoles.includes(role));
+  if (missingRole) {
+    return { status: "forbidden", reason: "bootstrap-role-not-allowed", role: missingRole };
+  }
+  const requestedOperatorScopes = normalizeDeviceAuthScopes(pending.scopes).filter((scope) =>
+    scope.startsWith(OPERATOR_SCOPE_PREFIX),
+  );
+  const missingScope = resolveMissingRequestedScope({
+    role: OPERATOR_ROLE,
+    requestedScopes: requestedOperatorScopes,
+    allowedScopes: approvedScopes,
+  });
+  if (missingScope) {
+    return { status: "forbidden", reason: "bootstrap-scope-not-allowed", scope: missingScope };
+  }
+
+  const now = Date.now();
+  const existing = state.pairedByDeviceId[pending.deviceId];
+  const roles = mergeRoles(
+    existing?.roles,
+    existing?.role,
+    pending.roles,
+    pending.role,
+    approvedRoles,
+  );
+  const nextApprovedScopes = mergeScopes(
+    existing?.approvedScopes ?? existing?.scopes,
+    pending.scopes,
+    approvedScopes,
+  );
+  const sanitizedApprovedScopes = resolveBootstrapProfileScopesForRoles(
+    approvedRoles,
+    nextApprovedScopes ?? [],
+  );
+  const tokens = existing?.tokens ? { ...existing.tokens } : {};
+  for (const roleForToken of approvedRoles) {
+    const existingToken = tokens[roleForToken];
+    const tokenScopes =
+      roleForToken === OPERATOR_ROLE
+        ? resolveBootstrapProfileScopesForRole(roleForToken, approvedScopes)
+        : [];
+    tokens[roleForToken] = buildDeviceAuthToken({
+      role: roleForToken,
+      scopes: tokenScopes,
+      existing: existingToken,
+      now,
+      ...(existingToken ? { rotatedAtMs: now } : {}),
+    });
+  }
+
+  const device: PairedDevice = {
+    deviceId: pending.deviceId,
+    publicKey: pending.publicKey,
+    displayName: pending.displayName,
+    platform: pending.platform,
+    deviceFamily: pending.deviceFamily,
+    clientId: pending.clientId,
+    clientMode: pending.clientMode,
+    role: pending.role,
+    roles,
+    scopes: sanitizedApprovedScopes,
+    approvedScopes: sanitizedApprovedScopes,
+    remoteIp: pending.remoteIp,
+    tokens,
+    createdAtMs: existing?.createdAtMs ?? now,
+    approvedAtMs: now,
+  };
+  delete state.pendingById[requestId];
+  state.pairedByDeviceId[device.deviceId] = device;
+  return { status: "approved", requestId, device };
+}
+
 export async function approveBootstrapDevicePairing(
   requestId: string,
   bootstrapProfile: DeviceBootstrapProfile,
@@ -695,89 +812,22 @@ export async function approveBootstrapDevicePairing(
   // QR bootstrap handoff is an explicit trust path: it can seed the bounded
   // node/operator baseline from the verified bootstrap profile without routing
   // operator scope approval through the generic interactive approval checker.
-  const approvedRoles = mergeRoles(bootstrapProfile.roles) ?? [];
-  const approvedScopes = resolveBootstrapProfileScopesForRoles(
-    approvedRoles,
-    bootstrapProfile.scopes,
-  );
   return await withLock(async () => {
     const state = await loadState(baseDir);
     const pending = state.pendingById[requestId];
     if (!pending) {
       return null;
     }
-    const requestedRoles = resolveRequestedRoles(pending);
-    const missingRole = requestedRoles.find((role) => !approvedRoles.includes(role));
-    if (missingRole) {
-      return { status: "forbidden", reason: "bootstrap-role-not-allowed", role: missingRole };
-    }
-    const requestedOperatorScopes = normalizeDeviceAuthScopes(pending.scopes).filter((scope) =>
-      scope.startsWith(OPERATOR_SCOPE_PREFIX),
-    );
-    const missingScope = resolveMissingRequestedScope({
-      role: OPERATOR_ROLE,
-      requestedScopes: requestedOperatorScopes,
-      allowedScopes: approvedScopes,
+    const approved = approveBootstrapDevicePairingInState({
+      state,
+      requestId,
+      pending,
+      bootstrapProfile,
     });
-    if (missingScope) {
-      return { status: "forbidden", reason: "bootstrap-scope-not-allowed", scope: missingScope };
+    if (approved.status === "approved") {
+      await persistState(state, baseDir, "both");
     }
-
-    const now = Date.now();
-    const existing = state.pairedByDeviceId[pending.deviceId];
-    const roles = mergeRoles(
-      existing?.roles,
-      existing?.role,
-      pending.roles,
-      pending.role,
-      approvedRoles,
-    );
-    const nextApprovedScopes = mergeScopes(
-      existing?.approvedScopes ?? existing?.scopes,
-      pending.scopes,
-      approvedScopes,
-    );
-    const sanitizedApprovedScopes = resolveBootstrapProfileScopesForRoles(
-      approvedRoles,
-      nextApprovedScopes ?? [],
-    );
-    const tokens = existing?.tokens ? { ...existing.tokens } : {};
-    for (const roleForToken of approvedRoles) {
-      const existingToken = tokens[roleForToken];
-      const tokenScopes =
-        roleForToken === OPERATOR_ROLE
-          ? resolveBootstrapProfileScopesForRole(roleForToken, approvedScopes)
-          : [];
-      tokens[roleForToken] = buildDeviceAuthToken({
-        role: roleForToken,
-        scopes: tokenScopes,
-        existing: existingToken,
-        now,
-        ...(existingToken ? { rotatedAtMs: now } : {}),
-      });
-    }
-
-    const device: PairedDevice = {
-      deviceId: pending.deviceId,
-      publicKey: pending.publicKey,
-      displayName: pending.displayName,
-      platform: pending.platform,
-      deviceFamily: pending.deviceFamily,
-      clientId: pending.clientId,
-      clientMode: pending.clientMode,
-      role: pending.role,
-      roles,
-      scopes: sanitizedApprovedScopes,
-      approvedScopes: sanitizedApprovedScopes,
-      remoteIp: pending.remoteIp,
-      tokens,
-      createdAtMs: existing?.createdAtMs ?? now,
-      approvedAtMs: now,
-    };
-    delete state.pendingById[requestId];
-    state.pairedByDeviceId[device.deviceId] = device;
-    await persistState(state, baseDir, "both");
-    return { status: "approved", requestId, device };
+    return approved;
   });
 }
 


### PR DESCRIPTION
## Summary

- Problem: Bootstrap token verification could bind a submitted device identity after matching only the token bytes.
- Why it matters: The stored device identity should only be accepted after the caller proves control of the submitted key.
- What changed: `verifyDeviceBootstrapToken` now checks the device id, submitted public key, and a signature proof before recording the binding; the gateway forwards the already-verified connect challenge payload into that verifier.
- What did NOT change (scope boundary): The existing bootstrap profile, silent pairing flow, token TTL, and invalid-token error path are unchanged.

AI-assisted: Yes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Bootstrap token auth now requires a matching device key proof before binding the identity tuple.
- Real environment tested: Not run in this automation step.
- Exact steps or command run after this patch: Not run; command execution for verification was restricted by the supervisor.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): N/A
- Observed result after fix: N/A
- What was not tested: Runtime gateway pairing flow and test suite execution.
- Before evidence (optional but encouraged): N/A

## Root Cause (if applicable)

- Root cause: Bootstrap token verification recorded the submitted device identity after token matching without requiring proof that the caller controlled the submitted public key.
- Missing detection / guardrail: There was no regression coverage for missing key proof, mismatched proof, or a mismatched device id during initial bootstrap binding.
- Contributing context (if known): The gateway already verified the connect challenge signature, but the bootstrap verifier did not receive that proof as part of its own decision boundary.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/device-bootstrap.test.ts`, `src/infra/device-pairing.test.ts`, `src/gateway/server/ws-connection/auth-context.test.ts`
- Scenario the test should lock in: Bootstrap verification rejects missing proof, proof from a different key, mismatched device id, and forwards the verified challenge payload through gateway auth context.
- Why this is the smallest reliable guardrail: It checks the verifier boundary directly and the gateway seam that supplies the proof.
- Existing test that already covers this (if any): Existing bootstrap binding tests covered token/profile behavior but not key proof.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Bootstrap-token auth with missing or invalid device key proof now fails through the existing invalid bootstrap token path.

## Diagram (if applicable)

```text
Before:
connect token + claimed identity -> token match -> identity binding

After:
connect token + claimed identity + challenge signature -> token match -> key proof check -> identity binding
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: Bootstrap token verification now also requires a matching public-key proof before identity binding; no new token material is stored.

## Repro + Verification

### Environment

- OS: Not run
- Runtime/container: Not run
- Model/provider: N/A
- Integration/channel (if any): Gateway bootstrap pairing
- Relevant config (redacted): N/A

### Steps

1. Exercise a bootstrap token connect request with a device signature over the gateway challenge.
2. Repeat with missing proof, mismatched proof, and mismatched device id.
3. Confirm only the matching proof path can bind the bootstrap record.

### Expected

- Matching proof succeeds.
- Missing, mismatched, or split identity proof fails with the existing invalid bootstrap token response.

### Actual

- Not run in this automation step.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Static review of affected verifier, gateway auth seam, and regression call sites.
- Edge cases checked: Missing proof, proof signed by another identity, mismatched device id, equivalent public-key encodings, and post-binding second identity rejection.
- What you did **not** verify: Runtime gateway flow or automated tests, due supervisor command restrictions.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Older or out-of-tree callers of bootstrap verification may not supply public-key proof.
  - Mitigation: Gateway connect auth now passes the verified challenge payload, and invalid requests use the existing invalid-token failure path.
