### PR TITLE
fix(command): retry claude-cli transcript probe to close flush race

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -450,6 +450,33 @@ describe("parseCliJsonl", () => {
     });
   });
 
+  it("captures the last Claude session_id when an ephemeral id precedes the canonical one", () => {
+    // claude-cli emits ephemeral session_ids from SessionStart hooks before the
+    // canonical resumed session_id surfaces in the init event and the terminal
+    // result event. First-wins capture would bind to the ephemeral id whose
+    // transcript JSONL never lands on disk; last-wins captures the canonical id.
+    const result = parseCliJsonl(
+      [
+        JSON.stringify({ type: "system", subtype: "init", session_id: "session-ephemeral" }),
+        JSON.stringify({ type: "system", subtype: "init", session_id: "session-canonical" }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-canonical",
+          result: "rotated reply",
+        }),
+      ].join("\n"),
+      {
+        command: "claude",
+        output: "jsonl",
+        sessionIdFields: ["session_id"],
+      },
+      "claude-cli",
+    );
+
+    expect(result?.sessionId).toBe("session-canonical");
+    expect(result?.text).toBe("rotated reply");
+  });
+
   it("extracts nested Claude API errors from failed stream-json output", () => {
     const { message, jsonl } = createClaudeApiErrorFixture();
     const result = extractCliErrorMessage(jsonl);

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -750,9 +750,9 @@ export function parseCliJsonl(
   const texts: string[] = [];
   for (const line of lines) {
     for (const parsed of parseJsonRecordCandidates(line)) {
-      if (!sessionId) {
-        sessionId = pickCliSessionId(parsed, backend);
-      }
+      // Last-wins so claude-cli mid-turn session_id rotations land in the captured
+      // sessionId. Matches parseCliJson and createCliJsonlStreamingParser.
+      sessionId = pickCliSessionId(parsed, backend) ?? sessionId;
       if (!sessionId && typeof parsed.thread_id === "string") {
         sessionId = parsed.thread_id.trim();
       }

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -750,8 +750,6 @@ export function parseCliJsonl(
   const texts: string[] = [];
   for (const line of lines) {
     for (const parsed of parseJsonRecordCandidates(line)) {
-      // Last-wins so claude-cli mid-turn session_id rotations land in the captured
-      // sessionId. Matches parseCliJson and createCliJsonlStreamingParser.
       sessionId = pickCliSessionId(parsed, backend) ?? sessionId;
       if (!sessionId && typeof parsed.thread_id === "string") {
         sessionId = parsed.thread_id.trim();

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1433,7 +1433,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         config: createCliBackendConfig(),
       });
 
-      expect(transcriptCheck).toHaveBeenCalledWith({ sessionId: "stale-claude-sid" });
+      expect(transcriptCheck).toHaveBeenCalledWith({
+        sessionId: "stale-claude-sid",
+        workspaceDir: dir,
+      });
       expect(context.reusableCliSession).toEqual({ invalidatedReason: "missing-transcript" });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -1481,7 +1484,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         config: createCliBackendConfig(),
       });
 
-      expect(transcriptCheck).toHaveBeenCalledWith({ sessionId: "live-claude-sid" });
+      expect(transcriptCheck).toHaveBeenCalledWith({
+        sessionId: "live-claude-sid",
+        workspaceDir: dir,
+      });
       expect(context.reusableCliSession).toEqual({ sessionId: "live-claude-sid" });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1494,6 +1494,60 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
+  it("checks claude-cli transcript content under the resolved cwd", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    const taskDir = path.join(dir, "task");
+    fs.mkdirSync(taskDir, { recursive: true });
+    try {
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "claude-cli",
+            pluginId: "anthropic",
+            bundleMcp: false,
+            config: {
+              command: "claude",
+              args: ["--print"],
+              resumeArgs: ["--resume", "{sessionId}"],
+              output: "jsonl",
+              input: "stdin",
+              sessionMode: "existing",
+            },
+          },
+        ],
+      });
+      const transcriptCheck = vi.fn(async () => true);
+      setCliRunnerPrepareTestDeps({
+        claudeCliSessionTranscriptHasContent: transcriptCheck,
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:telegram:direct:peer",
+        sessionFile,
+        workspaceDir: dir,
+        cwd: taskDir,
+        prompt: "follow-up",
+        provider: "claude-cli",
+        model: "opus",
+        timeoutMs: 1_000,
+        runId: "run-77011-cwd",
+        cliSessionBinding: { sessionId: "live-claude-sid", cwdHash: hashCliSessionText(taskDir) },
+        cliSessionId: "live-claude-sid",
+        config: createCliBackendConfig(),
+      });
+
+      expect(transcriptCheck).toHaveBeenCalledWith({
+        sessionId: "live-claude-sid",
+        workspaceDir: taskDir,
+      });
+      expect(context.reusableCliSession).toEqual({ sessionId: "live-claude-sid" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("omits Claude CLI prompt skills when the native skills plugin can carry them", async () => {
     const { dir, sessionFile } = createSessionFile();
     const skillDir = path.join(dir, "skills", "weather");

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -375,7 +375,7 @@ export async function prepareCliRunContext(
     isClaudeCliProvider(params.provider) &&
     !(await prepareDeps.claudeCliSessionTranscriptHasContent({
       sessionId: candidateClaudeCliSessionId,
-      workspaceDir,
+      workspaceDir: cwd,
     }));
   const reusableCliSession: CliReusableSession = claudeCliTranscriptMissing
     ? { invalidatedReason: "missing-transcript" }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -375,6 +375,7 @@ export async function prepareCliRunContext(
     isClaudeCliProvider(params.provider) &&
     !(await prepareDeps.claudeCliSessionTranscriptHasContent({
       sessionId: candidateClaudeCliSessionId,
+      workspaceDir,
     }));
   const reusableCliSession: CliReusableSession = claudeCliTranscriptMissing
     ? { invalidatedReason: "missing-transcript" }

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { runEmbeddedAgent, type EmbeddedAgentRunResult } from "../embedded-agent.js";
 import { FailoverError } from "../failover-error.js";
 import { persistCliTurnTranscript, runAgentAttempt } from "./attempt-execution.js";
+import { resolveClaudeCliProjectDirForWorkspace } from "./claude-cli-project-dir.js";
 
 const runCliAgentMock = vi.hoisted(() => vi.fn());
 const runEmbeddedAgentMock = vi.hoisted(() => vi.fn());
@@ -153,10 +154,6 @@ function firstEmbeddedAgentArg(callIndex = 0) {
   return requireMockArg(runEmbeddedAgentMock, callIndex, "embedded OpenClaw agent argument");
 }
 
-function encodeWorkspaceDirName(workspaceDir: string): string {
-  return workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
-}
-
 describe("CLI attempt execution", () => {
   let tmpDir: string;
   let storePath: string;
@@ -217,7 +214,10 @@ describe("CLI attempt execution", () => {
 
   async function writeClaudeCliAssistantTranscript(cliSessionId: string) {
     const homeDir = path.join(tmpDir, `home-${cliSessionId}`);
-    const projectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    const projectsDir = resolveClaudeCliProjectDirForWorkspace({
+      workspaceDir: tmpDir,
+      homeDir,
+    });
     process.env.HOME = homeDir;
     await fs.mkdir(projectsDir, { recursive: true });
     await fs.writeFile(
@@ -251,10 +251,10 @@ describe("CLI attempt execution", () => {
   it("clears stale Claude CLI session IDs before retrying after session expiration", async () => {
     const sessionKey = "agent:main:subagent:cli-expired";
     const homeDir = path.join(tmpDir, "home");
-    // v4 computes the JSONL path from workspaceDir; runClaudeCliAttempt below
-    // passes workspaceDir: tmpDir, so the probe walks
-    //   $HOME/.claude/projects/<encoded(tmpDir)>/<sessionId>.jsonl
-    const projectsDir = path.join(homeDir, ".claude", "projects", encodeWorkspaceDirName(tmpDir));
+    const projectsDir = resolveClaudeCliProjectDirForWorkspace({
+      workspaceDir: tmpDir,
+      homeDir,
+    });
     process.env.HOME = homeDir;
     await fs.mkdir(projectsDir, { recursive: true });
     await fs.writeFile(
@@ -444,8 +444,10 @@ describe("CLI attempt execution", () => {
     const sessionKey = "agent:main:direct:claude-transcript-present";
     const cliSessionId = "existing-claude-session";
     const homeDir = path.join(tmpDir, "home");
-    // v4 deterministic path lives under encoded(tmpDir), not a fixed name.
-    const projectsDir = path.join(homeDir, ".claude", "projects", encodeWorkspaceDirName(tmpDir));
+    const projectsDir = resolveClaudeCliProjectDirForWorkspace({
+      workspaceDir: tmpDir,
+      homeDir,
+    });
     process.env.HOME = homeDir;
     await fs.mkdir(projectsDir, { recursive: true });
     await fs.writeFile(

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -153,6 +153,10 @@ function firstEmbeddedAgentArg(callIndex = 0) {
   return requireMockArg(runEmbeddedAgentMock, callIndex, "embedded OpenClaw agent argument");
 }
 
+function encodeWorkspaceDirName(workspaceDir: string): string {
+  return workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
 describe("CLI attempt execution", () => {
   let tmpDir: string;
   let storePath: string;
@@ -247,7 +251,10 @@ describe("CLI attempt execution", () => {
   it("clears stale Claude CLI session IDs before retrying after session expiration", async () => {
     const sessionKey = "agent:main:subagent:cli-expired";
     const homeDir = path.join(tmpDir, "home");
-    const projectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    // v4 computes the JSONL path from workspaceDir; runClaudeCliAttempt below
+    // passes workspaceDir: tmpDir, so the probe walks
+    //   $HOME/.claude/projects/<encoded(tmpDir)>/<sessionId>.jsonl
+    const projectsDir = path.join(homeDir, ".claude", "projects", encodeWorkspaceDirName(tmpDir));
     process.env.HOME = homeDir;
     await fs.mkdir(projectsDir, { recursive: true });
     await fs.writeFile(
@@ -437,7 +444,8 @@ describe("CLI attempt execution", () => {
     const sessionKey = "agent:main:direct:claude-transcript-present";
     const cliSessionId = "existing-claude-session";
     const homeDir = path.join(tmpDir, "home");
-    const projectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    // v4 deterministic path lives under encoded(tmpDir), not a fixed name.
+    const projectsDir = path.join(homeDir, ".claude", "projects", encodeWorkspaceDirName(tmpDir));
     process.env.HOME = homeDir;
     await fs.mkdir(projectsDir, { recursive: true });
     await fs.writeFile(

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -180,6 +180,7 @@ describe("CLI attempt execution", () => {
     sessionStore: Record<string, SessionEntry>;
     body: string;
     runId: string;
+    cwd?: string;
   }) {
     await runAgentAttempt({
       providerOverride: "claude-cli",
@@ -192,6 +193,7 @@ describe("CLI attempt execution", () => {
       sessionAgentId: "main",
       sessionFile: path.join(tmpDir, "session.jsonl"),
       workspaceDir: tmpDir,
+      cwd: params.cwd,
       body: params.body,
       isFallbackRetry: false,
       resolvedThinkLevel: "medium",
@@ -493,6 +495,48 @@ describe("CLI attempt execution", () => {
     });
     expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe(cliSessionId);
     expect(sessionStore[sessionKey]?.claudeCliSessionId).toBe(cliSessionId);
+  });
+
+  it("checks Claude CLI transcript content under the process cwd", async () => {
+    const sessionKey = "agent:main:direct:claude-transcript-cwd-present";
+    const cliSessionId = "existing-claude-cwd-session";
+    const homeDir = path.join(tmpDir, "home");
+    const cwd = path.join(tmpDir, "task");
+    const projectsDir = resolveClaudeCliProjectDirForWorkspace({
+      workspaceDir: cwd,
+      homeDir,
+    });
+    process.env.HOME = homeDir;
+    await fs.mkdir(projectsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(projectsDir, `${cliSessionId}.jsonl`),
+      `${JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "previous reply" }],
+        },
+      })}\n`,
+      "utf-8",
+    );
+    const sessionEntry = makeClaudeCliSessionEntry("openclaw-session-cwd", cliSessionId);
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("resumed cli response"));
+
+    await runClaudeCliAttempt({
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      body: "continue from task cwd",
+      runId: "run-cli-transcript-cwd-present",
+      cwd,
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
+    expect(firstRunCliAgentArg().cwd).toBe(cwd);
+    expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe(cliSessionId);
   });
 
   it("passes session-bound OpenAI Codex auth profile to codex-cli aliases", async () => {

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -13,6 +13,7 @@ import {
   type ClaudeCliFallbackSeed,
   readClaudeCliFallbackSeed,
 } from "../../gateway/cli-session-history.js";
+import { cliBackendLog } from "../cli-runner/log.js";
 
 /** Maximum number of JSONL records to inspect before giving up. */
 const SESSION_FILE_MAX_RECORDS = 500;
@@ -26,14 +27,16 @@ function normalizeClaudeCliSessionId(sessionId: string | undefined): string | un
   return trimmed;
 }
 
-async function jsonlFileHasAssistantMessage(filePath: string | undefined): Promise<boolean> {
+type JsonlFileScan = { fileExists: boolean; hasAssistant: boolean };
+
+async function scanJsonlFile(filePath: string | undefined): Promise<JsonlFileScan> {
   if (!filePath) {
-    return false;
+    return { fileExists: false, hasAssistant: false };
   }
   try {
     const stat = await fs.lstat(filePath);
     if (stat.isSymbolicLink() || !stat.isFile()) {
-      return false;
+      return { fileExists: false, hasAssistant: false };
     }
 
     const fh = await fs.open(filePath, "r");
@@ -56,16 +59,20 @@ async function jsonlFileHasAssistantMessage(filePath: string | undefined): Promi
         }
         const rec = obj as Record<string, unknown> | null;
         if ((rec?.message as Record<string, unknown> | undefined)?.role === "assistant") {
-          return true;
+          return { fileExists: true, hasAssistant: true };
         }
       }
-      return false;
+      return { fileExists: true, hasAssistant: false };
     } finally {
       await fh.close();
     }
   } catch {
-    return false;
+    return { fileExists: false, hasAssistant: false };
   }
+}
+
+async function jsonlFileHasAssistantMessage(filePath: string | undefined): Promise<boolean> {
+  return (await scanJsonlFile(filePath)).hasAssistant;
 }
 
 /**
@@ -77,13 +84,31 @@ export async function sessionFileHasContent(sessionFile: string | undefined): Pr
   return await jsonlFileHasAssistantMessage(sessionFile);
 }
 
-export async function claudeCliSessionTranscriptHasContent(params: {
+type TranscriptProjectScan = { project: string; fileExists: boolean; hasAssistant: boolean };
+
+type TranscriptScanResult = {
+  hasAssistant: boolean;
+  fileExists: boolean;
+  sessionId: string | null;
+  homeDir: string | null;
+  projects: TranscriptProjectScan[];
+};
+
+/**
+ * Delay between the first negative scan and the rescan that covers claude-cli's
+ * asynchronous transcript flush. claude-cli writes the user-message header
+ * before the assistant turn is flushed, so the first scan can race the JSONL
+ * and see no assistant message even though one is about to land.
+ */
+const CLAUDE_CLI_TRANSCRIPT_FLUSH_RETRY_MS = 150;
+
+async function claudeCliSessionTranscriptScan(params: {
   sessionId: string | undefined;
   homeDir?: string;
-}): Promise<boolean> {
+}): Promise<TranscriptScanResult> {
   const sessionId = normalizeClaudeCliSessionId(params.sessionId);
   if (!sessionId) {
-    return false;
+    return { hasAssistant: false, fileExists: false, sessionId: null, homeDir: null, projects: [] };
   }
   const homeDir = params.homeDir?.trim() || process.env.HOME || os.homedir();
   const projectsDir = path.join(homeDir, CLAUDE_PROJECTS_RELATIVE_DIR);
@@ -91,16 +116,60 @@ export async function claudeCliSessionTranscriptHasContent(params: {
   try {
     projectEntries = await fs.readdir(projectsDir, { withFileTypes: true });
   } catch {
-    return false;
+    return { hasAssistant: false, fileExists: false, sessionId, homeDir, projects: [] };
   }
+  const projects: TranscriptProjectScan[] = [];
+  let anyFileExists = false;
   for (const entry of projectEntries) {
     if (!entry.isDirectory()) {
       continue;
     }
     const candidate = path.join(projectsDir, entry.name, `${sessionId}.jsonl`);
-    if (await jsonlFileHasAssistantMessage(candidate)) {
+    const scan = await scanJsonlFile(candidate);
+    projects.push({
+      project: entry.name,
+      fileExists: scan.fileExists,
+      hasAssistant: scan.hasAssistant,
+    });
+    if (scan.fileExists) {
+      anyFileExists = true;
+    }
+    if (scan.hasAssistant) {
+      return { hasAssistant: true, fileExists: true, sessionId, homeDir, projects };
+    }
+  }
+  return { hasAssistant: false, fileExists: anyFileExists, sessionId, homeDir, projects };
+}
+
+export async function claudeCliSessionTranscriptHasContent(params: {
+  sessionId: string | undefined;
+  homeDir?: string;
+}): Promise<boolean> {
+  const first = await claudeCliSessionTranscriptScan(params);
+  if (first.hasAssistant) {
+    return true;
+  }
+  // claude-cli flushes the user-message header before the assistant turn lands.
+  // If the JSONL is on disk but lacks an assistant message, the runtime is
+  // racing the flush — wait once and rescan before declaring transcript-missing.
+  // The wait is gated on fileExists so the genuinely-no-session path stays fast.
+  if (first.fileExists) {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, CLAUDE_CLI_TRANSCRIPT_FLUSH_RETRY_MS);
+    });
+    const second = await claudeCliSessionTranscriptScan(params);
+    if (second.hasAssistant) {
       return true;
     }
+    cliBackendLog.warn(
+      `claude-cli transcript probe negative after ${CLAUDE_CLI_TRANSCRIPT_FLUSH_RETRY_MS}ms retry: sessionId=${second.sessionId ?? ""} homeDir=${second.homeDir ?? ""} projects=${JSON.stringify(second.projects)}`,
+    );
+    return false;
+  }
+  if (first.sessionId) {
+    cliBackendLog.warn(
+      `claude-cli transcript probe negative (no matching jsonl): sessionId=${first.sessionId} homeDir=${first.homeDir ?? ""} projectCount=${first.projects.length}`,
+    );
   }
   return false;
 }

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import {
@@ -14,10 +13,9 @@ import {
   readClaudeCliFallbackSeed,
 } from "../../gateway/cli-session-history.js";
 import { cliBackendLog } from "../cli-runner/log.js";
+import { resolveClaudeCliProjectDirForWorkspace } from "./claude-cli-project-dir.js";
 
-/** Maximum number of JSONL records to inspect before giving up. */
 const SESSION_FILE_MAX_RECORDS = 500;
-const CLAUDE_PROJECTS_RELATIVE_DIR = path.join(".claude", "projects");
 
 function normalizeClaudeCliSessionId(sessionId: string | undefined): string | undefined {
   const trimmed = sessionId?.trim();
@@ -84,23 +82,6 @@ export async function sessionFileHasContent(sessionFile: string | undefined): Pr
   return await jsonlFileHasAssistantMessage(sessionFile);
 }
 
-/**
- * Compute the on-disk JSONL path claude-cli uses for a given session. The CLI
- * is now invoked with an orchestrator-minted `--session-id <uuid>` and `cwd
- * <workspaceDir>`, which together determine the path:
- *
- *   `<homeDir>/.claude/projects/<encoded(workspaceDir)>/<sessionId>.jsonl`
- *
- * The encoding rule was verified live: claude-cli replaces every non-
- * alphanumeric character in the absolute cwd with a hyphen (so
- * `/home/faris/.openclaw/workspace` becomes `-home-faris--openclaw-workspace`
- * and `/tmp/foo_bar.baz` becomes `-tmp-foo-bar-baz`). The rule is documented
- * by behavior alone, so we keep the encoding regexp localized to this helper
- * — if upstream Claude Code ever changes it, the probe stops finding the file
- * and v4 fails loud (see `claudeCliSessionTranscriptHasContent` below).
- *
- * Returns `null` when the session id is malformed or the workspace is empty.
- */
 export function claudeCliSessionTranscriptPath(params: {
   sessionId: string | undefined;
   workspaceDir: string | undefined;
@@ -114,23 +95,15 @@ export function claudeCliSessionTranscriptPath(params: {
   if (!workspaceDir) {
     return null;
   }
-  const homeDir = params.homeDir?.trim() || process.env.HOME || os.homedir();
-  const encodedWorkspace = workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
-  return path.join(homeDir, CLAUDE_PROJECTS_RELATIVE_DIR, encodedWorkspace, `${sessionId}.jsonl`);
+  return path.join(
+    resolveClaudeCliProjectDirForWorkspace({
+      workspaceDir,
+      homeDir: params.homeDir,
+    }),
+    `${sessionId}.jsonl`,
+  );
 }
 
-/**
- * Single grace window between the first and second probe of the on-disk
- * claude-cli transcript. v3 used a 0/250/500/1000/1500ms back-off ladder
- * (3250ms total) and still raced the JSONL flush — at 12:37:58 EDT 2026-05-13
- * a live user turn hit `transcript probe negative after 3250ms (no matching
- * jsonl)`, immediately followed by `cli session reset reason=missing-
- * transcript`. v4 abandons the ladder-widening dead-end: the orchestrator now
- * mints the session id (`--session-id <uuid>`), so the JSONL path is fully
- * determined by data we own. A miss past one short grace window is no longer
- * "we lost the race for picking the path" but "the file genuinely isn't
- * there", and we want that to fail loud instead of silently widening forever.
- */
 const CLAUDE_CLI_TRANSCRIPT_FLUSH_GRACE_MS = 250;
 
 export async function claudeCliSessionTranscriptHasContent(params: {
@@ -157,12 +130,6 @@ export async function claudeCliSessionTranscriptHasContent(params: {
   if (second.hasAssistant) {
     return true;
   }
-  // Loud, structured warn — distinct prefix from v1/v2/v3 so log readers can
-  // tell which strategy is live. Missing the orchestrator-owned path after a
-  // grace window means either the prior turn's claude-cli never flushed (real
-  // crash/FS-failure) or the cwd-encoding rule shifted upstream; both are
-  // worth investigating individually instead of being papered over by a wider
-  // back-off ladder.
   const sessionId = normalizeClaudeCliSessionId(params.sessionId);
   cliBackendLog.warn(
     `claude-cli transcript probe v4 miss (sessionId-deterministic path, grace ${CLAUDE_CLI_TRANSCRIPT_FLUSH_GRACE_MS}ms): sessionId=${sessionId ?? ""} expectedPath=${expectedPath} fileExists=${second.fileExists}`,

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -95,12 +95,26 @@ type TranscriptScanResult = {
 };
 
 /**
- * Delay between the first negative scan and the rescan that covers claude-cli's
- * asynchronous transcript flush. claude-cli writes the user-message header
- * before the assistant turn is flushed, so the first scan can race the JSONL
- * and see no assistant message even though one is about to land.
+ * Back-off ladder between negative scans of the claude-cli transcript. Element
+ * 0 is the first scan (no wait); subsequent entries are the delay before each
+ * retry. Two windows races together set the budget:
+ *  1. The within-file flush race: claude-cli writes the user-message header
+ *     before the assistant turn lands, so a fresh JSONL can briefly hold a
+ *     header with no assistant block.
+ *  2. The file-creation race: after a session-id rotation the JSONL itself
+ *     has not yet been created when the runtime probes; field observation
+ *     puts that window well past one second on busy hosts.
+ *
+ * The ladder covers both branches uniformly — the loop retries whether the
+ * file is missing or present-but-empty — and totals 3250ms of wait so a
+ * genuinely-no-session call still bounds out quickly while a slow flush has
+ * room to land.
  */
-const CLAUDE_CLI_TRANSCRIPT_FLUSH_RETRY_MS = 150;
+const CLAUDE_CLI_TRANSCRIPT_FLUSH_DELAYS_MS: readonly number[] = [0, 250, 500, 1000, 1500];
+const CLAUDE_CLI_TRANSCRIPT_FLUSH_TOTAL_MS = CLAUDE_CLI_TRANSCRIPT_FLUSH_DELAYS_MS.reduce(
+  (acc, n) => acc + n,
+  0,
+);
 
 async function claudeCliSessionTranscriptScan(params: {
   sessionId: string | undefined;
@@ -145,31 +159,34 @@ export async function claudeCliSessionTranscriptHasContent(params: {
   sessionId: string | undefined;
   homeDir?: string;
 }): Promise<boolean> {
-  const first = await claudeCliSessionTranscriptScan(params);
-  if (first.hasAssistant) {
-    return true;
-  }
-  // claude-cli flushes the user-message header before the assistant turn lands.
-  // If the JSONL is on disk but lacks an assistant message, the runtime is
-  // racing the flush — wait once and rescan before declaring transcript-missing.
-  // The wait is gated on fileExists so the genuinely-no-session path stays fast.
-  if (first.fileExists) {
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, CLAUDE_CLI_TRANSCRIPT_FLUSH_RETRY_MS);
-    });
-    const second = await claudeCliSessionTranscriptScan(params);
-    if (second.hasAssistant) {
+  let lastScan: TranscriptScanResult | null = null;
+  for (const wait of CLAUDE_CLI_TRANSCRIPT_FLUSH_DELAYS_MS) {
+    if (wait > 0) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, wait);
+      });
+    }
+    const scan = await claudeCliSessionTranscriptScan(params);
+    if (scan.hasAssistant) {
       return true;
     }
-    cliBackendLog.warn(
-      `claude-cli transcript probe negative after ${CLAUDE_CLI_TRANSCRIPT_FLUSH_RETRY_MS}ms retry: sessionId=${second.sessionId ?? ""} homeDir=${second.homeDir ?? ""} projects=${JSON.stringify(second.projects)}`,
-    );
-    return false;
+    lastScan = scan;
   }
-  if (first.sessionId) {
-    cliBackendLog.warn(
-      `claude-cli transcript probe negative (no matching jsonl): sessionId=${first.sessionId} homeDir=${first.homeDir ?? ""} projectCount=${first.projects.length}`,
-    );
+  // The probe is the last gate before transcript-missing recovery, so emit a
+  // diagnostic for both negative branches: the file landed but stayed empty
+  // (within-file flush race lost) vs no JSONL ever appeared (file-creation
+  // race lost). The branch tells us which window we need to widen if the
+  // back-off is still too short in the field.
+  if (lastScan?.sessionId) {
+    if (lastScan.fileExists) {
+      cliBackendLog.warn(
+        `claude-cli transcript probe negative after ${CLAUDE_CLI_TRANSCRIPT_FLUSH_TOTAL_MS}ms (file exists, no asst): sessionId=${lastScan.sessionId} homeDir=${lastScan.homeDir ?? ""} projects=${JSON.stringify(lastScan.projects)}`,
+      );
+    } else {
+      cliBackendLog.warn(
+        `claude-cli transcript probe negative after ${CLAUDE_CLI_TRANSCRIPT_FLUSH_TOTAL_MS}ms (no matching jsonl): sessionId=${lastScan.sessionId} homeDir=${lastScan.homeDir ?? ""} projectCount=${lastScan.projects.length}`,
+      );
+    }
   }
   return false;
 }

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -84,110 +84,89 @@ export async function sessionFileHasContent(sessionFile: string | undefined): Pr
   return await jsonlFileHasAssistantMessage(sessionFile);
 }
 
-type TranscriptProjectScan = { project: string; fileExists: boolean; hasAssistant: boolean };
-
-type TranscriptScanResult = {
-  hasAssistant: boolean;
-  fileExists: boolean;
-  sessionId: string | null;
-  homeDir: string | null;
-  projects: TranscriptProjectScan[];
-};
-
 /**
- * Back-off ladder between negative scans of the claude-cli transcript. Element
- * 0 is the first scan (no wait); subsequent entries are the delay before each
- * retry. Two windows races together set the budget:
- *  1. The within-file flush race: claude-cli writes the user-message header
- *     before the assistant turn lands, so a fresh JSONL can briefly hold a
- *     header with no assistant block.
- *  2. The file-creation race: after a session-id rotation the JSONL itself
- *     has not yet been created when the runtime probes; field observation
- *     puts that window well past one second on busy hosts.
+ * Compute the on-disk JSONL path claude-cli uses for a given session. The CLI
+ * is now invoked with an orchestrator-minted `--session-id <uuid>` and `cwd
+ * <workspaceDir>`, which together determine the path:
  *
- * The ladder covers both branches uniformly — the loop retries whether the
- * file is missing or present-but-empty — and totals 3250ms of wait so a
- * genuinely-no-session call still bounds out quickly while a slow flush has
- * room to land.
+ *   `<homeDir>/.claude/projects/<encoded(workspaceDir)>/<sessionId>.jsonl`
+ *
+ * The encoding rule was verified live: claude-cli replaces every non-
+ * alphanumeric character in the absolute cwd with a hyphen (so
+ * `/home/faris/.openclaw/workspace` becomes `-home-faris--openclaw-workspace`
+ * and `/tmp/foo_bar.baz` becomes `-tmp-foo-bar-baz`). The rule is documented
+ * by behavior alone, so we keep the encoding regexp localized to this helper
+ * — if upstream Claude Code ever changes it, the probe stops finding the file
+ * and v4 fails loud (see `claudeCliSessionTranscriptHasContent` below).
+ *
+ * Returns `null` when the session id is malformed or the workspace is empty.
  */
-const CLAUDE_CLI_TRANSCRIPT_FLUSH_DELAYS_MS: readonly number[] = [0, 250, 500, 1000, 1500];
-const CLAUDE_CLI_TRANSCRIPT_FLUSH_TOTAL_MS = CLAUDE_CLI_TRANSCRIPT_FLUSH_DELAYS_MS.reduce(
-  (acc, n) => acc + n,
-  0,
-);
-
-async function claudeCliSessionTranscriptScan(params: {
+export function claudeCliSessionTranscriptPath(params: {
   sessionId: string | undefined;
+  workspaceDir: string | undefined;
   homeDir?: string;
-}): Promise<TranscriptScanResult> {
+}): string | null {
   const sessionId = normalizeClaudeCliSessionId(params.sessionId);
   if (!sessionId) {
-    return { hasAssistant: false, fileExists: false, sessionId: null, homeDir: null, projects: [] };
+    return null;
+  }
+  const workspaceDir = params.workspaceDir?.trim();
+  if (!workspaceDir) {
+    return null;
   }
   const homeDir = params.homeDir?.trim() || process.env.HOME || os.homedir();
-  const projectsDir = path.join(homeDir, CLAUDE_PROJECTS_RELATIVE_DIR);
-  let projectEntries: import("node:fs").Dirent[];
-  try {
-    projectEntries = await fs.readdir(projectsDir, { withFileTypes: true });
-  } catch {
-    return { hasAssistant: false, fileExists: false, sessionId, homeDir, projects: [] };
-  }
-  const projects: TranscriptProjectScan[] = [];
-  let anyFileExists = false;
-  for (const entry of projectEntries) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-    const candidate = path.join(projectsDir, entry.name, `${sessionId}.jsonl`);
-    const scan = await scanJsonlFile(candidate);
-    projects.push({
-      project: entry.name,
-      fileExists: scan.fileExists,
-      hasAssistant: scan.hasAssistant,
-    });
-    if (scan.fileExists) {
-      anyFileExists = true;
-    }
-    if (scan.hasAssistant) {
-      return { hasAssistant: true, fileExists: true, sessionId, homeDir, projects };
-    }
-  }
-  return { hasAssistant: false, fileExists: anyFileExists, sessionId, homeDir, projects };
+  const encodedWorkspace = workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
+  return path.join(homeDir, CLAUDE_PROJECTS_RELATIVE_DIR, encodedWorkspace, `${sessionId}.jsonl`);
 }
+
+/**
+ * Single grace window between the first and second probe of the on-disk
+ * claude-cli transcript. v3 used a 0/250/500/1000/1500ms back-off ladder
+ * (3250ms total) and still raced the JSONL flush — at 12:37:58 EDT 2026-05-13
+ * a live user turn hit `transcript probe negative after 3250ms (no matching
+ * jsonl)`, immediately followed by `cli session reset reason=missing-
+ * transcript`. v4 abandons the ladder-widening dead-end: the orchestrator now
+ * mints the session id (`--session-id <uuid>`), so the JSONL path is fully
+ * determined by data we own. A miss past one short grace window is no longer
+ * "we lost the race for picking the path" but "the file genuinely isn't
+ * there", and we want that to fail loud instead of silently widening forever.
+ */
+const CLAUDE_CLI_TRANSCRIPT_FLUSH_GRACE_MS = 250;
 
 export async function claudeCliSessionTranscriptHasContent(params: {
   sessionId: string | undefined;
+  workspaceDir: string | undefined;
   homeDir?: string;
 }): Promise<boolean> {
-  let lastScan: TranscriptScanResult | null = null;
-  for (const wait of CLAUDE_CLI_TRANSCRIPT_FLUSH_DELAYS_MS) {
-    if (wait > 0) {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, wait);
-      });
-    }
-    const scan = await claudeCliSessionTranscriptScan(params);
-    if (scan.hasAssistant) {
-      return true;
-    }
-    lastScan = scan;
+  const expectedPath = claudeCliSessionTranscriptPath({
+    sessionId: params.sessionId,
+    workspaceDir: params.workspaceDir,
+    homeDir: params.homeDir,
+  });
+  if (!expectedPath) {
+    return false;
   }
-  // The probe is the last gate before transcript-missing recovery, so emit a
-  // diagnostic for both negative branches: the file landed but stayed empty
-  // (within-file flush race lost) vs no JSONL ever appeared (file-creation
-  // race lost). The branch tells us which window we need to widen if the
-  // back-off is still too short in the field.
-  if (lastScan?.sessionId) {
-    if (lastScan.fileExists) {
-      cliBackendLog.warn(
-        `claude-cli transcript probe negative after ${CLAUDE_CLI_TRANSCRIPT_FLUSH_TOTAL_MS}ms (file exists, no asst): sessionId=${lastScan.sessionId} homeDir=${lastScan.homeDir ?? ""} projects=${JSON.stringify(lastScan.projects)}`,
-      );
-    } else {
-      cliBackendLog.warn(
-        `claude-cli transcript probe negative after ${CLAUDE_CLI_TRANSCRIPT_FLUSH_TOTAL_MS}ms (no matching jsonl): sessionId=${lastScan.sessionId} homeDir=${lastScan.homeDir ?? ""} projectCount=${lastScan.projects.length}`,
-      );
-    }
+  const first = await scanJsonlFile(expectedPath);
+  if (first.hasAssistant) {
+    return true;
   }
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, CLAUDE_CLI_TRANSCRIPT_FLUSH_GRACE_MS);
+  });
+  const second = await scanJsonlFile(expectedPath);
+  if (second.hasAssistant) {
+    return true;
+  }
+  // Loud, structured warn — distinct prefix from v1/v2/v3 so log readers can
+  // tell which strategy is live. Missing the orchestrator-owned path after a
+  // grace window means either the prior turn's claude-cli never flushed (real
+  // crash/FS-failure) or the cwd-encoding rule shifted upstream; both are
+  // worth investigating individually instead of being papered over by a wider
+  // back-off ladder.
+  const sessionId = normalizeClaudeCliSessionId(params.sessionId);
+  cliBackendLog.warn(
+    `claude-cli transcript probe v4 miss (sessionId-deterministic path, grace ${CLAUDE_CLI_TRANSCRIPT_FLUSH_GRACE_MS}ms): sessionId=${sessionId ?? ""} expectedPath=${expectedPath} fileExists=${second.fileExists}`,
+  );
   return false;
 }
 

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -6,6 +6,7 @@ import { cliBackendLog } from "../cli-runner/log.js";
 import {
   buildClaudeCliFallbackContextPrelude,
   claudeCliSessionTranscriptHasContent,
+  claudeCliSessionTranscriptPath,
   createAcpVisibleTextAccumulator,
   formatClaudeCliFallbackPrelude,
   resolveFallbackRetryPrompt,
@@ -364,6 +365,69 @@ describe("sessionFileHasContent", () => {
   });
 });
 
+describe("claudeCliSessionTranscriptPath", () => {
+  it("returns null for malformed session ids", () => {
+    expect(
+      claudeCliSessionTranscriptPath({
+        sessionId: "../escape",
+        workspaceDir: "/tmp/ws",
+        homeDir: "/home/x",
+      }),
+    ).toBeNull();
+    expect(
+      claudeCliSessionTranscriptPath({
+        sessionId: "",
+        workspaceDir: "/tmp/ws",
+        homeDir: "/home/x",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when workspaceDir is empty or whitespace", () => {
+    expect(
+      claudeCliSessionTranscriptPath({
+        sessionId: "abc",
+        workspaceDir: "",
+        homeDir: "/home/x",
+      }),
+    ).toBeNull();
+    expect(
+      claudeCliSessionTranscriptPath({
+        sessionId: "abc",
+        workspaceDir: "   ",
+        homeDir: "/home/x",
+      }),
+    ).toBeNull();
+  });
+
+  it("encodes the cwd by replacing every non-alphanumeric character with a hyphen", () => {
+    // Live-verified rule: /home/faris/.openclaw/workspace →
+    // -home-faris--openclaw-workspace, /tmp/foo_bar.baz → -tmp-foo-bar-baz.
+    expect(
+      claudeCliSessionTranscriptPath({
+        sessionId: "11111111-2222-3333-4444-555555555555",
+        workspaceDir: "/home/faris/.openclaw/workspace",
+        homeDir: "/home/faris",
+      }),
+    ).toBe(
+      path.join(
+        "/home/faris",
+        ".claude",
+        "projects",
+        "-home-faris--openclaw-workspace",
+        "11111111-2222-3333-4444-555555555555.jsonl",
+      ),
+    );
+    expect(
+      claudeCliSessionTranscriptPath({
+        sessionId: "session-x",
+        workspaceDir: "/tmp/foo_bar.baz",
+        homeDir: "/home/x",
+      }),
+    ).toBe(path.join("/home/x", ".claude", "projects", "-tmp-foo-bar-baz", "session-x.jsonl"));
+  });
+});
+
 describe("claudeCliSessionTranscriptHasContent", () => {
   let tmpDir: string;
 
@@ -375,33 +439,58 @@ describe("claudeCliSessionTranscriptHasContent", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  async function writeClaudeProjectFile(sessionId: string, content: string) {
-    const projectDir = path.join(tmpDir, ".claude", "projects", "demo-workspace");
+  // v4 mints the session id and computes the JSONL path deterministically from
+  // the workspaceDir; helpers below mirror that path so tests stay readable.
+  function encodeWorkspaceDirName(workspaceDir: string) {
+    return workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
+  }
+
+  async function makeWorkspace() {
+    const workspaceDir = await fs.mkdtemp(path.join(tmpDir, "ws-"));
+    return workspaceDir;
+  }
+
+  async function writeClaudeProjectFile(workspaceDir: string, sessionId: string, content: string) {
+    const projectDir = path.join(
+      tmpDir,
+      ".claude",
+      "projects",
+      encodeWorkspaceDirName(workspaceDir),
+    );
     await fs.mkdir(projectDir, { recursive: true });
     const file = path.join(projectDir, `${sessionId}.jsonl`);
     await fs.writeFile(file, content, "utf-8");
     return file;
   }
 
+  // Mirrors CLAUDE_CLI_TRANSCRIPT_FLUSH_GRACE_MS in the source so tests fail
+  // loudly if the grace window is retuned.
+  const GRACE_MS = 250;
+
   it("returns false when the Claude project transcript is missing or empty", async () => {
+    const workspaceDir = await makeWorkspace();
     expect(
       await claudeCliSessionTranscriptHasContent({
         sessionId: "missing-session",
+        workspaceDir,
         homeDir: tmpDir,
       }),
     ).toBe(false);
 
-    await writeClaudeProjectFile("empty-session", "");
+    await writeClaudeProjectFile(workspaceDir, "empty-session", "");
     expect(
       await claudeCliSessionTranscriptHasContent({
         sessionId: "empty-session",
+        workspaceDir,
         homeDir: tmpDir,
       }),
     ).toBe(false);
   });
 
   it("returns true when the Claude project transcript has an assistant message", async () => {
+    const workspaceDir = await makeWorkspace();
     await writeClaudeProjectFile(
+      workspaceDir,
       "session-with-assistant",
       `${JSON.stringify({
         type: "assistant",
@@ -415,29 +504,39 @@ describe("claudeCliSessionTranscriptHasContent", () => {
     expect(
       await claudeCliSessionTranscriptHasContent({
         sessionId: "session-with-assistant",
+        workspaceDir,
         homeDir: tmpDir,
       }),
     ).toBe(true);
   });
 
   it("rejects path-like session ids instead of escaping the Claude projects tree", async () => {
-    await writeClaudeProjectFile("safe-session", "");
+    const workspaceDir = await makeWorkspace();
+    await writeClaudeProjectFile(workspaceDir, "safe-session", "");
     expect(
       await claudeCliSessionTranscriptHasContent({
         sessionId: "../safe-session",
+        workspaceDir,
         homeDir: tmpDir,
       }),
     ).toBe(false);
   });
 
-  // Back-off ladder lives in the source as CLAUDE_CLI_TRANSCRIPT_FLUSH_DELAYS_MS;
-  // mirrored here so the tests fail loudly when it changes.
-  const BACK_OFF_DELAYS = [250, 500, 1000, 1500] as const;
-  const TOTAL_BACK_OFF_MS = BACK_OFF_DELAYS.reduce((acc, n) => acc + n, 0);
+  it("returns false when workspaceDir is missing (path cannot be computed)", async () => {
+    expect(
+      await claudeCliSessionTranscriptHasContent({
+        sessionId: "any-session",
+        workspaceDir: undefined,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
 
-  it("returns true immediately when the assistant message is already flushed (no back-off sleep)", async () => {
+  it("returns true immediately when the assistant message is already flushed (no grace sleep)", async () => {
+    const workspaceDir = await makeWorkspace();
     await writeClaudeProjectFile(
-      "race-already-flushed",
+      workspaceDir,
+      "already-flushed",
       `${JSON.stringify({
         type: "assistant",
         message: { role: "assistant", content: [{ type: "text", text: "ack" }] },
@@ -448,54 +547,47 @@ describe("claudeCliSessionTranscriptHasContent", () => {
     try {
       expect(
         await claudeCliSessionTranscriptHasContent({
-          sessionId: "race-already-flushed",
+          sessionId: "already-flushed",
+          workspaceDir,
           homeDir: tmpDir,
         }),
       ).toBe(true);
-      // None of the back-off sleeps should fire when the first scan succeeds.
-      const sleepCalls = setTimeoutSpy.mock.calls.filter(([, delay]) =>
-        BACK_OFF_DELAYS.includes(delay as (typeof BACK_OFF_DELAYS)[number]),
-      );
-      expect(sleepCalls).toHaveLength(0);
+      // The grace sleep must NOT fire when the first scan already succeeds —
+      // v4's fast path is supposed to be allocation-free on healthy resumes.
+      const graceCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === GRACE_MS);
+      expect(graceCalls).toHaveLength(0);
     } finally {
       setTimeoutSpy.mockRestore();
     }
   });
 
-  it("returns true on a later attempt when the assistant message lands mid-back-off (file-exists branch)", async () => {
-    const sessionId = "race-flush-window";
-    const file = await writeClaudeProjectFile(sessionId, "");
-    // Pre-seed with a user header but no assistant — mirrors claude-cli's
-    // intermediate state right after a session-id rotation.
-    await fs.writeFile(
-      file,
+  it("returns true on the second scan when the assistant message lands during the grace window", async () => {
+    const workspaceDir = await makeWorkspace();
+    const sessionId = "fs-flush-latency";
+    const file = await writeClaudeProjectFile(
+      workspaceDir,
+      sessionId,
       `${JSON.stringify({
         type: "user",
         message: { role: "user", content: [{ type: "text", text: "hi" }] },
       })}\n`,
-      "utf-8",
     );
 
-    // Land the assistant flush during the second back-off (500ms slot) so the
-    // probe has to traverse at least two waits before succeeding.
-    let backOffsObserved = 0;
+    let graceFires = 0;
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
       handler: (...args: unknown[]) => void,
       delay?: number,
     ) => {
-      if (typeof delay === "number" && BACK_OFF_DELAYS.includes(delay as never)) {
-        backOffsObserved += 1;
-        const flush =
-          backOffsObserved === 2
-            ? fs.appendFile(
-                file,
-                `${JSON.stringify({
-                  type: "assistant",
-                  message: { role: "assistant", content: [{ type: "text", text: "ack" }] },
-                })}\n`,
-                "utf-8",
-              )
-            : Promise.resolve();
+      if (delay === GRACE_MS) {
+        graceFires += 1;
+        const flush = fs.appendFile(
+          file,
+          `${JSON.stringify({
+            type: "assistant",
+            message: { role: "assistant", content: [{ type: "text", text: "ack" }] },
+          })}\n`,
+          "utf-8",
+        );
         void flush.then(() => {
           handler();
         });
@@ -508,46 +600,27 @@ describe("claudeCliSessionTranscriptHasContent", () => {
       expect(
         await claudeCliSessionTranscriptHasContent({
           sessionId,
+          workspaceDir,
           homeDir: tmpDir,
         }),
       ).toBe(true);
-      // First attempt is t=0 (no setTimeout); attempts 2 + 3 each fire one
-      // back-off sleep; success on attempt 3 stops the loop. Total = 2.
-      expect(backOffsObserved).toBe(2);
+      // Exactly one grace-window sleep should fire (first scan miss → grace →
+      // second scan hits).
+      expect(graceFires).toBe(1);
     } finally {
       setTimeoutSpy.mockRestore();
     }
   });
 
-  it("returns true on a later attempt when the JSONL itself appears mid-back-off (file-creation branch)", async () => {
-    const sessionId = "race-file-creation";
-    const projectDir = path.join(tmpDir, ".claude", "projects", "demo-workspace");
-    await fs.mkdir(projectDir, { recursive: true });
-    // Intentionally do NOT pre-create the jsonl — the file-creation race is
-    // the second window v3 was widened to cover (v1 only retried within-file).
-    const targetFile = path.join(projectDir, `${sessionId}.jsonl`);
-
-    let backOffsObserved = 0;
+  it("returns false and emits a structured v4 warn when the JSONL never appears", async () => {
+    const workspaceDir = await makeWorkspace();
+    const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
       handler: (...args: unknown[]) => void,
       delay?: number,
     ) => {
-      if (typeof delay === "number" && BACK_OFF_DELAYS.includes(delay as never)) {
-        backOffsObserved += 1;
-        const flush =
-          backOffsObserved === 3
-            ? fs.writeFile(
-                targetFile,
-                `${JSON.stringify({
-                  type: "assistant",
-                  message: { role: "assistant", content: [{ type: "text", text: "ack" }] },
-                })}\n`,
-                "utf-8",
-              )
-            : Promise.resolve();
-        void flush.then(() => {
-          handler();
-        });
+      if (delay === GRACE_MS) {
+        handler();
         return 0 as unknown as ReturnType<typeof setTimeout>;
       }
       return 0 as unknown as ReturnType<typeof setTimeout>;
@@ -556,21 +629,31 @@ describe("claudeCliSessionTranscriptHasContent", () => {
     try {
       expect(
         await claudeCliSessionTranscriptHasContent({
-          sessionId,
+          sessionId: "ghost-session",
+          workspaceDir,
           homeDir: tmpDir,
         }),
-      ).toBe(true);
-      // File appears between the third and fourth scans, so all three
-      // preceding back-offs run.
-      expect(backOffsObserved).toBe(3);
+      ).toBe(false);
+      const v4Warnings = warnSpy.mock.calls.filter(
+        ([msg]) => typeof msg === "string" && msg.startsWith("claude-cli transcript probe v4 miss"),
+      );
+      expect(v4Warnings).toHaveLength(1);
+      const message = v4Warnings[0]?.[0] as string;
+      expect(message).toContain("sessionId=ghost-session");
+      expect(message).toContain(`grace ${GRACE_MS}ms`);
+      expect(message).toContain("fileExists=false");
+      expect(message).toContain(encodeWorkspaceDirName(workspaceDir));
     } finally {
       setTimeoutSpy.mockRestore();
+      warnSpy.mockRestore();
     }
   });
 
-  it("returns false and warns (file-exists branch) when the JSONL never gains an assistant message", async () => {
-    const sessionId = "race-never-flushes";
+  it("returns false and emits a v4 warn flagging fileExists=true when the JSONL stays headerless", async () => {
+    const workspaceDir = await makeWorkspace();
+    const sessionId = "user-header-only";
     await writeClaudeProjectFile(
+      workspaceDir,
       sessionId,
       `${JSON.stringify({
         type: "user",
@@ -583,7 +666,7 @@ describe("claudeCliSessionTranscriptHasContent", () => {
       handler: (...args: unknown[]) => void,
       delay?: number,
     ) => {
-      if (typeof delay === "number" && BACK_OFF_DELAYS.includes(delay as never)) {
+      if (delay === GRACE_MS) {
         handler();
         return 0 as unknown as ReturnType<typeof setTimeout>;
       }
@@ -594,52 +677,15 @@ describe("claudeCliSessionTranscriptHasContent", () => {
       expect(
         await claudeCliSessionTranscriptHasContent({
           sessionId,
+          workspaceDir,
           homeDir: tmpDir,
         }),
       ).toBe(false);
-      const expectedTag = `after ${TOTAL_BACK_OFF_MS}ms (file exists, no asst)`;
-      const retryWarnings = warnSpy.mock.calls.filter(
-        ([msg]) => typeof msg === "string" && msg.includes(expectedTag),
+      const v4Warnings = warnSpy.mock.calls.filter(
+        ([msg]) => typeof msg === "string" && msg.startsWith("claude-cli transcript probe v4 miss"),
       );
-      expect(retryWarnings).toHaveLength(1);
-      expect(retryWarnings[0]?.[0]).toContain(sessionId);
-    } finally {
-      setTimeoutSpy.mockRestore();
-      warnSpy.mockRestore();
-    }
-  });
-
-  it("returns false and warns (no-matching-jsonl branch) with projectCount when no project dir holds the jsonl", async () => {
-    // Create unrelated project dirs so projectCount reflects scanned candidates.
-    await writeClaudeProjectFile("other-session", "");
-    const otherProjectDir = path.join(tmpDir, ".claude", "projects", "another-workspace");
-    await fs.mkdir(otherProjectDir, { recursive: true });
-
-    const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
-      handler: (...args: unknown[]) => void,
-      delay?: number,
-    ) => {
-      if (typeof delay === "number" && BACK_OFF_DELAYS.includes(delay as never)) {
-        handler();
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      }
-      return 0 as unknown as ReturnType<typeof setTimeout>;
-    }) as typeof setTimeout);
-
-    try {
-      expect(
-        await claudeCliSessionTranscriptHasContent({
-          sessionId: "no-such-session",
-          homeDir: tmpDir,
-        }),
-      ).toBe(false);
-      const expectedTag = `after ${TOTAL_BACK_OFF_MS}ms (no matching jsonl)`;
-      const noMatchWarnings = warnSpy.mock.calls.filter(
-        ([msg]) => typeof msg === "string" && msg.includes(expectedTag),
-      );
-      expect(noMatchWarnings).toHaveLength(1);
-      expect(noMatchWarnings[0]?.[0]).toContain("projectCount=2");
+      expect(v4Warnings).toHaveLength(1);
+      expect(v4Warnings[0]?.[0]).toContain("fileExists=true");
     } finally {
       setTimeoutSpy.mockRestore();
       warnSpy.mockRestore();

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cliBackendLog } from "../cli-runner/log.js";
 import {
   buildClaudeCliFallbackContextPrelude,
   claudeCliSessionTranscriptHasContent,
@@ -427,6 +428,149 @@ describe("claudeCliSessionTranscriptHasContent", () => {
         homeDir: tmpDir,
       }),
     ).toBe(false);
+  });
+
+  it("returns true immediately when the assistant message is already flushed (no retry sleep)", async () => {
+    await writeClaudeProjectFile(
+      "race-already-flushed",
+      `${JSON.stringify({
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "ack" }] },
+      })}\n`,
+    );
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      expect(
+        await claudeCliSessionTranscriptHasContent({
+          sessionId: "race-already-flushed",
+          homeDir: tmpDir,
+        }),
+      ).toBe(true);
+      // No 150ms sleep should fire when the assistant message is present on first scan.
+      const sleepCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 150);
+      expect(sleepCalls).toHaveLength(0);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("returns true after retry when the assistant message lands during the flush window", async () => {
+    const sessionId = "race-flush-window";
+    const file = await writeClaudeProjectFile(sessionId, "");
+    // Pre-seed with a user header but no assistant — mirrors claude-cli's
+    // intermediate state right after a session-id rotation.
+    await fs.writeFile(
+      file,
+      `${JSON.stringify({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      })}\n`,
+      "utf-8",
+    );
+
+    let firstScanDone = false;
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      handler: (...args: unknown[]) => void,
+      delay?: number,
+    ) => {
+      if (delay === 150) {
+        // Simulate claude-cli flushing the assistant message during the retry
+        // window, then fire the retry continuation synchronously to unblock
+        // the rescan.
+        firstScanDone = true;
+        void fs
+          .appendFile(
+            file,
+            `${JSON.stringify({
+              type: "assistant",
+              message: { role: "assistant", content: [{ type: "text", text: "ack" }] },
+            })}\n`,
+            "utf-8",
+          )
+          .then(() => {
+            handler();
+          });
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return (setTimeoutSpy.getMockImplementation() as never) ?? (0 as never);
+    }) as typeof setTimeout);
+
+    try {
+      expect(
+        await claudeCliSessionTranscriptHasContent({
+          sessionId,
+          homeDir: tmpDir,
+        }),
+      ).toBe(true);
+      expect(firstScanDone).toBe(true);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("returns false and warns when the JSONL exists but never gains an assistant message", async () => {
+    const sessionId = "race-never-flushes";
+    await writeClaudeProjectFile(
+      sessionId,
+      `${JSON.stringify({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      })}\n`,
+    );
+
+    const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      handler: (...args: unknown[]) => void,
+      delay?: number,
+    ) => {
+      if (delay === 150) {
+        handler();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+
+    try {
+      expect(
+        await claudeCliSessionTranscriptHasContent({
+          sessionId,
+          homeDir: tmpDir,
+        }),
+      ).toBe(false);
+      const retryWarnings = warnSpy.mock.calls.filter(
+        ([msg]) => typeof msg === "string" && msg.includes("after 150ms retry"),
+      );
+      expect(retryWarnings).toHaveLength(1);
+      expect(retryWarnings[0]?.[0]).toContain(sessionId);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("returns false and warns with projectCount when no project dir holds a matching jsonl", async () => {
+    // Create unrelated project dirs so projectCount reflects scanned candidates.
+    await writeClaudeProjectFile("other-session", "");
+    const otherProjectDir = path.join(tmpDir, ".claude", "projects", "another-workspace");
+    await fs.mkdir(otherProjectDir, { recursive: true });
+
+    const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
+    try {
+      expect(
+        await claudeCliSessionTranscriptHasContent({
+          sessionId: "no-such-session",
+          homeDir: tmpDir,
+        }),
+      ).toBe(false);
+      const noMatchWarnings = warnSpy.mock.calls.filter(
+        ([msg]) => typeof msg === "string" && msg.includes("no matching jsonl"),
+      );
+      expect(noMatchWarnings).toHaveLength(1);
+      expect(noMatchWarnings[0]?.[0]).toContain("projectCount=2");
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -638,7 +638,7 @@ describe("claudeCliSessionTranscriptHasContent", () => {
         ([msg]) => typeof msg === "string" && msg.startsWith("claude-cli transcript probe v4 miss"),
       );
       expect(v4Warnings).toHaveLength(1);
-      const message = v4Warnings[0]?.[0] as string;
+      const message = v4Warnings[0]?.[0];
       expect(message).toContain("sessionId=ghost-session");
       expect(message).toContain(`grace ${GRACE_MS}ms`);
       expect(message).toContain("fileExists=false");

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -430,7 +430,12 @@ describe("claudeCliSessionTranscriptHasContent", () => {
     ).toBe(false);
   });
 
-  it("returns true immediately when the assistant message is already flushed (no retry sleep)", async () => {
+  // Back-off ladder lives in the source as CLAUDE_CLI_TRANSCRIPT_FLUSH_DELAYS_MS;
+  // mirrored here so the tests fail loudly when it changes.
+  const BACK_OFF_DELAYS = [250, 500, 1000, 1500] as const;
+  const TOTAL_BACK_OFF_MS = BACK_OFF_DELAYS.reduce((acc, n) => acc + n, 0);
+
+  it("returns true immediately when the assistant message is already flushed (no back-off sleep)", async () => {
     await writeClaudeProjectFile(
       "race-already-flushed",
       `${JSON.stringify({
@@ -447,15 +452,17 @@ describe("claudeCliSessionTranscriptHasContent", () => {
           homeDir: tmpDir,
         }),
       ).toBe(true);
-      // No 150ms sleep should fire when the assistant message is present on first scan.
-      const sleepCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 150);
+      // None of the back-off sleeps should fire when the first scan succeeds.
+      const sleepCalls = setTimeoutSpy.mock.calls.filter(([, delay]) =>
+        BACK_OFF_DELAYS.includes(delay as (typeof BACK_OFF_DELAYS)[number]),
+      );
       expect(sleepCalls).toHaveLength(0);
     } finally {
       setTimeoutSpy.mockRestore();
     }
   });
 
-  it("returns true after retry when the assistant message lands during the flush window", async () => {
+  it("returns true on a later attempt when the assistant message lands mid-back-off (file-exists branch)", async () => {
     const sessionId = "race-flush-window";
     const file = await writeClaudeProjectFile(sessionId, "");
     // Pre-seed with a user header but no assistant — mirrors claude-cli's
@@ -469,31 +476,32 @@ describe("claudeCliSessionTranscriptHasContent", () => {
       "utf-8",
     );
 
-    let firstScanDone = false;
+    // Land the assistant flush during the second back-off (500ms slot) so the
+    // probe has to traverse at least two waits before succeeding.
+    let backOffsObserved = 0;
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
       handler: (...args: unknown[]) => void,
       delay?: number,
     ) => {
-      if (delay === 150) {
-        // Simulate claude-cli flushing the assistant message during the retry
-        // window, then fire the retry continuation synchronously to unblock
-        // the rescan.
-        firstScanDone = true;
-        void fs
-          .appendFile(
-            file,
-            `${JSON.stringify({
-              type: "assistant",
-              message: { role: "assistant", content: [{ type: "text", text: "ack" }] },
-            })}\n`,
-            "utf-8",
-          )
-          .then(() => {
-            handler();
-          });
+      if (typeof delay === "number" && BACK_OFF_DELAYS.includes(delay as never)) {
+        backOffsObserved += 1;
+        const flush =
+          backOffsObserved === 2
+            ? fs.appendFile(
+                file,
+                `${JSON.stringify({
+                  type: "assistant",
+                  message: { role: "assistant", content: [{ type: "text", text: "ack" }] },
+                })}\n`,
+                "utf-8",
+              )
+            : Promise.resolve();
+        void flush.then(() => {
+          handler();
+        });
         return 0 as unknown as ReturnType<typeof setTimeout>;
       }
-      return (setTimeoutSpy.getMockImplementation() as never) ?? (0 as never);
+      return 0 as unknown as ReturnType<typeof setTimeout>;
     }) as typeof setTimeout);
 
     try {
@@ -503,13 +511,64 @@ describe("claudeCliSessionTranscriptHasContent", () => {
           homeDir: tmpDir,
         }),
       ).toBe(true);
-      expect(firstScanDone).toBe(true);
+      // First attempt is t=0 (no setTimeout); attempts 2 + 3 each fire one
+      // back-off sleep; success on attempt 3 stops the loop. Total = 2.
+      expect(backOffsObserved).toBe(2);
     } finally {
       setTimeoutSpy.mockRestore();
     }
   });
 
-  it("returns false and warns when the JSONL exists but never gains an assistant message", async () => {
+  it("returns true on a later attempt when the JSONL itself appears mid-back-off (file-creation branch)", async () => {
+    const sessionId = "race-file-creation";
+    const projectDir = path.join(tmpDir, ".claude", "projects", "demo-workspace");
+    await fs.mkdir(projectDir, { recursive: true });
+    // Intentionally do NOT pre-create the jsonl — the file-creation race is
+    // the second window v3 was widened to cover (v1 only retried within-file).
+    const targetFile = path.join(projectDir, `${sessionId}.jsonl`);
+
+    let backOffsObserved = 0;
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      handler: (...args: unknown[]) => void,
+      delay?: number,
+    ) => {
+      if (typeof delay === "number" && BACK_OFF_DELAYS.includes(delay as never)) {
+        backOffsObserved += 1;
+        const flush =
+          backOffsObserved === 3
+            ? fs.writeFile(
+                targetFile,
+                `${JSON.stringify({
+                  type: "assistant",
+                  message: { role: "assistant", content: [{ type: "text", text: "ack" }] },
+                })}\n`,
+                "utf-8",
+              )
+            : Promise.resolve();
+        void flush.then(() => {
+          handler();
+        });
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+
+    try {
+      expect(
+        await claudeCliSessionTranscriptHasContent({
+          sessionId,
+          homeDir: tmpDir,
+        }),
+      ).toBe(true);
+      // File appears between the third and fourth scans, so all three
+      // preceding back-offs run.
+      expect(backOffsObserved).toBe(3);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("returns false and warns (file-exists branch) when the JSONL never gains an assistant message", async () => {
     const sessionId = "race-never-flushes";
     await writeClaudeProjectFile(
       sessionId,
@@ -524,7 +583,7 @@ describe("claudeCliSessionTranscriptHasContent", () => {
       handler: (...args: unknown[]) => void,
       delay?: number,
     ) => {
-      if (delay === 150) {
+      if (typeof delay === "number" && BACK_OFF_DELAYS.includes(delay as never)) {
         handler();
         return 0 as unknown as ReturnType<typeof setTimeout>;
       }
@@ -538,8 +597,9 @@ describe("claudeCliSessionTranscriptHasContent", () => {
           homeDir: tmpDir,
         }),
       ).toBe(false);
+      const expectedTag = `after ${TOTAL_BACK_OFF_MS}ms (file exists, no asst)`;
       const retryWarnings = warnSpy.mock.calls.filter(
-        ([msg]) => typeof msg === "string" && msg.includes("after 150ms retry"),
+        ([msg]) => typeof msg === "string" && msg.includes(expectedTag),
       );
       expect(retryWarnings).toHaveLength(1);
       expect(retryWarnings[0]?.[0]).toContain(sessionId);
@@ -549,13 +609,24 @@ describe("claudeCliSessionTranscriptHasContent", () => {
     }
   });
 
-  it("returns false and warns with projectCount when no project dir holds a matching jsonl", async () => {
+  it("returns false and warns (no-matching-jsonl branch) with projectCount when no project dir holds the jsonl", async () => {
     // Create unrelated project dirs so projectCount reflects scanned candidates.
     await writeClaudeProjectFile("other-session", "");
     const otherProjectDir = path.join(tmpDir, ".claude", "projects", "another-workspace");
     await fs.mkdir(otherProjectDir, { recursive: true });
 
     const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      handler: (...args: unknown[]) => void,
+      delay?: number,
+    ) => {
+      if (typeof delay === "number" && BACK_OFF_DELAYS.includes(delay as never)) {
+        handler();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+
     try {
       expect(
         await claudeCliSessionTranscriptHasContent({
@@ -563,12 +634,14 @@ describe("claudeCliSessionTranscriptHasContent", () => {
           homeDir: tmpDir,
         }),
       ).toBe(false);
+      const expectedTag = `after ${TOTAL_BACK_OFF_MS}ms (no matching jsonl)`;
       const noMatchWarnings = warnSpy.mock.calls.filter(
-        ([msg]) => typeof msg === "string" && msg.includes("no matching jsonl"),
+        ([msg]) => typeof msg === "string" && msg.includes(expectedTag),
       );
       expect(noMatchWarnings).toHaveLength(1);
       expect(noMatchWarnings[0]?.[0]).toContain("projectCount=2");
     } finally {
+      setTimeoutSpy.mockRestore();
       warnSpy.mockRestore();
     }
   });

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -12,6 +12,7 @@ import {
   resolveFallbackRetryPrompt,
   sessionFileHasContent,
 } from "./attempt-execution.helpers.js";
+import { resolveClaudeCliProjectDirForWorkspace } from "./claude-cli-project-dir.js";
 
 describe("resolveFallbackRetryPrompt", () => {
   const originalBody = "Summarize the quarterly earnings report and highlight key trends.";
@@ -400,9 +401,7 @@ describe("claudeCliSessionTranscriptPath", () => {
     ).toBeNull();
   });
 
-  it("encodes the cwd by replacing every non-alphanumeric character with a hyphen", () => {
-    // Live-verified rule: /home/faris/.openclaw/workspace →
-    // -home-faris--openclaw-workspace, /tmp/foo_bar.baz → -tmp-foo-bar-baz.
+  it("uses the canonical Claude project dir resolver", () => {
     expect(
       claudeCliSessionTranscriptPath({
         sessionId: "11111111-2222-3333-4444-555555555555",
@@ -426,6 +425,31 @@ describe("claudeCliSessionTranscriptPath", () => {
       }),
     ).toBe(path.join("/home/x", ".claude", "projects", "-tmp-foo-bar-baz", "session-x.jsonl"));
   });
+
+  it("canonicalizes symlinked workspaces before resolving the Claude project dir", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "oc-claude-project-link-"));
+    try {
+      const workspaceDir = path.join(root, "workspace");
+      const linkDir = path.join(root, "workspace-link");
+      await fs.mkdir(workspaceDir);
+      await fs.symlink(workspaceDir, linkDir, "dir");
+
+      expect(
+        claudeCliSessionTranscriptPath({
+          sessionId: "session-link",
+          workspaceDir: linkDir,
+          homeDir: root,
+        }),
+      ).toBe(
+        path.join(
+          resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir: root }),
+          "session-link.jsonl",
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("claudeCliSessionTranscriptHasContent", () => {
@@ -439,32 +463,19 @@ describe("claudeCliSessionTranscriptHasContent", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  // v4 mints the session id and computes the JSONL path deterministically from
-  // the workspaceDir; helpers below mirror that path so tests stay readable.
-  function encodeWorkspaceDirName(workspaceDir: string) {
-    return workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
-  }
-
   async function makeWorkspace() {
     const workspaceDir = await fs.mkdtemp(path.join(tmpDir, "ws-"));
     return workspaceDir;
   }
 
   async function writeClaudeProjectFile(workspaceDir: string, sessionId: string, content: string) {
-    const projectDir = path.join(
-      tmpDir,
-      ".claude",
-      "projects",
-      encodeWorkspaceDirName(workspaceDir),
-    );
+    const projectDir = resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir: tmpDir });
     await fs.mkdir(projectDir, { recursive: true });
     const file = path.join(projectDir, `${sessionId}.jsonl`);
     await fs.writeFile(file, content, "utf-8");
     return file;
   }
 
-  // Mirrors CLAUDE_CLI_TRANSCRIPT_FLUSH_GRACE_MS in the source so tests fail
-  // loudly if the grace window is retuned.
   const GRACE_MS = 250;
 
   it("returns false when the Claude project transcript is missing or empty", async () => {
@@ -552,8 +563,6 @@ describe("claudeCliSessionTranscriptHasContent", () => {
           homeDir: tmpDir,
         }),
       ).toBe(true);
-      // The grace sleep must NOT fire when the first scan already succeeds —
-      // v4's fast path is supposed to be allocation-free on healthy resumes.
       const graceCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === GRACE_MS);
       expect(graceCalls).toHaveLength(0);
     } finally {
@@ -604,8 +613,6 @@ describe("claudeCliSessionTranscriptHasContent", () => {
           homeDir: tmpDir,
         }),
       ).toBe(true);
-      // Exactly one grace-window sleep should fire (first scan miss → grace →
-      // second scan hits).
       expect(graceFires).toBe(1);
     } finally {
       setTimeoutSpy.mockRestore();
@@ -642,7 +649,13 @@ describe("claudeCliSessionTranscriptHasContent", () => {
       expect(message).toContain("sessionId=ghost-session");
       expect(message).toContain(`grace ${GRACE_MS}ms`);
       expect(message).toContain("fileExists=false");
-      expect(message).toContain(encodeWorkspaceDirName(workspaceDir));
+      expect(message).toContain(
+        `expectedPath=${claudeCliSessionTranscriptPath({
+          sessionId: "ghost-session",
+          workspaceDir,
+          homeDir: tmpDir,
+        })}`,
+      );
     } finally {
       setTimeoutSpy.mockRestore();
       warnSpy.mockRestore();

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -21,6 +21,7 @@ import {
 } from "../../sessions/user-turn-transcript.js";
 import { buildWorkspaceSkillSnapshot } from "../../skills/loading/workspace.js";
 import { sanitizeForLog } from "../../terminal/ansi.js";
+import { resolveUserPath } from "../../utils.js";
 import { resolveMessageChannel } from "../../utils/message-channel.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
 import { ensureAuthProfileStore } from "../auth-profiles/store.js";
@@ -504,13 +505,14 @@ export function runAgentAttempt(params: {
       : undefined);
   if (!isRawModelRun && isCliProvider(cliExecutionProvider, params.cfg)) {
     const cliSessionBinding = getCliSessionBinding(params.sessionEntry, cliExecutionProvider);
+    const cliProcessCwd = params.cwd ? resolveUserPath(params.cwd) : params.workspaceDir;
     const resolveReusableCliSessionBinding = async () => {
       if (
         !isClaudeCliProvider(cliExecutionProvider) ||
         !cliSessionBinding?.sessionId ||
         (await claudeCliSessionTranscriptHasContent({
           sessionId: cliSessionBinding.sessionId,
-          workspaceDir: params.workspaceDir,
+          workspaceDir: cliProcessCwd,
         }))
       ) {
         return cliSessionBinding;

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -508,7 +508,10 @@ export function runAgentAttempt(params: {
       if (
         !isClaudeCliProvider(cliExecutionProvider) ||
         !cliSessionBinding?.sessionId ||
-        (await claudeCliSessionTranscriptHasContent({ sessionId: cliSessionBinding.sessionId }))
+        (await claudeCliSessionTranscriptHasContent({
+          sessionId: cliSessionBinding.sessionId,
+          workspaceDir: params.workspaceDir,
+        }))
       ) {
         return cliSessionBinding;
       }

--- a/src/agents/command/claude-cli-project-dir.ts
+++ b/src/agents/command/claude-cli-project-dir.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
+
+const CLAUDE_PROJECTS_DIRNAME = path.join(".claude", "projects");
+const MAX_SANITIZED_PROJECT_LENGTH = 200;
+
+function simpleHash36(input: string): string {
+  let hash = 0;
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash * 31 + input.charCodeAt(index)) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+function sanitizeClaudeCliProjectKey(workspaceDir: string): string {
+  const sanitized = workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
+  if (sanitized.length <= MAX_SANITIZED_PROJECT_LENGTH) {
+    return sanitized;
+  }
+  return `${sanitized.slice(0, MAX_SANITIZED_PROJECT_LENGTH)}-${simpleHash36(workspaceDir)}`;
+}
+
+function canonicalizeWorkspaceDir(workspaceDir: string): string {
+  const resolved = path.resolve(workspaceDir).normalize("NFC");
+  try {
+    return fs.realpathSync.native(resolved).normalize("NFC");
+  } catch {
+    return resolved;
+  }
+}
+
+export function resolveClaudeCliProjectDirForWorkspace(params: {
+  workspaceDir: string;
+  homeDir?: string;
+}): string {
+  const homeDir = normalizeOptionalString(params.homeDir) || process.env.HOME || os.homedir();
+  const canonicalWorkspaceDir = canonicalizeWorkspaceDir(params.workspaceDir);
+  return path.join(
+    homeDir,
+    CLAUDE_PROJECTS_DIRNAME,
+    sanitizeClaudeCliProjectKey(canonicalWorkspaceDir),
+  );
+}

--- a/src/commands/doctor-claude-cli.test.ts
+++ b/src/commands/doctor-claude-cli.test.ts
@@ -4,10 +4,8 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CLAUDE_CLI_PROFILE_ID } from "../agents/auth-profiles/constants.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import {
-  noteClaudeCliHealth,
-  resolveClaudeCliProjectDirForWorkspace,
-} from "./doctor-claude-cli.js";
+import { resolveClaudeCliProjectDirForWorkspace } from "../agents/command/claude-cli-project-dir.js";
+import { noteClaudeCliHealth } from "./doctor-claude-cli.js";
 
 function createStore(profiles: AuthProfileStore["profiles"] = {}): AuthProfileStore {
   return {

--- a/src/commands/doctor-claude-cli.ts
+++ b/src/commands/doctor-claude-cli.ts
@@ -1,6 +1,4 @@
 import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import {
   listAgentIds,
@@ -16,6 +14,7 @@ import type {
   TokenCredential,
 } from "../agents/auth-profiles/types.js";
 import { readClaudeCliCredentialsCached } from "../agents/cli-credentials.js";
+import { resolveClaudeCliProjectDirForWorkspace } from "../agents/command/claude-cli-project-dir.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveExecutablePath } from "../infra/executable-path.js";
@@ -28,8 +27,6 @@ import { note } from "../terminal/note.js";
 import { shortenHomePath } from "../utils.js";
 
 const CLAUDE_CLI_PROVIDER = "claude-cli";
-const CLAUDE_PROJECTS_DIRNAME = path.join(".claude", "projects");
-const MAX_SANITIZED_PROJECT_LENGTH = 200;
 
 type ClaudeCliReadableCredential =
   | Pick<OAuthCredential, "type" | "expires">
@@ -61,44 +58,6 @@ function resolveClaudeCliCommand(cfg: OpenClawConfig): string {
     }
   }
   return "claude";
-}
-
-function simpleHash36(input: string): string {
-  let hash = 0;
-  for (let index = 0; index < input.length; index += 1) {
-    hash = (hash * 31 + input.charCodeAt(index)) >>> 0;
-  }
-  return hash.toString(36);
-}
-
-function sanitizeClaudeCliProjectKey(workspaceDir: string): string {
-  const sanitized = workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
-  if (sanitized.length <= MAX_SANITIZED_PROJECT_LENGTH) {
-    return sanitized;
-  }
-  return `${sanitized.slice(0, MAX_SANITIZED_PROJECT_LENGTH)}-${simpleHash36(workspaceDir)}`;
-}
-
-function canonicalizeWorkspaceDir(workspaceDir: string): string {
-  const resolved = path.resolve(workspaceDir).normalize("NFC");
-  try {
-    return fs.realpathSync.native(resolved).normalize("NFC");
-  } catch {
-    return resolved;
-  }
-}
-
-export function resolveClaudeCliProjectDirForWorkspace(params: {
-  workspaceDir: string;
-  homeDir?: string;
-}): string {
-  const homeDir = normalizeOptionalString(params.homeDir) || process.env.HOME || os.homedir();
-  const canonicalWorkspaceDir = canonicalizeWorkspaceDir(params.workspaceDir);
-  return path.join(
-    homeDir,
-    CLAUDE_PROJECTS_DIRNAME,
-    sanitizeClaudeCliProjectKey(canonicalWorkspaceDir),
-  );
 }
 
 function probeDirectoryHealth(dirPath: string): ClaudeCliDirHealth {


### PR DESCRIPTION
## Summary

Closes #81042.

`claudeCliSessionTranscriptHasContent` in `src/agents/command/attempt-execution.helpers.ts` decides whether the runtime can resume a claude-cli session via `--resume` or has to start cold. The probe does a single-pass scan of the project JSONL for at least one assistant message. The problem is that claude-cli flushes the user-message header to the transcript **before** the assistant turn lands — there is a sub-100ms window where the JSONL exists on disk but lacks an assistant message. The current single-pass probe races that flush, returns `false`, the runtime decides "no transcript, cold start," and the prior turn's context is lost. The negative path was also fully silent, so gateway logs gave no signal that a `transcript-missing` reset was actually a flush race rather than a genuine missing-session.

Two small changes:

1. **Scan with one short retry.** The scan now records per-project `fileExists` and `hasAssistant`. If the first scan finds the JSONL exists but lacks an assistant message, the probe sleeps 150ms and re-scans once. The sleep is **gated on `fileExists`** so the genuinely-no-session path doesn't pay the latency.
2. **Diagnostic warn on the negative path.** Both negative outcomes (retry exhausted with file still empty; no matching JSONL in any project dir) emit `cliBackendLog.warn` with `sessionId`, `homeDir`, and the per-project diagnostic. This makes the failure mode visible instead of silent.

## Closes

Closes #81042

## Test plan

`src/agents/command/attempt-execution.test.ts` is the established home for these helpers; new tests extend that file:

1. **JSONL with assistant message present from t=0 → returns `true` immediately, no retry sleep observed.** Spies on `globalThis.setTimeout` and asserts no 150ms delay was scheduled.
2. **JSONL exists but empty at t=0, then assistant message appears during the 150ms window → returns `true`.** Mocks `setTimeout(_, 150)` so that the test appends the assistant message to the file before firing the continuation, exercising the rescan path.
3. **JSONL exists, never gains an assistant message → returns `false`, warn fires once with `"after 150ms retry"` and includes the sessionId.**
4. **No matching JSONL in any project dir → returns `false`, warn fires with `"no matching jsonl"` and `projectCount=<n>`.**

```
pnpm test src/agents/command/attempt-execution.test.ts
 Test Files  1 passed (1)
      Tests  38 passed (38)
```

`pnpm tsgo` and `pnpm check:test-types` both pass.

## Affected scope

- `claude-cli` backend only, on the **resume path**. First-turn / cold-start callers never hit this probe.
- API backends are unaffected — they don't use a transcript-based reuse check.

## Risk

- Adds at most one 150ms wait on the negative-but-file-exists path; that path is already a prelude to `transcript-missing` recovery, so the latency budget is essentially free. The truly-no-session path (no `.claude/projects/*/sessionId.jsonl` anywhere) keeps its current latency.
- `cliBackendLog` was previously imported only from inside `src/agents/cli-runner/`. The new import in `src/agents/command/attempt-execution.helpers.ts` is a one-line cross-module reference into `../cli-runner/log.js` — `log.ts` has no transitive imports from `command/` so there's no cycle. (Verified with `pnpm tsgo` and tests.)
- The new diagnostic log lines fire only on the negative path; on healthy resumes there is no log churn.

---

## Real Behavior Proof

**Behavior or issue addressed:** Closes #81042. `claudeCliSessionTranscriptHasContent` was returning `false` in the sub-100ms window where the claude-cli session JSONL existed on disk but had not yet been flushed with an assistant message. The runtime read this as `transcript-missing` and forced a cold session restart, losing all cross-turn context. The race fired most often immediately after a session-id rotation when the next inbound turn arrived before claude-cli completed its async transcript flush.

**Real environment tested:** Live OpenClaw 2026.5.7 install on Ubuntu 24.04 (`Linux 6.17.0-23-generic x86_64`), Node v22.22.0, claude-cli backend (Claude Max subscription), Telegram bot channel. Same scan-with-retry refactor as proposed in this PR was first applied as a runtime patch to the bundled `dist/attempt-execution.helpers-CENmB56f.js` so the comparison was made against actual runtime behavior, not staged simulations.

**Exact steps or command run after this patch:**

1. Apply the scan-with-retry refactor directly to the bundled `claudeCliSessionTranscriptHasContent` (matches this PR's diff: split scan into a helper returning `{ hasAssistant, fileExists, ... }` per project, retry once after 150ms when `fileExists && !hasAssistant`, log a `cliBackendLog.warn` diagnostic on the negative path).
2. `systemctl --user restart openclaw-gateway`
3. Resume normal Telegram chat use with the agent for ~75 minutes spanning ~30 turns including session rotations triggered by config changes and natural idle timeouts.
4. After the patch window, query the gateway journal for any `missing-transcript` or restart events:

```
journalctl --user -u openclaw-gateway --since "2026-05-12 09:11" \
  | grep -E "(cli-backend|claude-live|live session)" \
  | grep -E "reset|close|restart|rotate|reason="
```

**Evidence after fix:** Redacted live runtime journal output captured directly from `journalctl --user -u openclaw-gateway` on the actual install.

Pre-patch window (08:00–09:11 EDT) — three `missing-transcript` resets in 38 minutes of normal use, each cascading into a session restart. Post-hoc inspection of the JSONL files for these session ids confirmed they did exist on disk; the probe was racing the flush:

```
2026-05-12T08:13:06.295-04:00 [agent/cli-backend] cli session reset: provider=claude-cli reason=missing-transcript
2026-05-12T08:13:06.327-04:00 [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=restart
2026-05-12T08:45:08.710-04:00 [agent/cli-backend] cli session reset: provider=claude-cli reason=missing-transcript
2026-05-12T08:46:26.340-04:00 [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=restart
2026-05-12T08:51:32.073-04:00 [agent/cli-backend] cli session reset: provider=claude-cli reason=missing-transcript
2026-05-12T08:51:32.099-04:00 [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=restart
```

User-visible Telegram conversation excerpt at the moment of the 08:45:08 reset, showing the cross-turn amnesia symptom from the user's perspective:

```
[8:39 AM] Leonard: Watcher is armed — I'll page you as soon as the sentinel appears.
[8:44 AM] User:    still working on it?
[8:45 AM] Leonard: Nothing's actively in flight on my side… What's "it" referring to?
```

Post-patch window (09:11+ EDT) — full output of the same journal query:

```
$ journalctl --user -u openclaw-gateway --since "2026-05-12 09:11" \
    | grep -E "(cli-backend|claude-live|live session)" \
    | grep -E "reset|close|restart|rotate|reason="
(no matches)
```

Live Telegram screenshot from the affected install, captured pre-patch on 2026-05-12. The user asks "still working on it?" 5 minutes after the agent's earlier reply describing in-flight work; the agent denies anything is in flight and asks "What's 'it' referring to?". The user's next message quote-backs the agent's own prior message (with a hand-drawn arrow connecting the two). Two unrelated project names in the parenthetical have been redacted; the bug demonstration is not affected. This is the user-visible symptom of the runtime events shown in the journal log above.

![Telegram screenshot showing claude-cli context loss between turns](https://raw.githubusercontent.com/benjamin1492/openclaw/proof/screenshots/.github/proof-screenshots/cli-context-loss-redacted.png)

**Observed result after fix:** Zero `missing-transcript` resets in the post-patch window. Cross-turn context survives the resume path through transcript flushes that previously raced. The 150ms retry is gated on `fileExists`, so the no-session path takes the same time as before — verified by spot-checking gateway timing logs across cold-start invocations.

**What was not tested:** API-backend providers were not tested because they don't use `claudeCliSessionTranscriptHasContent`. The race was reproduced on Linux only; the same flush behavior in claude-cli should apply on macOS, but it was not exercised here. The companion fingerprint bug #81041 remained patched throughout these runs to keep session lifetimes long enough for the transcript probe to be exercised.
