### PR TITLE
Add CLI turn output digests

### DIFF
--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { cliBackendLog } from "./cli-runner/log.js";
 
 // vi.mock factories are hoisted above imports, so any references inside them
 // must come from vi.hoisted() so they exist at hoist time (otherwise they'd
@@ -114,6 +115,7 @@ afterEach(() => {
 
 describe("runCliAgent cron before_agent_reply seam", () => {
   it("lets before_agent_reply claim cron runs before the CLI subprocess is invoked", async () => {
+    const logInfoSpy = vi.spyOn(cliBackendLog, "info").mockImplementation(() => undefined);
     hasHooksMock.mockImplementation((hookName) => hookName === "before_agent_reply");
     runBeforeAgentReplyMock.mockResolvedValue({
       handled: true,
@@ -121,30 +123,43 @@ describe("runCliAgent cron before_agent_reply seam", () => {
     });
     const onExecutionPhase = vi.fn();
 
-    const result = await runCliAgent({
-      ...baseRunParams,
-      trigger: "cron",
-      jobId: "cron-job-123",
-      onExecutionPhase,
-    });
+    try {
+      const result = await runCliAgent({
+        ...baseRunParams,
+        trigger: "cron",
+        jobId: "cron-job-123",
+        onExecutionPhase,
+      });
 
-    expect(runBeforeAgentReplyMock).toHaveBeenCalledTimes(1);
-    expect(onExecutionPhase).toHaveBeenCalledWith({
-      phase: "before_agent_reply",
-      provider: baseRunParams.provider,
-      model: baseRunParams.model,
-    });
-    const [event, context] = runBeforeAgentReplyMock.mock.calls.at(0) ?? [];
-    expect(event).toEqual({ cleanedBody: baseRunParams.prompt });
-    const hookContext = context as Record<string, unknown> | undefined;
-    expect(hookContext?.jobId).toBe("cron-job-123");
-    expect(hookContext?.agentId).toBe(baseRunParams.agentId);
-    expect(hookContext?.sessionId).toBe(baseRunParams.sessionId);
-    expect(hookContext?.sessionKey).toBe(baseRunParams.sessionKey);
-    expect(hookContext?.workspaceDir).toBe(baseRunParams.workspaceDir);
-    expect(hookContext?.trigger).toBe("cron");
-    expect(executePreparedCliRunMock).not.toHaveBeenCalled();
-    expect(result.payloads?.[0]?.text).toBe("dreaming claimed via cli runner");
+      expect(runBeforeAgentReplyMock).toHaveBeenCalledTimes(1);
+      expect(onExecutionPhase).toHaveBeenCalledWith({
+        phase: "before_agent_reply",
+        provider: baseRunParams.provider,
+        model: baseRunParams.model,
+      });
+      const [event, context] = runBeforeAgentReplyMock.mock.calls.at(0) ?? [];
+      expect(event).toEqual({ cleanedBody: baseRunParams.prompt });
+      const hookContext = context as Record<string, unknown> | undefined;
+      expect(hookContext?.jobId).toBe("cron-job-123");
+      expect(hookContext?.agentId).toBe(baseRunParams.agentId);
+      expect(hookContext?.sessionId).toBe(baseRunParams.sessionId);
+      expect(hookContext?.sessionKey).toBe(baseRunParams.sessionKey);
+      expect(hookContext?.workspaceDir).toBe(baseRunParams.workspaceDir);
+      expect(hookContext?.trigger).toBe("cron");
+      expect(executePreparedCliRunMock).not.toHaveBeenCalled();
+      expect(result.payloads?.[0]?.text).toBe("dreaming claimed via cli runner");
+
+      const syntheticTurnLog = logInfoSpy.mock.calls
+        .map(([message]) => message)
+        .find((message) => message.startsWith("cli synthetic turn:"));
+      expect(syntheticTurnLog).toContain("provider=codex-cli");
+      expect(syntheticTurnLog).toContain("model=<synthetic>");
+      expect(syntheticTurnLog).toContain("requestedModel=gpt-5.5");
+      expect(syntheticTurnLog).toContain("outBytes=31 outHash=96317e453543");
+      expect(syntheticTurnLog).not.toContain("dreaming claimed via cli runner");
+    } finally {
+      logInfoSpy.mockRestore();
+    }
   });
 
   it("does not run prepareCliRunContext when the cron hook claims (no resource allocation, no leak)", async () => {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -39,6 +39,7 @@ import {
   executePreparedCliRun,
 } from "./cli-runner/execute.js";
 import { buildSystemPrompt } from "./cli-runner/helpers.js";
+import { cliBackendLog, formatCliBackendOutputDigest } from "./cli-runner/log.js";
 import { setCliRunnerPrepareTestDeps } from "./cli-runner/prepare.js";
 import type { PreparedCliRunContext } from "./cli-runner/types.js";
 import { createClaudeApiErrorFixture } from "./test-helpers/claude-api-error-fixture.js";
@@ -261,6 +262,11 @@ async function withTempOpenClawHome(run: (home: string) => Promise<void>): Promi
 }
 
 describe("runCliAgent spawn path", () => {
+  it("formats output digests without logging response content", () => {
+    expect(formatCliBackendOutputDigest("one")).toBe("outBytes=3 outHash=7692c3ad3540");
+    expect(formatCliBackendOutputDigest("∑")).toBe("outBytes=3 outHash=be27c7179a61");
+  });
+
   it("formats redacted CLI resume diagnostics without exposing raw session ids", () => {
     const logLine = buildCliExecLogLine({
       provider: "claude-cli",
@@ -890,6 +896,7 @@ describe("runCliAgent spawn path", () => {
   });
 
   it("reuses a Claude live session process across turns", async () => {
+    const logInfoSpy = vi.spyOn(cliBackendLog, "info").mockImplementation(() => undefined);
     const agentEvents: unknown[] = [];
     const stop = onAgentEvent((evt) => {
       if (evt.stream === "assistant") {
@@ -988,7 +995,16 @@ describe("runCliAgent spawn path", () => {
         { text: "one", delta: "one" },
         { text: "two", delta: "two" },
       ]);
+      const turnLogs = logInfoSpy.mock.calls
+        .map(([message]) => message)
+        .filter((message) => message.startsWith("claude live session turn:"));
+      expect(turnLogs).toHaveLength(2);
+      expect(turnLogs[0]).toContain("outBytes=3 outHash=7692c3ad3540");
+      expect(turnLogs[1]).toContain("outBytes=3 outHash=3fc4ccfe7458");
+      expect(turnLogs.join("\n")).not.toContain("one");
+      expect(turnLogs.join("\n")).not.toContain("two");
     } finally {
+      logInfoSpy.mockRestore();
       stop();
     }
   });

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -686,6 +686,7 @@ describe("runCliAgent spawn path", () => {
   });
 
   it("runs CLI through supervisor and returns payload", async () => {
+    const logInfoSpy = vi.spyOn(cliBackendLog, "info").mockImplementation(() => undefined);
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({
         reason: "exit",
@@ -706,32 +707,44 @@ describe("runCliAgent spawn path", () => {
     });
     context.reusableCliSession = { sessionId: "thread-123" };
 
-    const result = await executePreparedCliRun(context, "thread-123");
+    try {
+      const result = await executePreparedCliRun(context, "thread-123");
 
-    expect(result.text).toBe("ok");
-    const input = mockCallArg(supervisorSpawnMock) as {
-      argv?: string[];
-      mode?: string;
-      timeoutMs?: number;
-      noOutputTimeoutMs?: number;
-      replaceExistingScope?: boolean;
-      scopeKey?: string;
-    };
-    expect(input.mode).toBe("child");
-    expect(input.argv).toEqual([
-      "codex",
-      "exec",
-      "resume",
-      "thread-123",
-      "--skip-git-repo-check",
-      "--model",
-      "gpt-5.4",
-      "hi",
-    ]);
-    expect(input.timeoutMs).toBe(1_000);
-    expect(input.noOutputTimeoutMs).toBeGreaterThanOrEqual(1_000);
-    expect(input.replaceExistingScope).toBe(true);
-    expect(input.scopeKey).toContain("thread-123");
+      expect(result.text).toBe("ok");
+      const input = mockCallArg(supervisorSpawnMock) as {
+        argv?: string[];
+        mode?: string;
+        timeoutMs?: number;
+        noOutputTimeoutMs?: number;
+        replaceExistingScope?: boolean;
+        scopeKey?: string;
+      };
+      expect(input.mode).toBe("child");
+      expect(input.argv).toEqual([
+        "codex",
+        "exec",
+        "resume",
+        "thread-123",
+        "--skip-git-repo-check",
+        "--model",
+        "gpt-5.4",
+        "hi",
+      ]);
+      expect(input.timeoutMs).toBe(1_000);
+      expect(input.noOutputTimeoutMs).toBeGreaterThanOrEqual(1_000);
+      expect(input.replaceExistingScope).toBe(true);
+      expect(input.scopeKey).toContain("thread-123");
+
+      const turnLog = logInfoSpy.mock.calls
+        .map(([message]) => message)
+        .find((message) => message.startsWith("cli turn:"));
+      expect(turnLog).toContain("provider=codex-cli");
+      expect(turnLog).toContain("model=gpt-5.4");
+      expect(turnLog).toContain("outBytes=2 outHash=2689367b205c");
+      expect(turnLog).not.toContain("ok");
+    } finally {
+      logInfoSpy.mockRestore();
+    }
   });
 
   it("passes Codex system prompts through model_instructions_file", async () => {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -5,6 +5,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildAgentHookContextChannelFields } from "../plugins/hook-agent-context.js";
 import { resolveBlockMessage } from "../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { cliBackendLog, formatCliBackendOutputDigest } from "./cli-runner/log.js";
 import {
   loadCliSessionContextEngineMessages,
   loadCliSessionHistoryMessages,
@@ -238,6 +239,10 @@ export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedAg
         hookContext,
       );
       if (hookResult?.handled) {
+        const finalText = hookResult.reply?.text ?? SILENT_REPLY_TOKEN;
+        cliBackendLog.info(
+          `cli synthetic turn: provider=${params.provider} model=<synthetic> requestedModel=${params.model ?? ""} durationMs=${Date.now() - startedAt} ${formatCliBackendOutputDigest(finalText)}`,
+        );
         return {
           payloads: buildHandledReplyPayloads(hookResult.reply),
           meta: {
@@ -247,8 +252,8 @@ export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedAg
               provider: params.provider,
               model: params.model ?? "",
             },
-            finalAssistantVisibleText: hookResult.reply?.text ?? SILENT_REPLY_TOKEN,
-            finalAssistantRawText: hookResult.reply?.text ?? SILENT_REPLY_TOKEN,
+            finalAssistantVisibleText: finalText,
+            finalAssistantRawText: finalText,
           },
         };
       }

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -29,7 +29,7 @@ import {
 } from "../cli-output.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers.js";
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
-import { cliBackendLog } from "./log.js";
+import { cliBackendLog, formatCliBackendOutputDigest } from "./log.js";
 import type { PreparedCliRunContext } from "./types.js";
 
 type ProcessSupervisor = ReturnType<
@@ -376,7 +376,7 @@ function finishTurn(session: ClaudeLiveSession, output: CliOutput): void {
     return;
   }
   cliBackendLog.info(
-    `claude live session turn: provider=${session.providerId} model=${session.modelId} durationMs=${Date.now() - turn.startedAtMs} rawLines=${turn.rawLines.length}`,
+    `claude live session turn: provider=${session.providerId} model=${session.modelId} durationMs=${Date.now() - turn.startedAtMs} rawLines=${turn.rawLines.length} ${formatCliBackendOutputDigest(output.text)}`,
   );
   completeActiveClaudeLiveTools(turn);
   clearTurnTimers(turn);

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -40,6 +40,7 @@ import {
 import {
   cliBackendLog,
   CLI_BACKEND_LOG_OUTPUT_ENV,
+  formatCliBackendOutputDigest,
   LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV,
 } from "./log.js";
 import type { PreparedCliRunContext } from "./types.js";
@@ -368,6 +369,7 @@ export async function executePreparedCliRun(
 
   try {
     return await enqueueCliRun(queueKey, async () => {
+      const cliTurnStartedAt = Date.now();
       const restoreSkillEnv = params.skillsSnapshot
         ? applySkillEnvOverridesFromSnapshot({
             snapshot: params.skillsSnapshot,
@@ -781,6 +783,9 @@ export async function executePreparedCliRun(
             fallbackSessionId: resolvedSessionId,
           });
         const rawText = parsed.text;
+        cliBackendLog.info(
+          `cli turn: provider=${params.provider} model=${context.modelId} durationMs=${Date.now() - cliTurnStartedAt} ${formatCliBackendOutputDigest(rawText)}`,
+        );
         return {
           ...parsed,
           rawText,

--- a/src/agents/cli-runner/log.ts
+++ b/src/agents/cli-runner/log.ts
@@ -1,5 +1,12 @@
+import crypto from "node:crypto";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 
 export const cliBackendLog = createSubsystemLogger("agent/cli-backend");
 export const CLI_BACKEND_LOG_OUTPUT_ENV = "OPENCLAW_CLI_BACKEND_LOG_OUTPUT";
 export const LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV = "OPENCLAW_CLAUDE_CLI_LOG_OUTPUT";
+
+export function formatCliBackendOutputDigest(text: string): string {
+  const outBytes = Buffer.byteLength(text, "utf8");
+  const outHash = crypto.createHash("sha256").update(text).digest("hex").slice(0, 12);
+  return `outBytes=${outBytes} outHash=${outHash}`;
+}


### PR DESCRIPTION
## Summary

Fixes #81004.

Adds content-safe output fingerprints to CLI backend turn logs so repeated byte-identical responses can be detected from `gateway.log` without opening per-session transcript files.

## Root Cause

Claude live-session completion logs only included provider, model, duration, and raw line count. Cron `before_agent_reply` hooks that short-circuit into a synthetic assistant reply bypassed that live-session completion path entirely, so those turns had no comparable CLI backend turn log.

That made stuck loops where every assistant reply is byte-identical effectively invisible from gateway logs alone.

## Changes

- Add a shared CLI backend helper that reports `outBytes` and a 12-character SHA-256 `outHash` without logging response text.
- Include that digest on `claude live session turn` logs.
- Emit an equivalent `cli synthetic turn` log for cron `before_agent_reply` handled replies, with `model=<synthetic>` and the requested model preserved separately.
- Cover both paths with tests that assert digests are present and raw response text is not logged.

## Real behavior proof

- **Behavior or issue addressed:** CLI backend turn logs now expose stable byte count and short content hash fields for Claude live-session turns and synthetic cron hook replies, while still omitting the raw assistant response text.
- **Real environment tested:** Local OpenClaw checkout on macOS, branch `codex/cli-turn-output-digests`, after rebasing onto `origin/main`.
- **Exact steps or command run after this patch:** Ran a local Node/tsx command against the production CLI backend digest helper used by the new log sites:

```sh
node --import tsx - <<'NODE'
import { formatCliBackendOutputDigest } from './src/agents/cli-runner/log.ts';
const claudeReply = 'one';
const syntheticReply = 'dreaming claimed via cli runner';
console.log(`claude live session turn: provider=claude-cli model=sonnet durationMs=12 rawLines=3 ${formatCliBackendOutputDigest(claudeReply)}`);
console.log(`cli synthetic turn: provider=codex-cli model=<synthetic> requestedModel=gpt-5.5 durationMs=4 ${formatCliBackendOutputDigest(syntheticReply)}`);
console.log(`raw claude reply visible in log: ${String(`claude live session turn: provider=claude-cli model=sonnet durationMs=12 rawLines=3 ${formatCliBackendOutputDigest(claudeReply)}`).includes(claudeReply)}`);
console.log(`raw synthetic reply visible in log: ${String(`cli synthetic turn: provider=codex-cli model=<synthetic> requestedModel=gpt-5.5 durationMs=4 ${formatCliBackendOutputDigest(syntheticReply)}`).includes(syntheticReply)}`);
NODE
```

- **Evidence after fix:** Terminal output from the command above:

```text
claude live session turn: provider=claude-cli model=sonnet durationMs=12 rawLines=3 outBytes=3 outHash=7692c3ad3540
cli synthetic turn: provider=codex-cli model=<synthetic> requestedModel=gpt-5.5 durationMs=4 outBytes=31 outHash=96317e453543
raw claude reply visible in log: false
raw synthetic reply visible in log: false
```

- **Observed result after fix:** The copied log output includes `outBytes` and `outHash` for both target log shapes. The raw assistant response text is not present in either log line.
- **What was not tested:** I did not run a full live Gateway plus Claude CLI daemon session; the exact production log helper output was checked locally, and the two production call sites are covered by focused regression tests below.

## Verification

- `pnpm test src/agents/cli-runner.spawn.test.ts src/agents/cli-runner.before-agent-reply-cron.test.ts`
- `pnpm check:changed`
