### PR TITLE
fix(telegram): render supported HTML replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - fix(qqbot): authorize approval button callbacks [AI]. (#80892) Thanks @pgondhi987.
+- Telegram: render supported HTML tags in streamed and durable replies instead of showing literal markup. (#80977)
 - Scrub streamable MCP redirect headers [AI]. (#80906) Thanks @pgondhi987.
 - fix(memory-wiki): require admin scope for ingest [AI]. (#80897) Thanks @pgondhi987.
 - memory-wiki: require write scope for Obsidian search [AI]. (#80904) Thanks @pgondhi987.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -395,7 +395,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     Outbound text uses Telegram `parse_mode: "HTML"`.
 
     - Markdown-ish text is rendered to Telegram-safe HTML.
-    - Raw model HTML is escaped to reduce Telegram parse failures.
+    - Supported Telegram HTML tags are preserved; unsupported HTML is escaped.
     - If Telegram rejects parsed HTML, OpenClaw retries as plain text.
 
     Link previews are enabled by default and can be disabled with `channels.telegram.linkPreview: false`.

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   markdownToTelegramChunks,
   markdownToTelegramHtml,
+  renderTelegramHtmlText,
   splitTelegramHtmlChunks,
 } from "./format.js";
 
@@ -18,7 +19,12 @@ describe("markdownToTelegramHtml", () => {
         "see [docs](https://example.com)",
         'see <a href="https://example.com">docs</a>',
       ],
-      ["escapes raw HTML", "<b>nope</b>", "&lt;b&gt;nope&lt;/b&gt;"],
+      ["preserves Telegram HTML", "<b>yes</b>", "<b>yes</b>"],
+      [
+        "escapes unsupported raw HTML",
+        "<script>nope</script>",
+        "&lt;script&gt;nope&lt;/script&gt;",
+      ],
       ["escapes unsafe characters", "a & b < c", "a &amp; b &lt; c"],
       ["renders paragraphs with blank lines", "first\n\nsecond", "first\n\nsecond"],
       ["renders lists without block HTML", "- one\n- two", "• one\n• two"],
@@ -28,6 +34,39 @@ describe("markdownToTelegramHtml", () => {
     for (const [name, input, expected] of cases) {
       expect(markdownToTelegramHtml(input), name).toBe(expected);
     }
+  });
+
+  it("preserves supported Telegram HTML in stream markdown rendering", () => {
+    const input = [
+      "✉️ <b>Morning Email Rollup</b>",
+      "",
+      "<blockquote>✅ No important emails in the last 24 hours.</blockquote>",
+      "",
+      "<pre><code>oauth2: invalid_grant</code></pre>",
+    ].join("\n");
+
+    expect(markdownToTelegramHtml(input)).toBe(input);
+    expect(
+      markdownToTelegramChunks(input, 4096)
+        .map((chunk) => chunk.html)
+        .join(""),
+    ).toBe(input);
+  });
+
+  it("does not promote Telegram HTML tags inside code", () => {
+    expect(markdownToTelegramHtml("`<b>literal</b>`")).toBe(
+      "<code>&lt;b&gt;literal&lt;/b&gt;</code>",
+    );
+    expect(markdownToTelegramHtml("```\n<blockquote>literal</blockquote>\n```")).toBe(
+      "<pre><code>&lt;blockquote&gt;literal&lt;/blockquote&gt;\n</code></pre>",
+    );
+  });
+
+  it("keeps unsupported Telegram HTML variants escaped", () => {
+    expect(markdownToTelegramHtml('<b class="x">bad</b>')).toBe('&lt;b class="x"&gt;bad&lt;/b&gt;');
+    expect(renderTelegramHtmlText('<b class="x">bad</b>', { textMode: "html" })).toBe(
+      '&lt;b class="x"&gt;bad&lt;/b&gt;',
+    );
   });
 
   it("renders blockquotes as native Telegram blockquote tags", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -140,11 +140,12 @@ export function markdownToTelegramHtml(
     tableMode: options.tableMode,
   });
   const html = renderTelegramHtml(ir);
+  const telegramHtml = preserveSupportedTelegramHtmlTags(html);
   // Apply file reference wrapping if requested (for chunked rendering)
   if (options.wrapFileRefs !== false) {
-    return wrapFileReferencesInHtml(html);
+    return wrapFileReferencesInHtml(telegramHtml);
   }
-  return html;
+  return telegramHtml;
 }
 
 /**
@@ -162,8 +163,163 @@ function escapeRegex(str: string): string {
 
 const AUTO_LINKED_ANCHOR_PATTERN = /<a\s+href="https?:\/\/([^"]+)"[^>]*>\1<\/a>/gi;
 const HTML_TAG_PATTERN = /(<\/?)([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*?>/gi;
+const HTML_MODE_TAG_PATTERN = /^<(\/?)([a-zA-Z][a-zA-Z0-9-]*)([^<>]*)>$/;
+const ESCAPED_HTML_TAG_PATTERN = /&lt;(\/?)([a-zA-Z][a-zA-Z0-9-]*)(.*?)&gt;/g;
+const TELEGRAM_SIMPLE_HTML_TAGS = new Set([
+  "b",
+  "strong",
+  "i",
+  "em",
+  "u",
+  "ins",
+  "s",
+  "strike",
+  "del",
+  "code",
+  "pre",
+  "tg-spoiler",
+  "blockquote",
+]);
+const TELEGRAM_ATTR_HTML_TAG_PATTERNS = new Map([
+  ["a", /^\s+href="[^"]+"\s*$/],
+  ["span", /^\s+class="tg-spoiler"\s*$/],
+  ["tg-emoji", /^\s+emoji-id="[^"]+"\s*$/],
+  ["tg-time", /^\s+datetime="[^"]+"\s*$/],
+]);
 let fileReferencePattern: RegExp | undefined;
 let orphanedTldPattern: RegExp | undefined;
+
+function popLastTagName(tags: string[], name: string): boolean {
+  for (let index = tags.length - 1; index >= 0; index -= 1) {
+    if (tags[index] === name) {
+      tags.splice(index, 1);
+      return true;
+    }
+  }
+  return false;
+}
+
+function isSupportedTelegramHtmlTag(rawTag: string): boolean {
+  const match = HTML_MODE_TAG_PATTERN.exec(rawTag);
+  if (!match) {
+    return false;
+  }
+  const closing = match[1] === "/";
+  const name = normalizeLowercaseStringOrEmpty(match[2]);
+  const attrs = match[3] ?? "";
+  if (TELEGRAM_SIMPLE_HTML_TAGS.has(name)) {
+    return attrs.trim() === "";
+  }
+  if (closing) {
+    return attrs.trim() === "";
+  }
+  return TELEGRAM_ATTR_HTML_TAG_PATTERNS.get(name)?.test(attrs) ?? false;
+}
+
+function preserveTelegramHtmlTag(
+  rawTag: string,
+  openTags: string[],
+  escapeTag: (rawTag: string) => string,
+): string {
+  const match = HTML_MODE_TAG_PATTERN.exec(rawTag);
+  if (!match || !isSupportedTelegramHtmlTag(rawTag)) {
+    return escapeTag(rawTag);
+  }
+  const closing = match[1] === "/";
+  const tagName = normalizeLowercaseStringOrEmpty(match[2]);
+  if (closing) {
+    return popLastTagName(openTags, tagName) ? rawTag : escapeTag(rawTag);
+  }
+  openTags.push(tagName);
+  return rawTag;
+}
+
+function escapeUnsupportedTelegramHtml(text: string): string {
+  let result = "";
+  let index = 0;
+  const openTags: string[] = [];
+  while (index < text.length) {
+    const char = text[index];
+    if (char === "&") {
+      const entityEnd = findTelegramHtmlEntityEnd(text, index);
+      if (entityEnd !== -1) {
+        result += text.slice(index, entityEnd + 1);
+        index = entityEnd + 1;
+      } else {
+        result += "&amp;";
+        index += 1;
+      }
+      continue;
+    }
+    if (char === "<") {
+      const end = text.indexOf(">", index + 1);
+      if (end !== -1) {
+        const rawTag = text.slice(index, end + 1);
+        result += preserveTelegramHtmlTag(rawTag, openTags, escapeHtml);
+        index = end + 1;
+      } else {
+        result += "&lt;";
+        index += 1;
+      }
+      continue;
+    }
+    if (char === ">") {
+      result += "&gt;";
+      index += 1;
+      continue;
+    }
+    result += char;
+    index += 1;
+  }
+  return result;
+}
+
+function promoteEscapedSupportedTelegramTags(text: string, openTags: string[]): string {
+  ESCAPED_HTML_TAG_PATTERN.lastIndex = 0;
+  return text.replace(
+    ESCAPED_HTML_TAG_PATTERN,
+    (match, closing: string, name: string, attrs: string) =>
+      preserveTelegramHtmlTag(`<${closing}${name}${attrs}>`, openTags, () => match),
+  );
+}
+
+function preserveSupportedTelegramHtmlTags(html: string): string {
+  let codeDepth = 0;
+  let preDepth = 0;
+  let result = "";
+  let lastIndex = 0;
+  const openEscapedTags: string[] = [];
+
+  HTML_TAG_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HTML_TAG_PATTERN.exec(html)) !== null) {
+    const tagStart = match.index;
+    const tagEnd = HTML_TAG_PATTERN.lastIndex;
+    const tagName = normalizeLowercaseStringOrEmpty(match[2]);
+    const isClosing = match[1] === "</";
+    const textBefore = html.slice(lastIndex, tagStart);
+    result +=
+      codeDepth > 0 || preDepth > 0
+        ? textBefore
+        : promoteEscapedSupportedTelegramTags(textBefore, openEscapedTags);
+
+    if (tagName === "code") {
+      codeDepth = isClosing ? Math.max(0, codeDepth - 1) : codeDepth + 1;
+    } else if (tagName === "pre") {
+      preDepth = isClosing ? Math.max(0, preDepth - 1) : preDepth + 1;
+    }
+
+    result += html.slice(tagStart, tagEnd);
+    lastIndex = tagEnd;
+  }
+
+  const remainingText = html.slice(lastIndex);
+  result +=
+    codeDepth > 0 || preDepth > 0
+      ? remainingText
+      : promoteEscapedSupportedTelegramTags(remainingText, openEscapedTags);
+  return result;
+}
 
 function getFileReferencePattern(): RegExp {
   if (fileReferencePattern) {
@@ -272,8 +428,7 @@ export function renderTelegramHtmlText(
 ): string {
   const textMode = options.textMode ?? "markdown";
   if (textMode === "html") {
-    // For HTML mode, trust caller markup - don't modify
-    return text;
+    return escapeUnsupportedTelegramHtml(text);
   }
   // markdownToTelegramHtml already wraps file references by default
   return markdownToTelegramHtml(text, { tableMode: options.tableMode });
@@ -491,7 +646,7 @@ export function splitTelegramHtmlChunks(html: string, limit: number): string[] {
 }
 
 function renderTelegramChunkHtml(ir: MarkdownIR): string {
-  return wrapFileReferencesInHtml(renderTelegramHtml(ir));
+  return wrapFileReferencesInHtml(preserveSupportedTelegramHtmlTags(renderTelegramHtml(ir)));
 }
 
 function renderTelegramChunksWithinHtmlLimit(

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -167,6 +167,25 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-silent", chatId: "12345" });
   });
 
+  it("does not plain-text sanitize Telegram HTML before durable delivery", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-html", chatId: "12345" });
+
+    await telegramOutbound.sendText!({
+      cfg: {} as never,
+      to: "12345",
+      text: "<b>Morning</b> <code>oauth2</code>",
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    const options = callOptionsAt(
+      sendMessageTelegramMock,
+      0,
+      "12345",
+      "<b>Morning</b> <code>oauth2</code>",
+    );
+    expect(options.textMode).toBeUndefined();
+  });
+
   it("forwards audioAsVoice payload media to Telegram voice sends", async () => {
     sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-voice", chatId: "12345" });
 

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -7,7 +7,6 @@ import {
   presentationToInteractiveReply,
   renderMessagePresentationFallbackText,
 } from "openclaw/plugin-sdk/interactive-runtime";
-import { sanitizeForPlainText } from "openclaw/plugin-sdk/outbound-runtime";
 import type { OutboundDeliveryFormattingOptions } from "openclaw/plugin-sdk/outbound-runtime";
 import {
   resolveOutboundSendDep,
@@ -165,8 +164,6 @@ export function createTelegramOutboundAdapter(
     chunkedTextFormatting: { parseMode: "HTML" },
     extractMarkdownImages: true,
     textChunkLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
-    sanitizeText: ({ text }) => sanitizeForPlainText(text),
-    shouldSkipPlainTextSanitization: ({ payload }) => Boolean(payload.channelData),
     shouldSuppressLocalPayloadPrompt: options.shouldSuppressLocalPayloadPrompt,
     beforeDeliverPayload: options.beforeDeliverPayload,
     shouldTreatDeliveredTextAsVisible: options.shouldTreatDeliveredTextAsVisible,

--- a/extensions/telegram/src/telegram-outbound.test.ts
+++ b/extensions/telegram/src/telegram-outbound.test.ts
@@ -14,6 +14,7 @@ describe("telegramPlugin outbound", () => {
     expect(telegramOutbound.chunkerMode).toBe("markdown");
     expect(telegramOutbound.chunkedTextFormatting).toEqual({ parseMode: "HTML" });
     expect(telegramOutbound.textChunkLimit).toBe(4000);
+    expect(telegramOutbound.sanitizeText).toBeUndefined();
     expect(telegramOutbound.pollMaxOptions).toBe(10);
   });
 


### PR DESCRIPTION
Summary
- Preserve supported Telegram HTML in markdown and draft-stream rendering while unsupported tags stay escaped.
- Stop running Telegram durable outbound text through the generic plain-text sanitizer.
- Update Telegram docs for the supported-HTML contract.

Proof
- pnpm test extensions/telegram/src/format.test.ts extensions/telegram/src/outbound-adapter.test.ts extensions/telegram/src/telegram-outbound.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/bot-message-dispatch.test.ts
- OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed
- Live Telegram API proof: screenshot-shaped HTML payload returned bold, blockquote, and pre entities with no literal HTML tags.

Bot-to-bot E2E
- Command path: temporary gateway from this branch + mock OpenAI + Telegram driver/SUT bots.
- Sent driver message id: 7246.
- Observed SUT reply id: 7247, threaded to 7246.
- Mock OpenAI requests: 1.
- Observed entity types: bold, blockquote, pre.
- Literal HTML tags in observed Telegram text: false.
