### PR TITLE
docs: split plugin docs navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1191,11 +1191,12 @@
                   "tools/plugin",
                   "plugins/manage-plugins",
                   "plugins/community",
-                  "plugins/plugin-inventory",
-                  "plugins/reference",
-                  "plugins/bundles",
-                  "plugins/dependency-resolution",
-                  "plugins/install-overrides",
+                  "plugins/bundles"
+                ]
+              },
+              {
+                "group": "Bundled plugin guides",
+                "pages": [
                   "plugins/codex-harness",
                   "plugins/codex-computer-use",
                   "plugins/google-meet",
@@ -1203,40 +1204,20 @@
                   "plugins/voice-call",
                   "plugins/memory-wiki",
                   "plugins/memory-lancedb",
-                  "plugins/message-presentation",
                   "plugins/oc-path",
                   "plugins/skill-workshop",
-                  "plugins/zalouser",
-                  {
-                    "group": "Building plugins",
-                    "pages": [
-                      "plugins/building-plugins",
-                      "plugins/hooks",
-                      "plugins/sdk-channel-plugins",
-                      "plugins/sdk-channel-message",
-                      "plugins/sdk-provider-plugins",
-                      "plugins/cli-backend-plugins",
-                      "plugins/adding-capabilities",
-                      "plugins/compatibility",
-                      "plugins/sdk-migration"
-                    ]
-                  },
-                  {
-                    "group": "Plugin SDK reference",
-                    "pages": [
-                      "plugins/sdk-overview",
-                      "plugins/sdk-subpaths",
-                      "plugins/sdk-entrypoints",
-                      "plugins/sdk-runtime",
-                      "plugins/sdk-channel-turn",
-                      "plugins/sdk-agent-harness",
-                      "plugins/sdk-setup",
-                      "plugins/sdk-testing",
-                      "plugins/manifest",
-                      "plugins/architecture",
-                      "plugins/architecture-internals"
-                    ]
-                  }
+                  "plugins/zalouser"
+                ]
+              },
+              {
+                "group": "Building plugins",
+                "pages": [
+                  "plugins/building-plugins",
+                  "plugins/sdk-channel-plugins",
+                  "plugins/sdk-provider-plugins",
+                  "plugins/cli-backend-plugins",
+                  "plugins/hooks",
+                  "plugins/adding-capabilities"
                 ]
               },
               {
@@ -1715,6 +1696,41 @@
                   "plugins/codex-harness-reference",
                   "plugins/codex-harness-runtime",
                   "plugins/codex-native-plugins"
+                ]
+              },
+              {
+                "group": "Plugin reference",
+                "pages": [
+                  "plugins/plugin-inventory",
+                  "plugins/reference",
+                  "plugins/dependency-resolution",
+                  "plugins/install-overrides"
+                ]
+              },
+              {
+                "group": "Plugin SDK reference",
+                "pages": [
+                  "plugins/sdk-overview",
+                  "plugins/sdk-subpaths",
+                  "plugins/sdk-entrypoints",
+                  "plugins/sdk-runtime",
+                  "plugins/sdk-agent-harness",
+                  "plugins/sdk-setup",
+                  "plugins/sdk-testing",
+                  "plugins/manifest"
+                ]
+              },
+              {
+                "group": "Plugin maintainer reference",
+                "pages": [
+                  "plugins/architecture",
+                  "plugins/architecture-internals",
+                  "plugins/sdk-migration",
+                  "plugins/compatibility",
+                  "plugins/sdk-channel-message",
+                  "plugins/sdk-channel-turn",
+                  "plugins/sdk-channel-ingress",
+                  "plugins/message-presentation"
                 ]
               },
               {


### PR DESCRIPTION
## Summary
- Split the Capabilities plugin navigation into smaller reader-intent groups.
- Move plugin inventory, reference, SDK reference, and maintainer-oriented pages into Reference-side plugin groups.
- Keep Codex native plugin docs under Reference > Codex harness and keep redirect/generated reference routes out of visible nav.

## Real behavior proof
- Behavior or issue addressed: Plugin docs navigation now separates install/manage, bundled plugin guides, plugin author guides, generated plugin reference indexes, SDK reference, and maintainer reference pages without dropping existing nav routes.
- Real environment tested: Local OpenClaw docs checkout on macOS with Node 24.15.0, branch `codex/plugin-docs-nav-m1`, using the real `docs/docs.json` and generated plugin docs in this repository.
- Exact steps or command run after this patch: Ran a local docs-nav audit with `node` against `docs/docs.json`, compared `HEAD^` to `HEAD`, checked generated plugin docs with `node scripts/generate-plugin-inventory-doc.mjs --check`, and opened the docs preview navigation to capture the resulting sidebar.
- Evidence after fix: Screenshot after fix: <img width="3668" height="1872" alt="CleanShot 2026-05-12 at 11 36 22@2x" src="https://github.com/user-attachments/assets/24ab3b09-0318-437a-88a5-24d88057d012" />

  Copied live output from the local nav audit:

  ```text
  Overview | Plugins | Bundled plugin guides | Building plugins
  Codex harness | Plugin reference | Plugin SDK reference | Plugin maintainer reference | Templates
  plugins/codex-native-plugins 1
  plugins/building-extensions 0
  plugins/agent-tools 0
  generated children 0
  beforeUnique: 491
  afterUnique: 492
  removed: []
  added: ["plugins/sdk-channel-ingress"]
  pluginMissing: []
  generatedChildren: []
  redirectVisible: []
  ```
- Observed result after fix: The sidebar grouped plugin docs as intended, `plugins/codex-native-plugins` appeared once under Reference > Codex harness, redirect-only pages stayed hidden, generated `plugins/reference/*` child pages stayed out of handwritten nav, and no existing nav page was removed.
- What was not tested: I did not test the published Mintlify production deployment; this proof covers the local docs source, generated docs check, link/MDX checks, and local sidebar rendering.

## Verification
- `node scripts/docs-list.js`
- `node scripts/check-docs-mdx.mjs docs README.md`
- `node scripts/docs-link-audit.mjs`
- `node scripts/check-docs-i18n-glossary.mjs`
- `node scripts/generate-plugin-inventory-doc.mjs --check`
- `git diff --check`
