### PR TITLE
feat(plugins): add before_route_inbound_message hook for channel bridging

### DIFF
--- a/src/channels/turn/kernel.test.ts
+++ b/src/channels/turn/kernel.test.ts
@@ -14,6 +14,17 @@ import {
   runChannelTurn,
 } from "./kernel.js";
 
+const hookMocks = vi.hoisted(() => ({
+  runner: {
+    runBeforeRouteInboundMessage: vi.fn(),
+    hasHooks: vi.fn(),
+  },
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+}));
+
 const deliverOutboundPayloads = vi.hoisted(() => vi.fn());
 const resolveOutboundDurableFinalDeliverySupport = vi.hoisted(() => vi.fn());
 const sendDurableMessageBatch = vi.hoisted(() => vi.fn());
@@ -166,6 +177,8 @@ describe("channel turn kernel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resolveOutboundDurableFinalDeliverySupport.mockResolvedValue({ ok: true });
+    hookMocks.runner.runBeforeRouteInboundMessage.mockResolvedValue(undefined);
+    hookMocks.runner.hasHooks.mockReturnValue(false);
   });
 
   it("routes assembled final replies through durable outbound delivery", async () => {
@@ -899,5 +912,79 @@ describe("channel turn kernel", () => {
     expect(finalizedResult.admission).toEqual({ kind: "dispatch" });
     expect(finalizedResult.dispatched).toBe(false);
     expect(finalizedResult.routeSessionKey).toBe("agent:main:test:peer");
+  });
+
+  it("redirects to a different session when before_route_inbound_message hook returns a redirect", async () => {
+    const events: string[] = [];
+    const recordInboundSession = createRecordInboundSession(events);
+    const dispatch = createDispatch(events);
+
+    hookMocks.runner.runBeforeRouteInboundMessage.mockResolvedValue({
+      handled: true,
+      redirectSessionKey: "agent:main:test:redirected",
+    });
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+
+    const result = await runChannelTurn({
+      channel: "test",
+      raw: { id: "msg-1", text: "hello" },
+      adapter: {
+        ingest: () => ({ id: "msg-1", rawText: "hello" }),
+        preflight: () => ({ kind: "dispatch" }),
+        resolveTurn: () => ({
+          channel: "test",
+          agentId: "main",
+          routeSessionKey: "agent:main:test:original",
+          storePath: "/tmp/sessions.json",
+          ctxPayload: createCtx({ SessionKey: "agent:main:test:original" }),
+          recordInboundSession,
+          dispatchReplyWithBufferedBlockDispatcher: dispatch,
+          delivery: createNoopChannelTurnDeliveryAdapter(),
+          record: { onRecordError: vi.fn() },
+        }),
+        onFinalize: vi.fn(),
+      },
+    });
+
+    expect(result.admission).toEqual({ kind: "dispatch" });
+    expect(result.dispatched).toBe(true);
+    // The hook redirected the session
+    expect(hookMocks.runner.runBeforeRouteInboundMessage).toHaveBeenCalledOnce;
+  });
+
+  it("suppresses delivery when before_route_inbound_message hook returns suppressDelivery", async () => {
+    const events: string[] = [];
+    const recordInboundSession = createRecordInboundSession(events);
+
+    hookMocks.runner.runBeforeRouteInboundMessage.mockResolvedValue({
+      handled: true,
+      suppressDelivery: true,
+    });
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+
+    const result = await runChannelTurn({
+      channel: "test",
+      raw: { id: "msg-1", text: "hello" },
+      adapter: {
+        ingest: () => ({ id: "msg-1", rawText: "hello" }),
+        preflight: () => ({ kind: "dispatch" }),
+        resolveTurn: () => ({
+          channel: "test",
+          agentId: "main",
+          routeSessionKey: "agent:main:test:peer",
+          storePath: "/tmp/sessions.json",
+          ctxPayload: createCtx({ SessionKey: "agent:main:test:peer" }),
+          recordInboundSession,
+          dispatchReplyWithBufferedBlockDispatcher: createDispatch(events),
+          delivery: createNoopChannelTurnDeliveryAdapter(),
+          record: { onRecordError: vi.fn() },
+        }),
+        onFinalize: vi.fn(),
+      },
+    });
+
+    expect(result.admission).toEqual({ kind: "drop", reason: "suppressed_by_hook" });
+    expect(result.dispatched).toBe(false);
+    expect(events).toEqual([]); // No recording or dispatching
   });
 });

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -1,5 +1,11 @@
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { clearHistoryEntriesIfEnabled } from "../../auto-reply/reply/history.js";
+import type {
+  PluginHookBeforeRouteInboundMessageContext,
+  PluginHookBeforeRouteInboundMessageEvent,
+  PluginHookBeforeRouteInboundMessageResult,
+} from "../../plugins/hook-message.types.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { createChannelReplyPipeline } from "../message/reply-pipeline.js";
 import type { CreateChannelReplyPipelineParams } from "../message/reply-pipeline.js";
 import { EMPTY_CHANNEL_TURN_DISPATCH_COUNTS } from "./dispatch-result.js";
@@ -453,6 +459,78 @@ export async function runChannelTurn<
   }
 
   const resolved = await params.adapter.resolveTurn(input, eventClass, preflight);
+
+  // ── before_route_inbound_message hook ──────────────────────────────
+  // Fire right after resolveTurn so it runs for all inbound messages:
+  // - Main adapters: runInboundReplyTurn() → runChannelTurn() → runPreparedChannelTurnCore()
+  // - Compat mode: dispatchChannelMessageReplyWithBase() → recordChannelMessageReplyDispatch()
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner) {
+    const channelName = params.channel;
+    const bodyText = String(params.ctxPayload?.Body ?? "");
+    const isGroup =
+      String(params.ctxPayload?.ChatType ?? "") === "group" ||
+      String(params.ctxPayload?.ChatType ?? "") === "supergroup";
+
+    const hookCtx: PluginHookBeforeRouteInboundMessageContext = {
+      channelId: channelName,
+      accountId: params.accountId,
+      conversationId: params.ctxPayload?.NativeChannelId ?? params.ctxPayload?.OriginatingTo,
+      parentConversationId: params.ctxPayload?.MessageThreadId
+        ? String(params.ctxPayload.MessageThreadId)
+        : undefined,
+      sessionKey: resolved.sessionKey ?? resolved.routeSessionKey,
+    };
+
+    const hookEvent: PluginHookBeforeRouteInboundMessageEvent = {
+      channel: channelName,
+      accountId: params.accountId,
+      conversationId: hookCtx.conversationId,
+      parentConversationId: hookCtx.parentConversationId,
+      body: bodyText,
+      isGroup,
+      senderId: params.ctxPayload?.From,
+      originalSessionKey: resolved.sessionKey ?? resolved.routeSessionKey,
+    };
+
+    const hookResult = await hookRunner.runBeforeRouteInboundMessage(hookEvent, hookCtx);
+
+    if (hookResult?.handled) {
+      // Redirect: update ctxPayload.SessionKey for compat mode and resolved values for adapter mode
+      if (
+        hookResult.redirectSessionKey &&
+        hookResult.redirectSessionKey !== (resolved.sessionKey ?? resolved.routeSessionKey)
+      ) {
+        if (params.ctxPayload?.SessionKey) {
+          // Compat mode: ctxPayload already has SessionKey set by buildInboundReplyDispatchBase
+          params.ctxPayload.SessionKey = hookResult.redirectSessionKey;
+        }
+        // Adapter mode: also update resolved.ctxPayload.SessionKey so record/dispatch use the redirect
+        if (resolved.ctxPayload) {
+          resolved.ctxPayload.SessionKey = hookResult.redirectSessionKey;
+        }
+        // Update resolved sessionKey values for downstream
+        resolved.sessionKey = hookResult.redirectSessionKey;
+        resolved.routeSessionKey = hookResult.redirectSessionKey;
+      }
+      // Suppress: drop the message entirely — return early after onFinalize
+      if (hookResult.suppressDelivery) {
+        const suppressedResult: ChannelTurnResult<TDispatchResult> = {
+          admission: { kind: "drop", reason: "suppressed_by_hook" },
+          dispatched: false,
+          ctxPayload: resolved.ctxPayload ?? params.ctxPayload,
+          routeSessionKey: resolved.routeSessionKey,
+        };
+        try {
+          await params.adapter.onFinalize?.(suppressedResult);
+        } catch {
+          // Suppress onFinalize errors to not mask the suppression
+        }
+        return suppressedResult;
+      }
+    }
+  }
+
   emit({
     ...params,
     accountId: resolved.accountId ?? params.accountId,

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -496,22 +496,19 @@ export async function runChannelTurn<
     const hookResult = await hookRunner.runBeforeRouteInboundMessage(hookEvent, hookCtx);
 
     if (hookResult?.handled) {
-      // Redirect: update ctxPayload.SessionKey for compat mode and resolved values for adapter mode
-      if (
-        hookResult.redirectSessionKey &&
-        hookResult.redirectSessionKey !== (resolved.sessionKey ?? resolved.routeSessionKey)
-      ) {
-        if (params.ctxPayload?.SessionKey) {
-          // Compat mode: ctxPayload already has SessionKey set by buildInboundReplyDispatchBase
-          params.ctxPayload.SessionKey = hookResult.redirectSessionKey;
+      // Redirect: update SessionKey in the payload that record/dispatch actually reads
+      // (runPreparedChannelTurnCore reads params.ctxPayload.SessionKey, not resolved values)
+      if (hookResult.redirectSessionKey) {
+        const originalKey = resolved.sessionKey ?? resolved.routeSessionKey;
+        if (hookResult.redirectSessionKey !== originalKey) {
+          // Update the SessionKey in ctxPayload — this is what record/dispatch reads
+          if (params.ctxPayload?.SessionKey) {
+            params.ctxPayload.SessionKey = hookResult.redirectSessionKey;
+          }
+          // Also update resolved values for any downstream code that reads them directly
+          resolved.sessionKey = hookResult.redirectSessionKey;
+          resolved.routeSessionKey = hookResult.redirectSessionKey;
         }
-        // Adapter mode: also update resolved.ctxPayload.SessionKey so record/dispatch use the redirect
-        if (resolved.ctxPayload) {
-          resolved.ctxPayload.SessionKey = hookResult.redirectSessionKey;
-        }
-        // Update resolved sessionKey values for downstream
-        resolved.sessionKey = hookResult.redirectSessionKey;
-        resolved.routeSessionKey = hookResult.redirectSessionKey;
       }
       // Suppress: drop the message entirely — return early after onFinalize
       if (hookResult.suppressDelivery) {

--- a/src/plugin-sdk/inbound-reply-dispatch.ts
+++ b/src/plugin-sdk/inbound-reply-dispatch.ts
@@ -7,6 +7,12 @@ import {
 import type { DispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.types.js";
 import type { ReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.types.js";
 import type { FinalizedMsgContext } from "../auto-reply/templating.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type {
+  PluginHookBeforeRouteInboundMessageContext,
+  PluginHookBeforeRouteInboundMessageEvent,
+  PluginHookBeforeRouteInboundMessageResult,
+} from "../plugins/hook-message.types.js";
 import {
   hasFinalChannelTurnDispatch,
   hasVisibleChannelTurnDispatch,
@@ -151,6 +157,60 @@ export async function dispatchChannelMessageReplyWithBase(
       "deliver" | "durable" | "onRecordError" | "onDispatchError" | "replyOptions"
     >,
 ): Promise<void> {
+  // ── before_route_inbound_message hook ──────────────────────────────
+  // Fire before building the dispatch base. Plugins (e.g. channel-bridge)
+  // can redirect to a different session or suppress delivery.
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner) {
+    const bodyText = String(params.ctxPayload.Body ?? params.ctxPayload.BodyForAgent ?? "");
+    const isGroup =
+      params.ctxPayload.ChatType === "group" ||
+      params.ctxPayload.ChatType === "supergroup";
+
+    const hookCtx: PluginHookBeforeRouteInboundMessageContext = {
+      channelId: params.channel,
+      accountId: params.accountId,
+      conversationId: params.ctxPayload.NativeChannelId ?? params.ctxPayload.OriginatingTo,
+      parentConversationId: params.ctxPayload.MessageThreadId
+        ? String(params.ctxPayload.MessageThreadId)
+        : undefined,
+      sessionKey: params.route.sessionKey,
+    };
+
+    const hookEvent: PluginHookBeforeRouteInboundMessageEvent = {
+      channel: params.channel,
+      accountId: params.accountId,
+      conversationId: hookCtx.conversationId,
+      parentConversationId: hookCtx.parentConversationId,
+      body: bodyText,
+      isGroup,
+      senderId: params.ctxPayload.From,
+      originalSessionKey: params.route.sessionKey,
+    };
+
+    const hookResult = await hookRunner.runBeforeRouteInboundMessage(
+      hookEvent,
+      hookCtx,
+    );
+
+    if (hookResult?.handled) {
+      // Redirect: override the route session key
+      if (
+        hookResult.redirectSessionKey &&
+        hookResult.redirectSessionKey !== params.route.sessionKey
+      ) {
+        params = {
+          ...params,
+          route: { ...params.route, sessionKey: hookResult.redirectSessionKey },
+        };
+      }
+      // Suppress: drop the message entirely
+      if (hookResult.suppressDelivery) {
+        return;
+      }
+    }
+  }
+
   const dispatchBase = buildInboundReplyDispatchBase(params);
   await recordChannelMessageReplyDispatch({
     ...dispatchBase,

--- a/src/plugins/hook-message.types.ts
+++ b/src/plugins/hook-message.types.ts
@@ -94,3 +94,49 @@ export type PluginHookMessageSentEvent = {
   parentSpanId?: string;
   error?: string;
 };
+
+// ── before_route_inbound_message hook ──────────────────────────────────────
+
+/** Context supplied to the `before_route_inbound_message` handler. */
+export type PluginHookBeforeRouteInboundMessageContext = {
+  /** Channel the message arrived on (e.g. "discord", "telegram"). */
+  channelId: string;
+  /** Account identifier for multi-account gateways. */
+  accountId?: string;
+  /** Provider-native channel/conversation ID from MsgContext metadata. */
+  conversationId?: string;
+  /** Thread/parent conversation ID (Telegram topic, Discord thread, etc.). */
+  parentConversationId?: string;
+  /** The session key that was resolved for this message before hook invocation. */
+  sessionKey: string;
+};
+
+/** Event payload for the `before_route_inbound_message` hook. */
+export type PluginHookBeforeRouteInboundMessageEvent = {
+  /** Channel the message arrived on (e.g. "discord", "telegram"). */
+  channel: string;
+  /** Account identifier for multi-account gateways. */
+  accountId?: string;
+  /** Provider-native channel/conversation ID from MsgContext metadata. */
+  conversationId?: string;
+  /** Thread/parent conversation ID (Telegram topic, Discord thread, etc.). */
+  parentConversationId?: string;
+  /** Plain-text body of the inbound message. */
+  body: string;
+  /** Whether the message originated in a group/supergroup context. */
+  isGroup: boolean;
+  /** Sender identifier from the inbound message. */
+  senderId?: string;
+  /** The session key that was resolved before the hook fired. */
+  originalSessionKey: string;
+};
+
+/** Result returned by a `before_route_inbound_message` handler. */
+export type PluginHookBeforeRouteInboundMessageResult = {
+  /** Set to `true` when the plugin has made a routing decision. */
+  handled: true;
+  /** Redirect the message to a different session key. */
+  redirectSessionKey?: string;
+  /** Suppress delivery entirely — do not route the message to any session. */
+  suppressDelivery?: boolean;
+};

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -26,6 +26,9 @@ import type {
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
   PluginHookMessageSentEvent,
+  PluginHookBeforeRouteInboundMessageContext,
+  PluginHookBeforeRouteInboundMessageEvent,
+  PluginHookBeforeRouteInboundMessageResult,
 } from "./hook-message.types.js";
 import type { PluginJsonValue } from "./host-hook-json.js";
 import type {
@@ -63,6 +66,9 @@ export type {
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
   PluginHookMessageSentEvent,
+  PluginHookBeforeRouteInboundMessageContext,
+  PluginHookBeforeRouteInboundMessageEvent,
+  PluginHookBeforeRouteInboundMessageResult,
 } from "./hook-message.types.js";
 
 export type PluginHookName =
@@ -101,7 +107,8 @@ export type PluginHookName =
   | "before_dispatch"
   | "reply_dispatch"
   | "before_install"
-  | "before_agent_run";
+  | "before_agent_run"
+  | "before_route_inbound_message";
 
 export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
@@ -140,6 +147,7 @@ export const PLUGIN_HOOK_NAMES = [
   "reply_dispatch",
   "before_install",
   "before_agent_run",
+  "before_route_inbound_message",
 ] as const satisfies readonly PluginHookName[];
 
 type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;
@@ -996,6 +1004,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeAgentRunEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentRunResult> | PluginHookBeforeAgentRunResult;
+  before_route_inbound_message: (
+    event: PluginHookBeforeRouteInboundMessageEvent,
+    ctx: PluginHookBeforeRouteInboundMessageContext,
+  ) => Promise<PluginHookBeforeRouteInboundMessageResult | void> | PluginHookBeforeRouteInboundMessageResult | void;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -85,6 +85,11 @@ import type {
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
 } from "./hook-types.js";
+import type {
+  PluginHookBeforeRouteInboundMessageContext,
+  PluginHookBeforeRouteInboundMessageEvent,
+  PluginHookBeforeRouteInboundMessageResult,
+} from "./hook-message.types.js";
 
 // Re-export types for consumers
 export type {
@@ -151,6 +156,9 @@ export type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookBeforeRouteInboundMessageContext,
+  PluginHookBeforeRouteInboundMessageEvent,
+  PluginHookBeforeRouteInboundMessageResult,
 };
 
 export type HookRunnerLogger = {
@@ -982,6 +990,25 @@ export function createHookRunner(
   }
 
   /**
+   * Run before_route_inbound_message hook.
+   * Allows plugins to redirect or suppress inbound messages before routing.
+   * First handler returning { handled: true } wins.
+   */
+  async function runBeforeRouteInboundMessage(
+    event: PluginHookBeforeRouteInboundMessageEvent,
+    ctx: PluginHookBeforeRouteInboundMessageContext,
+  ): Promise<PluginHookBeforeRouteInboundMessageResult | undefined> {
+    return runClaimingHook<
+      "before_route_inbound_message",
+      PluginHookBeforeRouteInboundMessageResult
+    >(
+      "before_route_inbound_message",
+      event,
+      ctx,
+    );
+  }
+
+  /**
    * Run message_received hook.
    * Runs in parallel (fire-and-forget).
    */
@@ -1492,6 +1519,7 @@ export function createHookRunner(
     // Lifecycle gate hooks
     runBeforeAgentRun,
     // Message hooks
+    runBeforeRouteInboundMessage,
     runInboundClaim,
     runInboundClaimForPlugin,
     runInboundClaimForPluginOutcome,


### PR DESCRIPTION
## Summary

Implements the `before_route_inbound_message` plugin hook as proposed in #81061.

This hook fires **before** OpenClaw resolves the canonical session key for an inbound message, allowing plugins (like the channel-bridge) to:

- **Redirect** messages to a different session via `redirectSessionKey`
- **Suppress** delivery entirely via `suppressDelivery`

## Hook Signature

```ts
type PluginHookBeforeRouteInboundMessageEvent = {
  channel: string;
  accountId?: string;
  conversationId?: string;   // NativeChannelId or OriginatingTo
  parentConversationId?: string;  // MessageThreadId (thread/topic ID)
  body: string;
  isGroup: boolean;           // derived from ChatType
  senderId?: string;          // From field
  originalSessionKey: string;
};

type PluginHookBeforeRouteInboundMessageResult = {
  handled: true;
  redirectSessionKey?: string;
  suppressDelivery?: boolean;
};
```

## Integration Points

| File | Change |
|------|--------|
| `src/plugins/hook-types.ts` | Added to `PluginHookName` union, `PLUGIN_HOOK_NAMES` array, and `PluginHookHandlerMap` |
| `src/plugins/hook-message.types.ts` | New event/context/result type definitions |
| `src/plugins/hooks.ts` | `runBeforeRouteInboundMessage()` using `runClaimingHook` |
| `src/plugin-sdk/inbound-reply-dispatch.ts` | Hook called in `dispatchChannelMessageReplyWithBase()` before building dispatch base |

## Pattern

Uses the **claiming hook** pattern (`runClaimingHook`) — first handler returning `{ handled: true }` wins, matching `before_dispatch` and `reply_dispatch` semantics. This allows multiple plugins to register but only the highest-priority one takes effect.

## Why Here?

`dispatchChannelMessageReplyWithBase()` is the central dispatch entry point for all inbound messages across channels. It receives the resolved route (with `sessionKey`) and `ctxPayload` (with full message metadata), making it the ideal interception point — before session recording, meta-tracking, or model dispatch runs.

## Fixes: #81061