### PR TITLE
fix(telegram): archive already-delivered reasoning preview on forceNewMessage (#80862)

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -806,6 +806,7 @@ You can wait on more than just time/text:
   - `openclaw browser wait --url "**/dash"`
 - Wait for load state:
   - `openclaw browser wait --load networkidle`
+  - **Note:** `--load networkidle` is supported on the managed `openclaw` browser and remote-CDP profiles. It is not yet supported on `existing-session` / `user` profiles.
 - Wait for a JS predicate:
   - `openclaw browser wait --fn "window.ready===true"`
 - Wait for a selector to become visible:

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -493,6 +493,48 @@ describe("createTelegramDraftStream", () => {
     expect(api.editMessageText).not.toHaveBeenCalledWith(123, 17, "Message B partial");
   });
 
+  it("archives already-delivered preview id via onSupersededPreview when forceNewMessage is called after send completes", async () => {
+    // Regression: when forceNewMessage() is called after streamMessageId is already set
+    // (send completed), the old message was silently discarded without notifying
+    // onSupersededPreview. This left reasoning preview messages permanently in chat. (#80862)
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockResolvedValueOnce({ message_id: 17 })
+      .mockResolvedValueOnce({ message_id: 42 });
+    const onSupersededPreview = vi.fn();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      onSupersededPreview,
+    });
+
+    // First message delivered and send completed — streamMessageId is set.
+    stream.update("First reasoning block");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    // Confirm the first message was delivered via editMessageText on next update.
+    stream.update("First reasoning block — more text");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "First reasoning block — more text");
+
+    // Rotate to next reasoning step — send already completed so onSupersededPreview
+    // must be called synchronously inside forceNewMessage().
+    stream.forceNewMessage();
+    expect(onSupersededPreview).toHaveBeenCalledWith({
+      messageId: 17,
+      textSnapshot: "First reasoning block — more text",
+      parseMode: undefined,
+    });
+
+    // The second reasoning step creates a fresh message.
+    stream.update("Second reasoning block");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    expect(api.sendMessage).toHaveBeenLastCalledWith(123, "Second reasoning block", undefined);
+    // No attempt to edit the superseded first message.
+    expect(api.editMessageText).not.toHaveBeenCalledWith(123, 17, "Second reasoning block");
+  });
+
   it("marks sendMayHaveLanded after an ambiguous first preview send failure", async () => {
     const api = createMockDraftApi();
     api.sendMessage.mockRejectedValueOnce(new Error("timeout after Telegram accepted send"));

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -397,6 +397,19 @@ export function createTelegramDraftStream(params: {
   };
 
   const forceNewMessage = () => {
+    // Archive any already-delivered preview message before discarding its id.
+    // Without this, a reasoning lane that has already sent a message (streamMessageId
+    // is set) silently loses track of that message when forceNewMessage() is called
+    // for the next reasoning step. The superseded message stays in the chat permanently
+    // because onSupersededPreview only fires for sends that complete *after* the
+    // generation change — sends that completed earlier are never notified. (#80862)
+    if (typeof streamMessageId === "number" && previewTransport === "message") {
+      params.onSupersededPreview?.({
+        messageId: streamMessageId,
+        textSnapshot: lastDeliveredText,
+        parseMode: lastSentParseMode,
+      });
+    }
     streamState.final = false;
     generation += 1;
     messageSendAttempted = false;


### PR DESCRIPTION
## Problem

When `/reasoning stream` is enabled on Telegram, reasoning preview messages accumulate in the chat — each reasoning step (separated by `forceNewMessage()`) creates a new `sendMessage` while the previous preview message is never deleted.

Closes #80862.

## Root Cause

`forceNewMessage()` in `draft-stream.ts` increments the generation counter and resets `streamMessageId = undefined`, discarding the previously tracked message id. The `onSupersededPreview` callback is only called when a **pending** `sendMessage` resolves *after* the generation change — but if the send already completed (the common case once streaming is warm), `streamMessageId` is set synchronously and `onSupersededPreview` is never called for it.

The dispatch loop accumulates superseded reasoning preview ids via `onSupersededPreview` → `archivedReasoningPreviewIds` and deletes them in the post-dispatch cleanup. With `onSupersededPreview` never firing for already-delivered messages, `archivedReasoningPreviewIds` stays empty and nothing gets deleted.

## Fix

Before discarding `streamMessageId` inside `forceNewMessage()`, call `onSupersededPreview` synchronously with the known message id when:
- `streamMessageId` is already a number (send already completed), **and**
- `previewTransport === "message"` (draft transport ids are cleaned up differently)

This gives `archivedReasoningPreviewIds` the id it needs and the existing cleanup pass deletes it after the final reply is delivered.

## Test

Added a new unit test to `draft-stream.test.ts` that reproduces the exact scenario:
1. Send first reasoning block → `sendMessage` completes, `streamMessageId = 17`
2. Edit it → confirms `editMessageText` is used (not a new send)
3. Call `forceNewMessage()` → asserts `onSupersededPreview` fires with `{messageId: 17, ...}`
4. Send second reasoning block → new `sendMessage` (correct)
5. Assert first message id is not re-edited

## Existing tests

The pre-existing race-condition test ("does not rebind to an old message when forceNewMessage races an in-flight send") continues to pass — that test checks the *async* path where `sendMessage` resolves *after* `forceNewMessage()`; the new test covers the *synchronous* path where the send already completed.