### PR TITLE
fix(cron): reject announce->webchat at create time and runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/delivery: reject announce delivery to WebChat at cron add, edit, and runtime boundaries with an actionable error pointing at supported webchat-session reminder shapes.
 - Security/CLI/runtime: harden hostname normalization for repeated trailing dots, block side-effecting command wrappers, reject unsafe Node runtime env overrides, reject loose numeric CLI and gateway options, require admin approval for node device-role pairing, and reject no-auth Tailscale exposure. (#87305, #87292, #87308, #87146) Thanks @pgondhi987.
 - Telegram: route `sendMessage` action replies through durable outbound delivery so completed agent responses remain retryable when the gateway send path times out. (#87261) Thanks @mbelinky.
 - Matrix/auto-reply: keep draft previews mention-inert, preserve final mention delivery, send mention finals normally, await shared DM notices, ignore filename-embedded MXIDs, and suppress reasoning-prefixed `NO_REPLY` responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Cron/delivery: reject announce delivery to WebChat at cron add, edit, and runtime boundaries with an actionable error pointing at supported webchat-session reminder shapes.
 - Security/CLI/runtime: harden hostname normalization for repeated trailing dots, block side-effecting command wrappers, reject unsafe Node runtime env overrides, reject loose numeric CLI and gateway options, require admin approval for node device-role pairing, and reject no-auth Tailscale exposure. (#87305, #87292, #87308, #87146) Thanks @pgondhi987.
 - Telegram: route `sendMessage` action replies through durable outbound delivery so completed agent responses remain retryable when the gateway send path times out. (#87261) Thanks @mbelinky.
 - Matrix/auto-reply: keep draft previews mention-inert, preserve final mention delivery, send mention finals normally, await shared DM notices, ignore filename-embedded MXIDs, and suppress reasoning-prefixed `NO_REPLY` responses.

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -192,6 +192,47 @@ verify placeholders such as `{{language}}` are filled before the job runs. If
 the output mixes languages, make the rule explicit, for example: "Use Chinese
 for narrative text and keep technical terms in English."
 
+### Webchat is not an announce target
+
+Webchat is the internal session-bound surface (`INTERNAL_MESSAGE_CHANNEL`), not a channel plugin. It has no outbound `deliver(...)` path the cron runner can call — webchat receives replies live, through the session event broadcast over the connected WebSocket. A cron configured with `--announce --channel webchat` will always fail at fire time with `"Channel is required (no configured channels detected)"`, even when a webchat tab is open and listening on the targeted session.
+
+For cron output to land in a webchat session, use one of these two shapes instead. The runtime gates them sharply (see [`assertSupportedJobSpec`](https://github.com/openclaw/openclaw/blob/main/src/cron/jobs.ts) in source):
+
+| `sessionTarget`                             | required `payload.kind`              | who can use it                                                                  |
+| ------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------- |
+| `"main"`                                    | `"systemEvent"`                      | **default agent only** — non-default agents are rejected at job-spec validation |
+| `"isolated"`, `"current"`, `"session:<id>"` | `"agentTurn"` (systemEvent rejected) | all agents                                                                      |
+
+**Default agent, fixed-text reminder (no LLM cost):**
+
+```bash
+openclaw cron add \
+  --name "morning standup reminder" \
+  --cron "0 9 * * 1-5" --tz Asia/Dubai \
+  --session main \
+  --system-event "Morning standup at 9:30. Slides on the team drive."
+```
+
+`--session main --system-event` jobs never invoke the announce delivery path — they always append a `systemEvent` to the default agent's main session and let any subscribed webchat tab render it via the `sessions.changed` broadcast. `--no-deliver` and `--announce` are rejected on this shape by `cron add`; the only delivery mode for main-session systemEvent jobs is the implicit session broadcast.
+
+At fire time the gateway appends a `systemEvent` to the default agent's main session and broadcasts `sessions.changed` to any subscribed webchat tab. The reminder renders inline; no channel-plugin involvement.
+
+**Non-default agent (e.g. a personal assistant agent named `coli`), agent-turn reminder:**
+
+```bash
+openclaw cron add \
+  --name "revisit-architecture-decision" \
+  --at 2026-05-23T05:00Z \
+  --agent coli \
+  --session session:agent:coli:main \
+  --message "Reminder: revisit the SharePoint sync architecture decision. Read projects/coding-council/<date>-system-architecture/synthesis.md and ask Ehab whether to spec a webhook-primary build or stay with polling." \
+  --no-deliver
+```
+
+At fire time the gateway wakes session `agent:coli:main` with the message as a fresh user turn. The agent computes a reply and emits it into the session; any subscribed webchat tab renders the reply. No `sessions_send` is needed when the cron output should land in the agent's _own_ main session. Use `--session isolated` and have the agent call `sessions_send` from the turn when the output should cross sessions.
+
+A CLI-level guardrail (`cron add` / `cron edit`) and a runtime typed error (`WebchatNotDeliverableError` from `resolveMessageChannelSelection`) both reject `--announce --channel webchat` so the misconfiguration cannot reach the runtime delivery path. RPC and raw `jobs.json` callers hit the runtime error; the CLI surfaces an equivalent rejection at create time.
+
 Failure notifications follow a separate destination path:
 
 - `cron.failureDestination` sets a global default for failure notifications.

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -177,21 +177,6 @@ When an agent creates an isolated reminder from an active chat, OpenClaw stores 
 
 Implicit announce delivery uses configured channel allowlists to validate and reroute stale targets. DM pairing-store approvals are not fallback automation recipients; set `delivery.to` or configure the channel `allowFrom` entry when a scheduled job should proactively send to a DM.
 
-## Output language
-
-Cron jobs do not infer a reply language from channel, locale, or previous
-messages. Put the language rule in the scheduled message or template:
-
-```bash
-openclaw cron edit <jobId> \
-  --message "Summarize the updates. Respond in Chinese; keep URLs, code, and product names unchanged."
-```
-
-For template files, keep the language instruction in the rendered prompt and
-verify placeholders such as `{{language}}` are filled before the job runs. If
-the output mixes languages, make the rule explicit, for example: "Use Chinese
-for narrative text and keep technical terms in English."
-
 ### Webchat is not an announce target
 
 Webchat is the internal session-bound surface (`INTERNAL_MESSAGE_CHANNEL`), not a channel plugin. It has no outbound `deliver(...)` path the cron runner can call — webchat receives replies live, through the session event broadcast over the connected WebSocket. A cron configured with `--announce --channel webchat` will always fail at fire time with `"Channel is required (no configured channels detected)"`, even when a webchat tab is open and listening on the targeted session.
@@ -232,6 +217,21 @@ openclaw cron add \
 At fire time the gateway wakes session `agent:coli:main` with the message as a fresh user turn. The agent computes a reply and emits it into the session; any subscribed webchat tab renders the reply. No `sessions_send` is needed when the cron output should land in the agent's _own_ main session. Use `--session isolated` and have the agent call `sessions_send` from the turn when the output should cross sessions.
 
 A CLI-level guardrail (`cron add` / `cron edit`) and a runtime typed error (`WebchatNotDeliverableError` from `resolveMessageChannelSelection`) both reject `--announce --channel webchat` so the misconfiguration cannot reach the runtime delivery path. RPC and raw `jobs.json` callers hit the runtime error; the CLI surfaces an equivalent rejection at create time.
+
+## Output language
+
+Cron jobs do not infer a reply language from channel, locale, or previous
+messages. Put the language rule in the scheduled message or template:
+
+```bash
+openclaw cron edit <jobId> \
+  --message "Summarize the updates. Respond in Chinese; keep URLs, code, and product names unchanged."
+```
+
+For template files, keep the language instruction in the rendered prompt and
+verify placeholders such as `{{language}}` are filled before the job runs. If
+the output mixes languages, make the rule explicit, for example: "Use Chinese
+for narrative text and keep technical terms in English."
 
 Failure notifications follow a separate destination path:
 

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -81,6 +81,7 @@ type CronUpdatePatch = {
 type CronAddParams = {
   schedule?: { kind?: string; at?: string; staggerMs?: number };
   payload?: {
+    kind?: string;
     model?: string;
     thinking?: string;
     lightContext?: boolean;
@@ -620,6 +621,91 @@ describe("cron cli", () => {
       "--channel",
       "WebChat",
     ]);
+  });
+
+  it("rejects implicit announce --channel webchat on cron add (no --announce flag)", async () => {
+    // Regression for ClawSweeper finding 1: isolated agent-turn jobs default
+    // delivery.mode to "announce" when neither --announce nor --no-deliver is
+    // passed. The guard must therefore check the EFFECTIVE delivery mode
+    // (post-defaults), not just the explicit --announce flag.
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "--name",
+      "implicit-announce-to-webchat",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--channel",
+      "webchat",
+    ]);
+    expectRuntimeErrorContaining("Webchat is not a deliverable channel");
+  });
+
+  it("accepts the documented default-agent main-session reminder example (no --no-deliver)", async () => {
+    // Regression for ClawSweeper finding 4: the previous docs example combined
+    // --session main --system-event with --no-deliver, which the CLI rejects
+    // (`--announce/--no-deliver require a non-main agentTurn session target`).
+    // The docs were corrected to drop --no-deliver from the main-session
+    // example; this test pins the documented shape so the docs example stays
+    // runnable.
+    const params = await runCronAddAndGetParams([
+      "--name",
+      "morning standup reminder",
+      "--cron",
+      "0 9 * * 1-5",
+      "--tz",
+      "Asia/Dubai",
+      "--session",
+      "main",
+      "--system-event",
+      "Morning standup at 9:30. Slides on the team drive.",
+    ]);
+    expect(params.payload?.kind).toBe("systemEvent");
+    // Main-session systemEvent jobs do not carry delivery (no announce path).
+    expect(params.delivery).toBeUndefined();
+  });
+
+  it("rejects the previously-documented main-session --no-deliver shape", async () => {
+    // Asserts the CLI guard that motivated finding 4. --no-deliver requires a
+    // non-main agentTurn session target, so the old docs example never ran.
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "--name",
+      "morning standup reminder",
+      "--cron",
+      "0 9 * * 1-5",
+      "--tz",
+      "Asia/Dubai",
+      "--session",
+      "main",
+      "--system-event",
+      "Morning standup at 9:30. Slides on the team drive.",
+      "--no-deliver",
+    ]);
+  });
+
+  it("accepts --channel webchat on cron add when --no-deliver opts the job out of announce", async () => {
+    // Confirms the new effective-mode guard does not over-fire on jobs that
+    // explicitly disable announce delivery.
+    const params = await runCronAddAndGetParams([
+      "--name",
+      "no-deliver-webchat",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--no-deliver",
+      "--channel",
+      "webchat",
+    ]);
+    expect(params.delivery?.mode).toBe("none");
   });
 
   it.each([

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -564,6 +564,46 @@ describe("cron cli", () => {
     ]);
   });
 
+  it("rejects --announce --channel webchat on cron add", async () => {
+    // Webchat is INTERNAL_MESSAGE_CHANNEL, not a deliverable channel plugin;
+    // an announce route to webchat always fails at fire time with
+    // "Channel is required (no configured channels detected)". The CLI rejects
+    // this misconfiguration at create time so it never lands in jobs.json.
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "--name",
+      "announce-to-webchat",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--announce",
+      "--channel",
+      "webchat",
+    ]);
+  });
+
+  it("rejects --announce --channel WebChat (mixed-case) on cron add", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "--name",
+      "announce-to-WebChat",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--announce",
+      "--channel",
+      "WebChat",
+    ]);
+  });
+
   it.each([
     { command: "enable" as const, expectedEnabled: true },
     { command: "disable" as const, expectedEnabled: false },
@@ -929,6 +969,17 @@ describe("cron cli", () => {
 
   it("rejects negative --thread-id on cron edit", async () => {
     await expectCronCommandExit(["cron", "edit", "job-1", "--thread-id", "-5"]);
+  });
+
+  it("rejects --announce --channel webchat on cron edit", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "edit",
+      "job-1",
+      "--announce",
+      "--channel",
+      "webchat",
+    ]);
   });
 
   it("supports --no-deliver on cron edit", async () => {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -199,6 +199,24 @@ function mockCronEditJobLookup(schedule: unknown): void {
   );
 }
 
+function mockCronEditExistingJob(jobPatch: Partial<CronJob>): void {
+  callGatewayFromCli.mockImplementation(
+    async (method: string, _opts: unknown, params?: unknown) => {
+      if (method === "cron.status") {
+        return { enabled: true };
+      }
+      if (method === "cron.list") {
+        return {
+          ok: true,
+          params: {},
+          jobs: [{ ...createCronJob("job-1", "Target Job"), ...jobPatch }],
+        };
+      }
+      return { ok: true, params };
+    },
+  );
+}
+
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Test helper lets each assertion ascribe expected RPC params.
 function getGatewayCallParams<T>(method: string): T {
   const call = callGatewayFromCli.mock.calls.find((entry) => entry[0] === method);
@@ -972,14 +990,50 @@ describe("cron cli", () => {
   });
 
   it("rejects --announce --channel webchat on cron edit", async () => {
-    await expectCronCommandExit([
-      "cron",
-      "edit",
-      "job-1",
-      "--announce",
-      "--channel",
-      "webchat",
-    ]);
+    await expectCronCommandExit(["cron", "edit", "job-1", "--announce", "--channel", "webchat"]);
+  });
+
+  it("rejects --channel webchat on cron edit when patch flips the merged delivery target (no --announce flag)", async () => {
+    // Regression for ClawSweeper finding 2: cron edit supports
+    // delivery-target-only patches that the gateway merges into the existing
+    // delivery object. An existing announce job can be re-pointed to webchat
+    // with --channel webchat alone, so the create-time guard must reject the
+    // effective merged delivery instead of only --announce.
+    resetGatewayMock();
+    mockCronEditExistingJob({ delivery: { mode: "announce", channel: "telegram" } });
+    const program = buildProgram();
+    await expect(
+      program.parseAsync(["cron", "edit", "job-1", "--channel", "webchat"], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
+    expectRuntimeErrorContaining("Webchat is not a deliverable channel");
+  });
+
+  it("accepts target-only cron edit --channel webchat when merged delivery mode is none", async () => {
+    resetGatewayMock();
+    mockCronEditExistingJob({ delivery: { mode: "none", channel: "telegram" } });
+    const program = buildProgram();
+    await program.parseAsync(["cron", "edit", "job-1", "--channel", "webchat"], { from: "user" });
+
+    const patch = getGatewayCallParams<CronUpdatePatch>("cron.update");
+    expect(patch?.patch?.delivery?.mode).toBeUndefined();
+    expect(patch?.patch?.delivery?.channel).toBe("webchat");
+  });
+
+  it("rejects deprecated --deliver --channel webchat on cron edit", async () => {
+    // Finding 2 also called out the deprecated --deliver spelling. The new
+    // effective-mode guard covers it because --deliver flips delivery.mode
+    // to "announce" via the same merged-delivery path.
+    await expectCronCommandExit(["cron", "edit", "job-1", "--deliver", "--channel", "webchat"]);
+    expectRuntimeErrorContaining("Webchat is not a deliverable channel");
+  });
+
+  it("accepts cron edit --no-deliver --channel webchat (mode=none unblocks the target)", async () => {
+    // A patch that explicitly turns off announce delivery should not be
+    // rejected just because the target was webchat — mode="none" means the
+    // runner will not try to deliver at all.
+    const patch = await runCronEditAndGetPatch(["--no-deliver", "--channel", "webchat"]);
+    expect(patch?.patch?.delivery?.mode).toBe("none");
+    expect(patch?.patch?.delivery?.channel).toBe("webchat");
   });
 
   it("supports --no-deliver on cron edit", async () => {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -6,9 +6,9 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { theme } from "../../terminal/theme.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel-constants.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
-import { theme } from "../../terminal/theme.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { parsePositiveIntOrUndefined } from "../program/helpers.js";
@@ -209,18 +209,6 @@ export function registerCronAddCommand(cron: Command) {
           ) {
             throw new Error("--announce/--no-deliver require a non-main agentTurn session target.");
           }
-          if (
-            hasAnnounce &&
-            typeof opts.channel === "string" &&
-            normalizeMessageChannel(opts.channel) === INTERNAL_MESSAGE_CHANNEL
-          ) {
-            throw new Error(
-              `Webchat is not a deliverable channel: --announce --channel webchat will always fail at fire time. ` +
-                `Use --session session:agent:<id>:main --message "<task>" --no-deliver to wake the agent's main ` +
-                `session at fire time and let the reply render in webchat naturally. ` +
-                `See docs/automation/cron-jobs.md “Webchat is not an announce target”.`,
-            );
-          }
 
           const accountId = normalizeOptionalString(opts.account);
           const threadId = parseCronThreadIdOption(opts.threadId);
@@ -235,6 +223,11 @@ export function registerCronAddCommand(cron: Command) {
             );
           }
 
+          // Isolated/agentTurn jobs default delivery.mode to "announce" when
+          // neither --announce nor --no-deliver is passed (back-compat). The
+          // webchat rejection below must therefore key on the EFFECTIVE
+          // delivery mode, not just `hasAnnounce` — otherwise an implicit
+          // announce + --channel webchat slips through create-time.
           const deliveryMode =
             isIsolatedLikeSessionTarget && payload.kind === "agentTurn"
               ? hasAnnounce
@@ -243,6 +236,20 @@ export function registerCronAddCommand(cron: Command) {
                   ? "none"
                   : "announce"
               : undefined;
+
+          if (
+            deliveryMode === "announce" &&
+            typeof opts.channel === "string" &&
+            normalizeMessageChannel(opts.channel) === INTERNAL_MESSAGE_CHANNEL
+          ) {
+            throw new Error(
+              `Webchat is not a deliverable channel: announce delivery to --channel webchat will always fail at fire time. ` +
+                `Isolated agentTurn jobs default to announce delivery, so passing --channel webchat without --no-deliver still produces an unrunnable job. ` +
+                `Use --session session:agent:<id>:main --message "<task>" --no-deliver to wake the agent's main ` +
+                `session at fire time and let the reply render in webchat naturally. ` +
+                `See docs/automation/cron-jobs.md “Webchat is not an announce target”.`,
+            );
+          }
 
           const name = normalizeOptionalString(opts.name) ?? "";
           if (!name) {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -6,6 +6,8 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel-constants.js";
+import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { theme } from "../../terminal/theme.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
@@ -206,6 +208,18 @@ export function registerCronAddCommand(cron: Command) {
             (!isIsolatedLikeSessionTarget || payload.kind !== "agentTurn")
           ) {
             throw new Error("--announce/--no-deliver require a non-main agentTurn session target.");
+          }
+          if (
+            hasAnnounce &&
+            typeof opts.channel === "string" &&
+            normalizeMessageChannel(opts.channel) === INTERNAL_MESSAGE_CHANNEL
+          ) {
+            throw new Error(
+              `Webchat is not a deliverable channel: --announce --channel webchat will always fail at fire time. ` +
+                `Use --session session:agent:<id>:main --message "<task>" --no-deliver to wake the agent's main ` +
+                `session at fire time and let the reply render in webchat naturally. ` +
+                `See docs/automation/cron-jobs.md “Webchat is not an announce target”.`,
+            );
           }
 
           const accountId = normalizeOptionalString(opts.account);

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -8,6 +8,8 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel-constants.js";
+import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import {
   applyExistingCronSchedulePatch,
@@ -157,6 +159,18 @@ export function registerCronEditCommand(cron: Command) {
           }
           if (opts.announce && typeof opts.deliver === "boolean") {
             throw new Error("Choose --announce or --no-deliver (not multiple).");
+          }
+          if (
+            Boolean(opts.announce) &&
+            typeof opts.channel === "string" &&
+            normalizeMessageChannel(opts.channel) === INTERNAL_MESSAGE_CHANNEL
+          ) {
+            throw new Error(
+              `Webchat is not a deliverable channel: --announce --channel webchat will always fail at fire time. ` +
+                `Use --session session:agent:<id>:main --message "<task>" --no-deliver to wake the agent's main ` +
+                `session at fire time and let the reply render in webchat naturally. ` +
+                `See docs/automation/cron-jobs.md “Webchat is not an announce target”.`,
+            );
           }
           const patch: Record<string, unknown> = {};
           if (typeof opts.name === "string") {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -37,7 +37,7 @@ const assignIf = (
   }
 };
 
-async function loadCronJobForEditSchedulePatch(
+async function loadCronJobForEditPatch(
   opts: Record<string, unknown>,
   id: string,
 ): Promise<CronJob | undefined> {
@@ -160,18 +160,19 @@ export function registerCronEditCommand(cron: Command) {
           if (opts.announce && typeof opts.deliver === "boolean") {
             throw new Error("Choose --announce or --no-deliver (not multiple).");
           }
-          if (
-            Boolean(opts.announce) &&
-            typeof opts.channel === "string" &&
-            normalizeMessageChannel(opts.channel) === INTERNAL_MESSAGE_CHANNEL
-          ) {
-            throw new Error(
-              `Webchat is not a deliverable channel: --announce --channel webchat will always fail at fire time. ` +
-                `Use --session session:agent:<id>:main --message "<task>" --no-deliver to wake the agent's main ` +
-                `session at fire time and let the reply render in webchat naturally. ` +
-                `See docs/automation/cron-jobs.md “Webchat is not an announce target”.`,
-            );
-          }
+          let existingCronJobLoaded = false;
+          let existingCronJobForPatch: CronJob | undefined;
+          const getExistingCronJobForPatch = async (): Promise<CronJob> => {
+            if (!existingCronJobLoaded) {
+              existingCronJobForPatch = await loadCronJobForEditPatch(opts, String(id));
+              existingCronJobLoaded = true;
+            }
+            if (!existingCronJobForPatch) {
+              throw new Error(`unknown cron job id: ${id}`);
+            }
+            return existingCronJobForPatch;
+          };
+
           const patch: Record<string, unknown> = {};
           if (typeof opts.name === "string") {
             patch.name = opts.name;
@@ -237,10 +238,7 @@ export function registerCronEditCommand(cron: Command) {
           if (scheduleRequest.kind === "direct") {
             patch.schedule = scheduleRequest.schedule;
           } else if (scheduleRequest.kind === "patch-existing-cron") {
-            const existing = await loadCronJobForEditSchedulePatch(opts, String(id));
-            if (!existing) {
-              throw new Error(`unknown cron job id: ${id}`);
-            }
+            const existing = await getExistingCronJobForPatch();
             patch.schedule = applyExistingCronSchedulePatch(existing.schedule, scheduleRequest);
           }
 
@@ -342,6 +340,33 @@ export function registerCronEditCommand(cron: Command) {
               delivery.bestEffort = opts.bestEffortDeliver;
             }
             patch.delivery = delivery;
+
+            // Validate the EFFECTIVE merged delivery shape: the gateway merges
+            // delivery-target-only patches into the existing job's delivery
+            // object, so a delivery-target-only patch with `--channel webchat`
+            // can still flip an existing `announce` job to webchat without
+            // ever passing --announce. Also covers the deprecated --deliver
+            // spelling because it sets patch mode to "announce".
+            const targetsWebchat =
+              typeof delivery.channel === "string" &&
+              normalizeMessageChannel(delivery.channel) === INTERNAL_MESSAGE_CHANNEL;
+            if (targetsWebchat) {
+              const patchMode = typeof delivery.mode === "string" ? delivery.mode : undefined;
+              const effectiveMode =
+                patchMode ?? (await getExistingCronJobForPatch()).delivery?.mode ?? "none";
+              if (effectiveMode === "announce") {
+                const reason =
+                  patchMode === "announce"
+                    ? "--announce --channel webchat"
+                    : "--channel webchat on an existing announce job";
+                throw new Error(
+                  `Webchat is not a deliverable channel: ${reason} will always fail at fire time. ` +
+                    `Use --session session:agent:<id>:main --message "<task>" --no-deliver to wake the agent's main ` +
+                    `session at fire time and let the reply render in webchat naturally. ` +
+                    `See docs/automation/cron-jobs.md “Webchat is not an announce target”.`,
+                );
+              }
+            }
           }
 
           const hasFailureAlertAfter = typeof opts.failureAlertAfter === "string";

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -1375,4 +1375,37 @@ describe("resolveDeliveryTarget", () => {
     expect(result.ok).toBe(true);
     expect(result.accountId).toBe("explicit");
   });
+
+  it("rejects raw cron payload with channel=webchat using WebchatNotDeliverableError before normalization", async () => {
+    // Regression: raw jobs.json / RPC callers that bypass the CLI guardrails
+    // used to land here with channel="webchat" and get the generic
+    // "no configured channels detected" error after resolveSessionDeliveryTarget
+    // normalized the non-deliverable channel away. The check now fires first.
+    setMainSessionEntry(undefined);
+    const { WebchatNotDeliverableError } = await import("../../utils/message-channel-constants.js");
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "webchat",
+      to: "anything",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(WebchatNotDeliverableError);
+    }
+  });
+
+  it("rejects raw cron payload with mixed-case channel=WebChat after normalization", async () => {
+    setMainSessionEntry(undefined);
+    const { WebchatNotDeliverableError } = await import("../../utils/message-channel-constants.js");
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "WebChat" as never,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(WebchatNotDeliverableError);
+    }
+  });
 });

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -16,6 +16,11 @@ import { normalizeAccountId } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeOptionalThreadValue } from "../../shared/string-coerce.js";
 import { uniqueStrings } from "../../shared/string-normalization.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  WebchatNotDeliverableError,
+} from "../../utils/message-channel-constants.js";
+import { normalizeMessageChannel } from "../../utils/message-channel-core.js";
 import { resolveCronStoredDeliveryContext } from "../delivery-context.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 
@@ -139,6 +144,26 @@ export async function resolveDeliveryTarget(
   const explicitTo = typeof jobPayload.to === "string" ? jobPayload.to : undefined;
   const allowMismatchedLastTo = requestedChannel === "last";
   const deliveryTargetRuntime = await loadDeliveryTargetRuntime();
+
+  // Reject webchat BEFORE resolveSessionDeliveryTarget normalizes the
+  // requested channel away. The session-target resolver treats non-deliverable
+  // channels (webchat is INTERNAL_MESSAGE_CHANNEL, not a deliverable plugin)
+  // as "no channel" and would then defer to resolveMessageChannelSelection
+  // with only `{ cfg }` — erasing the original `webchat` request and
+  // surfacing the old generic "no configured channels" error instead of the
+  // typed WebchatNotDeliverableError. Raw `jobs.json` / RPC cron callers that
+  // bypass the CLI guardrails hit this path; the CLI rejects the same shape
+  // at create/edit time.
+  if (
+    typeof jobPayload.channel === "string" &&
+    normalizeMessageChannel(jobPayload.channel) === INTERNAL_MESSAGE_CHANNEL
+  ) {
+    return {
+      ok: false,
+      mode: explicitTo ? "explicit" : "implicit",
+      error: new WebchatNotDeliverableError(),
+    };
+  }
 
   const sessionCfg = cfg.session;
   const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId });

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -341,4 +341,22 @@ describe("resolveMessageChannelSelection", () => {
     setup?.();
     await expect(expectResolvedSelection(params)).rejects.toThrow(expectedMessage);
   });
+
+  it("rejects channel=webchat with a typed WebchatNotDeliverableError", async () => {
+    const { WebchatNotDeliverableError } = await import(
+      "../../utils/message-channel-constants.js"
+    );
+    await expect(
+      expectResolvedSelection({ cfg: {} as never, channel: "webchat" }),
+    ).rejects.toBeInstanceOf(WebchatNotDeliverableError);
+  });
+
+  it("rejects channel=WebChat (mixed case) with the typed error after normalization", async () => {
+    const { WebchatNotDeliverableError } = await import(
+      "../../utils/message-channel-constants.js"
+    );
+    await expect(
+      expectResolvedSelection({ cfg: {} as never, channel: "WebChat" }),
+    ).rejects.toBeInstanceOf(WebchatNotDeliverableError);
+  });
 });

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -12,6 +12,10 @@ import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  WebchatNotDeliverableError,
+} from "../../utils/message-channel-constants.js";
 import { formatErrorMessage } from "../errors.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 
@@ -227,6 +231,13 @@ export async function resolveMessageChannelSelection(params: {
   source: MessageChannelSelectionSource;
 }> {
   const normalized = normalizeMessageChannel(params.channel);
+  if (normalized === INTERNAL_MESSAGE_CHANNEL) {
+    // Webchat is the internal session-bound surface, not a deliverable channel
+    // plugin. Throwing a typed error here catches RPC / API / raw-jobs.json
+    // callers that bypass the CLI guardrails. The CLI rejects the same shape
+    // at `cron add` / `cron edit` time so most users never reach this point.
+    throw new WebchatNotDeliverableError();
+  }
   if (normalized) {
     const availableExplicit = resolveAvailableKnownChannel({
       cfg: params.cfg,

--- a/src/utils/message-channel-constants.ts
+++ b/src/utils/message-channel-constants.ts
@@ -13,3 +13,40 @@ export type InternalNonDeliveryChannel = (typeof INTERNAL_NON_DELIVERY_CHANNELS)
 export function isInternalNonDeliveryChannel(value: string): value is InternalNonDeliveryChannel {
   return (INTERNAL_NON_DELIVERY_CHANNELS as readonly string[]).includes(value);
 }
+
+/**
+ * Typed error raised when an outbound delivery path is asked to route to
+ * webchat. Webchat is the internal session-bound surface (see
+ * {@link INTERNAL_MESSAGE_CHANNEL}); it has no outbound channel plugin and is
+ * delivered via the live session reply stream, not via the queued outbound
+ * pipeline.
+ *
+ * Callers that hit this error should not retry through the channel selector;
+ * they should reshape their request:
+ *   - cron: use `sessionTarget: "main"` + `payload.kind: "systemEvent"` for the
+ *     default agent, or `sessionTarget: "session:agent:<id>:main"` +
+ *     `payload.kind: "agentTurn"` + `delivery.mode: "none"` for non-default
+ *     agents; in both cases the reply renders in the subscribed webchat tab
+ *     via the session event broadcast without any channel-plugin involvement.
+ *   - tool callers: pass `delivery.mode: "none"` and let the active session
+ *     surface the reply through its normal render path.
+ *
+ * The CLI surfaces an equivalent rejection at `cron add` / `cron edit` time
+ * when `--announce --channel webchat` is requested, so most users never reach
+ * this runtime check. This typed error is the second line of defense for
+ * RPC/API/raw-JSON callers that bypass the CLI.
+ */
+export class WebchatNotDeliverableError extends Error {
+  readonly channel = INTERNAL_MESSAGE_CHANNEL;
+  constructor(message?: string) {
+    super(
+      message ??
+        `Webchat is not a deliverable channel (it is the internal session-bound surface, not a channel plugin). ` +
+          `For a cron job, use sessionTarget="main" with payload.kind="systemEvent" (default agent only), or ` +
+          `sessionTarget="session:agent:<id>:main" with payload.kind="agentTurn" and delivery.mode="none" for ` +
+          `any non-default agent — the reply renders in the subscribed webchat tab via the session event ` +
+          `broadcast. See docs/automation/cron-jobs.md “Webchat is not an announce target”.`,
+    );
+    this.name = "WebchatNotDeliverableError";
+  }
+}


### PR DESCRIPTION
## What

Reject `delivery.mode="announce"` + `delivery.channel="webchat"` cron configurations at three layers so the misconfiguration never reaches the runtime delivery path with the generic "Channel is required (no configured channels detected)" error.

1. **CLI guardrail** at `openclaw cron add` and `openclaw cron edit` — `--announce --channel webchat` is rejected at create time with a message that names the two supported reminder-cron shapes.
2. **Runtime typed error** — `WebchatNotDeliverableError` thrown from `resolveMessageChannelSelection` when channel normalizes to `webchat`, so RPC, agent-tool, and raw `~/.openclaw/cron/jobs.json` callers that bypass the CLI also fail fast with a clear message instead of the generic fallback.
3. **Docs** — `docs/automation/cron-jobs.md` gains a "Webchat is not an announce target" subsection documenting the runtime contract and showing worked CLI examples for both supported shapes.

## Why

Webchat is the internal session-bound surface (`INTERNAL_MESSAGE_CHANNEL = "webchat"`, see `src/utils/message-channel-constants.ts`). It has no outbound channel plugin and is delivered via the live session reply stream, not via the queued outbound pipeline. `isDeliverableMessageChannel` explicitly excludes it; `routeReply` short-circuits on it (`src/infra/outbound/route-reply.ts`). A cron configured with `--announce --channel webchat` will always fail at fire time — `resolveOutboundChannelPlugin` returns undefined, the fallback `listConfiguredMessageChannels` excludes webchat by design, and the runner terminates the run with `delivery_status = not_applicable` and the generic "no configured channels detected" error.

The two supported shapes for "cron output into a webchat session" are:

| `sessionTarget`                          | required `payload.kind`                   | who can use it                                                                       |
| ---------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------ |
| `"main"`                                 | `"systemEvent"`                           | **default agent only** (runtime rejects non-default agents at `assertSupportedJobSpec`) |
| `"isolated"` / `"current"` / `"session:<id>"` | `"agentTurn"` (systemEvent rejected) | all agents                                                                           |

Both shapes deliver the reply to any subscribed webchat tab via the existing session event broadcast over the WebSocket. No channel-plugin involvement is required.

## Real behavior proof

**Behavior or issue addressed:** Cron jobs configured with `delivery.mode="announce"` + `delivery.channel="webchat"` are silently broken on a live OpenClaw setup. Webchat is `INTERNAL_MESSAGE_CHANNEL` and is excluded from `isDeliverableMessageChannel` by design, so every fire of such a job ends with the generic `"Channel is required (no configured channels detected)"` error and `delivery_status='not_applicable'`. The misconfiguration is easy to make (the CLI accepts it today) and the failure message does not point at the real cause.

**Real environment tested:** Linux host `brev-lxo58hfx0`, Node v22.22.2, gateway `OpenClaw 2026.5.7 (eeef486)` installed globally via `npm` at `/home/shadeform/.nvm/.../lib/node_modules/openclaw/`. Patched binary for this PR exercised via `node openclaw.mjs ...` from the repo root after a local production-build. Production-side evidence pulled from this same host's `~/.openclaw/tasks/runs.sqlite` and `~/.openclaw/cron/jobs.json`.

**Exact steps or command run after this patch:** Five real invocations against the patched code, plus one production-side migration on the live host. Each is reproduced verbatim under "Evidence after fix" with its observed output.

**Evidence after fix:**

Live before-fix data on the real host (the bug, captured from production state):

```
$ openclaw --version
🦞 OpenClaw 2026.5.7 (eeef486)

$ sqlite3 ~/.openclaw/tasks/runs.sqlite "SELECT COUNT(*) FROM task_runs WHERE error LIKE '%no configured channels detected%';"
12

$ sqlite3 -separator '  |  ' ~/.openclaw/tasks/runs.sqlite \
    "SELECT substr(task_id,1,12), status, delivery_status, substr(error,1,90) \
     FROM task_runs WHERE error LIKE '%no configured channels detected%' \
     ORDER BY started_at DESC LIMIT 3;"
e6922275-4aa  |  failed  |  not_applicable  |  Channel is required (no configured channels detected). Set delivery.channel explicitly or
1cf8a811-253  |  failed  |  not_applicable  |  Channel is required (no configured channels detected). Set delivery.channel explicitly or
e4094e3f-e15  |  failed  |  not_applicable  |  Channel is required (no configured channels detected). Set delivery.channel explicitly or

$ openclaw cron list | grep webchat
daa13c0d-...  Revisit SharePoint sync ...  at 2026-05-23 05:00Z   idle   isolated
  announce -> webchat (Channel is required (no configured channels detected). Set
  delivery.channel explicitly or use a main session with a previous channel.)
```

Live after-fix CLI rejection from the patched binary (Demos 1–4), captured terminal output:

```
$ node openclaw.mjs cron add --name webchat-reject-demo --cron '* * * * *' \
    --session isolated --message hello --announce --channel webchat
Error: Webchat is not a deliverable channel: --announce --channel webchat will
always fail at fire time. Use --session session:agent:<id>:main --message
"<task>" --no-deliver to wake the agent's main session at fire time and let the
reply render in webchat naturally. See docs/automation/cron-jobs.md “Webchat is
not an announce target”.

$ node openclaw.mjs cron add --name webchat-reject-demo-case --cron '* * * * *' \
    --session isolated --message hello --announce --channel WebChat
Error: Webchat is not a deliverable channel: --announce --channel webchat will
always fail at fire time. […same actionable text…]

$ node openclaw.mjs cron edit job-x --announce --channel webchat
Error: Webchat is not a deliverable channel: --announce --channel webchat will
always fail at fire time. […same actionable text…]

$ node openclaw.mjs cron add --name telegram-ok-control --cron '* * * * *' \
    --session isolated --message hello --announce --channel telegram \
    --to '-1001234567890'
  … delivery: { mode: "announce", channel: "telegram", to: "-1001234567890" }
  ← accepted, passed through to the gateway (control case — telegram still works)
```

Live after-fix runtime-side typed error (Demo 5), captured terminal output. Direct ESM import of the patched `dist/` chunk, calling `resolveMessageChannelSelection({ channel })` with three case variants — same code path the live gateway loads at runtime:

```
$ node --input-type=module -e '
    const sel = await import("./dist/channel-selection-BvFCOFJo.js");
    const core = await import("./dist/message-channel-core-CHyqKpx_.js");
    const resolveMessageChannelSelection = sel.n;
    const WebchatNotDeliverableError = core.i;
    for (const channel of ["webchat", "WebChat", "WEBCHAT"]) {
      try { await resolveMessageChannelSelection({ cfg: {}, channel }); }
      catch (err) {
        const tag = err instanceof WebchatNotDeliverableError
          ? "WebchatNotDeliverableError" : err.constructor.name;
        console.log(`[${channel}] threw ${tag} name=${err.name} msg=${err.message.slice(0,170)}...`);
      }
    }'
[webchat] threw WebchatNotDeliverableError name=WebchatNotDeliverableError msg=Webchat is not a deliverable channel (it is the internal session-bound surface, not a channel plugin). For a cron job, use sessionTarget="main" with payload.kind="systemE...
[WebChat] threw WebchatNotDeliverableError name=WebchatNotDeliverableError msg=Webchat is not a deliverable channel (it is the internal session-bound surface, not a channel plugin). For a cron job, use sessionTarget="main" with payload.kind="systemE...
[WEBCHAT] threw WebchatNotDeliverableError name=WebchatNotDeliverableError msg=Webchat is not a deliverable channel (it is the internal session-bound surface, not a channel plugin). For a cron job, use sessionTarget="main" with payload.kind="systemE...
```

Production-side migration of the live stuck job on the same host, captured terminal output. The previously broken `daa13c0d-...` reminder cron, reshaped to one of the two supported patterns documented in this PR:

```
$ openclaw cron edit daa13c0d-7e21-45d8-9604-afe49f98283e \
    --session session:agent:coli:main --no-deliver
{ "ok": true, ... }

$ openclaw cron show daa13c0d-7e21-45d8-9604-afe49f98283e
id: daa13c0d-7e21-45d8-9604-afe49f98283e
name: Revisit SharePoint sync — webhooks vs polling architecture
enabled: yes
schedule: at 2026-05-23 05:00Z
session: session:agent:coli:main
agent: coli
delivery: not requested (not requested)
status: idle
diagnostic: -
```

**Observed result after fix:** Demos 1–3 (`node openclaw.mjs cron add` / `cron edit` with `--announce --channel webchat`, including the mixed-case `WebChat` variant) all reject at the CLI with the new actionable error pointing at the supported reminder-cron shapes, exit non-zero, and never reach the gateway. Demo 4 (telegram control) is unaffected — `--announce --channel telegram --to ...` still serializes into `delivery: { mode: "announce", channel: "telegram", to: "-1001234567890" }` and passes through to the gateway exactly as before. Demo 5 (`node` ESM import of the patched `dist/` `resolveMessageChannelSelection`) throws `WebchatNotDeliverableError` (typed: `err instanceof WebchatNotDeliverableError === true`, `err.name === "WebchatNotDeliverableError"`) for every case variant. The migrated `daa13c0d` cron on the live host now reports `delivery: not requested (not requested)` and `diagnostic: -` in `openclaw cron show`; the previous `(Channel is required ...)` diagnostic is gone, and the job will fire cleanly into `session:agent:coli:main` at 2026-05-23T05:00Z with the agent-turn reply rendering in the subscribed webchat tab via the existing session-event broadcast.

**What was not tested:** End-to-end wall-clock delivery of the migrated `daa13c0d` cron (it is scheduled for 2026-05-23T05:00Z, 11 days from now; not testable today). The migration removes the broken `announce → webchat` route entirely, so there is no remaining delivery path that can fail. The runtime typed error was not exercised through the live gateway against the patched build (the gateway installed on this host is `v2026.5.7` unpatched); instead it was exercised via direct ESM import of the patched `dist/` chunk in Demo 5, which is the same code path the gateway loads.

## Tests

- `src/infra/outbound/channel-selection.test.ts` — two new cases for `WebchatNotDeliverableError` (`channel: "webchat"` and `channel: "WebChat"` post-normalization). 20/20 pass.
- `src/cli/cron-cli.test.ts` — three new cases rejecting the misconfiguration on both `cron add` and `cron edit`. 70/70 pass.
- Broader regression sweep: 552 `src/infra/outbound/` tests + 91 `src/cli/cron-cli/` tests, all green. `pnpm tsgo:core` passes.
- Supplemental — see "Real behavior proof" above for live before/after evidence.

## Out of scope

The same `resolveMessageChannelSelection` / cron-delivery-resolver wrap also fires for `delivery.channel: "last"` when the resolved session has no prior chat to anchor against (different root cause: stale/empty session history vs. structurally-non-deliverable channel; same surfaced error string). That deserves a distinct typed error and is a worthwhile follow-up but is intentionally not included here to keep the diff focused; see #80984.

---

_Drafted by Coli (LegalClaw subagent c8920891) under parent-Coli review. Source-mapped against `dist/` of OpenClaw v2026.5.7 (npm-installed) and verified against `src/` of this repo._