### PR TITLE
fix(subagents): surface blocked terminal states

### DIFF
--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -69,6 +69,24 @@ export type SubagentRunOutcome = {
   elapsedMs?: number;
 };
 
+const BLOCKED_SUBAGENT_ERROR = "Subagent run ended blocked.";
+
+function normalizeLivenessState(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+export function resolveBlockedSubagentOutcome(params: {
+  livenessState?: string;
+  error?: string;
+}): SubagentRunOutcome | undefined {
+  if (normalizeLivenessState(params.livenessState) !== "blocked") {
+    return undefined;
+  }
+  const error = params.error?.trim() || BLOCKED_SUBAGENT_ERROR;
+  return { status: "error", error };
+}
+
 function readFiniteNumber(value: number | undefined): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
@@ -381,7 +399,10 @@ export function applySubagentWaitOutcome(params: {
   } else if (params.wait?.status === "error") {
     outcome = { status: "error", error: waitError };
   } else if (params.wait?.status === "ok") {
-    outcome = { status: "ok" };
+    outcome = resolveBlockedSubagentOutcome({
+      livenessState: params.wait.livenessState,
+      error: waitError,
+    }) ?? { status: "ok" };
   }
   next.outcome = outcome ? withSubagentOutcomeTiming(outcome, next) : undefined;
   return next;

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -186,6 +186,17 @@ describe("subagent wait outcome timing", () => {
       wait: { status: "error", error: "boom" },
       expected: { status: "error", error: "boom" },
     },
+    {
+      wait: {
+        status: "ok",
+        livenessState: "blocked",
+        error: "Context overflow: estimated context size exceeds safe threshold.",
+      },
+      expected: {
+        status: "error",
+        error: "Context overflow: estimated context size exceeds safe threshold.",
+      },
+    },
   ] as const)("adds timing to $wait.status outcomes", ({ wait, expected }) => {
     const result = applySubagentWaitOutcome({
       wait,

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -8,7 +8,11 @@ import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { isRecoverableAgentWaitError, waitForAgentRun } from "./run-wait.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
-import { type SubagentRunOutcome, withSubagentOutcomeTiming } from "./subagent-announce-output.js";
+import {
+  resolveBlockedSubagentOutcome,
+  type SubagentRunOutcome,
+  withSubagentOutcomeTiming,
+} from "./subagent-announce-output.js";
 import {
   SUBAGENT_ENDED_OUTCOME_KILLED,
   SUBAGENT_ENDED_REASON_COMPLETE,
@@ -213,11 +217,12 @@ export function createSubagentRunManager(params: {
       }
       const waitError = typeof wait.error === "string" ? wait.error : undefined;
       const baseOutcome: SubagentRunOutcome =
-        wait.status === "error"
+        resolveBlockedSubagentOutcome({ livenessState: wait.livenessState, error: waitError }) ??
+        (wait.status === "error"
           ? { status: "error", error: waitError }
           : wait.status === "timeout"
             ? { status: "timeout" }
-            : { status: "ok" };
+            : { status: "ok" });
       const outcome = withSubagentOutcomeTiming(baseOutcome, {
         startedAt: entry.startedAt,
         endedAt: entry.endedAt,
@@ -234,7 +239,7 @@ export function createSubagentRunManager(params: {
         endedAt: entry.endedAt,
         outcome,
         reason:
-          wait.status === "error" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE,
+          outcome.status === "error" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE,
         sendFarewell: true,
         accountId: entry.requesterOrigin?.accountId,
         triggerCleanup: true,

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -310,6 +310,50 @@ describe("subagent registry seam flow", () => {
     expect(replacement?.endedAt).toBeUndefined();
   });
 
+  it("announces blocked wait snapshots as errors instead of successful completions", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "ok",
+          startedAt: 111,
+          endedAt: 222,
+          livenessState: "blocked",
+          error: "Context overflow: estimated context size exceeds safe threshold.",
+        };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-blocked-wait",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "report blocked wait state",
+      cleanup: "keep",
+    });
+
+    await waitForFast(() => {
+      const announceParams = findRecordCallArg(
+        mocks.runSubagentAnnounceFlow,
+        0,
+        "blocked wait announce",
+        (record) => record.childRunId === "run-blocked-wait",
+      );
+      expectRecordFields(
+        announceParams.outcome,
+        {
+          status: "error",
+          error: "Context overflow: estimated context size exceeds safe threshold.",
+          startedAt: 111,
+          endedAt: 222,
+          elapsedMs: 111,
+        },
+        "blocked wait announce outcome",
+      );
+    });
+  });
+
   it("reconciles stale active runs from persisted terminal session state during sweep", async () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {
@@ -557,6 +601,63 @@ describe("subagent registry seam flow", () => {
 
     await vi.advanceTimersByTimeAsync(20_000);
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces blocked lifecycle end events as errors instead of successful completions", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-blocked-lifecycle",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "report blocked lifecycle state",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-blocked-lifecycle",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 1_250,
+        livenessState: "blocked",
+        error: "Context overflow: estimated context size exceeds safe threshold.",
+      },
+    });
+
+    await waitForFast(() => {
+      const announceParams = findRecordCallArg(
+        mocks.runSubagentAnnounceFlow,
+        0,
+        "blocked lifecycle announce",
+        (record) => record.childRunId === "run-blocked-lifecycle",
+      );
+      expectRecordFields(
+        announceParams.outcome,
+        {
+          status: "error",
+          error: "Context overflow: estimated context size exceeds safe threshold.",
+          endedAt: 1_250,
+        },
+        "blocked lifecycle announce outcome",
+      );
+    });
   });
 
   it("deletes delete-mode completion runs when announce cleanup gives up after retry limit", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -18,7 +18,10 @@ import { importRuntimeModule } from "../shared/runtime-import.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
-import type { SubagentRunOutcome } from "./subagent-announce-output.js";
+import {
+  resolveBlockedSubagentOutcome,
+  type SubagentRunOutcome,
+} from "./subagent-announce-output.js";
 import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
 import {
   SUBAGENT_ENDED_REASON_COMPLETE,
@@ -926,11 +929,30 @@ function ensureListener() {
       }
       const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
       const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
+      const blockedOutcome = resolveBlockedSubagentOutcome({
+        livenessState:
+          typeof evt.data?.livenessState === "string" ? evt.data.livenessState : undefined,
+        error,
+      });
       if (phase === "error") {
         schedulePendingLifecycleError({
           runId: evt.runId,
           endedAt,
           error,
+        });
+        return;
+      }
+      if (blockedOutcome) {
+        clearPendingLifecycleError(evt.runId);
+        clearPendingLifecycleTimeout(evt.runId);
+        await completeSubagentRun({
+          runId: evt.runId,
+          endedAt,
+          outcome: blockedOutcome,
+          reason: SUBAGENT_ENDED_REASON_ERROR,
+          sendFarewell: true,
+          accountId: entry.requesterOrigin?.accountId,
+          triggerCleanup: true,
         });
         return;
       }

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -140,12 +140,20 @@ function createSnapshotFromLifecycleEvent(params: {
   const error = typeof data?.error === "string" ? data.error : undefined;
   const stopReason = typeof data?.stopReason === "string" ? data.stopReason : undefined;
   const livenessState = typeof data?.livenessState === "string" ? data.livenessState : undefined;
+  const status =
+    phase === "error"
+      ? "error"
+      : livenessState?.trim().toLowerCase() === "blocked"
+        ? "error"
+        : data?.aborted
+          ? "timeout"
+          : "ok";
   return {
     runId,
-    status: phase === "error" ? "error" : data?.aborted ? "timeout" : "ok",
+    status,
     startedAt,
     endedAt,
-    error,
+    error: status === "error" ? error || "Agent run ended blocked." : error,
     stopReason,
     livenessState,
     ...(data?.yielded === true ? { yielded: true } : {}),

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -135,6 +135,37 @@ describe("waitForAgentJob", () => {
     });
   });
 
+  it("maps blocked lifecycle end events to error snapshots", async () => {
+    const runId = `run-blocked-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const waitPromise = waitForAgentJob({ runId, timeoutMs: 1_000 });
+
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 425 },
+    });
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 425,
+        endedAt: 475,
+        livenessState: "blocked",
+        error: "Context overflow: estimated context size exceeds safe threshold.",
+      },
+    });
+
+    const snapshot = await waitPromise;
+    expectRecordFields(snapshot, {
+      status: "error",
+      startedAt: 425,
+      endedAt: 475,
+      livenessState: "blocked",
+      error: "Context overflow: estimated context size exceeds safe threshold.",
+    });
+  });
+
   it("ignores transient aborted end events when the same run later succeeds", async () => {
     const runId = `run-timeout-retry-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const waitPromise = waitForAgentJob({ runId, timeoutMs: 1_000 });


### PR DESCRIPTION
## Summary
- classify lifecycle end snapshots with `livenessState: "blocked"` as errors instead of ok
- preserve blocked/error classification through subagent wait handling and direct lifecycle completion
- add regression coverage for `agent.wait`, wait snapshots, and lifecycle end events

Fixes #80879.

## Real behavior proof
- **Behavior addressed:** Subagent terminal events and `agent.wait` snapshots that carry `livenessState: "blocked"` with a context-overflow error are now surfaced as error outcomes instead of parent-facing successful completions.
- **Real environment tested:** Local OpenClaw checkout on Linux, Node v22.22.2, branch `wolf/subagent-blocked-lifecycle-outcome`, production modules loaded with `node --import tsx`.
- **Exact steps or command run after this patch:**

```bash
node --import tsx -e 'const { waitForAgentJob } = await import("./src/gateway/server-methods/agent-job.ts"); const { emitAgentEvent } = await import("./src/infra/agent-events.ts"); const runId = `proof-${Date.now()}`; const wait = waitForAgentJob({ runId, timeoutMs: 1000 }); emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "start", startedAt: 100 } }); emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end", startedAt: 100, endedAt: 250, livenessState: "blocked", error: "Context overflow: estimated context size exceeds safe threshold." } }); console.log(JSON.stringify(await wait, null, 2));'
```

- **Evidence after fix:** Terminal output from the command above:

```json
{
  "runId": "proof-1778591406271",
  "status": "error",
  "startedAt": 100,
  "endedAt": 250,
  "error": "Context overflow: estimated context size exceeds safe threshold.",
  "livenessState": "blocked",
  "ts": 1778591406273
}
```

- **Observed result after fix:** The production `agent.wait` path returns `status: "error"` and preserves the blocked liveness state plus the context-overflow message, so downstream parent completion synthesis no longer has to treat that terminal state as success.
- **What was not tested:** A live Atlas/openai-codex overflow against an external model provider was not run; the patch was validated against the local OpenClaw production modules and focused regression coverage.

## Regression proof
- RED: `corepack pnpm test src/gateway/server-methods/server-methods.test.ts src/agents/subagent-announce.test.ts src/agents/subagent-registry.test.ts -- --run` failed before the fix with `expected 'ok' to deeply equal 'error'` in the blocked lifecycle test.
- GREEN: the same command now passes: gateway shard 90 tests passed; agents shard 28 tests passed.

## Validation
- `corepack pnpm test src/gateway/server-methods/server-methods.test.ts src/agents/subagent-announce.test.ts src/agents/subagent-registry.test.ts -- --run`
- `git diff --check`
- `corepack pnpm exec oxfmt --check --threads=1 src/gateway/server-methods/server-methods.test.ts src/gateway/server-methods/agent-job.ts src/agents/subagent-announce.test.ts src/agents/subagent-announce-output.ts src/agents/subagent-registry.test.ts src/agents/subagent-registry.ts src/agents/subagent-registry-run-manager.ts`
- `env PATH=/tmp/corepack-shims:$PATH corepack pnpm check:changed`