### PR TITLE
fix(memory-core): avoid anyOf in corpus schema for Azure OpenAI Responses compatibility

### DIFF
--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import { optionalStringEnum } from "openclaw/plugin-sdk/channel-actions";
 import {
   listMemoryCorpusSupplements,
   resolveMemorySearchConfig,
@@ -26,18 +27,14 @@ export const MemorySearchSchema = Type.Object({
   query: Type.String(),
   maxResults: Type.Optional(Type.Number()),
   minScore: Type.Optional(Type.Number()),
-  corpus: Type.Optional(
-    Type.Union([Type.Literal("memory"), Type.Literal("wiki"), Type.Literal("all")]),
-  ),
+  corpus: optionalStringEnum(["memory", "wiki", "all"] as const),
 });
 
 export const MemoryGetSchema = Type.Object({
   path: Type.String(),
   from: Type.Optional(Type.Number()),
   lines: Type.Optional(Type.Number()),
-  corpus: Type.Optional(
-    Type.Union([Type.Literal("memory"), Type.Literal("wiki"), Type.Literal("all")]),
-  ),
+  corpus: optionalStringEnum(["memory", "wiki", "all"] as const),
 });
 
 export function resolveMemoryToolContext(options: {

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -5,6 +5,7 @@ import {
   setMemorySearchImpl,
 } from "./memory-tool-manager-mock.js";
 import {
+  createMemoryGetToolOrThrow,
   createMemorySearchToolOrThrow,
   expectUnavailableMemorySearchDetails,
 } from "./tools.test-helpers.js";
@@ -102,5 +103,30 @@ describe("memory_search unavailable payloads", () => {
     expect((result.details as { debug?: { searchMs?: number } }).debug?.searchMs).toEqual(
       expect.any(Number),
     );
+  });
+});
+
+describe("memory tool schema regression", () => {
+  function assertNoCompositeKeywords(schema: unknown, path = "root"): void {
+    if (schema === null || typeof schema !== "object") {
+      return;
+    }
+    const keys = Object.keys(schema as Record<string, unknown>);
+    for (const key of ["anyOf", "oneOf", "allOf"]) {
+      expect(keys).not.toContain(key);
+    }
+    for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+      assertNoCompositeKeywords(value, `${path}.${key}`);
+    }
+  }
+
+  it("memory_search schema does not contain anyOf/oneOf/allOf", () => {
+    const tool = createMemorySearchToolOrThrow();
+    assertNoCompositeKeywords(tool.parameters);
+  });
+
+  it("memory_get schema does not contain anyOf/oneOf/allOf", () => {
+    const tool = createMemoryGetToolOrThrow();
+    assertNoCompositeKeywords(tool.parameters);
   });
 });


### PR DESCRIPTION
## Problem

Azure OpenAI Responses stalls before the first streaming event when memory tools are exposed. The root cause is that memory corpus schemas use `Type.Union([Type.Literal(...)])`, which generates `anyOf` constructs. Azure OpenAI Responses does not handle these well during tool schema parsing, causing the stream to hang.

## Solution

Replace `Type.Union([Type.Literal(...)])` with the repository's existing `optionalStringEnum` helper. This produces a flat `{ type: "string", enum: [...] }` schema instead of `anyOf`, which Azure OpenAI Responses can parse without stalling.

## Changes

- `extensions/memory-core/src/tools.shared.ts`: Use `optionalStringEnum` for corpus schemas.
- `extensions/memory-core/src/tools.test.ts`: Add regression test that recursively asserts the memory tool schema does not contain `anyOf`/`oneOf`/`allOf`.

## Verification

- Added recursive schema assertion in tests to prevent regressions.
- Confirmed the generated schema no longer contains `anyOf`.

Fixes #80926