### PR TITLE
feat(voice call): add Telnyx Media Streaming for voice-call realtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Voice Call/Telnyx: add realtime media-streaming call support for conversational voice calls. (#81024) Thanks @dynamite-bud.
 - Gateway/OpenAI HTTP: honor `max_completion_tokens` and `max_tokens` on inbound `/v1/chat/completions` requests so client-provided token caps reach the upstream provider via `streamParams.maxTokens`, with `max_completion_tokens` taking precedence when both are sent. Thanks @Lellansin.
 - Models/OpenAI CLI auth: make `openclaw models auth login --provider openai` start the ChatGPT/Codex account login by default, while `--method api-key` remains the explicit OpenAI API-key setup path.
 - Google/Gemini: normalize retired Gemini 3 Pro Preview ids inside explicit SDK OAuth auth-result config patches, so provider helpers emit `google/gemini-3.1-pro-preview` for Gemini 3.1 testing.

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -250,6 +250,31 @@ describe("validateProviderConfig", () => {
         "plugins.entries.voice-call.config.realtime.enabled and plugins.entries.voice-call.config.streaming.enabled cannot both be true",
       );
     });
+
+    it("accepts realtime.enabled with provider=telnyx", () => {
+      const config = createBaseConfig("telnyx");
+      config.realtime.enabled = true;
+      config.inboundPolicy = "allowlist";
+
+      const result = validateProviderConfig(config);
+
+      expect(result.errors).not.toContain(
+        'plugins.entries.voice-call.config.provider must be "twilio" or "telnyx" when realtime.enabled is true',
+      );
+    });
+
+    it("rejects realtime.enabled with providers that do not support it yet", () => {
+      const config = createBaseConfig("plivo");
+      config.realtime.enabled = true;
+      config.inboundPolicy = "allowlist";
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        'plugins.entries.voice-call.config.provider must be "twilio" or "telnyx" when realtime.enabled is true',
+      );
+    });
   });
 });
 

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -868,9 +868,14 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     );
   }
 
-  if (config.realtime.enabled && config.provider && config.provider !== "twilio") {
+  if (
+    config.realtime.enabled &&
+    config.provider &&
+    config.provider !== "twilio" &&
+    config.provider !== "telnyx"
+  ) {
     errors.push(
-      'plugins.entries.voice-call.config.provider must be "twilio" when realtime.enabled is true',
+      'plugins.entries.voice-call.config.provider must be "twilio" or "telnyx" when realtime.enabled is true',
     );
   }
 

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { VoiceCallConfig } from "./config.js";
-import type { CallManagerContext } from "./manager/context.js";
+import type { CallManagerContext, StreamSessionIssuer } from "./manager/context.js";
 import { processEvent as processManagerEvent } from "./manager/events.js";
 import { getCallByProviderCallId as getCallByProviderCallIdFromMaps } from "./manager/lookup.js";
 import {
@@ -86,6 +86,13 @@ export class CallManager {
   >();
   private maxDurationTimers = new Map<CallId, NodeJS.Timeout>();
   private initialMessageInFlight = new Set<CallId>();
+
+  /**
+   * Carrier-side stream session issuer. Wired by the runtime when realtime is
+   * enabled so the manager can pre-issue stream URLs for providers (e.g.
+   * Telnyx) that attach Media Streaming at dial or answer time.
+   */
+  streamSessionIssuer: StreamSessionIssuer | undefined;
 
   constructor(config: VoiceCallConfig, storePath?: string) {
     this.config = config;
@@ -339,6 +346,7 @@ export class CallManager {
       onCallAnswered: (call) => {
         this.maybeSpeakInitialMessageOnAnswered(call);
       },
+      streamSessionIssuer: this.streamSessionIssuer,
     };
   }
 

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -31,14 +31,6 @@ type CallManagerTransientState = {
   initialMessageInFlight: Set<CallId>;
 };
 
-/**
- * Lazily issue a per-call stream session (token + WSS URL) for carriers that
- * attach Media Streaming at dial or answer time (e.g. Telnyx). The manager
- * calls this just before delegating to the provider's initiate/answer so the
- * streaming params can be embedded in the carrier API payload.
- *
- * Returns `undefined` when realtime is not configured.
- */
 export type StreamSessionIssuer = (request: {
   providerName: "twilio" | "telnyx";
   callId: CallId;
@@ -48,9 +40,7 @@ export type StreamSessionIssuer = (request: {
 }) => { token: string; streamUrl: string } | undefined;
 
 type CallManagerHooks = {
-  /** Optional runtime hook invoked after an event transitions a call into answered state. */
   onCallAnswered?: (call: CallRecord) => void;
-  /** Carrier-side stream session issuer; supplied by runtime when realtime is enabled. */
   streamSessionIssuer?: StreamSessionIssuer;
 };
 

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -31,9 +31,27 @@ type CallManagerTransientState = {
   initialMessageInFlight: Set<CallId>;
 };
 
+/**
+ * Lazily issue a per-call stream session (token + WSS URL) for carriers that
+ * attach Media Streaming at dial or answer time (e.g. Telnyx). The manager
+ * calls this just before delegating to the provider's initiate/answer so the
+ * streaming params can be embedded in the carrier API payload.
+ *
+ * Returns `undefined` when realtime is not configured.
+ */
+export type StreamSessionIssuer = (request: {
+  providerName: "twilio" | "telnyx";
+  callId: CallId;
+  from?: string;
+  to?: string;
+  direction: "inbound" | "outbound";
+}) => { token: string; streamUrl: string } | undefined;
+
 type CallManagerHooks = {
   /** Optional runtime hook invoked after an event transitions a call into answered state. */
   onCallAnswered?: (call: CallRecord) => void;
+  /** Carrier-side stream session issuer; supplied by runtime when realtime is enabled. */
+  streamSessionIssuer?: StreamSessionIssuer;
 };
 
 export type CallManagerContext = CallManagerRuntimeState &

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -23,6 +23,7 @@ type EventContext = Pick<
   | "transcriptWaiters"
   | "maxDurationTimers"
   | "onCallAnswered"
+  | "streamSessionIssuer"
 >;
 
 function shouldAcceptInbound(config: EventContext["config"], from: string | undefined): boolean {
@@ -195,10 +196,26 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
     case "call.initiated":
       transitionState(call, "initiated");
       if (call.direction === "inbound" && call.providerCallId && ctx.provider?.answerCall) {
+        const inboundStreamSession =
+          ctx.config.realtime?.enabled && ctx.provider.name === "telnyx" && ctx.streamSessionIssuer
+            ? ctx.streamSessionIssuer({
+                providerName: "telnyx",
+                callId: call.callId,
+                from: call.from,
+                to: call.to,
+                direction: "inbound",
+              })
+            : undefined;
         void ctx.provider
           .answerCall({
             callId: call.callId,
             providerCallId: call.providerCallId,
+            ...(inboundStreamSession
+              ? {
+                  streamUrl: inboundStreamSession.streamUrl,
+                  streamAuthToken: inboundStreamSession.token,
+                }
+              : {}),
           })
           .catch((err) => {
             const message = formatErrorMessage(err);

--- a/extensions/voice-call/src/manager/outbound.test.ts
+++ b/extensions/voice-call/src/manager/outbound.test.ts
@@ -529,4 +529,101 @@ describe("voice-call outbound helpers", () => {
       ),
     ).resolves.toEqual({ success: true });
   });
+
+  it("issues a stream session and threads streamUrl + streamAuthToken through for Telnyx realtime", async () => {
+    const initiateProviderCall = vi.fn(async () => ({ providerCallId: "call-control-1" }));
+    const streamSessionIssuer = vi.fn(() => ({
+      token: "token-xyz",
+      streamUrl: "wss://example.test/voice/stream/realtime/token-xyz",
+    }));
+    const ctx = {
+      activeCalls: new Map(),
+      providerCallIdMap: new Map(),
+      provider: { name: "telnyx", initiateCall: initiateProviderCall },
+      config: {
+        maxConcurrentCalls: 3,
+        outbound: { defaultMode: "conversation" },
+        fromNumber: "+14155550100",
+        realtime: { enabled: true },
+      },
+      storePath: "/tmp/voice-call.json",
+      webhookUrl: "https://example.com/webhook",
+      streamSessionIssuer,
+    };
+
+    const result = await initiateCall(ctx as never, "+14155550123");
+
+    expect(result.success).toBe(true);
+    expect(streamSessionIssuer).toHaveBeenCalledTimes(1);
+    const issuerCall = (
+      streamSessionIssuer.mock.calls as unknown as Array<
+        [{ providerName: string; direction: string; to: string }]
+      >
+    )[0]?.[0];
+    expect(issuerCall?.providerName).toBe("telnyx");
+    expect(issuerCall?.direction).toBe("outbound");
+    expect(issuerCall?.to).toBe("+14155550123");
+    const providerCall = (
+      initiateProviderCall.mock.calls as unknown as Array<
+        [{ streamUrl?: string; streamAuthToken?: string }]
+      >
+    )[0]?.[0];
+    expect(providerCall?.streamUrl).toBe("wss://example.test/voice/stream/realtime/token-xyz");
+    expect(providerCall?.streamAuthToken).toBe("token-xyz");
+  });
+
+  it("skips the stream session for Twilio realtime (Twilio learns the URL from TwiML)", async () => {
+    const initiateProviderCall = vi.fn(async () => ({ providerCallId: "provider-1" }));
+    const streamSessionIssuer = vi.fn(() => ({
+      token: "should-not-be-used",
+      streamUrl: "wss://example.test/should-not-be-used",
+    }));
+    const ctx = {
+      activeCalls: new Map(),
+      providerCallIdMap: new Map(),
+      provider: { name: "twilio", initiateCall: initiateProviderCall },
+      config: {
+        maxConcurrentCalls: 3,
+        outbound: { defaultMode: "conversation" },
+        fromNumber: "+14155550100",
+        realtime: { enabled: true },
+      },
+      storePath: "/tmp/voice-call.json",
+      webhookUrl: "https://example.com/webhook",
+      streamSessionIssuer,
+    };
+
+    const result = await initiateCall(ctx as never, "+14155550123");
+
+    expect(result.success).toBe(true);
+    expect(streamSessionIssuer).not.toHaveBeenCalled();
+    const providerCall = (
+      initiateProviderCall.mock.calls as unknown as Array<[Record<string, unknown>]>
+    )[0]?.[0];
+    expect(providerCall?.streamUrl).toBeUndefined();
+    expect(providerCall?.streamAuthToken).toBeUndefined();
+  });
+
+  it("does not issue a stream session when realtime is disabled", async () => {
+    const initiateProviderCall = vi.fn(async () => ({ providerCallId: "call-control-1" }));
+    const streamSessionIssuer = vi.fn();
+    const ctx = {
+      activeCalls: new Map(),
+      providerCallIdMap: new Map(),
+      provider: { name: "telnyx", initiateCall: initiateProviderCall },
+      config: {
+        maxConcurrentCalls: 3,
+        outbound: { defaultMode: "conversation" },
+        fromNumber: "+14155550100",
+        realtime: { enabled: false },
+      },
+      storePath: "/tmp/voice-call.json",
+      webhookUrl: "https://example.com/webhook",
+      streamSessionIssuer,
+    };
+
+    await initiateCall(ctx as never, "+14155550123");
+
+    expect(streamSessionIssuer).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -24,7 +24,13 @@ import { generateDtmfRedirectTwiml, generateNotifyTwiml } from "./twiml.js";
 
 type InitiateContext = Pick<
   CallManagerContext,
-  "activeCalls" | "providerCallIdMap" | "provider" | "config" | "storePath" | "webhookUrl"
+  | "activeCalls"
+  | "providerCallIdMap"
+  | "provider"
+  | "config"
+  | "storePath"
+  | "webhookUrl"
+  | "streamSessionIssuer"
 >;
 
 type SpeakContext = Pick<
@@ -201,6 +207,17 @@ export async function initiateCall(
       );
     }
 
+    const streamSession =
+      ctx.config.realtime?.enabled && ctx.provider.name === "telnyx" && ctx.streamSessionIssuer
+        ? ctx.streamSessionIssuer({
+            providerName: "telnyx",
+            callId,
+            from,
+            to,
+            direction: "outbound",
+          })
+        : undefined;
+
     const result = await ctx.provider.initiateCall({
       callId,
       from,
@@ -208,6 +225,9 @@ export async function initiateCall(
       webhookUrl: ctx.webhookUrl,
       inlineTwiml,
       preConnectTwiml,
+      ...(streamSession
+        ? { streamUrl: streamSession.streamUrl, streamAuthToken: streamSession.token }
+        : {}),
     });
 
     callRecord.providerCallId = result.providerCallId;

--- a/extensions/voice-call/src/providers/base.ts
+++ b/extensions/voice-call/src/providers/base.ts
@@ -31,12 +31,6 @@ export interface VoiceCallProvider {
   /** Provider identifier */
   readonly name: ProviderName;
 
-  /**
-   * Update the public origin (`https://host[:port]`) the gateway is reachable
-   * at. Providers that build stream URLs at dial/answer time (e.g. Telnyx)
-   * use it; Twilio derives stream URLs from the request Host header inside
-   * TwiML rendering and may ignore.
-   */
   setPublicUrl?(url: string): void;
 
   /**

--- a/extensions/voice-call/src/providers/base.ts
+++ b/extensions/voice-call/src/providers/base.ts
@@ -32,6 +32,14 @@ export interface VoiceCallProvider {
   readonly name: ProviderName;
 
   /**
+   * Update the public origin (`https://host[:port]`) the gateway is reachable
+   * at. Providers that build stream URLs at dial/answer time (e.g. Telnyx)
+   * use it; Twilio derives stream URLs from the request Host header inside
+   * TwiML rendering and may ignore.
+   */
+  setPublicUrl?(url: string): void;
+
+  /**
    * Verify webhook signature/HMAC before processing.
    * Must be called before parseWebhookEvent.
    */

--- a/extensions/voice-call/src/providers/telnyx.test.ts
+++ b/extensions/voice-call/src/providers/telnyx.test.ts
@@ -315,6 +315,147 @@ describe("TelnyxProvider answer control", () => {
   });
 });
 
+describe("TelnyxProvider Media Streaming (PCMU)", () => {
+  it("embeds streaming fields in the dial payload when streamUrl is provided", async () => {
+    const release = vi.fn(async () => {});
+    apiMocks.fetchWithSsrFGuard.mockResolvedValue({
+      response: new Response(JSON.stringify({ data: { call_control_id: "call-control-1" } }), {
+        status: 200,
+      }),
+      release,
+    });
+    const provider = new TelnyxProvider({
+      apiKey: "KEY123",
+      connectionId: "CONN456",
+      publicKey: undefined,
+    });
+
+    await provider.initiateCall({
+      callId: "call-1",
+      from: "+15550000001",
+      to: "+15550000002",
+      webhookUrl: "https://example.test/voice/webhook",
+      streamUrl: "wss://example.test/voice/stream/realtime/token-xyz",
+      streamAuthToken: "token-xyz",
+    });
+
+    const request = requireFetchRequest();
+    const body = JSON.parse(request.init?.body as string) as Record<string, unknown>;
+    expect(body.stream_url).toBe("wss://example.test/voice/stream/realtime/token-xyz");
+    expect(body.stream_track).toBe("inbound_track");
+    expect(body.stream_codec).toBe("PCMU");
+    expect(body.stream_bidirectional_mode).toBe("rtp");
+    expect(body.stream_bidirectional_codec).toBe("PCMU");
+    expect(body.stream_bidirectional_sampling_rate).toBe(8000);
+    expect(body.stream_bidirectional_target_legs).toBe("self");
+    expect(body.stream_auth_token).toBe("token-xyz");
+  });
+
+  it("omits streaming fields from the dial payload when streamUrl is absent", async () => {
+    apiMocks.fetchWithSsrFGuard.mockResolvedValue({
+      response: new Response(JSON.stringify({ data: { call_control_id: "call-control-1" } }), {
+        status: 200,
+      }),
+      release: vi.fn(async () => {}),
+    });
+    const provider = new TelnyxProvider({
+      apiKey: "KEY123",
+      connectionId: "CONN456",
+      publicKey: undefined,
+    });
+
+    await provider.initiateCall({
+      callId: "call-1",
+      from: "+15550000001",
+      to: "+15550000002",
+      webhookUrl: "https://example.test/voice/webhook",
+    });
+
+    const body = JSON.parse(requireFetchRequest().init?.body as string) as Record<string, unknown>;
+    expect(body.stream_url).toBeUndefined();
+    expect(body.stream_codec).toBeUndefined();
+    expect(body.stream_bidirectional_codec).toBeUndefined();
+    expect(body.stream_auth_token).toBeUndefined();
+  });
+
+  it("embeds streaming fields in the answer action when streamUrl is provided", async () => {
+    apiMocks.fetchWithSsrFGuard.mockResolvedValue({
+      response: new Response(JSON.stringify({ data: {} }), { status: 200 }),
+      release: vi.fn(async () => {}),
+    });
+    const provider = new TelnyxProvider({
+      apiKey: "KEY123",
+      connectionId: "CONN456",
+      publicKey: undefined,
+    });
+
+    await provider.answerCall({
+      callId: "call-1",
+      providerCallId: "call-control-1",
+      streamUrl: "wss://example.test/voice/stream/realtime/token-xyz",
+      streamAuthToken: "token-xyz",
+    });
+
+    const body = JSON.parse(requireFetchRequest().init?.body as string) as Record<string, unknown>;
+    expect(body.command_id).toBe("openclaw-answer-call-1");
+    expect(body.stream_url).toBe("wss://example.test/voice/stream/realtime/token-xyz");
+    expect(body.stream_codec).toBe("PCMU");
+    expect(body.stream_bidirectional_target_legs).toBe("self");
+    expect(body.stream_auth_token).toBe("token-xyz");
+  });
+
+  it("normalizes call.streaming.failed into a non-retryable call.error event", () => {
+    const provider = new TelnyxProvider(
+      { apiKey: "KEY123", connectionId: "CONN456", publicKey: undefined },
+      { skipVerification: true },
+    );
+    const rawBody = JSON.stringify({
+      data: {
+        event_type: "call.streaming.failed",
+        id: "evt-1",
+        payload: {
+          call_control_id: "call-control-1",
+          client_state: Buffer.from("call-1").toString("base64"),
+          reason: "destination_unreachable",
+        },
+      },
+    });
+    const result = provider.parseWebhookEvent(createCtx({ rawBody }), {
+      verifiedRequestKey: "key-1",
+    });
+    expect(result.events).toHaveLength(1);
+    const event = result.events[0];
+    if (event?.type !== "call.error") {
+      throw new Error(`expected call.error, got ${event?.type}`);
+    }
+    expect(event.error).toBe("Telnyx streaming failed: destination_unreachable");
+    expect(event.retryable).toBe(false);
+    expect(event.callId).toBe("call-1");
+    expect(event.providerCallId).toBe("call-control-1");
+  });
+
+  it("silently acknowledges call.streaming.started and call.streaming.stopped", () => {
+    const provider = new TelnyxProvider(
+      { apiKey: "KEY123", connectionId: "CONN456", publicKey: undefined },
+      { skipVerification: true },
+    );
+    for (const eventType of ["call.streaming.started", "call.streaming.stopped"]) {
+      const rawBody = JSON.stringify({
+        data: {
+          event_type: eventType,
+          id: `evt-${eventType}`,
+          payload: { call_control_id: "call-control-1" },
+        },
+      });
+      const result = provider.parseWebhookEvent(createCtx({ rawBody }), {
+        verifiedRequestKey: "key-1",
+      });
+      expect(result.events).toHaveLength(0);
+      expect(result.statusCode).toBe(200);
+    }
+  });
+});
+
 describe("TelnyxProvider speak control", () => {
   it("passes custom Telnyx voice ids to the speak action", async () => {
     const release = vi.fn(async () => {});

--- a/extensions/voice-call/src/providers/telnyx.test.ts
+++ b/extensions/voice-call/src/providers/telnyx.test.ts
@@ -404,42 +404,16 @@ describe("TelnyxProvider Media Streaming (PCMU)", () => {
     expect(body.stream_auth_token).toBe("token-xyz");
   });
 
-  it("normalizes call.streaming.failed into a non-retryable call.error event", () => {
+  it("silently acknowledges streaming.started and streaming.stopped webhooks", () => {
     const provider = new TelnyxProvider(
       { apiKey: "KEY123", connectionId: "CONN456", publicKey: undefined },
       { skipVerification: true },
     );
-    const rawBody = JSON.stringify({
-      data: {
-        event_type: "call.streaming.failed",
-        id: "evt-1",
-        payload: {
-          call_control_id: "call-control-1",
-          client_state: Buffer.from("call-1").toString("base64"),
-          reason: "destination_unreachable",
-        },
-      },
-    });
-    const result = provider.parseWebhookEvent(createCtx({ rawBody }), {
-      verifiedRequestKey: "key-1",
-    });
-    expect(result.events).toHaveLength(1);
-    const event = result.events[0];
-    if (event?.type !== "call.error") {
-      throw new Error(`expected call.error, got ${event?.type}`);
-    }
-    expect(event.error).toBe("Telnyx streaming failed: destination_unreachable");
-    expect(event.retryable).toBe(false);
-    expect(event.callId).toBe("call-1");
-    expect(event.providerCallId).toBe("call-control-1");
-  });
-
-  it("silently acknowledges call.streaming.started and call.streaming.stopped", () => {
-    const provider = new TelnyxProvider(
-      { apiKey: "KEY123", connectionId: "CONN456", publicKey: undefined },
-      { skipVerification: true },
-    );
-    for (const eventType of ["call.streaming.started", "call.streaming.stopped"]) {
+    // Telnyx documents stream lifecycle webhooks as `streaming.started` and
+    // `streaming.stopped` (no `call.` prefix). The bridge tracks its own
+    // lifecycle on the WebSocket; we ack the carrier webhook with 200 and
+    // emit nothing to avoid duplicate signal at the manager.
+    for (const eventType of ["streaming.started", "streaming.stopped"]) {
       const rawBody = JSON.stringify({
         data: {
           event_type: eventType,

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -208,6 +208,23 @@ export class TelnyxProvider implements VoiceCallProvider {
           digits: data.payload?.digit || "",
         };
 
+      case "call.streaming.started":
+      case "call.streaming.stopped":
+        // Informational. The realtime bridge tracks its own lifecycle via the
+        // WebSocket; we acknowledge the webhook (200) but skip event emission
+        // to avoid duplicate signal at the manager.
+        return null;
+
+      case "call.streaming.failed": {
+        const reason = typeof data.payload?.reason === "string" ? data.payload.reason : undefined;
+        return {
+          ...baseEvent,
+          type: "call.error",
+          error: `Telnyx streaming failed${reason ? `: ${reason}` : ""}`,
+          retryable: false,
+        };
+      }
+
       default:
         return null;
     }
@@ -251,10 +268,12 @@ export class TelnyxProvider implements VoiceCallProvider {
   }
 
   /**
-   * Initiate an outbound call via Telnyx API.
+   * Initiate an outbound call via Telnyx API. When `input.streamUrl` is set,
+   * the dial payload also opens a bidirectional Media Streaming session on
+   * answer (PCMU 8 kHz), per the Telnyx documented "AI agent" pattern.
    */
   async initiateCall(input: InitiateCallInput): Promise<InitiateCallResult> {
-    const result = await this.apiRequest<TelnyxCallResponse>("/calls", {
+    const body: Record<string, unknown> = {
       connection_id: this.connectionId,
       to: input.to,
       from: input.from,
@@ -262,7 +281,11 @@ export class TelnyxProvider implements VoiceCallProvider {
       webhook_url_method: "POST",
       client_state: Buffer.from(input.callId).toString("base64"),
       timeout_secs: 30,
-    });
+      ...(input.streamUrl
+        ? buildTelnyxStreamingFields(input.streamUrl, input.streamAuthToken)
+        : {}),
+    };
+    const result = await this.apiRequest<TelnyxCallResponse>("/calls", body);
 
     return {
       providerCallId: result.data.call_control_id,
@@ -282,12 +305,18 @@ export class TelnyxProvider implements VoiceCallProvider {
   }
 
   /**
-   * Answer an inbound Telnyx Call Control leg.
+   * Answer an inbound Telnyx Call Control leg. When `input.streamUrl` is set,
+   * the answer action also attaches a bidirectional Media Streaming session
+   * (PCMU 8 kHz), per the Telnyx canonical "answer-action inline" pattern.
    */
   async answerCall(input: AnswerCallInput): Promise<void> {
-    await this.apiRequest(`/calls/${input.providerCallId}/actions/answer`, {
+    const body: Record<string, unknown> = {
       command_id: `openclaw-answer-${input.callId}`,
-    });
+      ...(input.streamUrl
+        ? buildTelnyxStreamingFields(input.streamUrl, input.streamAuthToken)
+        : {}),
+    };
+    await this.apiRequest(`/calls/${input.providerCallId}/actions/answer`, body);
   }
 
   /**
@@ -353,6 +382,28 @@ export class TelnyxProvider implements VoiceCallProvider {
       return { status: "error", isTerminal: false, isUnknown: true };
     }
   }
+}
+
+/**
+ * Build the streaming-related fields for a Telnyx dial or answer-action
+ * payload. PCMU 8 kHz mono only; bidirectional via RTP; target legs `"self"`
+ * so the bot receives both inbound and outbound audio without the routing
+ * gotcha that drops the call leg when `"opposite"` is configured.
+ */
+function buildTelnyxStreamingFields(
+  streamUrl: string,
+  streamAuthToken: string | undefined,
+): Record<string, unknown> {
+  return {
+    stream_url: streamUrl,
+    stream_track: "inbound_track",
+    stream_codec: "PCMU",
+    stream_bidirectional_mode: "rtp",
+    stream_bidirectional_codec: "PCMU",
+    stream_bidirectional_sampling_rate: 8000,
+    stream_bidirectional_target_legs: "self",
+    ...(streamAuthToken ? { stream_auth_token: streamAuthToken } : {}),
+  };
 }
 
 // -----------------------------------------------------------------------------

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -208,22 +208,16 @@ export class TelnyxProvider implements VoiceCallProvider {
           digits: data.payload?.digit || "",
         };
 
-      case "call.streaming.started":
-      case "call.streaming.stopped":
-        // Informational. The realtime bridge tracks its own lifecycle via the
-        // WebSocket; we acknowledge the webhook (200) but skip event emission
-        // to avoid duplicate signal at the manager.
+      case "streaming.started":
+      case "streaming.stopped":
+        // Informational webhook acknowledgement. The realtime bridge tracks
+        // its own lifecycle via the WebSocket; we ack the carrier webhook with
+        // 200 and skip event emission to avoid duplicate signal at the
+        // manager. Telnyx surfaces stream errors as `{event:"error"}` JSON
+        // frames over the WS, not as carrier webhooks, so there is no
+        // matching `streaming.failed` webhook to handle here — see the
+        // `error` branch in `TelnyxStreamFrameAdapter`.
         return null;
-
-      case "call.streaming.failed": {
-        const reason = typeof data.payload?.reason === "string" ? data.payload.reason : undefined;
-        return {
-          ...baseEvent,
-          type: "call.error",
-          error: `Telnyx streaming failed${reason ? `: ${reason}` : ""}`,
-          retryable: false,
-        };
-      }
 
       default:
         return null;

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -210,13 +210,6 @@ export class TelnyxProvider implements VoiceCallProvider {
 
       case "streaming.started":
       case "streaming.stopped":
-        // Informational webhook acknowledgement. The realtime bridge tracks
-        // its own lifecycle via the WebSocket; we ack the carrier webhook with
-        // 200 and skip event emission to avoid duplicate signal at the
-        // manager. Telnyx surfaces stream errors as `{event:"error"}` JSON
-        // frames over the WS, not as carrier webhooks, so there is no
-        // matching `streaming.failed` webhook to handle here — see the
-        // `error` branch in `TelnyxStreamFrameAdapter`.
         return null;
 
       default:
@@ -261,11 +254,6 @@ export class TelnyxProvider implements VoiceCallProvider {
     }
   }
 
-  /**
-   * Initiate an outbound call via Telnyx API. When `input.streamUrl` is set,
-   * the dial payload also opens a bidirectional Media Streaming session on
-   * answer (PCMU 8 kHz), per the Telnyx documented "AI agent" pattern.
-   */
   async initiateCall(input: InitiateCallInput): Promise<InitiateCallResult> {
     const body: Record<string, unknown> = {
       connection_id: this.connectionId,
@@ -298,11 +286,6 @@ export class TelnyxProvider implements VoiceCallProvider {
     );
   }
 
-  /**
-   * Answer an inbound Telnyx Call Control leg. When `input.streamUrl` is set,
-   * the answer action also attaches a bidirectional Media Streaming session
-   * (PCMU 8 kHz), per the Telnyx canonical "answer-action inline" pattern.
-   */
   async answerCall(input: AnswerCallInput): Promise<void> {
     const body: Record<string, unknown> = {
       command_id: `openclaw-answer-${input.callId}`,
@@ -378,12 +361,6 @@ export class TelnyxProvider implements VoiceCallProvider {
   }
 }
 
-/**
- * Build the streaming-related fields for a Telnyx dial or answer-action
- * payload. PCMU 8 kHz mono only; bidirectional via RTP; target legs `"self"`
- * so the bot receives both inbound and outbound audio without the routing
- * gotcha that drops the call leg when `"opposite"` is configured.
- */
 function buildTelnyxStreamingFields(
   streamUrl: string,
   streamAuthToken: string | undefined,
@@ -399,10 +376,6 @@ function buildTelnyxStreamingFields(
     ...(streamAuthToken ? { stream_auth_token: streamAuthToken } : {}),
   };
 }
-
-// -----------------------------------------------------------------------------
-// Telnyx-specific types
-// -----------------------------------------------------------------------------
 
 interface TelnyxEvent {
   id?: string;

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -457,11 +457,21 @@ export async function createVoiceCallRuntime(params: {
       );
     }
 
-    if (publicUrl && provider.name === "twilio") {
-      (provider as TwilioProvider).setPublicUrl(publicUrl);
+    if (publicUrl) {
+      provider.setPublicUrl?.(publicUrl);
     }
     if (publicUrl && realtimeProvider) {
       webhookServer.getRealtimeHandler()?.setPublicUrl(publicUrl);
+    }
+
+    // Once the realtime handler has its public URL, expose its session issuer
+    // to the manager so carriers that attach Media Streaming at dial / answer
+    // time (e.g. Telnyx) can embed the streaming params in their carrier API
+    // payloads. Twilio learns the stream URL from TwiML so this is a no-op
+    // for the Twilio path.
+    const realtimeHandler = webhookServer.getRealtimeHandler();
+    if (realtimeHandler) {
+      manager.streamSessionIssuer = (request) => realtimeHandler.issueStreamSession(request);
     }
 
     if (provider.name === "twilio" && config.streaming?.enabled) {

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -464,11 +464,6 @@ export async function createVoiceCallRuntime(params: {
       webhookServer.getRealtimeHandler()?.setPublicUrl(publicUrl);
     }
 
-    // Once the realtime handler has its public URL, expose its session issuer
-    // to the manager so carriers that attach Media Streaming at dial / answer
-    // time (e.g. Telnyx) can embed the streaming params in their carrier API
-    // payloads. Twilio learns the stream URL from TwiML so this is a no-op
-    // for the Twilio path.
     const realtimeHandler = webhookServer.getRealtimeHandler();
     if (realtimeHandler) {
       manager.streamSessionIssuer = (request) => realtimeHandler.issueStreamSession(request);

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -215,6 +215,15 @@ export type InitiateCallInput = {
   inlineTwiml?: string;
   /** TwiML to serve once before normal webhook-driven call handling resumes. */
   preConnectTwiml?: string;
+  /**
+   * Optional `wss://` URL the carrier should open for bidirectional Media
+   * Streaming on call connect. Used by carriers (e.g. Telnyx) that attach
+   * streaming at dial time. Twilio learns the URL from TwiML so it ignores
+   * this field.
+   */
+  streamUrl?: string;
+  /** Per-call auth token the carrier echoes back on the WS upgrade. */
+  streamAuthToken?: string;
 };
 
 export type InitiateCallResult = {
@@ -231,6 +240,15 @@ export type HangupCallInput = {
 export type AnswerCallInput = {
   callId: CallId;
   providerCallId: ProviderCallId;
+  /**
+   * Optional `wss://` URL the carrier should open for bidirectional Media
+   * Streaming on answer. Used by carriers (e.g. Telnyx) that attach
+   * streaming at answer time. Twilio learns the URL from TwiML so it ignores
+   * this field.
+   */
+  streamUrl?: string;
+  /** Per-call auth token the carrier echoes back on the WS upgrade. */
+  streamAuthToken?: string;
 };
 
 export type PlayTtsInput = {

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
@@ -1,22 +1,39 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  RealtimeAudioPacer,
   RealtimeMulawSpeechStartDetector,
-  RealtimeTwilioAudioPacer,
   calculateMulawRms,
+  type RealtimeAudioSerializer,
 } from "./realtime-audio-pacer.js";
 
-describe("RealtimeTwilioAudioPacer", () => {
+function createTwilioSerializer(streamSid: string): RealtimeAudioSerializer {
+  return {
+    media: (payload) => JSON.stringify({ event: "media", streamSid, media: { payload } }),
+    clear: () => JSON.stringify({ event: "clear", streamSid }),
+    mark: (name) => JSON.stringify({ event: "mark", streamSid, mark: { name } }),
+  };
+}
+
+function createTelnyxSerializer(): RealtimeAudioSerializer {
+  return {
+    media: (payload) => JSON.stringify({ event: "media", media: { payload } }),
+    clear: () => JSON.stringify({ event: "clear" }),
+    mark: (name) => JSON.stringify({ event: "mark", mark: { name } }),
+  };
+}
+
+describe("RealtimeAudioPacer", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("paces realtime audio as 20ms telephony frames before marks", async () => {
+  it("paces realtime audio as 20ms telephony frames before marks (Twilio shape)", async () => {
     vi.useFakeTimers();
     const sent: unknown[] = [];
-    const pacer = new RealtimeTwilioAudioPacer({
-      streamSid: "MZ-test",
-      sendJson: (message) => {
-        sent.push(message);
+    const pacer = new RealtimeAudioPacer({
+      serializer: createTwilioSerializer("MZ-test"),
+      send: (message) => {
+        sent.push(JSON.parse(message));
         return true;
       },
     });
@@ -43,13 +60,13 @@ describe("RealtimeTwilioAudioPacer", () => {
     });
   });
 
-  it("clears queued audio immediately", async () => {
+  it("clears queued audio immediately (Twilio shape)", async () => {
     vi.useFakeTimers();
     const sent: unknown[] = [];
-    const pacer = new RealtimeTwilioAudioPacer({
-      streamSid: "MZ-test",
-      sendJson: (message) => {
-        sent.push(message);
+    const pacer = new RealtimeAudioPacer({
+      serializer: createTwilioSerializer("MZ-test"),
+      send: (message) => {
+        sent.push(JSON.parse(message));
         return true;
       },
     });
@@ -66,12 +83,12 @@ describe("RealtimeTwilioAudioPacer", () => {
     vi.useFakeTimers();
     const sent: unknown[] = [];
     const onBackpressure = vi.fn();
-    const pacer = new RealtimeTwilioAudioPacer({
-      streamSid: "MZ-test",
+    const pacer = new RealtimeAudioPacer({
+      serializer: createTwilioSerializer("MZ-test"),
       maxQueuedAudioBytes: 320,
       onBackpressure,
-      sendJson: (message) => {
-        sent.push(message);
+      send: (message) => {
+        sent.push(JSON.parse(message));
         return true;
       },
     });
@@ -82,6 +99,27 @@ describe("RealtimeTwilioAudioPacer", () => {
 
     expect(onBackpressure).toHaveBeenCalledOnce();
     expect(sent).toStrictEqual([]);
+  });
+
+  it("paces audio in Telnyx envelope shape (no streamSid)", async () => {
+    vi.useFakeTimers();
+    const sent: unknown[] = [];
+    const pacer = new RealtimeAudioPacer({
+      serializer: createTelnyxSerializer(),
+      send: (message) => {
+        sent.push(JSON.parse(message));
+        return true;
+      },
+    });
+
+    pacer.sendAudio(Buffer.alloc(160, 0x7f));
+    pacer.clearAudio();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(sent).toEqual([
+      { event: "media", media: { payload: Buffer.alloc(160, 0x7f).toString("base64") } },
+      { event: "clear" },
+    ]);
   });
 });
 

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -12,7 +12,7 @@ for (let i = 0; i < MULAW_LINEAR_SAMPLES.length; i += 1) {
   MULAW_LINEAR_SAMPLES[i] = decodeMulawSample(i);
 }
 
-type RealtimeTwilioAudioQueueItem =
+type RealtimeAudioQueueItem =
   | {
       chunk: Buffer;
       durationMs: number;
@@ -23,10 +23,27 @@ type RealtimeTwilioAudioQueueItem =
       type: "mark";
     };
 
-export type RealtimeTwilioAudioPacerSendJson = (message: unknown) => boolean;
+export type RealtimeAudioSend = (message: string) => boolean;
 
-export class RealtimeTwilioAudioPacer {
-  private queue: RealtimeTwilioAudioQueueItem[] = [];
+/**
+ * Outbound frame serializers supplied by the active {@link StreamFrameAdapter}.
+ * Keeps the pacer carrier-agnostic; Twilio supplies streamSid in the resulting
+ * envelope while Telnyx omits it.
+ */
+export interface RealtimeAudioSerializer {
+  media(payloadBase64: string): string;
+  clear(): string;
+  mark(name: string): string;
+}
+
+/**
+ * Carrier-agnostic media-streaming pacer. Buffers μ-law audio into
+ * 20ms / 160-byte frames, serializes via the provided serializer, and
+ * dispatches at the telephony cadence. Marks are queued in order so the
+ * carrier observes them after the audio they tag has been delivered.
+ */
+export class RealtimeAudioPacer {
+  private queue: RealtimeAudioQueueItem[] = [];
   private timer: ReturnType<typeof setTimeout> | null = null;
   private queuedAudioBytes = 0;
   private closed = false;
@@ -35,8 +52,8 @@ export class RealtimeTwilioAudioPacer {
     private readonly params: {
       maxQueuedAudioBytes?: number;
       onBackpressure?: () => void;
-      sendJson: RealtimeTwilioAudioPacerSendJson;
-      streamSid: string;
+      send: RealtimeAudioSend;
+      serializer: RealtimeAudioSerializer;
     },
   ) {}
 
@@ -77,7 +94,7 @@ export class RealtimeTwilioAudioPacer {
     this.clearTimer();
     this.queue = [];
     this.queuedAudioBytes = 0;
-    this.params.sendJson({ event: "clear", streamSid: this.params.streamSid });
+    this.params.send(this.params.serializer.clear());
     return clearedAudioBytes;
   }
 
@@ -121,18 +138,10 @@ export class RealtimeTwilioAudioPacer {
     let sent = true;
     if (item.type === "audio") {
       this.queuedAudioBytes = Math.max(0, this.queuedAudioBytes - item.chunk.length);
-      sent = this.params.sendJson({
-        event: "media",
-        streamSid: this.params.streamSid,
-        media: { payload: item.chunk.toString("base64") },
-      });
+      sent = this.params.send(this.params.serializer.media(item.chunk.toString("base64")));
       delayMs = item.durationMs || TELEPHONY_CHUNK_MS;
     } else {
-      sent = this.params.sendJson({
-        event: "mark",
-        streamSid: this.params.streamSid,
-        mark: { name: item.name },
-      });
+      sent = this.params.send(this.params.serializer.mark(item.name));
     }
 
     if (!sent) {

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -25,23 +25,12 @@ type RealtimeAudioQueueItem =
 
 export type RealtimeAudioSend = (message: string) => boolean;
 
-/**
- * Outbound frame serializers supplied by the active {@link StreamFrameAdapter}.
- * Keeps the pacer carrier-agnostic; Twilio supplies streamSid in the resulting
- * envelope while Telnyx omits it.
- */
 export interface RealtimeAudioSerializer {
   media(payloadBase64: string): string;
   clear(): string;
   mark(name: string): string;
 }
 
-/**
- * Carrier-agnostic media-streaming pacer. Buffers μ-law audio into
- * 20ms / 160-byte frames, serializes via the provided serializer, and
- * dispatches at the telephony cadence. Marks are queued in order so the
- * carrier observes them after the audio they tag has been delivered.
- */
 export class RealtimeAudioPacer {
   private queue: RealtimeAudioQueueItem[] = [];
   private timer: ReturnType<typeof setTimeout> | null = null;

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -87,6 +87,7 @@ function makeHandler(
     config,
     {
       processEvent: vi.fn(),
+      getCall: vi.fn(),
       getCallByProviderCallId: vi.fn(),
       ...deps?.manager,
     } as unknown as CallManager,
@@ -122,6 +123,21 @@ const startRealtimeServer = async (
 
   return await startUpgradeWsServer({
     urlPath: match[1],
+    onUpgrade: (request, socket, head) => {
+      handler.handleWebSocketUpgrade(request, socket, head);
+    },
+  });
+};
+
+const startStreamSessionServer = async (
+  handler: RealtimeCallHandler,
+  streamUrl: string,
+): Promise<{
+  url: string;
+  close: () => Promise<void>;
+}> => {
+  return await startUpgradeWsServer({
+    urlPath: new URL(streamUrl).pathname,
     onUpgrade: (request, socket, head) => {
       handler.handleWebSocketUpgrade(request, socket, head);
     },
@@ -247,6 +263,130 @@ describe("RealtimeCallHandler path routing", () => {
           ws.close();
         }
       }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("joins Telnyx realtime streams to the token-bound call", async () => {
+    const processEvent = vi.fn();
+    const getCall = vi.fn(
+      (): CallRecord => ({
+        callId: "call-1",
+        providerCallId: "v3:call-1",
+        provider: "telnyx",
+        direction: "inbound",
+        state: "answered",
+        from: "+15550001234",
+        to: "+15550009999",
+        startedAt: Date.now(),
+        transcript: [],
+        processedEventIds: [],
+        metadata: { initialMessage: "hello" },
+      }),
+    );
+    const createBridge = vi.fn(() => makeBridge());
+    const handler = makeHandler(undefined, {
+      manager: {
+        processEvent,
+        getCall,
+      },
+      provider: {
+        name: "telnyx",
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    handler.setPublicUrl("https://public.example/voice/webhook");
+    const session = handler.issueStreamSession({
+      providerName: "telnyx",
+      callId: "call-1",
+      from: "+15550001234",
+      to: "+15550009999",
+      direction: "inbound",
+    });
+    const server = await startStreamSessionServer(handler, session.streamUrl);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            stream_id: "stream-1",
+            start: { call_control_id: "v3:call-1" },
+          }),
+        );
+        await waitForRealtimeTest(() => {
+          expect(createBridge).toHaveBeenCalled();
+        });
+
+        const eventTypes = processEvent.mock.calls.map(
+          ([event]) => (event as NormalizedEvent).type,
+        );
+        expect(eventTypes).toEqual(["call.answered"]);
+        expect((processEvent.mock.calls[0]?.[0] as NormalizedEvent | undefined)?.callId).toBe(
+          "call-1",
+        );
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects Telnyx stream starts that do not match the token-bound call", async () => {
+    const processEvent = vi.fn();
+    const getCall = vi.fn(
+      (): CallRecord => ({
+        callId: "call-1",
+        providerCallId: "v3:call-1",
+        provider: "telnyx",
+        direction: "inbound",
+        state: "answered",
+        from: "+15550001234",
+        to: "+15550009999",
+        startedAt: Date.now(),
+        transcript: [],
+        processedEventIds: [],
+        metadata: {},
+      }),
+    );
+    const createBridge = vi.fn(() => makeBridge());
+    const handler = makeHandler(undefined, {
+      manager: {
+        processEvent,
+        getCall,
+      },
+      provider: {
+        name: "telnyx",
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    handler.setPublicUrl("https://public.example/voice/webhook");
+    const session = handler.issueStreamSession({
+      providerName: "telnyx",
+      callId: "call-1",
+      direction: "inbound",
+    });
+    const server = await startStreamSessionServer(handler, session.streamUrl);
+
+    try {
+      const ws = await connectWs(server.url);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          stream_id: "stream-1",
+          start: { call_control_id: "v3:other" },
+        }),
+      );
+      const close = await waitForClose(ws);
+
+      expect(close.code).toBe(1008);
+      expect(createBridge).not.toHaveBeenCalled();
+      expect(processEvent).not.toHaveBeenCalled();
     } finally {
       await server.close();
     }

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -224,17 +224,7 @@ type PendingStreamToken = {
   from?: string;
   to?: string;
   direction?: "inbound" | "outbound";
-  /**
-   * Carrier identifier. Determines which {@link StreamFrameAdapter} the
-   * WebSocket upgrade picks. Defaults to `twilio` when unset for backward
-   * compatibility with the original (Twilio-only) flow.
-   */
   providerName?: "twilio" | "telnyx";
-  /**
-   * OpenClaw-side call identifier (UUID generated before the carrier dial /
-   * answer). Lets the WebSocket upgrade resolve the carrier-side
-   * `providerCallId` via the manager once the dial response has landed.
-   */
   callId?: string;
 };
 
@@ -362,9 +352,6 @@ export class RealtimeCallHandler {
     const rawDirection = params?.get("Direction");
     const previousOrigin = this.publicOrigin;
     if (!previousOrigin) {
-      // Fall back to the request Host header when no public URL has been
-      // pushed. issueStreamSession reads publicOrigin internally, so we
-      // temporarily seat it here before delegating, then restore.
       this.publicOrigin = req.headers.host ?? DEFAULT_HOST;
     }
     try {
@@ -401,15 +388,8 @@ export class RealtimeCallHandler {
     }
 
     const providerName = callerMeta.providerName ?? "twilio";
-    let telnyxProviderCallId = "";
-    if (providerName === "telnyx" && callerMeta.callId) {
-      const call = this.manager.getCall(callerMeta.callId);
-      telnyxProviderCallId = call?.providerCallId ?? "";
-    }
     const adapter: StreamFrameAdapter =
-      providerName === "telnyx"
-        ? new TelnyxStreamFrameAdapter(telnyxProviderCallId)
-        : new TwilioStreamFrameAdapter();
+      providerName === "telnyx" ? new TelnyxStreamFrameAdapter() : new TwilioStreamFrameAdapter();
 
     const wss = new WebSocketServer({
       noServer: true,
@@ -479,8 +459,6 @@ export class RealtimeCallHandler {
             console.error(
               `[voice-call] realtime WS error frame providerCallId=${activeCallSid} code=${frame.code ?? "?"} title=${frame.title ?? ""} detail=${frame.detail ?? ""}`,
             );
-            // Carrier closes the stream after an error frame; let the close
-            // handler tear the bridge down on the resulting WS close.
             return;
           }
           if (frame.kind === "stop") {
@@ -520,12 +498,6 @@ export class RealtimeCallHandler {
     }
   }
 
-  /**
-   * Issue a stream session: returns the per-call auth token plus the wss URL
-   * the carrier should connect to. Provider-agnostic — callers wrap it in
-   * whatever delivery shape the carrier expects (TwiML for Twilio, dial- or
-   * answer-action params for Telnyx).
-   */
   issueStreamSession(request: StreamSessionRequest = {}): StreamSession {
     const token = this.issueStreamToken({
       providerName: request.providerName ?? "twilio",
@@ -1175,14 +1147,7 @@ export class RealtimeCallHandler {
       ...(callerMeta.to ? { to: callerMeta.to } : {}),
     };
 
-    this.manager.processEvent({
-      id: `realtime-initiated-${callSid}`,
-      callId: callSid,
-      type: "call.initiated",
-      ...baseFields,
-    });
-
-    const callRecord = this.manager.getCallByProviderCallId(callSid);
+    const callRecord = this.resolveRealtimeCall(callSid, callerMeta, baseFields);
     if (!callRecord) {
       return null;
     }
@@ -1197,7 +1162,7 @@ export class RealtimeCallHandler {
 
     this.manager.processEvent({
       id: `realtime-answered-${callSid}`,
-      callId: callSid,
+      callId: callRecord.callId,
       type: "call.answered",
       ...baseFields,
     });
@@ -1209,6 +1174,32 @@ export class RealtimeCallHandler {
         initialGreeting,
       ),
     };
+  }
+
+  private resolveRealtimeCall(
+    callSid: string,
+    callerMeta: Omit<PendingStreamToken, "expiry">,
+    baseFields: {
+      providerCallId: string;
+      timestamp: number;
+      direction: "inbound" | "outbound";
+      from?: string;
+      to?: string;
+    },
+  ): CallRecord | null {
+    if (callerMeta.callId) {
+      const call = this.manager.getCall(callerMeta.callId);
+      return call?.providerCallId === callSid ? call : null;
+    }
+
+    this.manager.processEvent({
+      id: `realtime-initiated-${callSid}`,
+      callId: callSid,
+      type: "call.initiated",
+      ...baseFields,
+    });
+
+    return this.manager.getCallByProviderCallId(callSid) ?? null;
   }
 
   private extractInitialGreeting(call: CallRecord): string | undefined {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -22,10 +22,12 @@ import type { CallManager } from "../manager.js";
 import type { VoiceCallProvider } from "../providers/base.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
 import type { WebhookResponsePayload } from "../webhook.types.js";
+import { RealtimeAudioPacer, RealtimeMulawSpeechStartDetector } from "./realtime-audio-pacer.js";
 import {
-  RealtimeMulawSpeechStartDetector,
-  RealtimeTwilioAudioPacer,
-} from "./realtime-audio-pacer.js";
+  type StreamFrameAdapter,
+  TelnyxStreamFrameAdapter,
+  TwilioStreamFrameAdapter,
+} from "./stream-frame-adapter.js";
 
 export type ToolHandlerContext = {
   partialUserTranscript?: string;
@@ -222,6 +224,31 @@ type PendingStreamToken = {
   from?: string;
   to?: string;
   direction?: "inbound" | "outbound";
+  /**
+   * Carrier identifier. Determines which {@link StreamFrameAdapter} the
+   * WebSocket upgrade picks. Defaults to `twilio` when unset for backward
+   * compatibility with the original (Twilio-only) flow.
+   */
+  providerName?: "twilio" | "telnyx";
+  /**
+   * OpenClaw-side call identifier (UUID generated before the carrier dial /
+   * answer). Lets the WebSocket upgrade resolve the carrier-side
+   * `providerCallId` via the manager once the dial response has landed.
+   */
+  callId?: string;
+};
+
+export type StreamSessionRequest = {
+  providerName?: "twilio" | "telnyx";
+  callId?: string;
+  from?: string;
+  to?: string;
+  direction?: "inbound" | "outbound";
+};
+
+export type StreamSession = {
+  token: string;
+  streamUrl: string;
 };
 
 type CallRegistration = {
@@ -332,25 +359,35 @@ export class RealtimeCallHandler {
   }
 
   buildTwiMLPayload(req: http.IncomingMessage, params?: URLSearchParams): WebhookResponsePayload {
-    const host = this.publicOrigin || req.headers.host || DEFAULT_HOST;
     const rawDirection = params?.get("Direction");
-    const token = this.issueStreamToken({
-      from: params?.get("From") ?? undefined,
-      to: params?.get("To") ?? undefined,
-      direction: rawDirection?.startsWith("outbound") ? "outbound" : "inbound",
-    });
-    const wsUrl = `wss://${host}${this.getStreamPathPattern()}/${token}`;
-    const twiml = `<?xml version="1.0" encoding="UTF-8"?>
+    const previousOrigin = this.publicOrigin;
+    if (!previousOrigin) {
+      // Fall back to the request Host header when no public URL has been
+      // pushed. issueStreamSession reads publicOrigin internally, so we
+      // temporarily seat it here before delegating, then restore.
+      this.publicOrigin = req.headers.host ?? DEFAULT_HOST;
+    }
+    try {
+      const { streamUrl } = this.issueStreamSession({
+        providerName: "twilio",
+        from: params?.get("From") ?? undefined,
+        to: params?.get("To") ?? undefined,
+        direction: rawDirection?.startsWith("outbound") ? "outbound" : "inbound",
+      });
+      const twiml = `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Connect>
-    <Stream url="${wsUrl}" />
+    <Stream url="${streamUrl}" />
   </Connect>
 </Response>`;
-    return {
-      statusCode: 200,
-      headers: { "Content-Type": "text/xml" },
-      body: twiml,
-    };
+      return {
+        statusCode: 200,
+        headers: { "Content-Type": "text/xml" },
+        body: twiml,
+      };
+    } finally {
+      this.publicOrigin = previousOrigin;
+    }
   }
 
   handleWebSocketUpgrade(request: http.IncomingMessage, socket: Duplex, head: Buffer): void {
@@ -362,6 +399,17 @@ export class RealtimeCallHandler {
       socket.destroy();
       return;
     }
+
+    const providerName = callerMeta.providerName ?? "twilio";
+    let telnyxProviderCallId = "";
+    if (providerName === "telnyx" && callerMeta.callId) {
+      const call = this.manager.getCall(callerMeta.callId);
+      telnyxProviderCallId = call?.providerCallId ?? "";
+    }
+    const adapter: StreamFrameAdapter =
+      providerName === "telnyx"
+        ? new TelnyxStreamFrameAdapter(telnyxProviderCallId)
+        : new TwilioStreamFrameAdapter();
 
     const wss = new WebSocketServer({
       noServer: true,
@@ -378,18 +426,23 @@ export class RealtimeCallHandler {
 
       ws.on("message", (data: Buffer) => {
         try {
-          const msg = JSON.parse(data.toString()) as Record<string, unknown>;
-          if (!initialized && msg.event === "start") {
+          const frame = adapter.parseInbound(data.toString());
+          if (frame.kind === "ignored") {
+            return;
+          }
+          if (frame.kind === "start") {
+            if (initialized) {
+              return;
+            }
             initialized = true;
-            const startData =
-              typeof msg.start === "object" && msg.start !== null
-                ? (msg.start as Record<string, unknown>)
-                : undefined;
-            const streamSid =
-              typeof startData?.streamSid === "string" ? startData.streamSid : "unknown";
-            const callSid = typeof startData?.callSid === "string" ? startData.callSid : "unknown";
-            activeCallSid = callSid;
-            const nextBridge = this.handleCall(streamSid, callSid, ws, callerMeta);
+            activeCallSid = frame.providerCallId;
+            const nextBridge = this.handleCall(
+              frame.streamId,
+              frame.providerCallId,
+              ws,
+              callerMeta,
+              adapter,
+            );
             if (!nextBridge) {
               return;
             }
@@ -399,40 +452,30 @@ export class RealtimeCallHandler {
           if (!bridge) {
             return;
           }
-          const mediaData =
-            typeof msg.media === "object" && msg.media !== null
-              ? (msg.media as Record<string, unknown>)
-              : undefined;
-          if (msg.event === "media" && typeof mediaData?.payload === "string") {
-            const audio = Buffer.from(mediaData.payload, "base64");
+          if (frame.kind === "media") {
+            const audio = Buffer.from(frame.payloadBase64, "base64");
             bridge.sendAudio(audio);
-            const mediaTimestamp =
-              typeof mediaData.timestamp === "number"
-                ? mediaData.timestamp
-                : typeof mediaData.timestamp === "string"
-                  ? Number.parseInt(mediaData.timestamp, 10)
-                  : Number.NaN;
-            if (Number.isFinite(mediaTimestamp)) {
+            if (frame.timestampMs !== undefined) {
               if (lastMediaTimestamp !== undefined) {
-                const gapMs = mediaTimestamp - lastMediaTimestamp;
+                const gapMs = frame.timestampMs - lastMediaTimestamp;
                 const now = Date.now();
                 if ((gapMs > 120 || gapMs < 0) && now - lastMediaGapWarnAt > 5_000) {
                   lastMediaGapWarnAt = now;
                   console.warn(
-                    `[voice-call] realtime media timestamp gap providerCallId=${activeCallSid} gapMs=${gapMs} timestamp=${mediaTimestamp}`,
+                    `[voice-call] realtime media timestamp gap providerCallId=${activeCallSid} gapMs=${gapMs} timestamp=${frame.timestampMs}`,
                   );
                 }
               }
-              lastMediaTimestamp = mediaTimestamp;
-              bridge.setMediaTimestamp(mediaTimestamp);
+              lastMediaTimestamp = frame.timestampMs;
+              bridge.setMediaTimestamp(frame.timestampMs);
             }
             return;
           }
-          if (msg.event === "mark") {
+          if (frame.kind === "mark") {
             bridge.acknowledgeMark();
             return;
           }
-          if (msg.event === "stop") {
+          if (frame.kind === "stop") {
             stopReceived = true;
             this.closeTelephonyBridge(activeCallSid, bridge, "completed");
           }
@@ -469,6 +512,25 @@ export class RealtimeCallHandler {
     }
   }
 
+  /**
+   * Issue a stream session: returns the per-call auth token plus the wss URL
+   * the carrier should connect to. Provider-agnostic — callers wrap it in
+   * whatever delivery shape the carrier expects (TwiML for Twilio, dial- or
+   * answer-action params for Telnyx).
+   */
+  issueStreamSession(request: StreamSessionRequest = {}): StreamSession {
+    const token = this.issueStreamToken({
+      providerName: request.providerName ?? "twilio",
+      callId: request.callId,
+      from: request.from,
+      to: request.to,
+      direction: request.direction,
+    });
+    const host = this.publicOrigin || DEFAULT_HOST;
+    const streamUrl = `wss://${host}${this.getStreamPathPattern()}/${token}`;
+    return { token, streamUrl };
+  }
+
   private issueStreamToken(meta: Omit<PendingStreamToken, "expiry"> = {}): string {
     const token = randomUUID();
     this.pendingStreamTokens.set(token, { expiry: Date.now() + STREAM_TOKEN_TTL_MS, ...meta });
@@ -493,6 +555,8 @@ export class RealtimeCallHandler {
       from: entry.from,
       to: entry.to,
       direction: entry.direction,
+      providerName: entry.providerName,
+      callId: entry.callId,
     };
   }
 
@@ -501,6 +565,7 @@ export class RealtimeCallHandler {
     callSid: string,
     ws: WebSocket,
     callerMeta: Omit<PendingStreamToken, "expiry">,
+    adapter: StreamFrameAdapter,
   ): ActiveRealtimeVoiceBridge | null {
     const registration = this.registerCallInManager(callSid, callerMeta);
     if (!registration) {
@@ -567,7 +632,7 @@ export class RealtimeCallHandler {
       this.endCallInManager(callSid, callId, reason);
     };
 
-    const sendJson = (message: unknown): boolean => {
+    const sendString = (message: string): boolean => {
       if (ws.readyState !== WebSocket.OPEN) {
         return false;
       }
@@ -578,7 +643,7 @@ export class RealtimeCallHandler {
         ws.close(1013, "Backpressure: send buffer exceeded");
         return false;
       }
-      ws.send(JSON.stringify(message));
+      ws.send(message);
       if (ws.bufferedAmount > MAX_REALTIME_WS_BUFFERED_BYTES) {
         console.warn(
           `[voice-call] realtime outbound websocket backpressure after send callId=${callId} providerCallId=${callSid} bufferedBytes=${ws.bufferedAmount}`,
@@ -588,9 +653,13 @@ export class RealtimeCallHandler {
       }
       return true;
     };
-    const audioPacer = new RealtimeTwilioAudioPacer({
-      streamSid,
-      sendJson,
+    const audioPacer = new RealtimeAudioPacer({
+      send: sendString,
+      serializer: {
+        media: (payload) => adapter.serializeMedia(payload),
+        clear: () => adapter.serializeClear(),
+        mark: (name) => adapter.serializeMark(name),
+      },
       onBackpressure: () => {
         console.warn(
           `[voice-call] realtime paced audio backpressure callId=${callId} providerCallId=${callSid}`,

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -475,6 +475,14 @@ export class RealtimeCallHandler {
             bridge.acknowledgeMark();
             return;
           }
+          if (frame.kind === "error") {
+            console.error(
+              `[voice-call] realtime WS error frame providerCallId=${activeCallSid} code=${frame.code ?? "?"} title=${frame.title ?? ""} detail=${frame.detail ?? ""}`,
+            );
+            // Carrier closes the stream after an error frame; let the close
+            // handler tear the bridge down on the resulting WS close.
+            return;
+          }
           if (frame.kind === "stop") {
             stopReceived = true;
             this.closeTelephonyBridge(activeCallSid, bridge, "completed");

--- a/extensions/voice-call/src/webhook/stream-frame-adapter.test.ts
+++ b/extensions/voice-call/src/webhook/stream-frame-adapter.test.ts
@@ -68,7 +68,31 @@ describe("TwilioStreamFrameAdapter", () => {
 });
 
 describe("TelnyxStreamFrameAdapter", () => {
-  it("parses Telnyx start, media, mark, stop with no streamSid", () => {
+  it("parses Telnyx start with top-level stream_id and start.call_control_id", () => {
+    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
+
+    // Telnyx start frame: stream_id is top-level, call_control_id lives in start.
+    expect(
+      adapter.parseInbound(
+        JSON.stringify({
+          event: "start",
+          sequence_number: "1",
+          stream_id: "telnyx-stream-7",
+          start: {
+            call_control_id: "v3:carrier-call-id",
+            call_session_id: "session-1",
+            media_format: { encoding: "PCMU", sample_rate: 8000, channels: 1 },
+          },
+        }),
+      ),
+    ).toEqual({
+      kind: "start",
+      streamId: "telnyx-stream-7",
+      providerCallId: "v3:carrier-call-id",
+    });
+  });
+
+  it("falls back to the constructor providerCallId when start fields are absent", () => {
     const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
 
     expect(adapter.parseInbound(JSON.stringify({ event: "start", start: {} }))).toEqual({
@@ -76,24 +100,16 @@ describe("TelnyxStreamFrameAdapter", () => {
       streamId: "call-control-id-123",
       providerCallId: "call-control-id-123",
     });
+  });
 
-    expect(
-      adapter.parseInbound(
-        JSON.stringify({
-          event: "start",
-          start: { stream_id: "telnyx-stream-7" },
-        }),
-      ),
-    ).toEqual({
-      kind: "start",
-      streamId: "telnyx-stream-7",
-      providerCallId: "call-control-id-123",
-    });
+  it("parses media, mark, and stop with no streamSid", () => {
+    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
 
     expect(
       adapter.parseInbound(
         JSON.stringify({
           event: "media",
+          stream_id: "telnyx-stream-7",
           media: { payload: "AAA=", timestamp: 40, track: "inbound_track" },
         }),
       ),
@@ -109,6 +125,29 @@ describe("TelnyxStreamFrameAdapter", () => {
     ).toEqual({ kind: "mark", name: "audio-1" });
 
     expect(adapter.parseInbound(JSON.stringify({ event: "stop" }))).toEqual({ kind: "stop" });
+  });
+
+  it("surfaces Telnyx WS error frames so failures don't get swallowed", () => {
+    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
+
+    expect(
+      adapter.parseInbound(
+        JSON.stringify({
+          event: "error",
+          stream_id: "telnyx-stream-7",
+          payload: {
+            code: 100002,
+            title: "WebSocket error",
+            detail: "Unable to decode payload",
+          },
+        }),
+      ),
+    ).toEqual({
+      kind: "error",
+      code: "100002",
+      title: "WebSocket error",
+      detail: "Unable to decode payload",
+    });
   });
 
   it("serializes outbound frames without streamSid", () => {

--- a/extensions/voice-call/src/webhook/stream-frame-adapter.test.ts
+++ b/extensions/voice-call/src/webhook/stream-frame-adapter.test.ts
@@ -69,9 +69,8 @@ describe("TwilioStreamFrameAdapter", () => {
 
 describe("TelnyxStreamFrameAdapter", () => {
   it("parses Telnyx start with top-level stream_id and start.call_control_id", () => {
-    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
+    const adapter = new TelnyxStreamFrameAdapter();
 
-    // Telnyx start frame: stream_id is top-level, call_control_id lives in start.
     expect(
       adapter.parseInbound(
         JSON.stringify({
@@ -92,18 +91,25 @@ describe("TelnyxStreamFrameAdapter", () => {
     });
   });
 
-  it("falls back to the constructor providerCallId when start fields are absent", () => {
-    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
+  it("ignores Telnyx start frames without stream_id or call_control_id", () => {
+    const adapter = new TelnyxStreamFrameAdapter();
 
     expect(adapter.parseInbound(JSON.stringify({ event: "start", start: {} }))).toEqual({
-      kind: "start",
-      streamId: "call-control-id-123",
-      providerCallId: "call-control-id-123",
+      kind: "ignored",
     });
+    expect(
+      adapter.parseInbound(
+        JSON.stringify({
+          event: "start",
+          stream_id: "telnyx-stream-7",
+          start: {},
+        }),
+      ),
+    ).toEqual({ kind: "ignored" });
   });
 
   it("parses media, mark, and stop with no streamSid", () => {
-    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
+    const adapter = new TelnyxStreamFrameAdapter();
 
     expect(
       adapter.parseInbound(
@@ -128,7 +134,7 @@ describe("TelnyxStreamFrameAdapter", () => {
   });
 
   it("surfaces Telnyx WS error frames so failures don't get swallowed", () => {
-    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
+    const adapter = new TelnyxStreamFrameAdapter();
 
     expect(
       adapter.parseInbound(
@@ -151,7 +157,7 @@ describe("TelnyxStreamFrameAdapter", () => {
   });
 
   it("serializes outbound frames without streamSid", () => {
-    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
+    const adapter = new TelnyxStreamFrameAdapter();
 
     expect(JSON.parse(adapter.serializeMedia("payload-b64"))).toEqual({
       event: "media",
@@ -165,7 +171,7 @@ describe("TelnyxStreamFrameAdapter", () => {
   });
 
   it("ignores junk and unknown events", () => {
-    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
+    const adapter = new TelnyxStreamFrameAdapter();
     expect(adapter.parseInbound("not json")).toEqual({ kind: "ignored" });
     expect(adapter.parseInbound(JSON.stringify({ event: "media" }))).toEqual({ kind: "ignored" });
     expect(adapter.parseInbound(JSON.stringify({ event: "something-else" }))).toEqual({

--- a/extensions/voice-call/src/webhook/stream-frame-adapter.test.ts
+++ b/extensions/voice-call/src/webhook/stream-frame-adapter.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { TelnyxStreamFrameAdapter, TwilioStreamFrameAdapter } from "./stream-frame-adapter.js";
+
+describe("TwilioStreamFrameAdapter", () => {
+  it("parses Twilio start, media, mark, stop, and ignores junk", () => {
+    const adapter = new TwilioStreamFrameAdapter();
+
+    expect(
+      adapter.parseInbound(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-stream", callSid: "CA-call" },
+        }),
+      ),
+    ).toEqual({ kind: "start", streamId: "MZ-stream", providerCallId: "CA-call" });
+
+    expect(
+      adapter.parseInbound(
+        JSON.stringify({
+          event: "media",
+          media: { payload: "AAA=", timestamp: "20", track: "inbound" },
+        }),
+      ),
+    ).toEqual({
+      kind: "media",
+      payloadBase64: "AAA=",
+      timestampMs: 20,
+      track: "inbound",
+    });
+
+    expect(
+      adapter.parseInbound(JSON.stringify({ event: "mark", mark: { name: "audio-1" } })),
+    ).toEqual({ kind: "mark", name: "audio-1" });
+
+    expect(adapter.parseInbound(JSON.stringify({ event: "stop" }))).toEqual({ kind: "stop" });
+
+    expect(adapter.parseInbound("not json")).toEqual({ kind: "ignored" });
+    expect(adapter.parseInbound(JSON.stringify({ event: "media" }))).toEqual({ kind: "ignored" });
+    expect(
+      adapter.parseInbound(JSON.stringify({ event: "start", start: { streamSid: "MZ-only" } })),
+    ).toEqual({ kind: "ignored" });
+  });
+
+  it("serializes outbound frames with the streamSid captured at start", () => {
+    const adapter = new TwilioStreamFrameAdapter();
+    adapter.parseInbound(
+      JSON.stringify({
+        event: "start",
+        start: { streamSid: "MZ-stream", callSid: "CA-call" },
+      }),
+    );
+
+    expect(JSON.parse(adapter.serializeMedia("payload-b64"))).toEqual({
+      event: "media",
+      streamSid: "MZ-stream",
+      media: { payload: "payload-b64" },
+    });
+    expect(JSON.parse(adapter.serializeClear())).toEqual({
+      event: "clear",
+      streamSid: "MZ-stream",
+    });
+    expect(JSON.parse(adapter.serializeMark("audio-1"))).toEqual({
+      event: "mark",
+      streamSid: "MZ-stream",
+      mark: { name: "audio-1" },
+    });
+  });
+});
+
+describe("TelnyxStreamFrameAdapter", () => {
+  it("parses Telnyx start, media, mark, stop with no streamSid", () => {
+    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
+
+    expect(adapter.parseInbound(JSON.stringify({ event: "start", start: {} }))).toEqual({
+      kind: "start",
+      streamId: "call-control-id-123",
+      providerCallId: "call-control-id-123",
+    });
+
+    expect(
+      adapter.parseInbound(
+        JSON.stringify({
+          event: "start",
+          start: { stream_id: "telnyx-stream-7" },
+        }),
+      ),
+    ).toEqual({
+      kind: "start",
+      streamId: "telnyx-stream-7",
+      providerCallId: "call-control-id-123",
+    });
+
+    expect(
+      adapter.parseInbound(
+        JSON.stringify({
+          event: "media",
+          media: { payload: "AAA=", timestamp: 40, track: "inbound_track" },
+        }),
+      ),
+    ).toEqual({
+      kind: "media",
+      payloadBase64: "AAA=",
+      timestampMs: 40,
+      track: "inbound_track",
+    });
+
+    expect(
+      adapter.parseInbound(JSON.stringify({ event: "mark", mark: { name: "audio-1" } })),
+    ).toEqual({ kind: "mark", name: "audio-1" });
+
+    expect(adapter.parseInbound(JSON.stringify({ event: "stop" }))).toEqual({ kind: "stop" });
+  });
+
+  it("serializes outbound frames without streamSid", () => {
+    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
+
+    expect(JSON.parse(adapter.serializeMedia("payload-b64"))).toEqual({
+      event: "media",
+      media: { payload: "payload-b64" },
+    });
+    expect(JSON.parse(adapter.serializeClear())).toEqual({ event: "clear" });
+    expect(JSON.parse(adapter.serializeMark("audio-1"))).toEqual({
+      event: "mark",
+      mark: { name: "audio-1" },
+    });
+  });
+
+  it("ignores junk and unknown events", () => {
+    const adapter = new TelnyxStreamFrameAdapter("call-control-id-123");
+    expect(adapter.parseInbound("not json")).toEqual({ kind: "ignored" });
+    expect(adapter.parseInbound(JSON.stringify({ event: "media" }))).toEqual({ kind: "ignored" });
+    expect(adapter.parseInbound(JSON.stringify({ event: "something-else" }))).toEqual({
+      kind: "ignored",
+    });
+  });
+});

--- a/extensions/voice-call/src/webhook/stream-frame-adapter.ts
+++ b/extensions/voice-call/src/webhook/stream-frame-adapter.ts
@@ -1,18 +1,3 @@
-/**
- * Provider-shaped WebSocket frame adapter for Media Streaming.
- *
- * Twilio Media Streams and Telnyx Media Streaming both carry bidirectional
- * μ-law (PCMU) audio over a carrier-initiated WebSocket. The envelopes are
- * similar but not identical: Twilio tags every event with a `streamSid`;
- * Telnyx omits it and relies on the per-call auth token in the WS upgrade
- * URL to bind the connection to a call. This adapter normalizes inbound
- * frames into a small union and serializes outbound media / clear / mark
- * commands in the shape the carrier expects.
- *
- * The realtime bridge in `realtime-handler.ts` is otherwise carrier-agnostic
- * once it has an adapter.
- */
-
 export type StreamFrame =
   | { kind: "start"; streamId: string; providerCallId: string }
   | {
@@ -29,11 +14,8 @@ export type StreamFrame =
 export interface StreamFrameAdapter {
   readonly providerName: "twilio" | "telnyx";
   parseInbound(rawMessage: string): StreamFrame;
-  /** Serialize an outbound media frame carrying base64 μ-law audio. */
   serializeMedia(payloadBase64: string): string;
-  /** Serialize a clear command (drops queued outbound audio for barge-in). */
   serializeClear(): string;
-  /** Serialize a mark frame used to track playback completion. */
   serializeMark(name: string): string;
 }
 
@@ -60,15 +42,6 @@ function tryParseJson(rawMessage: string): Record<string, unknown> | null {
   return null;
 }
 
-/**
- * Twilio Media Streams frame format.
- *
- * Inbound `start` carries `start.streamSid` and `start.callSid`; subsequent
- * `media`, `mark`, and `stop` events reference the same streamSid. Outbound
- * frames must echo the streamSid Twilio sent at start.
- *
- * Reference: https://www.twilio.com/docs/voice/twiml/stream
- */
 export class TwilioStreamFrameAdapter implements StreamFrameAdapter {
   readonly providerName = "twilio" as const;
   private streamSid = "";
@@ -143,27 +116,8 @@ export class TwilioStreamFrameAdapter implements StreamFrameAdapter {
   }
 }
 
-/**
- * Telnyx Media Streaming frame format (PCMU profile).
- *
- * Inbound frames carry `stream_id` at the top level of the envelope; the
- * `start` frame additionally carries `start.call_control_id` (the carrier
- * call id). The WS is bound to a call via the per-call auth token in the
- * upgrade URL.
- *
- * Stream errors arrive as `{event:"error", payload:{...}}` frames over the
- * WebSocket — not as a webhook event. The adapter surfaces those as a
- * dedicated frame kind so the realtime bridge can log and tear down cleanly.
- *
- * Outbound frames are minimal envelopes: `{event:"media", media:{payload}}`,
- * `{event:"clear"}`, `{event:"mark", mark:{name}}`.
- *
- * Reference: https://developers.telnyx.com/docs/voice/programmable-voice/media-streaming
- */
 export class TelnyxStreamFrameAdapter implements StreamFrameAdapter {
   readonly providerName = "telnyx" as const;
-
-  constructor(private readonly providerCallId: string) {}
 
   parseInbound(rawMessage: string): StreamFrame {
     const msg = tryParseJson(rawMessage);
@@ -178,14 +132,17 @@ export class TelnyxStreamFrameAdapter implements StreamFrameAdapter {
         typeof msg.start === "object" && msg.start !== null
           ? (msg.start as Record<string, unknown>)
           : undefined;
-      const carrierCallControlId =
+      const providerCallId =
         typeof startData?.call_control_id === "string" && startData.call_control_id
           ? startData.call_control_id
-          : this.providerCallId;
+          : undefined;
+      if (!topLevelStreamId || !providerCallId) {
+        return { kind: "ignored" };
+      }
       return {
         kind: "start",
-        streamId: topLevelStreamId ?? this.providerCallId,
-        providerCallId: carrierCallControlId,
+        streamId: topLevelStreamId,
+        providerCallId,
       };
     }
     if (event === "media") {

--- a/extensions/voice-call/src/webhook/stream-frame-adapter.ts
+++ b/extensions/voice-call/src/webhook/stream-frame-adapter.ts
@@ -1,0 +1,228 @@
+/**
+ * Provider-shaped WebSocket frame adapter for Media Streaming.
+ *
+ * Twilio Media Streams and Telnyx Media Streaming both carry bidirectional
+ * μ-law (PCMU) audio over a carrier-initiated WebSocket. The envelopes are
+ * similar but not identical: Twilio tags every event with a `streamSid`;
+ * Telnyx omits it and relies on the per-call auth token in the WS upgrade
+ * URL to bind the connection to a call. This adapter normalizes inbound
+ * frames into a small union and serializes outbound media / clear / mark
+ * commands in the shape the carrier expects.
+ *
+ * The realtime bridge in `realtime-handler.ts` is otherwise carrier-agnostic
+ * once it has an adapter.
+ */
+
+export type StreamFrame =
+  | { kind: "start"; streamId: string; providerCallId: string }
+  | {
+      kind: "media";
+      payloadBase64: string;
+      timestampMs?: number;
+      track?: string;
+    }
+  | { kind: "mark"; name?: string }
+  | { kind: "stop" }
+  | { kind: "ignored" };
+
+export interface StreamFrameAdapter {
+  readonly providerName: "twilio" | "telnyx";
+  parseInbound(rawMessage: string): StreamFrame;
+  /** Serialize an outbound media frame carrying base64 μ-law audio. */
+  serializeMedia(payloadBase64: string): string;
+  /** Serialize a clear command (drops queued outbound audio for barge-in). */
+  serializeClear(): string;
+  /** Serialize a mark frame used to track playback completion. */
+  serializeMark(name: string): string;
+}
+
+function parseTimestampMs(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function tryParseJson(rawMessage: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(rawMessage) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+/**
+ * Twilio Media Streams frame format.
+ *
+ * Inbound `start` carries `start.streamSid` and `start.callSid`; subsequent
+ * `media`, `mark`, and `stop` events reference the same streamSid. Outbound
+ * frames must echo the streamSid Twilio sent at start.
+ *
+ * Reference: https://www.twilio.com/docs/voice/twiml/stream
+ */
+export class TwilioStreamFrameAdapter implements StreamFrameAdapter {
+  readonly providerName = "twilio" as const;
+  private streamSid = "";
+
+  parseInbound(rawMessage: string): StreamFrame {
+    const msg = tryParseJson(rawMessage);
+    if (!msg) {
+      return { kind: "ignored" };
+    }
+    const event = msg.event;
+    if (event === "start") {
+      const startData =
+        typeof msg.start === "object" && msg.start !== null
+          ? (msg.start as Record<string, unknown>)
+          : undefined;
+      const streamSid = typeof startData?.streamSid === "string" ? startData.streamSid : "";
+      const callSid = typeof startData?.callSid === "string" ? startData.callSid : "";
+      if (!streamSid || !callSid) {
+        return { kind: "ignored" };
+      }
+      this.streamSid = streamSid;
+      return { kind: "start", streamId: streamSid, providerCallId: callSid };
+    }
+    if (event === "media") {
+      const mediaData =
+        typeof msg.media === "object" && msg.media !== null
+          ? (msg.media as Record<string, unknown>)
+          : undefined;
+      const payload = typeof mediaData?.payload === "string" ? mediaData.payload : undefined;
+      if (!payload) {
+        return { kind: "ignored" };
+      }
+      return {
+        kind: "media",
+        payloadBase64: payload,
+        timestampMs: parseTimestampMs(mediaData?.timestamp),
+        track: typeof mediaData?.track === "string" ? mediaData.track : undefined,
+      };
+    }
+    if (event === "mark") {
+      const markData =
+        typeof msg.mark === "object" && msg.mark !== null
+          ? (msg.mark as Record<string, unknown>)
+          : undefined;
+      const name = typeof markData?.name === "string" ? markData.name : undefined;
+      return { kind: "mark", name };
+    }
+    if (event === "stop") {
+      return { kind: "stop" };
+    }
+    return { kind: "ignored" };
+  }
+
+  serializeMedia(payloadBase64: string): string {
+    return JSON.stringify({
+      event: "media",
+      streamSid: this.streamSid,
+      media: { payload: payloadBase64 },
+    });
+  }
+
+  serializeClear(): string {
+    return JSON.stringify({ event: "clear", streamSid: this.streamSid });
+  }
+
+  serializeMark(name: string): string {
+    return JSON.stringify({
+      event: "mark",
+      streamSid: this.streamSid,
+      mark: { name },
+    });
+  }
+}
+
+/**
+ * Telnyx Media Streaming frame format (PCMU profile).
+ *
+ * Inbound frames do not carry streamSid; the carrier binds the WS to a call
+ * via the per-call auth token in the upgrade URL. Outbound frames are minimal
+ * envelopes: `{event:"media", media:{payload}}`, `{event:"clear"}`,
+ * `{event:"mark", mark:{name}}`.
+ *
+ * Reference: https://developers.telnyx.com/docs/voice/programmable-voice/media-streaming
+ */
+export class TelnyxStreamFrameAdapter implements StreamFrameAdapter {
+  readonly providerName = "telnyx" as const;
+
+  constructor(private readonly providerCallId: string) {}
+
+  parseInbound(rawMessage: string): StreamFrame {
+    const msg = tryParseJson(rawMessage);
+    if (!msg) {
+      return { kind: "ignored" };
+    }
+    const event = msg.event;
+    if (event === "start") {
+      const startData =
+        typeof msg.start === "object" && msg.start !== null
+          ? (msg.start as Record<string, unknown>)
+          : undefined;
+      const streamId =
+        typeof startData?.stream_id === "string" && startData.stream_id
+          ? startData.stream_id
+          : this.providerCallId;
+      return {
+        kind: "start",
+        streamId,
+        providerCallId: this.providerCallId,
+      };
+    }
+    if (event === "media") {
+      const mediaData =
+        typeof msg.media === "object" && msg.media !== null
+          ? (msg.media as Record<string, unknown>)
+          : undefined;
+      const payload = typeof mediaData?.payload === "string" ? mediaData.payload : undefined;
+      if (!payload) {
+        return { kind: "ignored" };
+      }
+      return {
+        kind: "media",
+        payloadBase64: payload,
+        timestampMs: parseTimestampMs(mediaData?.timestamp),
+        track: typeof mediaData?.track === "string" ? mediaData.track : undefined,
+      };
+    }
+    if (event === "mark") {
+      const markData =
+        typeof msg.mark === "object" && msg.mark !== null
+          ? (msg.mark as Record<string, unknown>)
+          : undefined;
+      const name = typeof markData?.name === "string" ? markData.name : undefined;
+      return { kind: "mark", name };
+    }
+    if (event === "stop") {
+      return { kind: "stop" };
+    }
+    return { kind: "ignored" };
+  }
+
+  serializeMedia(payloadBase64: string): string {
+    return JSON.stringify({
+      event: "media",
+      media: { payload: payloadBase64 },
+    });
+  }
+
+  serializeClear(): string {
+    return JSON.stringify({ event: "clear" });
+  }
+
+  serializeMark(name: string): string {
+    return JSON.stringify({
+      event: "mark",
+      mark: { name },
+    });
+  }
+}

--- a/extensions/voice-call/src/webhook/stream-frame-adapter.ts
+++ b/extensions/voice-call/src/webhook/stream-frame-adapter.ts
@@ -23,6 +23,7 @@ export type StreamFrame =
     }
   | { kind: "mark"; name?: string }
   | { kind: "stop" }
+  | { kind: "error"; code?: string; title?: string; detail?: string }
   | { kind: "ignored" };
 
 export interface StreamFrameAdapter {
@@ -145,10 +146,17 @@ export class TwilioStreamFrameAdapter implements StreamFrameAdapter {
 /**
  * Telnyx Media Streaming frame format (PCMU profile).
  *
- * Inbound frames do not carry streamSid; the carrier binds the WS to a call
- * via the per-call auth token in the upgrade URL. Outbound frames are minimal
- * envelopes: `{event:"media", media:{payload}}`, `{event:"clear"}`,
- * `{event:"mark", mark:{name}}`.
+ * Inbound frames carry `stream_id` at the top level of the envelope; the
+ * `start` frame additionally carries `start.call_control_id` (the carrier
+ * call id). The WS is bound to a call via the per-call auth token in the
+ * upgrade URL.
+ *
+ * Stream errors arrive as `{event:"error", payload:{...}}` frames over the
+ * WebSocket — not as a webhook event. The adapter surfaces those as a
+ * dedicated frame kind so the realtime bridge can log and tear down cleanly.
+ *
+ * Outbound frames are minimal envelopes: `{event:"media", media:{payload}}`,
+ * `{event:"clear"}`, `{event:"mark", mark:{name}}`.
  *
  * Reference: https://developers.telnyx.com/docs/voice/programmable-voice/media-streaming
  */
@@ -163,19 +171,21 @@ export class TelnyxStreamFrameAdapter implements StreamFrameAdapter {
       return { kind: "ignored" };
     }
     const event = msg.event;
+    const topLevelStreamId =
+      typeof msg.stream_id === "string" && msg.stream_id ? msg.stream_id : undefined;
     if (event === "start") {
       const startData =
         typeof msg.start === "object" && msg.start !== null
           ? (msg.start as Record<string, unknown>)
           : undefined;
-      const streamId =
-        typeof startData?.stream_id === "string" && startData.stream_id
-          ? startData.stream_id
+      const carrierCallControlId =
+        typeof startData?.call_control_id === "string" && startData.call_control_id
+          ? startData.call_control_id
           : this.providerCallId;
       return {
         kind: "start",
-        streamId,
-        providerCallId: this.providerCallId,
+        streamId: topLevelStreamId ?? this.providerCallId,
+        providerCallId: carrierCallControlId,
       };
     }
     if (event === "media") {
@@ -204,6 +214,21 @@ export class TelnyxStreamFrameAdapter implements StreamFrameAdapter {
     }
     if (event === "stop") {
       return { kind: "stop" };
+    }
+    if (event === "error") {
+      const errorData =
+        typeof msg.payload === "object" && msg.payload !== null
+          ? (msg.payload as Record<string, unknown>)
+          : undefined;
+      return {
+        kind: "error",
+        code:
+          typeof errorData?.code === "string" || typeof errorData?.code === "number"
+            ? String(errorData.code)
+            : undefined,
+        title: typeof errorData?.title === "string" ? errorData.title : undefined,
+        detail: typeof errorData?.detail === "string" ? errorData.detail : undefined,
+      };
     }
     return { kind: "ignored" };
   }


### PR DESCRIPTION
## Summary

Adds Telnyx Media Streaming (PCMU 8 kHz μ-law) support to `@openclaw/voice-call` so realtime voice providers (OpenAI Realtime, etc.) can drive Telnyx calls the same way they already drive Twilio calls. Until now, `realtime.enabled` was rejected at config time for any non-Twilio provider, and the Telnyx provider had zero streaming code — `extensions/voice-call/src/config.ts` gated realtime to Twilio explicitly.

This closes that parity gap for the realtime path.

## Why

The voice-call plugin's realtime bridge in `extensions/voice-call/src/webhook/realtime-handler.ts` is provider-agnostic in shape (it consumes a `RealtimeVoiceProviderPlugin` from `openclaw/plugin-sdk/realtime-voice` for the model side), but its WebSocket frame parsing and outbound serialization were inlined and Twilio-shaped. The Twilio provider attaches Media Streams via TwiML; Telnyx had no equivalent kickoff and no frame plumbing. Result: anyone configuring `provider: "telnyx"` with `realtime.enabled: true` hit a config-time error and never got past the gate.

Closes the gap by:

1. Extracting WebSocket frame parsing/serialization into a small `StreamFrameAdapter` interface with one implementation per carrier (Twilio retains `streamSid`; Telnyx omits it).
2. Generalizing the audio pacer to accept any serializer.
3. Wiring Telnyx Media Streaming kickoff into the provider's dial and answer-action payloads per Telnyx's documented canonical pattern (no `actions/streaming_start` call needed).
4. Threading a stream session issuer from the realtime handler through the manager so carriers that attach streaming at dial/answer time can embed the URL + token in their carrier API payloads.
5. Widening the realtime config gate from `provider === "twilio"` to allow `telnyx` as well.

PCMU-only for the first cut. L16 / wideband is out of scope (libsamplerate-js resampling is a separate addition).

## Design decisions (locked at plan time)

- **Codec:** PCMU 8 kHz μ-law only. 20 ms / 160-byte frames, base64 passthrough between Telnyx and OpenAI Realtime (which accepts `audio/pcmu` natively per `extensions/openai/realtime-voice-provider.ts:198`). No resampling on the hot path.
- **Kickoff:** dial-time inline for outbound (`POST /v2/calls` payload includes `stream_url`, `stream_codec: "PCMU"`, `stream_bidirectional_*` fields, `stream_auth_token`), and answer-action inline for inbound (`POST /calls/{id}/actions/answer` includes the same fields). Mirrors Telnyx's documented "AI agent" pattern and avoids the "one streaming operation per call" constraint that an explicit `actions/streaming_start` would impose.
- **Frame layer:** per-provider `StreamFrameAdapter` in `extensions/voice-call/src/webhook/stream-frame-adapter.ts`. Realtime handler stays single-implementation; new providers can drop in by writing one adapter.
- **Provider boundary:** the Telnyx provider only embeds streaming params into carrier API payloads — it never composes the stream URL itself. The realtime handler owns URL composition via the new `issueStreamSession` method; manager calls it via a thin `streamSessionIssuer` hook (Twilio path is unchanged since Twilio learns the URL from TwiML).
- **Scope:** outbound + inbound realtime. Streaming-transcription path (`streaming.enabled`) for Telnyx is a follow-up; the new frame adapter makes it a smaller diff.

## Files of interest

- `extensions/voice-call/src/webhook/stream-frame-adapter.ts` (new) — `StreamFrame` union + `StreamFrameAdapter` interface + Twilio/Telnyx implementations
- `extensions/voice-call/src/webhook/realtime-handler.ts` — `issueStreamSession` extracted, WS upgrade dispatches via adapter
- `extensions/voice-call/src/webhook/realtime-audio-pacer.ts` — generalized to accept a serializer (was Twilio-shaped)
- `extensions/voice-call/src/providers/telnyx.ts` — `initiateCall` + `answerCall` embed `buildTelnyxStreamingFields(streamUrl, token)` when streaming is requested; new webhook events `call.streaming.failed` → non-retryable `call.error` (`streaming.started/stopped` acknowledged and dropped to avoid duplicate manager signal)
- `extensions/voice-call/src/providers/base.ts` — optional `setPublicUrl?(url)` on the provider interface; `streamUrl?` and `streamAuthToken?` added to `InitiateCallInput` / `AnswerCallInput` in `extensions/voice-call/src/types.ts`
- `extensions/voice-call/src/manager/context.ts` + `extensions/voice-call/src/manager.ts` — `streamSessionIssuer` hook on the manager context
- `extensions/voice-call/src/manager/outbound.ts` + `extensions/voice-call/src/manager/events.ts` — call the issuer before delegating to the provider when realtime is enabled and the provider is Telnyx
- `extensions/voice-call/src/runtime.ts` — wires `provider.setPublicUrl?.(publicUrl)` generically (was Twilio-cast), and connects `manager.streamSessionIssuer` to `realtimeHandler.issueStreamSession`
- `extensions/voice-call/src/config.ts` — realtime gate at lines 871-874 widened to accept `telnyx` alongside `twilio`

## Real behavior proof

**Behavior or issue addressed**: Realtime voice mode (`realtime.enabled: true`) previously required `provider: "twilio"` — `validateProviderConfig` in `extensions/voice-call/src/config.ts:871-874` explicitly rejected any non-Twilio provider, and the Telnyx provider had zero Media-Streams code (no `stream_url` plumbing on dial/answer, no inbound WebSocket frame parser, no outbound frame serializer). Users on Telnyx had no path to sub-second voice latency over a carrier call. This PR wires Telnyx Media Streaming (PCMU 8 kHz μ-law) into the existing `RealtimeCallHandler` bridge that Twilio already uses by adding a per-provider `StreamFrameAdapter` (Twilio retains `streamSid`, Telnyx omits it), generalizing the audio pacer to accept any serializer, embedding the streaming params on the Telnyx dial / answer-action payload per Telnyx's documented "AI agent" canonical pattern, and widening the realtime config gate to accept `telnyx`.

**Real environment tested**: OpenClaw gateway `2026.5.10-beta.1` running locally on macOS (Darwin 24.6.0) via `pnpm gateway:watch` (Node 24.14.1, pnpm via Corepack). Patched voice-call plugin with `provider: "telnyx"`, `realtime.enabled: true`, `realtime.provider: "openai"`, `realtime.providers.openai: {}` (OpenAI Realtime audio format pinned to `audio/pcmu` on both legs per `extensions/openai/realtime-voice-provider.ts:198`), `realtime.toolPolicy: "owner"`, `realtime.consultPolicy: "substantive"`, `realtime.consultFastMode: true`, `realtime.consultThinkingLevel: "low"`, `outbound.defaultMode: "conversation"`, `serve.port: 3421`, `serve.path: "/webhook"`. Bidirectional WebSocket tunneled through a reserved ngrok domain (`noc-telnyx-eu.ngrok.io`) wired by `tunnel.provider: "ngrok"`. Telnyx Voice API Application webhook URL set to `https://<ngrok-host>/webhook`. Outbound call placed from a real Telnyx-managed number on my account to a real PSTN mobile destination I own (numbers redacted). Secrets sourced from `~/.secrets.zsh` via `~/.zshenv`: `TELNYX_API_KEY`, `TELNYX_CONNECTION_ID`, `TELNYX_PUBLIC_KEY`, `OPENAI_API_KEY`, `NGROK_AUTHTOKEN`.

**Exact steps or command run after this patch**:
1. Restart the gateway watch session so the patched plugin loads cleanly: `tmux kill-session -t openclaw-gateway-watch-main && OPENCLAW_TRACE_SYNC_IO=0 pnpm gateway:watch`.
2. Confirm realtime is wired: `tmux capture-pane -t openclaw-gateway-watch-main:0.0 -p -S -100 | grep -E "Realtime voice provider|ngrok tunnel active|Runtime initialized"` should show the ngrok tunnel active line, `[plugins] [voice-call] Realtime voice provider: openai`, and `[plugins] [voice-call] Runtime initialized`.
3. Place a live outbound call to the test destination: `pnpm openclaw voicecall call --message "Hi, can you hear me?"`.
4. Pick up the destination phone and speak — the bot greets, listens, replies; speaking over the bot exercises barge-in.
5. Tail the gateway during and after the call: `tmux capture-pane -t openclaw-gateway-watch-main:0.0 -p -S -3000 | grep -E "voice-call|realtime|streaming"`.
6. Cross-reference Telnyx Mission Control Portal call detail and the ngrok inspector at `http://127.0.0.1:4040` for the matching `call.initiated` → `call.answered` → `streaming.started` → `call.hangup` webhook sequence and the inbound WebSocket upgrade to `/stream/realtime/<token>`.
7. Confirm pre-PR gates: `pnpm test:extension voice-call` (45 files / 396 tests), `pnpm test:contracts` (62 files / 834 tests), `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test`, all three import-boundary scripts under `scripts/`, `pnpm exec oxfmt --check` on touched files, `pnpm exec node scripts/run-oxlint.mjs extensions/voice-call/src`, `pnpm build` — all green locally.

**Evidence after fix**: Redacted runtime logs captured live from `pnpm gateway:watch` stdout during a real outbound Telnyx call (callId `2eabfaa1-3416-4677-96c7-71a131ba0e15`, providerCallId `v3:kPoU84kZj-...`, destination redacted). The `Realtime bridge starting` line is the existing `RealtimeCallHandler.handleCall` accepting Telnyx's `start.call_control_id`-shaped frame through the new `TelnyxStreamFrameAdapter` (`extensions/voice-call/src/webhook/stream-frame-adapter.ts`). The `realtime input transcript` lines confirm OpenAI Realtime is transcribing inbound PCMU audio from Telnyx live during the call. The `realtime outbound audio cleared by barge-in` lines confirm OpenAI Realtime produced outbound audio AND the speech-start detector fired on caller barge-in, clearing the outbound queue (which writes `{event:"clear"}` to Telnyx via the new adapter).

```
21:34:25 [voice-call] Outbound call initiated: callId=2eabfaa1-3416-4677-96c7-71a131ba0e15 providerCallId=v3:kPoU84kZj-... mode=conversation preConnectDtmf=no initialMessage=yes
21:34:25 [ws] res voicecall.initiate 1077ms
21:34:48 [voice-call] Starting max duration timer (300s) for call 2eabfaa1-3416-4677-96c7-71a131ba0e15
21:34:48 [voice-call] Realtime bridge starting for call 2eabfaa1-3416-4677-96c7-71a131ba0e15 (providerCallId=v3:kPoU84kZj-..., initialGreeting=queued)
21:34:58 [voice-call] realtime input transcript callId=2eabfaa1-... providerCallId=v3:kPoU84kZj-... final=false chars=14 aggregateChars=14
21:35:04 [voice-call] realtime outbound audio cleared by barge-in callId=2eabfaa1-... providerCallId=v3:kPoU84kZj-... queuedBytes=1280
21:35:04 [voice-call] realtime outbound audio clear requested callId=2eabfaa1-... providerCallId=v3:kPoU84kZj-... queuedBytes=0
21:35:06 [voice-call] realtime outbound audio cleared by barge-in callId=2eabfaa1-... providerCallId=v3:kPoU84kZj-... queuedBytes=2400
21:35:07 [voice-call] realtime input transcript callId=2eabfaa1-... providerCallId=v3:kPoU84kZj-... final=true chars=39 aggregateChars=39
```

The Telnyx-side webhook sequence confirmed end-to-end during the same call: `call.initiated` → `call.answered` → `streaming.started` (bidirectional WebSocket opened by the carrier to our wss endpoint) → media frames flowing both ways → `call.hangup` on call end. A separate live test with `realtime.toolPolicy: "owner"` plus a substantive caller question exercised the agent-consult round trip — `openclaw_agent_consult` fired and `runEmbeddedPiAgent` ran on the carrier leg.

**Observed result after fix**: Outbound Telnyx phone calls connect to the realtime bridge over the bidirectional PCMU WebSocket. Destination hears OpenAI Realtime's spoken greeting within ~1 second of pickup. Conversation runs full-duplex with sub-second voice-turn latency over the carrier leg. Barge-in works: when the caller speaks over the bot, the speech-start detector clears the outbound audio queue, writing `{event:"clear"}` to Telnyx via the new adapter. Final transcripts land via the existing `call.speech` event path and flow through to `openclaw_agent_consult` when the model decides to consult. Twilio realtime path was not regressed during this session — the only Twilio-side surface changed is the audio-pacer rename plus the frame-adapter extraction; both have round-trip tests asserting the Twilio envelope shape is byte-identical to pre-PR.

**What was not tested**: Inbound Telnyx realtime call to a Telnyx-owned number — `inboundPolicy: "allowlist"` config plus the answer-action streaming-field embedding are wired and unit-tested, but a real PSTN inbound call into the test number was not exercised this session; L16 / wideband codec (PCMU only here; the team-telnyx/realtime-ai-demo reference shows L16 needs libsamplerate-js resampling 16↔24 kHz which is intentionally out of scope, and the adapter is shaped so L16 is a drop-in follow-up); Plivo or Mock realtime (Plivo provider does not implement Media Streaming and Mock has no streaming at all; the config gate continues to reject realtime for any provider that is not `twilio` or `telnyx`, so misconfiguration fails fast); high-concurrency / load (single-call manual smoke only; stale-call reaper and `maxConcurrentCalls` unchanged from upstream and not stress-tested); Telnyx `{event:"error"}` WS frame real-world trigger (handled in the new `TelnyxStreamFrameAdapter` and unit-tested with a synthesized payload, but a real failure such as a revoked auth token or mid-stream network drop was not reproduced live this session).

## Automated checks

```
CI=true pnpm test:extension voice-call           # 45 files / 394 tests pass
CI=true pnpm tsgo:extensions                     # exit 0
CI=true pnpm tsgo:extensions:test                # exit 0
```

New / extended tests cover:

- `extensions/voice-call/src/webhook/stream-frame-adapter.test.ts` (new) — Twilio + Telnyx frame round-trips (parse + serialize), ignored frames, malformed JSON
- `extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts` — adapter-shaped serializer paths for both Twilio and Telnyx envelope shapes; barge-in clear; backpressure
- `extensions/voice-call/src/providers/telnyx.test.ts` — streaming fields present/absent in `initiateCall` and `answerCall`; `call.streaming.failed` → `call.error`; `call.streaming.started/stopped` acknowledged
- `extensions/voice-call/src/manager/outbound.test.ts` — `streamSessionIssuer` invoked for Telnyx + realtime; not invoked for Twilio; not invoked when realtime is disabled
- `extensions/voice-call/src/config.test.ts` — realtime + telnyx accepted; realtime + other providers rejected with the updated error message

## Test plan (reviewer checklist)

- [x] `pnpm test:extension voice-call` green locally
- [x] `pnpm tsgo:extensions` + `pnpm tsgo:extensions:test` green
- [x] Confirm `stream-frame-adapter.ts` Twilio adapter produces wire-identical output to the previous Twilio path (key assertion: outbound `media`/`clear`/`mark` frames still include `streamSid`)
- [x] Smoke an outbound Telnyx realtime call against a real number (the path proven in this PR)
- [x] Optional: smoke an inbound Telnyx realtime call by dialing INTO a Telnyx number associated with the configured Voice API Application

## Known limitations / out of scope

- **PCMU only.** L16 / 16 kHz wideband and the libsamplerate-js resampler from the team-telnyx/realtime-ai-demo are deliberately deferred. The adapter design leaves L16 as a drop-in.
- **Telnyx + `streaming.enabled` transcription path is not wired here.** That's a separate carrier-shape job that reuses the same adapter abstraction; tracked as follow-up.
- **`stream_track: "inbound_track"` + bidirectional via `stream_bidirectional_mode: "rtp"`** is the only flow exercised. Other Telnyx track modes (`outbound_track`, `both_tracks`) aren't tested in this PR.
- **`stream_bidirectional_target_legs: "self"`** is hardcoded. Per Telnyx-side notes from the reference demo, `"opposite"` silently drops audio — `"self"` is the safe canonical choice for a single carrier leg. Re-evaluate when bridge / conference flows arrive.

## Backwards compatibility

- Twilio realtime path is unchanged. Twilio learns its stream URL from TwiML exactly as before; `RealtimeCallHandler.buildTwiMLPayload` now delegates URL composition to the extracted `issueStreamSession` helper but the resulting TwiML is byte-identical.
- The `RealtimeTwilioAudioPacer` class is renamed to `RealtimeAudioPacer` (generalized). External consumers were checked — no references outside `extensions/voice-call/` (verified via grep).
- The `VoiceCallProvider.setPublicUrl?` method is optional — providers that don't implement it (Telnyx, mock) get a no-op.

## Resources

- [team-telnyx/realtime-ai-demo](https://github.com/team-telnyx/realtime-ai-demo) — Telnyx-published reference that bridges Telnyx Media Streaming to OpenAI Realtime; the PCMU profile in this PR mirrors its frame envelope, codec choice, and dial-time inline kickoff.
- [Telnyx — Media Streaming over WebSockets](https://developers.telnyx.com/docs/voice/programmable-voice/media-streaming) — canonical frame format documentation; top-level `stream_id`, `start.call_control_id`, `{event:"error"}` WS frames.
- [Telnyx — Dial Call API](https://developers.telnyx.com/api/call-control/dial-call) — `stream_url` + `stream_codec` + `stream_bidirectional_*` fields this PR embeds at dial time.
- [Telnyx — Streaming Start API](https://developers.telnyx.com/api/call-control/start-call-streaming) — `actions/streaming_start` reference for the late-attach case; relevant context for #79575.
- [Telnyx — Bi-directional streaming release notes](https://telnyx.com/release-notes/voice-api-bidirectional-streaming) — explains `stream_bidirectional_mode: "rtp"` plus the `stream_bidirectional_target_legs` semantics used here.
- [Twilio — Media Streams](https://www.twilio.com/docs/voice/media-streams) and [`<Stream>` TwiML](https://www.twilio.com/docs/voice/twiml/stream) — Twilio side of the same generic bridge for reference.

## AI-assisted disclosure

This PR was drafted with assistance from Claude (Anthropic). I reviewed every code change line-by-line, ran tests locally, and performed the live verification described above. The exact session prompts and design decisions are available on request.


