### PR TITLE
fix(browser): backfill top-level act fields into nested request

### DIFF
--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -1076,8 +1076,44 @@ describe("browser tool act compatibility", () => {
       1,
     );
     const opts = lastMockCallArg<{ profile?: string }>(browserActionsMocks.browserAct, 2);
-    expect(request).toEqual({ kind: "press", key: "Enter", targetId: "tab-2" });
+    // Top-level ref is backfilled into request (missing there), but nested fields win.
+    expect(request).toEqual({ kind: "press", key: "Enter", targetId: "tab-2", ref: "legacy-ref" });
     expect(opts.profile).toBeUndefined();
+  });
+
+  it("backfills top-level ref into nested request when ref is missing inside request", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", {
+      action: "act",
+      ref: "e22",
+      request: {
+        kind: "click",
+      },
+    });
+
+    const request = lastMockCallArg<{ kind?: string; ref?: string }>(
+      browserActionsMocks.browserAct,
+      1,
+    );
+    expect(request).toMatchObject({ kind: "click", ref: "e22" });
+  });
+
+  it("preserves nested ref when both top-level and nested ref are present", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", {
+      action: "act",
+      ref: "top-level-ref",
+      request: {
+        kind: "click",
+        ref: "nested-ref",
+      },
+    });
+
+    const request = lastMockCallArg<{ kind?: string; ref?: string }>(
+      browserActionsMocks.browserAct,
+      1,
+    );
+    expect(request.ref).toBe("nested-ref");
   });
 
   it("applies configured browser action timeout when act timeout is omitted", async () => {

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -172,7 +172,16 @@ const LEGACY_BROWSER_ACT_REQUEST_KEYS = [
 function readActRequestParam(params: Record<string, unknown>) {
   const requestParam = params.request;
   if (requestParam && typeof requestParam === "object") {
-    return requestParam as Parameters<typeof browserAct>[1];
+    // Backfill supported top-level act fields into nested request when missing,
+    // so callers that place e.g. `ref` beside `request` instead of inside it
+    // still work (the tool schema advertises both shapes).
+    const request = requestParam as Record<string, unknown>;
+    for (const key of LEGACY_BROWSER_ACT_REQUEST_KEYS) {
+      if (!Object.hasOwn(request, key) && Object.hasOwn(params, key)) {
+        request[key] = params[key];
+      }
+    }
+    return request as Parameters<typeof browserAct>[1];
   }
 
   const kind = readStringParam(params, "kind");


### PR DESCRIPTION
## Summary

- **Problem:** `readActRequestParam` returns `params.request` unchanged when it is an object, dropping top-level fields like `ref`, `selector`, and `targetId`. OpenAI models (gpt-4o-mini, gpt-4.1-mini) follow the tool schema literally and place `ref` at the top level beside `request`, causing "ref is required" errors on every `act` call.
- **Why it matters:** The tool schema advertises both top-level and nested shapes (`LEGACY_BROWSER_ACT_REQUEST_KEYS`), so callers reasonably send either. This breaks all OpenAI-family models for browser form filling, clicking, and typing.
- **What changed:** Added a backfill loop in `readActRequestParam` that copies supported top-level fields into the nested `request` only when missing. Nested fields always take precedence (no overwrite). Added two focused regression tests (backfill + precedence). Updated existing mixed-payload test expectation.
- **What did NOT change (scope boundary):** The `/act` service contract, gateway networking, auth, browser runtime behavior, and existing flattened-only path are all untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38762
- Related #81051, #38790
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Browser `act` with `ref` at top level and `request: { kind: "click" }` now succeeds instead of throwing "ref is required".
- **Real environment tested:** Arch Linux, Node 26.1.0, OpenClaw 2026.5.7, OpenRouter provider.
- **Exact steps or command run after this patch:**
  1. Applied the patch to `extensions/browser/src/browser-tool.ts` (backfill loop in `readActRequestParam`)
  2. Restarted OpenClaw gateway: `systemctl --user restart openclaw-gateway`
  3. Ran login flow via CLI: `openclaw agent --agent main --session-id test --message "Navigate to http://localhost:3080 and login"`
  4. Agent called `action="act"` with `ref="e22"` at top level and `request: { kind: "type", text: "..." }` — succeeded after patch
  5. Verified via gateway log: `tail /tmp/openclaw/openclaw-*.log | grep "browser failed"` — zero entries
  6. Verified visually via VNC (Xvfb display :99): form fields filled, Continue button clicked, page redirected to authenticated route /c/new
  7. Repeated with 4 models: gpt-4o-mini, gpt-4.1-mini, Claude Haiku 3.5, Claude Sonnet 4.5 — all succeeded
  8. Ran unit tests: `pnpm test:extension browser` — 98/98 files, 1060/1061 tests passed
- **Evidence after fix (4 models tested):**

| Model | Provider | Login flow | Errors |
|---|---|---|---|
| gpt-4o-mini | OpenAI via OpenRouter | Login complete, redirect to /c/new | 0 |
| gpt-4.1-mini | OpenAI via OpenRouter | Login complete | 0 |
| Claude Haiku 3.5 | Anthropic via OpenRouter | Browser functional (active session) | 0 |
| Claude Sonnet 4.5 | Anthropic via OpenRouter | Login complete, redirect to /c/new | 0 |

- **Observed result after fix:** Zero "browser failed" errors in gateway log across all 4 models.
- **What was not tested:** Remote CDP profiles. Batch act actions. Non-OpenRouter direct providers.
- **Before evidence:** Gateway log showed repeated `[tools] browser failed: type requires ref or selector raw_params={"action":"act","ref":"e22","request":{"kind":"type","text":"..."}}` for every OpenAI model act call.

## Root Cause (if applicable)

- **Root cause:** `readActRequestParam` (browser-tool.ts:172) returns `params.request` immediately when it is an object, before the legacy field copy loop can run. Top-level fields like `ref` are never copied into the request.
- **Missing detection / guardrail:** No test covered the mixed-payload case (top-level `ref` + nested `request` without `ref`).
- **Contributing context:** The tool schema (`browser-tool.schema.ts:114+`) exposes `ref` both at the top level and inside `BrowserActSchema`, so both shapes are part of the advertised API surface. OpenAI models follow the schema literally and prefer the top-level shape.

## Regression Test Plan (if applicable)

- Coverage level that should catch this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `extensions/browser/src/browser-tool.test.ts`
- **Scenario the test should lock in:** (1) Top-level `ref` is backfilled into nested `request` when missing. (2) Nested `ref` takes precedence when both are present.
- **Why this is the smallest reliable guardrail:** Unit test on `readActRequestParam` input/output covers the exact parser path without requiring a live browser.
- **Existing test that already covers this:** "prefers request payload when both request and flattened fields are present" — updated to reflect backfill behavior.
- **Test results:** 98/98 test files passed, 1060/1061 tests passed (1 skipped), Node 24.15.0.

## User-visible / Behavior Changes

OpenAI models (and any caller placing `ref` beside `request` instead of inside it) can now use browser `act` for click, type, fill, and other ref-based actions without errors.

## Diagram (if applicable)

```text
Before:
params = { action: "act", ref: "e22", request: { kind: "click" } }
  -> readActRequestParam returns { kind: "click" }          // ref lost
  -> /act normalizer: "click requires ref or selector"      // error

After:
params = { action: "act", ref: "e22", request: { kind: "click" } }
  -> readActRequestParam backfills: { kind: "click", ref: "e22" }  // ref preserved
  -> /act normalizer: succeeds                                      // works
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Arch Linux (x86_64)
- Runtime/container: Node 26.1.0
- Model/provider: Tested 4 models (gpt-4o-mini, gpt-4.1-mini, Claude Haiku 3.5, Claude Sonnet 4.5) via OpenRouter
- Integration/channel: Browser plugin, managed profile, headed + headless

### Steps

1. Start OpenClaw 2026.5.7 with any OpenAI model via OpenRouter
2. Send agent message requesting browser navigation + form interaction
3. Agent calls browser act with ref at top level

### Expected

Agent fills form fields and clicks submit button successfully.

### Actual

Before fix: "type requires ref or selector" on every act call (OpenAI models only).
After fix: Form interaction completes across all 4 tested models.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Gateway log before (ref dropped, OpenAI models):
```
[tools] browser failed: type requires ref or selector raw_params={"action":"act","ref":"e22","request":{"kind":"type","text":"..."}}
```

Gateway log after (all 4 models):
```
(no browser failed entries)
```

Unit test suite:
```
Test Files  98 passed (98)
     Tests  1060 passed | 1 skipped (1061)
```

## Human Verification (required)

- **Verified scenarios:** Full login flow on localhost app with 4 models across 2 providers (OpenAI + Anthropic). Navigate -> snapshot -> fill -> click -> verify redirect. Visual confirmation via VNC.
- **Edge cases checked:** Both ref present (nested wins). Only top-level ref (backfilled). Only nested ref (unchanged). No ref at all (error preserved). Multiple top-level fields backfilled simultaneously.
- **What you did NOT verify:** Remote CDP profiles. Batch act actions. Non-OpenRouter direct providers.

## Review Conversations

N/A — new PR, no review conversations yet.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Backfilling top-level fields could introduce unexpected fields into the request when a caller sends unrelated top-level params alongside a nested request.
  - **Mitigation:** Only fields from the existing `LEGACY_BROWSER_ACT_REQUEST_KEYS` allowlist are backfilled, and only when missing in the nested request. This is the same set already accepted by the flattened path, so no new fields are introduced.
