### PR TITLE
docs(i18n): add Simplified Chinese (zh-CN) documentation

### DIFF
--- a/docs/zh-CN/concepts/features.md
+++ b/docs/zh-CN/concepts/features.md
@@ -1,0 +1,91 @@
+---
+summary: "OpenClaw 在通道、路由、媒体和用户体验方面的能力。"
+read_when:
+  - 你想获取 OpenClaw 支持的功能完整列表
+title: "功能"
+---
+
+## 亮点
+
+<Columns>
+  <Card title="通道" icon="message-square" href="/zh-CN/channels">
+    一个 Gateway 即可支持 Discord、iMessage、Signal、Slack、Telegram、WhatsApp、WebChat 等。
+  </Card>
+  <Card title="插件" icon="plug" href="/zh-CN/tools/plugin">
+    捆绑插件在正式版本中添加 Matrix、Nextcloud Talk、Nostr、Twitch、Zalo 等支持，无需额外安装。
+  </Card>
+  <Card title="路由" icon="route" href="/zh-CN/concepts/multi-agent">
+    多代理路由，隔离会话。
+  </Card>
+  <Card title="媒体" icon="image" href="/zh-CN/nodes/images">
+    图片、音频、视频、文档，以及图片和视频生成。
+  </Card>
+  <Card title="应用与界面" icon="monitor" href="/zh-CN/web/control-ui">
+    Web 控制面板和 macOS 伴侣应用。
+  </Card>
+  <Card title="移动节点" icon="smartphone" href="/zh-CN/nodes">
+    iOS 和 Android 节点，支持配对、语音/聊天，以及丰富的设备命令。
+  </Card>
+</Columns>
+
+## 完整列表
+
+**通道：**
+
+- 内置通道包括 Discord、Google Chat、iMessage、IRC、Signal、Slack、Telegram、WebChat 和 WhatsApp
+- 捆绑插件通道包括飞书、LINE、Matrix、Mattermost、Microsoft Teams、Nextcloud Talk、Nostr、QQ Bot、Synology Chat、Tlon、Twitch、Zalo 和 Zalo Personal
+- 可选的单独安装通道插件包括 Voice Call 和第三方软件包（如微信）
+- 第三方通道插件可以进一步扩展 Gateway，例如微信
+- 群聊支持，基于提及的激活方式
+- 私聊安全保护，包含允许列表和配对机制
+
+**代理：**
+
+- 嵌入式代理运行时，支持工具流式调用
+- 多代理路由，按工作区或发送者隔离会话
+- 会话：私聊合并到共享的 `main`；群组隔离
+- 长回复支持流式和分段
+
+**认证与提供商：**
+
+- 35+ 模型提供商（Anthropic、OpenAI、Google 等）
+- 通过 OAuth 的订阅认证（如 OpenAI Codex）
+- 自定义和自托管提供商支持（vLLM、SGLang、Ollama，以及任何兼容 OpenAI 或 Anthropic 的端点）
+
+**媒体：**
+
+- 输入和输出图片、音频、视频和文档
+- 共享图片生成和视频生成功能界面
+- 语音笔记转录
+- 文本转语音，支持多个提供商
+
+**应用与界面：**
+
+- WebChat 和浏览器控制面板
+- macOS 菜单栏伴侣应用
+- iOS 节点，支持配对、Canvas、相机、屏幕录制、位置和语音
+- Android 节点，支持配对、聊天、语音、Canvas、相机和设备命令
+
+**工具与自动化：**
+
+- 浏览器自动化、执行、沙箱
+- 网页搜索（Brave、DuckDuckGo、Exa、Firecrawl、Gemini、Grok、Kimi、MiniMax Search、Ollama Web Search、Perplexity、SearXNG、Tavily）
+- Cron 任务和心跳调度
+- 技能、插件和工作流管道（Lobster）
+
+## 相关文档
+
+<CardGroup cols={2}>
+  <Card title="实验性功能" href="/zh-CN/concepts/experimental-features" icon="flask">
+    尚未发布到默认界面的可选功能。
+  </Card>
+  <Card title="代理运行时" href="/zh-CN/concepts/agent" icon="robot">
+    代理运行时模型以及运行的调度方式。
+  </Card>
+  <Card title="通道" href="/zh-CN/channels" icon="message-square">
+    从一个 Gateway 连接 Telegram、WhatsApp、Discord、Slack 等。
+  </Card>
+  <Card title="插件" href="/zh-CN/tools/plugin" icon="plug">
+    扩展 OpenClaw 的捆绑插件和第三方插件。
+  </Card>
+</CardGroup>

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -1,0 +1,196 @@
+---
+summary: "OpenClaw 是一个跨平台的 AI 代理网关，可在任何操作系统上运行。"
+read_when:
+  - 向新用户介绍 OpenClaw 时
+title: "OpenClaw"
+---
+
+# OpenClaw 🦞
+
+<p align="center">
+    <img
+        src="/assets/openclaw-logo-text-dark.png"
+        alt="OpenClaw"
+        width="500"
+        class="dark:hidden"
+    />
+    <img
+        src="/assets/openclaw-logo-text.png"
+        alt="OpenClaw"
+        width="500"
+        class="hidden dark:block"
+    />
+</p>
+
+> _"去角质！去角质！"_ — 大概是一只太空龙虾
+
+<p align="center">
+  <strong>适用于任何操作系统的 AI 代理多通道网关，支持 Discord、Google Chat、iMessage、Matrix、Microsoft Teams、Signal、Slack、Telegram、WhatsApp、Zalo 等平台。</strong><br />
+  发一条消息，从口袋里收到代理回复。在一个 Gateway 中运行内置通道、捆绑通道插件、WebChat 和移动节点。
+</p>
+
+<Columns>
+  <Card title="开始使用" href="/zh-CN/start/getting-started" icon="rocket">
+    安装 OpenClaw，几分钟内启动 Gateway。
+  </Card>
+  <Card title="运行引导向导" href="/zh-CN/start/wizard" icon="sparkles">
+    使用 `openclaw onboard` 进行引导设置和配对流程。
+  </Card>
+  <Card title="打开控制面板" href="/zh-CN/web/control-ui" icon="layout-dashboard">
+    在浏览器中启动仪表板，进行聊天、配置和会话管理。
+  </Card>
+</Columns>
+
+## 什么是 OpenClaw？
+
+OpenClaw 是一个**自托管网关**，将你喜爱的聊天应用和通道界面——包括内置通道以及 Discord、Google Chat、iMessage、Matrix、Microsoft Teams、Signal、Slack、Telegram、WhatsApp、Zalo 等捆绑或外部通道插件——连接到 AI 编程代理（如 Pi）。你在自己的机器（或服务器）上运行一个 Gateway 进程，它就会成为你的消息应用和随时待命的 AI 助手之间的桥梁。
+
+**适合谁？** 想要一个可以随时随地发消息的个人 AI 助手，但又不想放弃数据控制权或依赖托管服务的开发者和高级用户。
+
+**有什么不同？**
+
+- **自托管**：运行在你的硬件上，你的地盘你做主
+- **多通道**：一个 Gateway 同时服务内置通道和捆绑/外部通道插件
+- **代理原生**：专为编程代理设计，支持工具调用、会话、记忆和多代理路由
+- **开源**：MIT 许可证，社区驱动
+
+**你需要什么？** Node 24（推荐），或 Node 22 LTS（`22.16+`）兼容版本、你选择的服务提供商的 API 密钥，以及 5 分钟时间。为了最佳质量和安全性，请使用你信任的最新一代最强模型。
+
+## 工作原理
+
+```mermaid
+flowchart LR
+  A["聊天应用 + 插件"] --> B["Gateway"]
+  B --> C["Pi 代理"]
+  B --> D["CLI"]
+  B --> E["Web 控制面板"]
+  B --> F["macOS 应用"]
+  B --> G["iOS 和 Android 节点"]
+```
+
+Gateway 是会话、路由和通道连接的唯一真相源。
+
+## 核心能力
+
+<Columns>
+  <Card title="多通道网关" icon="network" href="/zh-CN/channels">
+    一个 Gateway 进程即可连接 Discord、iMessage、Signal、Slack、Telegram、WhatsApp、WebChat 等。
+  </Card>
+  <Card title="插件通道" icon="plug" href="/zh-CN/tools/plugin">
+    捆绑插件在正式版本中添加 Matrix、Nostr、Twitch、Zalo 等支持。
+  </Card>
+  <Card title="多代理路由" icon="route" href="/zh-CN/concepts/multi-agent">
+    按代理、工作区或发送者隔离会话。
+  </Card>
+  <Card title="媒体支持" icon="image" href="/zh-CN/nodes/images">
+    发送和接收图片、音频和文档。
+  </Card>
+  <Card title="Web 控制面板" icon="monitor" href="/zh-CN/web/control-ui">
+    浏览器仪表板，用于聊天、配置、会话和节点管理。
+  </Card>
+  <Card title="移动节点" icon="smartphone" href="/zh-CN/nodes">
+    配对 iOS 和 Android 节点，支持 Canvas、相机和语音工作流。
+  </Card>
+</Columns>
+
+## 快速开始
+
+<Steps>
+  <Step title="安装 OpenClaw">
+    ```bash
+    npm install -g openclaw@latest
+    ```
+  </Step>
+  <Step title="引导并安装服务">
+    ```bash
+    openclaw onboard --install-daemon
+    ```
+  </Step>
+  <Step title="开始聊天">
+    在浏览器中打开控制面板并发送消息：
+
+    ```bash
+    openclaw dashboard
+    ```
+
+    或者连接一个通道（[Telegram](/zh-CN/channels/telegram) 最快），从手机聊天。
+
+  </Step>
+</Steps>
+
+需要完整的安装和开发设置？查看[开始使用指南](/zh-CN/start/getting-started)。
+
+## 控制面板
+
+Gateway 启动后打开浏览器控制面板。
+
+- 本地默认：[http://127.0.0.1:18789/](http://127.0.0.1:18789/)
+- 远程访问：[Web 界面](/zh-CN/web) 和 [Tailscale](/zh-CN/gateway/tailscale)
+
+<p align="center">
+  <img src="/whatsapp-openclaw.jpg" alt="OpenClaw" width="420" />
+</p>
+
+## 配置（可选）
+
+配置文件位于 `~/.openclaw/openclaw.json`。
+
+- 如果你**什么都不做**，OpenClaw 会使用内置的 Pi 二进制文件，以 RPC 模式运行，每个发送者独立会话。
+- 如果你想锁定权限，从 `channels.whatsapp.allowFrom` 开始（对于群组）设置提及规则。
+
+示例：
+
+```json5
+{
+  channels: {
+    whatsapp: {
+      allowFrom: ["+15555550123"],
+      groups: { "*": { requireMention: true } },
+    },
+  },
+  messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+}
+```
+
+## 从这里开始
+
+<Columns>
+  <Card title="文档中心" href="/zh-CN/start/hubs" icon="book-open">
+    所有文档和指南，按使用场景分类整理。
+  </Card>
+  <Card title="配置" href="/zh-CN/gateway/configuration" icon="settings">
+    核心 Gateway 设置、令牌和服务商配置。
+  </Card>
+  <Card title="远程访问" href="/zh-CN/gateway/remote" icon="globe">
+    SSH 和 tailnet 访问模式。
+  </Card>
+  <Card title="通道" href="/zh-CN/channels/telegram" icon="message-square">
+    Feishu、Microsoft Teams、WhatsApp、Telegram、Discord 等通道的具体设置。
+  </Card>
+  <Card title="节点" href="/zh-CN/nodes" icon="smartphone">
+    iOS 和 Android 节点，支持配对、Canvas、相机和设备操作。
+  </Card>
+  <Card title="帮助" href="/zh-CN/help" icon="life-buoy">
+    常见修复和故障排除入口。
+  </Card>
+</Columns>
+
+## 了解更多
+
+<Columns>
+  <Card title="完整功能列表" href="/zh-CN/concepts/features" icon="list">
+    完整的通道、路由和媒体功能。
+  </Card>
+  <Card title="多代理路由" href="/zh-CN/concepts/multi-agent" icon="route">
+    工作区隔离和每个代理的会话。
+  </Card>
+  <Card title="安全" href="/zh-CN/gateway/security" icon="shield">
+    令牌、允许列表和安全控制。
+  </Card>
+  <Card title="故障排除" href="/zh-CN/gateway/troubleshooting" icon="wrench">
+    Gateway 诊断和常见错误。
+  </Card>
+  <Card title="关于与鸣谢" href="/zh-CN/reference/credits" icon="info">
+    项目起源、贡献者和许可证。
+  </Card>
+</Columns>

--- a/docs/zh-CN/start/getting-started.md
+++ b/docs/zh-CN/start/getting-started.md
@@ -1,0 +1,146 @@
+---
+summary: "几分钟内完成 OpenClaw 安装并运行你的第一次聊天。"
+read_when:
+  - 首次从零开始设置
+  - 你想最快获得一个可用的聊天环境
+title: "开始使用"
+---
+
+安装 OpenClaw、运行引导向导，与你的 AI 助手聊天——大约只需 5 分钟。完成后你将拥有一个运行中的 Gateway、已配置的认证，以及一个可用的聊天会话。
+
+## 你需要什么
+
+- **Node.js** — 推荐 Node 24（也支持 Node 22.16+）
+- **API 密钥** — 来自模型提供商（Anthropic、OpenAI、Google 等）——引导向导会提示你
+
+<Tip>
+用 `node --version` 检查你的 Node 版本。
+**Windows 用户：** 原生 Windows 和 WSL2 都受支持。WSL2 更稳定，推荐获得完整体验。查看 [Windows](/zh-CN/platforms/windows)。
+需要安装 Node？查看 [Node 设置](/zh-CN/install/node)。
+</Tip>
+
+## 快速设置
+
+<Steps>
+  <Step title="安装 OpenClaw">
+    <Tabs>
+      <Tab title="macOS / Linux">
+        ```bash
+        curl -fsSL https://openclaw.ai/install.sh | bash
+        ```
+        <img
+  src="/assets/install-script.svg"
+  alt="安装脚本流程"
+  className="rounded-lg"
+/>
+      </Tab>
+      <Tab title="Windows (PowerShell)">
+        ```powershell
+        iwr -useb https://openclaw.ai/install.ps1 | iex
+        ```
+      </Tab>
+    </Tabs>
+
+    <Note>
+    其他安装方法（Docker、Nix、npm）：[安装](/zh-CN/install)。
+    </Note>
+
+  </Step>
+  <Step title="运行引导向导">
+    ```bash
+    openclaw onboard --install-daemon
+    ```
+
+    向导会引导你选择模型提供商、设置 API 密钥，以及配置 Gateway。大约需要 2 分钟。
+
+    完整参考见[引导向导（CLI）](/zh-CN/start/wizard)。
+
+  </Step>
+  <Step title="验证 Gateway 正在运行">
+    ```bash
+    openclaw gateway status
+    ```
+
+    你应该能看到 Gateway 正在监听 18789 端口。
+
+  </Step>
+  <Step title="打开控制面板">
+    ```bash
+    openclaw dashboard
+    ```
+
+    这会在浏览器中打开控制面板。如果能正常加载，说明一切工作正常。
+
+  </Step>
+  <Step title="发送你的第一条消息">
+    在控制面板聊天中输入消息，你应该会收到 AI 回复。
+
+    想从手机聊天？最快设置的通道是
+    [Telegram](/zh-CN/channels/telegram)（只需要一个机器人令牌）。查看[通道](/zh-CN/channels)了解所有选项。
+
+  </Step>
+</Steps>
+
+<Accordion title="高级：挂载自定义控制面板构建">
+  如果你维护了一个本地化或定制化的仪表板构建，将
+  `gateway.controlUi.root` 指向包含你构建的静态资源和 `index.html` 的目录。
+
+```bash
+mkdir -p "$HOME/.openclaw/control-ui-custom"
+# 将你构建的静态文件复制到该目录。
+```
+
+然后设置：
+
+```json
+{
+  "gateway": {
+    "controlUi": {
+      "enabled": true,
+      "root": "$HOME/.openclaw/control-ui-custom"
+    }
+  }
+}
+```
+
+重启 Gateway 并重新打开控制面板：
+
+```bash
+openclaw gateway restart
+openclaw dashboard
+```
+
+</Accordion>
+
+## 接下来做什么
+
+<Columns>
+  <Card title="连接通道" href="/zh-CN/channels" icon="message-square">
+    Discord、飞书、iMessage、Matrix、Microsoft Teams、Signal、Slack、Telegram、WhatsApp、Zalo 等。
+  </Card>
+  <Card title="配对与安全" href="/zh-CN/channels/pairing" icon="shield">
+    控制谁可以向你的代理发消息。
+  </Card>
+  <Card title="配置 Gateway" href="/zh-CN/gateway/configuration" icon="settings">
+    模型、工具、沙箱和高级设置。
+  </Card>
+  <Card title="浏览工具" href="/zh-CN/tools" icon="wrench">
+    浏览器、执行、网页搜索、技能和插件。
+  </Card>
+</Columns>
+
+<Accordion title="高级：环境变量">
+  如果你以服务账户运行 OpenClaw 或需要自定义路径：
+
+- `OPENCLAW_HOME` — 内部路径解析的主目录
+- `OPENCLAW_STATE_DIR` — 覆盖状态目录
+- `OPENCLAW_CONFIG_PATH` — 覆盖配置文件路径
+
+完整参考：[环境变量](/zh-CN/help/environment)。
+</Accordion>
+
+## 相关文档
+
+- [安装概览](/zh-CN/install)
+- [通道概览](/zh-CN/channels)
+- [设置](/zh-CN/start/setup)


### PR DESCRIPTION
## Summary
Add the first three Simplified Chinese (zh-CN) documentation pages:
- `docs/zh-CN/index.md` — 首页
- `docs/zh-CN/start/getting-started.md` — 快速开始
- `docs/zh-CN/concepts/features.md` — 功能总览
These cover the most visible entry points for new Chinese-speaking users.
## Why now
The zh-Hans navigation config already exists in `docs/.i18n/zh-Hans-navigation.json` with 200+ page mappings, but the actual `zh-CN/` content directory did not exist. This PR establishes the content structure and delivers the first batch.
## Notes
- [x] AI-assisted translation
- [x] Links updated to `/zh-CN/` prefixed paths
- [x] Mermaid diagrams, Column/Card/Steps/Accordion components preserved
- Co-Authored-By: AI Assistant <ai@assistant.local>