### PR TITLE
fix(doctor): warn and document QMD session recall gates

### DIFF
--- a/docs/concepts/memory-qmd.md
+++ b/docs/concepts/memory-qmd.md
@@ -149,10 +149,19 @@ collection root.
 
 ## Indexing session transcripts
 
-Enable session indexing to recall earlier conversations:
+Enable session indexing to recall earlier conversations. QMD needs both the general
+`memorySearch` session source and the QMD transcript exporter:
 
 ```json5
 {
+  agents: {
+    defaults: {
+      memorySearch: {
+        experimental: { sessionMemory: true },
+        sources: ["memory", "sessions"],
+      },
+    },
+  },
   memory: {
     backend: "qmd",
     qmd: {
@@ -163,7 +172,14 @@ Enable session indexing to recall earlier conversations:
 ```
 
 Transcripts are exported as sanitized User/Assistant turns into a dedicated QMD
-collection under `~/.openclaw/agents/<id>/qmd/sessions/`.
+collection under `~/.openclaw/agents/<id>/qmd/sessions/`. Setting only
+`memorySearch.experimental.sessionMemory` does not export transcripts into QMD.
+
+Session hits are still filtered by
+[`tools.sessions.visibility`](/gateway/config-tools#toolssessions). The default
+`tree` visibility does not expose unrelated same-agent sessions. If a
+gateway-dispatched session should be recallable from a separate DM session, set
+`tools.sessions.visibility: "agent"` intentionally.
 
 ## Search scope
 

--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -135,7 +135,17 @@ setup.
 
 You can optionally index session transcripts so `memory_search` can recall
 earlier conversations. This is opt-in via
-`memorySearch.experimental.sessionMemory`. See the
+`memorySearch.experimental.sessionMemory` and `sources: ["sessions"]`; the default
+source list is memory-only. The experimental flag enables session transcript
+indexing, while `sources` controls whether session chunks are searched.
+
+Session hits obey `tools.sessions.visibility`: the default `tree` setting only
+exposes the current session and sessions it spawned. To recall an unrelated
+same-agent gateway-dispatched session from a separate DM session, intentionally
+widen visibility to `agent`.
+
+When using QMD, also set `memory.qmd.sessions.enabled: true` so transcripts are
+exported into a QMD collection. See the
 [configuration reference](/reference/memory-config) for details.
 
 ## Troubleshooting

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -422,6 +422,66 @@ Index session transcripts and surface them via `memory_search`:
 Session indexing is opt-in and runs asynchronously. Results can be slightly stale. Session logs live on disk, so treat filesystem access as the trust boundary.
 </Warning>
 
+Session transcript hits also obey
+[`tools.sessions.visibility`](/gateway/config-tools#toolssessions). The default
+`tree` visibility only exposes the current session and sessions it spawned. To
+recall an unrelated same-agent gateway-dispatched session from a different
+session, such as a DM, intentionally widen visibility to `agent` (or `all` only
+when cross-agent recall is also required and agent-to-agent policy allows it).
+
+The examples below place these settings under `agents.defaults`. You can also
+apply equivalent `memorySearch` settings in a per-agent override when only one
+agent should index and search session transcripts.
+
+For same-agent gateway-to-DM recall:
+
+<Tabs>
+  <Tab title="Builtin backend">
+    ```json5
+    {
+      agents: {
+        defaults: {
+          memorySearch: {
+            experimental: { sessionMemory: true },
+            sources: ["memory", "sessions"],
+          },
+        },
+      },
+      tools: {
+        sessions: { visibility: "agent" },
+      },
+    }
+    ```
+  </Tab>
+  <Tab title="QMD backend">
+    ```json5
+    {
+      agents: {
+        defaults: {
+          memorySearch: {
+            experimental: { sessionMemory: true },
+            sources: ["memory", "sessions"],
+          },
+        },
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          sessions: { enabled: true },
+        },
+      },
+      tools: {
+        sessions: { visibility: "agent" },
+      },
+    }
+    ```
+  </Tab>
+</Tabs>
+
+When using QMD, `agents.defaults.memorySearch.experimental.sessionMemory` and
+`sources: ["sessions"]` do not by themselves export transcripts into QMD. Set
+`memory.qmd.sessions.enabled: true` as well.
+
 ---
 
 ## SQLite vector acceleration (sqlite-vec)
@@ -454,7 +514,7 @@ Set `memory.backend = "qmd"` to enable. All QMD settings live under `memory.qmd`
 | `searchMode`             | `string`  | `search` | Search command: `search`, `vsearch`, `query`                                          |
 | `includeDefaultMemory`   | `boolean` | `true`   | Auto-index `MEMORY.md` + `memory/**/*.md`                                             |
 | `paths[]`                | `array`   | --       | Extra paths: `{ name, path, pattern? }`                                               |
-| `sessions.enabled`       | `boolean` | `false`  | Index session transcripts                                                             |
+| `sessions.enabled`       | `boolean` | `false`  | Export session transcripts into QMD                                                   |
 | `sessions.retentionDays` | `number`  | --       | Transcript retention                                                                  |
 | `sessions.exportDir`     | `string`  | --       | Export directory                                                                      |
 

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -497,6 +497,99 @@ describe("noteMemorySearchHealth", () => {
     expect(message).not.toContain("npm install -g @tobilu/qmd");
   });
 
+  it("warns when QMD backend uses session sources but QMD session export is disabled", async () => {
+    const qmdCfg = { memory: { backend: "qmd", qmd: { command: "qmd" } } } as OpenClawConfig;
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "auto",
+      sources: ["memory", "sessions"],
+      experimental: { sessionMemory: true },
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(qmdCfg, {});
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("memorySearch.sources with sessions");
+    expect(message).toContain("memory.qmd.sessions.enabled is not true");
+    expect(message).toContain("openclaw config set memory.qmd.sessions.enabled true");
+  });
+
+  it("warns when QMD session export is explicitly disabled", async () => {
+    const qmdCfg = {
+      memory: { backend: "qmd", qmd: { command: "qmd", sessions: { enabled: false } } },
+    } as OpenClawConfig;
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "auto",
+      sources: ["memory", "sessions"],
+      experimental: { sessionMemory: true },
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(qmdCfg, {});
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("QMD session transcript export is not enabled");
+  });
+
+  it("does not warn about QMD session export when session sources are not enabled", async () => {
+    const qmdCfg = { memory: { backend: "qmd", qmd: { command: "qmd" } } } as OpenClawConfig;
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "auto",
+      sources: ["memory"],
+      experimental: { sessionMemory: true },
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(qmdCfg, {});
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("reports QMD binary and session export warnings independently", async () => {
+    const qmdCfg = { memory: { backend: "qmd", qmd: { command: "qmd" } } } as OpenClawConfig;
+    checkQmdBinaryAvailability.mockResolvedValueOnce({
+      available: false,
+      error: "spawn qmd ENOENT",
+    });
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "auto",
+      sources: ["memory", "sessions"],
+      experimental: { sessionMemory: true },
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(qmdCfg, {});
+
+    expect(note).toHaveBeenCalledTimes(2);
+    expect(String(note.mock.calls[0]?.[0] ?? "")).toContain("spawn qmd ENOENT");
+    expect(String(note.mock.calls[1]?.[0] ?? "")).toContain(
+      "QMD session transcript export is not enabled",
+    );
+  });
+
+  it("does not warn when QMD session sources and QMD session export are both enabled", async () => {
+    const qmdCfg = {
+      memory: { backend: "qmd", qmd: { command: "qmd", sessions: { enabled: true } } },
+    } as OpenClawConfig;
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "auto",
+      sources: ["memory", "sessions"],
+      experimental: { sessionMemory: true },
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(qmdCfg, {});
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("does not warn when remote apiKey is configured for explicit provider", async () => {
     await expectNoWarningWithConfiguredRemoteApiKey("openai");
   });

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -462,6 +462,24 @@ export async function noteMemorySearchHealth(
         "Memory search",
       );
     }
+    if (resolved.sources?.includes("sessions") && cfg.memory?.qmd?.sessions?.enabled !== true) {
+      note(
+        [
+          "QMD memory backend is configured and the default agent resolves memorySearch.sources with sessions,",
+          "but QMD session transcript export is not enabled (memory.qmd.sessions.enabled is not true).",
+          "Session transcript hits will not appear in QMD-backed memory search until QMD session export is enabled.",
+          "",
+          "Fix (pick one):",
+          `- Enable QMD session export: ${formatCliCommand(
+            "openclaw config set memory.qmd.sessions.enabled true",
+          )}`,
+          "- Or remove sessions from the default agent's memorySearch.sources if QMD session recall is not intended.",
+          "",
+          `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+        ].join("\n"),
+        "Memory search",
+      );
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary

- Add an `openclaw doctor` warning when QMD is the active memory backend and the default agent searches `sessions`, but QMD session transcript export is not enabled.
- Clarify the session transcript recall gates in memory docs:
  - session-memory must be enabled;
  - `memorySearch.sources` must include `sessions`;
  - QMD transcript export additionally requires `memory.qmd.sessions.enabled: true`;
  - session hits still obey `tools.sessions.visibility`.
- Point users to either enable `memory.qmd.sessions.enabled` or remove `sessions` from the default agent's `memorySearch.sources` when QMD session recall is not intended.
- Cover the warning, enabled, explicit-disabled, memory-only, and combined QMD-binary-warning cases in `doctor-memory-search` tests.

## Why

Related to #53550 and supersedes #80935.

The underlying QMD session recall behavior has multiple gates that are easy to miss:

1. session-memory must be enabled;
2. `memorySearch.sources` must include `sessions`;
3. when QMD is the memory backend, transcript export must also be enabled with `memory.qmd.sessions.enabled: true`;
4. returned session hits are filtered by `tools.sessions.visibility`.

This PR keeps behavior unchanged. It adds documentation plus a diagnostic-only warning for the common QMD export mismatch. It does not enable QMD session export automatically, widen transcript visibility defaults, or change indexing/search behavior.

## Validation

- `git diff --check`
- `corepack pnpm exec vitest run --config test/vitest/vitest.commands.config.ts src/commands/doctor-memory-search.test.ts` (46 passed)
- `corepack pnpm dlx --config.resolution-mode=highest markdownlint-cli2 --config config/markdownlint-cli2.jsonc docs/concepts/memory-qmd.md docs/concepts/memory-search.md docs/reference/memory-config.md` (0 errors)
- `node scripts/check-docs-mdx.mjs docs/concepts/memory-qmd.md docs/concepts/memory-search.md docs/reference/memory-config.md` (passed)

## Real behavior proof

- **Behavior addressed:** `openclaw doctor` warns when QMD is the active memory backend, the default agent resolves `memorySearch.sources` with `sessions`, and QMD session transcript export is not enabled.
- **Real setup tested:** Disposable OpenClaw source checkout at current PR head `fe1bbb3ecad571be237e49e2173963aea557cfa1` on Linux/arm64. No live Gateway, live user config, live session store, or real secret-bearing environment was used.
- **Exact steps or command run after this patch:** In the disposable checkout, ran the focused doctor memory-search regression for the QMD session-source warning path:

  ```bash
  node <pinned-corepack-pnpm>/bin/pnpm.mjs exec vitest run --config test/vitest/vitest.commands.config.ts src/commands/doctor-memory-search.test.ts -t "QMD backend uses session sources" --reporter=dot --pool=forks --maxWorkers=1
  ```

- **Evidence after fix:** Vitest reported:

  ```text
  Test Files 1 passed (1)
  Tests 1 passed | 53 skipped (54)
  ```

  The focused regression asserts that the doctor note contains `memorySearch.sources with sessions`, `memory.qmd.sessions.enabled is not true`, and the remediation command `openclaw config set memory.qmd.sessions.enabled true`.
- **Observed result after fix:** The current-head doctor memory-search health contribution emits the new QMD session-transcript export warning with the affected gate and remediation path.
- **What was not tested:** Live gateway startup, live user configuration, real QMD indexing/search, and session transcript visibility were deliberately not exercised; this PR is diagnostic/docs-only and the proof is limited to the after-fix doctor warning path.

## Scope

Diagnostic and documentation only. No runtime behavior change to session transcript indexing, export, search, or visibility defaults.
