### PR TITLE
fix(openai): skip codex browser auth when callback port is busy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - fix(qqbot): authorize approval button callbacks [AI]. (#80892) Thanks @pgondhi987.
 - Telegram: render supported HTML tags in streamed and durable replies instead of showing literal markup. (#80977)
 - Scrub streamable MCP redirect headers [AI]. (#80906) Thanks @pgondhi987.
+- OpenAI Codex OAuth: skip the browser callback flow and prompt for manual entry immediately when localhost:1455 is already occupied. (#80963)
 - fix(memory-wiki): require admin scope for ingest [AI]. (#80897) Thanks @pgondhi987.
 - memory-wiki: require write scope for Obsidian search [AI]. (#80904) Thanks @pgondhi987.
 - Build: skip copied metadata for bundled plugins that are excluded from build entries, preventing update/status rebuilds from advertising missing QQ Bot runtime files. (#80925)

--- a/extensions/openai/openai-codex-oauth.runtime.ts
+++ b/extensions/openai/openai-codex-oauth.runtime.ts
@@ -1,3 +1,4 @@
+import net from "node:net";
 import path from "node:path";
 import { loginOpenAICodex, type OAuthCredentials } from "@earendil-works/pi-ai/oauth";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -9,6 +10,8 @@ const manualInputPromptMessage = "Paste the authorization code (or full redirect
 const openAICodexOAuthOriginator = "openclaw";
 const localManualFallbackDelayMs = 15_000;
 const localManualFallbackGraceMs = 1_000;
+const openAICodexCallbackPort = 1455;
+const openAICodexCallbackHost = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
 const openAIAuthProbeUrl =
   "https://auth.openai.com/oauth/authorize?response_type=code&client_id=openclaw-preflight&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback&scope=openid+profile+email";
 
@@ -161,6 +164,38 @@ function createNeverSettlingPromptResult(): Promise<string> {
   return new Promise<string>(() => undefined);
 }
 
+function formatLocalCallbackPortConflictMessage(): string {
+  return [
+    `OpenAI Codex OAuth automatic browser callback cannot use localhost:${openAICodexCallbackPort} because the port is already in use.`,
+    "OpenClaw will use manual OAuth entry instead of opening a browser flow that redirects to the wrong local process.",
+    `To identify the listener, run: lsof -nP -iTCP:${openAICodexCallbackPort} -sTCP:LISTEN`,
+    "If a browser tab shows `Invalid or expired OAuth state`, the callback may have been handled by the process occupying the port.",
+  ].join("\n");
+}
+
+async function isLocalCallbackPortAvailable(): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const server = net.createServer();
+    let settled = false;
+    const finish = (available: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      server.removeAllListeners();
+      if (server.listening) {
+        server.close(() => resolve(available));
+        return;
+      }
+      resolve(available);
+    };
+    server.once("error", (err: NodeJS.ErrnoException) => {
+      finish(err.code !== "EADDRINUSE");
+    });
+    server.listen(openAICodexCallbackPort, openAICodexCallbackHost, () => finish(true));
+  });
+}
+
 function createOpenAICodexOAuthError(
   code: OpenAICodexOAuthFailureCode,
   message: string,
@@ -260,6 +295,7 @@ export async function loginOpenAICodexOAuth(params: {
   isRemote: boolean;
   openUrl: (url: string) => Promise<void>;
   localBrowserMessage?: string;
+  isLocalCallbackPortAvailable?: () => Promise<boolean>;
 }): Promise<OAuthCredentials | null> {
   const { prompter, runtime, isRemote, openUrl, localBrowserMessage } = params;
 
@@ -273,20 +309,28 @@ export async function loginOpenAICodexOAuth(params: {
     throw new Error(`OpenAI Codex OAuth prerequisites failed: ${preflight.message}`);
   }
 
-  await prompter.note(
-    isRemote
-      ? [
-          "You are running in a remote/VPS environment.",
-          "A URL will be shown for you to open in your LOCAL browser.",
-          "After signing in, paste the redirect URL back here.",
-        ].join("\n")
-      : [
-          "Browser will open for OpenAI authentication.",
-          "If the callback doesn't auto-complete, paste the redirect URL.",
-          "OpenAI OAuth uses localhost:1455 for the callback.",
-        ].join("\n"),
-    "OpenAI Codex OAuth",
-  );
+  const localCallbackAvailable =
+    isRemote || (await (params.isLocalCallbackPortAvailable ?? isLocalCallbackPortAvailable)());
+  if (!isRemote && !localCallbackAvailable) {
+    const hint = formatLocalCallbackPortConflictMessage();
+    await prompter.note(hint, "OpenAI Codex OAuth");
+    runtime.log(hint);
+  } else {
+    await prompter.note(
+      isRemote
+        ? [
+            "You are running in a remote/VPS environment.",
+            "A URL will be shown for you to open in your LOCAL browser.",
+            "After signing in, paste the redirect URL back here.",
+          ].join("\n")
+        : [
+            "Browser will open for OpenAI authentication.",
+            "If the callback doesn't auto-complete, paste the redirect URL.",
+            "OpenAI OAuth uses localhost:1455 for the callback.",
+          ].join("\n"),
+      "OpenAI Codex OAuth",
+    );
+  }
 
   const spin = prompter.progress("Starting OAuth flow...");
   let progressActive = true;
@@ -317,6 +361,9 @@ export async function loginOpenAICodexOAuth(params: {
       manualPromptMessage: manualInputPromptMessage,
     });
     const onAuth: typeof baseOnAuth = async (event) => {
+      if (!isRemote && !localCallbackAvailable) {
+        return;
+      }
       browserAuthStarted = true;
       await baseOnAuth(event);
     };

--- a/src/plugins/provider-openai-codex-oauth.test.ts
+++ b/src/plugins/provider-openai-codex-oauth.test.ts
@@ -104,6 +104,7 @@ async function startCodexAuth(opts: CodexLoginOptions) {
 async function runCodexOAuth(params: {
   isRemote: boolean;
   openUrl?: (url: string) => Promise<void>;
+  isLocalCallbackPortAvailable?: () => Promise<boolean>;
 }) {
   const { prompter, spin } = createPrompter();
   const runtime = createRuntime();
@@ -112,6 +113,7 @@ async function runCodexOAuth(params: {
     runtime,
     isRemote: params.isRemote,
     openUrl: params.openUrl ?? (async () => {}),
+    isLocalCallbackPortAvailable: params.isLocalCallbackPortAvailable,
   });
   return { result, prompter, spin, runtime };
 }
@@ -462,6 +464,43 @@ describe("loginOpenAICodexOAuth", () => {
       ),
     ).toHaveLength(1);
     expect(runtime.log).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it("does not open the browser and prompts immediately when localhost callback port is busy", async () => {
+    vi.useFakeTimers();
+    const openUrl = vi.fn(async () => {});
+    const { prompter, spin, text } = createPrompter();
+    const runtime = createRuntime();
+    mocks.loginOpenAICodex.mockImplementation(async (opts: CodexLoginOptions) => {
+      await opts.onAuth({ url: CODEX_AUTHORIZE_URL });
+      expect(openUrl).not.toHaveBeenCalled();
+      const manualCode = await opts.onManualCodeInput?.();
+      return createCodexCredentials({ manualCode });
+    });
+
+    const result = await loginOpenAICodexOAuth({
+      prompter,
+      runtime,
+      isRemote: false,
+      openUrl,
+      isLocalCallbackPortAvailable: async () => false,
+    });
+    expectFields(result, {
+      access: "access-token",
+      refresh: "refresh-token",
+    });
+
+    expectPromptTextCall(prompter);
+    expect(spin.stop).toHaveBeenCalledWith("Manual OAuth entry required");
+    expect(spin.stop.mock.invocationCallOrder[0]).toBeLessThan(
+      text.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("localhost:1455"));
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("lsof -nP -iTCP:1455 -sTCP:LISTEN"),
+    );
     expect(vi.getTimerCount()).toBe(0);
     vi.useRealTimers();
   });

--- a/src/plugins/provider-openai-codex-oauth.ts
+++ b/src/plugins/provider-openai-codex-oauth.ts
@@ -1,6 +1,7 @@
 import { loginOpenAICodex, type OAuthCredentials } from "@earendil-works/pi-ai/oauth";
 import { formatErrorMessage } from "../infra/errors.js";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "../infra/net/undici-global-dispatcher.js";
+import { tryListenOnPort } from "../infra/ports-probe.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { OAuthPrompt } from "./provider-oauth-flow.js";
@@ -14,6 +15,8 @@ const manualInputPromptMessage = "Paste the authorization code (or full redirect
 const openAICodexOAuthOriginator = "openclaw";
 const localManualFallbackDelayMs = 15_000;
 const localManualFallbackGraceMs = 1_000;
+const openAICodexCallbackPort = 1455;
+const openAICodexCallbackHost = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
 
 type OpenAICodexOAuthFailureCode =
   | "callback_timeout"
@@ -44,6 +47,29 @@ function waitForDelayOrLoginSettle(params: {
 
 function createNeverSettlingPromptResult(): Promise<string> {
   return new Promise<string>(() => undefined);
+}
+
+function formatLocalCallbackPortConflictMessage(): string {
+  return [
+    `OpenAI Codex OAuth automatic browser callback cannot use localhost:${openAICodexCallbackPort} because the port is already in use.`,
+    "OpenClaw will use manual OAuth entry instead of opening a browser flow that redirects to the wrong local process.",
+    `To identify the listener, run: lsof -nP -iTCP:${openAICodexCallbackPort} -sTCP:LISTEN`,
+    "If a browser tab shows `Invalid or expired OAuth state`, the callback may have been handled by the process occupying the port.",
+  ].join("\n");
+}
+
+async function isLocalCallbackPortAvailable(): Promise<boolean> {
+  try {
+    await tryListenOnPort({
+      port: openAICodexCallbackPort,
+      host: openAICodexCallbackHost,
+      exclusive: true,
+    });
+    return true;
+  } catch (err) {
+    const code = err && typeof err === "object" ? (err as { code?: unknown }).code : undefined;
+    return code !== "EADDRINUSE";
+  }
 }
 
 function createOpenAICodexOAuthError(
@@ -148,6 +174,7 @@ export async function loginOpenAICodexOAuth(params: {
   isRemote: boolean;
   openUrl: (url: string) => Promise<void>;
   localBrowserMessage?: string;
+  isLocalCallbackPortAvailable?: () => Promise<boolean>;
 }): Promise<OAuthCredentials | null> {
   const { prompter, runtime, isRemote, openUrl, localBrowserMessage } = params;
 
@@ -161,20 +188,28 @@ export async function loginOpenAICodexOAuth(params: {
     throw new Error(`OpenAI Codex OAuth prerequisites failed: ${preflight.message}`);
   }
 
-  await prompter.note(
-    isRemote
-      ? [
-          "You are running in a remote/VPS environment.",
-          "A URL will be shown for you to open in your LOCAL browser.",
-          "After signing in, paste the redirect URL back here.",
-        ].join("\n")
-      : [
-          "Browser will open for OpenAI authentication.",
-          "If the callback doesn't auto-complete, paste the redirect URL.",
-          "OpenAI OAuth uses localhost:1455 for the callback.",
-        ].join("\n"),
-    "OpenAI Codex OAuth",
-  );
+  const localCallbackAvailable =
+    isRemote || (await (params.isLocalCallbackPortAvailable ?? isLocalCallbackPortAvailable)());
+  if (!isRemote && !localCallbackAvailable) {
+    const hint = formatLocalCallbackPortConflictMessage();
+    await prompter.note(hint, "OpenAI Codex OAuth");
+    runtime.log(hint);
+  } else {
+    await prompter.note(
+      isRemote
+        ? [
+            "You are running in a remote/VPS environment.",
+            "A URL will be shown for you to open in your LOCAL browser.",
+            "After signing in, paste the redirect URL back here.",
+          ].join("\n")
+        : [
+            "Browser will open for OpenAI authentication.",
+            "If the callback doesn't auto-complete, paste the redirect URL.",
+            "OpenAI OAuth uses localhost:1455 for the callback.",
+          ].join("\n"),
+      "OpenAI Codex OAuth",
+    );
+  }
 
   const spin = prompter.progress("Starting OAuth flow…");
   let progressActive = true;
@@ -205,6 +240,9 @@ export async function loginOpenAICodexOAuth(params: {
       manualPromptMessage: manualInputPromptMessage,
     });
     const onAuth: typeof baseOnAuth = async (event) => {
+      if (!isRemote && !localCallbackAvailable) {
+        return;
+      }
       browserAuthStarted = true;
       await baseOnAuth(event);
     };


### PR DESCRIPTION
## Summary

Fixes #80963.

When OpenAI Codex OAuth cannot use the fixed localhost callback port, the wrapper now detects that `localhost:1455` is already occupied before handing the browser URL to the opener. In that case it:

- prints an explicit port-conflict note with `lsof -nP -iTCP:1455 -sTCP:LISTEN`
- suppresses the browser open so the redirect does not land on the wrong local process
- prompts for manual OAuth entry immediately instead of waiting for the 15s callback timeout

The same behavior is mirrored in the bundled OpenAI extension runtime copy.

## Verification

```text
pnpm test src/plugins/provider-openai-codex-oauth.test.ts
Test Files  1 passed (1)
Tests       17 passed (17)
```

```text
pnpm exec oxfmt --check --threads=1 src/plugins/provider-openai-codex-oauth.ts src/plugins/provider-openai-codex-oauth.test.ts extensions/openai/openai-codex-oauth.runtime.ts
All matched files use the correct format.
```

```text
pnpm check:changed
0 warnings / 0 errors across changed lanes: core, coreTests, extensions, extensionTests, docs.
```

## Real behavior proof

Behavior or issue addressed: Local OpenAI Codex OAuth now checks whether the fixed callback port `localhost:1455` is already occupied before opening the browser authorization URL. If the port is busy, OpenClaw keeps the OAuth helper alive but does not call the browser opener, logs an explicit local-port conflict diagnostic, and asks for manual redirect/code paste immediately.

Real environment tested: Local OpenClaw checkout on Linux, branch `fix/openai-codex-oauth-port-conflict-80963`, commit `3d7ee4e58b`. I first built the branch with `pnpm build`, then ran the built CLI entrypoint from the checkout with `127.0.0.1:1455` occupied by `nc`. No OpenAI token exchange was completed; the run was intentionally cancelled after the fixed local preflight/manual-entry path appeared.

Exact steps or command run after the patch:
1. Checked out commit `3d7ee4e58b` on branch `fix/openai-codex-oauth-port-conflict-80963`.
2. Ran `pnpm build` so `node openclaw.mjs` used the updated bundled OpenAI runtime artifact.
3. Occupied the local callback port with `nc -l 127.0.0.1 1455`.
4. Verified the listener with `lsof -nP -iTCP:1455 -sTCP:LISTEN`.
5. Ran `env -u SSH_CLIENT -u SSH_TTY -u SSH_CONNECTION DISPLAY=:0 OPENCLAW_STATE_DIR=/tmp/openclaw-proof-80971-state-built OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-80971-config-built.json timeout 20s node openclaw.mjs models auth login --provider openai-codex --method oauth`.
6. Cancelled at the manual OAuth prompt without pasting credentials.

Evidence after fix:
```text
$ lsof -nP -iTCP:1455 -sTCP:LISTEN
COMMAND    PID       USER   FD   TYPE    DEVICE SIZE/OFF NODE NAME
nc      203113 chenglunhu    3u  IPv4 354421574      0t0  TCP 127.0.0.1:1455 (LISTEN)

$ env -u SSH_CLIENT -u SSH_TTY -u SSH_CONNECTION DISPLAY=:0 \
  OPENCLAW_STATE_DIR=/tmp/openclaw-proof-80971-state-built \
  OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-80971-config-built.json \
  timeout 20s node openclaw.mjs models auth login --provider openai-codex --method oauth

OpenAI Codex OAuth

OpenAI Codex OAuth automatic browser callback cannot use localhost:1455 because the port is already in use.
OpenClaw will use manual OAuth entry instead of opening a browser flow that redirects to the wrong local process.
To identify the listener, run: lsof -nP -iTCP:1455 -sTCP:LISTEN
If a browser tab shows `Invalid or expired OAuth state`, the callback may have been handled by the process occupying the port.

OpenAI Codex OAuth local callback did not start; switching to manual entry immediately.
Manual OAuth entry required
Paste the authorization code (or full redirect URL):
```

Observed result after fix: With a real listener already bound to `127.0.0.1:1455`, the built CLI did not emit the normal `Open: https://auth.openai.com/oauth/authorize?...` browser-open line. It printed the local port-conflict diagnostic, included the `lsof -nP -iTCP:1455 -sTCP:LISTEN` command, and moved immediately to manual OAuth entry instead of waiting for the 15s browser-callback timeout.

What was not tested: I did not complete a live OpenAI OAuth token exchange because that requires an interactive OpenAI account login and would create/refresh real credentials. The tested real behavior is the local occupied-port preflight and no-browser/manual-entry transition before token exchange.

## Audit

- Existing-helper check: reused `tryListenOnPort` in the core OAuth wrapper; bundled extension copy uses a local `net` probe because the helper is not exposed through plugin-sdk runtime imports.
- Shared-helper caller check: no shared helper contract changed; this adds a guarded path in the OAuth wrapper only.
- Broader-rival scan: no same-scope open PR for #80963; #62134 is remote MCP OAuth and not the OpenAI Codex localhost:1455 browser-callback issue.