### PR TITLE
[Fix] Cap WhatsApp inbound media streams

### DIFF
--- a/extensions/whatsapp/src/inbound.media.test.ts
+++ b/extensions/whatsapp/src/inbound.media.test.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   mockExtractMessageContent,
@@ -15,6 +16,7 @@ type MockMessageInput = Parameters<typeof mockNormalizeMessageContent>[0];
 const readAllowFromStoreMock = vi.fn().mockResolvedValue([]);
 const upsertPairingRequestMock = vi.fn().mockResolvedValue({ code: "PAIRCODE", created: true });
 const saveMediaBufferSpy = vi.fn();
+const downloadMediaMessageMock = vi.fn();
 let currentMockSocket:
   | {
       ev: import("node:events").EventEmitter;
@@ -110,7 +112,10 @@ vi.mock("baileys", async () => {
   return {
     ...actual,
     DisconnectReason: actual.DisconnectReason ?? { loggedOut: 401 },
-    downloadMediaMessage: vi.fn().mockResolvedValue(jpegBuffer),
+    downloadMediaMessage: downloadMediaMessageMock.mockImplementation(
+      async (_message: unknown, type: "buffer" | "stream") =>
+        type === "stream" ? Readable.from([jpegBuffer]) : jpegBuffer,
+    ),
     extractMessageContent: vi.fn((message: MockMessageInput) => mockExtractMessageContent(message)),
     getContentType: vi.fn((message: MockMessageInput) => mockGetContentType(message)),
     isJidGroup: vi.fn((jid: string | undefined | null) => mockIsJidGroup(jid)),
@@ -173,6 +178,7 @@ describe("web inbound media saves with extension", () => {
   beforeEach(() => {
     vi.useRealTimers();
     currentMockSocket = undefined;
+    downloadMediaMessageMock.mockClear();
     saveMediaBufferSpy.mockClear();
     resetWebInboundDedupe();
   });
@@ -325,6 +331,97 @@ describe("web inbound media saves with extension", () => {
     expect(saveMediaBufferSpy).toHaveBeenCalled();
     const lastCall = saveMediaBufferSpy.mock.calls.at(-1);
     expect(lastCall?.[3]).toBe(1 * 1024 * 1024);
+
+    await listener.close();
+  });
+
+  it("rejects over-limit inbound media before saving", async () => {
+    const onMessage = vi.fn();
+    const listener = await monitorWebInbox({
+      cfg: {
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        messages: { messagePrefix: undefined, responsePrefix: undefined },
+      } as never,
+      verbose: false,
+      onMessage,
+      mediaMaxMb: 0.000001,
+      accountId: "default",
+      authDir: path.join(HOME, "wa-auth"),
+    });
+    const realSock = await getMockSocket();
+    downloadMediaMessageMock.mockImplementationOnce(
+      async (_message: unknown, type: "buffer" | "stream") => {
+        const chunks = [Buffer.alloc(2), Buffer.alloc(2)];
+        return type === "stream" ? Readable.from(chunks) : Buffer.concat(chunks);
+      },
+    );
+
+    realSock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: { id: "img-over-limit", fromMe: false, remoteJid: "222@s.whatsapp.net" },
+          message: { imageMessage: { mimetype: "image/jpeg" } },
+          messageTimestamp: 1_700_000_006,
+        },
+      ],
+    });
+
+    const inbound = await waitForMessage(onMessage);
+    expect(downloadMediaMessageMock.mock.calls.at(-1)?.[1]).toBe("stream");
+    expect(inbound.mediaPath).toBeUndefined();
+    expect(saveMediaBufferSpy).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
+  it("does not fall back to quoted media after rejecting over-limit current media", async () => {
+    const onMessage = vi.fn();
+    const listener = await monitorWebInbox({
+      cfg: {
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        messages: { messagePrefix: undefined, responsePrefix: undefined },
+      } as never,
+      verbose: false,
+      onMessage,
+      mediaMaxMb: 0.000001,
+      accountId: "default",
+      authDir: path.join(HOME, "wa-auth"),
+    });
+    const realSock = await getMockSocket();
+    downloadMediaMessageMock.mockImplementationOnce(
+      async (_message: unknown, type: "buffer" | "stream") => {
+        const chunks = [Buffer.alloc(2), Buffer.alloc(2)];
+        return type === "stream" ? Readable.from(chunks) : Buffer.concat(chunks);
+      },
+    );
+
+    realSock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: { id: "img-over-limit-with-quote", fromMe: false, remoteJid: "222@s.whatsapp.net" },
+          message: {
+            imageMessage: {
+              mimetype: "image/jpeg",
+              contextInfo: {
+                stanzaId: "quoted-image",
+                participant: "333@s.whatsapp.net",
+                quotedMessage: {
+                  imageMessage: { mimetype: "image/jpeg" },
+                },
+              },
+            },
+          },
+          messageTimestamp: 1_700_000_007,
+        },
+      ],
+    });
+
+    const inbound = await waitForMessage(onMessage);
+    expect(downloadMediaMessageMock).toHaveBeenCalledTimes(1);
+    expect(inbound.mediaPath).toBeUndefined();
+    expect(saveMediaBufferSpy).not.toHaveBeenCalled();
 
     await listener.close();
   });

--- a/extensions/whatsapp/src/inbound/media.node.test.ts
+++ b/extensions/whatsapp/src/inbound/media.node.test.ts
@@ -5,7 +5,14 @@ type MockMessageInput = Parameters<typeof mockNormalizeMessageContent>[0];
 
 const { normalizeMessageContent, downloadMediaMessage } = vi.hoisted(() => ({
   normalizeMessageContent: vi.fn((msg: MockMessageInput) => mockNormalizeMessageContent(msg)),
-  downloadMediaMessage: vi.fn().mockResolvedValue(Buffer.from("fake-media-data")),
+  downloadMediaMessage: vi.fn(async (_message: unknown, type: "buffer" | "stream") => {
+    const buffer = Buffer.from("fake-media-data");
+    if (type === "stream") {
+      const { Readable } = await import("node:stream");
+      return Readable.from([buffer]);
+    }
+    return buffer;
+  }),
 }));
 
 vi.mock("baileys", async () => {

--- a/extensions/whatsapp/src/inbound/media.ts
+++ b/extensions/whatsapp/src/inbound/media.ts
@@ -40,9 +40,56 @@ function resolveMediaMimetype(message: proto.IMessage): string | undefined {
   return undefined;
 }
 
+type MediaByteStream = AsyncIterable<unknown> & {
+  destroy?: () => void;
+};
+
+class WhatsAppInboundMediaLimitExceededError extends Error {
+  constructor(limit: number) {
+    super(`WhatsApp inbound media exceeds ${limit} byte limit`);
+    this.name = "WhatsAppInboundMediaLimitExceededError";
+  }
+}
+
+function normalizeMediaChunk(chunk: unknown): Buffer {
+  if (Buffer.isBuffer(chunk)) {
+    return chunk;
+  }
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk);
+  }
+  if (chunk instanceof ArrayBuffer) {
+    return Buffer.from(chunk);
+  }
+  if (typeof chunk === "string") {
+    return Buffer.from(chunk);
+  }
+  throw new Error("Unexpected WhatsApp media stream chunk");
+}
+
+async function readMediaStream(stream: MediaByteStream, maxBytes?: number): Promise<Buffer> {
+  const limit =
+    typeof maxBytes === "number" && Number.isFinite(maxBytes) && maxBytes >= 0
+      ? maxBytes
+      : undefined;
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of stream) {
+    const buffer = normalizeMediaChunk(chunk);
+    totalBytes += buffer.byteLength;
+    if (limit !== undefined && totalBytes > limit) {
+      stream.destroy?.();
+      throw new WhatsAppInboundMediaLimitExceededError(limit);
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks, totalBytes);
+}
+
 export async function downloadInboundMedia(
   msg: proto.IWebMessageInfo,
   sock: Awaited<ReturnType<typeof createWaSocket>>,
+  maxBytes?: number,
 ): Promise<{ buffer: Buffer; mimetype?: string; fileName?: string } | undefined> {
   const message = unwrapMessage(msg.message as proto.IMessage | undefined);
   if (!message) {
@@ -60,17 +107,21 @@ export async function downloadInboundMedia(
     return undefined;
   }
   try {
-    const buffer = await downloadMediaMessage(
+    const stream = await downloadMediaMessage(
       msg as WAMessage,
-      "buffer",
+      "stream",
       {},
       {
         reuploadRequest: sock.updateMediaMessage,
         logger: sock.logger,
       },
     );
+    const buffer = await readMediaStream(stream, maxBytes);
     return { buffer, mimetype, fileName };
   } catch (err) {
+    if (err instanceof WhatsAppInboundMediaLimitExceededError) {
+      throw err;
+    }
     logVerbose(`downloadMediaMessage failed: ${String(err)}`);
     return undefined;
   }
@@ -79,6 +130,7 @@ export async function downloadInboundMedia(
 export async function downloadQuotedInboundMedia(
   msg: proto.IWebMessageInfo,
   sock: Awaited<ReturnType<typeof createWaSocket>>,
+  maxBytes?: number,
 ): Promise<{ buffer: Buffer; mimetype?: string; fileName?: string } | undefined> {
   const message = unwrapMessage(msg.message as proto.IMessage | undefined);
   const contextInfo = extractContextInfo(message);
@@ -98,5 +150,6 @@ export async function downloadQuotedInboundMedia(
       messageTimestamp: msg.messageTimestamp,
     },
     sock,
+    maxBytes,
   );
 }

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -633,15 +633,15 @@ export async function attachWebInboxToSocket(
     let mediaPath: string | undefined;
     let mediaType: string | undefined;
     let mediaFileName: string | undefined;
+    const maxMb =
+      typeof options.mediaMaxMb === "number" && options.mediaMaxMb > 0 ? options.mediaMaxMb : 50;
+    const maxBytes = maxMb * 1024 * 1024;
     const saveInboundMedia = async (
       inboundMedia: Awaited<ReturnType<typeof downloadInboundMedia>>,
     ) => {
       if (!inboundMedia) {
         return;
       }
-      const maxMb =
-        typeof options.mediaMaxMb === "number" && options.mediaMaxMb > 0 ? options.mediaMaxMb : 50;
-      const maxBytes = maxMb * 1024 * 1024;
       const saved = await saveMediaBuffer(
         inboundMedia.buffer,
         inboundMedia.mimetype,
@@ -654,11 +654,11 @@ export async function attachWebInboxToSocket(
       mediaFileName = inboundMedia.fileName;
     };
     try {
-      const inboundMedia = await downloadInboundMedia(msg as proto.IWebMessageInfo, sock);
+      const inboundMedia = await downloadInboundMedia(msg as proto.IWebMessageInfo, sock, maxBytes);
       await saveInboundMedia(inboundMedia);
       if (!mediaPath && replyContext) {
         await saveInboundMedia(
-          await downloadQuotedInboundMedia(msg as proto.IWebMessageInfo, sock),
+          await downloadQuotedInboundMedia(msg as proto.IWebMessageInfo, sock, maxBytes),
         );
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: WhatsApp inbound media used Baileys buffer downloads, so media could be fully materialized before `mediaMaxMb` was enforced.
- Why it matters: An over-limit inbound attachment should stop reading before persistence and should not fall through to quoted-media fallback.
- What changed: Switched inbound media downloads to Baileys stream mode, counted bytes while reading, rethrew over-limit errors, and added direct plus quoted-fallback regression coverage.
- What did NOT change (scope boundary): Accepted media is still buffered before `saveMediaBuffer`; this does not redesign media storage or add zero-copy persistence.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Over-limit WhatsApp inbound media is rejected during stream read before `saveMediaBuffer`, including when the current media message also has quoted media context.
- Real environment tested: Local macOS workspace, Node 22 project runtime, installed Baileys package from this repository checkout, and the OpenClaw WhatsApp inbound monitor test harness.
- Exact steps or command run after this patch: `pnpm test extensions/whatsapp/src/inbound.media.test.ts extensions/whatsapp/src/inbound/media.node.test.ts -- --reporter=verbose`
- Live WhatsApp proof status: Not run in this ship flow; the local gateway did not have a configured WhatsApp channel/account available for a real media download.
- Dependency contract checked: Installed Baileys exposes `downloadMediaMessage(..., "stream", ...)`, and the patched WhatsApp helper calls that mode before enforcing `mediaMaxMb` while reading.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `Test Files 2 passed (2); Tests 14 passed (14); [test] passed 1 Vitest shard in 5.86s`
- Observed result after fix: The over-limit WhatsApp current-media fixture uses `"stream"`, does not call `saveMediaBuffer`, and does not attempt a second quoted-media download.
- What was not tested: Live WhatsApp media download with real account credentials.
- Before evidence (optional but encouraged): Before the final fix, the WhatsApp quoted-fallback regression failed with `expected "vi.fn()" to be called 1 times, but got 2 times`.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `downloadInboundMedia` requested Baileys `"buffer"` output, and `monitor.ts` only passed `maxBytes` to `saveMediaBuffer` after the full buffer had already been returned.
- Missing detection / guardrail: Existing tests only proved `mediaMaxMb` reached `saveMediaBuffer`; they did not prove the download/read helper stopped before persistence or blocked quoted fallback after rejecting current media.
- Contributing context (if known): Baileys already exposes a stream mode, but the inbound helper was using the buffer path.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/inbound.media.test.ts`
- Scenario the test should lock in: Over-limit inbound media is read via stream, rejected before save, and does not fall back to quoted media.
- Why this is the smallest reliable guardrail: The monitor-level test exercises the inbound save path, Baileys download seam, and `saveMediaBuffer` boundary without requiring live WhatsApp credentials.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: New regression tests were added.

## User-visible / Behavior Changes

Over-limit WhatsApp inbound media is now rejected while reading instead of after full buffering. Messages can still be delivered without a saved media path when media download is rejected.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[WhatsApp media] -> [Baileys buffer download] -> [saveMediaBuffer max check]

After:
[WhatsApp media] -> [Baileys stream read + byte count] -> [save only if within cap]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 project runtime via `pnpm`
- Model/provider: N/A
- Integration/channel (if any): WhatsApp plugin
- Relevant config (redacted): `mediaMaxMb` test fixture set to `0.000001`

### Steps

1. Emit an inbound WhatsApp image fixture larger than the configured byte cap.
2. Emit an inbound WhatsApp image fixture larger than the cap with quoted image context.
3. Run `pnpm test extensions/whatsapp/src/inbound.media.test.ts extensions/whatsapp/src/inbound/media.node.test.ts -- --reporter=verbose`.

### Expected

- The download helper requests Baileys `"stream"` mode, rejects over-limit media before saving, and does not fall back to quoted media after rejecting current media.

### Actual

- The targeted test command passes with 14 tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Direct over-limit inbound media, current over-limit media with quoted media context, normal media save behavior, document filename preservation, quoted image save behavior.
- Edge cases checked: Baileys stream contract from installed source/types; over-limit error is rethrown while ordinary download failures still return `undefined`.
- What you did **not** verify: Live WhatsApp account media download.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Live WhatsApp media behavior may differ from the mocked seam.
  - Mitigation: The implementation uses Baileys' installed `"stream"` contract, and the regression tests exercise the OpenClaw inbound save boundary.


