### PR TITLE
Fix Google Chat message tool thread replies

### DIFF
--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -1,4 +1,8 @@
 import { adaptScopedAccountAccessor } from "openclaw/plugin-sdk/channel-config-helpers";
+import type {
+  ChannelThreadingContext,
+  ChannelThreadingToolContext,
+} from "openclaw/plugin-sdk/channel-contract";
 import {
   createMessageReceiptFromOutboundResults,
   defineChannelMessageAdapter,
@@ -126,6 +130,29 @@ export const googlechatThreadingAdapter = {
     resolveReplyToMode: (account: ResolvedGoogleChatAccount, _chatType?: string | null) =>
       account.config.replyToMode,
     fallback: "off" as const,
+  },
+  buildToolContext: ({
+    cfg,
+    accountId,
+    context,
+    hasRepliedRef,
+  }: {
+    cfg: OpenClawConfig;
+    accountId?: string | null;
+    context: ChannelThreadingContext;
+    hasRepliedRef?: { value: boolean };
+  }): ChannelThreadingToolContext => {
+    const currentChannelId = normalizeGoogleChatTarget(context.To);
+    const replyToId =
+      normalizeOptionalString(context.ReplyToIdFull) ?? normalizeOptionalString(context.ReplyToId);
+
+    return {
+      currentChannelId,
+      currentMessageId: replyToId,
+      currentThreadTs: replyToId,
+      replyToMode: resolveGoogleChatAccount({ cfg, accountId }).config.replyToMode,
+      hasRepliedRef,
+    };
   },
 };
 

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -439,6 +439,62 @@ describe("googlechatPlugin threading", () => {
       googlechatThreadingAdapter.scopedAccountReplyToMode.resolveReplyToMode(defaultAccount),
     ).toBe("all");
   });
+
+  it("uses the inbound thread resource as the current tool reply target", () => {
+    const cfg = {
+      channels: {
+        googlechat: {
+          replyToMode: "all",
+        },
+      },
+    } as OpenClawConfig;
+    const hasRepliedRef = { value: false };
+
+    const context = googlechatThreadingAdapter.buildToolContext({
+      cfg,
+      accountId: "default",
+      context: {
+        To: "googlechat:spaces/AAA",
+        CurrentMessageId: "spaces/AAA/messages/msg-1",
+        ReplyToId: "spaces/AAA/threads/thread-1",
+      },
+      hasRepliedRef,
+    });
+
+    expect(context).toMatchObject({
+      currentChannelId: "spaces/AAA",
+      currentMessageId: "spaces/AAA/threads/thread-1",
+      currentThreadTs: "spaces/AAA/threads/thread-1",
+      replyToMode: "all",
+      hasRepliedRef,
+    });
+  });
+
+  it("does not use message resources as implicit Google Chat reply targets", () => {
+    const cfg = {
+      channels: {
+        googlechat: {
+          replyToMode: "all",
+        },
+      },
+    } as OpenClawConfig;
+
+    const context = googlechatThreadingAdapter.buildToolContext({
+      cfg,
+      accountId: "default",
+      context: {
+        To: "googlechat:spaces/AAA",
+        CurrentMessageId: "spaces/AAA/messages/msg-1",
+      },
+    });
+
+    expect(context).toMatchObject({
+      currentChannelId: "spaces/AAA",
+      replyToMode: "all",
+    });
+    expect(context.currentMessageId).toBeUndefined();
+    expect(context.currentThreadTs).toBeUndefined();
+  });
 });
 
 const resolveTarget = googlechatOutboundAdapter.base.resolveTarget;

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -152,6 +152,7 @@ export function buildThreadingToolContext(params: {
         ChatType: sessionCtx.ChatType,
         CurrentMessageId: currentMessageId,
         ReplyToId: sessionCtx.ReplyToId,
+        ReplyToIdFull: sessionCtx.ReplyToIdFull,
         ThreadLabel: sessionCtx.ThreadLabel,
         MessageThreadId: sessionCtx.MessageThreadId,
         TransportThreadId: sessionCtx.TransportThreadId,
@@ -159,10 +160,13 @@ export function buildThreadingToolContext(params: {
       },
       hasRepliedRef,
     }) ?? {};
+  const hasAdapterCurrentMessageId = Object.hasOwn(context, "currentMessageId");
   return {
     ...context,
     currentChannelProvider: provider!, // guaranteed non-null since threading exists
-    currentMessageId: context.currentMessageId ?? currentMessageId,
+    // Some providers expose only thread resources as reply targets; explicit
+    // `undefined` means the adapter rejected the generic message-id fallback.
+    currentMessageId: hasAdapterCurrentMessageId ? context.currentMessageId : currentMessageId,
   };
 }
 

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -193,6 +193,44 @@ describe("buildThreadingToolContext", () => {
     expect(result.currentChannelId).toBe("C1");
     expect(result.currentThreadTs).toBe("123.456");
   });
+
+  it("lets plugin threading adapters suppress the generic message-id fallback", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "googlechat",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "googlechat", label: "Google Chat" }),
+            threading: {
+              buildToolContext: ({ context }) => ({
+                currentChannelId: context.To?.replace(/^googlechat:/, ""),
+                currentMessageId: undefined,
+                currentThreadTs: context.ReplyToIdFull ?? context.ReplyToId,
+              }),
+            },
+          } as ChannelPlugin,
+          source: "test",
+        },
+      ]),
+    );
+    const sessionCtx = {
+      Provider: "googlechat",
+      To: "googlechat:spaces/AAA",
+      MessageSidFull: "spaces/AAA/messages/msg-1",
+      ReplyToId: "spaces/AAA/threads/short",
+      ReplyToIdFull: "spaces/AAA/threads/full",
+    } as TemplateContext;
+
+    const result = buildThreadingToolContext({
+      sessionCtx,
+      config: { channels: { googlechat: { replyToMode: "all" } } } as OpenClawConfig,
+      hasRepliedRef: undefined,
+    });
+
+    expect(result.currentChannelId).toBe("spaces/AAA");
+    expect(result.currentThreadTs).toBe("spaces/AAA/threads/full");
+    expect(result.currentMessageId).toBeUndefined();
+  });
 });
 
 describe("applyReplyThreading auto-threading", () => {


### PR DESCRIPTION
## Summary

- Add a Google Chat threading tool context so message tool replies prefer the inbound thread resource.
- Preserve the resolved per-account `replyToMode` for Google Chat tool replies.
- Add regression coverage for `[[reply_to_current]]` resolving to `spaces/.../threads/...`.

Fixes #80995.

## Real behavior proof

Setup:
- OpenClaw gateway running with Google Chat enabled.
- Google Chat account config had `replyToMode: "all"`.
- Test was run from the `OpenClaw` Google Chat space, inside an existing Google Chat thread.
- Private space IDs, message IDs, user IDs, names, and email addresses are redacted below.

Before the fix, OpenClaw had the correct inbound Google Chat thread in runtime context, but `message(action=send)` still posted outside the thread in the Google Chat UI.

Redacted copied runtime transcript from the failing case:

```json
{
  "inbound": {
    "chat_id": "googlechat:spaces/REDACTED_SPACE",
    "message_id": "spaces/REDACTED_SPACE/messages/REDACTED_MESSAGE",
    "reply_to_id": "spaces/REDACTED_SPACE/threads/REDACTED_THREAD",
    "is_group_chat": true
  },
  "tool_call": {
    "name": "message",
    "arguments": {
      "action": "send",
      "message": "..."
    }
  },
  "tool_result": {
    "ok": true,
    "to": "spaces/REDACTED_SPACE"
  },
  "observed_google_chat_result": "reply appeared as a top-level space message, outside the original thread"
}
```

After applying this adapter change to the installed Google Chat plugin and restarting the gateway, the same flow stayed inside the original Google Chat thread.

Redacted copied runtime transcript from the passing case:

```json
{
  "inbound": {
    "chat_id": "googlechat:spaces/REDACTED_SPACE",
    "message_id": "spaces/REDACTED_SPACE/messages/cLJ5-iaALOU.cLJ5-iaALOU",
    "reply_to_id": "spaces/REDACTED_SPACE/threads/cLJ5-iaALOU",
    "timestamp": "Tue 2026-05-12 07:58 GMT-3",
    "is_group_chat": true
  },
  "tool_call": {
    "name": "message",
    "arguments": {
      "action": "send",
      "message": "[[reply_to_current]] Buen dia, Franco"
    }
  },
  "tool_result": {
    "ok": true,
    "to": "spaces/REDACTED_SPACE"
  },
  "observed_google_chat_result": "reply rendered inside the original thread with thread id spaces/REDACTED_SPACE/threads/cLJ5-iaALOU"
}
```

Operator confirmation from the live Google Chat UI after the patch:

```text
yep your fix worked
```

I also attempted to independently query Google Chat for the message thread after the UI verification, but the Chat app service account cannot use `spaces.messages.list` with app authentication:

```text
Google Chat API ListMessages: 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT
Ensure the scopes you are using support app authentication with a service account.
```

## Test plan

- `git diff --check`
- Attempted `node --run test:extension -- googlechat`; blocked before Vitest because the monorepo `pnpm install` was killed with `SIGKILL`.
- Attempted `node scripts/test-extension.mjs googlechat extensions/googlechat/src/channel.test.ts`; blocked before Vitest because the monorepo `pnpm install` was killed with `SIGKILL`.
- CI on this PR completed the relevant checks successfully, including `check`, `check-prod-types`, `check-test-types`, `check-lint`, `checks-node-channels`, and `checks-fast-contracts-channels`.

## AI assistance

This PR was prepared with Codex assistance. I understand the code change: it uses the Google Chat inbound `ReplyToId` thread resource as the message tool's current reply target so `[[reply_to_current]]` resolves to `spaces/.../threads/...` instead of falling back to the inbound message resource.

## Real Behavior Proof

Images show how the bot replied before and after the applied fix. Before:

<img width="1623" height="303" alt="image" src="https://github.com/user-attachments/assets/53a706ee-7e32-4d44-825f-bf672932174c" />


After:

<img width="1043" height="346" alt="image" src="https://github.com/user-attachments/assets/2bb518b3-609e-4dc1-ac9c-2cf0ccdf9b1f" />

<img width="1602" height="415" alt="image" src="https://github.com/user-attachments/assets/5386884b-cd04-404f-b09b-9ef493993518" />

That last one shows the last message outside of a thread, before the fix was applied. And also the first message with the fix applied, we can see that the thread now has replies



## Real Behavior Proof - Maintainer Validation

Behavior addressed: Google Chat message-tool replies preserve the inbound Google Chat thread resource so implicit replies and [[reply_to_current]] stay in the original thread instead of posting as top-level space messages.

Real environment tested: Local OpenClaw focused test environment on the refreshed PR head, plus the contributor's real Google Chat gateway/space proof already included above with redacted runtime transcript and screenshots.

Exact steps or command run after this patch: Ran focused regression tests for the Google Chat channel adapter and shared auto-reply threading wrapper, then ran format, lint, diff, and autoreview checks after applying the threading fixups.

Evidence after fix: Local Vitest passed 48 focused tests across extensions/googlechat/src/channel.test.ts and src/auto-reply/reply/reply-plumbing.test.ts. Format, lint, git diff --check, and autoreview also passed. The contributor's real Google Chat proof shows the same live message flow staying in the original Google Chat thread after the adapter change.

Observed result after fix: Google Chat tool context normalizes the current space target, uses ReplyToIdFull/ReplyToId as the thread resource, and lets the plugin adapter explicitly suppress the generic message-id fallback when no thread resource exists. Live Google Chat proof above shows replies rendering inside the original thread after the patch.

What was not tested: I did not perform a new live Google Chat send from this maintainer checkout; I relied on the contributor's real Google Chat proof plus local focused regression tests for the maintainer fixups.

## Real Behavior Proof - Final Maintainer Validation

Behavior or issue addressed: Google Chat message-tool replies preserve the inbound Google Chat thread resource so implicit replies and [[reply_to_current]] stay in the original thread instead of posting as top-level space messages.

Real environment tested: Contributor's live Google Chat space with OpenClaw gateway and Google Chat plugin enabled, using account config replyToMode all. Private space ids, message ids, user ids, names, and email addresses are redacted in the copied runtime transcript and screenshots above.

Exact steps or command run after this patch: Applied the patched Google Chat adapter to the installed Google Chat plugin, restarted the OpenClaw gateway, then sent a message from the same Google Chat space/thread that previously reproduced the top-level reply bug. The contributor then watched the live Google Chat UI after the message-tool reply landed.

Evidence after fix: Redacted copied runtime transcript above shows inbound reply_to_id spaces/REDACTED_SPACE/threads/cLJ5-iaALOU and the tool call message [[reply_to_current]] Buen dia, Franco, with observed_google_chat_result reporting that the reply rendered inside the original thread. The after screenshots are embedded above at https://github.com/user-attachments/assets/2bb518b3-609e-4dc1-ac9c-2cf0ccdf9b1f and https://github.com/user-attachments/assets/5386884b-cd04-404f-b09b-9ef493993518.

Observed result after fix: The live Google Chat UI showed the patched reply inside the original thread with thread id spaces/REDACTED_SPACE/threads/cLJ5-iaALOU. The contributor also confirmed in the live UI that the fix worked, and the before/after screenshots show the previous top-level reply behavior versus the fixed threaded reply.

What was not tested: I did not run a new live Google Chat send from this maintainer checkout; the maintainer validation relies on the contributor's real Google Chat transcript and screenshots for live behavior, with local regression tests as supplemental proof outside this section.
