### PR TITLE
fix(memory): skip empty dreaming placeholders

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1487,6 +1487,19 @@ describe("memory-core dreaming phases", () => {
     expect(corpus).not.toContain("Run the qmd sync");
   });
 
+  it("omits possible lasting truths section when rem finds no candidate truths", () => {
+    const preview = __testing.previewRemDreaming({
+      entries: [],
+      limit: 5,
+      minPatternStrength: 0,
+    });
+
+    expect(preview.candidateTruths).toStrictEqual([]);
+    expect(preview.bodyLines.join("\n")).toContain("### Reflections");
+    expect(preview.bodyLines.join("\n")).not.toContain("### Possible Lasting Truths");
+    expect(preview.bodyLines.join("\n")).not.toContain("No strong candidate truths surfaced");
+  });
+
   it("ignores chat scaffolding tags when building rem reflections", () => {
     const preview = __testing.previewRemDreaming({
       entries: [

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -1532,14 +1532,16 @@ export function previewRemDreaming(params: {
   const bodyLines = [
     "### Reflections",
     ...reflections,
-    "",
-    "### Possible Lasting Truths",
     ...(candidateTruths.length > 0
-      ? candidateTruths.map(
-          (entry) =>
-            `- ${entry.snippet} [confidence=${entry.confidence.toFixed(2)} evidence=${entry.evidence}]`,
-        )
-      : ["- No strong candidate truths surfaced."]),
+      ? [
+          "",
+          "### Possible Lasting Truths",
+          ...candidateTruths.map(
+            (entry) =>
+              `- ${entry.snippet} [confidence=${entry.confidence.toFixed(2)} evidence=${entry.evidence}]`,
+          ),
+        ]
+      : []),
   ];
   return {
     sourceEntryCount: params.entries.length,

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1110,12 +1110,65 @@ describe("short-term promotion", () => {
     ).toBe(false);
   });
 
+  it("treats empty rem candidate placeholders as contaminated", () => {
+    expect(
+      __testing.isEmptyDreamingCandidatePlaceholder("- No strong candidate truths surfaced."),
+    ).toBe(true);
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        "- Candidate: Possible Lasting Truths: No strong candidate truths surfaced.",
+      ),
+    ).toBe(true);
+  });
+
   it("treats transcript-style dreaming prompt echoes as contaminated", () => {
     expect(
       __testing.isContaminatedDreamingSnippet(
         "[main/dreaming-narrative-light.jsonl#L1] User: Write a dream diary entry from these memory fragments:",
       ),
     ).toBe(true);
+  });
+
+  it("skips empty rem candidate placeholders during apply", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        candidates: [
+          {
+            key: "memory:memory/2026-04-08.md:13:13",
+            path: "memory/2026-04-08.md",
+            startLine: 13,
+            endLine: 13,
+            source: "memory",
+            snippet: "- Candidate: Possible Lasting Truths: No strong candidate truths surfaced.",
+            recallCount: 3,
+            avgScore: 0.95,
+            maxScore: 0.95,
+            uniqueQueries: 2,
+            firstRecalledAt: "2026-04-08T00:00:00.000Z",
+            lastRecalledAt: "2026-04-09T00:00:00.000Z",
+            ageDays: 0,
+            score: 0.95,
+            recallDays: ["2026-04-08", "2026-04-09"],
+            conceptTags: ["candidate", "truths"],
+            components: {
+              frequency: 1,
+              relevance: 1,
+              diversity: 1,
+              recency: 1,
+              consolidation: 1,
+              conceptual: 1,
+            },
+          },
+        ],
+      });
+
+      expect(applied.applied).toBe(0);
+      await expectEnoent(fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"));
+    });
   });
 
   it("skips direct candidates that exceed maxAgeDays during apply", async () => {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -287,6 +287,18 @@ function hasDreamingNarrativeLead(snippet: string): boolean {
   return /^Candidate:/i.test(withoutPrefix) || /^Reflections?:/i.test(withoutPrefix);
 }
 
+function isEmptyDreamingCandidatePlaceholder(raw: string): boolean {
+  const snippet = normalizeSnippet(raw);
+  if (!snippet) {
+    return false;
+  }
+  const withoutPrefix = consumeDreamingLeadPrefix(snippet)
+    .replace(/^Candidate:\s*/i, "")
+    .replace(/^Possible Lasting Truths:\s*/i, "")
+    .trim();
+  return /^No strong candidate truths surfaced\.?$/i.test(withoutPrefix);
+}
+
 function isContaminatedDreamingSnippet(raw: string): boolean {
   const snippet = normalizeSnippet(raw);
   if (!snippet) {
@@ -294,7 +306,8 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   }
   if (
     /<!--\s*openclaw-memory-promotion:/i.test(snippet) ||
-    DREAMING_TRANSCRIPT_PROMPT_LINE_RE.test(snippet)
+    DREAMING_TRANSCRIPT_PROMPT_LINE_RE.test(snippet) ||
+    isEmptyDreamingCandidatePlaceholder(snippet)
   ) {
     return true;
   }
@@ -2018,4 +2031,5 @@ export const __testing = {
   buildClaimHash,
   totalSignalCountForEntry,
   isContaminatedDreamingSnippet,
+  isEmptyDreamingCandidatePlaceholder,
 };


### PR DESCRIPTION
## Summary

- stop REM preview from writing the `No strong candidate truths surfaced` placeholder under `### Possible Lasting Truths`
- defensively classify historical empty-result placeholders as contaminated so already-written daily memory candidates do not promote into `MEMORY.md`
- add regression coverage for both REM preview output and short-term promotion apply filtering

Fixes #80858

## Real behavior proof

- **Behavior or issue addressed:** Empty REM days should not emit candidate-like placeholder markdown, and already-written placeholder snippets should not be promoted into long-term `MEMORY.md`.
- **Real environment tested:** Harry's Mac mini, Darwin 25.4.0 arm64, Node v22.22.0, local OpenClaw checkout on branch `fix/80858-dreaming-empty-placeholder`.
- **Exact steps or command run after this patch:**

```bash
node --import tsx - <<'EOF'
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { __testing as dreamingTesting } from './extensions/memory-core/src/dreaming-phases.ts';
import { applyShortTermPromotions } from './extensions/memory-core/src/short-term-promotion.ts';

const preview = dreamingTesting.previewRemDreaming({ entries: [], limit: 5, minPatternStrength: 0 });
console.log('REM body contains placeholder:', preview.bodyLines.join('\n').includes('No strong candidate truths surfaced'));
console.log('REM body contains possible truths section:', preview.bodyLines.join('\n').includes('### Possible Lasting Truths'));
console.log('REM body:');
console.log(preview.bodyLines.join('\n'));

const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-80858-proof-'));
await fs.mkdir(path.join(workspaceDir, 'memory', '.dreams'), { recursive: true });
const applied = await applyShortTermPromotions({
  workspaceDir,
  minScore: 0,
  minRecallCount: 0,
  minUniqueQueries: 0,
  candidates: [{
    key: 'memory:memory/2026-04-08.md:13:13',
    path: 'memory/2026-04-08.md',
    startLine: 13,
    endLine: 13,
    source: 'memory',
    snippet: '- Candidate: Possible Lasting Truths: No strong candidate truths surfaced.',
    recallCount: 3,
    avgScore: 0.95,
    maxScore: 0.95,
    uniqueQueries: 2,
    firstRecalledAt: '2026-04-08T00:00:00.000Z',
    lastRecalledAt: '2026-04-09T00:00:00.000Z',
    ageDays: 0,
    score: 0.95,
    recallDays: ['2026-04-08', '2026-04-09'],
    conceptTags: ['candidate', 'truths'],
    components: { frequency: 1, relevance: 1, diversity: 1, recency: 1, consolidation: 1, conceptual: 1 },
  }],
});
console.log('placeholder promotions applied:', applied.applied);
console.log('MEMORY.md exists:', await fs.access(path.join(workspaceDir, 'MEMORY.md')).then(() => true, () => false));
EOF
```

- **Evidence after fix:** terminal output from the real local checkout:

```text
REM body contains placeholder: false
REM body contains possible truths section: false
REM body contains placeholder: false
REM body contains possible truths section: false
REM body line 1: ### Reflections
REM body line 2: - No strong patterns surfaced.
placeholder promotions applied: 0
MEMORY.md exists: false
```

- **Observed result after fix:** Empty REM preview output no longer contains `### Possible Lasting Truths` or `No strong candidate truths surfaced`; a historical placeholder-shaped promotion candidate applies `0` entries and does not create `MEMORY.md`.
- **What was not tested:** A full scheduled dreaming cron run; validation exercised the real REM preview and promotion code paths directly with a temp workspace.

## Validation

- `node scripts/test-projects.mjs extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/dreaming-phases.ts extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts`
- `pnpm check:changed`

## Notes

This is intentionally narrow and does not attempt to replace the broader dreaming-contamination hardening discussed in #68774.
