### PR TITLE
fix(agents): preserve subagent final delivery through retryable failures

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -783,6 +783,37 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("reports permanent requester-agent delivery errors structurally", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("chat not found");
+    }) as unknown as typeof runtimeCallGateway;
+
+    const result = await deliverTelegramDirectMessageCompletion({
+      callGateway,
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:worker:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "telegram completion",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "child completion output",
+          replyInstruction: "Summarize the result.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: false,
+      path: "direct",
+      error: "chat not found",
+      retryable: false,
+    });
+  });
+
   it("does not raw-send grouped child results when requester-agent output is empty", async () => {
     const callGateway = createGatewayMock({
       result: {
@@ -1011,6 +1042,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
           path: "direct",
           error:
             "active requester session could not be woken: queue_message_failed reason=not_streaming sessionId=requester-session-telegram gatewayHealth=live",
+          retryable: true,
         },
         {
           phase: "queue-fallback",

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -255,6 +255,13 @@ function isPermanentAnnounceDeliveryError(error: unknown): boolean {
   );
 }
 
+function resolveAnnounceDeliveryRetryable(error: unknown): boolean {
+  if (isPermanentAnnounceDeliveryError(error)) {
+    return false;
+  }
+  return true;
+}
+
 async function waitForAnnounceRetryDelay(ms: number, signal?: AbortSignal): Promise<void> {
   if (ms <= 0) {
     return;
@@ -719,6 +726,7 @@ async function sendSubagentAnnounceDirectly(params: {
             "active requester session could not be woken",
             wakeOutcome,
           ),
+          retryable: true,
         };
       }
     }
@@ -798,6 +806,7 @@ async function sendSubagentAnnounceDirectly(params: {
         delivered: false,
         path: "direct",
         error: "completion agent did not deliver through the message tool",
+        retryable: true,
       };
     }
     const directDeliveryFailure = shouldDeliverAgentFinal
@@ -808,6 +817,7 @@ async function sendSubagentAnnounceDirectly(params: {
         delivered: false,
         path: "direct",
         error: directDeliveryFailure,
+        retryable: resolveAnnounceDeliveryRetryable(directDeliveryFailure),
       };
     }
     if (
@@ -819,6 +829,7 @@ async function sendSubagentAnnounceDirectly(params: {
         delivered: false,
         path: "direct",
         error: "completion agent did not produce a visible reply",
+        retryable: true,
       };
     }
 
@@ -831,6 +842,7 @@ async function sendSubagentAnnounceDirectly(params: {
       delivered: false,
       path: "direct",
       error: summarizeDeliveryError(err),
+      retryable: resolveAnnounceDeliveryRetryable(err),
     };
   }
 }

--- a/src/agents/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagent-announce-dispatch.test.ts
@@ -116,6 +116,7 @@ describe("runSubagentAnnounceDispatch", () => {
       delivered: false,
       path: "direct" as const,
       error: "failed",
+      retryable: false,
     }));
 
     const result = await runSubagentAnnounceDispatch({
@@ -127,8 +128,15 @@ describe("runSubagentAnnounceDispatch", () => {
     expect(result.delivered).toBe(false);
     expect(result.path).toBe("direct");
     expect(result.error).toBe("failed");
+    expect(result.retryable).toBe(false);
     expect(result.phases).toEqual([
-      { phase: "direct-primary", delivered: false, path: "direct", error: "failed" },
+      {
+        phase: "direct-primary",
+        delivered: false,
+        path: "direct",
+        error: "failed",
+        retryable: false,
+      },
       { phase: "queue-fallback", delivered: false, path: "none", error: undefined },
     ]);
   });

--- a/src/agents/subagent-announce-dispatch.ts
+++ b/src/agents/subagent-announce-dispatch.ts
@@ -6,6 +6,7 @@ export type SubagentAnnounceDeliveryResult = {
   delivered: boolean;
   path: SubagentDeliveryPath;
   error?: string;
+  retryable?: boolean;
   phases?: SubagentAnnounceDispatchPhaseResult[];
 };
 
@@ -16,6 +17,7 @@ type SubagentAnnounceDispatchPhaseResult = {
   delivered: boolean;
   path: SubagentDeliveryPath;
   error?: string;
+  retryable?: boolean;
 };
 
 export function mapQueueOutcomeToDeliveryResult(
@@ -50,12 +52,16 @@ export async function runSubagentAnnounceDispatch(params: {
     phase: SubagentAnnounceDispatchPhase,
     result: SubagentAnnounceDeliveryResult,
   ) => {
-    phases.push({
+    const phaseResult: SubagentAnnounceDispatchPhaseResult = {
       phase,
       delivered: result.delivered,
       path: result.path,
       error: result.error,
-    });
+    };
+    if (result.retryable !== undefined) {
+      phaseResult.retryable = result.retryable;
+    }
+    phases.push(phaseResult);
   };
   const withPhases = (result: SubagentAnnounceDeliveryResult): SubagentAnnounceDeliveryResult => ({
     ...result,

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -294,6 +294,38 @@ describe("subagent announce seam flow", () => {
     });
   });
 
+  it("deletes delete-mode completion child sessions after ANNOUNCE_SKIP", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-session-delete-skip",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "thread-bound cleanup",
+      timeoutMs: 10,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "ANNOUNCE_SKIP",
+      spawnMode: "session",
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).not.toHaveBeenCalled();
+    expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
+    expect(sessionsDeleteSpy).toHaveBeenCalledWith({
+      method: "sessions.delete",
+      params: {
+        key: "agent:main:subagent:test",
+        deleteTranscript: true,
+        emitLifecycleHooks: true,
+      },
+      timeoutMs: 10_000,
+    });
+  });
+
   it("keeps lifecycle hooks enabled when deleting a completed session-mode child session", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:test",
@@ -323,6 +355,35 @@ describe("subagent announce seam flow", () => {
       },
       timeoutMs: 10_000,
     });
+  });
+
+  it("does not delete delete-mode completion child sessions after transient failed delivery", async () => {
+    agentSpy.mockRejectedValueOnce(new Error("gateway timeout after 120000ms"));
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-session-delete-transient-failure",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "-100123",
+        accountId: "default",
+      },
+      task: "thread-bound cleanup",
+      timeoutMs: 10,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "completed",
+      spawnMode: "session",
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(false);
+    expect(sessionsDeleteSpy).not.toHaveBeenCalled();
   });
 
   it("uses origin.provider for channel-specific queue settings in active announce delivery", async () => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -252,6 +252,7 @@ export async function runSubagentAnnounceFlow(params: {
   const expectsCompletionMessage = params.expectsCompletionMessage === true;
   const announceType = params.announceType ?? "subagent task";
   let shouldDeleteChildSession = params.cleanup === "delete";
+  let shouldSuppressDeleteForFailedCompletionDelivery = false;
   try {
     let targetRequesterSessionKey = params.requesterSessionKey;
     let targetRequesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
@@ -541,32 +542,43 @@ export async function runSubagentAnnounceFlow(params: {
           })
         : targetRequesterOrigin;
     const directIdempotencyKey = buildAnnounceIdempotencyKey(announceId);
-    const delivery = await deliverSubagentAnnouncement({
-      requesterSessionKey: targetRequesterSessionKey,
-      announceId,
-      triggerMessage,
-      steerMessage: triggerMessage,
-      internalEvents,
-      summaryLine: taskLabel,
-      requesterSessionOrigin: targetRequesterOrigin,
-      requesterOrigin:
-        expectsCompletionMessage && !requesterIsSubagent
-          ? completionDirectOrigin
-          : targetRequesterOrigin,
-      completionDirectOrigin,
-      directOrigin,
-      sourceSessionKey: params.childSessionKey,
-      sourceChannel: INTERNAL_MESSAGE_CHANNEL,
-      sourceTool: "subagent_announce",
-      targetRequesterSessionKey,
-      requesterIsSubagent,
-      expectsCompletionMessage: expectsCompletionMessage,
-      bestEffortDeliver: params.bestEffortDeliver,
-      directIdempotencyKey,
-      signal: params.signal,
-    });
+    let delivery: SubagentAnnounceDeliveryResult;
+    try {
+      delivery = await deliverSubagentAnnouncement({
+        requesterSessionKey: targetRequesterSessionKey,
+        announceId,
+        triggerMessage,
+        steerMessage: triggerMessage,
+        internalEvents,
+        summaryLine: taskLabel,
+        requesterSessionOrigin: targetRequesterOrigin,
+        requesterOrigin:
+          expectsCompletionMessage && !requesterIsSubagent
+            ? completionDirectOrigin
+            : targetRequesterOrigin,
+        completionDirectOrigin,
+        directOrigin,
+        sourceSessionKey: params.childSessionKey,
+        sourceChannel: INTERNAL_MESSAGE_CHANNEL,
+        sourceTool: "subagent_announce",
+        targetRequesterSessionKey,
+        requesterIsSubagent,
+        expectsCompletionMessage: expectsCompletionMessage,
+        bestEffortDeliver: params.bestEffortDeliver,
+        directIdempotencyKey,
+        signal: params.signal,
+      });
+    } catch (err) {
+      if (expectsCompletionMessage) {
+        shouldSuppressDeleteForFailedCompletionDelivery = true;
+      }
+      throw err;
+    }
     params.onDeliveryResult?.(delivery);
     didAnnounce = delivery.delivered;
+    if (expectsCompletionMessage && !delivery.delivered) {
+      shouldSuppressDeleteForFailedCompletionDelivery = true;
+    }
     if (!delivery.delivered && delivery.path === "direct" && delivery.error) {
       defaultRuntime.error?.(
         `Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,
@@ -587,6 +599,9 @@ export async function runSubagentAnnounceFlow(params: {
       } catch {
         // Best-effort
       }
+    }
+    if (shouldSuppressDeleteForFailedCompletionDelivery) {
+      shouldDeleteChildSession = false;
     }
     if (shouldDeleteChildSession) {
       await deleteSubagentSessionForCleanup({

--- a/src/agents/subagent-final-delivery-state.test.ts
+++ b/src/agents/subagent-final-delivery-state.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  loadFinalDeliveryState,
+  recordFinalDeliveryFailure,
+  recordFinalDeliverySuccess,
+  resolveFinalDeliveryResumeDecision,
+} from "./subagent-final-delivery-state.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+function makeEntry(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
+  return {
+    runId: "run-1",
+    childSessionKey: "agent:main:subagent:child",
+    requesterSessionKey: "agent:main:main",
+    requesterDisplayKey: "main",
+    task: "test",
+    cleanup: "keep",
+    createdAt: 0,
+    endedAt: 1_000,
+    expectsCompletionMessage: true,
+    ...overrides,
+  };
+}
+
+describe("subagent final delivery state", () => {
+  it("keeps transient completion delivery retryable past the normal announce retry count", () => {
+    const entry = makeEntry({ announceRetryCount: 3 });
+
+    const state = recordFinalDeliveryFailure({
+      entry,
+      now: 2_000,
+      hardExpiryMs: 30 * 60_000,
+      retryDelayMs: 8_000,
+      error: {
+        message: "gateway timeout after 120000ms",
+        retryability: "transient",
+        path: "direct",
+      },
+    });
+
+    expect(state).toEqual({
+      kind: "retrying",
+      attemptCount: 4,
+      nextRetryAt: 10_000,
+      lastError: {
+        message: "gateway timeout after 120000ms",
+        retryability: "transient",
+        path: "direct",
+      },
+    });
+    expect(entry.pendingFinalDelivery).toBe(true);
+    expect(entry.cleanupCompletedAt).toBeUndefined();
+  });
+
+  it("makes permanent completion delivery failure terminal", () => {
+    const entry = makeEntry();
+
+    const state = recordFinalDeliveryFailure({
+      entry,
+      now: 2_000,
+      hardExpiryMs: 30 * 60_000,
+      retryDelayMs: 1_000,
+      error: {
+        message: "chat not found",
+        retryability: "permanent",
+        path: "direct",
+      },
+    });
+
+    expect(state).toEqual({
+      kind: "terminal_failed",
+      reason: "permanent-failure",
+      error: {
+        message: "chat not found",
+        retryability: "permanent",
+        path: "direct",
+      },
+    });
+    expect(entry.pendingFinalDelivery).toBeUndefined();
+    expect(entry.lastAnnounceDeliveryRetryable).toBe(false);
+  });
+
+  it("hard-expires pending completion delivery", () => {
+    const entry = makeEntry({
+      finalDeliveryState: {
+        kind: "retrying",
+        attemptCount: 5,
+        nextRetryAt: 20_000,
+        lastError: {
+          message: "gateway timeout",
+          retryability: "transient",
+          path: "direct",
+        },
+      },
+    });
+
+    expect(
+      loadFinalDeliveryState({
+        entry,
+        now: 31 * 60_000,
+        hardExpiryMs: 30 * 60_000,
+      }),
+    ).toEqual({
+      kind: "expired",
+      expiredAt: 31 * 60_000,
+      lastError: {
+        message: "gateway timeout",
+        retryability: "transient",
+        path: "direct",
+      },
+    });
+  });
+
+  it("schedules retry on resume until retry time is due", () => {
+    const entry = makeEntry({
+      finalDeliveryState: {
+        kind: "retrying",
+        attemptCount: 2,
+        nextRetryAt: 5_000,
+      },
+    });
+
+    expect(
+      resolveFinalDeliveryResumeDecision({
+        entry,
+        now: 4_000,
+        hardExpiryMs: 30 * 60_000,
+      }),
+    ).toEqual({ kind: "schedule", delayMs: 1_000 });
+    expect(
+      resolveFinalDeliveryResumeDecision({
+        entry,
+        now: 5_000,
+        hardExpiryMs: 30 * 60_000,
+      }),
+    ).toEqual({ kind: "attempt" });
+  });
+
+  it("marks delivered state terminal for cleanup", () => {
+    const entry = makeEntry({
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryPayload: {
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        childSessionKey: "agent:main:subagent:child",
+        childRunId: "run-1",
+        task: "test",
+      },
+    });
+
+    recordFinalDeliverySuccess(entry, 4_000);
+
+    expect(entry.finalDeliveryState).toEqual({ kind: "delivered", deliveredAt: 4_000 });
+    expect(entry.completionAnnouncedAt).toBe(4_000);
+    expect(entry.pendingFinalDelivery).toBeUndefined();
+    expect(entry.pendingFinalDeliveryPayload).toBeUndefined();
+  });
+});

--- a/src/agents/subagent-final-delivery-state.ts
+++ b/src/agents/subagent-final-delivery-state.ts
@@ -1,26 +1,16 @@
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
+import type {
+  FinalDeliveryError,
+  FinalDeliveryState,
+  FinalDeliveryTerminalReason,
+} from "./subagent-final-delivery.types.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
-export type FinalDeliveryError = {
-  message: string;
-  retryability: "transient" | "permanent" | "unknown";
-  path: "queued" | "steered" | "direct" | "none";
-};
-
-export type FinalDeliveryState =
-  | { kind: "not_required" }
-  | { kind: "pending"; attemptCount: number; lastError?: FinalDeliveryError }
-  | {
-      kind: "retrying";
-      attemptCount: number;
-      nextRetryAt: number;
-      lastError?: FinalDeliveryError;
-    }
-  | { kind: "delivered"; deliveredAt: number }
-  | { kind: "terminal_failed"; reason: "permanent-failure"; error: FinalDeliveryError }
-  | { kind: "expired"; expiredAt: number; lastError?: FinalDeliveryError };
-
-export type FinalDeliveryTerminalReason = "permanent-failure" | "expiry";
+export type {
+  FinalDeliveryError,
+  FinalDeliveryState,
+  FinalDeliveryTerminalReason,
+} from "./subagent-final-delivery.types.js";
 
 type FinalDeliveryEvent =
   | { type: "delivered"; deliveredAt: number }

--- a/src/agents/subagent-final-delivery-state.ts
+++ b/src/agents/subagent-final-delivery-state.ts
@@ -1,0 +1,325 @@
+import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+export type FinalDeliveryError = {
+  message: string;
+  retryability: "transient" | "permanent" | "unknown";
+  path: "queued" | "steered" | "direct" | "none";
+};
+
+export type FinalDeliveryState =
+  | { kind: "not_required" }
+  | { kind: "pending"; attemptCount: number; lastError?: FinalDeliveryError }
+  | {
+      kind: "retrying";
+      attemptCount: number;
+      nextRetryAt: number;
+      lastError?: FinalDeliveryError;
+    }
+  | { kind: "delivered"; deliveredAt: number }
+  | { kind: "terminal_failed"; reason: "permanent-failure"; error: FinalDeliveryError }
+  | { kind: "expired"; expiredAt: number; lastError?: FinalDeliveryError };
+
+export type FinalDeliveryTerminalReason = "permanent-failure" | "expiry";
+
+type FinalDeliveryEvent =
+  | { type: "delivered"; deliveredAt: number }
+  | {
+      type: "failed";
+      now: number;
+      error: FinalDeliveryError;
+      retryDelayMs: number;
+      hardExpiryAt?: number;
+    }
+  | { type: "hard_expiry_reached"; expiredAt: number }
+  | { type: "not_required" };
+
+export function isFinalDeliveryTerminal(state: FinalDeliveryState): boolean {
+  return (
+    state.kind === "not_required" ||
+    state.kind === "delivered" ||
+    state.kind === "terminal_failed" ||
+    state.kind === "expired"
+  );
+}
+
+export function finalDeliveryTerminalReason(
+  state: FinalDeliveryState,
+): FinalDeliveryTerminalReason | undefined {
+  if (state.kind === "terminal_failed") {
+    return state.reason;
+  }
+  if (state.kind === "expired") {
+    return "expiry";
+  }
+  return undefined;
+}
+
+export function normalizeFinalDeliveryError(
+  delivery: SubagentAnnounceDeliveryResult,
+  fallbackMessage: string,
+): FinalDeliveryError {
+  const message = delivery.error?.trim() || fallbackMessage;
+  const retryability =
+    delivery.retryable === false
+      ? "permanent"
+      : delivery.retryable === true
+        ? "transient"
+        : "unknown";
+  return {
+    message,
+    retryability,
+    path: delivery.path,
+  };
+}
+
+export function reduceFinalDeliveryState(
+  state: FinalDeliveryState,
+  event: FinalDeliveryEvent,
+): FinalDeliveryState {
+  if (event.type === "not_required") {
+    return { kind: "not_required" };
+  }
+  if (event.type === "delivered") {
+    return { kind: "delivered", deliveredAt: event.deliveredAt };
+  }
+  if (event.type === "hard_expiry_reached") {
+    return lastErrorForState(state)
+      ? { kind: "expired", expiredAt: event.expiredAt, lastError: lastErrorForState(state) }
+      : { kind: "expired", expiredAt: event.expiredAt };
+  }
+  if (event.error.retryability === "permanent") {
+    return { kind: "terminal_failed", reason: "permanent-failure", error: event.error };
+  }
+  if (event.hardExpiryAt !== undefined && event.now >= event.hardExpiryAt) {
+    return { kind: "expired", expiredAt: event.now, lastError: event.error };
+  }
+  const attemptCount = attemptCountForState(state) + 1;
+  return {
+    kind: "retrying",
+    attemptCount,
+    nextRetryAt: event.now + event.retryDelayMs,
+    lastError: event.error,
+  };
+}
+
+export function loadFinalDeliveryState(params: {
+  entry: SubagentRunRecord;
+  now: number;
+  hardExpiryMs: number;
+}): FinalDeliveryState {
+  const { entry, now, hardExpiryMs } = params;
+  if (entry.expectsCompletionMessage !== true) {
+    return { kind: "not_required" };
+  }
+  if (typeof entry.completionAnnouncedAt === "number") {
+    return { kind: "delivered", deliveredAt: entry.completionAnnouncedAt };
+  }
+  const hardExpiryAt = typeof entry.endedAt === "number" ? entry.endedAt + hardExpiryMs : undefined;
+  const stored = entry.finalDeliveryState;
+  if (
+    stored &&
+    stored.kind !== "not_required" &&
+    stored.kind !== "delivered" &&
+    stored.kind !== "terminal_failed" &&
+    stored.kind !== "expired" &&
+    hardExpiryAt !== undefined &&
+    now >= hardExpiryAt
+  ) {
+    return reduceFinalDeliveryState(stored, {
+      type: "hard_expiry_reached",
+      expiredAt: now,
+    });
+  }
+  if (stored) {
+    return stored;
+  }
+  if (hardExpiryAt !== undefined && now >= hardExpiryAt) {
+    return { kind: "expired", expiredAt: now };
+  }
+  if (entry.pendingFinalDelivery === true || typeof entry.endedAt === "number") {
+    const lastError = legacyFinalDeliveryError(entry);
+    if (lastError?.retryability === "permanent") {
+      return { kind: "terminal_failed", reason: "permanent-failure", error: lastError };
+    }
+    const attemptCount = entry.pendingFinalDeliveryAttemptCount ?? entry.announceRetryCount ?? 0;
+    return lastError
+      ? { kind: "pending", attemptCount, lastError }
+      : { kind: "pending", attemptCount };
+  }
+  return { kind: "pending", attemptCount: 0 };
+}
+
+export function recordFinalDeliverySuccess(entry: SubagentRunRecord, deliveredAt: number): void {
+  writeFinalDeliveryState(entry, { kind: "delivered", deliveredAt }, deliveredAt);
+}
+
+export function recordFinalDeliveryFailure(params: {
+  entry: SubagentRunRecord;
+  now: number;
+  hardExpiryMs: number;
+  retryDelayMs: number;
+  error: FinalDeliveryError;
+}): FinalDeliveryState {
+  const current = loadFinalDeliveryState({
+    entry: params.entry,
+    now: params.now,
+    hardExpiryMs: params.hardExpiryMs,
+  });
+  const hardExpiryAt =
+    typeof params.entry.endedAt === "number"
+      ? params.entry.endedAt + params.hardExpiryMs
+      : undefined;
+  const next = reduceFinalDeliveryState(current, {
+    type: "failed",
+    now: params.now,
+    error: params.error,
+    retryDelayMs: params.retryDelayMs,
+    hardExpiryAt,
+  });
+  writeFinalDeliveryState(params.entry, next, params.now);
+  return next;
+}
+
+export function writeFinalDeliveryState(
+  entry: SubagentRunRecord,
+  state: FinalDeliveryState,
+  now: number,
+): void {
+  entry.finalDeliveryState = state;
+  if (state.kind === "not_required") {
+    clearPendingFinalDelivery(entry);
+    return;
+  }
+  if (state.kind === "delivered") {
+    entry.completionAnnouncedAt = state.deliveredAt;
+    clearPendingFinalDelivery(entry);
+    entry.lastAnnounceDeliveryError = undefined;
+    entry.lastAnnounceDeliveryRetryable = undefined;
+    return;
+  }
+  if (state.kind === "terminal_failed") {
+    clearPendingFinalDelivery(entry);
+    entry.lastAnnounceDeliveryError = state.error.message;
+    entry.lastAnnounceDeliveryRetryable = false;
+    return;
+  }
+  if (state.kind === "expired") {
+    clearPendingFinalDelivery(entry);
+    entry.lastAnnounceDeliveryError = state.lastError?.message ?? entry.lastAnnounceDeliveryError;
+    entry.lastAnnounceDeliveryRetryable = state.lastError
+      ? state.lastError.retryability !== "permanent"
+      : entry.lastAnnounceDeliveryRetryable;
+    return;
+  }
+  entry.pendingFinalDelivery = true;
+  entry.pendingFinalDeliveryCreatedAt ??= now;
+  entry.pendingFinalDeliveryLastAttemptAt = now;
+  entry.pendingFinalDeliveryAttemptCount = state.attemptCount;
+  entry.pendingFinalDeliveryLastError = state.lastError?.message ?? null;
+  entry.pendingFinalDeliveryLastRetryable = state.lastError
+    ? state.lastError.retryability !== "permanent"
+    : undefined;
+  entry.lastAnnounceDeliveryError = state.lastError?.message;
+  entry.lastAnnounceDeliveryRetryable = state.lastError
+    ? state.lastError.retryability !== "permanent"
+    : undefined;
+  if (state.kind === "retrying") {
+    entry.lastAnnounceRetryAt = now;
+    entry.announceRetryCount = state.attemptCount;
+  }
+}
+
+export function resolveFinalDeliveryResumeDecision(params: {
+  entry: SubagentRunRecord;
+  now: number;
+  hardExpiryMs: number;
+}):
+  | { kind: "complete"; reason?: FinalDeliveryTerminalReason }
+  | { kind: "attempt" }
+  | { kind: "schedule"; delayMs: number } {
+  const state = loadFinalDeliveryState(params);
+  const terminalReason = finalDeliveryTerminalReason(state);
+  if (terminalReason) {
+    writeFinalDeliveryState(params.entry, state, params.now);
+    return { kind: "complete", reason: terminalReason };
+  }
+  if (state.kind === "not_required" || state.kind === "delivered") {
+    writeFinalDeliveryState(params.entry, state, params.now);
+    return { kind: "complete" };
+  }
+  if (state.kind === "retrying" && params.now < state.nextRetryAt) {
+    return { kind: "schedule", delayMs: Math.max(1, state.nextRetryAt - params.now) };
+  }
+  return { kind: "attempt" };
+}
+
+export function hasRetryablePendingFinalDeliveryPayload(params: {
+  entry: SubagentRunRecord;
+  now: number;
+  hardExpiryMs: number;
+}): boolean {
+  const { entry } = params;
+  if (entry.expectsCompletionMessage !== true) {
+    return false;
+  }
+  const payload = entry.pendingFinalDeliveryPayload;
+  if (!payload) {
+    return false;
+  }
+  if (
+    !hasText(payload.requesterSessionKey) ||
+    !hasText(payload.requesterDisplayKey) ||
+    !hasText(payload.childSessionKey) ||
+    !hasText(payload.childRunId) ||
+    !hasText(payload.task)
+  ) {
+    return false;
+  }
+  const state = loadFinalDeliveryState(params);
+  return state.kind === "pending" || state.kind === "retrying";
+}
+
+function lastErrorForState(state: FinalDeliveryState): FinalDeliveryError | undefined {
+  if (state.kind === "pending" || state.kind === "retrying" || state.kind === "expired") {
+    return state.lastError;
+  }
+  if (state.kind === "terminal_failed") {
+    return state.error;
+  }
+  return undefined;
+}
+
+function attemptCountForState(state: FinalDeliveryState): number {
+  if (state.kind === "pending" || state.kind === "retrying") {
+    return state.attemptCount;
+  }
+  return 0;
+}
+
+function legacyFinalDeliveryError(entry: SubagentRunRecord): FinalDeliveryError | undefined {
+  const message = (entry.pendingFinalDeliveryLastError ?? entry.lastAnnounceDeliveryError)?.trim();
+  if (!message) {
+    return undefined;
+  }
+  const retryable = entry.pendingFinalDeliveryLastRetryable ?? entry.lastAnnounceDeliveryRetryable;
+  return {
+    message,
+    retryability: retryable === false ? "permanent" : retryable === true ? "transient" : "unknown",
+    path: "none",
+  };
+}
+
+function hasText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function clearPendingFinalDelivery(entry: SubagentRunRecord): void {
+  entry.pendingFinalDelivery = undefined;
+  entry.pendingFinalDeliveryCreatedAt = undefined;
+  entry.pendingFinalDeliveryLastAttemptAt = undefined;
+  entry.pendingFinalDeliveryAttemptCount = undefined;
+  entry.pendingFinalDeliveryLastError = undefined;
+  entry.pendingFinalDeliveryLastRetryable = undefined;
+  entry.pendingFinalDeliveryPayload = undefined;
+}

--- a/src/agents/subagent-final-delivery.types.ts
+++ b/src/agents/subagent-final-delivery.types.ts
@@ -1,0 +1,20 @@
+export type FinalDeliveryError = {
+  message: string;
+  retryability: "transient" | "permanent" | "unknown";
+  path: "queued" | "steered" | "direct" | "none";
+};
+
+export type FinalDeliveryState =
+  | { kind: "not_required" }
+  | { kind: "pending"; attemptCount: number; lastError?: FinalDeliveryError }
+  | {
+      kind: "retrying";
+      attemptCount: number;
+      nextRetryAt: number;
+      lastError?: FinalDeliveryError;
+    }
+  | { kind: "delivered"; deliveredAt: number }
+  | { kind: "terminal_failed"; reason: "permanent-failure"; error: FinalDeliveryError }
+  | { kind: "expired"; expiredAt: number; lastError?: FinalDeliveryError };
+
+export type FinalDeliveryTerminalReason = "permanent-failure" | "expiry";

--- a/src/agents/subagent-registry-cleanup.test.ts
+++ b/src/agents/subagent-registry-cleanup.test.ts
@@ -76,6 +76,16 @@ describe("resolveDeferredCleanupDecision", () => {
     expect(decision).toEqual({ kind: "retry", retryCount: 2, resumeDelayMs: 2_000 });
   });
 
+  it("keeps completion-message cleanup retryable past the regular retry limit", () => {
+    const decision = resolveDecision({
+      entry: makeEntry({ expectsCompletionMessage: true, announceRetryCount: 3 }),
+      activeDescendantRuns: 0,
+      resolveAnnounceRetryDelayMs: (retryCount) => retryCount * 1_000,
+    });
+
+    expect(decision).toEqual({ kind: "retry", retryCount: 4, resumeDelayMs: 4_000 });
+  });
+
   it("uses retry backoff for non-completion flows so cleanup can settle after announce failures", () => {
     const decision = resolveDecision({
       entry: makeEntry({ expectsCompletionMessage: false, announceRetryCount: 1 }),

--- a/src/agents/subagent-registry-cleanup.ts
+++ b/src/agents/subagent-registry-cleanup.ts
@@ -1,4 +1,9 @@
 import {
+  finalDeliveryTerminalReason,
+  loadFinalDeliveryState,
+  type FinalDeliveryTerminalReason,
+} from "./subagent-final-delivery-state.js";
+import {
   SUBAGENT_ENDED_REASON_COMPLETE,
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
@@ -11,7 +16,7 @@ type DeferredCleanupDecision =
     }
   | {
       kind: "give-up";
-      reason: "retry-limit" | "expiry";
+      reason: "retry-limit" | FinalDeliveryTerminalReason;
       retryCount?: number;
     }
   | {
@@ -44,6 +49,17 @@ export function resolveDeferredCleanupDecision(params: {
   const isCompletionMessageFlow = params.entry.expectsCompletionMessage === true;
   const completionHardExpiryExceeded =
     isCompletionMessageFlow && endedAgo > params.announceCompletionHardExpiryMs;
+  if (isCompletionMessageFlow) {
+    const finalDeliveryState = loadFinalDeliveryState({
+      entry: params.entry,
+      now: params.now,
+      hardExpiryMs: params.announceCompletionHardExpiryMs,
+    });
+    const terminalReason = finalDeliveryTerminalReason(finalDeliveryState);
+    if (terminalReason) {
+      return { kind: "give-up", reason: terminalReason };
+    }
+  }
   if (isCompletionMessageFlow && params.activeDescendantRuns > 0) {
     if (completionHardExpiryExceeded) {
       return { kind: "give-up", reason: "expiry" };
@@ -55,7 +71,10 @@ export function resolveDeferredCleanupDecision(params: {
   const expiryExceeded = isCompletionMessageFlow
     ? completionHardExpiryExceeded
     : endedAgo > params.announceExpiryMs;
-  if (retryCount >= params.maxAnnounceRetryCount || expiryExceeded) {
+  if (isCompletionMessageFlow && expiryExceeded) {
+    return { kind: "give-up", reason: "expiry", retryCount };
+  }
+  if (!isCompletionMessageFlow && (retryCount >= params.maxAnnounceRetryCount || expiryExceeded)) {
     return {
       kind: "give-up",
       reason: retryCount >= params.maxAnnounceRetryCount ? "retry-limit" : "expiry",

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -12,6 +12,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { defaultRuntime } from "../runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { withSubagentOutcomeTiming } from "./subagent-announce-output.js";
+import { hasRetryablePendingFinalDeliveryPayload } from "./subagent-final-delivery-state.js";
 import { SUBAGENT_ENDED_REASON_ERROR } from "./subagent-lifecycle-events.js";
 import { shouldUpdateRunOutcome } from "./subagent-registry-completion.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -64,7 +65,10 @@ export function resolveAnnounceRetryDelayMs(retryCount: number) {
   return Math.min(baseDelay, MAX_ANNOUNCE_RETRY_DELAY_MS);
 }
 
-export function logAnnounceGiveUp(entry: SubagentRunRecord, reason: "retry-limit" | "expiry") {
+export function logAnnounceGiveUp(
+  entry: SubagentRunRecord,
+  reason: "retry-limit" | "expiry" | "permanent-failure",
+) {
   const retryCount = entry.announceRetryCount ?? 0;
   const endedAgoMs =
     typeof entry.endedAt === "number" ? Math.max(0, Date.now() - entry.endedAt) : undefined;
@@ -325,6 +329,15 @@ export function reconcileOrphanedRestoredRuns(params: {
       now,
     });
     if (!orphanReason) {
+      continue;
+    }
+    if (
+      hasRetryablePendingFinalDeliveryPayload({
+        entry,
+        now,
+        hardExpiryMs: ANNOUNCE_COMPLETION_HARD_EXPIRY_MS,
+      })
+    ) {
       continue;
     }
     if (

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -15,6 +15,13 @@ import { retireSessionMcpRuntimeForSessionKey } from "./pi-bundle-mcp-tools.js";
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
 import { type SubagentRunOutcome, withSubagentOutcomeTiming } from "./subagent-announce-output.js";
 import {
+  recordFinalDeliveryFailure,
+  recordFinalDeliverySuccess,
+  writeFinalDeliveryState,
+  type FinalDeliveryError,
+  type FinalDeliveryTerminalReason,
+} from "./subagent-final-delivery-state.js";
+import {
   SUBAGENT_ENDED_REASON_COMPLETE,
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
@@ -327,6 +334,7 @@ export function createSubagentRegistryLifecycleController(params: {
     entry.pendingFinalDeliveryLastAttemptAt = undefined;
     entry.pendingFinalDeliveryAttemptCount = undefined;
     entry.pendingFinalDeliveryLastError = undefined;
+    entry.pendingFinalDeliveryLastRetryable = undefined;
     entry.pendingFinalDeliveryPayload = undefined;
   };
 
@@ -360,24 +368,73 @@ export function createSubagentRegistryLifecycleController(params: {
     };
   };
 
-  const markPendingFinalDelivery = (args: { entry: SubagentRunRecord; error?: string }) => {
+  const markPendingFinalDelivery = (args: {
+    entry: SubagentRunRecord;
+    error: FinalDeliveryError;
+    retryDelayMs: number;
+  }) => {
     const now = Date.now();
     const payload: PendingFinalDeliveryPayload = loadPendingFinalDeliveryPayload(args.entry);
 
-    args.entry.pendingFinalDelivery = true;
-    args.entry.pendingFinalDeliveryCreatedAt ??= now;
-    args.entry.pendingFinalDeliveryLastAttemptAt = now;
-    args.entry.pendingFinalDeliveryAttemptCount =
-      (args.entry.pendingFinalDeliveryAttemptCount ?? 0) + 1;
-    args.entry.pendingFinalDeliveryLastError = args.error ?? null;
+    recordFinalDeliveryFailure({
+      entry: args.entry,
+      now,
+      hardExpiryMs: ANNOUNCE_COMPLETION_HARD_EXPIRY_MS,
+      retryDelayMs: args.retryDelayMs,
+      error: args.error,
+    });
     args.entry.pendingFinalDeliveryPayload = payload;
+  };
+
+  const buildStoredFinalDeliveryError = (
+    entry: SubagentRunRecord,
+    fallbackMessage: string,
+  ): FinalDeliveryError => {
+    const retryability =
+      entry.lastAnnounceDeliveryRetryable === false
+        ? "permanent"
+        : entry.lastAnnounceDeliveryRetryable === true
+          ? "transient"
+          : "unknown";
+    return {
+      message: entry.lastAnnounceDeliveryError ?? fallbackMessage,
+      retryability,
+      path: "none",
+    };
+  };
+
+  const deleteChildSessionForTerminalCleanup = async (args: {
+    runId: string;
+    entry: SubagentRunRecord;
+  }) => {
+    if (args.entry.cleanup !== "delete") {
+      return;
+    }
+    await deleteSubagentSessionForCleanup({
+      callGateway: params.callGateway,
+      childSessionKey: args.entry.childSessionKey,
+      spawnMode: args.entry.spawnMode,
+      onError: (error) =>
+        params.warn("sessions.delete failed during terminal subagent cleanup", {
+          error: buildSafeLifecycleErrorMeta(error),
+          runId: maskRunId(args.runId),
+          childSessionKey: maskSessionKey(args.entry.childSessionKey),
+        }),
+    });
   };
 
   const finalizeResumedAnnounceGiveUp = async (giveUpParams: {
     runId: string;
     entry: SubagentRunRecord;
-    reason: "retry-limit" | "expiry";
+    reason: "retry-limit" | FinalDeliveryTerminalReason;
   }) => {
+    if (giveUpParams.entry.expectsCompletionMessage === true && giveUpParams.reason === "expiry") {
+      writeFinalDeliveryState(
+        giveUpParams.entry,
+        { kind: "expired", expiredAt: Date.now() },
+        Date.now(),
+      );
+    }
     clearPendingFinalDelivery(giveUpParams.entry);
     safeSetSubagentTaskDeliveryStatus({
       runId: giveUpParams.runId,
@@ -393,6 +450,10 @@ export function createSubagentRegistryLifecycleController(params: {
     if (shouldDeleteAttachments) {
       await safeRemoveAttachmentsDir(giveUpParams.entry);
     }
+    await deleteChildSessionForTerminalCleanup({
+      runId: giveUpParams.runId,
+      entry: giveUpParams.entry,
+    });
     const completionReason = resolveCleanupCompletionReason(giveUpParams.entry);
     logAnnounceGiveUp(giveUpParams.entry, giveUpParams.reason);
     // Retry-limit / expiry give-up should not leave cleanup stuck behind the
@@ -545,7 +606,11 @@ export function createSubagentRegistryLifecycleController(params: {
         entry.completionAnnouncedAt = Date.now();
         params.persist();
       }
-      clearPendingFinalDelivery(entry);
+      if (entry.expectsCompletionMessage === true) {
+        recordFinalDeliverySuccess(entry, entry.completionAnnouncedAt ?? Date.now());
+      } else {
+        clearPendingFinalDelivery(entry);
+      }
       if (!options?.skipDeliveryStatus) {
         safeSetSubagentTaskDeliveryStatus({
           runId,
@@ -598,12 +663,40 @@ export function createSubagentRegistryLifecycleController(params: {
       return;
     }
 
-    if (deferredDecision.retryCount != null) {
+    if (deferredDecision.retryCount != null && entry.expectsCompletionMessage !== true) {
       entry.announceRetryCount = deferredDecision.retryCount;
       entry.lastAnnounceRetryAt = now;
     }
 
     if (deferredDecision.kind === "give-up") {
+      if (entry.expectsCompletionMessage === true && deferredDecision.reason === "expiry") {
+        writeFinalDeliveryState(
+          entry,
+          {
+            kind: "expired",
+            expiredAt: now,
+            lastError: buildStoredFinalDeliveryError(entry, "completion final delivery expired"),
+          },
+          now,
+        );
+      }
+      if (
+        entry.expectsCompletionMessage === true &&
+        deferredDecision.reason === "permanent-failure"
+      ) {
+        writeFinalDeliveryState(
+          entry,
+          {
+            kind: "terminal_failed",
+            reason: "permanent-failure",
+            error: buildStoredFinalDeliveryError(
+              entry,
+              "completion final delivery permanently failed",
+            ),
+          },
+          now,
+        );
+      }
       clearPendingFinalDelivery(entry);
       safeSetSubagentTaskDeliveryStatus({
         runId,
@@ -618,6 +711,7 @@ export function createSubagentRegistryLifecycleController(params: {
       if (shouldDeleteAttachments) {
         await safeRemoveAttachmentsDir(entry);
       }
+      await deleteChildSessionForTerminalCleanup({ runId, entry });
       const completionReason = resolveCleanupCompletionReason(entry);
       logAnnounceGiveUp(entry, deferredDecision.reason);
       // Giving up on announce delivery is terminal for cleanup even if the
@@ -634,7 +728,10 @@ export function createSubagentRegistryLifecycleController(params: {
 
     markPendingFinalDelivery({
       entry,
-      error: didAnnounce ? undefined : "announce deferred or direct delivery failed",
+      error: buildStoredFinalDeliveryError(entry, "announce deferred or direct delivery failed"),
+      retryDelayMs:
+        deferredDecision.resumeDelayMs ??
+        resolveAnnounceRetryDelayMs(deferredDecision.retryCount ?? entry.announceRetryCount ?? 0),
     });
     entry.cleanupHandled = false;
     params.resumedRuns.delete(runId);
@@ -738,14 +835,19 @@ export function createSubagentRegistryLifecycleController(params: {
           if (delivery.delivered) {
             if (entry.lastAnnounceDeliveryError !== undefined) {
               entry.lastAnnounceDeliveryError = undefined;
+              entry.lastAnnounceDeliveryRetryable = undefined;
               params.persist();
             }
             latestDeliveryError = undefined;
             return;
           }
           latestDeliveryError = formatAnnounceDeliveryError(delivery);
-          if (entry.lastAnnounceDeliveryError !== latestDeliveryError) {
+          if (
+            entry.lastAnnounceDeliveryError !== latestDeliveryError ||
+            entry.lastAnnounceDeliveryRetryable !== delivery.retryable
+          ) {
             entry.lastAnnounceDeliveryError = latestDeliveryError;
+            entry.lastAnnounceDeliveryRetryable = delivery.retryable;
             params.persist();
           }
         },

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -645,6 +645,63 @@ describe("subagent registry persistence", () => {
     expect(listSubagentRunsForRequester("agent:main:main")).toHaveLength(0);
   });
 
+  it("does not prune retryable pending completion delivery when child session is missing on restore", async () => {
+    const now = Date.now();
+    const registryPath = await writePersistedRegistry(
+      {
+        version: 2,
+        runs: {
+          "run-pending-final-delivery": {
+            runId: "run-pending-final-delivery",
+            childSessionKey: "agent:main:subagent:missing-child",
+            requesterSessionKey: "agent:main:main",
+            requesterDisplayKey: "main",
+            task: "retry final delivery",
+            cleanup: "delete",
+            createdAt: now - 2_000,
+            startedAt: now - 1_000,
+            endedAt: now,
+            outcome: { status: "ok" },
+            expectsCompletionMessage: true,
+            pendingFinalDelivery: true,
+            pendingFinalDeliveryPayload: {
+              requesterSessionKey: "agent:main:main",
+              requesterDisplayKey: "main",
+              childSessionKey: "agent:main:subagent:missing-child",
+              childRunId: "run-pending-final-delivery",
+              task: "retry final delivery",
+              endedAt: now,
+              outcome: { status: "ok" },
+              expectsCompletionMessage: true,
+              frozenResultText: "final output",
+            },
+          },
+        },
+      },
+      { seedChildSessions: false },
+    );
+
+    announceSpy.mockResolvedValueOnce(false);
+    restartRegistry();
+    await waitForRegistryWork(async () => announceSpy.mock.calls.length === 1);
+
+    const announceCalls = announceSpy.mock.calls as unknown as Array<
+      [{ childSessionKey?: string; cleanup?: string; expectsCompletionMessage?: boolean }]
+    >;
+    const announceParams = announceCalls[0]?.[0];
+    expectFields(announceParams, {
+      childSessionKey: "agent:main:subagent:missing-child",
+      cleanup: "delete",
+      expectsCompletionMessage: true,
+    });
+    const after = await readPersistedRun<{
+      pendingFinalDelivery?: boolean;
+      cleanupCompletedAt?: number;
+    }>(registryPath, "run-pending-final-delivery");
+    expect(after?.pendingFinalDelivery).toBe(true);
+    expect(after?.cleanupCompletedAt).toBeUndefined();
+  });
+
   it("reconciles stale unended restored runs that are not restart-recoverable", async () => {
     const now = Date.now();
     const runId = "run-stale-unended-restore";

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -728,7 +728,7 @@ describe("subagent registry steer restarts", () => {
     expect(countMatching(childRunIds, (id) => id === "run-child")).toBe(1);
   });
 
-  it("retries completion-mode announce delivery with backoff and then gives up after retry limit", async () => {
+  it("retries completion-mode announce delivery past the regular retry limit", async () => {
     {
       vi.useFakeTimers();
       try {
@@ -759,8 +759,9 @@ describe("subagent registry steer restarts", () => {
         expect(listMainRuns()[0]?.announceRetryCount).toBe(3);
 
         await vi.advanceTimersByTimeAsync(4_001);
-        expect(announceSpy).toHaveBeenCalledTimes(3);
-        expect(listMainRuns()[0]?.cleanupCompletedAt).toBeTypeOf("number");
+        expect(announceSpy).toHaveBeenCalledTimes(4);
+        expect(listMainRuns()[0]?.pendingFinalDelivery).toBe(true);
+        expect(listMainRuns()[0]?.cleanupCompletedAt).toBeUndefined();
       } finally {
         vi.useRealTimers();
       }

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -559,7 +559,7 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
-  it("deletes delete-mode completion runs when announce cleanup gives up after retry limit", async () => {
+  it("keeps delete-mode completion runs retryable past the announce retry limit", async () => {
     mocks.runSubagentAnnounceFlow.mockResolvedValue(false);
     const endedAt = Date.parse("2026-03-24T12:00:00Z");
     mocks.callGateway.mockResolvedValueOnce({
@@ -595,15 +595,20 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(3);
 
     await vi.advanceTimersByTimeAsync(4_000);
-    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(3);
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(4);
     expect(
       mod
         .listSubagentRunsForRequester("agent:main:main")
         .find((entry) => entry.runId === "run-delete-give-up"),
-    ).toBeUndefined();
+    ).toMatchObject({
+      runId: "run-delete-give-up",
+      cleanup: "delete",
+      pendingFinalDelivery: true,
+    });
   });
 
-  it("finalizes retry-budgeted completion delete runs during resume", async () => {
+  it("retries retry-budgeted completion delete runs during resume", async () => {
+    mocks.runSubagentAnnounceFlow.mockResolvedValue(false);
     const endedHookRunner = {
       hasHooks: (hookName: string) => hookName === "subagent_ended",
       runSubagentEnded: mocks.runSubagentEnded,
@@ -634,22 +639,23 @@ describe("subagent registry seam flow", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
     await waitForFast(() => {
-      expect(mocks.runSubagentEnded).toHaveBeenCalledTimes(1);
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
     });
-    await waitForFast(() => {
-      expect(mocks.onSubagentEnded).toHaveBeenCalledWith({
-        childSessionKey: "agent:main:subagent:child",
-        reason: "deleted",
-        workspaceDir: undefined,
-      });
+    expect(mocks.runSubagentEnded).not.toHaveBeenCalled();
+    expect(mocks.onSubagentEnded).not.toHaveBeenCalledWith({
+      childSessionKey: "agent:main:subagent:child",
+      reason: "deleted",
+      workspaceDir: undefined,
     });
     expect(
       mod
         .listSubagentRunsForRequester("agent:main:main")
         .find((entry) => entry.runId === "run-resume-delete"),
-    ).toBeUndefined();
+    ).toMatchObject({
+      runId: "run-resume-delete",
+      pendingFinalDelivery: true,
+    });
   });
 
   it("finalizes expired delete-mode parents when descendant cleanup retriggers deferred announce handling", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -21,6 +21,10 @@ import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from 
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
 import {
+  hasRetryablePendingFinalDeliveryPayload,
+  resolveFinalDeliveryResumeDecision,
+} from "./subagent-final-delivery-state.js";
+import {
   SUBAGENT_ENDED_REASON_COMPLETE,
   SUBAGENT_ENDED_REASON_ERROR,
   SUBAGENT_ENDED_REASON_KILLED,
@@ -31,6 +35,7 @@ import {
   resolveLifecycleOutcomeFromRunOutcome,
 } from "./subagent-registry-completion.js";
 import {
+  ANNOUNCE_COMPLETION_HARD_EXPIRY_MS,
   ANNOUNCE_EXPIRY_MS,
   MAX_ANNOUNCE_RETRY_COUNT,
   reconcileOrphanedRestoredRuns,
@@ -594,7 +599,41 @@ function resumeSubagentRun(runId: string) {
     return;
   }
   // Skip entries that have exhausted their retry budget or expired (#18264).
-  if ((entry.announceRetryCount ?? 0) >= MAX_ANNOUNCE_RETRY_COUNT) {
+  if (entry.expectsCompletionMessage === true && typeof entry.endedAt === "number") {
+    const finalDeliveryDecision = resolveFinalDeliveryResumeDecision({
+      entry,
+      now: Date.now(),
+      hardExpiryMs: ANNOUNCE_COMPLETION_HARD_EXPIRY_MS,
+    });
+    if (finalDeliveryDecision.kind === "complete") {
+      if (finalDeliveryDecision.reason) {
+        void finalizeResumedAnnounceGiveUp({
+          runId,
+          entry,
+          reason: finalDeliveryDecision.reason,
+        });
+        return;
+      }
+    } else if (finalDeliveryDecision.kind === "schedule") {
+      const scheduledEntry = entry;
+      const timer = setTimeout(() => {
+        resumeRetryTimers.delete(timer);
+        if (subagentRuns.get(runId) !== scheduledEntry) {
+          return;
+        }
+        resumedRuns.delete(runId);
+        resumeSubagentRun(runId);
+      }, finalDeliveryDecision.delayMs);
+      timer.unref?.();
+      resumeRetryTimers.add(timer);
+      resumedRuns.add(runId);
+      return;
+    }
+  }
+  if (
+    entry.expectsCompletionMessage !== true &&
+    (entry.announceRetryCount ?? 0) >= MAX_ANNOUNCE_RETRY_COUNT
+  ) {
     void finalizeResumedAnnounceGiveUp({
       runId,
       entry,
@@ -641,7 +680,12 @@ function resumeSubagentRun(runId: string) {
 
   if (typeof entry.endedAt === "number" && entry.endedAt > 0) {
     const orphanReason = resolveSubagentRunOrphanReason({ entry });
-    if (orphanReason) {
+    const canRetryFinalDeliveryFromPayload = hasRetryablePendingFinalDeliveryPayload({
+      entry,
+      now,
+      hardExpiryMs: ANNOUNCE_COMPLETION_HARD_EXPIRY_MS,
+    });
+    if (orphanReason && !canRetryFinalDeliveryFromPayload) {
       if (
         reconcileOrphanedRun({
           runId,

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -1,6 +1,6 @@
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
-import type { FinalDeliveryState } from "./subagent-final-delivery-state.js";
+import type { FinalDeliveryState } from "./subagent-final-delivery.types.js";
 import type { SubagentLifecycleEndedReason } from "./subagent-lifecycle-events.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -1,5 +1,6 @@
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
+import type { FinalDeliveryState } from "./subagent-final-delivery-state.js";
 import type { SubagentLifecycleEndedReason } from "./subagent-lifecycle-events.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 
@@ -51,6 +52,8 @@ export type SubagentRunRecord = {
   announceRetryCount?: number;
   lastAnnounceRetryAt?: number;
   lastAnnounceDeliveryError?: string;
+  lastAnnounceDeliveryRetryable?: boolean;
+  finalDeliveryState?: FinalDeliveryState;
   endedReason?: SubagentLifecycleEndedReason;
   pauseReason?: "sessions_yield";
   wakeOnDescendantSettle?: boolean;
@@ -66,6 +69,7 @@ export type SubagentRunRecord = {
   pendingFinalDeliveryLastAttemptAt?: number;
   pendingFinalDeliveryAttemptCount?: number;
   pendingFinalDeliveryLastError?: string | null;
+  pendingFinalDeliveryLastRetryable?: boolean;
   pendingFinalDeliveryPayload?: PendingFinalDeliveryPayload;
   completionAnnouncedAt?: number;
   attachmentsDir?: string;


### PR DESCRIPTION
## Summary

- Problem: sub-agent completion delivery was treated as terminal from the ordinary run lifecycle, so a transient Gateway/websocket delivery failure could prune the child before the requester session received final output.
- Why it matters: parent agents can wait forever for child output after the Gateway hits announce-back timeouts, making chat sessions look non-responsive even though the child finished.
- What changed: final delivery now has a durable state machine that distinguishes retryable pending delivery from delivered, terminal failed, expired, and not-required states; cleanup waits for final delivery to become terminal.
- What did NOT change (scope boundary): no channel transport, Gateway timeout, model runtime, UI, docs, or plugin behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79032
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: sub-agent completion announce-back survives retryable final-delivery failures instead of deleting or pruning the child run before the parent can receive the result.
- Real environment tested: local OpenClaw checkout on macOS with Node 22/pnpm workspace dependencies after rebasing on `upstream/main`; production lifecycle smoke ran with `OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-empty-80911.json` to avoid unrelated local plugin config warnings.
- Exact steps or command run after this patch:
  - `pnpm check:madge-import-cycles`
  - `pnpm check:architecture`
  - `pnpm test src/agents/subagent-final-delivery-state.test.ts -- --reporter=verbose`
  - `pnpm check:changed --base upstream/main`
  - `git diff --check`
  - Production lifecycle smoke: `OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-empty-80911.json node --import tsx --input-type=module`, importing `createSubagentRegistryLifecycleController`, injecting one retryable final-delivery timeout from `runSubagentAnnounceFlow`, then retrying the same cleanup flow to delivery success.
- Evidence after fix (terminal capture / copied live output):
  - Import-cycle repair commit: `87f3bb0c5c2c04b71e6eac2ed0e7af18f0d9582c`.
  - Architecture gate: `pnpm check:architecture` reported `Import cycle check: 0 runtime value cycle(s).`, `Madge import cycle check: 0 cycle(s).`, `deprecated API usage guard passed`, and `deprecated JSDoc guard passed`.
  - Focused state test: `Test Files 1 passed (1)`, `Tests 5 passed (5)`, `passed 1 Vitest shard in 2.37s`.
  - Changed gate: `pnpm check:changed --base upstream/main` reported `lanes=core, coreTests`, typecheck core, typecheck core tests, lint core, runtime sidecar loader guard, runtime import cycles, webhook body guard, and pairing guards all exited 0.
  - Terminal output from production lifecycle smoke:

    ```text
    setup run=proof-final-delivery-retry cleanup=keep expectsCompletionMessage=true
    cleanupBrowserSessionsForLifecycleEnd agent:proof:subagent:child
    delivery attempt 1: retryable timeout
    after retryable failure {"retained":true,"cleanupHandled":false,"cleanupCompleted":false,"finalDeliveryState":{"kind":"retrying","attemptCount":1,"lastError":{"message":"simulated Gateway websocket timeout after 10000ms","retryability":"transient","path":"none"}},"pendingFinalDelivery":true,"pendingPayload":true,"persistCount":4,"resumeCalls":0}
    delivery attempt 2: delivered
    after retry success {"retained":true,"cleanupHandled":true,"cleanupCompleted":true,"finalDeliveryState":{"kind":"delivered"},"pendingFinalDelivery":null,"pendingPayload":false,"completionAnnouncedAt":true,"notified":["completed"],"warnings":[],"persistCount":8,"deliveryAttempt":2}
    ```
- Observed result after fix: a retryable completion-delivery timeout leaves the run retained, cleanup not completed, `finalDeliveryState.kind=retrying`, `pendingFinalDelivery=true`, and a stored payload available for retry; the next delivery attempt marks `finalDeliveryState.kind=delivered`, clears pending final-delivery state, records `completionAnnouncedAt`, and completes cleanup.
- What was not tested: a live external messaging-channel Gateway timeout over a 30-60 minute saturation window; this PR proves the local production lifecycle contract that preserves and retries the final-delivery payload after the failure mode from #79032.
- Before evidence (optional but encouraged): issue #79032 reports 10-second Gateway WS announce-back timeouts where parent agents never receive child output.

## Root Cause (if applicable)

- Root cause: final result delivery reused ordinary retry/terminalization semantics, so retryable announce-back failures and child cleanup could race each other without a durable final-delivery state.
- Missing detection / guardrail: tests covered announce success paths and ordinary retry paths, but not retryable final-delivery preservation across cleanup and restore.
- Contributing context (if known): completion delivery has several fallback routes, but cleanup logic did not have a single authoritative terminal predicate for final delivery.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/subagent-final-delivery-state.test.ts`
  - `src/agents/subagent-registry-lifecycle.test.ts`
  - `src/agents/subagent-registry-cleanup.test.ts`
  - `src/agents/subagent-registry.persistence.test.ts`
  - `src/agents/subagent-registry.steer-restart.test.ts`
- Scenario the test should lock in: retryable final-delivery failures stay retryable across cleanup and restore; terminal success/permanent failure/expiry still allow resource cleanup.
- Why this is the smallest reliable guardrail: the bug is in local lifecycle state, retry classification, persistence, and cleanup ordering; deterministic registry tests exercise that contract without depending on slow live Gateway timeout reproduction.
- Existing test that already covers this (if any): N/A; this PR adds the missing coverage.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Sub-agent final completion delivery is more resilient after transient announce-back failures. No new config, commands, UI, or docs surface.

## Diagram (if applicable)

```text
Before:
child completed -> announce failed transiently -> ordinary retry/cleanup can prune child -> parent never sees output

After:
child completed -> final_delivery=retrying -> cleanup waits -> restored retry payload can deliver -> final_delivery=delivered -> cleanup proceeds
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local worktree
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): local sub-agent registry and production lifecycle smoke for final-delivery retry/cleanup
- Relevant config (redacted): proof smoke used `OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-empty-80911.json`; no secrets or external endpoints were used.

### Steps

1. Rebase branch on latest `upstream/main`.
2. Run the targeted sub-agent final-delivery state test.
3. Run the production lifecycle smoke that drives `createSubagentRegistryLifecycleController` through retryable final-delivery failure and retry success.
4. Run `pnpm check:architecture` and `pnpm check:changed --base upstream/main`.
5. Run `git diff --check`.

### Expected

- Retryable final-delivery failures keep the child final payload eligible for retry and block cleanup completion until terminal delivery.
- A later successful delivery clears pending final-delivery state, records completion announcement, and allows cleanup to complete.
- Import-cycle and changed gates remain green after extracting the final-delivery leaf types.

### Actual

- Production lifecycle smoke showed `finalDeliveryState.kind=retrying`, `pendingFinalDelivery=true`, and `pendingPayload=true` after the retryable timeout, then `finalDeliveryState.kind=delivered`, `pendingFinalDelivery=null`, and `cleanupCompleted=true` after retry success.
- `pnpm check:architecture` passed with `Madge import cycle check: 0 cycle(s).`.
- `pnpm check:changed --base upstream/main` passed.
- `git diff --check` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: retryable final delivery preservation, permanent delivery failure terminalization, hard expiry, delete cleanup waiting for final delivery, restore/restart retry preservation, no-op terminal delivery cleanup, and a production lifecycle smoke where a retryable final-delivery timeout is retained and a later retry delivers successfully.
- Edge cases checked: `ANNOUNCE_SKIP`, delivery error retryability classification, persisted `finalDelivery` state normalization, cold-restore pruning predicates, and the import-cycle guard after moving final-delivery types to a leaf module.
- What you did **not** verify: live external-channel Gateway saturation or a production websocket timeout window.

## Review Conversations

- [x] No PR review conversations exist yet for this branch.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a retryable delivery could hold child cleanup longer than before.
  - Mitigation: final delivery has terminal states and hard expiry, and tests cover both retry preservation and terminal cleanup.
- Risk: delivery retry classification could mark an error retryable incorrectly.
  - Mitigation: retryability is decided at the delivery boundary and stored explicitly, so cleanup uses the durable final-delivery state instead of re-deriving from generic retry counters.

## AI-assisted development disclosure

This PR was implemented with AI-assisted local development and review. The final diff, staged scope, tests, review-swarm result, and shipped commit were verified locally before opening the PR.

