### PR TITLE
fix(telegram): limit startup getMe fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: keep optional audio decoding dependencies local to the external plugin so the core npm install no longer pulls WhatsApp-only media helpers.
 - Build: skip copied metadata for bundled plugins that are excluded from build entries, preventing update/status rebuilds from advertising missing QQ Bot runtime files. (#80925)
 - Control UI/sessions: nest subagent sessions under their parent session in the session picker dropdown using a visual `└─ ` prefix, making the parent-child relationship clear. Fixes #77628. (#78623) Thanks @chinar-amrutkar.
+- Telegram: limit concurrent startup `getMe` probes across multi-account bots so large Telegram configs do not fan out all account probes at once during gateway startup. Refs #80695. (#80986) Thanks @stainlu.
 - fix(config): reject auto-managed meta.lastTouched\* paths in config set/unset (#80856). Thanks @ai-hpc
 - Auto-reply: surface a visible error when the configured model backend fails and fallback produces no visible reply, while preserving intentional silent turns and side-effect-only deliveries. (#80917) Thanks @dutifulbob.
 - Agents/exec: skip redundant heartbeat wake-ups for subagent session exec completions, preventing spurious LLM invocations on parent sessions. Fixes #66748. (#66749) Thanks @ggzeng.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -293,6 +293,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 - Group sessions are isolated by group ID. Forum topics append `:topic:<threadId>` to keep topics isolated.
 - DM messages can carry `message_thread_id`; OpenClaw preserves the thread ID for replies but keeps DMs on the flat session by default. Configure `channels.telegram.dm.threadReplies: "inbound"`, `channels.telegram.direct.<chatId>.threadReplies: "inbound"`, `requireTopic: true`, or a matching topic config when you intentionally want DM topic session isolation.
 - Long polling uses grammY runner with per-chat/per-thread sequencing. Overall runner sink concurrency uses `agents.defaults.maxConcurrent`.
+- Multi-account startup bounds concurrent Telegram `getMe` probes so large bot fleets do not fan out every account probe at once.
 - Long polling is guarded inside each gateway process so only one active poller can use a bot token at a time. If you still see `getUpdates` 409 conflicts, another OpenClaw gateway, script, or external poller is likely using the same token.
 - Long-polling watchdog restarts trigger after 120 seconds without completed `getUpdates` liveness by default. Increase `channels.telegram.pollingStallThresholdMs` only if your deployment still sees false polling-stall restarts during long-running work. The value is in milliseconds and is allowed from `30000` to `600000`; per-account overrides are supported.
 - Telegram Bot API has no read-receipt support (`sendReadReceipts` does not apply).

--- a/extensions/telegram/src/channel.gateway.test.ts
+++ b/extensions/telegram/src/channel.gateway.test.ts
@@ -9,6 +9,7 @@ import type { TelegramMonitorFn } from "./monitor.types.js";
 import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
 import type { TelegramProbeFn } from "./runtime.types.js";
 import type { TelegramRuntime } from "./runtime.types.js";
+import { resetTelegramStartupProbeLimiterForTests } from "./startup-probe-limiter.js";
 
 const probeTelegram = vi.fn();
 const monitorTelegramProvider = vi.fn();
@@ -61,6 +62,7 @@ function createTelegramConfig(
 function startTelegramAccount(
   accountId = "default",
   telegramOverrides: Record<string, unknown> = {},
+  abortSignal?: AbortSignal,
 ) {
   const cfg = createTelegramConfig(accountId, telegramOverrides);
   const account = telegramPlugin.config.resolveAccount(cfg, accountId);
@@ -71,6 +73,7 @@ function startTelegramAccount(
   const ctx = createStartAccountContext({
     account,
     cfg,
+    ...(abortSignal ? { abortSignal } : {}),
   });
   return {
     ctx,
@@ -100,8 +103,19 @@ function sendMessageOptionsAt(index: number): Record<string, unknown> {
   return options;
 }
 
+async function waitForCondition(check: () => boolean, message: string, attempts = 100) {
+  for (let i = 0; i < attempts; i += 1) {
+    if (check()) {
+      return;
+    }
+    await Promise.resolve();
+  }
+  throw new Error(message);
+}
+
 afterEach(() => {
   clearTelegramRuntime();
+  resetTelegramStartupProbeLimiterForTests();
   probeTelegram.mockReset();
   monitorTelegramProvider.mockReset();
   sendMessageTelegram.mockReset();
@@ -234,6 +248,90 @@ describe("telegramPlugin gateway startup", () => {
       apiRoot: undefined,
       includeWebhookInfo: false,
     });
+  });
+
+  it("limits concurrent startup probes across Telegram accounts", async () => {
+    installTelegramRuntime();
+    const releaseProbe: Array<() => void> = [];
+    let activeProbes = 0;
+    let maxActiveProbes = 0;
+    probeTelegram.mockImplementation(async () => {
+      activeProbes += 1;
+      maxActiveProbes = Math.max(maxActiveProbes, activeProbes);
+      await new Promise<void>((resolve) => {
+        releaseProbe.push(resolve);
+      });
+      activeProbes -= 1;
+      return {
+        ok: true,
+        status: null,
+        error: null,
+        elapsedMs: 12,
+      };
+    });
+    monitorTelegramProvider.mockResolvedValue(undefined);
+
+    const first = startTelegramAccount("alpha");
+    const second = startTelegramAccount("bravo");
+    const third = startTelegramAccount("charlie");
+
+    await waitForCondition(
+      () => probeTelegram.mock.calls.length === 2,
+      "expected two startup probes to begin",
+    );
+    expect(maxActiveProbes).toBe(2);
+    expect(releaseProbe).toHaveLength(2);
+
+    releaseProbe.shift()?.();
+    await waitForCondition(
+      () => probeTelegram.mock.calls.length === 3,
+      "expected queued startup probe to begin after a slot opens",
+    );
+    expect(maxActiveProbes).toBe(2);
+
+    for (const release of releaseProbe.splice(0)) {
+      release();
+    }
+    await Promise.all([first.task, second.task, third.task]);
+    expect(monitorTelegramProvider).toHaveBeenCalledTimes(3);
+  });
+
+  it("abandons a queued startup probe when the account aborts", async () => {
+    installTelegramRuntime();
+    const releaseProbe: Array<() => void> = [];
+    probeTelegram.mockImplementation(
+      async () =>
+        await new Promise((resolve) => {
+          releaseProbe.push(() =>
+            resolve({
+              ok: true,
+              status: null,
+              error: null,
+              elapsedMs: 12,
+            }),
+          );
+        }),
+    );
+    monitorTelegramProvider.mockResolvedValue(undefined);
+
+    const first = startTelegramAccount("alpha");
+    const second = startTelegramAccount("bravo");
+    const abortQueued = new AbortController();
+    const queued = startTelegramAccount("charlie", {}, abortQueued.signal);
+
+    await waitForCondition(
+      () => probeTelegram.mock.calls.length === 2,
+      "expected startup probe slots to fill",
+    );
+    abortQueued.abort();
+    await expect(queued.task).resolves.toBeUndefined();
+
+    for (const release of releaseProbe.splice(0)) {
+      release();
+    }
+    await Promise.all([first.task, second.task]);
+    expect(probeTelegram).toHaveBeenCalledTimes(2);
+    expect(monitorTelegramProvider).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -73,6 +73,7 @@ import {
   formatDuplicateTelegramTokenReason,
   telegramConfigAdapter,
 } from "./shared.js";
+import { withTelegramStartupProbeSlot } from "./startup-probe-limiter.js";
 import { detectTelegramLegacyStateMigrations } from "./state-migrations.js";
 import { collectTelegramStatusIssues } from "./status-issues.js";
 import { parseTelegramTarget } from "./targets.js";
@@ -896,16 +897,18 @@ export const telegramPlugin = createChatChannelPlugin({
         let unauthorizedTokenReason: string | null = null;
         let botInfo: TelegramBotInfo | undefined;
         try {
-          const probe = await resolveTelegramProbe()(
-            token,
-            resolveTelegramStartupProbeTimeoutMs(account.config.timeoutSeconds),
-            {
-              accountId: account.accountId,
-              proxyUrl: account.config.proxy,
-              network: account.config.network,
-              apiRoot: account.config.apiRoot,
-              includeWebhookInfo: false,
-            },
+          const probe = await withTelegramStartupProbeSlot(ctx.abortSignal, () =>
+            resolveTelegramProbe()(
+              token,
+              resolveTelegramStartupProbeTimeoutMs(account.config.timeoutSeconds),
+              {
+                accountId: account.accountId,
+                proxyUrl: account.config.proxy,
+                network: account.config.network,
+                apiRoot: account.config.apiRoot,
+                includeWebhookInfo: false,
+              },
+            ),
           );
           const username = probe.ok ? probe.bot?.username?.trim() : null;
           if (username) {
@@ -916,6 +919,9 @@ export const telegramPlugin = createChatChannelPlugin({
             unauthorizedTokenReason = formatTelegramUnauthorizedTokenError(account);
           }
         } catch (err) {
+          if (ctx.abortSignal.aborted) {
+            return;
+          }
           if (getTelegramRuntime().logging.shouldLogVerbose()) {
             ctx.log?.debug?.(`[${account.accountId}] bot probe failed: ${String(err)}`);
           }

--- a/extensions/telegram/src/startup-probe-limiter.ts
+++ b/extensions/telegram/src/startup-probe-limiter.ts
@@ -1,0 +1,102 @@
+const TELEGRAM_STARTUP_PROBE_CONCURRENCY = 2;
+
+type StartupProbeSlot = () => void;
+
+type StartupProbeWaiter = {
+  resolve: (release: StartupProbeSlot) => void;
+  reject: (error: Error) => void;
+  abortSignal?: AbortSignal;
+  onAbort?: () => void;
+};
+
+let activeStartupProbes = 0;
+const pendingStartupProbeWaiters: StartupProbeWaiter[] = [];
+
+function buildStartupProbeAbortError(): Error {
+  return new Error("telegram startup probe wait aborted");
+}
+
+function detachAbortHandler(waiter: StartupProbeWaiter) {
+  if (!waiter.abortSignal || !waiter.onAbort) {
+    return;
+  }
+  waiter.abortSignal.removeEventListener("abort", waiter.onAbort);
+}
+
+function removePendingWaiter(waiter: StartupProbeWaiter) {
+  const index = pendingStartupProbeWaiters.indexOf(waiter);
+  if (index >= 0) {
+    pendingStartupProbeWaiters.splice(index, 1);
+  }
+}
+
+function releaseStartupProbeSlot() {
+  activeStartupProbes = Math.max(0, activeStartupProbes - 1);
+  drainStartupProbeWaiters();
+}
+
+function drainStartupProbeWaiters() {
+  while (
+    activeStartupProbes < TELEGRAM_STARTUP_PROBE_CONCURRENCY &&
+    pendingStartupProbeWaiters.length > 0
+  ) {
+    const waiter = pendingStartupProbeWaiters.shift();
+    if (!waiter) {
+      return;
+    }
+    detachAbortHandler(waiter);
+    if (waiter.abortSignal?.aborted) {
+      waiter.reject(buildStartupProbeAbortError());
+      continue;
+    }
+    activeStartupProbes += 1;
+    waiter.resolve(releaseStartupProbeSlot);
+  }
+}
+
+async function acquireStartupProbeSlot(abortSignal?: AbortSignal): Promise<StartupProbeSlot> {
+  if (abortSignal?.aborted) {
+    throw buildStartupProbeAbortError();
+  }
+  if (activeStartupProbes < TELEGRAM_STARTUP_PROBE_CONCURRENCY) {
+    activeStartupProbes += 1;
+    return releaseStartupProbeSlot;
+  }
+  return await new Promise<StartupProbeSlot>((resolve, reject) => {
+    const waiter: StartupProbeWaiter = {
+      resolve,
+      reject,
+      ...(abortSignal ? { abortSignal } : {}),
+    };
+    waiter.onAbort = () => {
+      removePendingWaiter(waiter);
+      reject(buildStartupProbeAbortError());
+    };
+    abortSignal?.addEventListener("abort", waiter.onAbort, { once: true });
+    pendingStartupProbeWaiters.push(waiter);
+  });
+}
+
+export async function withTelegramStartupProbeSlot<T>(
+  abortSignal: AbortSignal | undefined,
+  run: () => Promise<T>,
+): Promise<T> {
+  const release = await acquireStartupProbeSlot(abortSignal);
+  try {
+    if (abortSignal?.aborted) {
+      throw buildStartupProbeAbortError();
+    }
+    return await run();
+  } finally {
+    release();
+  }
+}
+
+export function resetTelegramStartupProbeLimiterForTests() {
+  activeStartupProbes = 0;
+  const pending = pendingStartupProbeWaiters.splice(0);
+  for (const waiter of pending) {
+    detachAbortHandler(waiter);
+    waiter.reject(buildStartupProbeAbortError());
+  }
+}


### PR DESCRIPTION
"## Summary\n\n- Problem: multi-account Telegram gateway startup can still fan out several `getMe` probes at once. The generic Gateway startup worker limit only throttles account task handoff; it does not hold a slot while the long-lived Telegram `startAccount` promise performs its startup probe.\n- Why it matters: #80695 reports Windows startup event-loop starvation with many Telegram accounts, including multiple `getMe` timeouts during `channels.telegram.start-account`.\n- What changed: Telegram now limits concurrent startup `getMe` probes to 2 across accounts, releases the slot before entering the long-running monitor, and treats abort while queued as cancellation instead of falling through to monitor startup.\n- What did NOT change: polling sink concurrency, message delivery concurrency, polling lease behavior, and Telegram runtime config shape are unchanged.\n\n## Coordination Note\n\n- This intentionally takes the narrow Telegram-local path. It overlaps with #78437, which changes broader Gateway startup staggering and prewarm ordering and has live Windows multi-bot proof.\n- If maintainers prefer the broader Gateway-level direction from #78437, this PR can stand down or be retargeted. If the narrower owner-local fix is preferred, this PR needs live/redacted multi-account Telegram startup proof before merge.\n\n## Change Type\n\n- [x] Bug fix\n- [ ] Feature\n- [ ] Refactor required for the fix\n- [x] Docs\n- [ ] Security hardening\n- [ ] Chore/infra\n\n## Scope\n\n- [ ] Gateway / orchestration\n- [ ] Skills / tool execution\n- [ ] Auth / tokens\n- [ ] Memory / storage\n- [x] Integrations\n- [ ] API / contracts\n- [ ] UI / DX\n- [ ] CI/CD / infra\n\n## Linked Issue/PR\n\n- Refs #80695\n- Related: #78437\n- [x] This PR fixes a bug or regression\n\n## Real behavior proof\n\n- Behavior addressed: Telegram account startup probes are now bounded even when several accounts start together.\n- Real environment tested: local OpenClaw checkout on macOS, running the actual Telegram channel gateway startup handler with OpenClaw's channel test context and a controlled Telegram runtime.\n- Exact steps or command run after this patch:\n\n```text\nenv OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm --config.manage-package-manager-versions=false test extensions/telegram/src/channel.gateway.test.ts src/gateway/server-channels.test.ts\n```\n\n- Evidence after fix:\n\n```text\nTest Files  1 passed (1)\nTests  31 passed (31)\n\nTest Files  1 passed (1)\nTests  10 passed (10)\n\n[test] passed 2 Vitest shards in 15.74s\n```\n\n- Observed result after fix: the new Telegram gateway regression launches three accounts concurrently, observes only two `probeTelegram` calls running until one slot releases, then verifies the queued third account starts and all three monitors run. A second regression aborts a queued third account and verifies the queued account exits as cancellation without starting a third probe or monitor.\n- What was not tested: live Windows 8-account Telegram startup with real Bot API credentials. This PR intentionally fixes the deterministic startup probe fanout piece from #80695 and does not claim to close the full transport/outbound cascade umbrella.\n\n## Root Cause\n\n- Root cause: the Gateway's generic account startup concurrency limit bounds account task setup, but Telegram's long-lived `startAccount` work is handed off to a tracked promise immediately. The Telegram `getMe` startup probe runs inside that long-lived promise, so several account probes can still overlap.\n- Missing detection / guardrail: existing Telegram gateway startup tests covered probe timeout, botInfo handoff, and unauthorized-token behavior, but not multi-account probe fanout or abort while queued behind startup work.\n- Contributing context: Telegram `startAccount` performs a visible Bot API control-plane probe before entering the long-running monitor; this is exactly the phase reported timing out in #80695.\n\n## Regression Test Plan\n\n- Coverage level that should have caught this:\n  - [x] Unit test\n  - [x] Seam / integration test\n  - [ ] End-to-end test\n  - [ ] Existing coverage already sufficient\n- Target test or file: `extensions/telegram/src/channel.gateway.test.ts`\n- Scenario the test should lock in: no more than two Telegram startup probes run concurrently across accounts, and an account aborted while queued does not continue into probe or monitor startup.\n- Why this is the smallest reliable guardrail: it exercises the Telegram plugin gateway `startAccount` boundary directly without requiring live Bot API credentials or a full Gateway process.\n- Existing test that already covers this: none.\n\n## User-visible / Behavior Changes\n\nLarge Telegram multi-account configs start account probes in a small bounded pool instead of probing every account at once.\n\n## Security Impact\n\n- New permissions/capabilities? No\n- Secrets/tokens handling changed? No\n- New/changed network calls? No\n- Command/tool execution surface changed? No\n- Data access scope changed? No\n\n## Human Verification\n\n- Verified scenarios: bounded startup probes, queued-start cancellation, existing unauthorized-token startup rejection, startup timeout propagation, botInfo handoff, and Gateway channel manager startup tests.\n- Edge cases checked: queued account abort before slot acquisition; slot release before monitor startup so the long-running monitor does not hold the limiter forever.\n- What you did not verify: live Telegram Bot API startup under the reporter's Windows 8-account setup.\n\n## Validation\n\n- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/channels/telegram.md extensions/telegram/src/channel.ts extensions/telegram/src/channel.gateway.test.ts extensions/telegram/src/startup-probe-limiter.ts`\n- `node scripts/format-docs.mjs --check docs/channels/telegram.md`\n- `git diff --check`\n- `env OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm --config.manage-package-manager-versions=false test extensions/telegram/src/channel.gateway.test.ts src/gateway/server-channels.test.ts`\n- `env OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD=1 pnpm --config.manage-package-manager-versions=false run tsgo:extensions`\n- `env OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD=1 pnpm --config.manage-package-manager-versions=false run tsgo:extensions:test`\n\n## Compatibility / Migration\n\n- Backward compatible? Yes\n- Config/env changes? No\n- Migration needed? No\n"
