### PR TITLE
auto-reply: suppress reasoning-prefixed NO_REPLY

### DIFF
--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -232,6 +232,22 @@ describe("normalizeReplyPayload", () => {
     expect(reasons).toEqual(["silent"]);
   });
 
+  it("suppresses leaked reasoning when the final answer is NO_REPLY (#66701)", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      {
+        text: [
+          "think",
+          "Cav is talking about a follow-up conversation.",
+          "I will stay quiet here.NO_REPLY",
+        ].join("\n"),
+      },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["silent"]);
+  });
+
   it("does not suppress JSON NO_REPLY objects with extra fields", () => {
     const result = normalizeReplyPayload({
       text: '{"action":"NO_REPLY","note":"example"}',

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -248,6 +248,21 @@ describe("normalizeReplyPayload", () => {
     expect(reasons).toEqual(["silent"]);
   });
 
+  it("suppresses tagged leaked reasoning when silence narration ends in NO_REPLY (#66701)", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      {
+        text: [
+          "<think>Cav is talking about a follow-up conversation.</think>",
+          "I will stay quiet here.NO_REPLY",
+        ].join("\n"),
+      },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["silent"]);
+  });
+
   it("does not suppress JSON NO_REPLY objects with extra fields", () => {
     const result = normalizeReplyPayload({
       text: '{"action":"NO_REPLY","note":"example"}',

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -55,9 +55,6 @@ describe("isSilentReplyPayloadText", () => {
         "think\nCav is talking about a follow-up conversation.\nI will stay quiet here.NO_REPLY",
       ),
     ).toBe(true);
-    expect(
-      isSilentReplyPayloadText("think\nCav is talking about a follow-up conversation.\nNO_REPLY"),
-    ).toBe(true);
     expect(isSilentReplyPayloadText("think\ninternal reasoning\nNO_REPLY")).toBe(true);
     expect(isSilentReplyPayloadText("<think>internal reasoning</think>\nNO_REPLY")).toBe(true);
     expect(
@@ -75,6 +72,10 @@ describe("isSilentReplyPayloadText", () => {
         "think\nHere is the actual answer.\nI will stay quiet here.NO_REPLY",
       ),
     ).toBe(false);
+    expect(
+      isSilentReplyPayloadText("think\nCav is talking about a follow-up conversation.\nNO_REPLY"),
+    ).toBe(false);
+    expect(isSilentReplyPayloadText("analysis\nMeeting moved to 3 pm.\nNO_REPLY")).toBe(false);
     expect(
       isSilentReplyPayloadText(
         "think\nThe user is asking whether the outage is resolved. Tell them the service is back up and they should retry.\nNO_REPLY",

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -55,9 +55,6 @@ describe("isSilentReplyPayloadText", () => {
         "think\nCav is talking about a follow-up conversation.\nI will stay quiet here.NO_REPLY",
       ),
     ).toBe(true);
-    expect(
-      isSilentReplyPayloadText("think\nCav is talking about a follow-up conversation.\nNO_REPLY"),
-    ).toBe(true);
     expect(isSilentReplyPayloadText("<think>internal reasoning</think>\nNO_REPLY")).toBe(true);
     expect(
       isSilentReplyPayloadText(
@@ -69,6 +66,19 @@ describe("isSilentReplyPayloadText", () => {
 
   it("keeps substantive replies that also contain a trailing NO_REPLY token", () => {
     expect(isSilentReplyPayloadText("Here is a helpful response.\n\nNO_REPLY")).toBe(false);
+    expect(
+      isSilentReplyPayloadText("think\nCav is talking about a follow-up conversation.\nNO_REPLY"),
+    ).toBe(false);
+    expect(
+      isSilentReplyPayloadText(
+        "think\nHere is the actual answer.\nI will stay quiet here.NO_REPLY",
+      ),
+    ).toBe(false);
+    expect(
+      isSilentReplyPayloadText(
+        "think\nThe user is asking whether the outage is resolved. Tell them the service is back up and they should retry.\nNO_REPLY",
+      ),
+    ).toBe(false);
     expect(
       isSilentReplyPayloadText("<think>internal reasoning</think>\nHere is the answer.\nNO_REPLY"),
     ).toBe(false);

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -55,6 +55,10 @@ describe("isSilentReplyPayloadText", () => {
         "think\nCav is talking about a follow-up conversation.\nI will stay quiet here.NO_REPLY",
       ),
     ).toBe(true);
+    expect(
+      isSilentReplyPayloadText("think\nCav is talking about a follow-up conversation.\nNO_REPLY"),
+    ).toBe(true);
+    expect(isSilentReplyPayloadText("think\ninternal reasoning\nNO_REPLY")).toBe(true);
     expect(isSilentReplyPayloadText("<think>internal reasoning</think>\nNO_REPLY")).toBe(true);
     expect(
       isSilentReplyPayloadText(
@@ -66,9 +70,6 @@ describe("isSilentReplyPayloadText", () => {
 
   it("keeps substantive replies that also contain a trailing NO_REPLY token", () => {
     expect(isSilentReplyPayloadText("Here is a helpful response.\n\nNO_REPLY")).toBe(false);
-    expect(
-      isSilentReplyPayloadText("think\nCav is talking about a follow-up conversation.\nNO_REPLY"),
-    ).toBe(false);
     expect(
       isSilentReplyPayloadText(
         "think\nHere is the actual answer.\nI will stay quiet here.NO_REPLY",

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -55,7 +55,15 @@ describe("isSilentReplyPayloadText", () => {
         "think\nCav is talking about a follow-up conversation.\nI will stay quiet here.NO_REPLY",
       ),
     ).toBe(true);
+    expect(
+      isSilentReplyPayloadText("think\nCav is talking about a follow-up conversation.\nNO_REPLY"),
+    ).toBe(true);
     expect(isSilentReplyPayloadText("<think>internal reasoning</think>\nNO_REPLY")).toBe(true);
+    expect(
+      isSilentReplyPayloadText(
+        "<think>internal reasoning</think>\nI will stay quiet here.NO_REPLY",
+      ),
+    ).toBe(true);
     expect(isSilentReplyPayloadText("<think>internal reasoning NO_REPLY")).toBe(true);
   });
 
@@ -63,6 +71,16 @@ describe("isSilentReplyPayloadText", () => {
     expect(isSilentReplyPayloadText("Here is a helpful response.\n\nNO_REPLY")).toBe(false);
     expect(
       isSilentReplyPayloadText("<think>internal reasoning</think>\nHere is the answer.\nNO_REPLY"),
+    ).toBe(false);
+    expect(
+      isSilentReplyPayloadText(
+        "<think>internal reasoning</think>\nYou should not reply to that email.\nNO_REPLY",
+      ),
+    ).toBe(false);
+    expect(
+      isSilentReplyPayloadText(
+        "<think>internal reasoning</think>\nHere is the answer: I will stay quiet in the meeting, but you should still send the agenda.NO_REPLY",
+      ),
     ).toBe(false);
   });
 });

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isSilentReplyPrefixText,
+  isSilentReplyPayloadText,
   isSilentReplyText,
   startsWithSilentToken,
   stripLeadingSilentToken,
@@ -44,6 +45,25 @@ describe("isSilentReplyText", () => {
 
   it("returns false for token embedded in text", () => {
     expect(isSilentReplyText("Please NO_REPLY to this")).toBe(false);
+  });
+});
+
+describe("isSilentReplyPayloadText", () => {
+  it("returns true when leaked reasoning text ends in NO_REPLY", () => {
+    expect(
+      isSilentReplyPayloadText(
+        "think\nCav is talking about a follow-up conversation.\nI will stay quiet here.NO_REPLY",
+      ),
+    ).toBe(true);
+    expect(isSilentReplyPayloadText("<think>internal reasoning</think>\nNO_REPLY")).toBe(true);
+    expect(isSilentReplyPayloadText("<think>internal reasoning NO_REPLY")).toBe(true);
+  });
+
+  it("keeps substantive replies that also contain a trailing NO_REPLY token", () => {
+    expect(isSilentReplyPayloadText("Here is a helpful response.\n\nNO_REPLY")).toBe(false);
+    expect(
+      isSilentReplyPayloadText("<think>internal reasoning</think>\nHere is the answer.\nNO_REPLY"),
+    ).toBe(false);
   });
 });
 

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -72,6 +72,7 @@ describe("isSilentReplyPayloadText", () => {
     expect(
       isSilentReplyPayloadText("<think>internal reasoning</think>\nHere is the answer.\nNO_REPLY"),
     ).toBe(false);
+    expect(isSilentReplyPayloadText("think\nHere is the actual answer.\nNO_REPLY")).toBe(false);
     expect(
       isSilentReplyPayloadText(
         "<think>internal reasoning</think>\nYou should not reply to that email.\nNO_REPLY",

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -64,7 +64,7 @@ describe("isSilentReplyPayloadText", () => {
         "<think>internal reasoning</think>\nI will stay quiet here.NO_REPLY",
       ),
     ).toBe(true);
-    expect(isSilentReplyPayloadText("<think>internal reasoning NO_REPLY")).toBe(true);
+    expect(isSilentReplyPayloadText("<think>I will stay quiet here.NO_REPLY")).toBe(true);
   });
 
   it("keeps substantive replies that also contain a trailing NO_REPLY token", () => {
@@ -77,6 +77,9 @@ describe("isSilentReplyPayloadText", () => {
       isSilentReplyPayloadText(
         "<think>internal reasoning</think>\nYou should not reply to that email.\nNO_REPLY",
       ),
+    ).toBe(false);
+    expect(
+      isSilentReplyPayloadText("<think>internal notes\nHere is the actual answer.\nNO_REPLY"),
     ).toBe(false);
     expect(
       isSilentReplyPayloadText(

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -71,11 +71,63 @@ function isSilentReplyEnvelopeText(
   }
 }
 
+const taggedReasoningPrefixRe =
+  /^\s*<\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>[\s\S]*?<\s*\/\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>\s*/i;
+const openReasoningPrefixRe =
+  /^\s*<\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/i;
+const plainReasoningPrefixRe = /^\s*(?:think(?:ing)?|thought|analysis|reasoning)\s*:?\s*\r?\n/i;
+
+function stripLeadingReasoningBlocks(text: string): string {
+  let current = text;
+  while (true) {
+    const next = current.replace(taggedReasoningPrefixRe, "");
+    if (next === current) {
+      return current;
+    }
+    current = next;
+  }
+}
+
+function hasFinalSilentToken(text: string, token: string): boolean {
+  const escaped = escapeRegExp(token);
+  return new RegExp(`(?:^|[\\s*.])${escaped}\\s*$`, "i").test(text);
+}
+
+function isReasoningPrefixedSilentReplyText(
+  text: string | undefined,
+  token: string = SILENT_REPLY_TOKEN,
+): boolean {
+  if (!text) {
+    return false;
+  }
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  const withoutLeadingReasoningBlocks = stripLeadingReasoningBlocks(trimmed);
+  if (withoutLeadingReasoningBlocks !== trimmed) {
+    return isSilentReplyText(withoutLeadingReasoningBlocks, token);
+  }
+
+  if (openReasoningPrefixRe.test(trimmed)) {
+    return hasFinalSilentToken(trimmed, token);
+  }
+  if (!plainReasoningPrefixRe.test(trimmed)) {
+    return false;
+  }
+  return hasFinalSilentToken(trimmed, token);
+}
+
 export function isSilentReplyPayloadText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,
 ): boolean {
-  return isSilentReplyText(text, token) || isSilentReplyEnvelopeText(text, token);
+  return (
+    isSilentReplyText(text, token) ||
+    isSilentReplyEnvelopeText(text, token) ||
+    isReasoningPrefixedSilentReplyText(text, token)
+  );
 }
 
 /**

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -110,6 +110,21 @@ function hasSilentIntentFinalSilentToken(text: string, token: string): boolean {
   return !withoutToken || silentIntentTextRe.test(withoutToken);
 }
 
+const plainReasoningOnlyTextRe =
+  /^\s*(?:(?:the\s+)?(?:user|sender|author|message|conversation|thread|chat)\b|[\p{L}\p{N}_-]{2,40}\s+is\b)[\s\S]{0,280}\b(?:talking|asking|saying|discussing|mentioning|referring|following\s+up|checking|wondering)\b[\s\S]*[.!?]?\s*$/iu;
+
+function hasPlainReasoningFinalSilentToken(text: string, token: string): boolean {
+  const withoutToken = stripFinalSilentToken(text, token);
+  if (withoutToken === null) {
+    return false;
+  }
+  return (
+    !withoutToken ||
+    silentIntentTextRe.test(withoutToken) ||
+    plainReasoningOnlyTextRe.test(withoutToken)
+  );
+}
+
 function isReasoningPrefixedSilentReplyText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,
@@ -136,7 +151,11 @@ function isReasoningPrefixedSilentReplyText(
   if (!plainReasoningPrefixRe.test(trimmed)) {
     return false;
   }
-  return hasFinalSilentToken(trimmed, token);
+  const withoutPlainReasoningPrefix = trimmed.replace(plainReasoningPrefixRe, "");
+  return (
+    isSilentReplyText(withoutPlainReasoningPrefix, token) ||
+    hasPlainReasoningFinalSilentToken(withoutPlainReasoningPrefix, token)
+  );
 }
 
 export function isSilentReplyPayloadText(

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -88,11 +88,6 @@ function stripLeadingReasoningBlocks(text: string): string {
   }
 }
 
-function hasFinalSilentToken(text: string, token: string): boolean {
-  const escaped = escapeRegExp(token);
-  return new RegExp(`(?:^|[\\s*.])${escaped}\\s*$`, "i").test(text);
-}
-
 function stripFinalSilentToken(text: string, token: string): string | null {
   const escaped = escapeRegExp(token);
   const stripped = text.replace(new RegExp(`(?:^|[\\s*.])${escaped}\\s*$`, "i"), "").trim();
@@ -146,7 +141,11 @@ function isReasoningPrefixedSilentReplyText(
   }
 
   if (openReasoningPrefixRe.test(trimmed)) {
-    return hasFinalSilentToken(trimmed, token);
+    const withoutOpenReasoningPrefix = trimmed.replace(openReasoningPrefixRe, "");
+    return (
+      isSilentReplyText(withoutOpenReasoningPrefix, token) ||
+      hasPlainReasoningFinalSilentToken(withoutOpenReasoningPrefix, token)
+    );
   }
   if (!plainReasoningPrefixRe.test(trimmed)) {
     return false;

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -93,6 +93,23 @@ function hasFinalSilentToken(text: string, token: string): boolean {
   return new RegExp(`(?:^|[\\s*.])${escaped}\\s*$`, "i").test(text);
 }
 
+function stripFinalSilentToken(text: string, token: string): string | null {
+  const escaped = escapeRegExp(token);
+  const stripped = text.replace(new RegExp(`(?:^|[\\s*.])${escaped}\\s*$`, "i"), "").trim();
+  return stripped === text.trim() ? null : stripped;
+}
+
+const silentIntentTextRe =
+  /^\s*(?:i|i'll|i\s+will|i'm|i\s+am|we|we'll|we\s+will|the\s+assistant|assistant|the\s+bot|bot|openclaw)\s+(?:(?:will\s+)?(?:stay|remain|keep|be)\s+(?:quiet|silent)(?:\s+(?:here|for\s+now|on\s+this|in\s+this\s+(?:chat|thread|channel|conversation)))?|(?:do\s+not|don't|dont|will\s+not|won't|would\s+not|should\s+not)\s+(?:reply|respond)(?:\s+(?:here|for\s+now|on\s+this|in\s+this\s+(?:chat|thread|channel|conversation)))?|(?:have|has)\s+nothing\s+(?:to|for)\s+(?:say|add|reply|respond))(?:[.!?]+)?\s*$/i;
+
+function hasSilentIntentFinalSilentToken(text: string, token: string): boolean {
+  const withoutToken = stripFinalSilentToken(text, token);
+  if (withoutToken === null) {
+    return false;
+  }
+  return !withoutToken || silentIntentTextRe.test(withoutToken);
+}
+
 function isReasoningPrefixedSilentReplyText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,
@@ -107,7 +124,10 @@ function isReasoningPrefixedSilentReplyText(
 
   const withoutLeadingReasoningBlocks = stripLeadingReasoningBlocks(trimmed);
   if (withoutLeadingReasoningBlocks !== trimmed) {
-    return isSilentReplyText(withoutLeadingReasoningBlocks, token);
+    return (
+      isSilentReplyText(withoutLeadingReasoningBlocks, token) ||
+      hasSilentIntentFinalSilentToken(withoutLeadingReasoningBlocks, token)
+    );
   }
 
   if (openReasoningPrefixRe.test(trimmed)) {

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -105,18 +105,28 @@ function hasSilentIntentFinalSilentToken(text: string, token: string): boolean {
   return !withoutToken || silentIntentTextRe.test(withoutToken);
 }
 
-const plainReasoningOnlyTextRe =
-  /^\s*(?:(?:the\s+)?(?:user|sender|author|message|conversation|thread|chat)\b|[\p{L}\p{N}_-]{2,40}\s+is\b)[\s\S]{0,280}\b(?:talking|asking|saying|discussing|mentioning|referring|following\s+up|checking|wondering)\b[\s\S]*[.!?]?\s*$/iu;
+const substantiveAnswerCueRe =
+  /\b(?:answer|here(?:'s|\s+is)|tell\s+them|you\s+(?:should|can|could|need|must)|please|try|use|send|service\s+is|resolved|retry|yes|no,|sure)\b/i;
 
 function hasPlainReasoningFinalSilentToken(text: string, token: string): boolean {
   const withoutToken = stripFinalSilentToken(text, token);
   if (withoutToken === null) {
     return false;
   }
-  return (
-    !withoutToken ||
-    silentIntentTextRe.test(withoutToken) ||
-    plainReasoningOnlyTextRe.test(withoutToken)
+  if (!withoutToken || silentIntentTextRe.test(withoutToken)) {
+    return true;
+  }
+  const lines = withoutToken
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const finalLine = lines.at(-1);
+  const previousLines = lines.slice(0, -1).join("\n");
+  return Boolean(
+    finalLine &&
+    silentIntentTextRe.test(finalLine) &&
+    previousLines &&
+    !substantiveAnswerCueRe.test(previousLines),
   );
 }
 

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -122,11 +122,13 @@ function hasPlainReasoningFinalSilentToken(text: string, token: string): boolean
     .filter(Boolean);
   const finalLine = lines.at(-1);
   const previousLines = lines.slice(0, -1).join("\n");
-  return Boolean(
-    finalLine &&
-    silentIntentTextRe.test(finalLine) &&
-    previousLines &&
-    !substantiveAnswerCueRe.test(previousLines),
+  return (
+    Boolean(
+      finalLine &&
+      silentIntentTextRe.test(finalLine) &&
+      previousLines &&
+      !substantiveAnswerCueRe.test(previousLines),
+    ) || !substantiveAnswerCueRe.test(withoutToken)
   );
 }
 

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -107,6 +107,8 @@ function hasSilentIntentFinalSilentToken(text: string, token: string): boolean {
 
 const substantiveAnswerCueRe =
   /\b(?:answer|here(?:'s|\s+is)|tell\s+them|you\s+(?:should|can|could|need|must)|please|try|use|send|service\s+is|resolved|retry|yes|no,|sure)\b/i;
+const bareReasoningPlaceholderRe =
+  /^\s*(?:(?:internal|private)\s+)?(?:reasoning|thinking|thoughts?|analysis)(?:\s+notes?)?\s*$/i;
 
 function hasPlainReasoningFinalSilentToken(text: string, token: string): boolean {
   const withoutToken = stripFinalSilentToken(text, token);
@@ -128,7 +130,7 @@ function hasPlainReasoningFinalSilentToken(text: string, token: string): boolean
       silentIntentTextRe.test(finalLine) &&
       previousLines &&
       !substantiveAnswerCueRe.test(previousLines),
-    ) || !substantiveAnswerCueRe.test(withoutToken)
+    ) || bareReasoningPlaceholderRe.test(withoutToken)
   );
 }
 

--- a/src/channels/message/inbound-reply-dispatch.ts
+++ b/src/channels/message/inbound-reply-dispatch.ts
@@ -276,9 +276,9 @@ export async function recordChannelMessageReplyDispatch(
     dispatchReplyWithBufferedBlockDispatcher: params.dispatchReplyWithBufferedBlockDispatcher,
     delivery: {
       preparePayload: (payload) =>
-        (payload && typeof payload === "object"
+        payload && typeof payload === "object"
           ? normalizeOutboundReplyPayload(payload as Record<string, unknown>)
-          : {}) as OutboundReplyPayload,
+          : {},
       deliver: async (payload, info) => {
         if (params.durable) {
           const durable = await deliverInboundReplyWithMessageSendContext({

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -78,6 +78,9 @@ describe("normalizeReplyPayloadsForDelivery", () => {
       normalizeReplyPayloadsForDelivery([
         { text: "NO_REPLY" },
         { text: "NO_REPLY\n\nNO_REPLY" },
+        {
+          text: "<think>Cav is talking about a follow-up conversation.</think>\nI will stay quiet here.NO_REPLY",
+        },
         { text: "Reasoning:\n_step_", isReasoning: true },
         { text: "final answer" },
       ]),


### PR DESCRIPTION
## Summary

Fixes #66701 by treating reasoning-prefixed `NO_REPLY` outputs as silent replies instead of letting leaked reasoning text reach group chats.

## Changes

- Detect `think`/reasoning-prefixed payloads that end in `NO_REPLY` in the shared silent reply payload classifier.
- Preserve the existing guard that keeps substantive replies visible when they merely contain a trailing `NO_REPLY` token.
- Add regression coverage for token detection and reply normalization.

## Real behavior proof

- Behavior or issue addressed: Fixes #66701. When an agent final reply starts with leaked reasoning text and ends in the silent `NO_REPLY` token, OpenClaw should suppress that payload before channel/outbound delivery instead of sending the reasoning text to a group chat.
- Real environment tested: Local OpenClaw checkout at `74c5d26863b082ff4cd4be42b69d657443a875f4` on Windows, using Node `v24.14.0` from the Codex bundled runtime and `pnpm 11.1.0`; exercised the production `createReplyDispatcher` final-reply outbound delivery seam with `surface: "telegram"`, `conversationType: "group"`, and a real `deliver` callback wired as the outbound send boundary.
- Exact steps or command run after this patch:

```powershell
$env:PATH='C:\Users\15944\AppData\Local\OpenAI\Codex\bin;' + $env:PATH; pnpm exec tsx -e "import { createReplyDispatcher } from './src/auto-reply/reply/reply-dispatcher.ts'; void (async () => { const deliveries=[]; const skipped=[]; const dispatcher=createReplyDispatcher({ silentReplyContext: { surface: 'telegram', conversationType: 'group', sessionKey: 'agent:main:telegram:group:proof' }, deliver: async (payload, info) => { deliveries.push({ kind: info.kind, text: payload.text ?? '', mediaUrl: payload.mediaUrl ?? null }); }, onSkip: (payload, info) => skipped.push({ kind: info.kind, reason: info.reason, originalText: payload.text }) }); const leaked=['think','Cav is talking about a follow-up conversation.','I will stay quiet here.NO_REPLY'].join('\n'); const leakQueued=dispatcher.sendFinalReply({ text: leaked }); const visibleQueued=dispatcher.sendFinalReply({ text: 'visible outbound sanity check' }); dispatcher.markComplete(); await dispatcher.waitForIdle(); console.log(JSON.stringify({ outboundSetup: 'createReplyDispatcher final reply delivery seam with telegram group silentReplyContext', leakQueued, visibleQueued, queuedCounts: dispatcher.getQueuedCounts(), failedCounts: dispatcher.getFailedCounts(), skipped, deliveries }, null, 2)); })();"
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the outbound delivery seam proof above:

```json
{
  "outboundSetup": "createReplyDispatcher final reply delivery seam with telegram group silentReplyContext",
  "leakQueued": false,
  "visibleQueued": true,
  "queuedCounts": {
    "tool": 0,
    "block": 0,
    "final": 1
  },
  "failedCounts": {
    "tool": 0,
    "block": 0,
    "final": 0
  },
  "skipped": [
    {
      "kind": "final",
      "reason": "silent",
      "originalText": "think\nCav is talking about a follow-up conversation.\nI will stay quiet here.NO_REPLY"
    }
  ],
  "deliveries": [
    {
      "kind": "final",
      "text": "visible outbound sanity check",
      "mediaUrl": null
    }
  ]
}
```

- Observed result after fix: The reasoning-prefixed `NO_REPLY` final reply was skipped with reason `silent`, was not queued, and did not reach `deliveries`; the visible sanity-check reply used the same dispatcher and did reach the outbound deliver seam. That proves the leak payload is stopped before channel delivery.
- What was not tested: No live credentialed Telegram/Discord send was performed. This PR intentionally keeps the policy boundary narrow to #66701's reasoning-prefixed silent-final leak class; broader non-reasoning leak classes and provider policy changes remain out of scope for maintainer follow-up.

## Verification

- `pnpm test src/auto-reply/tokens.test.ts src/auto-reply/reply/reply-utils.test.ts src/infra/outbound/payloads.test.ts -- --reporter=verbose` on 2026-05-12 with Node `v24.14.0`: 3 target files, 129 tests passed across the `unit-fast` and `auto-reply` Vitest shards.
- `pnpm check:changed`
- `pnpm check` via a temporary no-space Windows drive mapping
- `git diff --check`

Notes:
- `pnpm build` currently fails on Windows because the bootstrap guard looks for `.js` outputs while this build emitted `.mjs` files.
- `pnpm test:unit:fast` has existing Windows path/EPERM failures unrelated to this change.

