### PR TITLE
fix: skip metadata for build-excluded bundled plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Build: skip copied metadata for bundled plugins that are excluded from build entries, preventing update/status rebuilds from advertising missing QQ Bot runtime files.
+- Build: skip copied metadata for bundled plugins that are excluded from build entries, preventing update/status rebuilds from advertising missing QQ Bot runtime files. (#80925)
 - Control UI/sessions: nest subagent sessions under their parent session in the session picker dropdown using a visual `└─ ` prefix, making the parent-child relationship clear. Fixes #77628. (#78623) Thanks @chinar-amrutkar.
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Build: skip copied metadata for bundled plugins that are excluded from build entries, preventing update/status rebuilds from advertising missing QQ Bot runtime files.
 - Control UI/sessions: nest subagent sessions under their parent session in the session picker dropdown using a visual `└─ ` prefix, making the parent-child relationship clear. Fixes #77628. (#78623) Thanks @chinar-amrutkar.
 
 ### Changes

--- a/scripts/copy-bundled-plugin-metadata.mjs
+++ b/scripts/copy-bundled-plugin-metadata.mjs
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { NON_PACKAGED_BUNDLED_PLUGIN_DIRS } from "./lib/bundled-plugin-build-entries.mjs";
+import {
+  collectBundledPluginBuildEntries,
+  NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
+} from "./lib/bundled-plugin-build-entries.mjs";
 import { shouldBuildBundledCluster } from "./lib/optional-bundled-clusters.mjs";
 import {
   mergeGeneratedChannelConfigs,
@@ -17,7 +20,10 @@ const GENERATED_BUNDLED_SKILLS_DIR = "bundled-skills";
 const TRANSIENT_COPY_ERROR_CODES = new Set(["EEXIST", "ENOENT", "ENOTEMPTY", "EBUSY"]);
 const COPY_RETRY_DELAYS_MS = [10, 25, 50];
 
-function shouldCopyBundledPluginMetadata(id, env) {
+function shouldCopyBundledPluginMetadata(id, env, buildablePluginDirs) {
+  if (!buildablePluginDirs.has(id)) {
+    return false;
+  }
   if (!NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(id)) {
     return true;
   }
@@ -237,6 +243,9 @@ export function copyBundledPluginMetadata(params = {}) {
     return;
   }
 
+  const buildablePluginDirs = new Set(
+    collectBundledPluginBuildEntries({ cwd: repoRoot, env }).map((entry) => entry.id),
+  );
   const generatedChannelConfigsByPlugin = readGeneratedBundledChannelConfigs(repoRoot);
   const sourcePluginDirs = new Set();
   for (const dirent of fs.readdirSync(extensionsRoot, { withFileTypes: true })) {
@@ -252,7 +261,7 @@ export function copyBundledPluginMetadata(params = {}) {
       ? JSON.parse(fs.readFileSync(packageJsonPath, "utf8"))
       : undefined;
     const topLevelPublicSurfaceEntries = collectTopLevelPublicSurfaceEntries(pluginDir);
-    if (!shouldCopyBundledPluginMetadata(dirent.name, env)) {
+    if (!shouldCopyBundledPluginMetadata(dirent.name, env, buildablePluginDirs)) {
       removePathIfExists(distPluginDir);
       continue;
     }

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -437,6 +437,25 @@ describe("copyBundledPluginMetadata", () => {
     expect(fs.existsSync(path.join(repoRoot, "dist", "extensions", pluginId))).toBe(expectedExists);
   });
 
+  it("removes build-excluded bundled plugin metadata", () => {
+    const repoRoot = makeRepoRoot("openclaw-bundled-plugin-excluded-meta-");
+    createPlugin(repoRoot, {
+      id: "qqbot",
+      packageName: "@openclaw/qqbot",
+      packageOpenClaw: {
+        extensions: ["./index.ts"],
+        setupEntry: "./setup-entry.ts",
+      },
+    });
+    const staleDistDir = path.join(repoRoot, "dist", "extensions", "qqbot");
+    fs.mkdirSync(staleDistDir, { recursive: true });
+    fs.writeFileSync(path.join(staleDistDir, "index.js"), "export default {}\n", "utf8");
+
+    copyBundledPluginMetadata({ repoRoot });
+
+    expect(fs.existsSync(staleDistDir)).toBe(false);
+  });
+
   it("preserves manifest-less runtime support package outputs and copies package metadata", () => {
     const repoRoot = makeRepoRoot("openclaw-bundled-runtime-support-");
     const pluginDir = path.join(repoRoot, "extensions", "image-generation-core");


### PR DESCRIPTION
## Summary

- Skip copying bundled plugin metadata when the plugin is not part of the build entry set.
- Add regression coverage for the QQ Bot-style case where a source plugin has manifests but no built runtime entries.
- Add changelog note for the update/status startup validation fix.

## Real behavior proof

- Behavior or issue addressed: update/status rebuilds previously copied QQ Bot bundled metadata even though QQ Bot is excluded from bundled build entries, so config validation advertised missing `index.js` / `setup-entry.js` runtime files.
- Real environment tested: local OpenClaw source checkout on macOS, using the existing `~/.openclaw/openclaw.json` config and live gateway probe on `127.0.0.1:18789`.
- Exact steps or command run after this patch: `pnpm openclaw gateway status --deep`; also checked `dist/extensions/qqbot` is absent and required bundled plugin dist entries are present.
- Evidence after fix: terminal output from `pnpm openclaw gateway status --deep` after this patch:

```text
Config (cli): ~/.openclaw/openclaw.json
Config (service): ~/.openclaw/openclaw.json
Gateway: bind=lan (0.0.0.0), port=18789 (env/config)
Probe target: ws://127.0.0.1:18789
Connectivity probe: ok
Listening: *:18789
```

- Observed result after fix: the command completed without the previous `plugins.entries.qqbot: plugin qqbot: setup entry not found: setup-entry.js` and `extension entry not found: index.js` config validation failure.
- What was not tested: no packaged npm install/update flow was run locally; the proof covered source-checkout rebuild/status behavior plus focused regression tests.

## Verification

- `pnpm test src/plugins/copy-bundled-plugin-metadata.test.ts test/scripts/bundled-plugin-build-entries.test.ts`
- `git diff --check`
- `pnpm openclaw gateway status --deep`
