### PR TITLE
fix: keep run subagent output mediated

### DIFF
--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -253,6 +253,11 @@ describe("spawnSubagentDirect seam flow", () => {
     const agentParams = requireRecord(agentRequest.params);
     expect(agentParams.sessionKey).toBe(childSessionKey);
     expect(agentParams.cleanupBundleMcpOnRunEnd).toBe(true);
+    expect(agentParams.deliver).toBe(false);
+    expect(agentParams.channel).toBeUndefined();
+    expect(agentParams.to).toBeUndefined();
+    expect(agentParams.accountId).toBeUndefined();
+    expect(agentParams.threadId).toBeUndefined();
   });
 
   it("omits requesterOrigin threadId when no requester thread is provided", async () => {

--- a/src/agents/subagent-spawn.thread-binding.test.ts
+++ b/src/agents/subagent-spawn.thread-binding.test.ts
@@ -218,10 +218,11 @@ describe("spawnSubagentDirect thread binding delivery", () => {
     const agentCall = hoisted.callGatewayMock.mock.calls.find(
       ([call]) => (call as { method?: string }).method === "agent",
     )?.[0] as { params?: Record<string, unknown> } | undefined;
-    expect(agentCall?.params?.channel).toBe("matrix");
-    expect(agentCall?.params?.accountId).toBe("sut");
-    expect(agentCall?.params?.to).toBe("room:!parent:example");
     expect(agentCall?.params?.deliver).toBe(false);
+    expect(agentCall?.params?.channel).toBeUndefined();
+    expect(agentCall?.params?.accountId).toBeUndefined();
+    expect(agentCall?.params?.to).toBeUndefined();
+    expect(agentCall?.params?.threadId).toBeUndefined();
     const registeredRun = hoisted.registerSubagentRunMock.mock.calls.at(0)?.[0] as
       | {
           requesterOrigin?: { channel?: string; accountId?: string; to?: string };

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1126,11 +1126,13 @@ export async function spawnSubagentDirect(
       params: {
         message: childTaskMessage,
         sessionKey: childSessionKey,
-        channel: childSessionOrigin?.channel,
-        to: childSessionOrigin?.to ?? undefined,
-        accountId: childSessionOrigin?.accountId ?? undefined,
+        channel: deliverInitialChildRunDirectly ? childSessionOrigin?.channel : undefined,
+        to: deliverInitialChildRunDirectly ? (childSessionOrigin?.to ?? undefined) : undefined,
+        accountId: deliverInitialChildRunDirectly
+          ? (childSessionOrigin?.accountId ?? undefined)
+          : undefined,
         threadId:
-          childSessionOrigin?.threadId != null
+          deliverInitialChildRunDirectly && childSessionOrigin?.threadId != null
             ? stringifyRouteThreadId(childSessionOrigin.threadId)
             : undefined,
         idempotencyKey: childIdem,


### PR DESCRIPTION
## Summary
- keep run-mode subagent starts from receiving direct chat delivery origin unless the initial child run is explicitly delivered directly
- preserve requester origin in the subagent registry so completion announcements can still return through the mediated/orchestrator path
- add regression assertions for ordinary run-mode spawns and generic thread binding fallback

## Why
For `sessions_spawn(mode="run")`, `deliver:false` should mean the child result is mediated by the subagent completion/announce path. Passing `channel`/`to`/`accountId`/`threadId` into the child `agent` call can give the child enough route context to emit raw final output directly to the chat, bypassing the orchestrator conversion step.

## Test
- `./node_modules/.bin/vitest run src/agents/subagent-spawn.test.ts src/agents/subagent-spawn.thread-binding.test.ts`


## Real behavior proof

**Behavior addressed:** Run-mode native subagent completions should be mediated by the subagent completion/announce path. A child subagent should not receive direct chat delivery origin when `deliver:false`, because that can let raw child final output appear directly in Telegram before the orchestrator converts it into a normal user-facing update.

**Real environment tested:** Live OpenClaw setup on Moeed's Mac mini, Telegram System topic, Operator agent. Runtime containment patch applied locally and gateway restarted before the after-fix smoke test.

**Exact steps or command run after the patch:**
1. Spawned a native `sessions_spawn(mode="run")` subagent with a task that returns a raw marker only.
2. Yielded for the subagent completion event.
3. Observed whether the marker appeared as direct Telegram child output or as internal `subagent_announce` completion context for Operator delivery.

**Evidence after fix:** Copied live output from the actual OpenClaw Telegram/system session after the fix/restart:

```text
[Inter-session message] sourceSession=agent:openclaw:subagent:411fb53d-6fdb-4c2e-afe7-6d6f2acb89d9 sourceTool=subagent_announce
[Internal task completion event]
source: subagent
session_key: agent:openclaw:subagent:411fb53d-6fdb-4c2e-afe7-6d6f2acb89d9
type: subagent task
task: subagent-restart-polish-verify
status: completed successfully

Result:
SUBAGENT_RESTART_POLISH_OK_20260512

Action:
A completed subagent task is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now.
```

Before-fix observed live output for comparison:

```text
SUBAGENT_POSTPATCH_OK_20260512
```

**Observed result after fix:** The raw child result was delivered as internal completion context through `subagent_announce`, not posted directly to the Telegram topic as the child final answer. Operator retained delivery ownership and converted the completion into the user-facing closure.

**What was not tested:** No multi-level nested subagent chain was tested for this PR. The covered behavior is the direct run-mode child start path that previously leaked raw output.
