### PR TITLE
fix(feishu): normalize webhook rate-limit client keys [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(feishu): normalize webhook rate-limit client keys [AI]. (#80975) Thanks @pgondhi987.
 - fix(auth): prevent bootstrap pairing scope changes [AI]. (#80976) Thanks @pgondhi987.
 - Validate Control UI loopback retry endpoints [AI]. (#80900) Thanks @pgondhi987.
 - Harden exported markdown link rendering [AI]. (#80902) Thanks @pgondhi987.

--- a/extensions/feishu/src/monitor-transport-runtime-api.ts
+++ b/extensions/feishu/src/monitor-transport-runtime-api.ts
@@ -1,6 +1,9 @@
 export type { RuntimeEnv } from "../runtime-api.js";
 export { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
-export { applyBasicWebhookRequestGuards } from "openclaw/plugin-sdk/webhook-ingress";
+export {
+  applyBasicWebhookRequestGuards,
+  resolveRequestClientIp,
+} from "openclaw/plugin-sdk/webhook-ingress";
 export {
   installRequestBodyLimitGuard,
   readWebhookBodyOrReject,

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -5,10 +5,11 @@ import { waitForAbortableDelay } from "./async.js";
 import { createFeishuWSClient } from "./client.js";
 import {
   applyBasicWebhookRequestGuards,
-  type RuntimeEnv,
   installRequestBodyLimitGuard,
   readWebhookBodyOrReject,
+  resolveRequestClientIp,
   safeEqualSecret,
+  type RuntimeEnv,
 } from "./monitor-transport-runtime-api.js";
 import {
   botNames,
@@ -88,6 +89,30 @@ function respondText(res: http.ServerResponse, statusCode: number, body: string)
   res.statusCode = statusCode;
   res.setHeader("Content-Type", "text/plain; charset=utf-8");
   res.end(body);
+}
+
+function normalizeFeishuWebhookRateLimitClient(remoteAddress: string | undefined): string {
+  const clientIp = resolveRequestClientIp({
+    headers: {},
+    socket: { remoteAddress },
+  } as http.IncomingMessage);
+  if (!clientIp) {
+    return "unknown";
+  }
+  if (clientIp === "::1" || clientIp.startsWith("127.")) {
+    return "loopback";
+  }
+  return clientIp;
+}
+
+export function buildFeishuWebhookRateLimitKeyForTest(params: {
+  accountId: string;
+  path: string;
+  remoteAddress?: string;
+}): string {
+  return `${params.accountId}:${params.path}:${normalizeFeishuWebhookRateLimitClient(
+    params.remoteAddress,
+  )}`;
 }
 
 function getFeishuWsReconnectDelayMs(attempt: number): number {
@@ -300,7 +325,11 @@ export async function monitorWebhook({
       recordWebhookStatus(runtime, accountId, path, res.statusCode);
     });
 
-    const rateLimitKey = `${accountId}:${path}:${req.socket.remoteAddress ?? "unknown"}`;
+    const rateLimitKey = buildFeishuWebhookRateLimitKeyForTest({
+      accountId,
+      path,
+      remoteAddress: req.socket.remoteAddress,
+    });
     if (
       !applyBasicWebhookRequestGuards({
         req,

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -91,11 +91,7 @@ function respondText(res: http.ServerResponse, statusCode: number, body: string)
   res.end(body);
 }
 
-function normalizeFeishuWebhookRateLimitClient(remoteAddress: string | undefined): string {
-  const clientIp = resolveRequestClientIp({
-    headers: {},
-    socket: { remoteAddress },
-  } as http.IncomingMessage);
+function normalizeFeishuWebhookRateLimitClient(clientIp: string | undefined): string {
   if (!clientIp) {
     return "unknown";
   }
@@ -105,15 +101,17 @@ function normalizeFeishuWebhookRateLimitClient(remoteAddress: string | undefined
   return clientIp;
 }
 
-export function buildFeishuWebhookRateLimitKeyForTest(params: {
+function buildFeishuWebhookRateLimitKey(params: {
   accountId: string;
   path: string;
-  remoteAddress?: string;
+  clientIp?: string;
 }): string {
   return `${params.accountId}:${params.path}:${normalizeFeishuWebhookRateLimitClient(
-    params.remoteAddress,
+    params.clientIp,
   )}`;
 }
+
+export { buildFeishuWebhookRateLimitKey as buildFeishuWebhookRateLimitKeyForTest };
 
 function getFeishuWsReconnectDelayMs(attempt: number): number {
   return Math.min(
@@ -325,10 +323,10 @@ export async function monitorWebhook({
       recordWebhookStatus(runtime, accountId, path, res.statusCode);
     });
 
-    const rateLimitKey = buildFeishuWebhookRateLimitKeyForTest({
+    const rateLimitKey = buildFeishuWebhookRateLimitKey({
       accountId,
       path,
-      remoteAddress: req.socket.remoteAddress,
+      clientIp: resolveRequestClientIp(req),
     });
     if (
       !applyBasicWebhookRequestGuards({

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -44,7 +44,7 @@ import {
   monitorFeishuProvider,
   stopFeishuMonitor,
 } from "./monitor.js";
-import { monitorWebhook } from "./monitor.transport.js";
+import { buildFeishuWebhookRateLimitKeyForTest, monitorWebhook } from "./monitor.transport.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 async function waitForSlowBodyTimeoutResponse(
@@ -312,6 +312,25 @@ describe("Feishu webhook security hardening", () => {
         expect(saw429).toBe(true);
       },
     );
+  });
+
+  it("uses one webhook rate-limit key for loopback address-family variants", () => {
+    const base = {
+      accountId: "rate-limit-key",
+      path: "/hook-rate-limit-key",
+    };
+
+    expect([
+      buildFeishuWebhookRateLimitKeyForTest({ ...base, remoteAddress: "127.0.0.1" }),
+      buildFeishuWebhookRateLimitKeyForTest({ ...base, remoteAddress: "127.0.0.42" }),
+      buildFeishuWebhookRateLimitKeyForTest({ ...base, remoteAddress: "::ffff:127.0.0.1" }),
+      buildFeishuWebhookRateLimitKeyForTest({ ...base, remoteAddress: "::1" }),
+    ]).toEqual([
+      "rate-limit-key:/hook-rate-limit-key:loopback",
+      "rate-limit-key:/hook-rate-limit-key:loopback",
+      "rate-limit-key:/hook-rate-limit-key:loopback",
+      "rate-limit-key:/hook-rate-limit-key:loopback",
+    ]);
   });
 
   it("caps tracked webhook rate-limit keys to prevent unbounded growth", () => {

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from "node:http";
 import { createConnection } from "node:net";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -37,6 +38,7 @@ vi.mock("./monitor.state.js", async (importOriginal) => {
 });
 
 import type { RuntimeEnv } from "../runtime-api.js";
+import { resolveRequestClientIp } from "./monitor-transport-runtime-api.js";
 import {
   clearFeishuWebhookRateLimitStateForTest,
   getFeishuWebhookRateLimitStateSizeForTest,
@@ -148,6 +150,13 @@ async function waitForOversizedBodyResponse(url: string): Promise<string> {
       reject(new Error("payload-too-large response did not arrive within 1000ms"));
     }, 1_000);
   });
+}
+
+function resolveTestClientIp(remoteAddress: string | undefined): string | undefined {
+  return resolveRequestClientIp({
+    headers: {},
+    socket: { remoteAddress },
+  } as IncomingMessage);
 }
 
 afterEach(() => {
@@ -321,16 +330,42 @@ describe("Feishu webhook security hardening", () => {
     };
 
     expect([
-      buildFeishuWebhookRateLimitKeyForTest({ ...base, remoteAddress: "127.0.0.1" }),
-      buildFeishuWebhookRateLimitKeyForTest({ ...base, remoteAddress: "127.0.0.42" }),
-      buildFeishuWebhookRateLimitKeyForTest({ ...base, remoteAddress: "::ffff:127.0.0.1" }),
-      buildFeishuWebhookRateLimitKeyForTest({ ...base, remoteAddress: "::1" }),
+      buildFeishuWebhookRateLimitKeyForTest({
+        ...base,
+        clientIp: resolveTestClientIp("127.0.0.1"),
+      }),
+      buildFeishuWebhookRateLimitKeyForTest({
+        ...base,
+        clientIp: resolveTestClientIp("127.0.0.42"),
+      }),
+      buildFeishuWebhookRateLimitKeyForTest({
+        ...base,
+        clientIp: resolveTestClientIp("::ffff:127.0.0.1"),
+      }),
+      buildFeishuWebhookRateLimitKeyForTest({
+        ...base,
+        clientIp: resolveTestClientIp("::1"),
+      }),
     ]).toEqual([
       "rate-limit-key:/hook-rate-limit-key:loopback",
       "rate-limit-key:/hook-rate-limit-key:loopback",
       "rate-limit-key:/hook-rate-limit-key:loopback",
       "rate-limit-key:/hook-rate-limit-key:loopback",
     ]);
+  });
+
+  it("keeps non-loopback and unknown webhook rate-limit key suffixes distinct", () => {
+    const base = {
+      accountId: "rate-limit-key",
+      path: "/hook-rate-limit-key",
+    };
+
+    expect(buildFeishuWebhookRateLimitKeyForTest({ ...base, clientIp: "10.0.0.1" })).toBe(
+      "rate-limit-key:/hook-rate-limit-key:10.0.0.1",
+    );
+    expect(buildFeishuWebhookRateLimitKeyForTest(base)).toBe(
+      "rate-limit-key:/hook-rate-limit-key:unknown",
+    );
   });
 
   it("caps tracked webhook rate-limit keys to prevent unbounded growth", () => {


### PR DESCRIPTION
## Summary

- Problem: Feishu webhook rate-limit keys used raw socket address strings, so equivalent loopback client forms could land in separate buckets.
- Why it matters: Webhook burst throttling should apply consistently to the same local client identity before deeper request processing.
- What changed: The Feishu webhook transport now builds rate-limit keys through the webhook ingress IP resolver and folds loopback address-family variants into one client bucket.
- What did NOT change (scope boundary): No changes to webhook authentication, request body limits, Feishu event dispatch, or shared limiter semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: private maintainer tracking
- [x] This PR addresses a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Feishu webhook rate-limit key construction now treats loopback IPv4, IPv4-mapped IPv6, and IPv6 loopback forms as the same local client bucket.
- Real environment tested: Not run in this metadata drafting step.
- Exact steps or command run after this patch: Not run; supervisor owns deterministic verification commands.
- Evidence after change: Regression coverage added in `extensions/feishu/src/monitor.webhook-security.test.ts`.
- Observed result after change: Not executed in this step.
- What was not tested: Live dual-stack webhook harness and package-level command verification.
- Before evidence (optional but encouraged): N/A

## Root Cause (if applicable)

- Root cause: Feishu webhook rate-limit keys included `req.socket.remoteAddress` directly instead of a normalized client identity.
- Missing detection / guardrail: Existing coverage checked rate limiting for a stable client key but did not lock equivalent loopback address-family forms to the same key.
- Contributing context (if known): The shared fixed-window limiter stores counters by exact key string, so caller-provided key normalization is required.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/monitor.webhook-security.test.ts`
- Scenario the test should lock in: Feishu webhook rate-limit key construction maps loopback IPv4, IPv4-mapped IPv6, and IPv6 loopback forms to one bucket.
- Why this is the smallest reliable guardrail: It verifies the key builder used by the request path without requiring a live dual-stack listener.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Feishu webhook burst throttling now applies consistently across equivalent loopback address-family forms for the same account and path.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Not run in this metadata drafting step
- Runtime/container: Not run in this metadata drafting step
- Model/provider: N/A
- Integration/channel (if any): Feishu webhook
- Relevant config (redacted): Webhook mode with default in-memory rate limiter

### Steps

1. Start a Feishu webhook listener with dual-stack loopback reachability.
2. Send enough signed webhook requests over IPv4 loopback to reach the configured burst limit.
3. Send a follow-up signed webhook request over IPv6 loopback from the same local host.

### Expected

- The IPv6 loopback follow-up uses the same local client bucket and receives the same throttling result once the bucket is exhausted.

### Actual

- Not executed in this metadata drafting step.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression coverage in `extensions/feishu/src/monitor.webhook-security.test.ts`; command execution is left to the supervisor workflow.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Reviewed the Feishu webhook transport key construction and confirmed the request path now uses the normalized key helper.
- Edge cases checked: Missing remote address, IPv4 loopback, IPv4-mapped IPv6 loopback, and IPv6 loopback key construction.
- What you did **not** verify: Live dual-stack listener behavior or package command output in this metadata drafting step.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Loopback IPv4 and IPv6 forms now share one Feishu webhook burst bucket for a given account and path.
  - Mitigation: This is intentional normalization for equivalent local client identities; non-loopback addresses continue to use normalized IP identity.
