### PR TITLE
fix(daemon): hand off systemd gateway restart

### DIFF
--- a/src/daemon/systemd-restart-handoff.ts
+++ b/src/daemon/systemd-restart-handoff.ts
@@ -1,0 +1,97 @@
+import { spawn } from "node:child_process";
+import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
+import { renderPosixRestartLogSetup } from "./restart-logs.js";
+import type { GatewayServiceEnv } from "./service-types.js";
+
+type SystemdRestartHandoffResult = {
+  ok: boolean;
+  pid?: number;
+  detail?: string;
+};
+
+const SYSTEMD_UNIT_NAME_RE = /^[A-Za-z0-9:_.@\\-]+\.service$/;
+
+function normalizeSystemdUnitName(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.endsWith(".service") ? trimmed : `${trimmed}.service`;
+}
+
+function assertValidSystemdUnitName(unitName: string): string {
+  if (!SYSTEMD_UNIT_NAME_RE.test(unitName)) {
+    throw new Error(`Invalid systemd unit name: ${unitName}`);
+  }
+  return unitName;
+}
+
+function readCurrentSystemdUnitName(env: GatewayServiceEnv): string | null {
+  const raw = env.OPENCLAW_SYSTEMD_UNIT?.trim();
+  return raw ? normalizeSystemdUnitName(raw) : null;
+}
+
+export function isCurrentProcessSystemdGatewayService(
+  unitName: string,
+  env: GatewayServiceEnv,
+): boolean {
+  const marker = env.OPENCLAW_SERVICE_MARKER?.trim();
+  const serviceKind = env.OPENCLAW_SERVICE_KIND?.trim();
+  const currentUnit = readCurrentSystemdUnitName(env);
+  return marker === "openclaw" && serviceKind === "gateway" && currentUnit === unitName;
+}
+
+function buildSystemdRestartHandoffScript(restartLogEnv: GatewayServiceEnv): string {
+  return `unit_name="$1"
+wait_pid="$2"
+${renderPosixRestartLogSetup(restartLogEnv)}
+printf '[%s] openclaw restart attempt source=systemd-handoff target=%s waitPid=%s\\n' "$(date -u +%FT%TZ)" "$unit_name" "$wait_pid" >&2
+if [ -n "$wait_pid" ] && [ "$wait_pid" -gt 1 ] 2>/dev/null; then
+  while kill -0 "$wait_pid" >/dev/null 2>&1; do
+    sleep 0.1
+  done
+fi
+if systemctl --user restart "$unit_name"; then
+  printf '[%s] openclaw restart done source=systemd-handoff\\n' "$(date -u +%FT%TZ)" >&2
+  exit 0
+fi
+status=$?
+printf '[%s] openclaw restart failed source=systemd-handoff status=%s\\n' "$(date -u +%FT%TZ)" "$status" >&2
+exit "$status"
+`;
+}
+
+export function scheduleDetachedSystemdRestartHandoff(params: {
+  env: GatewayServiceEnv;
+  unitName: string;
+  waitForPid?: number;
+}): SystemdRestartHandoffResult {
+  try {
+    const unitName = assertValidSystemdUnitName(params.unitName);
+    const handoffUnit = assertValidSystemdUnitName(
+      `openclaw-gateway-restart-handoff-${process.pid}.service`,
+    );
+    const waitForPid = String(params.waitForPid ?? process.pid);
+    const child = spawn(
+      "systemd-run",
+      [
+        "--user",
+        "--collect",
+        `--unit=${handoffUnit}`,
+        "--description=OpenClaw gateway restart handoff",
+        "/bin/sh",
+        "-c",
+        buildSystemdRestartHandoffScript(params.env),
+        "openclaw-systemd-restart-handoff",
+        unitName,
+        waitForPid,
+      ],
+      {
+        detached: true,
+        stdio: "ignore",
+        env: sanitizeHostExecEnv({ baseEnv: { ...process.env, ...params.env } }),
+      },
+    );
+    child.unref();
+    return { ok: true, pid: child.pid ?? undefined };
+  } catch (err) {
+    return { ok: false, detail: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -4,14 +4,20 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileMock = vi.hoisted(() => vi.fn());
+const spawnMock = vi.hoisted(() => vi.fn());
+const unrefMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => {
   const { mockNodeChildProcessExecFile } = await import("openclaw/plugin-sdk/test-node-mocks");
-  return mockNodeChildProcessExecFile(
+  const mocked = await mockNodeChildProcessExecFile(
     Object.assign(execFileMock, {
       __promisify__: vi.fn(),
     }) as typeof import("node:child_process").execFile,
   );
+  return {
+    ...mocked,
+    spawn: (...args: unknown[]) => spawnMock(...args),
+  };
 });
 
 import { splitArgsPreservingQuotes } from "./arg-split.js";
@@ -141,6 +147,9 @@ const assertRestartSuccess = async (env: NodeJS.ProcessEnv) => {
 describe("systemd availability", () => {
   beforeEach(() => {
     execFileMock.mockReset();
+    spawnMock.mockReset();
+    unrefMock.mockReset();
+    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
   });
 
   it("returns true when systemctl --user succeeds", async () => {
@@ -1265,6 +1274,48 @@ describe("systemd service control", () => {
         cb(null, "", "");
       });
     await assertRestartSuccess({ OPENCLAW_PROFILE: "work" });
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("schedules a detached restart handoff from inside the managed systemd gateway service", async () => {
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      assertUserSystemctlArgs(args, "status");
+      cb(null, "", "");
+    });
+    const { write, stdout } = createWritableStreamMock();
+
+    const result = await restartSystemdService({
+      stdout,
+      env: {
+        HOME: "/home/debian",
+        OPENCLAW_SYSTEMD_UNIT: GATEWAY_SERVICE,
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      },
+    });
+
+    expect(result).toEqual({ outcome: "scheduled" });
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(requireFirstWrite(write)).toContain("Scheduled systemd service restart");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [command, args, options] = spawnMock.mock.calls[0] as [
+      string,
+      string[],
+      { detached: boolean; stdio: string; env: Record<string, string | undefined> },
+    ];
+    expect(command).toBe("systemd-run");
+    expect(args).toContain("--user");
+    expect(args).toContain("--collect");
+    expect(args.some((arg) => arg.startsWith("--unit=openclaw-gateway-restart-handoff-"))).toBe(
+      true,
+    );
+    expect(args).toContain("/bin/sh");
+    expect(args).toContain(GATEWAY_SERVICE);
+    expect(args.join("\n")).toContain("systemctl --user restart");
+    expect(options.detached).toBe(true);
+    expect(options.stdio).toBe("ignore");
+    expect(options.env.OPENCLAW_SYSTEMD_UNIT).toBe(GATEWAY_SERVICE);
+    expect(unrefMock).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces stop failures with systemctl detail", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -35,6 +35,10 @@ import type {
 } from "./service-types.js";
 import { enableSystemdUserLinger, readSystemdUserLingerStatus } from "./systemd-linger.js";
 import {
+  isCurrentProcessSystemdGatewayService,
+  scheduleDetachedSystemdRestartHandoff,
+} from "./systemd-restart-handoff.js";
+import {
   classifySystemdUnavailableDetail,
   isSystemctlMissingDetail,
   isSystemdUserBusUnavailableDetail,
@@ -824,12 +828,27 @@ export async function restartSystemdService({
   stdout,
   env,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
-  await runSystemdServiceAction({
-    stdout,
-    env,
-    action: "restart",
-    label: "Restarted systemd service",
-  });
+  const serviceEnv = env ?? process.env;
+  await assertSystemdAvailable(serviceEnv);
+  const serviceName = resolveSystemdServiceName(serviceEnv);
+  const unitName = `${serviceName}.service`;
+  if (isCurrentProcessSystemdGatewayService(unitName, serviceEnv)) {
+    const handoff = scheduleDetachedSystemdRestartHandoff({
+      env: serviceEnv,
+      unitName,
+      waitForPid: process.pid,
+    });
+    if (!handoff.ok) {
+      throw new Error(`systemd restart handoff failed: ${handoff.detail ?? "unknown error"}`);
+    }
+    stdout.write(`${formatLine("Scheduled systemd service restart", unitName)}\n`);
+    return { outcome: "scheduled" };
+  }
+  const res = await execSystemctlUser(serviceEnv, ["restart", unitName]);
+  if (res.code !== 0) {
+    throw new Error(`systemctl restart failed: ${res.stderr || res.stdout}`.trim());
+  }
+  stdout.write(`${formatLine("Restarted systemd service", unitName)}\n`);
   return { outcome: "completed" };
 }
 


### PR DESCRIPTION
## Summary
- schedule Linux `gateway restart` through a detached `systemd-run --user` handoff when the command is invoked from the managed OpenClaw gateway service
- keep normal external CLI restarts on the existing synchronous `systemctl --user restart` path
- add focused coverage for the scheduled handoff path and preserve the existing profile-specific restart behavior

Fixes #68109

## Scout audit
- Audit A (existing helper): launchd restart handoff exists and was used as the shape; no systemd equivalent existed
- Audit B (shared callers): `restartSystemdService` remains the only changed external contract; existing completed result preserved for non-service callers; service-internal callers now receive existing `{ outcome: "scheduled" }` shape
- Audit C (broader rival): no open PR referencing #68109

## Real behavior proof

- Behavior or issue addressed: Linux managed-gateway `openclaw gateway restart` should return a normal scheduled restart result instead of synchronously stopping the process that is serving the command.
- Real environment tested: Ubuntu/Linux shell in the OpenClaw repo, Node 22.22.0, executing the actual `restartSystemdService` entry point after this patch. The probe placed controlled `systemctl` and `systemd-run` executables at the front of `PATH` so the live Node process could exercise the service-internal handoff path without restarting this workstation's gateway.
- Exact steps or command run after this patch: `node --import tsx - <<'JS' ... restartSystemdService({ env: process.env }) ... JS`
- Evidence after fix: terminal output from the after-patch command:

```json
{
  "result": {
    "outcome": "scheduled"
  },
  "stdout": "Scheduled systemd service restart: openclaw-gateway.service",
  "systemctlCalls": [
    "--user status"
  ],
  "systemdRunIncludes": {
    "user": true,
    "collect": true,
    "unit": true,
    "shell": true,
    "restartCommand": true,
    "targetUnit": true
  }
}
```

- Observed result after fix: the restart command returned `{ outcome: "scheduled" }`, wrote `Scheduled systemd service restart: openclaw-gateway.service`, performed only the availability `systemctl --user status` check synchronously, and delegated the actual restart command to `systemd-run --user --collect`.
- What was not tested: a destructive live restart of an installed gateway service on this machine; the probe avoids disrupting the local agent environment while still exercising the production Node restart branch and command construction.

## Verification
- `pnpm test src/daemon/systemd.test.ts src/daemon/launchd-restart-handoff.test.ts -- --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 src/daemon/systemd-restart-handoff.ts src/daemon/systemd.ts src/daemon/systemd.test.ts`
- `pnpm run check:changed`
