### PR TITLE
fix(agents): remove transient session-repair backups (supersedes #77945)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Codex app-server: release raw assistant completions when `turn/completed` is missing while keeping commentary/status items as progress, preventing completed Codex runs from hanging until timeout. Fixes #82343. (#82403) Thanks @IWhatsskill.
+- Agents/sessions: remove the transient `*.bak-<pid>-<ts>` backup written by `repairSessionFileIfNeeded` once the atomic replace succeeds, so a stuck session with a persistently malformed JSONL line no longer accumulates one snapshot per repair invocation. Fixes #80960. (#80969) Thanks @100yenadmin. Co-authored by @tynamite.
 - CLI/status: show plain empty-state messages instead of empty Channels and Sessions tables when no channels or sessions exist.
 - CLI/dashboard: probe Gateway readiness before handing out the dashboard URL, prompting to start or install the managed service when the Gateway is stopped and printing recovery commands instead of opening a dead browser tab.
 - CLI/context engines: bootstrap and finalize non-legacy context engines for CLI turns while preserving transcript snapshots and deferred maintenance ownership. (#81869) Thanks @sahilsatralkar.

--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -7,7 +7,7 @@ read_when:
 title: "Transcript hygiene"
 ---
 
-OpenClaw applies **provider-specific fixes** to transcripts before a run (building model context). Most of these are **in-memory** adjustments used to satisfy strict provider requirements. A separate session-file repair pass may also rewrite stored JSONL before the session is loaded, but only for malformed lines or persisted turns that are invalid durable records. Delivered assistant replies are preserved on disk; provider-specific assistant-prefill stripping happens only while constructing outbound payloads. When a repair occurs, the original file is backed up alongside the session file.
+OpenClaw applies **provider-specific fixes** to transcripts before a run (building model context). Most of these are **in-memory** adjustments used to satisfy strict provider requirements. A separate session-file repair pass may also rewrite stored JSONL before the session is loaded, but only for malformed lines or persisted turns that are invalid durable records. Delivered assistant replies are preserved on disk; provider-specific assistant-prefill stripping happens only while constructing outbound payloads. When a repair occurs, the original file is written to a transient `*.bak-<pid>-<ts>` sibling before the atomic replace and removed once the replace succeeds; the backup is only retained if cleanup itself fails (in which case the path is reported back).
 
 Scope includes:
 

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -49,6 +49,7 @@ function requireFirstLogMessage(log: ReturnType<typeof vi.fn>): string {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -91,6 +92,25 @@ describe("repairSessionFileIfNeeded", () => {
       expect(result.droppedLines).toBe(1);
       await expectNoRetainedBackup(file, result);
     }
+  });
+
+  it("reports retained backup path when successful repair backup cleanup fails", async () => {
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const content = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n{"type":"message"`;
+    await fs.writeFile(file, content, "utf-8");
+    vi.spyOn(fs, "unlink").mockRejectedValueOnce(new Error("simulated cleanup failure"));
+
+    const debug = vi.fn();
+    const result = await repairSessionFileIfNeeded({ sessionFile: file, debug });
+
+    expect(result.repaired).toBe(true);
+    expect(result.backupPath).toMatch(/session\.jsonl\.bak-/);
+    expect(debug.mock.calls.some(([message]) => String(message).includes("cleanup failed"))).toBe(
+      true,
+    );
+    const siblings = await fs.readdir(path.dirname(file));
+    expect(siblings.filter((name) => name.includes(".bak-"))).toHaveLength(1);
   });
 
   it("does not drop CRLF-terminated JSONL lines", async () => {

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -30,11 +30,14 @@ async function createTempSessionPath() {
   return { dir, file: path.join(dir, "session.jsonl") };
 }
 
-function requireBackupPath(result: { backupPath?: string }): string {
-  if (!result.backupPath) {
-    throw new Error("expected session repair backup path");
-  }
-  return result.backupPath;
+async function expectNoRetainedBackup(
+  file: string,
+  result: { backupPath?: string },
+): Promise<void> {
+  expect(result.backupPath).toBeUndefined();
+  const siblings = await fs.readdir(path.dirname(file));
+  const leftover = siblings.filter((name) => name.includes(".bak-"));
+  expect(leftover).toEqual([]);
 }
 
 function requireFirstLogMessage(log: ReturnType<typeof vi.fn>): string {
@@ -60,7 +63,6 @@ describe("repairSessionFileIfNeeded", () => {
     const result = await repairSessionFileIfNeeded({ sessionFile: file });
     expect(result.repaired).toBe(true);
     expect(result.droppedLines).toBe(1);
-    const backupPath = requireBackupPath(result);
 
     const repaired = await fs.readFile(file, "utf-8");
     const repairedLines = repaired
@@ -69,8 +71,26 @@ describe("repairSessionFileIfNeeded", () => {
       .map((line) => JSON.parse(line));
     expect(repairedLines).toEqual([header, message]);
 
-    const backup = await fs.readFile(backupPath, "utf-8");
-    expect(backup).toBe(content);
+    await expectNoRetainedBackup(file, result);
+  });
+
+  it("does not accumulate backups across repeated repairs of a persistently corrupted file", async () => {
+    // Regression for #80960: a stuck session with a writer that keeps
+    // appending a malformed line caused every repair invocation to leave a
+    // ~1.8 MB `.bak-<pid>-<ts>` snapshot, accumulating 2,180 files / 2.1 GB
+    // on a single agent over ~25 hours.
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const malformedTail = '{"type":"message"';
+
+    for (let i = 0; i < 5; i++) {
+      const content = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${malformedTail}`;
+      await fs.writeFile(file, content, "utf-8");
+      const result = await repairSessionFileIfNeeded({ sessionFile: file });
+      expect(result.repaired).toBe(true);
+      expect(result.droppedLines).toBe(1);
+      await expectNoRetainedBackup(file, result);
+    }
   });
 
   it("does not drop CRLF-terminated JSONL lines", async () => {
@@ -151,7 +171,7 @@ describe("repairSessionFileIfNeeded", () => {
     expect(result.repaired).toBe(true);
     expect(result.droppedLines).toBe(0);
     expect(result.rewrittenAssistantMessages).toBe(1);
-    await expect(fs.readFile(requireBackupPath(result), "utf-8")).resolves.toBe(original);
+    await expectNoRetainedBackup(file, result);
     expect(debug).toHaveBeenCalledTimes(1);
     const debugMessage = requireFirstLogMessage(debug);
     expect(debugMessage).toContain("rewrote 1 assistant message(s)");
@@ -528,8 +548,7 @@ describe("repairSessionFileIfNeeded", () => {
 
     expect(result.repaired).toBe(true);
     expect(result.insertedToolResults).toBe(1);
-    const backup = await fs.readFile(requireBackupPath(result), "utf-8");
-    expect(backup).toBe(original);
+    await expectNoRetainedBackup(file, result);
 
     const lines = (await fs.readFile(file, "utf-8")).trimEnd().split("\n");
     expect(lines).toHaveLength(5);
@@ -773,7 +792,7 @@ describe("repairSessionFileIfNeeded", () => {
 
     expect(result.repaired).toBe(true);
     expect(result.droppedLines).toBe(3);
-    await expect(fs.readFile(requireBackupPath(result), "utf-8")).resolves.toBe(`${content}\n`);
+    await expectNoRetainedBackup(file, result);
 
     const after = await fs.readFile(file, "utf-8");
     const lines = after.trimEnd().split("\n");

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -399,6 +399,7 @@ export async function repairSessionFileIfNeeded(params: {
 
   const cleaned = `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
   const backupPath = `${sessionFile}.bak-${process.pid}-${Date.now()}`;
+  let retainedBackupPath: string | undefined;
   try {
     const stat = await fs.stat(sessionFile).catch(() => null);
     await fs.writeFile(backupPath, content, "utf-8");
@@ -410,6 +411,14 @@ export async function repairSessionFileIfNeeded(params: {
       content: cleaned,
       preserveExistingMode: true,
       tempPrefix: `${path.basename(sessionFile)}.repair`,
+    });
+    await fs.unlink(backupPath).catch((cleanupErr: unknown) => {
+      retainedBackupPath = backupPath;
+      params.debug?.(
+        `session file repair backup cleanup failed: ${cleanupErr instanceof Error ? cleanupErr.message : "unknown error"} (${path.basename(
+          backupPath,
+        )})`,
+      );
     });
   } catch (err) {
     return {
@@ -438,6 +447,6 @@ export async function repairSessionFileIfNeeded(params: {
     droppedBlankUserMessages,
     rewrittenUserMessages,
     insertedToolResults,
-    backupPath,
+    ...(retainedBackupPath ? { backupPath: retainedBackupPath } : {}),
   };
 }

--- a/src/commands/gateway-readiness.ts
+++ b/src/commands/gateway-readiness.ts
@@ -51,9 +51,7 @@ async function defaultGatherStatus(params: {
 }): Promise<DaemonStatus> {
   const { gatherDaemonStatus } = await daemonStatusModuleLoader.load();
   return gatherDaemonStatus({
-    rpc: {
-      ...(params.probeUrl ? { url: params.probeUrl } : {}),
-    },
+    rpc: params.probeUrl ? { url: params.probeUrl } : {},
     probe: true,
     requireRpc: params.requireRpc,
     deep: false,
@@ -67,10 +65,10 @@ function activeProbePortStatus(status: DaemonStatus): DaemonStatus["port"] {
         try {
           return Number(new URL(probeUrl).port);
         } catch {
-          return NaN;
+          return Number.NaN;
         }
       })()
-    : NaN;
+    : Number.NaN;
   if (Number.isFinite(probePort) && status.portCli?.port === probePort) {
     return status.portCli;
   }


### PR DESCRIPTION
This PR stops successful session-repair runs from leaving behind transient `.bak-*` files, while preserving backups when cleanup itself fails. The outcome is cleaner transcript directories without weakening crash-safety or postmortem evidence for unsuccessful repair paths.

## Summary

This PR fixes unbounded session-repair backup growth. `repairSessionFileIfNeeded` needs a backup during atomic repair for crash safety, but successful repairs were retaining every `*.bak-<pid>-<timestamp>` sibling forever. In the field this created 2,180 backup files and about 2.1 GB of debris for one mostly unused session.

- Problem: every successful repair left a full session backup on disk, so repeated repair loops grew linearly without TTL, rotation, or dedupe.
- Why it matters: this creates real disk pressure today and can contaminate future JSONL-to-SQLite transcript migration inputs.
- What changed: the backup is deleted after `replaceFileAtomic` succeeds; `backupPath` is returned only if that post-success cleanup fails.
- What did NOT change (scope boundary): the crash-safety backup still exists during atomic replace, and failed atomic replace behavior remains out of scope.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #80960
- Supersedes #77945
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: repeated successful session-file repairs should not leave one retained `.bak-*` sibling per repair invocation.
- Real environment tested: macOS local OpenClaw worktree at `/Volumes/LEXAR/repos/openclaw-pr80960`, real `node:fs` I/O against a real temporary directory, no filesystem mocks for the proof driver.
- Exact steps or command run after this patch:

```bash
node --import tsx /tmp/proof-session-repair.mjs
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/session-file-repair.test.ts
pnpm exec oxfmt --check --threads=1 src/agents/session-file-repair.test.ts src/agents/session-file-repair.ts
git diff --check
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Patched branch proof driver, 5 repeated repairs:

```text
=== iteration 1 ===
after:  file size=301B, lines=2, .bak-* count=0, .bak-* files=[]
...
=== iteration 5 ===
after:  file size=301B, lines=2, .bak-* count=0, .bak-* files=[]

--- final temp dir contents ---
[ 'session.jsonl' ]
```

Unpatched `upstream/main` baseline on the same driver:

```text
=== iteration 1 ===
after:  .bak-* count=1
=== iteration 2 ===
after:  .bak-* count=2
=== iteration 3 ===
after:  .bak-* count=3
=== iteration 4 ===
after:  .bak-* count=4
=== iteration 5 ===
after:  .bak-* count=5
```

Follow-up validation after ClawSweeper's test-gap question:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/session-file-repair.test.ts
passed: 1 Vitest shard, 27 tests

pnpm exec oxfmt --check --threads=1 src/agents/session-file-repair.test.ts src/agents/session-file-repair.ts
passed

git diff --check
passed before commit
```

- Observed result after fix: repeated successful repairs keep zero retained `.bak-*` siblings; cleanup-failure coverage now asserts `result.backupPath` is returned, debug mentions cleanup failure, and exactly one `.bak-*` sibling remains when `fs.unlink` fails.
- What was not tested: changing behavior when `replaceFileAtomic` itself throws. That is intentionally out of scope because the original session has not been replaced, so retaining the backup remains postmortem/crash-safety behavior.
- Before evidence (optional but encouraged): field repro from #80960 observed 2,180 retained backup files and roughly 2.1 GB of duplicate session snapshots.

## Root Cause (if applicable)

- Root cause: `repairSessionFileIfNeeded` wrote `${session}.bak-${process.pid}-${Date.now()}` before atomic replace and returned it after every successful repair, making the backup permanent on the success path.
- Missing detection / guardrail: existing tests verified a backup path existed but did not assert the success path cleaned up transient backups.
- Contributing context (if known): spawn attempts and compaction can both repeatedly invoke repair on a persistently dirty transcript.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/session-file-repair.test.ts`
- Scenario the test should lock in: repeated repairs do not retain success-path backups; cleanup failure reports retained backup path.
- Why this is the smallest reliable guardrail: the helper owns the backup lifecycle and can be tested with real filesystem temp dirs.
- Existing test that already covers this (if any): earlier repair tests covered retained backups but encoded the old behavior.
- If no new test is added, why not: N/A, tests are included.

## User-visible / Behavior Changes

Successful transcript repair no longer leaves permanent `.bak-*` siblings. A backup is retained and reported only if cleanup fails after a successful atomic replace.

## Diagram (if applicable)

<!-- reviewer-map -->

```mermaid
flowchart LR
  corrupt["Repairable session JSONL"] --> backup["Create transient .bak file"]
  backup --> replace["Atomic replace succeeds"]
  replace --> cleanup["Delete transient backup"]
  cleanup --> clean["No stale .bak left behind"]
  cleanup -->|unlink fails| retain["Return retained backup path"]
```

```text
Before:
[repair needed] -> [write .bak] -> [atomic replace succeeds] -> [.bak retained forever]

After:
[repair needed] -> [write .bak] -> [atomic replace succeeds] -> [unlink .bak]
                                             -> [if unlink fails, report backupPath]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local development host
- Runtime/container: local OpenClaw worktree
- Model/provider: not model-provider dependent
- Integration/channel (if any): session-file repair helper
- Relevant config (redacted): real temporary directory and synthetic malformed JSONL session file

### Steps

1. Run the proof driver against patched branch and `upstream/main` baseline.
2. Run focused session repair tests.
3. Run formatter and whitespace checks.

### Expected

- Patched branch leaves zero `.bak-*` files on successful repeated repair.
- Main baseline accumulates one `.bak-*` per successful repair.
- Cleanup-failure path retains and reports exactly one backup.

### Actual

- Patched branch left only `session.jsonl` after 5 iterations.
- Main baseline accumulated 5 backup siblings after 5 iterations.
- Focused test shard passed 27 tests.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: repeated success-path cleanup, main-baseline accumulation, cleanup-failure retained-backup path.
- Edge cases checked: real filesystem temp dir, malformed tail reintroduced before every repair, `fs.unlink` failure after successful atomic repair.
- What you did **not** verify: failed `replaceFileAtomic` behavior changes, because that is intentionally out of scope.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

ClawSweeper's cleanup-failure test gap is addressed by `eb2711afbee0`.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: operators may expect every successful repair to leave a permanent copy.
  - Mitigation: crash safety is preserved during atomic replace; retained backup is still reported when cleanup fails.
