### PR TITLE
fix(gateway): align reply diagnostics and noop recovery lane cleanup

### DIFF
--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -1,3 +1,7 @@
+import {
+  markDiagnosticEmbeddedRunEnded,
+  markDiagnosticEmbeddedRunStarted,
+} from "../../logging/diagnostic-run-activity.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 
@@ -180,6 +184,10 @@ function getAttachedBackend(operation: ReplyOperation): ReplyBackendHandle | und
 }
 
 function clearReplyRunState(params: { sessionKey: string; sessionId: string }): void {
+  markDiagnosticEmbeddedRunEnded({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+  });
   replyRunState.activeRunsByKey.delete(params.sessionKey);
   if (replyRunState.activeSessionIdsByKey.get(params.sessionKey) === params.sessionId) {
     replyRunState.activeSessionIdsByKey.delete(params.sessionKey);
@@ -303,11 +311,13 @@ export function createReplyOperation(params: {
         );
       }
       replyRunState.activeKeysBySessionId.delete(currentSessionId);
+      markDiagnosticEmbeddedRunEnded({ sessionId: currentSessionId, sessionKey });
       registerWaitSessionId(sessionKey, currentSessionId);
       currentSessionId = normalizedNextSessionId;
       replyRunState.activeSessionIdsByKey.set(sessionKey, currentSessionId);
       replyRunState.activeKeysBySessionId.set(currentSessionId, sessionKey);
       registerWaitSessionId(sessionKey, currentSessionId);
+      markDiagnosticEmbeddedRunStarted({ sessionId: currentSessionId, sessionKey });
     },
     attachBackend(handle) {
       if (result) {
@@ -372,6 +382,7 @@ export function createReplyOperation(params: {
   replyRunState.activeSessionIdsByKey.set(sessionKey, currentSessionId);
   replyRunState.activeKeysBySessionId.set(currentSessionId, sessionKey);
   registerWaitSessionId(sessionKey, currentSessionId);
+  markDiagnosticEmbeddedRunStarted({ sessionId: currentSessionId, sessionKey });
 
   return operation;
 }

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -2,6 +2,7 @@ import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { markDiagnosticActivity as markActivity } from "./diagnostic-runtime.js";
 import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
 import {
+  recoveryOutcomeClearsQueuedSessionState,
   recoveryOutcomeMutatesSessionState,
   recoveryOutcomeReleasedCount,
   type StuckSessionRecoveryOutcome,
@@ -108,7 +109,10 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
   state.lastStuckWarnAgeMs = undefined;
   state.lastLongRunningWarnAgeMs = undefined;
   const released = recoveryOutcomeReleasedCount(params.outcome);
-  state.queueDepth = released > 0 ? 0 : Math.max(0, state.queueDepth - 1);
+  state.queueDepth =
+    released > 0 || recoveryOutcomeClearsQueuedSessionState(params.outcome)
+      ? 0
+      : Math.max(0, state.queueDepth - 1);
   emitDiagnosticEvent({
     type: "session.state",
     sessionId: state.sessionId,

--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -73,7 +73,17 @@ export function recoveryOutcomeMutatesSessionState(
   if (!outcome) {
     return false;
   }
-  return outcome.status === "aborted" || outcome.status === "released";
+  return (
+    outcome.status === "aborted" ||
+    outcome.status === "released" ||
+    recoveryOutcomeClearsQueuedSessionState(outcome)
+  );
+}
+
+export function recoveryOutcomeClearsQueuedSessionState(
+  outcome: StuckSessionRecoveryOutcome,
+): boolean {
+  return outcome.status === "noop" && outcome.reason === "no_active_work";
 }
 
 export function recoveryOutcomeReleasedCount(outcome: StuckSessionRecoveryOutcome): number {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  __testing as replyRunRegistryTesting,
+  createReplyOperation,
+} from "../auto-reply/reply/reply-run-registry.js";
+import {
   emitDiagnosticEvent,
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -271,11 +275,13 @@ describe("logger import side effects", () => {
 describe("stuck session diagnostics threshold", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    replyRunRegistryTesting.resetReplyRunRegistry();
     resetDiagnosticStateForTest();
     resetDiagnosticEventsForTest();
   });
 
   afterEach(() => {
+    replyRunRegistryTesting.resetReplyRunRegistry();
     resetDiagnosticEventsForTest();
     resetDiagnosticStateForTest();
     vi.restoreAllMocks();
@@ -354,6 +360,47 @@ describe("stuck session diagnostics threshold", () => {
       { sessionId: "s1", sessionKey: "main", queueDepth: 1 },
       ["ageMs", "stateGeneration"],
     );
+  });
+
+  it("does not classify queued diagnostic state as stuck while reply work is active", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logMessageQueued({ sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionKey: "main", state: "processing" });
+      createReplyOperation({
+        sessionKey: "main",
+        sessionId: "active-reply-session",
+        resetTriggered: false,
+      }).setPhase("running");
+
+      vi.advanceTimersByTime(61_000);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events.some((event) => event.type === "session.stuck")).toBe(false);
+    const stalledEvents = events.filter((event) => event.type === "session.stalled");
+    expect(stalledEvents).toHaveLength(1);
+    expect(stalledEvents[0]).toMatchObject({
+      classification: "stalled_agent_run",
+      reason: "active_work_without_progress",
+      activeWorkKind: "embedded_run",
+      queueDepth: 1,
+    });
+    expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
   it("does not warn while a processing session continues reporting progress", () => {
@@ -641,6 +688,49 @@ describe("stuck session diagnostics threshold", () => {
       events,
       { type: "session.recovery.completed", status: "released", action: "release_lane" },
       "released recovery event",
+    );
+  });
+
+  it("clears queued diagnostic state after no-active-work recovery", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn().mockResolvedValue({
+      status: "noop",
+      action: "none",
+      reason: "no_active_work",
+      sessionId: "s1",
+      sessionKey: "main",
+    });
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+      vi.advanceTimersByTime(61_000);
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    const state = getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" });
+    expect(state.state).toBe("idle");
+    expect(state.queueDepth).toBe(0);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "session.recovery.completed",
+        status: "noop",
+        outcomeReason: "no_active_work",
+      }),
     );
   });
 


### PR DESCRIPTION
## Summary

This PR integrates the two open fix slices that `#80677` depends on:

1. Mirror reply-run lifecycle into diagnostic active-work state (`reply-run-registry.ts`)
2. Treat `noop/no_active_work` recovery as a state-clearing outcome that zeroes queued diagnostic depth

Together, this removes the detector/recovery disagreement where diagnostics can report queued stale work while recovery sees active reply work, and it ensures `noop/no_active_work` leaves session state at `idle`/`queueDepth=0`.

## Root cause

`#80677` and `#79612` both show queue-state divergence symptoms:

- attention classifies `queued_work_without_active_run`
- recovery then observes active reply work and skips
- or recovery returns `noop/no_active_work` but queued depth remains stale

The underlying gaps were:

- reply operations were not mirrored into diagnostic embedded-run activity
- `noop/no_active_work` was treated as non-mutating for queue cleanup

## Changes

- `src/auto-reply/reply/reply-run-registry.ts`
  - mark diagnostic embedded run start/end on create/rebind/clear
- `src/logging/diagnostic-session-recovery.ts`
  - add `recoveryOutcomeClearsQueuedSessionState()`
  - include noop/no_active_work in mutating-state classification
- `src/logging/diagnostic-session-recovery-coordinator.ts`
  - clear queue depth when recovery outcome proves no active work
- `src/logging/diagnostic.test.ts`
  - regression: queued state with active reply run emits `session.stalled`, not `session.stuck`
  - regression: `noop/no_active_work` recovery clears to `idle` + `queueDepth=0`

## Verification

```bash
pnpm test src/logging/diagnostic.test.ts src/logging/diagnostic-session-attention.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/auto-reply/reply/reply-run-registry.test.ts
pnpm exec oxfmt --check --threads=1 src/logging/diagnostic.ts src/logging/diagnostic-session-attention.ts src/logging/diagnostic-run-activity.ts src/logging/diagnostic-session-recovery.ts src/logging/diagnostic-session-recovery-coordinator.ts src/logging/diagnostic-stuck-session-recovery.runtime.ts src/auto-reply/reply/reply-run-registry.ts src/logging/diagnostic.test.ts
git diff --check
```

All pass locally on this branch.

## Local Telegram evidence (non-code proof)

From `~/.openclaw` logs and session transcript on 2026-05-12 (America/Chicago):

- `12:43:25` user sent `/skill` (`cc55ba36-...jsonl`)
- immediate outbound failures:
  - `sendMessage failed` / `slash final reply failed` (`gateway.err.log` lines 359-360)
- successful outbound resumed:
  - `12:43:32` and `12:43:38` `sendMessage ok` (`gateway.log` lines 637-638)
- same session later handled `hi` normally (`12:48:42` -> reply at `12:48:44`)

This supports the incident shape in `#80677`: queued/transport turbulence around compaction windows with delayed or misleading user-visible behavior.

## Related PRs reviewed

- `#79695` (active reply diagnostics mirroring)
- `#77865` (noop recovery queue cleanup)
- historical superseded drafts: `#79683`, `#79669`, `#77853`

This branch intentionally integrates the behavioral fixes from `#79695` + the relevant diagnostic recovery slice from `#77865` without additional unrelated changes.
