### PR TITLE
fix(agents): answer Claude control requests

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1630,6 +1630,209 @@ describe("runCliAgent spawn path", () => {
     expect(result.text).toBe("mixed-ok");
   });
 
+  it("denies Claude live native tool permission requests with MCP guidance", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const stdinWrites: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        stdinWrites.push(data);
+        const parsed = requireRecord(JSON.parse(data), "stdin write");
+        if (parsed.type === "user") {
+          stdoutListener?.(
+            [
+              JSON.stringify({ type: "system", subtype: "init", session_id: "live-permission" }),
+              JSON.stringify({
+                type: "control_request",
+                request_id: "permission-1",
+                request: {
+                  subtype: "can_use_tool",
+                  tool_name: "Bash",
+                  input: { command: "tail -n 50 /var/log/syslog" },
+                  tool_use_id: "toolu_1",
+                },
+              }),
+            ].join("\n") + "\n",
+          );
+        } else if (parsed.type === "control_response") {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "result",
+              session_id: "live-permission",
+              result: "permission-ok",
+            })}\n`,
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run",
+        pid: 2345,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-live-permission",
+        backend: {
+          liveSession: "claude-stdio",
+        },
+      }),
+    );
+
+    expect(result.text).toBe("permission-ok");
+    const controlResponses = stdinWrites
+      .map((data) => requireRecord(JSON.parse(data), "stdin write"))
+      .filter((write) => write.type === "control_response");
+    expect(controlResponses).toHaveLength(1);
+    const response = requireRecord(controlResponses[0]?.response, "control response");
+    expect(response.subtype).toBe("success");
+    expect(response.request_id).toBe("permission-1");
+    const decision = requireRecord(response.response, "control response decision");
+    expect(decision.behavior).toBe("deny");
+    expect(decision.message).toContain("Bash");
+    expect(decision.message).toContain("OpenClaw MCP tools");
+    expect(decision.toolUseID).toBe("toolu_1");
+    expect(decision.decisionClassification).toBe("user_reject");
+  });
+
+  it("responds to unsupported Claude live control requests with an error frame", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const stdinWrites: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        stdinWrites.push(data);
+        const parsed = requireRecord(JSON.parse(data), "stdin write");
+        if (parsed.type === "user") {
+          stdoutListener?.(
+            [
+              JSON.stringify({ type: "system", subtype: "init", session_id: "live-unsupported" }),
+              JSON.stringify({
+                type: "control_request",
+                request_id: "control-unsupported-1",
+                request: { subtype: "read_file" },
+              }),
+            ].join("\n") + "\n",
+          );
+        } else if (parsed.type === "control_response") {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "result",
+              session_id: "live-unsupported",
+              result: "unsupported-ok",
+            })}\n`,
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run",
+        pid: 2345,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-live-unsupported",
+        backend: {
+          liveSession: "claude-stdio",
+        },
+      }),
+    );
+
+    expect(result.text).toBe("unsupported-ok");
+    const controlResponses = stdinWrites
+      .map((data) => requireRecord(JSON.parse(data), "stdin write"))
+      .filter((write) => write.type === "control_response");
+    expect(controlResponses).toHaveLength(1);
+    const response = requireRecord(controlResponses[0]?.response, "control response");
+    expect(response.subtype).toBe("error");
+    expect(response.request_id).toBe("control-unsupported-1");
+    expect(response.error).toContain("Unsupported Claude control request subtype: read_file");
+  });
+
+  it("ignores malformed Claude live control requests without writing malformed responses", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const stdinWrites: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        stdinWrites.push(data);
+        const parsed = requireRecord(JSON.parse(data), "stdin write");
+        if (parsed.type === "user") {
+          stdoutListener?.(
+            [
+              JSON.stringify({
+                type: "control_request",
+                request: {
+                  subtype: "can_use_tool",
+                  tool_name: "Bash",
+                  tool_use_id: "toolu_missing_request",
+                },
+              }),
+              JSON.stringify({
+                type: "result",
+                session_id: "live-malformed",
+                result: "malformed-ok",
+              }),
+            ].join("\n") + "\n",
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run",
+        pid: 2345,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-live-malformed",
+        backend: {
+          liveSession: "claude-stdio",
+        },
+      }),
+    );
+
+    expect(result.text).toBe("malformed-ok");
+    const controlResponses = stdinWrites
+      .map((data) => requireRecord(JSON.parse(data), "stdin write"))
+      .filter((write) => write.type === "control_response");
+    expect(controlResponses).toHaveLength(0);
+  });
+
   it("fails Claude live turns on is_error results", async () => {
     let stdoutListener: ((chunk: string) => void) | undefined;
     const stdin = {

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -519,6 +519,63 @@ function createResultError(
   });
 }
 
+function createNativeToolDenyMessage(toolName: string): string {
+  const toolLabel = toolName ? ` ${toolName}` : "";
+  return `Denied by OpenClaw: Claude native tool${toolLabel} is not available in this bridge; use OpenClaw MCP tools instead.`;
+}
+
+function handleClaudeLiveControlRequest(
+  session: ClaudeLiveSession,
+  parsed: Record<string, unknown>,
+): boolean {
+  if (parsed.type !== "control_request") {
+    return false;
+  }
+  const requestId = typeof parsed.request_id === "string" ? parsed.request_id.trim() : "";
+  const request = isRecord(parsed.request) ? parsed.request : null;
+  if (!requestId) {
+    return false;
+  }
+  const subtype =
+    typeof request?.subtype === "string" && request.subtype.trim()
+      ? request.subtype.trim()
+      : "unknown";
+  if (!request || subtype !== "can_use_tool") {
+    void writeClaudeLiveJsonLine(session, {
+      type: "control_response",
+      response: {
+        subtype: "error",
+        request_id: requestId,
+        error: `Unsupported Claude control request subtype: ${subtype}`,
+      },
+    }).catch((error) => {
+      closeLiveSession(session, "abort", error);
+    });
+    return true;
+  }
+  const toolName = typeof request.tool_name === "string" ? request.tool_name.trim() : "";
+  const toolUseId = typeof request.tool_use_id === "string" ? request.tool_use_id.trim() : "";
+  const response: Record<string, unknown> = {
+    behavior: "deny",
+    message: createNativeToolDenyMessage(toolName),
+    decisionClassification: "user_reject",
+  };
+  if (toolUseId) {
+    response.toolUseID = toolUseId;
+  }
+  void writeClaudeLiveJsonLine(session, {
+    type: "control_response",
+    response: {
+      subtype: "success",
+      request_id: requestId,
+      response,
+    },
+  }).catch((error) => {
+    closeLiveSession(session, "abort", error);
+  });
+  return true;
+}
+
 function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   const turn = session.currentTurn;
   const trimmed = line.trim();
@@ -560,6 +617,9 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   turn.rawLines.push(trimmed);
   turn.streamingParser.push(`${trimmed}\n`);
   turn.sessionId = parseSessionId(parsed) ?? turn.sessionId;
+  if (handleClaudeLiveControlRequest(session, parsed)) {
+    return;
+  }
   if (parsed.type !== "result") {
     return;
   }
@@ -662,6 +722,25 @@ function createClaudeUserInputMessage(content: string): string {
       content,
     },
   })}\n`;
+}
+
+async function writeClaudeLiveJsonLine(
+  session: ClaudeLiveSession,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const stdin = session.managedRun.stdin;
+  if (!stdin) {
+    throw new Error("Claude CLI live session stdin is unavailable");
+  }
+  await new Promise<void>((resolve, reject) => {
+    stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
 }
 
 async function writeTurnInput(session: ClaudeLiveSession, prompt: string): Promise<void> {


### PR DESCRIPTION
## Summary

  - Problem: Claude CLI live sessions can emit `control_request` frames for native tool permission checks, but
  OpenClaw ignored them.
  - Why it matters: Ignored control requests leave Claude waiting for a response and can make live runs hang until
  timeout.
  - What changed: Added `control_response` handling for Claude live `can_use_tool` requests, denying unsupported
  native tools with guidance to use OpenClaw MCP tools instead.
  - What did NOT change (scope boundary): Did not add native Claude tool execution, change MCP tool permissions,
  alter provider defaults, or touch non-Claude CLI runners.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [x] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [x] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #80819
  - Related #
  - [x] This PR fixes a bug or regression

  ## Real behavior proof (required for external PRs)

  - Behavior or issue addressed: Claude live-session bridge no longer ignores Claude CLI `control_request` frames
  for native tool permission prompts.
  - Real environment tested: Local OpenClaw checkout on macOS with Node 22 / pnpm. Live Claude CLI runtime was not
  available locally.
  - Exact steps or command run after this patch:
    - `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/cli-runner.spawn.test.ts -- -t "Claude live"`
    - `pnpm build`
    - `pnpm check:changed`
    - `/opt/homebrew/bin/codex review --base origin/main`
  - Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked
  artifact, or copied live output):
    - Focused Claude live regression tests passed.
    - `pnpm build` passed.
    - `pnpm check:changed` passed.
    - Codex review found no correctness issues in the modified paths.
  - Observed result after fix: Mocked Claude live `can_use_tool` control requests receive a `control_response`
  denial instead of being ignored; unsupported control request subtypes receive a structured error response;
  malformed requests without `request_id` are ignored without writing malformed responses.
  - What was not tested: A live Claude CLI run against Anthropic credentials was not tested because this local
  environment did not have the `claude` binary or Claude auth configured.
  - Before evidence (optional but encouraged): Source inspection showed Claude live JSONL handling returned early
  for every non-`result` frame, so `control_request` frames had no stdin response path.

  ## Root Cause (if applicable)

  - Root cause: The Claude live-session bridge forced Claude CLI into stream JSON mode with stdio permission
  prompts, but only handled `result` frames and user stdin writes. It did not implement the Claude SDK
  `control_request` / `control_response` contract.
  - Missing detection / guardrail: Existing Claude live tests covered result, streaming, timeout, restart, and error
  behavior, but not permission-control frames.
  - Contributing context (if known): The bundled Anthropic CLI backend allows OpenClaw MCP tools while disabling
  native Claude tool execution through OpenClaw’s bridge, so permission prompts needed an explicit bridge-level
  response.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [ ] Unit test
    - [x] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `src/agents/cli-runner.spawn.test.ts`
  - Scenario the test should lock in: Claude live `control_request` frames receive protocol-correct
  `control_response` frames and do not block turn completion.
  - Why this is the smallest reliable guardrail: The tests exercise the existing live-session spawn/stdin/stdout
  seam without requiring a real Claude binary or external credentials.
  - Existing test that already covers this (if any): None before this change.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  Claude CLI live runs that ask for unsupported native Claude tool permission should now continue instead of hanging
  until timeout. The native tool is denied with guidance to use OpenClaw MCP tools.

  ## Diagram (if applicable)

  ```text
  Before:
  [Claude emits control_request] -> [OpenClaw ignores frame] -> [Claude waits] -> [timeout/hang]

  After:
  [Claude emits control_request] -> [OpenClaw writes control_response deny] -> [Claude continues]
  ```

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) No
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) No
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation: N/A

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Node 22, pnpm workspace
  - Model/provider: Claude CLI / Anthropic plugin
  - Integration/channel (if any): CLI live-session bridge
  - Relevant config (redacted): No live Claude credentials configured locally

  ### Steps

  1. Start a Claude live-session turn that emits a control_request with subtype can_use_tool.
  2. Observe OpenClaw writing a control_response denial to Claude CLI stdin.
  3. Complete the turn after Claude emits a result frame.

  ### Expected

  - OpenClaw responds to the permission request instead of ignoring it.
  - Unsupported native Claude tools are denied.
  - OpenClaw MCP tools remain the intended tool path.

  ### Actual

  - After this patch, focused regression tests show OpenClaw writes the expected control_response and completes the
    live turn.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios:
      - Claude live can_use_tool request writes a successful control_response with behavior: "deny".
      - Unsupported Claude live control request subtype writes an error control_response.
      - Malformed control request without request_id does not write a malformed response.
      - Existing Claude live test subset still passes.
      - Project builds successfully.
      - Changed-file checks pass.
      - Codex review found no correctness issues.
  - Edge cases checked:
      - Tool-use ID is preserved as toolUseID when present.
      - Unsupported subtype reports the subtype in the error response.
      - Missing request ID is ignored rather than producing an invalid protocol response.
  - What you did not verify:
      - Live Claude CLI behavior with real Anthropic credentials, because the local environment did not have the
        claude binary or Claude auth configured.

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review
  conversation cleanup for maintainers.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  - Risk: Claude CLI could add more control request subtypes later.
      - Mitigation: Unsupported subtypes now receive a structured error response instead of being silently ignored.