### PR TITLE
fix(cli): error on unknown command root when --help/--version is appended (#81077)

### DIFF
--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -672,6 +672,26 @@ describe("runCli exit behavior", () => {
     expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
   });
 
+  it("rejects unowned command roots even when --help is appended (regression for #81077)", async () => {
+    await expect(runCli(["node", "openclaw", "foo", "--help"])).rejects.toThrow(
+      'No built-in command or plugin CLI metadata owns "foo"',
+    );
+
+    expect(startProxyMock).not.toHaveBeenCalled();
+    expect(tryRouteCliMock).not.toHaveBeenCalled();
+    expect(buildProgramMock).not.toHaveBeenCalled();
+    expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unowned command roots even when --version is appended", async () => {
+    await expect(runCli(["node", "openclaw", "foo", "--version"])).rejects.toThrow(
+      'No built-in command or plugin CLI metadata owns "foo"',
+    );
+
+    expect(startProxyMock).not.toHaveBeenCalled();
+    expect(tryRouteCliMock).not.toHaveBeenCalled();
+  });
+
   it("does not suggest plugins.allow for unknown command roots before proxy startup", async () => {
     loadConfigMock.mockReturnValueOnce({
       plugins: {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -397,7 +397,6 @@ async function resolveUnownedCliPrimary(params: {
   const invocation = resolveCliArgvInvocation(rewriteUpdateFlagArgv(params.argv));
   const { primary } = invocation;
   if (
-    invocation.hasHelpOrVersion ||
     !primary ||
     primary === "help" ||
     isReservedNonPluginCommandRoot(primary) ||
@@ -613,6 +612,19 @@ export async function runCli(argv: string[] = process.argv) {
         if (outputPrecomputedNodesHelpText()) {
           return;
         }
+      }
+    }
+
+    // Reject unowned command roots before help/version routing, so that
+    // `openclaw <typo> --help` surfaces the same Unknown command error as
+    // `openclaw <typo>` instead of silently showing generic top-level help.
+    // Runs after legitimate precomputed help fast paths so known help commands
+    // still dispatch normally. See #81077.
+    {
+      const config = await readBestEffortCliConfig();
+      const unownedPrimary = await resolveUnownedCliPrimary({ argv: normalizedArgv, config });
+      if (unownedPrimary) {
+        throw new Error(await resolveUnownedCliPrimaryMessage({ primary: unownedPrimary, config }));
       }
     }
 


### PR DESCRIPTION
Fixes #81077.

## Summary

`openclaw <unknown-command> --help` silently fell through to generic top-level help and exited 0, while the same `openclaw <unknown-command>` (no `--help`) correctly errored with `Unknown command: openclaw <name>. No built-in command or plugin CLI metadata owns "<name>"` and exited 1. The asymmetry is at `src/cli/run-main.ts:369-377` and the gated caller at line 494, both of which short-circuited the unknown-primary check when `invocation.hasHelpOrVersion` was true.

This PR:

- Drops the `invocation.hasHelpOrVersion ||` bail in `resolveUnownedCliPrimary` so the helper continues to validate the primary when `--help` or `--version` is present.
- Adds an unconditional unknown-primary check inside `runCli` after the root and browser help fast paths, before any other dispatch. Legitimate help paths (`openclaw --help`, `openclaw status --help`, `openclaw browser --help`, etc.) keep working through the precomputed fast paths or the standard built-in/plugin help routing; unknown roots now error consistently regardless of `--help`/`--version`.
- Adds two regression tests in `src/cli/run-main.exit.test.ts` paralleling the existing no-help unknown-root test.

## Real behavior proof

- **Behavior or issue addressed**: `openclaw <unknown-command> --help` silently rendered generic top-level help and exited 0, hiding from the user that the command they typed does not exist; the same invocation without `--help` correctly errored and exited 1. See #81077.
- **Real environment tested**: Local source checkout rebased on `upstream/main`, `pnpm build` against the working tree, Node v22.22.2 via nvm, pnpm 10.33.0, Linux x86_64 (Ubuntu noble). Real CLI invocation via `node openclaw.mjs <args>` so the wrapper is exercised the same way an installed npm global runs.
- **Exact steps or command run after this patch**:

  ```
  pnpm build
  node openclaw.mjs heartbeat > /tmp/no-help.out 2>&1; echo "exit=$?"
  node openclaw.mjs heartbeat --help > /tmp/help.out 2>&1; echo "exit=$?"
  node openclaw.mjs heartbeat --version > /tmp/version.out 2>&1; echo "exit=$?"
  node openclaw.mjs --help > /tmp/root-help.out 2>&1; echo "exit=$?"
  node openclaw.mjs status --help > /tmp/status-help.out 2>&1; echo "exit=$?"
  node openclaw.mjs browser --help > /tmp/browser-help.out 2>&1; echo "exit=$?"
  ```

- **Evidence after fix**: Verbatim terminal output (stdout+stderr merged) from the local CLI:

  ```text
  ## openclaw heartbeat (unchanged baseline)
  [openclaw] Could not start the CLI.
  [openclaw] Reason: Unknown command: openclaw heartbeat. No built-in command or plugin CLI metadata owns "heartbeat".
  [openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
  [openclaw] Try: openclaw doctor
  [openclaw] Help: openclaw --help
  exit=1

  ## openclaw heartbeat --help (FIX target)
  [openclaw] Could not start the CLI.
  [openclaw] Reason: Unknown command: openclaw heartbeat. No built-in command or plugin CLI metadata owns "heartbeat".
  [openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
  [openclaw] Try: openclaw doctor
  [openclaw] Help: openclaw --help
  exit=1

  ## openclaw heartbeat --version (also fixed by the same code path)
  [openclaw] Could not start the CLI.
  [openclaw] Reason: Unknown command: openclaw heartbeat. No built-in command or plugin CLI metadata owns "heartbeat".
  [openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
  [openclaw] Try: openclaw doctor
  [openclaw] Help: openclaw --help
  exit=1

  ## openclaw --help (legitimate root help — still works)
  🦞 OpenClaw 2026.5.12-beta.1 (d0c2cce) — All your chats, one OpenClaw.
  ...
  exit=0

  ## openclaw status --help (legitimate built-in help — still works)
  🦞 OpenClaw 2026.5.12-beta.1 (d0c2cce) — All your chats, one OpenClaw.
  ...
  exit=0

  ## openclaw browser --help (legitimate plugin help — still works via precomputed fast path)
  🦞 OpenClaw 2026.5.12-beta.1 (d0c2cce) — All your chats, one OpenClaw.
  ...
  exit=0
  ```

- **Observed result after fix**: `openclaw heartbeat`, `openclaw heartbeat --help`, and `openclaw heartbeat --version` all error consistently with the same `Unknown command` message and all exit 1. `openclaw --help`, `openclaw status --help`, and `openclaw browser --help` still render their respective help and exit 0. This matches the bot's acceptance criteria on #81077 ("Manual/source run after fix … `openclaw heartbeat --help; echo exit=$?` should show the unknown-command error and exit 1") and preserves the existing built-in / precomputed-help paths.
- **What was not tested**: A live invocation through an installed `npm install -g openclaw` global binary. The proof above uses the in-tree wrapper `node openclaw.mjs`, which exercises the same `runCli` dispatch path the installed binary runs against the built dist. The unit tests in `src/cli/run-main.exit.test.ts` also pin the rejection behavior through the mocked program builder.

## Verification

```
pnpm test src/cli/run-main.exit.test.ts src/cli/argv.test.ts src/cli/argv-invocation.test.ts
# Test Files 2 passed (2)
# Tests 76 passed (76)

pnpm exec oxfmt --check --threads=1 src/cli/run-main.ts src/cli/run-main.exit.test.ts
# clean

pnpm check:changed
# (see CI)
```
