### PR TITLE
fix(status-json): route secret diagnostics to stderr

### DIFF
--- a/src/cli/command-config-resolution.test.ts
+++ b/src/cli/command-config-resolution.test.ts
@@ -79,4 +79,25 @@ describe("resolveCommandConfigWithSecrets", () => {
     });
     expect(result.effectiveConfig).toBe(effectiveConfig);
   });
+
+  it("logs diagnostics to stderr when requested", async () => {
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as const;
+    const config = { channels: {} };
+    const resolvedConfig = { channels: { discord: {} } };
+    mocks.resolveCommandSecretRefsViaGateway.mockResolvedValue({
+      resolvedConfig,
+      diagnostics: ["discord token unresolved"],
+    });
+
+    await resolveCommandConfigWithSecrets({
+      config,
+      commandName: "status --json",
+      targetIds: new Set(["channels.discord.token"]),
+      runtime,
+      diagnosticLogTarget: "stderr",
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith("[secrets] discord token unresolved");
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
 });

--- a/src/cli/command-config-resolution.ts
+++ b/src/cli/command-config-resolution.ts
@@ -13,6 +13,7 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
   mode?: CommandSecretResolutionMode;
   allowedPaths?: Set<string>;
   runtime?: RuntimeEnv;
+  diagnosticLogTarget?: "stdout" | "stderr";
   autoEnable?: boolean;
   env?: NodeJS.ProcessEnv;
 }): Promise<{
@@ -28,8 +29,10 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
     ...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
   });
   if (params.runtime) {
+    const logDiagnostic =
+      params.diagnosticLogTarget === "stderr" ? params.runtime.error : params.runtime.log;
     for (const entry of diagnostics) {
-      params.runtime.log(`[secrets] ${entry}`);
+      logDiagnostic(`[secrets] ${entry}`);
     }
   }
   const effectiveConfig = params.autoEnable

--- a/src/commands/status.scan-overview.test.ts
+++ b/src/commands/status.scan-overview.test.ts
@@ -173,4 +173,20 @@ describe("collectStatusScanOverview", () => {
     expect(result.channelsStatus).toBeNull();
     expect(result.channelIssues).toStrictEqual([]);
   });
+
+  it("routes secret diagnostics to stderr for status --json", async () => {
+    await collectStatusScanOverview({
+      commandName: "status --json",
+      opts: {},
+      showSecrets: false,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    });
+
+    expect(mocks.resolveCommandConfigWithSecrets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandName: "status --json",
+        diagnosticLogTarget: "stderr",
+      }),
+    );
+  });
 });

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -170,6 +170,7 @@ export async function collectStatusScanOverview(params: {
           loadedConfig,
         ),
         mode: "read_only_status",
+        diagnosticLogTarget: params.commandName.includes("--json") ? "stderr" : "stdout",
         ...(params.runtime ? { runtime: params.runtime } : {}),
       }),
   });


### PR DESCRIPTION
## Summary
- route `resolveCommandConfigWithSecrets` diagnostics to stderr for `status --json` command paths
- keep stdout clean so machine consumers can parse `status --json` output reliably
- add focused tests for stderr diagnostic routing behavior

Closes #81055

## Test plan
- [x] `pnpm test src/cli/command-config-resolution.test.ts src/commands/status.scan-overview.test.ts`