### PR TITLE
fix(sandbox): clarify Docker startup failures

### DIFF
--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -11,6 +11,13 @@ type SpawnCall = {
   args: string[];
 };
 
+type ScriptedDockerResult = {
+  prefix: string[];
+  code: number;
+  stdout?: string;
+  stderr?: string;
+};
+
 type MockDockerChild = EventEmitter & {
   stdout: Readable;
   stderr: Readable;
@@ -20,8 +27,10 @@ type MockDockerChild = EventEmitter & {
 
 const spawnState = vi.hoisted(() => ({
   calls: [] as SpawnCall[],
+  containerExists: true,
   inspectRunning: true,
   labelHash: "",
+  scriptedResults: [] as ScriptedDockerResult[],
 }));
 
 const registryMocks = vi.hoisted(() => ({
@@ -43,18 +52,39 @@ function createMockDockerChild(): MockDockerChild {
   return child;
 }
 
+function normalizeMockCommand(command: string): string {
+  return /(?:^|[\\/])docker(?:\.exe)?$/i.test(command) ? "docker" : command;
+}
+
 function spawnDockerProcess(command: string, args: string[]) {
-  spawnState.calls.push({ command, args });
+  const normalizedCommand = normalizeMockCommand(command);
+  spawnState.calls.push({ command: normalizedCommand, args });
   const child = createMockDockerChild();
 
   let code = 0;
   let stdout = "";
   let stderr = "";
-  if (command !== "docker") {
+  const scriptedIndex =
+    normalizedCommand === "docker"
+      ? spawnState.scriptedResults.findIndex((result) =>
+          result.prefix.every((part, index) => args[index] === part),
+        )
+      : -1;
+  if (scriptedIndex >= 0) {
+    const [result] = spawnState.scriptedResults.splice(scriptedIndex, 1);
+    code = result?.code ?? 0;
+    stdout = result?.stdout ?? "";
+    stderr = result?.stderr ?? "";
+  } else if (normalizedCommand !== "docker") {
     code = 1;
     stderr = `unexpected command: ${command}`;
   } else if (args[0] === "inspect" && args[1] === "-f" && args[2] === "{{.State.Running}}") {
-    stdout = spawnState.inspectRunning ? "true\n" : "false\n";
+    if (!spawnState.containerExists) {
+      code = 1;
+      stderr = "No such container";
+    } else {
+      stdout = spawnState.inspectRunning ? "true\n" : "false\n";
+    }
   } else if (
     args[0] === "inspect" &&
     args[1] === "-f" &&
@@ -105,6 +135,10 @@ async function loadFreshDockerModuleForTest() {
   }));
   vi.doMock("node:child_process", async () => createChildProcessMock());
   ({ ensureSandboxContainer } = await import("./docker.js"));
+}
+
+function queueDockerResult(prefix: string[], result: Omit<ScriptedDockerResult, "prefix">) {
+  spawnState.scriptedResults.push({ prefix, ...result });
 }
 
 function createSandboxConfig(
@@ -182,8 +216,10 @@ async function ensureSandboxCreateCallForTest(params: {
 describe("ensureSandboxContainer config-hash recreation", () => {
   beforeEach(async () => {
     spawnState.calls.length = 0;
+    spawnState.containerExists = true;
     spawnState.inspectRunning = true;
     spawnState.labelHash = "";
+    spawnState.scriptedResults.length = 0;
     registryMocks.readRegistryEntry.mockClear();
     registryMocks.updateRegistry.mockClear();
     registryMocks.updateRegistry.mockResolvedValue(undefined);
@@ -316,5 +352,143 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     expect(createCall.args).toContain(
       `openclaw.mountFormatVersion=${SANDBOX_MOUNT_FORMAT_VERSION}`,
     );
+  });
+
+  it("throws a clear Docker sandbox create error without command args", async () => {
+    const cfg = createSandboxConfig([]);
+    spawnState.containerExists = false;
+    queueDockerResult(["create"], {
+      code: 125,
+      stderr: "invalid mount config for type bind",
+    });
+
+    let error: unknown;
+    try {
+      await ensureSandboxContainer({
+        sessionKey: "agent:main:session-1",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg,
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toMatch(
+      /Docker sandbox failed during create for container oc-test-shared \(image openclaw-sandbox:test\) with exit code 125/,
+    );
+    expect(message).toContain("invalid mount config");
+    expect(message).not.toContain("create --name");
+    expect(message).not.toContain("/tmp/workspace");
+  });
+
+  it("throws a clear start error for a stopped existing container", async () => {
+    const workspaceDir = "/tmp/workspace";
+    const cfg = createSandboxConfig([]);
+    spawnState.inspectRunning = false;
+    spawnState.labelHash = computeSandboxConfigHash({
+      docker: cfg.docker,
+      workspaceAccess: cfg.workspaceAccess,
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    });
+    queueDockerResult(["start", "oc-test-shared"], {
+      code: 1,
+      stderr: "container failed to start",
+    });
+
+    await expect(
+      ensureSandboxContainer({
+        sessionKey: "agent:main:session-1",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        cfg,
+      }),
+    ).rejects.toThrow(
+      /Docker sandbox failed during start for container oc-test-shared \(image openclaw-sandbox:test\) with exit code 1/,
+    );
+  });
+
+  it("surfaces setupCommand failure clearly and does not retry it", async () => {
+    const cfg = createSandboxConfig([]);
+    cfg.docker.setupCommand = "echo setup";
+    spawnState.containerExists = false;
+    queueDockerResult(["exec", "-i", "oc-test-shared"], {
+      code: 7,
+      stderr: "setup failed",
+    });
+
+    await expect(
+      ensureSandboxContainer({
+        sessionKey: "agent:main:session-1",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg,
+      }),
+    ).rejects.toThrow(
+      /Docker sandbox failed during setupCommand for container oc-test-shared \(image openclaw-sandbox:test\) with exit code 7/,
+    );
+
+    const execCalls = spawnState.calls.filter(
+      (call) => call.command === "docker" && call.args[0] === "exec",
+    );
+    expect(execCalls).toHaveLength(1);
+  });
+
+  it("does not retry create failures", async () => {
+    const cfg = createSandboxConfig([]);
+    spawnState.containerExists = false;
+    queueDockerResult(["create"], {
+      code: 125,
+      stderr: "invalid bind mount config",
+    });
+
+    await expect(
+      ensureSandboxContainer({
+        sessionKey: "agent:main:session-1",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg,
+      }),
+    ).rejects.toThrow(/invalid bind mount config/);
+
+    const createCalls = spawnState.calls.filter(
+      (call) => call.command === "docker" && call.args[0] === "create",
+    );
+    expect(createCalls).toHaveLength(1);
+  });
+
+  it("does not retry start failures", async () => {
+    const workspaceDir = "/tmp/workspace";
+    const cfg = createSandboxConfig([]);
+    spawnState.inspectRunning = false;
+    spawnState.labelHash = computeSandboxConfigHash({
+      docker: cfg.docker,
+      workspaceAccess: cfg.workspaceAccess,
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    });
+    queueDockerResult(["start", "oc-test-shared"], {
+      code: 1,
+      stderr: "invalid restart policy",
+    });
+
+    await expect(
+      ensureSandboxContainer({
+        sessionKey: "agent:main:session-1",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        cfg,
+      }),
+    ).rejects.toThrow(/invalid restart policy/);
+
+    const startCalls = spawnState.calls.filter(
+      (call) => call.command === "docker" && call.args[0] === "start",
+    );
+    expect(startCalls).toHaveLength(1);
   });
 });

--- a/src/agents/sandbox/docker.test.ts
+++ b/src/agents/sandbox/docker.test.ts
@@ -30,13 +30,18 @@ function createMockDockerChild(): MockDockerChild {
   return child;
 }
 
+function normalizeMockCommand(command: string): string {
+  return /(?:^|[\\/])docker(?:\.exe)?$/i.test(command) ? "docker" : command;
+}
+
 function spawnDockerProcess(command: string, args: string[]) {
-  spawnState.calls.push({ command, args });
+  const normalizedCommand = normalizeMockCommand(command);
+  spawnState.calls.push({ command: normalizedCommand, args });
   const child = createMockDockerChild();
 
   let code = 0;
   let stderr = "";
-  if (command !== "docker") {
+  if (normalizedCommand !== "docker") {
     code = 1;
     stderr = `unexpected command: ${command}`;
   } else if (args[0] === "image" && args[1] === "inspect") {
@@ -110,6 +115,8 @@ describe("ensureDockerImage", () => {
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toContain("scripts/sandbox-setup.sh");
     expect((err as Error).message).toContain("python3");
+    expect((err as Error).message).toContain("with exit code 1");
+    expect((err as Error).message).toContain("No such image");
     expect(spawnState.calls).toEqual([
       {
         command: "docker",

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -176,6 +176,19 @@ import { appendWorkspaceMountArgs, SANDBOX_MOUNT_FORMAT_VERSION } from "./worksp
 const log = createSubsystemLogger("docker");
 
 const HOT_CONTAINER_WINDOW_MS = 5 * 60 * 1000;
+const DOCKER_STARTUP_OUTPUT_LIMIT = 2000;
+
+type DockerStartupPhase = "image inspect" | "create" | "start" | "setupCommand";
+
+type DockerStartupErrorContext = {
+  phase: DockerStartupPhase;
+  containerName?: string;
+  image: string;
+};
+
+type DockerImageInspectState =
+  | { state: "exists" }
+  | { state: "missing"; code: number; stdout: string; stderr: string };
 
 export type ExecDockerOptions = ExecDockerRawOptions;
 
@@ -186,6 +199,92 @@ export async function execDocker(args: string[], opts?: ExecDockerOptions) {
     stderr: result.stderr.toString("utf8"),
     code: result.code,
   };
+}
+
+function isExecDockerRawError(error: unknown): error is ExecDockerRawError {
+  return (
+    error instanceof Error &&
+    typeof (error as { code?: unknown }).code === "number" &&
+    Buffer.isBuffer((error as { stdout?: unknown }).stdout) &&
+    Buffer.isBuffer((error as { stderr?: unknown }).stderr)
+  );
+}
+
+function sanitizeDockerOutput(value: string): string {
+  const cleaned = value
+    .replace(/\u001b\[[0-9;]*m/g, "")
+    .replace(
+      /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASS|KEY|CREDENTIAL)[A-Z0-9_]*)=([^\s]+)/gi,
+      "$1=[redacted]",
+    )
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "")
+    .trim();
+  if (cleaned.length <= DOCKER_STARTUP_OUTPUT_LIMIT) {
+    return cleaned;
+  }
+  return `${cleaned.slice(0, DOCKER_STARTUP_OUTPUT_LIMIT)}... [truncated]`;
+}
+
+function safeErrorMessage(error: unknown): string {
+  if (isExecDockerRawError(error)) {
+    return "";
+  }
+  if (error instanceof Error) {
+    return sanitizeDockerOutput(error.message);
+  }
+  return sanitizeDockerOutput(String(error));
+}
+
+function createDockerSandboxStartupError(params: {
+  context: DockerStartupErrorContext;
+  error?: unknown;
+  exitCode?: number;
+  stdout?: Buffer | string;
+  stderr?: Buffer | string;
+}) {
+  const stderr = sanitizeDockerOutput(
+    Buffer.isBuffer(params.stderr) ? params.stderr.toString("utf8") : (params.stderr ?? ""),
+  );
+  const stdout = sanitizeDockerOutput(
+    Buffer.isBuffer(params.stdout) ? params.stdout.toString("utf8") : (params.stdout ?? ""),
+  );
+  const errorMessage = safeErrorMessage(params.error);
+  const exitCode =
+    typeof params.exitCode === "number"
+      ? params.exitCode
+      : isExecDockerRawError(params.error)
+        ? params.error.code
+        : undefined;
+  const outputParts = [
+    errorMessage ? `error: ${errorMessage}` : undefined,
+    stderr ? `stderr: ${stderr}` : undefined,
+    stdout ? `stdout: ${stdout}` : undefined,
+  ].filter((part): part is string => Boolean(part));
+  const contextParts = [
+    `Docker sandbox failed during ${params.context.phase}`,
+    params.context.containerName ? `for container ${params.context.containerName}` : undefined,
+    `(image ${params.context.image})`,
+    typeof exitCode === "number" ? `with exit code ${exitCode}` : undefined,
+  ].filter((part): part is string => Boolean(part));
+  const details = outputParts.length > 0 ? ` Docker said: ${outputParts.join("; ")}` : "";
+  return new Error(`${contextParts.join(" ")}.${details}`, { cause: params.error });
+}
+
+async function execDockerStartupCommand(args: string[], context: DockerStartupErrorContext) {
+  try {
+    return await execDocker(args);
+  } catch (error) {
+    throw createDockerSandboxStartupError({
+      context,
+      error,
+      ...(isExecDockerRawError(error)
+        ? {
+            stdout: error.stdout,
+            stderr: error.stderr,
+          }
+        : {}),
+    });
+  }
 }
 
 export async function readDockerContainerLabel(
@@ -294,34 +393,85 @@ export function formatDockerDaemonUnavailableError(stderr: string): string {
     .join(" ");
 }
 
-async function inspectDockerImage(image: string): Promise<"exists" | "missing"> {
+async function inspectDockerImage(
+  image: string,
+  context: Omit<DockerStartupErrorContext, "phase" | "image"> = {},
+): Promise<DockerImageInspectState> {
+  const startupContext: DockerStartupErrorContext = {
+    phase: "image inspect",
+    image,
+    ...context,
+  };
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,
+  }).catch((error: unknown): never => {
+    throw createDockerSandboxStartupError({
+      context: startupContext,
+      error,
+      ...(isExecDockerRawError(error)
+        ? {
+            stdout: error.stdout,
+            stderr: error.stderr,
+          }
+        : {}),
+    });
   });
   if (result.code === 0) {
-    return "exists";
+    return { state: "exists" };
   }
   const stderr = result.stderr.trim();
   if (stderr.toLowerCase().includes("no such image")) {
-    return "missing";
+    return {
+      state: "missing",
+      code: result.code,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
   }
   if (isDockerDaemonUnavailable(stderr)) {
-    throw new Error(formatDockerDaemonUnavailableError(stderr));
+    throw createDockerSandboxStartupError({
+      context: startupContext,
+      error: new Error(formatDockerDaemonUnavailableError(stderr)),
+      exitCode: result.code,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    });
   }
-  throw new Error(`Failed to inspect sandbox image: ${stderr}`);
+  throw createDockerSandboxStartupError({
+    context: startupContext,
+    error: new Error("Failed to inspect sandbox image"),
+    exitCode: result.code,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  });
 }
 
-export async function ensureDockerImage(image: string) {
-  const imageState = await inspectDockerImage(image);
-  if (imageState === "exists") {
+export async function ensureDockerImage(
+  image: string,
+  context: Omit<DockerStartupErrorContext, "phase" | "image"> = {},
+) {
+  const imageState = await inspectDockerImage(image, context);
+  if (imageState.state === "exists") {
     return;
   }
   if (image === DEFAULT_SANDBOX_IMAGE) {
-    throw new Error(
-      `Sandbox image not found: ${image}. Build it with scripts/sandbox-setup.sh before enabling Docker sandboxing. The default image includes python3 for sandbox write/edit helpers; OpenClaw will not substitute plain debian:bookworm-slim.`,
-    );
+    throw createDockerSandboxStartupError({
+      context: { phase: "image inspect", image, ...context },
+      error: new Error(
+        `Sandbox image not found: ${image}. Build it with scripts/sandbox-setup.sh before enabling Docker sandboxing. The default image includes python3 for sandbox write/edit helpers; OpenClaw will not substitute plain debian:bookworm-slim.`,
+      ),
+      exitCode: imageState.code,
+      stdout: imageState.stdout,
+      stderr: imageState.stderr,
+    });
   }
-  throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);
+  throw createDockerSandboxStartupError({
+    context: { phase: "image inspect", image, ...context },
+    error: new Error(`Sandbox image not found: ${image}. Build or pull it first.`),
+    exitCode: imageState.code,
+    stdout: imageState.stdout,
+    stderr: imageState.stderr,
+  });
 }
 
 export async function dockerContainerState(name: string) {
@@ -506,7 +656,7 @@ async function createSandboxContainer(params: {
   configHash?: string;
 }) {
   const { name, cfg, workspaceDir, scopeKey } = params;
-  await ensureDockerImage(cfg.image);
+  await ensureDockerImage(cfg.image, { containerName: name });
 
   const args = buildSandboxCreateArgs({
     name,
@@ -527,11 +677,23 @@ async function createSandboxContainer(params: {
   appendCustomBinds(args, cfg);
   args.push(cfg.image, "sleep", "infinity");
 
-  await execDocker(args);
-  await execDocker(["start", name]);
+  await execDockerStartupCommand(args, {
+    phase: "create",
+    containerName: name,
+    image: cfg.image,
+  });
+  await execDockerStartupCommand(["start", name], {
+    phase: "start",
+    containerName: name,
+    image: cfg.image,
+  });
 
   if (cfg.setupCommand?.trim()) {
-    await execDocker(["exec", "-i", name, "/bin/sh", "-lc", cfg.setupCommand]);
+    await execDockerStartupCommand(["exec", "-i", name, "/bin/sh", "-lc", cfg.setupCommand], {
+      phase: "setupCommand",
+      containerName: name,
+      image: cfg.image,
+    });
   }
 }
 
@@ -614,7 +776,11 @@ export async function ensureSandboxContainer(params: {
       configHash: expectedHash,
     });
   } else if (!running) {
-    await execDocker(["start", containerName]);
+    await execDockerStartupCommand(["start", containerName], {
+      phase: "start",
+      containerName,
+      image: params.cfg.docker.image,
+    });
   }
   await updateRegistry({
     containerName,


### PR DESCRIPTION
﻿## Summary
- Wrap Docker sandbox startup failures with a clear phase-specific error.
- Include the failed phase, container name, image, exit code, and sanitized Docker stdout/stderr.
- Cover image inspect/missing image, `docker create`, `docker start`, existing-container start, and `setupCommand` failures.
- Keep full Docker command args out of the error text.

Refs #57992.

## Verification
- `corepack pnpm test src/agents/sandbox/docker.test.ts src/agents/sandbox/docker.config-hash-recreate.test.ts`
- `corepack pnpm check:changed`
- `git diff --check`
- Local Docker smoke: forced a sandbox `setupCommand` failure and confirmed the user-facing error included the phase, image, exit code, and sanitized stdout without exposing full Docker command args.

## sessions_spawn Scope Note
I originally explored moving sandbox resolution into the `sessions_spawn` lifecycle path so child runs could directly record Docker startup failures. I removed that from this PR because I could not prove the combined live path cleanly on this machine.

What I verified instead:
- existing focused `sessions_spawn` tests pass separately
- live `sessions_spawn` works with Claude CLI, but that route did not exercise Docker sandboxing
- this PR now leaves `sessions_spawn` and embedded-runner code untouched

This PR is intentionally scoped to Docker sandbox startup error reporting and Docker sandbox tests only.

## AI Assistance
I used AI assistance to inspect the code, write the patch, and run local verification.
