### PR TITLE
fix(telegram): preserve quote and code formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: cap native quote reply text before sending chunked replies and preserve model-emitted code tags in HTML-formatted outbound messages.
 - fix(node-pairing): replace changed pending requests [AI]. (#80894) Thanks @pgondhi987.
 - Rate limit Google Chat webhook requests [AI]. (#80974) Thanks @pgondhi987.
 - Docker: mount the auth-profile secret key directory so OAuth-backed auth profiles survive container rebuilds. (#80991)

--- a/extensions/telegram/src/channel.gateway.test.ts
+++ b/extensions/telegram/src/channel.gateway.test.ts
@@ -245,6 +245,25 @@ describe("telegramPlugin outbound attachments", () => {
     expect(sendMessageTelegram.mock.calls.at(1)?.[2]?.textMode).toBe("html");
   });
 
+  it("normalizes model-emitted code tags before HTML outbound chunking", async () => {
+    installTelegramRuntime();
+    sendMessageTelegram.mockResolvedValue({ messageId: "tg-code", chatId: "12345" });
+    const sendText = telegramPlugin.outbound?.sendText;
+    if (!sendText) {
+      throw new Error("Expected Telegram outbound sendText");
+    }
+
+    await sendText({
+      cfg: createTelegramConfig(),
+      to: "12345",
+      text: "run <code>pnpm test</code>",
+      formatting: { parseMode: "HTML" },
+    });
+
+    expect(sendMessageTelegram.mock.calls.at(0)?.[1]).toBe("run <code>pnpm test</code>");
+    expect(sendMessageTelegram.mock.calls.at(0)?.[2]?.textMode).toBe("html");
+  });
+
   it("preserves explicit HTML parse mode for payload media captions", async () => {
     installTelegramRuntime();
     sendMessageTelegram.mockResolvedValue({ messageId: "tg-payload", chatId: "12345" });

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -21,6 +21,16 @@ describe("markdownToTelegramHtml", () => {
       ],
       ["preserves Telegram HTML", "<b>yes</b>", "<b>yes</b>"],
       [
+        "preserves model-emitted code tags",
+        "run <code>pnpm test</code>",
+        "run <code>pnpm test</code>",
+      ],
+      [
+        "preserves model-emitted pre-code tags",
+        "<pre><code>pnpm test</code></pre>",
+        "<pre><code>pnpm test</code></pre>",
+      ],
+      [
         "escapes unsupported raw HTML",
         "<script>nope</script>",
         "&lt;script&gt;nope&lt;/script&gt;",

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -27,6 +27,13 @@ function escapeHtmlAttr(text: string): string {
   return escapeHtml(text).replace(/"/g, "&quot;");
 }
 
+function unescapeModelEmittedTelegramCodeTags(html: string): string {
+  return html.replace(
+    /&lt;(\/?)((?:code|pre))&gt;/gi,
+    (_match, slash: string, tag: string) => `<${slash}${tag.toLowerCase()}>`,
+  );
+}
+
 /**
  * File extensions that share TLDs and commonly appear in code/documentation.
  * These are wrapped in <code> tags to prevent Telegram from generating
@@ -61,7 +68,7 @@ function buildTelegramLink(link: MarkdownLinkSpan, text: string) {
 }
 
 function renderTelegramHtml(ir: MarkdownIR): string {
-  return renderMarkdownWithMarkers(ir, {
+  const html = renderMarkdownWithMarkers(ir, {
     styleMarkers: {
       bold: { open: "<b>", close: "</b>" },
       italic: { open: "<i>", close: "</i>" },
@@ -74,6 +81,7 @@ function renderTelegramHtml(ir: MarkdownIR): string {
     escapeText: escapeHtml,
     buildLink: buildTelegramLink,
   });
+  return unescapeModelEmittedTelegramCodeTags(html);
 }
 
 function leadingWhitespaceLength(line: string): number {

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -19,7 +19,11 @@ import {
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";
-import { markdownToTelegramHtmlChunks, splitTelegramHtmlChunks } from "./format.js";
+import {
+  markdownToTelegramHtmlChunks,
+  renderTelegramHtmlText,
+  splitTelegramHtmlChunks,
+} from "./format.js";
 import { resolveTelegramInteractiveTextFallback } from "./interactive-fallback.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
 
@@ -52,7 +56,7 @@ function chunkTelegramOutboundText(
   ctx?: { formatting?: OutboundDeliveryFormattingOptions },
 ): string[] {
   return ctx?.formatting?.parseMode === "HTML"
-    ? splitTelegramHtmlChunks(text, limit)
+    ? splitTelegramHtmlChunks(renderTelegramHtmlText(text), limit)
     : markdownToTelegramHtmlChunks(text, limit);
 }
 

--- a/extensions/telegram/src/reply-parameters.test.ts
+++ b/extensions/telegram/src/reply-parameters.test.ts
@@ -47,6 +47,28 @@ describe("telegram reply parameters", () => {
     });
   });
 
+  it("caps native quote text and entities before sending", () => {
+    const longQuote = `${"a".repeat(1020)}bold tail`;
+
+    expect(
+      buildTelegramThreadReplyParams({
+        replyToMessageId: 77,
+        replyQuoteMessageId: 77,
+        replyQuoteText: longQuote,
+        replyQuotePosition: 3,
+        replyQuoteEntities: [{ type: "bold", offset: 1020, length: 9 }],
+      }),
+    ).toEqual({
+      reply_parameters: {
+        message_id: 77,
+        quote: `${"a".repeat(1020)}bold`,
+        quote_position: 3,
+        quote_entities: [{ type: "bold", offset: 1020, length: 4 }],
+        allow_sending_without_reply: true,
+      },
+    });
+  });
+
   it("falls back to legacy reply id for blank quotes or mismatched quote sources", () => {
     expect(
       buildTelegramThreadReplyParams({

--- a/extensions/telegram/src/reply-parameters.ts
+++ b/extensions/telegram/src/reply-parameters.ts
@@ -1,5 +1,6 @@
 import type { MessageEntity } from "@grammyjs/types";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
+import { buildTelegramNativeQuoteCandidate } from "./bot/native-quote.js";
 import { normalizeTelegramReplyToMessageId } from "./outbound-params.js";
 
 type TelegramReplyParameters = {
@@ -63,7 +64,13 @@ export function buildTelegramThreadReplyParams(opts?: {
   const replyQuoteTextRaw =
     replyQuoteMessageId === replyToMessageId ? opts?.replyQuoteText : undefined;
   const replyQuoteText = replyQuoteTextRaw?.trim() ? replyQuoteTextRaw : undefined;
-  if (!replyQuoteText) {
+  const replyQuoteCandidate = buildTelegramNativeQuoteCandidate({
+    text: replyQuoteText,
+    entities: Array.isArray(opts?.replyQuoteEntities)
+      ? (opts.replyQuoteEntities as MessageEntity[])
+      : undefined,
+  });
+  if (!replyQuoteCandidate) {
     params.reply_to_message_id = replyToMessageId;
     params.allow_sending_without_reply = true;
     return params;
@@ -71,14 +78,14 @@ export function buildTelegramThreadReplyParams(opts?: {
 
   const replyParameters: TelegramReplyParameters = {
     message_id: replyToMessageId,
-    quote: replyQuoteText,
+    quote: replyQuoteCandidate.text,
     allow_sending_without_reply: true,
   };
   if (typeof opts?.replyQuotePosition === "number" && Number.isFinite(opts.replyQuotePosition)) {
     replyParameters.quote_position = Math.trunc(opts.replyQuotePosition);
   }
-  if (Array.isArray(opts?.replyQuoteEntities) && opts.replyQuoteEntities.length > 0) {
-    replyParameters.quote_entities = opts.replyQuoteEntities as MessageEntity[];
+  if (replyQuoteCandidate.entities) {
+    replyParameters.quote_entities = replyQuoteCandidate.entities as MessageEntity[];
   }
   params.reply_parameters = replyParameters;
   return params;


### PR DESCRIPTION
## Summary
- cap Telegram native quote reply text/entities before sending reply parameters so long quoted messages do not dominate chunked replies
- preserve model-emitted Telegram HTML code/pre tags through HTML-formatted outbound chunking
- add regression coverage for quote capping and HTML/code rendering paths

## Verification
- CI=true pnpm test extensions/telegram/src/format.test.ts extensions/telegram/src/channel.gateway.test.ts extensions/telegram/src/reply-parameters.test.ts
- git diff --check
- CI=true pnpm build
- live Telegram cron announce retest rendered <code>...</code> as code instead of literal tags
