### PR TITLE
[feat]: thread currentTokenCount into ContextEngine.assemble

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -74,7 +74,7 @@ Every time OpenClaw runs a model prompt, the context engine participates at four
     Called when a new message is added to the session. The engine can store or index the message in its own data store.
   </Accordion>
   <Accordion title="2. Assemble">
-    Called before each model run. The engine returns an ordered set of messages (and an optional `systemPromptAddition`) that fit within the token budget. OpenClaw also passes an optional `currentTokenCount` — a best-effort estimate of tokens already consumed by `messages + system prompt + incoming prompt` — so engines can bound any `systemPromptAddition` against the remaining headroom.
+    Called before each model run. The engine returns an ordered set of messages (and an optional `systemPromptAddition`) that fit within the token budget. OpenClaw also passes an optional `currentTokenCount` — a best-effort estimate of the tokens the pre-assembly `messages` already consume — so engines can bound any `systemPromptAddition` against the remaining headroom.
   </Accordion>
   <Accordion title="3. Compact">
     Called when the context window is full, or when the user runs `/compact`. The engine summarizes older history to free space.
@@ -108,19 +108,18 @@ The `assemble` method can return a `systemPromptAddition` string. OpenClaw prepe
 `assemble` receives two values that together let engines bound their injection:
 
 <ParamField path="tokenBudget" type="number">
-  The model's full input context window for this run (e.g. `200_000`, `1_048_576`). Not the headroom remaining — engines must subtract what is already consumed.
+  The budget available for the assembled messages. The runtime computes this as the model's context window minus its compaction reserve (when the harness holds one) and the rendered system/user prompt pressure — engines do not subtract those themselves.
 </ParamField>
 <ParamField path="currentTokenCount" type="number">
-  Best-effort pre-assembly estimate of tokens already consumed by `messages + system prompt + incoming prompt`. Computed by the runtime via the same estimator the preemptive overflow precheck uses, so engines see the same number the runtime would. Optional — may be `undefined` on older OpenClaw runtimes; treat absence as "no headroom info, inject conservatively or skip the guard."
+  Best-effort estimate of the tokens the pre-assembly `messages` already consume, computed with the same transcript estimator the runtime uses (`estimateTranscriptTokenPressure` on `openclaw/plugin-sdk/agent-harness-runtime`), so engines see the same number the runtime would. Optional — `undefined` on older OpenClaw runtimes; treat absence as "no headroom info, inject conservatively or skip the guard."
 </ParamField>
 
-A typical guard looks like:
+Both values live on the same scale, so the remaining headroom for a `systemPromptAddition` is their difference:
 
 ```ts
-const responseReserve = 8_192; // assistant response budget; not in currentTokenCount
 const remaining =
   tokenBudget !== undefined && currentTokenCount !== undefined
-    ? Math.max(0, tokenBudget - currentTokenCount - responseReserve)
+    ? Math.max(0, tokenBudget - currentTokenCount)
     : undefined;
 
 if (remaining !== undefined && estimateTokens(additionContent) > remaining) {

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -74,7 +74,7 @@ Every time OpenClaw runs a model prompt, the context engine participates at four
     Called when a new message is added to the session. The engine can store or index the message in its own data store.
   </Accordion>
   <Accordion title="2. Assemble">
-    Called before each model run. The engine returns an ordered set of messages (and an optional `systemPromptAddition`) that fit within the token budget.
+    Called before each model run. The engine returns an ordered set of messages (and an optional `systemPromptAddition`) that fit within the token budget. OpenClaw also passes an optional `currentTokenCount` — a best-effort estimate of tokens already consumed by `messages + system prompt + incoming prompt` — so engines can bound any `systemPromptAddition` against the remaining headroom.
   </Accordion>
   <Accordion title="3. Compact">
     Called when the context window is full, or when the user runs `/compact`. The engine summarizes older history to free space.
@@ -102,6 +102,35 @@ OpenClaw calls two optional subagent lifecycle hooks:
 ### System prompt addition
 
 The `assemble` method can return a `systemPromptAddition` string. OpenClaw prepends this to the system prompt for the run. This lets engines inject dynamic recall guidance, retrieval instructions, or context-aware hints without requiring static workspace files.
+
+### Sizing `systemPromptAddition`
+
+`assemble` receives two values that together let engines bound their injection:
+
+<ParamField path="tokenBudget" type="number">
+  The model's full input context window for this run (e.g. `200_000`, `1_048_576`). Not the headroom remaining — engines must subtract what is already consumed.
+</ParamField>
+<ParamField path="currentTokenCount" type="number">
+  Best-effort pre-assembly estimate of tokens already consumed by `messages + system prompt + incoming prompt`. Computed by the runtime via the same estimator the preemptive overflow precheck uses, so engines see the same number the runtime would. Optional — may be `undefined` on older OpenClaw runtimes; treat absence as "no headroom info, inject conservatively or skip the guard."
+</ParamField>
+
+A typical guard looks like:
+
+```ts
+const responseReserve = 8_192; // assistant response budget; not in currentTokenCount
+const remaining =
+  tokenBudget !== undefined && currentTokenCount !== undefined
+    ? Math.max(0, tokenBudget - currentTokenCount - responseReserve)
+    : undefined;
+
+if (remaining !== undefined && estimateTokens(additionContent) > remaining) {
+  // skip injection so the turn proceeds without an oversized prompt
+} else {
+  return { messages, estimatedTokens, systemPromptAddition: format(additionContent) };
+}
+```
+
+OpenClaw's own preemptive-compaction runs _before_ assemble, so it does not catch overflow caused by the engine's injection. Sizing the addition against `remaining` is the engine's responsibility.
 
 ## The legacy engine
 
@@ -136,8 +165,17 @@ export default function register(api) {
       return { ingested: true };
     },
 
-    async assemble({ sessionId, messages, tokenBudget, availableTools, citationsMode }) {
-      // Return messages that fit the budget
+    async assemble({
+      sessionId,
+      messages,
+      tokenBudget,
+      currentTokenCount,
+      availableTools,
+      citationsMode,
+    }) {
+      // Return messages that fit the budget. When both tokenBudget and
+      // currentTokenCount are present, you can size any systemPromptAddition
+      // against the remaining headroom (see "Sizing systemPromptAddition").
       return {
         messages: buildContext(messages, tokenBudget),
         estimatedTokens: countTokens(messages),

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -425,6 +425,10 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(assembleParams.prompt).toBe("hello");
     expect(assembleParams.messages.map((message) => message.role)).toEqual(["assistant"]);
     expect(assembleParams.availableTools).toEqual(new Set());
+    // Codex harness must thread a pre-assembly token estimate so engines can
+    // bound systemPromptAddition against tokenBudget on this path too.
+    expect(typeof assembleParams.currentTokenCount).toBe("number");
+    expect(assembleParams.currentTokenCount).toBeGreaterThan(0);
 
     const threadStartParams = requireRequestParams(harness, "thread/start");
     expect(optionalString(threadStartParams.developerInstructions)).toContain(

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -408,7 +408,12 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     >[0];
     expect(assembleParams.sessionId).toBe("session-1");
     expect(assembleParams.sessionKey).toBe("agent:main:session-1");
-    expect(assembleParams.tokenBudget).toBe(321);
+    // The harness passes the message budget: contextTokenBudget (321) minus the
+    // rendered developer-instructions/prompt pressure, with no reserve on the
+    // codex path (native compaction).
+    expect(typeof assembleParams.tokenBudget).toBe("number");
+    expect(assembleParams.tokenBudget as number).toBeGreaterThan(0);
+    expect(assembleParams.tokenBudget as number).toBeLessThan(321);
     expect(assembleParams.citationsMode).toBe("on");
     expect(assembleParams.model).toBe("gpt-5.4-codex");
     expect(assembleParams.runtimeSettings).toMatchObject({

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -11,7 +11,8 @@ import {
   clearActiveEmbeddedRun,
   embeddedAgentLog,
   emitAgentEvent as emitGlobalAgentEvent,
-  estimateLlmBoundaryTokenPressure,
+  computeContextEngineMessageBudget,
+  estimateTranscriptTokenPressure,
   finalizeHarnessContextEngineTurn,
   FAST_MODE_AUTO_PROGRESS_KIND,
   formatFastModeAutoProgressText,
@@ -1025,18 +1026,27 @@ export async function runCodexAppServerAttempt(
     if (!activeContextEngine) {
       return;
     }
-    // Pre-assembly token estimate so engines can bound any systemPromptAddition against tokenBudget.
-    const preassemblyCurrentTokenCount = estimateLlmBoundaryTokenPressure({
-      messages: historyMessages,
-      systemPrompt: developerInstructions,
-      prompt: params.prompt ?? "",
-    });
+    // Codex app-server owns compaction natively, so no OpenClaw compaction
+    // reserve is held back on this path — the budget only sets aside the
+    // rendered developer-instructions/prompt pressure.
+    const assembleTokenBudget =
+      typeof params.contextTokenBudget === "number"
+        ? computeContextEngineMessageBudget({
+            contextWindowTokens: params.contextTokenBudget,
+            compactionReserveTokens: 0,
+            systemPrompt: developerInstructions,
+            prompt: params.prompt ?? "",
+          })
+        : undefined;
+    // Messages-only estimate: engines size any systemPromptAddition as
+    // tokenBudget - currentTokenCount.
+    const preassemblyCurrentTokenCount = estimateTranscriptTokenPressure(historyMessages);
     const assembled = await assembleHarnessContextEngine({
       contextEngine: activeContextEngine,
       sessionId: activeSessionId,
       sessionKey: contextSessionKey,
       messages: historyMessages,
-      tokenBudget: params.contextTokenBudget,
+      tokenBudget: assembleTokenBudget,
       currentTokenCount: preassemblyCurrentTokenCount,
       availableTools: new Set(
         flattenCodexDynamicToolFunctions(toolBridge.availableSpecs)

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -11,6 +11,7 @@ import {
   clearActiveEmbeddedRun,
   embeddedAgentLog,
   emitAgentEvent as emitGlobalAgentEvent,
+  estimateLlmBoundaryTokenPressure,
   finalizeHarnessContextEngineTurn,
   FAST_MODE_AUTO_PROGRESS_KIND,
   formatFastModeAutoProgressText,
@@ -1024,12 +1025,19 @@ export async function runCodexAppServerAttempt(
     if (!activeContextEngine) {
       return;
     }
+    // Pre-assembly token estimate so engines can bound any systemPromptAddition against tokenBudget.
+    const preassemblyCurrentTokenCount = estimateLlmBoundaryTokenPressure({
+      messages: historyMessages,
+      systemPrompt: developerInstructions,
+      prompt: params.prompt ?? "",
+    });
     const assembled = await assembleHarnessContextEngine({
       contextEngine: activeContextEngine,
       sessionId: activeSessionId,
       sessionKey: contextSessionKey,
       messages: historyMessages,
       tokenBudget: params.contextTokenBudget,
+      currentTokenCount: preassemblyCurrentTokenCount,
       availableTools: new Set(
         flattenCodexDynamicToolFunctions(toolBridge.availableSpecs)
           .map((tool) => tool.name)

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2978,6 +2978,43 @@ describe("runEmbeddedAttempt context engine mid-turn precheck integration", () =
     expect(loopHookParams.midTurnPrecheck).toBeUndefined();
   });
 
+  it("populates currentTokenCount in the loop-hook getRuntimeContext callback", async () => {
+    await createContextEngineAttemptRunner({
+      contextEngine: {
+        ...createContextEngineBootstrapAndAssemble(),
+        info: { ownsCompaction: true },
+      },
+      sessionKey,
+      tempPaths,
+    });
+
+    const loopHookParams = mockParams(
+      hoisted.installContextEngineLoopHookMock,
+      0,
+      "context engine loop hook params",
+    );
+    const getRuntimeContext = loopHookParams.getRuntimeContext as
+      | ((p: {
+          messages: AgentMessage[];
+          prePromptMessageCount: number;
+        }) => Record<string, unknown> | undefined)
+      | undefined;
+    expect(typeof getRuntimeContext).toBe("function");
+
+    const runtimeContext = getRuntimeContext?.({
+      messages: [
+        {
+          role: "user",
+          content: "loop iteration probe with non-trivial content",
+          timestamp: 1,
+        } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+    });
+    expect(typeof runtimeContext?.currentTokenCount).toBe("number");
+    expect(runtimeContext?.currentTokenCount as number).toBeGreaterThan(0);
+  });
+
   it("recovers when the runtime persists the mid-turn precheck as an assistant error", async () => {
     hoisted.installToolResultContextGuardMock.mockImplementation((...args: unknown[]) => {
       const params = args[0] as ToolResultGuardInstallParams;

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -3013,6 +3013,11 @@ describe("runEmbeddedAttempt context engine mid-turn precheck integration", () =
     });
     expect(typeof runtimeContext?.currentTokenCount).toBe("number");
     expect(runtimeContext?.currentTokenCount as number).toBeGreaterThan(0);
+
+    // The install site also derives a loop assemble budget (window minus
+    // reserve and rendered system-prompt pressure) for the hook.
+    expect(typeof loopHookParams.assembleTokenBudget).toBe("number");
+    expect(loopHookParams.assembleTokenBudget as number).toBeGreaterThan(0);
   });
 
   it("recovers when the runtime persists the mid-turn precheck as an assistant error", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts
@@ -251,4 +251,32 @@ describe("embedded attempt context injection", () => {
       { role: "assistant", content: "real answer" },
     ]);
   });
+
+  it("threads currentTokenCount through assembleAttemptContextEngine to the engine", async () => {
+    const assemble = vi.fn(async ({ messages }: { messages: AgentMessage[] }) => ({
+      messages,
+      estimatedTokens: 0,
+    }));
+
+    await assembleAttemptContextEngine({
+      contextEngine: {
+        info: { id: "test", name: "Test", version: "0.0.1" },
+        ingest: async () => ({ ingested: true }),
+        compact: async () => ({ ok: false, compacted: false, reason: "unused" }),
+        assemble,
+      } satisfies AttemptContextEngine,
+      sessionId: "session",
+      sessionKey: "agent:main",
+      messages: [{ role: "user", content: "ask", timestamp: 1 } as AgentMessage],
+      tokenBudget: 200_000,
+      currentTokenCount: 42_000,
+      modelId: "gpt-test",
+    });
+
+    const assembleInput = assemble.mock.calls.at(0)?.[0] as
+      | { currentTokenCount?: number; tokenBudget?: number }
+      | undefined;
+    expect(assembleInput?.currentTokenCount).toBe(42_000);
+    expect(assembleInput?.tokenBudget).toBe(200_000);
+  });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2696,6 +2696,14 @@ export async function runEmbeddedAttempt(
               cwd: effectiveCwd,
               agentDir,
               tokenBudget: params.contextTokenBudget,
+              // Mid-tool-loop the next model call has no new user prompt — the
+              // continuation is driven by tool results that are already in
+              // `messages`. Estimate against messages + system prompt only.
+              currentTokenCount: estimateLlmBoundaryTokenPressure({
+                messages,
+                systemPrompt: systemPromptText,
+                prompt: "",
+              }),
               promptCache:
                 promptCache ??
                 buildLoopPromptCacheInfo({
@@ -3377,12 +3385,19 @@ export async function runEmbeddedAttempt(
               1,
               contextEngineAssemblePromptBudget - contextEngineAssembleRenderedPromptTokens,
             );
+            // Pre-assembly token estimate so engines can bound any systemPromptAddition against tokenBudget.
+            const preassemblyCurrentTokenCount = estimateLlmBoundaryTokenPressure({
+              messages: activeSession.messages,
+              systemPrompt: systemPromptText,
+              prompt: params.prompt ?? "",
+            });
             const assembled = await assembleAttemptContextEngine({
               contextEngine: activeContextEngine,
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
               messages: activeSession.messages,
               tokenBudget: contextEngineAssembleMessageBudget,
+              currentTokenCount: preassemblyCurrentTokenCount,
               availableTools: new Set(capabilityToolNames),
               citationsMode: params.config?.memory?.citations,
               modelId: params.modelId,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -499,8 +499,9 @@ import {
 import {
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
   buildPrePromptContextBudgetStatus,
+  computeContextEngineMessageBudget,
   estimateLlmBoundaryTokenPressure,
-  estimateRenderedLlmBoundaryTokenPressure,
+  estimateTranscriptTokenPressure,
   formatPrePromptPrecheckLog,
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
@@ -2671,6 +2672,15 @@ export async function runEmbeddedAttempt(
           fallbackReason: params.fallbackReason,
           degradedReason: params.degradedReason,
         });
+        // Mid-tool-loop assemble calls carry no new user prompt — the original
+        // prompt is already part of the transcript — so the loop budget only
+        // sets aside the system prompt and the compaction reserve.
+        const loopAssembleTokenBudget = computeContextEngineMessageBudget({
+          contextWindowTokens: contextTokenBudgetForGuard,
+          compactionReserveTokens: settingsManager.getCompactionReserveTokens(),
+          systemPrompt: systemPromptText,
+          prompt: "",
+        });
         const removeContextEngineLoopHook = installContextEngineLoopHook({
           agent: activeSession.agent,
           contextEngine: activeContextEngine,
@@ -2678,6 +2688,7 @@ export async function runEmbeddedAttempt(
           sessionKey: params.sessionKey,
           sessionFile: params.sessionFile,
           tokenBudget: params.contextTokenBudget,
+          assembleTokenBudget: loopAssembleTokenBudget,
           modelId: params.modelId,
           ...(transcriptPolicy.repairToolUseResultPairing
             ? {
@@ -2696,14 +2707,9 @@ export async function runEmbeddedAttempt(
               cwd: effectiveCwd,
               agentDir,
               tokenBudget: params.contextTokenBudget,
-              // Mid-tool-loop the next model call has no new user prompt — the
-              // continuation is driven by tool results that are already in
-              // `messages`. Estimate against messages + system prompt only.
-              currentTokenCount: estimateLlmBoundaryTokenPressure({
-                messages,
-                systemPrompt: systemPromptText,
-                prompt: "",
-              }),
+              // Messages-only estimate to match the assemble contract: the loop
+              // assemble budget already sets aside the system prompt and reserve.
+              currentTokenCount: estimateTranscriptTokenPressure(messages),
               promptCache:
                 promptCache ??
                 buildLoopPromptCacheInfo({
@@ -3372,25 +3378,18 @@ export async function runEmbeddedAttempt(
                   DEFAULT_CONTEXT_TOKENS,
               ),
             );
-            const contextEngineAssemblePromptBudget = Math.max(
-              1,
-              contextEngineAssembleContextTokenBudget - contextEngineAssembleReserveTokens,
-            );
-            const contextEngineAssembleRenderedPromptTokens =
-              estimateRenderedLlmBoundaryTokenPressure({
-                systemPrompt: systemPromptText,
-                prompt: params.prompt ?? "",
-              });
-            const contextEngineAssembleMessageBudget = Math.max(
-              1,
-              contextEngineAssemblePromptBudget - contextEngineAssembleRenderedPromptTokens,
-            );
-            // Pre-assembly token estimate so engines can bound any systemPromptAddition against tokenBudget.
-            const preassemblyCurrentTokenCount = estimateLlmBoundaryTokenPressure({
-              messages: activeSession.messages,
+            const contextEngineAssembleMessageBudget = computeContextEngineMessageBudget({
+              contextWindowTokens: contextEngineAssembleContextTokenBudget,
+              compactionReserveTokens: contextEngineAssembleReserveTokens,
               systemPrompt: systemPromptText,
               prompt: params.prompt ?? "",
             });
+            // Messages-only estimate: tokenBudget already accounts for the rendered
+            // system/user prompt and the compaction reserve, so engines size any
+            // systemPromptAddition as tokenBudget - currentTokenCount.
+            const preassemblyCurrentTokenCount = estimateTranscriptTokenPressure(
+              activeSession.messages,
+            );
             const assembled = await assembleAttemptContextEngine({
               contextEngine: activeContextEngine,
               sessionId: params.sessionId,

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -287,6 +287,41 @@ export function estimateRenderedLlmBoundaryTokenPressure(params: {
   return Math.max(0, Math.ceil((systemTokens + promptTokens) * SAFETY_MARGIN));
 }
 
+/**
+ * Estimates the token pressure of transcript messages alone — no system prompt or
+ * incoming prompt. This is the estimator behind `ContextEngine.assemble`'s
+ * `currentTokenCount`: it pairs with `computeContextEngineMessageBudget` so engines
+ * can compute assemble headroom as `tokenBudget - currentTokenCount`.
+ */
+export function estimateTranscriptTokenPressure(messages: AgentMessage[]): number {
+  const historyTokens = messages.reduce(
+    (sum, message) => sum + estimateMessageTokenPressure(message),
+    0,
+  );
+  return Math.max(0, Math.ceil(historyTokens * SAFETY_MARGIN));
+}
+
+/**
+ * Budget available to a context engine's assembled messages: the resolved context
+ * window minus the runtime's compaction reserve and the rendered system/user prompt
+ * pressure. Every `ContextEngine.assemble` call site derives `tokenBudget` through
+ * this helper so the field means the same thing on every harness path.
+ */
+export function computeContextEngineMessageBudget(params: {
+  contextWindowTokens: number;
+  compactionReserveTokens: number;
+  systemPrompt?: string;
+  prompt: string;
+}): number {
+  const reserveTokens = Math.max(0, Math.floor(params.compactionReserveTokens));
+  const promptBudget = Math.max(1, Math.floor(params.contextWindowTokens) - reserveTokens);
+  const renderedPromptTokens = estimateRenderedLlmBoundaryTokenPressure({
+    systemPrompt: params.systemPrompt,
+    prompt: params.prompt,
+  });
+  return Math.max(1, promptBudget - renderedPromptTokens);
+}
+
 function normalizeLlmBoundaryTokenPressure(
   pressure: LlmBoundaryTokenPressure | undefined,
 ): LlmBoundaryTokenPressure | undefined {

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -737,6 +737,29 @@ describe("installContextEngineLoopHook", () => {
     expect(assembleParams).not.toHaveProperty("currentTokenCount");
   });
 
+  it("prefers assembleTokenBudget for assemble while afterTurn keeps tokenBudget", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      assembleTokenBudget: 2048,
+      modelId,
+      getPrePromptMessageCount: () => 1,
+    });
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, messages);
+
+    expect(recordMockArg(engine.afterTurn).tokenBudget).toBe(tokenBudget);
+    const assembleParams = engine.assemble.mock.calls.at(0)?.[0];
+    expect(assembleParams?.tokenBudget).toBe(2048);
+  });
+
   it("passes loop messages and the prompt fence into the runtimeContext callback", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine();

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -699,6 +699,44 @@ describe("installContextEngineLoopHook", () => {
     expect(recordMockArg(engine.assemble).runtimeSettings).toBe(runtimeSettings);
   });
 
+  it("passes currentTokenCount from runtimeContext through to loop-hook assemble", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installHook(agent, engine, 1, () => ({ currentTokenCount: 17_500 }));
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, messages);
+
+    expect(engine.assemble).toHaveBeenCalledTimes(1);
+    const assembleParams = engine.assemble.mock.calls.at(0)?.[0];
+    expect(assembleParams?.currentTokenCount).toBe(17_500);
+    expect(assembleParams?.tokenBudget).toBe(tokenBudget);
+  });
+
+  it("omits currentTokenCount when runtimeContext does not include it", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installHook(agent, engine, 1, () => ({ provider: "anthropic" }));
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, messages);
+
+    const assembleParams = engine.assemble.mock.calls.at(0)?.[0];
+    expect(assembleParams).not.toHaveProperty("currentTokenCount");
+  });
+
+  it("omits currentTokenCount when no runtimeContext callback is wired up", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installHook(agent, engine, 1);
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, messages);
+
+    const assembleParams = engine.assemble.mock.calls.at(0)?.[0];
+    expect(assembleParams).not.toHaveProperty("currentTokenCount");
+  });
+
   it("passes loop messages and the prompt fence into the runtimeContext callback", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine();

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -433,11 +433,18 @@ export function installContextEngineLoopHook(params: {
       lastSeenLength = transcriptMessages.length;
       params.onAfterTurnCheckpoint?.(lastSeenLength);
       lastSourceMessages = transcriptMessages;
+      const loopCurrentTokenCount = params.getRuntimeContext?.({
+        messages: sourceMessages,
+        prePromptMessageCount,
+      })?.currentTokenCount;
       const assembled = await contextEngine.assemble({
         sessionId,
         sessionKey,
         messages: providerMessages,
         tokenBudget,
+        ...(typeof loopCurrentTokenCount === "number"
+          ? { currentTokenCount: loopCurrentTokenCount }
+          : {}),
         model: modelId,
         runtimeSettings: params.runtimeSettings,
       });

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -330,6 +330,8 @@ export function installContextEngineLoopHook(params: {
   sessionKey?: string;
   sessionFile: string;
   tokenBudget?: number;
+  /** Budget for assemble calls: context window minus compaction reserve and rendered system-prompt pressure. Falls back to `tokenBudget` when absent. */
+  assembleTokenBudget?: number;
   modelId: string;
   repairAssembledMessages?: (messages: AgentMessage[]) => AgentMessage[];
   getPrePromptMessageCount?: () => number;
@@ -393,6 +395,12 @@ export function installContextEngineLoopHook(params: {
       return lastAssembledView ?? providerMessages;
     }
     try {
+      // Resolved once per iteration: afterTurn and assemble share it, so the
+      // currentTokenCount estimate inside the callback is computed once.
+      const loopRuntimeContext = params.getRuntimeContext?.({
+        messages: transcriptMessages,
+        prePromptMessageCount,
+      });
       if (typeof contextEngine.afterTurn === "function") {
         await contextEngine.afterTurn({
           sessionId,
@@ -401,10 +409,7 @@ export function installContextEngineLoopHook(params: {
           messages: transcriptMessages,
           prePromptMessageCount,
           tokenBudget,
-          runtimeContext: params.getRuntimeContext?.({
-            messages: transcriptMessages,
-            prePromptMessageCount,
-          }),
+          runtimeContext: loopRuntimeContext,
           runtimeSettings: params.runtimeSettings,
           isHeartbeat: params.isHeartbeat,
         });
@@ -433,15 +438,12 @@ export function installContextEngineLoopHook(params: {
       lastSeenLength = transcriptMessages.length;
       params.onAfterTurnCheckpoint?.(lastSeenLength);
       lastSourceMessages = transcriptMessages;
-      const loopCurrentTokenCount = params.getRuntimeContext?.({
-        messages: sourceMessages,
-        prePromptMessageCount,
-      })?.currentTokenCount;
+      const loopCurrentTokenCount = loopRuntimeContext?.currentTokenCount;
       const assembled = await contextEngine.assemble({
         sessionId,
         sessionKey,
         messages: providerMessages,
-        tokenBudget,
+        tokenBudget: params.assembleTokenBudget ?? tokenBudget,
         ...(typeof loopCurrentTokenCount === "number"
           ? { currentTokenCount: loopCurrentTokenCount }
           : {}),

--- a/src/agents/harness/context-engine-lifecycle.test.ts
+++ b/src/agents/harness/context-engine-lifecycle.test.ts
@@ -337,6 +337,46 @@ describe("harness context engine lifecycle", () => {
     expect(afterTurnParams?.prePromptMessageCount).toBe(2);
   });
 
+  it("passes currentTokenCount through to the engine when provided", async () => {
+    const assemble = vi.fn(async (params: Parameters<ContextEngine["assemble"]>[0]) => ({
+      messages: params.messages,
+      estimatedTokens: 0,
+    }));
+
+    await assembleHarnessContextEngine({
+      contextEngine: createContextEngine({ assemble }),
+      sessionId: sessionParams.sessionId,
+      sessionKey: sessionParams.sessionKey,
+      messages: [textMessage("user", "ask", 1)],
+      tokenBudget: 200_000,
+      currentTokenCount: 42_000,
+      modelId: "gpt-test",
+    });
+
+    const assembleParams = assemble.mock.calls.at(0)?.[0];
+    expect(assembleParams?.currentTokenCount).toBe(42_000);
+    expect(assembleParams?.tokenBudget).toBe(200_000);
+  });
+
+  it("omits currentTokenCount when not provided so engines can detect older runtimes", async () => {
+    const assemble = vi.fn(async (params: Parameters<ContextEngine["assemble"]>[0]) => ({
+      messages: params.messages,
+      estimatedTokens: 0,
+    }));
+
+    await assembleHarnessContextEngine({
+      contextEngine: createContextEngine({ assemble }),
+      sessionId: sessionParams.sessionId,
+      sessionKey: sessionParams.sessionKey,
+      messages: [textMessage("user", "ask", 1)],
+      tokenBudget: 200_000,
+      modelId: "gpt-test",
+    });
+
+    const assembleParams = assemble.mock.calls.at(0)?.[0];
+    expect(assembleParams).not.toHaveProperty("currentTokenCount");
+  });
+
   describe("assembleHarnessContextEngine result validation", () => {
     // Regression for #75541: plugins that return a malformed assemble result
     // previously poisoned activeSession.messages with `undefined`, which then

--- a/src/agents/harness/context-engine-lifecycle.ts
+++ b/src/agents/harness/context-engine-lifecycle.ts
@@ -136,6 +136,7 @@ export async function assembleHarnessContextEngine(params: {
   sessionKey?: string;
   messages: AgentMessage[];
   tokenBudget?: number;
+  currentTokenCount?: number;
   availableTools?: Set<string>;
   citationsMode?: MemoryCitationsMode;
   modelId: string;
@@ -161,6 +162,9 @@ export async function assembleHarnessContextEngine(params: {
     sessionKey: params.sessionKey,
     messages,
     tokenBudget: params.tokenBudget,
+    ...(typeof params.currentTokenCount === "number"
+      ? { currentTokenCount: params.currentTokenCount }
+      : {}),
     ...(params.availableTools ? { availableTools: params.availableTools } : {}),
     ...(params.citationsMode ? { citationsMode: params.citationsMode } : {}),
     model: params.modelId,

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -381,8 +381,9 @@ export interface ContextEngine {
     sessionId: string;
     sessionKey?: string;
     messages: AgentMessage[];
+    /** Budget available for the assembled messages. The runtime has already subtracted its compaction reserve (when it holds one) and the rendered system/user prompt pressure from the context window. */
     tokenBudget?: number;
-    /** Best-effort pre-assembly prompt token estimate so engines can bound any `systemPromptAddition` against `tokenBudget`. */
+    /** Best-effort token estimate of `messages` alone, from the runtime's transcript estimator. Remaining headroom for any `systemPromptAddition` is `tokenBudget - currentTokenCount`. Omitted on runtimes that predate the field. */
     currentTokenCount?: number;
     /** Tool names available for this run so engines can align prompt guidance with runtime tool access. */
     availableTools?: Set<string>;

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -382,6 +382,8 @@ export interface ContextEngine {
     sessionKey?: string;
     messages: AgentMessage[];
     tokenBudget?: number;
+    /** Best-effort pre-assembly prompt token estimate so engines can bound any `systemPromptAddition` against `tokenBudget`. */
+    currentTokenCount?: number;
     /** Tool names available for this run so engines can align prompt guidance with runtime tool access. */
     availableTools?: Set<string>;
     /** Active memory citation mode when engines want to mirror memory prompt guidance. */

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -357,6 +357,7 @@ export {
   resolveCompactionTimeoutMs,
 } from "../agents/embedded-agent-runner/compaction-safety-timeout.js";
 export {
+  estimateLlmBoundaryTokenPressure,
   estimateRenderedLlmBoundaryTokenPressure,
   formatPrePromptPrecheckLog,
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -357,8 +357,9 @@ export {
   resolveCompactionTimeoutMs,
 } from "../agents/embedded-agent-runner/compaction-safety-timeout.js";
 export {
-  estimateLlmBoundaryTokenPressure,
+  computeContextEngineMessageBudget,
   estimateRenderedLlmBoundaryTokenPressure,
+  estimateTranscriptTokenPressure,
   formatPrePromptPrecheckLog,
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
   shouldPreemptivelyCompactBeforePrompt,


### PR DESCRIPTION
## Summary

- **Problem:** `ContextEngine.assemble` receives only `tokenBudget` (the full model context window) and has no signal for how many of those tokens are already consumed by `messages + systemPrompt + prompt`. Engines that prepend a `systemPromptAddition` have no way to size it against actual remaining headroom.
- **Why it matters:** On long sessions an engine's injection can push the prompt past the model's context limit. The runtime's `preemptive-compaction` (which has full visibility) runs *before* assemble, so it does not catch overflow caused by the engine's injection — the next LLM call simply fails with a context-limit error.
- **What changed:** Added an optional `currentTokenCount?: number` field to `ContextEngine.assemble` params, plumbed it through `assembleHarnessContextEngine`, and wired computation at every production caller: the PI runner main assemble (`runEmbeddedAttempt`), the PI runner tool-loop hook (`installContextEngineLoopHook` via the `getRuntimeContext` callback), and the Codex harness (`extensions/codex/src/app-server/run-attempt.ts`). `estimatePrePromptTokens` is re-exported from `openclaw/plugin-sdk/agent-harness-runtime` so extension harnesses use the same estimator the PI runner uses — defining the semantics once. Docs updated.
- **What did NOT change (scope boundary):** Behavior of engines that don't read the new field (it's optional). Semantics or value of `tokenBudget`. `preemptive-compaction` logic. No public type was renamed or removed. No new dependency was added.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

> No upstream OpenClaw issue. Motivation comes from a downstream context-engine plugin (`@byterover/byterover`) that hit a real overflow on long sessions and could not implement a precise guard without this field.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Context-engine plugins cannot precisely guard their `systemPromptAddition` against the model's remaining headroom because `assemble` receives only `tokenBudget`, not `currentTokenCount`. After this change, engines can compute `remaining = tokenBudget - currentTokenCount - <reserve>` and skip injection when the curated content would not fit.
- **Real environment tested:** macOS (Darwin 25.2.0), local pnpm workspace, `pnpm exec vitest run` on the touched test files. **Not yet tested against a live model on a long session** — verification so far is at the unit/integration-test layer. A follow-up real-session repro on a Gemini 1M-context channel where pre-this-PR overflow was observed is planned before merge.
- **Exact steps or command run after this patch:**

```bash
cd ~/dpmemories/openclawdp/openclaw
pnpm install
pnpm exec vitest run \
  src/agents/harness/context-engine-lifecycle.test.ts \
  src/agents/pi-embedded-runner/tool-result-context-guard.test.ts \
  src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts \
  src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts \
  extensions/codex/src/app-server/run-attempt.context-engine.test.ts
```

- **Evidence after fix:**

```
RUN  v4.1.6 /Users/datpham/dpmemories/openclawdp/openclaw

Test Files  9 passed (9)
     Tests  194 passed (194)
  Duration  19.96s
```

- **Observed result after fix:** New field is plumbed end-to-end across every production assemble path.
  - **PI runner main assemble**: `runEmbeddedAttempt` computes `preassemblyCurrentTokenCount` via `estimatePrePromptTokens` from `{ activeSession.messages, systemPromptText, params.prompt }` and passes it through `assembleAttemptContextEngine`.
  - **PI runner tool-loop hook**: `installContextEngineLoopHook` reads `currentTokenCount` from the existing `getRuntimeContext()` callback. The production install site at `attempt.ts:1996` now computes the estimate from the loop messages and `systemPromptText` (with empty `prompt` — the continuation is driven by tool results already in `messages`), so engines see a real value on this path too.
  - **Codex harness**: `extensions/codex/src/app-server/run-attempt.ts:624` computes the same estimate from `{ historyMessages, developerInstructions, params.prompt }` and passes it through `assembleHarnessContextEngine`.
- **What was not tested:** A live overflow scenario with a real LLM provider. The downstream plugin's consumption of this field (which is where the real-world payoff happens) is tracked in a separate plugin PR.
- **Before evidence (optional but encouraged):** N/A — this PR adds new capability rather than fixing a behavior already present in OpenClaw.

## Root Cause (if applicable)

N/A — this is a capability addition, not a bug fix in OpenClaw. The existing behavior (passing only `tokenBudget`) is by design.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): Plugin authors building context engines that inject `systemPromptAddition` discovered they had no way to size injection safely. The `ContextEngineRuntimeContext` type already defined `currentTokenCount` for other lifecycle hooks (`afterTurn`, `maintain`, `compact`) — `assemble` was the only one that didn't receive it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/harness/context-engine-lifecycle.test.ts` — wrapper pass-through (present + absent)
  - `src/agents/pi-embedded-runner/tool-result-context-guard.test.ts` — tool-loop hook propagation (from runtimeContext, missing-from-context, no-callback)
  - `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts` — attempt-level alias plumbs the field
  - `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts` — captures loop-hook params and asserts `getRuntimeContext()` returns a positive `currentTokenCount` in production
  - `extensions/codex/src/app-server/run-attempt.context-engine.test.ts` — Codex harness path now asserts a positive `currentTokenCount` reaches the engine
- Scenario the test should lock in: `currentTokenCount` reaches `engine.assemble` from every production harness path; field is omitted (not undefined-valued) when no estimate is available, so engines can detect older runtimes.
- Why this is the smallest reliable guardrail: Each wiring layer (wrapper, PI main computation site, PI loop-hook computation site, Codex computation site, attempt-level re-export) has its own test. Refactoring any one of them without preserving pass-through will fail an existing test.
- Existing test that already covers this (if any): `preemptive-compaction.test.ts` already covers the underlying `estimatePrePromptTokens` helper that produces the value.
- If no new test is added, why not: N/A (9 new tests / assertions added across 5 test files).

## User-visible / Behavior Changes

None for OpenClaw end users. Plugin authors implementing `ContextEngine` get a new optional `currentTokenCount?: number` param on `assemble`. Plugins that do not read it see unchanged behavior. Extension authors gain a new re-export `estimatePrePromptTokens` on `openclaw/plugin-sdk/agent-harness-runtime` for use when wiring custom harnesses.

## Diagram (if applicable)

```text
Before:
runEmbeddedAttempt          (PI harness — main + loop-hook)
  └─ contextEngine.assemble({ tokenBudget, messages, prompt, ... })

extensions/codex run-attempt (Codex harness)
  └─ contextEngine.assemble({ tokenBudget, messages, prompt, ... })

  (engines have no view of pre-assembly consumed tokens)

After:
runEmbeddedAttempt          (PI harness)
  ├─ main assemble
  │   ├─ estimatePrePromptTokens(messages + systemPrompt + prompt) → N
  │   └─ contextEngine.assemble({ tokenBudget, currentTokenCount: N, ... })
  └─ tool-loop hook (getRuntimeContext callback at install site)
      ├─ estimatePrePromptTokens(loopMessages + systemPrompt + "") → N
      └─ contextEngine.assemble({ tokenBudget, currentTokenCount: N, ... })

extensions/codex run-attempt (Codex harness)
  ├─ estimatePrePromptTokens(historyMessages + developerInstructions + prompt) → N
  └─ contextEngine.assemble({ tokenBudget, currentTokenCount: N, ... })

  (engines can compute remaining = tokenBudget - currentTokenCount - reserve)
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: macOS Darwin 25.2.0
- Runtime/container: pnpm 11.x workspace, Node 22, vitest 4.1.6
- Model/provider: N/A (tests use mocked `ContextEngine`)
- Integration/channel (if any): N/A
- Relevant config (redacted): default `tsconfig.json` + workspace `pnpm-workspace.yaml`

### Steps

1. `git checkout feat/context-engine-current-token-count`
2. `pnpm install`
3. `pnpm exec vitest run src/agents/harness/context-engine-lifecycle.test.ts src/agents/pi-embedded-runner/tool-result-context-guard.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts`

### Expected

- All 194 tests across the 9 affected test files pass.
- `git diff --stat origin/main..HEAD` shows only the touched source, test, and docs files.

### Actual

- 194/194 tests pass (see Evidence above).

## Evidence

- [x] Failing test/log before + passing after — not applicable; this is a feature addition, no prior failing test existed.
- [x] Trace/log snippets — vitest summary above.
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant) — `estimatePrePromptTokens` is now invoked at each main assemble call site (PI main, Codex) and once per tool-loop iteration (PI loop hook). The helper already runs at the preemptive-compaction precheck on the same turn (PI main path), so the marginal cost there is one extra encode of `messages + systemPrompt + prompt`. Loop-hook iterations add one encode per iteration. Not measured separately.

## Human Verification (required)

- **Verified scenarios:**
  - `assembleHarnessContextEngine` passes `currentTokenCount` to the engine when supplied.
  - `assembleHarnessContextEngine` omits the field when caller does not supply it (so engines can detect older runtimes via `params.currentTokenCount === undefined`).
  - `installContextEngineLoopHook` reads `currentTokenCount` from `getRuntimeContext()` when the callback returns it; omits otherwise; omits when no callback is wired.
  - The production loop-hook install site at `attempt.ts:1996` computes `currentTokenCount` and feeds it into the `getRuntimeContext` runtime context (asserted by capturing the callback in `attempt.spawn-workspace.context-engine.test.ts`).
  - The attempt-level `assembleAttemptContextEngine` re-export still plumbs the field.
  - The Codex harness call at `extensions/codex/src/app-server/run-attempt.ts:624` computes a positive `currentTokenCount` and passes it through (asserted in `run-attempt.context-engine.test.ts`).
- **Edge cases checked:**
  - Missing `getRuntimeContext` callback in the loop hook → field omitted.
  - `getRuntimeContext` returns an object without `currentTokenCount` → field omitted.
  - Older callers that don't supply `currentTokenCount` → unchanged behavior.
- **What you did NOT verify:**
  - End-to-end run against a real LLM provider where pre-this-PR overflow would have occurred. This is the most important real-world signal and will be performed before merge.
  - Performance impact of the additional `estimatePrePromptTokens` calls under stress (large transcripts, fast tool loops).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A. The new field is optional. Existing context engines compile and run unchanged. Engines that want to opt in simply read `params.currentTokenCount` and gate behavior on whether it is present.

## Risks and Mitigations

- **Risk:** The additional `estimatePrePromptTokens` call at each main assemble call site adds one extra token-estimation pass per turn, plus one per tool-loop iteration on the PI loop-hook path.
  - **Mitigation:** Uses the same helper the runtime already invokes at the preemptive-compaction precheck on the same turn (PI main path), so the marginal cost there is small and amortized. Loop-hook iterations add one encode per iteration; if this proves measurably costly under sustained tool loops, the result can be cached or computed lazily.
- **Risk:** Engines that misread the new field (e.g. treat absent as zero) could over-restrict their injection on older runtimes that don't pass the field.
  - **Mitigation:** Field is explicitly **omitted** rather than set to `undefined` or `0` when not supplied (see the `...(typeof x === "number" ? { x } : {})` spread idiom in the wrappers). Engines that follow the documented contract (`params.currentTokenCount === undefined` ⇒ no headroom info available) behave correctly.
- **Risk:** Re-exporting `estimatePrePromptTokens` from `openclaw/plugin-sdk/agent-harness-runtime` widens the public extension API by one function and commits us to maintaining its signature.
  - **Mitigation:** The function is small, pure, and stable — it already exists at its source location and is used internally. Re-exporting just makes the same shape available to extension harnesses. If the internal signature ever needs to change, the barrel re-export can be wrapped at that point.
