### PR TITLE
docs(cli): clarify strict json parsing

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -89,13 +89,15 @@ openclaw config set 'agents.list[1].tools.exec.node' "node-id-or-name"
 
 ## Values
 
-Values are parsed as JSON5 when possible; otherwise they are treated as strings. Use `--strict-json` to require JSON5 parsing. `--json` remains supported as a legacy alias.
+Values are parsed as JSON5 when possible; otherwise they are treated as strings. Use `--strict-json` to require standard JSON parsing with no string fallback. `--json` remains supported as a legacy alias for `--strict-json`.
 
 ```bash
 openclaw config set agents.defaults.heartbeat.every "0m"
 openclaw config set gateway.port 19001 --strict-json
 openclaw config set channels.whatsapp.groups '["*"]' --strict-json
 ```
+
+When `--strict-json` is enabled, JSON5-only syntax such as comments, trailing commas, or unquoted object keys is rejected. Omit `--strict-json` for JSON5 value parsing with raw-string fallback.
 
 `config get <path> --json` prints the raw value as JSON instead of terminal-formatted text.
 


### PR DESCRIPTION
## Summary

- Problem: the CLI docs said values use JSON5 parsing with string fallback, but did not clearly separate the strict JSON mode.
- Why it matters: users trying `--strict-json` need to know it errors instead of silently falling back to a raw string.
- What changed: clarified the docs wording for `--strict-json`, including the legacy `--json` alias and examples for number and array values.
- What did NOT change (scope boundary): no CLI behavior changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to #65345; addresses only the strict JSON docs mismatch and should not close the broader tracker.
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `--strict-json` requires JSON parsing and errors on invalid JSON instead of using the raw string fallback.
- Real environment tested: local OpenClaw checkout on Linux, Node v24.13.0, pnpm test runner.
- Exact steps or command run after this patch:
  - `openclaw config set gateway.port 19001 --strict-json`
  - `openclaw config set channels.whatsapp.groups '["*"]' --strict-json`
  - `openclaw config set gateway.port '{bad' --strict-json`
  - `CI=true pnpm docs:list`
  - `CI=true pnpm test src/cli/config-cli.test.ts`
  - `git diff --check`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  - `openclaw config set gateway.port 19001 --strict-json` accepted numeric JSON input.
  - `openclaw config set channels.whatsapp.groups '["*"]' --strict-json` accepted array JSON input.
  - `openclaw config set gateway.port '{bad' --strict-json` printed `Could not parse "{bad" as JSON for --strict-json.` and `For plain strings, omit --strict-json.`
  - `CI=true pnpm docs:list` passed.
  - `CI=true pnpm test src/cli/config-cli.test.ts` passed with 76 tests.
  - `git diff --check` passed.
- Observed result after fix: the documentation now matches the observed strict parsing behavior and the CLI tests still pass.
- What was not tested: full repository test suite.
- Before evidence (optional but encouraged): issue #65345 described the docs/code drift around `--strict-json`.

## Root Cause (if applicable)

- Root cause: the docs described the normal JSON5 parsing fallback, but the strict parsing flag was not called out precisely enough.
- Missing detection / guardrail: docs review did not catch the distinction between normal value parsing and strict parsing.
- Contributing context (if known): `--json` remains as a legacy alias while `--strict-json` is the clearer name.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/cli/config-cli.test.ts`
- Scenario the test should lock in: strict JSON mode rejects invalid JSON instead of falling back to a plain string.
- Why this is the smallest reliable guardrail: the behavior already has targeted CLI coverage, this PR only updates docs.
- Existing test that already covers this (if any): `src/cli/config-cli.test.ts`
- If no new test is added, why not: this is a docs-only clarification for behavior already covered by tests.

## User-visible / Behavior Changes

Documentation only. CLI behavior is unchanged.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v24.13.0 with pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): temporary local config values only

### Steps

1. Review `docs/cli/config.md` strict JSON wording.
2. Run strict JSON CLI examples with valid number and array inputs.
3. Run strict JSON CLI example with invalid JSON input.
4. Run docs listing, targeted CLI tests, and whitespace diff check.

### Expected

- Docs describe strict JSON behavior accurately.
- Valid JSON values are accepted with `--strict-json`.
- Invalid JSON fails with the strict JSON error.
- Existing targeted tests pass.

### Actual

- Docs now describe strict JSON behavior accurately.
- Valid JSON values were accepted with `--strict-json`.
- Invalid JSON failed with `Could not parse "{bad" as JSON for --strict-json.`
- `CI=true pnpm docs:list`, `CI=true pnpm test src/cli/config-cli.test.ts`, and `git diff --check` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: strict JSON docs wording, valid strict JSON number and array examples, invalid strict JSON parse error, docs listing, targeted CLI tests, and whitespace diff check.
- Edge cases checked: invalid JSON under `--strict-json` does not fall back to a plain string.
- What you did **not** verify: full repository test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.

