### PR TITLE
fix(sessions): skip key-shaped sessionId in cleanup to prevent crash

### DIFF
--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -207,6 +207,10 @@ function pruneMissingTranscriptEntries(params: {
     if (!entry?.sessionId) {
       continue;
     }
+    // Skip entries with key-shaped sessionId (legacy malformed stores where sessionId contains ':' like "agent:main:main")
+    if (entry.sessionId.includes(':')) {
+      continue;
+    }
     const transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
     if (!fs.existsSync(transcriptPath)) {
       delete params.store[key];


### PR DESCRIPTION
## Summary

Fixed `openclaw sessions cleanup --fix-missing` crash when legacy stores contain key-shaped sessionId.

## Root Cause

Legacy session stores may have entries where:
- `sessionId` field contains session **key** (e.g., `agent:main:main`)
- Not a valid UUID session **id**

`validateSessionId` rejects these with: `Error: Invalid session ID: agent:main:main`

## Fix

Add pre-check in `pruneMissingTranscriptEntries` to skip entries with sessionId containing `:` before calling `resolveSessionFilePath`.

```typescript
// Skip entries with key-shaped sessionId (legacy malformed stores)
if (entry.sessionId.includes(':')) {
  continue;
}
```

## Testing

- TypeScript compilation passes
- Tested with malformed sessionId containing `:`

## Files Changed

- `src/config/sessions/cleanup-service.ts` (+4)

---

**Fixes**: #80970