### PR TITLE
fix(telegram): fall back to root groups on empty account allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Docs: https://docs.openclaw.ai
 - fix(gateway): honor minimal discovery mode for wide-area DNS-SD [AI]. (#80903) Thanks @pgondhi987.
 - slack: enforce reaction notification policy [AI]. (#80907) Thanks @pgondhi987.
 - Enforce gateway command scopes by caller context [AI]. (#80891) Thanks @pgondhi987.
-- Telegram/groups: in single-account setups, treat an explicit empty `accounts.<id>.groups: {}` map the same as undefined so the root `channels.telegram.groups` allowlist still applies, instead of silently dropping every group update under the default `groupPolicy: "allowlist"`. Multi-account semantics are unchanged so per-account explicit-empty groups still scope-disable a single account without affecting siblings; the explicit way to block all groups for any account remains `groupPolicy: "disabled"`. Fixes #79427. Thanks @nikolaykazakovvs-ux.
+- Telegram/groups: in single-account setups, treat an explicit empty `accounts.<id>.groups: {}` map the same as undefined so the root `channels.telegram.groups` allowlist still applies, instead of silently dropping every group update under the default `groupPolicy: "allowlist"`. Multi-account semantics are unchanged so per-account explicit-empty groups still scope-disable a single account without affecting siblings; the explicit way to block all groups for any account remains `groupPolicy: "disabled"`. Fixes #79427. (#81030) Thanks @kinjitakabe.
 - Enforce Slack plugin approval button authorization [AI]. (#80899) Thanks @pgondhi987.
 - Recognize PowerShell -ec inline commands [AI]. (#80893) Thanks @pgondhi987.
 - fix(qqbot): authorize approval button callbacks [AI]. (#80892) Thanks @pgondhi987.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 - fix(gateway): honor minimal discovery mode for wide-area DNS-SD [AI]. (#80903) Thanks @pgondhi987.
 - slack: enforce reaction notification policy [AI]. (#80907) Thanks @pgondhi987.
 - Enforce gateway command scopes by caller context [AI]. (#80891) Thanks @pgondhi987.
+- Telegram/groups: in single-account setups, treat an explicit empty `accounts.<id>.groups: {}` map the same as undefined so the root `channels.telegram.groups` allowlist still applies, instead of silently dropping every group update under the default `groupPolicy: "allowlist"`. Multi-account semantics are unchanged so per-account explicit-empty groups still scope-disable a single account without affecting siblings; the explicit way to block all groups for any account remains `groupPolicy: "disabled"`. Fixes #79427. Thanks @nikolaykazakovvs-ux.
 - Enforce Slack plugin approval button authorization [AI]. (#80899) Thanks @pgondhi987.
 - Recognize PowerShell -ec inline commands [AI]. (#80893) Thanks @pgondhi987.
 - fix(qqbot): authorize approval button callbacks [AI]. (#80892) Thanks @pgondhi987.

--- a/extensions/telegram/src/account-config.ts
+++ b/extensions/telegram/src/account-config.ts
@@ -68,9 +68,19 @@ export function mergeTelegramAccountConfig(
   const account = resolveTelegramAccountConfig(cfg, accountId) ?? {};
 
   // Multi-account bots must not inherit channel-level groups unless explicitly set.
+  // Single-account bots fall back to root `channels.telegram.groups` when the
+  // account does not declare its own groups — including the empty-literal case
+  // `accounts.<id>.groups: {}`, which is almost always a config-migration
+  // artifact rather than an intentional "block all" declaration (use
+  // `groupPolicy: "disabled"` for that).
   const configuredAccountIds = Object.keys(cfg.channels?.telegram?.accounts ?? {});
   const isMultiAccount = configuredAccountIds.length > 1;
-  const groups = account.groups ?? (isMultiAccount ? undefined : channelGroups);
+  const hasAccountGroups = account.groups && Object.keys(account.groups).length > 0;
+  const groups = isMultiAccount
+    ? account.groups
+    : hasAccountGroups
+      ? account.groups
+      : channelGroups;
   const allowFrom = resolveMergedAllowFrom({
     baseAllowFrom: base.allowFrom,
     accountAllowFrom: account.allowFrom,

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -536,6 +536,24 @@ describe("resolveTelegramAccount groups inheritance (#30673)", () => {
     expect(resolved.config.groups).toEqual({ "-100123": { requireMention: false } });
   });
 
+  it("inherits channel-level groups when single-account explicitly sets `groups: {}` (regression: #79427)", () => {
+    const resolved = resolveTelegramAccount({
+      cfg: {
+        channels: {
+          telegram: {
+            groups: { "-100123": { requireMention: false } },
+            accounts: {
+              default: { botToken: "123:default", groups: {} },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(resolved.config.groups).toEqual({ "-100123": { requireMention: false } });
+  });
+
   it("does NOT inherit channel-level groups to secondary account in multi-account setup", () => {
     const resolved = resolveTelegramAccount({
       cfg: createMultiAccountGroupsConfig(),

--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -169,6 +169,68 @@ describe("resolveChannelGroupPolicy", () => {
       }),
     ).toBe(false);
   });
+
+  it("falls back to root channel groups when account.groups is an empty object (regression: #79427)", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          groups: {
+            "-100123": { requireMention: false },
+          },
+          accounts: {
+            default: { botToken: "123:default", groups: {} },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const policy = resolveChannelGroupPolicy({
+      cfg,
+      channel: "telegram",
+      groupId: "-100123",
+      accountId: "default",
+    });
+
+    expect(policy.allowlistEnabled).toBe(true);
+    expect(policy.allowed).toBe(true);
+  });
+
+  it("uses populated account.groups instead of root when both are configured", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          groups: {
+            "-100root": { requireMention: false },
+          },
+          accounts: {
+            default: {
+              botToken: "123:default",
+              groups: { "-100account": { requireMention: false } },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveChannelGroupPolicy({
+        cfg,
+        channel: "telegram",
+        groupId: "-100account",
+        accountId: "default",
+      }).allowed,
+    ).toBe(true);
+    expect(
+      resolveChannelGroupPolicy({
+        cfg,
+        channel: "telegram",
+        groupId: "-100root",
+        accountId: "default",
+      }).allowed,
+    ).toBe(false);
+  });
 });
 
 describe("resolveToolsBySender", () => {

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -340,6 +340,21 @@ function resolveChannelGroups(
     return undefined;
   }
   const accountGroups = resolveAccountEntry(channelConfig.accounts, normalizedAccountId)?.groups;
+  // In a single-account setup, treat an explicit empty account groups map
+  // (`accounts.<id>.groups: {}`) the same as undefined for fallback: the empty
+  // literal is almost always a config-migration artifact, not an intentional
+  // "block all groups" declaration — the explicit way to block is
+  // `groupPolicy: "disabled"` (or omitting the group from a populated
+  // allowlist). Without this, an empty `{}` paired with the default
+  // `groupPolicy: "allowlist"` silently denies every group update even though
+  // root `channels.<channel>.groups` is populated. Multi-account contexts keep
+  // the existing semantics so per-account explicit-empty groups still scope
+  // disable a single account without affecting siblings.
+  const isMultiAccount = Object.keys(channelConfig.accounts ?? {}).length > 1;
+  if (!isMultiAccount) {
+    const hasAccountGroups = accountGroups && Object.keys(accountGroups).length > 0;
+    return hasAccountGroups ? accountGroups : channelConfig.groups;
+  }
   return accountGroups ?? channelConfig.groups;
 }
 


### PR DESCRIPTION
## Summary

Both `mergeTelegramAccountConfig` and the generic `resolveChannelGroups` used `accountGroups ?? channelConfig.groups` to fall back to the root channel allowlist. Nullish coalescing only catches `undefined` / `null`, so an explicit empty literal `accounts.<id>.groups: {}` survived the fallback and overrode the root allowlist with an empty allowlist. Paired with the default `groupPolicy: "allowlist"`, that empty map then drops every group update — the symptom the reporter saw with a populated `channels.telegram.groups` at root.

In **single-account** setups (one or zero configured accounts), treat an explicit empty `{}` the same as undefined for fallback purposes. The empty literal is almost always a config-migration artifact (the user added the account-level wrapper without realizing `groups: {}` overrides root), not an intentional "block all groups" declaration — the documented explicit-block mechanism is `groupPolicy: "disabled"`, which this PR does not touch.

**Multi-account semantics are preserved** so per-account explicit-empty groups still scope-disable a single account without affecting siblings; an account with `groups: {}` in a multi-account bot continues to block every group for that one account.

Fixes #79427.

## Root cause

[extensions/telegram/src/account-config.ts:73](extensions/telegram/src/account-config.ts#L73) (pre-fix):

```ts
const groups = account.groups ?? (isMultiAccount ? undefined : channelGroups);
```

[src/config/group-policy.ts:343](src/config/group-policy.ts#L343) (pre-fix):

```ts
const accountGroups = resolveAccountEntry(channelConfig.accounts, normalizedAccountId)?.groups;
return accountGroups ?? channelConfig.groups;
```

Both `??` chains let `{}` through as-is. The downstream `resolveChannelGroupPolicy` at [group-policy.ts:382-383](src/config/group-policy.ts#L382-L383) then computes:

```ts
const hasGroups = Boolean(groups && Object.keys(groups).length > 0);
const allowlistEnabled = groupPolicy === "allowlist" || hasGroups;
```

…and decides `allowlistEnabled = true` (default `groupPolicy: "allowlist"` is in effect) while `hasGroups = false` because the resolved map is empty. The result is "allowlist with zero allowed groups → reject every update," and Telegram drops the message via the `not-allowed` reason log at [extensions/telegram/src/bot-handlers.runtime.ts:671](extensions/telegram/src/bot-handlers.runtime.ts#L671).

## What changed (scope boundary)

- **MOD** [src/config/group-policy.ts:343](src/config/group-policy.ts#L343) — `resolveChannelGroups` detects single-account vs multi-account by counting configured account keys. Single-account: empty `{}` falls back to root `channelConfig.groups`. Multi-account: existing `accountGroups ?? channelConfig.groups` semantics preserved.
- **MOD** [extensions/telegram/src/account-config.ts:73](extensions/telegram/src/account-config.ts#L73) — `mergeTelegramAccountConfig` mirrors the same fallback rule. Multi-account explicit `{}` continues to return `{}` (account merge keeps the explicit empty to scope-disable a single account).
- **NEW test** in [src/config/group-policy.test.ts](src/config/group-policy.test.ts) — empty `{}` account.groups falls back to root + populated account.groups takes priority over root.
- **NEW test** in [extensions/telegram/src/accounts.test.ts](extensions/telegram/src/accounts.test.ts) — single-account explicit `groups: {}` inherits root channel groups (regression: #79427).
- **MOD** [CHANGELOG.md](CHANGELOG.md) — single entry under `## Unreleased` › `### Fixes`.

## What did NOT change (scope boundary)

- **Multi-account semantics**: an account with `groups: {}` in a multi-account bot still blocks every group for that account. The fix only changes single-account behavior.
- **`groupPolicy: "disabled"`**: the documented explicit way to disable all groups for any account is untouched.
- **`groupPolicy: "allowlist"` semantics**: the downstream policy resolution at [group-policy.ts:382-383](src/config/group-policy.ts#L382-L383) is untouched — `allowlistEnabled` still derives from `groupPolicy` and `hasGroups`. The fix changes only which groups map reaches that branch.
- **No new config knob.** `accounts.<id>.groups: {}` is the same documented surface; we changed its fallback semantics, not its shape.
- **Other channels (Slack, Discord, WhatsApp, iMessage, etc.)** that use the generic `resolveChannelGroups` get the same fix automatically. No channel-specific overrides exist; the helper was already the single resolution point for all channels.

## Regression test plan

`src/config/group-policy.test.ts` — `describe("resolveChannelGroupPolicy")`:

1. **Empty account groups falls back to root (regression: #79427)**: `accounts.default.groups: {}` + root `channels.telegram.groups: { "-100123": {...} }` → `allowlistEnabled: true`, `allowed: true` for `-100123`.
2. **Populated account groups overrides root**: account `-100account` allowed, root-only `-100root` not allowed when account.groups is populated. Confirms account-level priority preserved.

`extensions/telegram/src/accounts.test.ts` — `describe("resolveTelegramAccount")`:

1. **Single-account explicit `groups: {}` inherits root** (regression: #79427): `resolved.config.groups` equals root groups when account has `groups: {}` and channel has populated groups.

Existing tests for multi-account isolation, single-account inheritance with omitted account.groups, and account-priority-over-root continue to pass unmodified.

## Real behavior proof

**Behavior or issue addressed:** Single-account Telegram setups with both root `channels.telegram.groups` populated AND an explicit `accounts.<id>.groups: {}` map at the account level silently drop every inbound group update under the default `groupPolicy: "allowlist"`. The merged policy resolution treats the empty literal as an empty allowlist, the `not-allowed` branch fires in `bot-handlers.runtime.ts`, and the reporter sees their bot stop responding in every group despite the root allowlist being correct. Repro of #79427.

**Real environment tested:**
- OpenClaw commit: `45a8a25947` (current `upstream/main`) plus this patch
- Node: `v24.14.1`
- OS: `Linux 6.17.0-22-generic x86_64`
- Runtime: production module imports — `node --import tsx` against the patched `src/config/group-policy.ts` and `extensions/telegram/src/account-config.ts` (no test seam, no vitest mock, no injection between the public exports and the production `resolveChannelGroupPolicy` / `mergeTelegramAccountConfig` callers in the Telegram runtime path)

**Exact steps or command run after this patch:**

1. Write a focused production-path probe exercising the reporter's exact config shape (single-account + explicit `accounts.default.groups: {}` + populated root groups) plus the two multi-account scenarios the fix must preserve:

   ```bash
   cat > /tmp/proof_79427.mjs <<'JS'
   import { resolveChannelGroupPolicy } from "./src/config/group-policy.ts";
   import { mergeTelegramAccountConfig } from "./extensions/telegram/src/account-config.ts";

   const cfgSingle = {
     channels: {
       telegram: {
         groupPolicy: "allowlist",
         groups: { "-100123": { requireMention: false } },
         accounts: { default: { botToken: "123:default", groups: {} } },
       },
     },
   };
   console.log("Single-account merged.groups:",
     JSON.stringify(mergeTelegramAccountConfig(cfgSingle, "default").groups));
   console.log("Single-account allowed on -100123:",
     resolveChannelGroupPolicy({ cfg: cfgSingle, channel: "telegram",
       groupId: "-100123", accountId: "default" }).allowed);

   const cfgMulti = {
     channels: {
       telegram: {
         groupPolicy: "allowlist",
         groups: { "-100root": { requireMention: false } },
         accounts: {
           a: { botToken: "1:a", groups: { "-100a": { requireMention: false } } },
           b: { botToken: "2:b", groups: {} },
         },
       },
     },
   };
   console.log("Multi 'b' (empty {}) allowed on -100root:",
     resolveChannelGroupPolicy({ cfg: cfgMulti, channel: "telegram",
       groupId: "-100root", accountId: "b" }).allowed);
   console.log("Multi 'a' (populated) allowed on -100a:",
     resolveChannelGroupPolicy({ cfg: cfgMulti, channel: "telegram",
       groupId: "-100a", accountId: "a" }).allowed);
   console.log("Multi 'a' (populated) allowed on -100root:",
     resolveChannelGroupPolicy({ cfg: cfgMulti, channel: "telegram",
       groupId: "-100root", accountId: "a" }).allowed);
   JS

   node --import tsx /tmp/proof_79427.mjs
   ```

2. Run the unit suites Codex listed as acceptance plus the adjacent multi-account inheritance tests:

   ```bash
   node --import tsx node_modules/vitest/dist/cli.js run \
     src/config/group-policy.test.ts \
     extensions/telegram/src/accounts.test.ts
   ```

3. Format check the touched files:

   ```bash
   node_modules/oxfmt/bin/oxfmt --check --threads=1 \
     src/config/group-policy.ts \
     src/config/group-policy.test.ts \
     extensions/telegram/src/account-config.ts \
     extensions/telegram/src/accounts.test.ts \
     CHANGELOG.md
   ```

**Evidence after fix:** terminal capture from steps 1–3 above against the patched production modules — same modules the Telegram runtime imports via `openclaw/plugin-sdk/channel-policy` and the Telegram bot core. No test seam, no injection:

```
Single-account merged.groups: {"-100123":{"requireMention":false}}
Single-account allowed on -100123: true
Multi 'b' (empty {}) allowed on -100root: false
Multi 'a' (populated) allowed on -100a: true
Multi 'a' (populated) allowed on -100root: false
```

```
 RUN  v4.1.5 /tmp/openclaw-79427

 ✓ src/config/group-policy.test.ts > resolveChannelGroupPolicy > falls back to root channel groups when account.groups is an empty object (regression: #79427)
 ✓ src/config/group-policy.test.ts > resolveChannelGroupPolicy > uses populated account.groups instead of root when both are configured
 ✓ extensions/telegram/src/accounts.test.ts > resolveTelegramAccount (groups inheritance) > inherits channel-level groups when single-account explicitly sets `groups: {}` (regression: #79427)
 ✓ extensions/telegram/src/accounts.test.ts > resolveTelegramAccount (groups inheritance) > inherits channel-level groups in single-account setup
 ✓ extensions/telegram/src/accounts.test.ts > resolveTelegramAccount (groups inheritance) > does NOT inherit channel-level groups to secondary account in multi-account setup
 ✓ extensions/telegram/src/accounts.test.ts > resolveTelegramAccount (groups inheritance) > does NOT inherit channel-level groups to default account in multi-account setup
 ✓ extensions/telegram/src/accounts.test.ts > resolveTelegramAccount (groups inheritance) > uses account-level groups even in multi-account setup
 ✓ extensions/telegram/src/accounts.test.ts > resolveTelegramAccount (groups inheritance) > account-level groups takes priority over channel-level in single-account setup

 Test Files  2 passed (2)
      Tests  51 passed (51)
```

```
Checking formatting...
Finished in 1940ms on 5 files using 1 threads.
All matched files use the correct format.
```

**Observed result after fix:**

- **Single-account repro (regression case)**: `mergeTelegramAccountConfig` now returns the populated root groups instead of `{}`; `resolveChannelGroupPolicy` evaluates `hasGroups: true` and `allowed: true` for `-100123`. The reporter's bot would now accept the root-allowlisted group.
- **Multi-account `b` with `groups: {}` (preservation case)**: `allowed: false` for any root-only group. The explicit empty per-account map still scope-disables groups for account `b`, exactly as before this patch. Multi-account semantics are not regressed.
- **Multi-account `a` with populated `groups` (preservation case)**: `allowed: true` for the account's own group, `allowed: false` for root-only groups. Account-level priority over root is preserved.

The downstream `resolveChannelGroupPolicy` branch at [group-policy.ts:382-383](src/config/group-policy.ts#L382-L383) — `allowlistEnabled = groupPolicy === "allowlist" || hasGroups` — is unchanged. The fix changes only which groups map reaches that branch.

**What was not tested:** A live end-to-end Telegram polling session with a real bot token, a populated root allowlist, and an explicit `accounts.default.groups: {}` — the exact runtime path from `bot-handlers.runtime.ts:671` through `resolveChannelGroupPolicy` to a real group update. Not feasible without burning a Telegram bot token against a real supergroup and reproducing the reporter's `groupPolicy: "allowlist"` flake organically. The production code path from the policy-resolution boundary downward is unchanged by this PR; the wiring tests in step 2 capture the exact merged-groups and policy-resolution outputs that the runtime path consumes.

## User-visible behavior change

**Single-account setups**: previously, a single-account bot with both `channels.telegram.groups` populated AND `accounts.<id>.groups: {}` set silently dropped every group update. After this patch, the root allowlist applies and the bot responds to root-listed groups. No config change required from the operator — they keep their existing root `channels.telegram.groups` and the migration-artifact empty `{}` simply stops blocking it.

**Multi-account setups**: no change. Per-account explicit-empty `groups: {}` still scope-disables groups for that account without affecting siblings.

For operators who actually want to disable all groups for a single-account bot, the documented mechanism `groupPolicy: "disabled"` is untouched and remains the canonical way to do so.

## Security impact

None. The fix relaxes a denial path; it does not loosen the policy decision itself. `groupPolicy: "allowlist"` still requires an explicit per-group entry, the `not-allowed` branch still fires for groups not in the resolved allowlist, and the explicit `groupPolicy: "disabled"` deny path is unchanged. No new privileged surface, no payload mutation, no change to allowFrom/sender authorization.

A multi-account user who previously relied on `groups: {}` to block groups for one specific account in a multi-account bot continues to see the same blocking behavior (preserved on purpose). Single-account users who relied on `groups: {}` as a deliberate "block all" mechanism — a previously-undocumented pattern that was effectively a footgun — should migrate to `groupPolicy: "disabled"` for an explicit declaration.
