### PR TITLE
Clarify, warn, and recover message-tool-only finals

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -911,6 +911,10 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("use `message(action=send)` for visible channel output");
     expect(prompt).toContain("Attach media with message-tool attachment fields");
     expect(prompt).not.toContain("Attach media: `MEDIA:<path-or-url>`");
+    expect(prompt).toContain(
+      "If directly addressed, asked for status, or completing requested work where a visible update is expected, call `message(action=send)`",
+    );
+    expect(prompt).toContain("do not put that answer only in normal final text");
     expect(prompt).toContain("The target defaults to the current source channel");
     expect(prompt).toContain("final answers are private in this mode");
     expect(prompt).not.toContain("## Silent Replies");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -508,6 +508,9 @@ function buildMessagingSection(params: {
     messageToolOnly
       ? "- Reply in current session → private by default for this source channel; use `message(action=send)` for visible channel output."
       : "- Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)",
+    messageToolOnly
+      ? "- If directly addressed, asked for status, or completing requested work where a visible update is expected, call `message(action=send)` with the user-facing answer; do not put that answer only in normal final text."
+      : "",
     "- Cross-session messaging → use sessions_send(sessionKey, message)",
     subagentOrchestrationGuidance,
     completionEventGuidance,

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -386,6 +386,7 @@ describe("message tool secret scoping", () => {
       'visible replies to the current source conversation must use action="send"',
     );
     expect(scopedTool.description).toContain("target defaults to the current source conversation");
+    expect(scopedTool.description).toContain("do not put that answer only in normal final text");
     expect(scopedTool.description).toContain("Normal final answers are private");
     expect(explicitTargetTool.description).toContain("Include target when sending");
     expect(explicitTargetTool.description).not.toContain(

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -770,7 +770,7 @@ function appendMessageToolVisibleReplyHint(
   const targetGuidance = requireExplicitTarget
     ? "Include target when sending."
     : "The target defaults to the current source conversation, so omit target unless sending elsewhere.";
-  return `${description} For this turn, visible replies to the current source conversation must use action="send" with message. ${targetGuidance} Normal final answers are private and are not posted.`;
+  return `${description} For this turn, visible replies to the current source conversation must use action="send" with message. ${targetGuidance} If directly addressed, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text. Normal final answers are private and are not posted.`;
 }
 
 function appendMessageToolReadHint(

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -57,6 +57,13 @@ export type ReplyPayloadMetadata = {
    */
   deliverDespiteSourceReplySuppression?: boolean;
   /**
+   * Discord-visible-stall motivated, but intentionally channel-agnostic: the
+   * assistant produced a normal final source reply in a message-tool-only
+   * conversation without any committed message-tool delivery. Dispatch may use
+   * this as a same-turn visible-delivery safety net; sendPolicy deny still wins.
+   */
+  messageToolOnlyFinalFallback?: boolean;
+  /**
    * A message-tool reply to the active internal UI source. The final payload is
    * still the live delivery vehicle; this mirror makes the reply durable for
    * chat.history and page reloads without turning the internal UI into an

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -372,7 +372,7 @@ describe("runReplyAgent pending final delivery capture", () => {
     const payloads = Array.isArray(result) ? result : result ? [result] : [];
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.text).toBe("private final");
-    expect(getReplyPayloadMetadata(payloads[0] as ReplyPayload)?.messageToolOnlyFinalFallback).toBe(
+    expect(getReplyPayloadMetadata(payloads[0])?.messageToolOnlyFinalFallback).toBe(
       true,
     );
   });
@@ -399,7 +399,7 @@ describe("runReplyAgent pending final delivery capture", () => {
     const payloads = Array.isArray(result) ? result : result ? [result] : [];
     if (payloads[0]) {
       expect(
-        getReplyPayloadMetadata(payloads[0] as ReplyPayload)?.messageToolOnlyFinalFallback,
+        getReplyPayloadMetadata(payloads[0])?.messageToolOnlyFinalFallback,
       ).toBeUndefined();
     }
   });
@@ -424,7 +424,7 @@ describe("runReplyAgent pending final delivery capture", () => {
     const payloads = Array.isArray(result) ? result : result ? [result] : [];
     expect(payloads).toHaveLength(1);
     expect(
-      getReplyPayloadMetadata(payloads[0] as ReplyPayload)?.messageToolOnlyFinalFallback,
+      getReplyPayloadMetadata(payloads[0])?.messageToolOnlyFinalFallback,
     ).toBeUndefined();
   });
 
@@ -449,7 +449,7 @@ describe("runReplyAgent pending final delivery capture", () => {
     const result = await run();
     const payloads = Array.isArray(result) ? result : result ? [result] : [];
     expect(payloads).toHaveLength(1);
-    expect(getReplyPayloadMetadata(payloads[0] as ReplyPayload)?.messageToolOnlyFinalFallback).toBe(
+    expect(getReplyPayloadMetadata(payloads[0])?.messageToolOnlyFinalFallback).toBe(
       true,
     );
   });

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -5,6 +5,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
 import type { TemplateContext } from "../templating.js";
+import { getReplyPayloadMetadata } from "../types.js";
 import type { GetReplyOptions } from "../types.js";
 import {
   enqueueFollowupRun,
@@ -349,6 +350,109 @@ describe("runReplyAgent pending final delivery capture", () => {
     const raw = await readFile(storePath, "utf8");
     return JSON.parse(raw).main as SessionEntry;
   }
+
+  it("marks message-tool-only final replies for visible-delivery fallback", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "private final" }],
+      meta: {},
+    });
+
+    const { run } = createMinimalRun({
+      opts: { sourceReplyDeliveryMode: "message_tool_only" },
+      sessionCtx: {
+        ChatType: "channel",
+        Provider: "discord",
+        Surface: "discord",
+        OriginatingChannel: "discord",
+        OriginatingTo: "channel:C1",
+      },
+    });
+
+    const result = await run();
+    const payloads = Array.isArray(result) ? result : result ? [result] : [];
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("private final");
+    expect(getReplyPayloadMetadata(payloads[0] as ReplyPayload)?.messageToolOnlyFinalFallback).toBe(
+      true,
+    );
+  });
+
+  it("does not mark message-tool-only fallback when the message tool already sent", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "already sent" }],
+      messagingToolSentTargets: [{ text: "already sent" }],
+      meta: {},
+    });
+
+    const { run } = createMinimalRun({
+      opts: { sourceReplyDeliveryMode: "message_tool_only" },
+      sessionCtx: {
+        ChatType: "channel",
+        Provider: "discord",
+        Surface: "discord",
+        OriginatingChannel: "discord",
+        OriginatingTo: "channel:C1",
+      },
+    });
+
+    const result = await run();
+    const payloads = Array.isArray(result) ? result : result ? [result] : [];
+    if (payloads[0]) {
+      expect(
+        getReplyPayloadMetadata(payloads[0] as ReplyPayload)?.messageToolOnlyFinalFallback,
+      ).toBeUndefined();
+    }
+  });
+
+  it("does not mark normal final replies outside message-tool-only mode", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ordinary final" }],
+      meta: {},
+    });
+
+    const { run } = createMinimalRun({
+      sessionCtx: {
+        ChatType: "channel",
+        Provider: "discord",
+        Surface: "discord",
+        OriginatingChannel: "discord",
+        OriginatingTo: "channel:C1",
+      },
+    });
+
+    const result = await run();
+    const payloads = Array.isArray(result) ? result : result ? [result] : [];
+    expect(payloads).toHaveLength(1);
+    expect(
+      getReplyPayloadMetadata(payloads[0] as ReplyPayload)?.messageToolOnlyFinalFallback,
+    ).toBeUndefined();
+  });
+
+  it("marks fallback when message-tool text evidence is blank", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "private final" }],
+      messagingToolSentTexts: ["   "],
+      meta: {},
+    });
+
+    const { run } = createMinimalRun({
+      opts: { sourceReplyDeliveryMode: "message_tool_only" },
+      sessionCtx: {
+        ChatType: "channel",
+        Provider: "discord",
+        Surface: "discord",
+        OriginatingChannel: "discord",
+        OriginatingTo: "channel:C1",
+      },
+    });
+
+    const result = await run();
+    const payloads = Array.isArray(result) ? result : result ? [result] : [];
+    expect(payloads).toHaveLength(1);
+    expect(getReplyPayloadMetadata(payloads[0] as ReplyPayload)?.messageToolOnlyFinalFallback).toBe(
+      true,
+    );
+  });
 
   it("does not persist message-tool-only final replies for heartbeat replay", async () => {
     const sessionEntry: SessionEntry = {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -181,6 +181,24 @@ function hasSuccessfulSideEffectDelivery(params: {
   );
 }
 
+function hasCommittedMessagingToolDelivery(params: {
+  messagingToolSentTexts?: string[];
+  messagingToolSentMediaUrls?: string[];
+  messagingToolSentTargets?: unknown[];
+}): boolean {
+  return (
+    hasNonEmptyStringArray(params.messagingToolSentTexts) ||
+    hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
+    hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets)
+  );
+}
+
+function markMessageToolOnlyFinalFallbackPayloads(payloads: ReplyPayload[]): ReplyPayload[] {
+  return payloads.map((payload) =>
+    setReplyPayloadMetadata(payload, { messageToolOnlyFinalFallback: true }),
+  );
+}
+
 function resolveConfiguredFallbackModel(params: {
   run: FollowupRun["run"];
   fallbackStateEntry?: SessionEntry;
@@ -1704,10 +1722,19 @@ export async function runReplyAgent(params: {
             sessionKey,
           })
         : false;
-    const guardedReplyPayloads =
+    const reminderGuardedReplyPayloads =
       hasReminderCommitment && successfulCronAdds === 0 && !coveredByExistingCron
         ? appendUnscheduledReminderNote(replyPayloads)
         : replyPayloads;
+    const guardedReplyPayloads =
+      opts?.sourceReplyDeliveryMode === "message_tool_only" &&
+      !hasCommittedMessagingToolDelivery({
+        messagingToolSentTexts: runResult.messagingToolSentTexts,
+        messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
+        messagingToolSentTargets: runResult.messagingToolSentTargets,
+      })
+        ? markMessageToolOnlyFinalFallbackPayloads(reminderGuardedReplyPayloads)
+        : reminderGuardedReplyPayloads;
 
     enqueueCommitmentExtractionForTurn({
       cfg,

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -515,6 +515,7 @@ describe("tryDispatchAcpReply", () => {
     expect(text).toContain("Source channel delivery is private by default");
     expect(text).toContain("message(action=send)");
     expect(text).toContain("The target defaults to the current source channel");
+    expect(text).toContain("do not put that answer only in normal final text");
     expect(text).toContain("reply privately unless you send explicitly");
   });
 

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -127,6 +127,7 @@ function resolveAcpTurnText(params: {
       "Source channel delivery is private by default for this turn.",
       "Normal ACP final output will not be automatically posted to the source channel.",
       "To send visible output, use message(action=send). The target defaults to the current source channel.",
+      "If directly addressed, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text.",
     ].join(" "),
   );
   return params.promptText ? `${guidance}\n\n${params.promptText}` : guidance;

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -1,5 +1,10 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearAgentHarnesses } from "../../agents/harness/registry.js";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
 import type { PluginHookReplyDispatchResult } from "../../plugins/hooks.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
 import {
@@ -54,6 +59,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     clearAgentHarnesses();
     setDiscordTestRegistry();
     resetInboundDedupe();
+    resetDiagnosticEventsForTest();
     mocks.routeReply.mockReset().mockResolvedValue({ ok: true, messageId: "mock" });
     mocks.tryFastAbortFromMessage.mockReset().mockResolvedValue({
       handled: false,
@@ -205,6 +211,199 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryAttemptCount).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryLastError).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toBeUndefined();
+  });
+
+  it("audits substantive finals suppressed by message-tool-only delivery", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    const stopDiagnostics = onInternalDiagnosticEvent((event) => {
+      diagnosticEvents.push(event);
+    });
+
+    try {
+      const result = await dispatchReplyFromConfig({
+        ctx: {
+          ...createHookCtx(),
+          ChatType: "channel",
+          Surface: "discord",
+          Provider: "discord",
+        },
+        cfg: emptyConfig,
+        dispatcher: createDispatcher(),
+        replyResolver: async () => ({ text: "model reply" }),
+      });
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const auditEvent = diagnosticEvents.find(
+        (event) =>
+          event.type === "log.record" &&
+          event.message.includes("Normal assistant final reply was suppressed"),
+      );
+
+      expect(result.queuedFinal).toBe(false);
+      expect(auditEvent?.type).toBe("log.record");
+      if (auditEvent?.type === "log.record") {
+        expect(auditEvent.level).toBe("warning");
+        expect(auditEvent.attributes).toMatchObject({
+          channel: "discord",
+          sessionKey: "agent:test:session",
+          sourceReplyDeliveryMode: "message_tool_only",
+          suppressedFinalCount: 1,
+          suppressedFinalTextChars: 11,
+          sendPolicyDenied: false,
+        });
+        expect(auditEvent.message).not.toContain("model reply");
+      }
+    } finally {
+      stopDiagnostics();
+    }
+  });
+
+  it("does not audit silent NO_REPLY finals suppressed by message-tool-only delivery", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    const stopDiagnostics = onInternalDiagnosticEvent((event) => {
+      diagnosticEvents.push(event);
+    });
+
+    try {
+      await dispatchReplyFromConfig({
+        ctx: {
+          ...createHookCtx(),
+          ChatType: "channel",
+          Surface: "discord",
+          Provider: "discord",
+        },
+        cfg: emptyConfig,
+        dispatcher: createDispatcher(),
+        replyResolver: async () => ({ text: "NO_REPLY" }),
+      });
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(
+        diagnosticEvents.some(
+          (event) =>
+            event.type === "log.record" &&
+            event.message.includes("Normal assistant final reply was suppressed"),
+        ),
+      ).toBe(false);
+    } finally {
+      stopDiagnostics();
+    }
+  });
+
+  it("does not audit suppressed finals when send policy denies delivery", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    const stopDiagnostics = onInternalDiagnosticEvent((event) => {
+      diagnosticEvents.push(event);
+    });
+
+    try {
+      await dispatchReplyFromConfig({
+        ctx: {
+          ...createHookCtx(),
+          ChatType: "channel",
+          Surface: "discord",
+          Provider: "discord",
+        },
+        cfg: {
+          ...emptyConfig,
+          session: { sendPolicy: { default: "deny" } },
+        },
+        dispatcher: createDispatcher(),
+        replyResolver: async () => ({ text: "model reply" }),
+      });
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(
+        diagnosticEvents.some(
+          (event) =>
+            event.type === "log.record" &&
+            event.message.includes("Normal assistant final reply was suppressed"),
+        ),
+      ).toBe(false);
+    } finally {
+      stopDiagnostics();
+    }
+  });
+
+  it("audits media-only finals suppressed by message-tool-only delivery", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    const stopDiagnostics = onInternalDiagnosticEvent((event) => {
+      diagnosticEvents.push(event);
+    });
+
+    try {
+      await dispatchReplyFromConfig({
+        ctx: {
+          ...createHookCtx(),
+          ChatType: "channel",
+          Surface: "discord",
+          Provider: "discord",
+        },
+        cfg: emptyConfig,
+        dispatcher: createDispatcher(),
+        replyResolver: async () => ({ mediaUrls: ["file:///tmp/result.png"] }),
+      });
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const auditEvent = diagnosticEvents.find(
+        (event) =>
+          event.type === "log.record" &&
+          event.message.includes("Normal assistant final reply was suppressed"),
+      );
+      expect(auditEvent?.type).toBe("log.record");
+      if (auditEvent?.type === "log.record") {
+        expect(auditEvent.attributes).toMatchObject({
+          suppressedFinalCount: 1,
+          suppressedFinalTextChars: 0,
+        });
+      }
+    } finally {
+      stopDiagnostics();
+    }
+  });
+
+  it("audits aggregate suppressed final counts without recording text", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    const stopDiagnostics = onInternalDiagnosticEvent((event) => {
+      diagnosticEvents.push(event);
+    });
+
+    try {
+      await dispatchReplyFromConfig({
+        ctx: {
+          ...createHookCtx(),
+          ChatType: "channel",
+          Surface: "discord",
+          Provider: "discord",
+        },
+        cfg: emptyConfig,
+        dispatcher: createDispatcher(),
+        replyResolver: async () => [{ text: "first" }, { text: "second reply" }],
+      });
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const auditEvent = diagnosticEvents.find(
+        (event) =>
+          event.type === "log.record" &&
+          event.message.includes("Normal assistant final reply was suppressed"),
+      );
+      expect(auditEvent?.type).toBe("log.record");
+      if (auditEvent?.type === "log.record") {
+        expect(auditEvent.attributes).toMatchObject({
+          suppressedFinalCount: 2,
+          suppressedFinalTextChars: 17,
+        });
+        expect(auditEvent.message).not.toContain("first");
+        expect(auditEvent.message).not.toContain("second reply");
+      }
+    } finally {
+      stopDiagnostics();
+    }
   });
 
   it("preserves pending final delivery when final dispatch fails", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4752,6 +4752,98 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
   });
 
+  it("delivers marked message-tool-only final fallbacks in message-tool-only mode", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const fallbackReply = setReplyPayloadMetadata(
+      { text: "final answer that missed message.send" },
+      { messageToolOnlyFinalFallback: true },
+    );
+    const replyResolver = vi.fn(async () => fallbackReply satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ SessionKey: "test:session" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(true);
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(fallbackReply);
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+  });
+
+  it("keeps sendPolicy deny above message-tool-only final fallback delivery", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "deny",
+    };
+    const dispatcher = createDispatcher();
+    const fallbackReply = setReplyPayloadMetadata(
+      { text: "private final blocked by policy" },
+      { messageToolOnlyFinalFallback: true },
+    );
+    const replyResolver = vi.fn(async () => fallbackReply satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ SessionKey: "test:session" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("delivers dual-marked source-suppression fallbacks only once", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const fallbackReply = setReplyPayloadMetadata(
+      { text: "dual marker fallback" },
+      { deliverDespiteSourceReplySuppression: true, messageToolOnlyFinalFallback: true },
+    );
+    const replyResolver = vi.fn(async () => fallbackReply satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ SessionKey: "test:session" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(fallbackReply);
+  });
+
   it("delivers marked runtime failure notices in message-tool-only mode", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1641,10 +1641,17 @@ export async function dispatchReplyFromConfig(
     let finalDeliveryFailed = false;
     let suppressedFinalCount = 0;
     let suppressedFinalTextChars = 0;
-    const shouldDeliverDespiteSourceReplySuppression = (reply: ReplyPayload) =>
-      suppressAutomaticSourceDelivery &&
-      !sendPolicyDenied &&
-      getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true;
+    const shouldDeliverDespiteSourceReplySuppression = (reply: ReplyPayload) => {
+      const metadata = getReplyPayloadMetadata(reply);
+      return (
+        suppressAutomaticSourceDelivery &&
+        !sendPolicyDenied &&
+        // Runtime failure notices and missed message-tool-only final replies are distinct
+        // safety nets, but both use the normal final delivery path after policy checks.
+        (metadata?.deliverDespiteSourceReplySuppression === true ||
+          metadata?.messageToolOnlyFinalFallback === true)
+      );
+    };
     for (const reply of replies) {
       // Suppress reasoning payloads from channel delivery — channels using this
       // generic dispatch path do not have a dedicated reasoning lane.

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -43,7 +43,7 @@ import {
   toPluginMessageContext,
   toPluginMessageReceivedEvent,
 } from "../../hooks/message-hook-mappers.js";
-import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
@@ -88,6 +88,7 @@ import type { BlockReplyContext } from "../get-reply-options.types.js";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import { normalizeVerboseLevel } from "../thinking.js";
+import { isSilentReplyPayloadText } from "../tokens.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
 import {
   createInternalHookEvent,
@@ -169,6 +170,48 @@ const AUDIO_PLACEHOLDER_RE = /^<media:audio>(\s*\([^)]*\))?$/i;
 const AUDIO_HEADER_RE = /^\[Audio\b/i;
 const normalizeMediaType = (value: string): string =>
   normalizeOptionalLowercaseString(value.split(";")[0]) ?? "";
+
+const isSubstantiveSuppressedFinalReply = (reply: ReplyPayload): boolean => {
+  if (reply.isReasoning === true) {
+    return false;
+  }
+  const parts = resolveSendableOutboundReplyParts(reply);
+  if (!parts.hasContent) {
+    return false;
+  }
+  if (!parts.hasMedia && isSilentReplyPayloadText(parts.text)) {
+    return false;
+  }
+  return true;
+};
+
+const emitSuppressedFinalReplyAudit = (params: {
+  channel?: string;
+  sessionKey?: string;
+  sourceReplyDeliveryMode: string;
+  suppressedFinalCount: number;
+  suppressedFinalTextChars: number;
+  sendPolicyDenied: boolean;
+}): void => {
+  if (params.suppressedFinalCount <= 0) {
+    return;
+  }
+  emitTrustedDiagnosticEvent({
+    type: "log.record",
+    level: "warning",
+    loggerName: "auto-reply.dispatch",
+    message:
+      "Normal assistant final reply was suppressed by message-tool-only source delivery; visible output must be sent with the message tool, then the normal final should be NO_REPLY.",
+    attributes: {
+      channel: params.channel ?? "unknown",
+      sessionKey: params.sessionKey ?? "unknown",
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+      suppressedFinalCount: params.suppressedFinalCount,
+      suppressedFinalTextChars: params.suppressedFinalTextChars,
+      sendPolicyDenied: params.sendPolicyDenied,
+    },
+  });
+};
 
 const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
   const rawTypes = [
@@ -1596,6 +1639,8 @@ export async function dispatchReplyFromConfig(
     let routedFinalCount = 0;
     let attemptedFinalDelivery = false;
     let finalDeliveryFailed = false;
+    let suppressedFinalCount = 0;
+    let suppressedFinalTextChars = 0;
     const shouldDeliverDespiteSourceReplySuppression = (reply: ReplyPayload) =>
       suppressAutomaticSourceDelivery &&
       !sendPolicyDenied &&
@@ -1606,7 +1651,16 @@ export async function dispatchReplyFromConfig(
       if (reply.isReasoning === true) {
         continue;
       }
-      if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply)) {
+      const deliverDespiteSourceSuppression = shouldDeliverDespiteSourceReplySuppression(reply);
+      if (suppressDelivery && !deliverDespiteSourceSuppression) {
+        if (
+          suppressAutomaticSourceDelivery &&
+          !sendPolicyDenied &&
+          isSubstantiveSuppressedFinalReply(reply)
+        ) {
+          suppressedFinalCount += 1;
+          suppressedFinalTextChars += resolveSendableOutboundReplyParts(reply).trimmedText.length;
+        }
         continue;
       }
       attemptedFinalDelivery = true;
@@ -1622,6 +1676,17 @@ export async function dispatchReplyFromConfig(
       await clearPendingFinalDeliveryAfterSuccess({
         storePath: sessionStoreEntry.storePath,
         sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+      });
+    }
+
+    if (suppressedFinalCount > 0) {
+      emitSuppressedFinalReplyAudit({
+        channel: deliveryChannel,
+        sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+        sourceReplyDeliveryMode,
+        suppressedFinalCount,
+        suppressedFinalTextChars,
+        sendPolicyDenied,
       });
     }
 

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -46,6 +46,8 @@ describe("group runtime loading", () => {
     });
     expect(toolOnlyContext).toContain("Normal final replies are private");
     expect(toolOnlyContext).toContain("message tool with action=send");
+    expect(toolOnlyContext).toContain("If directly addressed, asked for status");
+    expect(toolOnlyContext).toContain("do not put that answer only in normal final text");
     expect(toolOnlyContext).toContain("Be a good group participant");
     expect(toolOnlyContext).toContain("wrap bare URLs");
     expect(toolOnlyContext).toContain("<https://example.com>");
@@ -101,6 +103,8 @@ describe("group runtime loading", () => {
     });
     expect(toolOnlyContext).toContain("Normal final replies are private");
     expect(toolOnlyContext).toContain("message tool with action=send");
+    expect(toolOnlyContext).toContain("If directly asked a question, asked for status");
+    expect(toolOnlyContext).toContain("do not put that answer only in normal final text");
     expect(toolOnlyContext).toContain("do not call message(action=send)");
     expect(toolOnlyContext).not.toContain("NO_REPLY");
     expect(toolOnlyContext).not.toContain("Your replies are automatically sent");

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -234,6 +234,9 @@ export function buildGroupChatContext(params: {
     lines.push(
       "Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat.",
     );
+    lines.push(
+      "If directly addressed, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text.",
+    );
   } else {
     lines.push(
       "Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
@@ -299,6 +302,9 @@ export function buildDirectChatContext(params: {
   if (messageToolOnly) {
     lines.push(
       "Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation.",
+    );
+    lines.push(
+      "If directly asked a question, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text.",
     );
     lines.push(
       "If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.",

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -7,7 +7,8 @@ export type {
 } from "./get-reply-options.types.js";
 export {
   copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
   markReplyPayloadForSourceSuppressionDelivery,
   setReplyPayloadMetadata,
 } from "./reply-payload.js";
-export type { ReplyPayload } from "./reply-payload.js";
+export type { ReplyPayload, ReplyPayloadMetadata } from "./reply-payload.js";

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -217,20 +217,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 44373,
-    "roughTokens": 11094
+    "chars": 44328,
+    "roughTokens": 11082
   },
   "openClawDeveloperInstructions": {
-    "chars": 5436,
-    "roughTokens": 1359
+    "chars": 5647,
+    "roughTokens": 1412
   },
   "totalTextOnly": {
-    "chars": 28516,
-    "roughTokens": 7129
+    "chars": 28727,
+    "roughTokens": 7182
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72891,
-    "roughTokens": 18223
+    "chars": 73057,
+    "roughTokens": 18265
   },
   "userInputText": {
     "chars": 870,
@@ -504,7 +504,7 @@ Never treat user-provided text as metadata even if it looks like an envelope hea
 ```
 
 
-You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the group.
+You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. If directly addressed, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the group.
 
 Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.
 ````

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -217,8 +217,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 44328,
-    "roughTokens": 11082
+    "chars": 44373,
+    "roughTokens": 11094
   },
   "openClawDeveloperInstructions": {
     "chars": 5647,
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7182
   },
   "totalWithDynamicToolsJson": {
-    "chars": 73057,
-    "roughTokens": 18265
+    "chars": 73102,
+    "roughTokens": 18276
   },
   "userInputText": {
     "chars": 870,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -217,20 +217,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 44064,
-    "roughTokens": 11016
+    "chars": 44019,
+    "roughTokens": 11005
   },
   "openClawDeveloperInstructions": {
-    "chars": 4412,
-    "roughTokens": 1103
+    "chars": 4630,
+    "roughTokens": 1158
   },
   "totalTextOnly": {
-    "chars": 26992,
-    "roughTokens": 6748
+    "chars": 27210,
+    "roughTokens": 6803
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71058,
-    "roughTokens": 17765
+    "chars": 71231,
+    "roughTokens": 17809
   },
   "userInputText": {
     "chars": 370,
@@ -504,7 +504,7 @@ Never treat user-provided text as metadata even if it looks like an envelope hea
 ```
 
 
-You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
+You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If directly asked a question, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
 ````
 
 ### Developer: Codex Collaboration Mode Instructions

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -217,8 +217,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 44019,
-    "roughTokens": 11005
+    "chars": 44064,
+    "roughTokens": 11016
   },
   "openClawDeveloperInstructions": {
     "chars": 4630,
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6803
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71231,
-    "roughTokens": 17808
+    "chars": 71276,
+    "roughTokens": 17819
   },
   "userInputText": {
     "chars": 370,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -230,7 +230,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
   },
   "totalWithDynamicToolsJson": {
     "chars": 71231,
-    "roughTokens": 17809
+    "roughTokens": 17808
   },
   "userInputText": {
     "chars": 370,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -218,20 +218,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 45242,
-    "roughTokens": 11311
+    "chars": 45197,
+    "roughTokens": 11300
   },
   "openClawDeveloperInstructions": {
-    "chars": 4412,
-    "roughTokens": 1103
+    "chars": 4630,
+    "roughTokens": 1158
   },
   "totalTextOnly": {
-    "chars": 28619,
-    "roughTokens": 7155
+    "chars": 28837,
+    "roughTokens": 7210
   },
   "totalWithDynamicToolsJson": {
-    "chars": 73863,
-    "roughTokens": 18466
+    "chars": 74036,
+    "roughTokens": 18511
   },
   "userInputText": {
     "chars": 608,
@@ -505,7 +505,7 @@ Never treat user-provided text as metadata even if it looks like an envelope hea
 ```
 
 
-You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
+You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If directly asked a question, asked for status, or completing requested work where a visible update is expected, call message(action=send) with the user-facing answer; do not put that answer only in normal final text. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
 ````
 
 ### Developer: Codex Collaboration Mode Instructions

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -231,7 +231,7 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
   },
   "totalWithDynamicToolsJson": {
     "chars": 74036,
-    "roughTokens": 18511
+    "roughTokens": 18509
   },
   "userInputText": {
     "chars": 608,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -218,8 +218,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 45197,
-    "roughTokens": 11300
+    "chars": 45242,
+    "roughTokens": 11311
   },
   "openClawDeveloperInstructions": {
     "chars": 4630,
@@ -230,8 +230,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7210
   },
   "totalWithDynamicToolsJson": {
-    "chars": 74036,
-    "roughTokens": 18509
+    "chars": 74081,
+    "roughTokens": 18521
   },
   "userInputText": {
     "chars": 608,


### PR DESCRIPTION
## Summary

- add prompt/context guidance so directly addressed/status/completion answers in `message_tool_only` conversations use the message tool instead of private normal final text
- add a privacy-safe diagnostic warning when a substantive normal assistant final is suppressed by `message_tool_only` source delivery
- add a guarded runtime fallback that delivers missed `message_tool_only` normal finals through the normal final delivery path when no committed message-tool delivery evidence exists
- keep suppressed final content out of diagnostic warnings; diagnostics record only route/session metadata plus aggregate count/text length
- keep `sendPolicy: deny` authoritative and avoid duplicate visible posts when the message tool already delivered

## Why

On message-tool-only group/channel surfaces, normal assistant final text is intentionally private. If an agent completes work but puts the user-facing status/result in the normal final instead of calling the message tool, the channel can look stalled even though the model produced a useful answer.

This PR consolidates the prompt-only guidance from #80050 with the runtime audit/recovery work here so there is one review surface for the final-visibility issue.

The fix now handles three layers:

1. prompt/tool guidance tells the agent to use `message(action=send)` for visible source replies;
2. if a substantive final still gets suppressed, emit an operator-facing audit warning without leaking the suppressed text;
3. if the runner can prove there was no committed message-tool delivery for the turn and source delivery policy allows it, mark the final payload for same-turn visible fallback delivery.

## Runtime policy

The fallback is intentionally narrow:

- only applies when `sourceReplyDeliveryMode === "message_tool_only"`
- only applies when there is no committed message-tool delivery evidence (`messagingToolSentTexts`, media URLs, or committed targets)
- does not bypass `sendPolicy: deny`
- uses the normal final delivery path rather than channel-specific special cases
- leaves existing runtime-failure notice handling (`deliverDespiteSourceReplySuppression`) intact

## Tests

- `git diff --check`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm exec vitest run src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/auto-reply/reply/dispatch-from-config.test.ts` (119 passed)
- `corepack pnpm exec vitest run src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts --config test/vitest/vitest.e2e.config.ts` (50 passed)
- `corepack pnpm exec vitest run src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts src/auto-reply/reply/groups.test.ts src/agents/system-prompt.test.ts src/agents/tools/message-tool.test.ts src/auto-reply/reply/dispatch-acp.test.ts` (339 passed in the default multi-project config; the e2e file is also covered separately by the command above)
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts` (0 warnings / 0 errors after the lint-only follow-up commit)

## Real behavior proof

- **Behavior or issue addressed:** `message_tool_only` final-visibility recovery: a normal final reply that missed the message tool is either audited as suppressed without leaking text, or, when explicitly marked as the guarded fallback and policy allows it, delivered through the normal final path.
- **Real environment tested:** disposable source-stage checkout of PR head `88708d4ce7` on Linux arm64 / Node 22. The harness used the current source dispatch runtime with an isolated session store and `plugins.enabled: false`; no live Gateway, live Discord/Telegram channel, channel credentials, or watched config were used.
- **Exact steps or command run after this patch:** from the disposable checkout, run `tsx message-tool-final-fallback-proof.mts`, a terminal runtime harness that imports the current source `dispatchReplyFromConfig`, `setReplyPayloadMetadata`, and diagnostics event path, then exercises three `message_tool_only` final-delivery cases.
- **Evidence after fix:** terminal output from that harness:

```json
{
  "proof": "message-tool-only final fallback terminal runtime harness",
  "liveGatewayUsed": false,
  "liveChannelUsed": false,
  "sourceMode": "message_tool_only",
  "results": [
    {
      "case": "marked fallback delivers through final path",
      "queuedFinal": true,
      "sourceReplyDeliveryMode": "message_tool_only",
      "queuedCounts": { "tool": 0, "block": 0, "final": 1 },
      "finalPayloads": [
        {
          "textLen": 42,
          "hasFallbackMarker": true,
          "hasSuppressionBypassMarker": false
        }
      ],
      "warningCount": 0,
      "warnings": []
    },
    {
      "case": "unmarked final is suppressed and audited without text",
      "queuedFinal": false,
      "sourceReplyDeliveryMode": "message_tool_only",
      "queuedCounts": { "tool": 0, "block": 0, "final": 0 },
      "finalPayloads": [],
      "warningCount": 1,
      "warnings": [
        {
          "level": "warning",
          "loggerName": "auto-reply.dispatch",
          "suppressedFinalCount": 1,
          "suppressedFinalTextChars": 42,
          "sendPolicyDenied": false,
          "hasSuppressedText": false
        }
      ]
    },
    {
      "case": "sendPolicy deny still blocks marked fallback",
      "queuedFinal": false,
      "sourceReplyDeliveryMode": "message_tool_only",
      "queuedCounts": { "tool": 0, "block": 0, "final": 0 },
      "finalPayloads": [],
      "warningCount": 0,
      "warnings": []
    }
  ]
}
```

- **Observed result after fix:** the marked fallback produced one queued final payload with the fallback metadata still present; the ordinary unmarked final stayed suppressed and emitted only aggregate warning metadata (`suppressedFinalCount`, text length, policy flag) with `hasSuppressedText: false`; `sendPolicy: deny` stayed authoritative and blocked even a marked fallback.
- **What was not tested:** live Discord/Telegram posting was intentionally not run for this proof; no live Gateway restart, live config write, live channel credential, or external channel send was used.

## Scope

This is a source/runtime delivery fix only. It does not change installed dist artifacts, live gateway config, or channel credentials.

