### PR TITLE
fix(sessions): tolerate key-shaped sessionId in cleanup --fix-missing

### DIFF
--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -207,7 +207,18 @@ function pruneMissingTranscriptEntries(params: {
     if (!entry?.sessionId) {
       continue;
     }
-    const transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
+    let transcriptPath: string;
+    try {
+      transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
+    } catch {
+      // Malformed legacy rows (e.g. key-shaped `sessionId` like `agent:main:main`)
+      // cannot resolve a transcript. Treat as missing under --fix-missing instead
+      // of crashing the entire cleanup pass.
+      delete params.store[key];
+      removed += 1;
+      params.onPruned?.(key);
+      continue;
+    }
     if (!fs.existsSync(transcriptPath)) {
       delete params.store[key];
       removed += 1;

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -403,6 +403,48 @@ describe("Integration: saveSessionStore with pruning", () => {
     expect(archivedDirectTranscripts.length).toBeGreaterThan(0);
   });
 
+  it("sessions cleanup --fix-missing prunes legacy rows with key-shaped sessionId instead of crashing", async () => {
+    applyEnforcedMaintenanceConfig(mockLoadConfig);
+
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        // Legacy rows accidentally persisted a session KEY (with colons) as the
+        // sessionId. The cleanup path must not crash on these (#80970).
+        sessionId: "agent:main:main",
+        updatedAt: now,
+      },
+      fresh: {
+        sessionId: "fresh-session",
+        updatedAt: now,
+      },
+    };
+    await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+    await fs.writeFile(path.join(testDir, "fresh-session.jsonl"), "fresh", "utf-8");
+
+    const dryRun = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, dryRun: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+    expect(dryRun.previewResults[0]?.summary.missing).toBe(1);
+    expect(dryRun.previewResults[0]?.summary.beforeCount).toBe(2);
+    expect(dryRun.previewResults[0]?.summary.afterCount).toBe(1);
+
+    const applied = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+    expect(applied.appliedSummaries).toHaveLength(1);
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      SessionEntry
+    >;
+    expect(Object.keys(persisted)).toEqual(["fresh"]);
+  });
+
   it("sessions cleanup dry-run does not double-count artifacts already covered by disk budget", async () => {
     mockLoadConfig.mockReturnValue({
       session: {


### PR DESCRIPTION
## Summary

`openclaw sessions cleanup --fix-missing` crashes with `Error: Invalid session ID: agent:main:main` because `pruneMissingTranscriptEntries` calls `resolveSessionFilePath(entry.sessionId, ...)`, which falls through to `validateSessionId` whenever no usable `sessionFile` is persisted. The strict transcript-id regex (`SAFE_SESSION_ID_RE`) does not allow colons, so legacy rows that accidentally persisted a session **key** (e.g. `agent:main:main`) as the entry `sessionId` blow up the entire cleanup pass — including the path that would have removed them.

Wrap the resolve call with a narrow `catch` so malformed rows are treated as missing and pruned under `--fix-missing` instead of throwing. Transcript filename validation stays strict everywhere else; the relaxation is cleanup-specific and only converts an already-invalid row into a pruned row.

Fixes #80970.

## Real behavior proof

- Behavior or issue addressed: `openclaw sessions cleanup --dry-run --fix-missing` throws `Invalid session ID: agent:main:main` and exits 1 before any pruning runs, against a store containing the legacy key-shaped `sessionId` reported in #80970.
- Real environment tested: Local OpenClaw checkout, macOS 25.4.0 (darwin arm64), Node 22.21.1, `pnpm build` against `main` (commit baseline of #80970) and against this branch. Synthetic store at `/tmp/oc-proof-80970/agents/main/sessions/sessions.json` with one `agent:main:main` row and one healthy `fresh` row.
- Exact steps or command run after this patch: `OPENCLAW_HOME=/tmp/oc-proof-80970 pnpm openclaw sessions cleanup --dry-run --fix-missing --store /tmp/oc-proof-80970/agents/main/sessions/sessions.json`
- Evidence after fix:
  - Before (current `main`, pre-patch):
    ```
    $ node scripts/run-node.mjs sessions cleanup --dry-run --fix-missing --store /tmp/oc-proof-80970/agents/main/sessions/sessions.json
    Error: Invalid session ID: agent:main:main
    [ELIFECYCLE] Command failed with exit code 1.
    ```
  - After (this branch, post-patch):
    ```
    $ node scripts/run-node.mjs sessions cleanup --dry-run --fix-missing --store /tmp/oc-proof-80970/agents/main/sessions/sessions.json
    Session store: /tmp/oc-proof-80970/agents/main/sessions/sessions.json
    Maintenance mode: enforce
    Entries: 2 -> 0 (remove 2)
    Would prune missing transcripts: 1
    Would retire stale direct DM sessions: 0
    Would prune stale: 1
    Would cap overflow: 0
    Would prune unreferenced artifacts: 0

    Planned session actions:
    Action           Key                        Age       Model          Flags
    prune-missing    agent:main:main            366d ago  gpt-5.5        id:agent:main:main
    prune-stale      fresh                      366d ago  gpt-5.5        id:fresh-session
    ```
- Observed result after fix: The malformed `agent:main:main` row is classified as `prune-missing` (because the resolver throw is now caught and treated as missing); the `fresh` row is classified as `prune-stale` from the standard age sweep. The command exits 0 instead of 1, so the rest of the cleanup pipeline (missing / dm-scope / stale / cap / artifacts / disk-budget) actually runs.
- What was not tested: A live operator install on Raspberry Pi Linux exactly matching the reporter (#80970 was filed against OpenClaw 2026.5.7 on linux/arm); reproduction here was synthetic but exercises the same code path and the same legacy row shape. No live messaging/channel I/O. No coverage for `--all-agents` against multiple agent stores, only `--store` against a single one.

Added regression test `sessions cleanup --fix-missing prunes legacy rows with key-shaped sessionId instead of crashing` in `src/config/sessions/store.pruning.integration.test.ts:406` covers the exact reporter case (`agent:main:main` alongside a healthy `fresh` row) for both dry-run and applied modes.

## Notes

Recovery path on a stale-metadata row is the same as before for any other unresolvable row: the entry is removed and `summary.missing` increments. No transcript filesystem operations are attempted with the malformed id, so there is no risk of widening file-path validation.