### PR TITLE
docs(memory): clarify session transcript recall gates

### DIFF
--- a/docs/concepts/memory-qmd.md
+++ b/docs/concepts/memory-qmd.md
@@ -149,10 +149,19 @@ collection root.
 
 ## Indexing session transcripts
 
-Enable session indexing to recall earlier conversations:
+Enable session indexing to recall earlier conversations. QMD needs both the general
+`memorySearch` session source and the QMD transcript exporter:
 
 ```json5
 {
+  agents: {
+    defaults: {
+      memorySearch: {
+        experimental: { sessionMemory: true },
+        sources: ["memory", "sessions"],
+      },
+    },
+  },
   memory: {
     backend: "qmd",
     qmd: {
@@ -163,7 +172,14 @@ Enable session indexing to recall earlier conversations:
 ```
 
 Transcripts are exported as sanitized User/Assistant turns into a dedicated QMD
-collection under `~/.openclaw/agents/<id>/qmd/sessions/`.
+collection under `~/.openclaw/agents/<id>/qmd/sessions/`. Setting only
+`memorySearch.experimental.sessionMemory` does not export transcripts into QMD.
+
+Session hits are still filtered by
+[`tools.sessions.visibility`](/gateway/config-tools#toolssessions). The default
+`tree` visibility does not expose unrelated same-agent sessions. If a
+gateway-dispatched session should be recallable from a separate DM session, set
+`tools.sessions.visibility: "agent"` intentionally.
 
 ## Search scope
 

--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -134,7 +134,17 @@ setup.
 
 You can optionally index session transcripts so `memory_search` can recall
 earlier conversations. This is opt-in via
-`memorySearch.experimental.sessionMemory`. See the
+`memorySearch.experimental.sessionMemory` and `sources: ["sessions"]`; the default
+source list is memory-only. The experimental flag enables session transcript
+indexing, while `sources` controls whether session chunks are searched.
+
+Session hits obey `tools.sessions.visibility`: the default `tree` setting only
+exposes the current session and sessions it spawned. To recall an unrelated
+same-agent gateway-dispatched session from a separate DM session, intentionally
+widen visibility to `agent`.
+
+When using QMD, also set `memory.qmd.sessions.enabled: true` so transcripts are
+exported into a QMD collection. See the
 [configuration reference](/reference/memory-config) for details.
 
 ## Troubleshooting

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -449,6 +449,66 @@ Index session transcripts and surface them via `memory_search`:
 Session indexing is opt-in and runs asynchronously. Results can be slightly stale. Session logs live on disk, so treat filesystem access as the trust boundary.
 </Warning>
 
+Session transcript hits also obey
+[`tools.sessions.visibility`](/gateway/config-tools#toolssessions). The default
+`tree` visibility only exposes the current session and sessions it spawned. To
+recall an unrelated same-agent gateway-dispatched session from a different
+session, such as a DM, intentionally widen visibility to `agent` (or `all` only
+when cross-agent recall is also required and agent-to-agent policy allows it).
+
+The examples below place these settings under `agents.defaults`. You can also
+apply equivalent `memorySearch` settings in a per-agent override when only one
+agent should index and search session transcripts.
+
+For same-agent gateway-to-DM recall:
+
+<Tabs>
+  <Tab title="Builtin backend">
+    ```json5
+    {
+      agents: {
+        defaults: {
+          memorySearch: {
+            experimental: { sessionMemory: true },
+            sources: ["memory", "sessions"],
+          },
+        },
+      },
+      tools: {
+        sessions: { visibility: "agent" },
+      },
+    }
+    ```
+  </Tab>
+  <Tab title="QMD backend">
+    ```json5
+    {
+      agents: {
+        defaults: {
+          memorySearch: {
+            experimental: { sessionMemory: true },
+            sources: ["memory", "sessions"],
+          },
+        },
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          sessions: { enabled: true },
+        },
+      },
+      tools: {
+        sessions: { visibility: "agent" },
+      },
+    }
+    ```
+  </Tab>
+</Tabs>
+
+When using QMD, `agents.defaults.memorySearch.experimental.sessionMemory` and
+`sources: ["sessions"]` do not by themselves export transcripts into QMD. Set
+`memory.qmd.sessions.enabled: true` as well.
+
 ---
 
 ## SQLite vector acceleration (sqlite-vec)
@@ -481,7 +541,7 @@ Set `memory.backend = "qmd"` to enable. All QMD settings live under `memory.qmd`
 | `searchMode`             | `string`  | `search` | Search command: `search`, `vsearch`, `query`                                          |
 | `includeDefaultMemory`   | `boolean` | `true`   | Auto-index `MEMORY.md` + `memory/**/*.md`                                             |
 | `paths[]`                | `array`   | --       | Extra paths: `{ name, path, pattern? }`                                               |
-| `sessions.enabled`       | `boolean` | `false`  | Index session transcripts                                                             |
+| `sessions.enabled`       | `boolean` | `false`  | Export session transcripts into QMD                                                   |
 | `sessions.retentionDays` | `number`  | --       | Transcript retention                                                                  |
 | `sessions.exportDir`     | `string`  | --       | Export directory                                                                      |
 


### PR DESCRIPTION
## Summary

- Clarify that session transcript recall needs both `memorySearch.experimental.sessionMemory` and a `sessions` source.
- Document that QMD session transcript export additionally requires `memory.qmd.sessions.enabled: true`.
- Document that session transcript hits obey `tools.sessions.visibility`, so same-agent gateway-to-DM recall requires an intentional visibility setting such as `agent`.

## Why

Related #53550.

Issue #53550 reports that enabling experimental session memory did not surface gateway-dispatched sessions in `memory_search`.

The current behavior has two separate gates that are easy to miss:

1. QMD transcript export is controlled by `memory.qmd.sessions.enabled`.
2. Session hits are filtered by `tools.sessions.visibility`; the default `tree` visibility only exposes the current session and sessions it spawned.

This PR keeps behavior unchanged and documents the required configuration instead of widening transcript export or visibility defaults.

## Real behavior proof

- Behavior or issue addressed: The rendered docs now tell users that session transcript recall needs the session-memory flag, a `sessions` search source, QMD transcript export when using QMD, and intentional `tools.sessions.visibility` widening for unrelated same-agent session recall.
- Real environment tested: Disposable OpenClaw source checkout at PR head `701bbabfdb1e` on Linux arm64 with Node available; docs files were inspected directly from the patched source tree.
- Exact steps or command run after this patch: `git diff --check origin/main...HEAD` and a small source-tree proof script that checks the changed docs for the new session-memory/QMD/visibility guidance, balanced `<Tabs>/<Tab>` structure in the new example, and the linked `tools.sessions` docs target.
- Evidence after fix: Terminal transcript from the disposable checkout:

  ```text
  $ git rev-parse --short=12 HEAD
  701bbabfdb1e
  $ git diff --check origin/main...HEAD
  $ python3 /path/to/prove_80935_docs.py
  OK content: docs/concepts/memory-search.md (3 expected clarifications present)
  OK content: docs/concepts/memory-qmd.md (3 expected clarifications present)
  OK content: docs/reference/memory-config.md (4 expected clarifications present)
  OK structure: session-memory Tabs/Tab example block is balanced
  OK link target: docs/gateway/config-tools.md contains tools.sessions target text
  ```
- Observed result after fix: The patched docs contain the missing recall gates in all three affected pages, the new QMD/Builtin example block is structurally balanced, the `tools.sessions.visibility` link target exists, and `git diff --check` produced no whitespace errors.
- What was not tested: Live Gateway/runtime recall was intentionally not run for this docs-only change, and no production config or runtime state was used.

## Validation

- `corepack pnpm docs:check-mdx`
- `corepack pnpm format:docs:check`
- `git diff --check`
- structural docs check for balanced `<Tabs>/<Tab>` blocks and the `tools.sessions` anchor target
