### PR TITLE
fix(anthropic): enable Claude CLI session-expired history reseed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Anthropic: reseed Claude CLI fresh-session retries from bounded OpenClaw transcript history after session rotation, preventing conversation amnesia. Fixes #80905. (#80934) Thanks @bitloi.
 - Require explicit browser device pairing [AI]. (#81289) Thanks @pgondhi987.
 - Require Control UI pairing before proxy-scoped access [AI]. (#81288) Thanks @pgondhi987.
 - Harden trusted-proxy source validation [AI]. (#81290) Thanks @pgondhi987.

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -63,6 +63,7 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
       imagePathScope: "workspace",
       sessionArg: "--session-id",
       sessionMode: "always",
+      reseedFromRawTranscriptWhenUncompacted: true,
       sessionIdFields: [...CLAUDE_CLI_SESSION_ID_FIELDS],
       systemPromptFileArg: "--append-system-prompt-file",
       systemPromptMode: "append",

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -261,6 +261,15 @@ describe("normalizeClaudeBackendConfig", () => {
     expect(backend.resolveExecutionArgs).toBe(resolveClaudeCliExecutionArgs);
   });
 
+  it("opts bundled Claude CLI into bounded raw transcript reseed without disabling native resume", () => {
+    const backend = buildAnthropicCliBackend();
+
+    expect(backend.config.reseedFromRawTranscriptWhenUncompacted).toBe(true);
+    expect(backend.config.sessionMode).toBe("always");
+    expect(backend.config.resumeArgs).toContain("--resume");
+    expect(backend.config.resumeArgs).toContain("{sessionId}");
+  });
+
   it("leaves claude cli subscription-managed, restricts setting sources, and clears inherited env overrides", () => {
     const backend = buildAnthropicCliBackend();
 


### PR DESCRIPTION
## Summary

- Problem: Claude CLI `session_expired` recovery could retry fresh without OpenClaw transcript history.
- Why it matters: users could see conversation amnesia after Claude CLI rotation even though OpenClaw transcript history was still available.
- What changed: enabled the existing bounded raw transcript reseed opt-in for the bundled Claude CLI backend.
- What did NOT change (scope boundary): native Claude resume, custom CLI backend defaults, and auth-boundary no-reseed protections.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope 

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80905
- Related #79764
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: Claude CLI `session_expired` fresh-session recovery can now use bounded OpenClaw transcript reseed because the bundled Claude backend opts into the existing reseed contract.
- Real environment tested: Local OpenClaw source checkout on Linux, branch `fix/issue-80905-claude-cli-reseed`, built from `upstream/main` `abb4f96b81df4f91ab2b593d0aea2ebc9698e445`.
- Exact steps or command run after this patch:
  - `node scripts/run-node.mjs --help`
  - `CI=true corepack pnpm test:extension anthropic`
  - `CI=true corepack pnpm test extensions/anthropic/cli-shared.test.ts`
  - `CI=true corepack pnpm test src/agents/cli-runner/session-history.test.ts src/agents/cli-runner/prepare.test.ts src/agents/cli-runner.reliability.test.ts extensions/anthropic/cli-shared.test.ts`
  - `CI=true corepack pnpm test extensions/anthropic`
  - `CI=true corepack pnpm check:changed`
- Evidence after fix (terminal capture):

```text
$ node scripts/run-node.mjs --help
[openclaw] Building TypeScript (dist is stale: missing_build_stamp - build stamp missing).
[openclaw] Building bundled plugin assets.
OpenClaw 2026.5.12-beta.1 (abb4f96) -- All your chats, one OpenClaw.
Usage: openclaw [options] [command]
Commands:
  agent                Run one agent turn via the Gateway
  gateway *            Run, inspect, and query the OpenClaw Gateway
  models *             List, scan, and set model providers
  sessions *           List stored conversation sessions

$ CI=true corepack pnpm test:extension anthropic
[test-extension] Running 6 test files for anthropic
Test Files  6 passed (6)
Tests       69 passed (69)

$ CI=true corepack pnpm test extensions/anthropic/cli-shared.test.ts
Test Files  1 passed (1)
Tests       17 passed (17)

$ CI=true corepack pnpm test src/agents/cli-runner/session-history.test.ts src/agents/cli-runner/prepare.test.ts src/agents/cli-runner.reliability.test.ts extensions/anthropic/cli-shared.test.ts
Test Files  3 passed (3)
Tests       50 passed (50)
Test Files  1 passed (1)
Tests       17 passed (17)

$ CI=true corepack pnpm test extensions/anthropic
Test Files  6 passed (6)
Tests       69 passed (69)

$ CI=true corepack pnpm check:changed
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).
```

- Observed result after fix: source-built OpenClaw starts locally, and the bundled Claude CLI backend now reports `reseedFromRawTranscriptWhenUncompacted: true` while preserving native resume args. The regression test failed before the fix with `expected undefined to be true`, then passed after the backend opt-in was added.
- What was not tested: live authenticated Claude CLI rotation. This environment does not have a `claude` binary installed (`command -v claude` returned exit code 1), so live provider rotation proof needs a Claude-authenticated environment or maintainer `proof: override`.
- Before evidence (optional but encouraged):

```text
$ CI=true corepack pnpm test extensions/anthropic/cli-shared.test.ts
FAIL extensions/anthropic/cli-shared.test.ts > normalizeClaudeBackendConfig > opts bundled Claude CLI into bounded raw transcript reseed without disabling native resume
AssertionError: expected undefined to be true
```

## Root Cause

- Root cause: bundled Claude CLI had native resume configured but did not opt into the existing bounded raw transcript reseed contract, so `session_expired` fresh retries could be prepared without OpenClaw history.
- Missing detection / guardrail: no extension-level regression test asserted that the bundled Claude backend enabled the reseed contract while preserving native resume.
- Contributing context (if known): #79764 added the generic opt-in reseed machinery, but left backend participation explicit and disabled by default.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/anthropic/cli-shared.test.ts`
- Scenario the test should lock in: bundled Claude CLI opts into bounded raw transcript reseed without disabling native resume.
- Why this is the smallest reliable guardrail: the bug was a missing bundled-backend config opt-in; generic runner reseed behavior was already covered.
- Existing test that already covers this (if any): `src/agents/cli-runner/session-history.test.ts`, `src/agents/cli-runner/prepare.test.ts`, and `src/agents/cli-runner.reliability.test.ts` cover the safe reseed, `session_expired`, and preserved auth-boundary behavior.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Claude CLI fresh-session recovery after safe invalidations can include bounded OpenClaw transcript history instead of retrying with only the current prompt.

## Diagram

```text
Before:
Claude resume -> session_expired -> fresh retry -> current prompt only

After:
Claude resume -> session_expired -> fresh retry -> bounded OpenClaw history + current prompt
```

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local source checkout
- Model/provider: `claude-cli` backend config; no live Claude binary available in this environment
- Integration/channel (if any): Anthropic bundled CLI backend
- Relevant config (redacted): default bundled backend config

### Steps

1. Add an extension-level regression assertion that `buildAnthropicCliBackend().config.reseedFromRawTranscriptWhenUncompacted` is true and native resume args remain present.
2. Run the regression before the fix and observe it fail with `expected undefined to be true`.
3. Enable `reseedFromRawTranscriptWhenUncompacted: true` in the bundled Claude backend config.
4. Run the targeted regression, issue acceptance tests, Anthropic extension tests, formatting check, and changed-file check.

### Expected

- Bundled Claude CLI opts into bounded raw transcript reseed.
- Native Claude resume remains configured with `sessionMode: "always"` and `--resume {sessionId}`.
- Existing raw-reseed safety behavior remains governed by generic CLI runner/session-history tests.

### Actual

- All targeted tests and checks passed after the one-field backend config fix.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

What you personally verified (not just CI), and how:

- Verified scenarios: new regression failed before and passed after; Anthropic extension lane passed; issue acceptance test slice passed; local OpenClaw CLI built and printed help from this checkout.
- Edge cases checked: native resume args are preserved; generic tests cover safe invalidation reasons and auth-boundary no-reseed behavior.
- What you did **not** verify: live authenticated Claude CLI rotation or an actual provider-side `session_expired` event in a Claude-authenticated runtime.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: live Claude rotation was not reproduced locally because the environment lacks the `claude` binary.
  - Mitigation: the patch uses existing bounded reseed machinery, adds a regression for the exact bundled-backend opt-in, and runs the issue's requested acceptance tests. Maintainers can either apply `proof: override` or rerun the same branch in a Claude-authenticated environment for live proof.
- Risk: raw transcript reseed could be too broad.
  - Mitigation: this PR only opts the bundled Claude backend into the existing bounded contract; generic session-history tests preserve auth-profile and credential-epoch no-reseed protections.
