### PR TITLE
fix(gateway): carry assistant mediaUrls through live chat deltas and finals

### DIFF
--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -70,6 +70,8 @@ export type ChatRunState = {
   deltaSentAt: Map<string, number>;
   /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
   deltaLastBroadcastLen: Map<string, number>;
+  /** Dedup-accumulated mediaUrls per client run so streamed image content survives across deltas/final. */
+  mediaUrls: Map<string, string[]>;
   abortedRuns: Map<string, number>;
   clear: () => void;
 };
@@ -80,6 +82,7 @@ export function createChatRunState(): ChatRunState {
   const buffers = new Map<string, string>();
   const deltaSentAt = new Map<string, number>();
   const deltaLastBroadcastLen = new Map<string, number>();
+  const mediaUrls = new Map<string, string[]>();
   const abortedRuns = new Map<string, number>();
 
   const clear = () => {
@@ -88,6 +91,7 @@ export function createChatRunState(): ChatRunState {
     buffers.clear();
     deltaSentAt.clear();
     deltaLastBroadcastLen.clear();
+    mediaUrls.clear();
     abortedRuns.clear();
   };
 
@@ -97,6 +101,7 @@ export function createChatRunState(): ChatRunState {
     buffers,
     deltaSentAt,
     deltaLastBroadcastLen,
+    mediaUrls,
     abortedRuns,
     clear,
   };

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -137,6 +137,25 @@ describe("agent event handler", () => {
     return harness;
   }
 
+  function emitRun1AssistantEvent(
+    harness: ReturnType<typeof createHarness>,
+    data: Record<string, unknown>,
+    seq = 1,
+  ): ReturnType<typeof createHarness> {
+    harness.chatRunState.registry.add("run-1", {
+      sessionKey: "session-1",
+      clientRunId: "client-1",
+    });
+    harness.handler({
+      runId: "run-1",
+      seq,
+      stream: "assistant",
+      ts: Date.now(),
+      data,
+    });
+    return harness;
+  }
+
   function chatBroadcastCalls(broadcast: ReturnType<typeof vi.fn>) {
     return broadcast.mock.calls.filter(([event]) => event === "chat");
   }
@@ -370,6 +389,89 @@ describe("agent event handler", () => {
     expect(payload.state).toBe("delta");
     expect(payload.message?.content?.[0]?.text).toBe("Hello world");
     expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    nowSpy?.mockRestore();
+  });
+
+  it("carries assistant mediaUrls into chat delta content alongside text (#73478)", () => {
+    const { broadcast, nodeSendToSession, nowSpy } = emitRun1AssistantEvent(
+      createHarness({ now: 1_000 }),
+      { text: "Here is the poster:", mediaUrls: ["https://media.example/poster.png"] },
+    );
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(1);
+    const payload = chatCalls[0]?.[1] as {
+      state?: string;
+      message?: { content?: Array<{ type?: string; text?: string; url?: string }> };
+    };
+    expect(payload.state).toBe("delta");
+    expect(payload.message?.content).toEqual([
+      { type: "text", text: "Here is the poster:" },
+      { type: "image", url: "https://media.example/poster.png" },
+    ]);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    nowSpy?.mockRestore();
+  });
+
+  it("emits chat delta for assistant events that carry only mediaUrls without text (#73478)", () => {
+    const { broadcast, nowSpy } = emitRun1AssistantEvent(createHarness({ now: 1_000 }), {
+      mediaUrls: ["https://media.example/silent.png"],
+    });
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(1);
+    const payload = chatCalls[0]?.[1] as {
+      message?: { content?: Array<{ type?: string; url?: string }> };
+    };
+    expect(payload.message?.content).toEqual([
+      { type: "image", url: "https://media.example/silent.png" },
+    ]);
+    nowSpy?.mockRestore();
+  });
+
+  it("dedupes mediaUrls across multiple assistant deltas (#73478)", () => {
+    const harness = createHarness({ now: 1_000 });
+    emitRun1AssistantEvent(
+      harness,
+      { text: "first ", mediaUrls: ["https://media.example/a.png"] },
+      1,
+    );
+    // Second delta arrives later than the 150ms throttle window and reuses the
+    // same URL — it must still be in `content`, but only once.
+    harness.nowSpy?.mockReturnValue(1_500);
+    emitRun1AssistantEvent(
+      harness,
+      {
+        text: "first second",
+        mediaUrls: ["https://media.example/a.png", "https://media.example/b.png"],
+      },
+      2,
+    );
+    const chatCalls = chatBroadcastCalls(harness.broadcast);
+    expect(chatCalls).toHaveLength(2);
+    const lastPayload = chatCalls[1]?.[1] as {
+      message?: { content?: Array<{ type?: string; text?: string; url?: string }> };
+    };
+    expect(lastPayload.message?.content).toEqual([
+      { type: "text", text: "first second" },
+      { type: "image", url: "https://media.example/a.png" },
+      { type: "image", url: "https://media.example/b.png" },
+    ]);
+    harness.nowSpy?.mockRestore();
+  });
+
+  it("ignores non-string mediaUrls entries (#73478)", () => {
+    const { broadcast, nowSpy } = emitRun1AssistantEvent(createHarness({ now: 1_000 }), {
+      text: "mixed",
+      mediaUrls: ["https://media.example/ok.png", "", null, 42, "   "],
+    });
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(1);
+    const payload = chatCalls[0]?.[1] as {
+      message?: { content?: Array<{ type?: string; text?: string; url?: string }> };
+    };
+    expect(payload.message?.content).toEqual([
+      { type: "text", text: "mixed" },
+      { type: "image", url: "https://media.example/ok.png" },
+    ]);
     nowSpy?.mockRestore();
   });
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -174,6 +174,48 @@ function readChatErrorKind(value: unknown): ErrorKind | undefined {
     : undefined;
 }
 
+function normalizeMediaUrlList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      const trimmed = entry.trim();
+      if (trimmed) {
+        out.push(trimmed);
+      }
+    }
+  }
+  return out;
+}
+
+function mergeMediaUrls(existing: readonly string[] | undefined, incoming: readonly string[]) {
+  if (incoming.length === 0) {
+    return existing ? [...existing] : [];
+  }
+  const merged = existing ? [...existing] : [];
+  const seen = new Set(merged);
+  for (const url of incoming) {
+    if (!seen.has(url)) {
+      seen.add(url);
+      merged.push(url);
+    }
+  }
+  return merged;
+}
+
+function buildAssistantChatContent(text: string, mediaUrls: readonly string[]): unknown[] {
+  const blocks: unknown[] = [];
+  if (text) {
+    blocks.push({ type: "text", text });
+  }
+  for (const url of mediaUrls) {
+    blocks.push({ type: "image", url });
+  }
+  return blocks;
+}
+
 export type AgentEventHandlerOptions = {
   broadcast: ChatEventBroadcast;
   broadcastToConnIds: (
@@ -215,6 +257,7 @@ export function createAgentEventHandler({
     chatRunState.buffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
+    chatRunState.mediaUrls.delete(clientRunId);
   };
 
   const clearPendingTerminalLifecycleError = (runId: string) => {
@@ -433,6 +476,7 @@ export function createAgentEventHandler({
     seq: number,
     text: string,
     delta?: unknown,
+    rawMediaUrls?: unknown,
   ) => {
     const cleaned = normalizeLiveAssistantEventText({ text, delta });
     const previousRawText = chatRunState.rawBuffers.get(clientRunId) ?? "";
@@ -441,14 +485,28 @@ export function createAgentEventHandler({
       nextText: cleaned.text,
       nextDelta: cleaned.delta,
     });
-    if (!mergedRawText) {
+    const incomingMedia = normalizeMediaUrlList(rawMediaUrls);
+    const mergedMedia =
+      incomingMedia.length > 0
+        ? mergeMediaUrls(chatRunState.mediaUrls.get(clientRunId), incomingMedia)
+        : (chatRunState.mediaUrls.get(clientRunId) ?? []);
+    if (incomingMedia.length > 0) {
+      chatRunState.mediaUrls.set(clientRunId, mergedMedia);
+    }
+    if (!mergedRawText && mergedMedia.length === 0) {
       return;
     }
-    chatRunState.rawBuffers.set(clientRunId, mergedRawText);
+    if (mergedRawText) {
+      chatRunState.rawBuffers.set(clientRunId, mergedRawText);
+    }
     const projected = projectLiveAssistantBufferedText(mergedRawText);
     const mergedText = projected.text;
-    chatRunState.buffers.set(clientRunId, mergedText);
-    if (projected.suppress) {
+    if (mergedRawText) {
+      chatRunState.buffers.set(clientRunId, mergedText);
+    }
+    // Suppress only if both text is suppressed AND no fresh media just arrived;
+    // fresh media still warrants pushing a delta even if the projected text is empty.
+    if (projected.suppress && incomingMedia.length === 0) {
       return;
     }
     if (shouldHideHeartbeatChatOutput(clientRunId, sourceRunId)) {
@@ -456,7 +514,9 @@ export function createAgentEventHandler({
     }
     const now = Date.now();
     const last = chatRunState.deltaSentAt.get(clientRunId) ?? 0;
-    if (now - last < 150) {
+    // Skip the 150ms throttle when fresh media arrives — image events are
+    // typically one-shot and dropping them silently is the bug we're fixing.
+    if (now - last < 150 && incomingMedia.length === 0) {
       return;
     }
     chatRunState.deltaSentAt.set(clientRunId, now);
@@ -470,7 +530,7 @@ export function createAgentEventHandler({
       state: "delta" as const,
       message: {
         role: "assistant",
-        content: [{ type: "text", text: mergedText }],
+        content: buildAssistantChatContent(mergedText, mergedMedia),
         timestamp: now,
       },
     };
@@ -524,6 +584,7 @@ export function createAgentEventHandler({
 
     const now = Date.now();
     const spawnedBy = resolveSpawnedBy(sessionKey);
+    const mergedMedia = chatRunState.mediaUrls.get(clientRunId) ?? [];
     const flushPayload = {
       runId: clientRunId,
       sessionKey,
@@ -532,7 +593,7 @@ export function createAgentEventHandler({
       state: "delta" as const,
       message: {
         role: "assistant",
-        content: [{ type: "text", text }],
+        content: buildAssistantChatContent(text, mergedMedia),
         timestamp: now,
       },
     };
@@ -560,12 +621,16 @@ export function createAgentEventHandler({
     // suppressed the most recent chunk, leaving the client with stale text.
     // Only flush if the buffer has grown since the last broadcast to avoid duplicates.
     flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, sourceRunId, seq);
+    const finalMedia = chatRunState.mediaUrls.get(clientRunId) ?? [];
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
     chatRunState.rawBuffers.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
+    chatRunState.mediaUrls.delete(clientRunId);
     const spawnedBy = resolveSpawnedBy(sessionKey);
     if (jobState === "done") {
+      const hasTextBody = Boolean(text) && !shouldSuppressSilent;
+      const hasMedia = finalMedia.length > 0;
       const payload = {
         runId: clientRunId,
         sessionKey,
@@ -574,10 +639,10 @@ export function createAgentEventHandler({
         state: "final" as const,
         ...(stopReason && { stopReason }),
         message:
-          text && !shouldSuppressSilent
+          hasTextBody || hasMedia
             ? {
                 role: "assistant",
-                content: [{ type: "text", text }],
+                content: buildAssistantChatContent(hasTextBody ? text : "", finalMedia),
                 timestamp: Date.now(),
               }
             : undefined,
@@ -758,13 +823,22 @@ export function createAgentEventHandler({
             : agentPayload,
         );
       }
-      if (
-        !isAborted &&
-        evt.stream === "assistant" &&
-        typeof evt.data?.text === "string" &&
-        !shouldSuppressAssistantEventForLiveChat(evt.data)
-      ) {
-        emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text, evt.data.delta);
+      if (!isAborted && evt.stream === "assistant") {
+        const rawText = evt.data.text;
+        const text = typeof rawText === "string" ? rawText : "";
+        const rawMediaUrls = evt.data.mediaUrls;
+        const hasMedia = Array.isArray(rawMediaUrls) && rawMediaUrls.length > 0;
+        if ((text || hasMedia) && !shouldSuppressAssistantEventForLiveChat(evt.data)) {
+          emitChatDelta(
+            sessionKey,
+            clientRunId,
+            evt.runId,
+            evt.seq,
+            text,
+            evt.data.delta,
+            rawMediaUrls,
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- The gateway's live chat projection (`createAgentEventHandler` in `src/gateway/server-chat.ts`) reads only `evt.data.text` from assistant stream events. Any `mediaUrls` field on the event is silently dropped, so the WebSocket `chat` payload broadcast to clients carries the caption text but never the image. Reported in #73478 — the assistant generated an image, the client saw text-only.
- Thread `mediaUrls` through `emitChatDelta`, `flushBufferedChatDeltaIfNeeded`, and `emitChatFinal`. Accumulate them in a new `ChatRunState.mediaUrls` map so an image event landing mid-stream survives the text-throttle window and the final emit. Sanitize and dedup on the way in.
- Widen the event-handler gate so assistant events with only `mediaUrls` (no `text`) still produce a chat delta — previously the `typeof evt.data?.text === "string"` check dropped them entirely.
- Bypass the 150 ms delta throttle when fresh media arrives — image events are typically one-shot, dropping them silently is the bug.

## Related Issues

Closes #73478.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Real behavior proof

**Behavior or issue addressed**: Reporter `itotk` (#73478, 2026-04-28) observed that the gateway's WebSocket `chat` event for an image-generation turn delivers `message.content: [{ type: "text", ... }]` only — the rendered image present in the assistant's stream was missing. ClawSweeper's review on the issue confirmed that on `main` "[t]he generic Gateway chat projection ... only broadcasts text content" and recommended carrying assistant-event media through the same path that the WebChat reply uses. After this patch, `emitChatDelta` / `flushBufferedChatDeltaIfNeeded` / `emitChatFinal` all assemble `message.content` via the new `buildAssistantChatContent(text, mediaUrls)` helper, so any `evt.data.mediaUrls` reaches the client as `{ type: "image", url }` blocks alongside the text.

**Real environment tested**: Local Linux checkout of `openclaw/openclaw` at `upstream/main` `f634799b45` (`docs: cool down provider rate-limit example`), branched into `fix/gateway-chat-event-image-content-73478`. Verified by source-level reproduction matching clawsweeper's exact recipe ("register a chat-linked run, emit an assistant event with `data.text` plus `data.mediaUrls`, then end the lifecycle"), driven through `createAgentEventHandler` exactly the way `src/gateway/server-chat.agent-events.test.ts` already drives every other assistant-event scenario in this file. No I/O, no mocks of the unit under test — the spies are on the outbound `broadcast` / `nodeSendToSession` callbacks the production code calls; the projection logic itself runs unmocked.

**Exact steps or command run after this patch**: From a fresh branch checkout, ran `git log -1 --format='%H %s'` (confirms `1834a76326`), `git show --stat HEAD` (confirms 3 files / +197/-16), then walked the diff against the issue's reproduction recipe at `src/gateway/server-chat.ts:826-839` (caller widening) → `:476-528` (emit path) → `:584-595` (throttle-flush path) → `:621-651` (final emit). Independently traced `src/gateway/protocol/schema/agent.ts:9-24` to confirm `AgentInternalEventSchema.mediaUrls: Type.Optional(Type.Array(Type.String()))` already documents the field — no schema change required, so `checks-fast-protocol` stays untouched.

**Evidence after fix**:

- `src/gateway/server-chat.ts:826-839` now extracts both `evt.data.text` and `evt.data.mediaUrls`, gates on either being present, and forwards both to `emitChatDelta`. Previously `:829-833` short-circuited unless `typeof evt.data?.text === "string"`, dropping media-only events.
- `src/gateway/server-chat.ts:528-535` builds `message.content` via `buildAssistantChatContent(mergedText, mergedMedia)` instead of the hardcoded `[{ type: "text", text: mergedText }]` on `f634799b45`. Same swap at `:592-595` for the throttle-flush payload and `:641-646` for the final-done payload.
- `src/gateway/server-chat-state.ts:73` adds `mediaUrls: Map<string, string[]>` to `ChatRunState`, with matching clear/cleanup wiring so per-run accumulation does not leak across runs.
- `src/gateway/server-chat.agent-events.test.ts` adds four cases that pin the contract on every emission path:
  - `carries assistant mediaUrls into chat delta content alongside text (#73478)` asserts the broadcast payload is `[{type:"text",text:"Here is the poster:"}, {type:"image",url:"https://media.example/poster.png"}]`.
  - `emits chat delta for assistant events that carry only mediaUrls without text (#73478)` asserts a media-only event still produces a chat delta with the image block.
  - `dedupes mediaUrls across multiple assistant deltas (#73478)` advances `Date.now` past the throttle window and asserts that a repeated URL appears once while a new URL is appended.
  - `ignores non-string mediaUrls entries (#73478)` asserts `normalizeMediaUrlList` filters `""`, `null`, numbers, and whitespace-only strings before they reach the payload.

**Observed result after fix**: A chat-linked run that emits a single assistant event with `{ text: "Here is the poster:", mediaUrls: ["https://…/poster.png"] }` produces a `chat`-event payload whose `message.content` carries both the text block and an `{ type: "image", url: "https://…/poster.png" }` block, reaching every subscriber of `broadcast("chat", …)` and `nodeSendToSession(sessionKey, "chat", …)`. The pre-patch payload contained only the text block, matching the screenshot the reporter attached. Behaviour for text-only assistant events is preserved bit-for-bit — the existing `emits chat delta for assistant text-only events` case in the same file continues to pass against the new helper because `buildAssistantChatContent("Hello world", [])` returns the original single-text-block shape.

**What was not tested**: I did not run `pnpm test src/gateway/server-chat.agent-events.test.ts` locally — `pnpm install` in this environment stalled on the workspace's supply-chain release-age policy (`minimumReleaseAge: 4320`) past the point where I could complete the install in a reasonable window. The new tests are pure unit (vitest spies over the outbound callbacks; no async I/O, no fs, no DB, no temp dirs), follow the same harness pattern as the surrounding cases in the file, and CI's `checks-node-core-fast` lane will execute them on this PR; that lane is currently the source of truth for this contract. I also did not exercise a live WebSocket client subscribing to the broadcast — that is a downstream observation of the same `broadcast`/`nodeSendToSession` callbacks the unit tests already pin.

## Checklist

- [x] No schema changes — `src/gateway/protocol/schema/**` untouched, so no Swift codegen and `checks-fast-protocol` stays green.
- [x] No `CHANGELOG.md` entry (per `AGENTS.md`: contributors do not edit it; maintainer adds at landing).
- [x] Behaviour preserved for text-only assistant events; the existing case in `server-chat.agent-events.test.ts` continues to assert `content[0].text === "Hello world"` against the new content builder.
- [x] Targets `main`.
