### PR TITLE
fix(heartbeat): silence trailing notify=false fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Heartbeat/Telegram: strip trailing `notify=false` heartbeat markers and send remaining replies silently instead of leaking the marker into chat. Fixes #80569. Thanks @stainlu.
 - Limit hook CLI tool authority [AI]. (#81065) Thanks @pgondhi987.
 - Require admin scope for node device token management [AI]. (#81067) Thanks @pgondhi987.
 - Restrict chat sender allowlist matching [AI]. (#80898) Thanks @pgondhi987.

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -302,6 +302,12 @@ describe("runHeartbeatOnce ack handling", () => {
       expectedCalls: 1,
       expectedText: "Status includes notify=false in config",
     },
+    {
+      title: "does not mark ordinary trailing whitespace replies silent",
+      replyText: "Status done\n",
+      expectedCalls: 1,
+      expectedText: "Status done",
+    },
   ])("$title", async ({ replyText, messages, expectedCalls, expectedText, expectedSilent }) => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const { sendTelegram, cfg } = await runTelegramHeartbeatWithDefaults({

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -78,7 +78,7 @@ describe("runHeartbeatOnce ack handling", () => {
 
   function expectTelegramMessageSend(
     send: ReturnType<typeof vi.fn>,
-    params: { to: string; text: string; cfg: OpenClawConfig },
+    params: { to: string; text: string; cfg: OpenClawConfig; silent?: boolean },
   ) {
     expect(send.mock.calls).toEqual([
       [
@@ -88,6 +88,7 @@ describe("runHeartbeatOnce ack handling", () => {
           verbose: false,
           cfg: params.cfg,
           accountId: undefined,
+          ...(params.silent !== undefined ? { silent: params.silent } : {}),
         },
       ],
     ]);
@@ -283,7 +284,25 @@ describe("runHeartbeatOnce ack handling", () => {
       expectedCalls: 1,
       expectedText: "History check complete",
     },
-  ])("$title", async ({ replyText, messages, expectedCalls, expectedText }) => {
+    {
+      title: "strips trailing notify=false and sends the heartbeat reply silently",
+      replyText: "No interruption needed.\n\nnotify=false",
+      expectedCalls: 1,
+      expectedText: "No interruption needed.",
+      expectedSilent: true,
+    },
+    {
+      title: "drops a marker-only notify=false heartbeat reply",
+      replyText: "notify=false",
+      expectedCalls: 0,
+    },
+    {
+      title: "does not strip inline notify=false text",
+      replyText: "Status includes notify=false in config",
+      expectedCalls: 1,
+      expectedText: "Status includes notify=false in config",
+    },
+  ])("$title", async ({ replyText, messages, expectedCalls, expectedText, expectedSilent }) => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const { sendTelegram, cfg } = await runTelegramHeartbeatWithDefaults({
         tmpDir,
@@ -299,6 +318,7 @@ describe("runHeartbeatOnce ack handling", () => {
           to: TELEGRAM_GROUP,
           text: expectedText,
           cfg,
+          ...(expectedSilent !== undefined ? { silent: expectedSilent } : {}),
         });
       }
     });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -776,11 +776,11 @@ function stripTrailingHeartbeatNotifyFalseMarker(text: string): {
   text: string;
   silent: boolean;
 } {
-  const stripped = text.replace(/(?:^|\r?\n)[ \t]*notify=false[ \t]*$/i, "").trimEnd();
-  if (stripped === text) {
+  const withoutMarker = text.replace(/(?:^|\r?\n)[ \t]*notify=false[ \t]*$/i, "");
+  if (withoutMarker === text) {
     return { text, silent: false };
   }
-  return { text: stripped, silent: true };
+  return { text: withoutMarker.trimEnd(), silent: true };
 }
 
 function normalizeHeartbeatReply(

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -765,14 +765,33 @@ function stripLeadingHeartbeatResponsePrefix(
   return text.replace(prefixPattern, "");
 }
 
+type NormalizedHeartbeatReply = {
+  shouldSkip: boolean;
+  text: string;
+  hasMedia: boolean;
+  silent?: boolean;
+};
+
+function stripTrailingHeartbeatNotifyFalseMarker(text: string): {
+  text: string;
+  silent: boolean;
+} {
+  const stripped = text.replace(/(?:^|\r?\n)[ \t]*notify=false[ \t]*$/i, "").trimEnd();
+  if (stripped === text) {
+    return { text, silent: false };
+  }
+  return { text: stripped, silent: true };
+}
+
 function normalizeHeartbeatReply(
   payload: ReplyPayload,
   responsePrefix: string | undefined,
   ackMaxChars: number,
-) {
+): NormalizedHeartbeatReply {
   const rawText = typeof payload.text === "string" ? payload.text : "";
   const textForStrip = stripLeadingHeartbeatResponsePrefix(rawText, responsePrefix);
-  const stripped = stripHeartbeatToken(textForStrip, {
+  const notifyMarker = stripTrailingHeartbeatNotifyFalseMarker(textForStrip);
+  const stripped = stripHeartbeatToken(notifyMarker.text, {
     mode: "heartbeat",
     maxAckChars: ackMaxChars,
   });
@@ -782,19 +801,25 @@ function normalizeHeartbeatReply(
       shouldSkip: true,
       text: "",
       hasMedia,
+      ...(notifyMarker.silent ? { silent: true } : {}),
     };
   }
   let finalText = stripped.text;
   if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
     finalText = `${responsePrefix} ${finalText}`;
   }
-  return { shouldSkip: false, text: finalText, hasMedia };
+  return {
+    shouldSkip: false,
+    text: finalText,
+    hasMedia,
+    ...(notifyMarker.silent ? { silent: true } : {}),
+  };
 }
 
 function normalizeHeartbeatToolNotification(
   response: HeartbeatToolResponse,
   responsePrefix: string | undefined,
-) {
+): NormalizedHeartbeatReply {
   let finalText = getHeartbeatToolNotificationText(response);
   if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
     finalText = `${responsePrefix} ${finalText}`;
@@ -1973,6 +1998,7 @@ export async function runHeartbeatOnce(opts: {
             ]),
       ],
       deps: opts.deps,
+      silent: normalized.silent === true ? true : undefined,
     });
     if (send.status === "failed" || send.status === "partial_failed") {
       throw send.error;

--- a/test/helpers/infra/heartbeat-runner-channel-plugins.ts
+++ b/test/helpers/infra/heartbeat-runner-channel-plugins.ts
@@ -36,6 +36,7 @@ function createHeartbeatOutboundAdapter(channelId: HeartbeatSendChannelId): Chan
               ...baseOptions,
               ...(typeof threadId === "number" ? { messageThreadId: threadId } : {}),
               ...(typeof replyToId === "string" ? { replyToMessageId: Number(replyToId) } : {}),
+              ...(opts.silent === true ? { silent: true } : {}),
             }
           : {
               ...baseOptions,


### PR DESCRIPTION
## Summary

- Problem: heartbeat fallback replies could leak a trailing standalone `notify=false` marker into Telegram instead of treating it as silent-delivery metadata.
- What changed: heartbeat fallback normalization now strips only a final standalone `notify=false`, carries `silent: true` into durable delivery for the remaining reply, and drops marker-only no-op replies.
- Test support: the heartbeat Telegram test adapter now forwards `silent` so heartbeat regression tests cover the same metadata path as the real Telegram outbound adapter.

Closes #80569

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Real behavior proof

- Behavior or issue addressed: a heartbeat reply ending with a standalone `notify=false` is delivered without exposing the marker and with silent Telegram send metadata.
- Real environment tested: local OpenClaw source checkout running `runHeartbeatOnce` through the Telegram channel plugin shim and durable message send path with a temp OpenClaw state directory and seeded main Telegram session.
- Exact steps or command run after this patch: created a temp OpenClaw heartbeat setup, seeded the main Telegram session, returned a fallback reply of `"No interruption needed.\n\nnotify=false"`, captured the outbound Telegram send, and ran:

```text
node --import tsx /private/tmp/heartbeat-notify-proof.mjs
```

- Evidence after fix (console output):

```text
{
  "result": {
    "status": "ran",
    "durationMs": 1778607539148
  },
  "sends": [
    {
      "to": "-1001234567890",
      "text": "No interruption needed.",
      "silent": true,
      "leakedMarker": false
    }
  ]
}
```

- Observed result after fix: the regression test sends `"No interruption needed.\n\nnotify=false"` and asserts Telegram receives `"No interruption needed."` with `silent: true`; a marker-only `"notify=false"` reply is suppressed; inline `notify=false` text is preserved.
- What was not tested: live Telegram Bot API delivery.

## Root Cause

- Root cause: heartbeat text fallback normalized `HEARTBEAT_OK` but did not consume the `notify=false` response-tool hint when the model emitted it as plain trailing text.
- Missing guardrail: coverage checked structured `heartbeat_respond({ notify: false })`, but not a plain fallback reply ending in `notify=false`.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts`
- Scenario locked in: final standalone `notify=false` becomes silent delivery metadata, marker-only replies are dropped, and inline user text containing `notify=false` remains untouched.

## User-visible / Behavior Changes

Telegram heartbeat fallback replies no longer show a trailing `notify=false` control marker. When remaining text is delivered, it is sent silently.

## Validation

- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts test/helpers/infra/heartbeat-runner-channel-plugins.ts`
- `pnpm test src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts src/infra/heartbeat-runner.tool-response.test.ts`
- `pnpm test src/infra/heartbeat-events-filter.test.ts extensions/telegram/src/outbound-adapter.test.ts src/channels/message/send.test.ts`
- `git diff --check`
