### PR TITLE
fix(codex/app-server): project user mcp.servers into thread config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - fix(gateway): honor minimal discovery mode for wide-area DNS-SD [AI]. (#80903) Thanks @pgondhi987.
 - slack: enforce reaction notification policy [AI]. (#80907) Thanks @pgondhi987.
 - Enforce gateway command scopes by caller context [AI]. (#80891) Thanks @pgondhi987.
+- Codex (app-server): project user-configured `mcp.servers` into the Codex thread config's `mcp_servers` field for both new and resumed threads, matching the codex-cli runtime's existing `-c mcp_servers=…` behavior, so app-server-runtime agents see the same user MCP servers the CLI runtime already exposes. Plugin-curated apps remain attached via the separate `apps` config patch. Fixes #80814. Thanks @mbs-vhs.
 - Enforce Slack plugin approval button authorization [AI]. (#80899) Thanks @pgondhi987.
 - Recognize PowerShell -ec inline commands [AI]. (#80893) Thanks @pgondhi987.
 - fix(qqbot): authorize approval button callbacks [AI]. (#80892) Thanks @pgondhi987.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-f26833e053032e3da94025c8a5a8cb62dcddd275797b527440a19be5886a4783  plugin-sdk-api-baseline.json
-429fe1d6d119379b914bf84b15705233dc8d2d9e1a8131bb28ea19b19afbe6a0  plugin-sdk-api-baseline.jsonl
+3edd8854e1155ef9b16d4612e20c1432045d53f645dc7bbaf5612b083f46c600  plugin-sdk-api-baseline.json
+d91ecfea012d1e17dce69e786a837d2c7f57655296d46e1b3b9ce3dcfe87b7ea  plugin-sdk-api-baseline.jsonl

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -2,6 +2,7 @@ import {
   embeddedAgentLog,
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { buildCodexUserMcpServersThreadConfigPatch } from "openclaw/plugin-sdk/codex-mcp-projection";
 import {
   CODEX_GPT5_HEARTBEAT_PROMPT_OVERLAY,
   renderCodexPromptOverlay,
@@ -60,6 +61,7 @@ export async function startOrResumeThread(params: {
   pluginThreadConfig?: CodexPluginThreadConfigProvider;
 }): Promise<CodexAppServerThreadBinding> {
   const dynamicToolsFingerprint = fingerprintDynamicTools(params.dynamicTools);
+  const userMcpServersConfigPatch = buildCodexUserMcpServersThreadConfigPatch(params.params.config);
   let binding = await readCodexAppServerBinding(params.params.sessionFile, {
     authProfileStore: params.params.authProfileStore,
     agentDir: params.params.agentDir,
@@ -142,7 +144,7 @@ export async function startOrResumeThread(params: {
               authProfileId,
               appServer: params.appServer,
               developerInstructions: params.developerInstructions,
-              config: params.config,
+              config: mergeCodexThreadConfigs(params.config, userMcpServersConfigPatch),
             }),
           ),
         );
@@ -201,7 +203,11 @@ export async function startOrResumeThread(params: {
   const pluginThreadConfig = params.pluginThreadConfig?.enabled
     ? (prebuiltPluginThreadConfig ?? (await params.pluginThreadConfig.build()))
     : undefined;
-  const config = mergeCodexThreadConfigs(params.config, pluginThreadConfig?.configPatch);
+  const config = mergeCodexThreadConfigs(
+    params.config,
+    userMcpServersConfigPatch,
+    pluginThreadConfig?.configPatch,
+  );
   const response = assertCodexThreadStartResponse(
     await params.client.request(
       "thread/start",

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -129,7 +129,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     const startCall = request.mock.calls.find(([method]) => method === "thread/start");
     const startParams = startCall?.[1] as { config?: { mcp_servers?: Record<string, unknown> } };
     expect(startParams?.config?.mcp_servers).toBeDefined();
-    expect(startParams!.config!.mcp_servers).toMatchObject({
+    expect(startParams.config!.mcp_servers).toMatchObject({
       outlook: { command: "node", args: ["/opt/outlook-mcp/dist/index.js"] },
     });
   });
@@ -198,7 +198,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
       config?: { mcp_servers?: Record<string, unknown> };
     };
     expect(resumeParams?.config?.mcp_servers).toBeDefined();
-    expect(resumeParams!.config!.mcp_servers).toMatchObject({
+    expect(resumeParams.config!.mcp_servers).toMatchObject({
       notes: { command: "node", args: ["/opt/notes-mcp/dist/index.js"] },
     });
   });

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexAppServerRuntimeOptions } from "./config.js";
 import { writeCodexAppServerBinding } from "./session-binding.js";
 import { startOrResumeThread } from "./thread-lifecycle.js";
 
@@ -45,7 +46,7 @@ function threadResumeResult(threadId = "thread-existing"): Record<string, unknow
   return threadStartResult(threadId);
 }
 
-function createAppServerOptions() {
+function createAppServerOptions(): CodexAppServerRuntimeOptions {
   return {
     start: {
       transport: "stdio",
@@ -55,10 +56,10 @@ function createAppServerOptions() {
     },
     requestTimeoutMs: 60_000,
     turnCompletionIdleTimeoutMs: 60_000,
-    approvalPolicy: "never" as const,
-    approvalsReviewer: "user" as const,
-    sandbox: "workspace-write" as const,
-  };
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: "workspace-write",
+  } as unknown as CodexAppServerRuntimeOptions;
 }
 
 function createParams(
@@ -82,7 +83,7 @@ function createParams(
     authProfileStore: { version: 1, profiles: {} },
     modelRegistry: {} as never,
     config: configOverrides,
-  } as EmbeddedRunAttemptParams;
+  } as unknown as EmbeddedRunAttemptParams;
 }
 
 describe("startOrResumeThread — user mcp.servers projection (regression: #80814)", () => {
@@ -120,7 +121,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
             },
           },
         },
-      } as EmbeddedRunAttemptParams["config"]),
+      } as unknown as EmbeddedRunAttemptParams["config"]),
       cwd: workspaceDir,
       dynamicTools: [],
       appServer: createAppServerOptions(),
@@ -187,7 +188,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
             },
           },
         },
-      } as EmbeddedRunAttemptParams["config"]),
+      } as unknown as EmbeddedRunAttemptParams["config"]),
       cwd: workspaceDir,
       dynamicTools: [],
       appServer: createAppServerOptions(),

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -1,0 +1,205 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeCodexAppServerBinding } from "./session-binding.js";
+import { startOrResumeThread } from "./thread-lifecycle.js";
+
+function threadStartResult(threadId = "thread-1"): Record<string, unknown> {
+  return {
+    thread: {
+      id: threadId,
+      sessionId: "session-1",
+      forkedFromId: null,
+      preview: "",
+      ephemeral: false,
+      modelProvider: "openai",
+      createdAt: 1,
+      updatedAt: 1,
+      status: { type: "idle" },
+      path: null,
+      cwd: "/tmp",
+      cliVersion: "0.125.0",
+      source: "unknown",
+      agentNickname: null,
+      agentRole: null,
+      gitInfo: null,
+      name: null,
+      turns: [],
+    },
+    model: "gpt-5.4-codex",
+    modelProvider: "openai",
+    serviceTier: null,
+    cwd: "/tmp",
+    instructionSources: [],
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: { type: "dangerFullAccess" },
+    permissionProfile: null,
+    reasoningEffort: null,
+  };
+}
+
+function threadResumeResult(threadId = "thread-existing"): Record<string, unknown> {
+  return threadStartResult(threadId);
+}
+
+function createAppServerOptions() {
+  return {
+    start: {
+      transport: "stdio",
+      command: "codex",
+      args: ["app-server"],
+      headers: {},
+    },
+    requestTimeoutMs: 60_000,
+    turnCompletionIdleTimeoutMs: 60_000,
+    approvalPolicy: "never" as const,
+    approvalsReviewer: "user" as const,
+    sandbox: "workspace-write" as const,
+  };
+}
+
+function createParams(
+  sessionFile: string,
+  workspaceDir: string,
+  configOverrides?: EmbeddedRunAttemptParams["config"],
+): EmbeddedRunAttemptParams {
+  return {
+    prompt: "hello",
+    sessionId: "session-1",
+    sessionKey: "agent:main:session-1",
+    sessionFile,
+    workspaceDir,
+    runId: "run-1",
+    provider: "codex",
+    modelId: "gpt-5.4-codex",
+    thinkLevel: "medium",
+    disableTools: true,
+    timeoutMs: 5_000,
+    authStorage: {} as never,
+    authProfileStore: { version: 1, profiles: {} },
+    modelRegistry: {} as never,
+    config: configOverrides,
+  } as EmbeddedRunAttemptParams;
+}
+
+describe("startOrResumeThread — user mcp.servers projection (regression: #80814)", () => {
+  let tempDir = "";
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-80814-"));
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("projects cfg.mcp.servers into the thread/start config patch under mcp_servers", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir, {
+        mcp: {
+          servers: {
+            outlook: {
+              transport: "stdio",
+              command: "node",
+              args: ["/opt/outlook-mcp/dist/index.js"],
+            },
+          },
+        },
+      } as EmbeddedRunAttemptParams["config"]),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+    });
+
+    const startCall = request.mock.calls.find(([method]) => method === "thread/start");
+    const startParams = startCall?.[1] as { config?: { mcp_servers?: Record<string, unknown> } };
+    expect(startParams?.config?.mcp_servers).toBeDefined();
+    expect(startParams!.config!.mcp_servers).toMatchObject({
+      outlook: { command: "node", args: ["/opt/outlook-mcp/dist/index.js"] },
+    });
+  });
+
+  it("omits mcp_servers from the start config when cfg has no user MCP servers", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+    });
+
+    const startCall = request.mock.calls.find(([method]) => method === "thread/start");
+    const startParams = startCall?.[1] as { config?: { mcp_servers?: Record<string, unknown> } };
+    expect(startParams?.config?.mcp_servers).toBeUndefined();
+  });
+
+  it("projects cfg.mcp.servers into resumed-thread config too so re-attached threads see user MCP", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-existing",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+    });
+
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/resume") {
+        return threadResumeResult();
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir, {
+        mcp: {
+          servers: {
+            notes: {
+              transport: "stdio",
+              command: "node",
+              args: ["/opt/notes-mcp/dist/index.js"],
+            },
+          },
+        },
+      } as EmbeddedRunAttemptParams["config"]),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+    });
+
+    const resumeCall = request.mock.calls.find(([method]) => method === "thread/resume");
+    const resumeParams = resumeCall?.[1] as {
+      config?: { mcp_servers?: Record<string, unknown> };
+    };
+    expect(resumeParams?.config?.mcp_servers).toBeDefined();
+    expect(resumeParams!.config!.mcp_servers).toMatchObject({
+      notes: { command: "node", args: ["/opt/notes-mcp/dist/index.js"] },
+    });
+  });
+});

--- a/scripts/lib/plugin-sdk-private-local-only-subpaths.json
+++ b/scripts/lib/plugin-sdk-private-local-only-subpaths.json
@@ -1,4 +1,5 @@
 [
+  "codex-mcp-projection",
   "codex-native-task-runtime",
   "qa-channel",
   "qa-channel-protocol",

--- a/src/agents/cli-runner/bundle-mcp-codex.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.ts
@@ -9,10 +9,11 @@ import {
 } from "./bundle-mcp-adapter-shared.js";
 import { serializeTomlInlineValue } from "./toml-inline.js";
 
-// Mutable JSON shape that matches the Codex app-server's `JsonObject`
-// (extensions/codex/src/app-server/protocol.ts) so this projection result is
-// structurally assignable to `mergeCodexThreadConfigs`' parameters without
-// pulling plugin-local types across the boundary.
+// Mutable JSON shape structurally compatible with the bundled Codex
+// app-server thread-config JsonObject (see the protocol module in the codex
+// plugin). Defined locally so this projection result stays assignable to
+// mergeCodexThreadConfigs without pulling plugin-local types across the
+// extensions boundary.
 type CodexThreadConfigValue =
   | string
   | number

--- a/src/agents/cli-runner/bundle-mcp-codex.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.ts
@@ -9,6 +9,19 @@ import {
 } from "./bundle-mcp-adapter-shared.js";
 import { serializeTomlInlineValue } from "./toml-inline.js";
 
+// Mutable JSON shape that matches the Codex app-server's `JsonObject`
+// (extensions/codex/src/app-server/protocol.ts) so this projection result is
+// structurally assignable to `mergeCodexThreadConfigs`' parameters without
+// pulling plugin-local types across the boundary.
+type CodexThreadConfigValue =
+  | string
+  | number
+  | boolean
+  | null
+  | CodexThreadConfigValue[]
+  | { [key: string]: CodexThreadConfigValue };
+type CodexThreadConfigObject = { [key: string]: CodexThreadConfigValue };
+
 function isOpenClawLoopbackMcpServer(name: string, server: BundleMcpServerConfig): boolean {
   return (
     name === "openclaw" &&
@@ -20,8 +33,8 @@ function isOpenClawLoopbackMcpServer(name: string, server: BundleMcpServerConfig
 function normalizeCodexServerConfig(
   name: string,
   server: BundleMcpServerConfig,
-): Record<string, unknown> {
-  const next: Record<string, unknown> = {};
+): CodexThreadConfigObject {
+  const next: CodexThreadConfigObject = {};
   applyCommonServerConfig(next, server);
   if (isOpenClawLoopbackMcpServer(name, server)) {
     next.default_tools_approval_mode = "approve";
@@ -81,13 +94,13 @@ export function injectCodexMcpConfigArgs(
  */
 export function buildCodexUserMcpServersThreadConfigPatch(
   cfg: OpenClawConfig | undefined,
-): { mcp_servers: Record<string, Record<string, unknown>> } | undefined {
+): { mcp_servers: CodexThreadConfigObject } | undefined {
   const userServers = normalizeConfiguredMcpServers(cfg?.mcp?.servers);
   const entries = Object.entries(userServers);
   if (entries.length === 0) {
     return undefined;
   }
-  const mcp_servers: Record<string, Record<string, unknown>> = {};
+  const mcp_servers: CodexThreadConfigObject = {};
   for (const [name, server] of entries) {
     mcp_servers[name] = normalizeCodexServerConfig(name, server as BundleMcpServerConfig);
   }

--- a/src/agents/cli-runner/bundle-mcp-codex.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.ts
@@ -1,3 +1,5 @@
+import { normalizeConfiguredMcpServers } from "../../config/mcp-config-normalize.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { BundleMcpConfig, BundleMcpServerConfig } from "../../plugins/bundle-mcp.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import {
@@ -63,4 +65,31 @@ export function injectCodexMcpConfigArgs(
     ),
   );
   return [...(args ?? []), "-c", `mcp_servers=${overrides}`];
+}
+
+/**
+ * Codex app-server runtime (extensions/codex) receives its thread config as a
+ * JSON object through JSON-RPC `thread/start`/`thread/resume`, not as `-c` CLI
+ * args. This returns a thread-config patch projecting user-configured
+ * `cfg.mcp.servers` entries into Codex's `mcp_servers` table using the same
+ * per-server normalization the CLI path uses, so app-server agents see the
+ * same user MCP servers the CLI runtime exposes via `injectCodexMcpConfigArgs`.
+ *
+ * Only user-configured servers (`cfg.mcp.servers`) are projected. Plugin-
+ * curated app-server apps are already attached separately through the codex
+ * plugin thread-config `apps` patch, so they must not be re-projected here.
+ */
+export function buildCodexUserMcpServersThreadConfigPatch(
+  cfg: OpenClawConfig | undefined,
+): { mcp_servers: Record<string, Record<string, unknown>> } | undefined {
+  const userServers = normalizeConfiguredMcpServers(cfg?.mcp?.servers);
+  const entries = Object.entries(userServers);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  const mcp_servers: Record<string, Record<string, unknown>> = {};
+  for (const [name, server] of entries) {
+    mcp_servers[name] = normalizeCodexServerConfig(name, server as BundleMcpServerConfig);
+  }
+  return { mcp_servers };
 }

--- a/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { buildCodexUserMcpServersThreadConfigPatch } from "./bundle-mcp-codex.js";
+
+describe("buildCodexUserMcpServersThreadConfigPatch", () => {
+  it("returns undefined when cfg has no mcp.servers (regression: #80814)", () => {
+    expect(buildCodexUserMcpServersThreadConfigPatch(undefined)).toBeUndefined();
+    expect(buildCodexUserMcpServersThreadConfigPatch({} as OpenClawConfig)).toBeUndefined();
+    expect(
+      buildCodexUserMcpServersThreadConfigPatch({ mcp: {} } as OpenClawConfig),
+    ).toBeUndefined();
+    expect(
+      buildCodexUserMcpServersThreadConfigPatch({ mcp: { servers: {} } } as OpenClawConfig),
+    ).toBeUndefined();
+  });
+
+  it("projects a stdio user MCP server entry into mcp_servers (regression: #80814)", () => {
+    const patch = buildCodexUserMcpServersThreadConfigPatch({
+      mcp: {
+        servers: {
+          outlook: {
+            transport: "stdio",
+            command: "node",
+            args: ["/opt/outlook-mcp/dist/index.js"],
+            env: { OUTLOOK_USER: "alice@example.org" },
+          },
+        },
+      },
+    } as OpenClawConfig);
+    expect(patch).toStrictEqual({
+      mcp_servers: {
+        outlook: {
+          command: "node",
+          args: ["/opt/outlook-mcp/dist/index.js"],
+          env: { OUTLOOK_USER: "alice@example.org" },
+        },
+      },
+    });
+  });
+
+  it("projects a streamable-http user MCP server with bearer auth into mcp_servers", () => {
+    const patch = buildCodexUserMcpServersThreadConfigPatch({
+      mcp: {
+        servers: {
+          notes: {
+            transport: "streamable-http",
+            url: "https://notes.example.org/mcp",
+            headers: {
+              Authorization: "Bearer ${NOTES_TOKEN}",
+              "x-tenant": "${NOTES_TENANT}",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig);
+    expect(patch).toStrictEqual({
+      mcp_servers: {
+        notes: {
+          url: "https://notes.example.org/mcp",
+          bearer_token_env_var: "NOTES_TOKEN",
+          env_http_headers: { "x-tenant": "NOTES_TENANT" },
+        },
+      },
+    });
+  });
+
+  it("preserves multiple user MCP servers as independent mcp_servers entries", () => {
+    const patch = buildCodexUserMcpServersThreadConfigPatch({
+      mcp: {
+        servers: {
+          one: { transport: "stdio", command: "one" },
+          two: { transport: "stdio", command: "two" },
+        },
+      },
+    } as OpenClawConfig);
+    expect(patch?.mcp_servers).toBeDefined();
+    expect(Object.keys(patch!.mcp_servers).toSorted()).toEqual(["one", "two"]);
+    expect(patch!.mcp_servers.one).toMatchObject({ command: "one" });
+    expect(patch!.mcp_servers.two).toMatchObject({ command: "two" });
+  });
+});

--- a/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
@@ -26,7 +26,7 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
           },
         },
       },
-    } as OpenClawConfig);
+    } as unknown as OpenClawConfig);
     expect(patch).toStrictEqual({
       mcp_servers: {
         outlook: {
@@ -52,7 +52,7 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
           },
         },
       },
-    } as OpenClawConfig);
+    } as unknown as OpenClawConfig);
     expect(patch).toStrictEqual({
       mcp_servers: {
         notes: {
@@ -72,7 +72,7 @@ describe("buildCodexUserMcpServersThreadConfigPatch", () => {
           two: { transport: "stdio", command: "two" },
         },
       },
-    } as OpenClawConfig);
+    } as unknown as OpenClawConfig);
     expect(patch?.mcp_servers).toBeDefined();
     expect(Object.keys(patch!.mcp_servers).toSorted()).toEqual(["one", "two"]);
     expect(patch!.mcp_servers.one).toMatchObject({ command: "one" });

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -1,0 +1,6 @@
+// Private helper surface for the bundled Codex plugin. Mirrors the Codex CLI
+// runtime's user-mcp-server projection so the bundled Codex app-server harness
+// can attach the same user `mcp.servers` entries to its thread config without
+// deep-importing core helpers.
+
+export { buildCodexUserMcpServersThreadConfigPatch } from "../agents/cli-runner/bundle-mcp-codex.js";

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -266,6 +266,11 @@ const cachedPluginSdkScopedAliasMaps = new PluginLruCache<Record<string, string>
 );
 const PLUGIN_SDK_PACKAGE_NAMES = ["openclaw/plugin-sdk", "@openclaw/plugin-sdk"] as const;
 const CODEX_NATIVE_TASK_RUNTIME_PLUGIN_SDK_SUBPATH = "codex-native-task-runtime";
+const CODEX_MCP_PROJECTION_PLUGIN_SDK_SUBPATH = "codex-mcp-projection";
+const BUNDLED_CODEX_PRIVATE_PLUGIN_SDK_SUBPATHS = new Set([
+  CODEX_NATIVE_TASK_RUNTIME_PLUGIN_SDK_SUBPATH,
+  CODEX_MCP_PROJECTION_PLUGIN_SDK_SUBPATH,
+]);
 const PLUGIN_SDK_SOURCE_CANDIDATE_EXTENSIONS = [
   ".ts",
   ".mts",
@@ -474,7 +479,7 @@ function shouldIncludePrivateLocalOnlyPluginSdkSubpath(params: {
 }) {
   return (
     shouldIncludePrivateLocalOnlyPluginSdkSubpaths() ||
-    (params.subpath === CODEX_NATIVE_TASK_RUNTIME_PLUGIN_SDK_SUBPATH &&
+    (BUNDLED_CODEX_PRIVATE_PLUGIN_SDK_SUBPATHS.has(params.subpath) &&
       isBundledCodexPluginModulePath({
         packageRoot: params.packageRoot,
         modulePath: params.modulePath,


### PR DESCRIPTION
## Summary

The bundled `@openclaw/codex` app-server harness merged its plugin-curated `apps` configPatch into the JSON-RPC `thread/start` config but never read `cfg.mcp.servers`, so user-configured MCP servers under `mcp.servers.<name>` in `openclaw.json` were silently dropped from agents running under `agentRuntime.id: codex`. Result reported in #80814:

- `openclaw mcp list` shows the server (CLI reads `openclaw.json` directly) ✓
- `openclaw plugins inspect <id>` reports the plugin loaded ✓
- Agent's outbound provider request body **never carries the `server__*` tools** for user MCP entries
- Plugin-marketplace MCP (gmail/figma/github) keeps working because it goes through the separate `apps` configPatch
- Codex CLI runtime is unaffected because its [src/agents/cli-runner/bundle-mcp-codex.ts:53-66](src/agents/cli-runner/bundle-mcp-codex.ts#L53-L66) already projects the same config via `-c mcp_servers=…` CLI args

This PR adds a sibling JSON-shaped projection at the app-server boundary, mirroring the CLI runtime's normalization exactly so the two runtimes stay in lockstep for user MCP server exposure.

Fixes #80814.

## Root cause

[extensions/codex/src/app-server/thread-lifecycle.ts:201-205](extensions/codex/src/app-server/thread-lifecycle.ts#L201-L205) (pre-fix):

```ts
const pluginThreadConfig = params.pluginThreadConfig?.enabled
  ? (prebuiltPluginThreadConfig ?? (await params.pluginThreadConfig.build()))
  : undefined;
const config = mergeCodexThreadConfigs(params.config, pluginThreadConfig?.configPatch);
```

[extensions/codex/src/app-server/plugin-thread-config.ts:212](extensions/codex/src/app-server/plugin-thread-config.ts#L212) (pre-fix):

```ts
const configPatch = { apps };
```

No `mcp_servers` projection exists. The codex app-server runtime only sees plugin-curated `apps`.

## What changed (scope boundary)

- **NEW** `src/agents/cli-runner/bundle-mcp-codex.ts:69-92` — sibling helper `buildCodexUserMcpServersThreadConfigPatch(cfg)` reusing the existing `normalizeCodexServerConfig(name, server)` per-server pipeline. Returns `{ mcp_servers: {...} }` JSON patch or `undefined`.
- **NEW** `src/plugin-sdk/codex-mcp-projection.ts` — private-local-only SDK subpath that re-exports the helper for `extensions/codex` consumption (same pattern as `codex-native-task-runtime`).
- **MOD** `scripts/lib/plugin-sdk-private-local-only-subpaths.json` — register the new subpath.
- **MOD** `extensions/codex/src/app-server/thread-lifecycle.ts` — compute the patch once at the start of `startOrResumeThread`, merge into both `thread/resume` and `thread/start` config via the existing `mergeCodexThreadConfigs(...)` helper.
- **NEW** `src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts` — 4 helper unit tests (stdio shape, http+bearer shape, empty cfg, multi-server).
- **NEW** `extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts` — 3 wiring tests (`thread/start` carries `mcp_servers`, omitted when cfg empty, resumed thread also carries it).
- **REGEN** `docs/.generated/plugin-sdk-api-baseline.sha256` (new SDK subpath registers in API surface).
- **MOD** `CHANGELOG.md` — entry under `## Unreleased` › `### Fixes`.

## What did NOT change (scope boundary)

- Plugin-curated apps still flow through the existing `apps` configPatch at [plugin-thread-config.ts:212](extensions/codex/src/app-server/plugin-thread-config.ts#L212) — **not** double-counted via this PR's `mcp_servers` path. Only user-configured `cfg.mcp.servers` are projected (via `normalizeConfiguredMcpServers`), keeping the two surfaces orthogonal.
- The codex CLI runtime's `injectCodexMcpConfigArgs` and its acceptance test `src/agents/cli-runner/bundle-mcp.codex.test.ts` are untouched.
- No change to the codex thread-config schema, `mergeCodexThreadConfigs` merge semantics, fingerprinting, or session-binding code.
- No new user-facing config knob. `cfg.mcp.servers` was already the documented surface for OpenClaw-managed MCP server definitions ([docs/cli/mcp.md](https://docs.openclaw.ai/cli/mcp)).
- Plugin boundary respected: `extensions/codex` consumes the helper exclusively via the `openclaw/plugin-sdk/codex-mcp-projection` private SDK subpath; no deep imports of `src/agents/...` or `src/config/...`.

## Regression test plan

`src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts` — `describe("buildCodexUserMcpServersThreadConfigPatch")` covers:

1. Empty / undefined cfg returns `undefined` (no thread-config noise when user has no MCP entries).
2. Stdio user MCP server projects with `command`, `args`, `env` preserved.
3. Streamable-HTTP user MCP server projects with bearer-env-var decoding (`Authorization: Bearer ${ENV}` → `bearer_token_env_var: "ENV"`) and env-header decoding (`${ENV}` placeholders → `env_http_headers`).
4. Multiple user MCP servers preserved as independent `mcp_servers` entries.

`extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts` — `describe("startOrResumeThread — user mcp.servers projection")` covers:

1. `thread/start` request's `config.mcp_servers` contains the projected user server (regression: #80814).
2. `thread/start` request's `config.mcp_servers` is absent when cfg has no user MCP entries (no noise when the feature isn't used).
3. `thread/resume` request's `config.mcp_servers` carries the projection too — re-attached threads see user MCP without needing to start a new thread.

Existing `src/agents/cli-runner/bundle-mcp.codex.test.ts` (codex CLI runtime projection) and SDK contract tests at `src/plugins/contracts/plugin-sdk-root-alias.test.ts` + `src/plugins/sdk-alias.test.ts` continue to pass unmodified.

## Real behavior proof

**Behavior or issue addressed:** Agents running under `agentRuntime.id: codex` (the bundled `@openclaw/codex` app-server harness, not `codex-cli`) cannot see tools from user-configured `mcp.servers.<name>` entries in `openclaw.json`, despite (a) the server child process being healthy and reachable via direct stdio probe, (b) `openclaw mcp list` and `openclaw plugins inspect` both reporting the server configured and loaded, and (c) the codex CLI runtime's `injectCodexMcpConfigArgs` path correctly projecting the same entries for the `agentRuntime.id: codex-cli` case. Wire-level evidence in the reporter's body (#80814) shows zero `server__*` entries in the agent's outbound provider request body. Same root-cause class as the closed cluster #74387/#74726/#74844 for embedded Pi runtime, but specific to the codex app-server runtime.

**Real environment tested:**
- OpenClaw commit: `9b07f80559` (current `upstream/main`) plus this patch
- Node: `v24.14.1`
- OS: `Linux 6.17.0-22-generic x86_64`
- Runtime: production module imports — `node --import tsx` against the patched `openclaw/plugin-sdk/codex-mcp-projection` re-export of the production `buildCodexUserMcpServersThreadConfigPatch` helper (no test seam, no vitest mock, no injection between the SDK boundary the codex extension imports and the core helper it resolves to)
- Verified import path: `openclaw/plugin-sdk/codex-mcp-projection` → `src/agents/cli-runner/bundle-mcp-codex.ts:69` exactly the path `extensions/codex/src/app-server/thread-lifecycle.ts:5` now imports from

**Exact steps or command run after this patch:**

1. Build / confirm the patched module loads from the production SDK import path:

   ```bash
   pnpm install
   node --import tsx -e "import('./src/plugin-sdk/codex-mcp-projection.ts').then(m => console.log(Object.keys(m)))"
   ```

2. Write a focused production-path probe exercising every projection branch — stdio shape, HTTP+bearer shape, empty cfg, multi-server — by importing the helper through the same SDK subpath the codex extension uses:

   ```bash
   cat > /tmp/proof_80814.mjs <<'JS'
   import { buildCodexUserMcpServersThreadConfigPatch } from "./src/plugin-sdk/codex-mcp-projection.ts";

   console.log("Case 1 — stdio user MCP:");
   console.log(JSON.stringify(buildCodexUserMcpServersThreadConfigPatch({
     mcp: { servers: { outlook: {
       transport: "stdio", command: "node",
       args: ["/opt/outlook-mcp/dist/index.js"],
       env: { OUTLOOK_USER: "alice@example.org" },
     }}}}), null, 2));

   console.log("Case 2 — streamable-http with bearer + env headers:");
   console.log(JSON.stringify(buildCodexUserMcpServersThreadConfigPatch({
     mcp: { servers: { notes: {
       transport: "streamable-http",
       url: "https://notes.example.org/mcp",
       headers: {
         Authorization: "Bearer ${NOTES_TOKEN}",
         "x-tenant": "${NOTES_TENANT}",
       },
     }}}}), null, 2));

   console.log("Case 3 — empty / no user MCP:");
   console.log("undefined:", buildCodexUserMcpServersThreadConfigPatch(undefined));
   console.log("empty mcp.servers:", buildCodexUserMcpServersThreadConfigPatch({ mcp: { servers: {} } }));

   console.log("Case 4 — multiple user MCP servers:");
   console.log(JSON.stringify(buildCodexUserMcpServersThreadConfigPatch({
     mcp: { servers: {
       one: { transport: "stdio", command: "one" },
       two: { transport: "stdio", command: "two" },
     }}}), null, 2));
   JS

   node --import tsx /tmp/proof_80814.mjs
   ```

3. Run the new and adjacent unit suites against the patched module:

   ```bash
   node --import tsx node_modules/vitest/dist/cli.js run \
     src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts \
     src/agents/cli-runner/bundle-mcp.codex.test.ts \
     extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts \
     src/plugins/contracts/plugin-sdk-root-alias.test.ts \
     src/plugins/sdk-alias.test.ts
   ```

4. Format check the touched files:

   ```bash
   node_modules/oxfmt/bin/oxfmt --check --threads=1 \
     src/plugin-sdk/codex-mcp-projection.ts \
     src/agents/cli-runner/bundle-mcp-codex.ts \
     src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts \
     extensions/codex/src/app-server/thread-lifecycle.ts \
     extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts \
     CHANGELOG.md
   ```

**Evidence after fix:** terminal capture from steps 2–4 above against the patched production SDK boundary (no test seam — the same module the codex extension imports via `openclaw/plugin-sdk/codex-mcp-projection`):

```
Case 1 — stdio user MCP:
{
  "mcp_servers": {
    "outlook": {
      "command": "node",
      "args": [
        "/opt/outlook-mcp/dist/index.js"
      ],
      "env": {
        "OUTLOOK_USER": "alice@example.org"
      }
    }
  }
}
Case 2 — streamable-http with bearer + env headers:
{
  "mcp_servers": {
    "notes": {
      "url": "https://notes.example.org/mcp",
      "bearer_token_env_var": "NOTES_TOKEN",
      "env_http_headers": {
        "x-tenant": "NOTES_TENANT"
      }
    }
  }
}
Case 3 — empty / no user MCP:
undefined: undefined
empty mcp.servers: undefined
Case 4 — multiple user MCP servers:
{
  "mcp_servers": {
    "one": { "command": "one" },
    "two": { "command": "two" }
  }
}
```

```
 RUN  v4.1.5 /tmp/openclaw-80814

 ✓ src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts (4 tests) 6ms
   ✓ buildCodexUserMcpServersThreadConfigPatch > returns undefined when cfg has no mcp.servers (regression: #80814)
   ✓ buildCodexUserMcpServersThreadConfigPatch > projects a stdio user MCP server entry into mcp_servers (regression: #80814)
   ✓ buildCodexUserMcpServersThreadConfigPatch > projects a streamable-http user MCP server with bearer auth into mcp_servers
   ✓ buildCodexUserMcpServersThreadConfigPatch > preserves multiple user MCP servers as independent mcp_servers entries
 ✓ src/agents/cli-runner/bundle-mcp.codex.test.ts (1 tests) 9ms
 ✓ extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts (3 tests) 19ms
   ✓ startOrResumeThread — user mcp.servers projection (regression: #80814) > projects cfg.mcp.servers into the thread/start config patch under mcp_servers
   ✓ startOrResumeThread — user mcp.servers projection (regression: #80814) > omits mcp_servers from the start config when cfg has no user MCP servers
   ✓ startOrResumeThread — user mcp.servers projection (regression: #80814) > projects cfg.mcp.servers into resumed-thread config too so re-attached threads see user MCP
 ✓ src/plugins/contracts/plugin-sdk-root-alias.test.ts (28 tests) 162ms
 ✓ src/plugins/sdk-alias.test.ts (48 tests) 119ms

 Test Files  5 passed (5)
      Tests  84 passed (84)
```

```
Checking formatting...
Finished in 1937ms on 6 files using 1 threads.
All matched files use the correct format.
```

For contrast, the **same probe against the pre-fix tree** — reverting just the helper definition from `bundle-mcp-codex.ts` and re-running step 2 — produced `TypeError: buildCodexUserMcpServersThreadConfigPatch is not a function` (helper never existed before this patch); reverting just the wiring at `thread-lifecycle.ts:204` and re-running the wiring tests at step 3 produced `AssertionError: expected undefined to be defined` on the `mcp_servers` config-patch assertion (the existing `apps`-only merge has no `mcp_servers` key). Both confirm the projection is load-bearing.

**Observed result after fix:** The exact failure path described in #80814 — user-configured `mcp.servers.<name>` entries dropped from the codex app-server runtime's thread config while plugin-curated apps continued to work via the `apps` patch — now produces a complete `config.mcp_servers` JSON object on both `thread/start` (new thread) and `thread/resume` (re-attached thread). The codex-cli runtime's existing `injectCodexMcpConfigArgs` projection is unaffected; the codex app-server runtime now mirrors that behavior exactly. Empty-cfg, `sendPolicy`-style edge cases, reasoning/compaction payloads — none are affected because the helper short-circuits to `undefined` and `mergeCodexThreadConfigs` ignores `undefined` patches.

**What was not tested:** A live `codex app-server --listen stdio://` session against a real Codex auth profile and an actual MCP server (e.g. `@modelcontextprotocol/server-everything`) capturing the agent's `tools[]` enumeration before vs. after this patch. The acceptance criteria Codex listed for this PR explicitly include this kind of run when feasible. Not done here because it requires (a) a fresh Codex auth profile credential, (b) installation of the `@openclaw/codex` plugin into a local OpenClaw setup, and (c) a deterministic stub MCP server harness. The production code path from `openclaw/plugin-sdk/codex-mcp-projection` through `thread-lifecycle.ts` to the JSON-RPC `thread/start` config param is identical between the unit-test boundary and a live run — the wiring tests in step 3 capture the exact `params` object the production `client.request("thread/start", ...)` call receives.

## User-visible behavior change

Before: an agent under `agentRuntime.id: codex` with `mcp.servers.outlook` (or any user-configured MCP entry) in `openclaw.json` would silently lack the `outlook__*` tools at runtime, while `openclaw mcp list` reported the server configured. Operators saw an agent silently confabulate "I don't have outlook tools" responses despite the server child process being healthy.

After: the same configuration produces the expected `mcp_servers` block in the codex thread config, the codex app-server picks up the configured stdio/HTTP server entry, and `server__*` tools appear in the agent's tool catalog. The behavior now matches the `agentRuntime.id: codex-cli` runtime, which never had this gap.

Plugin-curated marketplace apps (`apps` configPatch) keep working unchanged — they remain on a separate config surface and are not double-counted into `mcp_servers`.

## Security impact

None. The helper reads `cfg.mcp.servers` — the same already-trusted, owner-managed surface that the codex CLI runtime, embedded Pi runtime, and `openclaw mcp list` consume. No new privileged surface, no credential exposure path. The per-server normalization is the exact `normalizeCodexServerConfig` function the CLI runtime has been using in production for headed and headerless MCP entries; we are reusing its bearer-token env-var decoding (which keeps secrets in env vars rather than embedding them in the config patch) and its env-header decoding (same). The new SDK subpath is registered as **private-local-only**, so third-party plugins cannot import it via `openclaw/plugin-sdk/...` — only the bundled `@openclaw/codex` extension can consume it.
