### PR TITLE
fix: migrate plugin tool contracts in doctor

### DIFF
--- a/src/commands/doctor-plugin-manifests.test.ts
+++ b/src/commands/doctor-plugin-manifests.test.ts
@@ -128,6 +128,42 @@ describe("doctor plugin manifest legacy contract repair", () => {
     ]);
   });
 
+  it("collects legacy top-level plugin tool keys for migration", () => {
+    const pluginsRoot = makeTrustedBundledPluginsDir();
+    const root = path.join(pluginsRoot, "cortex");
+    fs.mkdirSync(root, { recursive: true });
+    writePackageJson(root);
+    writeManifest(root, {
+      id: "cortex",
+      tools: ["cortex_search", "cortex_remember"],
+      configSchema: { type: "object" },
+    });
+
+    const migrations = collectLegacyPluginManifestContractMigrations({
+      config: configWithPluginLoadPath(pluginsRoot),
+      env: {
+        ...process.env,
+      },
+      manifestRoots: [pluginsRoot],
+    });
+
+    const manifestPath = path.join(root, "openclaw.plugin.json");
+    expect(migrations).toStrictEqual([
+      {
+        changeLines: [`- ${manifestPath}: moved tools to contracts.tools`],
+        manifestPath,
+        nextRaw: {
+          id: "cortex",
+          contracts: {
+            tools: ["cortex_search", "cortex_remember"],
+          },
+          configSchema: { type: "object" },
+        },
+        pluginId: "cortex",
+      },
+    ]);
+  });
+
   it("rewrites legacy top-level capability keys into contracts", async () => {
     const pluginsRoot = makeTrustedBundledPluginsDir();
     const root = path.join(pluginsRoot, "openai");
@@ -166,6 +202,41 @@ describe("doctor plugin manifest legacy contract repair", () => {
       speechProviders: ["openai"],
       mediaUnderstandingProviders: ["openai"],
       webSearchProviders: ["gemini"],
+    });
+  });
+
+  it("removes duplicate legacy top-level plugin tools while keeping contracts.tools", async () => {
+    const pluginsRoot = makeTrustedBundledPluginsDir();
+    const root = path.join(pluginsRoot, "cortex");
+    fs.mkdirSync(root, { recursive: true });
+    writePackageJson(root);
+    writeManifest(root, {
+      id: "cortex",
+      tools: ["legacy_tool"],
+      contracts: {
+        tools: ["contract_tool"],
+      },
+      configSchema: { type: "object" },
+    });
+
+    await maybeRepairLegacyPluginManifestContracts({
+      config: configWithPluginLoadPath(pluginsRoot),
+      env: {
+        ...process.env,
+      },
+      manifestRoots: [pluginsRoot],
+      runtime: createRuntime(),
+      prompter: createPrompter(),
+      note: vi.fn(),
+    });
+
+    const next = JSON.parse(fs.readFileSync(path.join(root, "openclaw.plugin.json"), "utf-8")) as {
+      tools?: string[];
+      contracts?: Record<string, string[]>;
+    };
+    expect(next.tools).toBeUndefined();
+    expect(next.contracts).toEqual({
+      tools: ["contract_tool"],
     });
   });
 

--- a/src/commands/doctor-plugin-manifests.ts
+++ b/src/commands/doctor-plugin-manifests.ts
@@ -15,6 +15,7 @@ const LEGACY_MANIFEST_CONTRACT_KEYS = [
   "speechProviders",
   "mediaUnderstandingProviders",
   "imageGenerationProviders",
+  "tools",
 ] as const;
 
 type LegacyManifestContractMigration = {


### PR DESCRIPTION
This PR keeps plugin authors on the supported manifest contract by teaching `openclaw doctor --fix` to migrate legacy top-level `tools` into `contracts.tools`. The practical effect is small but important: a plugin that can run today should not silently lose tool declarations after the doctor migration path.

## Summary

This PR fixes a beta.5 migration gap in `openclaw doctor`: runtime now expects plugin tools under `contracts.tools`, but doctor did not migrate legacy top-level `tools`. The fix adds `tools` to the existing legacy manifest contract migration list so local plugins can be repaired instead of failing at runtime.

- Problem: legacy plugin manifests with top-level `tools` are rejected by runtime contract enforcement, but doctor had no migration for them.
- Why it matters: beta.5 users with local plugins need `doctor --fix` to repair manifests instead of leaving plugin tools unusable.
- What changed: doctor moves top-level `tools` into `contracts.tools`, and removes duplicate top-level `tools` when the contract already exists.
- What did NOT change (scope boundary): runtime contract enforcement is not weakened; only the doctor migration list and tests change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #81111
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw doctor --fix --non-interactive` should migrate a plugin manifest with legacy top-level `tools` into beta.5-required `contracts.tools`.
- Real environment tested: local Lexar-backed checkout `/Volumes/LEXAR/repos/openclaw-doctor-plugin-tools-contract` at PR head `af06604bc0d1`, with isolated `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_AGENT_DIR` under `/Volumes/LEXAR/Codex/doctor-tools-proof.TXaZzO`.
- Exact steps or command run after this patch:

```bash
VITEST_MAX_WORKERS=1 pnpm test src/commands/doctor-plugin-manifests.test.ts

OPENCLAW_CONFIG_PATH=/Volumes/LEXAR/Codex/doctor-tools-proof.TXaZzO/openclaw.json \
OPENCLAW_STATE_DIR=/Volumes/LEXAR/Codex/doctor-tools-proof.TXaZzO/state \
OPENCLAW_AGENT_DIR=/Volumes/LEXAR/Codex/doctor-tools-proof.TXaZzO/agent \
pnpm openclaw doctor --fix --non-interactive
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
Test Files  1 passed (1)
Tests  5 passed (5)

Legacy plugin manifest capability keys detected.
- /Volumes/LEXAR/Codex/doctor-tools-proof.TXaZzO/plugins/cortex/openclaw.plugin.json:
  moved tools to contracts.tools

Doctor changes
- /Volumes/LEXAR/Codex/doctor-tools-proof.TXaZzO/plugins/cortex/openclaw.plugin.json:
  moved tools to contracts.tools
```

Observed manifest after fix:

```json
{
  "id": "cortex",
  "configSchema": { "type": "object" },
  "contracts": {
    "tools": ["cortex_search", "cortex_remember"]
  }
}
```

- Observed result after fix: top-level `tools` is moved to `contracts.tools`, duplicate top-level `tools` is removed when `contracts.tools` already exists, and the disposable manifest has no top-level `tools` left.
- What was not tested: the user's real Cortex plugin was not mutated in place; proof used an isolated disposable manifest with the same legacy top-level `tools` shape.
- Before evidence (optional but encouraged): a real local manifest shape motivating the repair used top-level `tools` for `cortex_search`, `cortex_remember`, and `cortex_forget`.

## Root Cause (if applicable)

- Root cause: `LEGACY_MANIFEST_CONTRACT_KEYS` included provider capability keys but omitted `tools`, while runtime plugin registration reads `record.contracts.tools`.
- Missing detection / guardrail: doctor manifest migration coverage did not include top-level plugin tool declarations.
- Contributing context (if known): beta.5 tightened plugin tool declarations under `contracts.tools` without a matching doctor repair path for older local manifests.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor-plugin-manifests.test.ts`
- Scenario the test should lock in: move legacy top-level `tools` to `contracts.tools`; remove duplicate top-level `tools` when contract exists.
- Why this is the smallest reliable guardrail: the migration helper is deterministic and does not require loading a real plugin runtime.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A, tests are included.

## User-visible / Behavior Changes

`openclaw doctor --fix` can now repair legacy plugin tool declarations for beta.5 users.

## Diagram (if applicable)

<!-- reviewer-map -->

```mermaid
flowchart LR
  legacy["Legacy plugin.json top-level tools"] --> doctor["openclaw doctor --fix"]
  doctor --> contract["contracts.tools"]
  contract --> loader["Runtime/plugin loader"]
  loader --> tools["Declared plugin tools remain available"]
  doctor --> report["Migration report + proof output"]
```

```text
Before doctor:
{ "tools": ["cortex_search"] }

After doctor --fix:
{ "contracts": { "tools": ["cortex_search"] } }
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local development host
- Runtime/container: local Lexar-backed OpenClaw checkout
- Model/provider: not model-provider dependent
- Integration/channel (if any): doctor plugin manifest migration
- Relevant config (redacted): isolated disposable config/state/agent dirs

### Steps

1. Run the focused doctor manifest tests.
2. Run doctor against a disposable legacy plugin manifest.
3. Inspect the migrated manifest.

### Expected

- `tools` moves under `contracts.tools`.
- Top-level `tools` is removed.

### Actual

- Focused tests passed.
- Disposable doctor run moved `tools` to `contracts.tools`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: migration when `contracts.tools` is absent, duplicate top-level removal when contract exists, real `doctor --fix --non-interactive` disposable manifest run.
- Edge cases checked: isolated config/state/agent dirs to avoid mutating real local plugins.
- What you did **not** verify: in-place mutation of a user's real third-party plugin.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

ClawSweeper already classified this as no repair needed after proof; remaining action is maintainer review/CI.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): Doctor performs the migration when run with `--fix`.
- If yes, exact upgrade steps: `openclaw doctor --fix --non-interactive`

## Risks and Mitigations

- Risk: doctor could move malformed `tools` values that were never valid contracts.
  - Mitigation: this reuses the existing legacy contract migration helper and test coverage for the contract move/remove behavior.

