### PR TITLE
[AI-assisted] fix(docker): pin setup-time container paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docker: pin setup-time container paths so stale host `.env` OpenClaw paths cannot leak into Linux containers. Fixes #80381. (#81105) Thanks @brokemac79.
 - Channels/WeCom: refresh the official onboarding install to `@wecom/wecom-openclaw-plugin@2026.5.7` and update existing managed npm installs instead of failing on the package directory. Fixes #79884. (#80390) Thanks @brokemac79.
 - Control UI/WebChat: keep short assistant replies clear of in-bubble copy/open action buttons by applying the existing reserved action spacing in the grouped chat renderer. Fixes #79509. (#81244) Thanks @JARVIS-Glasses.
 - Anthropic: reseed Claude CLI fresh-session retries from bounded OpenClaw transcript history after session rotation, preventing conversation amnesia. Fixes #80905. (#80934) Thanks @bitloi.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,16 @@ services:
         required: false
     environment:
       HOME: /home/node
+      OPENCLAW_HOME: /home/node
       TERM: xterm-256color
-      # Pin container-side workspace and config paths so host values written to
+      # Pin container-side state, workspace, and config paths so host values written to
       # `.env` (used by Compose for the bind-mount source below) cannot leak
       # into runtime code that resolves these env vars inside the container.
       # Without this override, a macOS host path like /Users/<you>/.openclaw/...
       # imported from .env caused first-reply `mkdir '/Users'` EACCES failures
       # in Linux Docker (#77436).
+      OPENCLAW_STATE_DIR: /home/node/.openclaw
+      OPENCLAW_CONFIG_PATH: /home/node/.openclaw/openclaw.json
       OPENCLAW_CONFIG_DIR: /home/node/.openclaw
       OPENCLAW_WORKSPACE_DIR: /home/node/.openclaw/workspace
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-}
@@ -98,9 +101,12 @@ services:
       - no-new-privileges:true
     environment:
       HOME: /home/node
+      OPENCLAW_HOME: /home/node
       TERM: xterm-256color
-      # Pin container-side workspace and config paths so host values written to
+      # Pin container-side state, workspace, and config paths so host values written to
       # `.env` cannot leak into runtime code via the env_file import (#77436).
+      OPENCLAW_STATE_DIR: /home/node/.openclaw
+      OPENCLAW_CONFIG_PATH: /home/node/.openclaw/openclaw.json
       OPENCLAW_CONFIG_DIR: /home/node/.openclaw
       OPENCLAW_WORKSPACE_DIR: /home/node/.openclaw/workspace
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-}

--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -149,7 +149,16 @@ run_prestart_cli() {
   # requires the gateway container's network namespace to already exist. That
   # creates a circular dependency for config writes that are needed before the
   # gateway can start cleanly.
-  run_prestart_gateway --entrypoint node openclaw-gateway \
+  # Host OPENCLAW_* paths are Compose bind-mount sources. Setup-time CLI writes
+  # must still resolve state/config paths inside the container.
+  run_prestart_gateway \
+    -e HOME=/home/node \
+    -e OPENCLAW_HOME=/home/node \
+    -e OPENCLAW_STATE_DIR=/home/node/.openclaw \
+    -e OPENCLAW_CONFIG_PATH=/home/node/.openclaw/openclaw.json \
+    -e OPENCLAW_CONFIG_DIR=/home/node/.openclaw \
+    -e OPENCLAW_WORKSPACE_DIR=/home/node/.openclaw/workspace \
+    --entrypoint node openclaw-gateway \
     dist/index.js "$@"
 }
 

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -90,6 +90,15 @@ async function createDockerSetupSandbox(): Promise<DockerSetupSandbox> {
 
 const sandboxRootTracker = createSuiteTempRootTracker({ prefix: "openclaw-docker-setup-" });
 
+const prestartContainerEnvFlags = [
+  "-e HOME=/home/node",
+  "-e OPENCLAW_HOME=/home/node",
+  "-e OPENCLAW_STATE_DIR=/home/node/.openclaw",
+  "-e OPENCLAW_CONFIG_PATH=/home/node/.openclaw/openclaw.json",
+  "-e OPENCLAW_CONFIG_DIR=/home/node/.openclaw",
+  "-e OPENCLAW_WORKSPACE_DIR=/home/node/.openclaw/workspace",
+].join(" ");
+
 function createEnv(
   sandbox: DockerSetupSandbox,
   overrides: Record<string, string | undefined> = {},
@@ -275,10 +284,10 @@ describe("scripts/docker/setup.sh", () => {
     const log = await readDockerLog(activeSandbox);
     expect(log).toContain("--build-arg OPENCLAW_DOCKER_APT_PACKAGES=ffmpeg build-essential");
     expect(log).toContain(
-      "run --rm --no-deps --entrypoint node openclaw-gateway dist/index.js onboard --mode local --no-install-daemon",
+      `run --rm --no-deps ${prestartContainerEnvFlags} --entrypoint node openclaw-gateway dist/index.js onboard --mode local --no-install-daemon`,
     );
     expect(log).toContain(
-      'run --rm --no-deps --entrypoint node openclaw-gateway dist/index.js config set --batch-json [{"path":"gateway.mode","value":"local"},{"path":"gateway.bind","value":"lan"},{"path":"gateway.controlUi.allowedOrigins","value":["http://localhost:18789","http://127.0.0.1:18789"]}]',
+      `run --rm --no-deps ${prestartContainerEnvFlags} --entrypoint node openclaw-gateway dist/index.js config set --batch-json [{"path":"gateway.mode","value":"local"},{"path":"gateway.bind","value":"lan"},{"path":"gateway.controlUi.allowedOrigins","value":["http://localhost:18789","http://127.0.0.1:18789"]}]`,
     );
     expect(log).not.toContain("run --rm openclaw-cli onboard --mode local --no-install-daemon");
   });
@@ -311,6 +320,32 @@ describe("scripts/docker/setup.sh", () => {
       /\bcompose\b.*\brun\b.*\bopenclaw-cli\b/.test(line),
     );
     expect(prestartCliRunLines).toStrictEqual([]);
+  });
+
+  it("pins setup-time CLI state paths inside the container", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+
+    await resetDockerLog(activeSandbox);
+    const result = runDockerSetup(activeSandbox, {
+      OPENCLAW_HOME: "/mnt/c/Users/Trevor",
+      OPENCLAW_STATE_DIR: "/mnt/c/Users/Trevor/.openclaw",
+      OPENCLAW_CONFIG_PATH: "/mnt/c/Users/Trevor/.openclaw/openclaw.json",
+      OPENCLAW_SKIP_ONBOARDING: "1",
+    });
+    expect(result.status).toBe(0);
+
+    const lines = await readDockerLogLines(activeSandbox);
+    const gatewayStartIdx = findGatewayStartLineIndex(lines);
+    expect(gatewayStartIdx).toBeGreaterThanOrEqual(0);
+
+    const prestartConfigLines = collectMatchingLines(lines.slice(0, gatewayStartIdx), (line) =>
+      line.includes(" dist/index.js config "),
+    );
+    expect(prestartConfigLines.length).toBeGreaterThan(0);
+    for (const line of prestartConfigLines) {
+      expect(line).toContain(prestartContainerEnvFlags);
+      expect(line).not.toContain("/mnt/c");
+    }
   });
 
   it("forces BuildKit for local and sandbox docker builds", async () => {
@@ -692,12 +727,16 @@ describe("scripts/docker/setup.sh", () => {
     expect(compose.match(/TZ: \$\{OPENCLAW_TZ:-UTC\}/g)).toHaveLength(2);
   });
 
-  it("pins container-side workspace and config dirs on both services so host .env paths cannot leak (#77436)", async () => {
+  it("pins container-side state, workspace, and config dirs on both services so host .env paths cannot leak (#77436)", async () => {
     const compose = await readFile(join(repoRoot, "docker-compose.yml"), "utf8");
-    // Both gateway and CLI services must override the env_file values with the
-    // canonical container paths so a host-style OPENCLAW_WORKSPACE_DIR like
-    // `/Users/<you>/.openclaw/workspace` written to `.env` by docker-setup.sh
-    // cannot reach runtime code inside Linux Docker.
+    // Both gateway and CLI services must override env_file values with the
+    // canonical container paths so host-style paths written to `.env` cannot
+    // reach runtime code inside Linux Docker.
+    expect(compose.match(/OPENCLAW_HOME: \/home\/node$/gm)).toHaveLength(2);
+    expect(compose.match(/OPENCLAW_STATE_DIR: \/home\/node\/\.openclaw$/gm)).toHaveLength(2);
+    expect(
+      compose.match(/OPENCLAW_CONFIG_PATH: \/home\/node\/\.openclaw\/openclaw\.json$/gm),
+    ).toHaveLength(2);
     expect(compose.match(/OPENCLAW_CONFIG_DIR: \/home\/node\/\.openclaw$/gm)).toHaveLength(2);
     expect(
       compose.match(/OPENCLAW_WORKSPACE_DIR: \/home\/node\/\.openclaw\/workspace$/gm),


### PR DESCRIPTION
## Summary

- Pin Docker gateway and CLI container env for `HOME`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, `OPENCLAW_CONFIG_DIR`, and `OPENCLAW_WORKSPACE_DIR` so host `.env` paths stay bind-mount sources only.
- Force setup-time `docker compose run` CLI config commands to use the same container-local paths before the gateway starts.
- Add Docker setup e2e coverage for WSL-style `/mnt/c` host path leakage into prestart config commands.

Fixes #80381.

## Real behavior proof

Behavior or issue addressed: Windows/WSL Docker setup can fail during `sync_gateway_config()` with `Error: EACCES: permission denied, mkdir '/mnt/c'` when host-path config/home/state env leaks into setup-time container config writes.

Real environment tested: Windows 10 Home `10.0.19045.6466`, Docker Desktop `4.71.0`, Docker Engine `29.4.1`, Docker Compose `v5.1.3`, Docker Desktop WSL2 backend with `docker-desktop` distro running, PR worktree `C:\oc80381`, and isolated proof bind mounts under `C:\oc81105-proof`. No live OpenClaw install, gateway, auth profile, VPS, or user state was touched.

Exact steps or command run after this patch:

```powershell
$docker = "$env:LOCALAPPDATA\Programs\DockerDesktop\resources\bin\docker.exe"
$env:COMPOSE_PROJECT_NAME = 'openclaw-pr-81105-proof'
$env:OPENCLAW_IMAGE = 'openclaw-pr-81105-proof:local'
$env:OPENCLAW_CONFIG_DIR = 'C:\oc81105-proof\config'
$env:OPENCLAW_WORKSPACE_DIR = 'C:\oc81105-proof\workspace'
$env:OPENCLAW_AUTH_PROFILE_SECRET_DIR = 'C:\oc81105-proof\secrets'
$env:OPENCLAW_GATEWAY_TOKEN = 'redacted-proof-token'
$env:OPENCLAW_GATEWAY_PORT = '18081'
$env:OPENCLAW_BRIDGE_PORT = '18082'
$env:OPENCLAW_GATEWAY_BIND = '127.0.0.1'
$env:OPENCLAW_DISABLE_BONJOUR = '1'

$env:OPENCLAW_HOME = '/mnt/c/Users/marti/openclaw-pr-81105-host-home'
$env:OPENCLAW_STATE_DIR = '/mnt/c/Users/marti/openclaw-pr-81105-host-state'
$env:OPENCLAW_CONFIG_PATH = '/mnt/c/Users/marti/openclaw-pr-81105-host-state/openclaw.json'

& $docker compose -p openclaw-pr-81105-proof -f docker-compose.yml config
& $docker compose -p openclaw-pr-81105-proof -f docker-compose.yml build openclaw-gateway
& $docker compose -p openclaw-pr-81105-proof -f docker-compose.yml run -T --rm --no-deps --user root --entrypoint sh openclaw-gateway -c 'find /home/node/.openclaw -xdev -exec chown node:node {} +; find /home/node/.config/openclaw -xdev -exec chown node:node {} +'
& $docker compose -p openclaw-pr-81105-proof -f docker-compose.yml run -T --rm --no-deps -e HOME=/home/node -e OPENCLAW_HOME=/home/node -e OPENCLAW_STATE_DIR=/home/node/.openclaw -e OPENCLAW_CONFIG_PATH=/home/node/.openclaw/openclaw.json -e OPENCLAW_CONFIG_DIR=/home/node/.openclaw -e OPENCLAW_WORKSPACE_DIR=/home/node/.openclaw/workspace --entrypoint node openclaw-gateway dist/index.js config set --batch-json '[{"path":"gateway.mode","value":"local"},{"path":"gateway.bind","value":"lan"},{"path":"gateway.controlUi.allowedOrigins","value":["http://localhost:18789","http://127.0.0.1:18789"]}]'
& $docker compose -p openclaw-pr-81105-proof -f docker-compose.yml run -T --rm --no-deps -e HOME=/home/node -e OPENCLAW_HOME=/home/node -e OPENCLAW_STATE_DIR=/home/node/.openclaw -e OPENCLAW_CONFIG_PATH=/home/node/.openclaw/openclaw.json -e OPENCLAW_CONFIG_DIR=/home/node/.openclaw -e OPENCLAW_WORKSPACE_DIR=/home/node/.openclaw/workspace --entrypoint node openclaw-gateway -e "const fs=require('node:fs'); const p=process.env.OPENCLAW_CONFIG_PATH; console.log('inside OPENCLAW_HOME='+process.env.OPENCLAW_HOME); console.log('inside OPENCLAW_STATE_DIR='+process.env.OPENCLAW_STATE_DIR); console.log('inside OPENCLAW_CONFIG_PATH='+p); console.log('inside OPENCLAW_CONFIG_PATH_HAS_MNT_C='+String(p.includes('/mnt/c'))); console.log('inside config exists='+String(fs.existsSync(p))); console.log('inside leaked /mnt/c config exists='+String(fs.existsSync('/mnt/c/Users/marti/openclaw-pr-81105-host-state/openclaw.json'))); const text=fs.readFileSync(p,'utf8'); console.log('inside config contains gateway.local='+String(text.includes('local')));"
& $docker compose -p openclaw-pr-81105-proof -f docker-compose.yml down --volumes --remove-orphans
```

Evidence after fix:

```text
Docker: 29.4.1 client / 29.4.1 server
Compose: Docker Compose version v5.1.3
Host intentionally leaked OPENCLAW_HOME=/mnt/c/Users/marti/openclaw-pr-81105-host-home
Host intentionally leaked OPENCLAW_STATE_DIR=/mnt/c/Users/marti/openclaw-pr-81105-host-state
Host intentionally leaked OPENCLAW_CONFIG_PATH=/mnt/c/Users/marti/openclaw-pr-81105-host-state/openclaw.json
Host bind mount OPENCLAW_CONFIG_DIR=C:\oc81105-proof\config

compose config pinned service env:
OPENCLAW_HOME: /home/node
OPENCLAW_STATE_DIR: /home/node/.openclaw
OPENCLAW_CONFIG_PATH: /home/node/.openclaw/openclaw.json
OPENCLAW_CONFIG_DIR: /home/node/.openclaw
OPENCLAW_WORKSPACE_DIR: /home/node/.openclaw/workspace
source: C:\oc81105-proof\config
source: C:\oc81105-proof\workspace
source: C:\oc81105-proof\secrets

real prestart config set with fixed container env pins:
Updated 3 config paths. Restart the gateway to apply.
exit=0

inspect real container config path after write:
inside OPENCLAW_HOME=/home/node
inside OPENCLAW_STATE_DIR=/home/node/.openclaw
inside OPENCLAW_CONFIG_PATH=/home/node/.openclaw/openclaw.json
inside OPENCLAW_CONFIG_PATH_HAS_MNT_C=false
inside config exists=true
inside leaked /mnt/c config exists=false
inside config contains gateway.local=true
inside config excerpt={ "gateway": { "mode": "local", "bind": "lan", "controlUi": { "allowedOrigins": [ "http://localhost:18789", "http://127.0.0.1:18789" ] } }, "meta": { "lastTouchedVersion": "2026.5.12-beta.1", "lastTouchedAt": "2026-05-12T19:26:20.588Z" } }

host-mounted config file:
host config exists=true path=C:\oc81105-proof\config\openclaw.json
```

Observed result after fix: a real Docker Desktop Compose run built the PR image and executed the setup-time `dist/index.js config set` path with the same container-local env pins added by this PR. Even with host env deliberately set to `/mnt/c/...`, the container observed `OPENCLAW_CONFIG_PATH=/home/node/.openclaw/openclaw.json`, did not resolve `/mnt/c`, wrote the gateway config successfully, and the host-mounted isolated config file appeared under `C:\oc81105-proof\config\openclaw.json`.

What was not tested: I did not run the full interactive `scripts/docker/setup.sh` flow from an Ubuntu user distro because no user WSL distro is installed on this machine. I also did not start a long-lived Gateway container; this proof is the narrower real Compose prestart config-write path ClawSweeper asked for. The earlier local regression-harness lane still passes (`4 passed, 26 skipped`), and the full Docker setup e2e file still has two unrelated Windows-local environment blockers (`OPENCLAW_TZ` zoneinfo and Unix socket `EACCES`).

## Duplicate / ownership scan

- Issue #80381 is open, unassigned, created on 2026-05-10, and reports current affected releases through `2026.5.7`.
- ClawSweeper identified this as a narrow Docker setup regression and did not mark it maintainer-only.
- Exact issue-number PR scan found no open PR for #80381 before branch creation or before PR creation.

## Notes

AI-assisted contribution. No `CHANGELOG.md` edits.