### PR TITLE
fix(tui): suppress error-stop assistant turns in history replay

### DIFF
--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -415,4 +415,61 @@ describe("tui session actions", () => {
     expect(state.currentSessionId).toBe("session-main");
     expect(rememberSessionKey).toHaveBeenCalledWith("agent:main:main");
   });
+
+  it("suppresses error-stop assistant turns during history replay", async () => {
+    // Regression: stream-error fallback turns (stopReason: "error") accumulated
+    // in session files from failed boot-time connections were replayed verbatim
+    // as "[assistant turn failed before producing content]" chat lines, spamming
+    // the scroll on every session load. They must be silently skipped.
+    const finalizeAssistant = vi.fn();
+    const addSystem = vi.fn();
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-main",
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "model not ready",
+          content: [{ type: "text", text: "[assistant turn failed before producing content]" }],
+        },
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "gateway not connected",
+          content: [{ type: "text", text: "[assistant turn failed before producing content]" }],
+        },
+        {
+          role: "assistant",
+          stopReason: "end_turn",
+          content: [{ type: "text", text: "Hello! How can I help?" }],
+        },
+      ],
+    });
+
+    const { loadHistory: runLoadHistory } = createTestSessionActions({
+      client: {
+        listSessions: vi.fn().mockResolvedValue({
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 1,
+          defaults: {},
+          sessions: [{ key: "agent:main:main", sessionId: "session-main" }],
+        }),
+        loadHistory,
+      } as unknown as TuiBackend,
+      chatLog: {
+        addSystem,
+        clearAll: vi.fn(),
+        finalizeAssistant,
+      } as unknown as import("./components/chat-log.js").ChatLog,
+    });
+
+    await runLoadHistory();
+
+    // Only the non-error assistant turn should be rendered
+    expect(finalizeAssistant).toHaveBeenCalledTimes(1);
+    expect(finalizeAssistant).toHaveBeenCalledWith("Hello! How can I help?");
+    // The fallback error text must never appear in the chat log
+    expect(addSystem).not.toHaveBeenCalledWith("[assistant turn failed before producing content]");
+  });
 });

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -337,6 +337,14 @@ export function createSessionActions(context: SessionActionContext) {
           continue;
         }
         if (message.role === "assistant") {
+          // Skip error-stop turns in history — these are synthetic fallback entries
+          // written by session-file-repair when a stream attempt failed before
+          // producing content (e.g. gateway not yet connected at boot time).
+          // Displaying them as "[assistant turn failed before producing content]"
+          // spams the chat scroll on session reload with stale noise.
+          if (message.stopReason === "error") {
+            continue;
+          }
           const text = extractTextFromMessage(message, {
             includeThinking: state.showThinking,
           });


### PR DESCRIPTION
## Summary

- When a CVM boots and the TUI connects before the gateway's inference backend is ready, gateway stream attempts fail and are saved in the session file as synthetic `[assistant turn failed before producing content]` entries (with `stopReason: "error"`). These are stored intentionally to keep the session transcript coherent for model replay.
- On the next TUI startup, `loadHistory()` replayed every one of these error-stop entries as a chat message, causing dozens of stale noise lines to spam the chat scroll before the user's first real message appeared.
- Fix: skip any assistant history entry with `stopReason === "error"` in `loadHistory()`. Error-stop fallback entries carry no user-visible information worth redisplaying.

## Test plan

- [ ] `pnpm test src/tui/tui-session-actions.test.ts` — new regression test "suppresses error-stop assistant turns during history replay" added, all 8 tests pass
- [ ] Fresh TUI session with a clean session file: no change in behaviour
- [ ] Session file containing prior `stopReason: "error"` entries: those entries no longer appear in chat scroll on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)