### PR TITLE
fix(skills): block non-bundled installs that claim bundled skill keys or collide on tools directory [AI]

### DIFF
--- a/src/agents/skills-install.test.ts
+++ b/src/agents/skills-install.test.ts
@@ -132,6 +132,35 @@ function emptyBundledSkillsContext() {
   return { names: new Set<string>(), skillKeys: new Set<string>() };
 }
 
+function createCaseProbeFs(caseInsensitive: boolean) {
+  const files = new Set<string>();
+  const keyFor = (file: unknown) => {
+    const key = String(file);
+    return caseInsensitive ? key.toLowerCase() : key;
+  };
+  return {
+    existsSync: (file: unknown) => files.has(keyFor(file)),
+    mkdirSync: () => undefined,
+    writeFileSync: (file: unknown) => {
+      files.add(keyFor(file));
+    },
+    rmSync: (file: unknown) => {
+      files.delete(keyFor(file));
+    },
+  };
+}
+
+function createFailingCaseProbeFs() {
+  return {
+    existsSync: () => false,
+    mkdirSync: () => {
+      throw new Error("permission denied");
+    },
+    writeFileSync: () => undefined,
+    rmSync: () => undefined,
+  };
+}
+
 function setSkillsInstallTestDeps(
   overrides: NonNullable<Parameters<typeof skillsInstallTesting.setDepsForTest>[0]> = {},
 ) {
@@ -455,6 +484,40 @@ describe("installSkill code safety scanning", () => {
         platform: "linux",
       }),
     ).toBe("/var/lib/openclaw");
+  });
+
+  it("uses the tools directory case probe before platform fallback", () => {
+    expect(
+      skillsInstallTesting.resolveCaseInsensitiveToolsFilesystemForTest({
+        toolsDir: "/mnt/c/.openclaw/tools",
+        platform: "linux",
+        fsImpl: createCaseProbeFs(true),
+      }),
+    ).toBe(true);
+    expect(
+      skillsInstallTesting.resolveCaseInsensitiveToolsFilesystemForTest({
+        toolsDir: "/Volumes/case-sensitive/.openclaw/tools",
+        platform: "darwin",
+        fsImpl: createCaseProbeFs(false),
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to the platform when the tools directory case probe cannot run", () => {
+    expect(
+      skillsInstallTesting.resolveCaseInsensitiveToolsFilesystemForTest({
+        toolsDir: "/root/.openclaw/tools",
+        platform: "linux",
+        fsImpl: createFailingCaseProbeFs(),
+      }),
+    ).toBe(false);
+    expect(
+      skillsInstallTesting.resolveCaseInsensitiveToolsFilesystemForTest({
+        toolsDir: "/Users/tester/.openclaw/tools",
+        platform: "darwin",
+        fsImpl: createFailingCaseProbeFs(),
+      }),
+    ).toBe(true);
   });
 
   it("blocks install when skill scan fails", async () => {

--- a/src/agents/skills-install.test.ts
+++ b/src/agents/skills-install.test.ts
@@ -36,7 +36,17 @@ async function writeInstallableSkill(
     skillKey?: string;
   },
 ): Promise<string> {
-  const skillDir = path.join(workspaceDir, "skills", name);
+  return writeInstallableSkillInRoot(path.join(workspaceDir, "skills"), name, options);
+}
+
+async function writeInstallableSkillInRoot(
+  skillsRootDir: string,
+  name: string,
+  options?: {
+    skillKey?: string;
+  },
+): Promise<string> {
+  const skillDir = path.join(skillsRootDir, name);
   await fs.mkdir(skillDir, { recursive: true });
   const metadata = {
     openclaw: {
@@ -81,10 +91,15 @@ function mockDangerousSkillScanFinding(skillDir: string) {
 
 function loadTestWorkspaceSkillEntries(
   workspaceDir: string,
-  source = "openclaw-workspace",
+  source: unknown = "openclaw-workspace",
 ): SkillEntry[] {
+  const resolvedSource = typeof source === "string" ? source : "openclaw-workspace";
+  return loadTestSkillEntriesFromDir(path.join(workspaceDir, "skills"), resolvedSource);
+}
+
+function loadTestSkillEntriesFromDir(dir: string, source = "openclaw-workspace"): SkillEntry[] {
   const skills = loadSkillsFromDirSafe({
-    dir: path.join(workspaceDir, "skills"),
+    dir,
     source,
   }).skills;
   return skills.map((skill) => {
@@ -122,6 +137,7 @@ function setSkillsInstallTestDeps(
 ) {
   skillsInstallTesting.setDepsForTest({
     loadWorkspaceSkillEntries: loadTestWorkspaceSkillEntries,
+    loadWorkspaceSkillEntriesForInstallCollision: loadTestWorkspaceSkillEntries,
     resolveNodeInstallStateDir: () => {
       const stateDir = process.env.OPENCLAW_STATE_DIR;
       if (!stateDir) {
@@ -278,6 +294,39 @@ describe("installSkill code safety scanning", () => {
       expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
     });
   });
+
+  it.each(["openclaw-managed", "openclaw-extra"])(
+    "blocks non-bundled installs that shadow a trusted %s skill tools directory",
+    async (trustedSource) => {
+      await withWorkspaceCase(async ({ workspaceDir }) => {
+        const trustedSkillsRoot = path.join(workspaceDir, `${trustedSource}-skills`);
+        await writeInstallableSkillInRoot(trustedSkillsRoot, "runtime-owner", {
+          skillKey: "shared-runtime",
+        });
+        await writeInstallableSkill(workspaceDir, "runtime-owner", {
+          skillKey: "shared-runtime",
+        });
+        setSkillsInstallTestDeps({
+          loadWorkspaceSkillEntriesForInstallCollision: (dir) => [
+            ...loadTestSkillEntriesFromDir(trustedSkillsRoot, trustedSource),
+            ...loadTestWorkspaceSkillEntries(dir),
+          ],
+        });
+
+        const result = await installSkill({
+          workspaceDir,
+          skillName: "runtime-owner",
+          installId: "deps",
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.message).toContain(
+          `Skill "runtime-owner" install blocked: tools directory collides with runtime-owner (${trustedSource}).`,
+        );
+        expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+      });
+    },
+  );
 
   it("allows dangerous skill installs when forced unsafe install is set", async () => {
     await withWorkspaceCase(async ({ workspaceDir }) => {

--- a/src/agents/skills-install.test.ts
+++ b/src/agents/skills-install.test.ts
@@ -29,15 +29,27 @@ vi.mock("./skills/plugin-skills.js", () => ({
   resolvePluginSkillDirs: () => [],
 }));
 
-async function writeInstallableSkill(workspaceDir: string, name: string): Promise<string> {
+async function writeInstallableSkill(
+  workspaceDir: string,
+  name: string,
+  options?: {
+    skillKey?: string;
+  },
+): Promise<string> {
   const skillDir = path.join(workspaceDir, "skills", name);
   await fs.mkdir(skillDir, { recursive: true });
+  const metadata = {
+    openclaw: {
+      ...(options?.skillKey ? { skillKey: options.skillKey } : {}),
+      install: [{ id: "deps", kind: "node", package: "example-package" }],
+    },
+  };
   await fs.writeFile(
     path.join(skillDir, "SKILL.md"),
     `---
 name: ${name}
 description: test skill
-metadata: {"openclaw":{"install":[{"id":"deps","kind":"node","package":"example-package"}]}}
+metadata: ${JSON.stringify(metadata)}
 ---
 
 # ${name}
@@ -98,6 +110,27 @@ function lastRunCommandCall(): unknown[] | undefined {
   return calls[calls.length - 1];
 }
 
+function emptyBundledSkillsContext() {
+  return { names: new Set<string>(), skillKeys: new Set<string>() };
+}
+
+function setSkillsInstallTestDeps(
+  overrides: NonNullable<Parameters<typeof skillsInstallTesting.setDepsForTest>[0]> = {},
+) {
+  skillsInstallTesting.setDepsForTest({
+    loadWorkspaceSkillEntries: loadTestWorkspaceSkillEntries,
+    resolveNodeInstallStateDir: () => {
+      const stateDir = process.env.OPENCLAW_STATE_DIR;
+      if (!stateDir) {
+        throw new Error("OPENCLAW_STATE_DIR missing in skills install test");
+      }
+      return stateDir;
+    },
+    resolveBundledSkillsContext: emptyBundledSkillsContext,
+    ...overrides,
+  });
+}
+
 const workspaceSuite = createFixtureSuite("openclaw-skills-install-");
 
 beforeAll(async () => {
@@ -129,16 +162,7 @@ describe("installSkill code safety scanning", () => {
     resetGlobalHookRunner();
     runCommandWithTimeoutMock.mockClear();
     scanDirectoryWithSummaryMock.mockClear();
-    skillsInstallTesting.setDepsForTest({
-      loadWorkspaceSkillEntries: loadTestWorkspaceSkillEntries,
-      resolveNodeInstallStateDir: () => {
-        const stateDir = process.env.OPENCLAW_STATE_DIR;
-        if (!stateDir) {
-          throw new Error("OPENCLAW_STATE_DIR missing in skills install test");
-        }
-        return stateDir;
-      },
-    });
+    setSkillsInstallTestDeps();
     runCommandWithTimeoutMock.mockResolvedValue({
       code: 0,
       stdout: "ok",
@@ -171,6 +195,55 @@ describe("installSkill code safety scanning", () => {
       const warningOutput = (result.warnings ?? []).join("\n");
       expect(warningOutput).toContain("dangerous code patterns");
       expect(warningOutput).toContain("runner.js:1");
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("blocks non-bundled installs that claim a bundled skill key", async () => {
+    await withWorkspaceCase(async ({ workspaceDir }) => {
+      await writeInstallableSkill(workspaceDir, "tts-helper", {
+        skillKey: " sherpa-onnx-tts ",
+      });
+      setSkillsInstallTestDeps({
+        resolveBundledSkillsContext: () => ({
+          names: new Set(["sherpa-onnx-tts"]),
+          skillKeys: new Set(["sherpa-onnx-tts"]),
+        }),
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "tts-helper",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain(
+        'Skill "tts-helper" install blocked: non-bundled source "openclaw-workspace" claims bundled skill key "sherpa-onnx-tts".',
+      );
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("blocks non-bundled installs whose tools directory collides with another skill", async () => {
+    await withWorkspaceCase(async ({ workspaceDir }) => {
+      await writeInstallableSkill(workspaceDir, "runtime-owner", {
+        skillKey: "shared-runtime",
+      });
+      await writeInstallableSkill(workspaceDir, "runtime-helper", {
+        skillKey: "shared-runtime",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "runtime-helper",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain(
+        'Skill "runtime-helper" install blocked: tools directory collides with runtime-owner (openclaw-workspace).',
+      );
       expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
     });
   });

--- a/src/agents/skills-install.test.ts
+++ b/src/agents/skills-install.test.ts
@@ -79,10 +79,13 @@ function mockDangerousSkillScanFinding(skillDir: string) {
   });
 }
 
-function loadTestWorkspaceSkillEntries(workspaceDir: string): SkillEntry[] {
+function loadTestWorkspaceSkillEntries(
+  workspaceDir: string,
+  source = "openclaw-workspace",
+): SkillEntry[] {
   const skills = loadSkillsFromDirSafe({
     dir: path.join(workspaceDir, "skills"),
-    source: "openclaw-workspace",
+    source,
   }).skills;
   return skills.map((skill) => {
     const frontmatter =
@@ -224,6 +227,34 @@ describe("installSkill code safety scanning", () => {
       expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
     });
   });
+
+  it.each(["openclaw-managed", "openclaw-extra"])(
+    "allows trusted %s installs that use a bundled skill key",
+    async (source) => {
+      await withWorkspaceCase(async ({ workspaceDir }) => {
+        await writeInstallableSkill(workspaceDir, "trusted-tts", {
+          skillKey: "sherpa-onnx-tts",
+        });
+        setSkillsInstallTestDeps({
+          loadWorkspaceSkillEntries: (dir) => loadTestWorkspaceSkillEntries(dir, source),
+          resolveBundledSkillsContext: () => ({
+            names: new Set(["sherpa-onnx-tts"]),
+            skillKeys: new Set(["sherpa-onnx-tts"]),
+          }),
+        });
+
+        const result = await installSkill({
+          workspaceDir,
+          skillName: "trusted-tts",
+          installId: "deps",
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.warnings ?? []).toEqual([]);
+        expect(runCommandWithTimeoutMock).toHaveBeenCalled();
+      });
+    },
+  );
 
   it("blocks non-bundled installs whose tools directory collides with another skill", async () => {
     await withWorkspaceCase(async ({ workspaceDir }) => {

--- a/src/agents/skills-install.test.ts
+++ b/src/agents/skills-install.test.ts
@@ -146,6 +146,7 @@ function setSkillsInstallTestDeps(
       return stateDir;
     },
     resolveBundledSkillsContext: emptyBundledSkillsContext,
+    isCaseInsensitiveToolsFilesystem: () => false,
     ...overrides,
   });
 }
@@ -244,6 +245,33 @@ describe("installSkill code safety scanning", () => {
     });
   });
 
+  it("blocks case-only bundled skill key claims on case-insensitive tools filesystems", async () => {
+    await withWorkspaceCase(async ({ workspaceDir }) => {
+      await writeInstallableSkill(workspaceDir, "tts-helper", {
+        skillKey: " Sherpa-Onnx-TTS ",
+      });
+      setSkillsInstallTestDeps({
+        isCaseInsensitiveToolsFilesystem: () => true,
+        resolveBundledSkillsContext: () => ({
+          names: new Set(["sherpa-onnx-tts"]),
+          skillKeys: new Set(["sherpa-onnx-tts"]),
+        }),
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "tts-helper",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain(
+        'Skill "tts-helper" install blocked: non-bundled source "openclaw-workspace" claims bundled skill key "Sherpa-Onnx-TTS".',
+      );
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    });
+  });
+
   it.each(["openclaw-managed", "openclaw-extra"])(
     "allows trusted %s installs that use a bundled skill key",
     async (source) => {
@@ -279,6 +307,32 @@ describe("installSkill code safety scanning", () => {
       });
       await writeInstallableSkill(workspaceDir, "runtime-helper", {
         skillKey: "shared-runtime",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "runtime-helper",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain(
+        'Skill "runtime-helper" install blocked: tools directory collides with runtime-owner (openclaw-workspace).',
+      );
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("blocks case-only tools directory collisions on case-insensitive tools filesystems", async () => {
+    await withWorkspaceCase(async ({ workspaceDir }) => {
+      await writeInstallableSkill(workspaceDir, "runtime-owner", {
+        skillKey: "shared-runtime",
+      });
+      await writeInstallableSkill(workspaceDir, "runtime-helper", {
+        skillKey: "Shared-Runtime",
+      });
+      setSkillsInstallTestDeps({
+        isCaseInsensitiveToolsFilesystem: () => true,
       });
 
       const result = await installSkill({

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -11,7 +11,7 @@ import {
   type SkillInstallSpecMetadata,
 } from "../plugins/install-security-scan.js";
 import { runCommandWithTimeout, type CommandOptions } from "../process/exec.js";
-import { resolveUserPath } from "../utils.js";
+import { resolveConfigDir, resolveUserPath } from "../utils.js";
 import { installDownloadSpec } from "./skills-install-download.js";
 import { formatInstallFailureMessage } from "./skills-install-output.js";
 import type { SkillInstallResult } from "./skills-install.types.js";
@@ -68,9 +68,62 @@ const defaultSkillsInstallDeps: SkillsInstallDeps = {
 let skillsInstallDeps = defaultSkillsInstallDeps;
 
 const trustedInstallSources = new Set(["openclaw-bundled", "openclaw-managed", "openclaw-extra"]);
+type CaseProbeFs = Pick<typeof fs, "existsSync" | "mkdirSync" | "rmSync" | "writeFileSync">;
+let caseInsensitiveToolsFilesystemCache: { toolsDir: string; value: boolean } | undefined;
+
+function resolveDefaultToolsDir(): string {
+  return path.join(resolveConfigDir(), "tools");
+}
+
+function fallbackCaseInsensitivePlatform(platform: NodeJS.Platform): boolean {
+  return platform === "darwin" || platform === "win32";
+}
+
+function probeCaseInsensitiveDirectory(dir: string, fsImpl: CaseProbeFs = fs): boolean | undefined {
+  const probeName = `.openclaw-case-probe-${process.pid}-${Date.now()}-${Math.random()
+    .toString(16)
+    .slice(2)}-a`;
+  const alternateName = probeName.toUpperCase();
+  if (alternateName === probeName) {
+    return false;
+  }
+  const probePath = path.join(dir, probeName);
+  const alternatePath = path.join(dir, alternateName);
+  try {
+    fsImpl.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fsImpl.writeFileSync(probePath, "", { flag: "wx", mode: 0o600 });
+    try {
+      return fsImpl.existsSync(alternatePath);
+    } finally {
+      fsImpl.rmSync(probePath, { force: true });
+      fsImpl.rmSync(alternatePath, { force: true });
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveCaseInsensitiveToolsFilesystem(params?: {
+  toolsDir?: string;
+  platform?: NodeJS.Platform;
+  fsImpl?: CaseProbeFs;
+}): boolean {
+  const toolsDir = params?.toolsDir ?? resolveDefaultToolsDir();
+  const probed = probeCaseInsensitiveDirectory(toolsDir, params?.fsImpl);
+  if (probed !== undefined) {
+    return probed;
+  }
+  return fallbackCaseInsensitivePlatform(params?.platform ?? process.platform);
+}
 
 function isCaseInsensitiveToolsFilesystemByDefault(): boolean {
-  return process.platform === "darwin" || process.platform === "win32";
+  const toolsDir = resolveDefaultToolsDir();
+  if (caseInsensitiveToolsFilesystemCache?.toolsDir === toolsDir) {
+    return caseInsensitiveToolsFilesystemCache.value;
+  }
+  const value = resolveCaseInsensitiveToolsFilesystem({ toolsDir });
+  caseInsensitiveToolsFilesystemCache = { toolsDir, value };
+  return value;
 }
 
 function normalizeToolsCollisionValue(value: string, caseInsensitive: boolean): string {
@@ -706,7 +759,9 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
 
 export const testing = {
   resolveDefaultNodeInstallStateDir,
+  resolveCaseInsensitiveToolsFilesystemForTest: resolveCaseInsensitiveToolsFilesystem,
   setDepsForTest(overrides?: Partial<SkillsInstallDeps>): void {
+    caseInsensitiveToolsFilesystemCache = undefined;
     skillsInstallDeps = {
       ...defaultSkillsInstallDeps,
       ...overrides,

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -23,7 +23,13 @@ import {
   type SkillInstallSpec,
   type SkillsInstallPreferences,
 } from "./skills.js";
+import {
+  resolveBundledSkillsContext as defaultResolveBundledSkillsContext,
+  type BundledSkillsContext,
+} from "./skills/bundled-context.js";
+import { resolveSkillKey } from "./skills/frontmatter.js";
 import { resolveSkillSource } from "./skills/source.js";
+import { resolveSkillToolsRootDir } from "./skills/tools-dir.js";
 
 export type SkillInstallRequest = InstallSafetyOverrides & {
   workspaceDir: string;
@@ -41,6 +47,7 @@ type SkillsInstallDeps = {
   resolveBrewExecutable: () => string | undefined;
   isContainerEnvironment: () => boolean;
   resolveSkillsInstallPreferences: typeof defaultResolveSkillsInstallPreferences;
+  resolveBundledSkillsContext: () => BundledSkillsContext;
 };
 
 const defaultSkillsInstallDeps: SkillsInstallDeps = {
@@ -50,6 +57,7 @@ const defaultSkillsInstallDeps: SkillsInstallDeps = {
   resolveBrewExecutable: defaultResolveBrewExecutable,
   isContainerEnvironment: defaultIsContainerEnvironment,
   resolveSkillsInstallPreferences: defaultResolveSkillsInstallPreferences,
+  resolveBundledSkillsContext: defaultResolveBundledSkillsContext,
 };
 
 let skillsInstallDeps = defaultSkillsInstallDeps;
@@ -78,6 +86,45 @@ function findInstallSpec(entry: SkillEntry, installId: string): SkillInstallSpec
     if (resolveInstallId(spec, index) === installId) {
       return spec;
     }
+  }
+  return undefined;
+}
+
+function sameSkillInstallSource(left: SkillEntry, right: SkillEntry): boolean {
+  return (
+    path.resolve(left.skill.baseDir) === path.resolve(right.skill.baseDir) &&
+    path.resolve(left.skill.filePath) === path.resolve(right.skill.filePath)
+  );
+}
+
+function formatSkillInstallSource(entry: SkillEntry): string {
+  return `${entry.skill.name} (${resolveSkillSource(entry.skill)})`;
+}
+
+function resolveSkillToolsRootCollision(params: {
+  entry: SkillEntry;
+  entries: readonly SkillEntry[];
+  bundledContext: BundledSkillsContext;
+}): string | undefined {
+  const source = resolveSkillSource(params.entry.skill);
+  if (source === "openclaw-bundled") {
+    return undefined;
+  }
+
+  const skillKey = resolveSkillKey(params.entry.skill, params.entry);
+  if (params.bundledContext.skillKeys.has(skillKey) || params.bundledContext.names.has(skillKey)) {
+    return `Skill "${params.entry.skill.name}" install blocked: non-bundled source "${source}" claims bundled skill key "${skillKey}".`;
+  }
+
+  const toolsRoot = path.resolve(resolveSkillToolsRootDir(params.entry));
+  for (const other of params.entries) {
+    if (sameSkillInstallSource(params.entry, other)) {
+      continue;
+    }
+    if (path.resolve(resolveSkillToolsRootDir(other)) !== toolsRoot) {
+      continue;
+    }
+    return `Skill "${params.entry.skill.name}" install blocked: tools directory collides with ${formatSkillInstallSource(other)}.`;
   }
   return undefined;
 }
@@ -500,6 +547,7 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
       warnings,
     );
   }
+
   // Warn when install is triggered from a non-bundled source.
   // Workspace/project/personal agent skills can contain attacker-controlled metadata.
   const trustedInstallSources = new Set(["openclaw-bundled", "openclaw-managed", "openclaw-extra"]);
@@ -520,6 +568,25 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
       warnings,
     );
   }
+
+  const toolsRootCollision = resolveSkillToolsRootCollision({
+    entry,
+    entries,
+    bundledContext: deps.resolveBundledSkillsContext(),
+  });
+  if (toolsRootCollision) {
+    return withWarnings(
+      {
+        ok: false,
+        message: toolsRootCollision,
+        stdout: "",
+        stderr: toolsRootCollision,
+        code: null,
+      },
+      warnings,
+    );
+  }
+
   if (spec.kind === "download") {
     const downloadResult = await installDownloadSpec({ entry, spec, timeoutMs });
     return withWarnings(downloadResult, warnings);

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -62,6 +62,8 @@ const defaultSkillsInstallDeps: SkillsInstallDeps = {
 
 let skillsInstallDeps = defaultSkillsInstallDeps;
 
+const trustedInstallSources = new Set(["openclaw-bundled", "openclaw-managed", "openclaw-extra"]);
+
 function getSkillsInstallDeps(): SkillsInstallDeps {
   return skillsInstallDeps;
 }
@@ -101,13 +103,17 @@ function formatSkillInstallSource(entry: SkillEntry): string {
   return `${entry.skill.name} (${resolveSkillSource(entry.skill)})`;
 }
 
+function isTrustedInstallSource(source: string): boolean {
+  return trustedInstallSources.has(source);
+}
+
 function resolveSkillToolsRootCollision(params: {
   entry: SkillEntry;
   entries: readonly SkillEntry[];
   bundledContext: BundledSkillsContext;
 }): string | undefined {
   const source = resolveSkillSource(params.entry.skill);
-  if (source === "openclaw-bundled") {
+  if (isTrustedInstallSource(source)) {
     return undefined;
   }
 
@@ -550,8 +556,7 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
 
   // Warn when install is triggered from a non-bundled source.
   // Workspace/project/personal agent skills can contain attacker-controlled metadata.
-  const trustedInstallSources = new Set(["openclaw-bundled", "openclaw-managed", "openclaw-extra"]);
-  if (!trustedInstallSources.has(skillSource)) {
+  if (!isTrustedInstallSource(skillSource)) {
     warnings.push(
       `WARNING: Skill "${params.skillName}" install triggered from non-bundled source "${skillSource}". Verify the install recipe is trusted.`,
     );

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -18,6 +18,7 @@ import type { SkillInstallResult } from "./skills-install.types.js";
 import {
   hasBinary as defaultHasBinary,
   loadWorkspaceSkillEntries as defaultLoadWorkspaceSkillEntries,
+  loadWorkspaceSkillEntriesForInstallCollision as defaultLoadWorkspaceSkillEntriesForInstallCollision,
   resolveSkillsInstallPreferences as defaultResolveSkillsInstallPreferences,
   type SkillEntry,
   type SkillInstallSpec,
@@ -43,6 +44,7 @@ export type { SkillInstallResult } from "./skills-install.types.js";
 type SkillsInstallDeps = {
   hasBinary: (bin: string) => boolean;
   loadWorkspaceSkillEntries: typeof defaultLoadWorkspaceSkillEntries;
+  loadWorkspaceSkillEntriesForInstallCollision: typeof defaultLoadWorkspaceSkillEntriesForInstallCollision;
   resolveNodeInstallStateDir: () => string;
   resolveBrewExecutable: () => string | undefined;
   isContainerEnvironment: () => boolean;
@@ -53,6 +55,7 @@ type SkillsInstallDeps = {
 const defaultSkillsInstallDeps: SkillsInstallDeps = {
   hasBinary: defaultHasBinary,
   loadWorkspaceSkillEntries: defaultLoadWorkspaceSkillEntries,
+  loadWorkspaceSkillEntriesForInstallCollision: defaultLoadWorkspaceSkillEntriesForInstallCollision,
   resolveNodeInstallStateDir: resolveDefaultNodeInstallStateDir,
   resolveBrewExecutable: defaultResolveBrewExecutable,
   isContainerEnvironment: defaultIsContainerEnvironment,
@@ -576,7 +579,9 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
 
   const toolsRootCollision = resolveSkillToolsRootCollision({
     entry,
-    entries,
+    entries: deps.loadWorkspaceSkillEntriesForInstallCollision(workspaceDir, {
+      config: params.config,
+    }),
     bundledContext: deps.resolveBundledSkillsContext(),
   });
   if (toolsRootCollision) {

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -50,6 +50,7 @@ type SkillsInstallDeps = {
   isContainerEnvironment: () => boolean;
   resolveSkillsInstallPreferences: typeof defaultResolveSkillsInstallPreferences;
   resolveBundledSkillsContext: () => BundledSkillsContext;
+  isCaseInsensitiveToolsFilesystem: () => boolean;
 };
 
 const defaultSkillsInstallDeps: SkillsInstallDeps = {
@@ -61,11 +62,48 @@ const defaultSkillsInstallDeps: SkillsInstallDeps = {
   isContainerEnvironment: defaultIsContainerEnvironment,
   resolveSkillsInstallPreferences: defaultResolveSkillsInstallPreferences,
   resolveBundledSkillsContext: defaultResolveBundledSkillsContext,
+  isCaseInsensitiveToolsFilesystem: isCaseInsensitiveToolsFilesystemByDefault,
 };
 
 let skillsInstallDeps = defaultSkillsInstallDeps;
 
 const trustedInstallSources = new Set(["openclaw-bundled", "openclaw-managed", "openclaw-extra"]);
+
+function isCaseInsensitiveToolsFilesystemByDefault(): boolean {
+  return process.platform === "darwin" || process.platform === "win32";
+}
+
+function normalizeToolsCollisionValue(value: string, caseInsensitive: boolean): string {
+  const normalized = value.normalize("NFC");
+  return caseInsensitive ? normalized.toLowerCase() : normalized;
+}
+
+function hasCollisionValue(
+  values: ReadonlySet<string>,
+  candidate: string,
+  caseInsensitive: boolean,
+): boolean {
+  if (values.has(candidate)) {
+    return true;
+  }
+  if (!caseInsensitive) {
+    return false;
+  }
+  const normalizedCandidate = normalizeToolsCollisionValue(candidate, true);
+  for (const value of values) {
+    if (normalizeToolsCollisionValue(value, true) === normalizedCandidate) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveToolsRootCollisionValue(entry: SkillEntry, caseInsensitive: boolean): string {
+  return normalizeToolsCollisionValue(
+    path.resolve(resolveSkillToolsRootDir(entry)),
+    caseInsensitive,
+  );
+}
 
 function getSkillsInstallDeps(): SkillsInstallDeps {
   return skillsInstallDeps;
@@ -114,6 +152,7 @@ function resolveSkillToolsRootCollision(params: {
   entry: SkillEntry;
   entries: readonly SkillEntry[];
   bundledContext: BundledSkillsContext;
+  caseInsensitiveToolsFilesystem: boolean;
 }): string | undefined {
   const source = resolveSkillSource(params.entry.skill);
   if (isTrustedInstallSource(source)) {
@@ -121,16 +160,28 @@ function resolveSkillToolsRootCollision(params: {
   }
 
   const skillKey = resolveSkillKey(params.entry.skill, params.entry);
-  if (params.bundledContext.skillKeys.has(skillKey) || params.bundledContext.names.has(skillKey)) {
+  if (
+    hasCollisionValue(
+      params.bundledContext.skillKeys,
+      skillKey,
+      params.caseInsensitiveToolsFilesystem,
+    ) ||
+    hasCollisionValue(params.bundledContext.names, skillKey, params.caseInsensitiveToolsFilesystem)
+  ) {
     return `Skill "${params.entry.skill.name}" install blocked: non-bundled source "${source}" claims bundled skill key "${skillKey}".`;
   }
 
-  const toolsRoot = path.resolve(resolveSkillToolsRootDir(params.entry));
+  const toolsRoot = resolveToolsRootCollisionValue(
+    params.entry,
+    params.caseInsensitiveToolsFilesystem,
+  );
   for (const other of params.entries) {
     if (sameSkillInstallSource(params.entry, other)) {
       continue;
     }
-    if (path.resolve(resolveSkillToolsRootDir(other)) !== toolsRoot) {
+    if (
+      resolveToolsRootCollisionValue(other, params.caseInsensitiveToolsFilesystem) !== toolsRoot
+    ) {
       continue;
     }
     return `Skill "${params.entry.skill.name}" install blocked: tools directory collides with ${formatSkillInstallSource(other)}.`;
@@ -583,6 +634,7 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
       config: params.config,
     }),
     bundledContext: deps.resolveBundledSkillsContext(),
+    caseInsensitiveToolsFilesystem: deps.isCaseInsensitiveToolsFilesystem(),
   });
   if (toolsRootCollision) {
     return withWarnings(

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -80,9 +81,7 @@ function fallbackCaseInsensitivePlatform(platform: NodeJS.Platform): boolean {
 }
 
 function probeCaseInsensitiveDirectory(dir: string, fsImpl: CaseProbeFs = fs): boolean | undefined {
-  const probeName = `.openclaw-case-probe-${process.pid}-${Date.now()}-${Math.random()
-    .toString(16)
-    .slice(2)}-a`;
+  const probeName = `.openclaw-case-probe-${randomUUID()}-caseprobea`;
   const alternateName = probeName.toUpperCase();
   if (alternateName === probeName) {
     return false;

--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -18,6 +18,7 @@ import {
 } from "./skills.js";
 import { resolveEffectiveAgentSkillFilter } from "./skills/agent-filter.js";
 import { resolveBundledSkillsContext } from "./skills/bundled-context.js";
+import { resolveSkillKey } from "./skills/frontmatter.js";
 import { resolveSkillSource } from "./skills/source.js";
 
 export type SkillStatusConfigCheck = RequirementConfigCheck;
@@ -61,10 +62,6 @@ export type SkillStatusReport = {
   agentSkillFilter?: string[];
   skills: SkillStatusEntry[];
 };
-
-function resolveSkillKey(entry: SkillEntry): string {
-  return entry.metadata?.skillKey ?? entry.skill.name;
-}
 
 function selectPreferredInstallSpec(
   install: SkillInstallSpec[],
@@ -205,7 +202,7 @@ function buildSkillStatus(
   bundledNames?: Set<string>,
   agentSkillFilter?: string[],
 ): SkillStatusEntry {
-  const skillKey = resolveSkillKey(entry);
+  const skillKey = resolveSkillKey(entry.skill, entry);
   const skillConfig = resolveSkillConfig(config, skillKey);
   const disabled = skillConfig?.enabled === false;
   const allowBundled = resolveBundledAllowlist(config);

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -33,6 +33,7 @@ export {
   filterWorkspaceSkillEntries,
   filterWorkspaceSkillEntriesWithOptions,
   loadWorkspaceSkillEntries,
+  loadWorkspaceSkillEntriesForInstallCollision,
   resolveSkillsPromptForRun,
   syncSkillsToWorkspace,
 } from "./skills/workspace.js";

--- a/src/agents/skills/bundled-context.ts
+++ b/src/agents/skills/bundled-context.ts
@@ -1,14 +1,16 @@
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveBundledSkillsDir, type BundledSkillsResolveOptions } from "./bundled-dir.js";
+import { resolveOpenClawMetadata, resolveSkillKey } from "./frontmatter.js";
 import { loadSkillsFromDirSafe } from "./local-loader.js";
 
 const skillsLogger = createSubsystemLogger("skills");
 let hasWarnedMissingBundledDir = false;
-let cachedBundledContext: { dir: string; names: Set<string> } | null = null;
+let cachedBundledContext: { dir: string; names: Set<string>; skillKeys: Set<string> } | null = null;
 
 export type BundledSkillsContext = {
   dir?: string;
   names: Set<string>;
+  skillKeys: Set<string>;
 };
 
 export function resolveBundledSkillsContext(
@@ -23,18 +25,29 @@ export function resolveBundledSkillsContext(
         "Bundled skills directory could not be resolved; built-in skills may be missing.",
       );
     }
-    return { dir, names };
+    return { dir, names, skillKeys: new Set() };
   }
 
   if (cachedBundledContext?.dir === dir) {
-    return { dir, names: new Set(cachedBundledContext.names) };
+    return {
+      dir,
+      names: new Set(cachedBundledContext.names),
+      skillKeys: new Set(cachedBundledContext.skillKeys),
+    };
   }
   const result = loadSkillsFromDirSafe({ dir, source: "openclaw-bundled" });
+  const skillKeys = new Set<string>();
   for (const skill of result.skills) {
     if (skill.name.trim()) {
       names.add(skill.name);
     }
+    const frontmatter = result.frontmatterByFilePath.get(skill.filePath) ?? {};
+    const metadata = resolveOpenClawMetadata(frontmatter);
+    const skillKey = resolveSkillKey(skill, { skill, frontmatter, metadata });
+    if (skillKey.trim()) {
+      skillKeys.add(skillKey);
+    }
   }
-  cachedBundledContext = { dir, names: new Set(names) };
-  return { dir, names };
+  cachedBundledContext = { dir, names: new Set(names), skillKeys: new Set(skillKeys) };
+  return { dir, names, skillKeys };
 }

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -219,5 +219,9 @@ export function resolveSkillInvocationPolicy(
 }
 
 export function resolveSkillKey(skill: Skill, entry?: SkillEntry): string {
-  return entry?.metadata?.skillKey ?? skill.name;
+  const metadataKey = entry?.metadata?.skillKey?.trim();
+  if (metadataKey) {
+    return metadataKey;
+  }
+  return skill.name.trim() || skill.name;
 }

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -611,6 +611,7 @@ function loadSkillEntries(
     managedSkillsDir?: string;
     bundledSkillsDir?: string;
     pluginSkillsDir?: string;
+    preserveSourceDuplicates?: boolean;
   },
 ): SkillEntry[] {
   const limits = resolveSkillsLimits(opts?.config, opts?.agentId);
@@ -897,28 +898,26 @@ function loadSkillEntries(
     source: "openclaw-workspace",
   });
 
-  const merged = new Map<string, LoadedSkillRecord>();
-  // Precedence: extra < bundled < managed < agents-skills-personal < agents-skills-project < workspace
-  for (const record of extraSkills) {
-    merged.set(record.skill.name, record);
-  }
-  for (const record of bundledSkills) {
-    merged.set(record.skill.name, record);
-  }
-  for (const record of managedSkills) {
-    merged.set(record.skill.name, record);
-  }
-  for (const record of personalAgentsSkills) {
-    merged.set(record.skill.name, record);
-  }
-  for (const record of projectAgentsSkills) {
-    merged.set(record.skill.name, record);
-  }
-  for (const record of workspaceSkills) {
-    merged.set(record.skill.name, record);
-  }
+  const sourceRecords = [
+    ...extraSkills,
+    ...bundledSkills,
+    ...managedSkills,
+    ...personalAgentsSkills,
+    ...projectAgentsSkills,
+    ...workspaceSkills,
+  ];
+  const records = opts?.preserveSourceDuplicates
+    ? sourceRecords
+    : (() => {
+        const merged = new Map<string, LoadedSkillRecord>();
+        // Precedence: extra < bundled < managed < agents-skills-personal < agents-skills-project < workspace
+        for (const record of sourceRecords) {
+          merged.set(record.skill.name, record);
+        }
+        return Array.from(merged.values());
+      })();
 
-  const skillEntries: SkillEntry[] = Array.from(merged.values())
+  const skillEntries: SkillEntry[] = records
     .sort((a, b) => a.skill.name.localeCompare(b.skill.name, "en"))
     .map((record) => {
       const skill = record.skill;
@@ -1178,6 +1177,22 @@ export function loadWorkspaceSkillEntries(
     return entries;
   }
   return filterSkillEntries(entries, opts?.config, effectiveSkillFilter, opts?.eligibility);
+}
+
+export function loadWorkspaceSkillEntriesForInstallCollision(
+  workspaceDir: string,
+  opts?: {
+    config?: OpenClawConfig;
+    managedSkillsDir?: string;
+    bundledSkillsDir?: string;
+    pluginSkillsDir?: string;
+    agentId?: string;
+  },
+): SkillEntry[] {
+  return loadSkillEntries(workspaceDir, {
+    ...opts,
+    preserveSourceDuplicates: true,
+  });
 }
 
 export function loadVisibleWorkspaceSkillEntries(


### PR DESCRIPTION
## Summary

- **Problem:** A workspace skill could declare `metadata.openclaw.skillKey` equal to a bundled skill's key (e.g. `sherpa-onnx-tts`), triggering an install that wrote attacker-controlled binaries into the bundled skill's trusted tools root. The trusted bundled wrapper later executed those binaries, giving host code execution.
- **Why it matters:** The install path only warned on non-bundled sources but did not block name/key hijacking, so the warning was the only signal and was trivially ignored.
- **What changed:** Two new blocking gates added to `installSkill`: (1) reject any non-bundled skill whose resolved `skillKey` matches a bundled skill name or explicit key; (2) reject any skill whose computed tools root directory collides with a different skill's tools root. `resolveSkillKey` is now canonical, exported from `frontmatter.ts`, and trims whitespace before comparison. `BundledSkillsContext` is extended with a `skillKeys` set populated at cache-fill time.
- **What did NOT change:** Bundled, managed, and extra-source skills are exempt from the new gates. No install flow changes for trusted sources.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior addressed:** Non-bundled workspace skill claiming a bundled `skillKey` is now blocked before any download or extraction occurs.
- **Real environment tested:** Vitest unit tests run against the patched source tree.
- **Exact steps or command run after this patch:** `pnpm test src/agents/skills-install.test.ts`
- **Evidence after fix:** Two new test cases pass:
  - `"blocks non-bundled installs that claim a bundled skill key"` — install returns `ok: false` with message `non-bundled source "openclaw-workspace" claims bundled skill key "sherpa-onnx-tts".`; no install command is invoked.
  - `"blocks non-bundled installs whose tools directory collides with another skill"` — install returns `ok: false` with message `tools directory collides with runtime-owner (openclaw-workspace).`; no install command is invoked.
- **Observed result after fix:** Both attacks are blocked at the gate; `runCommandWithTimeout` is never called.
- **What was not tested:** Live runtime with actual bundled sherpa-onnx-tts binary; other OS platforms.

## Root Cause

- **Root cause:** `installSkill` warned on non-bundled sources but did not validate whether the declared `skillKey` shadowed a bundled namespace. `resolveSkillKey` was duplicated between `skills-status.ts` and used inline without trimming, allowing whitespace-padded keys to bypass string comparisons.
- **Missing detection / guardrail:** No check existed to compare a skill's resolved key or tools root against the bundled skill registry before executing the install.
- **Contributing context:** The `BundledSkillsContext` type only tracked skill names, not explicit `skillKey` values, so a bundled skill with an explicit key different from its name could not be matched by key alone.

## Regression Test Plan

- **Coverage level:** Unit test
- [x] Unit test
- **Target test:** `src/agents/skills-install.test.ts` — `"blocks non-bundled installs that claim a bundled skill key"` and `"blocks non-bundled installs whose tools directory collides with another skill"`
- **Scenario locked in:** Any workspace/project/personal-agent skill that claims a bundled key or shares a tools root with another skill is rejected before any network or filesystem mutation.
- **Why smallest reliable guardrail:** Tests inject the full `installSkill` code path with a real temp workspace and a mocked bundled context; no subprocess or network call is made.
- **If no new test added, why not:** N/A — tests are added.

## User-visible / Behavior Changes

Install attempts from workspace/project/personal-agent skills that claim a bundled `skillKey` or collide on tools directory now return an explicit error rather than proceeding with a warning. No change for bundled, managed, or extra-source skills.

## Diagram

```text
Before:
[installSkill] -> warn("non-bundled source") -> continue -> download/extract into bundled tools root

After:
[installSkill] -> warn("non-bundled source") -> [resolveSkillToolsRootCollision]
  -> skillKey in bundledContext.skillKeys|names? -> BLOCK (ok=false, no download)
  -> toolsRoot == another skill's toolsRoot?     -> BLOCK (ok=false, no download)
  -> proceed with install
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — install is now blocked for colliding keys/directories before any subprocess or download is invoked.
- Data access scope changed? No
- **Risk + mitigation:** The new gates are conservative (they block, not warn). A workspace skill that legitimately shares a name with a bundled skill will now be rejected. This is the intended behavior; users who need the skill can install it from a managed/extra source.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel: N/A

### Steps

1. Apply patch.
2. Run `pnpm test src/agents/skills-install.test.ts`.
3. Confirm both new test cases pass and `runCommandWithTimeout` is not called in either.

### Expected

- `result.ok === false`
- `result.message` contains `"claims bundled skill key"` / `"tools directory collides with"`
- `runCommandWithTimeoutMock` call count: 0

### Actual

All assertions pass.

## Evidence

- [x] Failing test/log before + passing after (new test cases added; pre-patch these tests would fail as install would proceed)

## Human Verification (required)

- **Verified scenarios:** Both new blocking paths exercised via unit tests with injected bundled context; `sameSkillInstallSource` correctly skips self-comparison; whitespace trimming on `skillKey` verified by test using `" sherpa-onnx-tts "` (padded) matching unpadded bundled set.
- **Edge cases checked:** Skill with no `skillKey` falls back to name (trimmed); bundled-source skills bypass the gate entirely; empty bundled context (default in other tests) does not block any installs.
- **What you did not verify:** Behavior on Windows paths; interaction with `openclaw-managed` or `openclaw-extra` source installs (they are in the trusted allowlist and skip the non-bundled warning, so the collision gate would still apply — this is correct).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — no config or API surface changes.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** A workspace skill that happens to share a name with a bundled skill is now rejected, which may surprise users.
  - **Mitigation:** The error message names the exact collision and the source, making the cause clear. Users can move the skill to a managed/extra source if needed.