### PR TITLE
fix(agents): preserve final text after stale incomplete-turn state

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -4,6 +4,7 @@ import { hasCommittedMessagingToolDeliveryEvidence } from "./delivery-evidence.j
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
+  mockedBuildEmbeddedRunPayloads,
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
   mockedLog,
@@ -1181,6 +1182,37 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(incompleteTurnText).toBeNull();
   });
 
+  it("uses current attempt assistant state instead of stale lastAssistant for incomplete-turn detection (#80918)", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Compression complete and verified. Here is the summary."],
+        toolMetas: [{ toolName: "update_plan" }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "toolUse",
+          provider: "openrouter",
+          model: "deepseek/deepseek-v4-pro",
+          content: [{ type: "tool_use", id: "tool_1", name: "update_plan", input: {} }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        currentAttemptAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openrouter",
+          model: "deepseek/deepseek-v4-pro",
+          content: [
+            { type: "thinking", thinking: "update_plan returned successfully" },
+            { type: "text", text: "Compression complete and verified. Here is the summary." },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toBeNull();
+  });
+
   it("surfaces an error for tool-use terminal turn with pre-tool text via runEmbeddedPiAgent (#76477)", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
@@ -1210,6 +1242,56 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("couldn't generate a response");
     expectWarnMessageWith("incomplete turn detected");
+  });
+
+  it("preserves final assistant text when lastAssistant is stale after update_plan (#80918)", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedBuildEmbeddedRunPayloads.mockReturnValueOnce([
+      { text: "Compression complete and verified. Here is the summary." },
+    ]);
+    const currentAttemptAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-pro",
+      content: [
+        { type: "thinking", thinking: "update_plan returned successfully" },
+        { type: "text", text: "Compression complete and verified. Here is the summary." },
+      ],
+    } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"];
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Compression complete and verified. Here is the summary."],
+        toolMetas: [{ toolName: "update_plan" }],
+        lastAssistant: {
+          stopReason: "toolUse",
+          provider: "openrouter",
+          model: "deepseek/deepseek-v4-pro",
+          content: [{ type: "tool_use", id: "tool_1", name: "update_plan", input: {} }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        currentAttemptAssistant,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-pro",
+      runId: "run-update-plan-stale-last-assistant",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(mockedBuildEmbeddedRunPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({ lastAssistant: currentAttemptAssistant }),
+    );
+    expect(result.payloads?.[0]).toMatchObject({
+      text: "Compression complete and verified. Here is the summary.",
+    });
+    expect(result.payloads?.[0]?.isError).not.toBe(true);
+    expectNoWarnMessageWith("incomplete turn detected");
+    expect(result.meta?.finalAssistantVisibleText).toBe(
+      "Compression complete and verified. Here is the summary.",
+    );
   });
 
   it("treats missing replay metadata as replay-invalid", () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2470,13 +2470,16 @@ export async function runEmbeddedPiAgent(
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
             compactionTokensAfter: lastCompactionTokensAfter,
           };
-          const finalAssistantVisibleText = resolveFinalAssistantVisibleText(sessionLastAssistant);
-          const finalAssistantRawText = resolveFinalAssistantRawText(sessionLastAssistant);
+          const terminalAssistantForPayloads = currentAttemptAssistant ?? sessionLastAssistant;
+          const finalAssistantVisibleText = resolveFinalAssistantVisibleText(
+            terminalAssistantForPayloads,
+          );
+          const finalAssistantRawText = resolveFinalAssistantRawText(terminalAssistantForPayloads);
 
           const payloads = buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
             toolMetas: attempt.toolMetas,
-            lastAssistant: attempt.lastAssistant,
+            lastAssistant: terminalAssistantForPayloads,
             lastToolError: attempt.lastToolError,
             config: params.config,
             isCronTrigger: params.trigger === "cron",

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -231,7 +231,8 @@ export function resolveIncompleteTurnPayloadText(params: {
   // Pre-tool text alone (payloadCount > 0) must not suppress the incomplete-
   // turn check in that case — the final post-tool response was never
   // produced. (#76477)
-  const toolUseTerminal = params.attempt.lastAssistant?.stopReason === "toolUse";
+  const terminalAssistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
+  const toolUseTerminal = terminalAssistant?.stopReason === "toolUse";
 
   if (
     (params.payloadCount !== 0 && !toolUseTerminal) ||
@@ -256,7 +257,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   const stopReason = params.attempt.lastAssistant?.stopReason;
   const incompleteTerminalAssistant = isIncompleteTerminalAssistantTurn({
     hasAssistantVisibleText: params.payloadCount > 0,
-    lastAssistant: params.attempt.lastAssistant,
+    lastAssistant: terminalAssistant,
   });
   const reasoningOnlyAssistant = isReasoningOnlyAssistantTurn(
     params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant,


### PR DESCRIPTION
Fixes #80918

## Summary
- Treat `currentAttemptAssistant` as the freshest terminal assistant state for incomplete-turn detection.
- Pass that same terminal assistant into payload construction and final assistant metadata.
- Preserve the post-`update_plan` final answer when `lastAssistant` is still the previous `toolUse` snapshot.

## Real behavior proof

- **Behavior or issue addressed:** A run shaped as `assistant(toolUse update_plan) -> toolResult(empty) -> assistant(stop, visible final text)` must not be classified as incomplete just because `lastAssistant` still points at the previous `toolUse` snapshot.
- **Real environment tested:** Local OpenClaw source checkout on Node 22.22.0, importing the patched runtime helper directly from `src/agents/pi-embedded-runner/run/incomplete-turn.ts` with `node --conditions=openclaw-source --import tsx`. No live WhatsApp/OpenRouter credentials were used.
- **Exact steps or command run after this patch:**
  - Runtime probe: `node --conditions=openclaw-source --import tsx -e '<imports resolveIncompleteTurnPayloadText from source; stale lastAssistant=toolUse; fresh currentAttemptAssistant=stop; payloadCount=1>'`
  - Supplemental regression checks: `pnpm test src/agents/pi-embedded-runner/run.incomplete-turn.test.ts -- --reporter=verbose`
  - Supplemental adjacent checks: `pnpm test src/agents/pi-embedded-runner/run/payloads.test.ts src/cron/isolated-agent/helpers.test.ts -- --reporter=verbose`
  - Supplemental project checks: `pnpm run check:changed`
- **Evidence after fix:** Terminal output from the runtime probe against the patched OpenClaw source tree:

```console
$ node --conditions=openclaw-source --import tsx -e '<imports resolveIncompleteTurnPayloadText from source; stale lastAssistant=toolUse; fresh currentAttemptAssistant=stop; payloadCount=1>'
{
  "staleLastAssistantStopReason": "toolUse",
  "currentAttemptAssistantStopReason": "stop",
  "payloadCount": 1,
  "incompleteTurnPayload": null,
  "visibleFinalText": "Final user-visible answer after update_plan."
}
```

  Supplemental local checks also passed: `run.incomplete-turn.test.ts` 94/94, `run/payloads.test.ts` 24/24, `cron/isolated-agent/helpers.test.ts` 22/22, and `check:changed` exited 0 with 0 oxlint warnings/errors plus 0 runtime value import cycles.
- **Observed result after fix:** With stale `lastAssistant.stopReason = "toolUse"` and fresh `currentAttemptAssistant.stopReason = "stop"`, the patched source returns `incompleteTurnPayload: null` while preserving the visible final text. That is the non-error branch needed for the issue's post-`update_plan` final answer.
- **What was not tested:** I did not run a live WhatsApp/OpenRouter reproduction. The reporter's production trace covers the live channel symptom; this PR covers the source-level data-loss branch and regression tests.

## Risk
- Low scope: changes only terminal assistant selection in the embedded runner and incomplete-turn helper.
- Existing `#76477` guard remains covered: terminal `toolUse` with only pre-tool text still surfaces the incomplete-turn error.
