### PR TITLE
fix(telegram): eliminate event-loop saturation from polling restart bursts

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -30,6 +30,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 }));
 
 let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;
+let __resetTelegramBotSetupSemaphoreForTests: (typeof import("./polling-session.js"))["__resetTelegramBotSetupSemaphoreForTests"];
 
 type TelegramApiMiddleware = (
   prev: (...args: unknown[]) => Promise<unknown>,
@@ -260,7 +261,9 @@ async function waitForApiMiddleware(
 
 describe("TelegramPollingSession", () => {
   beforeAll(async () => {
-    ({ TelegramPollingSession } = await import("./polling-session.js"));
+    ({ TelegramPollingSession, __resetTelegramBotSetupSemaphoreForTests } = await import(
+      "./polling-session.js"
+    ));
   });
 
   beforeEach(() => {
@@ -269,6 +272,10 @@ describe("TelegramPollingSession", () => {
     isRecoverableTelegramNetworkErrorMock.mockReset().mockReturnValue(true);
     computeBackoffMock.mockReset().mockReturnValue(0);
     sleepWithAbortMock.mockReset().mockResolvedValue(undefined);
+    // The setup semaphore is module-level state shared with other test cases.
+    // Reset between cases so a leak from one test (e.g. an unfinished await)
+    // does not starve the next case of slots.
+    __resetTelegramBotSetupSemaphoreForTests();
   });
 
   it("uses backoff helpers for recoverable polling retries", async () => {
@@ -1134,5 +1141,77 @@ describe("TelegramPollingSession", () => {
     // dispose() closes transport2 since it becomes the held transport after the rebuild.
     expect(transport1.close).toHaveBeenCalled();
     expect(transport2.close).toHaveBeenCalled();
+  });
+
+  it("waits for the prior cycle teardown before starting the next bot setup", async () => {
+    // Reproducer for the 409 tight-loop fix: when a polling cycle errors out
+    // (recoverable network error here), the next createTelegramBot call must
+    // not start until the prior runner.stop()/bot.stop() have settled.
+    const abort = new AbortController();
+    const recoverableError = new Error("recoverable polling error");
+    let stopRelease: (() => void) | undefined;
+    const stopPromise = new Promise<void>((resolve) => {
+      stopRelease = resolve;
+    });
+    const runnerStop = vi.fn(async () => {
+      await stopPromise;
+    });
+    const botStop = vi.fn(async () => undefined);
+
+    let cycle = 0;
+    createTelegramBotMock.mockImplementation(() => ({
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        getUpdates: vi.fn(async () => []),
+        config: { use: vi.fn() },
+      },
+      stop: botStop,
+    }));
+    runMock.mockImplementation(() => {
+      cycle += 1;
+      if (cycle === 1) {
+        return {
+          task: async () => {
+            throw recoverableError;
+          },
+          stop: runnerStop,
+          isRunning: () => false,
+        };
+      }
+      return {
+        task: async () => {
+          abort.abort();
+        },
+        stop: vi.fn(async () => undefined),
+        isRunning: () => false,
+      };
+    });
+
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log: () => undefined,
+      telegramTransport: undefined,
+    });
+
+    const runPromise = session.runUntilAbort();
+    for (let i = 0; i < 50; i += 1) {
+      await Promise.resolve();
+    }
+    // First cycle is in flight; runner stop is blocked, so createTelegramBot
+    // should only have been called once. The second call must wait on the
+    // stoppingCycle teardown.
+    expect(createTelegramBotMock).toHaveBeenCalledTimes(1);
+
+    stopRelease?.();
+    await runPromise;
+    expect(createTelegramBotMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -158,6 +158,12 @@ export class TelegramPollingSession {
   #transportState: TelegramPollingTransportState;
   #status: ReturnType<typeof createTelegramPollingStatusPublisher>;
   #stallThresholdMs: number;
+  // Tracks the in-flight runner+bot teardown so we cannot start a new
+  // `#createPollingBot` cycle until the previous transport is closed and the
+  // runner promise has settled. Without this, a 409-conflict path can re-enter
+  // `#createPollingBot` while the old keep-alive socket is still being held
+  // open by Telegram, producing the tight 409 retry loop seen in #69787.
+  #stoppingCycle: Promise<void> | undefined;
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {
     this.#transportState = new TelegramPollingTransportState({
@@ -245,6 +251,21 @@ export class TelegramPollingSession {
   }
 
   async #createPollingBot(): Promise<TelegramBot | undefined> {
+    // Wait for the prior runner+bot to finish settling before we attempt to
+    // spin up a new bot. Otherwise a 409-conflict tight loop can re-enter
+    // this method while Telegram still treats the previous keep-alive socket
+    // as the live session, immediately returning 409 again. (#69787)
+    if (this.#stoppingCycle) {
+      try {
+        await this.#stoppingCycle;
+      } catch {
+        // Stopping errors are already logged at their source; never block
+        // restart attempts on cleanup failure.
+      }
+    }
+    if (this.opts.abortSignal?.aborted) {
+      return undefined;
+    }
     // Per-process TLS handshake throttle. createTelegramBot performs the
     // getMe handshake to api.telegram.org synchronously; uncapped fleet
     // restarts produce 7s+ event-loop freezes (see freeze dumps 2026-05-12).
@@ -469,11 +490,25 @@ export class TelegramPollingSession {
       }
       this.opts.abortSignal?.removeEventListener("abort", abortFetch);
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
-      await waitForGracefulStop(stopRunner);
-      await waitForGracefulStop(stopBot);
-      this.#activeRunner = undefined;
-      if (this.#activeFetchAbort === fetchAbortController) {
-        this.#activeFetchAbort = undefined;
+      // Capture the teardown as a single promise so the next #createPollingBot
+      // can await it. Refusing to start a new bot until the prior runner has
+      // settled prevents the 409 conflict tight loop where the new session is
+      // requested before Telegram has released the previous one. (#69787)
+      const teardown = (async () => {
+        await waitForGracefulStop(stopRunner);
+        await waitForGracefulStop(stopBot);
+      })();
+      this.#stoppingCycle = teardown;
+      try {
+        await teardown;
+      } finally {
+        if (this.#stoppingCycle === teardown) {
+          this.#stoppingCycle = undefined;
+        }
+        this.#activeRunner = undefined;
+        if (this.#activeFetchAbort === fetchAbortController) {
+          this.#activeFetchAbort = undefined;
+        }
       }
     }
   }

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -493,10 +493,14 @@ export class TelegramPollingSession {
       // Capture the teardown as a single promise so the next #createPollingBot
       // can await it. Refusing to start a new bot until the prior runner has
       // settled prevents the 409 conflict tight loop where the new session is
-      // requested before Telegram has released the previous one. (#69787)
+      // requested before Telegram has released the previous one. We also close
+      // the dirty undici dispatcher synchronously here so the next cycle does
+      // not race a new TLS handshake against the slow close() of the prior
+      // keep-alive pool. (#69787)
       const teardown = (async () => {
         await waitForGracefulStop(stopRunner);
         await waitForGracefulStop(stopBot);
+        await this.#transportState.disposeIfDirty();
       })();
       this.#stoppingCycle = teardown;
       try {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -32,6 +32,73 @@ const TELEGRAM_POLLING_CLIENT_TIMEOUT_FLOOR_SECONDS = Math.ceil(
   TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS / 1000,
 );
 
+// Per-process limit on simultaneous Telegram bot setup. createTelegramBot()
+// does an HTTPS getMe handshake to api.telegram.org; on fleets with many
+// accounts a restart burst stacks TLS handshakes on the event loop and
+// produces 7s+ event-loop freeze traces (see freeze dumps 2026-05-12). Two
+// concurrent handshakes is enough to keep throughput up without saturating
+// the loop. Inline semaphore — intentionally no new dependency.
+const TELEGRAM_BOT_SETUP_CONCURRENCY = 2;
+
+let telegramBotSetupInFlight = 0;
+const telegramBotSetupWaiters: Array<() => void> = [];
+
+async function acquireTelegramBotSetupSlot(abortSignal?: AbortSignal): Promise<void> {
+  if (telegramBotSetupInFlight < TELEGRAM_BOT_SETUP_CONCURRENCY) {
+    telegramBotSetupInFlight += 1;
+    return;
+  }
+  if (abortSignal?.aborted) {
+    throw new Error("aborted while waiting for telegram bot setup slot");
+  }
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const grant = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (abortSignal) {
+        abortSignal.removeEventListener("abort", onAbort);
+      }
+      // Caller (releaseTelegramBotSetupSlot) hands the slot to us without
+      // decrementing in-flight, so the count stays at the cap.
+      resolve();
+    };
+    const onAbort = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      const idx = telegramBotSetupWaiters.indexOf(grant);
+      if (idx >= 0) {
+        telegramBotSetupWaiters.splice(idx, 1);
+      }
+      reject(new Error("aborted while waiting for telegram bot setup slot"));
+    };
+    telegramBotSetupWaiters.push(grant);
+    if (abortSignal) {
+      abortSignal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
+function releaseTelegramBotSetupSlot(): void {
+  const waiter = telegramBotSetupWaiters.shift();
+  if (waiter) {
+    // Hand the in-flight slot to the next waiter without decrementing.
+    waiter();
+    return;
+  }
+  telegramBotSetupInFlight = Math.max(0, telegramBotSetupInFlight - 1);
+}
+
+/** Test-only: reset the per-process semaphore between test cases. */
+export function __resetTelegramBotSetupSemaphoreForTests(): void {
+  telegramBotSetupInFlight = 0;
+  telegramBotSetupWaiters.length = 0;
+}
+
 type TelegramBot = ReturnType<typeof createTelegramBot>;
 
 const waitForGracefulStop = async (stop: () => Promise<void>) => {
@@ -178,6 +245,16 @@ export class TelegramPollingSession {
   }
 
   async #createPollingBot(): Promise<TelegramBot | undefined> {
+    // Per-process TLS handshake throttle. createTelegramBot performs the
+    // getMe handshake to api.telegram.org synchronously; uncapped fleet
+    // restarts produce 7s+ event-loop freezes (see freeze dumps 2026-05-12).
+    let slotAcquired = false;
+    try {
+      await acquireTelegramBotSetupSlot(this.opts.abortSignal);
+      slotAcquired = true;
+    } catch {
+      return undefined;
+    }
     const fetchAbortController = new AbortController();
     this.#activeFetchAbort = fetchAbortController;
     const telegramTransport = this.#transportState.acquireForNextCycle();
@@ -203,6 +280,10 @@ export class TelegramPollingSession {
         this.#activeFetchAbort = undefined;
       }
       return undefined;
+    } finally {
+      if (slotAcquired) {
+        releaseTelegramBotSetupSlot();
+      }
     }
   }
 

--- a/extensions/telegram/src/polling-transport-state.test.ts
+++ b/extensions/telegram/src/polling-transport-state.test.ts
@@ -141,6 +141,52 @@ describe("TelegramPollingTransportState", () => {
     expect(createTelegramTransport).not.toHaveBeenCalled();
   });
 
+  it("disposeIfDirty() awaits close() and clears the slot when dirty", async () => {
+    const initial = makeMockTransport("initial");
+    const state = new TelegramPollingTransportState({
+      log,
+      initialTransport: initial,
+    });
+
+    state.markDirty();
+    let closeResolved = false;
+    initial.close.mockImplementationOnce(async () => {
+      await Promise.resolve();
+      closeResolved = true;
+    });
+
+    await state.disposeIfDirty();
+
+    expect(initial.close).toHaveBeenCalledTimes(1);
+    expect(closeResolved).toBe(true);
+    expect(anyLogMatches(log, "closed dirty transport at cycle teardown")).toBe(true);
+  });
+
+  it("disposeIfDirty() is a no-op when not dirty", async () => {
+    const initial = makeMockTransport("initial");
+    const state = new TelegramPollingTransportState({
+      log,
+      initialTransport: initial,
+    });
+
+    await state.disposeIfDirty();
+
+    expect(initial.close).not.toHaveBeenCalled();
+  });
+
+  it("disposeIfDirty() swallows close() errors and still clears state", async () => {
+    const initial = makeMockTransport("initial");
+    initial.close.mockRejectedValueOnce(new Error("boom"));
+    const state = new TelegramPollingTransportState({
+      log,
+      initialTransport: initial,
+    });
+    state.markDirty();
+
+    await expect(state.disposeIfDirty()).resolves.toBeUndefined();
+    expect(anyLogMatches(log, "failed to close dirty transport at cycle teardown")).toBe(true);
+  });
+
   it("clears the dirty flag even when no factory is configured", () => {
     const initial = makeMockTransport("initial");
     const state = new TelegramPollingTransportState({

--- a/extensions/telegram/src/polling-transport-state.ts
+++ b/extensions/telegram/src/polling-transport-state.ts
@@ -19,6 +19,34 @@ export class TelegramPollingTransportState {
     this.#transportDirty = true;
   }
 
+  /**
+   * Close the current transport awaitedly if it has been marked dirty. Use at
+   * cycle teardown so the next `acquireForNextCycle()` does not race the slow
+   * undici `client.close()` against a new TLS handshake. Without this, the
+   * stale keep-alive dispatcher can survive a stall+restart and Telegram
+   * keeps returning 409 on the new session. (#69787 + freeze dumps 2026-05-12)
+   */
+  async disposeIfDirty(): Promise<void> {
+    if (this.#disposed || !this.#transportDirty) {
+      return;
+    }
+    const previous = this.#telegramTransport;
+    if (!previous) {
+      this.#transportDirty = false;
+      return;
+    }
+    this.#telegramTransport = undefined;
+    this.#transportDirty = false;
+    try {
+      await previous.close();
+      this.opts.log("[telegram][diag] closed dirty transport at cycle teardown");
+    } catch (err) {
+      this.opts.log(
+        `[telegram][diag] failed to close dirty transport at cycle teardown: ${formatCloseError(err)}`,
+      );
+    }
+  }
+
   acquireForNextCycle(): TelegramTransport | undefined {
     if (this.#disposed) {
       return undefined;

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -42,7 +42,10 @@ vi.mock("../../infra/channel-activity.js", () => ({
   getChannelActivity: mocks.getChannelActivity,
 }));
 
-import { channelsHandlers } from "./channels.js";
+import {
+  __resetChannelStatusProbeCacheForTests,
+  channelsHandlers,
+} from "./channels.js";
 
 function getSuccessPayload(respond: ReturnType<typeof vi.fn>): Record<string, unknown> {
   return requireRespondPayload(respond);
@@ -97,6 +100,10 @@ function requireRespondPayload(respond: ReturnType<typeof vi.fn>): Record<string
 describe("channelsHandlers channels.status", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The probe-result cache is module-level (per-process) so it bleeds across
+    // test cases. Reset it before each case so probe stubs do not return a
+    // memoized result from a prior case.
+    __resetChannelStatusProbeCacheForTests();
     mocks.getRuntimeConfig.mockReturnValue({});
     mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
     mocks.buildChannelUiCatalog.mockReturnValue({

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -393,6 +393,20 @@ export const channelsHandlers: GatewayRequestHandlers = {
     ) => {
       const account = plugin.config.resolveAccount(cfg, accountId);
       const enabled = isAccountEnabled(plugin, account);
+      // Per-invocation memo: `isConfigured` is asked once for the probe path
+      // and again for the audit path within the same channels.status call.
+      // Memoize the promise so both callers share one resolution. Per-call
+      // only — does not bleed across requests.
+      let isConfiguredPromise: Promise<boolean> | undefined;
+      const resolveIsConfigured = (): Promise<boolean> => {
+        if (!plugin.config.isConfigured) {
+          return Promise.resolve(true);
+        }
+        if (!isConfiguredPromise) {
+          isConfiguredPromise = Promise.resolve(plugin.config.isConfigured(account, cfg));
+        }
+        return isConfiguredPromise;
+      };
       let probeResult: unknown;
       let lastProbeAt: number | null = null;
       // Cached probe/audit short-circuit: watchdog + agent-view hit
@@ -409,10 +423,7 @@ export const channelsHandlers: GatewayRequestHandlers = {
         lastProbeAt = cached.lastProbeAt;
       }
       if (!cached && probe && enabled && plugin.status?.probeAccount) {
-        let configured = true;
-        if (plugin.config.isConfigured) {
-          configured = await plugin.config.isConfigured(account, cfg);
-        }
+        const configured = await resolveIsConfigured();
         if (configured) {
           probeResult = await runChannelStatusHook({
             channelId,
@@ -432,10 +443,7 @@ export const channelsHandlers: GatewayRequestHandlers = {
       }
       let auditResult: unknown = auditResultEarly;
       if (!cached && probe && enabled && plugin.status?.auditAccount) {
-        let configured = true;
-        if (plugin.config.isConfigured) {
-          configured = await plugin.config.isConfigured(account, cfg);
-        }
+        const configured = await resolveIsConfigured();
         if (configured) {
           auditResult = await runChannelStatusHook({
             channelId,

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -55,7 +55,47 @@ type ChannelStopPayload = {
 };
 
 const CHANNEL_STATUS_MAX_TIMEOUT_MS = 30_000;
-const CHANNEL_STATUS_PROBE_CONCURRENCY = 5;
+// Each probe issues a fresh TLS handshake (Telegram getMe, etc.); high fan-out
+// stacks handshakes on the event loop and contributes to the 7s+ freeze traces
+// observed against the polling restart bursts. Watchdog + agent-view both call
+// channels.status repeatedly, so a 30s probe-result cache + 2-wide fan-out is
+// the sweet spot for keeping the loop responsive without making status stale.
+const CHANNEL_STATUS_PROBE_CONCURRENCY = 2;
+const CHANNEL_STATUS_PROBE_CACHE_TTL_MS = 30_000;
+
+type ProbeCacheEntry = {
+  ts: number;
+  probe?: unknown;
+  audit?: unknown;
+  lastProbeAt: number | null;
+};
+
+const channelStatusProbeCache = new Map<string, ProbeCacheEntry>();
+
+function probeCacheKey(channelId: string, accountId: string): string {
+  return `${channelId}::${accountId}`;
+}
+
+function getFreshProbeCacheEntry(
+  channelId: string,
+  accountId: string,
+  now: number,
+): ProbeCacheEntry | undefined {
+  const entry = channelStatusProbeCache.get(probeCacheKey(channelId, accountId));
+  if (!entry) {
+    return undefined;
+  }
+  if (now - entry.ts > CHANNEL_STATUS_PROBE_CACHE_TTL_MS) {
+    channelStatusProbeCache.delete(probeCacheKey(channelId, accountId));
+    return undefined;
+  }
+  return entry;
+}
+
+/** Test-only: clear the probe result cache between cases. */
+export function __resetChannelStatusProbeCacheForTests(): void {
+  channelStatusProbeCache.clear();
+}
 
 function channelStatusTimeoutPayload(step: string, timeoutMs: number): Record<string, unknown> {
   return {
@@ -355,7 +395,20 @@ export const channelsHandlers: GatewayRequestHandlers = {
       const enabled = isAccountEnabled(plugin, account);
       let probeResult: unknown;
       let lastProbeAt: number | null = null;
-      if (probe && enabled && plugin.status?.probeAccount) {
+      // Cached probe/audit short-circuit: watchdog + agent-view hit
+      // channels.status every ~30s, so re-fanning TLS probes against
+      // api.telegram.org each time pegs the event loop. Reuse a fresh-enough
+      // probe result here to break that loop.
+      const cacheNow = Date.now();
+      const cached =
+        probe && enabled ? getFreshProbeCacheEntry(channelId, accountId, cacheNow) : undefined;
+      let auditResultEarly: unknown;
+      if (cached) {
+        probeResult = cached.probe;
+        auditResultEarly = cached.audit;
+        lastProbeAt = cached.lastProbeAt;
+      }
+      if (!cached && probe && enabled && plugin.status?.probeAccount) {
         let configured = true;
         if (plugin.config.isConfigured) {
           configured = await plugin.config.isConfigured(account, cfg);
@@ -377,8 +430,8 @@ export const channelsHandlers: GatewayRequestHandlers = {
           lastProbeAt = Date.now();
         }
       }
-      let auditResult: unknown;
-      if (probe && enabled && plugin.status?.auditAccount) {
+      let auditResult: unknown = auditResultEarly;
+      if (!cached && probe && enabled && plugin.status?.auditAccount) {
         let configured = true;
         if (plugin.config.isConfigured) {
           configured = await plugin.config.isConfigured(account, cfg);
@@ -399,6 +452,14 @@ export const channelsHandlers: GatewayRequestHandlers = {
               }),
           });
         }
+      }
+      if (!cached && probe && enabled) {
+        channelStatusProbeCache.set(probeCacheKey(channelId, accountId), {
+          ts: cacheNow,
+          probe: probeResult,
+          audit: auditResult,
+          lastProbeAt,
+        });
       }
       const runtimeSnapshot = resolveRuntimeSnapshot(channelId, accountId, defaultAccountId);
       const snapshot = await buildChannelAccountSnapshot({


### PR DESCRIPTION
## Summary

- **Problem:** Long-running gateways with 4+ Telegram polling accounts hit recurring 7s+ event-loop freezes (180+ freeze dumps in the 36h before 2026-05-12 in one production setup). The freeze pattern is "TLS handshake burst" — a stall or 409 conflict in one polling cycle triggers a restart cascade where multiple accounts simultaneously call `createTelegramBot` (synchronous getMe handshake to api.telegram.org), saturating the loop.
- **Why it matters:** Frozen event loop drops Telegram updates, blocks RPC responses, and triggers watchdog/agent-view to fan out more probe traffic which compounds the freeze. A real production fleet had to split a polling account into a separate gateway process on 2026-05-12 as a workaround.
- **What changed (5 focused commits):**
  1. `extensions/telegram/src/polling-session.ts`: 2-wide per-process semaphore around `createTelegramBot` so restart bursts cannot stack TLS handshakes on the loop.
  2. `extensions/telegram/src/polling-session.ts`: Track an in-flight `#stoppingCycle` so the next `#createPollingBot` cannot start until the prior runner+bot teardown has settled (fixes #69787 409-conflict tight loop).
  3. `extensions/telegram/src/polling-transport-state.ts`: New `disposeIfDirty()` awaited at cycle teardown, closing the dirty undici dispatcher synchronously instead of lazily fire-and-forget on the next `acquireForNextCycle()`. Closes the keep-alive socket leak window during stall+restart.
  4. `src/gateway/server-methods/channels.ts`: Lower `CHANNEL_STATUS_PROBE_CONCURRENCY` from 5 to 2 and add a 30s probe-result cache. Watchdog + agent-view both call `channels.status` repeatedly; without the cache they re-fan-out fresh TLS probes against every channel/account every ~30s.
  5. `src/gateway/server-methods/channels.ts`: Memoize the duplicate `plugin.config.isConfigured` call within one `channels.status` invocation. Strictly per-call.
- **What did NOT change:** Public APIs, configuration shape, plugin SDK surface, runtime behavior at steady state. The Coach split on 2026-05-12 was a workaround, not a fix; this PR addresses the root cause so a future Coach-merge does not relapse.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Related #69787 (Telegram 409 conflict tight loop)
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `createTelegramBot` performs a synchronous TLS handshake to api.telegram.org as part of its constructor. With multiple polling accounts running on one gateway, any event that triggers simultaneous restarts (stall watchdog firing on several accounts at once, a config reload, gateway boot) stacks N TLS handshakes on the event loop. Combined with `channels.status` being polled every ~30s by both watchdog and agent-view at fan-out 5, the loop is starved and freeze traces accumulate. The 409 conflict tight loop in #69787 was a downstream symptom: the new bot was constructed before Telegram had released the previous session's keep-alive socket, producing immediate 409s in a backoff-then-retry cycle.
- **Missing detection / guardrail:** There is no per-process throttle on Telegram bot setup; each `TelegramPollingSession` independently called `createTelegramBot`. There is no probe-result cache in `channels.status`, so repeated polls re-paid TLS handshake cost.
- **Contributing context:** Production setup with 4 named Telegram accounts on one gateway, watchdog interval 30s, agent-view interval 30s.

## Regression Test Plan

- Coverage level: **Unit test** (added).
- Target tests added:
  - `extensions/telegram/src/polling-transport-state.test.ts`: `disposeIfDirty()` awaits close on dirty / no-op when clean / swallows errors.
  - `extensions/telegram/src/polling-session.test.ts`: next `createTelegramBot` waits on the prior runner stop (`#stoppingCycle`).
- Existing coverage that gates against regression on the channels.status side: `src/gateway/server-methods/channels.status.test.ts` (cache reset hook added so cache state doesn't leak across cases).

## User-visible / Behavior Changes

None. All changes are internal throttling/caching/teardown ordering.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (the change is to reduce concurrent network calls; nothing new is dialed)
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Windows 11 x64, Node 22
- Runtime: openclaw 2026.5.10-beta.5 (installed) / 2026.5.10-beta.1 (this branch base)
- Integration: Telegram polling, 4 accounts
- Relevant config: 4 named Telegram accounts; watchdog + agent-view polling at 30s

### Steps to repro the freeze (pre-fix)

1. Configure a gateway with 4+ Telegram polling accounts.
2. Let it run for ~12 hours.
3. Observe `~/.openclaw/logs/freezes/freeze-*.json` accumulating dumps with `delay > 7000ms` and stack traces pointing into `createTelegramBot` / undici TLS / `channels.status` probe fan-out.

### Expected after fix

- Freeze dump rate drops to near-zero (transient stalls only, not bursts).
- 409 conflict tight loop on `getUpdates` does not recur after stall.

### Verification done

- `pnpm tsgo:core` clean
- `pnpm tsgo:extensions` clean
- `pnpm tsgo:core:test` clean
- `pnpm tsgo:extensions:test` clean
- `pnpm test extensions/telegram/src/polling-session.test.ts`: 20 passed
- `pnpm test extensions/telegram/src/polling-transport-state.test.ts`: 11 passed
- `pnpm test src/gateway/server-methods/channels.status.test.ts`: 7 passed

## Evidence

- [x] Failing test/log before + passing after (added regression tests)
- [x] Trace/log snippets (freeze dump referenced below)

Exhibit A (a representative freeze dump from the production setup that motivated this PR): `~/.openclaw/logs/freezes/freeze-2026-05-12T09-33-18-839Z-32220.json`. Stack frames in the dump are concentrated in `createTelegramBot` TLS handshakes and `channels.status` probe fan-out, both of which this PR throttles.

## Human Verification

- Verified scenarios: typecheck clean across core + extensions + tests; unit tests cover the new `disposeIfDirty` path and the `#stoppingCycle` reentry guard.
- Edge cases checked: semaphore abort path (no slot leak on abort); `disposeIfDirty` is a no-op when not dirty; probe cache TTL eviction.
- What I did **not** verify: live multi-day soak run with this exact branch (the production fleet remained on a workaround split; rolling this in would be the soak test).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** A 30s probe-result cache means `channels.status` may serve stale data for up to 30s after a channel state change.
  - **Mitigation:** 30s is the same interval the watchdog and agent-view already poll at, so the staleness is bounded by the existing polling cadence. The cache is keyed per channel+account and only applies when `probe: true`.
- **Risk:** The setup semaphore is per-process module-level state. Two `TelegramPollingSession` instances cannot construct `createTelegramBot` in parallel beyond 2.
  - **Mitigation:** This is the intended behavior — capping at 2 is what eliminates the freeze. Throughput cost is negligible (handshake is ~100ms) and the semaphore honors abort signals so shutdown is not blocked.