### PR TITLE
Fix status JSON diagnostics and add config unset dry-run

### DIFF
--- a/src/cli/command-config-resolution.test.ts
+++ b/src/cli/command-config-resolution.test.ts
@@ -79,4 +79,25 @@ describe("resolveCommandConfigWithSecrets", () => {
     });
     expect(result.effectiveConfig).toBe(effectiveConfig);
   });
+
+  it("logs diagnostics to stderr when requested", async () => {
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as const;
+    const config = { channels: {} };
+    const resolvedConfig = { channels: { discord: {} } };
+    mocks.resolveCommandSecretRefsViaGateway.mockResolvedValue({
+      resolvedConfig,
+      diagnostics: ["discord token unresolved"],
+    });
+
+    await resolveCommandConfigWithSecrets({
+      config,
+      commandName: "status --json",
+      targetIds: new Set(["channels.discord.token"]),
+      runtime,
+      diagnosticLogTarget: "stderr",
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith("[secrets] discord token unresolved");
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
 });

--- a/src/cli/command-config-resolution.ts
+++ b/src/cli/command-config-resolution.ts
@@ -13,6 +13,7 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
   mode?: CommandSecretResolutionMode;
   allowedPaths?: Set<string>;
   runtime?: RuntimeEnv;
+  diagnosticLogTarget?: "stdout" | "stderr";
   autoEnable?: boolean;
   env?: NodeJS.ProcessEnv;
 }): Promise<{
@@ -28,8 +29,10 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
     ...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
   });
   if (params.runtime) {
+    const logDiagnostic =
+      params.diagnosticLogTarget === "stderr" ? params.runtime.error : params.runtime.log;
     for (const entry of diagnostics) {
-      params.runtime.log(`[secrets] ${entry}`);
+      logDiagnostic(`[secrets] ${entry}`);
     }
   }
   const effectiveConfig = params.autoEnable

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2254,6 +2254,35 @@ describe("config cli", () => {
         unsetPaths: [["channels", "discord", "guilds", "123"]],
       });
     });
+
+    it("supports --dry-run for config unset without writing", async () => {
+      const resolved: OpenClawConfig = {
+        tools: {
+          profile: "coding",
+          alsoAllow: ["agents_list"],
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "unset", "tools.alsoAllow", "--dry-run"]);
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining("Dry run successful: removal of tools.alsoAllow validated"),
+      );
+    });
+
+    it("includes --dry-run in config unset help output", () => {
+      const program = new Command();
+      registerConfigCli(program);
+
+      const configCommand = program.commands.find((command) => command.name() === "config");
+      const unsetCommand = configCommand?.commands.find((command) => command.name() === "unset");
+      const helpText = unsetCommand?.helpInformation() ?? "";
+
+      expect(helpText).toContain("--dry-run");
+      expect(helpText).toContain("Validate removal without writing openclaw.json");
+    });
   });
 
   describe("config file", () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -82,6 +82,9 @@ type ConfigPatchOptions = {
   json?: boolean | undefined;
   replacePath?: string[] | undefined;
 };
+type ConfigUnsetOptions = {
+  dryRun?: boolean | undefined;
+};
 type ConfigMutationOptions = {
   dryRun?: boolean | undefined;
   allowExec?: boolean | undefined;
@@ -1685,8 +1688,13 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
   }
 }
 
-export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv }) {
+export async function runConfigUnset(opts: {
+  path: string;
+  cliOptions?: ConfigUnsetOptions;
+  runtime?: RuntimeEnv;
+}) {
   const runtime = opts.runtime ?? defaultRuntime;
+  const cliOptions = opts.cliOptions ?? {};
   try {
     const parsedPath = parseRequiredPath(opts.path);
     const snapshot = await loadValidConfig(runtime);
@@ -1698,6 +1706,30 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
     if (!unsetResult.removed) {
       runtime.error(danger(`Config path not found: ${opts.path}`));
       runtime.exit(1);
+      return;
+    }
+    const operation = buildDeleteOperation(parsedPath);
+    const nextConfig = next as OpenClawConfig;
+    if (cliOptions.dryRun) {
+      const policyIssues = collectUnsupportedSecretRefPolicyIssues(nextConfig);
+      const errors = collectDryRunSchemaErrors({
+        config: nextConfig,
+        operations: [operation],
+      });
+      if (policyIssues.length > 0) {
+        errors.push(
+          ...formatConfigIssueLines(policyIssues, "", { normalizeRoot: true })
+            .map((line) => line.trim())
+            .map((message) => ({ kind: "schema" as const, message })),
+        );
+      }
+      const dedupedErrors = dedupeDryRunErrors(errors);
+      if (dedupedErrors.length > 0) {
+        throw new Error(formatDryRunFailureMessage({ errors: dedupedErrors, skippedExecRefs: 0 }));
+      }
+      runtime.log(
+        info(`Dry run successful: removal of ${opts.path} validated against ${shortenHomePath(snapshot.path)}.`),
+      );
       return;
     }
     await replaceConfigFile({
@@ -1945,8 +1977,9 @@ export function registerConfigCli(program: Command) {
     .command("unset")
     .description("Remove a config value by dot path")
     .argument("<path>", "Config path (dot or bracket notation)")
-    .action(async (path: string) => {
-      await runConfigUnset({ path });
+    .option("--dry-run", "Validate removal without writing openclaw.json", false)
+    .action(async (path: string, opts: ConfigUnsetOptions) => {
+      await runConfigUnset({ path, cliOptions: opts });
     });
 
   cmd

--- a/src/commands/status.scan-overview.test.ts
+++ b/src/commands/status.scan-overview.test.ts
@@ -179,4 +179,20 @@ describe("collectStatusScanOverview", () => {
     expect(result.channelsStatus).toBeNull();
     expect(result.channelIssues).toEqual([]);
   });
+
+  it("routes secret diagnostics to stderr for status --json", async () => {
+    await collectStatusScanOverview({
+      commandName: "status --json",
+      opts: {},
+      showSecrets: false,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    });
+
+    expect(mocks.resolveCommandConfigWithSecrets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandName: "status --json",
+        diagnosticLogTarget: "stderr",
+      }),
+    );
+  });
 });

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -170,6 +170,7 @@ export async function collectStatusScanOverview(params: {
           loadedConfig,
         ),
         mode: "read_only_status",
+        diagnosticLogTarget: params.commandName.includes("--json") ? "stderr" : "stdout",
         ...(params.runtime ? { runtime: params.runtime } : {}),
       }),
   });


### PR DESCRIPTION
## Summary
- route `resolveCommandConfigWithSecrets` diagnostics to stderr for `status --json` paths so JSON stdout remains machine-parseable
- add `config unset --dry-run` support to validate removals without mutating `openclaw.json`
- add focused tests for stderr diagnostic routing and unset dry-run behavior/help parity

## Test plan
- [x] `pnpm test src/cli/command-config-resolution.test.ts src/commands/status.scan-overview.test.ts src/cli/config-cli.test.ts`