### PR TITLE
Policy: add runtime audit metadata and attestation enforcement

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5727,6 +5727,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
     public let title: String
     public let description: String
     public let severity: String?
+    public let metadata: AnyCodable?
     public let toolname: String?
     public let toolcallid: String?
     public let alloweddecisions: [String]?
@@ -5744,6 +5745,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         title: String,
         description: String,
         severity: String?,
+        metadata: AnyCodable?,
         toolname: String?,
         toolcallid: String?,
         alloweddecisions: [String]?,
@@ -5760,6 +5762,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         self.title = title
         self.description = description
         self.severity = severity
+        self.metadata = metadata
         self.toolname = toolname
         self.toolcallid = toolcallid
         self.alloweddecisions = alloweddecisions
@@ -5778,6 +5781,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         case title
         case description
         case severity
+        case metadata
         case toolname = "toolName"
         case toolcallid = "toolCallId"
         case alloweddecisions = "allowedDecisions"

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -55,10 +55,7 @@ policy for channels and tool metadata looks like this:
     ],
   },
   "tools": {
-    "settings": {
-      "requireRisk": true,
-      "requireSensitivity": true,
-    },
+    "requireMetadata": ["risk", "sensitivity", "owner"],
   },
 }
 ```
@@ -117,8 +114,6 @@ Policy config lives under `plugins.entries.policy.config`.
         "config": {
           "enabled": true,
           "path": "policy.jsonc",
-          "requireRisk": true,
-          "requireSensitivity": true,
           "runtimeToolPolicy": false,
           "workspaceRepairs": false,
           "expectedHash": "sha256:...",
@@ -130,22 +125,20 @@ Policy config lives under `plugins.entries.policy.config`.
 }
 ```
 
-| Setting                   | Purpose                                                             |
-| ------------------------- | ------------------------------------------------------------------- |
-| `enabled`                 | Enable policy checks even before `policy.jsonc` exists.             |
-| `requireRisk`             | Require governed tool declarations to include risk metadata.        |
-| `requireSensitivity`      | Require governed tool declarations to include sensitivity metadata. |
-| `runtimeToolPolicy`       | Apply enabled tool requirements through the trusted tool hook.      |
-| `workspaceRepairs`        | Allow `doctor --fix` to edit policy-managed workspace settings.     |
-| `expectedHash`            | Optional hash-lock for the approved policy artifact.                |
-| `expectedAttestationHash` | Optional hash-lock for the last accepted clean policy check.        |
-| `path`                    | Workspace-relative location of the policy artifact.                 |
+| Setting                   | Purpose                                                                  |
+| ------------------------- | ------------------------------------------------------------------------ |
+| `enabled`                 | Enable policy checks even before `policy.jsonc` exists.                  |
+| `runtimeToolPolicy`       | Apply authored tool metadata requirements through the trusted tool hook. |
+| `workspaceRepairs`        | Allow `doctor --fix` to edit policy-managed workspace settings.          |
+| `expectedHash`            | Optional hash-lock for the approved policy artifact.                     |
+| `expectedAttestationHash` | Optional hash-lock for the last accepted clean policy check.             |
+| `path`                    | Workspace-relative location of the policy artifact.                      |
 
 Set `plugins.entries.policy.config.enabled` to `false` to disable policy checks
 for a workspace while leaving the plugin installed.
 
-Tool requirement booleans can also live under `tools.settings` in
-`policy.jsonc`. Config wins when both places set the same value.
+Tool metadata requirements are authored in `policy.jsonc` with
+`tools.requireMetadata`, for example `["risk", "sensitivity", "owner"]`.
 
 ## Accept policy state
 
@@ -240,13 +233,13 @@ Policy currently verifies:
 | `policy/tools-missing-sensitivity-token` | A governed tool declaration is missing sensitivity metadata.        |
 | `policy/tools-unknown-sensitivity-token` | A governed tool declaration uses an unknown sensitivity value.      |
 
-Example JSON finding:
-
 Policy findings can include both `target` and `requirement`. `target` is the
 observed workspace thing that does not conform. `requirement` is the authored
 policy rule that made it a finding. Both values are addresses today, usually
 `oc://` paths, but the field names describe their policy role rather than the
 address format.
+
+Example JSON finding:
 
 ```json
 {
@@ -274,7 +267,7 @@ Example tool finding:
   "line": 12,
   "ocPath": "oc://TOOLS.md/tools/deploy",
   "target": "oc://TOOLS.md/tools/deploy",
-  "requirement": "oc://policy.jsonc/tools/settings/requireRisk"
+  "requirement": "oc://policy.jsonc/tools/requireMetadata"
 }
 ```
 

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -93,6 +93,8 @@ Run policy-only checks during authoring:
 openclaw policy check
 openclaw policy check --json
 openclaw policy check --severity-min error
+openclaw policy watch --once
+openclaw policy diff before.json after.json
 ```
 
 `policy check` runs only the policy check set and emits evidence, findings, and
@@ -259,6 +261,11 @@ Use this lifecycle when accepting policy state:
 3. If the result is clean, record `attestation.policy.hash` as `expectedHash`.
 4. Record `attestation.attestationHash` as `expectedAttestationHash`.
 5. Re-run `openclaw doctor --lint` in CI or release gates.
+
+`policy diff` compares two saved `policy check --json` outputs to explain what
+changed: the authored policy, observed evidence, finding set, or clean/dirty
+result. It ignores `checkedAt` for drift decisions because that timestamp is
+audit metadata, not part of the accepted stable attestation.
 
 The tool runtime gate also includes structured approval metadata on gateway
 approval requests: policy path/hash, configured expected hash when present, the

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -17,10 +17,13 @@ report drift through `doctor --lint`. The final conformance signal is a clean
 `doctor --lint` run; policy contributes findings to that shared lint surface
 instead of creating a separate health gate.
 
-Policy currently manages configured channels and governed tool declarations.
-For example, IT or a workspace operator can record that Telegram is not an
-approved channel provider, require governed tools to carry risk and sensitivity
-metadata, then use `doctor --lint` as the shared conformance gate.
+Policy currently manages configured channels, MCP servers, model providers,
+network SSRF posture, and governed tool declarations. For example, IT or a
+workspace operator can record that Telegram is not an approved channel
+provider, restrict MCP servers and model refs to approved entries, require
+private-network fetch/browser access to remain disabled, require governed tools
+to carry risk and sensitivity metadata, then use `doctor --lint` as the shared
+conformance gate.
 
 Use policy when a workspace needs a durable statement such as "these channels
 must not be enabled" or "governed tools must declare approval metadata" and a
@@ -41,7 +44,8 @@ arbitrary plugins. The plugin remains enabled if `policy.jsonc` is missing, so
 doctor can report the missing artifact.
 
 Policy is authored, not generated from the user's current settings. A minimal
-policy for channels and tool metadata looks like this:
+policy for channels, MCP servers, model providers, network posture, and tool
+metadata looks like this:
 
 ```jsonc
 {
@@ -54,6 +58,23 @@ policy for channels and tool metadata looks like this:
       },
     ],
   },
+  "mcp": {
+    "servers": {
+      "allow": ["docs"],
+      "deny": ["untrusted"],
+    },
+  },
+  "models": {
+    "providers": {
+      "allow": ["openai", "anthropic"],
+      "deny": ["openrouter"],
+    },
+  },
+  "network": {
+    "privateNetwork": {
+      "allow": false,
+    },
+  },
   "tools": {
     "requireMetadata": ["risk", "sensitivity", "owner"],
   },
@@ -62,8 +83,9 @@ policy for channels and tool metadata looks like this:
 
 The rules are the authority. A category block is only a namespace; checks run
 when a concrete rule is present. OpenClaw reads current `channels.*` settings
-and `TOOLS.md` declarations as evidence, then reports observed state that does
-not conform.
+`mcp.servers.*`, `models.providers.*`, selected agent model refs, network SSRF
+settings, and `TOOLS.md` declarations as evidence, then reports observed state
+that does not conform.
 
 Run policy-only checks during authoring:
 
@@ -169,6 +191,35 @@ Example JSON output:
         "enabled": false
       }
     ],
+    "mcpServers": [
+      {
+        "id": "docs",
+        "transport": "stdio",
+        "source": "oc://openclaw.config/mcp/servers/docs",
+        "command": "npx"
+      }
+    ],
+    "modelProviders": [
+      {
+        "id": "openai",
+        "source": "oc://openclaw.config/models/providers/openai"
+      }
+    ],
+    "modelRefs": [
+      {
+        "ref": "openai/gpt-5.5",
+        "provider": "openai",
+        "model": "gpt-5.5",
+        "source": "oc://openclaw.config/agents/defaults/model"
+      }
+    ],
+    "network": [
+      {
+        "id": "browser-private-network",
+        "source": "oc://openclaw.config/browser/ssrfPolicy/dangerouslyAllowPrivateNetwork",
+        "value": false
+      }
+    ],
     "tools": [
       {
         "id": "deploy",
@@ -180,7 +231,7 @@ Example JSON output:
       }
     ]
   },
-  "checksRun": 6,
+  "checksRun": 14,
   "checksSkipped": 0,
   "findings": []
 }
@@ -222,18 +273,23 @@ only `expectedAttestationHash` usually changes.
 
 Policy currently verifies:
 
-| Check id                                 | Finding                                                             |
-| ---------------------------------------- | ------------------------------------------------------------------- |
-| `policy/policy-jsonc-missing`            | Policy is enabled but `policy.jsonc` is missing.                    |
-| `policy/policy-jsonc-invalid`            | Policy cannot be parsed or has malformed rules.                     |
-| `policy/policy-hash-mismatch`            | Policy does not match configured `expectedHash`.                    |
-| `policy/attestation-hash-mismatch`       | Current policy evidence no longer matches the accepted attestation. |
-| `policy/channels-denied-provider`        | An enabled channel matches a channel deny rule.                     |
-| `policy/tools-missing-owner`             | A governed tool declaration is missing owner metadata.              |
-| `policy/tools-missing-risk-level`        | A governed tool declaration is missing risk metadata.               |
-| `policy/tools-missing-sensitivity-token` | A governed tool declaration is missing sensitivity metadata.        |
-| `policy/tools-unknown-risk-level`        | A governed tool declaration uses an unknown risk value.             |
-| `policy/tools-unknown-sensitivity-token` | A governed tool declaration uses an unknown sensitivity value.      |
+| Check id                                 | Finding                                                               |
+| ---------------------------------------- | --------------------------------------------------------------------- |
+| `policy/policy-jsonc-missing`            | Policy is enabled but `policy.jsonc` is missing.                      |
+| `policy/policy-jsonc-invalid`            | Policy cannot be parsed or contains malformed rule entries.           |
+| `policy/policy-hash-mismatch`            | Policy does not match configured `expectedHash`.                      |
+| `policy/attestation-hash-mismatch`       | Current policy evidence no longer matches the accepted attestation.   |
+| `policy/channels-denied-provider`        | An enabled channel matches a channel deny rule.                       |
+| `policy/mcp-denied-server`               | A configured MCP server is denied by policy.                          |
+| `policy/mcp-unapproved-server`           | A configured MCP server is outside the allowlist.                     |
+| `policy/models-denied-provider`          | A configured model provider or model ref uses a denied provider.      |
+| `policy/models-unapproved-provider`      | A configured model provider or model ref is outside the allowlist.    |
+| `policy/network-private-access-enabled`  | A private-network SSRF escape hatch is enabled when policy denies it. |
+| `policy/tools-missing-risk-level`        | A governed tool declaration is missing risk metadata.                 |
+| `policy/tools-unknown-risk-level`        | A governed tool declaration uses an unknown risk value.               |
+| `policy/tools-missing-sensitivity-token` | A governed tool declaration is missing sensitivity metadata.          |
+| `policy/tools-missing-owner`             | A governed tool declaration is missing owner metadata.                |
+| `policy/tools-unknown-sensitivity-token` | A governed tool declaration uses an unknown sensitivity value.        |
 
 Policy findings can include both `target` and `requirement`. `target` is the
 observed workspace thing that does not conform. `requirement` is the authored
@@ -270,6 +326,51 @@ Example tool finding:
   "ocPath": "oc://TOOLS.md/tools/deploy",
   "target": "oc://TOOLS.md/tools/deploy",
   "requirement": "oc://policy.jsonc/tools/requireMetadata"
+}
+```
+
+Example MCP finding:
+
+```json
+{
+  "checkId": "policy/mcp-unapproved-server",
+  "severity": "error",
+  "message": "MCP server 'remote' is not in the policy allowlist.",
+  "source": "policy",
+  "path": "openclaw config",
+  "ocPath": "oc://openclaw.config/mcp/servers/remote",
+  "target": "oc://openclaw.config/mcp/servers/remote",
+  "requirement": "oc://policy.jsonc/mcp/servers/allow"
+}
+```
+
+Example model-provider finding:
+
+```json
+{
+  "checkId": "policy/models-unapproved-provider",
+  "severity": "error",
+  "message": "Model ref 'anthropic/claude-sonnet-4.7' uses unapproved provider 'anthropic'.",
+  "source": "policy",
+  "path": "openclaw config",
+  "ocPath": "oc://openclaw.config/agents/defaults/model/fallbacks/#0",
+  "target": "oc://openclaw.config/agents/defaults/model/fallbacks/#0",
+  "requirement": "oc://policy.jsonc/models/providers/allow"
+}
+```
+
+Example network finding:
+
+```json
+{
+  "checkId": "policy/network-private-access-enabled",
+  "severity": "error",
+  "message": "Network setting 'browser-private-network' allows private-network access.",
+  "source": "policy",
+  "path": "openclaw config",
+  "ocPath": "oc://openclaw.config/browser/ssrfPolicy/dangerouslyAllowPrivateNetwork",
+  "target": "oc://openclaw.config/browser/ssrfPolicy/dangerouslyAllowPrivateNetwork",
+  "requirement": "oc://policy.jsonc/network/privateNetwork/allow"
 }
 ```
 

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw policy` channel conformance checks"
+summary: "CLI reference for `openclaw policy` conformance checks"
 read_when:
   - You want to check OpenClaw settings against an authored policy.jsonc
   - You want policy findings in doctor lint
@@ -10,14 +10,23 @@ title: "Policy"
 # `openclaw policy`
 
 `openclaw policy` is provided by the bundled Policy plugin. Policy is an
-enterprise conformance layer over existing OpenClaw settings: `policy.jsonc`
-defines authored requirements, OpenClaw observes the active workspace as
-evidence, and policy health checks report drift through `doctor --lint`.
+enterprise conformance layer over existing OpenClaw settings. It does not add a
+second configuration system. `policy.jsonc` defines authored requirements,
+OpenClaw observes the active workspace as evidence, and policy health checks
+report drift through `doctor --lint`. The final conformance signal is a clean
+`doctor --lint` run; policy contributes findings to that shared lint surface
+instead of creating a separate health gate.
 
-This first policy slice manages configured channels. For example, IT can record
-that Telegram is not approved, then `doctor --lint` reports any enabled Telegram
-channel and `doctor --fix` can turn it off when workspace repairs are explicitly
-enabled.
+Policy currently manages configured channels and governed tool declarations.
+For example, IT or a workspace operator can record that Telegram is not an
+approved channel provider, require governed tools to carry risk and sensitivity
+metadata, then use `doctor --lint` as the shared conformance gate.
+
+Use policy when a workspace needs a durable statement such as "these channels
+must not be enabled" or "governed tools must declare approval metadata" and a
+repeatable way to prove that OpenClaw still conforms to that statement. Use
+regular config and workspace docs alone when you only need local behavior and
+do not need policy findings or attestation output.
 
 ## Quick start
 
@@ -32,7 +41,7 @@ arbitrary plugins. The plugin remains enabled if `policy.jsonc` is missing, so
 doctor can report the missing artifact.
 
 Policy is authored, not generated from the user's current settings. A minimal
-channel policy looks like this:
+policy for channels and tool metadata looks like this:
 
 ```jsonc
 {
@@ -45,12 +54,19 @@ channel policy looks like this:
       },
     ],
   },
+  "tools": {
+    "settings": {
+      "requireRisk": true,
+      "requireSensitivity": true,
+    },
+  },
 }
 ```
 
 The rules are the authority. A category block is only a namespace; checks run
 when a concrete rule is present. OpenClaw reads current `channels.*` settings
-and reports settings that do not conform.
+and `TOOLS.md` declarations as evidence, then reports observed state that does
+not conform.
 
 Run policy-only checks during authoring:
 
@@ -101,6 +117,8 @@ Policy config lives under `plugins.entries.policy.config`.
         "config": {
           "enabled": true,
           "path": "policy.jsonc",
+          "requireRisk": true,
+          "requireSensitivity": true,
           "workspaceRepairs": false,
           "expectedHash": "sha256:...",
           "expectedAttestationHash": "sha256:...",
@@ -111,23 +129,77 @@ Policy config lives under `plugins.entries.policy.config`.
 }
 ```
 
-| Setting                   | Purpose                                                         |
-| ------------------------- | --------------------------------------------------------------- |
-| `enabled`                 | Enable policy checks even before `policy.jsonc` exists.         |
-| `workspaceRepairs`        | Allow `doctor --fix` to edit policy-managed workspace settings. |
-| `expectedHash`            | Optional hash-lock for the approved policy artifact.            |
-| `expectedAttestationHash` | Optional hash-lock for the last accepted clean policy check.    |
-| `path`                    | Workspace-relative location of the policy artifact.             |
+| Setting                   | Purpose                                                             |
+| ------------------------- | ------------------------------------------------------------------- |
+| `enabled`                 | Enable policy checks even before `policy.jsonc` exists.             |
+| `requireRisk`             | Require governed tool declarations to include risk metadata.        |
+| `requireSensitivity`      | Require governed tool declarations to include sensitivity metadata. |
+| `workspaceRepairs`        | Allow `doctor --fix` to edit policy-managed workspace settings.     |
+| `expectedHash`            | Optional hash-lock for the approved policy artifact.                |
+| `expectedAttestationHash` | Optional hash-lock for the last accepted clean policy check.        |
+| `path`                    | Workspace-relative location of the policy artifact.                 |
 
 Set `plugins.entries.policy.config.enabled` to `false` to disable policy checks
 for a workspace while leaving the plugin installed.
 
+Tool requirement booleans can also live under `tools.settings` in
+`policy.jsonc`. Config wins when both places set the same value.
+
 ## Accept policy state
 
-The attestation hash identifies the stable claim: policy hash, evidence hash,
-findings hash, and whether the result was clean. It intentionally does not
-include `checkedAt`, so the same policy state produces the same attestation
-across repeated checks.
+Example JSON output:
+
+```json
+{
+  "ok": true,
+  "attestation": {
+    "checkedAt": "2026-05-10T20:00:00.000Z",
+    "policy": {
+      "path": "policy.jsonc",
+      "hash": "sha256:..."
+    },
+    "workspace": {
+      "scope": "policy",
+      "hash": "sha256:..."
+    },
+    "findingsHash": "sha256:...",
+    "attestationHash": "sha256:..."
+  },
+  "evidence": {
+    "channels": [
+      {
+        "id": "telegram",
+        "provider": "telegram",
+        "source": "oc://openclaw.config/channels/telegram",
+        "enabled": false
+      }
+    ],
+    "tools": [
+      {
+        "id": "deploy",
+        "ocPath": "oc://TOOLS.md/tools/deploy",
+        "line": 12,
+        "risk": "critical",
+        "sensitivity": "restricted",
+        "capabilities": ["IRREVERSIBLE_EXTERNAL"]
+      }
+    ]
+  },
+  "checksRun": 6,
+  "checksSkipped": 0,
+  "findings": []
+}
+```
+
+The policy hash identifies the authored rule artifact. The evidence block
+records the observed OpenClaw state used by the policy checks. The
+`workspace.hash` value identifies that evidence payload for the checked scope.
+The findings hash identifies the exact finding set returned by the check.
+`checkedAt` records when the evaluation ran. The attestation hash identifies
+the stable claim: policy hash, evidence hash, findings hash, and whether the
+result was clean. It intentionally does not include `checkedAt`, so the same
+policy state produces the same attestation across repeated checks. Together,
+these form the audit tuple for this policy check.
 
 If a later gateway or supervisor uses policy to block, approve, or annotate a
 runtime action, it should record the attestation hash from the last clean policy
@@ -150,16 +222,48 @@ only `expectedAttestationHash` usually changes.
 
 Policy currently verifies:
 
-| Check id                           | Finding                                                             |
-| ---------------------------------- | ------------------------------------------------------------------- |
-| `policy/policy-jsonc-missing`      | Policy is enabled but `policy.jsonc` is missing.                    |
-| `policy/policy-jsonc-invalid`      | Policy cannot be parsed or has malformed rules.                     |
-| `policy/policy-hash-mismatch`      | Policy does not match configured `expectedHash`.                    |
-| `policy/attestation-hash-mismatch` | Current policy evidence no longer matches the accepted attestation. |
-| `policy/channels-denied-provider`  | An enabled channel matches a channel deny rule.                     |
+| Check id                                 | Finding                                                             |
+| ---------------------------------------- | ------------------------------------------------------------------- |
+| `policy/policy-jsonc-missing`            | Policy is enabled but `policy.jsonc` is missing.                    |
+| `policy/policy-jsonc-invalid`            | Policy cannot be parsed or has malformed rules.                     |
+| `policy/policy-hash-mismatch`            | Policy does not match configured `expectedHash`.                    |
+| `policy/attestation-hash-mismatch`       | Current policy evidence no longer matches the accepted attestation. |
+| `policy/channels-denied-provider`        | An enabled channel matches a channel deny rule.                     |
+| `policy/tools-missing-risk-level`        | A governed tool declaration is missing risk metadata.               |
+| `policy/tools-missing-sensitivity-token` | A governed tool declaration is missing sensitivity metadata.        |
+| `policy/tools-unknown-sensitivity-token` | A governed tool declaration uses an unknown sensitivity value.      |
 
-Policy findings can include `target` and `requirement`: the observed workspace
-thing that does not conform, and the authored rule that made it a finding.
+Example JSON finding:
+
+```json
+{
+  "checkId": "policy/channels-denied-provider",
+  "severity": "error",
+  "message": "Channel 'telegram' uses denied provider 'telegram'.",
+  "source": "policy",
+  "path": "openclaw config",
+  "ocPath": "oc://openclaw.config/channels/telegram",
+  "target": "oc://openclaw.config/channels/telegram",
+  "requirement": "oc://policy.jsonc/channels/denyRules/#0",
+  "fixHint": "Telegram is not approved for this workspace."
+}
+```
+
+Example tool finding:
+
+```json
+{
+  "checkId": "policy/tools-missing-risk-level",
+  "severity": "error",
+  "message": "TOOLS.md tool 'deploy' has no explicit risk classification.",
+  "source": "policy",
+  "path": "TOOLS.md",
+  "line": 12,
+  "ocPath": "oc://TOOLS.md/tools/deploy",
+  "target": "oc://TOOLS.md/tools/deploy",
+  "requirement": "oc://policy.jsonc/tools/settings/requireRisk"
+}
+```
 
 ## Repair
 

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -260,10 +260,13 @@ Use this lifecycle when accepting policy state:
 4. Record `attestation.attestationHash` as `expectedAttestationHash`.
 5. Re-run `openclaw doctor --lint` in CI or release gates.
 
-The tool runtime gate also includes structured approval metadata on approval
-requests: policy path/hash, configured expected hash when present, the policy
-evidence hash, and the target tool reference. That keeps audit values separate
-from the human-readable approval message.
+The tool runtime gate also includes structured approval metadata on gateway
+approval requests: policy path/hash, configured expected hash when present, the
+policy evidence hash, and the target tool reference. Gateway approval request,
+list, and resolve events preserve that metadata so supervisors can audit the
+decision against the policy and workspace state that produced it. The UI and
+text approval surfaces summarize those values, but the audit trail remains
+structured.
 
 If policy rules change intentionally, update both accepted hashes from a clean
 check. If workspace settings change intentionally but policy stays the same,

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -284,29 +284,31 @@ only `expectedAttestationHash` usually changes.
 
 Policy currently verifies:
 
-| Check id                                 | Finding                                                               |
-| ---------------------------------------- | --------------------------------------------------------------------- |
-| `policy/policy-jsonc-missing`            | Policy is enabled but `policy.jsonc` is missing.                      |
-| `policy/policy-jsonc-invalid`            | Policy cannot be parsed or contains malformed rule entries.           |
-| `policy/policy-hash-mismatch`            | Policy does not match configured `expectedHash`.                      |
-| `policy/attestation-hash-mismatch`       | Current policy evidence no longer matches the accepted attestation.   |
-| `policy/channels-denied-provider`        | An enabled channel matches a channel deny rule.                       |
-| `policy/mcp-denied-server`               | A configured MCP server is denied by policy.                          |
-| `policy/mcp-unapproved-server`           | A configured MCP server is outside the allowlist.                     |
-| `policy/models-denied-provider`          | A configured model provider or model ref uses a denied provider.      |
-| `policy/models-unapproved-provider`      | A configured model provider or model ref is outside the allowlist.    |
-| `policy/network-private-access-enabled`  | A private-network SSRF escape hatch is enabled when policy denies it. |
-| `policy/tools-missing-risk-level`        | A governed tool declaration is missing risk metadata.                 |
-| `policy/tools-unknown-risk-level`        | A governed tool declaration uses an unknown risk value.               |
-| `policy/tools-missing-sensitivity-token` | A governed tool declaration is missing sensitivity metadata.          |
-| `policy/tools-missing-owner`             | A governed tool declaration is missing owner metadata.                |
-| `policy/tools-unknown-sensitivity-token` | A governed tool declaration uses an unknown sensitivity value.        |
+| Check id                                  | Finding                                                                 |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `policy/policy-jsonc-missing`             | Policy is enabled but `policy.jsonc` is missing.                        |
+| `policy/policy-jsonc-invalid`             | Policy cannot be parsed or contains malformed rule entries.             |
+| `policy/policy-hash-mismatch`             | Policy does not match configured `expectedHash`.                        |
+| `policy/attestation-hash-mismatch`        | Current policy evidence no longer matches the accepted attestation.     |
+| `policy/channels-denied-provider`         | An enabled channel matches a channel deny rule.                         |
+| `policy/channels-denied-provider-running` | A denied channel account is still running in supplied runtime evidence. |
+| `policy/mcp-denied-server`                | A configured MCP server is denied by policy.                            |
+| `policy/mcp-unapproved-server`            | A configured MCP server is outside the allowlist.                       |
+| `policy/models-denied-provider`           | A configured model provider or model ref uses a denied provider.        |
+| `policy/models-unapproved-provider`       | A configured model provider or model ref is outside the allowlist.      |
+| `policy/network-private-access-enabled`   | A private-network SSRF escape hatch is enabled when policy denies it.   |
+| `policy/tools-missing-risk-level`         | A governed tool declaration is missing risk metadata.                   |
+| `policy/tools-unknown-risk-level`         | A governed tool declaration uses an unknown risk value.                 |
+| `policy/tools-missing-sensitivity-token`  | A governed tool declaration is missing sensitivity metadata.            |
+| `policy/tools-missing-owner`              | A governed tool declaration is missing owner metadata.                  |
+| `policy/tools-unknown-sensitivity-token`  | A governed tool declaration uses an unknown sensitivity value.          |
 
 Policy findings can include both `target` and `requirement`. `target` is the
-observed workspace thing that does not conform. `requirement` is the authored
-policy rule that made it a finding. Both values are addresses today, usually
-`oc://` paths, but the field names describe their policy role rather than the
-address format.
+observed thing that does not conform. `requirement` is the authored policy rule
+that made it a finding. Config and workspace findings usually use `oc://`
+paths because they can point to resolvable documents. Runtime findings can use
+non-`oc://` evidence refs, such as `runtime:channels/...`, because they point
+to observed runtime state rather than an editable oc-path document.
 
 Example JSON finding:
 

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -341,9 +341,9 @@ hooks.
 
 ## Exit codes
 
-| Command               | `0`                                                                           | `1`                                                        | `2`                          |
-| --------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------- |
-| `policy check`        | No findings at the threshold.                                                 | One or more findings met the threshold.                    | Argument or runtime failure. |
+| Command        | `0`                           | `1`                                     | `2`                          |
+| -------------- | ----------------------------- | --------------------------------------- | ---------------------------- |
+| `policy check` | No findings at the threshold. | One or more findings met the threshold. | Argument or runtime failure. |
 
 ## Related
 

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -229,8 +229,10 @@ Policy currently verifies:
 | `policy/policy-hash-mismatch`            | Policy does not match configured `expectedHash`.                    |
 | `policy/attestation-hash-mismatch`       | Current policy evidence no longer matches the accepted attestation. |
 | `policy/channels-denied-provider`        | An enabled channel matches a channel deny rule.                     |
+| `policy/tools-missing-owner`             | A governed tool declaration is missing owner metadata.              |
 | `policy/tools-missing-risk-level`        | A governed tool declaration is missing risk metadata.               |
 | `policy/tools-missing-sensitivity-token` | A governed tool declaration is missing sensitivity metadata.        |
+| `policy/tools-unknown-risk-level`        | A governed tool declaration uses an unknown risk value.             |
 | `policy/tools-unknown-sensitivity-token` | A governed tool declaration uses an unknown sensitivity value.      |
 
 Policy findings can include both `target` and `requirement`. `target` is the

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -305,10 +305,10 @@ Policy currently verifies:
 
 Policy findings can include both `target` and `requirement`. `target` is the
 observed thing that does not conform. `requirement` is the authored policy rule
-that made it a finding. Config and workspace findings usually use `oc://`
-paths because they can point to resolvable documents. Runtime findings can use
-non-`oc://` evidence refs, such as `runtime:channels/...`, because they point
-to observed runtime state rather than an editable oc-path document.
+that made it a finding. Config and workspace findings can use `oc://` when
+they point to resolvable documents. Runtime findings stay focused on the
+runtime evidence payload; any `target` value is only a compact evidence label,
+not a new path language.
 
 Example JSON finding:
 

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -119,6 +119,7 @@ Policy config lives under `plugins.entries.policy.config`.
           "path": "policy.jsonc",
           "requireRisk": true,
           "requireSensitivity": true,
+          "runtimeToolPolicy": false,
           "workspaceRepairs": false,
           "expectedHash": "sha256:...",
           "expectedAttestationHash": "sha256:...",
@@ -134,6 +135,7 @@ Policy config lives under `plugins.entries.policy.config`.
 | `enabled`                 | Enable policy checks even before `policy.jsonc` exists.             |
 | `requireRisk`             | Require governed tool declarations to include risk metadata.        |
 | `requireSensitivity`      | Require governed tool declarations to include sensitivity metadata. |
+| `runtimeToolPolicy`       | Apply enabled tool requirements through the trusted tool hook.      |
 | `workspaceRepairs`        | Allow `doctor --fix` to edit policy-managed workspace settings.     |
 | `expectedHash`            | Optional hash-lock for the approved policy artifact.                |
 | `expectedAttestationHash` | Optional hash-lock for the last accepted clean policy check.        |
@@ -177,7 +179,7 @@ Example JSON output:
     "tools": [
       {
         "id": "deploy",
-        "ocPath": "oc://TOOLS.md/tools/deploy",
+        "source": "oc://TOOLS.md/tools/deploy",
         "line": 12,
         "risk": "critical",
         "sensitivity": "restricted",
@@ -214,6 +216,11 @@ Use this lifecycle when accepting policy state:
 4. Record `attestation.attestationHash` as `expectedAttestationHash`.
 5. Re-run `openclaw doctor --lint` in CI or release gates.
 
+The tool runtime gate also includes structured approval metadata on approval
+requests: policy path/hash, configured expected hash when present, the policy
+evidence hash, and the target tool reference. That keeps audit values separate
+from the human-readable approval message.
+
 If policy rules change intentionally, update both accepted hashes from a clean
 check. If workspace settings change intentionally but policy stays the same,
 only `expectedAttestationHash` usually changes.
@@ -234,6 +241,12 @@ Policy currently verifies:
 | `policy/tools-unknown-sensitivity-token` | A governed tool declaration uses an unknown sensitivity value.      |
 
 Example JSON finding:
+
+Policy findings can include both `target` and `requirement`. `target` is the
+observed workspace thing that does not conform. `requirement` is the authored
+policy rule that made it a finding. Both values are addresses today, usually
+`oc://` paths, but the field names describe their policy role rather than the
+address format.
 
 ```json
 {
@@ -292,7 +305,54 @@ configured channel:
 }
 ```
 
+## Runtime Tool Policy
+
+OpenClaw config can also opt into a small runtime tool gate:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "policy": {
+        "enabled": true,
+        "config": {
+          "enabled": true,
+          "runtimeToolPolicy": true,
+        },
+      },
+    },
+  },
+}
+```
+
+When `runtimeToolPolicy` is enabled, the bundled Policy plugin registers an
+OpenClaw trusted tool policy. It uses the same `policy.jsonc` requirements and
+`TOOLS.md` evidence as `policy check`.
+
+The runtime gate is enabled from OpenClaw config, not from `policy.jsonc`, so a
+missing policy artifact still fails closed instead of disabling the gate.
+
+The runtime gate:
+
+- blocks tool calls if the enabled policy artifact is missing or does not match
+  `expectedHash`;
+- blocks governed tool calls whose required metadata is missing or invalid;
+- asks for approval for governed tools marked `risk:critical` or
+  `IRREVERSIBLE_EXTERNAL`;
+- otherwise lets the normal tool call path continue.
+
+This is not a separate plugin loader path for doctor. The plugin registers
+the trusted tool policy when the Policy plugin is enabled, and the existing
+tool runtime invokes the registered policy before regular `before_tool_call`
+hooks.
+
 ## Exit codes
 
-`policy check` exits `0` when there are no findings at the threshold, `1` when
-findings are present, and `2` for argument or runtime failures.
+| Command               | `0`                                                                           | `1`                                                        | `2`                          |
+| --------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------- |
+| `policy check`        | No findings at the threshold.                                                 | One or more findings met the threshold.                    | Argument or runtime failure. |
+
+## Related
+
+- [Doctor lint mode](/cli/doctor#lint-mode)
+- [Path CLI](/cli/path)

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -161,6 +161,12 @@ Policy config lives under `plugins.entries.policy.config`.
 Set `plugins.entries.policy.config.enabled` to `false` to disable policy checks
 for a workspace while leaving the plugin installed.
 
+`expectedHash` and `expectedAttestationHash` are enforcement inputs only when
+OpenClaw config is controlled by a trusted operator, gateway, or supervisor. If
+the governed workspace can edit its own OpenClaw config, those values are
+advisory audit locks: they can still detect drift, but they do not by
+themselves create a boundary against that workspace.
+
 Tool metadata requirements are authored in `policy.jsonc` with
 `tools.requireMetadata`, for example `["risk", "sensitivity", "owner"]`.
 
@@ -251,15 +257,18 @@ these form the audit tuple for this policy check.
 
 If a later gateway or supervisor uses policy to block, approve, or annotate a
 runtime action, it should record the attestation hash from the last clean policy
-check. `checkedAt` stays in JSON output for audit logs, but is not part of the
-stable attestation hash.
+check in a config source the governed workspace cannot silently rewrite.
+`checkedAt` stays in JSON output for audit logs, but is not part of the stable
+attestation hash.
 
 Use this lifecycle when accepting policy state:
 
 1. Author or review `policy.jsonc`.
 2. Run `openclaw policy check --json`.
-3. If the result is clean, record `attestation.policy.hash` as `expectedHash`.
-4. Record `attestation.attestationHash` as `expectedAttestationHash`.
+3. If the result is clean, record `attestation.policy.hash` as `expectedHash`
+   in trusted OpenClaw config.
+4. Record `attestation.attestationHash` as `expectedAttestationHash` in trusted
+   OpenClaw config.
 5. Re-run `openclaw doctor --lint` in CI or release gates.
 
 `policy diff` compares two saved `policy check --json` outputs to explain what
@@ -272,9 +281,11 @@ approval requests: policy path/hash, configured expected hash when present, the
 accepted attestation hash when present, the current policy evidence hash, and
 the target tool reference. Gateway approval request, list, and resolve events
 preserve that metadata so supervisors can audit the decision against the policy
-and workspace state that produced it. If the current attestation no longer
-matches `expectedAttestationHash`, the runtime gate fails closed before asking
-for approval and reports both the current and expected attestation hashes.
+and workspace state that produced it. If trusted config supplies
+`expectedAttestationHash` and the current attestation no longer matches it, the
+runtime gate fails closed before asking for approval and reports both the
+current and expected attestation hashes. If the governed workspace owns the
+config value, treat this as drift detection rather than a security boundary.
 
 If policy rules change intentionally, update both accepted hashes from a clean
 check. If workspace settings change intentionally but policy stays the same,
@@ -445,8 +456,8 @@ The runtime gate:
 
 - blocks tool calls if the enabled policy artifact is missing or does not match
   `expectedHash`;
-- blocks tool calls if `expectedAttestationHash` is configured and the current
-  policy evidence no longer matches the accepted clean policy check;
+- blocks tool calls if trusted config supplies `expectedAttestationHash` and the
+  current policy evidence no longer matches the accepted clean policy check;
 - blocks governed tool calls whose required metadata is missing or invalid;
 - asks for approval for governed tools marked `risk:critical` or
   `IRREVERSIBLE_EXTERNAL`;

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -262,11 +262,12 @@ Use this lifecycle when accepting policy state:
 
 The tool runtime gate also includes structured approval metadata on gateway
 approval requests: policy path/hash, configured expected hash when present, the
-policy evidence hash, and the target tool reference. Gateway approval request,
-list, and resolve events preserve that metadata so supervisors can audit the
-decision against the policy and workspace state that produced it. The UI and
-text approval surfaces summarize those values, but the audit trail remains
-structured.
+accepted attestation hash when present, the current policy evidence hash, and
+the target tool reference. Gateway approval request, list, and resolve events
+preserve that metadata so supervisors can audit the decision against the policy
+and workspace state that produced it. If the current attestation no longer
+matches `expectedAttestationHash`, the runtime gate fails closed before asking
+for approval and reports both the current and expected attestation hashes.
 
 If policy rules change intentionally, update both accepted hashes from a clean
 check. If workspace settings change intentionally but policy stays the same,
@@ -435,6 +436,8 @@ The runtime gate:
 
 - blocks tool calls if the enabled policy artifact is missing or does not match
   `expectedHash`;
+- blocks tool calls if `expectedAttestationHash` is configured and the current
+  policy evidence no longer matches the accepted clean policy check;
 - blocks governed tool calls whose required metadata is missing or invalid;
 - asks for approval for governed tools marked `risk:critical` or
   `IRREVERSIBLE_EXTERNAL`;

--- a/docs/plugins/reference/policy.md
+++ b/docs/plugins/reference/policy.md
@@ -36,8 +36,10 @@ stable attestation hash.
 When `runtimeToolPolicy` is enabled, the Policy plugin registers a trusted tool
 policy that blocks unverifiable governed tool calls and requests approval for
 critical or irreversible governed tools. If `expectedAttestationHash` is
-configured, the same gate fails closed when current policy evidence no longer
-matches the accepted clean policy check.
+configured by a trusted operator, gateway, or supervisor, the same gate fails
+closed when current policy evidence no longer matches the accepted clean policy
+check. If the governed workspace can edit its own OpenClaw config, the hash is
+an advisory audit lock rather than a boundary against that workspace.
 
 Policy findings do not have to be backed by oc-path. Config and workspace
 findings use `oc://` targets only when the system can point to a resolvable

--- a/docs/plugins/reference/policy.md
+++ b/docs/plugins/reference/policy.md
@@ -39,6 +39,12 @@ critical or irreversible governed tools. If `expectedAttestationHash` is
 configured, the same gate fails closed when current policy evidence no longer
 matches the accepted clean policy check.
 
+Policy findings do not have to be backed by oc-path. Config and workspace
+findings use `oc://` targets only when the system can point to a resolvable
+document address. Runtime audit findings stay centered on the runtime evidence
+payload; any `target` value is a compact evidence label, not a separate path
+syntax.
+
 ## Related docs
 
 - [Policy CLI](/cli/policy)

--- a/docs/plugins/reference/policy.md
+++ b/docs/plugins/reference/policy.md
@@ -23,7 +23,8 @@ plugin; CLI command: [`openclaw policy`](/cli/policy)
 The Policy plugin contributes doctor health checks for policy-managed OpenClaw
 settings and governed workspace declarations. Policy currently covers channel
 conformance, governed tool metadata, MCP server posture, model-provider posture,
-private-network access posture, and accepted-attestation runtime audit.
+private-network access posture, runtime channel audit, and accepted-attestation
+runtime audit.
 
 Policy stores authored requirements in `policy.jsonc`, observes existing
 OpenClaw settings and workspace declarations as evidence, and reports drift

--- a/docs/plugins/reference/policy.md
+++ b/docs/plugins/reference/policy.md
@@ -1,5 +1,5 @@
 ---
-summary: "Adds policy-backed doctor checks for workspace conformance."
+summary: "Policy-backed doctor checks for workspace conformance."
 read_when:
   - You are installing, configuring, or auditing the policy plugin
 title: "Policy plugin"
@@ -7,7 +7,7 @@ title: "Policy plugin"
 
 # Policy plugin
 
-Adds policy-backed doctor checks for workspace conformance.
+Policy-backed doctor checks for workspace conformance.
 
 ## Distribution
 
@@ -16,8 +16,26 @@ Adds policy-backed doctor checks for workspace conformance.
 
 ## Surface
 
-plugin
+plugin; CLI command: [`openclaw policy`](/cli/policy)
+
+## Behavior
+
+The Policy plugin contributes doctor health checks for policy-managed OpenClaw
+settings and governed workspace declarations. Policy currently covers channel
+conformance, governed tool metadata, MCP server posture, model-provider posture,
+and private-network access posture.
+
+Policy stores authored requirements in `policy.jsonc`, observes existing
+OpenClaw settings and workspace declarations as evidence, and reports drift
+through `openclaw policy check` and `openclaw doctor --lint`. A clean policy
+check emits policy, evidence, findings, and attestation hashes that operators
+can record for audit.
+
+When `runtimeToolPolicy` is enabled, the Policy plugin registers a trusted tool
+policy that blocks unverifiable governed tool calls and requests approval for
+critical or irreversible governed tools.
 
 ## Related docs
 
-- [policy](/cli/policy)
+- [Policy CLI](/cli/policy)
+- [Doctor lint mode](/cli/doctor#lint-mode)

--- a/docs/plugins/reference/policy.md
+++ b/docs/plugins/reference/policy.md
@@ -23,17 +23,20 @@ plugin; CLI command: [`openclaw policy`](/cli/policy)
 The Policy plugin contributes doctor health checks for policy-managed OpenClaw
 settings and governed workspace declarations. Policy currently covers channel
 conformance, governed tool metadata, MCP server posture, model-provider posture,
-and private-network access posture.
+private-network access posture, and accepted-attestation runtime audit.
 
 Policy stores authored requirements in `policy.jsonc`, observes existing
 OpenClaw settings and workspace declarations as evidence, and reports drift
 through `openclaw policy check` and `openclaw doctor --lint`. A clean policy
 check emits policy, evidence, findings, and attestation hashes that operators
-can record for audit.
+can record for audit. `checkedAt` is audit metadata and is excluded from the
+stable attestation hash.
 
 When `runtimeToolPolicy` is enabled, the Policy plugin registers a trusted tool
 policy that blocks unverifiable governed tool calls and requests approval for
-critical or irreversible governed tools.
+critical or irreversible governed tools. If `expectedAttestationHash` is
+configured, the same gate fails closed when current policy evidence no longer
+matches the accepted clean policy check.
 
 ## Related docs
 

--- a/extensions/oc-path/api.ts
+++ b/extensions/oc-path/api.ts
@@ -1,0 +1,2 @@
+export { parseMd } from "./src/oc-path/parse.js";
+export type { AstBlock, AstItem, Diagnostic, MdAst, ParseResult } from "./src/oc-path/ast.js";

--- a/extensions/oc-path/package.json
+++ b/extensions/oc-path/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./index.ts",
-    "./api.js": "./src/oc-path/index.ts"
+    "./api.js": "./api.ts"
   },
   "dependencies": {
     "commander": "14.0.3",

--- a/extensions/oc-path/package.json
+++ b/extensions/oc-path/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "description": "OpenClaw oc:// workspace path plugin",
   "type": "module",
+  "exports": {
+    ".": "./index.ts",
+    "./api.js": "./src/oc-path/index.ts"
+  },
   "dependencies": {
     "commander": "14.0.3",
     "jsonc-parser": "3.3.1",

--- a/extensions/policy/index.ts
+++ b/extensions/policy/index.ts
@@ -1,6 +1,7 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { registerPolicyCli } from "./src/cli.js";
 import { registerPolicyDoctorChecks } from "./src/doctor/register.js";
+import { registerPolicyTrustedToolPolicy } from "./src/runtime-tool-policy.js";
 
 export default definePluginEntry({
   id: "policy",
@@ -22,5 +23,6 @@ export default definePluginEntry({
       },
     );
     registerPolicyDoctorChecks();
+    registerPolicyTrustedToolPolicy(api);
   },
 });

--- a/extensions/policy/openclaw.plugin.json
+++ b/extensions/policy/openclaw.plugin.json
@@ -20,14 +20,6 @@
         "type": "boolean",
         "description": "Enable policy doctor checks even before policy.jsonc exists."
       },
-      "requireRisk": {
-        "type": "boolean",
-        "description": "Require governed tool declarations in TOOLS.md to include risk metadata."
-      },
-      "requireSensitivity": {
-        "type": "boolean",
-        "description": "Require governed tool declarations in TOOLS.md to include sensitivity metadata."
-      },
       "runtimeToolPolicy": {
         "type": "boolean",
         "description": "Apply enabled policy tool requirements at runtime through the trusted tool policy hook."

--- a/extensions/policy/openclaw.plugin.json
+++ b/extensions/policy/openclaw.plugin.json
@@ -30,11 +30,11 @@
       },
       "expectedHash": {
         "type": "string",
-        "description": "Optional sha256 hash for hash-locking the approved policy artifact."
+        "description": "Optional sha256 hash for hash-locking the approved policy artifact from trusted config."
       },
       "expectedAttestationHash": {
         "type": "string",
-        "description": "Optional sha256 hash for the last accepted clean policy check."
+        "description": "Optional sha256 hash for the last accepted clean policy check from trusted config."
       },
       "path": {
         "type": "string",

--- a/extensions/policy/openclaw.plugin.json
+++ b/extensions/policy/openclaw.plugin.json
@@ -28,6 +28,10 @@
         "type": "boolean",
         "description": "Require governed tool declarations in TOOLS.md to include sensitivity metadata."
       },
+      "runtimeToolPolicy": {
+        "type": "boolean",
+        "description": "Apply enabled policy tool requirements at runtime through the trusted tool policy hook."
+      },
       "workspaceRepairs": {
         "type": "boolean",
         "description": "Allow doctor --fix to repair policy-managed workspace settings."

--- a/extensions/policy/openclaw.plugin.json
+++ b/extensions/policy/openclaw.plugin.json
@@ -20,6 +20,14 @@
         "type": "boolean",
         "description": "Enable policy doctor checks even before policy.jsonc exists."
       },
+      "requireRisk": {
+        "type": "boolean",
+        "description": "Require governed tool declarations in TOOLS.md to include risk metadata."
+      },
+      "requireSensitivity": {
+        "type": "boolean",
+        "description": "Require governed tool declarations in TOOLS.md to include sensitivity metadata."
+      },
       "workspaceRepairs": {
         "type": "boolean",
         "description": "Allow doctor --fix to repair policy-managed workspace settings."

--- a/extensions/policy/package.json
+++ b/extensions/policy/package.json
@@ -5,6 +5,7 @@
   "description": "OpenClaw policy doctor checks for workspace conformance",
   "type": "module",
   "dependencies": {
+    "@openclaw/oc-path": "workspace:*",
     "json5": "2.2.3"
   },
   "devDependencies": {

--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -1,7 +1,6 @@
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { clearHealthChecksForTest } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { clearConfigCache } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { policyCheckCommand, policyDiffCommand, policyWatchCommand } from "./cli.js";

--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -102,6 +102,23 @@ describe("policy commands", () => {
     });
   });
 
+  it("reports unparseable policy files in policy check output", async () => {
+    await fs.writeFile(join(workspaceDir, "policy.jsonc"), "{ channels: ", "utf-8");
+    const { exitCode, parsed } = await runPolicyCheckJson();
+
+    expect(exitCode).toBe(1);
+    expect(parsed).toMatchObject({
+      ok: false,
+      findings: [
+        {
+          checkId: "policy/policy-jsonc-invalid",
+          severity: "error",
+          target: "oc://policy.jsonc",
+        },
+      ],
+    });
+  });
+
   it("links policy findings to evidence and policy requirement refs", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);

--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -56,6 +56,7 @@ describe("policy commands", () => {
     const policyHash = policyDocumentHash(policy);
     const evidence = {
       channels: [],
+      channelRuntime: [],
       mcpServers: [],
       modelProviders: [],
       modelRefs: [],

--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -1,9 +1,10 @@
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { clearHealthChecksForTest } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { clearConfigCache } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { policyCheckCommand } from "./cli.js";
+import { policyCheckCommand, policyDiffCommand, policyWatchCommand } from "./cli.js";
 import { resetPolicyDoctorChecksForTest } from "./doctor/register.js";
 import {
   policyAttestationHash,
@@ -284,5 +285,114 @@ describe("policy commands", () => {
     expect(parsed.findings).toEqual([
       expect.objectContaining({ checkId: "policy/config-invalid", severity: "error" }),
     ]);
+  });
+
+  it("compares policy check outputs without treating checkedAt as drift", async () => {
+    const beforePath = join(workspaceDir, "before.json");
+    const afterPath = join(workspaceDir, "after.json");
+    const base = {
+      ok: true,
+      attestation: {
+        checkedAt: "2026-05-10T20:00:00.000Z",
+        policy: { path: "policy.jsonc", hash: "sha256:policy" },
+        workspace: { scope: "policy", hash: "sha256:evidence" },
+        findingsHash: "sha256:findings",
+        attestationHash: "sha256:attestation",
+      },
+      findings: [],
+    };
+    await fs.writeFile(beforePath, JSON.stringify(base), "utf-8");
+    await fs.writeFile(
+      afterPath,
+      JSON.stringify({
+        ...base,
+        attestation: {
+          ...base.attestation,
+          checkedAt: "2026-05-10T20:01:00.000Z",
+        },
+      }),
+      "utf-8",
+    );
+    const output: string[] = [];
+
+    const exitCode = await policyDiffCommand(
+      beforePath,
+      afterPath,
+      { json: true },
+      {
+        writeStdout(value) {
+          output.push(value);
+        },
+        error(value) {
+          output.push(value);
+        },
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(output.at(-1) ?? "{}")).toMatchObject({
+      changed: [],
+      before: {
+        checkedAt: "2026-05-10T20:00:00.000Z",
+      },
+      after: {
+        checkedAt: "2026-05-10T20:01:00.000Z",
+      },
+    });
+  });
+
+  it("reports policy evidence drift between policy check outputs", async () => {
+    const beforePath = join(workspaceDir, "before.json");
+    const afterPath = join(workspaceDir, "after.json");
+    await fs.writeFile(
+      beforePath,
+      JSON.stringify({
+        ok: true,
+        attestation: {
+          workspace: { scope: "policy", hash: "sha256:evidence-before" },
+          findingsHash: "sha256:findings",
+          attestationHash: "sha256:attestation-before",
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      afterPath,
+      JSON.stringify({
+        ok: true,
+        attestation: {
+          workspace: { scope: "policy", hash: "sha256:evidence-after" },
+          findingsHash: "sha256:findings",
+          attestationHash: "sha256:attestation-after",
+        },
+      }),
+      "utf-8",
+    );
+    const output: string[] = [];
+
+    const exitCode = await policyDiffCommand(
+      beforePath,
+      afterPath,
+      { json: true },
+      {
+        writeStdout(value) {
+          output.push(value);
+        },
+        error(value) {
+          output.push(value);
+        },
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(output.at(-1) ?? "{}")).toMatchObject({
+      changed: ["evidence", "attestation"],
+      before: {
+        evidenceHash: "sha256:evidence-before",
+      },
+      after: {
+        evidenceHash: "sha256:evidence-after",
+      },
+    });
   });
 });

--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -53,7 +53,7 @@ describe("policy commands", () => {
 
     expect(exitCode).toBe(0);
     const policyHash = policyDocumentHash(policy);
-    const evidence = { channels: [] };
+    const evidence = { channels: [], tools: [] };
     const workspaceHash = policyWorkspaceHash(evidence);
     const findingsHash = policyFindingsHash([]);
     expect(typeof parsed.attestation.checkedAt).toBe("string");

--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -53,7 +53,7 @@ describe("policy commands", () => {
 
     expect(exitCode).toBe(0);
     const policyHash = policyDocumentHash(policy);
-    const evidence = { channels: [], tools: [] };
+    const evidence = { channels: [] };
     const workspaceHash = policyWorkspaceHash(evidence);
     const findingsHash = policyFindingsHash([]);
     expect(typeof parsed.attestation.checkedAt).toBe("string");

--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -53,7 +53,13 @@ describe("policy commands", () => {
 
     expect(exitCode).toBe(0);
     const policyHash = policyDocumentHash(policy);
-    const evidence = { channels: [] };
+    const evidence = {
+      channels: [],
+      mcpServers: [],
+      modelProviders: [],
+      modelRefs: [],
+      network: [],
+    };
     const workspaceHash = policyWorkspaceHash(evidence);
     const findingsHash = policyFindingsHash([]);
     expect(typeof parsed.attestation.checkedAt).toBe("string");
@@ -78,6 +84,44 @@ describe("policy commands", () => {
         }),
       },
       evidence,
+      findings: [],
+    });
+  });
+
+  it("reports policy findings in policy check output", async () => {
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        channels: {
+          denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
+        },
+      }),
+      "utf-8",
+    );
+    const output: string[] = [];
+
+    const exitCode = await policyCheckCommand(
+      { cwd: workspaceDir, json: true },
+      {
+        writeStdout(value) {
+          output.push(value);
+        },
+        error(value) {
+          output.push(value);
+        },
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(output.at(-1) ?? "{}")).toMatchObject({
+      ok: true,
+      evidence: {
+        channels: [],
+        mcpServers: [],
+        modelProviders: [],
+        modelRefs: [],
+        network: [],
+      },
       findings: [],
     });
   });

--- a/extensions/policy/src/cli.ts
+++ b/extensions/policy/src/cli.ts
@@ -1,3 +1,5 @@
+import { promises as fs } from "node:fs";
+import { setTimeout as sleep } from "node:timers/promises";
 import type { Command } from "commander";
 import {
   exitCodeFromFindings,
@@ -15,12 +17,22 @@ import { createPolicyAttestation } from "./policy-state.js";
 export type PolicyCommandRuntime = {
   writeStdout(value: string): void;
   error(value: string): void;
+  sleep?(ms: number): Promise<void>;
 };
 
 export interface PolicyCheckOptions {
   readonly json?: boolean;
   readonly severityMin?: string;
   readonly cwd?: string;
+}
+
+export interface PolicyWatchOptions extends PolicyCheckOptions {
+  readonly intervalMs?: string | number;
+  readonly once?: boolean;
+}
+
+export interface PolicyDiffOptions {
+  readonly json?: boolean;
 }
 
 type PolicyCheckReport = {
@@ -41,6 +53,9 @@ const defaultRuntime: PolicyCommandRuntime = {
   error(value) {
     process.stderr.write(`${value}\n`);
   },
+  sleep(ms) {
+    return sleep(ms);
+  },
 };
 
 export function registerPolicyCli(program: Command): void {
@@ -53,6 +68,27 @@ export function registerPolicyCli(program: Command): void {
     .option("--severity-min <severity>", "Minimum severity: info, warning, or error")
     .action(async (options: PolicyCheckOptions) => {
       process.exitCode = await policyCheckCommand(options);
+    });
+
+  policy
+    .command("watch")
+    .description("Watch policy evidence and report accepted-attestation drift")
+    .option("--json", "Emit JSON output")
+    .option("--severity-min <severity>", "Minimum severity: info, warning, or error")
+    .option("--interval-ms <ms>", "Polling interval in milliseconds")
+    .option("--once", "Run one watch evaluation and exit")
+    .action(async (options: PolicyWatchOptions) => {
+      process.exitCode = await policyWatchCommand(options);
+    });
+
+  policy
+    .command("diff")
+    .description("Compare two policy check JSON outputs")
+    .argument("<before>", "Earlier policy check JSON output")
+    .argument("<after>", "Later policy check JSON output")
+    .option("--json", "Emit JSON output")
+    .action(async (before: string, after: string, options: PolicyDiffOptions) => {
+      process.exitCode = await policyDiffCommand(before, after, options);
     });
 }
 
@@ -68,6 +104,44 @@ export async function policyCheckCommand(
     runtime.error(err instanceof Error ? err.message : String(err));
     return 2;
   }
+}
+
+export async function policyWatchCommand(
+  options: PolicyWatchOptions,
+  runtime: PolicyCommandRuntime = defaultRuntime,
+): Promise<number> {
+  const intervalMs = normalizeWatchIntervalMs(options.intervalMs);
+  let previousKey: string | undefined;
+  for (;;) {
+    const report = await buildPolicyCheckReport(options, runtime);
+    const status = policyWatchStatus(report);
+    const key = `${status}:${report.attestation?.attestationHash ?? ""}:${report.exitCode}`;
+    if (previousKey === undefined || previousKey !== key || options.once === true) {
+      writePolicyWatchReport(report, status, options, runtime);
+      previousKey = key;
+    }
+    if (options.once === true) {
+      return status === "stale" ? 1 : report.exitCode;
+    }
+    if (runtime.sleep !== undefined) {
+      await runtime.sleep(intervalMs);
+    } else {
+      await sleep(intervalMs);
+    }
+  }
+}
+
+export async function policyDiffCommand(
+  beforePath: string,
+  afterPath: string,
+  options: PolicyDiffOptions,
+  runtime: PolicyCommandRuntime = defaultRuntime,
+): Promise<number> {
+  const before = await readPolicyCheckOutput(beforePath);
+  const after = await readPolicyCheckOutput(afterPath);
+  const diff = buildPolicyDiff(before, after);
+  writePolicyDiffReport(diff, options, runtime);
+  return diff.changed.length === 0 ? 0 : 1;
 }
 
 async function buildPolicyCheckReport(
@@ -100,7 +174,7 @@ async function buildPolicyCheckReport(
       exitCode: visibleFindings.length === 0 ? 0 : 1,
     };
   }
-  const cfg = snapshot.valid ? policyCommandConfig(snapshot.config) : {};
+  const cfg = policyCommandConfig(snapshot.config);
   const cwd = options.cwd ?? resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
   const ctx: HealthCheckContext = {
     mode: "lint",
@@ -169,6 +243,72 @@ function policyCommandConfig(cfg: HealthCheckContext["cfg"]): HealthCheckContext
   };
 }
 
+type PolicyDiffReport = {
+  readonly changed: readonly string[];
+  readonly before: PolicyDiffSnapshot;
+  readonly after: PolicyDiffSnapshot;
+};
+
+type PolicyDiffSnapshot = {
+  readonly ok?: boolean;
+  readonly policyHash?: string;
+  readonly evidenceHash?: string;
+  readonly findingsHash?: string;
+  readonly attestationHash?: string;
+  readonly checkedAt?: string;
+};
+
+function buildPolicyDiff(before: unknown, after: unknown): PolicyDiffReport {
+  const beforeSnapshot = policyDiffSnapshot(before);
+  const afterSnapshot = policyDiffSnapshot(after);
+  const changed = [
+    ...changedField(beforeSnapshot, afterSnapshot, "ok", "result"),
+    ...changedField(beforeSnapshot, afterSnapshot, "policyHash", "policy"),
+    ...changedField(beforeSnapshot, afterSnapshot, "evidenceHash", "evidence"),
+    ...changedField(beforeSnapshot, afterSnapshot, "findingsHash", "findings"),
+    ...changedField(beforeSnapshot, afterSnapshot, "attestationHash", "attestation"),
+  ];
+  return {
+    changed,
+    before: beforeSnapshot,
+    after: afterSnapshot,
+  };
+}
+
+function changedField(
+  before: PolicyDiffSnapshot,
+  after: PolicyDiffSnapshot,
+  key: keyof PolicyDiffSnapshot,
+  label: string,
+): readonly string[] {
+  return before[key] === after[key] ? [] : [label];
+}
+
+function policyDiffSnapshot(value: unknown): PolicyDiffSnapshot {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const attestation = isRecord(value.attestation) ? value.attestation : {};
+  const policy = isRecord(attestation.policy) ? attestation.policy : {};
+  const workspace = isRecord(attestation.workspace) ? attestation.workspace : {};
+  return {
+    ...(typeof value.ok === "boolean" ? { ok: value.ok } : {}),
+    ...(typeof policy.hash === "string" ? { policyHash: policy.hash } : {}),
+    ...(typeof workspace.hash === "string" ? { evidenceHash: workspace.hash } : {}),
+    ...(typeof attestation.findingsHash === "string"
+      ? { findingsHash: attestation.findingsHash }
+      : {}),
+    ...(typeof attestation.attestationHash === "string"
+      ? { attestationHash: attestation.attestationHash }
+      : {}),
+    ...(typeof attestation.checkedAt === "string" ? { checkedAt: attestation.checkedAt } : {}),
+  };
+}
+
+async function readPolicyCheckOutput(path: string): Promise<unknown> {
+  return JSON.parse(await fs.readFile(path, "utf-8"));
+}
+
 function writePolicyCheckReport(
   report: PolicyCheckReport,
   options: PolicyCheckOptions,
@@ -204,6 +344,78 @@ function writePolicyCheckReport(
   }
 }
 
+function writePolicyDiffReport(
+  report: PolicyDiffReport,
+  options: PolicyDiffOptions,
+  runtime: PolicyCommandRuntime,
+): void {
+  if (options.json === true || !process.stdout.isTTY) {
+    runtime.writeStdout(JSON.stringify(report) + "\n");
+    return;
+  }
+  if (report.changed.length === 0) {
+    runtime.writeStdout(
+      `policy diff: no drift (attestation ${report.after.attestationHash ?? "missing"})\n`,
+    );
+    return;
+  }
+  runtime.writeStdout(`policy diff: changed ${report.changed.join(", ")}\n`);
+  runtime.writeStdout(
+    `  before: attestation ${report.before.attestationHash ?? "missing"}, evidence ${report.before.evidenceHash ?? "missing"}\n`,
+  );
+  runtime.writeStdout(
+    `  after:  attestation ${report.after.attestationHash ?? "missing"}, evidence ${report.after.evidenceHash ?? "missing"}\n`,
+  );
+}
+
+function writePolicyWatchReport(
+  report: PolicyCheckReport,
+  status: "clean" | "findings" | "stale",
+  options: PolicyWatchOptions,
+  runtime: PolicyCommandRuntime,
+): void {
+  if (options.json === true || !process.stdout.isTTY) {
+    runtime.writeStdout(
+      JSON.stringify({
+        status,
+        ok: report.ok,
+        expectedAttestationHash: report.expectedAttestationHash,
+        attestation: report.attestation,
+        findings: report.findings,
+      }) + "\n",
+    );
+    return;
+  }
+  if (status === "stale") {
+    runtime.writeStdout(
+      `policy watch: accepted attestation is stale (current ${report.attestation?.attestationHash ?? "missing"}, expected ${report.expectedAttestationHash}). Review policy check output, then update the supervisor/gateway accepted attestation.\n`,
+    );
+    return;
+  }
+  if (status === "findings") {
+    runtime.writeStdout(
+      `policy watch: ${report.findings.length} finding(s); accepted attestation cannot be updated until policy check is clean.\n`,
+    );
+    return;
+  }
+  runtime.writeStdout(
+    `policy watch: clean (attestation ${report.attestation?.attestationHash ?? "missing"}, evidence ${report.attestation?.workspace.hash ?? "unavailable"})\n`,
+  );
+}
+
+function policyWatchStatus(report: PolicyCheckReport): "clean" | "findings" | "stale" {
+  const expected = report.expectedAttestationHash?.trim();
+  if (expected && report.attestation !== undefined && report.attestation.attestationHash !== expected) {
+    return "stale";
+  }
+  return report.ok ? "clean" : "findings";
+}
+
+function normalizeWatchIntervalMs(value: string | number | undefined): number {
+  const raw = typeof value === "number" ? value : Number.parseInt(value ?? "", 10);
+  return Number.isFinite(raw) && raw >= 250 ? raw : 2000;
+}
+
 function toJsonFinding(finding: HealthFinding): Record<string, unknown> {
   return {
     checkId: finding.checkId,
@@ -217,4 +429,8 @@ function toJsonFinding(finding: HealthFinding): Record<string, unknown> {
     ...(finding.requirement !== undefined ? { requirement: finding.requirement } : {}),
     ...(finding.fixHint !== undefined ? { fixHint: finding.fixHint } : {}),
   };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -390,7 +390,7 @@ describe("registerPolicyDoctorChecks", () => {
     const cfg = {
       ...cfgWithPolicy(),
       channels: { telegram: { enabled: true } },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
@@ -432,7 +432,7 @@ describe("registerPolicyDoctorChecks", () => {
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       channels: { telegram: { enabled: true } },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
@@ -460,7 +460,7 @@ describe("registerPolicyDoctorChecks", () => {
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: false }),
       channels: { telegram: { enabled: true } },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
@@ -490,7 +490,7 @@ describe("registerPolicyDoctorChecks", () => {
     const cfg = {
       ...cfgWithPolicy(),
       channels: { telegram: { enabled: true } },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
@@ -521,7 +521,7 @@ describe("registerPolicyDoctorChecks", () => {
     const cfg = {
       ...cfgWithPolicy(),
       channels: { telegram: { enabled: false } },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
@@ -909,7 +909,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
@@ -945,7 +945,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         ],
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
@@ -1000,7 +1000,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
@@ -1076,7 +1076,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
@@ -1193,7 +1193,7 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
@@ -1232,7 +1232,7 @@ describe("registerPolicyDoctorChecks", () => {
           allowPrivateNetwork: true,
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -117,6 +117,7 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/policy-hash-mismatch",
       "policy/attestation-hash-mismatch",
       "policy/channels-denied-provider",
+      "policy/channels-denied-provider-running",
       "policy/mcp-denied-server",
       "policy/mcp-unapproved-server",
       "policy/models-denied-provider",
@@ -546,6 +547,64 @@ describe("registerPolicyDoctorChecks", () => {
     await expect(runPolicyChecks(ctx(configPath, cfg))).resolves.toMatchObject({
       findings: [],
     });
+  });
+
+  it("reports denied channels that are still running in gateway runtime evidence", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      channels: { telegram: { enabled: false } },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify(
+        {
+          channels: {
+            denyRules: [
+              {
+                id: "no-telegram",
+                when: { provider: "telegram" },
+                reason: "Telegram is not approved for this workspace.",
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks({
+      ...ctx(configPath, cfg),
+      runtimeEvidence: {
+        channels: {
+          channelAccounts: {
+            telegram: {
+              default: {
+                accountId: "default",
+                enabled: true,
+                configured: true,
+                running: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/channels-denied-provider-running",
+        severity: "error",
+        path: "gateway runtime",
+        target: "runtime:channels/telegram/accounts/default",
+        requirement: "oc://policy.jsonc/channels/denyRules/#0",
+        fixHint: "Telegram is not approved for this workspace.",
+      }),
+    ]);
   });
 
   it("does not run policy checks for empty category namespaces", async () => {

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -352,6 +352,29 @@ describe("registerPolicyDoctorChecks", () => {
     expect(result.findings).toEqual([]);
   });
 
+  it("does not include unrelated TOOLS.md evidence in channel-only attestations", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const policy = { channels: { denyRules: [] } };
+    const policyHash = policyDocumentHash(policy);
+    const acceptedAttestationHash = createPolicyAttestation({
+      ok: true,
+      checkedAt: "2026-05-10T20:00:00.000Z",
+      policyPath: "policy.jsonc",
+      policyHash,
+      evidence: collectPolicyEvidence({}),
+      findings: [],
+    }).attestationHash;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
+
+    const result = await runPolicyChecks(
+      ctx(configPath, cfgWithPolicy({ expectedAttestationHash: acceptedAttestationHash })),
+    );
+
+    expect(result.findings).toEqual([]);
+  });
+
   it("reports configured channels denied by policy", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
@@ -553,6 +576,31 @@ describe("registerPolicyDoctorChecks", () => {
         severity: "error",
         path: "policy.jsonc",
         target: "oc://policy.jsonc/tools/requireMetadata/#1",
+      }),
+    ]);
+  });
+
+  it("reports invalid requireMetadata entries against a configured policy path", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "workspace.policy.jsonc"),
+      JSON.stringify({ tools: { requireMetadata: ["unsupported"] } }),
+      "utf-8",
+    );
+
+    const result = await runDoctorLintChecks(
+      ctx(configPath, cfgWithPolicy({ path: "workspace.policy.jsonc" })),
+      {
+        checks: registerChecks(),
+      },
+    );
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/policy-jsonc-invalid",
+        path: "workspace.policy.jsonc",
+        target: "oc://workspace.policy.jsonc/tools/requireMetadata/#0",
       }),
     ]);
   });

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -9,7 +9,11 @@ import {
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/health";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createPolicyAttestation, policyDocumentHash } from "../policy-state.js";
+import {
+  collectPolicyEvidence,
+  createPolicyAttestation,
+  policyDocumentHash,
+} from "../policy-state.js";
 import { registerPolicyDoctorChecks, resetPolicyDoctorChecksForTest } from "./register.js";
 
 let workspaceDir: string;
@@ -107,6 +111,7 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/attestation-hash-mismatch",
       "policy/channels-denied-provider",
       "policy/tools-missing-risk-level",
+      "policy/tools-unknown-risk-level",
       "policy/tools-missing-sensitivity-token",
       "policy/tools-unknown-sensitivity-token",
     ]);
@@ -331,7 +336,7 @@ describe("registerPolicyDoctorChecks", () => {
       checkedAt: "2026-05-10T20:00:00.000Z",
       policyPath: "policy.jsonc",
       policyHash,
-      evidence: { channels: [] },
+      evidence: collectPolicyEvidence({}),
       findings: [],
     }).attestationHash;
     await fs.writeFile(configPath, "{}", "utf-8");
@@ -547,6 +552,33 @@ describe("registerPolicyDoctorChecks", () => {
       }),
       expect.objectContaining({
         checkId: "policy/tools-missing-sensitivity-token",
+        severity: "error",
+        path: "TOOLS.md",
+        ocPath: "oc://TOOLS.md/tools/deploy",
+      }),
+    ]);
+  });
+
+  it("reports unknown governed tool risk metadata", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ tools: { settings: { requireRisk: true } } }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      "## Tools\n\n### deploy risk:critcal\n",
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/tools-unknown-risk-level",
         severity: "error",
         path: "TOOLS.md",
         ocPath: "oc://TOOLS.md/tools/deploy",

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -121,7 +121,7 @@ describe("registerPolicyDoctorChecks", () => {
     expect(duplicateChecks).toEqual([]);
   });
 
-  it("reports a missing policy file when the policy extension is enabled", async () => {
+  it("reports a missing policy file when the Policy plugin is enabled", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     await fs.writeFile(configPath, "{}", "utf-8");
 

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -596,6 +596,66 @@ describe("registerPolicyDoctorChecks", () => {
     );
   });
 
+  it("accepts governed tool metadata declared on following lines", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ tools: { requireMetadata: ["risk", "sensitivity", "owner"] } }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      [
+        "## Tools",
+        "",
+        "### deploy",
+        "risk: critical",
+        "sensitivity: restricted",
+        "owner: ops",
+        "IRREVERSIBLE_EXTERNAL",
+        "",
+        "### inspect",
+        "risk: low",
+        "sensitivity: public",
+        "owner: support",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()), {
+      checks: registerChecks(),
+    });
+    const evidence = collectPolicyEvidence(
+      {},
+      {
+        toolsRaw: await fs.readFile(join(workspaceDir, "TOOLS.md"), "utf-8"),
+      },
+    );
+
+    expect(result.findings).toEqual([]);
+    expect(evidence.tools).toEqual([
+      {
+        id: "deploy",
+        source: "oc://TOOLS.md/tools/deploy",
+        line: 3,
+        risk: "critical",
+        sensitivity: "restricted",
+        owner: "ops",
+        capabilities: ["IRREVERSIBLE_EXTERNAL"],
+      },
+      {
+        id: "inspect",
+        source: "oc://TOOLS.md/tools/inspect",
+        line: 9,
+        risk: "low",
+        sensitivity: "public",
+        owner: "support",
+      },
+    ]);
+  });
+
   it("reports unknown governed tool risk metadata", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     await fs.writeFile(configPath, "{}", "utf-8");

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -106,6 +106,9 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/policy-hash-mismatch",
       "policy/attestation-hash-mismatch",
       "policy/channels-denied-provider",
+      "policy/tools-missing-risk-level",
+      "policy/tools-missing-sensitivity-token",
+      "policy/tools-unknown-sensitivity-token",
     ]);
     expect(duplicateChecks).toEqual([]);
   });
@@ -520,5 +523,61 @@ describe("registerPolicyDoctorChecks", () => {
     const result = await runPolicyChecks(ctx(configPath, cfg));
 
     expect(result.findings).toEqual([]);
+  });
+
+  it("reports governed tools missing risk and sensitivity metadata", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ tools: { settings: { requireRisk: true, requireSensitivity: true } } }),
+      "utf-8",
+    );
+    await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/tools-missing-risk-level",
+        severity: "error",
+        path: "TOOLS.md",
+        ocPath: "oc://TOOLS.md/tools/deploy",
+      }),
+      expect.objectContaining({
+        checkId: "policy/tools-missing-sensitivity-token",
+        severity: "error",
+        path: "TOOLS.md",
+        ocPath: "oc://TOOLS.md/tools/deploy",
+      }),
+    ]);
+  });
+
+  it("reports unknown governed tool sensitivity metadata", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ tools: { settings: { requireSensitivity: true } } }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      "## Tools\n\n### deploy risk:critical sensitivity:secret\n",
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/tools-unknown-sensitivity-token",
+        severity: "error",
+        path: "TOOLS.md",
+        ocPath: "oc://TOOLS.md/tools/deploy",
+      }),
+    ]);
   });
 });

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -14,6 +14,7 @@ import {
   collectPolicyEvidence,
   createPolicyAttestation,
   policyDocumentHash,
+  scanPolicyMcpServers,
 } from "../policy-state.js";
 import { registerPolicyDoctorChecks, resetPolicyDoctorChecksForTest } from "./register.js";
 
@@ -74,6 +75,10 @@ async function runPolicyChecks(checkCtx: HealthCheckContext): Promise<{
   return { findings };
 }
 
+async function runPolicyDoctorLint(checkCtx: HealthCheckContext) {
+  return runDoctorLintChecks(checkCtx, { checks: registerChecks() });
+}
+
 async function runDeniedChannelRepair(repairCheckCtx: HealthRepairContext) {
   const check = registerChecks().find((entry) => entry.id === "policy/channels-denied-provider");
   if (check?.detect === undefined || check.repair === undefined) {
@@ -112,6 +117,11 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/policy-hash-mismatch",
       "policy/attestation-hash-mismatch",
       "policy/channels-denied-provider",
+      "policy/mcp-denied-server",
+      "policy/mcp-unapproved-server",
+      "policy/models-denied-provider",
+      "policy/models-unapproved-provider",
+      "policy/network-private-access-enabled",
       "policy/tools-missing-risk-level",
       "policy/tools-unknown-risk-level",
       "policy/tools-missing-sensitivity-token",
@@ -538,18 +548,22 @@ describe("registerPolicyDoctorChecks", () => {
     });
   });
 
-  it("does not run channel checks for an empty category namespace", async () => {
+  it("does not run policy checks for empty category namespaces", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       channels: { telegram: { enabled: true } },
-    } as OpenClawConfig;
+      mcp: { servers: { untrusted: { command: "uvx", args: ["untrusted-mcp"] } } },
+      models: { providers: { openrouter: {} } },
+      browser: { ssrfPolicy: { dangerouslyAllowPrivateNetwork: true } },
+    } as unknown as OpenClawConfig;
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ channels: {} }),
+      JSON.stringify({ channels: {}, mcp: {}, models: {}, network: {}, tools: {} }),
       "utf-8",
     );
+    await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
 
@@ -730,6 +744,535 @@ describe("registerPolicyDoctorChecks", () => {
         ocPath: "oc://TOOLS.md/tools/deploy",
       }),
     ]);
+  });
+
+  it("reports model providers denied by policy", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.ai/api/v1",
+            models: [],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: "openrouter/openai/gpt-5.5",
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        models: {
+          providers: { deny: ["openrouter"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/models-denied-provider",
+        severity: "error",
+        ocPath: "oc://openclaw.config/models/providers/openrouter",
+        requirement: "oc://policy.jsonc/models/providers/deny",
+      }),
+      expect.objectContaining({
+        checkId: "policy/models-denied-provider",
+        severity: "error",
+        ocPath: "oc://openclaw.config/agents/defaults/model",
+        requirement: "oc://policy.jsonc/models/providers/deny",
+      }),
+    ]);
+  });
+
+  it("reports model refs outside the policy allowlist", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["anthropic/claude-sonnet-4.7"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        models: {
+          providers: { allow: ["openai"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/models-unapproved-provider",
+        severity: "error",
+        ocPath: "oc://openclaw.config/agents/defaults/model/fallbacks/#0",
+        requirement: "oc://policy.jsonc/models/providers/allow",
+      }),
+    ]);
+  });
+
+  it("reports model allowlist keys outside the policy allowlist", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      agents: {
+        defaults: {
+          models: {
+            "openrouter/*": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        models: {
+          providers: { allow: ["openai"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/models-unapproved-provider",
+        severity: "error",
+        ocPath: "oc://openclaw.config/agents/defaults/models/openrouter~1*",
+        requirement: "oc://policy.jsonc/models/providers/allow",
+      }),
+    ]);
+  });
+
+  it("reports configured model providers outside the policy allowlist", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      models: {
+        providers: {
+          anthropic: {},
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        models: {
+          providers: { allow: ["openai"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/models-unapproved-provider",
+        severity: "error",
+        ocPath: "oc://openclaw.config/models/providers/anthropic",
+        requirement: "oc://policy.jsonc/models/providers/allow",
+      }),
+    ]);
+  });
+
+  it("reports non-default agent model refs outside the policy allowlist", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      agents: {
+        defaults: {
+          imageModel: "openai/gpt-5.5",
+          subagents: {
+            model: "anthropic/claude-sonnet-4.7",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        models: {
+          providers: { allow: ["openai"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/models-unapproved-provider",
+        severity: "error",
+        ocPath: "oc://openclaw.config/agents/defaults/subagents/model",
+        requirement: "oc://policy.jsonc/models/providers/allow",
+      }),
+    ]);
+  });
+
+  it("reports per-agent model refs outside the policy allowlist", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      agents: {
+        list: [
+          {
+            id: "research",
+            model: { primary: "openrouter/openai/gpt-5.5" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        models: {
+          providers: { deny: ["openrouter"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/models-denied-provider",
+        severity: "error",
+        ocPath: "oc://openclaw.config/agents/list/#0/model/primary",
+        requirement: "oc://policy.jsonc/models/providers/deny",
+      }),
+    ]);
+  });
+
+  it("does not enable tool metadata checks from a model-only policy block", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        models: {
+          providers: { allow: ["openai"] },
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfgWithPolicy({ enabled: undefined })));
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("reports MCP servers denied by policy", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      mcp: {
+        servers: {
+          untrusted: {
+            command: "uvx",
+            args: ["untrusted-mcp"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        mcp: {
+          servers: { deny: ["untrusted"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/mcp-denied-server",
+        severity: "error",
+        ocPath: "oc://openclaw.config/mcp/servers/untrusted",
+        requirement: "oc://policy.jsonc/mcp/servers/deny",
+      }),
+    ]);
+  });
+
+  it("preserves MCP server casing for deny rules", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      mcp: {
+        servers: {
+          DocsServer: {
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-fetch"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        mcp: {
+          servers: { deny: ["DocsServer"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/mcp-denied-server",
+        severity: "error",
+        ocPath: "oc://openclaw.config/mcp/servers/DocsServer",
+        requirement: "oc://policy.jsonc/mcp/servers/deny",
+      }),
+    ]);
+  });
+
+  it("reports MCP servers outside the policy allowlist", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      mcp: {
+        servers: {
+          docs: {
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-fetch"],
+          },
+          remote: {
+            url: "https://example.com/mcp",
+            transport: "streamable-http",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        mcp: {
+          servers: { allow: ["docs"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/mcp-unapproved-server",
+        severity: "error",
+        ocPath: "oc://openclaw.config/mcp/servers/remote",
+        requirement: "oc://policy.jsonc/mcp/servers/allow",
+      }),
+    ]);
+  });
+
+  it("preserves MCP server casing for allowlists", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      mcp: {
+        servers: {
+          DocsServer: {
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-fetch"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        mcp: {
+          servers: { allow: ["DocsServer"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("redacts MCP server URLs in policy evidence", () => {
+    const [server] = scanPolicyMcpServers({
+      mcp: {
+        servers: {
+          remote: {
+            url: "https://user:pass@example.com/mcp?token=secret",
+            transport: "streamable-http",
+          },
+        },
+      },
+    });
+
+    expect(server).toEqual(
+      expect.objectContaining({
+        id: "remote",
+        url: "https://example.com",
+      }),
+    );
+  });
+
+  it("does not enable model checks from an MCP-only policy block", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy({ enabled: undefined }),
+      models: {
+        providers: {
+          openrouter: {},
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        mcp: {
+          servers: { allow: ["docs"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("reports private-network SSRF settings denied by policy", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      browser: {
+        ssrfPolicy: {
+          dangerouslyAllowPrivateNetwork: true,
+        },
+      },
+      tools: {
+        web: {
+          fetch: {
+            ssrfPolicy: {
+              allowIpv6UniqueLocalRange: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        network: {
+          privateNetwork: { allow: false },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/network-private-access-enabled",
+        severity: "error",
+        ocPath: "oc://openclaw.config/browser/ssrfPolicy/dangerouslyAllowPrivateNetwork",
+        requirement: "oc://policy.jsonc/network/privateNetwork/allow",
+      }),
+      expect.objectContaining({
+        checkId: "policy/network-private-access-enabled",
+        severity: "error",
+        ocPath: "oc://openclaw.config/tools/web/fetch/ssrfPolicy/allowIpv6UniqueLocalRange",
+        requirement: "oc://policy.jsonc/network/privateNetwork/allow",
+      }),
+    ]);
+  });
+
+  it("allows private-network SSRF settings when policy permits them", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      browser: {
+        ssrfPolicy: {
+          allowPrivateNetwork: true,
+        },
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        network: {
+          privateNetwork: { allow: true },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("does not enable model checks from a network-only policy block", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy({ enabled: undefined }),
+      models: {
+        providers: {
+          openrouter: {},
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        network: {
+          privateNetwork: { allow: false },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
   });
 
   it("reports unknown governed tool sensitivity metadata", async () => {

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  runDoctorLintChecks,
   type HealthCheck,
   type HealthCheckContext,
   type HealthFinding,
@@ -87,6 +88,7 @@ async function runDeniedChannelRepair(repairCheckCtx: HealthRepairContext) {
 
 describe("registerPolicyDoctorChecks", () => {
   beforeEach(async () => {
+    resetPolicyDoctorChecksForTest();
     workspaceDir = await fs.mkdtemp(join(tmpdir(), "policy-doctor-"));
   });
 
@@ -113,6 +115,7 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/tools-missing-risk-level",
       "policy/tools-unknown-risk-level",
       "policy/tools-missing-sensitivity-token",
+      "policy/tools-missing-owner",
       "policy/tools-unknown-sensitivity-token",
     ]);
     expect(duplicateChecks).toEqual([]);
@@ -530,33 +533,67 @@ describe("registerPolicyDoctorChecks", () => {
     expect(result.findings).toEqual([]);
   });
 
+  it("reports invalid requireMetadata policy entries", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ tools: { requireMetadata: ["risk", "unsupported"] } }),
+      "utf-8",
+    );
+    await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
+
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()), {
+      checks: registerChecks(),
+    });
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/policy-jsonc-invalid",
+        severity: "error",
+        path: "policy.jsonc",
+        target: "oc://policy.jsonc/tools/requireMetadata/#1",
+      }),
+    ]);
+  });
+
   it("reports governed tools missing risk and sensitivity metadata", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { settings: { requireRisk: true, requireSensitivity: true } } }),
+      JSON.stringify({ tools: { requireMetadata: ["risk", "sensitivity", "owner"] } }),
       "utf-8",
     );
     await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()), {
+      checks: registerChecks(),
+    });
 
-    expect(result.findings).toEqual([
-      expect.objectContaining({
-        checkId: "policy/tools-missing-risk-level",
-        severity: "error",
-        path: "TOOLS.md",
-        ocPath: "oc://TOOLS.md/tools/deploy",
-      }),
-      expect.objectContaining({
-        checkId: "policy/tools-missing-sensitivity-token",
-        severity: "error",
-        path: "TOOLS.md",
-        ocPath: "oc://TOOLS.md/tools/deploy",
-      }),
-    ]);
+    expect(result.findings).toHaveLength(3);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/tools-missing-risk-level",
+          severity: "error",
+          path: "TOOLS.md",
+          ocPath: "oc://TOOLS.md/tools/deploy",
+        }),
+        expect.objectContaining({
+          checkId: "policy/tools-missing-sensitivity-token",
+          severity: "error",
+          path: "TOOLS.md",
+          ocPath: "oc://TOOLS.md/tools/deploy",
+        }),
+        expect.objectContaining({
+          checkId: "policy/tools-missing-owner",
+          severity: "error",
+          path: "TOOLS.md",
+          ocPath: "oc://TOOLS.md/tools/deploy",
+        }),
+      ]),
+    );
   });
 
   it("reports unknown governed tool risk metadata", async () => {
@@ -564,7 +601,7 @@ describe("registerPolicyDoctorChecks", () => {
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { settings: { requireRisk: true } } }),
+      JSON.stringify({ tools: { requireMetadata: ["risk"] } }),
       "utf-8",
     );
     await fs.writeFile(
@@ -573,8 +610,9 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()), {
+      checks: registerChecks(),
+    });
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -591,7 +629,7 @@ describe("registerPolicyDoctorChecks", () => {
     await fs.writeFile(configPath, "{}", "utf-8");
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { settings: { requireSensitivity: true } } }),
+      JSON.stringify({ tools: { requireMetadata: ["sensitivity"] } }),
       "utf-8",
     );
     await fs.writeFile(
@@ -600,8 +638,9 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()), {
+      checks: registerChecks(),
+    });
 
     expect(result.findings).toEqual([
       expect.objectContaining({

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -222,11 +222,7 @@ const policyToolsMissingOwnerCheck: HealthCheck = {
 async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEvaluation> {
   const settings = policySettings(ctx);
   const policyPath = policyDisplayName(ctx);
-  const toolsFile = await readWorkspaceFile(ctx, "TOOLS.md");
-  const evidence = collectPolicyEvidence(
-    ctx.cfg as Record<string, unknown>,
-    toolsFile === null ? {} : { toolsRaw: toolsFile.raw },
-  );
+  let evidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>);
   const findings: HealthFinding[] = [];
 
   if (!policyChecksEnabled(ctx, settings)) {
@@ -298,13 +294,23 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     };
   }
 
-  const metadataRequirementFindings = toolMetadataRequirementFindings(policy, policyFile.ocDocName);
+  const metadataRequirementFindings = toolMetadataRequirementFindings(
+    policy,
+    policyFile.displayName,
+    policyFile.ocDocName,
+  );
+  const requiredMetadata =
+    metadataRequirementFindings.length === 0 ? requiredToolMetadata(policy) : new Set<string>();
+  if (requiredMetadata.size > 0) {
+    const toolsFile = await readWorkspaceFile(ctx, "TOOLS.md");
+    evidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
+      toolsRaw: toolsFile?.raw ?? "",
+    });
+  }
   const policyFindings: HealthFinding[] = [
     ...channelFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...metadataRequirementFindings,
   ];
-  const requiredMetadata =
-    metadataRequirementFindings.length === 0 ? requiredToolMetadata(policy) : new Set<string>();
   if (requiredMetadata.has("risk")) {
     policyFindings.push(...toolRiskFindings(policyFile.ocDocName, evidence));
     policyFindings.push(...toolUnknownRiskFindings(policyFile.ocDocName, evidence));
@@ -461,6 +467,7 @@ function toAttestedFinding(finding: HealthFinding): Record<string, unknown> {
 
 function toolMetadataRequirementFindings(
   policy: unknown,
+  policyPath: string,
   policyDocName: string,
 ): readonly HealthFinding[] {
   if (!isRecord(policy) || !isRecord(policy.tools) || policy.tools.requireMetadata === undefined) {
@@ -471,9 +478,9 @@ function toolMetadataRequirementFindings(
       {
         checkId: CHECK_IDS.policyInvalidFile,
         severity: "error",
-        message: "policy.jsonc tools.requireMetadata must be an array of metadata keys.",
+        message: `${policyPath} tools.requireMetadata must be an array of metadata keys.`,
         source: "policy",
-        path: "policy.jsonc",
+        path: policyPath,
         target: `oc://${policyDocName}/tools/requireMetadata`,
         fixHint: `Use supported metadata keys: ${SUPPORTED_TOOL_METADATA.join(", ")}.`,
       },
@@ -494,9 +501,9 @@ function toolMetadataRequirementFindings(
     {
       checkId: CHECK_IDS.policyInvalidFile,
       severity: "error",
-      message: `policy.jsonc tools.requireMetadata[${invalidIndex}] must be a supported metadata key.`,
+      message: `${policyPath} tools.requireMetadata[${invalidIndex}] must be a supported metadata key.`,
       source: "policy",
-      path: "policy.jsonc",
+      path: policyPath,
       target: `oc://${policyDocName}/tools/requireMetadata/#${invalidIndex}`,
       fixHint: `Use supported metadata keys: ${SUPPORTED_TOOL_METADATA.join(", ")}.`,
     },

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -97,7 +97,7 @@ export function evaluatePolicy(ctx: HealthCheckContext): Promise<PolicyEvaluatio
 const policyMissingFileCheck: HealthCheck = {
   id: CHECK_IDS.policyMissingFile,
   kind: "plugin",
-  description: "The enabled policy extension has a policy file to verify.",
+  description: "The enabled Policy plugin has a policy file to verify.",
   source: "policy",
   async detect(ctx) {
     return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyMissingFile);
@@ -244,7 +244,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     findings.push({
       checkId: CHECK_IDS.policyMissingFile,
       severity: "warning",
-      message: `${policyPath} is missing for the enabled policy extension.`,
+      message: `${policyPath} is missing for the enabled Policy plugin.`,
       source: "policy",
       path: policyPath,
       fixHint: `Restore ${policyPath} or add the policy artifact for this workspace.`,
@@ -300,12 +300,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
 
   const metadataRequirementFindings = toolMetadataRequirementFindings(policy, policyFile.ocDocName);
   const policyFindings: HealthFinding[] = [
-    ...channelFindings(
-      policy,
-      policyFile.displayName,
-      policyFile.ocDocName,
-      evidence,
-    ),
+    ...channelFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...metadataRequirementFindings,
   ];
   const requiredMetadata =

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -19,6 +19,9 @@ const CHECK_IDS = {
   policyHashMismatch: "policy/policy-hash-mismatch",
   policyInvalidFile: "policy/policy-jsonc-invalid",
   policyMissingFile: "policy/policy-jsonc-missing",
+  policyMissingToolRisk: "policy/tools-missing-risk-level",
+  policyMissingToolSensitivity: "policy/tools-missing-sensitivity-token",
+  policyUnknownToolSensitivity: "policy/tools-unknown-sensitivity-token",
 } as const;
 
 export const POLICY_CHECK_IDS = [
@@ -27,7 +30,12 @@ export const POLICY_CHECK_IDS = [
   CHECK_IDS.policyHashMismatch,
   CHECK_IDS.policyAttestationMismatch,
   CHECK_IDS.policyDeniedChannelProvider,
+  CHECK_IDS.policyMissingToolRisk,
+  CHECK_IDS.policyMissingToolSensitivity,
+  CHECK_IDS.policyUnknownToolSensitivity,
 ] as const;
+
+const KNOWN_SENSITIVITY_LEVELS = ["public", "internal", "confidential", "restricted"] as const;
 
 let registered = false;
 const policyEvaluationCache = new WeakMap<HealthCheckContext, Promise<PolicyEvaluation>>();
@@ -58,6 +66,9 @@ export function registerPolicyDoctorChecks(host?: PolicyDoctorRegistrationHost):
   registerHealthCheck(policyHashMismatchCheck);
   registerHealthCheck(policyAttestationMismatchCheck);
   registerHealthCheck(policyChannelsDeniedProviderCheck);
+  registerHealthCheck(policyToolsMissingRiskCheck);
+  registerHealthCheck(policyToolsMissingSensitivityCheck);
+  registerHealthCheck(policyToolsUnknownSensitivityCheck);
   registered = true;
 }
 
@@ -150,10 +161,44 @@ const policyChannelsDeniedProviderCheck: HealthCheck = {
   },
 };
 
+const policyToolsMissingRiskCheck: HealthCheck = {
+  id: CHECK_IDS.policyMissingToolRisk,
+  kind: "plugin",
+  description: "TOOLS.md policy entries declare explicit risk levels.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyMissingToolRisk);
+  },
+};
+
+const policyToolsMissingSensitivityCheck: HealthCheck = {
+  id: CHECK_IDS.policyMissingToolSensitivity,
+  kind: "plugin",
+  description: "TOOLS.md policy entries declare default artifact sensitivity.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyMissingToolSensitivity);
+  },
+};
+
+const policyToolsUnknownSensitivityCheck: HealthCheck = {
+  id: CHECK_IDS.policyUnknownToolSensitivity,
+  kind: "plugin",
+  description: "TOOLS.md policy entries use known sensitivity levels.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyUnknownToolSensitivity);
+  },
+};
+
 async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEvaluation> {
   const settings = policySettings(ctx);
   const policyPath = policyDisplayName(ctx);
-  const evidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>);
+  const toolsFile = await readWorkspaceFile(ctx, "TOOLS.md");
+  const evidence = collectPolicyEvidence(
+    ctx.cfg as Record<string, unknown>,
+    toolsFile === null ? {} : { toolsRaw: toolsFile.raw },
+  );
   const findings: HealthFinding[] = [];
 
   if (!policyChecksEnabled(ctx, settings)) {
@@ -225,12 +270,20 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     };
   }
 
-  const policyFindings = channelFindings(
+  const policyFindings: HealthFinding[] = [
+    ...channelFindings(
     policy,
     policyFile.displayName,
     policyFile.ocDocName,
     evidence,
-  );
+    ),
+  ];
+  if (policyRequirementEnabled(settings, policy, "requireRisk")) {
+    policyFindings.push(...toolRiskFindings(policyFile.ocDocName, evidence));
+  }
+  if (policyRequirementEnabled(settings, policy, "requireSensitivity")) {
+    policyFindings.push(...toolSensitivityFindings(policyFile.ocDocName, evidence));
+  }
   const attestationFindings = policyAttestationFindings(
     policyFile.displayName,
     policyHash,
@@ -413,6 +466,74 @@ function invalidChannelDenyRuleFindings(
   ];
 }
 
+function toolRiskFindings(
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  return evidence.tools
+    .filter((tool) => tool.risk === undefined)
+    .map((tool): HealthFinding => {
+      return {
+        checkId: CHECK_IDS.policyMissingToolRisk,
+        severity: "error",
+        message: `TOOLS.md tool '${tool.id}' has no explicit risk classification.`,
+        source: "policy",
+        path: "TOOLS.md",
+        line: tool.line,
+        ocPath: tool.ocPath,
+        target: tool.ocPath,
+        requirement: `oc://${policyDocName}/tools/settings/requireRisk`,
+        fixHint:
+          "Declare risk:low, risk:medium, risk:high, risk:critical, or an R0-R5 review alias.",
+      };
+    });
+}
+
+function toolSensitivityFindings(
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  return evidence.tools.flatMap((tool): HealthFinding[] => {
+    if (tool.sensitivity === undefined) {
+      return [
+        {
+          checkId: CHECK_IDS.policyMissingToolSensitivity,
+          severity: "error",
+          message: `TOOLS.md tool '${tool.id}' has no declared artifact sensitivity.`,
+          source: "policy",
+          path: "TOOLS.md",
+          line: tool.line,
+          ocPath: tool.ocPath,
+          target: tool.ocPath,
+          requirement: `oc://${policyDocName}/tools/settings/requireSensitivity`,
+          fixHint: `Declare sensitivity as one of: ${KNOWN_SENSITIVITY_LEVELS.join(", ")}.`,
+        },
+      ];
+    }
+    if (
+      KNOWN_SENSITIVITY_LEVELS.includes(
+        tool.sensitivity as (typeof KNOWN_SENSITIVITY_LEVELS)[number],
+      )
+    ) {
+      return [];
+    }
+    return [
+      {
+        checkId: CHECK_IDS.policyUnknownToolSensitivity,
+        severity: "error",
+        message: `TOOLS.md tool '${tool.id}' declares unknown sensitivity '${tool.sensitivity}'.`,
+        source: "policy",
+        path: "TOOLS.md",
+        line: tool.line,
+        ocPath: tool.ocPath,
+        target: tool.ocPath,
+        requirement: `oc://${policyDocName}/tools/settings/requireSensitivity`,
+        fixHint: `Use one of: ${KNOWN_SENSITIVITY_LEVELS.join(", ")}.`,
+      },
+    ];
+  });
+}
+
 async function readPolicyFile(
   ctx: HealthCheckContext,
 ): Promise<{ raw: string; path: string; displayName: string; ocDocName: string } | null> {
@@ -426,6 +547,22 @@ async function readPolicyFile(
       displayName,
       ocDocName: basename(displayName),
     };
+  } catch (err) {
+    if (isNotFound(err)) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function readWorkspaceFile(
+  ctx: HealthCheckContext,
+  fileName: string,
+): Promise<{ raw: string; path: string } | null> {
+  const path = resolveWorkspacePath(ctx, fileName);
+  try {
+    const fs = await import("node:fs/promises");
+    return { raw: await fs.readFile(path, "utf-8"), path };
   } catch (err) {
     if (isNotFound(err)) {
       return null;
@@ -581,6 +718,8 @@ function disableChannels(
 
 type PolicySettings = {
   readonly enabled?: boolean;
+  readonly requireRisk?: boolean;
+  readonly requireSensitivity?: boolean;
   readonly workspaceRepairs?: boolean;
   readonly expectedHash?: string;
   readonly expectedAttestationHash?: string;
@@ -603,6 +742,34 @@ function policyChecksEnabled(ctx: HealthCheckContext, settings: PolicySettings):
   return settings.enabled !== false;
 }
 
+function policyRequirementEnabled(
+  settings: ReturnType<typeof policySettings>,
+  policy: unknown,
+  setting: "requireRisk" | "requireSensitivity",
+): boolean {
+  const configured = settings[setting];
+  if (typeof configured === "boolean") {
+    return configured;
+  }
+  return (
+    readPolicyBoolean(policy, ["tools", "settings", setting]) ??
+    readPolicyBoolean(policy, ["settings", setting]) ??
+    readPolicyBoolean(policy, ["policy", setting]) ??
+    readPolicyBoolean(policy, [setting]) ??
+    false
+  );
+}
+
+function readPolicyBoolean(policy: unknown, path: readonly string[]): boolean | undefined {
+  let current: unknown = policy;
+  for (const part of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[part];
+  }
+  return typeof current === "boolean" ? current : undefined;
+}
 function policyPathSetting(ctx: HealthCheckContext): string {
   const configured = policySettings(ctx).path;
   return typeof configured === "string" && configured.trim() !== ""

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -545,7 +545,7 @@ function toolRiskFindings(
   policyDocName: string,
   evidence: PolicyEvidence,
 ): readonly HealthFinding[] {
-  return evidence.tools
+  return (evidence.tools ?? [])
     .filter((tool) => tool.risk === undefined)
     .map((tool): HealthFinding => {
       return {
@@ -568,7 +568,7 @@ function toolUnknownRiskFindings(
   policyDocName: string,
   evidence: PolicyEvidence,
 ): readonly HealthFinding[] {
-  return evidence.tools
+  return (evidence.tools ?? [])
     .filter(
       (tool) =>
         tool.risk !== undefined &&
@@ -594,7 +594,7 @@ function toolSensitivityFindings(
   policyDocName: string,
   evidence: PolicyEvidence,
 ): readonly HealthFinding[] {
-  return evidence.tools.flatMap((tool): HealthFinding[] => {
+  return (evidence.tools ?? []).flatMap((tool): HealthFinding[] => {
     if (tool.sensitivity === undefined) {
       return [
         {
@@ -639,7 +639,7 @@ function toolOwnerFindings(
   policyDocName: string,
   evidence: PolicyEvidence,
 ): readonly HealthFinding[] {
-  return evidence.tools
+  return (evidence.tools ?? [])
     .filter((tool) => tool.owner === undefined)
     .map((tool): HealthFinding => {
       return {

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -21,6 +21,7 @@ const CHECK_IDS = {
   policyMissingFile: "policy/policy-jsonc-missing",
   policyMissingToolRisk: "policy/tools-missing-risk-level",
   policyMissingToolSensitivity: "policy/tools-missing-sensitivity-token",
+  policyUnknownToolRisk: "policy/tools-unknown-risk-level",
   policyUnknownToolSensitivity: "policy/tools-unknown-sensitivity-token",
 } as const;
 
@@ -31,10 +32,12 @@ export const POLICY_CHECK_IDS = [
   CHECK_IDS.policyAttestationMismatch,
   CHECK_IDS.policyDeniedChannelProvider,
   CHECK_IDS.policyMissingToolRisk,
+  CHECK_IDS.policyUnknownToolRisk,
   CHECK_IDS.policyMissingToolSensitivity,
   CHECK_IDS.policyUnknownToolSensitivity,
 ] as const;
 
+const KNOWN_RISK_LEVELS = ["low", "medium", "high", "critical"] as const;
 const KNOWN_SENSITIVITY_LEVELS = ["public", "internal", "confidential", "restricted"] as const;
 
 let registered = false;
@@ -67,6 +70,7 @@ export function registerPolicyDoctorChecks(host?: PolicyDoctorRegistrationHost):
   registerHealthCheck(policyAttestationMismatchCheck);
   registerHealthCheck(policyChannelsDeniedProviderCheck);
   registerHealthCheck(policyToolsMissingRiskCheck);
+  registerHealthCheck(policyToolsUnknownRiskCheck);
   registerHealthCheck(policyToolsMissingSensitivityCheck);
   registerHealthCheck(policyToolsUnknownSensitivityCheck);
   registered = true;
@@ -168,6 +172,16 @@ const policyToolsMissingRiskCheck: HealthCheck = {
   source: "policy",
   async detect(ctx) {
     return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyMissingToolRisk);
+  },
+};
+
+const policyToolsUnknownRiskCheck: HealthCheck = {
+  id: CHECK_IDS.policyUnknownToolRisk,
+  kind: "plugin",
+  description: "TOOLS.md policy entries use known risk levels.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyUnknownToolRisk);
   },
 };
 
@@ -280,6 +294,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
   ];
   if (policyRequirementEnabled(settings, policy, "requireRisk")) {
     policyFindings.push(...toolRiskFindings(policyFile.ocDocName, evidence));
+    policyFindings.push(...toolUnknownRiskFindings(policyFile.ocDocName, evidence));
   }
   if (policyRequirementEnabled(settings, policy, "requireSensitivity")) {
     policyFindings.push(...toolSensitivityFindings(policyFile.ocDocName, evidence));
@@ -480,11 +495,37 @@ function toolRiskFindings(
         source: "policy",
         path: "TOOLS.md",
         line: tool.line,
-        ocPath: tool.ocPath,
-        target: tool.ocPath,
+        ocPath: tool.source,
+        target: tool.source,
         requirement: `oc://${policyDocName}/tools/settings/requireRisk`,
         fixHint:
           "Declare risk:low, risk:medium, risk:high, risk:critical, or an R0-R5 review alias.",
+      };
+    });
+}
+
+function toolUnknownRiskFindings(
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  return evidence.tools
+    .filter(
+      (tool) =>
+        tool.risk !== undefined &&
+        !KNOWN_RISK_LEVELS.includes(tool.risk as (typeof KNOWN_RISK_LEVELS)[number]),
+    )
+    .map((tool): HealthFinding => {
+      return {
+        checkId: CHECK_IDS.policyUnknownToolRisk,
+        severity: "error",
+        message: `TOOLS.md tool '${tool.id}' declares unknown risk '${tool.risk}'.`,
+        source: "policy",
+        path: "TOOLS.md",
+        line: tool.line,
+        ocPath: tool.source,
+        target: tool.source,
+        requirement: `oc://${policyDocName}/tools/settings/requireRisk`,
+        fixHint: `Use one of: ${KNOWN_RISK_LEVELS.join(", ")}.`,
       };
     });
 }
@@ -503,8 +544,8 @@ function toolSensitivityFindings(
           source: "policy",
           path: "TOOLS.md",
           line: tool.line,
-          ocPath: tool.ocPath,
-          target: tool.ocPath,
+          ocPath: tool.source,
+          target: tool.source,
           requirement: `oc://${policyDocName}/tools/settings/requireSensitivity`,
           fixHint: `Declare sensitivity as one of: ${KNOWN_SENSITIVITY_LEVELS.join(", ")}.`,
         },
@@ -525,8 +566,8 @@ function toolSensitivityFindings(
         source: "policy",
         path: "TOOLS.md",
         line: tool.line,
-        ocPath: tool.ocPath,
-        target: tool.ocPath,
+        ocPath: tool.source,
+        target: tool.source,
         requirement: `oc://${policyDocName}/tools/settings/requireSensitivity`,
         fixHint: `Use one of: ${KNOWN_SENSITIVITY_LEVELS.join(", ")}.`,
       },

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -16,6 +16,7 @@ import {
 const CHECK_IDS = {
   policyAttestationMismatch: "policy/attestation-hash-mismatch",
   policyDeniedChannelProvider: "policy/channels-denied-provider",
+  policyDeniedChannelRuntime: "policy/channels-denied-provider-running",
   policyHashMismatch: "policy/policy-hash-mismatch",
   policyInvalidFile: "policy/policy-jsonc-invalid",
   policyMissingFile: "policy/policy-jsonc-missing",
@@ -37,6 +38,7 @@ export const POLICY_CHECK_IDS = [
   CHECK_IDS.policyHashMismatch,
   CHECK_IDS.policyAttestationMismatch,
   CHECK_IDS.policyDeniedChannelProvider,
+  CHECK_IDS.policyDeniedChannelRuntime,
   CHECK_IDS.policyDeniedMcpServer,
   CHECK_IDS.policyUnapprovedMcpServer,
   CHECK_IDS.policyDeniedModelProvider,
@@ -82,6 +84,7 @@ export function registerPolicyDoctorChecks(host?: PolicyDoctorRegistrationHost):
   registerHealthCheck(policyHashMismatchCheck);
   registerHealthCheck(policyAttestationMismatchCheck);
   registerHealthCheck(policyChannelsDeniedProviderCheck);
+  registerHealthCheck(policyChannelsDeniedRuntimeCheck);
   registerHealthCheck(policyMcpDeniedServerCheck);
   registerHealthCheck(policyMcpUnapprovedServerCheck);
   registerHealthCheck(policyModelsDeniedProviderCheck);
@@ -181,6 +184,16 @@ const policyChannelsDeniedProviderCheck: HealthCheck = {
       config: next.config,
       changes: next.changed.map((id) => `Disabled channels.${id}.enabled for policy conformance.`),
     };
+  },
+};
+
+const policyChannelsDeniedRuntimeCheck: HealthCheck = {
+  id: CHECK_IDS.policyDeniedChannelRuntime,
+  kind: "plugin",
+  description: "Running channel accounts satisfy policy deny rules.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyDeniedChannelRuntime);
   },
 };
 
@@ -287,7 +300,10 @@ const policyToolsMissingOwnerCheck: HealthCheck = {
 async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEvaluation> {
   const settings = policySettings(ctx);
   const policyPath = policyDisplayName(ctx);
-  let evidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>);
+  let evidence = collectPolicyEvidence(
+    ctx.cfg as Record<string, unknown>,
+    policyRuntimeEvidenceOptions(ctx),
+  );
   const findings: HealthFinding[] = [];
 
   if (!policyChecksEnabled(ctx, settings)) {
@@ -370,10 +386,12 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     const toolsFile = await readWorkspaceFile(ctx, "TOOLS.md");
     evidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
       toolsRaw: toolsFile?.raw ?? "",
+      ...policyRuntimeEvidenceOptions(ctx),
     });
   }
   const policyFindings: HealthFinding[] = [
     ...channelFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
+    ...channelRuntimeFindings(policy, policyFile.ocDocName, evidence),
     ...mcpServerFindings(policy, policyFile.ocDocName, evidence),
     ...modelProviderFindings(policy, policyFile.ocDocName, evidence),
     ...networkFindings(policy, policyFile.ocDocName, evidence),
@@ -412,6 +430,17 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     findings,
     attestedFindings: policyFindings,
   };
+}
+
+function policyRuntimeEvidenceOptions(ctx: HealthCheckContext): {
+  readonly channelRuntime?: unknown;
+} {
+  const runtimeEvidence = ctx.runtimeEvidence;
+  if (!isRecord(runtimeEvidence)) {
+    return {};
+  }
+  const channelRuntime = runtimeEvidence.channels ?? runtimeEvidence.channelRuntime;
+  return channelRuntime === undefined ? {} : { channelRuntime };
 }
 
 function policyParseFinding(
@@ -476,6 +505,40 @@ function channelFindings(
         fixHint:
           rule.reason ??
           "Disable this channel, remove it from config, or update the policy deny rule.",
+      },
+    ];
+  });
+}
+
+function channelRuntimeFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const denyRules = readChannelDenyRules(policy, policyDocName);
+  if (denyRules.length === 0 || evidence.channelRuntime.length === 0) {
+    return [];
+  }
+  return evidence.channelRuntime.flatMap((channel): HealthFinding[] => {
+    if (!channel.running) {
+      return [];
+    }
+    const rule = denyRules.find((candidate) => candidate.when?.provider === channel.id);
+    if (rule === undefined) {
+      return [];
+    }
+    return [
+      {
+        checkId: CHECK_IDS.policyDeniedChannelRuntime,
+        severity: "error",
+        message: `Channel '${channel.id}' account '${channel.accountId}' is denied by policy but is still running.`,
+        source: "policy",
+        path: "gateway runtime",
+        target: channel.source,
+        requirement: rule.requirement,
+        fixHint:
+          rule.reason ??
+          "Stop this running channel account, restart or refresh the gateway, and rerun policy check.",
       },
     ];
   });

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -19,6 +19,7 @@ const CHECK_IDS = {
   policyHashMismatch: "policy/policy-hash-mismatch",
   policyInvalidFile: "policy/policy-jsonc-invalid",
   policyMissingFile: "policy/policy-jsonc-missing",
+  policyMissingToolOwner: "policy/tools-missing-owner",
   policyMissingToolRisk: "policy/tools-missing-risk-level",
   policyMissingToolSensitivity: "policy/tools-missing-sensitivity-token",
   policyUnknownToolRisk: "policy/tools-unknown-risk-level",
@@ -34,11 +35,13 @@ export const POLICY_CHECK_IDS = [
   CHECK_IDS.policyMissingToolRisk,
   CHECK_IDS.policyUnknownToolRisk,
   CHECK_IDS.policyMissingToolSensitivity,
+  CHECK_IDS.policyMissingToolOwner,
   CHECK_IDS.policyUnknownToolSensitivity,
 ] as const;
 
 const KNOWN_RISK_LEVELS = ["low", "medium", "high", "critical"] as const;
 const KNOWN_SENSITIVITY_LEVELS = ["public", "internal", "confidential", "restricted"] as const;
+const SUPPORTED_TOOL_METADATA = ["risk", "sensitivity", "owner"] as const;
 
 let registered = false;
 const policyEvaluationCache = new WeakMap<HealthCheckContext, Promise<PolicyEvaluation>>();
@@ -72,6 +75,7 @@ export function registerPolicyDoctorChecks(host?: PolicyDoctorRegistrationHost):
   registerHealthCheck(policyToolsMissingRiskCheck);
   registerHealthCheck(policyToolsUnknownRiskCheck);
   registerHealthCheck(policyToolsMissingSensitivityCheck);
+  registerHealthCheck(policyToolsMissingOwnerCheck);
   registerHealthCheck(policyToolsUnknownSensitivityCheck);
   registered = true;
 }
@@ -205,6 +209,16 @@ const policyToolsUnknownSensitivityCheck: HealthCheck = {
   },
 };
 
+const policyToolsMissingOwnerCheck: HealthCheck = {
+  id: CHECK_IDS.policyMissingToolOwner,
+  kind: "plugin",
+  description: "TOOLS.md policy entries declare an accountable owner.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyMissingToolOwner);
+  },
+};
+
 async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEvaluation> {
   const settings = policySettings(ctx);
   const policyPath = policyDisplayName(ctx);
@@ -284,20 +298,27 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     };
   }
 
+  const metadataRequirementFindings = toolMetadataRequirementFindings(policy, policyFile.ocDocName);
   const policyFindings: HealthFinding[] = [
     ...channelFindings(
-    policy,
-    policyFile.displayName,
-    policyFile.ocDocName,
-    evidence,
+      policy,
+      policyFile.displayName,
+      policyFile.ocDocName,
+      evidence,
     ),
+    ...metadataRequirementFindings,
   ];
-  if (policyRequirementEnabled(settings, policy, "requireRisk")) {
+  const requiredMetadata =
+    metadataRequirementFindings.length === 0 ? requiredToolMetadata(policy) : new Set<string>();
+  if (requiredMetadata.has("risk")) {
     policyFindings.push(...toolRiskFindings(policyFile.ocDocName, evidence));
     policyFindings.push(...toolUnknownRiskFindings(policyFile.ocDocName, evidence));
   }
-  if (policyRequirementEnabled(settings, policy, "requireSensitivity")) {
+  if (requiredMetadata.has("sensitivity")) {
     policyFindings.push(...toolSensitivityFindings(policyFile.ocDocName, evidence));
+  }
+  if (requiredMetadata.has("owner")) {
+    policyFindings.push(...toolOwnerFindings(policyFile.ocDocName, evidence));
   }
   const attestationFindings = policyAttestationFindings(
     policyFile.displayName,
@@ -443,6 +464,50 @@ function toAttestedFinding(finding: HealthFinding): Record<string, unknown> {
   };
 }
 
+function toolMetadataRequirementFindings(
+  policy: unknown,
+  policyDocName: string,
+): readonly HealthFinding[] {
+  if (!isRecord(policy) || !isRecord(policy.tools) || policy.tools.requireMetadata === undefined) {
+    return [];
+  }
+  if (!Array.isArray(policy.tools.requireMetadata)) {
+    return [
+      {
+        checkId: CHECK_IDS.policyInvalidFile,
+        severity: "error",
+        message: "policy.jsonc tools.requireMetadata must be an array of metadata keys.",
+        source: "policy",
+        path: "policy.jsonc",
+        target: `oc://${policyDocName}/tools/requireMetadata`,
+        fixHint: `Use supported metadata keys: ${SUPPORTED_TOOL_METADATA.join(", ")}.`,
+      },
+    ];
+  }
+  const invalidIndex = policy.tools.requireMetadata.findIndex(
+    (entry) =>
+      typeof entry !== "string" ||
+      (entry.trim() !== "" &&
+        !SUPPORTED_TOOL_METADATA.includes(
+          entry.trim().toLowerCase() as (typeof SUPPORTED_TOOL_METADATA)[number],
+        )),
+  );
+  if (invalidIndex < 0) {
+    return [];
+  }
+  return [
+    {
+      checkId: CHECK_IDS.policyInvalidFile,
+      severity: "error",
+      message: `policy.jsonc tools.requireMetadata[${invalidIndex}] must be a supported metadata key.`,
+      source: "policy",
+      path: "policy.jsonc",
+      target: `oc://${policyDocName}/tools/requireMetadata/#${invalidIndex}`,
+      fixHint: `Use supported metadata keys: ${SUPPORTED_TOOL_METADATA.join(", ")}.`,
+    },
+  ];
+}
+
 function invalidChannelDenyRuleFindings(
   policy: unknown,
   policyPath: string,
@@ -497,7 +562,7 @@ function toolRiskFindings(
         line: tool.line,
         ocPath: tool.source,
         target: tool.source,
-        requirement: `oc://${policyDocName}/tools/settings/requireRisk`,
+        requirement: `oc://${policyDocName}/tools/requireMetadata`,
         fixHint:
           "Declare risk:low, risk:medium, risk:high, risk:critical, or an R0-R5 review alias.",
       };
@@ -524,7 +589,7 @@ function toolUnknownRiskFindings(
         line: tool.line,
         ocPath: tool.source,
         target: tool.source,
-        requirement: `oc://${policyDocName}/tools/settings/requireRisk`,
+        requirement: `oc://${policyDocName}/tools/requireMetadata`,
         fixHint: `Use one of: ${KNOWN_RISK_LEVELS.join(", ")}.`,
       };
     });
@@ -546,7 +611,7 @@ function toolSensitivityFindings(
           line: tool.line,
           ocPath: tool.source,
           target: tool.source,
-          requirement: `oc://${policyDocName}/tools/settings/requireSensitivity`,
+          requirement: `oc://${policyDocName}/tools/requireMetadata`,
           fixHint: `Declare sensitivity as one of: ${KNOWN_SENSITIVITY_LEVELS.join(", ")}.`,
         },
       ];
@@ -568,11 +633,33 @@ function toolSensitivityFindings(
         line: tool.line,
         ocPath: tool.source,
         target: tool.source,
-        requirement: `oc://${policyDocName}/tools/settings/requireSensitivity`,
+        requirement: `oc://${policyDocName}/tools/requireMetadata`,
         fixHint: `Use one of: ${KNOWN_SENSITIVITY_LEVELS.join(", ")}.`,
       },
     ];
   });
+}
+
+function toolOwnerFindings(
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  return evidence.tools
+    .filter((tool) => tool.owner === undefined)
+    .map((tool): HealthFinding => {
+      return {
+        checkId: CHECK_IDS.policyMissingToolOwner,
+        severity: "error",
+        message: `TOOLS.md tool '${tool.id}' has no declared owner.`,
+        source: "policy",
+        path: "TOOLS.md",
+        line: tool.line,
+        ocPath: tool.source,
+        target: tool.source,
+        requirement: `oc://${policyDocName}/tools/requireMetadata`,
+        fixHint: "Declare owner:<team-or-person> for this tool.",
+      };
+    });
 }
 
 async function readPolicyFile(
@@ -759,8 +846,6 @@ function disableChannels(
 
 type PolicySettings = {
   readonly enabled?: boolean;
-  readonly requireRisk?: boolean;
-  readonly requireSensitivity?: boolean;
   readonly workspaceRepairs?: boolean;
   readonly expectedHash?: string;
   readonly expectedAttestationHash?: string;
@@ -783,25 +868,14 @@ function policyChecksEnabled(ctx: HealthCheckContext, settings: PolicySettings):
   return settings.enabled !== false;
 }
 
-function policyRequirementEnabled(
-  settings: ReturnType<typeof policySettings>,
-  policy: unknown,
-  setting: "requireRisk" | "requireSensitivity",
-): boolean {
-  const configured = settings[setting];
-  if (typeof configured === "boolean") {
-    return configured;
-  }
-  return (
-    readPolicyBoolean(policy, ["tools", "settings", setting]) ??
-    readPolicyBoolean(policy, ["settings", setting]) ??
-    readPolicyBoolean(policy, ["policy", setting]) ??
-    readPolicyBoolean(policy, [setting]) ??
-    false
-  );
+function requiredToolMetadata(policy: unknown): ReadonlySet<string> {
+  return new Set(readPolicyStringArray(policy, ["tools", "requireMetadata"]) ?? []);
 }
 
-function readPolicyBoolean(policy: unknown, path: readonly string[]): boolean | undefined {
+function readPolicyStringArray(
+  policy: unknown,
+  path: readonly string[],
+): readonly string[] | undefined {
   let current: unknown = policy;
   for (const part of path) {
     if (!isRecord(current)) {
@@ -809,7 +883,10 @@ function readPolicyBoolean(policy: unknown, path: readonly string[]): boolean | 
     }
     current = current[part];
   }
-  return typeof current === "boolean" ? current : undefined;
+  if (!Array.isArray(current) || !current.every((entry) => typeof entry === "string")) {
+    return undefined;
+  }
+  return current.map((entry) => entry.trim().toLowerCase()).filter(Boolean);
 }
 function policyPathSetting(ctx: HealthCheckContext): string {
   const configured = policySettings(ctx).path;

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -19,6 +19,11 @@ const CHECK_IDS = {
   policyHashMismatch: "policy/policy-hash-mismatch",
   policyInvalidFile: "policy/policy-jsonc-invalid",
   policyMissingFile: "policy/policy-jsonc-missing",
+  policyDeniedMcpServer: "policy/mcp-denied-server",
+  policyUnapprovedMcpServer: "policy/mcp-unapproved-server",
+  policyDeniedModelProvider: "policy/models-denied-provider",
+  policyUnapprovedModelProvider: "policy/models-unapproved-provider",
+  policyPrivateNetworkAccess: "policy/network-private-access-enabled",
   policyMissingToolOwner: "policy/tools-missing-owner",
   policyMissingToolRisk: "policy/tools-missing-risk-level",
   policyMissingToolSensitivity: "policy/tools-missing-sensitivity-token",
@@ -32,6 +37,11 @@ export const POLICY_CHECK_IDS = [
   CHECK_IDS.policyHashMismatch,
   CHECK_IDS.policyAttestationMismatch,
   CHECK_IDS.policyDeniedChannelProvider,
+  CHECK_IDS.policyDeniedMcpServer,
+  CHECK_IDS.policyUnapprovedMcpServer,
+  CHECK_IDS.policyDeniedModelProvider,
+  CHECK_IDS.policyUnapprovedModelProvider,
+  CHECK_IDS.policyPrivateNetworkAccess,
   CHECK_IDS.policyMissingToolRisk,
   CHECK_IDS.policyUnknownToolRisk,
   CHECK_IDS.policyMissingToolSensitivity,
@@ -72,6 +82,11 @@ export function registerPolicyDoctorChecks(host?: PolicyDoctorRegistrationHost):
   registerHealthCheck(policyHashMismatchCheck);
   registerHealthCheck(policyAttestationMismatchCheck);
   registerHealthCheck(policyChannelsDeniedProviderCheck);
+  registerHealthCheck(policyMcpDeniedServerCheck);
+  registerHealthCheck(policyMcpUnapprovedServerCheck);
+  registerHealthCheck(policyModelsDeniedProviderCheck);
+  registerHealthCheck(policyModelsUnapprovedProviderCheck);
+  registerHealthCheck(policyNetworkPrivateAccessCheck);
   registerHealthCheck(policyToolsMissingRiskCheck);
   registerHealthCheck(policyToolsUnknownRiskCheck);
   registerHealthCheck(policyToolsMissingSensitivityCheck);
@@ -166,6 +181,56 @@ const policyChannelsDeniedProviderCheck: HealthCheck = {
       config: next.config,
       changes: next.changed.map((id) => `Disabled channels.${id}.enabled for policy conformance.`),
     };
+  },
+};
+
+const policyMcpDeniedServerCheck: HealthCheck = {
+  id: CHECK_IDS.policyDeniedMcpServer,
+  kind: "plugin",
+  description: "Configured MCP servers do not match policy deny rules.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyDeniedMcpServer);
+  },
+};
+
+const policyMcpUnapprovedServerCheck: HealthCheck = {
+  id: CHECK_IDS.policyUnapprovedMcpServer,
+  kind: "plugin",
+  description: "Configured MCP servers do not match policy allow rules.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyUnapprovedMcpServer);
+  },
+};
+
+const policyModelsDeniedProviderCheck: HealthCheck = {
+  id: CHECK_IDS.policyDeniedModelProvider,
+  kind: "plugin",
+  description: "Configured model providers do not match policy deny rules.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyDeniedModelProvider);
+  },
+};
+
+const policyModelsUnapprovedProviderCheck: HealthCheck = {
+  id: CHECK_IDS.policyUnapprovedModelProvider,
+  kind: "plugin",
+  description: "Configured model providers do not match policy allow rules.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyUnapprovedModelProvider);
+  },
+};
+
+const policyNetworkPrivateAccessCheck: HealthCheck = {
+  id: CHECK_IDS.policyPrivateNetworkAccess,
+  kind: "plugin",
+  description: "Network SSRF policy settings match private-network requirements.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyPrivateNetworkAccess);
   },
 };
 
@@ -309,6 +374,9 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
   }
   const policyFindings: HealthFinding[] = [
     ...channelFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
+    ...mcpServerFindings(policy, policyFile.ocDocName, evidence),
+    ...modelProviderFindings(policy, policyFile.ocDocName, evidence),
+    ...networkFindings(policy, policyFile.ocDocName, evidence),
     ...metadataRequirementFindings,
   ];
   if (requiredMetadata.has("risk")) {
@@ -546,6 +614,167 @@ function invalidChannelDenyRuleFindings(
       fixHint: `Fix ${policyPath} so each channel deny rule has a provider match.`,
     },
   ];
+}
+
+function mcpServerFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const denied = new Set(readStringList(policy, ["mcp", "servers", "deny"], { lowercase: false }));
+  const allowed = readStringList(policy, ["mcp", "servers", "allow"], { lowercase: false });
+  const allowedSet = new Set(allowed);
+  const findings: HealthFinding[] = [];
+
+  for (const server of evidence.mcpServers) {
+    if (denied.has(server.id)) {
+      findings.push({
+        checkId: CHECK_IDS.policyDeniedMcpServer,
+        severity: "error",
+        message: `MCP server '${server.id}' is denied by policy.`,
+        source: "policy",
+        path: "openclaw config",
+        ocPath: server.source,
+        target: server.source,
+        requirement: `oc://${policyDocName}/mcp/servers/deny`,
+        fixHint: "Remove this configured MCP server or update the policy after review.",
+      });
+      continue;
+    }
+    if (allowedSet.size > 0 && !allowedSet.has(server.id)) {
+      findings.push({
+        checkId: CHECK_IDS.policyUnapprovedMcpServer,
+        severity: "error",
+        message: `MCP server '${server.id}' is not in the policy allowlist.`,
+        source: "policy",
+        path: "openclaw config",
+        ocPath: server.source,
+        target: server.source,
+        requirement: `oc://${policyDocName}/mcp/servers/allow`,
+        fixHint: "Use an approved MCP server or update the policy after review.",
+      });
+    }
+  }
+
+  return findings;
+}
+
+function modelProviderFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const denied = new Set(readStringList(policy, ["models", "providers", "deny"]));
+  const allowed = readStringList(policy, ["models", "providers", "allow"]);
+  const allowedSet = new Set(allowed);
+  const findings: HealthFinding[] = [];
+
+  for (const provider of evidence.modelProviders) {
+    findings.push(...modelProviderConformanceFindings(provider, denied, allowedSet, policyDocName));
+  }
+  for (const modelRef of evidence.modelRefs) {
+    findings.push(...modelRefConformanceFindings(modelRef, denied, allowedSet, policyDocName));
+  }
+
+  return findings;
+}
+
+function modelProviderConformanceFindings(
+  provider: PolicyEvidence["modelProviders"][number],
+  denied: ReadonlySet<string>,
+  allowed: ReadonlySet<string>,
+  policyDocName: string,
+): readonly HealthFinding[] {
+  const findings: HealthFinding[] = [];
+  if (denied.has(provider.id)) {
+    findings.push({
+      checkId: CHECK_IDS.policyDeniedModelProvider,
+      severity: "error",
+      message: `Model provider '${provider.id}' is denied by policy.`,
+      source: "policy",
+      path: "openclaw config",
+      ocPath: provider.source,
+      target: provider.source,
+      requirement: `oc://${policyDocName}/models/providers/deny`,
+      fixHint: "Remove this configured provider or update the policy after review.",
+    });
+  }
+  if (!denied.has(provider.id) && allowed.size > 0 && !allowed.has(provider.id)) {
+    findings.push({
+      checkId: CHECK_IDS.policyUnapprovedModelProvider,
+      severity: "error",
+      message: `Model provider '${provider.id}' is not in the policy allowlist.`,
+      source: "policy",
+      path: "openclaw config",
+      ocPath: provider.source,
+      target: provider.source,
+      requirement: `oc://${policyDocName}/models/providers/allow`,
+      fixHint: "Use an approved model provider or update the policy after review.",
+    });
+  }
+  return findings;
+}
+
+function modelRefConformanceFindings(
+  modelRef: PolicyEvidence["modelRefs"][number],
+  denied: ReadonlySet<string>,
+  allowed: ReadonlySet<string>,
+  policyDocName: string,
+): readonly HealthFinding[] {
+  const findings: HealthFinding[] = [];
+  if (denied.has(modelRef.provider)) {
+    findings.push({
+      checkId: CHECK_IDS.policyDeniedModelProvider,
+      severity: "error",
+      message: `Model ref '${modelRef.ref}' uses denied provider '${modelRef.provider}'.`,
+      source: "policy",
+      path: "openclaw config",
+      ocPath: modelRef.source,
+      target: modelRef.source,
+      requirement: `oc://${policyDocName}/models/providers/deny`,
+      fixHint: "Select an approved model provider or update the policy after review.",
+    });
+  }
+  if (!denied.has(modelRef.provider) && allowed.size > 0 && !allowed.has(modelRef.provider)) {
+    findings.push({
+      checkId: CHECK_IDS.policyUnapprovedModelProvider,
+      severity: "error",
+      message: `Model ref '${modelRef.ref}' uses unapproved provider '${modelRef.provider}'.`,
+      source: "policy",
+      path: "openclaw config",
+      ocPath: modelRef.source,
+      target: modelRef.source,
+      requirement: `oc://${policyDocName}/models/providers/allow`,
+      fixHint: "Select an approved model provider or update the policy after review.",
+    });
+  }
+  return findings;
+}
+
+function networkFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const allowPrivateNetwork = readPolicyBoolean(policy, ["network", "privateNetwork", "allow"]);
+  if (allowPrivateNetwork !== false) {
+    return [];
+  }
+  return evidence.network
+    .filter((setting) => setting.value)
+    .map((setting): HealthFinding => {
+      return {
+        checkId: CHECK_IDS.policyPrivateNetworkAccess,
+        severity: "error",
+        message: `Network setting '${setting.id}' allows private-network access.`,
+        source: "policy",
+        path: "openclaw config",
+        ocPath: setting.source,
+        target: setting.source,
+        requirement: `oc://${policyDocName}/network/privateNetwork/allow`,
+        fixHint: "Disable this private-network access setting or update policy after review.",
+      };
+    });
 }
 
 function toolRiskFindings(
@@ -877,6 +1106,7 @@ function requiredToolMetadata(policy: unknown): ReadonlySet<string> {
 function readPolicyStringArray(
   policy: unknown,
   path: readonly string[],
+  options: { readonly lowercase?: boolean } = {},
 ): readonly string[] | undefined {
   let current: unknown = policy;
   for (const part of path) {
@@ -888,7 +1118,32 @@ function readPolicyStringArray(
   if (!Array.isArray(current) || !current.every((entry) => typeof entry === "string")) {
     return undefined;
   }
-  return current.map((entry) => entry.trim().toLowerCase()).filter(Boolean);
+  const lowercase = options.lowercase ?? true;
+  return current
+    .map((entry) => {
+      const trimmed = entry.trim();
+      return lowercase ? trimmed.toLowerCase() : trimmed;
+    })
+    .filter(Boolean);
+}
+
+function readStringList(
+  policy: unknown,
+  path: readonly string[],
+  options?: { readonly lowercase?: boolean },
+): readonly string[] {
+  return readPolicyStringArray(policy, path, options) ?? [];
+}
+
+function readPolicyBoolean(policy: unknown, path: readonly string[]): boolean | undefined {
+  let current: unknown = policy;
+  for (const part of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[part];
+  }
+  return typeof current === "boolean" ? current : undefined;
 }
 function policyPathSetting(ctx: HealthCheckContext): string {
   const configured = policySettings(ctx).path;

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { parseMd } from "@openclaw/oc-path/api.js";
 
 export type PolicyAttestation = {
   readonly checkedAt: string;
@@ -130,22 +131,19 @@ export function scanPolicyTools(raw: string): readonly PolicyToolEvidence[] {
 }
 
 function scanPolicyToolHeaders(raw: string): readonly PolicyToolEvidence[] {
-  const lines = raw.split(/\r?\n/);
-  const toolsHeading = lines.findIndex((line) => /^##\s+tools\s*$/i.test(line.trim()));
-  if (toolsHeading < 0) {
+  const toolsBlock = parseMd(raw).ast.blocks.find((block) => block.slug === "tools");
+  if (toolsBlock === undefined) {
     return [];
   }
-  const nextHeading = lines.findIndex(
-    (line, index) => index > toolsHeading && /^##\s+\S+/.test(line.trim()),
-  );
-  const body = lines.slice(toolsHeading + 1, nextHeading < 0 ? undefined : nextHeading);
-  return body.flatMap((line, index): readonly PolicyToolEvidence[] => {
+  const body = toolsBlock.bodyText.split(/\r?\n/);
+  const tools: PolicyToolEvidence[] = [];
+  for (let index = 0; index < body.length; index += 1) {
+    const line = body[index];
     const match = /^###\s+([^\s#]+)(.*)$/.exec(line);
     if (match === null) {
-      return [];
+      continue;
     }
     const id = match[1].trim();
-    const meta = match[2] ?? "";
     const entry: {
       id: string;
       source: string;
@@ -157,12 +155,21 @@ function scanPolicyToolHeaders(raw: string): readonly PolicyToolEvidence[] {
     } = {
       id,
       source: `oc://TOOLS.md/tools/${id}`,
-      line: toolsHeading + index + 2,
+      line: toolsBlock.line + index + 1,
     };
+    const metaLines = [match[2] ?? ""];
+    for (let metaIndex = index + 1; metaIndex < body.length; metaIndex += 1) {
+      const metaLine = body[metaIndex];
+      if (/^###\s+\S+/.test(metaLine.trim())) {
+        break;
+      }
+      metaLines.push(metaLine);
+    }
+    const meta = metaLines.join("\n");
     const risk = riskFromMeta(meta);
     const sensitivity = /\bsensitivity\s*:\s*([a-z0-9_-]+)\b/i.exec(meta)?.[1]?.toLowerCase();
     const owner = /\bowner\s*:\s*([^\s#]+)\b/i.exec(meta)?.[1];
-    const capabilities = meta.match(/\b[A-Z][A-Z0-9_]{2,}\b/g) ?? [];
+    const capabilities = capabilityTokensFromMetaLines(metaLines);
     if (risk !== undefined) {
       entry.risk = risk;
     }
@@ -175,8 +182,9 @@ function scanPolicyToolHeaders(raw: string): readonly PolicyToolEvidence[] {
     if (capabilities.length > 0) {
       entry.capabilities = capabilities;
     }
-    return [entry];
-  });
+    tools.push(entry);
+  }
+  return tools;
 }
 
 function riskFromMeta(meta: string): string | undefined {
@@ -199,6 +207,23 @@ function riskFromMeta(meta: string): string | undefined {
     default:
       return undefined;
   }
+}
+
+function capabilityTokensFromMetaLines(lines: readonly string[]): readonly string[] {
+  return lines.flatMap((line, index): string[] => {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      return [];
+    }
+    const tokens = trimmed.match(/\b[A-Z][A-Z0-9_]{2,}\b/g) ?? [];
+    if (index === 0 || /\bcapabilities\s*:/i.test(trimmed)) {
+      return tokens;
+    }
+    const withoutTokens = tokens.reduce((remaining, token) => {
+      return remaining.replace(token, "");
+    }, trimmed);
+    return /^[\s,;:[\](){}#*_-]*$/.test(withoutTokens) ? tokens : [];
+  });
 }
 
 function configuredChannels(cfg: Record<string, unknown>): Record<string, unknown> {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -18,6 +18,7 @@ export type PolicyAttestation = {
 export type PolicyEvidence = {
   readonly channels: readonly PolicyChannelEvidence[];
   readonly tools?: readonly PolicyToolEvidence[];
+  readonly channelRuntime: readonly PolicyChannelRuntimeEvidence[];
   readonly mcpServers: readonly PolicyMcpServerEvidence[];
   readonly modelProviders: readonly PolicyModelProviderEvidence[];
   readonly modelRefs: readonly PolicyModelRefEvidence[];
@@ -29,6 +30,15 @@ export type PolicyChannelEvidence = {
   readonly provider: string;
   readonly source: string;
   readonly enabled?: boolean;
+};
+
+export type PolicyChannelRuntimeEvidence = {
+  readonly id: string;
+  readonly accountId: string;
+  readonly source: string;
+  readonly running: boolean;
+  readonly enabled?: boolean;
+  readonly configured?: boolean;
 };
 
 export type PolicyMcpServerEvidence = {
@@ -126,10 +136,11 @@ export function createPolicyAttestation(input: {
 
 export function collectPolicyEvidence(
   cfg: Record<string, unknown>,
-  options: { readonly toolsRaw?: string } = {},
+  options: { readonly toolsRaw?: string; readonly channelRuntime?: unknown } = {},
 ): PolicyEvidence {
   const evidence: PolicyEvidence = {
     channels: scanPolicyChannels(cfg),
+    channelRuntime: scanPolicyChannelRuntime(options.channelRuntime),
     mcpServers: scanPolicyMcpServers(cfg),
     modelProviders: scanPolicyModelProviders(cfg),
     modelRefs: scanPolicyModelRefs(cfg),
@@ -139,6 +150,48 @@ export function collectPolicyEvidence(
     return evidence;
   }
   return { ...evidence, tools: scanPolicyTools(options.toolsRaw) };
+}
+
+export function scanPolicyChannelRuntime(
+  runtime: unknown,
+): readonly PolicyChannelRuntimeEvidence[] {
+  if (!isRecord(runtime) || !isRecord(runtime.channelAccounts)) {
+    return [];
+  }
+  const entries: PolicyChannelRuntimeEvidence[] = [];
+  for (const [channelId, accounts] of Object.entries(runtime.channelAccounts)) {
+    if (!isRecord(accounts)) {
+      continue;
+    }
+    for (const [accountId, snapshot] of Object.entries(accounts)) {
+      if (!isRecord(snapshot)) {
+        continue;
+      }
+      const entry: {
+        id: string;
+        accountId: string;
+        source: string;
+        running: boolean;
+        enabled?: boolean;
+        configured?: boolean;
+      } = {
+        id: channelId,
+        accountId,
+        source: `runtime:channels/${channelId}/accounts/${accountId}`,
+        running: snapshot.running === true,
+      };
+      if (typeof snapshot.enabled === "boolean") {
+        entry.enabled = snapshot.enabled;
+      }
+      if (typeof snapshot.configured === "boolean") {
+        entry.configured = snapshot.configured;
+      }
+      entries.push(entry);
+    }
+  }
+  return entries.toSorted(
+    (a, b) => a.id.localeCompare(b.id) || a.accountId.localeCompare(b.accountId),
+  );
 }
 
 export function scanPolicyChannels(cfg: Record<string, unknown>): readonly PolicyChannelEvidence[] {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -29,7 +29,7 @@ export type PolicyChannelEvidence = {
 
 export type PolicyToolEvidence = {
   readonly id: string;
-  readonly ocPath: string;
+  readonly source: string;
   readonly line: number;
   readonly risk?: string;
   readonly sensitivity?: string;
@@ -147,14 +147,14 @@ function scanPolicyToolHeaders(ast: MdAst): readonly PolicyToolEvidence[] {
     const meta = match[2] ?? "";
     const entry: {
       id: string;
-      ocPath: string;
+      source: string;
       line: number;
       risk?: string;
       sensitivity?: string;
       capabilities?: readonly string[];
     } = {
       id,
-      ocPath: `oc://TOOLS.md/tools/${id}`,
+      source: `oc://TOOLS.md/tools/${id}`,
       line: tools.line + index + 1,
     };
     const risk = riskFromMeta(meta);
@@ -174,7 +174,7 @@ function scanPolicyToolHeaders(ast: MdAst): readonly PolicyToolEvidence[] {
 }
 
 function riskFromMeta(meta: string): string | undefined {
-  const namedRisk = /\brisk\s*:\s*(low|medium|high|critical)\b/i.exec(meta)?.[1];
+  const namedRisk = /\brisk\s*:\s*([a-z0-9_-]+)\b/i.exec(meta)?.[1];
   if (namedRisk !== undefined) {
     return namedRisk.toLowerCase();
   }

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -17,7 +17,7 @@ export type PolicyAttestation = {
 
 export type PolicyEvidence = {
   readonly channels: readonly PolicyChannelEvidence[];
-  readonly tools: readonly PolicyToolEvidence[];
+  readonly tools?: readonly PolicyToolEvidence[];
 };
 
 export type PolicyChannelEvidence = {
@@ -98,10 +98,11 @@ export function collectPolicyEvidence(
   cfg: Record<string, unknown>,
   options: { readonly toolsRaw?: string } = {},
 ): PolicyEvidence {
-  return {
-    channels: scanPolicyChannels(cfg),
-    tools: options.toolsRaw === undefined ? [] : scanPolicyTools(options.toolsRaw),
-  };
+  const channels = scanPolicyChannels(cfg);
+  if (options.toolsRaw === undefined) {
+    return { channels };
+  }
+  return { channels, tools: scanPolicyTools(options.toolsRaw) };
 }
 
 export function scanPolicyChannels(cfg: Record<string, unknown>): readonly PolicyChannelEvidence[] {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -1,5 +1,4 @@
 import { createHash } from "node:crypto";
-import { parseOcDocument, type MdAst } from "@openclaw/oc-path/api.js";
 
 export type PolicyAttestation = {
   readonly checkedAt: string;
@@ -33,6 +32,7 @@ export type PolicyToolEvidence = {
   readonly line: number;
   readonly risk?: string;
   readonly sensitivity?: string;
+  readonly owner?: string;
   readonly capabilities?: readonly string[];
 };
 
@@ -126,19 +126,20 @@ export function scanPolicyChannels(cfg: Record<string, unknown>): readonly Polic
 }
 
 export function scanPolicyTools(raw: string): readonly PolicyToolEvidence[] {
-  const parsed = parseOcDocument(raw, { fileName: "TOOLS.md" });
-  if (parsed.ast.kind !== "md") {
-    return [];
-  }
-  return scanPolicyToolHeaders(parsed.ast);
+  return scanPolicyToolHeaders(raw);
 }
 
-function scanPolicyToolHeaders(ast: MdAst): readonly PolicyToolEvidence[] {
-  const tools = ast.blocks.find((entry) => entry.slug === "tools");
-  if (tools === undefined) {
+function scanPolicyToolHeaders(raw: string): readonly PolicyToolEvidence[] {
+  const lines = raw.split(/\r?\n/);
+  const toolsHeading = lines.findIndex((line) => /^##\s+tools\s*$/i.test(line.trim()));
+  if (toolsHeading < 0) {
     return [];
   }
-  return tools.bodyText.split(/\r?\n/).flatMap((line, index): readonly PolicyToolEvidence[] => {
+  const nextHeading = lines.findIndex(
+    (line, index) => index > toolsHeading && /^##\s+\S+/.test(line.trim()),
+  );
+  const body = lines.slice(toolsHeading + 1, nextHeading < 0 ? undefined : nextHeading);
+  return body.flatMap((line, index): readonly PolicyToolEvidence[] => {
     const match = /^###\s+([^\s#]+)(.*)$/.exec(line);
     if (match === null) {
       return [];
@@ -151,20 +152,25 @@ function scanPolicyToolHeaders(ast: MdAst): readonly PolicyToolEvidence[] {
       line: number;
       risk?: string;
       sensitivity?: string;
+      owner?: string;
       capabilities?: readonly string[];
     } = {
       id,
       source: `oc://TOOLS.md/tools/${id}`,
-      line: tools.line + index + 1,
+      line: toolsHeading + index + 2,
     };
     const risk = riskFromMeta(meta);
     const sensitivity = /\bsensitivity\s*:\s*([a-z0-9_-]+)\b/i.exec(meta)?.[1]?.toLowerCase();
+    const owner = /\bowner\s*:\s*([^\s#]+)\b/i.exec(meta)?.[1];
     const capabilities = meta.match(/\b[A-Z][A-Z0-9_]{2,}\b/g) ?? [];
     if (risk !== undefined) {
       entry.risk = risk;
     }
     if (sensitivity !== undefined) {
       entry.sensitivity = sensitivity;
+    }
+    if (owner !== undefined) {
+      entry.owner = owner;
     }
     if (capabilities.length > 0) {
       entry.capabilities = capabilities;

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -18,6 +18,10 @@ export type PolicyAttestation = {
 export type PolicyEvidence = {
   readonly channels: readonly PolicyChannelEvidence[];
   readonly tools?: readonly PolicyToolEvidence[];
+  readonly mcpServers: readonly PolicyMcpServerEvidence[];
+  readonly modelProviders: readonly PolicyModelProviderEvidence[];
+  readonly modelRefs: readonly PolicyModelRefEvidence[];
+  readonly network: readonly PolicyNetworkEvidence[];
 };
 
 export type PolicyChannelEvidence = {
@@ -25,6 +29,14 @@ export type PolicyChannelEvidence = {
   readonly provider: string;
   readonly source: string;
   readonly enabled?: boolean;
+};
+
+export type PolicyMcpServerEvidence = {
+  readonly id: string;
+  readonly transport: "stdio" | "sse" | "streamable-http" | "unknown";
+  readonly source: string;
+  readonly command?: string;
+  readonly url?: string;
 };
 
 export type PolicyToolEvidence = {
@@ -35,6 +47,24 @@ export type PolicyToolEvidence = {
   readonly sensitivity?: string;
   readonly owner?: string;
   readonly capabilities?: readonly string[];
+};
+
+export type PolicyModelProviderEvidence = {
+  readonly id: string;
+  readonly source: string;
+};
+
+export type PolicyModelRefEvidence = {
+  readonly ref: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly source: string;
+};
+
+export type PolicyNetworkEvidence = {
+  readonly id: string;
+  readonly source: string;
+  readonly value: boolean;
 };
 
 const RESERVED_CHANNEL_CONFIG_KEYS = new Set(["defaults", "modelByChannel"]);
@@ -98,11 +128,17 @@ export function collectPolicyEvidence(
   cfg: Record<string, unknown>,
   options: { readonly toolsRaw?: string } = {},
 ): PolicyEvidence {
-  const channels = scanPolicyChannels(cfg);
+  const evidence: PolicyEvidence = {
+    channels: scanPolicyChannels(cfg),
+    mcpServers: scanPolicyMcpServers(cfg),
+    modelProviders: scanPolicyModelProviders(cfg),
+    modelRefs: scanPolicyModelRefs(cfg),
+    network: scanPolicyNetwork(cfg),
+  };
   if (options.toolsRaw === undefined) {
-    return { channels };
+    return evidence;
   }
-  return { channels, tools: scanPolicyTools(options.toolsRaw) };
+  return { ...evidence, tools: scanPolicyTools(options.toolsRaw) };
 }
 
 export function scanPolicyChannels(cfg: Record<string, unknown>): readonly PolicyChannelEvidence[] {
@@ -125,6 +161,100 @@ export function scanPolicyChannels(cfg: Record<string, unknown>): readonly Polic
       }
       return entry;
     });
+}
+
+export function scanPolicyMcpServers(
+  cfg: Record<string, unknown>,
+): readonly PolicyMcpServerEvidence[] {
+  return Object.entries(configuredMcpServers(cfg))
+    .toSorted(([a], [b]) => a.localeCompare(b))
+    .map(([id, value]) => {
+      const entry: {
+        id: string;
+        transport: "stdio" | "sse" | "streamable-http" | "unknown";
+        source: string;
+        command?: string;
+        url?: string;
+      } = {
+        id,
+        transport: mcpServerTransport(value),
+        source: `oc://openclaw.config/mcp/servers/${id}`,
+      };
+      if (isRecord(value)) {
+        if (typeof value.command === "string") {
+          entry.command = value.command;
+        }
+        if (typeof value.url === "string") {
+          entry.url = redactMcpUrlForEvidence(value.url);
+        }
+      }
+      return entry;
+    });
+}
+
+export function scanPolicyModelProviders(
+  cfg: Record<string, unknown>,
+): readonly PolicyModelProviderEvidence[] {
+  return Object.keys(configuredModelProviders(cfg))
+    .toSorted((a, b) => a.localeCompare(b))
+    .map((id) => ({
+      id,
+      source: `oc://openclaw.config/models/providers/${id}`,
+    }));
+}
+
+export function scanPolicyModelRefs(
+  cfg: Record<string, unknown>,
+): readonly PolicyModelRefEvidence[] {
+  const refs: PolicyModelRefEvidence[] = [];
+  if (isRecord(cfg.agents)) {
+    collectModelRefsFromRecord(refs, cfg.agents, "oc://openclaw.config/agents");
+    collectModelRefsFromAgentAllowlist(refs, cfg.agents);
+  }
+  return refs.toSorted(
+    (a, b) => a.provider.localeCompare(b.provider) || a.model.localeCompare(b.model),
+  );
+}
+
+export function scanPolicyNetwork(cfg: Record<string, unknown>): readonly PolicyNetworkEvidence[] {
+  return [
+    networkBooleanEvidence(
+      cfg,
+      "browser-private-network",
+      ["browser", "ssrfPolicy", "dangerouslyAllowPrivateNetwork"],
+      "oc://openclaw.config/browser/ssrfPolicy/dangerouslyAllowPrivateNetwork",
+    ),
+    networkBooleanEvidence(
+      cfg,
+      "browser-private-network-legacy",
+      ["browser", "ssrfPolicy", "allowPrivateNetwork"],
+      "oc://openclaw.config/browser/ssrfPolicy/allowPrivateNetwork",
+    ),
+    networkBooleanEvidence(
+      cfg,
+      "web-fetch-private-network",
+      ["tools", "web", "fetch", "ssrfPolicy", "dangerouslyAllowPrivateNetwork"],
+      "oc://openclaw.config/tools/web/fetch/ssrfPolicy/dangerouslyAllowPrivateNetwork",
+    ),
+    networkBooleanEvidence(
+      cfg,
+      "web-fetch-private-network-legacy",
+      ["tools", "web", "fetch", "ssrfPolicy", "allowPrivateNetwork"],
+      "oc://openclaw.config/tools/web/fetch/ssrfPolicy/allowPrivateNetwork",
+    ),
+    networkBooleanEvidence(
+      cfg,
+      "web-fetch-rfc2544-benchmark-range",
+      ["tools", "web", "fetch", "ssrfPolicy", "allowRfc2544BenchmarkRange"],
+      "oc://openclaw.config/tools/web/fetch/ssrfPolicy/allowRfc2544BenchmarkRange",
+    ),
+    networkBooleanEvidence(
+      cfg,
+      "web-fetch-ipv6-unique-local-range",
+      ["tools", "web", "fetch", "ssrfPolicy", "allowIpv6UniqueLocalRange"],
+      "oc://openclaw.config/tools/web/fetch/ssrfPolicy/allowIpv6UniqueLocalRange",
+    ),
+  ].filter((entry): entry is PolicyNetworkEvidence => entry !== undefined);
 }
 
 export function scanPolicyTools(raw: string): readonly PolicyToolEvidence[] {
@@ -229,6 +359,152 @@ function capabilityTokensFromMetaLines(lines: readonly string[]): readonly strin
 
 function configuredChannels(cfg: Record<string, unknown>): Record<string, unknown> {
   return isRecord(cfg.channels) ? cfg.channels : {};
+}
+
+function configuredMcpServers(cfg: Record<string, unknown>): Record<string, unknown> {
+  return isRecord(cfg.mcp) && isRecord(cfg.mcp.servers) ? cfg.mcp.servers : {};
+}
+
+function mcpServerTransport(value: unknown): PolicyMcpServerEvidence["transport"] {
+  if (!isRecord(value)) {
+    return "unknown";
+  }
+  if (typeof value.command === "string") {
+    return "stdio";
+  }
+  if (value.transport === "sse" || value.transport === "streamable-http") {
+    return value.transport;
+  }
+  if (typeof value.url === "string") {
+    return "streamable-http";
+  }
+  return "unknown";
+}
+
+function redactMcpUrlForEvidence(raw: string): string {
+  try {
+    const url = new URL(raw);
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return "[redacted-url]";
+  }
+}
+
+function configuredModelProviders(cfg: Record<string, unknown>): Record<string, unknown> {
+  return isRecord(cfg.models) && isRecord(cfg.models.providers) ? cfg.models.providers : {};
+}
+
+function networkBooleanEvidence(
+  cfg: Record<string, unknown>,
+  id: string,
+  path: readonly string[],
+  source: string,
+): PolicyNetworkEvidence | undefined {
+  const value = readBooleanPath(cfg, path);
+  return value === undefined ? undefined : { id, source, value };
+}
+
+function readBooleanPath(value: unknown, path: readonly string[]): boolean | undefined {
+  let current = value;
+  for (const part of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[part];
+  }
+  return typeof current === "boolean" ? current : undefined;
+}
+
+function collectModelRefsFromValue(
+  refs: PolicyModelRefEvidence[],
+  value: unknown,
+  source: string,
+): void {
+  if (typeof value === "string") {
+    pushModelRef(refs, value, source);
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  if (typeof value.primary === "string") {
+    pushModelRef(refs, value.primary, `${source}/primary`);
+  }
+  if (Array.isArray(value.fallbacks)) {
+    for (const [index, fallback] of value.fallbacks.entries()) {
+      if (typeof fallback === "string") {
+        pushModelRef(refs, fallback, `${source}/fallbacks/#${index}`);
+      }
+    }
+  }
+}
+
+function collectModelRefsFromRecord(
+  refs: PolicyModelRefEvidence[],
+  value: Record<string, unknown>,
+  source: string,
+): void {
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${source}/${key}`;
+    if (isModelSettingKey(key)) {
+      collectModelRefsFromValue(refs, child, childPath);
+      continue;
+    }
+    if (Array.isArray(child)) {
+      for (const [index, item] of child.entries()) {
+        if (isRecord(item)) {
+          collectModelRefsFromRecord(refs, item, `${childPath}/#${index}`);
+        }
+      }
+      continue;
+    }
+    if (isRecord(child)) {
+      collectModelRefsFromRecord(refs, child, childPath);
+    }
+  }
+}
+
+function collectModelRefsFromAgentAllowlist(
+  refs: PolicyModelRefEvidence[],
+  agents: Record<string, unknown>,
+): void {
+  const defaults = agents.defaults;
+  if (!isRecord(defaults) || !isRecord(defaults.models)) {
+    return;
+  }
+  for (const ref of Object.keys(defaults.models)) {
+    pushModelRef(refs, ref, `oc://openclaw.config/agents/defaults/models/${escapeRefSegment(ref)}`);
+  }
+}
+
+function isModelSettingKey(key: string): boolean {
+  return key === "model" || key.endsWith("Model");
+}
+
+function escapeRefSegment(value: string): string {
+  return value.replaceAll("/", "~1");
+}
+
+function pushModelRef(refs: PolicyModelRefEvidence[], ref: string, source: string): void {
+  const parsed = parseModelRef(ref);
+  if (parsed === undefined) {
+    return;
+  }
+  refs.push({ ref, provider: parsed.provider, model: parsed.model, source });
+}
+
+function parseModelRef(
+  ref: string,
+): { readonly provider: string; readonly model: string } | undefined {
+  const trimmed = ref.trim();
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0 || slash >= trimmed.length - 1) {
+    return undefined;
+  }
+  return {
+    provider: trimmed.slice(0, slash),
+    model: trimmed.slice(slash + 1),
+  };
 }
 
 function sha256(value: string): string {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { parseOcDocument, type MdAst } from "@openclaw/oc-path/api.js";
 
 export type PolicyAttestation = {
   readonly checkedAt: string;
@@ -16,6 +17,7 @@ export type PolicyAttestation = {
 
 export type PolicyEvidence = {
   readonly channels: readonly PolicyChannelEvidence[];
+  readonly tools: readonly PolicyToolEvidence[];
 };
 
 export type PolicyChannelEvidence = {
@@ -23,6 +25,15 @@ export type PolicyChannelEvidence = {
   readonly provider: string;
   readonly source: string;
   readonly enabled?: boolean;
+};
+
+export type PolicyToolEvidence = {
+  readonly id: string;
+  readonly ocPath: string;
+  readonly line: number;
+  readonly risk?: string;
+  readonly sensitivity?: string;
+  readonly capabilities?: readonly string[];
 };
 
 const RESERVED_CHANNEL_CONFIG_KEYS = new Set(["defaults", "modelByChannel"]);
@@ -82,9 +93,13 @@ export function createPolicyAttestation(input: {
   };
 }
 
-export function collectPolicyEvidence(cfg: Record<string, unknown>): PolicyEvidence {
+export function collectPolicyEvidence(
+  cfg: Record<string, unknown>,
+  options: { readonly toolsRaw?: string } = {},
+): PolicyEvidence {
   return {
     channels: scanPolicyChannels(cfg),
+    tools: options.toolsRaw === undefined ? [] : scanPolicyTools(options.toolsRaw),
   };
 }
 
@@ -108,6 +123,76 @@ export function scanPolicyChannels(cfg: Record<string, unknown>): readonly Polic
       }
       return entry;
     });
+}
+
+export function scanPolicyTools(raw: string): readonly PolicyToolEvidence[] {
+  const parsed = parseOcDocument(raw, { fileName: "TOOLS.md" });
+  if (parsed.ast.kind !== "md") {
+    return [];
+  }
+  return scanPolicyToolHeaders(parsed.ast);
+}
+
+function scanPolicyToolHeaders(ast: MdAst): readonly PolicyToolEvidence[] {
+  const tools = ast.blocks.find((entry) => entry.slug === "tools");
+  if (tools === undefined) {
+    return [];
+  }
+  return tools.bodyText.split(/\r?\n/).flatMap((line, index): readonly PolicyToolEvidence[] => {
+    const match = /^###\s+([^\s#]+)(.*)$/.exec(line);
+    if (match === null) {
+      return [];
+    }
+    const id = match[1].trim();
+    const meta = match[2] ?? "";
+    const entry: {
+      id: string;
+      ocPath: string;
+      line: number;
+      risk?: string;
+      sensitivity?: string;
+      capabilities?: readonly string[];
+    } = {
+      id,
+      ocPath: `oc://TOOLS.md/tools/${id}`,
+      line: tools.line + index + 1,
+    };
+    const risk = riskFromMeta(meta);
+    const sensitivity = /\bsensitivity\s*:\s*([a-z0-9_-]+)\b/i.exec(meta)?.[1]?.toLowerCase();
+    const capabilities = meta.match(/\b[A-Z][A-Z0-9_]{2,}\b/g) ?? [];
+    if (risk !== undefined) {
+      entry.risk = risk;
+    }
+    if (sensitivity !== undefined) {
+      entry.sensitivity = sensitivity;
+    }
+    if (capabilities.length > 0) {
+      entry.capabilities = capabilities;
+    }
+    return [entry];
+  });
+}
+
+function riskFromMeta(meta: string): string | undefined {
+  const namedRisk = /\brisk\s*:\s*(low|medium|high|critical)\b/i.exec(meta)?.[1];
+  if (namedRisk !== undefined) {
+    return namedRisk.toLowerCase();
+  }
+  const alias = /\bR([0-5])\b/.exec(meta)?.[1];
+  switch (alias) {
+    case "0":
+    case "1":
+      return "low";
+    case "2":
+    case "3":
+      return "medium";
+    case "4":
+      return "high";
+    case "5":
+      return "critical";
+    default:
+      return undefined;
+  }
 }
 
 function configuredChannels(cfg: Record<string, unknown>): Record<string, unknown> {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -177,7 +177,7 @@ export function scanPolicyChannelRuntime(
       } = {
         id: channelId,
         accountId,
-        source: `runtime:channels/${channelId}/accounts/${accountId}`,
+        source: `runtime:channels/${runtimeRefSegment(channelId)}/accounts/${runtimeRefSegment(accountId)}`,
         running: snapshot.running === true,
       };
       if (typeof snapshot.enabled === "boolean") {
@@ -192,6 +192,10 @@ export function scanPolicyChannelRuntime(
   return entries.toSorted(
     (a, b) => a.id.localeCompare(b.id) || a.accountId.localeCompare(b.accountId),
   );
+}
+
+function runtimeRefSegment(value: string): string {
+  return encodeURIComponent(value);
 }
 
 export function scanPolicyChannels(cfg: Record<string, unknown>): readonly PolicyChannelEvidence[] {

--- a/extensions/policy/src/runtime-tool-policy.test.ts
+++ b/extensions/policy/src/runtime-tool-policy.test.ts
@@ -2,8 +2,11 @@ import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { policyDocumentHash } from "./policy-state.js";
-import { evaluatePolicyTrustedToolCall } from "./runtime-tool-policy.js";
+import { collectPolicyEvidence, policyDocumentHash, policyWorkspaceHash } from "./policy-state.js";
+import {
+  evaluatePolicyTrustedToolCall,
+  registerPolicyTrustedToolPolicy,
+} from "./runtime-tool-policy.js";
 
 let workspaceDir: string;
 
@@ -194,6 +197,23 @@ describe("policy trusted tool runtime", () => {
     });
   });
 
+  it("does not reject optional unknown risk when policy does not require risk", async () => {
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        tools: { requireMetadata: ["owner"] },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      "## Tools\n\n### deploy risk:critcal owner:ops\n",
+      "utf-8",
+    );
+
+    await expect(evaluate("deploy")).resolves.toBeUndefined();
+  });
+
   it("requires approval for critical or irreversible tools", async () => {
     const policy = {
       tools: { requireMetadata: ["risk"] },
@@ -293,6 +313,24 @@ describe("policy trusted tool runtime", () => {
     });
   });
 
+  it("hashes missing TOOLS.md as empty tool evidence when metadata is required", async () => {
+    const policy = {
+      tools: { requireMetadata: ["risk"] },
+    };
+    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+
+    await expect(evaluate("deploy")).resolves.toMatchObject({
+      requireApproval: {
+        metadata: {
+          workspace: {
+            scope: "policy",
+            hash: policyWorkspaceHash(collectPolicyEvidence({}, { toolsRaw: "" })),
+          },
+        },
+      },
+    });
+  });
+
   it("allows declared low-risk tools without a runtime decision", async () => {
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
@@ -308,5 +346,58 @@ describe("policy trusted tool runtime", () => {
     );
 
     await expect(evaluate("inspect")).resolves.toBeUndefined();
+  });
+
+  it("uses the active tool cwd before the default agent workspace", async () => {
+    const agentWorkspace = await fs.mkdtemp(join(tmpdir(), "policy-agent-runtime-"));
+    try {
+      await fs.writeFile(
+        join(workspaceDir, "policy.jsonc"),
+        JSON.stringify({ tools: { requireMetadata: ["risk"] } }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        join(workspaceDir, "TOOLS.md"),
+        "## Tools\n\n### deploy risk:critical\n",
+        "utf-8",
+      );
+      await fs.writeFile(
+        join(agentWorkspace, "policy.jsonc"),
+        JSON.stringify({ tools: { requireMetadata: ["risk"] } }),
+        "utf-8",
+      );
+      await fs.writeFile(join(agentWorkspace, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
+
+      let evaluate:
+        | ((
+            event: { toolName: string; params: Record<string, unknown> },
+            ctx: { toolName: string; cwd?: string },
+          ) => ReturnType<typeof evaluatePolicyTrustedToolCall>)
+        | undefined;
+      registerPolicyTrustedToolPolicy({
+        config: cfg(),
+        runtime: {
+          config: { current: () => cfg() },
+          agent: { resolveAgentWorkspaceDir: () => agentWorkspace },
+        },
+        registerTrustedToolPolicy(policy) {
+          evaluate = policy.evaluate as typeof evaluate;
+        },
+      });
+
+      await expect(
+        evaluate?.({ toolName: "deploy", params: {} }, { toolName: "deploy", cwd: workspaceDir }),
+      ).resolves.toMatchObject({
+        requireApproval: expect.objectContaining({
+          title: "Review policy-governed tool",
+          severity: "critical",
+          metadata: expect.objectContaining({
+            target: "oc://TOOLS.md/tools/deploy",
+          }),
+        }),
+      });
+    } finally {
+      await fs.rm(agentWorkspace, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/policy/src/runtime-tool-policy.test.ts
+++ b/extensions/policy/src/runtime-tool-policy.test.ts
@@ -2,7 +2,12 @@ import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { collectPolicyEvidence, policyDocumentHash, policyWorkspaceHash } from "./policy-state.js";
+import {
+  collectPolicyEvidence,
+  createPolicyAttestation,
+  policyDocumentHash,
+  policyWorkspaceHash,
+} from "./policy-state.js";
 import {
   evaluatePolicyTrustedToolCall,
   registerPolicyTrustedToolPolicy,
@@ -30,12 +35,35 @@ async function evaluate(
 ) {
   return evaluatePolicyTrustedToolCall(
     { toolName, params: {} },
-    { toolName },
+    {},
     {
       cwd: workspaceDir,
       readConfig: () => cfg(settings, entryEnabled),
     },
   );
+}
+
+function acceptedAttestationHash(params: {
+  readonly policy: unknown;
+  readonly toolsRaw: string;
+  readonly settings?: Record<string, unknown>;
+}): string {
+  const policyHash = policyDocumentHash(params.policy);
+  const evidence = collectPolicyEvidence(cfg(params.settings ?? {}) as Record<string, unknown>, {
+    toolsRaw: params.toolsRaw,
+  });
+  const attestationHash = createPolicyAttestation({
+    ok: true,
+    checkedAt: "2026-05-12T00:00:00.000Z",
+    policyPath: "policy.jsonc",
+    policyHash,
+    evidence,
+    findings: [],
+  }).attestationHash;
+  if (attestationHash === undefined) {
+    throw new Error("expected policy attestation hash");
+  }
+  return attestationHash;
 }
 
 describe("policy trusted tool runtime", () => {
@@ -274,6 +302,63 @@ describe("policy trusted tool runtime", () => {
           policy: {
             path: "policy.jsonc",
             hash: policyDocumentHash(policy),
+          },
+          workspace: {
+            scope: "policy",
+            hash: expect.stringMatching(/^sha256:/),
+          },
+          target: "oc://TOOLS.md/tools/deploy",
+        },
+      },
+    });
+  });
+
+  it("blocks when watched tool evidence no longer matches the accepted attestation", async () => {
+    const policy = {
+      tools: { requireMetadata: ["risk"] },
+    };
+    const acceptedTools = "## Tools\n\n### deploy risk:low sensitivity:internal\n";
+    const expectedAttestationHash = acceptedAttestationHash({
+      policy,
+      toolsRaw: acceptedTools,
+    });
+    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      "## Tools\n\n### deploy risk:critical sensitivity:internal\n",
+      "utf-8",
+    );
+
+    const result = await evaluate("deploy", { expectedAttestationHash });
+
+    expect(result).toMatchObject({
+      block: true,
+      blockReason: expect.stringContaining(
+        `policy.jsonc no longer matches the accepted policy attestation`,
+      ),
+    });
+    expect((result as { blockReason?: string }).blockReason).toContain(
+      `expected ${expectedAttestationHash}`,
+    );
+  });
+
+  it("includes matching attestation metadata in runtime approvals", async () => {
+    const policy = {
+      tools: { requireMetadata: ["risk"] },
+    };
+    const toolsRaw =
+      "## Tools\n\n### deploy risk:critical sensitivity:internal IRREVERSIBLE_EXTERNAL\n";
+    const expectedAttestationHash = acceptedAttestationHash({ policy, toolsRaw });
+    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    await fs.writeFile(join(workspaceDir, "TOOLS.md"), toolsRaw, "utf-8");
+
+    await expect(evaluate("deploy", { expectedAttestationHash })).resolves.toMatchObject({
+      requireApproval: {
+        metadata: {
+          source: "policy",
+          attestation: {
+            hash: expectedAttestationHash,
+            expectedHash: expectedAttestationHash,
           },
           workspace: {
             scope: "policy",

--- a/extensions/policy/src/runtime-tool-policy.test.ts
+++ b/extensions/policy/src/runtime-tool-policy.test.ts
@@ -1,0 +1,235 @@
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { policyDocumentHash } from "./policy-state.js";
+import { evaluatePolicyTrustedToolCall } from "./runtime-tool-policy.js";
+
+let workspaceDir: string;
+
+function cfg(settings: Record<string, unknown> = {}, entryEnabled = true) {
+  return {
+    plugins: {
+      entries: {
+        policy: {
+          enabled: entryEnabled,
+          config: { runtimeToolPolicy: true, ...settings },
+        },
+      },
+    },
+  };
+}
+
+async function evaluate(
+  toolName: string,
+  settings: Record<string, unknown> = {},
+  entryEnabled = true,
+) {
+  return evaluatePolicyTrustedToolCall(
+    { toolName, params: {} },
+    { toolName },
+    {
+      cwd: workspaceDir,
+      readConfig: () => cfg(settings, entryEnabled),
+    },
+  );
+}
+
+describe("policy trusted tool runtime", () => {
+  beforeEach(async () => {
+    workspaceDir = await fs.mkdtemp(join(tmpdir(), "policy-runtime-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("does nothing until runtime tool policy is enabled", async () => {
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ tools: { settings: { runtimeToolPolicy: true, requireRisk: true } } }),
+      "utf-8",
+    );
+    await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
+
+    await expect(evaluate("deploy", { runtimeToolPolicy: false })).resolves.toBeUndefined();
+  });
+
+  it("honors plugin entry enablement without requiring config.enabled", async () => {
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ tools: { settings: { requireRisk: true } } }),
+      "utf-8",
+    );
+    await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
+
+    await expect(evaluate("deploy")).resolves.toEqual({
+      block: true,
+      blockReason: "Policy requires risk metadata for 'deploy', but TOOLS.md does not declare it.",
+    });
+  });
+
+  it("honors explicit policy disablement", async () => {
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ tools: { settings: { requireRisk: true } } }),
+      "utf-8",
+    );
+    await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
+
+    await expect(evaluate("deploy", { enabled: false })).resolves.toBeUndefined();
+  });
+
+  it("blocks when the enabled runtime policy file is missing", async () => {
+    await expect(evaluate("deploy")).resolves.toEqual({
+      block: true,
+      blockReason: "Policy tool runtime is enabled, but policy.jsonc is missing.",
+    });
+  });
+
+  it("blocks when the enabled runtime policy file is malformed", async () => {
+    await fs.writeFile(join(workspaceDir, "policy.jsonc"), "{ tools: ", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      "## Tools\n\n### deploy risk:low\n",
+      "utf-8",
+    );
+
+    await expect(evaluate("deploy")).resolves.toEqual({
+      block: true,
+      blockReason: "Policy tool runtime is enabled, but policy.jsonc could not be parsed.",
+    });
+  });
+
+  it("blocks when the enabled runtime policy file has invalid containers", async () => {
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ tools: { entries: {} } }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      "## Tools\n\n### deploy risk:low\n",
+      "utf-8",
+    );
+
+    await expect(evaluate("deploy")).resolves.toEqual({
+      block: true,
+      blockReason:
+        "Policy tool runtime is enabled, but policy.jsonc has an invalid tools.entries section.",
+    });
+  });
+
+  it("blocks tool calls whose required metadata is missing", async () => {
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        tools: { settings: { runtimeToolPolicy: true, requireRisk: true } },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
+
+    await expect(evaluate("deploy")).resolves.toEqual({
+      block: true,
+      blockReason: "Policy requires risk metadata for 'deploy', but TOOLS.md does not declare it.",
+    });
+  });
+
+  it("blocks tool calls whose risk metadata is unknown", async () => {
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        tools: { settings: { runtimeToolPolicy: true, requireRisk: true } },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      "## Tools\n\n### deploy risk:critcal\n",
+      "utf-8",
+    );
+
+    await expect(evaluate("deploy")).resolves.toEqual({
+      block: true,
+      blockReason:
+        "Policy requires known risk metadata for 'deploy', but TOOLS.md declares 'critcal'.",
+    });
+  });
+
+  it("requires approval for critical or irreversible tools", async () => {
+    const policy = {
+      tools: { settings: { runtimeToolPolicy: true, requireRisk: true } },
+    };
+    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      "## Tools\n\n### deploy risk:critical sensitivity:internal IRREVERSIBLE_EXTERNAL\n",
+      "utf-8",
+    );
+
+    await expect(evaluate("deploy")).resolves.toMatchObject({
+      requireApproval: {
+        title: "Review policy-governed tool",
+        severity: "critical",
+        metadata: {
+          source: "policy",
+          policy: {
+            path: "policy.jsonc",
+            hash: policyDocumentHash(policy),
+          },
+          workspace: {
+            scope: "policy",
+            hash: expect.stringMatching(/^sha256:/),
+          },
+          target: "oc://TOOLS.md/tools/deploy",
+        },
+      },
+    });
+  });
+
+  it("includes policy metadata when undeclared tools need approval", async () => {
+    const policy = {
+      tools: { settings: { runtimeToolPolicy: true, requireRisk: true } },
+    };
+    const expectedHash = policyDocumentHash(policy);
+    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n", "utf-8");
+
+    await expect(evaluate("deploy", { expectedHash })).resolves.toMatchObject({
+      requireApproval: {
+        title: "Review undeclared tool",
+        metadata: {
+          source: "policy",
+          policy: {
+            path: "policy.jsonc",
+            hash: expectedHash,
+            expectedHash,
+          },
+          workspace: {
+            scope: "policy",
+            hash: expect.stringMatching(/^sha256:/),
+          },
+          target: "oc://TOOLS.md/tools/deploy",
+        },
+      },
+    });
+  });
+
+  it("allows declared low-risk tools without a runtime decision", async () => {
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        tools: { settings: { runtimeToolPolicy: true, requireRisk: true } },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      "## Tools\n\n### inspect risk:low sensitivity:public\n",
+      "utf-8",
+    );
+
+    await expect(evaluate("inspect")).resolves.toBeUndefined();
+  });
+});

--- a/extensions/policy/src/runtime-tool-policy.test.ts
+++ b/extensions/policy/src/runtime-tool-policy.test.ts
@@ -374,16 +374,23 @@ describe("policy trusted tool runtime", () => {
             ctx: { toolName: string; cwd?: string },
           ) => ReturnType<typeof evaluatePolicyTrustedToolCall>)
         | undefined;
-      registerPolicyTrustedToolPolicy({
+      const api = {
         config: cfg(),
         runtime: {
           config: { current: () => cfg() },
           agent: { resolveAgentWorkspaceDir: () => agentWorkspace },
         },
-        registerTrustedToolPolicy(policy) {
+        registerTrustedToolPolicy(
+          policy: Parameters<
+            Parameters<typeof registerPolicyTrustedToolPolicy>[0]["registerTrustedToolPolicy"]
+          >[0],
+        ) {
           evaluate = policy.evaluate as typeof evaluate;
         },
-      });
+      };
+      registerPolicyTrustedToolPolicy(
+        api as unknown as Parameters<typeof registerPolicyTrustedToolPolicy>[0],
+      );
 
       await expect(
         evaluate?.({ toolName: "deploy", params: {} }, { toolName: "deploy", cwd: workspaceDir }),

--- a/extensions/policy/src/runtime-tool-policy.test.ts
+++ b/extensions/policy/src/runtime-tool-policy.test.ts
@@ -47,7 +47,7 @@ describe("policy trusted tool runtime", () => {
   it("does nothing until runtime tool policy is enabled", async () => {
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { settings: { runtimeToolPolicy: true, requireRisk: true } } }),
+      JSON.stringify({ tools: { requireMetadata: ["risk"] } }),
       "utf-8",
     );
     await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
@@ -58,7 +58,7 @@ describe("policy trusted tool runtime", () => {
   it("honors plugin entry enablement without requiring config.enabled", async () => {
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { settings: { requireRisk: true } } }),
+      JSON.stringify({ tools: { requireMetadata: ["risk"] } }),
       "utf-8",
     );
     await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
@@ -72,7 +72,7 @@ describe("policy trusted tool runtime", () => {
   it("honors explicit policy disablement", async () => {
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { settings: { requireRisk: true } } }),
+      JSON.stringify({ tools: { requireMetadata: ["risk"] } }),
       "utf-8",
     );
     await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
@@ -120,11 +120,30 @@ describe("policy trusted tool runtime", () => {
     });
   });
 
+  it("blocks when requireMetadata contains unsupported entries", async () => {
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ tools: { requireMetadata: ["risk", "unsupported"] } }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      "## Tools\n\n### deploy risk:low\n",
+      "utf-8",
+    );
+
+    await expect(evaluate("deploy")).resolves.toEqual({
+      block: true,
+      blockReason:
+        "Policy tool runtime is enabled, but policy.jsonc has unsupported tools.requireMetadata 'unsupported'.",
+    });
+  });
+
   it("blocks tool calls whose required metadata is missing", async () => {
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
       JSON.stringify({
-        tools: { settings: { runtimeToolPolicy: true, requireRisk: true } },
+        tools: { requireMetadata: ["risk"] },
       }),
       "utf-8",
     );
@@ -136,11 +155,29 @@ describe("policy trusted tool runtime", () => {
     });
   });
 
+  it("blocks tool calls whose required owner metadata is missing", async () => {
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ tools: { requireMetadata: ["owner"] } }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      "## Tools\n\n### deploy risk:low sensitivity:internal\n",
+      "utf-8",
+    );
+
+    await expect(evaluate("deploy")).resolves.toEqual({
+      block: true,
+      blockReason: "Policy requires owner metadata for 'deploy', but TOOLS.md does not declare it.",
+    });
+  });
+
   it("blocks tool calls whose risk metadata is unknown", async () => {
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
       JSON.stringify({
-        tools: { settings: { runtimeToolPolicy: true, requireRisk: true } },
+        tools: { requireMetadata: ["risk"] },
       }),
       "utf-8",
     );
@@ -159,7 +196,7 @@ describe("policy trusted tool runtime", () => {
 
   it("requires approval for critical or irreversible tools", async () => {
     const policy = {
-      tools: { settings: { runtimeToolPolicy: true, requireRisk: true } },
+      tools: { requireMetadata: ["risk"] },
     };
     await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
     await fs.writeFile(
@@ -190,7 +227,7 @@ describe("policy trusted tool runtime", () => {
 
   it("includes policy metadata when undeclared tools need approval", async () => {
     const policy = {
-      tools: { settings: { runtimeToolPolicy: true, requireRisk: true } },
+      tools: { requireMetadata: ["risk"] },
     };
     const expectedHash = policyDocumentHash(policy);
     await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
@@ -220,7 +257,7 @@ describe("policy trusted tool runtime", () => {
     await fs.writeFile(
       join(workspaceDir, "policy.jsonc"),
       JSON.stringify({
-        tools: { settings: { runtimeToolPolicy: true, requireRisk: true } },
+        tools: { requireMetadata: ["risk"] },
       }),
       "utf-8",
     );

--- a/extensions/policy/src/runtime-tool-policy.test.ts
+++ b/extensions/policy/src/runtime-tool-policy.test.ts
@@ -225,6 +225,46 @@ describe("policy trusted tool runtime", () => {
     });
   });
 
+  it("requires approval for critical tools with multiline metadata", async () => {
+    const policy = {
+      tools: { requireMetadata: ["risk", "sensitivity", "owner"] },
+    };
+    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "TOOLS.md"),
+      [
+        "## Tools",
+        "",
+        "### deploy",
+        "risk: critical",
+        "sensitivity: internal",
+        "owner: ops",
+        "IRREVERSIBLE_EXTERNAL",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await expect(evaluate("deploy")).resolves.toMatchObject({
+      requireApproval: {
+        title: "Review policy-governed tool",
+        severity: "critical",
+        metadata: {
+          source: "policy",
+          policy: {
+            path: "policy.jsonc",
+            hash: policyDocumentHash(policy),
+          },
+          workspace: {
+            scope: "policy",
+            hash: expect.stringMatching(/^sha256:/),
+          },
+          target: "oc://TOOLS.md/tools/deploy",
+        },
+      },
+    });
+  });
+
   it("includes policy metadata when undeclared tools need approval", async () => {
     const policy = {
       tools: { requireMetadata: ["risk"] },

--- a/extensions/policy/src/runtime-tool-policy.ts
+++ b/extensions/policy/src/runtime-tool-policy.ts
@@ -1,0 +1,373 @@
+import { promises as fs } from "node:fs";
+import { basename, isAbsolute, resolve } from "node:path";
+import { parseOcDocument, type Diagnostic, type JsoncAst } from "@openclaw/oc-path/api.js";
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  OpenClawPluginApi,
+  PluginJsonValue,
+  PluginTrustedToolPolicyRegistration,
+} from "openclaw/plugin-sdk/core";
+import { jsoncValueToUnknown } from "./jsonc-value.js";
+import {
+  collectPolicyEvidence,
+  policyDocumentHash,
+  policyWorkspaceHash,
+  type PolicyEvidence,
+  type PolicyToolEvidence,
+} from "./policy-state.js";
+
+type PolicyRuntimeSettings = {
+  readonly enabled?: boolean;
+  readonly runtimeToolPolicy?: boolean;
+  readonly requireRisk?: boolean;
+  readonly requireSensitivity?: boolean;
+  readonly expectedHash?: string;
+  readonly path?: string;
+};
+
+type RuntimePolicyState = {
+  readonly policyPath: string;
+  readonly policyError?: string;
+  readonly policyHash?: string;
+  readonly policy?: unknown;
+  readonly evidence: PolicyEvidence;
+  readonly settings: PolicyRuntimeSettings;
+};
+
+type RuntimePolicyDeps = {
+  readonly readConfig?: () => OpenClawConfig;
+  readonly cwd?: string;
+  readonly resolveWorkspaceDir?: (cfg: OpenClawConfig, ctx: PolicyToolContext) => string;
+};
+
+type PolicyToolEvent = {
+  readonly toolName: string;
+  readonly params: Record<string, unknown>;
+};
+
+type PolicyToolContext = {
+  readonly agentId?: string;
+  readonly toolName?: string;
+  readonly workspaceDir?: string;
+};
+
+type PolicyToolDecision = Awaited<ReturnType<PluginTrustedToolPolicyRegistration["evaluate"]>>;
+
+const POLICY_APPROVAL_DECISIONS: Array<"allow-once" | "deny"> = ["allow-once", "deny"];
+
+export function registerPolicyTrustedToolPolicy(
+  api: Pick<OpenClawPluginApi, "config" | "registerTrustedToolPolicy" | "runtime">,
+  deps: RuntimePolicyDeps = {},
+): void {
+  api.registerTrustedToolPolicy({
+    id: "policy-tool-runtime",
+    description: "Apply enabled policy tool requirements before tool calls.",
+    async evaluate(event, ctx) {
+      return evaluatePolicyTrustedToolCall(event, ctx, {
+        cwd: deps.cwd,
+        readConfig:
+          deps.readConfig ??
+          (() => (api.runtime.config?.current?.() as OpenClawConfig | undefined) ?? api.config),
+        resolveWorkspaceDir:
+          deps.resolveWorkspaceDir ??
+          ((cfg, context) => {
+            const agentId = context.agentId ?? resolveDefaultAgentId(cfg);
+            return context.workspaceDir ?? api.runtime.agent.resolveAgentWorkspaceDir(cfg, agentId);
+          }),
+      });
+    },
+  });
+}
+
+export async function evaluatePolicyTrustedToolCall(
+  event: PolicyToolEvent,
+  ctx: PolicyToolContext,
+  deps: RuntimePolicyDeps = {},
+): Promise<PolicyToolDecision> {
+  const cfg = deps.readConfig?.();
+  if (cfg === undefined) {
+    return undefined;
+  }
+  const settings = policySettings(cfg);
+  if (!policyExtensionEnabled(cfg)) {
+    return undefined;
+  }
+  if (settings.runtimeToolPolicy !== true) {
+    return undefined;
+  }
+
+  const workspaceDir = deps.cwd ?? deps.resolveWorkspaceDir?.(cfg, ctx);
+  if (workspaceDir === undefined) {
+    return undefined;
+  }
+  const state = await loadRuntimePolicyState(cfg, settings, workspaceDir);
+
+  const expectedHash = state.settings.expectedHash;
+  if (state.policyError !== undefined) {
+    return {
+      block: true,
+      blockReason: state.policyError,
+    };
+  }
+  if (state.policy === undefined) {
+    return {
+      block: true,
+      blockReason: `Policy tool runtime is enabled, but ${state.policyPath} is missing.`,
+    };
+  }
+  if (
+    typeof expectedHash === "string" &&
+    expectedHash.trim() !== "" &&
+    state.policyHash !== expectedHash.trim()
+  ) {
+    return {
+      block: true,
+      blockReason: `${state.policyPath} does not match the configured policy hash.`,
+    };
+  }
+
+  const tool = state.evidence.tools.find((entry) => entry.id === event.toolName);
+  if (tool === undefined) {
+    if (toolMetadataRequired(state)) {
+      return {
+        requireApproval: {
+          title: "Review undeclared tool",
+          description: `Policy requires tool metadata, but '${event.toolName}' is not declared in TOOLS.md.`,
+          severity: "warning" as const,
+          metadata: runtimeApprovalMetadata(state, event.toolName),
+          allowedDecisions: [...POLICY_APPROVAL_DECISIONS],
+        },
+      };
+    }
+    return undefined;
+  }
+
+  const metadataBlockReason = toolMetadataBlockReason(tool, state);
+  if (metadataBlockReason !== undefined) {
+    return {
+      block: true,
+      blockReason: metadataBlockReason,
+    };
+  }
+
+  const approvalReason = toolApprovalReason(tool);
+  if (approvalReason === undefined) {
+    return undefined;
+  }
+  return {
+    requireApproval: {
+      title: "Review policy-governed tool",
+      description: `${event.toolName} requires approval because ${approvalReason}.`,
+      severity: tool.risk === "critical" ? ("critical" as const) : ("warning" as const),
+      metadata: runtimeApprovalMetadata(state, event.toolName, tool),
+      allowedDecisions: [...POLICY_APPROVAL_DECISIONS],
+    },
+  };
+}
+
+function runtimeApprovalMetadata(
+  state: RuntimePolicyState,
+  toolName: string,
+  tool?: PolicyToolEvidence,
+): PluginJsonValue {
+  const expectedHash = state.settings.expectedHash?.trim();
+  return {
+    source: "policy",
+    policy: {
+      path: state.policyPath,
+      ...(state.policyHash !== undefined ? { hash: state.policyHash } : {}),
+      ...(expectedHash ? { expectedHash } : {}),
+    },
+    workspace: {
+      scope: "policy",
+      hash: policyWorkspaceHash(state.evidence),
+    },
+    target: tool?.ocPath ?? `oc://TOOLS.md/tools/${toolName}`,
+  };
+}
+
+async function loadRuntimePolicyState(
+  cfg: OpenClawConfig,
+  settings: PolicyRuntimeSettings,
+  cwd: string,
+): Promise<RuntimePolicyState> {
+  const policyPath = policyDisplayName(settings);
+  const toolsRaw = await readFileIfExists(resolve(cwd, "TOOLS.md"));
+  const evidence = collectPolicyEvidence(
+    cfg as Record<string, unknown>,
+    toolsRaw === null ? {} : { toolsRaw },
+  );
+  const policyRaw = await readFileIfExists(resolveWorkspacePath(cwd, policyPathSetting(settings)));
+  if (policyRaw === null) {
+    return { policyPath, evidence, settings };
+  }
+  const parsed = parsePolicyFile(policyRaw, policyPath);
+  if (parsed.diagnostics.some((diagnostic) => diagnostic.severity === "error")) {
+    return {
+      policyPath,
+      policyError: `Policy tool runtime is enabled, but ${policyPath} could not be parsed.`,
+      evidence,
+      settings,
+    };
+  }
+  const policy = parsed.ast.root === null ? {} : jsoncValueToUnknown(parsed.ast.root);
+  const policyShapeError = validateRuntimePolicyShape(policy, policyPath);
+  if (policyShapeError !== undefined) {
+    return { policyPath, policyError: policyShapeError, evidence, settings };
+  }
+  return {
+    policyPath,
+    policy,
+    policyHash: policyDocumentHash(policy),
+    evidence,
+    settings,
+  };
+}
+
+function toolMetadataRequired(state: RuntimePolicyState): boolean {
+  return requireRisk(state) || requireSensitivity(state);
+}
+
+function toolMetadataBlockReason(
+  tool: PolicyToolEvidence,
+  state: RuntimePolicyState,
+): string | undefined {
+  if (requireRisk(state) && tool.risk === undefined) {
+    return `Policy requires risk metadata for '${tool.id}', but TOOLS.md does not declare it.`;
+  }
+  if (tool.risk !== undefined && !["low", "medium", "high", "critical"].includes(tool.risk)) {
+    return `Policy requires known risk metadata for '${tool.id}', but TOOLS.md declares '${tool.risk}'.`;
+  }
+  if (requireSensitivity(state)) {
+    if (tool.sensitivity === undefined) {
+      return `Policy requires sensitivity metadata for '${tool.id}', but TOOLS.md does not declare it.`;
+    }
+    if (!["public", "internal", "confidential", "restricted"].includes(tool.sensitivity)) {
+      return `Policy requires known sensitivity metadata for '${tool.id}', but TOOLS.md declares '${tool.sensitivity}'.`;
+    }
+  }
+  return undefined;
+}
+
+function validateRuntimePolicyShape(policy: unknown, policyPath: string): string | undefined {
+  if (!isRecord(policy)) {
+    return `Policy tool runtime is enabled, but ${policyPath} does not contain an object.`;
+  }
+  if (policy.tools !== undefined && !isRecord(policy.tools)) {
+    return `Policy tool runtime is enabled, but ${policyPath} has an invalid tools section.`;
+  }
+  if (isRecord(policy.tools)) {
+    if (policy.tools.settings !== undefined && !isRecord(policy.tools.settings)) {
+      return `Policy tool runtime is enabled, but ${policyPath} has an invalid tools.settings section.`;
+    }
+    if (policy.tools.entries !== undefined && !Array.isArray(policy.tools.entries)) {
+      return `Policy tool runtime is enabled, but ${policyPath} has an invalid tools.entries section.`;
+    }
+  }
+  if (policy.channels !== undefined && !isRecord(policy.channels)) {
+    return `Policy tool runtime is enabled, but ${policyPath} has an invalid channels section.`;
+  }
+  if (
+    isRecord(policy.channels) &&
+    policy.channels.denyRules !== undefined &&
+    !Array.isArray(policy.channels.denyRules)
+  ) {
+    return `Policy tool runtime is enabled, but ${policyPath} has an invalid channels.denyRules section.`;
+  }
+  return undefined;
+}
+
+function requireRisk(state: RuntimePolicyState): boolean {
+  return (
+    state.settings.requireRisk === true ||
+    readPolicyBoolean(state.policy, ["tools", "settings", "requireRisk"]) === true
+  );
+}
+
+function requireSensitivity(state: RuntimePolicyState): boolean {
+  return (
+    state.settings.requireSensitivity === true ||
+    readPolicyBoolean(state.policy, ["tools", "settings", "requireSensitivity"]) === true
+  );
+}
+
+function toolApprovalReason(tool: PolicyToolEvidence): string | undefined {
+  const reasons: string[] = [];
+  if (tool.risk === "critical") {
+    reasons.push("risk is critical");
+  }
+  if (tool.capabilities?.includes("IRREVERSIBLE_EXTERNAL")) {
+    reasons.push("it can perform irreversible external actions");
+  }
+  return reasons.length === 0 ? undefined : reasons.join(" and ");
+}
+
+function policySettings(cfg: OpenClawConfig): PolicyRuntimeSettings {
+  const pluginConfig = cfg.plugins?.entries?.policy?.config;
+  return isRecord(pluginConfig) ? pluginConfig : {};
+}
+
+function policyExtensionEnabled(cfg: OpenClawConfig): boolean {
+  const entry = cfg.plugins?.entries?.policy;
+  const settings = policySettings(cfg);
+  if (entry === undefined || entry.enabled === false || settings.enabled === false) {
+    return false;
+  }
+  return entry.enabled === true || settings.enabled === true;
+}
+
+function policyPathSetting(settings: PolicyRuntimeSettings): string {
+  return typeof settings.path === "string" && settings.path.trim() !== ""
+    ? settings.path.trim()
+    : "policy.jsonc";
+}
+
+function policyDisplayName(settings: PolicyRuntimeSettings): string {
+  const configured = policyPathSetting(settings);
+  return isAbsolute(configured) ? basename(configured) : configured;
+}
+
+function resolveWorkspacePath(cwd: string, fileName: string): string {
+  return isAbsolute(fileName) ? fileName : resolve(cwd, fileName);
+}
+
+async function readFileIfExists(path: string): Promise<string | null> {
+  try {
+    return await fs.readFile(path, "utf-8");
+  } catch (err) {
+    if (typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+function parsePolicyFile(
+  raw: string,
+  fileName: string,
+): {
+  readonly ast: JsoncAst;
+  readonly diagnostics: readonly Diagnostic[];
+} {
+  const parsed = parseOcDocument(raw, { fileName });
+  if (parsed.ast.kind !== "jsonc") {
+    throw new Error(`${fileName} did not parse as jsonc.`);
+  }
+  return { ast: parsed.ast, diagnostics: parsed.diagnostics };
+}
+
+function readPolicyBoolean(policy: unknown, path: readonly string[]): boolean | undefined {
+  let current: unknown = policy;
+  for (const part of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[part];
+  }
+  return typeof current === "boolean" ? current : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/extensions/policy/src/runtime-tool-policy.ts
+++ b/extensions/policy/src/runtime-tool-policy.ts
@@ -48,6 +48,7 @@ type PolicyToolEvent = {
 type PolicyToolContext = {
   readonly agentId?: string;
   readonly toolName?: string;
+  readonly cwd?: string;
   readonly workspaceDir?: string;
 };
 
@@ -72,7 +73,11 @@ export function registerPolicyTrustedToolPolicy(
           deps.resolveWorkspaceDir ??
           ((cfg, context) => {
             const agentId = context.agentId ?? resolveDefaultAgentId(cfg);
-            return context.workspaceDir ?? api.runtime.agent.resolveAgentWorkspaceDir(cfg, agentId);
+            return (
+              context.cwd ??
+              context.workspaceDir ??
+              api.runtime.agent.resolveAgentWorkspaceDir(cfg, agentId)
+            );
           }),
       });
     },
@@ -96,7 +101,7 @@ export async function evaluatePolicyTrustedToolCall(
     return undefined;
   }
 
-  const workspaceDir = deps.cwd ?? deps.resolveWorkspaceDir?.(cfg, ctx);
+  const workspaceDir = deps.cwd ?? ctx.cwd ?? deps.resolveWorkspaceDir?.(cfg, ctx);
   if (workspaceDir === undefined) {
     return undefined;
   }
@@ -215,6 +220,18 @@ async function loadRuntimePolicyState(
   if (policyShapeError !== undefined) {
     return { policyPath, policyError: policyShapeError, evidence, settings };
   }
+  if (requiredToolMetadata(policy).size > 0) {
+    const toolEvidence = collectPolicyEvidence(cfg as Record<string, unknown>, {
+      toolsRaw: toolsRaw ?? "",
+    });
+    return {
+      policyPath,
+      policy,
+      policyHash: policyDocumentHash(policy),
+      evidence: toolEvidence,
+      settings,
+    };
+  }
   return {
     policyPath,
     policy,
@@ -236,7 +253,11 @@ function toolMetadataBlockReason(
   if (required.has("risk") && tool.risk === undefined) {
     return `Policy requires risk metadata for '${tool.id}', but TOOLS.md does not declare it.`;
   }
-  if (tool.risk !== undefined && !["low", "medium", "high", "critical"].includes(tool.risk)) {
+  if (
+    required.has("risk") &&
+    tool.risk !== undefined &&
+    !["low", "medium", "high", "critical"].includes(tool.risk)
+  ) {
     return `Policy requires known risk metadata for '${tool.id}', but TOOLS.md declares '${tool.risk}'.`;
   }
   if (required.has("sensitivity")) {

--- a/extensions/policy/src/runtime-tool-policy.ts
+++ b/extensions/policy/src/runtime-tool-policy.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import { basename, isAbsolute, resolve } from "node:path";
-import { parseOcDocument, type Diagnostic, type JsoncAst } from "@openclaw/oc-path/api.js";
+import JSON5 from "json5";
 import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
@@ -8,7 +8,6 @@ import type {
   PluginJsonValue,
   PluginTrustedToolPolicyRegistration,
 } from "openclaw/plugin-sdk/core";
-import { jsoncValueToUnknown } from "./jsonc-value.js";
 import {
   collectPolicyEvidence,
   policyDocumentHash,
@@ -17,11 +16,11 @@ import {
   type PolicyToolEvidence,
 } from "./policy-state.js";
 
+const SUPPORTED_TOOL_METADATA = ["risk", "sensitivity", "owner"] as const;
+
 type PolicyRuntimeSettings = {
   readonly enabled?: boolean;
   readonly runtimeToolPolicy?: boolean;
-  readonly requireRisk?: boolean;
-  readonly requireSensitivity?: boolean;
   readonly expectedHash?: string;
   readonly path?: string;
 };
@@ -183,7 +182,7 @@ function runtimeApprovalMetadata(
       scope: "policy",
       hash: policyWorkspaceHash(state.evidence),
     },
-    target: tool?.ocPath ?? `oc://TOOLS.md/tools/${toolName}`,
+    target: tool?.source ?? `oc://TOOLS.md/tools/${toolName}`,
   };
 }
 
@@ -202,8 +201,8 @@ async function loadRuntimePolicyState(
   if (policyRaw === null) {
     return { policyPath, evidence, settings };
   }
-  const parsed = parsePolicyFile(policyRaw, policyPath);
-  if (parsed.diagnostics.some((diagnostic) => diagnostic.severity === "error")) {
+  const parsed = parsePolicyFile(policyRaw);
+  if (!parsed.ok) {
     return {
       policyPath,
       policyError: `Policy tool runtime is enabled, but ${policyPath} could not be parsed.`,
@@ -211,7 +210,7 @@ async function loadRuntimePolicyState(
       settings,
     };
   }
-  const policy = parsed.ast.root === null ? {} : jsoncValueToUnknown(parsed.ast.root);
+  const policy = parsed.value;
   const policyShapeError = validateRuntimePolicyShape(policy, policyPath);
   if (policyShapeError !== undefined) {
     return { policyPath, policyError: policyShapeError, evidence, settings };
@@ -226,26 +225,30 @@ async function loadRuntimePolicyState(
 }
 
 function toolMetadataRequired(state: RuntimePolicyState): boolean {
-  return requireRisk(state) || requireSensitivity(state);
+  return requiredToolMetadata(state.policy).size > 0;
 }
 
 function toolMetadataBlockReason(
   tool: PolicyToolEvidence,
   state: RuntimePolicyState,
 ): string | undefined {
-  if (requireRisk(state) && tool.risk === undefined) {
+  const required = requiredToolMetadata(state.policy);
+  if (required.has("risk") && tool.risk === undefined) {
     return `Policy requires risk metadata for '${tool.id}', but TOOLS.md does not declare it.`;
   }
   if (tool.risk !== undefined && !["low", "medium", "high", "critical"].includes(tool.risk)) {
     return `Policy requires known risk metadata for '${tool.id}', but TOOLS.md declares '${tool.risk}'.`;
   }
-  if (requireSensitivity(state)) {
+  if (required.has("sensitivity")) {
     if (tool.sensitivity === undefined) {
       return `Policy requires sensitivity metadata for '${tool.id}', but TOOLS.md does not declare it.`;
     }
     if (!["public", "internal", "confidential", "restricted"].includes(tool.sensitivity)) {
       return `Policy requires known sensitivity metadata for '${tool.id}', but TOOLS.md declares '${tool.sensitivity}'.`;
     }
+  }
+  if (required.has("owner") && tool.owner === undefined) {
+    return `Policy requires owner metadata for '${tool.id}', but TOOLS.md does not declare it.`;
   }
   return undefined;
 }
@@ -258,6 +261,16 @@ function validateRuntimePolicyShape(policy: unknown, policyPath: string): string
     return `Policy tool runtime is enabled, but ${policyPath} has an invalid tools section.`;
   }
   if (isRecord(policy.tools)) {
+    if (
+      policy.tools.requireMetadata !== undefined &&
+      !isStringArray(policy.tools.requireMetadata)
+    ) {
+      return `Policy tool runtime is enabled, but ${policyPath} has an invalid tools.requireMetadata section.`;
+    }
+    const unsupported = unsupportedToolMetadata(policy.tools.requireMetadata);
+    if (unsupported !== undefined) {
+      return `Policy tool runtime is enabled, but ${policyPath} has unsupported tools.requireMetadata '${unsupported}'.`;
+    }
     if (policy.tools.settings !== undefined && !isRecord(policy.tools.settings)) {
       return `Policy tool runtime is enabled, but ${policyPath} has an invalid tools.settings section.`;
     }
@@ -278,18 +291,42 @@ function validateRuntimePolicyShape(policy: unknown, policyPath: string): string
   return undefined;
 }
 
-function requireRisk(state: RuntimePolicyState): boolean {
-  return (
-    state.settings.requireRisk === true ||
-    readPolicyBoolean(state.policy, ["tools", "settings", "requireRisk"]) === true
-  );
+function requiredToolMetadata(policy: unknown): ReadonlySet<string> {
+  return new Set(readPolicyStringArray(policy, ["tools", "requireMetadata"]) ?? []);
 }
 
-function requireSensitivity(state: RuntimePolicyState): boolean {
-  return (
-    state.settings.requireSensitivity === true ||
-    readPolicyBoolean(state.policy, ["tools", "settings", "requireSensitivity"]) === true
-  );
+function readPolicyStringArray(
+  policy: unknown,
+  path: readonly string[],
+): readonly string[] | undefined {
+  let current: unknown = policy;
+  for (const part of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[part];
+  }
+  if (!Array.isArray(current) || !current.every((entry) => typeof entry === "string")) {
+    return undefined;
+  }
+  return current.map((entry) => entry.trim().toLowerCase()).filter(Boolean);
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function unsupportedToolMetadata(value: unknown): string | undefined {
+  if (!isStringArray(value)) {
+    return undefined;
+  }
+  return value
+    .map((entry) => entry.trim().toLowerCase())
+    .find(
+      (entry) =>
+        entry !== "" &&
+        !SUPPORTED_TOOL_METADATA.includes(entry as (typeof SUPPORTED_TOOL_METADATA)[number]),
+    );
 }
 
 function toolApprovalReason(tool: PolicyToolEvidence): string | undefined {
@@ -345,27 +382,12 @@ async function readFileIfExists(path: string): Promise<string | null> {
 
 function parsePolicyFile(
   raw: string,
-  fileName: string,
-): {
-  readonly ast: JsoncAst;
-  readonly diagnostics: readonly Diagnostic[];
-} {
-  const parsed = parseOcDocument(raw, { fileName });
-  if (parsed.ast.kind !== "jsonc") {
-    throw new Error(`${fileName} did not parse as jsonc.`);
+): { readonly ok: true; readonly value: unknown } | { readonly ok: false } {
+  try {
+    return { ok: true, value: JSON5.parse(raw) };
+  } catch {
+    return { ok: false };
   }
-  return { ast: parsed.ast, diagnostics: parsed.diagnostics };
-}
-
-function readPolicyBoolean(policy: unknown, path: readonly string[]): boolean | undefined {
-  let current: unknown = policy;
-  for (const part of path) {
-    if (!isRecord(current)) {
-      return undefined;
-    }
-    current = current[part];
-  }
-  return typeof current === "boolean" ? current : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/extensions/policy/src/runtime-tool-policy.ts
+++ b/extensions/policy/src/runtime-tool-policy.ts
@@ -126,7 +126,7 @@ export async function evaluatePolicyTrustedToolCall(
     };
   }
 
-  const tool = state.evidence.tools.find((entry) => entry.id === event.toolName);
+  const tool = (state.evidence.tools ?? []).find((entry) => entry.id === event.toolName);
   if (tool === undefined) {
     if (toolMetadataRequired(state)) {
       return {

--- a/extensions/policy/src/runtime-tool-policy.ts
+++ b/extensions/policy/src/runtime-tool-policy.ts
@@ -10,8 +10,9 @@ import type {
 } from "openclaw/plugin-sdk/core";
 import {
   collectPolicyEvidence,
+  createPolicyAttestation,
   policyDocumentHash,
-  policyWorkspaceHash,
+  type PolicyAttestation,
   type PolicyEvidence,
   type PolicyToolEvidence,
 } from "./policy-state.js";
@@ -22,6 +23,7 @@ type PolicyRuntimeSettings = {
   readonly enabled?: boolean;
   readonly runtimeToolPolicy?: boolean;
   readonly expectedHash?: string;
+  readonly expectedAttestationHash?: string;
   readonly path?: string;
 };
 
@@ -31,6 +33,7 @@ type RuntimePolicyState = {
   readonly policyHash?: string;
   readonly policy?: unknown;
   readonly evidence: PolicyEvidence;
+  readonly attestation?: PolicyAttestation;
   readonly settings: PolicyRuntimeSettings;
 };
 
@@ -130,6 +133,18 @@ export async function evaluatePolicyTrustedToolCall(
       blockReason: `${state.policyPath} does not match the configured policy hash.`,
     };
   }
+  const expectedAttestationHash = state.settings.expectedAttestationHash?.trim();
+  if (
+    expectedAttestationHash !== undefined &&
+    expectedAttestationHash !== "" &&
+    state.attestation?.attestationHash !== expectedAttestationHash
+  ) {
+    const currentAttestationHash = state.attestation?.attestationHash ?? "missing";
+    return {
+      block: true,
+      blockReason: `${state.policyPath} no longer matches the accepted policy attestation (current ${currentAttestationHash}, expected ${expectedAttestationHash}).`,
+    };
+  }
 
   const tool = (state.evidence.tools ?? []).find((entry) => entry.id === event.toolName);
   if (tool === undefined) {
@@ -176,6 +191,7 @@ function runtimeApprovalMetadata(
   tool?: PolicyToolEvidence,
 ): PluginJsonValue {
   const expectedHash = state.settings.expectedHash?.trim();
+  const expectedAttestationHash = state.settings.expectedAttestationHash?.trim();
   return {
     source: "policy",
     policy: {
@@ -183,9 +199,17 @@ function runtimeApprovalMetadata(
       ...(state.policyHash !== undefined ? { hash: state.policyHash } : {}),
       ...(expectedHash ? { expectedHash } : {}),
     },
+    attestation: {
+      ...(state.attestation?.attestationHash !== undefined
+        ? { hash: state.attestation.attestationHash }
+        : {}),
+      ...(expectedAttestationHash ? { expectedHash: expectedAttestationHash } : {}),
+    },
     workspace: {
       scope: "policy",
-      hash: policyWorkspaceHash(state.evidence),
+      ...(state.attestation?.workspace.hash !== undefined
+        ? { hash: state.attestation.workspace.hash }
+        : {}),
     },
     target: tool?.source ?? `oc://TOOLS.md/tools/${toolName}`,
   };
@@ -220,23 +244,26 @@ async function loadRuntimePolicyState(
   if (policyShapeError !== undefined) {
     return { policyPath, policyError: policyShapeError, evidence, settings };
   }
-  if (requiredToolMetadata(policy).size > 0) {
-    const toolEvidence = collectPolicyEvidence(cfg as Record<string, unknown>, {
-      toolsRaw: toolsRaw ?? "",
-    });
-    return {
-      policyPath,
-      policy,
-      policyHash: policyDocumentHash(policy),
-      evidence: toolEvidence,
-      settings,
-    };
-  }
+  const policyHash = policyDocumentHash(policy);
+  const attestationEvidence =
+    requiredToolMetadata(policy).size > 0
+      ? collectPolicyEvidence(cfg as Record<string, unknown>, {
+          toolsRaw: toolsRaw ?? "",
+        })
+      : evidence;
   return {
     policyPath,
     policy,
-    policyHash: policyDocumentHash(policy),
-    evidence,
+    policyHash,
+    evidence: attestationEvidence,
+    attestation: createPolicyAttestation({
+      ok: true,
+      checkedAt: new Date().toISOString(),
+      policyPath,
+      policyHash,
+      evidence: attestationEvidence,
+      findings: [],
+    }),
     settings,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1237,6 +1237,9 @@ importers:
 
   extensions/policy:
     dependencies:
+      '@openclaw/oc-path':
+        specifier: workspace:*
+        version: link:../oc-path
       json5:
         specifier: 2.2.3
         version: 2.2.3

--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -75,31 +75,54 @@ function writeJsonFile(targetPath, value) {
 
 function ensureOpenClawExtensionAlias(params) {
   const pluginSdkDir = path.join(params.repoRoot, "dist", "plugin-sdk");
-  if (!fs.existsSync(pluginSdkDir)) {
-    return;
+  const aliasDir = path.join(params.distExtensionsRoot, "node_modules", "openclaw");
+
+  if (fs.existsSync(pluginSdkDir)) {
+    const pluginSdkAliasPath = path.join(aliasDir, "plugin-sdk");
+    fs.mkdirSync(aliasDir, { recursive: true });
+    writeJsonFile(path.join(aliasDir, "package.json"), {
+      name: "openclaw",
+      type: "module",
+      exports: {
+        "./plugin-sdk": "./plugin-sdk/index.js",
+        "./plugin-sdk/*": "./plugin-sdk/*.js",
+      },
+    });
+    removePathIfExists(pluginSdkAliasPath);
+    fs.mkdirSync(pluginSdkAliasPath, { recursive: true });
+    for (const dirent of fs.readdirSync(pluginSdkDir, { withFileTypes: true })) {
+      if (!dirent.isFile() || path.extname(dirent.name) !== ".js") {
+        continue;
+      }
+      writeRuntimeModuleWrapper(
+        path.join(pluginSdkDir, dirent.name),
+        path.join(pluginSdkAliasPath, dirent.name),
+      );
+    }
   }
 
-  const aliasDir = path.join(params.distExtensionsRoot, "node_modules", "openclaw");
-  const pluginSdkAliasPath = path.join(aliasDir, "plugin-sdk");
-  fs.mkdirSync(aliasDir, { recursive: true });
-  writeJsonFile(path.join(aliasDir, "package.json"), {
-    name: "openclaw",
-    type: "module",
-    exports: {
-      "./plugin-sdk": "./plugin-sdk/index.js",
-      "./plugin-sdk/*": "./plugin-sdk/*.js",
-    },
-  });
-  removePathIfExists(pluginSdkAliasPath);
-  fs.mkdirSync(pluginSdkAliasPath, { recursive: true });
-  for (const dirent of fs.readdirSync(pluginSdkDir, { withFileTypes: true })) {
-    if (!dirent.isFile() || path.extname(dirent.name) !== ".js") {
-      continue;
-    }
-    writeRuntimeModuleWrapper(
-      path.join(pluginSdkDir, dirent.name),
-      path.join(pluginSdkAliasPath, dirent.name),
+  const ocPathDir = path.join(params.distExtensionsRoot, "oc-path");
+  const ocPathApiPath = path.join(ocPathDir, "api.js");
+  if (fs.existsSync(ocPathApiPath)) {
+    const ocPathAliasDir = path.join(
+      params.distExtensionsRoot,
+      "node_modules",
+      "@openclaw",
+      "oc-path",
     );
+    writeJsonFile(path.join(ocPathAliasDir, "package.json"), {
+      name: "@openclaw/oc-path",
+      type: "module",
+      exports: {
+        ".": "./index.js",
+        "./api.js": "./api.js",
+      },
+    });
+    writeRuntimeModuleWrapper(
+      path.join(ocPathDir, "index.js"),
+      path.join(ocPathAliasDir, "index.js"),
+    );
+    writeRuntimeModuleWrapper(ocPathApiPath, path.join(ocPathAliasDir, "api.js"));
   }
 }
 

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -191,6 +191,7 @@ async function requestPluginToolApproval(params: {
         title: approval.title,
         description: approval.description,
         severity: approval.severity,
+        metadata: approval.metadata,
         allowedDecisions: approval.allowedDecisions,
         toolName: params.toolName,
         toolCallId: params.toolCallId,

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -534,6 +534,7 @@ export async function runBeforeToolCallHook(args: {
       ...(args.ctx?.sessionKey && { sessionKey: args.ctx.sessionKey }),
       ...(args.ctx?.sessionId && { sessionId: args.ctx.sessionId }),
       ...(args.ctx?.runId && { runId: args.ctx.runId }),
+      ...(args.ctx?.cwd && { cwd: args.ctx.cwd }),
       ...(args.ctx?.trace && { trace: freezeDiagnosticTraceContext(args.ctx.trace) }),
       ...(args.toolCallId && { toolCallId: args.toolCallId }),
       ...(args.ctx?.channelId && { channelId: args.ctx.channelId }),

--- a/src/flows/bundled-health-checks.test.ts
+++ b/src/flows/bundled-health-checks.test.ts
@@ -44,7 +44,9 @@ describe("registerBundledHealthChecks", () => {
       dirName: "policy",
       artifactBasename: "api.js",
     });
-    expect(mocks.registerPolicyDoctorChecks).toHaveBeenCalled();
+    expect(mocks.registerPolicyDoctorChecks).toHaveBeenCalledWith({
+      registerHealthCheck: expect.any(Function),
+    });
   });
 
   it("does not use policy.jsonc existence as extension activation", () => {

--- a/src/flows/health-checks.ts
+++ b/src/flows/health-checks.ts
@@ -49,6 +49,10 @@ export interface HealthCheckContext {
   readonly cfg: OpenClawConfig;
   readonly cwd?: string;
   readonly configPath?: string;
+  readonly runtimeEvidence?: {
+    readonly channels?: unknown;
+    readonly channelRuntime?: unknown;
+  };
 }
 
 export interface HealthRepairContext extends Omit<HealthCheckContext, "mode"> {

--- a/src/gateway/protocol/schema/plugin-approvals.ts
+++ b/src/gateway/protocol/schema/plugin-approvals.ts
@@ -28,6 +28,7 @@ export const PluginApprovalRequestParamsSchema = Type.Object(
     turnSourceTo: Type.Optional(Type.String()),
     turnSourceAccountId: Type.Optional(Type.String()),
     turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+    metadata: Type.Optional(PluginJsonValueSchema),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_PLUGIN_APPROVAL_TIMEOUT_MS })),
     twoPhase: Type.Optional(Type.Boolean()),
   },

--- a/src/gateway/protocol/schema/plugin-approvals.ts
+++ b/src/gateway/protocol/schema/plugin-approvals.ts
@@ -28,7 +28,6 @@ export const PluginApprovalRequestParamsSchema = Type.Object(
     turnSourceTo: Type.Optional(Type.String()),
     turnSourceAccountId: Type.Optional(Type.String()),
     turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
-    metadata: Type.Optional(PluginJsonValueSchema),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_PLUGIN_APPROVAL_TIMEOUT_MS })),
     twoPhase: Type.Optional(Type.Boolean()),
   },

--- a/src/gateway/protocol/schema/plugin-approvals.ts
+++ b/src/gateway/protocol/schema/plugin-approvals.ts
@@ -4,6 +4,7 @@ import {
   PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH,
   PLUGIN_APPROVAL_TITLE_MAX_LENGTH,
 } from "../../../infra/plugin-approvals.js";
+import { PluginJsonValueSchema } from "./plugins.js";
 import { NonEmptyString } from "./primitives.js";
 
 export const PluginApprovalRequestParamsSchema = Type.Object(
@@ -12,6 +13,7 @@ export const PluginApprovalRequestParamsSchema = Type.Object(
     title: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_TITLE_MAX_LENGTH }),
     description: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH }),
     severity: Type.Optional(Type.String({ enum: ["info", "warning", "critical"] })),
+    metadata: Type.Optional(PluginJsonValueSchema),
     toolName: Type.Optional(Type.String()),
     toolCallId: Type.Optional(Type.String()),
     allowedDecisions: Type.Optional(

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -215,6 +215,51 @@ describe("createPluginApprovalHandlers", () => {
       expect(responseCall(respond as unknown as MockCallSource, 1).error).toBeUndefined();
     });
 
+    it("persists structured plugin approval metadata", async () => {
+      const handlers = createPluginApprovalHandlers(manager);
+      const respond = vi.fn();
+      const opts = createMockOptions(
+        "plugin.approval.request",
+        {
+          title: "Policy-governed tool",
+          description: "deploy requires policy approval",
+          severity: "critical",
+          metadata: {
+            policyHash: "sha256:policy",
+            evidenceHash: "sha256:evidence",
+            target: "oc://TOOLS.md/tools/deploy",
+          },
+          twoPhase: true,
+        },
+        { respond },
+      );
+
+      const handlerPromise = handlers["plugin.approval.request"](opts);
+
+      await vi.waitFor(() => {
+        expect(acceptedResult(respond as unknown as MockCallSource).status).toBe("accepted");
+      });
+
+      const approvalId = acceptedApprovalId(respond as unknown as MockCallSource);
+      expect(manager.getSnapshot(approvalId)?.request.metadata).toEqual({
+        policyHash: "sha256:policy",
+        evidenceHash: "sha256:evidence",
+        target: "oc://TOOLS.md/tools/deploy",
+      });
+      const broadcastRequest = requireRecord(
+        broadcastCall(opts).payload.request,
+        "broadcast request",
+      );
+      expect(broadcastRequest.metadata).toEqual({
+        policyHash: "sha256:policy",
+        evidenceHash: "sha256:evidence",
+        target: "oc://TOOLS.md/tools/deploy",
+      });
+
+      manager.resolve(approvalId, "allow-once");
+      await handlerPromise;
+    });
+
     it("expires immediately when no approval route", async () => {
       const handlers = createPluginApprovalHandlers(manager);
       const opts = createMockOptions(

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -246,7 +246,11 @@ describe("createPluginApprovalHandlers", () => {
         evidenceHash: "sha256:evidence",
         target: "oc://TOOLS.md/tools/deploy",
       });
-      expect(broadcastCall(opts).payload.request.metadata).toEqual({
+      const broadcastRequest = requireRecord(
+        broadcastCall(opts).payload.request,
+        "broadcast request",
+      );
+      expect(broadcastRequest.metadata).toEqual({
         policyHash: "sha256:policy",
         evidenceHash: "sha256:evidence",
         target: "oc://TOOLS.md/tools/deploy",

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -246,11 +246,7 @@ describe("createPluginApprovalHandlers", () => {
         evidenceHash: "sha256:evidence",
         target: "oc://TOOLS.md/tools/deploy",
       });
-      const broadcastRequest = requireRecord(
-        broadcastCall(opts).payload.request,
-        "broadcast request",
-      );
-      expect(broadcastRequest.metadata).toEqual({
+      expect(broadcastCall(opts).payload.request.metadata).toEqual({
         policyHash: "sha256:policy",
         evidenceHash: "sha256:evidence",
         target: "oc://TOOLS.md/tools/deploy",

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -470,6 +470,66 @@ describe("createPluginApprovalHandlers", () => {
       manager.resolve(approvalId, "deny");
       await handlerPromise;
     });
+
+    it("preserves structured approval metadata for policy audit trails", async () => {
+      const handlers = createPluginApprovalHandlers(manager);
+      const respond = vi.fn();
+      const metadata = {
+        source: "policy",
+        policy: {
+          path: "policy.jsonc",
+          hash: "sha256:policy",
+          expectedHash: "sha256:expected-policy",
+        },
+        workspace: {
+          scope: "policy",
+          hash: "sha256:workspace",
+        },
+        target: "oc://TOOLS.md/tools/deploy",
+      };
+      const opts = createMockOptions(
+        "plugin.approval.request",
+        {
+          title: "Policy approval required",
+          description: "Deploy touches a governed target",
+          metadata,
+          twoPhase: true,
+        },
+        { respond },
+      );
+
+      const handlerPromise = handlers["plugin.approval.request"](opts);
+      await vi.waitFor(() => {
+        const accepted = acceptedResult(respond as unknown as MockCallSource);
+        expect(accepted.status).toBe("accepted");
+      });
+
+      const approvalId = acceptedApprovalId(respond as unknown as MockCallSource);
+      expect(manager.getSnapshot(approvalId)?.request.metadata).toEqual(metadata);
+      const requestedBroadcast = broadcastCall(opts);
+      expect(
+        requireRecord(requestedBroadcast.payload.request, "broadcast request").metadata,
+      ).toEqual(metadata);
+
+      manager.resolve(approvalId, "allow-once");
+      await handlerPromise;
+    });
+
+    it("rejects non-JSON approval metadata", async () => {
+      const handlers = createPluginApprovalHandlers(manager);
+      const opts = createMockOptions("plugin.approval.request", {
+        title: "T",
+        description: "D",
+        metadata: { value: Number.NaN },
+      });
+
+      await handlers["plugin.approval.request"](opts);
+
+      expect(responseCall(opts.respond as unknown as MockCallSource).ok).toBe(false);
+      expect(responseError(opts.respond as unknown as MockCallSource).message).toBe(
+        "metadata must be JSON-compatible",
+      );
+    });
   });
 
   describe("plugin.approval.list", () => {

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -64,6 +64,7 @@ export function createPluginApprovalHandlers(
         title: string;
         description: string;
         severity?: string | null;
+        metadata?: PluginApprovalRequestPayload["metadata"];
         toolName?: string | null;
         toolCallId?: string | null;
         allowedDecisions?: string[] | null;
@@ -90,6 +91,7 @@ export function createPluginApprovalHandlers(
         title: p.title,
         description: p.description,
         severity: (p.severity as PluginApprovalRequestPayload["severity"]) ?? null,
+        ...(p.metadata !== undefined ? { metadata: p.metadata } : {}),
         toolName: p.toolName ?? null,
         toolCallId: p.toolCallId ?? null,
         ...(Array.isArray(p.allowedDecisions)

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -7,6 +7,7 @@ import {
   MAX_PLUGIN_APPROVAL_TIMEOUT_MS,
   resolvePluginApprovalRequestAllowedDecisions,
 } from "../../infra/plugin-approvals.js";
+import { isPluginJsonValue } from "../../plugins/host-hooks.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
 import {
@@ -74,6 +75,7 @@ export function createPluginApprovalHandlers(
         turnSourceTo?: string | null;
         turnSourceAccountId?: string | null;
         turnSourceThreadId?: string | number | null;
+        metadata?: unknown;
         timeoutMs?: number;
         twoPhase?: boolean;
       };
@@ -85,6 +87,14 @@ export function createPluginApprovalHandlers(
 
       const normalizeTrimmedString = (value?: string | null): string | null =>
         normalizeOptionalString(value) || null;
+      if (p.metadata !== undefined && !isPluginJsonValue(p.metadata)) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "metadata must be JSON-compatible"),
+        );
+        return;
+      }
 
       const request: PluginApprovalRequestPayload = {
         pluginId: p.pluginId ?? null,
@@ -107,6 +117,7 @@ export function createPluginApprovalHandlers(
         turnSourceTo: normalizeTrimmedString(p.turnSourceTo),
         turnSourceAccountId: normalizeTrimmedString(p.turnSourceAccountId),
         turnSourceThreadId: p.turnSourceThreadId ?? null,
+        ...(p.metadata !== undefined ? { metadata: p.metadata } : {}),
       };
 
       // Always server-generate the ID — never accept plugin-provided IDs.

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -75,7 +75,6 @@ export function createPluginApprovalHandlers(
         turnSourceTo?: string | null;
         turnSourceAccountId?: string | null;
         turnSourceThreadId?: string | number | null;
-        metadata?: unknown;
         timeoutMs?: number;
         twoPhase?: boolean;
       };

--- a/src/infra/approval-view-model.test.ts
+++ b/src/infra/approval-view-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildPendingApprovalView } from "./approval-view-model.js";
 import type { ExecApprovalRequest } from "./exec-approvals.js";
+import type { PluginApprovalRequest } from "./plugin-approvals.js";
 
 describe("buildPendingApprovalView", () => {
   it("passes command analysis through exec approval views", () => {
@@ -28,5 +29,45 @@ describe("buildPendingApprovalView", () => {
       throw new Error("expected exec approval view");
     }
     expect(view.commandAnalysis?.warningLines).toEqual(["Contains inline-eval: python -c"]);
+  });
+
+  it("projects policy approval metadata into plugin approval views", () => {
+    const request: PluginApprovalRequest = {
+      id: "plugin:approval-id",
+      createdAtMs: 1,
+      expiresAtMs: 2,
+      request: {
+        title: "Policy approval required",
+        description: "Deploy touches a governed target",
+        severity: "warning",
+        toolName: "deploy",
+        metadata: {
+          source: "policy",
+          policy: {
+            path: "policy.jsonc",
+            hash: "sha256:policy",
+          },
+          workspace: {
+            scope: "policy",
+            hash: "sha256:workspace",
+          },
+          target: "oc://TOOLS.md/tools/deploy",
+        },
+      },
+    };
+
+    const view = buildPendingApprovalView(request);
+
+    expect(view.approvalKind).toBe("plugin");
+    if (view.approvalKind !== "plugin") {
+      throw new Error("expected plugin approval view");
+    }
+    expect(view.metadata).toEqual(
+      expect.arrayContaining([
+        { label: "Policy Hash", value: "sha256:policy" },
+        { label: "Workspace Hash", value: "sha256:workspace" },
+        { label: "Policy Target", value: "oc://TOOLS.md/tools/deploy" },
+      ]),
+    );
   });
 });

--- a/src/infra/approval-view-model.test.ts
+++ b/src/infra/approval-view-model.test.ts
@@ -51,6 +51,10 @@ describe("buildPendingApprovalView", () => {
             scope: "policy",
             hash: "sha256:workspace",
           },
+          attestation: {
+            hash: "sha256:attestation",
+            expectedHash: "sha256:expected-attestation",
+          },
           target: "oc://TOOLS.md/tools/deploy",
         },
       },
@@ -66,6 +70,8 @@ describe("buildPendingApprovalView", () => {
       expect.arrayContaining([
         { label: "Policy Hash", value: "sha256:policy" },
         { label: "Workspace Hash", value: "sha256:workspace" },
+        { label: "Attestation Hash", value: "sha256:attestation" },
+        { label: "Expected Attestation", value: "sha256:expected-attestation" },
         { label: "Policy Target", value: "oc://TOOLS.md/tools/deploy" },
       ]),
     );

--- a/src/infra/approval-view-model.ts
+++ b/src/infra/approval-view-model.ts
@@ -18,6 +18,7 @@ import {
   resolvePluginApprovalRequestAllowedDecisions,
   type PluginApprovalRequest,
 } from "./plugin-approvals.js";
+import { policyApprovalMetadataEntries } from "./policy-approval-metadata.js";
 
 type ApprovalPhase = "pending" | "resolved" | "expired";
 
@@ -54,6 +55,7 @@ function buildPluginMetadata(request: PluginApprovalRequest): ApprovalMetadataVi
   if (request.request.agentId) {
     metadata.push({ label: "Agent", value: request.request.agentId });
   }
+  metadata.push(...policyApprovalMetadataEntries(request.request.metadata));
   return metadata;
 }
 

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -1,10 +1,19 @@
 import type { ExecApprovalDecision } from "./exec-approvals.js";
 
+type PluginApprovalJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | PluginApprovalJsonValue[]
+  | { [key: string]: PluginApprovalJsonValue };
+
 export type PluginApprovalRequestPayload = {
   pluginId?: string | null;
   title: string;
   description: string;
   severity?: "info" | "warning" | "critical" | null;
+  metadata?: PluginApprovalJsonValue;
   toolName?: string | null;
   toolCallId?: string | null;
   allowedDecisions?: readonly ExecApprovalDecision[] | null;

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -1,8 +1,5 @@
 import type { ExecApprovalDecision } from "./exec-approvals.js";
-import {
-  policyApprovalMetadataLines,
-  type ApprovalMetadataValue,
-} from "./policy-approval-metadata.js";
+import { policyApprovalMetadataLines } from "./policy-approval-metadata.js";
 
 type PluginApprovalJsonValue =
   | string
@@ -27,7 +24,6 @@ export type PluginApprovalRequestPayload = {
   turnSourceTo?: string | null;
   turnSourceAccountId?: string | null;
   turnSourceThreadId?: string | number | null;
-  metadata?: ApprovalMetadataValue;
 };
 
 export type PluginApprovalRequest = {

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -1,4 +1,8 @@
 import type { ExecApprovalDecision } from "./exec-approvals.js";
+import {
+  policyApprovalMetadataLines,
+  type ApprovalMetadataValue,
+} from "./policy-approval-metadata.js";
 
 type PluginApprovalJsonValue =
   | string
@@ -23,6 +27,7 @@ export type PluginApprovalRequestPayload = {
   turnSourceTo?: string | null;
   turnSourceAccountId?: string | null;
   turnSourceThreadId?: string | number | null;
+  metadata?: ApprovalMetadataValue;
 };
 
 export type PluginApprovalRequest = {
@@ -95,6 +100,10 @@ export function buildPluginApprovalRequestMessage(
   }
   if (request.request.agentId) {
     lines.push(`Agent: ${request.request.agentId}`);
+  }
+  const policyMetadata = policyApprovalMetadataLines(request.request.metadata);
+  for (const line of policyMetadata) {
+    lines.push(line);
   }
   lines.push(`ID: ${request.id}`);
   const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMsValue) / 1000));

--- a/src/infra/policy-approval-metadata.ts
+++ b/src/infra/policy-approval-metadata.ts
@@ -32,6 +32,7 @@ export function policyApprovalMetadataEntries(
     return [];
   }
   const policy = asRecord(root.policy);
+  const attestation = asRecord(root.attestation);
   const workspace = asRecord(root.workspace);
   const entries: ApprovalMetadataView[] = [];
   const policyHash = recordString(policy, "hash") ?? recordString(policy, "expectedHash");
@@ -41,6 +42,14 @@ export function policyApprovalMetadataEntries(
   const workspaceHash = recordString(workspace, "hash");
   if (workspaceHash) {
     entries.push({ label: "Workspace Hash", value: workspaceHash });
+  }
+  const attestationHash = recordString(attestation, "hash");
+  if (attestationHash) {
+    entries.push({ label: "Attestation Hash", value: attestationHash });
+  }
+  const expectedAttestationHash = recordString(attestation, "expectedHash");
+  if (expectedAttestationHash) {
+    entries.push({ label: "Expected Attestation", value: expectedAttestationHash });
   }
   const target = recordString(root, "target");
   if (target) {

--- a/src/infra/policy-approval-metadata.ts
+++ b/src/infra/policy-approval-metadata.ts
@@ -1,0 +1,54 @@
+import type { ApprovalMetadataView } from "./approval-view-model.types.js";
+
+export type ApprovalMetadataValue =
+  | null
+  | boolean
+  | number
+  | string
+  | ApprovalMetadataValue[]
+  | { [key: string]: ApprovalMetadataValue };
+
+function asRecord(
+  value: ApprovalMetadataValue | undefined,
+): Record<string, ApprovalMetadataValue> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, ApprovalMetadataValue>)
+    : null;
+}
+
+function recordString(
+  record: Record<string, ApprovalMetadataValue> | null,
+  key: string,
+): string | null {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+export function policyApprovalMetadataEntries(
+  metadata: ApprovalMetadataValue | undefined,
+): ApprovalMetadataView[] {
+  const root = asRecord(metadata);
+  if (!root || root.source !== "policy") {
+    return [];
+  }
+  const policy = asRecord(root.policy);
+  const workspace = asRecord(root.workspace);
+  const entries: ApprovalMetadataView[] = [];
+  const policyHash = recordString(policy, "hash") ?? recordString(policy, "expectedHash");
+  if (policyHash) {
+    entries.push({ label: "Policy Hash", value: policyHash });
+  }
+  const workspaceHash = recordString(workspace, "hash");
+  if (workspaceHash) {
+    entries.push({ label: "Workspace Hash", value: workspaceHash });
+  }
+  const target = recordString(root, "target");
+  if (target) {
+    entries.push({ label: "Policy Target", value: target });
+  }
+  return entries;
+}
+
+export function policyApprovalMetadataLines(metadata: ApprovalMetadataValue | undefined): string[] {
+  return policyApprovalMetadataEntries(metadata).map((entry) => `${entry.label}: ${entry.value}`);
+}

--- a/src/infra/secret-file.test.ts
+++ b/src/infra/secret-file.test.ts
@@ -111,7 +111,7 @@ describe("readSecretFileSync", () => {
     await expectSecretFileError({ setup, expectedMessage, options });
   });
 
-  it("throws from the try helper for rejected files", async () => {
+  it("returns undefined from the try helper for rejected files", async () => {
     const file = await createSecretPath(async (dir) => {
       const target = path.join(dir, "target.txt");
       const link = path.join(dir, "secret-link.txt");
@@ -120,9 +120,9 @@ describe("readSecretFileSync", () => {
       return link;
     });
 
-    expect(() =>
-      tryReadSecretFileSync(file, "Telegram bot token", { rejectSymlink: true }),
-    ).toThrow(`Telegram bot token file at ${file} must not be a symlink.`);
+    expect(tryReadSecretFileSync(file, "Telegram bot token", { rejectSymlink: true })).toBe(
+      undefined,
+    );
   });
 
   it.each([

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -478,6 +478,7 @@ export type PluginHookBeforeToolCallResult = {
     title: string;
     description: string;
     severity?: "info" | "warning" | "critical";
+    metadata?: PluginJsonValue;
     timeoutMs?: number;
     timeoutBehavior?: "allow" | "deny";
     allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -433,6 +433,7 @@ export type PluginHookToolContext = {
   sessionKey?: string;
   sessionId?: string;
   runId?: string;
+  cwd?: string;
   trace?: DiagnosticTraceContext;
   toolName: string;
   toolCallId?: string;

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1113,6 +1113,28 @@ describe("loadOpenClawPlugins", () => {
     expect(fs.readFileSync(path.join(aliasDir, "core.js"), "utf8")).toContain("core.js");
   });
 
+  it("writes bundled oc-path package aliases for dist plugin consumers", () => {
+    const distRoot = makeTempDir();
+    const ocPathDir = path.join(distRoot, "extensions", "oc-path");
+    fs.mkdirSync(ocPathDir, { recursive: true });
+    fs.writeFileSync(path.join(ocPathDir, "index.js"), "export const full = true;\n", "utf8");
+    fs.writeFileSync(path.join(ocPathDir, "api.js"), "export const md = true;\n", "utf8");
+
+    ensureOpenClawPluginSdkAlias(distRoot);
+
+    const aliasDir = path.join(distRoot, "extensions", "node_modules", "@openclaw", "oc-path");
+    expect(JSON.parse(fs.readFileSync(path.join(aliasDir, "package.json"), "utf8"))).toMatchObject({
+      name: "@openclaw/oc-path",
+      exports: {
+        ".": "./index.js",
+        "./api.js": "./api.js",
+      },
+    });
+    expect(fs.readFileSync(path.join(aliasDir, "api.js"), "utf8")).toContain(
+      "../../../oc-path/api.js",
+    );
+  });
+
   it("disables bundled plugins by default", () => {
     const bundledDir = makeTempDir();
     writePlugin({

--- a/src/plugins/plugin-sdk-dist-alias.ts
+++ b/src/plugins/plugin-sdk-dist-alias.ts
@@ -20,9 +20,30 @@ function writeRuntimeModuleWrapper(sourcePath: string, targetPath: string): void
   fs.writeFileSync(targetPath, content, "utf8");
 }
 
+function ensureOpenClawOcPathAlias(distRoot: string): void {
+  const ocPathDir = path.join(distRoot, "extensions", "oc-path");
+  const ocPathApiPath = path.join(ocPathDir, "api.js");
+  if (!fs.existsSync(ocPathApiPath)) {
+    return;
+  }
+
+  const aliasDir = path.join(distRoot, "extensions", "node_modules", "@openclaw", "oc-path");
+  writeRuntimeJsonFile(path.join(aliasDir, "package.json"), {
+    name: "@openclaw/oc-path",
+    type: "module",
+    exports: {
+      ".": "./index.js",
+      "./api.js": "./api.js",
+    },
+  });
+  writeRuntimeModuleWrapper(path.join(ocPathDir, "index.js"), path.join(aliasDir, "index.js"));
+  writeRuntimeModuleWrapper(ocPathApiPath, path.join(aliasDir, "api.js"));
+}
+
 export function ensureOpenClawPluginSdkAlias(distRoot: string): void {
   const pluginSdkDir = path.join(distRoot, "plugin-sdk");
   if (!fs.existsSync(pluginSdkDir)) {
+    ensureOpenClawOcPathAlias(distRoot);
     return;
   }
 
@@ -53,4 +74,5 @@ export function ensureOpenClawPluginSdkAlias(distRoot: string): void {
       path.join(pluginSdkAliasDir, entry.name),
     );
   }
+  ensureOpenClawOcPathAlias(distRoot);
 }

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -107,6 +107,8 @@ describe("stageBundledPluginRuntime", () => {
       "dist/plugin-sdk/channel-entry-contract.js":
         "export { contract } from '../channel-entry-contract-abc.js';\n",
       "dist/channel-entry-contract-abc.js": "export const contract = true;\n",
+      [bundledDistPluginFile("oc-path", "index.js")]: "export const full = true;\n",
+      [bundledDistPluginFile("oc-path", "api.js")]: "export const md = true;\n",
       [bundledDistPluginFile("diffs", "index.js")]: "export default {}\n",
       [bundledDistPluginFile("diffs", "node_modules/@pierre/diffs/index.js")]:
         "export default {}\n",
@@ -146,6 +148,26 @@ describe("stageBundledPluginRuntime", () => {
         "utf8",
       ),
     ).toContain('"./plugin-sdk/*": "./plugin-sdk/*.js"');
+    expect(
+      fs.readFileSync(
+        path.join(
+          repoRoot,
+          "dist",
+          "extensions",
+          "node_modules",
+          "@openclaw",
+          "oc-path",
+          "package.json",
+        ),
+        "utf8",
+      ),
+    ).toContain('"./api.js": "./api.js"');
+    expect(
+      fs.readFileSync(
+        path.join(repoRoot, "dist", "extensions", "node_modules", "@openclaw", "oc-path", "api.js"),
+        "utf8",
+      ),
+    ).toContain("../../../oc-path/api.js");
     expect(
       fs.readFileSync(
         path.join(


### PR DESCRIPTION
# Policy: add runtime audit metadata and attestation enforcement

Branch: `policy-runtime-audit`
GitHub base: `main`
Logical base: `policy-conformance-examples`
Current draft: https://github.com/openclaw/openclaw/pull/81104
Draft status: final policy runtime/audit step

## Title

Policy: add runtime audit metadata and attestation enforcement

## Summary

This PR closes the first policy arc by connecting clean policy checks to
runtime decisions and runtime audit evidence.

xarlier policy drafts establish the model:

- `policy.jsonc` defines authored requirements.
- OpenClaw config and workspace declarations are observed as evidence.
- Policy registers health checks.
- `doctor --lint` and `policy check` report conformance findings.
- `policy check --json` emits a stable attestation hash for the accepted clean
  state.

This PR makes that attestation useful at runtime. When the policy runtime tool
gate is enabled, approval decisions carry structured policy metadata. If
`expectedAttestationHash` is configured and watched evidence changes, the gate
fails closed before approval. That lets a supervisor or gateway compare a tool
decision against the exact policy/evidence state that was previously accepted.
`policy diff` can then compare two saved `policy check --json` outputs to
explain whether the policy, evidence, findings, or clean result changed.

The PR also adds the first runtime evidence slice for policy health checks.
Health checks can receive a channel runtime snapshot and report a denied
channel account that is still running. The important contract is the runtime
evidence payload; any finding `target` is only a compact evidence label, not a
new path language.

The intended ownership model is that a workspace can produce a candidate clean
attestation, but a supervisor or gateway authority accepts the attestation. The
agent/container should not be able to silently update the accepted hash that
governs its own runtime decisions.

## Motivation

Policy conformance is only useful for runtime governance if the runtime can
prove which policy check it is relying on. Otherwise an operator can run
`policy check`, accept a clean result, and then miss a later change to the
watched evidence before a tool call is approved.

This PR adds the missing handshake:

- a clean `policy check` produces the accepted attestation hash;
- a supervisor or gateway accepts that hash out of band;
- OpenClaw config can record that accepted hash as `expectedAttestationHash`;
- the runtime gate recomputes the current attestation from `policy.jsonc` and
  watched evidence;
- matching hashes allow normal policy runtime decisions;
- mismatched hashes block before approval and report both hashes.

The runtime gate still uses OpenClaw's existing trusted tool policy hook. This
does not add a new gateway protocol or a second policy engine.

`checkedAt` remains audit timing metadata. It is not part of
`attestationHash`, so repeated clean checks of unchanged policy state do not
force a new accepted hash.

## Maintainer Input Requested

1. **Is the accepted-attestation handshake the right runtime boundary?**

   The draft treats `expectedAttestationHash` as the compact value a supervisor
   or gateway can compare against. It binds policy hash, evidence hash,
   findings hash, and clean result. Is that the right unit to carry into
   runtime decisions, and should the accepted value be owned by the supervisor
   rather than by the workspace being governed?

2. **Is `runtimeEvidence` the right health-check input for runtime audits?**

   The draft adds optional `runtimeEvidence` to the health check context. The
   policy extension uses it for channel runtime snapshots and keeps runtime
   findings focused on the evidence package rather than oc-path syntax. Is this
   the right shape for health checks that need to compare config/policy against
   live runtime state?

3. **Should runtime evidence refs stay `runtime://...`, or become read-only `oc://runtime/...` paths?**

   The draft intentionally separates live runtime evidence from document/config
   oc-paths: policy findings can point to resolvable files with `oc://...`, but
   running channel accounts and other live observations are evidence refs rather
   than writable workspace documents. We chose a separate `runtime://...`-style
   namespace for that boundary. Would maintainers prefer exposing runtime
   evidence as read-only `oc://runtime/...` paths instead, so path tooling can
   discover/search them consistently with config and workspace paths? In
   particular, should `openclaw path find` (or the future shared find surface)
   be able to search runtime refs alongside document-backed `oc://` paths while
   still making runtime refs non-mutating and clearly evidence-only?

4. **Should block decisions have structured metadata too?**

   Approval decisions already carry structured metadata through gateway approval
   records. Attestation mismatch blocks currently include both hashes in the
   block reason because the existing block result shape has no metadata slot.
   Should blocked trusted-tool-policy decisions also gain structured metadata,
   or is the human-readable block reason enough for this first step?

5. **Is this the right place to thread approval metadata?**

   This PR keeps metadata on the existing approval descriptor and preserves it
   through gateway approval list/resolve events. Is that the correct audit path,
   or should policy decisions be recorded in a separate runtime audit event?

## What Changed

- Added attestation metadata to policy trusted-tool approval requests.
- Preserved plugin approval metadata through gateway approval request, list,
  and resolve paths.
- Added small view-model support so approval surfaces can display policy hash,
  evidence hash, current/expected attestation hash, and target tool reference.
- Added runtime enforcement of `expectedAttestationHash`.
- Added `policy diff` for comparing two saved policy check outputs.
- Added optional health-check `runtimeEvidence` and a policy channel runtime
  audit check for denied channel accounts that are still running.
- Added a test where `TOOLS.md` changes after an accepted clean policy check
  and the runtime gate refuses the tool request because the current
  attestation differs.
- Updated policy docs to describe accepted attestation runtime enforcement.

## Runtime Shape

Config records the accepted clean policy check:

```jsonc
{
  "plugins": {
    "entries": {
      "policy": {
        "enabled": true,
        "config": {
          "enabled": true,
          "runtimeToolPolicy": true,
          "expectedAttestationHash": "sha256:..."
        }
      }
    }
  }
}
```

In an enterprise deployment, that value should come from a supervisor/gateway
acceptance flow, not from the agent updating its own workspace. A typical review
loop is:

1. Run `policy check --json > accepted.json` for the currently accepted state.
2. Change the workspace, for example by adding a new tool with risk and
   sensitivity metadata.
3. Run `policy check --json > candidate.json`.
4. Run `policy diff accepted.json candidate.json`.
5. If the diff shows an acceptable clean change, the supervisor accepts the new
   `attestationHash`.
6. The gateway/runtime uses that accepted hash as `expectedAttestationHash`.

At runtime:

1. Policy reads `policy.jsonc`.
2. The runtime gate observes current `TOOLS.md` evidence.
3. It builds the same attestation shape as `policy check`.
4. If the current attestation differs from `expectedAttestationHash`, the tool
   call is blocked before approval.
5. If the attestation matches, existing tool metadata rules decide whether the
   call proceeds or requires approval.

Policy health checks can also receive runtime evidence. The first supported
runtime shape is a channel runtime snapshot with `channelAccounts`. If policy
denies a channel provider but that provider still has a running account, policy
reports `policy/channels-denied-provider-running` against that runtime evidence:

```json
{
  "checkId": "policy/channels-denied-provider-running",
  "path": "gateway runtime",
  "target": "runtime:channels/telegram/accounts/default",
  "requirement": "oc://policy.jsonc/channels/denyRules/#0"
}
```

The `target` string is intentionally minimal. It is a label inside the runtime
evidence package, not a new oc-path surface. Config and workspace findings keep
using real `oc://` paths when they point to resolvable documents.

## Real Behavior Proof

**Behavior addressed**: Policy check should emit auditable policy/evidence/findings/attestation hashes, `policy diff`/`policy watch` should distinguish timestamp-only checks from real drift, runtime tool policy should fail closed when `expectedAttestationHash` is stale, and policy-governed approval requests should carry structured policy/evidence/attestation metadata.

**Real environment tested**: Clean WSL detached worktrees for upstream/main and PR #81104 head, with a temporary workspace containing `policy.jsonc` and `TOOLS.md`. The source-level probe imported the PR-head policy runtime modules through the repo `tsx` loader.

**Exact steps or command run after this patch**:

1. Created a clean upstream/main worktree and a clean PR-head worktree at #81104 head.
2. In each worktree, ran `node --import ./node_modules/tsx/dist/loader.mjs probe-policy-runtime-audit.mjs`.
3. Built a clean policy/evidence attestation from `policy.jsonc` and a critical governed `deploy` tool in `TOOLS.md`.
4. Recomputed the attestation with only `checkedAt` changed and compared it to the original.
5. Recomputed the attestation after evidence drift and compared the diff summary.
6. Evaluated the runtime trusted-tool policy with a matching `expectedAttestationHash` to capture approval metadata.
7. Evaluated the runtime trusted-tool policy with stale `expectedAttestationHash=sha256:not-current` to prove fail-closed behavior.

**Evidence before fix**: Upstream/main has no policy check/watch/diff CLI layer, no runtime `expectedAttestationHash` enforcement, no policy approval metadata view, no audit hash tuple, no watch/diff stale-attestation result, and no fail-closed runtime block for stale accepted attestations.

**Evidence after fix**:

![Fresh before/after proof for runtime audit metadata and attestation enforcement](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-81104-fresh/pr-81104/pr-81104-policy-runtime-audit-attestation-before-after-proof.png)

**Observed result after fix**: PR #81104 emits policy, evidence, findings, and attestation hashes; keeps the attestation stable when only `checkedAt` changes; reports no diff for timestamp-only changes; reports `evidence` and `attestation` drift when evidence changes; marks a mismatched accepted attestation as `stale`; includes Policy Hash, Workspace Hash, Attestation Hash, Expected Attestation, and Policy Target approval metadata; and blocks runtime tool calls when the current attestation no longer matches the accepted one.

**What was not tested**: This proof focuses on the runtime audit/attestation contract and does not exercise every policy category already covered by earlier stack PRs.

## Testing

```bash
pnpm test src/infra/approval-view-model.test.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts extensions/policy/src/runtime-tool-policy.test.ts -- --reporter=dot
pnpm tsgo:prod
pnpm exec oxfmt --check --threads=1 src/infra/policy-approval-metadata.ts src/infra/approval-view-model.test.ts src/flows/health-checks.ts extensions/policy/src/policy-state.ts extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts docs/cli/policy.md docs/plugins/reference/policy.md
pnpm check:changed
git diff --check
```

Latest local result:

- Policy runtime/CLI/doctor plus approval metadata tests: 4 files, 58 tests passed.
- Formatting check: passed.
- Production TypeScript check: passed.
- Changed-file check: passed.
- Whitespace check: passed.

## Related

- Doctor health contract and lint validation:
  https://github.com/openclaw/openclaw/pull/80055
- Channels-first policy conformance:
  https://github.com/openclaw/openclaw/pull/80407
- Tool metadata conformance and basic runtime trusted tool policy:
  https://github.com/openclaw/openclaw/pull/80056
- Model, network, and MCP conformance examples:
  https://github.com/openclaw/openclaw/pull/80783
<!-- policy-stack-links:start -->

## Policy stack links

This PR is part of the Policy 1.0 proof stack. Final category branches added after the runtime-audit layer:

- #81974 — Policy: add secrets auth provenance checks
- #81981 — Policy: add gateway exposure checks

Full stack reference:

1. #80407 — Policy: add conformance system with channel checks
2. #80056 — Policy: add tool metadata conformance and runtime checks
3. #80783 — Policy: add model, network, and MCP conformance checks
4. #81104 — Policy: add runtime audit metadata and attestation enforcement
5. #81974 — Policy: add secrets auth provenance checks
6. #81981 — Policy: add gateway exposure checks

<!-- policy-stack-links:end -->
