### PR TITLE
docs: remove platforms from channel list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Run `openclaw doctor` to surface risky/misconfigured DM policies.
 ## Highlights
 
 - **[Local-first Gateway](https://docs.openclaw.ai/gateway)** — single control plane for sessions, channels, tools, and events.
-- **[Multi-channel inbox](https://docs.openclaw.ai/channels)** — WhatsApp, Telegram, Slack, Discord, Google Chat, Signal, iMessage, IRC, Microsoft Teams, Matrix, Feishu, LINE, Mattermost, Nextcloud Talk, Nostr, Synology Chat, Tlon, Twitch, Zalo, Zalo Personal, WeChat, QQ, WebChat, macOS, iOS/Android.
+- **[Multi-channel inbox](https://docs.openclaw.ai/channels)** — WhatsApp, Telegram, Slack, Discord, Google Chat, Signal, iMessage, IRC, Microsoft Teams, Matrix, Feishu, LINE, Mattermost, Nextcloud Talk, Nostr, Synology Chat, Tlon, Twitch, Zalo, Zalo Personal, WeChat, QQ, WebChat.
 - **[Multi-agent routing](https://docs.openclaw.ai/gateway/configuration)** — route inbound channels/accounts/peers to isolated agents (workspaces + per-agent sessions).
 - **[Voice Wake](https://docs.openclaw.ai/nodes/voicewake) + [Talk Mode](https://docs.openclaw.ai/nodes/talk)** — wake words on macOS/iOS and continuous voice on Android (ElevenLabs + system TTS fallback).
 - **[Live Canvas](https://docs.openclaw.ai/platforms/mac/canvas)** — agent-driven visual workspace with [A2UI](https://docs.openclaw.ai/platforms/mac/canvas#canvas-a2ui).


### PR DESCRIPTION
## What

Removes `macOS, iOS/Android` from the channel list in the README Highlights section.

## Why

The channel list was mixing messaging channels (WhatsApp, Telegram, Discord, etc.) with platform nodes (macOS, iOS/Android). This creates confusion because:

- Platforms are not messaging channels
- They're already documented in the "Companion apps" section below
- The list is specifically about messaging surface integrations, not execution platforms

## Changes

- Line 149: Removed `, macOS, iOS/Android` from the Multi-channel inbox bullet point

## Real behavior proof

**Behavior or issue addressed**: README incorrectly lists platform types (macOS, iOS/Android) alongside messaging channels in the Multi-channel inbox bullet point.

**Real environment tested**: Local markdown rendering with GitHub preview and VS Code markdown preview.

**Exact steps or command run after this patch**:
1. Viewed README.md in GitHub web interface
2. Verified markdown renders correctly
3. Confirmed channel list now only contains messaging services
4. Verified "Companion apps" section still documents platform apps

**Evidence after fix**: 
- Before: Line 149 ended with `...WeChat, QQ, WebChat, macOS, iOS/Android.`
- After: Line 149 ends with `...WeChat, QQ, WebChat.`
- The platforms are already covered in lines 181-208 under "Apps (optional)" section
- Screenshot: <img width="812" height="76" alt="Screenshot 2026-05-12 at 17 32 17" src="https://github.com/user-attachments/assets/1b638eaf-96f9-484a-9eb4-7e236bd3fa99" />

**Observed result after fix**: The channel list now accurately reflects only messaging channel integrations, improving reader clarity. Platforms remain documented in their proper section.

**What was not tested**: No functional code changes - documentation only.

---

**Category:** Documentation cleanup  
**Impact:** Low - improves clarity, no functional changes
