### PR TITLE
fix(agents): honor claude-cli configured context token caps

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -226,6 +226,118 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("persists configured Anthropic contextTokens for claude-cli runtime models", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [
+                {
+                  id: "claude-opus-4-7",
+                  contextWindow: 1_048_576,
+                  contextTokens: 100_000,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-claude-cli-context-cap";
+      const sessionId = "test-claude-cli-context-cap-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 1,
+          executionTrace: { runner: "cli" },
+          agentMeta: {
+            sessionId,
+            provider: "claude-cli",
+            model: "anthropic/claude-opus-4-7",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "claude-cli",
+        defaultModel: "anthropic/claude-opus-4-7",
+        result,
+      });
+
+      expect(sessionStore[sessionKey]?.contextTokens).toBe(100_000);
+      expect(loadSessionStore(storePath)[sessionKey]?.contextTokens).toBe(100_000);
+    });
+  });
+
+  it("persists configured non-1M Anthropic contextTokens for claude-cli runtime models", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [
+                {
+                  id: "claude-haiku-3-5",
+                  contextWindow: 200_000,
+                  contextTokens: 64_000,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-claude-cli-haiku-context-cap";
+      const sessionId = "test-claude-cli-haiku-context-cap-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 1,
+          executionTrace: { runner: "cli" },
+          agentMeta: {
+            sessionId,
+            provider: "claude-cli",
+            model: "anthropic/claude-haiku-3-5",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "claude-cli",
+        defaultModel: "anthropic/claude-haiku-3-5",
+        result,
+      });
+
+      expect(sessionStore[sessionKey]?.contextTokens).toBe(64_000);
+      expect(loadSessionStore(storePath)[sessionKey]?.contextTokens).toBe(64_000);
+    });
+  });
+
   it("clears the embedded harness pin after a CLI run", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -439,6 +439,58 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
+  it("honors configured contextTokens caps for Anthropic models routed through claude-cli", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [
+                {
+                  ...testModelContextWindow("claude-opus-4-7", ANTHROPIC_CONTEXT_1M_TOKENS),
+                  contextTokens: 100_000,
+                },
+              ],
+            },
+          },
+        },
+      },
+      provider: "claude-cli",
+      model: "anthropic/claude-opus-4-7",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(100_000);
+  });
+
+  it("honors configured non-1M Anthropic caps routed through claude-cli", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [
+                {
+                  ...testModelContextWindow("claude-haiku-3-5", 200_000),
+                  contextTokens: 64_000,
+                },
+              ],
+            },
+          },
+        },
+      },
+      provider: "claude-cli",
+      model: "anthropic/claude-haiku-3-5",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(64_000);
+  });
+
   it("does not force 1M context for non-Anthropic providers with opus 4.7 ids", () => {
     const result = resolveContextTokensForModel({
       provider: "github-copilot",

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -11,6 +11,7 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveDefaultAgentDir } from "./agent-scope.js";
 import { lookupCachedContextTokens, MODEL_CONTEXT_TOKEN_CACHE } from "./context-cache.js";
 import { CONTEXT_WINDOW_RUNTIME_STATE } from "./context-runtime-state.js";
+import { listLegacyRuntimeModelProviderAliases } from "./model-runtime-aliases.js";
 import { normalizeProviderId } from "./model-selection.js";
 
 export { resetContextWindowCacheForTest } from "./context-runtime-state.js";
@@ -321,6 +322,46 @@ function resolveProviderModelRef(params: {
   return { provider, model };
 }
 
+function resolvePositiveContextTokenValue(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+function stripProviderPrefixForMatch(provider: string, model: string): string {
+  const slash = model.indexOf("/");
+  if (slash <= 0) {
+    return model;
+  }
+  const modelProvider = normalizeProviderId(model.slice(0, slash));
+  if (modelProvider !== normalizeProviderId(provider)) {
+    return model;
+  }
+  return model.slice(slash + 1).trim() || model;
+}
+
+function configuredModelIdMatches(provider: string, configuredId: string, model: string): boolean {
+  if (configuredId === model) {
+    return true;
+  }
+  return (
+    stripProviderPrefixForMatch(provider, configuredId) ===
+    stripProviderPrefixForMatch(provider, model)
+  );
+}
+
+function providerLookupCandidates(provider: string): string[] {
+  const normalizedProvider = normalizeProviderId(provider);
+  const candidates = [provider, normalizedProvider];
+  const runtimeAlias = listLegacyRuntimeModelProviderAliases().find(
+    (entry) => normalizeProviderId(entry.legacyProvider) === normalizedProvider,
+  );
+  if (runtimeAlias) {
+    candidates.push(runtimeAlias.provider, normalizeProviderId(runtimeAlias.provider));
+  }
+  return Array.from(new Set(candidates.filter(Boolean)));
+}
+
 // Look up an explicit runtime context cap for a specific provider+model
 // directly from config, without going through the shared discovery cache.
 // This avoids the cache keyspace collision where "provider/model" synthetic
@@ -362,7 +403,7 @@ function resolveConfiguredProviderContextTokens(
                 : undefined;
           if (
             typeof m?.id === "string" &&
-            m.id === model &&
+            configuredModelIdMatches(providerId, m.id, model) &&
             typeof contextTokens === "number" &&
             contextTokens > 0
           ) {
@@ -389,6 +430,40 @@ function resolveConfiguredProviderContextTokens(
   // 2. Normalized fallback: covers alias keys such as "z.ai" → "zai".
   const normalizedProvider = normalizeProviderId(provider);
   return findContextTokens((id) => normalizeProviderId(id) === normalizedProvider);
+}
+
+function resolveConfiguredProviderContextTokenCap(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+  model: string,
+): number | undefined {
+  const providers = (cfg?.models as ModelsConfig | undefined)?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  for (const candidate of providerLookupCandidates(provider)) {
+    const normalizedCandidate = normalizeProviderId(candidate);
+    for (const [providerId, providerConfig] of Object.entries(providers)) {
+      if (normalizeProviderId(providerId) !== normalizedCandidate) {
+        continue;
+      }
+      if (Array.isArray(providerConfig?.models)) {
+        for (const m of providerConfig.models) {
+          if (typeof m?.id === "string" && configuredModelIdMatches(providerId, m.id, model)) {
+            const modelCap = resolvePositiveContextTokenValue(m.contextTokens);
+            if (modelCap !== undefined) {
+              return modelCap;
+            }
+          }
+        }
+      }
+      const providerCap = resolvePositiveContextTokenValue(providerConfig?.contextTokens);
+      if (providerCap !== undefined) {
+        return providerCap;
+      }
+    }
+  }
+  return undefined;
 }
 
 function isAnthropic1MModel(provider: string, model: string): boolean {
@@ -456,6 +531,16 @@ export function resolveContextTokensForModel(params: {
   });
   const explicitProvider = params.provider?.trim();
   if (ref) {
+    if (explicitProvider) {
+      const configuredContextTokenCap = resolveConfiguredProviderContextTokenCap(
+        params.cfg,
+        explicitProvider,
+        ref.model,
+      );
+      if (configuredContextTokenCap !== undefined) {
+        return configuredContextTokenCap;
+      }
+    }
     if (explicitProvider && isAnthropic1MModel(ref.provider, ref.model)) {
       return ANTHROPIC_CONTEXT_1M_TOKENS;
     }


### PR DESCRIPTION
Fixes #80933

## Summary
- Keep configured `contextTokens` caps authoritative for Anthropic models routed through the `claude-cli` runtime.
- Reuse the existing legacy runtime-provider alias table so `claude-cli` can look up canonical `anthropic` model caps without hard-coding another alias path.
- Preserve existing 1M Anthropic Opus/Sonnet behavior when only `contextWindow` is configured; only explicit `contextTokens` caps override the 1M runtime window.

## Real behavior proof

- **Behavior or issue addressed:** A `claude-cli` runtime session using canonical model `anthropic/claude-opus-4-7` with `models.providers.anthropic.models[].contextTokens = 100000` must persist and compact against the configured 100k budget, not the 1M Anthropic runtime window or the cold fallback.
- **Real environment tested:** Local OpenClaw source checkout on Node 22.22.0, importing the patched `resolveContextTokensForModel` source with `node --import tsx`. No live Claude CLI credentials or Anthropic account were used.
- **Exact steps or command run after this patch:**
  - Runtime probe: `node --import tsx -e '<imports resolveContextTokensForModel from src/agents/context.ts; cfg has anthropic claude-opus-4-7 contextWindow=1048576 and contextTokens=100000; provider=claude-cli; model=anthropic/claude-opus-4-7>'`
  - Regression tests: `pnpm test src/agents/context.test.ts src/agents/command/session-store.test.ts src/agents/context.lookup.test.ts src/agents/command/cli-compaction.test.ts -- --reporter=verbose`
  - Formatting/whitespace: `pnpm exec oxfmt --check --threads=1 src/agents/context.ts src/agents/context.test.ts src/agents/command/session-store.test.ts && git diff --check`
  - Project changed checks: `pnpm run check:changed`
- **Evidence after fix:** Terminal output from the runtime probe against the patched source tree:

```console
$ node --import tsx -e '<imports resolveContextTokensForModel from source; claude-cli runtime; canonical anthropic model; configured contextTokens=100000>'
{
  "provider": "claude-cli",
  "model": "anthropic/claude-opus-4-7",
  "configuredAnthropicContextTokens": 100000,
  "configuredAnthropicContextWindow": 1048576,
  "resolvedContextTokens": 100000
}
```

  Supplemental local checks also passed: context/session-store/lookup/cli-compaction tests 71/71, `check:changed` exited 0, oxfmt check passed, and `git diff --check` passed.
- **Observed result after fix:** The patched source resolves `resolvedContextTokens: 100000` for the `claude-cli` runtime path. The new session-store regression also persists that 100k cap into `SessionEntry.contextTokens`, which is the field `runCliTurnCompactionLifecycle` uses before evaluating CLI compaction.
- **What was not tested:** I did not run a live Claude CLI session with Anthropic OAuth. The reporter's live fleet output covers the live symptom; this PR verifies the source-level budget resolution and session persistence path that gates CLI compaction.

## Risk
- Low-to-medium scope: context-token lookup is shared, but the changed override only applies when an explicit `contextTokens` cap is configured.
- Existing 1M Anthropic Opus/Sonnet `contextWindow` behavior remains covered and unchanged.
