### PR TITLE
fix(model status): show codex runtime auth on bare `codex/<model>` picker rows

### DIFF
--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -640,6 +640,47 @@ describe("/model chat UX", () => {
     expect(reply?.text).toContain("openai-codex:patrick@example.test=OAuth");
   });
 
+  it("reports Codex runtime auth for bare codex status rows (#79131)", async () => {
+    setAuthProfiles({
+      "openai-codex:patrick@example.test": {
+        type: "oauth",
+        provider: "openai-codex",
+        access: "access-token",
+        refresh: "refresh-token",
+        expires: Date.now() + 60_000,
+      },
+    });
+
+    const reply = await resolveModelInfoReply({
+      directives: parseInlineDirectives("/model status"),
+      provider: "openai",
+      model: "gpt-5.5",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      cfg: {
+        commands: { text: true },
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex" },
+            model: { primary: "openai/gpt-5.5" },
+            models: {
+              "codex/gpt-5.5": {},
+              "openai/gpt-5.5": {},
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      allowedModelCatalog: [
+        { provider: "codex", id: "gpt-5.5", name: "GPT-5.5" },
+        { provider: "openai", id: "gpt-5.5", name: "GPT-5.5" },
+      ],
+    });
+
+    expect(reply?.text).toContain("[codex] endpoint: default auth:");
+    expect(reply?.text).not.toContain("[codex] endpoint: default auth: missing");
+    expect(reply?.text).toContain("via codex runtime / openai-codex");
+  });
+
   it("keeps direct provider auth labels when OpenAI API key auth exists", async () => {
     setAuthProfiles({
       "openai:api-key": {

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -74,9 +74,15 @@ async function resolveStatusAuthLabel(params: {
     config: params.cfg,
     agentId: params.activeAgentId,
   });
+  // Display-only: keep `isOpenAICodexProvider` strict so selectAgentHarness's
+  // support/priority probing keeps treating bare `codex` as a normal provider,
+  // but route this auth label through the codex runtime so an existing
+  // openai-codex profile shows up instead of `auth: missing`.
+  const statusHarnessRuntime =
+    harnessPolicy.runtime === "auto" && provider === "codex" ? "codex" : harnessPolicy.runtime;
   const harnessRuntime = resolveStatusHarnessRuntime({
     sessionEntry: params.sessionEntry,
-    defaultRuntime: harnessPolicy.runtime,
+    defaultRuntime: statusHarnessRuntime,
   });
   const runtimeAuthPlan = buildAgentRuntimeAuthPlan({
     provider,


### PR DESCRIPTION
## Summary

- **Problem:** Telegram `/model status` reports `auth: missing` for the `[codex]` provider row even when the active runtime authenticates through an `openai-codex` OAuth profile (issue #79131).
- **Why it matters:** Misleading status output. `/status` correctly reports OAuth via the codex runtime, but `/model status` contradicts it. Operators reading `/model status` cannot tell if their codex setup is working from the auth labels alone.
- **What changed:** `resolveStatusAuthLabel` in `src/auto-reply/reply/directive-handling.model.ts` now applies a display-only alias: when `resolveAgentHarnessPolicy` returns `runtime: "auto"` for a normalized provider of `codex`, the function passes `"codex"` as the harness runtime hint into `buildAgentRuntimeAuthPlan` so the existing runtime-aware fallback can surface the `openai-codex` harness auth provider.
- **What did NOT change (scope boundary):** `isOpenAICodexProvider` and `resolveAgentHarnessPolicy` are unchanged. Harness selection, plugin auto-load, and every other consumer of those classifications keep their current behavior. In particular, the existing `selectAgentHarness` tests in `src/agents/harness/selection.test.ts` that pin provider-codex auto-routing support/priority probing keep passing (verified locally — 19/19).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79131
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** The status auth-label fallback in `resolveStatusAuthLabel` only fires when `resolveAgentHarnessPolicy` reports a non-`auto` runtime. For `provider: "openai"` with default base URL it already returns `runtime: "codex"` (via `openAIProviderUsesCodexRuntimeByDefault`), and the `[openai]` row therefore prints `via codex runtime / openai-codex …`. For a user-authored `provider: "codex"` the policy intentionally leaves the runtime on `auto` (broadening the predicate would force `selectAgentHarness` off its auto-routing path and skip the support/priority probes that existing tests pin). Without that runtime hint, `buildAgentRuntimeAuthPlan` returns no `harnessAuthProvider`, the fallback short-circuits, and the row prints `auth: missing`.
- **Missing detection / guardrail:** No test exercised `/model status` against a config that includes `codex/<model>` in the allowed catalog with an `openai-codex` OAuth profile active. The symmetric assertion for the `[openai]` row already existed.
- **Contributing context (if known):** The `[openai]` row was already correctly handled by the runtime-aware fallback after the codex routing work landed. The `[codex]` row was the remaining gap.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/auto-reply/reply/directive-handling.model.test.ts` — new `it("reports Codex runtime auth for bare codex status rows (#79131)", ...)` inside `describe("/model chat UX", ...)`.
- **Scenario the test should lock in:** With an `openai-codex` OAuth profile in the store, `agents.defaults.agentRuntime.id = "codex"`, and an allowed catalog that includes both `codex/<model>` and `openai/<model>`, `/model status` must print `via codex runtime / openai-codex` for the `[codex]` row instead of `auth: missing`. Mirrors the existing `[openai]` assertion immediately above it.
- **Why this is the smallest reliable guardrail:** Drives the public entry `maybeHandleModelDirectiveInfo`, so the test exercises the exact rendering path operators see in Telegram. Pinning at this layer catches the regression without depending on filesystem auth-profile fixtures (the file already mocks `ensureAuthProfileStore`).
- **Existing test that already covers this (if any):** `it("reports Codex runtime auth for OpenAI status rows", ...)` covers the `[openai]` row. Nothing covered the `[codex]` row before.
- **If no new test is added, why not:** N/A — added.

## User-visible / Behavior Changes

- `/model status` rows whose provider key is the bare `codex` (e.g. from `agents.defaults.models["codex/<model>"]`) now display the same `via codex runtime / openai-codex …` label that the `[openai]` row already shows when the codex runtime is in effect. Rows for any other provider see no change.
- No harness-selection or plugin auto-load behavior changes. Configs with `codex/<model>` still route through `selectAgentHarness`'s auto path exactly as they did before.

## Diagram (if applicable)

```text
provider="codex", agentRuntime.id="codex", openai-codex OAuth profile active

Before:
  resolveAgentHarnessPolicy → { runtime: "auto" }
  buildAgentRuntimeAuthPlan → { harnessAuthProvider: undefined }
  resolveStatusAuthLabel    → "auth: missing"                        ✗

After (this PR — display-only):
  resolveAgentHarnessPolicy → { runtime: "auto" }       (unchanged)
  statusHarnessRuntime alias→ "codex"                   (local to resolveStatusAuthLabel)
  buildAgentRuntimeAuthPlan → { harnessAuthProvider: "openai-codex" }
  resolveStatusAuthLabel    → "via codex runtime / openai-codex …"   ✓
  selectAgentHarness behavior for provider:"codex"      (unchanged)
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No** (label formatting only; underlying auth resolution is unchanged)
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime: Node 22, OpenClaw on `origin/main` (`17237fc44f`)
- Provider / routing chain: `openai-codex` OAuth profile via `agents.defaults.agentRuntime.id: "codex"`
- Relevant config (redacted):

```json
{
  "agents": {
    "defaults": {
      "model": { "primary": "openai/gpt-5.5" },
      "models": {
        "codex/gpt-5.5": {},
        "openai/gpt-5.5": {}
      },
      "agentRuntime": { "id": "codex" }
    }
  }
}
```

### Steps

1. With the config above and an `openai-codex` OAuth profile installed, run `/model status` from Telegram.
2. Observe the `[codex]` and `[openai]` rows in the picker output.

### Expected

- `[openai]` row reports `auth: … via codex runtime / openai-codex …`.
- `[codex]` row reports the same effective auth (not `auth: missing`).

### Actual (before this PR)

- `[openai]` row: already correct on current `main`.
- `[codex]` row: `auth: missing`, despite the active codex-runtime auth.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

The new test (`reports Codex runtime auth for bare codex status rows (#79131)`) fails against current `main` (asserts `via codex runtime / openai-codex` but the `[codex]` row prints `missing`) and passes against this branch. All 58 tests in `directive-handling.model.test.ts` pass in isolation, and all 19 tests in `harness/selection.test.ts` pass — pinning the provider-codex auto-routing semantics this PR deliberately preserves.

## Human Verification (required)

- **Verified scenarios:**
  - With the reporter's config, the `[codex]` row produces `via codex runtime / openai-codex …` (new test).
  - With the same config, the `[openai]` row still produces the same label (existing test passes unchanged).
  - With an `openai` API-key profile in addition to `openai-codex` OAuth, the `[openai]` row still prefers the direct provider auth label (existing test passes unchanged).
  - With OpenAI policy pinned to `pi` runtime, the codex fallback does not borrow codex auth (existing test passes unchanged).
  - `selectAgentHarness({provider: "codex"})` still calls `supports()` once per registered harness and honors priority — confirmed by running `harness/selection.test.ts` in full.
- **Edge cases checked:** Bare `codex` provider with `runtime: "auto"` (alias fires), `openai-codex` provider with `runtime: "codex"` (no change), `openai` provider with custom baseUrl that produces `runtime: "auto"` (alias does NOT fire), unrelated providers like `anthropic` (alias does NOT fire). Predicate behavior unchanged — verified by reverting the alias and re-running selection tests.
- **What you did NOT verify:** A live Telegram `/model status` capture against a deployed gateway. The test covers the picker output end-to-end through `maybeHandleModelDirectiveInfo`, which is the same code path Telegram drives; no rendering happens outside that entry.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**. The alias is scoped to one auth-label code path; nothing else observes it.
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** Drift between the harness-selection treatment of `codex` and the status-label treatment.
  - **Mitigation:** The alias lives in one place (`resolveStatusAuthLabel`) and is guarded on `harnessPolicy.runtime === "auto" && provider === "codex"`. If a future change makes `resolveAgentHarnessPolicy` route bare `codex` through the codex runtime explicitly, the alias becomes a no-op (the first conjunct stops being true) and harmlessly self-disables — no breakage, just dead code waiting to be deleted in that follow-up.
- **Risk:** `provider: "codex"` could mean something other than `openai-codex` in some future plugin.
  - **Mitigation:** This is no different than the existing `[openai]` row treatment, which has been printing `via codex runtime / openai-codex …` since the runtime-aware fallback landed. The alias matches that established convention rather than introducing a new one.
