### PR TITLE
fix(sglang): preserve reasoning replay history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway: hide pending Node pairing commands, capabilities, and permissions until approval, and refresh the live approved surface when pairings change. (#80741) Thanks @samzong.
+- SGLang: preserve replayed reasoning history for OpenAI-compatible chat completions, keeping thinking-capable local models from losing prior reasoning turns. (#81091) Thanks @akrimm702.
 - Plugins/Feishu/WhatsApp/Line: enforce inbound media size caps while reading download streams, avoiding full buffering of oversized attachments. (#81044, #81050) Thanks @samzong.
 - Config: serialize and retry semantic config mutations centrally, so concurrent commands can rebase safe changes instead of clobbering or hand-rolling command-local retry loops. (#76601)
 - Require approval for setup-code device pairing [AI]. (#81292) Thanks @pgondhi987.

--- a/extensions/sglang/index.test.ts
+++ b/extensions/sglang/index.test.ts
@@ -1,0 +1,34 @@
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+describe("sglang provider plugin", () => {
+  it("owns OpenAI-compatible replay without dropping reasoning history", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const policy = provider.buildReplayPolicy?.({
+      provider: "sglang",
+      modelApi: "openai-completions",
+      modelId: "moonshotai/kimi-k2-thinking",
+    } as never);
+
+    expect(policy).toMatchObject({
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+      applyAssistantFirstOrderingFix: true,
+      validateGeminiTurns: true,
+      validateAnthropicTurns: true,
+    });
+    expect(policy).not.toHaveProperty("dropReasoningFromHistory");
+  });
+
+  it("still drops historical reasoning for Gemma 4 chat-completions models", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const policy = provider.buildReplayPolicy?.({
+      provider: "sglang",
+      modelApi: "openai-completions",
+      modelId: "google/gemma-4-26b-a4b-it",
+    } as never);
+
+    expect(policy).toHaveProperty("dropReasoningFromHistory", true);
+  });
+});

--- a/extensions/sglang/index.ts
+++ b/extensions/sglang/index.ts
@@ -3,6 +3,7 @@ import {
   type OpenClawPluginApi,
   type ProviderAuthMethodNonInteractiveContext,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   SGLANG_DEFAULT_API_KEY_ENV_VAR,
   SGLANG_DEFAULT_BASE_URL,
@@ -69,6 +70,10 @@ export default definePluginEntry({
           });
         },
       },
+      ...buildProviderReplayFamilyHooks({
+        family: "openai-compatible",
+        dropReasoningFromHistory: false,
+      }),
       wizard: {
         setup: {
           choiceId: "sglang",


### PR DESCRIPTION
## Summary

- Adds an SGLang-owned OpenAI-compatible replay policy instead of inheriting the strict fallback that drops historical reasoning by default.
- Keeps the existing Gemma 4 protection: Gemma 4 `openai-completions` model ids still drop historical reasoning.
- Adds focused provider-plugin regression coverage for both the SGLang/Kimi reasoning case and the Gemma 4 guardrail.

Closes #81058.

## Root Cause

SGLang models are registered as `openai-completions`, but the provider did not own its replay policy. That made it fall through to the core strict OpenAI-compatible fallback, which sets `dropReasoningFromHistory: true` for unowned `openai-completions` providers. For reasoning-capable self-hosted SGLang/Kimi models, that can strip replayed reasoning history and contribute to empty user-facing responses.

## Fix

SGLang now uses `buildProviderReplayFamilyHooks({ family: "openai-compatible", dropReasoningFromHistory: false })`, matching the existing provider-owned opt-out pattern used by reasoning-capable OpenAI-compatible providers. The helper still forces `dropReasoningFromHistory: true` for Gemma 4 model ids, preserving the prior parser-safety behavior.

## Regression Proof

I checked the fix before republishing the branch:

- `main` at validation base `ea7f74ff` had no SGLang replay-policy hook.
- The PR adds the provider-owned replay policy only for SGLang.
- Regression coverage proves Kimi-style SGLang reasoning history is preserved.
- The Gemma 4 guardrail remains covered and still drops historical reasoning.
- Published PR head: `d162f0c7cf83187bb578d7f90405e1d6b0123f1b`.
- GitHub currently reports the PR as mergeable against `main`.

## Validation

Latest local validation after rebasing and publishing the PR branch:

- `PNPM_CONFIG_OFFLINE=true pnpm test extensions/sglang/index.test.ts src/plugins/provider-replay-helpers.test.ts src/agents/transcript-policy.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
- `PNPM_CONFIG_OFFLINE=true pnpm exec oxfmt --check extensions/sglang/index.ts extensions/sglang/index.test.ts`
- `PNPM_CONFIG_OFFLINE=true pnpm exec tsc -p extensions/sglang/tsconfig.json --noEmit --pretty false`
- `PNPM_CONFIG_OFFLINE=true pnpm check:changed`

## Risk

Low and provider-scoped. This does not change the global OpenAI-compatible fallback. The main compatibility risk is accidental reintroduction of replayed reasoning for Gemma 4-style chat-completions models, covered by the new test.

## Maintainer Verification

Maintainer proof after rebasing and adding changelog:

- PR branch head: `d55083d7e126ce1fc4d576fb841b47efe1c9093e`.
- Local targeted regression: `pnpm test extensions/sglang/index.test.ts -- --reporter=verbose` -> 2 tests passed.
- Local whitespace check: `git diff --check` -> passed.
- Live SGLang proof: Blacksmith Testbox `tbx_01krgt6yqe7bte96dwsmker05p`, GitHub Actions run `25803983869`.
- Live server: source-built SGLang CPU, `sglang 0.0.0.dev1+g9e00b7ca9.d20260513`, `torch 2.9.0+cpu`, model `Qwen/Qwen3-0.6B`, `/v1/models` returned the model id.
- Direct replay request sent prior assistant `reasoning_content`; SGLang returned `content: "replay ok"`, non-empty `reasoning_content`, `finish: "stop"`.
- PR unit regression on the same Testbox: `pnpm test extensions/sglang/index.test.ts -- --reporter=verbose` -> 2 tests passed.


## Real behavior proof

- Behavior or issue addressed: SGLang OpenAI-compatible chat completions should preserve replayed assistant `reasoning_content` for thinking-capable local models instead of stripping reasoning history through the strict fallback.
- Real environment tested: Blacksmith Testbox `tbx_01krgt6yqe7bte96dwsmker05p`, GitHub Actions run `25803983869`, source-built SGLang CPU server, `sglang 0.0.0.dev1+g9e00b7ca9.d20260513`, `torch 2.9.0+cpu`, model `Qwen/Qwen3-0.6B` served on `127.0.0.1:30000`.
- Exact steps or command run after this patch: Launched `python -m sglang.launch_server --model Qwen/Qwen3-0.6B --trust-remote-code --disable-overlap-schedule --device cpu --host 127.0.0.1 --port 30000 --tp 1 --reasoning-parser qwen3 --max-total-tokens 4096`, then sent a live `curl http://127.0.0.1:30000/v1/chat/completions` request containing a prior assistant message with `reasoning_content`.
- Evidence after fix: Terminal output from the live run: `/v1/models` returned `Qwen/Qwen3-0.6B`; the direct replay response JSON was `{ "model": "Qwen/Qwen3-0.6B", "content": "replay ok", "reasoning": "Okay, the user wants me to answer exactly: ...", "finish": "stop" }`.
- Observed result after fix: SGLang accepted the replayed `reasoning_content`, returned visible content `replay ok`, returned non-empty `reasoning_content`, and finished with `stop`; the PR regression test on the same Testbox also passed 2/2.
- What was not tested: Kimi/GPU SGLang was not tested because AWS GPU spot/on-demand quota blocked `g5.xlarge` and `g4dn.xlarge`; CPU SGLang with Qwen3 tested the same OpenAI-compatible `reasoning_content` replay contract.

