### PR TITLE
fix(dashboard): allow macOS open with stale ssh env

### DIFF
--- a/src/infra/browser-open.test.ts
+++ b/src/infra/browser-open.test.ts
@@ -3,10 +3,19 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveBrowserOpenCommand } from "./browser-open.js";
 import { _resetWindowsInstallRootsForTests } from "./windows-install-roots.js";
 
+const mocks = vi.hoisted(() => ({
+  detectBinary: vi.fn(),
+}));
+
+vi.mock("./detect-binary.js", () => ({
+  detectBinary: mocks.detectBinary,
+}));
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
   _resetWindowsInstallRootsForTests();
+  mocks.detectBinary.mockReset();
 });
 
 describe("resolveBrowserOpenCommand", () => {
@@ -43,5 +52,29 @@ describe("resolveBrowserOpenCommand", () => {
     const rundll32 = path.win32.join("D:\\Windows", "System32", "rundll32.exe");
     expect(resolved.argv).toEqual([rundll32, "url.dll,FileProtocolHandler"]);
     expect(resolved.command).toBe(rundll32);
+  });
+
+  it("uses the macOS open command even when stale SSH variables are present", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.stubEnv("SSH_CLIENT", "100.64.0.1 12345 22");
+    vi.stubEnv("DISPLAY", "");
+    vi.stubEnv("WAYLAND_DISPLAY", "");
+    mocks.detectBinary.mockImplementation(async (name: string) => name === "open");
+
+    const resolved = await resolveBrowserOpenCommand();
+
+    expect(resolved).toEqual({ argv: ["open"], command: "open" });
+  });
+
+  it("keeps Linux SSH sessions without display on the no-display fallback path", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.stubEnv("SSH_CONNECTION", "100.64.0.1 12345 100.64.0.2 22");
+    vi.stubEnv("DISPLAY", "");
+    vi.stubEnv("WAYLAND_DISPLAY", "");
+
+    const resolved = await resolveBrowserOpenCommand();
+
+    expect(resolved).toEqual({ argv: null, reason: "ssh-no-display" });
+    expect(mocks.detectBinary).not.toHaveBeenCalled();
   });
 });

--- a/src/infra/browser-open.ts
+++ b/src/infra/browser-open.ts
@@ -48,7 +48,7 @@ export async function resolveBrowserOpenCommand(): Promise<BrowserOpenCommand> {
     Boolean(process.env.SSH_TTY) ||
     Boolean(process.env.SSH_CONNECTION);
 
-  if (isSsh && !hasDisplay && platform !== "win32") {
+  if (isSsh && !hasDisplay && platform !== "win32" && platform !== "darwin") {
     return { argv: null, reason: "ssh-no-display" };
   }
 


### PR DESCRIPTION
Fixes #67088.

## Summary
- Let macOS dashboard/onboarding browser opening reach the native `open` command even when stale `SSH_*` environment variables are present.
- Preserve the existing Linux SSH/no-display fallback and Windows browser launch behavior.
- Add focused regression coverage for the macOS stale-SSH case and Linux guard.

## Real behavior proof
- Behavior addressed: `openclaw dashboard` could report `No GUI detected` on macOS when a local shell inherited stale `SSH_*` variables and had no `DISPLAY`/`WAYLAND_DISPLAY`, because `resolveBrowserOpenCommand()` returned `ssh-no-display` before reaching the Darwin `open` branch.
- Real environment tested: local Linux checkout on Node v22.22.2, current branch rebased on `origin/main`; the OS branch was exercised with `process.platform` stubbed to `darwin`/`linux` because this worker is not macOS.
- Exact steps or command run after the patch: ran the focused browser-open and onboarding helper tests after first confirming the new Darwin stale-SSH regression test failed on the old behavior.
- Evidence after fix:
```text
$ corepack pnpm test src/infra/browser-open.test.ts src/commands/onboard-helpers.test.ts -- --reporter=verbose
✓ |infra| src/infra/browser-open.test.ts > resolveBrowserOpenCommand > uses the macOS open command even when stale SSH variables are present
✓ |infra| src/infra/browser-open.test.ts > resolveBrowserOpenCommand > keeps Linux SSH sessions without display on the no-display fallback path
✓ |commands| src/commands/onboard-helpers.test.ts > resolveBrowserOpenCommand > uses trusted rundll32 on win32
[test] passed 2 Vitest shards in 28.84s
```
- Observed result after fix: the Darwin stale-SSH scenario resolves to `{ argv: ["open"], command: "open" }`; Linux SSH without display still resolves to `{ argv: null, reason: "ssh-no-display" }`.
- What was not tested: I did not run a live `openclaw dashboard` command on a physical macOS desktop. The proof is source-level OS branch coverage plus the existing command helper regression suite.

## Verification
```text
$ corepack pnpm test src/infra/browser-open.test.ts src/commands/onboard-helpers.test.ts -- --reporter=verbose
[test] passed 2 Vitest shards in 28.84s

$ PATH=/tmp/openclaw-corepack-shims:$PATH pnpm check:changed -- --base origin/main
# exited 0

$ git diff --check origin/main..HEAD
# exited 0
```
