### PR TITLE
fix(azure): bound Responses first-event stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Azure OpenAI Responses: flatten memory tool corpus schemas and fail post-header no-event stalls with a bounded diagnostic instead of waiting for the embedded run timeout. Fixes #80926. Thanks @galiniliev.
 - fix(node-pairing): replace changed pending requests [AI]. (#80894) Thanks @pgondhi987.
 - Rate limit Google Chat webhook requests [AI]. (#80974) Thanks @pgondhi987.
 - Docker: mount the auth-profile secret key directory so OAuth-backed auth profiles survive container rebuilds. (#80991)

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -1,3 +1,4 @@
+import { optionalStringEnum } from "openclaw/plugin-sdk/channel-actions";
 import {
   listMemoryCorpusSupplements,
   resolveMemorySearchConfig,
@@ -31,23 +32,14 @@ export const MemorySearchSchema = Type.Object({
   query: Type.String(),
   maxResults: Type.Optional(Type.Number()),
   minScore: Type.Optional(Type.Number()),
-  corpus: Type.Optional(
-    Type.Union([
-      Type.Literal("memory"),
-      Type.Literal("wiki"),
-      Type.Literal("all"),
-      Type.Literal("sessions"),
-    ]),
-  ),
+  corpus: optionalStringEnum(["memory", "wiki", "all", "sessions"] as const),
 });
 
 export const MemoryGetSchema = Type.Object({
   path: Type.String(),
   from: Type.Optional(Type.Number()),
   lines: Type.Optional(Type.Number()),
-  corpus: Type.Optional(
-    Type.Union([Type.Literal("memory"), Type.Literal("wiki"), Type.Literal("all")]),
-  ),
+  corpus: optionalStringEnum(["memory", "wiki", "all"] as const),
 });
 
 function resolveMemoryToolContext(options: MemoryToolOptions) {

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -7,6 +7,7 @@ import {
   setMemorySearchImpl,
 } from "./memory-tool-manager-mock.js";
 import { createMemorySearchTool } from "./tools.js";
+import { MemoryGetSchema, MemorySearchSchema } from "./tools.shared.js";
 import {
   asOpenClawConfig,
   createMemorySearchToolOrThrow,
@@ -31,6 +32,24 @@ vi.mock("openclaw/plugin-sdk/session-transcript-hit", async (importOriginal) => 
       store: sessionStore,
     })),
   };
+});
+
+describe("memory tool schemas", () => {
+  it("uses flat corpus enums for provider-compatible tool schemas", () => {
+    const searchCorpus = MemorySearchSchema.properties.corpus;
+    const getCorpus = MemoryGetSchema.properties.corpus;
+
+    expect(searchCorpus).toMatchObject({
+      type: "string",
+      enum: ["memory", "wiki", "all", "sessions"],
+    });
+    expect(getCorpus).toMatchObject({
+      type: "string",
+      enum: ["memory", "wiki", "all"],
+    });
+    expect(searchCorpus).not.toHaveProperty("anyOf");
+    expect(getCorpus).not.toHaveProperty("anyOf");
+  });
 });
 
 describe("memory_search unavailable payloads", () => {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -22,6 +22,7 @@ import {
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./system-prompt-cache-boundary.js";
 
 type OpenAICompletionsOutput = Parameters<typeof __testing.processOpenAICompletionsStream>[1];
+type OpenAIResponsesOutput = Parameters<typeof __testing.processResponsesStream>[1];
 
 type CapturedStreamEvent = { type?: string; delta?: string };
 
@@ -60,6 +61,54 @@ function createAssistantOutput(model: Model<"openai-completions">): OpenAIComple
   };
 }
 
+function createResponsesAssistantOutput(
+  model: Model<"azure-openai-responses">,
+): OpenAIResponsesOutput {
+  return {
+    role: "assistant" as const,
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+function createAzureResponsesModel(): Model<"azure-openai-responses"> {
+  return {
+    id: "gpt-5.4-pro",
+    name: "GPT-5.4 Pro",
+    api: "azure-openai-responses",
+    provider: "azure-openai-responses-devdiv",
+    baseUrl: "https://example.openai.azure.com/openai/responses",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 8192,
+  };
+}
+
+function neverYieldsStream(): AsyncIterable<unknown> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => await new Promise<IteratorResult<unknown>>(() => undefined),
+        return: async () => ({ done: true, value: undefined }),
+      };
+    },
+  };
+}
+
 async function* streamChunks(chunks: readonly unknown[]): AsyncGenerator<never> {
   for (const chunk of chunks) {
     yield chunk as never;
@@ -78,6 +127,19 @@ function expectRecordFields(record: unknown, expected: Record<string, unknown>) 
 }
 
 describe("openai transport stream", () => {
+  it("fails Azure Responses streams when headers arrive but no first event follows", async () => {
+    const model = createAzureResponsesModel();
+    await expect(
+      __testing.processResponsesStream(
+        neverYieldsStream(),
+        createResponsesAssistantOutput(model),
+        { push: vi.fn() },
+        model,
+        { firstEventTimeoutMs: 1 },
+      ),
+    ).rejects.toThrow(/did not deliver a first event within 1ms after HTTP streaming headers/);
+  });
+
   it("summarizes model payload tools with full names when requested", () => {
     const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
     process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "tools";

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -70,6 +70,7 @@ import { mergeTransportMetadata, sanitizeTransportPayloadText } from "./transpor
 const DEFAULT_AZURE_OPENAI_API_VERSION = "2024-12-01-preview";
 const OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT = " ";
 const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validator";
+const AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS = 30_000;
 const log = createSubsystemLogger("openai-transport");
 
 type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };
@@ -649,6 +650,62 @@ function resolveOpenAIStrictToolFlagWithDiagnostics(
   return strict;
 }
 
+function createResponsesFirstEventTimeoutError(model: Model<Api>, timeoutMs: number): Error {
+  return new Error(
+    `Azure OpenAI Responses stream did not deliver a first event within ${timeoutMs}ms after HTTP streaming headers. ` +
+      `provider=${model.provider} model=${model.id}. ` +
+      "The provider may be stalled while parsing the tool payload; retry with a smaller tool surface or enable OPENCLAW_DEBUG_MODEL_PAYLOAD=tools to inspect exposed tools.",
+  );
+}
+
+function withResponsesFirstEventTimeout(
+  openaiStream: AsyncIterable<unknown>,
+  model: Model<Api>,
+  timeoutMs: number | undefined,
+): AsyncIterable<unknown> {
+  if (timeoutMs === undefined || timeoutMs <= 0 || !Number.isFinite(timeoutMs)) {
+    return openaiStream;
+  }
+  return {
+    async *[Symbol.asyncIterator]() {
+      const iterator = openaiStream[Symbol.asyncIterator]();
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const clear = () => {
+        if (timer) {
+          clearTimeout(timer);
+          timer = undefined;
+        }
+      };
+      try {
+        const first = await new Promise<IteratorResult<unknown>>((resolve, reject) => {
+          timer = setTimeout(
+            () => reject(createResponsesFirstEventTimeoutError(model, timeoutMs)),
+            timeoutMs,
+          );
+          iterator.next().then(resolve, reject);
+        }).finally(clear);
+        if (!first.done) {
+          yield first.value;
+        } else {
+          return;
+        }
+        while (true) {
+          const next = await iterator.next();
+          if (next.done) {
+            return;
+          }
+          yield next.value;
+        }
+      } catch (error) {
+        void iterator.return?.().catch(() => undefined);
+        throw error;
+      } finally {
+        clear();
+      }
+    },
+  };
+}
+
 async function processResponsesStream(
   openaiStream: AsyncIterable<unknown>,
   output: MutableAssistantOutput,
@@ -660,6 +717,7 @@ async function processResponsesStream(
       usage: MutableAssistantOutput["usage"],
       serviceTier?: ResponseCreateParamsStreaming["service_tier"],
     ) => void;
+    firstEventTimeoutMs?: number;
   },
 ) {
   let currentItem: Record<string, unknown> | null = null;
@@ -669,7 +727,12 @@ async function processResponsesStream(
   const eventTypes = new Map<string, number>();
   const sseDebugMode = resolveModelSseDebugMode();
   const blockIndex = () => output.content.length - 1;
-  for await (const rawEvent of openaiStream) {
+  const guardedStream = withResponsesFirstEventTimeout(
+    openaiStream,
+    model,
+    options?.firstEventTimeoutMs,
+  );
+  for await (const rawEvent of guardedStream) {
     const event = rawEvent as Record<string, unknown>;
     const type = stringifyUnknown(event.type);
     eventCount += 1;
@@ -1421,7 +1484,9 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
             `elapsedMs=${Date.now() - requestStartedAt}`,
         );
         stream.push({ type: "start", partial: output as never });
-        await processResponsesStream(responseStream, output, stream, model);
+        await processResponsesStream(responseStream, output, stream, model, {
+          firstEventTimeoutMs: AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS,
+        });
         if (options?.signal?.aborted) {
           throw new Error("Request was aborted");
         }
@@ -2455,7 +2520,9 @@ export const __testing = {
   sanitizeOpenAICodexResponsesParams,
   buildOpenAICompletionsClientConfig,
   processOpenAICompletionsStream,
+  processResponsesStream,
   formatModelTransportDebugBaseUrl,
   summarizeResponsesPayload,
   summarizeResponsesTools,
+  withResponsesFirstEventTimeout,
 };


### PR DESCRIPTION
## Summary

- Problem: Azure OpenAI Responses can return HTTP 200 streaming headers and then never yield the first parsed Responses event when memory tools are exposed.
- Why it matters: the embedded run waits until the broader timeout, leaving users with an opaque stall instead of a provider/actionable error.
- What changed: memory tool `corpus` schemas now use flat string enums instead of TypeBox literal unions, and Azure Responses streams now fail with a bounded post-header first-event diagnostic after 30 seconds.
- What did NOT change (scope boundary): this does not add Azure retries, alter non-Azure Responses streams, or claim every Azure/tool payload will stream successfully; it makes the known memory schema incompatibility smaller and makes the remaining stall bounded and diagnosable.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80926
- Related #80927
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Azure Responses should not sit forever after HTTP streaming headers when the provider never yields a first parsed Responses event; memory tool schemas should not expose `anyOf` for corpus enums.
- Real environment tested: local OpenClaw checkout on Linux, Node/Corepack repo runtime, branch `fix/azure-responses-first-event-timeout` at commit `087a8a5364`.
- Exact steps or command run after this patch: `pnpm test src/agents/openai-transport-stream.test.ts extensions/memory-core/src/tools.test.ts -- --reporter=verbose`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output showed `src/agents/openai-transport-stream.test.ts > openai transport stream > fails Azure Responses streams when headers arrive but no first event follows` passed, and `extensions/memory-core/src/tools.test.ts > memory tool schemas > uses flat corpus enums for provider-compatible tool schemas` passed; full command summary: `Test Files 1 passed (1), Tests 119 passed (119)` for the agent shard and `Test Files 1 passed (1), Tests 7 passed (7)` for the memory shard.
- Observed result after fix: the no-first-event Responses stream rejects with `Azure OpenAI Responses stream did not deliver a first event within 1ms after HTTP streaming headers` in the regression test, and the memory schemas expose flat `enum` values with no `anyOf`.
- What was not tested: live Azure OpenAI Responses against the reporter's private deployment was not run; `~/.profile` did not expose Azure/OpenAI credentials in this environment.
- Before evidence (optional but encouraged): #80926 includes live before/control logs showing HTTP 200 SSE headers with no `[responses] first_event` when memory tools were exposed, and success when memory tools were excluded.

## Root Cause (if applicable)

- Root cause: memory-core used TypeBox literal unions for `corpus`, which emit provider-sensitive `anyOf`; separately, the Azure Responses stream path had no first-event watchdog after headers, so a provider stall remained hidden until the outer run timeout.
- Missing detection / guardrail: no memory schema regression asserted flat corpus enums, and no Responses stream test covered the post-header/no-first-event failure mode.
- Contributing context (if known): #80927 identified the memory schema shape as a concrete partial compatibility issue; #80926 reported that the broader Azure stall still needed bounded behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/tools.test.ts`; `src/agents/openai-transport-stream.test.ts`.
- Scenario the test should lock in: memory corpus schemas stay flat-enum/no-`anyOf`, and Azure Responses processing fails when headers are followed by no first event.
- Why this is the smallest reliable guardrail: it checks the exact schema objects and stream processing seam without requiring private Azure credentials.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Azure OpenAI Responses runs that receive streaming headers but no first parsed event now fail after 30 seconds with an actionable diagnostic instead of waiting for the broader embedded run timeout.

## Diagram (if applicable)

```text
Before:
Azure headers -> no parsed event -> embedded run timeout

After:
Azure headers -> no parsed event for 30s -> actionable Responses first-event error
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo runtime via pnpm/Corepack
- Model/provider: Azure OpenAI Responses seam, simulated no-first-event stream for deterministic proof
- Integration/channel (if any): memory-core plugin tool schema
- Relevant config (redacted): no live Azure/OpenAI credentials found in `~/.profile`; no secrets printed

### Steps

1. Build the memory schemas from `extensions/memory-core/src/tools.shared.ts`.
2. Process an Azure Responses async stream that never yields a first event.
3. Run focused tests, changed gate, and build.

### Expected

- Memory schemas use flat string `enum` values without `anyOf`.
- Azure Responses stream processing fails with a bounded first-event diagnostic.

### Actual

- Both regression tests passed.
- `pnpm check:changed --base upstream/main` passed.
- `pnpm build` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: flat memory corpus schema enums; no-first-event Azure Responses stream diagnostic; scoped type/lint guards; full build.
- Edge cases checked: stream iterator `return()` is invoked best-effort without blocking the timeout rejection; existing OpenAI transport test suite still passes.
- What you did **not** verify: live Azure deployment behavior with private credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a legitimate Azure Responses run could take longer than 30 seconds after headers before the first parsed event.
  - Mitigation: Responses normally emits `response.created` promptly after stream headers; the timeout is Azure-only and the error is explicit enough to guide follow-up if a valid slow-first-event case appears.
