### PR TITLE
fix(ui): preserve WebChat messages across session switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: mirror successful same-source message-tool sends into session transcripts so delivered replies stay in later history/context. (#84837) Thanks @iFiras-Max1.
 - Media generation: keep image, music, and video completion delivery from duplicating or losing task ownership when generated media finishes through active session replies. (#84006) Thanks @fuller-stack-dev.
 - CLI/doctor: remove stale bundled plugin load paths from old versioned OpenClaw package roots after pnpm/npm upgrades. Fixes #58626. Thanks @solink7.
+- Control UI/WebChat: preserve visible messages across session switches so returning to a conversation does not blank recent reports or replies. Fixes #80855. (#81037) Thanks @luoyanglang.
 - Infra/json: retry transient `File changed during read` races while loading JSON state so config and state reads recover instead of failing the turn. (#84285)
 - Plugins/providers: fail closed for workspace provider plugins during setup-mode discovery unless explicitly trusted, preventing untrusted workspace plugin code from running during provider setup. (#81069) Thanks @mmaps.
 - Providers/Ollama: resolve configured Ollama Cloud `OLLAMA_API_KEY` markers to the real discovery key so cloud provider entries keep authenticated model catalog access. (#85037)

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1276,6 +1276,14 @@ describe("handleSendChat", () => {
   });
 
   it("clears BTW side results when /clear resets chat history", async () => {
+    const cachedSessionKeys = [
+      "home",
+      "agent:main:home",
+      "agent:ops:main",
+      "agent:ops:home",
+      "agent:main:main",
+    ];
+    const cachedMessage = [{ role: "user", content: "hello", timestamp: 1 }];
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.reset") {
         return { ok: true };
@@ -1289,14 +1297,10 @@ describe("handleSendChat", () => {
       client: { request } as unknown as ChatHost["client"],
       sessionKey: "home",
       chatMessage: "/clear",
-      chatMessages: [{ role: "user", content: "hello", timestamp: 1 }],
-      chatMessagesBySession: {
-        home: [{ role: "user", content: "hello", timestamp: 1 }],
-        "agent:main:home": [{ role: "user", content: "hello", timestamp: 1 }],
-        "agent:ops:main": [{ role: "user", content: "hello", timestamp: 1 }],
-        "agent:ops:home": [{ role: "user", content: "hello", timestamp: 1 }],
-        "agent:main:main": [{ role: "user", content: "hello", timestamp: 1 }],
-      },
+      chatMessages: cachedMessage,
+      chatMessagesBySession: Object.fromEntries(
+        cachedSessionKeys.map((key) => [key, cachedMessage]),
+      ),
       hello: {
         snapshot: {
           sessionDefaults: {
@@ -1321,11 +1325,9 @@ describe("handleSendChat", () => {
 
     expect(request).toHaveBeenCalledWith("sessions.reset", { key: "home" });
     expect(host.chatMessages).toStrictEqual([]);
-    expect(host.chatMessagesBySession?.home).toBeUndefined();
-    expect(host.chatMessagesBySession?.["agent:main:home"]).toBeUndefined();
-    expect(host.chatMessagesBySession?.["agent:ops:main"]).toBeUndefined();
-    expect(host.chatMessagesBySession?.["agent:ops:home"]).toBeUndefined();
-    expect(host.chatMessagesBySession?.["agent:main:main"]).toBeUndefined();
+    for (const key of cachedSessionKeys) {
+      expect(host.chatMessagesBySession?.[key]).toBeUndefined();
+    }
     expect(host.chatSideResult).toBeNull();
     expect(host.chatSideResultTerminalRuns?.size).toBe(0);
     expect(host.chatRunId).toBeNull();

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1287,13 +1287,28 @@ describe("handleSendChat", () => {
     });
     const host = makeHost({
       client: { request } as unknown as ChatHost["client"],
-      sessionKey: "main",
+      sessionKey: "home",
       chatMessage: "/clear",
       chatMessages: [{ role: "user", content: "hello", timestamp: 1 }],
+      chatMessagesBySession: {
+        home: [{ role: "user", content: "hello", timestamp: 1 }],
+        "agent:main:home": [{ role: "user", content: "hello", timestamp: 1 }],
+        "agent:ops:main": [{ role: "user", content: "hello", timestamp: 1 }],
+        "agent:ops:home": [{ role: "user", content: "hello", timestamp: 1 }],
+        "agent:main:main": [{ role: "user", content: "hello", timestamp: 1 }],
+      },
+      hello: {
+        snapshot: {
+          sessionDefaults: {
+            defaultAgentId: "ops",
+            mainKey: "home",
+          },
+        },
+      } as ChatHost["hello"],
       chatSideResult: {
         kind: "btw",
         runId: "btw-run-clear",
-        sessionKey: "main",
+        sessionKey: "home",
         question: "what changed?",
         text: "Detached BTW result",
         isError: false,
@@ -1304,8 +1319,13 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    expect(request).toHaveBeenCalledWith("sessions.reset", { key: "main" });
+    expect(request).toHaveBeenCalledWith("sessions.reset", { key: "home" });
     expect(host.chatMessages).toStrictEqual([]);
+    expect(host.chatMessagesBySession?.home).toBeUndefined();
+    expect(host.chatMessagesBySession?.["agent:main:home"]).toBeUndefined();
+    expect(host.chatMessagesBySession?.["agent:ops:main"]).toBeUndefined();
+    expect(host.chatMessagesBySession?.["agent:ops:home"]).toBeUndefined();
+    expect(host.chatMessagesBySession?.["agent:main:main"]).toBeUndefined();
     expect(host.chatSideResult).toBeNull();
     expect(host.chatSideResultTerminalRuns?.size).toBe(0);
     expect(host.chatRunId).toBeNull();

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -18,6 +18,10 @@ import {
   type ChatInputHistoryState,
 } from "./chat/input-history.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
+import {
+  readChatMessageCacheSessionDefaults,
+  resolveEquivalentChatMessageCacheKeys,
+} from "./chat/session-message-cache-keys.ts";
 import type { ChatSideResult } from "./chat/side-result.ts";
 import { executeSlashCommand } from "./chat/slash-command-executor.ts";
 import { parseSlashCommand, refreshSlashCommands } from "./chat/slash-commands.ts";
@@ -51,6 +55,7 @@ export type ChatHost = ChatInputHistoryState & {
   client: GatewayBrowserClient | null;
   chatStream: string | null;
   connected: boolean;
+  chatMessagesBySession?: Record<string, unknown[]>;
   chatAttachments: ChatAttachment[];
   chatQueue: ChatQueueItem[];
   chatRunId: string | null;
@@ -149,6 +154,18 @@ export function hasAbortableSessionRun(host: {
       (session) => session.key === host.sessionKey && isSessionRunActive(session),
     ),
   );
+}
+
+function clearCachedChatMessagesForSession(host: ChatHost, sessionKey: string) {
+  if (!host.chatMessagesBySession) {
+    return;
+  }
+  const messagesBySession = { ...host.chatMessagesBySession };
+  const defaults = readChatMessageCacheSessionDefaults(host);
+  for (const cacheKey of resolveEquivalentChatMessageCacheKeys(sessionKey, defaults)) {
+    delete messagesBySession[cacheKey];
+  }
+  host.chatMessagesBySession = messagesBySession;
 }
 
 export function isChatStopCommand(text: string) {
@@ -774,6 +791,7 @@ async function clearChatHistory(host: ChatHost) {
   try {
     await host.client.request("sessions.reset", { key: host.sessionKey });
     host.chatMessages = [];
+    clearCachedChatMessagesForSession(host, host.sessionKey);
     host.chatSideResult = null;
     reconcileChatRunLifecycle(host as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
       outcome: hadActiveRun ? "interrupted" : undefined,

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -165,6 +165,10 @@ function createChatSessionState(overrides: Partial<AppViewState> = {}) {
   return state;
 }
 
+function assistantTextMessage(text: string) {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}
+
 /* ================================================================
  *  parseSessionKey – low-level key → type / fallback mapping
  * ================================================================ */
@@ -1037,40 +1041,17 @@ describe("switchChatSession", () => {
   });
 
   it("restores visible messages when switching back before history reloads", () => {
-    const settings = createSettings();
-    const mainMessages = [{ role: "assistant", content: [{ type: "text", text: "main report" }] }];
-    const otherMessages = [{ role: "assistant", content: [{ type: "text", text: "other reply" }] }];
-    const state = {
+    const mainMessages = [assistantTextMessage("main report")];
+    const otherMessages = [assistantTextMessage("other reply")];
+    const state = createChatSessionState({
       sessionKey: "main",
       chatMessage: "",
       chatAttachments: [],
       chatMessages: mainMessages,
-      chatToolMessages: [],
-      chatStreamSegments: [],
-      chatThinkingLevel: null,
-      chatStream: null,
-      chatSideResult: null,
-      lastError: null,
-      compactionStatus: null,
-      fallbackStatus: null,
-      chatAvatarUrl: null,
       chatQueue: [],
       chatQueueBySession: {},
       chatMessagesBySession: {},
-      chatRunId: null,
-      sessionsShowArchived: false,
-      chatSideResultTerminalRuns: new Set<string>(),
-      chatStreamStartedAt: null,
-      settings,
-      announceSessionSwitch: vi.fn(),
-      applySettings(next: typeof settings) {
-        state.settings = next;
-      },
-      loadAssistantIdentity: vi.fn(),
-      resetToolStream: vi.fn(),
-      resetChatScroll: vi.fn(),
-      resetChatInputHistoryNavigation: vi.fn(),
-    } as unknown as AppViewState;
+    });
 
     refreshChatAvatarMock.mockResolvedValue(undefined);
     refreshSlashCommandsMock.mockResolvedValue(undefined);
@@ -1087,30 +1068,16 @@ describe("switchChatSession", () => {
   });
 
   it("restores visible messages across configured default-session aliases", () => {
-    const settings = createSettings();
-    const mainMessages = [{ role: "assistant", content: [{ type: "text", text: "ops report" }] }];
-    const otherMessages = [{ role: "assistant", content: [{ type: "text", text: "other reply" }] }];
-    const state = {
+    const mainMessages = [assistantTextMessage("ops report")];
+    const otherMessages = [assistantTextMessage("other reply")];
+    const state = createChatSessionState({
       sessionKey: "home",
       chatMessage: "",
       chatAttachments: [],
       chatMessages: mainMessages,
-      chatToolMessages: [],
-      chatStreamSegments: [],
-      chatThinkingLevel: null,
-      chatStream: null,
-      chatSideResult: null,
-      lastError: null,
-      compactionStatus: null,
-      fallbackStatus: null,
-      chatAvatarUrl: null,
       chatQueue: [],
       chatQueueBySession: {},
       chatMessagesBySession: {},
-      chatRunId: null,
-      sessionsShowArchived: false,
-      chatSideResultTerminalRuns: new Set<string>(),
-      chatStreamStartedAt: null,
       hello: {
         snapshot: {
           sessionDefaults: {
@@ -1118,17 +1085,8 @@ describe("switchChatSession", () => {
             mainKey: "home",
           },
         },
-      },
-      settings,
-      announceSessionSwitch: vi.fn(),
-      applySettings(next: typeof settings) {
-        state.settings = next;
-      },
-      loadAssistantIdentity: vi.fn(),
-      resetToolStream: vi.fn(),
-      resetChatScroll: vi.fn(),
-      resetChatInputHistoryNavigation: vi.fn(),
-    } as unknown as AppViewState;
+      } as AppViewState["hello"],
+    });
 
     refreshChatAvatarMock.mockResolvedValue(undefined);
     refreshSlashCommandsMock.mockResolvedValue(undefined);
@@ -1148,42 +1106,17 @@ describe("switchChatSession", () => {
   });
 
   it("restores visible messages across plain and canonical non-main keys", () => {
-    const settings = createSettings();
-    const projectMessages = [
-      { role: "assistant", content: [{ type: "text", text: "project report" }] },
-    ];
-    const mainMessages = [{ role: "assistant", content: [{ type: "text", text: "main reply" }] }];
-    const state = {
+    const projectMessages = [assistantTextMessage("project report")];
+    const mainMessages = [assistantTextMessage("main reply")];
+    const state = createChatSessionState({
       sessionKey: "project",
       chatMessage: "",
       chatAttachments: [],
       chatMessages: projectMessages,
-      chatToolMessages: [],
-      chatStreamSegments: [],
-      chatThinkingLevel: null,
-      chatStream: null,
-      chatSideResult: null,
-      lastError: null,
-      compactionStatus: null,
-      fallbackStatus: null,
-      chatAvatarUrl: null,
       chatQueue: [],
       chatQueueBySession: {},
       chatMessagesBySession: {},
-      chatRunId: null,
-      sessionsShowArchived: false,
-      chatSideResultTerminalRuns: new Set<string>(),
-      chatStreamStartedAt: null,
-      settings,
-      announceSessionSwitch: vi.fn(),
-      applySettings(next: typeof settings) {
-        state.settings = next;
-      },
-      loadAssistantIdentity: vi.fn(),
-      resetToolStream: vi.fn(),
-      resetChatScroll: vi.fn(),
-      resetChatInputHistoryNavigation: vi.fn(),
-    } as unknown as AppViewState;
+    });
 
     refreshChatAvatarMock.mockResolvedValue(undefined);
     refreshSlashCommandsMock.mockResolvedValue(undefined);

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1036,6 +1036,56 @@ describe("switchChatSession", () => {
     expect(state.chatQueue).toEqual([{ id: "queued-1", text: "message B", createdAt: 1 }]);
   });
 
+  it("restores visible messages when switching back before history reloads", () => {
+    const settings = createSettings();
+    const mainMessages = [{ role: "assistant", content: [{ type: "text", text: "main report" }] }];
+    const otherMessages = [{ role: "assistant", content: [{ type: "text", text: "other reply" }] }];
+    const state = {
+      sessionKey: "main",
+      chatMessage: "",
+      chatAttachments: [],
+      chatMessages: mainMessages,
+      chatToolMessages: [],
+      chatStreamSegments: [],
+      chatThinkingLevel: null,
+      chatStream: null,
+      chatSideResult: null,
+      lastError: null,
+      compactionStatus: null,
+      fallbackStatus: null,
+      chatAvatarUrl: null,
+      chatQueue: [],
+      chatQueueBySession: {},
+      chatMessagesBySession: {},
+      chatRunId: null,
+      sessionsShowArchived: false,
+      chatSideResultTerminalRuns: new Set<string>(),
+      chatStreamStartedAt: null,
+      settings,
+      announceSessionSwitch: vi.fn(),
+      applySettings(next: typeof settings) {
+        state.settings = next;
+      },
+      loadAssistantIdentity: vi.fn(),
+      resetToolStream: vi.fn(),
+      resetChatScroll: vi.fn(),
+      resetChatInputHistoryNavigation: vi.fn(),
+    } as unknown as AppViewState;
+
+    refreshChatAvatarMock.mockResolvedValue(undefined);
+    refreshSlashCommandsMock.mockResolvedValue(undefined);
+    loadChatHistoryMock.mockResolvedValue(undefined);
+    loadSessionsMock.mockResolvedValue(undefined);
+
+    switchChatSession(state, "agent:main:other");
+    state.chatMessages = otherMessages;
+
+    switchChatSession(state, "main");
+
+    expect(state.chatMessages).toEqual(mainMessages);
+    expect(state.chatMessagesBySession["agent:main:other"]).toEqual(otherMessages);
+  });
+
   it("does not force agentId=main for plain session keys", async () => {
     const settings = createSettings();
     const state = {

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1086,6 +1086,120 @@ describe("switchChatSession", () => {
     expect(state.chatMessagesBySession["agent:main:other"]).toEqual(otherMessages);
   });
 
+  it("restores visible messages across configured default-session aliases", () => {
+    const settings = createSettings();
+    const mainMessages = [{ role: "assistant", content: [{ type: "text", text: "ops report" }] }];
+    const otherMessages = [{ role: "assistant", content: [{ type: "text", text: "other reply" }] }];
+    const state = {
+      sessionKey: "home",
+      chatMessage: "",
+      chatAttachments: [],
+      chatMessages: mainMessages,
+      chatToolMessages: [],
+      chatStreamSegments: [],
+      chatThinkingLevel: null,
+      chatStream: null,
+      chatSideResult: null,
+      lastError: null,
+      compactionStatus: null,
+      fallbackStatus: null,
+      chatAvatarUrl: null,
+      chatQueue: [],
+      chatQueueBySession: {},
+      chatMessagesBySession: {},
+      chatRunId: null,
+      sessionsShowArchived: false,
+      chatSideResultTerminalRuns: new Set<string>(),
+      chatStreamStartedAt: null,
+      hello: {
+        snapshot: {
+          sessionDefaults: {
+            defaultAgentId: "ops",
+            mainKey: "home",
+          },
+        },
+      },
+      settings,
+      announceSessionSwitch: vi.fn(),
+      applySettings(next: typeof settings) {
+        state.settings = next;
+      },
+      loadAssistantIdentity: vi.fn(),
+      resetToolStream: vi.fn(),
+      resetChatScroll: vi.fn(),
+      resetChatInputHistoryNavigation: vi.fn(),
+    } as unknown as AppViewState;
+
+    refreshChatAvatarMock.mockResolvedValue(undefined);
+    refreshSlashCommandsMock.mockResolvedValue(undefined);
+    loadChatHistoryMock.mockResolvedValue(undefined);
+    loadSessionsMock.mockResolvedValue(undefined);
+
+    switchChatSession(state, "agent:ops:other");
+    state.chatMessages = otherMessages;
+
+    switchChatSession(state, "agent:ops:home");
+
+    expect(state.chatMessages).toEqual(mainMessages);
+    expect(state.chatMessagesBySession.home).toEqual(mainMessages);
+    expect(state.chatMessagesBySession["agent:main:home"]).toEqual(mainMessages);
+    expect(state.chatMessagesBySession["agent:ops:main"]).toEqual(mainMessages);
+    expect(state.chatMessagesBySession["agent:ops:other"]).toEqual(otherMessages);
+  });
+
+  it("restores visible messages across plain and canonical non-main keys", () => {
+    const settings = createSettings();
+    const projectMessages = [
+      { role: "assistant", content: [{ type: "text", text: "project report" }] },
+    ];
+    const mainMessages = [{ role: "assistant", content: [{ type: "text", text: "main reply" }] }];
+    const state = {
+      sessionKey: "project",
+      chatMessage: "",
+      chatAttachments: [],
+      chatMessages: projectMessages,
+      chatToolMessages: [],
+      chatStreamSegments: [],
+      chatThinkingLevel: null,
+      chatStream: null,
+      chatSideResult: null,
+      lastError: null,
+      compactionStatus: null,
+      fallbackStatus: null,
+      chatAvatarUrl: null,
+      chatQueue: [],
+      chatQueueBySession: {},
+      chatMessagesBySession: {},
+      chatRunId: null,
+      sessionsShowArchived: false,
+      chatSideResultTerminalRuns: new Set<string>(),
+      chatStreamStartedAt: null,
+      settings,
+      announceSessionSwitch: vi.fn(),
+      applySettings(next: typeof settings) {
+        state.settings = next;
+      },
+      loadAssistantIdentity: vi.fn(),
+      resetToolStream: vi.fn(),
+      resetChatScroll: vi.fn(),
+      resetChatInputHistoryNavigation: vi.fn(),
+    } as unknown as AppViewState;
+
+    refreshChatAvatarMock.mockResolvedValue(undefined);
+    refreshSlashCommandsMock.mockResolvedValue(undefined);
+    loadChatHistoryMock.mockResolvedValue(undefined);
+    loadSessionsMock.mockResolvedValue(undefined);
+
+    switchChatSession(state, "main");
+    state.chatMessages = mainMessages;
+
+    switchChatSession(state, "agent:main:project");
+
+    expect(state.chatMessages).toEqual(projectMessages);
+    expect(state.chatMessagesBySession.project).toEqual(projectMessages);
+    expect(state.chatMessagesBySession["agent:main:project"]).toEqual(projectMessages);
+  });
+
   it("does not force agentId=main for plain session keys", async () => {
     const settings = createSettings();
     const state = {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -120,15 +120,33 @@ function restoreChatQueueForSession(state: AppViewState, sessionKey: string): Ch
   return [...(state.chatQueueBySession?.[sessionKey] ?? [])];
 }
 
+function saveChatMessagesForSession(state: AppViewState, sessionKey: string) {
+  const messagesBySession = (state.chatMessagesBySession ??= {});
+  if (state.chatMessages.length > 0) {
+    messagesBySession[sessionKey] = [...state.chatMessages];
+    state.chatMessagesBySession = { ...messagesBySession };
+    return;
+  }
+  if (Object.prototype.hasOwnProperty.call(messagesBySession, sessionKey)) {
+    delete messagesBySession[sessionKey];
+    state.chatMessagesBySession = { ...messagesBySession };
+  }
+}
+
+function restoreChatMessagesForSession(state: AppViewState, sessionKey: string): unknown[] {
+  return [...(state.chatMessagesBySession?.[sessionKey] ?? [])];
+}
+
 function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string) {
   const host = state as unknown as SessionSwitchHost;
   const previousSessionKey = state.sessionKey;
   saveChatQueueForSession(state, previousSessionKey);
+  saveChatMessagesForSession(state, previousSessionKey);
   state.sessionKey = sessionKey;
   (state as unknown as { currentSessionId?: string | null }).currentSessionId = null;
   state.chatMessage = "";
   state.chatAttachments = [];
-  state.chatMessages = [];
+  state.chatMessages = restoreChatMessagesForSession(state, sessionKey);
   state.chatToolMessages = [];
   state.chatStreamSegments = [];
   state.chatThinkingLevel = null;

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -8,6 +8,10 @@ import {
   renderChatSessionSelect as renderChatSessionSelectBase,
   resolveSessionOptionGroups,
 } from "./chat/session-controls.ts";
+import {
+  readChatMessageCacheSessionDefaults,
+  resolveEquivalentChatMessageCacheKeys,
+} from "./chat/session-message-cache-keys.ts";
 import { refreshSlashCommands } from "./chat/slash-commands.ts";
 import { resolveControlUiAuthToken } from "./control-ui-auth.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
@@ -121,20 +125,28 @@ function restoreChatQueueForSession(state: AppViewState, sessionKey: string): Ch
 }
 
 function saveChatMessagesForSession(state: AppViewState, sessionKey: string) {
-  const messagesBySession = (state.chatMessagesBySession ??= {});
-  if (state.chatMessages.length > 0) {
-    messagesBySession[sessionKey] = [...state.chatMessages];
-    state.chatMessagesBySession = { ...messagesBySession };
-    return;
+  const messagesBySession = { ...state.chatMessagesBySession };
+  const defaults = readChatMessageCacheSessionDefaults(state);
+  const cacheKeys = resolveEquivalentChatMessageCacheKeys(sessionKey, defaults);
+  for (const cacheKey of cacheKeys) {
+    if (state.chatMessages.length > 0) {
+      messagesBySession[cacheKey] = [...state.chatMessages];
+    } else if (Object.prototype.hasOwnProperty.call(messagesBySession, cacheKey)) {
+      delete messagesBySession[cacheKey];
+    }
   }
-  if (Object.prototype.hasOwnProperty.call(messagesBySession, sessionKey)) {
-    delete messagesBySession[sessionKey];
-    state.chatMessagesBySession = { ...messagesBySession };
-  }
+  state.chatMessagesBySession = messagesBySession;
 }
 
 function restoreChatMessagesForSession(state: AppViewState, sessionKey: string): unknown[] {
-  return [...(state.chatMessagesBySession?.[sessionKey] ?? [])];
+  const defaults = readChatMessageCacheSessionDefaults(state);
+  for (const cacheKey of resolveEquivalentChatMessageCacheKeys(sessionKey, defaults)) {
+    const cached = state.chatMessagesBySession?.[cacheKey];
+    if (cached && cached.length > 0) {
+      return [...cached];
+    }
+  }
+  return [];
 }
 
 function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -26,6 +26,10 @@ import { warnQueryToken } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import {
+  readChatMessageCacheSessionDefaults,
+  resolveEquivalentChatMessageCacheKeys,
+} from "./chat/session-message-cache-keys.ts";
+import {
   controlUiNowMs,
   recordControlUiRenderTiming,
   roundedControlUiDurationMs,
@@ -2774,6 +2778,17 @@ export function renderApp(state: AppViewState) {
                     try {
                       await state.client.request("sessions.reset", { key: state.sessionKey });
                       state.chatMessages = [];
+                      {
+                        const messagesBySession = { ...state.chatMessagesBySession };
+                        const defaults = readChatMessageCacheSessionDefaults(state);
+                        for (const cacheKey of resolveEquivalentChatMessageCacheKeys(
+                          state.sessionKey,
+                          defaults,
+                        )) {
+                          delete messagesBySession[cacheKey];
+                        }
+                        state.chatMessagesBySession = messagesBySession;
+                      }
                       state.chatSideResult = null;
                       reconcileChatRunLifecycle(
                         state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -125,6 +125,7 @@ export type AppViewState = {
   announceSessionSwitch?: (sessionKey: string, label: string) => void;
   chatQueue: ChatQueueItem[];
   chatQueueBySession: Record<string, ChatQueueItem[]>;
+  chatMessagesBySession: Record<string, unknown[]>;
   chatLocalInputHistoryBySession: Record<string, Array<{ text: string; ts: number }>>;
   chatInputHistorySessionKey: string | null;
   chatInputHistoryItems: string[] | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -246,6 +246,7 @@ export class OpenClawApp extends LitElement {
   private sessionSwitchFlashTimer: number | null = null;
   @state() chatQueue: ChatQueueItem[] = [];
   @state() chatQueueBySession: Record<string, ChatQueueItem[]> = {};
+  @state() chatMessagesBySession: Record<string, unknown[]> = {};
   @state() chatAttachments: ChatAttachment[] = [];
   @state() realtimeTalkActive = false;
   @state() realtimeTalkStatus: RealtimeTalkStatus = "idle";

--- a/ui/src/ui/chat/session-message-cache-keys.ts
+++ b/ui/src/ui/chat/session-message-cache-keys.ts
@@ -17,18 +17,9 @@ const DEFAULT_CANONICAL_MAIN_SESSION_KEY = buildAgentMainSessionKey({
   mainKey: DEFAULT_MAIN_KEY,
 });
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object";
-}
-
 function toTrimmedString(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
-}
-
-function readStringProperty(record: Record<string, unknown>, key: string): string | undefined {
-  const value = record[key];
-  return typeof value === "string" ? value : undefined;
 }
 
 function resolveDefaultMainSessionKey(defaults?: ChatMessageCacheSessionDefaults): string {
@@ -48,17 +39,34 @@ function uniqueStrings(values: string[]): string[] {
 export function readChatMessageCacheSessionDefaults(
   host: unknown,
 ): ChatMessageCacheSessionDefaults | undefined {
-  if (!isRecord(host) || !isRecord(host.hello)) {
+  if (!host || typeof host !== "object" || !("hello" in host)) {
     return undefined;
   }
-  const snapshot = host.hello.snapshot;
-  if (!isRecord(snapshot) || !isRecord(snapshot.sessionDefaults)) {
+  const { hello } = host;
+  if (!hello || typeof hello !== "object" || !("snapshot" in hello)) {
+    return undefined;
+  }
+  const { snapshot } = hello;
+  if (!snapshot || typeof snapshot !== "object" || !("sessionDefaults" in snapshot)) {
+    return undefined;
+  }
+  const { sessionDefaults } = snapshot;
+  if (!sessionDefaults || typeof sessionDefaults !== "object") {
     return undefined;
   }
   return {
-    defaultAgentId: readStringProperty(snapshot.sessionDefaults, "defaultAgentId"),
-    mainKey: readStringProperty(snapshot.sessionDefaults, "mainKey"),
-    mainSessionKey: readStringProperty(snapshot.sessionDefaults, "mainSessionKey"),
+    defaultAgentId:
+      "defaultAgentId" in sessionDefaults && typeof sessionDefaults.defaultAgentId === "string"
+        ? sessionDefaults.defaultAgentId
+        : undefined,
+    mainKey:
+      "mainKey" in sessionDefaults && typeof sessionDefaults.mainKey === "string"
+        ? sessionDefaults.mainKey
+        : undefined,
+    mainSessionKey:
+      "mainSessionKey" in sessionDefaults && typeof sessionDefaults.mainSessionKey === "string"
+        ? sessionDefaults.mainSessionKey
+        : undefined,
   };
 }
 

--- a/ui/src/ui/chat/session-message-cache-keys.ts
+++ b/ui/src/ui/chat/session-message-cache-keys.ts
@@ -1,0 +1,154 @@
+import {
+  buildAgentMainSessionKey,
+  DEFAULT_AGENT_ID,
+  DEFAULT_MAIN_KEY,
+  parseAgentSessionKey,
+} from "../session-key.ts";
+import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
+
+export type ChatMessageCacheSessionDefaults = {
+  defaultAgentId?: string;
+  mainKey?: string;
+  mainSessionKey?: string;
+};
+
+const DEFAULT_CANONICAL_MAIN_SESSION_KEY = buildAgentMainSessionKey({
+  agentId: DEFAULT_AGENT_ID,
+  mainKey: DEFAULT_MAIN_KEY,
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}
+
+function toTrimmedString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function readStringProperty(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function resolveDefaultMainSessionKey(defaults?: ChatMessageCacheSessionDefaults): string {
+  return (
+    toTrimmedString(defaults?.mainSessionKey) ??
+    buildAgentMainSessionKey({
+      agentId: toTrimmedString(defaults?.defaultAgentId) ?? DEFAULT_AGENT_ID,
+      mainKey: toTrimmedString(defaults?.mainKey) ?? DEFAULT_MAIN_KEY,
+    })
+  );
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim()))];
+}
+
+export function readChatMessageCacheSessionDefaults(
+  host: unknown,
+): ChatMessageCacheSessionDefaults | undefined {
+  if (!isRecord(host) || !isRecord(host.hello)) {
+    return undefined;
+  }
+  const snapshot = host.hello.snapshot;
+  if (!isRecord(snapshot) || !isRecord(snapshot.sessionDefaults)) {
+    return undefined;
+  }
+  return {
+    defaultAgentId: readStringProperty(snapshot.sessionDefaults, "defaultAgentId"),
+    mainKey: readStringProperty(snapshot.sessionDefaults, "mainKey"),
+    mainSessionKey: readStringProperty(snapshot.sessionDefaults, "mainSessionKey"),
+  };
+}
+
+export function normalizeChatMessageCacheSessionKey(
+  sessionKey: string,
+  defaults?: ChatMessageCacheSessionDefaults,
+): string {
+  const raw = sessionKey.trim();
+  const normalized = normalizeLowercaseStringOrEmpty(raw);
+  const mainKey = toTrimmedString(defaults?.mainKey) ?? DEFAULT_MAIN_KEY;
+  const defaultAgentId = toTrimmedString(defaults?.defaultAgentId) ?? DEFAULT_AGENT_ID;
+  const defaultMainSessionKey = resolveDefaultMainSessionKey(defaults);
+  const aliases = [
+    DEFAULT_MAIN_KEY,
+    mainKey,
+    DEFAULT_CANONICAL_MAIN_SESSION_KEY,
+    defaultMainSessionKey,
+    buildAgentMainSessionKey({ agentId: DEFAULT_AGENT_ID, mainKey }),
+    buildAgentMainSessionKey({ agentId: defaultAgentId, mainKey: DEFAULT_MAIN_KEY }),
+    buildAgentMainSessionKey({ agentId: defaultAgentId, mainKey }),
+  ].map((entry) => normalizeLowercaseStringOrEmpty(entry));
+  if (aliases.includes(normalized)) {
+    return normalizeLowercaseStringOrEmpty(defaultMainSessionKey);
+  }
+  const parsed = parseAgentSessionKey(raw);
+  if (parsed) {
+    const normalizedAgentId = normalizeLowercaseStringOrEmpty(parsed.agentId);
+    const normalizedDefaultAgentId = normalizeLowercaseStringOrEmpty(defaultAgentId);
+    if (normalizedAgentId === normalizedDefaultAgentId || normalizedAgentId === DEFAULT_AGENT_ID) {
+      return normalizeLowercaseStringOrEmpty(parsed.rest);
+    }
+  }
+  return normalized;
+}
+
+export function chatMessageCacheSessionKeysMatch(
+  left: string,
+  right: string,
+  defaults?: ChatMessageCacheSessionDefaults,
+): boolean {
+  return (
+    normalizeChatMessageCacheSessionKey(left, defaults) ===
+    normalizeChatMessageCacheSessionKey(right, defaults)
+  );
+}
+
+export function resolveEquivalentChatMessageCacheKeys(
+  sessionKey: string,
+  defaults?: ChatMessageCacheSessionDefaults,
+): string[] {
+  const raw = sessionKey.trim();
+  const mainKey = toTrimmedString(defaults?.mainKey) ?? DEFAULT_MAIN_KEY;
+  const defaultAgentId = toTrimmedString(defaults?.defaultAgentId) ?? DEFAULT_AGENT_ID;
+  const normalized = normalizeChatMessageCacheSessionKey(raw, defaults);
+  const defaultMainSessionKey = resolveDefaultMainSessionKey(defaults);
+  if (normalized !== normalizeLowercaseStringOrEmpty(defaultMainSessionKey)) {
+    const parsed = parseAgentSessionKey(raw);
+    if (parsed) {
+      const normalizedAgentId = normalizeLowercaseStringOrEmpty(parsed.agentId);
+      const normalizedDefaultAgentId = normalizeLowercaseStringOrEmpty(defaultAgentId);
+      if (
+        normalizedAgentId !== normalizedDefaultAgentId &&
+        normalizedAgentId !== DEFAULT_AGENT_ID
+      ) {
+        return uniqueStrings([raw]);
+      }
+      return uniqueStrings([
+        raw,
+        parsed.rest,
+        buildAgentMainSessionKey({ agentId: defaultAgentId, mainKey: parsed.rest }),
+        buildAgentMainSessionKey({ agentId: DEFAULT_AGENT_ID, mainKey: parsed.rest }),
+      ]);
+    }
+    if (normalized.startsWith("agent:")) {
+      return uniqueStrings([raw]);
+    }
+    return uniqueStrings([
+      raw,
+      buildAgentMainSessionKey({ agentId: defaultAgentId, mainKey: raw }),
+      buildAgentMainSessionKey({ agentId: DEFAULT_AGENT_ID, mainKey: raw }),
+    ]);
+  }
+  return uniqueStrings([
+    raw,
+    DEFAULT_MAIN_KEY,
+    mainKey,
+    DEFAULT_CANONICAL_MAIN_SESSION_KEY,
+    defaultMainSessionKey,
+    buildAgentMainSessionKey({ agentId: DEFAULT_AGENT_ID, mainKey }),
+    buildAgentMainSessionKey({ agentId: defaultAgentId, mainKey: DEFAULT_MAIN_KEY }),
+    buildAgentMainSessionKey({ agentId: defaultAgentId, mainKey }),
+  ]);
+}

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -113,6 +113,29 @@ describe("handleChatEvent", () => {
     expect(handleChatEvent(state, payload)).toBe(null);
   });
 
+  it("caches final messages for a switched-away session", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatMessages: [{ role: "assistant", content: [{ type: "text", text: "main visible" }] }],
+      chatMessagesBySession: {},
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "other",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "other final" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe(null);
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "main visible" }] },
+    ]);
+    expect(state.chatMessagesBySession?.other).toEqual([payload.message]);
+  });
+
   it("accepts delta events for the active run when gateway emits a canonical session key", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -136,6 +136,129 @@ describe("handleChatEvent", () => {
     expect(state.chatMessagesBySession?.other).toEqual([payload.message]);
   });
 
+  it("caches canonical default-session finals under the main alias", () => {
+    const state = createState({
+      sessionKey: "agent:main:other",
+      chatMessages: [{ role: "assistant", content: [{ type: "text", text: "other visible" }] }],
+      chatMessagesBySession: {},
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "main final" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe(null);
+    expect(state.chatMessagesBySession?.main).toEqual([payload.message]);
+    expect(state.chatMessagesBySession?.["agent:main:main"]).toEqual([payload.message]);
+  });
+
+  it("caches configured default-session finals under runtime aliases", () => {
+    const state = createState({
+      sessionKey: "agent:ops:other",
+      chatMessagesBySession: {},
+    }) as ChatState & {
+      hello: { snapshot: { sessionDefaults: { defaultAgentId: string; mainKey: string } } };
+    };
+    state.hello = {
+      snapshot: {
+        sessionDefaults: {
+          defaultAgentId: "ops",
+          mainKey: "home",
+        },
+      },
+    };
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "agent:ops:home",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "ops main final" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe(null);
+    expect(state.chatMessagesBySession?.home).toEqual([payload.message]);
+    expect(state.chatMessagesBySession?.["agent:main:home"]).toEqual([payload.message]);
+    expect(state.chatMessagesBySession?.["agent:ops:main"]).toEqual([payload.message]);
+    expect(state.chatMessagesBySession?.["agent:ops:home"]).toEqual([payload.message]);
+  });
+
+  it("caches canonical non-main finals under the plain session key", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatMessagesBySession: {},
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "agent:main:project",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "project final" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe(null);
+    expect(state.chatMessagesBySession?.project).toEqual([payload.message]);
+    expect(state.chatMessagesBySession?.["agent:main:project"]).toEqual([payload.message]);
+  });
+
+  it("accepts configured default-session final events through equivalent aliases", () => {
+    const state = createState({
+      sessionKey: "home",
+      chatRunId: null,
+      chatMessages: [],
+    }) as ChatState & {
+      hello: { snapshot: { sessionDefaults: { defaultAgentId: string; mainKey: string } } };
+    };
+    state.hello = {
+      snapshot: {
+        sessionDefaults: {
+          defaultAgentId: "ops",
+          mainKey: "home",
+        },
+      },
+    };
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "agent:main:home",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Live reply" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([payload.message]);
+  });
+
+  it("accepts canonical non-main final events through the plain session key", () => {
+    const state = createState({
+      sessionKey: "project",
+      chatRunId: null,
+      chatMessages: [],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "agent:main:project",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Project reply" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([payload.message]);
+  });
+
   it("accepts delta events for the active run when gateway emits a canonical session key", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -93,8 +93,33 @@ function createOtherRunSilentFinalPayload(text: string): ChatEventPayload {
   };
 }
 
+function createAssistantFinalPayload(sessionKey: string, text: string): ChatEventPayload {
+  return {
+    runId: "run-1",
+    sessionKey,
+    state: "final",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
 function createOtherRunNoReplyFinalPayload(): ChatEventPayload {
   return createOtherRunSilentFinalPayload("NO_REPLY");
+}
+
+function applyConfiguredSessionDefaults(state: ChatState): ChatState {
+  return Object.assign(state, {
+    hello: {
+      snapshot: {
+        sessionDefaults: {
+          defaultAgentId: "ops",
+          mainKey: "home",
+        },
+      },
+    },
+  });
 }
 
 describe("handleChatEvent", () => {
@@ -114,150 +139,94 @@ describe("handleChatEvent", () => {
   });
 
   it("caches final messages for a switched-away session", () => {
+    const visibleMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "main visible" }],
+    };
     const state = createState({
       sessionKey: "main",
-      chatMessages: [{ role: "assistant", content: [{ type: "text", text: "main visible" }] }],
+      chatMessages: [visibleMessage],
       chatMessagesBySession: {},
     });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "other",
-      state: "final",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "other final" }],
-      },
-    };
+    const payload = createAssistantFinalPayload("other", "other final");
 
     expect(handleChatEvent(state, payload)).toBe(null);
-    expect(state.chatMessages).toEqual([
-      { role: "assistant", content: [{ type: "text", text: "main visible" }] },
-    ]);
+    expect(state.chatMessages).toEqual([visibleMessage]);
     expect(state.chatMessagesBySession?.other).toEqual([payload.message]);
   });
 
-  it("caches canonical default-session finals under the main alias", () => {
-    const state = createState({
-      sessionKey: "agent:main:other",
-      chatMessages: [{ role: "assistant", content: [{ type: "text", text: "other visible" }] }],
-      chatMessagesBySession: {},
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "agent:main:main",
-      state: "final",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "main final" }],
-      },
-    };
+  it.each([
+    {
+      name: "canonical default-session finals under the main alias",
+      activeSessionKey: "agent:main:other",
+      payloadSessionKey: "agent:main:main",
+      cacheKeys: ["main", "agent:main:main"],
+      withConfiguredDefaults: false,
+    },
+    {
+      name: "configured default-session finals under runtime aliases",
+      activeSessionKey: "agent:ops:other",
+      payloadSessionKey: "agent:ops:home",
+      cacheKeys: ["home", "agent:main:home", "agent:ops:main", "agent:ops:home"],
+      withConfiguredDefaults: true,
+    },
+    {
+      name: "canonical non-main finals under the plain session key",
+      activeSessionKey: "main",
+      payloadSessionKey: "agent:main:project",
+      cacheKeys: ["project", "agent:main:project"],
+      withConfiguredDefaults: false,
+    },
+  ])(
+    "caches $name",
+    ({ activeSessionKey, payloadSessionKey, cacheKeys, withConfiguredDefaults }) => {
+      const state = createState({ sessionKey: activeSessionKey, chatMessagesBySession: {} });
+      const payload = createAssistantFinalPayload(payloadSessionKey, "cached final");
 
-    expect(handleChatEvent(state, payload)).toBe(null);
-    expect(state.chatMessagesBySession?.main).toEqual([payload.message]);
-    expect(state.chatMessagesBySession?.["agent:main:main"]).toEqual([payload.message]);
-  });
+      if (withConfiguredDefaults) {
+        applyConfiguredSessionDefaults(state);
+      }
 
-  it("caches configured default-session finals under runtime aliases", () => {
-    const state = createState({
-      sessionKey: "agent:ops:other",
-      chatMessagesBySession: {},
-    }) as ChatState & {
-      hello: { snapshot: { sessionDefaults: { defaultAgentId: string; mainKey: string } } };
-    };
-    state.hello = {
-      snapshot: {
-        sessionDefaults: {
-          defaultAgentId: "ops",
-          mainKey: "home",
-        },
-      },
-    };
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "agent:ops:home",
-      state: "final",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "ops main final" }],
-      },
-    };
+      expect(handleChatEvent(state, payload)).toBe(null);
+      for (const cacheKey of cacheKeys) {
+        expect(state.chatMessagesBySession?.[cacheKey]).toEqual([payload.message]);
+      }
+    },
+  );
 
-    expect(handleChatEvent(state, payload)).toBe(null);
-    expect(state.chatMessagesBySession?.home).toEqual([payload.message]);
-    expect(state.chatMessagesBySession?.["agent:main:home"]).toEqual([payload.message]);
-    expect(state.chatMessagesBySession?.["agent:ops:main"]).toEqual([payload.message]);
-    expect(state.chatMessagesBySession?.["agent:ops:home"]).toEqual([payload.message]);
-  });
+  it.each([
+    {
+      name: "configured default-session",
+      activeSessionKey: "home",
+      payloadSessionKey: "agent:main:home",
+      text: "Live reply",
+      withConfiguredDefaults: true,
+    },
+    {
+      name: "canonical non-main",
+      activeSessionKey: "project",
+      payloadSessionKey: "agent:main:project",
+      text: "Project reply",
+      withConfiguredDefaults: false,
+    },
+  ])(
+    "accepts $name final events through equivalent aliases",
+    ({ activeSessionKey, payloadSessionKey, text, withConfiguredDefaults }) => {
+      const state = createState({
+        sessionKey: activeSessionKey,
+        chatRunId: null,
+        chatMessages: [],
+      });
+      const payload = createAssistantFinalPayload(payloadSessionKey, text);
 
-  it("caches canonical non-main finals under the plain session key", () => {
-    const state = createState({
-      sessionKey: "main",
-      chatMessagesBySession: {},
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "agent:main:project",
-      state: "final",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "project final" }],
-      },
-    };
+      if (withConfiguredDefaults) {
+        applyConfiguredSessionDefaults(state);
+      }
 
-    expect(handleChatEvent(state, payload)).toBe(null);
-    expect(state.chatMessagesBySession?.project).toEqual([payload.message]);
-    expect(state.chatMessagesBySession?.["agent:main:project"]).toEqual([payload.message]);
-  });
-
-  it("accepts configured default-session final events through equivalent aliases", () => {
-    const state = createState({
-      sessionKey: "home",
-      chatRunId: null,
-      chatMessages: [],
-    }) as ChatState & {
-      hello: { snapshot: { sessionDefaults: { defaultAgentId: string; mainKey: string } } };
-    };
-    state.hello = {
-      snapshot: {
-        sessionDefaults: {
-          defaultAgentId: "ops",
-          mainKey: "home",
-        },
-      },
-    };
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "agent:main:home",
-      state: "final",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Live reply" }],
-      },
-    };
-
-    expect(handleChatEvent(state, payload)).toBe("final");
-    expect(state.chatMessages).toEqual([payload.message]);
-  });
-
-  it("accepts canonical non-main final events through the plain session key", () => {
-    const state = createState({
-      sessionKey: "project",
-      chatRunId: null,
-      chatMessages: [],
-    });
-    const payload: ChatEventPayload = {
-      runId: "run-1",
-      sessionKey: "agent:main:project",
-      state: "final",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Project reply" }],
-      },
-    };
-
-    expect(handleChatEvent(state, payload)).toBe("final");
-    expect(state.chatMessages).toEqual([payload.message]);
-  });
+      expect(handleChatEvent(state, payload)).toBe("final");
+      expect(state.chatMessages).toEqual([payload.message]);
+    },
+  );
 
   it("accepts delta events for the active run when gateway emits a canonical session key", () => {
     const state = createState({

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -9,6 +9,11 @@ import {
 } from "../chat/heartbeat-display.ts";
 import { extractText } from "../chat/message-extract.ts";
 import { reconcileChatRunLifecycle } from "../chat/run-lifecycle.ts";
+import {
+  chatMessageCacheSessionKeysMatch,
+  readChatMessageCacheSessionDefaults,
+  resolveEquivalentChatMessageCacheKeys,
+} from "../chat/session-message-cache-keys.ts";
 import { formatConnectError } from "../connect-error.ts";
 import { GatewayRequestError, type GatewayBrowserClient } from "../gateway.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
@@ -306,18 +311,28 @@ function setCachedChatMessages(state: ChatState, sessionKey: string, messages: u
   if (!state.chatMessagesBySession) {
     return;
   }
-  const messagesBySession = state.chatMessagesBySession;
+  const messagesBySession = { ...state.chatMessagesBySession };
   if (messages.length > 0) {
     messagesBySession[sessionKey] = [...messages];
   } else {
     delete messagesBySession[sessionKey];
   }
-  state.chatMessagesBySession = { ...messagesBySession };
+  state.chatMessagesBySession = messagesBySession;
 }
 
 function appendCachedChatMessage(state: ChatState, sessionKey: string, message: unknown) {
-  const current = state.chatMessagesBySession?.[sessionKey] ?? [];
-  setCachedChatMessages(state, sessionKey, [...current, message]);
+  const defaults = readChatMessageCacheSessionDefaults(state);
+  for (const cacheKey of resolveEquivalentChatMessageCacheKeys(sessionKey, defaults)) {
+    const current = state.chatMessagesBySession?.[cacheKey] ?? [];
+    setCachedChatMessages(state, cacheKey, [...current, message]);
+  }
+}
+
+function replaceCachedChatMessages(state: ChatState, sessionKey: string, messages: unknown[]) {
+  const defaults = readChatMessageCacheSessionDefaults(state);
+  for (const cacheKey of resolveEquivalentChatMessageCacheKeys(sessionKey, defaults)) {
+    setCachedChatMessages(state, cacheKey, messages);
+  }
 }
 
 export async function loadChatHistory(state: ChatState) {
@@ -368,7 +383,7 @@ export async function loadChatHistory(state: ChatState) {
     const messages = Array.isArray(res.messages) ? res.messages : [];
     const visibleMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
     state.chatMessages = preserveOptimisticTailMessages(visibleMessages, previousMessages);
-    setCachedChatMessages(state, sessionKey, state.chatMessages);
+    replaceCachedChatMessages(state, sessionKey, state.chatMessages);
     state.currentSessionId =
       typeof res.sessionId === "string" && res.sessionId.trim() ? res.sessionId : null;
     state.chatThinkingLevel = res.thinkingLevel ?? null;
@@ -682,7 +697,12 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (!payload) {
     return null;
   }
-  const sessionMatches = payload.sessionKey === state.sessionKey;
+  const sessionDefaults = readChatMessageCacheSessionDefaults(state);
+  const sessionMatches = chatMessageCacheSessionKeysMatch(
+    payload.sessionKey,
+    state.sessionKey,
+    sessionDefaults,
+  );
   const activeRunMatches =
     state.chatRunId !== null &&
     typeof payload.runId === "string" &&
@@ -722,7 +742,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       sessionStatus,
       runId: terminalRunId,
       sessionKey: state.sessionKey,
-      sessionKeys: payload.sessionKey === state.sessionKey ? [payload.sessionKey] : [],
+      sessionKeys: sessionMatches ? [payload.sessionKey] : [],
       clearLocalRun: true,
       clearChatStream: true,
     });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -270,6 +270,7 @@ export type ChatState = {
   currentSessionId?: string | null;
   chatLoading: boolean;
   chatMessages: unknown[];
+  chatMessagesBySession?: Record<string, unknown[]>;
   chatThinkingLevel: string | null;
   chatSending: boolean;
   chatMessage: string;
@@ -299,6 +300,24 @@ function maybeResetToolStream(state: ChatState) {
   ) {
     resetToolStream(toolHost as Parameters<typeof resetToolStream>[0]);
   }
+}
+
+function setCachedChatMessages(state: ChatState, sessionKey: string, messages: unknown[]) {
+  if (!state.chatMessagesBySession) {
+    return;
+  }
+  const messagesBySession = state.chatMessagesBySession;
+  if (messages.length > 0) {
+    messagesBySession[sessionKey] = [...messages];
+  } else {
+    delete messagesBySession[sessionKey];
+  }
+  state.chatMessagesBySession = { ...messagesBySession };
+}
+
+function appendCachedChatMessage(state: ChatState, sessionKey: string, message: unknown) {
+  const current = state.chatMessagesBySession?.[sessionKey] ?? [];
+  setCachedChatMessages(state, sessionKey, [...current, message]);
 }
 
 export async function loadChatHistory(state: ChatState) {
@@ -349,6 +368,7 @@ export async function loadChatHistory(state: ChatState) {
     const messages = Array.isArray(res.messages) ? res.messages : [];
     const visibleMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
     state.chatMessages = preserveOptimisticTailMessages(visibleMessages, previousMessages);
+    setCachedChatMessages(state, sessionKey, state.chatMessages);
     state.currentSessionId =
       typeof res.sessionId === "string" && res.sessionId.trim() ? res.sessionId : null;
     state.chatThinkingLevel = res.thinkingLevel ?? null;
@@ -668,6 +688,12 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     typeof payload.runId === "string" &&
     payload.runId === state.chatRunId;
   if (!sessionMatches && !activeRunMatches) {
+    if (payload.state === "final") {
+      const finalMessage = normalizeFinalAssistantMessage(payload.message);
+      if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
+        appendCachedChatMessage(state, payload.sessionKey, finalMessage);
+      }
+    }
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Fixes #80855.
- Cache visible WebChat messages per session when switching conversations, then restore cached messages immediately when switching back before chat.history returns.
- Cache final assistant messages for switched-away sessions so subagent/report events are not dropped while another conversation is selected.

## Real behavior proof
- Behavior addressed: WebChat session switching should not leave the restored conversation blank, and final assistant/subagent messages for a switched-away session should not be silently dropped.
- Real environment tested: Local OpenClaw checkout on Linux with production TypeScript UI modules executed through Node 22.22.2 and tsx; no test runner or mocks were used for the proof commands.
- Exact steps or command run after the patch: Ran two node --import tsx commands from the repository root. One imported switchChatSession from ui/src/ui/app-render.helpers.ts and switched main -> other -> main with real session state. The other imported handleChatEvent from ui/src/ui/controllers/chat.ts and delivered a final event for agent:main:webchat while main was selected.
- Evidence after fix:

```text
$ node --import tsx -e '<imports switchChatSession from ui/src/ui/app-render.helpers.ts and switches main -> other -> main>'
{
  "activeSession": "main",
  "visibleMessagesAfterSwitchBack": [
    "main report before switch"
  ],
  "cachedOtherMessages": [
    "other reply before switch back"
  ]
}
```

```text
$ node --import tsx -e '<imports handleChatEvent from ui/src/ui/controllers/chat.ts and sends final event for agent:main:webchat while main is selected>'
{
  "result": null,
  "currentSession": "main",
  "currentMessages": [
    "main visible"
  ],
  "cachedWebchatMessages": [
    "subagent report while switched away"
  ]
}
```

- Observed result after fix: Switching back to main immediately restored "main report before switch" instead of an empty message list, and a final message for the switched-away WebChat session was retained in cachedWebchatMessages while the currently visible main session stayed unchanged.
- What was not tested: No browser screenshot or live multi-channel WSL2 deployment was captured; the proof exercises the production UI state-transition modules directly.

## Verification
- RED: corepack pnpm test ui/src/ui/app-render.helpers.node.test.ts failed on the new switch-back preservation test before implementation.
- RED: corepack pnpm test ui/src/ui/controllers/chat.test.ts failed on the new switched-away final-event cache test before implementation.
- GREEN: corepack pnpm test ui/src/ui/controllers/chat.test.ts
- GREEN: corepack pnpm test ui/src/ui/app-render.helpers.node.test.ts ui/src/ui/controllers/chat.test.ts
- GREEN: PATH=/tmp/openclaw-corepack-shims:$PATH pnpm check:changed -- --base origin/main
- GREEN: git diff --check