### PR TITLE
fix(auth): prevent bootstrap pairing scope changes [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(auth): prevent bootstrap pairing scope changes [AI]. (#80976) Thanks @pgondhi987.
 - Validate Control UI loopback retry endpoints [AI]. (#80900) Thanks @pgondhi987.
 - Harden exported markdown link rendering [AI]. (#80902) Thanks @pgondhi987.
 - fix(gateway): honor minimal discovery mode for wide-area DNS-SD [AI]. (#80903) Thanks @pgondhi987.

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -97,6 +97,54 @@ describe("device bootstrap tokens", () => {
     expect(parsed[issued.token]?.publicKey).toBe("public-key-123");
   });
 
+  it("rejects changing the requested profile while a bound use is pending", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDeviceBootstrapToken({
+      baseDir,
+      profile: {
+        roles: ["operator"],
+        scopes: ["operator.approvals", "operator.read", "operator.write"],
+      },
+    });
+
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        role: "operator",
+        scopes: ["operator.read"],
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        role: "operator",
+        scopes: ["operator.write", "operator.approvals"],
+      }),
+    ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        role: "operator",
+        scopes: ["operator.read"],
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(
+      redeemDeviceBootstrapTokenProfile({
+        baseDir,
+        token: issued.token,
+        role: "operator",
+        scopes: ["operator.read"],
+      }),
+    ).resolves.toEqual({
+      recorded: true,
+      fullyRedeemed: false,
+    });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        role: "operator",
+        scopes: ["operator.write", "operator.approvals"],
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
   it("loads the issued bootstrap profile for a valid token", async () => {
     const baseDir = await createTempDir();
     const issued = await issueDeviceBootstrapToken({ baseDir });

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -23,6 +23,7 @@ export type DeviceBootstrapTokenRecord = {
   publicKey?: string;
   profile?: DeviceBootstrapProfile;
   redeemedProfile?: DeviceBootstrapProfile;
+  pendingProfile?: DeviceBootstrapProfile;
   roles?: string[];
   scopes?: string[];
   issuedAtMs: number;
@@ -65,6 +66,35 @@ function resolvePersistedRedeemedProfile(
   record: Partial<DeviceBootstrapTokenRecord>,
 ): DeviceBootstrapProfile {
   return normalizeDeviceBootstrapProfile(record.redeemedProfile);
+}
+
+function resolvePersistedPendingProfile(
+  record: Partial<DeviceBootstrapTokenRecord>,
+): DeviceBootstrapProfile | null {
+  return record.pendingProfile ? normalizeDeviceBootstrapProfile(record.pendingProfile) : null;
+}
+
+function resolveRequestedBootstrapProfile(params: {
+  role: string;
+  scopes: readonly string[];
+}): DeviceBootstrapProfile {
+  return normalizeDeviceBootstrapProfile({
+    roles: [params.role],
+    scopes: resolveBootstrapProfileScopesForRole(params.role, params.scopes),
+  });
+}
+
+function sameBootstrapProfile(
+  left: DeviceBootstrapProfile,
+  right: DeviceBootstrapProfile,
+): boolean {
+  if (left.roles.length !== right.roles.length || left.scopes.length !== right.scopes.length) {
+    return false;
+  }
+  return (
+    left.roles.every((role, index) => role === right.roles[index]) &&
+    left.scopes.every((scope, index) => scope === right.scopes[index])
+  );
 }
 
 function resolveIssuedBootstrapProfile(params: {
@@ -173,10 +203,12 @@ async function loadState(baseDir?: string): Promise<DeviceBootstrapStateFile> {
       typeof record.token === "string" && record.token.trim().length > 0 ? record.token : tokenKey;
     const issuedAtMs = typeof record.issuedAtMs === "number" ? record.issuedAtMs : 0;
     const profile = resolvePersistedBootstrapProfile(record);
+    const pendingProfile = resolvePersistedPendingProfile(record);
     state[tokenKey] = {
       token,
       profile,
       redeemedProfile: resolvePersistedRedeemedProfile(record),
+      ...(pendingProfile ? { pendingProfile } : {}),
       deviceId: typeof record.deviceId === "string" ? record.deviceId : undefined,
       publicKey: typeof record.publicKey === "string" ? record.publicKey : undefined,
       issuedAtMs,
@@ -304,6 +336,7 @@ export async function redeemDeviceBootstrapTokenProfile(params: {
     }
     const [tokenKey, record] = found;
     const issuedProfile = resolvePersistedBootstrapProfile(record);
+    const pendingProfile = resolvePersistedPendingProfile(record);
     const redeemedProfile = normalizeDeviceBootstrapProfile({
       roles: [...resolvePersistedRedeemedProfile(record).roles, params.role],
       scopes: [
@@ -311,11 +344,25 @@ export async function redeemDeviceBootstrapTokenProfile(params: {
         ...resolveBootstrapProfileScopesForRole(params.role, params.scopes),
       ],
     });
-    state[tokenKey] = {
+    const nextPendingProfile =
+      pendingProfile &&
+      !bootstrapProfileSatisfiesProfile({
+        actualProfile: redeemedProfile,
+        requiredProfile: pendingProfile,
+      })
+        ? pendingProfile
+        : undefined;
+    const nextRecord: DeviceBootstrapTokenRecord = {
       ...record,
       profile: issuedProfile,
       redeemedProfile,
     };
+    if (nextPendingProfile) {
+      nextRecord.pendingProfile = nextPendingProfile;
+    } else {
+      delete nextRecord.pendingProfile;
+    }
+    state[tokenKey] = nextRecord;
     await persistState(state, params.baseDir);
     return {
       recorded: true,
@@ -368,6 +415,10 @@ export async function verifyDeviceBootstrapToken(params: {
     ) {
       return { ok: false, reason: "bootstrap_token_invalid" };
     }
+    const requestedProfile = resolveRequestedBootstrapProfile({
+      role,
+      scopes: params.scopes,
+    });
 
     const boundDeviceId = record.deviceId?.trim();
     const boundPublicKey =
@@ -378,9 +429,14 @@ export async function verifyDeviceBootstrapToken(params: {
       if (boundDeviceId !== deviceId || boundPublicKey !== publicKey) {
         return { ok: false, reason: "bootstrap_token_invalid" };
       }
+      const pendingProfile = resolvePersistedPendingProfile(record);
+      if (pendingProfile && !sameBootstrapProfile(pendingProfile, requestedProfile)) {
+        return { ok: false, reason: "bootstrap_token_invalid" };
+      }
       state[tokenKey] = {
         ...record,
         profile: allowedProfile,
+        pendingProfile: pendingProfile ?? requestedProfile,
         deviceId,
         publicKey,
         lastUsedAtMs: Date.now(),
@@ -392,6 +448,7 @@ export async function verifyDeviceBootstrapToken(params: {
     state[tokenKey] = {
       ...record,
       profile: allowedProfile,
+      pendingProfile: requestedProfile,
       deviceId,
       publicKey,
       lastUsedAtMs: Date.now(),

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -590,7 +590,7 @@ describe("device pairing tokens", () => {
     const issued = await issueDeviceBootstrapToken({
       baseDir,
       roles: ["operator"],
-      scopes: ["operator.read"],
+      scopes: ["operator.approvals", "operator.read", "operator.write"],
     });
 
     await expect(
@@ -620,10 +620,14 @@ describe("device pairing tokens", () => {
         deviceId: "device-1",
         publicKey: "public-key-1",
         role: "operator",
-        scopes: ["operator.admin"],
+        scopes: ["operator.write", "operator.approvals"],
         baseDir,
       }),
     ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
+
+    const pending = await listDevicePairing(baseDir);
+    expect(pending.pending).toHaveLength(1);
+    expect(pending.pending[0]?.scopes).toEqual(["operator.read"]);
 
     await approveDevicePairing(
       first.request.requestId,


### PR DESCRIPTION
## Summary

- Problem: bound bootstrap token use could be repeated with a different requested operator scope set before the earlier request completed.
- Why it matters: pending pairing approval should reflect the scope profile originally requested for that outstanding bootstrap use.
- What changed: bootstrap token records now track the outstanding requested profile and reject same-device role or scope changes until that use is redeemed.
- What did NOT change (scope boundary): existing pairing supersede behavior remains available for non-bootstrap paths and identical bootstrap retries still use the same pending profile.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: bootstrap-backed pending pairing no longer accepts a same-device role or scope change while an earlier bootstrap use is still pending.
- Real environment tested: Not tested in a live OpenClaw setup.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/device-bootstrap.test.ts src/infra/device-pairing.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `Test Files 2 passed (2); Tests 72 passed (72)`
- Observed result after fix: focused infra regression coverage passes and the pending pairing request remains scoped to the original operator request.
- What was not tested: live Gateway WebSocket setup flow.
- Before evidence (optional but encouraged): N/A

## Root Cause (if applicable)

- Root cause: bootstrap verification allowed a bound token to authenticate a later same-device request with a different requested role or scope profile before the previous use had completed bookkeeping.
- Missing detection / guardrail: regression coverage only rejected requests outside the issued profile, not requests that widened within the issued profile while a prior use was pending.
- Contributing context (if known): pending pairing supersede logic intentionally merges changed requests for normal pairing paths.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/device-bootstrap.test.ts`, `src/infra/device-pairing.test.ts`
- Scenario the test should lock in: a bound bootstrap token cannot change from `operator.read` to broader operator scopes until the prior bootstrap use is redeemed, and the pending pairing request remains unchanged.
- Why this is the smallest reliable guardrail: the vulnerable decision is made in bootstrap verification before pairing supersede logic can merge scopes.
- Existing test that already covers this (if any): existing coverage checked issued-profile allowlist rejection, but not same-profile widening while pending.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Bootstrap pairing retries that request a different role or scope set while a previous bootstrap use is pending are rejected. Identical retries remain valid.

## Diagram (if applicable)

```text
Before:
[bootstrap operator.read] -> [pending operator.read]
[same token operator.write + operator.approvals] -> [pending scopes widened]

After:
[bootstrap operator.read] -> [pending operator.read]
[same token operator.write + operator.approvals] -> [auth rejected] -> [pending unchanged]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: bootstrap token records now persist an outstanding requested profile. The added state is limited to roles and scopes already present in the pairing flow, and it is cleared when the matching bootstrap use is redeemed.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node test runner wrapper
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/device-bootstrap.test.ts src/infra/device-pairing.test.ts`.
2. Confirm bootstrap verification rejects a changed requested profile while the previous use is pending.
3. Confirm pending pairing scopes remain `operator.read`.

### Expected

- Changed same-device bootstrap requests are rejected before pending scopes can change.

### Actual

- Focused infra tests passed with the expected rejection and unchanged pending scopes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused infra tests for bootstrap token verification and pending pairing scope preservation.
- Edge cases checked: identical bound-token retry remains accepted; changed profile after redemption is accepted when still within the issued profile.
- What you did **not** verify: live Gateway WebSocket setup flow.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: legitimate clients retrying bootstrap pairing with a different role or scope set before the first use completes will now be rejected.
  - Mitigation: clients can retry the same requested profile, or start a fresh bootstrap flow for a different profile.
