### PR TITLE
feat(config): add --dry-run to config unset

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2365,6 +2365,46 @@ describe("config cli", () => {
       );
     });
 
+    it("fails config unset --dry-run when provider removal breaks existing refs", async () => {
+      const resolved: OpenClawConfig = {
+        secrets: {
+          providers: {
+            vaultfile: { source: "file", path: "/tmp/secrets.json", mode: "json" },
+          },
+        },
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+              apiKey: {
+                source: "file",
+                provider: "vaultfile",
+                id: "/providers/search/apiKey",
+              },
+            },
+          },
+        } as never,
+      };
+      setSnapshot(resolved, resolved);
+      mockResolveSecretRefValue.mockRejectedValueOnce(new Error("provider mismatch"));
+
+      await expect(
+        runConfigCommand(["config", "unset", "secrets.providers.vaultfile", "--dry-run"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockResolveSecretRefValue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "vaultfile",
+          id: "/providers/search/apiKey",
+        }),
+        expect.any(Object),
+      );
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining("Dry run failed: 1 SecretRef assignment(s) could not be resolved."),
+      );
+    });
+
     it("includes --dry-run in config unset help output", () => {
       const program = new Command();
       registerConfigCli(program);

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2347,6 +2347,35 @@ describe("config cli", () => {
         unsetPaths: [["channels", "discord", "guilds", "123"]],
       });
     });
+
+    it("supports --dry-run for config unset without writing", async () => {
+      const resolved: OpenClawConfig = {
+        tools: {
+          profile: "coding",
+          alsoAllow: ["agents_list"],
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "unset", "tools.alsoAllow", "--dry-run"]);
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining("Dry run successful: removal of tools.alsoAllow validated"),
+      );
+    });
+
+    it("includes --dry-run in config unset help output", () => {
+      const program = new Command();
+      registerConfigCli(program);
+
+      const configCommand = program.commands.find((command) => command.name() === "config");
+      const unsetCommand = configCommand?.commands.find((command) => command.name() === "unset");
+      const helpText = unsetCommand?.helpInformation() ?? "";
+
+      expect(helpText).toContain("--dry-run");
+      expect(helpText).toContain("Validate removal without writing openclaw.json");
+    });
   });
 
   describe("config file", () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -87,6 +87,9 @@ type ConfigPatchOptions = {
   json?: boolean | undefined;
   replacePath?: string[] | undefined;
 };
+type ConfigUnsetOptions = {
+  dryRun?: boolean | undefined;
+};
 type ConfigMutationOptions = {
   dryRun?: boolean | undefined;
   allowExec?: boolean | undefined;
@@ -1763,8 +1766,13 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
   }
 }
 
-export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv }) {
+export async function runConfigUnset(opts: {
+  path: string;
+  cliOptions?: ConfigUnsetOptions;
+  runtime?: RuntimeEnv;
+}) {
   const runtime = opts.runtime ?? defaultRuntime;
+  const cliOptions = opts.cliOptions ?? {};
   try {
     const parsedPath = parseRequiredPath(opts.path);
     const snapshot = await loadValidConfig(runtime);
@@ -1780,6 +1788,30 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
         ),
       );
       runtime.exit(1);
+      return;
+    }
+    const operation = buildDeleteOperation(parsedPath);
+    const nextConfig = next as OpenClawConfig;
+    if (cliOptions.dryRun) {
+      const policyIssues = collectUnsupportedSecretRefPolicyIssues(nextConfig);
+      const errors = collectDryRunSchemaErrors({
+        config: nextConfig,
+        operations: [operation],
+      });
+      if (policyIssues.length > 0) {
+        errors.push(
+          ...formatConfigIssueLines(policyIssues, "", { normalizeRoot: true })
+            .map((line) => line.trim())
+            .map((message) => ({ kind: "schema" as const, message })),
+        );
+      }
+      const dedupedErrors = dedupeDryRunErrors(errors);
+      if (dedupedErrors.length > 0) {
+        throw new Error(formatDryRunFailureMessage({ errors: dedupedErrors, skippedExecRefs: 0 }));
+      }
+      runtime.log(
+        info(`Dry run successful: removal of ${opts.path} validated against ${shortenHomePath(snapshot.path)}.`),
+      );
       return;
     }
     await replaceConfigFile({
@@ -2031,8 +2063,9 @@ export function registerConfigCli(program: Command) {
     .command("unset")
     .description("Remove a config value by dot path")
     .argument("<path>", "Config path (dot or bracket notation)")
-    .action(async (path: string) => {
-      await runConfigUnset({ path });
+    .option("--dry-run", "Validate removal without writing openclaw.json", false)
+    .action(async (path: string, opts: ConfigUnsetOptions) => {
+      await runConfigUnset({ path, cliOptions: opts });
     });
 
   cmd

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1027,12 +1027,16 @@ function pathKey(path: PathSegment[]): string {
 }
 
 function buildDeleteOperation(path: PathSegment[]): ConfigSetOperation {
+  const resolved = resolveConfigSecretTargetByPath(path);
+  const providerAlias = parseProviderAliasFromTargetPath(path);
   return {
     inputMode: "json",
     requestedPath: path,
     setPath: path,
     value: undefined,
     mutation: "delete",
+    ...(resolved ? { touchedSecretTargetPath: toDotPath(resolved.pathSegments) } : {}),
+    ...(providerAlias ? { touchedProviderAlias: providerAlias } : {}),
   };
 }
 
@@ -1794,7 +1798,14 @@ export async function runConfigUnset(opts: {
     const nextConfig = next as OpenClawConfig;
     if (cliOptions.dryRun) {
       const policyIssues = collectUnsupportedSecretRefPolicyIssues(nextConfig);
-      const errors = collectDryRunSchemaErrors({
+      const selectedDryRunRefs = selectDryRunRefsForResolution({
+        refs: collectDryRunRefs({
+          config: nextConfig,
+          operations: [operation],
+        }),
+        allowExecInDryRun: false,
+      });
+      const errors: ConfigSetDryRunError[] = collectDryRunSchemaErrors({
         config: nextConfig,
         operations: [operation],
       });
@@ -1805,9 +1816,26 @@ export async function runConfigUnset(opts: {
             .map((message) => ({ kind: "schema" as const, message })),
         );
       }
+      errors.push(
+        ...collectDryRunStaticErrorsForSkippedExecRefs({
+          refs: selectedDryRunRefs.skippedExecRefs,
+          config: nextConfig,
+        }),
+      );
+      errors.push(
+        ...(await collectDryRunResolvabilityErrors({
+          refs: selectedDryRunRefs.refsToResolve,
+          config: nextConfig,
+        })),
+      );
       const dedupedErrors = dedupeDryRunErrors(errors);
       if (dedupedErrors.length > 0) {
-        throw new Error(formatDryRunFailureMessage({ errors: dedupedErrors, skippedExecRefs: 0 }));
+        throw new Error(
+          formatDryRunFailureMessage({
+            errors: dedupedErrors,
+            skippedExecRefs: selectedDryRunRefs.skippedExecRefs.length,
+          }),
+        );
       }
       runtime.log(
         info(`Dry run successful: removal of ${opts.path} validated against ${shortenHomePath(snapshot.path)}.`),


### PR DESCRIPTION
## Summary
- add `--dry-run` support to `openclaw config unset`
- validate unset removals against config schema/policy without mutating `openclaw.json`
- add tests for dry-run behavior and help parity in the config CLI

Closes #80721

## Test plan
- [x] `pnpm test src/cli/config-cli.test.ts`