### PR TITLE
fix(cli-runner): drop volatile systemPromptHash from claude-cli live fingerprint

### DIFF
--- a/src/agents/cli-runner/claude-live-session.fingerprint.test.ts
+++ b/src/agents/cli-runner/claude-live-session.fingerprint.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { buildClaudeLiveFingerprint } from "./claude-live-session.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+function buildContext(overrides?: {
+  systemPrompt?: string;
+  extraSystemPromptHash?: string;
+  normalizedModel?: string;
+  workspaceDir?: string;
+}): PreparedCliRunContext {
+  const backend = {
+    command: "claude",
+    args: [],
+    output: "jsonl" as const,
+    input: "stdin" as const,
+    serialize: true,
+    liveSession: "claude-stdio" as const,
+    sessionArg: "--session",
+    systemPromptArg: "--system-prompt",
+    systemPromptFileArg: "--system-prompt-file",
+  };
+  return {
+    params: {
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: overrides?.workspaceDir ?? "/tmp/workspace",
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "model",
+      timeoutMs: 1_000,
+      runId: "run-1",
+    },
+    started: Date.now(),
+    workspaceDir: overrides?.workspaceDir ?? "/tmp/workspace",
+    backendResolved: {
+      id: "claude-cli",
+      config: backend,
+      bundleMcp: false,
+    },
+    preparedBackend: {
+      backend,
+      env: {},
+    },
+    reusableCliSession: {},
+    modelId: "model",
+    normalizedModel: overrides?.normalizedModel ?? "model",
+    systemPrompt: overrides?.systemPrompt ?? "you are an agent",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    bootstrapPromptWarningLines: [],
+    authEpochVersion: 2,
+    extraSystemPromptHash: overrides?.extraSystemPromptHash ?? "static-hash-a",
+  };
+}
+
+describe("buildClaudeLiveFingerprint", () => {
+  it("ignores volatile changes to the per-turn system prompt", () => {
+    // Per-turn inbound metadata (timestamps, sender envelope, heartbeat, channel
+    // guidance) is folded into `context.systemPrompt`. The fingerprint must not
+    // diverge on these volatile chunks — otherwise the runtime rotates the live
+    // claude-cli subprocess on every turn and loses prior context.
+    const baselineArgv = ["claude", "--model", "model"];
+    const a = buildClaudeLiveFingerprint({
+      context: buildContext({ systemPrompt: "[turn 1 metadata]\nyou are an agent" }),
+      argv: baselineArgv,
+      env: {},
+    });
+    const b = buildClaudeLiveFingerprint({
+      context: buildContext({ systemPrompt: "[turn 2 different metadata]\nyou are an agent" }),
+      argv: baselineArgv,
+      env: {},
+    });
+    expect(a).toBe(b);
+  });
+
+  it("diverges when extraSystemPromptHash changes (static config still gates session reuse)", () => {
+    const argv = ["claude", "--model", "model"];
+    const a = buildClaudeLiveFingerprint({
+      context: buildContext({ extraSystemPromptHash: "static-hash-a" }),
+      argv,
+      env: {},
+    });
+    const b = buildClaudeLiveFingerprint({
+      context: buildContext({ extraSystemPromptHash: "static-hash-b" }),
+      argv,
+      env: {},
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("diverges when the normalized model changes", () => {
+    const argv = ["claude", "--model", "model"];
+    const a = buildClaudeLiveFingerprint({
+      context: buildContext({ normalizedModel: "sonnet-4.6" }),
+      argv,
+      env: {},
+    });
+    const b = buildClaudeLiveFingerprint({
+      context: buildContext({ normalizedModel: "opus-4.7" }),
+      argv,
+      env: {},
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("diverges when the workspace directory changes", () => {
+    const argv = ["claude", "--model", "model"];
+    const a = buildClaudeLiveFingerprint({
+      context: buildContext({ workspaceDir: "/tmp/one" }),
+      argv,
+      env: {},
+    });
+    const b = buildClaudeLiveFingerprint({
+      context: buildContext({ workspaceDir: "/tmp/two" }),
+      argv,
+      env: {},
+    });
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -259,7 +259,7 @@ function buildClaudeLiveKey(context: PreparedCliRunContext): string {
   )}`;
 }
 
-function buildClaudeLiveFingerprint(params: {
+export function buildClaudeLiveFingerprint(params: {
   context: PreparedCliRunContext;
   argv: string[];
   env: Record<string, string>;
@@ -326,7 +326,6 @@ function buildClaudeLiveFingerprint(params: {
     cwdHash: params.context.cwdHash ?? sha256(params.context.cwd ?? params.context.workspaceDir),
     provider: params.context.params.provider,
     model: params.context.normalizedModel,
-    systemPromptHash: sha256(params.context.systemPrompt),
     authProfileIdHash: params.context.effectiveAuthProfileId
       ? sha256(params.context.effectiveAuthProfileId)
       : undefined,


### PR DESCRIPTION
## Summary

Closes #81041.

The `buildClaudeLiveFingerprint` helper in `src/agents/cli-runner/claude-live-session.ts` hashes `context.systemPrompt` as one of the keys deciding whether the active claude-cli subprocess is still valid. On chat channels (Telegram, Discord, Slack, iMessage, Signal, WhatsApp, etc.) OpenClaw injects per-turn-volatile content into that same `systemPrompt` — inbound metadata (`[Tue 2026-05-12 09:33 EDT]`, message id, sender envelope), heartbeat poll text, channel guidance, runtime status banner. Every inbound turn produces a fresh hash, the fingerprint diverges, and the live session is torn down and rebuilt. The new subprocess has no memory of the prior turn, so the agent looks amnesiac to the user (e.g. references its own last message and gets "what are you talking about?").

`extraSystemPromptHash` already covers the **static** side of the system prompt (the agent's persona, SOUL.md, USER.md, AGENTS.md, etc.) via `extraSystemPromptStatic` — see `prepare.ts:151`. So removing the volatile `systemPromptHash` field doesn't weaken the integrity check; it just stops the fingerprint from rejecting valid live sessions on every turn.

## Diff

```diff
-    systemPromptHash: sha256(params.context.systemPrompt),
```

The helper is also exported so the new unit test can exercise it directly (matches the pattern of `resetClaudeLiveSessionsForTest` already in the same module).

## Test plan

New file `src/agents/cli-runner/claude-live-session.fingerprint.test.ts` covers:

1. Two builds with different `context.systemPrompt` (per-turn volatile content) but everything else identical → fingerprints **equal**. This is the regression.
2. Changing `context.extraSystemPromptHash` → fingerprints **differ**. Proves the static-config integrity check is still in force.
3. Changing `context.normalizedModel` → fingerprints **differ**. Proves model swaps still rotate the session.
4. Changing `context.workspaceDir` → fingerprints **differ**. Proves workspace identity still gates reuse.

```
pnpm test src/agents/cli-runner/claude-live-session.fingerprint.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

`pnpm tsgo` and `pnpm check:test-types` both pass.

## Affected scope

- claude-cli backend only. API backends (Anthropic Messages, OpenAI, OpenRouter, Vertex, Bedrock) do not maintain a fingerprinted persistent process and so are unaffected.
- Multi-turn chat channels with per-turn metadata injection are the primary beneficiaries; one-shot CLI runs (`openclaw run`) don't expose the multi-turn symptom but are also covered.

## Risk

The narrow theoretical risk is: if there exists a scenario where two distinct `systemPrompt` values intentionally need separate live sessions while sharing the **same** `extraSystemPromptHash` (and same model, workspace, auth, MCP, skills, argv, env), this change would let them share one subprocess. I searched the codebase for that case — `systemPromptHash` is referenced only at the one site removed here (no readers anywhere else in `src/`, `extensions/`, or `test/`), and `extraSystemPromptHash` is purpose-built (see `prepare.ts:148-154`) to capture the static portion of the system prompt while excluding per-message metadata, which is exactly the dimension callers need to fingerprint on. I believe no such scenario exists. If reviewers know of one I missed, please flag it.

No public API change (the helper was previously private; exporting it for tests is the only signature delta and is internal-only).

---

## Real Behavior Proof

**Behavior or issue addressed:** Closes #81041. On the `claude-cli` backend with chat channels (Telegram/Discord/etc.), `buildClaudeLiveFingerprint` was hashing the entire system prompt including OpenClaw's per-turn-volatile metadata block (timestamps, inbound envelope, heartbeat text, channel guidance). Every turn produced a different hash, so the runtime decided the live CLI subprocess no longer matched the requested session and rotated to a fresh subprocess — losing all cross-turn context.

**Real environment tested:** Live OpenClaw 2026.5.7 install on Ubuntu 24.04 (`Linux 6.17.0-23-generic x86_64`), Node v22.22.0, claude-cli backend (Claude Max subscription), Telegram bot channel. Same change as proposed in this PR was first applied as a runtime patch to the bundled `dist/claude-live-session-C0vmXU_W.js` so the comparison was made against actual runtime behavior, not staged simulations.

**Exact steps or command run after this patch:**

1. Apply the one-line removal directly to the bundled `buildClaudeLiveFingerprint` (matches this PR's diff verbatim — `systemPromptHash` field removed from the returned object).
2. `systemctl --user restart openclaw-gateway`
3. Resume normal Telegram chat use with the agent (Leonard) for ~75 minutes spanning ~30 turns of multi-step work (issue triage, fork/clone via gh CLI, GitHub API calls, drafting this PR description). Mix of short turns and long turns including some with multi-minute gaps.
4. After the patch window, query the gateway journal for any cli/live-session restart events:

```
journalctl --user -u openclaw-gateway --since "2026-05-12 09:11" \
  | grep -E "(cli-backend|claude-live|live session)" \
  | grep -E "reset|close|restart|rotate|reason="
```

**Evidence after fix:** Redacted live runtime journal output, captured from `journalctl --user -u openclaw-gateway` on the actual install.

Pre-patch window (08:00–09:11 EDT, fingerprint bug active) — every Telegram turn that included new metadata triggered a fingerprint divergence, with downstream session restarts visible as `reason=missing-transcript` (companion bug #81042) cascading into `reason=restart`:

```
2026-05-12T08:13:06.295-04:00 [agent/cli-backend] cli session reset: provider=claude-cli reason=missing-transcript
2026-05-12T08:13:06.327-04:00 [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=restart
2026-05-12T08:45:08.710-04:00 [agent/cli-backend] cli session reset: provider=claude-cli reason=missing-transcript
2026-05-12T08:46:26.340-04:00 [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=restart
2026-05-12T08:51:32.073-04:00 [agent/cli-backend] cli session reset: provider=claude-cli reason=missing-transcript
2026-05-12T08:51:32.099-04:00 [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=restart
```

Post-patch window (09:11+ EDT, this PR's change live in the bundle) — full output of the same journal query:

```
$ journalctl --user -u openclaw-gateway --since "2026-05-12 09:11" \
    | grep -E "(cli-backend|claude-live|live session)" \
    | grep -E "reset|close|restart|rotate|reason="
(no matches)
```

User-visible Telegram conversation excerpt confirming the symptom pre-patch (agent forgetting its own message from 6 minutes earlier in the same thread):

```
[8:39 AM] Leonard: Watcher is armed — I'll page you as soon as the sentinel appears.
[8:44 AM] User:    still working on it?
[8:45 AM] Leonard: Nothing's actively in flight on my side… What's "it" referring to?
```

The 8:45 turn corresponds 1:1 with the `08:45:08 reason=missing-transcript` log line above.

Live Telegram screenshot from the affected install, captured pre-patch on 2026-05-12. The user asks "still working on it?" 5 minutes after the agent's earlier reply describing in-flight work; the agent denies anything is in flight and asks "What's 'it' referring to?". The user's next message quote-backs the agent's own prior message (with a hand-drawn arrow connecting the two). Two unrelated project names in the parenthetical have been redacted; the bug demonstration is not affected. This is the user-visible symptom of the runtime events shown in the journal log above.

![Telegram screenshot showing claude-cli context loss between turns](https://raw.githubusercontent.com/benjamin1492/openclaw/proof/screenshots/.github/proof-screenshots/cli-context-loss-redacted.png)

**Observed result after fix:** Zero fingerprint-driven session restarts in the post-patch window. Cross-turn context is retained across multi-minute gaps in the same Telegram conversation. The agent now references its own messages from 5+ minutes earlier without losing the thread. This very PR description was drafted across multiple Telegram turns spanning >30 minutes, with all cross-turn references intact.

**What was not tested:** Other chat surfaces (Discord, Slack, iMessage, Signal, WhatsApp) — the bug analysis predicts they're also affected because they inject similar per-turn metadata, but only Telegram was reproduced and verified on the live runtime here. API-backend providers (Anthropic Messages, OpenAI, OpenRouter) were not tested because they don't go through `buildClaudeLiveFingerprint`.
