### PR TITLE
fix(acpx): drop "timeout" config option for all ACP agents [AI]

### DIFF
--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -917,11 +917,15 @@ export class AcpxRuntime implements AcpRuntime {
     const delegate = await this.resolveDelegateForHandle(input.handle);
     const command = await this.resolveCommandForHandle(input.handle);
     const key = input.key.trim().toLowerCase();
-    const isCodexAcp = isCodexAcpCommand(command);
-    if (WIRE_TIMEOUT_CONFIG_KEYS.has(key) && (isCodexAcp || isClaudeAcpCommand(command))) {
+    // `timeout` / `timeout_seconds` is an acpx-runtime concept derived from
+    // `plugins.entries.acpx.config.timeoutSeconds`; no ACP agent treats it as
+    // a session config option. Forwarding it causes claude-agent-acp 0.32+ to
+    // reject with -32603 "Unknown config option", which surfaces upstream as
+    // ACP_TURN_FAILED. Skip for every backend, not just the known allowlist.
+    if (WIRE_TIMEOUT_CONFIG_KEYS.has(key)) {
       return;
     }
-    if (isCodexAcp) {
+    if (isCodexAcpCommand(command)) {
       if (
         key === "model" ||
         key === "thinking" ||


### PR DESCRIPTION
## Summary

- **Problem:** `AcpxRuntime.setConfigOption` short-circuits the unsupported `timeout` / `timeout_seconds` key only inside the `isCodexAcpCommand(command)` branch. For Claude (and any other non-Codex ACP backend) the option falls through to `delegate.setConfigOption(input)` and reaches the wire as `session/set_config_option {configId:"timeout", value:"120"}`. `@agentclientprotocol/claude-agent-acp` 0.32 only advertises `mode` / `model` / `effort` as configIds and rejects `timeout` with JSON-RPC `-32603 Internal error: Unknown config option: timeout`, which surfaces upstream as `ACP_TURN_FAILED` (UNAVAILABLE).
- **Why it matters:** `sessions_spawn` for non-Codex ACP agents is completely non-functional on `2026.5.7` — every spawn fails ~6 s after `session/new`. The opaque `Internal error` surface has produced several closed-stale issues (#30346, #35861, plausibly #28708 / #31065 / #31273 / #31686) where the symptom is reported but the root cause was never localized.
- **What changed:** Hoist the `timeout` / `timeout_seconds` early-return out of the codex-only branch so it applies universally. Flip the existing `forwards timeout config controls for non-Codex ACP agents` test, which asserted the buggy passthrough through a mocked delegate that never exercised the real wire-side rejection. Add a companion test confirming non-timeout keys (`mode`) still forward.
- **What did NOT change (scope boundary):** Codex-specific `model` / `thinking` / `reasoning_effort` translation; `setMode` / `cancel` / session-lifecycle paths; the (separately broken) plumbing of the user-configured `plugins.entries.acpx.config.timeoutSeconds` value into the runtime call — that surfaced `value:"120"` instead of the configured `900` and deserves its own follow-up.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

Touched area: `extensions/acpx`.

## Linked Issue/PR

- Closes #81005
- Related: #30346, #35861 (closed-stale; same symptom — eligible to close-as-duplicate of #81005 once this lands)
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

**Behavior addressed:** Spawning `claude` (or any non-Codex ACP agent) through `AcpxRuntime` fails with `ACP_TURN_FAILED` ~6 s after `session/new`.

**Real environment tested:**

- OpenClaw `2026.5.7` (`commit eeef486`)
- `@openclaw/acpx` `2026.5.7` (installed under `~/.openclaw/npm/node_modules/@openclaw/acpx`)
- `@agentclientprotocol/claude-agent-acp` `0.32.0` + bundled `claude` CLI `2.1.126`
- Ubuntu `24.04.3` LTS, Node `24.14.1`
- Main agent: `openai/gpt-5.5` over `api: openai-responses` via `api.proxyapi.ru` (no API-key changes), `agentRuntime.id = codex`
- Subagent: `runtime.acp.agent="claude"`, `backend="acpx"`, `mode="persistent"`

**Exact command run after this patch (applied in-place against the installed bundle, mirroring this PR's TypeScript diff):**

```sh
$ openclaw agent --agent main --to <chatId> --channel telegram \
    -m "spawn claude to list files in home directory and tell me the result, do not do it yourself"
```

**Evidence after fix (gateway journal, relevant lines):**

```text
13:43:38 [agent/embedded] embedded run tool start: runId=58741136 tool=sessions_spawn …
13:43:41 [plugins] embedded acpx runtime backend registered (cwd: …/openclaw/workspace)
13:43:45 [agent/embedded] embedded run tool end:   runId=58741136 tool=sessions_spawn
13:43:48 [agent/embedded] embedded run agent end:  runId=58741136 isError=false
```

Stdio tap on `claude-agent-acp/dist/index.js` (added temporarily for this investigation, removed after) shows the full ACP exchange now completing cleanly:

```text
IN:  initialize / session/load / session/new / session/prompt
OUT: result(capabilities) / error(-32002 — expected on first run) /
     result(sessionId) / session/update*(agent_message_chunk … directory listing) /
     result(stopReason=end_turn, usage=…)
```

**Observed result after fix:** `stopReason=end_turn`. The spawned Claude session lists `/home/<user>` correctly, the main agent's `sessions_spawn` tool returns `isError=false`, and the embedded run completes.

**Before evidence (pre-fix journal + tap):**

```text
12:41:03 [ws] ⇄ res ✗ agent errorCode=UNAVAILABLE
  errorMessage=AcpRuntimeError: Internal error: code=ACP_TURN_FAILED
# Tap response from claude-agent-acp:
{"id":3,"error":{"code":-32603,"message":"Internal error","data":{"details":"Unknown config option: timeout"}}}
```

**Local verification (in the fork on this branch):**

- `pnpm install --filter ./extensions/acpx --filter . --frozen-lockfile` — Done in 22.3 s
- `pnpm test extensions/acpx/src/runtime.test.ts` — `Test Files 1 passed (1) · Tests 34 passed (34) · 892 ms`
- `pnpm format:check extensions/acpx/src/runtime.ts extensions/acpx/src/runtime.test.ts` — `All matched files use the correct format.`
- `pnpm check:changed` — typecheck (extensions + extension tests), oxlint, runtime sidecar loader guard, import cycle check all green for files touched by this PR. The lane surfaces pre-existing `oxfmt --check` issues in 19 unrelated files (`extensions/oc-path/**`, `scripts/lib/local-build-metadata.d.mts`, `src/gateway/server-chat.stream-text-merge.test.ts`); they are untouched by this diff.

**What was not tested locally:**

- Other non-Codex ACP backends (Gemini / OpenCode / Kimi / Pi adapters). By inspection of each adapter's `configOptions` advertisement they also do not accept `timeout` as a `configId`, but they were not end-to-end exercised here.
- Full repo `pnpm test` / `pnpm build` / Crabbox / Testbox. Per the repo's "small/narrow tests local; broad proof on Testbox" guidance, the broad gate is intentionally deferred to CI / a maintainer's Crabbox.

## Root Cause

- **Root cause:** `extensions/acpx/src/runtime.ts` `AcpxRuntime.setConfigOption` short-circuits `timeout` / `timeout_seconds` only inside the codex-only branch; non-Codex agents receive a `set_config_option` for an option they don't advertise. The shape was introduced in d3e4640 ("fix(acpx): ignore Codex ACP timeout config") which correctly narrowed the codex special-case but never broadened the skip when other ACP backends started landing.
- **Missing detection / guardrail:** the existing non-codex test in `runtime.test.ts` mocks the delegate, so it asserted that "we forwarded `timeout` to the delegate" without exercising the real wire-side rejection. The runtime's `Internal error` wrapper also discards the inner ACP error message before logging, so `ACP_TURN_FAILED` reaches the journal with no signal about which method / key triggered it — that's why this has stayed open across multiple stale issues without a localized root cause.
- **Contributing context:** the original codex-side skip was a deliberate "don't forward an acpx-runtime concern to the ACP wire" choice; it just wasn't generalized when other ACP adapters landed.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `extensions/acpx/src/runtime.test.ts` — flipped existing `forwards timeout config controls for non-Codex ACP agents` to `ignores unsupported timeout config controls for non-Codex ACP agents` (asserts `setConfigOption` was **not** called on the delegate for `key:"timeout"` or `key:"Timeout_Seconds"`), and added `still forwards non-timeout config controls for non-Codex ACP agents` to lock in that `mode` (and by extension the rest of the keys) still pass through.
- **Scenario the test should lock in:** given a session whose stored `agentCommand` is **not** the codex ACP command, calling `runtime.setConfigOption({key:"timeout"|"timeout_seconds"})` must not invoke `delegate.setConfigOption`. Case variants are covered.
- **Why this is the smallest reliable guardrail:** the bug is purely in the dispatcher gating; a unit test with a mocked delegate spy pins the exact contract being violated. A live end-to-end run is what surfaced the bug in the first place but is heavier and not strictly necessary to prevent regression.
- **Existing test that already covers this:** none — the closest was the now-flipped test, which actively asserted the buggy passthrough.
- **If no new test is added, why not:** N/A — test included in this PR.

## User-visible / Behavior Changes

`sessions_spawn` for non-Codex ACP agents now actually works on 2026.5.7+. No new config keys, env vars, or defaults; nothing renamed; no migration. Anyone who was relying on `timeout` reaching a non-Codex ACP backend was already broken — that wire call has always failed.

Follow-up worth filing separately: even with this fix in place, the user-configured `plugins.entries.acpx.config.timeoutSeconds` is not actually threaded to the runtime call (we observed `value:"120"` on the wire — the schema default — despite a configured `900`). This PR makes the key a no-op, so the value mismatch becomes cosmetic, but the caller-side plumbing is still wrong.

## Diagram

```text
Before (non-Codex agent path):
  AcpxRuntime.setConfigOption({key:"timeout"})
    → isCodexAcpCommand? no
    → delegate.setConfigOption({key:"timeout"})            # forwards to the wire
    → claude-agent-acp: session/set_config_option
    → throws "Unknown config option: timeout"
    → JSON-RPC -32603 Internal error
    → AcpxRuntime wraps as ACP_TURN_FAILED                 # opaque failure

After:
  AcpxRuntime.setConfigOption({key:"timeout"})
    → key in {timeout, timeout_seconds}? yes → return      # never reaches the wire
    → spawn proceeds: session/new → session/prompt → end_turn
```

## Security Impact

- New permissions / capabilities? **No.**
- Secrets / tokens handling changed? **No.**
- New / changed network calls? **No** — in fact this PR **removes** one unsupported JSON-RPC call per spawn from non-Codex agents.
- Command / tool execution surface changed? **No.**
- Data access scope changed? **No.**

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.3 LTS (kernel 6.17, x64)
- Runtime / container: Node 24.14.1 via nvm; `openclaw-gateway.service` (systemd --user)
- Model / provider: main `openai/gpt-5.5` via openclaw → `api.proxyapi.ru` → OpenAI (`api: openai-responses`); subagent `default` model in `@agentclientprotocol/claude-agent-acp` 0.32.0 (OAuth via local `claude` CLI 2.1.126)
- Integration / channel: Telegram (and `openclaw agent` CLI for the post-fix verification run)
- Relevant config (redacted):

```jsonc
{
  "plugins": { "entries": { "acpx": {
    "config": { "probeAgent": "claude", "permissionMode": "approve-all",
                "nonInteractivePermissions": "deny", "timeoutSeconds": 900 } } } },
  "acp": { "enabled": true, "backend": "acpx", "defaultAgent": "claude",
           "allowedAgents": ["claude", "codex"] },
  "agents": { "list": [
    { "id": "main",       "model": { "primary": "openai/gpt-5.5" }, "agentRuntime": { "id": "codex" } },
    { "id": "claude-acp", "runtime": { "type": "acp",
        "acp": { "agent": "claude", "backend": "acpx", "mode": "persistent" } } }
  ] }
}
```

### Steps

1. Run OpenClaw 2026.5.7 with the configuration above.
2. `openclaw agent --agent main --to <chatId> --channel telegram -m "spawn claude to list files in home directory and tell me the result, do not do it yourself"`.
3. Watch `journalctl --user -u openclaw-gateway.service -f`.

### Expected

`embedded run tool end ... tool=sessions_spawn` followed by `embedded run agent end ... isError=false`. Claude's reply contains a directory listing.

### Actual (pre-fix)

`[ws] ⇄ res ✗ agent errorCode=UNAVAILABLE errorMessage=AcpRuntimeError: Internal error: code=ACP_TURN_FAILED` within ~6 seconds of `embedded acpx runtime backend registered`. After-fix: matches Expected.

---

<sub>AI-assisted PR (`[AI]` tag in title). Root cause attributed from a stdio tap on `claude-agent-acp/dist/index.js`; the tap was used only during investigation and is not part of this PR.</sub>
