### PR TITLE
Rate limit Google Chat webhook requests [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Rate limit Google Chat webhook requests [AI]. (#80974) Thanks @pgondhi987.
 - fix(feishu): normalize webhook rate-limit client keys [AI]. (#80975) Thanks @pgondhi987.
 - fix(auth): prevent bootstrap pairing scope changes [AI]. (#80976) Thanks @pgondhi987.
 - Validate Control UI loopback retry endpoints [AI]. (#80900) Thanks @pgondhi987.

--- a/extensions/googlechat/src/monitor-routing.ts
+++ b/extensions/googlechat/src/monitor-routing.ts
@@ -1,4 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  createFixedWindowRateLimiter,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+} from "openclaw/plugin-sdk/webhook-ingress";
 import { createWebhookInFlightLimiter } from "openclaw/plugin-sdk/webhook-request-guards";
 import { registerWebhookTargetWithPluginRoute } from "openclaw/plugin-sdk/webhook-targets";
 import type { WebhookTarget } from "./monitor-types.js";
@@ -8,6 +12,11 @@ import type { GoogleChatEvent } from "./types.js";
 type ProcessGoogleChatEvent = (event: GoogleChatEvent, target: WebhookTarget) => Promise<void>;
 
 const webhookTargets = new Map<string, WebhookTarget[]>();
+const webhookRateLimiter = createFixedWindowRateLimiter({
+  windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
+  maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
+  maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS.maxTrackedKeys,
+});
 const webhookInFlightLimiter = createWebhookInFlightLimiter();
 
 let processGoogleChatEvent: ProcessGoogleChatEvent = async () => {};
@@ -18,6 +27,7 @@ export function setGoogleChatWebhookEventProcessor(processEvent: ProcessGoogleCh
 
 const googleChatWebhookRequestHandler = createGoogleChatWebhookRequestHandler({
   webhookTargets,
+  webhookRateLimiter,
   webhookInFlightLimiter,
   processEvent: async (event, target) => {
     await processGoogleChatEvent(event, target);

--- a/extensions/googlechat/src/monitor-webhook.test.ts
+++ b/extensions/googlechat/src/monitor-webhook.test.ts
@@ -26,15 +26,21 @@ type ProcessEventFn = (event: GoogleChatEvent, target: WebhookTarget) => Promise
 let createGoogleChatWebhookRequestHandler: typeof import("./monitor-webhook.js").createGoogleChatWebhookRequestHandler;
 let warnAppPrincipalMisconfiguration: typeof import("./monitor-webhook.js").warnAppPrincipalMisconfiguration;
 
-function createRequest(authorization?: string): IncomingMessage {
+function createRequest(options?: {
+  authorization?: string;
+  headers?: Record<string, string>;
+  remoteAddress?: string;
+  url?: string;
+}): IncomingMessage {
   return {
     method: "POST",
-    url: "/googlechat",
+    url: options?.url ?? "/googlechat",
     headers: {
-      authorization: authorization ?? "",
+      authorization: options?.authorization ?? "",
       "content-type": "application/json",
+      ...options?.headers,
     },
-    socket: { remoteAddress: "203.0.113.10" },
+    socket: { remoteAddress: options?.remoteAddress ?? "203.0.113.10" },
   } as IncomingMessage;
 }
 
@@ -94,7 +100,7 @@ async function runWebhookHandler(options?: {
     webhookInFlightLimiter: {} as never,
     processEvent,
   });
-  const req = createRequest(options?.authorization);
+  const req = createRequest({ authorization: options?.authorization });
   const res = createResponse();
   await expect(handler(req, res)).resolves.toBe(true);
   return { processEvent, res };
@@ -151,15 +157,13 @@ describe("googlechat monitor webhook", () => {
       webhookInFlightLimiter: {} as never,
       processEvent: vi.fn(async () => {}),
     });
-    const req = {
-      ...createRequest(),
+    const req = createRequest({
       url: "/googlechat?ignored=1",
       headers: {
-        ...createRequest().headers,
         "x-forwarded-for": "198.51.100.7, 10.0.0.1",
       },
-      socket: { remoteAddress: "10.0.0.1" },
-    } as IncomingMessage;
+      remoteAddress: "10.0.0.1",
+    });
     const res = createResponse();
     withResolvedWebhookRequestPipeline.mockResolvedValue(true);
 
@@ -207,10 +211,7 @@ describe("googlechat monitor webhook", () => {
       webhookInFlightLimiter: {} as never,
       processEvent: vi.fn(async () => {}),
     });
-    const req = {
-      ...createRequest(),
-      socket: { remoteAddress: "10.0.0.1" },
-    } as IncomingMessage;
+    const req = createRequest({ remoteAddress: "10.0.0.1" });
     const res = createResponse();
     withResolvedWebhookRequestPipeline.mockResolvedValue(true);
 

--- a/extensions/googlechat/src/monitor-webhook.test.ts
+++ b/extensions/googlechat/src/monitor-webhook.test.ts
@@ -147,7 +147,7 @@ describe("googlechat monitor webhook", () => {
             core: {} as never,
             path: "/googlechat",
             mediaMaxMb: 20,
-          } as WebhookTarget,
+          } as unknown as WebhookTarget,
         ],
       ],
     ]);
@@ -201,7 +201,7 @@ describe("googlechat monitor webhook", () => {
             core: {} as never,
             path: "/googlechat",
             mediaMaxMb: 20,
-          } as WebhookTarget,
+          } as unknown as WebhookTarget,
         ],
       ],
     ]);

--- a/extensions/googlechat/src/monitor-webhook.test.ts
+++ b/extensions/googlechat/src/monitor-webhook.test.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { FixedWindowRateLimiter } from "openclaw/plugin-sdk/webhook-ingress";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WebhookTarget } from "./monitor-types.js";
 import type { GoogleChatEvent } from "./types.js";
@@ -33,6 +34,7 @@ function createRequest(authorization?: string): IncomingMessage {
       authorization: authorization ?? "",
       "content-type": "application/json",
     },
+    socket: { remoteAddress: "203.0.113.10" },
   } as IncomingMessage;
 }
 
@@ -78,11 +80,17 @@ function installSimplePipeline(targets: unknown[]) {
 async function runWebhookHandler(options?: {
   processEvent?: ProcessEventFn;
   authorization?: string;
+  webhookRateLimiter?: FixedWindowRateLimiter;
 }) {
   const processEvent: ProcessEventFn =
     options?.processEvent ?? (vi.fn(async () => {}) as ProcessEventFn);
   const handler = createGoogleChatWebhookRequestHandler({
     webhookTargets: new Map(),
+    webhookRateLimiter: options?.webhookRateLimiter ?? {
+      isRateLimited: vi.fn(() => false),
+      size: vi.fn(() => 0),
+      clear: vi.fn(),
+    },
     webhookInFlightLimiter: {} as never,
     processEvent,
   });
@@ -107,6 +115,62 @@ describe("googlechat monitor webhook", () => {
     vi.doUnmock("openclaw/plugin-sdk/webhook-targets");
     vi.doUnmock("./auth.js");
     vi.resetModules();
+  });
+
+  it("passes a fixed-window request limiter to the shared webhook pipeline", async () => {
+    const rateLimiter: FixedWindowRateLimiter = {
+      isRateLimited: vi.fn(() => false),
+      size: vi.fn(() => 0),
+      clear: vi.fn(),
+    };
+    const webhookTargets = new Map<string, WebhookTarget[]>([
+      [
+        "/googlechat",
+        [
+          {
+            account: {
+              accountId: "default",
+              config: { appPrincipal: "chat-app" },
+            },
+            config: {
+              gateway: {
+                trustedProxies: ["10.0.0.0/24"],
+              },
+            },
+            runtime: {},
+            core: {} as never,
+            path: "/googlechat",
+            mediaMaxMb: 20,
+          } as WebhookTarget,
+        ],
+      ],
+    ]);
+    const handler = createGoogleChatWebhookRequestHandler({
+      webhookTargets,
+      webhookRateLimiter: rateLimiter,
+      webhookInFlightLimiter: {} as never,
+      processEvent: vi.fn(async () => {}),
+    });
+    const req = {
+      ...createRequest(),
+      url: "/googlechat?ignored=1",
+      headers: {
+        ...createRequest().headers,
+        "x-forwarded-for": "198.51.100.7, 10.0.0.1",
+      },
+      socket: { remoteAddress: "10.0.0.1" },
+    } as IncomingMessage;
+    const res = createResponse();
+    withResolvedWebhookRequestPipeline.mockResolvedValue(true);
+
+    await expect(handler(req, res)).resolves.toBe(true);
+
+    expect(withResolvedWebhookRequestPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rateLimiter,
+        rateLimitKey: "/googlechat:198.51.100.7",
+      }),
+    );
   });
 
   it("accepts add-on payloads that carry systemIdToken in the body", async () => {

--- a/extensions/googlechat/src/monitor-webhook.test.ts
+++ b/extensions/googlechat/src/monitor-webhook.test.ts
@@ -173,6 +173,57 @@ describe("googlechat monitor webhook", () => {
     );
   });
 
+  it("uses the unknown rate-limit bucket when a trusted proxy omits client headers", async () => {
+    const rateLimiter: FixedWindowRateLimiter = {
+      isRateLimited: vi.fn(() => false),
+      size: vi.fn(() => 0),
+      clear: vi.fn(),
+    };
+    const webhookTargets = new Map<string, WebhookTarget[]>([
+      [
+        "/googlechat",
+        [
+          {
+            account: {
+              accountId: "default",
+              config: { appPrincipal: "chat-app" },
+            },
+            config: {
+              gateway: {
+                trustedProxies: ["10.0.0.0/24"],
+              },
+            },
+            runtime: {},
+            core: {} as never,
+            path: "/googlechat",
+            mediaMaxMb: 20,
+          } as WebhookTarget,
+        ],
+      ],
+    ]);
+    const handler = createGoogleChatWebhookRequestHandler({
+      webhookTargets,
+      webhookRateLimiter: rateLimiter,
+      webhookInFlightLimiter: {} as never,
+      processEvent: vi.fn(async () => {}),
+    });
+    const req = {
+      ...createRequest(),
+      socket: { remoteAddress: "10.0.0.1" },
+    } as IncomingMessage;
+    const res = createResponse();
+    withResolvedWebhookRequestPipeline.mockResolvedValue(true);
+
+    await expect(handler(req, res)).resolves.toBe(true);
+
+    expect(withResolvedWebhookRequestPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rateLimiter,
+        rateLimitKey: "/googlechat:unknown",
+      }),
+    );
+  });
+
   it("accepts add-on payloads that carry systemIdToken in the body", async () => {
     const target = {
       account: {

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -1,5 +1,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  normalizeWebhookPath,
+  resolveRequestClientIp,
+  type FixedWindowRateLimiter,
+} from "openclaw/plugin-sdk/webhook-ingress";
 import type { WebhookInFlightLimiter } from "openclaw/plugin-sdk/webhook-request-guards";
 import { readJsonWebhookBodyOrReject } from "openclaw/plugin-sdk/webhook-request-guards";
 import {
@@ -183,16 +188,30 @@ export function warnAppPrincipalMisconfiguration(params: {
 
 export function createGoogleChatWebhookRequestHandler(params: {
   webhookTargets: Map<string, WebhookTarget[]>;
+  webhookRateLimiter: FixedWindowRateLimiter;
   webhookInFlightLimiter: WebhookInFlightLimiter;
   processEvent: (event: GoogleChatEvent, target: WebhookTarget) => Promise<void>;
 }): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
   return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
+    const path = normalizeWebhookPath(new URL(req.url ?? "/", "http://localhost").pathname);
+    const config = params.webhookTargets.get(path)?.[0]?.config;
+    const clientIp =
+      resolveRequestClientIp(
+        req,
+        config?.gateway?.trustedProxies,
+        config?.gateway?.allowRealIpFallback === true,
+      ) ??
+      req.socket.remoteAddress ??
+      "unknown";
+
     return await withResolvedWebhookRequestPipeline({
       req,
       res,
       targetsByPath: params.webhookTargets,
       allowMethods: ["POST"],
       requireJsonContentType: true,
+      rateLimiter: params.webhookRateLimiter,
+      rateLimitKey: `${path}:${clientIp}`,
       inFlightLimiter: params.webhookInFlightLimiter,
       handle: async ({ targets }) => {
         const headerBearer = extractBearerToken(req.headers.authorization);

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -194,15 +194,14 @@ export function createGoogleChatWebhookRequestHandler(params: {
 }): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
   return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
     const path = normalizeWebhookPath(new URL(req.url ?? "/", "http://localhost").pathname);
+    // Shared-path registrations use the same gateway proxy settings in normal runtime setup.
     const config = params.webhookTargets.get(path)?.[0]?.config;
     const clientIp =
       resolveRequestClientIp(
         req,
         config?.gateway?.trustedProxies,
         config?.gateway?.allowRealIpFallback === true,
-      ) ??
-      req.socket.remoteAddress ??
-      "unknown";
+      ) ?? "unknown";
 
     return await withResolvedWebhookRequestPipeline({
       req,


### PR DESCRIPTION
## Summary

- Problem: Google Chat webhook requests were routed through the shared webhook pipeline without a fixed-window request limiter.
- Why it matters: repeated requests could continue into body parsing and authentication handling instead of receiving `429 Too Many Requests` after the shared budget is exceeded.
- What changed: added a Google Chat webhook fixed-window limiter, derives a path/client key using gateway proxy settings, and passes `rateLimiter` plus `rateLimitKey` into the shared pipeline.
- What did NOT change (scope boundary): no auth token validation rules, config schema, SDK guard behavior, or webhook body limits were changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: N/A
- [x] This PR addresses a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: repeated Google Chat webhook requests now pass through the shared fixed-window request limiter before body parsing and target authentication.
- Real environment tested: Not run in a live setup for this metadata draft.
- Exact steps or command run after this patch: Not run.
- Evidence after change: Regression coverage added in `extensions/googlechat/src/monitor-webhook.test.ts` to assert the handler supplies the limiter and path/client key to the shared pipeline.
- Observed result after change: Not manually exercised.
- What was not tested: live Google Chat webhook traffic and a full local test command.
- Before evidence: Existing handler omitted `rateLimiter` and `rateLimitKey` when calling `withResolvedWebhookRequestPipeline`.

## Root Cause (if applicable)

- Root cause: the Google Chat webhook handler supplied method, content-type, and in-flight guards to the shared pipeline, but omitted the fixed-window limiter fields.
- Missing detection / guardrail: no Google Chat regression test asserted that webhook requests configure the shared limiter before parsing and authentication.
- Contributing context (if known): similar webhook implementations already used a path/client limiter key, but this route only had in-flight limiting.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/googlechat/src/monitor-webhook.test.ts`
- Scenario the test should lock in: the Google Chat webhook handler passes a fixed-window limiter and normalized path/client key to the shared webhook pipeline.
- Why this is the smallest reliable guardrail: it checks the exact call contract that activates the existing shared limiter without requiring a live Google Chat endpoint.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Google Chat webhook requests from the same path/client may now receive `429 Too Many Requests` after exceeding the shared webhook rate limit budget.

## Diagram (if applicable)

```text
Before:
[Google Chat webhook] -> [shared pipeline without request limiter] -> [body parse/auth handling]

After:
[Google Chat webhook] -> [shared pipeline + path/client request limiter] -> [body parse/auth handling or 429]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Not run
- Runtime/container: Not run
- Model/provider: N/A
- Integration/channel (if any): Google Chat
- Relevant config (redacted): N/A

### Steps

1. Not run for this metadata draft.

### Expected

- Repeated requests over the shared webhook budget receive `429 Too Many Requests` before body parsing and authentication handling.

### Actual

- Not manually exercised in this metadata draft.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the Google Chat handler path, routing initialization, shared pipeline parameters, and added unit coverage.
- Edge cases checked: trusted proxy client IP key derivation and keeping existing auth/body parsing behavior unchanged.
- What you did **not** verify: live webhook traffic, full test suite, lint, typecheck, or build.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: legitimate high-volume Google Chat webhook bursts from one client/path may receive `429` once the shared default budget is exceeded.
  - Mitigation: the limiter uses existing shared webhook defaults and keys by normalized path plus resolved client IP.
