### PR TITLE
fix(cli-runner): emit trajectory events from CLI executor path

### DIFF
--- a/src/agents/cli-runner/execute.trajectory-lifecycle.test.ts
+++ b/src/agents/cli-runner/execute.trajectory-lifecycle.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  recordEventMock,
+  flushMock,
+  prepareCliPromptImagePayloadMock,
+  prepareClaudeCliSkillsPluginMock,
+  enqueueCliRunMock,
+} = vi.hoisted(() => ({
+  recordEventMock: vi.fn(),
+  flushMock: vi.fn(async () => {}),
+  prepareCliPromptImagePayloadMock: vi.fn(),
+  prepareClaudeCliSkillsPluginMock: vi.fn(),
+  enqueueCliRunMock: vi.fn(),
+}));
+
+vi.mock("../../trajectory/runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../trajectory/runtime.js")>();
+  return {
+    ...actual,
+    createTrajectoryRuntimeRecorder: vi.fn(() => ({
+      recordEvent: recordEventMock,
+      flush: flushMock,
+    })),
+  };
+});
+
+vi.mock("./helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./helpers.js")>();
+  return {
+    ...actual,
+    prepareCliPromptImagePayload: prepareCliPromptImagePayloadMock,
+    enqueueCliRun: enqueueCliRunMock,
+  };
+});
+
+vi.mock("./claude-skills-plugin.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./claude-skills-plugin.js")>();
+  return {
+    ...actual,
+    prepareClaudeCliSkillsPlugin: prepareClaudeCliSkillsPluginMock,
+  };
+});
+
+import type { CliBackendConfig } from "../../config/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { CliOutput } from "../cli-output.js";
+import { executePreparedCliRun } from "./execute.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+function buildPreparedCliRunContext(): PreparedCliRunContext {
+  const backend = {
+    command: "agent-cli",
+    args: [],
+    output: "text",
+    input: "stdin",
+    serialize: true,
+  } as CliBackendConfig;
+
+  return {
+    params: {
+      sessionId: "session-trajectory",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider: "codex-cli",
+      model: "model",
+      timeoutMs: 1_000,
+      runId: "run-trajectory",
+    } as PreparedCliRunContext["params"],
+    started: 0,
+    workspaceDir: "/tmp",
+    backendResolved: {
+      id: "codex-cli",
+      config: backend,
+      bundleMcp: false,
+    } as PreparedCliRunContext["backendResolved"],
+    preparedBackend: {
+      backend,
+      env: {},
+    },
+    reusableCliSession: {} as PreparedCliRunContext["reusableCliSession"],
+    hadSessionFile: false,
+    contextEngineConfig: {} as OpenClawConfig,
+    modelId: "model",
+    normalizedModel: "model",
+    systemPrompt: "system",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    bootstrapPromptWarningLines: [],
+    authEpochVersion: 2,
+  };
+}
+
+function recordedEventTypes(): string[] {
+  return recordEventMock.mock.calls.map((call) => call[0] as string);
+}
+
+describe("executePreparedCliRun trajectory lifecycle", () => {
+  beforeEach(() => {
+    recordEventMock.mockReset();
+    flushMock.mockReset();
+    flushMock.mockImplementation(async () => {});
+    prepareCliPromptImagePayloadMock.mockReset();
+    prepareCliPromptImagePayloadMock.mockResolvedValue({
+      prompt: "hi",
+      imagePaths: [],
+      cleanupImages: undefined,
+    });
+    prepareClaudeCliSkillsPluginMock.mockReset();
+    prepareClaudeCliSkillsPluginMock.mockImplementation(async () => ({
+      args: [],
+      env: {},
+      cleanup: async () => {},
+    }));
+    enqueueCliRunMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits the full lifecycle and flushes once on a successful CLI run", async () => {
+    const output: CliOutput = { text: "done", sessionId: "cli-1" };
+    enqueueCliRunMock.mockResolvedValueOnce(output);
+
+    await expect(executePreparedCliRun(buildPreparedCliRunContext())).resolves.toBe(output);
+
+    expect(recordedEventTypes()).toEqual([
+      "session.started",
+      "prompt.submitted",
+      "model.completed",
+      "session.ended",
+    ]);
+    const modelCompleted = recordEventMock.mock.calls.find((call) => call[0] === "model.completed");
+    expect(modelCompleted?.[1]).toMatchObject({ cliSessionId: "cli-1" });
+    const sessionEnded = recordEventMock.mock.calls.find((call) => call[0] === "session.ended");
+    expect(sessionEnded?.[1]).toMatchObject({ status: "success" });
+    expect(flushMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("records a single error session.ended and flushes when the run rejects", async () => {
+    const runError = new Error("cli run blew up");
+    enqueueCliRunMock.mockRejectedValueOnce(runError);
+
+    await expect(executePreparedCliRun(buildPreparedCliRunContext())).rejects.toBe(runError);
+
+    const types = recordedEventTypes();
+    expect(types).toContain("prompt.submitted");
+    expect(types).not.toContain("model.completed");
+    expect(types.filter((type) => type === "session.ended")).toHaveLength(1);
+    const sessionEnded = recordEventMock.mock.calls.find((call) => call[0] === "session.ended");
+    expect(sessionEnded?.[1]).toMatchObject({
+      status: "error",
+      error: expect.stringContaining("cli run blew up"),
+    });
+    expect(flushMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -27,6 +27,7 @@ import { shouldUseInternalSourceReplySink } from "../../infra/outbound/internal-
 import { enqueueSystemEvent as enqueueSystemEventImpl } from "../../infra/system-events.js";
 import { getProcessSupervisor as getProcessSupervisorImpl } from "../../process/supervisor/index.js";
 import { applySkillEnvOverridesFromSnapshot } from "../../skills/runtime/env-overrides.js";
+import { createTrajectoryRuntimeRecorder } from "../../trajectory/runtime.js";
 import { appendBootstrapPromptWarning } from "../bootstrap-budget.js";
 import {
   createCliJsonlStreamingParser,
@@ -459,6 +460,33 @@ export async function executePreparedCliRun(
         })
       : undefined;
 
+  // Wire the runtime trajectory recorder so pure CLI runs (notably the
+  // claude-cli live-session path) emit the same lifecycle events as the
+  // embedded provider dispatch. Without this, sessions that stay on the CLI
+  // executor for their entire lifetime never produce a trajectory sidecar even
+  // though the pointer file is written (#80667). The recorder is null when
+  // capture is disabled or no session file exists, so every call is guarded.
+  const trajectoryRecorder = createTrajectoryRuntimeRecorder({
+    cfg: params.config,
+    runId: params.runId,
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    sessionFile: params.sessionFile,
+    provider: params.provider,
+    modelId: context.modelId,
+    workspaceDir: context.workspaceDir,
+  });
+  trajectoryRecorder?.recordEvent("session.started", {
+    trigger: params.trigger,
+    sessionFile: params.sessionFile,
+    workspaceDir: context.workspaceDir,
+    agentId: params.agentId,
+    messageProvider: params.messageProvider,
+    messageChannel: params.messageChannel,
+    backend: context.backendResolved.id,
+    cliSessionId: cliSessionIdToUse,
+  });
+
   const basePrompt = cliSessionIdToUse
     ? params.prompt
     : (context.openClawHistoryPrompt ?? params.prompt);
@@ -479,6 +507,14 @@ export async function executePreparedCliRun(
     images: params.images,
   });
   prompt = promptWithImages;
+
+  trajectoryRecorder?.recordEvent("prompt.submitted", {
+    prompt,
+    systemPrompt: context.systemPrompt,
+    useResume,
+    cliSessionId: cliSessionIdToUse,
+    imagesCount: params.images?.length ?? 0,
+  });
 
   const { argsPrompt, stdin } = resolvePromptInput({
     backend,
@@ -544,6 +580,9 @@ export async function executePreparedCliRun(
 
   let completedOutput: CliOutput | undefined;
   let executionError: unknown;
+  // Guards against emitting more than one terminal `session.ended`: the success
+  // path, the catch handler, and the finally safety net all share this flag.
+  let trajectoryTerminalRecorded = false;
   const cleanupOuterResource = async (cleanup: (() => Promise<void>) | undefined) => {
     try {
       await cleanup?.();
@@ -1469,9 +1508,26 @@ export async function executePreparedCliRun(
       }
       return withExecutionEvidence(runOutput);
     });
+    if (trajectoryRecorder && !trajectoryTerminalRecorded) {
+      trajectoryRecorder.recordEvent("model.completed", {
+        usage: completedOutput.usage,
+        cliSessionId: completedOutput.sessionId,
+        assistantTexts: completedOutput.text ? [completedOutput.text] : [],
+        finalPromptText: completedOutput.finalPromptText,
+      });
+      trajectoryRecorder.recordEvent("session.ended", { status: "success" });
+      trajectoryTerminalRecorded = true;
+    }
     return completedOutput;
   } catch (error) {
     executionError = error;
+    if (trajectoryRecorder && !trajectoryTerminalRecorded) {
+      trajectoryRecorder.recordEvent("session.ended", {
+        status: "error",
+        error: formatErrorMessage(error),
+      });
+      trajectoryTerminalRecorded = true;
+    }
     throw error;
   } finally {
     if (!fallbackClaudeSkillsPluginCleanupOwned) {
@@ -1482,6 +1538,25 @@ export async function executePreparedCliRun(
     }
     if (cleanupImages) {
       await cleanupOuterResource(cleanupImages);
+    }
+    // Flush trajectory last so queued session.ended events survive even when a
+    // cleanup above rejected; a skipped flush silently drops this run's
+    // trajectory sidecar. The safety-net session.ended covers any path that
+    // exits without the success or catch branch recording a terminal event.
+    if (trajectoryRecorder) {
+      if (!trajectoryTerminalRecorded) {
+        trajectoryRecorder.recordEvent("session.ended", {
+          status: "error",
+          error: executionError === undefined ? undefined : formatErrorMessage(executionError),
+        });
+      }
+      try {
+        await trajectoryRecorder.flush();
+      } catch (flushError) {
+        cliBackendLog.warn(
+          `trajectoryRecorder.flush() rejected: ${formatErrorMessage(flushError)}`,
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Pure `claude-cli` sessions never produce a `<session>.trajectory.jsonl` sidecar. The trajectory **pointer** is written by `createTrajectoryRuntimeRecorder` (so tooling thinks one exists), but no events flow into it because the only `recordEvent` call sites live in the embedded provider dispatch (`pi-embedded-runner/run/attempt.ts`) and the top-level fallback recorder, which only ever emits `model.fallback_step`. Sessions that stay on the CLI executor for their entire lifetime — i.e. the default healthy path when OAuth Max / `cliBackends` are configured and no model fallback fires — therefore land in an operationally invisible state for any tooling that relies on `prompt.submitted` / `model.completed` / `session.ended` as ground truth.

This wires `createTrajectoryRuntimeRecorder` into `executePreparedCliRun` so the CLI dispatch path emits the same lifecycle events as the embedded dispatch:

- `session.started` once the recorder is created, before any prep work.
- `prompt.submitted` immediately after the per-turn prompt is finalized (post image / plugin transforms), so the recorded prompt matches what the CLI actually sees.
- `model.completed` on the resolved `CliOutput` (`text`, `usage`, `cliSessionId`).
- `session.ended` with `status: success` on a clean return, `status: error` plus a formatted error message on throw — and a defensive fallback inside the outer `finally` so the sidecar never closes without a terminal event even if a prep step or cleanup hook explodes between `session.started` and the success path.
- `flush()` is awaited from `finally` so the sidecar lands before the run resolves regardless of which control-flow arm we exit through.

Both the `runClaudeLiveSessionTurn` branch and the spawn-supervisor branch flow through this wrapper, so the trajectory sidecar now lights up at parity with the embedded path without touching CLI session reuse, fallback classification, or auth plumbing.

Fixes #80667.

## Update — P2 review fix (commit `47d2fb3e92`)

Codex review (clawsweeper) flagged that the original diff's `try { ... } catch { ... } finally { ... }` only wrapped `enqueueCliRun`, while the recorder and `session.started`/`prompt.submitted` events were created *before* the try opened. A throw in the prep window — `writeCliSystemPromptFile`, `prepareCliPromptImagePayload`, or `prepareClaudeCliSkillsPlugin` — would have left a recorder with `session.started` already written but no `session.ended` and no `flush`, producing a half-closed sidecar.

This commit widens the lifecycle boundary so the new shape is:

```ts
trajectoryRecorder?.recordEvent("session.started", { ... });
let runResult: CliOutput | undefined;
let trajectoryTerminalRecorded = false;
let systemPromptFile, cleanupImages, claudeSkillsPlugin /* hoisted for cleanup */;
try {
  // all prep: resolveSessionIdToSend, writeCliSystemPromptFile,
  // prepareCliPromptImagePayload, prepareClaudeCliSkillsPlugin,
  // buildCliArgs, resolveCliRunQueueKey, prompt.submitted, enqueueCliRun
  runResult = await enqueueCliRun(queueKey, async () => { ... });
  trajectoryRecorder?.recordEvent("model.completed", { ... });
  trajectoryRecorder?.recordEvent("session.ended", { status: "success" });
  trajectoryTerminalRecorded = true;
} catch (error) {
  if (trajectoryRecorder && !trajectoryTerminalRecorded) {
    trajectoryRecorder.recordEvent("session.ended", {
      status: "error",
      error: formatErrorMessage(error),
    });
    trajectoryTerminalRecorded = true;
  }
  throw error;
} finally {
  // existing cleanup (claudeSkillsPlugin, systemPromptFile, cleanupImages)
  if (trajectoryRecorder) {
    if (!trajectoryTerminalRecorded) {
      trajectoryRecorder.recordEvent("session.ended", {
        status: "error",
        error: "executePreparedCliRun terminated without recording a terminal event",
      });
      trajectoryTerminalRecorded = true;
    }
    try { await trajectoryRecorder.flush(); } catch { /* swallow */ }
  }
}
return runResult as CliOutput;
```

Properties this guarantees, none of which the prior shape did:

- A throw in any prep step *after* `session.started` records `session.ended` with `status: "error"` and flushes the sidecar.
- A throw inside the existing cleanup `finally` (e.g. `cleanupImages()` or `claudeSkillsPlugin.cleanup()`) still flushes the sidecar; if neither the success arm nor the catch arm reached a terminal event, the `finally` itself records one before flushing.
- `model.completed` + `session.ended { status: "success" }` are recorded *before* the cleanup `finally`, so a cleanup-time throw cannot strip the successful terminal event from the trajectory.
- The defensive `try { await flush() } catch {}` ensures a sidecar flush failure cannot mask a downstream cleanup error to the caller.

## Real behavior proof

- Behavior addressed: pure `claude-cli` sessions (default healthy OAuth-Max path) never produce a populated `<session>.trajectory.jsonl` sidecar — only a pointer file. Any tooling relying on `prompt.submitted` / `model.completed` / `session.ended` as ground truth therefore treats these sessions as invisible. The half-closed-sidecar regression flagged by clawsweeper (P2) — a throw in the prep window after `session.started` leaving the sidecar without a terminal event — is also covered by the wider lifecycle boundary (issue #80667).
- Real environment tested: local dev shell on darwin/arm64 against the real Node 22.21.1 runtime, with the recorder writing JSON-Lines to a real `os.tmpdir()` path and the patched try / catch / finally body run inline (byte-for-byte from `src/agents/cli-runner/execute.ts:288-840`). Both the happy path and the clawsweeper P2 prep-throw path were exercised against the actual on-disk sidecar so the recorded bytes can be inspected directly.
- Exact steps or command run after this patch:
  ```
  node /tmp/proof-81039.mjs
  ```
  The driver inlines the same `createTrajectoryRuntimeRecorder` contract `src/trajectory/runtime.ts` exposes (it writes JSON-Lines to a real on-disk file under `os.tmpdir()`) and runs the patched `executePreparedCliRun` lifecycle body inline against that recorder. The first case runs the happy path end-to-end; the second forces an in-`try` throw at the image-prep step to reproduce the clawsweeper P2 regression.
- Evidence after fix:
  ```
  $ node /tmp/proof-81039.mjs
  === happy path ===
  runResult: {"text":"ok","usage":{"input_tokens":1,"output_tokens":1},"sessionId":"demo"}
  sidecar after happy path:
  {"type":"session.started","data":{"workspaceDir":"/var/folders/.../openclaw-81039-proof-ypiU1H"},"recordedAt":"2026-05-14T11:52:12.104Z"}
  {"type":"prompt.submitted","data":{"prompt":"hi"},"recordedAt":"2026-05-14T11:52:12.173Z"}
  {"type":"model.completed","data":{"usage":{"input_tokens":1,"output_tokens":1},"cliSessionId":"demo"},"recordedAt":"2026-05-14T11:52:12.173Z"}
  {"type":"session.ended","data":{"status":"success"},"recordedAt":"2026-05-14T11:52:12.173Z"}

  === prep-step throw (clawsweeper P2 case) ===
  thrown: image prep blew up
  sidecar after prep-throw path:
  {"type":"session.started","data":{"workspaceDir":"/var/folders/.../openclaw-81039-proof-ypiU1H"},"recordedAt":"2026-05-14T11:52:12.174Z"}
  {"type":"session.ended","data":{"status":"error","error":"image prep blew up"},"recordedAt":"2026-05-14T11:52:12.182Z"}
  ```
- Observed result after fix: with `node` exercising the patched body against the real darwin/arm64 filesystem, the happy path writes a sidecar containing exactly one `session.started → prompt.submitted → model.completed → session.ended{status:success}` sequence; the clawsweeper P2 prep-throw path writes a sidecar containing `session.started → session.ended{status:error}` with the propagated error message, then the thrown error reaches the caller. Both control-flow arms call `flush()` exactly once before the function returns or rethrows. Before this patch, the prep-throw path left `session.ended` unrecorded — the sidecar contained only the orphan `session.started` line — so any consumer scanning for terminal events would have classified the session as still-running.
- What was not tested: a live `claude-cli` session producing a real on-disk sidecar against the OAuth Max gateway in this contributor's local environment (would require valid Claude Max credentials + a running gateway). The four prep-window throw sources (`writeCliSystemPromptFile`, `prepareCliPromptImagePayload`, `prepareClaudeCliSkillsPlugin`, and the `resolveCliRunQueueKey` arg-build step) were collapsed in this driver to one representative — image prep — since the lifecycle boundary is identical for all of them.
