### PR TITLE
[Fix] Cap Lark/Feishu inbound media downloads

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -385,6 +385,7 @@ export async function resolveFeishuMediaList(params: {
           fileKey: imageKey,
           type: "image",
           accountId,
+          maxBytes,
         });
         const contentType =
           result.contentType ?? (await core.media.detectMime({ buffer: result.buffer }));
@@ -413,6 +414,7 @@ export async function resolveFeishuMediaList(params: {
           fileKey: media.fileKey,
           type: "file",
           accountId,
+          maxBytes,
         });
         const contentType =
           result.contentType ?? (await core.media.detectMime({ buffer: result.buffer }));
@@ -451,6 +453,7 @@ export async function resolveFeishuMediaList(params: {
       fileKey,
       type: toMessageResourceType(messageType),
       accountId,
+      maxBytes,
     });
     const contentType =
       result.contentType ?? (await core.media.detectMime({ buffer: result.buffer }));

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1796,6 +1796,7 @@ describe("handleFeishuMessage command authorization", () => {
       channels: {
         feishu: {
           dmPolicy: "open",
+          mediaMaxMb: 1,
         },
       },
     } as ClawdbotConfig;
@@ -1823,18 +1824,20 @@ describe("handleFeishuMessage command authorization", () => {
 
     const videoDownloadRequest = mockCallArg<{
       fileKey?: string;
+      maxBytes?: number;
       messageId?: string;
       type?: string;
     }>(mockDownloadMessageResourceFeishu, 0, 0);
     expect(videoDownloadRequest.messageId).toBe("msg-video-inbound");
     expect(videoDownloadRequest.fileKey).toBe("file_video_payload");
     expect(videoDownloadRequest.type).toBe("file");
+    expect(videoDownloadRequest.maxBytes).toBe(1024 * 1024);
     const mediaBuffer = mockCallArg<Buffer>(mockSaveMediaBuffer, 0, 0);
     expect(Buffer.isBuffer(mediaBuffer)).toBe(true);
     expect(mediaBuffer.toString()).toBe("video");
     expect(mockCallArg(mockSaveMediaBuffer, 0, 1)).toBe("video/mp4");
     expect(mockCallArg(mockSaveMediaBuffer, 0, 2)).toBe("inbound");
-    expect(typeof mockCallArg(mockSaveMediaBuffer, 0, 3)).toBe("number");
+    expect(mockCallArg(mockSaveMediaBuffer, 0, 3)).toBe(1024 * 1024);
     expect(mockCallArg(mockSaveMediaBuffer, 0, 4)).toBe("clip.mp4");
   });
 

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -1,6 +1,7 @@
-import { realpathSync } from "node:fs";
+import { promises as nodeFsPromises, realpathSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
@@ -93,6 +94,11 @@ function mockCallArg<T>(
   const call = mock.mock.calls[callIndex];
   expect(call).toBeDefined();
   return call?.[argIndex] as T;
+}
+
+function arrayBufferFromText(text: string): ArrayBuffer {
+  const buffer = Buffer.from(text);
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
 }
 
 function callData<T>(
@@ -706,6 +712,89 @@ describe("downloadMessageResourceFeishu", () => {
     expect(request.params).toEqual({ type: "image" });
     expectMediaTimeoutClientConfigured();
     expect(result.buffer).toBeInstanceOf(Buffer);
+  });
+
+  it("rejects buffer-like message resources that exceed maxBytes", async () => {
+    const responses: unknown[] = [
+      Buffer.from("abcde"),
+      arrayBufferFromText("abcde"),
+      { data: Buffer.from("abcde") },
+      { data: arrayBufferFromText("abcde") },
+    ];
+
+    for (const [index, response] of responses.entries()) {
+      messageResourceGetMock.mockResolvedValueOnce(response);
+
+      await expect(
+        downloadMessageResourceFeishu({
+          cfg: emptyConfig,
+          messageId: `om_over_limit_${index}`,
+          fileKey: `file_key_over_limit_${index}`,
+          type: "file",
+          maxBytes: 4,
+        }),
+      ).rejects.toThrow("payload exceeds maxBytes 4");
+    }
+  });
+
+  it("rejects readable message resources when chunks exceed maxBytes", async () => {
+    messageResourceGetMock.mockResolvedValueOnce({
+      getReadableStream: () => Readable.from([Buffer.from("abc"), Buffer.from("de")]),
+    });
+
+    await expect(
+      downloadMessageResourceFeishu({
+        cfg: emptyConfig,
+        messageId: "om_stream_over_limit",
+        fileKey: "file_key_stream_over_limit",
+        type: "file",
+        maxBytes: 4,
+      }),
+    ).rejects.toThrow("payload exceeds maxBytes 4");
+  });
+
+  it("rejects async-iterable message resources when chunks exceed maxBytes", async () => {
+    messageResourceGetMock.mockResolvedValueOnce({
+      async *[Symbol.asyncIterator]() {
+        yield Buffer.from("abc");
+        yield "de";
+      },
+    });
+
+    await expect(
+      downloadMessageResourceFeishu({
+        cfg: emptyConfig,
+        messageId: "om_async_over_limit",
+        fileKey: "file_key_async_over_limit",
+        type: "file",
+        maxBytes: 4,
+      }),
+    ).rejects.toThrow("payload exceeds maxBytes 4");
+  });
+
+  it("rejects over-limit writeFile downloads before reading the temp file", async () => {
+    const readFileSpy = vi.spyOn(nodeFsPromises, "readFile");
+    messageResourceGetMock.mockResolvedValueOnce({
+      writeFile: async (tmpPath: string) => {
+        await fs.writeFile(tmpPath, Buffer.from("abcde"));
+      },
+    });
+
+    try {
+      await expect(
+        downloadMessageResourceFeishu({
+          cfg: emptyConfig,
+          messageId: "om_write_file_over_limit",
+          fileKey: "file_key_write_file_over_limit",
+          type: "file",
+          maxBytes: 4,
+        }),
+      ).rejects.toThrow("payload exceeds maxBytes 4");
+
+      expect(readFileSpy).not.toHaveBeenCalled();
+    } finally {
+      readFileSpy.mockRestore();
+    }
   });
 
   it("extracts content-type and filename metadata from download headers", async () => {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -242,25 +242,82 @@ function extractFeishuDownloadMetadata(response: FeishuDownloadResponse): {
   return { contentType, fileName };
 }
 
-async function readReadableBuffer(stream: Readable): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of stream) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+function createFeishuDownloadSizeError(params: { errorPrefix: string; maxBytes: number }): Error {
+  return new Error(`${params.errorPrefix}: payload exceeds maxBytes ${params.maxBytes}`);
+}
+
+function checkedFeishuDownloadBuffer(
+  buffer: Buffer,
+  params: { errorPrefix: string; maxBytes?: number },
+): Buffer {
+  if (params.maxBytes !== undefined && buffer.byteLength > params.maxBytes) {
+    throw createFeishuDownloadSizeError({
+      errorPrefix: params.errorPrefix,
+      maxBytes: params.maxBytes,
+    });
   }
-  return Buffer.concat(chunks);
+  return buffer;
+}
+
+function toReadableBufferChunk(chunk: Buffer | Uint8Array | string): Buffer {
+  return Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+}
+
+async function readReadableBuffer(
+  stream: Readable,
+  params: { errorPrefix: string; maxBytes?: number },
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of stream) {
+    const buffer = toReadableBufferChunk(chunk);
+    const nextTotal = total + buffer.byteLength;
+    if (params.maxBytes !== undefined && nextTotal > params.maxBytes) {
+      stream.destroy();
+      throw createFeishuDownloadSizeError({
+        errorPrefix: params.errorPrefix,
+        maxBytes: params.maxBytes,
+      });
+    }
+    chunks.push(buffer);
+    total = nextTotal;
+  }
+  return Buffer.concat(chunks, total);
+}
+
+async function readAsyncIterableBuffer(
+  asyncIterable: AsyncIterable<Buffer | Uint8Array | string>,
+  params: { errorPrefix: string; maxBytes?: number },
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of asyncIterable) {
+    const buffer = toReadableBufferChunk(chunk);
+    const nextTotal = total + buffer.byteLength;
+    if (params.maxBytes !== undefined && nextTotal > params.maxBytes) {
+      throw createFeishuDownloadSizeError({
+        errorPrefix: params.errorPrefix,
+        maxBytes: params.maxBytes,
+      });
+    }
+    chunks.push(buffer);
+    total = nextTotal;
+  }
+  return Buffer.concat(chunks, total);
 }
 
 async function readFeishuResponseBuffer(params: {
   response: FeishuDownloadResponse;
   tmpDirPrefix: string;
   errorPrefix: string;
+  maxBytes?: number;
 }): Promise<Buffer> {
   const { response } = params;
   if (Buffer.isBuffer(response)) {
-    return response;
+    return checkedFeishuDownloadBuffer(response, params);
   }
   if (response instanceof ArrayBuffer) {
-    return Buffer.from(response);
+    return checkedFeishuDownloadBuffer(Buffer.from(response), params);
   }
   const responseWithOptionalFields = response as FeishuDownloadResponse & {
     code?: number;
@@ -275,30 +332,35 @@ async function readFeishuResponseBuffer(params: {
   }
 
   if (responseWithOptionalFields.data && Buffer.isBuffer(responseWithOptionalFields.data)) {
-    return responseWithOptionalFields.data;
+    return checkedFeishuDownloadBuffer(responseWithOptionalFields.data, params);
   }
   if (responseWithOptionalFields.data instanceof ArrayBuffer) {
-    return Buffer.from(responseWithOptionalFields.data);
+    return checkedFeishuDownloadBuffer(Buffer.from(responseWithOptionalFields.data), params);
   }
   if (typeof response.getReadableStream === "function") {
-    return readReadableBuffer(response.getReadableStream());
+    return readReadableBuffer(response.getReadableStream(), params);
   }
   if (typeof response.writeFile === "function") {
     return await withTempDownloadPath({ prefix: params.tmpDirPrefix }, async (tmpPath) => {
       await response.writeFile(tmpPath);
+      if (params.maxBytes !== undefined) {
+        const stat = await fs.promises.stat(tmpPath);
+        if (stat.size > params.maxBytes) {
+          throw createFeishuDownloadSizeError({
+            errorPrefix: params.errorPrefix,
+            maxBytes: params.maxBytes,
+          });
+        }
+      }
       return await fs.promises.readFile(tmpPath);
     });
   }
   if (responseWithOptionalFields[Symbol.asyncIterator]) {
     const asyncIterable = responseWithOptionalFields as AsyncIterable<Buffer | Uint8Array | string>;
-    const chunks: Buffer[] = [];
-    for await (const chunk of asyncIterable) {
-      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    }
-    return Buffer.concat(chunks);
+    return readAsyncIterableBuffer(asyncIterable, params);
   }
   if (response instanceof Readable) {
-    return readReadableBuffer(response);
+    return readReadableBuffer(response, params);
   }
 
   const keys = Object.keys(response as object);
@@ -313,8 +375,9 @@ export async function downloadImageFeishu(params: {
   cfg: ClawdbotConfig;
   imageKey: string;
   accountId?: string;
+  maxBytes?: number;
 }): Promise<DownloadImageResult> {
-  const { cfg, imageKey, accountId } = params;
+  const { cfg, imageKey, accountId, maxBytes } = params;
   const normalizedImageKey = normalizeFeishuExternalKey(imageKey);
   if (!normalizedImageKey) {
     throw new Error("Feishu image download failed: invalid image_key");
@@ -329,6 +392,7 @@ export async function downloadImageFeishu(params: {
     response,
     tmpDirPrefix: "openclaw-feishu-img-",
     errorPrefix: "Feishu image download failed",
+    maxBytes,
   });
   const meta = extractFeishuDownloadMetadata(response);
   return { buffer, contentType: meta.contentType };
@@ -339,6 +403,7 @@ async function downloadMessageResourceWithType(params: {
   messageId: string;
   fileKey: string;
   type: FeishuMessageResourceDownloadType;
+  maxBytes?: number;
 }): Promise<DownloadMessageResourceResult> {
   const response = await params.client.im.messageResource.get({
     path: { message_id: params.messageId, file_key: params.fileKey },
@@ -349,6 +414,7 @@ async function downloadMessageResourceWithType(params: {
     response,
     tmpDirPrefix: "openclaw-feishu-resource-",
     errorPrefix: "Feishu message resource download failed",
+    maxBytes: params.maxBytes,
   });
   return { buffer, ...extractFeishuDownloadMetadata(response) };
 }
@@ -363,8 +429,9 @@ export async function downloadMessageResourceFeishu(params: {
   fileKey: string;
   type: "image" | "file";
   accountId?: string;
+  maxBytes?: number;
 }): Promise<DownloadMessageResourceResult> {
-  const { cfg, messageId, fileKey, type, accountId } = params;
+  const { cfg, messageId, fileKey, type, accountId, maxBytes } = params;
   const normalizedFileKey = normalizeFeishuExternalKey(fileKey);
   if (!normalizedFileKey) {
     throw new Error("Feishu message resource download failed: invalid file_key");
@@ -377,6 +444,7 @@ export async function downloadMessageResourceFeishu(params: {
       messageId,
       fileKey: normalizedFileKey,
       type,
+      maxBytes,
     });
   } catch (err) {
     if (type !== "file" || !isHttpStatusError(err, 502)) {
@@ -388,6 +456,7 @@ export async function downloadMessageResourceFeishu(params: {
         messageId,
         fileKey: normalizedFileKey,
         type: "media",
+        maxBytes,
       });
     } catch {
       throw err;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Feishu inbound media downloads could fully buffer or read back over-limit resources before `saveMediaBuffer` rejected them.
- Why it matters: large inbound media could consume memory or read large temp files even when the configured Feishu media cap should reject the payload.
- What changed: Feishu response reads now accept `maxBytes`, reject over-limit `Buffer`, `ArrayBuffer`, `data`, readable stream, async iterable, and `writeFile` temp-file responses, and inbound message handling passes the same cap into the download helper.
- What did NOT change (scope boundary): no WhatsApp changes, no provider SDK rewrite, no shared media-store redesign, and no Feishu outbound send behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: over-limit Feishu inbound media must be rejected while reading the SDK response or before reading a temp file back into memory.
- Real environment tested: local OpenClaw source checkout on Darwin 25.4.0 arm64, Node v24.14.0 for CLI commands, managed Gateway runtime on Node v25.9.0, pnpm 11.0.8, Feishu default channel connected over WebSocket with real app credentials and `channels.feishu.mediaMaxMb = 1`.
- Exact steps or command run after this patch:
  1. Installed/restarted the managed Gateway from this checkout.
  2. Verified the LaunchAgent command points at this PR checkout with `pnpm openclaw gateway status --deep`.
  3. Verified Feishu is running with `pnpm openclaw channels status --deep`.
  4. Sent an over-limit document to the configured Feishu bot in a real p2p DM.
  5. Watched `/tmp/openclaw/openclaw-2026-05-12.log` for Feishu/media/download lines.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ pnpm openclaw gateway status --deep
Command: /opt/homebrew/bin/node /Users/x/git/openclaw--fix--feishu-inbound-media-streaming-cap/dist/index.js gateway --port 18789
Runtime: running (pid 94522, state active)
Connectivity probe: ok

$ pnpm openclaw channels status --deep
Gateway reachable.
- Feishu default: enabled, configured, running

Live Feishu p2p DM, redacted open_id/chat_id, channels.feishu.mediaMaxMb = 1
2026-05-12T14:18:42.982Z info channels/feishu feishu[default]: received message from ou_[redacted] in oc_[redacted] (p2p)
2026-05-12T14:18:42.997Z info channels/feishu feishu[default]: Feishu[default] DM from ou_[redacted]: <media:document> (ChatGPT Image Apr 23, 2026, 09_06_58 PM.png)
2026-05-12T14:18:43.854Z info channels/feishu feishu: failed to download file media: Error: Feishu message resource download failed: payload exceeds maxBytes 1048576
```

Supplemental targeted regression proof:

```text
$ node scripts/test-projects.mjs extensions/feishu/src/media.test.ts extensions/feishu/src/bot.test.ts -- --reporter=verbose
[test] starting test/vitest/vitest.extension-feishu.config.ts

RUN  v4.1.5 /Users/x/git/openclaw--fix--feishu-inbound-media-streaming-cap

✓ extensions/feishu/src/media.test.ts > downloadMessageResourceFeishu > rejects buffer-like message resources that exceed maxBytes
✓ extensions/feishu/src/media.test.ts > downloadMessageResourceFeishu > rejects readable message resources when chunks exceed maxBytes
✓ extensions/feishu/src/media.test.ts > downloadMessageResourceFeishu > rejects async-iterable message resources when chunks exceed maxBytes
✓ extensions/feishu/src/media.test.ts > downloadMessageResourceFeishu > rejects over-limit writeFile downloads before reading the temp file
✓ extensions/feishu/src/bot.test.ts > handleFeishuMessage command authorization > uses video file_key (not thumbnail image_key) for inbound video download

Test Files  2 passed (2)
Tests  108 passed (108)
[test] passed 1 Vitest shard in 4.48s
```

- Observed result after fix: the live Feishu document hit the bounded message-resource download path and failed with `Feishu message resource download failed: payload exceeds maxBytes 1048576`, before the older final persistence cap error `Media exceeds 1MB limit`.
- What was not tested: live under-limit Feishu media success in this proof pass; the existing tests cover successful bounded reads for in-limit fixtures.
- Before evidence (optional but encouraged): before switching the managed Gateway to this PR checkout, the same real Feishu over-limit flow failed later with `Media exceeds 1MB limit`. The targeted command also failed before the production fix with 5 failures: the bot download request had `maxBytes: undefined`, and the buffer-like, readable, async-iterable, and `writeFile` over-limit fixtures resolved instead of rejecting.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `downloadMessageResourceFeishu` did not accept the inbound media cap, and `readFeishuResponseBuffer` returned fully materialized buffers for Feishu SDK response shapes before any size check.
- Missing detection / guardrail: Feishu media tests covered response shapes and metadata, but not over-limit streaming, async-iterator, buffer-like, or temp-file read-back paths.
- Contributing context (if known): `saveMediaBuffer` had the final persistence cap, which hid the fact that download/read-back had already materialized the payload.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/media.test.ts`, `extensions/feishu/src/bot.test.ts`.
- Scenario the test should lock in: Feishu download rejects over-limit buffer-like, stream, async-iterable, and `writeFile` responses, and inbound media download receives the configured `maxBytes` before persistence.
- Why this is the smallest reliable guardrail: the behavior lives at the Feishu SDK response-reader seam and the inbound bot handoff into that seam.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A; new regression tests are included.

## User-visible / Behavior Changes

Over-limit Feishu inbound media is rejected earlier during download/read-back instead of only at final media-store persistence.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
Feishu SDK response -> full buffer/readFile -> saveMediaBuffer(maxBytes) -> reject

After:
Feishu SDK response -> bounded read/stat(maxBytes) -> reject or buffer -> saveMediaBuffer(maxBytes)
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Darwin 25.4.0 arm64
- Runtime/container: local source checkout, Node v24.14.0, pnpm 11.0.8
- Model/provider: N/A
- Integration/channel (if any): Feishu plugin
- Relevant config (redacted): test fixture `channels.feishu.mediaMaxMb = 1`; Feishu app credentials configured locally and redacted; `channels.feishu.mediaMaxMb = 1`

### Steps

1. Run `pnpm test extensions/feishu/src/media.test.ts extensions/feishu/src/bot.test.ts -- --reporter=verbose`.
2. Observe the over-limit Feishu response-shape tests and inbound bot cap-forwarding test.
3. Run touched-surface lint/format checks for the four changed Feishu files.

### Expected

- Over-limit Feishu SDK response shapes reject before returning a buffer.
- Inbound bot media download forwards the configured byte cap to `downloadMessageResourceFeishu`.
- Touched Feishu files pass lint and format checks.

### Actual

- Targeted Feishu tests passed: 2 files, 108 tests.
- Touched Feishu files passed oxlint and oxfmt checks.
- `pnpm check:changed` passed conflict-marker, changelog attribution, wildcard re-export, duplicate coverage, extension typecheck, and extension-test typecheck gates, then failed on an unrelated pre-existing browser lint issue: `extensions/browser/src/cli/browser-cli-state.option-collisions.test.ts:41 no-control-regex`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Feishu media/bot tests, changed-lane discovery, touched-file oxlint, touched-file oxfmt, `git diff --check`, and pre-ship review scan.
- Edge cases checked: exact cap boundary rejection for buffer-like responses, chunked readable stream overflow, async-iterable overflow, temp-file size check before `readFile`, and inbound configured `mediaMaxMb` propagation.
- What you did **not** verify: live under-limit Feishu media success in this proof pass.

## AI-assisted disclosure

- [x] This PR was implemented with Codex assistance.
- [x] I reviewed the diff and ran the verification above from my local checkout.
- [x] No `CHANGELOG.md` changes are included.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

No existing bot review conversations for this new PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: The Feishu SDK `writeFile` path still downloads the resource into a temp file before OpenClaw can inspect file size.
  - Mitigation: this PR rejects before reading that temp file back into memory and keeps `saveMediaBuffer` as the final cap. A deeper SDK-level streaming/cancel path would be a separate change if Feishu exposes a suitable API.
