### PR TITLE
[codex] Keep app-server watchdog armed after dynamic tool handoff

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1247,6 +1247,98 @@ describe("runCodexAppServerAttempt", () => {
     expect(queueActiveRunMessageForTest("session-1", "after timeout")).toBe(false);
   });
 
+  it("keeps the post-tool completion watchdog armed across dynamic tool completion bookkeeping", async () => {
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    let handleRequest:
+      | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
+      | undefined;
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+    __testing.setCodexAppServerClientFactoryForTests(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: (
+            handler: (request: {
+              id: string;
+              method: string;
+              params?: unknown;
+            }) => Promise<unknown>,
+          ) => {
+            handleRequest = handler;
+            return () => undefined;
+          },
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 5,
+      turnTerminalIdleTimeoutMs: 200,
+    });
+    await vi.waitFor(() => expect(handleRequest).toBeTypeOf("function"), { interval: 1 });
+
+    const toolResult = (await handleRequest?.({
+      id: "request-tool-1",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: null,
+        tool: "message",
+        arguments: { action: "send", text: "already sent" },
+      },
+    })) as { success?: boolean };
+    expect(toolResult.success).toBe(false);
+    await notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "dynamicToolCall",
+          id: "call-1",
+          tool: "message",
+        },
+      },
+    });
+
+    const result = await run;
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+    expect(
+      warn.mock.calls.some(
+        ([message]) => message === "codex app-server turn idle timed out waiting for completion",
+      ),
+    ).toBe(true);
+    expect(
+      warn.mock.calls.some(
+        ([message]) =>
+          message === "codex app-server turn idle timed out waiting for terminal event",
+      ),
+    ).toBe(false);
+  });
+
   it("closes the app-server client when the active turn exceeds the attempt timeout", async () => {
     const close = vi.fn();
     const request = vi.fn(async (method: string) => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -924,6 +924,7 @@ export async function runCodexAppServerAttempt(
   let turnCompletionLastActivityDetails: Record<string, unknown> | undefined;
   let activeAppServerTurnRequests = 0;
   const activeTurnItemIds = new Set<string>();
+  const activeOpenClawDynamicToolCallIds = new Set<string>();
 
   const clearTurnCompletionIdleTimer = () => {
     if (turnCompletionIdleTimer) {
@@ -1268,12 +1269,16 @@ export async function runCodexAppServerAttempt(
       turnCompletionIdleWatchArmed &&
       !turnCompletionIdleWatchPinnedByTerminalError &&
       notification.method !== "turn/completed" &&
-      isCurrentTurnNotification
+      isCurrentTurnNotification &&
+      !isTrackedOpenClawDynamicToolCompletionNotification(
+        notification,
+        activeOpenClawDynamicToolCallIds,
+      )
     ) {
       // The short completion-idle watchdog only guards the blind gap after
-      // OpenClaw hands a turn-scoped request result back to Codex. Once Codex
-      // sends another current-turn notification, the app-server is alive again;
-      // the longer terminal watchdog remains the stuck-turn backstop.
+      // OpenClaw hands a turn-scoped request result back to Codex. Bookkeeping
+      // that closes the just-served OpenClaw dynamic tool item is still part of
+      // that handoff, so keep the short watchdog armed for that notification.
       disarmTurnCompletionIdleWatch();
     }
     // Determine terminal-turn status before invoking the projector so a throw
@@ -1369,6 +1374,7 @@ export async function runCodexAppServerAttempt(
         return undefined;
       }
       armCompletionWatchOnResponse = true;
+      activeOpenClawDynamicToolCallIds.add(call.callId);
       trajectoryRecorder?.recordEvent("tool.call", {
         threadId: call.threadId,
         turnId: call.turnId,
@@ -2656,6 +2662,23 @@ function shouldDisarmAssistantCompletionIdleWatch(notification: CodexServerNotif
     return true;
   }
   return false;
+}
+
+function isTrackedOpenClawDynamicToolCompletionNotification(
+  notification: CodexServerNotification,
+  activeOpenClawDynamicToolCallIds: ReadonlySet<string>,
+): boolean {
+  if (notification.method !== "item/completed" || !isJsonObject(notification.params)) {
+    return false;
+  }
+  const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
+  const itemId =
+    (item ? readString(item, "id") : undefined) ?? readString(notification.params, "itemId");
+  if (!itemId || !activeOpenClawDynamicToolCallIds.has(itemId)) {
+    return false;
+  }
+  const itemType = item ? readString(item, "type") : undefined;
+  return itemType === undefined || itemType === "dynamicToolCall";
 }
 
 function readNotificationItemId(notification: CodexServerNotification): string | undefined {


### PR DESCRIPTION
## Summary

- keep the short Codex app-server completion watchdog armed when the current-turn notification is only bookkeeping for the OpenClaw dynamic tool call that just returned
- track OpenClaw dynamic tool call ids and exempt their `item/completed` notification from disarming the post-tool watchdog
- add a regression test for the no-`turn/completed` / no-`model.completed` path after dynamic tool handoff

## Root cause

The existing app-server logic disarmed the short post-tool completion watchdog on any current-turn notification after a dynamic tool response. If Codex emitted only `item/completed` for the dynamic tool call and then went quiet, OpenClaw treated that bookkeeping notification as liveness and fell back to the much longer terminal watchdog, leaving the session lane stuck for too long.

## Related prior work

This PR is a narrow follow-up to the recent Codex app-server watchdog/liveness fixes, not a replacement for them.

- [#80776](https://github.com/openclaw/openclaw/pull/80776) is the closest merged prior fix. It releases the OpenClaw session lane after a completed `agentMessage` item goes quiet without `turn/completed`, but only once no current-turn app-server request or observed item is still active. That handles the later case where Codex has already produced completed assistant message content and should be treated as effectively done.
- [#79667](https://github.com/openclaw/openclaw/pull/79667) also merged in the same area and tightened liveness accounting by ignoring account/rate-limit notifications for active-turn progress. That establishes the same principle this PR follows: not every app-server notification is meaningful turn progress.
- [#77454](https://github.com/openclaw/openclaw/pull/77454) introduced the current behavior of disarming the short post-tool watchdog after non-terminal current-turn activity, so live turns are not falsely aborted after a dynamic tool response. This PR preserves that behavior, but carves out OpenClaw-owned dynamic-tool completion bookkeeping because `dynamicToolCall` `item/completed` is not proof that Codex resumed after the tool response.
- [#77989](https://github.com/openclaw/openclaw/pull/77989) / [#77984](https://github.com/openclaw/openclaw/issues/77984) are the closest prior root-cause analogue: a mid-turn completion-style notification (`rawResponseItem/completed`) should not reset the completion-idle watchdog because it is not the post-tool idle boundary the short watchdog is meant to guard.

The key difference from merged [#80776](https://github.com/openclaw/openclaw/pull/80776): #80776 releases the lane after a completed assistant message goes quiet, while this PR runs earlier in the post-dynamic-tool handoff window. At this point there may be no assistant final content and no `turn/completed`; the correct behavior is not to release the lane immediately, but to keep the short post-tool watchdog armed so the missing terminal event is detected promptly instead of waiting for the long terminal watchdog.

## Real behavior proof

**Behavior or issue addressed:** A real Feishu-triggered embedded Codex app-server run got stuck after dynamic-tool completion bookkeeping. Gateway diagnostics showed the active work remained in `embedded_run` with `lastProgress=codex_app_server:notification:item/completed` and no terminal trajectory events before the Feishu per-chat 300s cap evicted the queued task.

**Real environment tested:** Local macOS OpenClaw + Feishu websocket setup, using this PR head built locally as `OpenClaw 2026.5.12-beta.1 (b9a89f7)`. Secrets, auth profile, workspace path, and Feishu chat/session IDs are redacted. The after-fix command used the real Gateway delivery path with `agentHarnessId=codex` and `runner=embedded`.

**Exact steps or command run after this patch:**

```bash
pnpm openclaw agent \
  --session-id pr-80980-real-proof \
  --message "PR #80980 real-behavior proof: please send exactly PROOF_OK." \
  --deliver \
  --reply-channel feishu \
  --reply-to <redacted-feishu-chat> \
  --timeout 180 \
  --json
```

**Evidence after fix:** Redacted terminal output and trajectory log excerpt from the PR-head real run:

```json
{
  "runId": "09a8cfef-3d14-4be5-a26c-291bb38080b1",
  "status": "ok",
  "summary": "completed",
  "result": {
    "payloads": [{ "text": "PROOF_OK", "mediaUrl": null }],
    "meta": {
      "durationMs": 7765,
      "agentMeta": {
        "sessionId": "pr-80980-real-proof",
        "provider": "openai",
        "model": "gpt-5.5",
        "agentHarnessId": "codex",
        "usage": { "input": 29122, "output": 23, "cacheRead": 6528, "total": 35673 }
      },
      "aborted": false,
      "finalAssistantVisibleText": "PROOF_OK",
      "stopReason": "stop",
      "executionTrace": { "runner": "embedded", "fallbackUsed": false },
      "completion": { "stopReason": "stop", "finishReason": "stop" }
    },
    "deliverySucceeded": true
  }
}
```

```text
2026-05-13T01:18:34.514Z model.completed runId=09a8cfef-3d14-4be5-a26c-291bb38080b1 timedOut=false yieldDetected=false aborted=false promptError=null assistantTexts=["PROOF_OK"]
2026-05-13T01:18:34.516Z session.ended runId=09a8cfef-3d14-4be5-a26c-291bb38080b1 status=success timedOut=false yieldDetected=false promptError=null
```

Pre-fix redacted runtime logs from the same local setup showed the stuck path this PR targets:

```text
2026-05-12T15:43:06.295+08:00 WARN long-running session: sessionId=<session-id> sessionKey=<feishu-session-key> state=processing age=126s queueDepth=1 reason=queued_behind_active_work classification=long_running activeWorkKind=embedded_run lastProgress=codex_app_server:notification:item/completed lastProgressAge=120s recovery=none
2026-05-12T15:43:36.255+08:00 WARN stalled session: sessionId=<session-id> sessionKey=<feishu-session-key> state=processing age=156s queueDepth=1 reason=active_work_without_progress classification=stalled_agent_run activeWorkKind=embedded_run lastProgress=codex_app_server:notification:item/completed lastProgressAge=150s recovery=none
2026-05-12T15:45:22.895+08:00 INFO feishu[default]: per-chat task exceeded 300000ms cap (key=<feishu-chat-key>); evicting from queue so later same-key messages can proceed (#70133)
```

**Observed result after fix:** The PR-head run returned `status=ok`, delivered `PROOF_OK` to Feishu, reported `deliverySucceeded=true`, and recorded both missing terminal events: `model.completed` followed by `session.ended status=success` with `promptError=null` and `timedOut=false`.

**What was not tested:** Other IM channels were not exercised in the real setup; the exact deterministic no-terminal-event edge is covered by the new regression test because the live model does not reliably emit that same bookkeeping-only sequence on demand.

## Validation

- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `git diff --check`
- `pnpm exec vitest run extensions/codex/src/app-server/run-attempt.test.ts -t "post-tool completion watchdog"`
- `pnpm exec vitest run extensions/codex/src/app-server/run-attempt.test.ts`
