### PR TITLE
Persist model exhaustion cooldowns

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1044,6 +1044,8 @@ async function agentCommandInternal(
           provider,
           model,
           runId,
+          sessionId,
+          sessionAgentId,
           agentDir,
           fallbacksOverride: effectiveFallbacksOverride,
           onFallbackStep: (step) => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -694,6 +694,9 @@ async function agentCommandInternal(
         sessionStartedAt: current.sessionStartedAt ?? now,
         skillsSnapshot,
       };
+      if (current.sessionId !== sessionId) {
+        delete next.exhaustedModels;
+      }
       await persistSessionEntry({
         sessionStore,
         sessionKey,
@@ -715,6 +718,9 @@ async function agentCommandInternal(
         sessionStartedAt: entry.sessionStartedAt ?? now,
         lastInteractionAt: now,
       };
+      if (entry.sessionId !== sessionId) {
+        delete next.exhaustedModels;
+      }
       if (thinkOverride) {
         next.thinkingLevel = thinkOverride;
       }

--- a/src/agents/model-exhaustion-session.test.ts
+++ b/src/agents/model-exhaustion-session.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { runWithModelFallback } from "./model-fallback.js";
+import { updateSessionStoreEntry, resolveStoredSessionKeyForSessionId } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { FailoverError } from "./failover-error.js";
+
+vi.mock("../config/sessions.js", () => ({
+  updateSessionStoreEntry: vi.fn(),
+  resolveStoredSessionKeyForSessionId: vi.fn(),
+}));
+
+vi.mock("./auth-profiles/source-check.js", () => ({
+  hasAnyAuthProfileStoreSource: vi.fn(() => false),
+}));
+
+describe("model exhaustion session persistence", () => {
+  const cfg: OpenClawConfig = {
+    agents: {
+      defaults: {
+        modelExhaustionRetryMinutes: 10,
+        model: {
+          primary: "openai/gpt-4o",
+          fallbacks: ["anthropic/claude-3-5-sonnet", "google/gemini-1.5-pro"],
+        },
+      },
+    },
+  } as any as OpenClawConfig;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips multiple exhausted models in the same session", async () => {
+    const sessionId = "test-session";
+    const sessionKey = "test-session-key";
+    const storePath = "/tmp/test-sessions.json";
+    const now = Date.now();
+
+    const exhaustedModels = {
+      "openai/gpt-4o": now + 600000,
+      "anthropic/claude-3-5-sonnet": now + 600000,
+    };
+
+    const sessionEntry = {
+      sessionId,
+      exhaustedModels,
+    };
+
+    (resolveStoredSessionKeyForSessionId as any).mockReturnValue({
+      sessionKey,
+      sessionStore: { [sessionKey]: sessionEntry },
+      storePath,
+    });
+
+    const run = vi.fn().mockResolvedValue("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4o",
+      sessionId,
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(result.provider).toBe("google");
+    expect(result.model).toBe("gemini-1.5-pro");
+    // Should have skipped gpt-4o and claude-3-5-sonnet
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("google", "gemini-1.5-pro");
+  });
+
+  it("records multiple exhausted models in the same session", async () => {
+    const sessionId = "test-session";
+    const sessionKey = "test-session-key";
+    const storePath = "/tmp/test-sessions.json";
+
+    (resolveStoredSessionKeyForSessionId as any).mockReturnValue({
+      sessionKey,
+      sessionStore: { [sessionKey]: { sessionId } },
+      storePath,
+    });
+
+    const run = vi.fn()
+      .mockRejectedValueOnce(new FailoverError("rate limit", { reason: "rate_limit", provider: "openai", model: "gpt-4o" }))
+      .mockResolvedValueOnce("ok");
+
+    await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4o",
+      sessionId,
+      run,
+    });
+
+    expect(updateSessionStoreEntry).toHaveBeenCalled();
+    const updateCall = (updateSessionStoreEntry as any).mock.calls[0][0];
+    expect(updateCall.sessionKey).toBe(sessionKey);
+    
+    // Test the update function
+    const entry = { sessionId };
+    const updateResult = await updateCall.update(entry);
+    expect(updateResult.exhaustedModels).toBeDefined();
+    expect(updateResult.exhaustedModels["openai/gpt-4o"]).toBeGreaterThan(Date.now());
+  });
+});

--- a/src/agents/model-exhaustion-session.test.ts
+++ b/src/agents/model-exhaustion-session.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import { runWithModelFallback } from "./model-fallback.js";
-import { updateSessionStoreEntry, resolveStoredSessionKeyForSessionId } from "./command/session.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { updateSessionStoreEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveStoredSessionKeyForSessionId } from "./command/session.js";
 import { FailoverError } from "./failover-error.js";
+import { runWithModelFallback } from "./model-fallback.js";
 
 vi.mock("./command/session.js", () => ({
-  updateSessionStoreEntry: vi.fn(),
   resolveStoredSessionKeyForSessionId: vi.fn(),
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  updateSessionStoreEntry: vi.fn(),
 }));
 
 vi.mock("./auth-profiles/source-check.js", () => ({
@@ -65,7 +69,6 @@ describe("model exhaustion session persistence", () => {
     expect(result.result).toBe("ok");
     expect(result.provider).toBe("google");
     expect(result.model).toBe("gemini-1.5-pro");
-    // Should have skipped gpt-4o and claude-3-5-sonnet
     expect(run).toHaveBeenCalledTimes(1);
     expect(run).toHaveBeenCalledWith("google", "gemini-1.5-pro");
   });
@@ -81,8 +84,15 @@ describe("model exhaustion session persistence", () => {
       storePath,
     });
 
-    const run = vi.fn()
-      .mockRejectedValueOnce(new FailoverError("rate limit", { reason: "rate_limit", provider: "openai", model: "gpt-4o" }))
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new FailoverError("rate limit", {
+          reason: "rate_limit",
+          provider: "openai",
+          model: "gpt-4o",
+        }),
+      )
       .mockResolvedValueOnce("ok");
 
     await runWithModelFallback({
@@ -96,8 +106,7 @@ describe("model exhaustion session persistence", () => {
     expect(updateSessionStoreEntry).toHaveBeenCalled();
     const updateCall = (updateSessionStoreEntry as any).mock.calls[0][0];
     expect(updateCall.sessionKey).toBe(sessionKey);
-    
-    // Test the update function
+
     const entry = { sessionId };
     const updateResult = await updateCall.update(entry);
     expect(updateResult.exhaustedModels).toBeDefined();

--- a/src/agents/model-exhaustion-session.test.ts
+++ b/src/agents/model-exhaustion-session.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { runWithModelFallback } from "./model-fallback.js";
-import { updateSessionStoreEntry, resolveStoredSessionKeyForSessionId } from "../config/sessions.js";
+import { updateSessionStoreEntry, resolveStoredSessionKeyForSessionId } from "./command/session.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { FailoverError } from "./failover-error.js";
 

--- a/src/agents/model-exhaustion-session.test.ts
+++ b/src/agents/model-exhaustion-session.test.ts
@@ -4,7 +4,7 @@ import { updateSessionStoreEntry, resolveStoredSessionKeyForSessionId } from "./
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { FailoverError } from "./failover-error.js";
 
-vi.mock("../config/sessions.js", () => ({
+vi.mock("./command/session.js", () => ({
   updateSessionStoreEntry: vi.fn(),
   resolveStoredSessionKeyForSessionId: vi.fn(),
 }));

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1,7 +1,10 @@
+import path from "node:path";
 import {
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
 } from "../config/model-input.js";
+import { updateSessionStoreEntry } from "../config/sessions.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitFailoverEvent } from "../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -13,6 +16,7 @@ import { sanitizeForLog } from "../terminal/ansi.js";
 import { externalCliDiscoveryForProviders } from "./auth-profiles/external-cli-discovery.js";
 import { hasAnyAuthProfileStoreSource } from "./auth-profiles/source-check.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { resolveStoredSessionKeyForSessionId } from "./command/session.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import {
   FailoverError,
@@ -206,6 +210,89 @@ function buildFallbackSuccess<T>(params: {
     model: params.model,
     attempts: params.attempts,
   };
+}
+
+const DEFAULT_MODEL_EXHAUSTION_RETRY_MINUTES = 10;
+
+function resolveModelExhaustionRetryMs(cfg: OpenClawConfig | undefined): number {
+  const raw = Number((cfg as any)?.agents?.defaults?.modelExhaustionRetryMinutes);
+  const minutes = Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MODEL_EXHAUSTION_RETRY_MINUTES;
+  return minutes * 60_000;
+}
+
+function resolveSessionModelExhaustionState(params: {
+  cfg: OpenClawConfig | undefined;
+  sessionId?: string;
+  agentDir?: string;
+}): { sessionKey: string; storePath: string; exhaustedModels: Record<string, number> } | null {
+  if (!params.cfg || !params.sessionId) {
+    return null;
+  }
+
+  const { sessionKey, sessionStore, storePath } = resolveStoredSessionKeyForSessionId({
+    cfg: params.cfg,
+    sessionId: params.sessionId,
+    agentId: params.agentDir ? path.basename(params.agentDir) : undefined,
+  });
+
+  if (!sessionKey) {
+    return null;
+  }
+
+  return {
+    sessionKey,
+    storePath,
+    exhaustedModels: { ...(sessionStore[sessionKey]?.exhaustedModels ?? {}) },
+  };
+}
+
+function isModelSessionCooldownActive(params: {
+  exhaustedModels: Record<string, number>;
+  provider: string;
+  model: string;
+  now: number;
+}): boolean {
+  const expiresAt = params.exhaustedModels[modelKey(params.provider, params.model)];
+  return typeof expiresAt === "number" && Number.isFinite(expiresAt) && expiresAt > params.now;
+}
+
+async function persistSessionModelExhaustion(params: {
+  cfg: OpenClawConfig | undefined;
+  state: { sessionKey: string; storePath: string; exhaustedModels: Record<string, number> };
+  provider: string;
+  model: string;
+  clear?: boolean;
+}): Promise<void> {
+  const key = modelKey(params.provider, params.model);
+  const now = Date.now();
+
+  try {
+    await updateSessionStoreEntry({
+      storePath: params.state.storePath,
+      sessionKey: params.state.sessionKey,
+      update: async () => {
+        const nextExhaustedModels = { ...params.state.exhaustedModels };
+        if (params.clear) {
+          delete nextExhaustedModels[key];
+        } else {
+          nextExhaustedModels[key] = now + resolveModelExhaustionRetryMs(params.cfg);
+        }
+        return { exhaustedModels: nextExhaustedModels };
+      },
+    });
+
+    if (params.clear) {
+      delete params.state.exhaustedModels[key];
+    } else {
+      params.state.exhaustedModels[key] = now + resolveModelExhaustionRetryMs(params.cfg);
+    }
+  } catch (err) {
+    log.warn("failed to persist session model exhaustion", {
+      provider: params.provider,
+      model: params.model,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 async function runFallbackCandidate<T>(params: {
@@ -847,6 +934,11 @@ export async function runWithModelFallback<T>(params: {
         }),
       })
     : null;
+  const sessionModelExhaustionState = resolveSessionModelExhaustionState({
+    cfg: params.cfg,
+    sessionId: params.sessionId,
+    agentDir: params.agentDir,
+  });
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
   const cooldownProbeUsedProviders = new Set<string>();
@@ -881,6 +973,43 @@ export async function runWithModelFallback<T>(params: {
     const requestedModel = requestedCandidate
       ? sameModelCandidate(candidate, requestedCandidate)
       : false;
+
+    if (
+      sessionModelExhaustionState &&
+      isModelSessionCooldownActive({
+        exhaustedModels: sessionModelExhaustionState.exhaustedModels,
+        provider: candidate.provider,
+        model: candidate.model,
+        now: Date.now(),
+      })
+    ) {
+      const error = `Model ${candidate.provider}/${candidate.model} is in session cooldown`;
+      attempts.push({
+        provider: candidate.provider,
+        model: candidate.model,
+        error,
+        reason: "rate_limit",
+      });
+      await observeDecision({
+        decision: "skip_candidate",
+        runId: params.runId,
+        sessionId: params.sessionId,
+        lane: params.lane,
+        requestedProvider: params.provider,
+        requestedModel: params.model,
+        candidate,
+        attempt: i + 1,
+        total: candidates.length,
+        reason: "rate_limit",
+        error,
+        nextCandidate: candidates[i + 1],
+        isPrimary,
+        requestedModelMatched: requestedModel,
+        fallbackConfigured: hasFallbackCandidates,
+      });
+      continue;
+    }
+
     let runOptions: ModelFallbackRunOptions | undefined;
     let attemptedDuringCooldown = false;
     let transientProbeProviderForAttempt: string | null = null;
@@ -1062,6 +1191,15 @@ export async function runWithModelFallback<T>(params: {
       attribution: { sessionId: params.sessionId, lane: params.lane },
     });
     if ("success" in attemptRun) {
+      if (sessionModelExhaustionState) {
+        await persistSessionModelExhaustion({
+          cfg: params.cfg,
+          state: sessionModelExhaustionState,
+          provider: candidate.provider,
+          model: candidate.model,
+          clear: true,
+        });
+      }
       if (i > 0 || attempts.length > 0 || attemptedDuringCooldown) {
         await observeDecision({
           decision: "candidate_succeeded",
@@ -1160,6 +1298,19 @@ export async function runWithModelFallback<T>(params: {
       // there are remaining candidates.  Only abort/context-overflow errors
       // (handled above) are truly non-retryable.
       const isKnownFailover = isFailoverError(normalized);
+      const failureDescription = describeFailoverError(normalized);
+      if (
+        sessionModelExhaustionState &&
+        isKnownFailover &&
+        shouldUseTransientCooldownProbeSlot(failureDescription.reason)
+      ) {
+        await persistSessionModelExhaustion({
+          cfg: params.cfg,
+          state: sessionModelExhaustionState,
+          provider: candidate.provider,
+          model: candidate.model,
+        });
+      }
       if (!isKnownFailover && i === candidates.length - 1) {
         throw err;
       }

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -223,6 +223,7 @@ function resolveModelExhaustionRetryMs(cfg: OpenClawConfig | undefined): number 
 function resolveSessionModelExhaustionState(params: {
   cfg: OpenClawConfig | undefined;
   sessionId?: string;
+  sessionAgentId?: string;
   agentDir?: string;
 }): { sessionKey: string; storePath: string; exhaustedModels: Record<string, number> } | null {
   if (!params.cfg || !params.sessionId) {
@@ -232,7 +233,9 @@ function resolveSessionModelExhaustionState(params: {
   const { sessionKey, sessionStore, storePath } = resolveStoredSessionKeyForSessionId({
     cfg: params.cfg,
     sessionId: params.sessionId,
-    agentId: params.agentDir ? path.basename(path.dirname(params.agentDir)) : undefined,
+    agentId:
+      params.sessionAgentId ??
+      (params.agentDir ? path.basename(path.dirname(params.agentDir)) : undefined),
   });
 
   if (!sessionKey) {
@@ -909,6 +912,7 @@ export async function runWithModelFallback<T>(params: {
   model: string;
   runId?: string;
   sessionId?: string;
+  sessionAgentId?: string;
   lane?: string;
   agentDir?: string;
   /** Optional explicit fallbacks list; when provided (even empty), replaces agents.defaults.model.fallbacks. */
@@ -939,6 +943,7 @@ export async function runWithModelFallback<T>(params: {
   const sessionModelExhaustionState = resolveSessionModelExhaustionState({
     cfg: params.cfg,
     sessionId: params.sessionId,
+    sessionAgentId: params.sessionAgentId,
     agentDir: params.agentDir,
   });
   const attempts: FallbackAttempt[] = [];

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -232,7 +232,7 @@ function resolveSessionModelExhaustionState(params: {
   const { sessionKey, sessionStore, storePath } = resolveStoredSessionKeyForSessionId({
     cfg: params.cfg,
     sessionId: params.sessionId,
-    agentId: params.agentDir ? path.basename(params.agentDir) : undefined,
+    agentId: params.agentDir ? path.basename(path.dirname(params.agentDir)) : undefined,
   });
 
   if (!sessionKey) {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -267,11 +267,11 @@ async function persistSessionModelExhaustion(params: {
   const now = Date.now();
 
   try {
-    await updateSessionStoreEntry({
+    const persisted = await updateSessionStoreEntry({
       storePath: params.state.storePath,
       sessionKey: params.state.sessionKey,
-      update: async () => {
-        const nextExhaustedModels = { ...params.state.exhaustedModels };
+      update: async (entry: SessionEntry) => {
+        const nextExhaustedModels = { ...(entry.exhaustedModels ?? {}) };
         if (params.clear) {
           delete nextExhaustedModels[key];
         } else {
@@ -281,7 +281,9 @@ async function persistSessionModelExhaustion(params: {
       },
     });
 
-    if (params.clear) {
+    if (persisted?.exhaustedModels) {
+      params.state.exhaustedModels = { ...persisted.exhaustedModels };
+    } else if (params.clear) {
       delete params.state.exhaustedModels[key];
     } else {
       params.state.exhaustedModels[key] = now + resolveModelExhaustionRetryMs(params.cfg);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -243,6 +243,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Default max characters kept for a single live tool result before truncation. This affects both persisted live tool-result writes and overflow-recovery truncation heuristics.",
   "agents.defaults.contextLimits.postCompactionMaxChars":
     "Default max characters retained from AGENTS.md during post-compaction context refresh injection. Lower this to make compaction recovery cheaper, or raise it for agents that depend on longer startup guidance.",
+  "agents.defaults.modelExhaustionRetryMinutes":
+    "How long, in minutes, a model stays excluded after it exhausts the session fallback path. Use a smaller positive value to retry sooner, or raise it when repeated rate-limit bursts should stay quarantined longer.",
   "agents.list":
     "Explicit list of configured agents with IDs and optional overrides for model, tools, identity, and workspace. Keep IDs stable over time so bindings, approvals, and session routing remain deterministic.",
   "agents.list[].skillsLimits":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -86,6 +86,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.contextLimits.memoryGetDefaultLines": "Default memory_get Line Window",
   "agents.defaults.contextLimits.toolResultMaxChars": "Default Tool Result Max Chars",
   "agents.defaults.contextLimits.postCompactionMaxChars": "Default Post-compaction Max Chars",
+  "agents.defaults.modelExhaustionRetryMinutes": "Model Exhaustion Retry Minutes",
   "agents.defaults.agentRuntime": "Legacy Default Agent Runtime",
   "agents.defaults.agentRuntime.id": "Legacy Default Agent Runtime ID",
   "agents.defaults.embeddedHarness": "Default Legacy Embedded Harness Settings",

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -218,6 +218,8 @@ export type SessionEntry = {
   subagentRecovery?: SubagentRecoveryState;
   /** Quota cascade protection and state-aware failover status. */
   quotaSuspension?: QuotaSuspension;
+  /** Session-scoped model cooldowns keyed as provider/model. */
+  exhaustedModels?: Record<string, number>;
   /** Timestamp (ms) when the current sessionId first became active. */
   sessionStartedAt?: number;
   /** Stable usage lineage key for transcript-backed rollups across sessionId rotations. */

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -209,6 +209,8 @@ export type AgentDefaultsConfig = {
   embeddedHarness?: AgentEmbeddedHarnessConfig;
   /** Primary model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   model?: AgentModelConfig;
+  /** Session cooldown window in minutes for exhausted models (default: 10). */
+  modelExhaustionRetryMinutes?: number;
   /** Optional image-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   imageModel?: AgentModelConfig;
   /** Optional image-generation model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -55,6 +55,7 @@ export const AgentDefaultsSchema = z
     agentRuntime: AgentRuntimePolicySchema,
     embeddedHarness: AgentEmbeddedHarnessSchema,
     model: AgentModelSchema.optional(),
+    modelExhaustionRetryMinutes: z.number().positive().optional(),
     imageModel: AgentModelSchema.optional(),
     imageGenerationModel: AgentModelSchema.optional(),
     videoGenerationModel: AgentModelSchema.optional(),


### PR DESCRIPTION
This keeps exhausted models out of the retry loop for a configurable window instead of hammering them again immediately.\n\nWhat changed:\n- persist exhausted model state in session storage\n- skip models that are still inside their cooldown\n- clear the marker once the model works again or the session resets\n- add coverage for skip, persist, and clear flows\n\nTested with:\n- pnpm exec vitest run src/agents/model-fallback.test.ts --config test/vitest/vitest.agents-core.config.ts