### PR TITLE
fix(telegram): allow inline button sends in group prompts

### DIFF
--- a/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
+++ b/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
@@ -51,7 +51,7 @@ export function registerGroupIntroPromptCases(): void {
           Provider: "whatsapp",
         },
         expected: [
-          "You are in a WhatsApp group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
+          "You are in a WhatsApp group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send plain text to this same group — reply normally. Exception: when a live decision needs channel-native interactive controls such as inline buttons, use the message tool with action=send and presentation.blocks buttons, then make the final assistant turn silent to avoid a duplicate.",
           groupParticipationNote,
           groupSilentNote,
           groupSilentProseGuard,

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -29,7 +29,7 @@ describe("group runtime loading", () => {
       silentToken: "NO_REPLY",
     });
     expect(groupChatContext).toContain(
-      "You are in a WhatsApp group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
+      "You are in a WhatsApp group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send plain text to this same group — reply normally. Exception: when a live decision needs channel-native interactive controls such as inline buttons, use the message tool with action=send and presentation.blocks buttons, then make the final assistant turn silent to avoid a duplicate.",
     );
     expect(groupChatContext).toContain("Minimize empty lines and use normal chat conventions");
     expect(groupChatContext).not.toContain("wrap bare URLs");

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -235,7 +235,7 @@ export function buildGroupChatContext(params: {
     );
   } else {
     lines.push(
-      "Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
+      "Your replies are automatically sent to this group chat. Do not use the message tool to send plain text to this same group — reply normally. Exception: when a live decision needs channel-native interactive controls such as inline buttons, use the message tool with action=send and presentation.blocks buttons, then make the final assistant turn silent to avoid a duplicate.",
     );
   }
   lines.push(


### PR DESCRIPTION
## Summary
- Updates group-chat auto-reply guidance so same-group plain-text sends still use the normal assistant reply, while live channel-native decisions can use `message` with `action=send` and `presentation.blocks` inline buttons.
- Adds the explicit silent-final-turn instruction after button sends to avoid duplicate delivery.
- Aligns both focused group prompt tests and the group intro prompt fixture, and refreshes the codex prompt snapshots after rebase on the latest `origin/main`.

## Why
The old prompt was a blanket same-group `message` tool ban. That accidentally discouraged valid Telegram inline-button sends even though the runtime already supports presentation-backed buttons in group/topic targets.

## Scope
Prompt and prompt-snapshot fixture only. No runtime delivery code, package metadata, config, generated dist, or installed OpenClaw files changed.

## Real behavior proof
- Behavior or issue addressed: `buildGroupChatContext` in `src/auto-reply/reply/groups.ts` now emits an explicit exception clause that allows the `message` tool with `action=send` and `presentation.blocks` inline buttons inside a group chat, replacing the prior blanket same-group ban; the matching group intro prompt fixture and the focused group runtime test were updated to the same wording.
- Real environment tested: Local OpenClaw source worktree on macOS 25.5.0 arm64, Node v22.22.3, branch rebased on `origin/main` at `661a9ba559`, no installed OpenClaw daemon, no gateway runtime, no Telegram or WhatsApp channel credentials in scope.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/groups.test.ts` to exercise the rebuilt prompt path against the asserted exception clause.
  2. `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts` to cover the trigger-handling end-to-end flow that owns the group-intro reply path.
  3. `node --import tsx scripts/generate-prompt-snapshots.ts --check` after `node --import tsx scripts/generate-prompt-snapshots.ts --write` to confirm the codex prompt fixtures match the rebuilt prompt output.
- Evidence after fix: terminal capture from the local worktree after the patch.
  ```text
  $ node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts \
      src/auto-reply/reply/groups.test.ts
   RUN  v4.1.7 /Users/moeedahmed/.openclaw/workspace/_worktrees/telegram-group-inline-button-prompt-pr-20260528
   Test Files  1 passed (1)
        Tests  5 passed (5)
     Duration  410ms

  $ node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts \
      src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
   Test Files  1 passed (1)
        Tests  20 passed (20)
     Duration  47.66s

  $ node --import tsx scripts/generate-prompt-snapshots.ts --check
  Prompt snapshots are current (7 files).
  ```
  Rebuilt group-chat prompt line emitted by the patched `buildGroupChatContext` in this worktree (redacted runtime log, captured from the source-of-truth template):
  ```text
  Your replies are automatically sent to this group chat. Do not use the message tool to send plain text to this same group — reply normally. Exception: when a live decision needs channel-native interactive controls such as inline buttons, use the message tool with action=send and presentation.blocks buttons, then make the final assistant turn silent to avoid a duplicate.
  ```
- Observed result after fix: The focused group prompt assertions, the targets-active-session-native-stop end-to-end suite, and the codex prompt snapshot check all match the rebuilt source; the emitted group-chat prompt now carries the new exception clause verbatim, and the codex prompt fixtures account for the recentMinutes integer-type adjustment that landed on `origin/main` in the same rebase window.
- What was not tested: No live Telegram or WhatsApp round-trip, no live gateway delivery, and no channel-credential-backed send were exercised; this PR is prompt and prompt-snapshot only, and the runtime inline-button delivery path was already shipped.
