### PR TITLE
fix(cli): keep status json secret diagnostics off stdout

### DIFF
--- a/src/cli/command-config-resolution.test.ts
+++ b/src/cli/command-config-resolution.test.ts
@@ -54,7 +54,7 @@ describe("resolveCommandConfigWithSecrets", () => {
     });
   });
 
-  it("routes diagnostics to stderr for json commands", async () => {
+  it("routes diagnostics to stderr when requested for json output", async () => {
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as const;
     const config = { channels: {} };
     const resolvedConfig = { channels: { discord: {} } };
@@ -67,9 +67,10 @@ describe("resolveCommandConfigWithSecrets", () => {
 
     await resolveCommandConfigWithSecrets({
       config,
-      commandName: "status --json",
+      commandName: "models status",
       targetIds: new Set(["channels.discord.token"]),
       mode: "read_only_status",
+      diagnosticStream: "stderr",
       runtime,
     });
 
@@ -77,6 +78,26 @@ describe("resolveCommandConfigWithSecrets", () => {
     expect(runtime.error).toHaveBeenCalledWith(
       '[secrets] status --json: failed to resolve channels.discord.token locally (Environment variable "DISCORD_BOT_TOKEN" is missing or empty.).',
     );
+  });
+
+  it("routes diagnostics to stdout only when explicitly requested", async () => {
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as const;
+    const config = { channels: {} };
+    mocks.resolveCommandSecretRefsViaGateway.mockResolvedValue({
+      resolvedConfig: config,
+      diagnostics: ["resolved channels.discord.token"],
+    });
+
+    await resolveCommandConfigWithSecrets({
+      config,
+      commandName: "status",
+      targetIds: new Set(["channels.discord.token"]),
+      diagnosticStream: "stdout",
+      runtime,
+    });
+
+    expect(runtime.log).toHaveBeenCalledWith("[secrets] resolved channels.discord.token");
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 
   it("returns auto-enabled config when requested", async () => {

--- a/src/cli/command-config-resolution.test.ts
+++ b/src/cli/command-config-resolution.test.ts
@@ -54,6 +54,31 @@ describe("resolveCommandConfigWithSecrets", () => {
     });
   });
 
+  it("routes diagnostics to stderr for json commands", async () => {
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as const;
+    const config = { channels: {} };
+    const resolvedConfig = { channels: { discord: {} } };
+    mocks.resolveCommandSecretRefsViaGateway.mockResolvedValue({
+      resolvedConfig,
+      diagnostics: [
+        'status --json: failed to resolve channels.discord.token locally (Environment variable "DISCORD_BOT_TOKEN" is missing or empty.).',
+      ],
+    });
+
+    await resolveCommandConfigWithSecrets({
+      config,
+      commandName: "status --json",
+      targetIds: new Set(["channels.discord.token"]),
+      mode: "read_only_status",
+      runtime,
+    });
+
+    expect(runtime.log).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      '[secrets] status --json: failed to resolve channels.discord.token locally (Environment variable "DISCORD_BOT_TOKEN" is missing or empty.).',
+    );
+  });
+
   it("returns auto-enabled config when requested", async () => {
     const resolvedConfig = { channels: {} };
     const effectiveConfig = { channels: {}, plugins: { allow: ["telegram"] } };

--- a/src/cli/command-config-resolution.ts
+++ b/src/cli/command-config-resolution.ts
@@ -6,9 +6,7 @@ import {
   resolveCommandSecretRefsViaGateway,
 } from "./command-secret-gateway.js";
 
-function shouldRouteSecretDiagnosticsToStderr(commandName: string): boolean {
-  return commandName.split(/\s+/).includes("--json");
-}
+export type CommandSecretDiagnosticStream = "stdout" | "stderr";
 
 export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawConfig>(params: {
   config: TConfig;
@@ -19,6 +17,7 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
   forcedActivePaths?: Set<string>;
   optionalActivePaths?: Set<string>;
   runtime?: RuntimeEnv;
+  diagnosticStream?: CommandSecretDiagnosticStream;
   autoEnable?: boolean;
   env?: NodeJS.ProcessEnv;
 }): Promise<{
@@ -36,9 +35,8 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
     ...(params.optionalActivePaths ? { optionalActivePaths: params.optionalActivePaths } : {}),
   });
   if (params.runtime) {
-    const emitDiagnostic = shouldRouteSecretDiagnosticsToStderr(params.commandName)
-      ? params.runtime.error
-      : params.runtime.log;
+    const emitDiagnostic =
+      params.diagnosticStream === "stdout" ? params.runtime.log : params.runtime.error;
     for (const entry of diagnostics) {
       emitDiagnostic(`[secrets] ${entry}`);
     }

--- a/src/cli/command-config-resolution.ts
+++ b/src/cli/command-config-resolution.ts
@@ -6,6 +6,10 @@ import {
   resolveCommandSecretRefsViaGateway,
 } from "./command-secret-gateway.js";
 
+function shouldRouteSecretDiagnosticsToStderr(commandName: string): boolean {
+  return commandName.split(/\s+/).includes("--json");
+}
+
 export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawConfig>(params: {
   config: TConfig;
   commandName: string;
@@ -32,8 +36,11 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
     ...(params.optionalActivePaths ? { optionalActivePaths: params.optionalActivePaths } : {}),
   });
   if (params.runtime) {
+    const emitDiagnostic = shouldRouteSecretDiagnosticsToStderr(params.commandName)
+      ? params.runtime.error
+      : params.runtime.log;
     for (const entry of diagnostics) {
-      params.runtime.error(`[secrets] ${entry}`);
+      emitDiagnostic(`[secrets] ${entry}`);
     }
   }
   const effectiveConfig = params.autoEnable

--- a/src/commands/models/aliases.ts
+++ b/src/commands/models/aliases.ts
@@ -14,7 +14,11 @@ export async function modelsAliasesListCommand(
   runtime: RuntimeEnv,
 ) {
   ensureFlagCompatibility(opts);
-  const cfg = await loadModelsConfig({ commandName: "models aliases list", runtime });
+  const cfg = await loadModelsConfig({
+    commandName: "models aliases list",
+    runtime,
+    json: opts.json,
+  });
   const models = cfg.agents?.defaults?.models ?? {};
   const aliases = Object.entries(models).reduce<Record<string, string>>(
     (acc, [modelKey, entry]) => {

--- a/src/commands/models/auth-list.ts
+++ b/src/commands/models/auth-list.ts
@@ -121,7 +121,7 @@ export async function modelsAuthListCommand(
   opts: { provider?: string; agent?: string; json?: boolean },
   runtime: RuntimeEnv,
 ) {
-  const cfg = await loadModelsConfig({ commandName: "models auth list", runtime });
+  const cfg = await loadModelsConfig({ commandName: "models auth list", runtime, json: opts.json });
   const { agentId, agentDir } = resolveTargetAgent(cfg, opts.agent);
   const providerFilter = resolveProviderFilter(opts.provider);
   const store = ensureAuthProfileStore(

--- a/src/commands/models/auth-order.ts
+++ b/src/commands/models/auth-order.ts
@@ -33,7 +33,7 @@ function describeOrder(store: AuthProfileStore, provider: string): string[] {
 }
 
 async function resolveAuthOrderContext(
-  opts: { provider: string; agent?: string },
+  opts: { provider: string; agent?: string; json?: boolean },
   runtime: RuntimeEnv,
 ) {
   const rawProvider = opts.provider?.trim();
@@ -43,7 +43,11 @@ async function resolveAuthOrderContext(
     );
   }
   const provider = normalizeProviderId(rawProvider);
-  const cfg = await loadModelsConfig({ commandName: "models auth-order", runtime });
+  const cfg = await loadModelsConfig({
+    commandName: "models auth-order",
+    runtime,
+    json: opts.json,
+  });
   const { agentId, agentDir } = resolveTargetAgent(cfg, opts.agent);
   return { cfg, agentId, agentDir, provider };
 }

--- a/src/commands/models/fallbacks-shared.ts
+++ b/src/commands/models/fallbacks-shared.ts
@@ -53,7 +53,11 @@ export async function listFallbacksCommand(
   runtime: RuntimeEnv,
 ) {
   ensureFlagCompatibility(opts);
-  const cfg = await loadModelsConfig({ commandName: `models ${params.key} list`, runtime });
+  const cfg = await loadModelsConfig({
+    commandName: `models ${params.key} list`,
+    runtime,
+    json: opts.json,
+  });
   const fallbacks = getFallbacks(cfg, params.key);
 
   if (opts.json) {

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -82,6 +82,7 @@ export async function modelsListCommand(
   const { resolvedConfig: cfg } = await loadModelsConfigWithSource({
     commandName: "models list",
     runtime,
+    json: opts.json,
   });
   const agentDir = resolveDefaultAgentDir(cfg);
   const authStore = loadAuthProfileStoreWithoutExternalProfiles(agentDir);

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -231,7 +231,7 @@ export async function modelsStatusCommand(
     throw new Error("--probe cannot be used with --plain output.");
   }
   const configPath = createConfigIO().configPath;
-  const cfg = await loadModelsConfig({ commandName: "models status", runtime });
+  const cfg = await loadModelsConfig({ commandName: "models status", runtime, json: opts.json });
   const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent });
   const workspaceAgentId = agentId ?? resolveDefaultAgentId(cfg);
   const agentDir = agentId

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -244,6 +244,7 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
 
 import { buildAuthHealthSummary } from "../../agents/auth-health.js";
 import { modelsStatusCommand } from "./list.status-command.js";
+import { loadModelsConfig } from "./load-config.js";
 
 const defaultResolveEnvApiKeyImpl:
   | ((provider: string) => { apiKey: string; source: string } | null)
@@ -365,6 +366,11 @@ describe("modelsStatusCommand auth overview", () => {
     await modelsStatusCommand({ json: true }, runtime as never);
     const payload = parseFirstJsonLog(runtime);
 
+    expect(vi.mocked(loadModelsConfig)).toHaveBeenCalledWith({
+      commandName: "models status",
+      runtime,
+      json: true,
+    });
     expectResolveAgentDirCalledFor("main");
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalled();
     expect(payload.defaultModel).toBe("anthropic/claude-opus-4-6");

--- a/src/commands/models/load-config.test.ts
+++ b/src/commands/models/load-config.test.ts
@@ -87,6 +87,17 @@ describe("models load-config", () => {
     expect(mocks.setRuntimeConfigSnapshot).toHaveBeenCalledWith(resolvedConfig, sourceConfig);
   });
 
+  it("routes diagnostics to stderr when loading for json output", async () => {
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const sourceConfig = { models: { providers: {} } };
+    mockResolvedConfigFlow({ sourceConfig, diagnostics: ["missing model api key"] });
+
+    await loadModelsConfigWithSource({ commandName: "models status", runtime, json: true });
+
+    expect(runtime.log).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith("[secrets] missing model api key");
+  });
+
   it("does not reread config when no source snapshot is pinned", async () => {
     mocks.getRuntimeConfig.mockReturnValue(runtimeConfig);
     mocks.getRuntimeConfigSourceSnapshot.mockReturnValue(null);

--- a/src/commands/models/load-config.ts
+++ b/src/commands/models/load-config.ts
@@ -17,6 +17,7 @@ export type LoadedModelsConfig = {
 export async function loadModelsConfigWithSource(params: {
   commandName: string;
   runtime?: RuntimeEnv;
+  json?: boolean;
 }): Promise<LoadedModelsConfig> {
   const runtimeConfig = getRuntimeConfig();
   const pinnedSourceConfig = getRuntimeConfigSourceSnapshot();
@@ -25,6 +26,7 @@ export async function loadModelsConfigWithSource(params: {
     config: runtimeConfig,
     commandName: params.commandName,
     targetIds: getModelsCommandSecretTargetIds(),
+    ...(params.json ? { diagnosticStream: "stderr" as const } : {}),
     runtime: params.runtime,
   });
   if (pinnedSourceConfig) {
@@ -42,6 +44,7 @@ export async function loadModelsConfigWithSource(params: {
 export async function loadModelsConfig(params: {
   commandName: string;
   runtime?: RuntimeEnv;
+  json?: boolean;
 }): Promise<OpenClawConfig> {
   return (await loadModelsConfigWithSource(params)).resolvedConfig;
 }

--- a/src/commands/models/scan.ts
+++ b/src/commands/models/scan.ts
@@ -203,7 +203,7 @@ export async function modelsScanCommand(
     storedKey = getEnvApiKey("openrouter")?.trim() || undefined;
     if (!storedKey) {
       try {
-        const cfg = await loadModelsConfig({ commandName: "models scan" });
+        const cfg = await loadModelsConfig({ commandName: "models scan", json: opts.json });
         const resolved = await resolveApiKeyForProvider({
           provider: "openrouter",
           cfg,

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -170,6 +170,7 @@ export async function collectStatusScanOverview(params: {
           loadedConfig,
         ),
         mode: "read_only_status",
+        ...(params.commandName === "status --json" ? { diagnosticStream: "stderr" as const } : {}),
         ...(params.runtime ? { runtime: params.runtime } : {}),
       }),
   });

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -5,6 +5,70 @@ import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 
 describe("cli json stdout contract", () => {
+  it("keeps `status --json` stdout parseable when SecretRef diagnostics are emitted", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const configDir = path.join(tempHome, ".openclaw");
+        await fs.mkdir(configDir, { recursive: true });
+        await fs.writeFile(
+          path.join(configDir, "openclaw.json"),
+          JSON.stringify(
+            {
+              channels: {
+                discord: {
+                  enabled: true,
+                  token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+                },
+              },
+              secrets: {
+                providers: {
+                  default: { source: "env" },
+                },
+              },
+            },
+            null,
+            2,
+          ),
+          "utf8",
+        );
+
+        const env = {
+          ...process.env,
+          HOME: tempHome,
+          USERPROFILE: tempHome,
+          OPENCLAW_TEST_FAST: "1",
+        };
+        delete env.DISCORD_BOT_TOKEN;
+        delete env.OPENCLAW_HOME;
+        delete env.OPENCLAW_STATE_DIR;
+        delete env.OPENCLAW_CONFIG_PATH;
+        delete env.VITEST;
+
+        const entry = path.resolve(process.cwd(), "src/entry.ts");
+        const result = spawnSync(
+          process.execPath,
+          ["--import", "tsx", entry, "status", "--json", "--timeout", "1"],
+          { cwd: process.cwd(), env, encoding: "utf8" },
+        );
+
+        expect(result.status).toBe(0);
+        const stdout = result.stdout.trim();
+        expect(stdout.startsWith("{")).toBe(true);
+        expect(stdout).not.toContain("[secrets]");
+
+        const parsed = JSON.parse(stdout) as { secretDiagnostics?: unknown };
+        expect(Array.isArray(parsed.secretDiagnostics)).toBe(true);
+        expect(parsed.secretDiagnostics).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining("channels.discord.token"),
+            expect.stringContaining("DISCORD_BOT_TOKEN"),
+          ]),
+        );
+      },
+      { prefix: "openclaw-status-json-secretref-" },
+    );
+  });
+
   it("keeps `update status --json` stdout parseable even with legacy doctor preflight inputs", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
Fixes #81055.

## Summary
- Route command SecretRef diagnostics for `--json` commands through stderr instead of `runtime.log` stdout.
- Add a real CLI e2e regression for `status --json` with an unresolved Discord SecretRef.

## Real behavior proof
- Behavior addressed: `openclaw status --json` emitted `[secrets] ...` diagnostics on stdout before the JSON payload when a configured SecretRef was unresolved, breaking `jq` and `JSON.parse` consumers.
- Real environment tested: local Linux checkout on Node v22.22.2, current branch rebased on `origin/main`, temp HOME containing an `openclaw.json` with `channels.discord.token` as an env SecretRef and `DISCORD_BOT_TOKEN` intentionally unset.
- Exact steps or command run after the patch: ran `node --import tsx src/entry.ts status --json --timeout 1` with stdout and stderr redirected separately, then parsed stdout with `JSON.parse` and checked which stream contained `[secrets]`.
- Evidence after fix:
```text
$ env -u DISCORD_BOT_TOKEN -u OPENCLAW_HOME -u OPENCLAW_STATE_DIR -u OPENCLAW_CONFIG_PATH -u VITEST HOME="$TMP_HOME" USERPROFILE="$TMP_HOME" OPENCLAW_TEST_FAST=1 node --import tsx src/entry.ts status --json --timeout 1 >"$OUT" 2>"$ERR"
$ node - "$OUT" "$ERR" <<"NODE"
const fs = require("node:fs");
const [outPath, errPath] = process.argv.slice(2);
const out = fs.readFileSync(outPath, "utf8");
JSON.parse(out);
const err = fs.readFileSync(errPath, "utf8");
console.log(JSON.stringify({ stdoutStartsWith: out.trimStart()[0], stdoutHasSecrets: out.includes("[secrets]"), stderrHasSecrets: err.includes("[secrets]") }));
NODE
{"stdoutStartsWith":"{","stdoutHasSecrets":false,"stderrHasSecrets":true}
```
- Observed result after fix: stdout starts with `{`, parses directly with `JSON.parse`, and no `[secrets]` diagnostics appear on stdout; the diagnostics are preserved on stderr and in the JSON `secretDiagnostics` field.
- What was not tested: I did not run an installed npm package binary; the proof uses the repository TS entrypoint with a temp HOME so the unresolved SecretRef path is deterministic.

## Verification
```text
$ corepack pnpm test src/cli/route.test.ts src/cli/command-execution-startup.test.ts src/cli/command-config-resolution.test.ts src/commands/status-json-command.test.ts test/cli-json-stdout.e2e.test.ts -- --reporter=verbose
[test] passed 3 Vitest shards in 54.45s

$ PATH=/tmp/openclaw-corepack-shims:$PATH pnpm check:changed -- --base origin/main
# exited 0

$ git diff --check origin/main..HEAD
# exited 0
```
