### PR TITLE
fix(anthropic): reseed Claude CLI context after session-expired retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Build: skip copied metadata for bundled plugins that are excluded from build entries, preventing update/status rebuilds from advertising missing QQ Bot runtime files. (#80925)
 - Control UI/sessions: nest subagent sessions under their parent session in the session picker dropdown using a visual `└─ ` prefix, making the parent-child relationship clear. Fixes #77628. (#78623) Thanks @chinar-amrutkar.
 - Auto-reply: surface a visible error when the configured model backend fails and fallback produces no visible reply, while preserving intentional silent turns and side-effect-only deliveries. (#80917) Thanks @dutifulbob.
+- Anthropic/Claude CLI: opt into raw transcript reseed on safe session invalidations so session-expired retries preserve prior uncompacted context instead of starting with amnesia. Fixes #80905.
 
 ### Changes
 

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -63,6 +63,7 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
       imagePathScope: "workspace",
       sessionArg: "--session-id",
       sessionMode: "always",
+      reseedFromRawTranscriptWhenUncompacted: true,
       sessionIdFields: [...CLAUDE_CLI_SESSION_ID_FIELDS],
       systemPromptFileArg: "--append-system-prompt-file",
       systemPromptMode: "append",

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -138,6 +138,11 @@ describe("resolveClaudeCliExecutionArgs", () => {
 });
 
 describe("normalizeClaudeBackendConfig", () => {
+  it("opts in to raw transcript reseed for safe session invalidations", () => {
+    const backend = buildAnthropicCliBackend();
+    expect(backend.config.reseedFromRawTranscriptWhenUncompacted).toBe(true);
+  });
+
   it("normalizes both args and resumeArgs for custom overrides", () => {
     const normalized = normalizeClaudeBackendConfig({
       command: "claude",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Claude CLI session rotation (`session-expired`) could restart with missing prior context for Anthropic backend runs.
- Why it matters: users can see conversation amnesia after retry, even when uncompacted transcript tail exists.
- What changed: enabled Anthropic backend opt-in for raw transcript reseed and added a regression check.
- What did NOT change (scope boundary): no core runner policy changes, no new protocol/config surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80905
- Related #80934
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: preserve Anthropic Claude CLI context across `session-expired` retry by enabling reseed from uncompacted transcript tail.
- Real environment tested: local OpenClaw setup on Ubuntu 24.04 (Node 22, pnpm 11) in this workspace.
- Exact steps or command run after this patch:
  - `pnpm openclaw --version`
  - `node -e "const fs=require('fs');const p='extensions/anthropic/cli-backend.ts';const t=fs.readFileSync(p,'utf8');const i=t.indexOf('reseedFromRawTranscriptWhenUncompacted: true');console.log(i>=0?'FOUND reseed flag in '+p:'MISSING reseed flag');"`
  - `pnpm test extensions/anthropic/cli-shared.test.ts -t "opts in to raw transcript reseed for safe session invalidations"`
- Evidence after fix (terminal capture, copied live output):

```text
$ pnpm openclaw --version
OpenClaw 2026.5.12-beta.1 (b99386b)

$ node -e "..."
FOUND reseed flag in extensions/anthropic/cli-backend.ts

$ pnpm test extensions/anthropic/cli-shared.test.ts -t "opts in to raw transcript reseed for safe session invalidations"
Test Files  1 passed (1)
Tests       1 passed | 16 skipped (17)
```

- Observed result after fix: Anthropic backend now ships with reseed opt-in enabled, and the focused regression scenario passes in a live local OpenClaw environment.
- What was not tested: fully authenticated external Claude account session-rotation replay with provider-side expiry timing control.
- Before evidence (optional but encouraged): issue report #80905 and pre-sent PR #80934 discussion describe amnesia behavior before this owner-plugin opt-in.

## Root Cause (if applicable)

- Root cause: Anthropic backend config did not set `reseedFromRawTranscriptWhenUncompacted: true`, so existing generic reseed path stayed disabled for this backend.
- Missing detection / guardrail: no explicit backend-level regression asserting this opt-in contract.
- Contributing context (if known): core reseed machinery already existed and was bounded; this was a plugin-owned config gap.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/anthropic/cli-shared.test.ts`; existing reseed path checks remain in `src/agents/cli-runner/prepare.test.ts`.
- Scenario the test should lock in: Anthropic backend remains opted into raw transcript reseed for safe invalidation reasons, including `session-expired` retry path support.
- Why this is the smallest reliable guardrail: the regression source is backend opt-in drift, so a focused assertion is direct and stable.
- Existing test that already covers this (if any): generic runner tests validate reseed behavior when backend opt-in is enabled.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Anthropic Claude CLI retries after `session-expired` now preserve prior uncompacted context via raw-tail reseed instead of potentially restarting without that context.

## Diagram (if applicable)

```text
Before:
session-expired -> retry -> Anthropic backend not opted in -> no raw-tail reseed -> context-loss risk

After:
session-expired -> retry -> Anthropic backend opted in -> raw-tail reseed -> prior context preserved
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 22 + pnpm 11 workspace
- Model/provider: Anthropic Claude CLI backend path
- Integration/channel (if any): N/A
- Relevant config (redacted): bundled Anthropic backend defaults with the added reseed opt-in

### Steps

1. Confirm OpenClaw runtime is available (`pnpm openclaw --version`).
2. Confirm backend opt-in is present in source (`node -e ...`).
3. Run focused regression scenario (`pnpm test ... -t "opts in ..."`).

### Expected

- Anthropic backend opts into reseed and regression scenario passes.

### Actual

- Matched expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: runtime availability, backend opt-in presence, focused regression pass.
- Edge cases checked: scope remains plugin-local; no core runtime branch changes.
- What you did **not** verify: provider-account live expiry timing orchestration in external Anthropic environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: accidental backend opt-in removal in future edits could reintroduce amnesia behavior.
  - Mitigation: added explicit Anthropic regression assertion for this config contract.
