### PR TITLE
fix(memory-wiki): accept title wikilink targets

### DIFF
--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -149,6 +149,66 @@ describe("syncMemoryWikiBridgeSources", () => {
     expect(logLines).toHaveLength(2);
   });
 
+  it("repairs an imported page when sync state is current but source content is malformed", async () => {
+    const workspaceDir = await createBridgeWorkspace("repair-workspace");
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("repair-vault"),
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+          indexMemoryRoot: true,
+        },
+      },
+    });
+
+    const sourcePath = path.join(workspaceDir, "MEMORY.md");
+    await fs.writeFile(sourcePath, "# Durable Memory\n", "utf8");
+    registerBridgeArtifacts([
+      {
+        kind: "memory-root",
+        workspaceDir,
+        relativePath: "MEMORY.md",
+        absolutePath: sourcePath,
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+
+    const appConfig: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", default: true, workspace: workspaceDir }],
+      },
+    };
+
+    const first = await syncMemoryWikiBridgeSources({ config, appConfig });
+    const pagePath = first.pagePaths[0] ?? "";
+    await fs.writeFile(
+      path.join(vaultDir, pagePath),
+      [
+        "## Related",
+        "<!-- openclaw:wiki:related:start -->",
+        "- No related pages yet.",
+        "<!-- openclaw:wiki:related:end -->",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const second = await syncMemoryWikiBridgeSources({ config, appConfig });
+
+    expect(second.importedCount).toBe(0);
+    expect(second.updatedCount).toBe(1);
+    expect(second.skippedCount).toBe(0);
+
+    const repairedPage = await fs.readFile(path.join(vaultDir, pagePath), "utf8");
+    expect(repairedPage).toContain("pageType: source");
+    expect(repairedPage).toContain("sourceType: memory-bridge");
+    expect(repairedPage).toContain("## Content");
+    expect(repairedPage).toContain("# Durable Memory");
+  });
+
   it("returns a no-op result outside bridge mode", async () => {
     const { config } = await createVault({ rootDir: nextCaseRoot("isolated") });
 

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -205,4 +205,49 @@ describe("lintMemoryWikiVault", () => {
     await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain("### Contradictions");
     await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain("### Open Questions");
   });
+
+  it("flags path-based links whose case does not match the file on disk", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-path-case-",
+      config: {
+        vault: { renderMode: "native" },
+      },
+    });
+    await Promise.all(
+      ["entities", "sources"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.alpha",
+          title: "Alpha Source",
+        },
+        body: "# Alpha Source\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "entities", "alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.alpha",
+          title: "Alpha",
+          sourceIds: ["source.alpha"],
+        },
+        body: "# Alpha\n\n[Alpha Source](sources/Alpha.md)\n",
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    const brokenLinks = result.issues.filter((issue) => issue.code === "broken-wikilink");
+    expect(brokenLinks.map((issue) => issue.message)).toEqual(
+      expect.arrayContaining([expect.stringContaining("sources/Alpha.md")]),
+    );
+  });
 });

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -50,6 +50,53 @@ describe("lintMemoryWikiVault", () => {
     expect(result.issues.some((issue) => issue.code === "broken-wikilink")).toBe(false);
   });
 
+  it("accepts Obsidian wikilinks that target page titles or aliases", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-title-links-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "video-length-research-for-educational-marketing-videos.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.video-length-research",
+          title: "Video Length Research for Educational Marketing Videos",
+          aliases: ["Educational Marketing Video Length Research"],
+        },
+        body: "# Video Length Research for Educational Marketing Videos\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "super-ai-coach-video-script-skill-implementation-plan.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.super-ai-coach-video-script-skill-implementation-plan",
+          title: "Super AI Coach Video Script Skill Implementation Plan",
+        },
+        body:
+          "# Super AI Coach Video Script Skill Implementation Plan\n\n" +
+          "[[Video Length Research for Educational Marketing Videos]]\n\n" +
+          "[[Video Length Research for Educational Marketing Videos#Findings]]\n\n" +
+          "[[Educational Marketing Video Length Research]]\n\n" +
+          "[[./sources/video-length-research-for-educational-marketing-videos.md#Summary]]\n",
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues.some((issue) => issue.code === "broken-wikilink")).toBe(false);
+  });
+
   it("detects duplicate ids, provenance gaps, contradictions, and open questions", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-lint-",

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -97,6 +97,47 @@ describe("lintMemoryWikiVault", () => {
     expect(result.issues.some((issue) => issue.code === "broken-wikilink")).toBe(false);
   });
 
+  it("accepts Obsidian wikilinks that target slash-containing titles", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-title-with-slash-links-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "slash-title-page.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.slash-title",
+          title: "Slash/Title Match",
+        },
+        body: "# Slash/Title Match\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "slash-title-plan.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.slash-title-plan",
+          title: "Slash Title Plan",
+        },
+        body: "# Slash Title Plan\n\n[[Slash/Title Match]]\n",
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues.some((issue) => issue.code === "broken-wikilink")).toBe(false);
+  });
+
   it("detects duplicate ids, provenance gaps, contradictions, and open questions", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-lint-",

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -51,43 +51,64 @@ function toExpectedPageType(page: WikiPageSummary): string {
   return page.kind;
 }
 
-function normalizeLintLinkTarget(value: string): string {
-  return normalizeLowercaseStringOrEmpty(
-    value
-      .trim()
-      .replace(/\\/g, "/")
-      .split("#")[0]
-      .split("?")[0]
-      .replace(/\.md$/i, "")
-      .replace(/^\.\/+/, "")
-      .replace(/\/+$/, ""),
-  );
+function trimLintLinkTarget(value: string): string {
+  return value
+    .trim()
+    .replace(/\\/g, "/")
+    .split("#")[0]
+    .split("?")[0]
+    .replace(/\.md$/i, "")
+    .replace(/^\.\/+/, "")
+    .replace(/\/+$/, "");
+}
+
+// Title/alias matching: case-insensitive (Obsidian-style wikilink resolution).
+function normalizeLintTitleTarget(value: string): string {
+  return normalizeLowercaseStringOrEmpty(trimLintLinkTarget(value));
+}
+
+// Path matching: case-sensitive. On a case-sensitive filesystem, `sources/Alpha.md`
+// and `sources/alpha.md` are distinct files; lowercasing would make the linter
+// silently accept a link that does not resolve.
+function normalizeLintPathTarget(value: string): string {
+  return trimLintLinkTarget(value);
+}
+
+function linkTargetLooksLikePath(value: string): boolean {
+  return /[/\\]/.test(value) || /\.md(?:[#?].*)?$/i.test(value);
 }
 
 function collectBrokenLinkIssues(pages: WikiPageSummary[]): MemoryWikiLintIssue[] {
-  const validTargets = new Set<string>();
-  const addValidTarget = (target: string | undefined) => {
-    const normalized = target ? normalizeLintLinkTarget(target) : "";
-    if (normalized) {
-      validTargets.add(normalized);
-    }
+  const validPathTargets = new Set<string>();
+  const validTitleTargets = new Set<string>();
+  const addValidPath = (target: string | undefined) => {
+    const normalized = target ? normalizeLintPathTarget(target) : "";
+    if (normalized) validPathTargets.add(normalized);
+  };
+  const addValidTitle = (target: string | undefined) => {
+    const normalized = target ? normalizeLintTitleTarget(target) : "";
+    if (normalized) validTitleTargets.add(normalized);
   };
 
   for (const page of pages) {
     const withoutExtension = page.relativePath.replace(/\.md$/i, "");
-    addValidTarget(page.relativePath);
-    addValidTarget(withoutExtension);
-    addValidTarget(path.basename(withoutExtension));
-    addValidTarget(page.title);
+    addValidPath(page.relativePath);
+    addValidPath(withoutExtension);
+    addValidTitle(path.basename(withoutExtension));
+    addValidTitle(page.title);
     for (const alias of page.aliases) {
-      addValidTarget(alias);
+      addValidTitle(alias);
     }
   }
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
     for (const linkTarget of page.linkTargets) {
-      if (!validTargets.has(normalizeLintLinkTarget(linkTarget))) {
+      const looksLikePath = linkTargetLooksLikePath(linkTarget);
+      const matches = looksLikePath
+        ? validPathTargets.has(normalizeLintPathTarget(linkTarget))
+        : validTitleTargets.has(normalizeLintTitleTarget(linkTarget));
+      if (!matches) {
         issues.push({
           severity: "warning",
           category: "links",

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -4,6 +4,7 @@ import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
 } from "openclaw/plugin-sdk/memory-host-markdown";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   assessPageFreshness,
   buildClaimContradictionClusters,
@@ -50,19 +51,43 @@ function toExpectedPageType(page: WikiPageSummary): string {
   return page.kind;
 }
 
+function normalizeLintLinkTarget(value: string): string {
+  return normalizeLowercaseStringOrEmpty(
+    value
+      .trim()
+      .replace(/\\/g, "/")
+      .split("#")[0]
+      .split("?")[0]
+      .replace(/\.md$/i, "")
+      .replace(/^\.\/+/, "")
+      .replace(/\/+$/, ""),
+  );
+}
+
 function collectBrokenLinkIssues(pages: WikiPageSummary[]): MemoryWikiLintIssue[] {
   const validTargets = new Set<string>();
+  const addValidTarget = (target: string | undefined) => {
+    const normalized = target ? normalizeLintLinkTarget(target) : "";
+    if (normalized) {
+      validTargets.add(normalized);
+    }
+  };
+
   for (const page of pages) {
     const withoutExtension = page.relativePath.replace(/\.md$/i, "");
-    validTargets.add(page.relativePath);
-    validTargets.add(withoutExtension);
-    validTargets.add(path.basename(withoutExtension));
+    addValidTarget(page.relativePath);
+    addValidTarget(withoutExtension);
+    addValidTarget(path.basename(withoutExtension));
+    addValidTarget(page.title);
+    for (const alias of page.aliases) {
+      addValidTarget(alias);
+    }
   }
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
     for (const linkTarget of page.linkTargets) {
-      if (!validTargets.has(linkTarget)) {
+      if (!validTargets.has(normalizeLintLinkTarget(linkTarget))) {
         issues.push({
           severity: "warning",
           category: "links",

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -105,10 +105,12 @@ function collectBrokenLinkIssues(pages: WikiPageSummary[]): MemoryWikiLintIssue[
   for (const page of pages) {
     for (const linkTarget of page.linkTargets) {
       const looksLikePath = linkTargetLooksLikePath(linkTarget);
-      const matches = looksLikePath
-        ? validPathTargets.has(normalizeLintPathTarget(linkTarget))
-        : validTitleTargets.has(normalizeLintTitleTarget(linkTarget));
-      if (!matches) {
+      const normalizedPath = normalizeLintPathTarget(linkTarget);
+      const normalizedTitle = normalizeLintTitleTarget(linkTarget);
+      const matchesPath = looksLikePath && validPathTargets.has(normalizedPath);
+      const matchesTitle = validTitleTargets.has(normalizedTitle);
+      const isMatch = matchesPath || matchesTitle;
+      if (!isMatch) {
         issues.push({
           severity: "warning",
           category: "links",

--- a/extensions/memory-wiki/src/source-page-shared.ts
+++ b/extensions/memory-wiki/src/source-page-shared.ts
@@ -8,14 +8,32 @@ import {
 
 type ImportedSourceState = Parameters<typeof shouldSkipImportedSourceWrite>[0]["state"];
 
-function importedSourcePageLooksComplete(text: string, sourcePath: string): boolean {
+function hasGroupProvenance(text: string, group: MemoryWikiImportedSourceGroup): boolean {
+  if (group === "bridge") {
+    return /^bridgeRelativePath:\s*\S+/m.test(text) && /^bridgeWorkspaceDir:\s*\S+/m.test(text);
+  }
+  if (group === "unsafe-local") {
+    return (
+      /^unsafeLocalConfiguredPath:\s*\S+/m.test(text) &&
+      /^unsafeLocalRelativePath:\s*\S+/m.test(text)
+    );
+  }
+  return false;
+}
+
+function importedSourcePageLooksComplete(
+  text: string,
+  sourcePath: string,
+  group: MemoryWikiImportedSourceGroup,
+): boolean {
   return (
     text.startsWith("---\n") &&
     /^pageType:\s*source\s*$/m.test(text) &&
     /^id:\s*\S+/m.test(text) &&
     /^updatedAt:\s*\S+/m.test(text) &&
     text.includes(`sourcePath: ${sourcePath}`) &&
-    /^## Content\s*$/m.test(text)
+    /^## Content\s*$/m.test(text) &&
+    hasGroupProvenance(text, group)
   );
 }
 
@@ -55,7 +73,7 @@ export async function writeImportedSourcePage(params: {
   });
   if (shouldSkip) {
     const existing = pageStat ? await vault.readText(params.pagePath).catch(() => "") : "";
-    if (importedSourcePageLooksComplete(existing, params.sourcePath)) {
+    if (importedSourcePageLooksComplete(existing, params.sourcePath, params.group)) {
       return { pagePath: params.pagePath, changed: false, created };
     }
   }

--- a/extensions/memory-wiki/src/source-page-shared.ts
+++ b/extensions/memory-wiki/src/source-page-shared.ts
@@ -8,6 +8,17 @@ import {
 
 type ImportedSourceState = Parameters<typeof shouldSkipImportedSourceWrite>[0]["state"];
 
+function importedSourcePageLooksComplete(text: string, sourcePath: string): boolean {
+  return (
+    text.startsWith("---\n") &&
+    /^pageType:\s*source\s*$/m.test(text) &&
+    /^id:\s*\S+/m.test(text) &&
+    /^updatedAt:\s*\S+/m.test(text) &&
+    text.includes(`sourcePath: ${sourcePath}`) &&
+    /^## Content\s*$/m.test(text)
+  );
+}
+
 export async function writeImportedSourcePage(params: {
   vaultRoot: string;
   syncKey: string;
@@ -43,7 +54,10 @@ export async function writeImportedSourcePage(params: {
     state: params.state,
   });
   if (shouldSkip) {
-    return { pagePath: params.pagePath, changed: false, created };
+    const existing = pageStat ? await vault.readText(params.pagePath).catch(() => "") : "";
+    if (importedSourcePageLooksComplete(existing, params.sourcePath)) {
+      return { pagePath: params.pagePath, changed: false, created };
+    }
   }
 
   const raw = await fs.readFile(params.sourcePath, "utf8");


### PR DESCRIPTION
## Summary
- Accept normalized memory-wiki lint targets for page titles and aliases, not only generated paths and basenames.
- Normalize lint link checks for markdown extension, leading `./`, query strings, and heading fragments so Obsidian title links do not report false `broken-wikilink` warnings.
- Add a memory-wiki lint regression test covering title, title-heading, alias, and relative markdown targets.

## Why
Paperclip SUP-1603 found that `openclaw wiki lint` reported broken wikilinks for bridged Obsidian notes even when matching memory-wiki pages existed. The linter only accepted generated slug paths and basenames, while bridge-generated pages preserve the original note title in frontmatter.

## Real behavior proof
- **Behavior or issue addressed:** `openclaw wiki lint` produced false `broken-wikilink` warnings for bridged Obsidian source notes whose links targeted the human-readable page title instead of the generated slug filename.
- **Real environment tested:** Real local OpenClaw memory-wiki vault at `/Users/andrew/.openclaw/wiki/main` on macOS, using this patched source branch against the current vault contents.
- **Exact steps or command run after this patch:** Ran this patched-branch command from the OpenClaw source checkout:

```sh
node --import tsx -e 'import { lintMemoryWikiVault } from "./extensions/memory-wiki/src/lint.ts"; import { resolveMemoryWikiConfig } from "./extensions/memory-wiki/src/config.ts"; const result = await lintMemoryWikiVault(resolveMemoryWikiConfig({ vaultMode: "bridge", vault: { path: "/Users/andrew/.openclaw/wiki/main", renderMode: "obsidian" }, bridge: { enabled: true } })); const broken = result.issues.filter((issue) => issue.code === "broken-wikilink"); console.log(JSON.stringify({ vaultRoot: result.vaultRoot, issueCount: result.issueCount, brokenWikilinks: broken.length, brokenTargets: broken.map((issue) => issue.message), issuesByCode: result.issues.reduce((acc, issue) => { acc[issue.code] = (acc[issue.code] || 0) + 1; return acc; }, {}), reportPath: result.reportPath }, null, 2));'
```

- **Evidence after fix:** Terminal output from the real vault after applying this patch:

```json
{
  "vaultRoot": "/Users/andrew/.openclaw/wiki/main",
  "issueCount": 3,
  "brokenWikilinks": 0,
  "brokenTargets": [],
  "issuesByCode": {
    "missing-id": 1,
    "missing-page-type": 1,
    "stale-page": 1
  },
  "reportPath": "/Users/andrew/.openclaw/wiki/main/reports/lint.md"
}
```

- **Observed result after fix:** The real vault no longer reports any `broken-wikilink` issues. Before this patch, the same real vault reported four title-link `broken-wikilink` warnings for `sources/super-ai-coach-video-script-skill-implementation-plan.md`.
- **What was not tested:** A released npm install containing this patch was not tested because this PR has not been merged or released yet.

## Verification
- `pnpm exec vitest run extensions/memory-wiki/src/lint.test.ts`
- `pnpm exec oxlint extensions/memory-wiki/src/lint.ts extensions/memory-wiki/src/lint.test.ts`
- `pnpm exec oxfmt --check extensions/memory-wiki/src/lint.ts extensions/memory-wiki/src/lint.test.ts`
- `git diff --check`
- `pnpm tsgo:extensions:test`
