### PR TITLE
fix(sessions): prune invalid cleanup session ids

### DIFF
--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -207,7 +207,15 @@ function pruneMissingTranscriptEntries(params: {
     if (!entry?.sessionId) {
       continue;
     }
-    const transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
+    let transcriptPath: string;
+    try {
+      transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
+    } catch {
+      delete params.store[key];
+      removed += 1;
+      params.onPruned?.(key);
+      continue;
+    }
     if (!fs.existsSync(transcriptPath)) {
       delete params.store[key];
       removed += 1;

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -482,6 +482,46 @@ describe("Integration: saveSessionStore with pruning", () => {
     await expectPathExists(freshTranscript);
   });
 
+  it("sessions cleanup fix-missing prunes entries whose sessionId is a session key", async () => {
+    applyEnforcedMaintenanceConfig(mockLoadConfig);
+
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:main": {
+            sessionId: "agent:main:main",
+            updatedAt: Date.now(),
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const dryRun = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, dryRun: true, enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    const preview = dryRun.previewResults[0];
+    expect(preview?.summary.missing).toBe(1);
+    expect(preview?.summary.afterCount).toBe(0);
+    expect(preview?.missingKeys.has("agent:main:main")).toBe(true);
+    expect(loadSessionStore(storePath, { skipCache: true })).toHaveProperty("agent:main:main");
+
+    const applied = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    expect(applied.appliedSummaries[0]?.missing).toBe(1);
+    expect(loadSessionStore(storePath, { skipCache: true })).not.toHaveProperty("agent:main:main");
+  });
+
   it("cleans up archived transcripts older than the prune window", async () => {
     applyEnforcedMaintenanceConfig(mockLoadConfig);
 


### PR DESCRIPTION
Fixes #80970.

## Summary

`sessions cleanup --fix-missing` now treats a stored `sessionId` that cannot be resolved into a safe transcript path as a missing transcript entry. That lets cleanup prune malformed legacy rows such as:

```json
"agent:main:main": {
  "sessionId": "agent:main:main"
}
```

instead of throwing `Invalid session ID: agent:main:main` before cleanup can report or remove the row.

## Verification

```text
pnpm test src/config/sessions/store.pruning.integration.test.ts
Test Files  1 passed (1)
Tests       29 passed (29)
```

```text
pnpm exec oxfmt --check --threads=1 src/config/sessions/cleanup-service.ts src/config/sessions/store.pruning.integration.test.ts
All matched files use the correct format.
```

```text
pnpm check:changed
0 warnings / 0 errors across changed lanes: core, coreTests.
```

```text
git diff --check
# no output
```

## Real behavior proof

Behavior or issue addressed: `openclaw sessions cleanup --dry-run --fix-missing` no longer crashes when a session-store row has a key-shaped value such as `sessionId: "agent:main:main"`. The malformed row is reported as `prune-missing`, matching the intended `--fix-missing` behavior.

Real environment tested: Local OpenClaw checkout on Linux, branch `fix/sessions-cleanup-invalid-session-key-80970`, commit `82a4502894`. The CLI command was run against a temporary sessions store containing only the malformed row from the report.

Exact steps or command run after the patch:
1. Created a temporary `sessions.json` with key `agent:main:main` and stored `sessionId: "agent:main:main"`.
2. Ran `node --import tsx src/entry.ts sessions cleanup --store /tmp/openclaw-80970-proof-X3b5jN/sessions.json --dry-run --fix-missing`.

Evidence after fix:
```text
STORE=/tmp/openclaw-80970-proof-X3b5jN/sessions.json
Session store: /tmp/openclaw-80970-proof-X3b5jN/sessions.json
Maintenance mode: enforce
Entries: 1 -> 0 (remove 1)
Would prune missing transcripts: 1
Would retire stale direct DM sessions: 0
Would prune stale: 0
Would cap overflow: 0
Would prune unreferenced artifacts: 0

Planned session actions:
Action           Key                        Age       Model          Flags
prune-missing    agent:main:main            unknown   gpt-5.5        id:agent:main:main
```

Observed result after fix: The command exited `0` and produced the dry-run cleanup table. It did not throw `Invalid session ID: agent:main:main`.

What was not tested: I did not run against a user’s real session store. The regression uses a minimal temporary store with the same malformed `sessionId` shape described in the issue, and the integration test covers both dry-run and enforced removal.

## Audit

- Existing-helper check: reused existing `resolveSessionFilePath`; the change catches its validation failure only inside the `--fix-missing` pruning path.
- Shared-helper caller check: no shared helper contract changed; `validateSessionId` and `resolveSessionFilePath` keep strict behavior for normal transcript path resolution.
- Broader-rival scan: no open same-scope PR for #80970; active PR searches for `80970` and cleanup/session-key terms returned no open rivals.
