### PR TITLE
fix(diagnostics-otel): suppress exporter rejection crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Diagnostics/OpenTelemetry plugin: suppress handled OTLP exporter promise rejections so collector shutdowns no longer crash the Gateway. (#81085) Thanks @luoyanglang.
 - Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.
 - Memory-core/dreaming: reuse stable narrative subagent session keys per workspace and phase while keeping per-run idempotency and bounded cleanup, so stale `dreaming-narrative-*` sessions do not accumulate. Fixes #68252, #69187, and #70402. (#70464) Thanks @chiyouYCH.
 - CLI/perf: keep `setup --help`, `onboard --help`, and `configure --help` out of the full wizard runtime while preserving the existing help output. (#84488) Thanks @frankekn.

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -578,6 +578,20 @@ describe("diagnostics-otel service", () => {
     expect(unhandledRejectionHandlerState.getHandlers()).toHaveLength(0);
   });
 
+  test("does not retain an OTLP exporter handler when startup setup fails", async () => {
+    const startupError = new Error("trace exporter setup failed");
+    traceExporterCtor.mockImplementationOnce(() => {
+      throw startupError;
+    });
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
+
+    await expect(service.start(ctx)).rejects.toBe(startupError);
+
+    expect(unhandledRejectionHandlerState.register).not.toHaveBeenCalled();
+    expect(unhandledRejectionHandlerState.getHandlers()).toHaveLength(0);
+  });
+
   test("uses a preloaded OpenTelemetry SDK without dropping diagnostic listeners", async () => {
     process.env.OPENCLAW_OTEL_PRELOADED = "1";
     const service = createDiagnosticsOtelService();

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -53,6 +53,21 @@ const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const traceExporterCtor = vi.hoisted(() => vi.fn());
 const metricExporterCtor = vi.hoisted(() => vi.fn());
 const logExporterCtor = vi.hoisted(() => vi.fn());
+const unhandledRejectionHandlerState = vi.hoisted(() => {
+  let handlers: Array<(reason: unknown) => boolean> = [];
+  return {
+    getHandlers: () => handlers,
+    register: vi.fn((handler: (reason: unknown) => boolean) => {
+      handlers.push(handler);
+      return () => {
+        handlers = handlers.filter((candidate) => candidate !== handler);
+      };
+    }),
+    reset: () => {
+      handlers = [];
+    },
+  };
+});
 
 vi.mock("@opentelemetry/api", () => ({
   context: {
@@ -97,6 +112,10 @@ vi.mock("@opentelemetry/exporter-logs-otlp-proto", () => ({
   OTLPLogExporter: function OTLPLogExporter(options?: unknown) {
     logExporterCtor(options);
   },
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  registerUnhandledRejectionHandler: unhandledRejectionHandlerState.register,
 }));
 
 vi.mock("@opentelemetry/sdk-logs", () => ({
@@ -336,6 +355,8 @@ describe("diagnostics-otel service", () => {
     traceExporterCtor.mockClear();
     metricExporterCtor.mockClear();
     logExporterCtor.mockClear();
+    unhandledRejectionHandlerState.reset();
+    unhandledRejectionHandlerState.register.mockClear();
     delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
     delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
     delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
@@ -529,6 +550,32 @@ describe("diagnostics-otel service", () => {
       durationMs: 10,
     });
     expect(telemetryState.tracer.startSpan).not.toHaveBeenCalled();
+  });
+
+  test("registers and removes an OTLP exporter unhandled rejection handler", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true, logs: true });
+
+    await service.start(ctx);
+
+    expect(unhandledRejectionHandlerState.register).toHaveBeenCalledTimes(1);
+    const handler = unhandledRejectionHandlerState.getHandlers()[0];
+    expect(handler).toBeTypeOf("function");
+
+    const errorInstance = Object.assign(new Error("collector gone"), {
+      name: "OTLPExporterError",
+      code: 410,
+    });
+    expect(handler?.(errorInstance)).toBe(true);
+    expect(handler?.({ name: "OTLPExporterError", code: 410, data: "user_stop" })).toBe(true);
+    expect(handler?.([{ name: "OTLPExporterError", code: 410, data: "user_stop" }])).toBe(true);
+    expect(handler?.(new Error("other exporter error"))).toBe(false);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "diagnostics-otel: suppressed OTLP exporter unhandled rejection (code=410)",
+    );
+
+    await service.stop?.(ctx);
+    expect(unhandledRejectionHandlerState.getHandlers()).toHaveLength(0);
   });
 
   test("uses a preloaded OpenTelemetry SDK without dropping diagnostic listeners", async () => {

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -569,6 +569,14 @@ describe("diagnostics-otel service", () => {
     expect(handler?.(errorInstance)).toBe(true);
     expect(handler?.({ name: "OTLPExporterError", code: 410, data: "user_stop" })).toBe(true);
     expect(handler?.([{ name: "OTLPExporterError", code: 410, data: "user_stop" }])).toBe(true);
+    expect(
+      handler?.(
+        new AggregateError(
+          [{ name: "OTLPExporterError", code: 410, data: "user_stop" }],
+          "export failed",
+        ),
+      ),
+    ).toBe(true);
     expect(handler?.(new Error("other exporter error"))).toBe(false);
     expect(ctx.logger.warn).toHaveBeenCalledWith(
       "diagnostics-otel: suppressed OTLP exporter unhandled rejection (code=410)",

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -201,6 +201,13 @@ function collectNestedErrorCandidates(err: unknown): unknown[] {
         queue.push(nested);
       }
     }
+    if (Array.isArray(record.errors)) {
+      for (const nested of record.errors) {
+        if (nested != null && !seen.has(nested)) {
+          queue.push(nested);
+        }
+      }
+    }
   }
 
   return candidates;

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -670,18 +670,6 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         return;
       }
 
-      unregisterUnhandledRejectionHandler = registerUnhandledRejectionHandler((reason) => {
-        const otlpError = findOtlpExporterError(reason);
-        if (!otlpError) {
-          return false;
-        }
-        const code = readErrorCode(otlpError) ?? "unknown";
-        ctx.logger.warn(
-          `diagnostics-otel: suppressed OTLP exporter unhandled rejection (code=${String(code)})`,
-        );
-        return true;
-      });
-
       const endpoint = normalizeEndpoint(
         otel.endpoint ?? process.env[OTEL_EXPORTER_OTLP_ENDPOINT_ENV],
       );
@@ -2551,6 +2539,18 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             `diagnostics-otel: event handler failed (${evt.type}): ${formatError(err)}`,
           );
         }
+      });
+
+      unregisterUnhandledRejectionHandler = registerUnhandledRejectionHandler((reason) => {
+        const otlpError = findOtlpExporterError(reason);
+        if (!otlpError) {
+          return false;
+        }
+        const code = readErrorCode(otlpError) ?? "unknown";
+        ctx.logger.warn(
+          `diagnostics-otel: suppressed OTLP exporter unhandled rejection (code=${String(code)})`,
+        );
+        return true;
       });
 
       emitForSignals(enabledSignals, {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -15,6 +15,7 @@ import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ParentBasedSampler, TraceIdRatioBasedSampler } from "@opentelemetry/sdk-trace-base";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import { registerUnhandledRejectionHandler } from "openclaw/plugin-sdk/runtime-env";
 import type {
   DiagnosticEventMetadata,
   DiagnosticEventPayload,
@@ -167,6 +168,71 @@ function errorCategory(err: unknown): string {
   } catch {
     return "unknown";
   }
+}
+
+function collectNestedErrorCandidates(err: unknown): unknown[] {
+  const queue: unknown[] = [err];
+  const seen = new Set<unknown>();
+  const candidates: unknown[] = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current == null || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    candidates.push(current);
+
+    if (Array.isArray(current)) {
+      for (const item of current) {
+        if (item != null && !seen.has(item)) {
+          queue.push(item);
+        }
+      }
+      continue;
+    }
+    if (typeof current !== "object") {
+      continue;
+    }
+
+    const record = current as Record<string, unknown>;
+    for (const nested of [record.cause, record.reason, record.original, record.error]) {
+      if (nested != null && !seen.has(nested)) {
+        queue.push(nested);
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function readErrorName(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const name = (err as { name?: unknown }).name;
+  return typeof name === "string" && name.trim() ? name : undefined;
+}
+
+function readErrorCode(err: unknown): string | number | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" || typeof code === "number" ? code : undefined;
+}
+
+function findOtlpExporterError(reason: unknown): object | undefined {
+  for (const candidate of collectNestedErrorCandidates(reason)) {
+    if (
+      readErrorName(candidate) === "OTLPExporterError" &&
+      candidate &&
+      typeof candidate === "object"
+    ) {
+      return candidate;
+    }
+  }
+  return undefined;
 }
 
 function redactOtelAttributes(attributes: Record<string, string | number | boolean>) {
@@ -524,18 +590,22 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
   let logProvider: LoggerProvider | null = null;
   let unsubscribe: (() => void) | null = null;
   let stopActiveTrustedSpans: (() => void) | null = null;
+  let unregisterUnhandledRejectionHandler: (() => void) | null = null;
 
   const stopStarted = async () => {
     const currentUnsubscribe = unsubscribe;
     const currentLogProvider = logProvider;
     const currentSdk = sdk;
     const currentStopActiveTrustedSpans = stopActiveTrustedSpans;
+    const currentUnregisterUnhandledRejectionHandler = unregisterUnhandledRejectionHandler;
 
     unsubscribe = null;
     logProvider = null;
     sdk = null;
     stopActiveTrustedSpans = null;
+    unregisterUnhandledRejectionHandler = null;
 
+    currentUnregisterUnhandledRejectionHandler?.();
     currentUnsubscribe?.();
     currentStopActiveTrustedSpans?.();
     if (currentLogProvider) {
@@ -599,6 +669,18 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         ctx.logger.warn(`diagnostics-otel: unsupported protocol ${protocol}`);
         return;
       }
+
+      unregisterUnhandledRejectionHandler = registerUnhandledRejectionHandler((reason) => {
+        const otlpError = findOtlpExporterError(reason);
+        if (!otlpError) {
+          return false;
+        }
+        const code = readErrorCode(otlpError) ?? "unknown";
+        ctx.logger.warn(
+          `diagnostics-otel: suppressed OTLP exporter unhandled rejection (code=${String(code)})`,
+        );
+        return true;
+      });
 
       const endpoint = normalizeEndpoint(
         otel.endpoint ?? process.env[OTEL_EXPORTER_OTLP_ENDPOINT_ENV],


### PR DESCRIPTION
## Impact / triage

Fixes #80284.

When diagnostics-otel is enabled, `OTLPExporterError` rejections from unavailable or non-retryable OTLP collectors can fall through OpenClaw's fatal unhandled-rejection path and crash the running process. This PR keeps that exporter-specific failure local to diagnostics-otel while the service is active, then unregisters the handler on stop/restart so disabled diagnostics do not retain stale process behavior.

Triage fields:
- User-visible failure: OpenClaw process crash from diagnostics-otel exporter rejection.
- Affected surface: `extensions/diagnostics-otel` service plus the existing core unhandled-rejection handler registry.
- Scope: plugin-local rejection classification, no dependency/workflow/secret changes.
- Proof: copied live output from running the actual diagnostics-otel service and core handler registry from source, plus targeted regression tests.

## Summary
- Register a diagnostics-otel-owned unhandled rejection handler while the service is active.
- Suppress only nested `OTLPExporterError` shapes, including Error instances, plain objects, and array-wrapped exporter failures.
- Unregister the handler during restart/stop so disabled diagnostics do not keep stale process handlers.

## Real behavior proof

Behavior addressed: diagnostics-otel OTLP exporter failures could surface as unhandled promise rejections and fall through the core fatal unhandled-rejection path, crashing OpenClaw when the collector became unavailable or returned a non-retryable response.

Real environment tested: local Linux checkout on Node v22.22.2. I ran the actual diagnostics-otel service and the actual core unhandled-rejection registry from source with `node --import tsx`; this proof does not mock `openclaw/plugin-sdk/runtime-env` or the core handler registry. The external collector HTTP 410 transport was not reproduced.

Exact steps or command run after the patch:

```sh
node --import tsx -e 'const { createDiagnosticsOtelService } = await import("./extensions/diagnostics-otel/src/service.ts"); const { isUnhandledRejectionHandled } = await import("./src/infra/unhandled-rejections.ts"); const warnings = []; const logger = { info() {}, warn(message) { warnings.push(String(message)); }, error(message) { console.error(message); }, debug() {} }; const service = createDiagnosticsOtelService(); const reason = [{ name: "OTLPExporterError", code: 410, data: "user_stop" }]; const ctx = { config: { diagnostics: { enabled: true, otel: { enabled: true, endpoint: "http://127.0.0.1:9", protocol: "http/protobuf", traces: true, metrics: false, logs: false } } }, logger, stateDir: "/tmp/openclaw-otel-proof" }; await service.start(ctx); const handledDuringService = isUnhandledRejectionHandled(reason); await service.stop?.(ctx); const handledAfterStop = isUnhandledRejectionHandled(reason); console.log(JSON.stringify({ handledDuringService, handledAfterStop, warnings }, null, 2)); if (!handledDuringService || handledAfterStop || warnings.length === 0) process.exit(1);'
corepack pnpm test extensions/diagnostics-otel/src/service.test.ts src/infra/unhandled-rejections.test.ts -- --reporter=verbose
PATH=/tmp/openclaw-corepack-shims:$PATH pnpm check:changed -- --base origin/main
git diff --check origin/main..HEAD
```

Evidence after fix: console output from the real source proof:

```text
diagnostics-otel: internal diagnostics capability unavailable
{
  "handledDuringService": true,
  "handledAfterStop": false,
  "warnings": [
    "diagnostics-otel: suppressed OTLP exporter unhandled rejection (code=410)"
  ]
}
```

The regression coverage also verifies direct Error, plain-object, and array-wrapped `OTLPExporterError` shapes while preserving unrelated rejection behavior.

Observed result after fix: the real source proof exited 0, and the copied live output above shows the active service handler caught the array-wrapped `OTLPExporterError` only while diagnostics-otel was running. The targeted test command passed 2 Vitest shards with `src/infra/unhandled-rejections.test.ts` passing 64 tests and `extensions/diagnostics-otel/src/service.test.ts` passing 51 tests. `check:changed` completed successfully after the branch was rebased onto latest `origin/main`, and `git diff --check origin/main..HEAD` produced no whitespace errors.

What was not tested: no live collector/OTLP HTTP 410 integration run was performed, and no physical macOS process crash reproduction was run locally.
