### PR TITLE
fix(config): preserve user-set meta.lastTouchedVersion during config set

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -894,14 +894,24 @@ function warnOnConfigMiskeys(raw: unknown, logger: Pick<typeof console, "warn">)
   }
 }
 
-function stampConfigVersion(cfg: OpenClawConfig): OpenClawConfig {
+function stampConfigVersion(
+  cfg: OpenClawConfig,
+  explicitSetPaths?: readonly (readonly string[])[],
+): OpenClawConfig {
+  const userTouchedVersion =
+    explicitSetPaths?.some(
+      (p) => p.length === 2 && p[0] === "meta" && p[1] === "lastTouchedVersion",
+    ) ?? false;
+  const userTouchedAt =
+    explicitSetPaths?.some((p) => p.length === 2 && p[0] === "meta" && p[1] === "lastTouchedAt") ??
+    false;
   const now = new Date().toISOString();
   return {
     ...cfg,
     meta: {
       ...cfg.meta,
-      lastTouchedVersion: VERSION,
-      lastTouchedAt: now,
+      ...(userTouchedVersion ? {} : { lastTouchedVersion: VERSION }),
+      ...(userTouchedAt ? {} : { lastTouchedAt: now }),
     },
   };
 }
@@ -2111,7 +2121,7 @@ export function createConfigIO(
     const outputConfig = applyUnsetPathsForWrite(tildeRestoredOutputConfig, unsetPaths);
     // Do NOT apply runtime defaults when writing - user config should only contain
     // explicitly set values. Runtime defaults are applied when loading (issue #6070).
-    const stampedOutputConfig = stampConfigVersion(outputConfig);
+    const stampedOutputConfig = stampConfigVersion(outputConfig, options.explicitSetPaths);
     const json = JSON.stringify(stampedOutputConfig, null, 2).trimEnd().concat("\n");
     const nextHash = hashConfigRaw(json);
     const previousHash = resolveConfigSnapshotHash(snapshot);

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1549,4 +1549,133 @@ describe("config io write", () => {
       expect(persisted.logging?.level).toBe("debug");
     });
   });
+
+  it("preserves user-set meta.lastTouchedVersion when explicitSetPaths includes meta.lastTouchedVersion", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        gateway: { mode: "local" },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      const userVersion = "2099.12.31";
+      const next = {
+        meta: { lastTouchedVersion: userVersion, lastTouchedAt: "2099-01-01T00:00:00.000Z" },
+        gateway: { mode: "local" },
+      } satisfies OpenClawConfig;
+
+      await io.writeConfigFile(next, {
+        baseSnapshot,
+        explicitSetPaths: [["meta", "lastTouchedVersion"]],
+        explicitSetValueSource: next,
+      });
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;
+      expect(persisted.meta?.lastTouchedVersion).toBe(userVersion);
+    });
+  });
+
+  it("preserves user-set meta.lastTouchedAt when explicitSetPaths includes meta.lastTouchedAt", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        gateway: { mode: "local" },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      const userAt = "2099-01-01T00:00:00.000Z";
+      const next = {
+        meta: { lastTouchedVersion: "2099.12.31", lastTouchedAt: userAt },
+        gateway: { mode: "local" },
+      } satisfies OpenClawConfig;
+
+      await io.writeConfigFile(next, {
+        baseSnapshot,
+        explicitSetPaths: [["meta", "lastTouchedAt"]],
+        explicitSetValueSource: next,
+      });
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;
+      expect(persisted.meta?.lastTouchedAt).toBe(userAt);
+    });
+  });
+
+  it("still stamps meta fields on writes without explicitSetPaths", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        gateway: { mode: "local" },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await io.writeConfigFile({ gateway: { mode: "local" } }, { baseSnapshot });
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;
+      expect(typeof persisted.meta?.lastTouchedVersion).toBe("string");
+      expect(typeof persisted.meta?.lastTouchedAt).toBe("string");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #80849.

`stampConfigVersion()` in `src/config/io.ts` unconditionally overwrote `meta.lastTouchedVersion` and `meta.lastTouchedAt` on every config write. This caused `openclaw config set meta.lastTouchedVersion <value>` to silently report success while the value was immediately overridden.

## Changes

- `stampConfigVersion` now accepts an optional `explicitSetPaths` parameter.
- If the user explicitly set `meta.lastTouchedVersion` or `meta.lastTouchedAt` (via `explicitSetPaths`), the stamp skips overwriting that field.
- Writes without `explicitSetPaths` (e.g., normal gateway startup) continue to stamp both fields as before.

## Verification

- Added 3 regression tests in `src/config/io.write-config.test.ts` covering:
  - Preserving `meta.lastTouchedVersion` when explicitly set
  - Preserving `meta.lastTouchedAt` when explicitly set
  - Still stamping both fields when `explicitSetPaths` is absent
- All existing tests pass locally.