### PR TITLE
fix(onboard): accept Codex auth in model check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - fix(node-pairing): replace changed pending requests [AI]. (#80894) Thanks @pgondhi987.
 - Rate limit Google Chat webhook requests [AI]. (#80974) Thanks @pgondhi987.
 - Docker: mount the auth-profile secret key directory so OAuth-backed auth profiles survive container rebuilds. (#80991)
+- Onboarding: accept Codex auth profiles for canonical OpenAI model checks, avoiding false missing-auth warnings. (#80913) Thanks @rubencu.
 - fix(feishu): normalize webhook rate-limit client keys [AI]. (#80975) Thanks @pgondhi987.
 - fix(auth): prevent bootstrap pairing scope changes [AI]. (#80976) Thanks @pgondhi987.
 - Validate Control UI loopback retry endpoints [AI]. (#80900) Thanks @pgondhi987.

--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -91,6 +91,8 @@ describe("warnIfModelConfigLooksOff", () => {
     expect(note).not.toHaveBeenCalled();
     expect(listProfilesForProvider).toHaveBeenCalledWith(store, "openai");
     expect(listProfilesForProvider).toHaveBeenCalledWith(store, "openai-codex");
+    expect(resolveEnvApiKey).not.toHaveBeenCalled();
+    expect(hasUsableCustomProviderApiKey).not.toHaveBeenCalled();
   });
 
   it("keeps custom OpenAI-compatible provider auth separate from Codex OAuth profiles", async () => {

--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -47,12 +47,10 @@ describe("warnIfModelConfigLooksOff", () => {
     expect(loadModelCatalog).not.toHaveBeenCalled();
     expect(ensureAuthProfileStore).toHaveBeenCalledOnce();
     expect(listProfilesForProvider).toHaveBeenCalledOnce();
-    const [profileStore, providerId] = listProfilesForProvider.mock.calls.at(0) as unknown as [
-      AuthProfileStore,
-      string,
-    ];
-    expect(profileStore?.profiles).toEqual({});
-    expect(providerId).toBe("openai-codex");
+    expect(listProfilesForProvider).toHaveBeenCalledWith(
+      { version: 1, profiles: {} },
+      "openai-codex",
+    );
     expect(note).toHaveBeenCalledWith(
       'No auth configured for provider "openai-codex". The agent may fail until credentials are added. Run `openclaw models auth login --provider openai-codex`, `openclaw configure`, or set an API key env var.',
       "Model check",

--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -57,6 +57,75 @@ describe("warnIfModelConfigLooksOff", () => {
     );
   });
 
+  it("accepts Codex OAuth profiles for canonical OpenAI models using the Codex runtime", async () => {
+    const note = vi.fn(async () => {});
+    const prompter = makePrompter({ note });
+    const store = {
+      version: 1,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        },
+      },
+    } satisfies AuthProfileStore;
+    ensureAuthProfileStore.mockReturnValue(store);
+    listProfilesForProvider.mockImplementation((_store, provider) =>
+      provider === "openai-codex" ? ["openai-codex:default"] : [],
+    );
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await warnIfModelConfigLooksOff(config, prompter, { validateCatalog: false });
+
+    expect(note).not.toHaveBeenCalled();
+    expect(listProfilesForProvider).toHaveBeenCalledWith(store, "openai");
+    expect(listProfilesForProvider).toHaveBeenCalledWith(store, "openai-codex");
+  });
+
+  it("keeps custom OpenAI-compatible provider auth separate from Codex OAuth profiles", async () => {
+    const note = vi.fn(async () => {});
+    const prompter = makePrompter({ note });
+    listProfilesForProvider.mockImplementation((_store, provider) =>
+      provider === "openai-codex" ? ["openai-codex:default"] : [],
+    );
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+          },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://example.test/v1",
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await warnIfModelConfigLooksOff(config, prompter, { validateCatalog: false });
+
+    expect(listProfilesForProvider.mock.calls.map(([, provider]) => provider)).toEqual(["openai"]);
+    expect(note).toHaveBeenCalledWith(
+      'No auth configured for provider "openai". The agent may fail until credentials are added. Run `openclaw models auth login --provider openai`, `openclaw configure`, or set an API key env var.',
+      "Model check",
+    );
+  });
+
   it("keeps full catalog validation enabled by default", async () => {
     const note = vi.fn(async () => {});
     const prompter = makePrompter({ note });

--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -10,7 +10,9 @@ vi.mock("../agents/model-catalog.js", () => ({
 }));
 
 const ensureAuthProfileStore = vi.hoisted(() => vi.fn(() => ({ version: 1, profiles: {} })));
-const listProfilesForProvider = vi.hoisted(() => vi.fn(() => []));
+const listProfilesForProvider = vi.hoisted(() =>
+  vi.fn<(store: AuthProfileStore, provider: string) => string[]>(() => []),
+);
 vi.mock("../agents/auth-profiles.js", () => ({
   ensureAuthProfileStore,
   listProfilesForProvider,

--- a/src/commands/auth-choice.model-check.ts
+++ b/src/commands/auth-choice.model-check.ts
@@ -8,20 +8,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { buildProviderAuthRecoveryHint } from "./provider-auth-guidance.js";
 
-function uniqueProviders(providers: readonly string[]): string[] {
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const provider of providers) {
-    const trimmed = provider.trim();
-    if (!trimmed || seen.has(trimmed)) {
-      continue;
-    }
-    seen.add(trimmed);
-    result.push(trimmed);
-  }
-  return result;
-}
-
 function resolveAuthProviderCandidates(params: {
   config: OpenClawConfig;
   provider: string;
@@ -34,13 +20,15 @@ function resolveAuthProviderCandidates(params: {
     config: params.config,
     agentId: params.agentId,
   });
-  return uniqueProviders([
-    params.provider,
-    ...listOpenAIAuthProfileProvidersForAgentRuntime({
-      provider: params.provider,
-      harnessRuntime: harnessPolicy.runtime,
-    }),
-  ]);
+  return [
+    ...new Set([
+      params.provider,
+      ...listOpenAIAuthProfileProvidersForAgentRuntime({
+        provider: params.provider,
+        harnessRuntime: harnessPolicy.runtime,
+      }),
+    ]),
+  ];
 }
 
 export async function warnIfModelConfigLooksOff(

--- a/src/commands/auth-choice.model-check.ts
+++ b/src/commands/auth-choice.model-check.ts
@@ -1,10 +1,47 @@
 import { ensureAuthProfileStore, listProfilesForProvider } from "../agents/auth-profiles.js";
+import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { hasUsableCustomProviderApiKey, resolveEnvApiKey } from "../agents/model-auth.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
+import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../agents/openai-codex-routing.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { buildProviderAuthRecoveryHint } from "./provider-auth-guidance.js";
+
+function uniqueProviders(providers: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const provider of providers) {
+    const trimmed = provider.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function resolveAuthProviderCandidates(params: {
+  config: OpenClawConfig;
+  provider: string;
+  modelId: string;
+  agentId?: string;
+}): string[] {
+  const harnessPolicy = resolveAgentHarnessPolicy({
+    provider: params.provider,
+    modelId: params.modelId,
+    config: params.config,
+    agentId: params.agentId,
+  });
+  return uniqueProviders([
+    params.provider,
+    ...listOpenAIAuthProfileProvidersForAgentRuntime({
+      provider: params.provider,
+      harnessRuntime: harnessPolicy.runtime,
+    }),
+  ]);
+}
 
 export async function warnIfModelConfigLooksOff(
   config: OpenClawConfig,
@@ -34,9 +71,19 @@ export async function warnIfModelConfigLooksOff(
   }
 
   const store = ensureAuthProfileStore(options?.agentDir);
-  const hasProfile = listProfilesForProvider(store, ref.provider).length > 0;
-  const envKey = resolveEnvApiKey(ref.provider);
-  const hasCustomKey = hasUsableCustomProviderApiKey(config, ref.provider);
+  const authProviders = resolveAuthProviderCandidates({
+    config,
+    provider: ref.provider,
+    modelId: ref.model,
+    agentId: options?.agentId,
+  });
+  const hasProfile = authProviders.some(
+    (provider) => listProfilesForProvider(store, provider).length > 0,
+  );
+  const envKey = authProviders.some((provider) => resolveEnvApiKey(provider));
+  const hasCustomKey = authProviders.some((provider) =>
+    hasUsableCustomProviderApiKey(config, provider),
+  );
   if (!hasProfile && !envKey && !hasCustomKey) {
     warnings.push(
       `No auth configured for provider "${ref.provider}". The agent may fail until credentials are added. ${buildProviderAuthRecoveryHint(

--- a/src/commands/auth-choice.model-check.ts
+++ b/src/commands/auth-choice.model-check.ts
@@ -77,14 +77,11 @@ export async function warnIfModelConfigLooksOff(
     modelId: ref.model,
     agentId: options?.agentId,
   });
-  const hasProfile = authProviders.some(
-    (provider) => listProfilesForProvider(store, provider).length > 0,
-  );
-  const envKey = authProviders.some((provider) => resolveEnvApiKey(provider));
-  const hasCustomKey = authProviders.some((provider) =>
-    hasUsableCustomProviderApiKey(config, provider),
-  );
-  if (!hasProfile && !envKey && !hasCustomKey) {
+  const hasAuth =
+    authProviders.some((provider) => listProfilesForProvider(store, provider).length > 0) ||
+    authProviders.some((provider) => resolveEnvApiKey(provider)) ||
+    authProviders.some((provider) => hasUsableCustomProviderApiKey(config, provider));
+  if (!hasAuth) {
     warnings.push(
       `No auth configured for provider "${ref.provider}". The agent may fail until credentials are added. ${buildProviderAuthRecoveryHint(
         {


### PR DESCRIPTION
## Summary

- Problem: after OpenAI Codex onboarding, the model check resolved the canonical model as `openai/gpt-5.5` but only looked for direct `openai` auth profiles.
- Why it matters: a successful Codex login writes an `openai-codex:*` profile, so onboarding could warn that `openai` auth was missing even though the selected Codex runtime route was usable.
- What changed: the model check now uses the existing OpenAI/Codex runtime routing contract to include valid Codex auth profile providers for the selected model/runtime, and it short-circuits once any usable auth source is found.
- What did NOT change (scope boundary): no auth storage format, OAuth flow, provider config, runtime execution, or new config surface changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: onboarding model check should not warn `No auth configured for provider "openai"` when the selected canonical model is `openai/gpt-5.5` and the agent has a usable `openai-codex` OAuth profile for the default Codex runtime route.
- Real environment tested: local OpenClaw checkout at head `7ae4f38478001707e7d6cde09119521c2c315acf`, Node 22 via repo scripts, temporary isolated `OPENCLAW_STATE_DIR`, temporary agent auth store with redacted fake OAuth token material.
- Exact steps or command run after this patch: `timeout 30s node --import tsx` with a small harness that writes `agent/auth-profiles.json` containing `openai-codex:default`, calls `warnIfModelConfigLooksOff` for `openai/gpt-5.5`, and captures prompter notes.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): terminal capture:

```text
temporary state dir: state
temporary agent auth store: agent/auth-profiles.json
model: openai/gpt-5.5
stored profile provider: openai-codex
model-check notes emitted: 0
```

- Observed result after fix: the actual model-check helper emitted zero notes, so the erroneous warning is suppressed when Codex OAuth auth is present for the canonical OpenAI model route.
- What was not tested: live browser OAuth against a real OpenAI account; the changed behavior is the post-auth local profile check, so the proof uses a temporary local auth store with redacted credential material and no network access.
- Before evidence (optional but encouraged): regression test locks the previous failure shape by exercising `openai/gpt-5.5` with only an `openai-codex` profile.

## Root Cause (if applicable)

- Root cause: the onboarding model check treated the model provider prefix as the only auth profile provider to inspect, but OpenAI agent model refs can use the Codex runtime and `openai-codex` auth profiles.
- Missing detection / guardrail: there was no regression coverage for canonical `openai/*` model refs backed by Codex OAuth profiles during onboarding warning checks.
- Contributing context (if known): other model list/status paths already had OpenAI/Codex runtime fallback logic; this helper had not been updated to use that contract.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/auth-choice.model-check.test.ts`
- Scenario the test should lock in: `openai/gpt-5.5` with a stored `openai-codex:default` OAuth profile emits no model-check warning when Codex runtime is selected.
- Why this is the smallest reliable guardrail: it covers the exact helper that emits the onboarding warning without requiring live OAuth or gateway startup.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A; new tests were added.

## User-visible / Behavior Changes

The onboarding model check no longer warns that OpenAI auth is missing after successful Codex OAuth setup for the canonical `openai/gpt-5.5` route. No new config surface.

## Diagram (if applicable)

```text
Before:
[Codex login] -> [openai-codex profile saved] -> [model check only inspects openai] -> [false warning]

After:
[Codex login] -> [openai-codex profile saved] -> [model check uses runtime auth candidates] -> [no false warning]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux dev worktree
- Runtime/container: Node 22, pnpm 11.1.0 after rebase
- Model/provider: `openai/gpt-5.5` with `openai-codex` auth profile
- Integration/channel (if any): onboarding command helper only
- Relevant config (redacted): `agents.defaults.model.primary = "openai/gpt-5.5"`; temp auth profile provider `openai-codex`

### Steps

1. Create a temporary agent auth store with an `openai-codex:default` OAuth profile.
2. Run `warnIfModelConfigLooksOff` against `agents.defaults.model.primary = "openai/gpt-5.5"` with catalog validation disabled, matching onboarding's post-auth warning path.
3. Capture model-check notes from the prompter.

### Expected

- No `Model check` warning is emitted when Codex OAuth auth is present for the Codex runtime route.

### Actual

- `model-check notes emitted: 0`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification run:

```text
pnpm test src/commands/auth-choice.model-check.test.ts
Test Files  1 passed (1)
Tests  4 passed (4)
```

```text
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/commands/auth-choice.model-check.ts src/commands/auth-choice.model-check.test.ts
Found 0 warnings and 0 errors.
```

```text
pnpm check:test-types
completed successfully
```

```text
Manual live onboarding test (2026-05-12)
Tester completed the OpenAI Codex onboarding/auth flow against this PR branch. After Codex auth succeeded, the follow-up Model check did not show `No auth configured for provider "openai"`.
```


```text
pnpm changed:lanes --json
"core": true, "coreTests": true, "all": false
```

```text
codex review --base origin/main
No actionable correctness issues were found in the changed model auth warning path or its regression tests.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: temporary local auth-store proof for `openai/gpt-5.5` plus `openai-codex:default`; targeted regression tests; targeted lint; post-rebase focused test; local Codex review loop; manual live onboarding/auth test on this PR branch. Local test typecheck was also run after the typed mock fix.
- Edge cases checked: custom OpenAI-compatible `models.providers.openai.baseUrl` does not borrow Codex OAuth auth and still warns for missing direct OpenAI auth.
- What you did **not** verify: live browser OAuth against OpenAI, gateway startup, or channel delivery; the touched surface is the local post-auth model-check helper.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: accepting Codex auth too broadly could hide missing direct OpenAI auth for custom OpenAI-compatible endpoints.
  - Mitigation: the helper uses the existing runtime policy, and a regression test verifies custom OpenAI-compatible base URLs remain separate.


