### PR TITLE
fix: keep codex webchat replies automatic

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4960,6 +4960,50 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(firstFinalReplyPayload(dispatcher)?.text).toBe("visible webchat reply");
   });
 
+  it("keeps harness message-tool delivery for explicit external WebChat origins", async () => {
+    setNoAbort();
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      deliveryDefaults: { sourceVisibleReplies: "message_tool" },
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt: vi.fn(async () => ({}) as never),
+    });
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      agentHarnessId: "codex",
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
+      return { text: "external reply should use message tool" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "direct",
+        CommandSource: undefined,
+        From: "webchat:user",
+        To: "webchat:main",
+        Provider: "webchat",
+        Surface: "webchat",
+        OriginatingChannel: "imessage",
+        OriginatingTo: "imessage:+15550001111",
+        ExplicitDeliverRoute: true,
+        SessionKey: "agent:main:main",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("falls back to automatic group/channel delivery when the message tool is unavailable", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4918,6 +4918,48 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("keeps internal webchat source delivery automatic even when harness defaults to message tool", async () => {
+    setNoAbort();
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      deliveryDefaults: { sourceVisibleReplies: "message_tool" },
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt: vi.fn(async () => ({}) as never),
+    });
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      agentHarnessId: "codex",
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("automatic");
+      return { text: "visible webchat reply" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "direct",
+        CommandSource: undefined,
+        From: "webchat:user",
+        To: "webchat:main",
+        Provider: "webchat",
+        Surface: "webchat",
+        OriginatingChannel: "webchat",
+        SessionKey: "agent:main:main",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(true);
+    expect(firstFinalReplyPayload(dispatcher)?.text).toBe("visible webchat reply");
+  });
+
   it("falls back to automatic group/channel delivery when the message tool is unavailable", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -296,10 +296,17 @@ const createShouldEmitVerboseProgress = (params: {
   };
 };
 
-const isInternalWebchatSourceContext = (ctx: FinalizedMsgContext): boolean =>
-  normalizeMessageChannel(ctx.Provider) === INTERNAL_MESSAGE_CHANNEL ||
-  normalizeMessageChannel(ctx.Surface) === INTERNAL_MESSAGE_CHANNEL ||
-  normalizeMessageChannel(ctx.OriginatingChannel) === INTERNAL_MESSAGE_CHANNEL;
+const isInternalWebchatSourceContext = (ctx: FinalizedMsgContext): boolean => {
+  const provider = normalizeMessageChannel(ctx.Provider);
+  const surface = normalizeMessageChannel(ctx.Surface);
+  const originatingChannel = normalizeMessageChannel(ctx.OriginatingChannel);
+  const currentSurfaceIsWebchat =
+    provider === INTERNAL_MESSAGE_CHANNEL || surface === INTERNAL_MESSAGE_CHANNEL;
+  if (!currentSurfaceIsWebchat) {
+    return false;
+  }
+  return !originatingChannel || originatingChannel === INTERNAL_MESSAGE_CHANNEL;
+};
 
 const resolveHarnessSourceVisibleRepliesDefault = (params: {
   cfg: OpenClawConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -296,6 +296,11 @@ const createShouldEmitVerboseProgress = (params: {
   };
 };
 
+const isInternalWebchatSourceContext = (ctx: FinalizedMsgContext): boolean =>
+  normalizeMessageChannel(ctx.Provider) === INTERNAL_MESSAGE_CHANNEL ||
+  normalizeMessageChannel(ctx.Surface) === INTERNAL_MESSAGE_CHANNEL ||
+  normalizeMessageChannel(ctx.OriginatingChannel) === INTERNAL_MESSAGE_CHANNEL;
+
 const resolveHarnessSourceVisibleRepliesDefault = (params: {
   cfg: OpenClawConfig;
   ctx: FinalizedMsgContext;
@@ -304,6 +309,9 @@ const resolveHarnessSourceVisibleRepliesDefault = (params: {
   sessionKey?: string;
 }): "automatic" | "message_tool" | undefined => {
   if (params.ctx.CommandSource === "native") {
+    return undefined;
+  }
+  if (isInternalWebchatSourceContext(params.ctx)) {
     return undefined;
   }
   try {

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { clearAgentHarnesses, registerAgentHarness } from "../agents/harness/registry.js";
 import type { GetReplyOptions } from "../auto-reply/get-reply-options.types.js";
 import { clearConfigCache } from "../config/config.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -9,6 +10,7 @@ import { __setMaxChatHistoryMessagesBytesForTest } from "./server-constants.js";
 import type { GatewayRequestContext, RespondFn } from "./server-methods/shared-types.js";
 import {
   connectOk,
+  connectWebchatClient,
   createGatewaySuiteHarness,
   dispatchInboundMessageMock,
   getReplyFromConfig,
@@ -711,6 +713,63 @@ describe("gateway server chat", () => {
         testState.agentConfig = undefined;
       }
     });
+  });
+
+  test("webchat chat.send keeps Codex harness visible replies automatic", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-webchat-codex-"));
+    let webchatWs: GatewaySocket | undefined;
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            updatedAt: Date.now(),
+            agentHarnessId: "codex",
+          },
+        },
+      });
+      registerAgentHarness({
+        id: "codex",
+        label: "Codex",
+        deliveryDefaults: { sourceVisibleReplies: "message_tool" },
+        supports: () => ({ supported: true, priority: 100 }),
+        runAttempt: vi.fn(async () => ({}) as never),
+      });
+
+      let capturedOpts: GetReplyOptions | undefined;
+      mockGetReplyFromConfigOnce(async (_ctx, opts) => {
+        capturedOpts = opts;
+        return { text: "visible webchat reply" };
+      });
+
+      webchatWs = await connectWebchatClient({ port: harness.port });
+      const finalPromise = onceMessage(
+        webchatWs,
+        (o) =>
+          o.type === "event" &&
+          o.event === "chat" &&
+          o.payload?.state === "final" &&
+          o.payload?.runId === "idem-webchat-codex-visible",
+        8000,
+      );
+
+      const sendRes = await rpcReq(webchatWs, "chat.send", {
+        sessionKey: "main",
+        message: "hello from browser webchat",
+        idempotencyKey: "idem-webchat-codex-visible",
+      });
+      expect(sendRes.ok).toBe(true);
+      const finalEvent = await finalPromise;
+
+      expect(capturedOpts?.sourceReplyDeliveryMode).toBe("automatic");
+      expect(JSON.stringify(finalEvent.payload)).toContain("visible webchat reply");
+    } finally {
+      clearAgentHarnesses();
+      testState.sessionStorePath = undefined;
+      webchatWs?.close();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
   });
 
   test("chat.history hard-caps single oversized nested payloads", async () => {


### PR DESCRIPTION
This PR separates internal WebChat turns from external channel-origin WebChat delivery so Codex harness defaults do not accidentally suppress normal same-surface replies. Internal WebChat keeps automatic final delivery, while explicit external origins still use the message-tool-only policy where that contract is required.

## Summary

This is the narrow safety fix for #81109. Codex harnesses default direct visible replies to the `message` tool, which is right for external direct-chat surfaces, but internal WebChat is not an outbound delivery target. This PR keeps WebChat-only turns automatic so the user sees the assistant's final reply, while preserving `message_tool_only` for explicit external origins that happen to be operated through WebChat.

- Problem: internal WebChat Codex turns could suppress the visible final reply and steer the model toward `message(action="send")`, producing `Sent.` or no useful visible answer.
- Why it matters: WebChat is the local interactive surface; users need the answer rendered directly unless the turn is explicitly acting on behalf of an external origin.
- What changed: harness `sourceVisibleReplies: "message_tool"` defaults are skipped only for internal-only WebChat source contexts.
- What did NOT change (scope boundary): external-origin WebChat routes still keep the Codex message-tool default, and external channel delivery behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #81109
- Alternative to #81144
- Related #81092
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a direct internal WebChat Codex turn should render the assistant final reply to the WebChat thread instead of suppressing automatic delivery, while explicit external WebChat origins should still use the Codex message-tool default.
- Real environment tested: local OpenClaw checkout at `/Volumes/LEXAR/repos/openclaw-codex-webchat-delivery`, branch `fix/codex-webchat-direct-delivery`, latest patch `d34e6ee76d4`, including dispatch policy tests and in-process Gateway WebSocket WebChat proof.
- Exact steps or command run after this patch:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/auto-reply/reply/dispatch-from-config.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts
pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts
git diff --check
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
[test] passed 2 Vitest shards in 16.09s
Gateway shard: Test Files 1 passed, Tests 18 passed
Auto-reply shard: Test Files 1 passed, Tests 108 passed

oxfmt: All matched files use the correct format.
git diff --check: passed
```

- Observed result after fix: the internal WebChat regression asserts `sourceReplyDeliveryMode === "automatic"`, `queuedFinal === true`, and the final payload text is `visible webchat reply`. The new external-origin regression asserts `sourceReplyDeliveryMode === "message_tool_only"`, `queuedFinal === false`, and no automatic final WebChat send occurs for an explicit `OriginatingChannel: "imessage"` route.
- What was not tested: manual browser DOM rendering. The Gateway proof uses the same in-process WebSocket route that WebChat uses.
- Before evidence (optional but encouraged): ClawSweeper identified the first guard as too broad because it matched WebChat surface/provider even when an explicit external origin was present.

## Root Cause (if applicable)

- Root cause: the first guard treated any WebChat provider/surface/origin as internal WebChat, but `chat.send` can carry WebChat surface metadata while explicitly operating on behalf of another channel.
- Missing detection / guardrail: coverage proved internal WebChat stayed automatic but did not assert the external-origin WebChat route kept `message_tool_only`.
- Contributing context (if known): #81092 explicitly calls out preserving message-tool delivery when WebChat is acting as an external-origin operator surface.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-from-config.test.ts`, `src/gateway/server.chat.gateway-server-chat-b.test.ts`
- Scenario the test should lock in: internal-only WebChat stays automatic; explicit external WebChat origins keep Codex message-tool delivery.
- Why this is the smallest reliable guardrail: dispatch policy is deterministic and the Gateway test exercises the WebChat `chat.send` route without needing a browser.
- Existing test that already covers this (if any): none for the explicit external-origin harness default before this patch.
- If no new test is added, why not: N/A, a new regression is included.

## User-visible / Behavior Changes

Internal WebChat Codex replies render automatically again. WebChat sessions that explicitly deliver on behalf of an external channel still preserve message-tool-only behavior.

## Diagram (if applicable)

<!-- reviewer-map -->

```mermaid
flowchart LR
  turn["Incoming WebChat turn"] --> origin{"External origin?"}
  origin -->|no| internal["Internal WebChat"]
  internal --> auto["Automatic final reply"]
  origin -->|yes| external["Explicit external-origin route"]
  external --> messageOnly["message_tool_only contract"]
  messageOnly --> channel["Channel-specific delivery"]
```

```text
Internal WebChat:
[WebChat source only] -> [Codex harness default skipped] -> [automatic final reply]

Explicit external origin through WebChat:
[WebChat surface + OriginatingChannel=imessage]
  -> [Codex harness default preserved]
  -> [message_tool_only, no accidental automatic external final]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local development host
- Runtime/container: local Lexar-backed OpenClaw checkout
- Model/provider: Codex harness delivery-default policy, not model-provider dependent
- Integration/channel (if any): WebChat dispatch and in-process Gateway WebSocket route
- Relevant config (redacted): harness `deliveryDefaults.sourceVisibleReplies: "message_tool"`

### Steps

1. Run the dispatch and Gateway WebChat proof command.
2. Confirm internal WebChat uses automatic source reply delivery.
3. Confirm explicit external-origin WebChat keeps `message_tool_only`.

### Expected

- Internal WebChat final text is queued and visible.
- Explicit external-origin WebChat does not bypass the Codex message-tool default.

### Actual

- 126 focused tests passed across dispatch and Gateway shards.
- Formatter and whitespace checks passed.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: internal WebChat automatic delivery, external-origin WebChat message-tool preservation, Gateway WebSocket WebChat final reply path.
- Edge cases checked: `OriginatingChannel: "webchat"` vs `OriginatingChannel: "imessage"`, explicit deliver route, Codex harness `message_tool` default.
- What you did **not** verify: manual browser DOM rendering and full GitHub CI matrix.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

ClawSweeper P2 addressed by `d34e6ee76d4`: limit the WebChat bypass to internal-only sources.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: maintainers may prefer #81144's personality-preserving message-tool renderer instead of this automatic-delivery carveout.
  - Mitigation: this PR stays narrow and is explicitly framed as the conservative option; #81144 remains available as the product-shape alternative.

