### PR TITLE
fix: render WebChat message tool replies

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -14,6 +14,7 @@ import {
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMessageTool } from "../../../../src/agents/tools/message-tool.js";
 import {
   CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
   createCodexDynamicToolBridge,
@@ -316,6 +317,49 @@ describe("createCodexDynamicToolBridge", () => {
         threadId: "thread-ts-1",
         text: "hello from Codex",
         mediaUrls: ["/tmp/reply.png"],
+      },
+    ]);
+  });
+
+  it("treats same-session WebChat message sends as successful codex tool results", async () => {
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "webchat",
+      currentChannelId: "webchat-session-1",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runMessageAction: vi.fn(),
+    });
+    const bridge = createCodexDynamicToolBridge({
+      tools: [tool],
+      signal: new AbortController().signal,
+    });
+
+    const result = await handleMessageToolCall(bridge, {
+      action: "send",
+      message: "Visible reply from Codex.",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.contentItems).toHaveLength(1);
+    const content = result.contentItems[0];
+    expect(content?.type).toBe("inputText");
+    const details = JSON.parse(content?.type === "inputText" ? content.text : "{}") as Record<
+      string,
+      unknown
+    >;
+    expect(details).toMatchObject({
+      ok: true,
+      status: "ok",
+      deliveryStatus: "sent",
+      delivery: "webchat-session",
+    });
+    expect(bridge.telemetry.didSendViaMessagingTool).toBe(true);
+    expect(bridge.telemetry.messagingToolSentTexts).toEqual(["Visible reply from Codex."]);
+    expect(bridge.telemetry.messagingToolSentTargets).toEqual([
+      {
+        tool: "message",
+        provider: "message",
+        text: "Visible reply from Codex.",
       },
     ]);
   });

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -354,6 +354,41 @@ describe("createCodexDynamicToolBridge", () => {
     ]);
   });
 
+  it("records sanitized message text from successful message tool result details", async () => {
+    const tool = createTool({
+      name: "message",
+      execute: vi.fn(async () =>
+        textToolResult("Sent.", {
+          ok: true,
+          status: "ok",
+          deliveryStatus: "sent",
+          delivery: "webchat-session",
+          message: "Visible reply from Codex.",
+        }),
+      ),
+    });
+    const bridge = createCodexDynamicToolBridge({
+      tools: [tool],
+      signal: new AbortController().signal,
+    });
+
+    const result = await handleMessageToolCall(bridge, {
+      action: "send",
+      message: "<think>internal scratchpad</think>Visible reply from Codex.",
+    });
+
+    expect(result).toEqual(expectInputText("Sent."));
+    expect(bridge.telemetry.didSendViaMessagingTool).toBe(true);
+    expect(bridge.telemetry.messagingToolSentTexts).toEqual(["Visible reply from Codex."]);
+    expect(bridge.telemetry.messagingToolSentTargets).toEqual([
+      {
+        tool: "message",
+        provider: "message",
+        text: "Visible reply from Codex.",
+      },
+    ]);
+  });
+
   it("does not record messaging side effects when the send fails", async () => {
     const tool = createTool({
       name: "message",

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -14,7 +14,6 @@ import {
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createMessageTool } from "../../../../src/agents/tools/message-tool.js";
 import {
   CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
   createCodexDynamicToolBridge,
@@ -321,13 +320,17 @@ describe("createCodexDynamicToolBridge", () => {
     ]);
   });
 
-  it("treats same-session WebChat message sends as successful codex tool results", async () => {
-    const tool = createMessageTool({
-      config: {} as never,
-      currentChannelProvider: "webchat",
-      currentChannelId: "webchat-session-1",
-      sourceReplyDeliveryMode: "message_tool_only",
-      runMessageAction: vi.fn(),
+  it("treats same-session WebChat message status as a successful codex tool result", async () => {
+    const tool = createTool({
+      name: "message",
+      execute: vi.fn(async () =>
+        textToolResult("Sent.", {
+          ok: true,
+          status: "ok",
+          deliveryStatus: "sent",
+          delivery: "webchat-session",
+        }),
+      ),
     });
     const bridge = createCodexDynamicToolBridge({
       tools: [tool],
@@ -339,20 +342,7 @@ describe("createCodexDynamicToolBridge", () => {
       message: "Visible reply from Codex.",
     });
 
-    expect(result.success).toBe(true);
-    expect(result.contentItems).toHaveLength(1);
-    const content = result.contentItems[0];
-    expect(content?.type).toBe("inputText");
-    const details = JSON.parse(content?.type === "inputText" ? content.text : "{}") as Record<
-      string,
-      unknown
-    >;
-    expect(details).toMatchObject({
-      ok: true,
-      status: "ok",
-      deliveryStatus: "sent",
-      delivery: "webchat-session",
-    });
+    expect(result).toEqual(expectInputText("Sent."));
     expect(bridge.telemetry.didSendViaMessagingTool).toBe(true);
     expect(bridge.telemetry.messagingToolSentTexts).toEqual(["Visible reply from Codex."]);
     expect(bridge.telemetry.messagingToolSentTargets).toEqual([

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -279,7 +279,9 @@ function collectToolTelemetry(params: {
     return;
   }
   params.telemetry.didSendViaMessagingTool = true;
-  const text = readFirstString(params.args, ["text", "message", "body", "content"]);
+  const text =
+    readToolResultDetailString(params.result, ["text", "message", "body", "content"]) ??
+    readFirstString(params.args, ["text", "message", "body", "content"]);
   if (text) {
     params.telemetry.messagingToolSentTexts.push(text);
   }
@@ -370,6 +372,16 @@ function readFirstString(record: Record<string, unknown>, keys: string[]): strin
     }
   }
   return undefined;
+}
+
+function readToolResultDetailString(
+  result: AgentToolResult<unknown> | undefined,
+  keys: string[],
+): string | undefined {
+  if (!isRecord(result?.details)) {
+    return undefined;
+  }
+  return readFirstString(result.details, keys);
 }
 
 function collectMediaUrls(record: Record<string, unknown>): string[] {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -20,7 +20,11 @@ import type { CommandQueueEnqueueOptions } from "../../process/command-queue.typ
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { sanitizeForLog } from "../../terminal/ansi.js";
 import { resolveUserPath } from "../../utils.js";
-import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  isMarkdownCapableMessageChannel,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
 import {
   hasConfiguredModelFallbacks,
   resolveAgentExecutionContract,
@@ -253,6 +257,30 @@ function hasCompletedModelProgressForIdleBreaker(attempt: EmbeddedRunAttemptForR
     hasMessagingToolDeliveryEvidence(attempt) ||
     attempt.itemLifecycle.completedCount > 0
   );
+}
+
+function collectNonEmptyMessagingToolTexts(texts?: readonly string[]): string[] {
+  return (texts ?? []).map((text) => text.trim()).filter(Boolean);
+}
+
+function resolveRenderableWebchatMessagingToolTexts(params: {
+  sourceReplyDeliveryMode?: RunEmbeddedPiAgentParams["sourceReplyDeliveryMode"];
+  messageChannel?: string;
+  messageProvider?: string;
+  didSendViaMessagingTool?: boolean;
+  messagingToolSentTexts?: readonly string[];
+}): string[] {
+  if (
+    params.sourceReplyDeliveryMode !== "message_tool_only" ||
+    params.didSendViaMessagingTool !== true
+  ) {
+    return [];
+  }
+  const sourceChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
+  if (sourceChannel !== INTERNAL_MESSAGE_CHANNEL) {
+    return [];
+  }
+  return collectNonEmptyMessagingToolTexts(params.messagingToolSentTexts);
 }
 
 function createEmptyAuthProfileStore(): AuthProfileStore {
@@ -2476,9 +2504,19 @@ export async function runEmbeddedPiAgent(
           };
           const finalAssistantVisibleText = resolveFinalAssistantVisibleText(sessionLastAssistant);
           const finalAssistantRawText = resolveFinalAssistantRawText(sessionLastAssistant);
+          const webchatMessagingToolReplyTexts = resolveRenderableWebchatMessagingToolTexts({
+            sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+            messageChannel: params.messageChannel,
+            messageProvider: params.messageProvider,
+            didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+            messagingToolSentTexts: attempt.messagingToolSentTexts,
+          });
+          const shouldRenderWebchatMessagingToolReply = webchatMessagingToolReplyTexts.length > 0;
 
           const payloads = buildEmbeddedRunPayloads({
-            assistantTexts: attempt.assistantTexts,
+            assistantTexts: shouldRenderWebchatMessagingToolReply
+              ? webchatMessagingToolReplyTexts
+              : attempt.assistantTexts,
             toolMetas: attempt.toolMetas,
             lastAssistant: attempt.lastAssistant,
             lastToolError: attempt.lastToolError,
@@ -2494,6 +2532,8 @@ export async function runEmbeddedPiAgent(
             suppressToolErrorWarnings: params.suppressToolErrorWarnings,
             inlineToolResultsAllowed: false,
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+            deliverAssistantRepliesDespiteSourceSuppression: shouldRenderWebchatMessagingToolReply,
+            preferAssistantTextsOverFinalAnswer: shouldRenderWebchatMessagingToolReply,
             didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
             heartbeatToolResponse: attempt.heartbeatToolResponse,
           });

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
+import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import {
   buildPayloads,
   expectSinglePayloadText,
@@ -161,6 +162,54 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
 
     expectSinglePayloadText(payloads, "Done.");
+  });
+
+  it("can mark assistant-text payloads for source-suppression delivery", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Actual visible reply from the message tool."],
+      deliverAssistantRepliesDespiteSourceSuppression: true,
+    });
+
+    expectSinglePayloadText(payloads, "Actual visible reply from the message tool.");
+    const [payload] = payloads;
+    if (!payload) {
+      throw new Error("Expected a visible reply payload");
+    }
+    expect(getReplyPayloadMetadata(payload)?.deliverDespiteSourceReplySuppression).toBe(true);
+  });
+
+  it("can prefer multiple assistant text payloads over a generic final answer", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["First message-tool reply.", "Second message-tool reply."],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "Sent.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+      preferAssistantTextsOverFinalAnswer: true,
+      deliverAssistantRepliesDespiteSourceSuppression: true,
+    });
+
+    expect(payloads.map((payload) => payload.text)).toEqual([
+      "First message-tool reply.",
+      "Second message-tool reply.",
+    ]);
+    expect(
+      payloads.every(
+        (payload) =>
+          getReplyPayloadMetadata(payload)?.deliverDespiteSourceReplySuppression === true,
+      ),
+    ).toBe(true);
   });
 
   it("surfaces concise exec tool errors when verbose mode is off", () => {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -4,6 +4,7 @@ import {
   createHeartbeatToolResponsePayload,
   type HeartbeatToolResponse,
 } from "../../../auto-reply/heartbeat-tool-response.js";
+import { markReplyPayloadForSourceSuppressionDelivery } from "../../../auto-reply/reply-payload.js";
 import { parseReplyDirectives } from "../../../auto-reply/reply/reply-directives.js";
 import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
@@ -187,6 +188,8 @@ export function buildEmbeddedRunPayloads(params: {
   suppressToolErrorWarnings?: boolean;
   inlineToolResultsAllowed: boolean;
   didSendViaMessagingTool?: boolean;
+  deliverAssistantRepliesDespiteSourceSuppression?: boolean;
+  preferAssistantTextsOverFinalAnswer?: boolean;
   didSendDeterministicApprovalPrompt?: boolean;
   heartbeatToolResponse?: HeartbeatToolResponse;
 }): Array<{
@@ -214,6 +217,7 @@ export function buildEmbeddedRunPayloads(params: {
     replyToId?: string;
     replyToTag?: boolean;
     replyToCurrent?: boolean;
+    deliverDespiteSourceReplySuppression?: boolean;
   }> = [];
 
   const useMarkdown = params.toolResultFormat === "markdown";
@@ -367,6 +371,7 @@ export function buildEmbeddedRunPayloads(params: {
     ? normalizeReplyTextForComparison(fallbackAnswerSourceText)
     : "";
   const shouldUseCanonicalFinalAnswer =
+    params.preferAssistantTextsOverFinalAnswer !== true &&
     nonEmptyAssistantTexts.length > 1 &&
     fallbackAnswerSourceText.length > 0 &&
     normalizedFallbackAnswerSourceText.length > 0;
@@ -406,6 +411,8 @@ export function buildEmbeddedRunPayloads(params: {
       replyToId,
       replyToTag,
       replyToCurrent,
+      deliverDespiteSourceReplySuppression:
+        params.deliverAssistantRepliesDespiteSourceSuppression === true,
     });
     hasUserFacingAssistantReply = true;
     if (cleanedText && hasExplicitMutatingToolFailureAcknowledgement(cleanedText)) {
@@ -461,6 +468,10 @@ export function buildEmbeddedRunPayloads(params: {
   const hasAudioAsVoiceTag = replyItems.some((item) => item.audioAsVoice);
   return replyItems
     .map((item) => {
+      const markIfNeeded = <T extends object>(payload: T): T =>
+        item.deliverDespiteSourceReplySuppression
+          ? markReplyPayloadForSourceSuppressionDelivery(payload)
+          : payload;
       const payload = {
         text: normalizeOptionalString(item.text),
         mediaUrls: item.media?.length ? item.media : undefined,
@@ -475,11 +486,11 @@ export function buildEmbeddedRunPayloads(params: {
         const silentText = payload.text;
         payload.text = undefined;
         if (hasOutboundReplyContent(payload)) {
-          return payload;
+          return markIfNeeded(payload);
         }
         payload.text = silentText;
       }
-      return payload;
+      return markIfNeeded(payload);
     })
     .filter((p) => {
       if (!hasOutboundReplyContent(p)) {

--- a/src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import {
+  getReplyPayloadMetadata,
+  markReplyPayloadForSourceSuppressionDelivery,
+} from "../../../auto-reply/reply-payload.js";
 import { mergeAttemptToolMediaPayloads } from "./tool-media-payloads.js";
 
 describe("mergeAttemptToolMediaPayloads", () => {
@@ -38,5 +42,24 @@ describe("mergeAttemptToolMediaPayloads", () => {
         audioAsVoice: true,
       },
     ]);
+  });
+
+  it("preserves payload metadata when attaching tool media", () => {
+    const payload = markReplyPayloadForSourceSuppressionDelivery({ text: "done" });
+    const [merged] =
+      mergeAttemptToolMediaPayloads({
+        payloads: [payload],
+        toolMediaUrls: ["/tmp/render.png"],
+      }) ?? [];
+    if (!merged) {
+      throw new Error("Expected merged payload");
+    }
+
+    expect(merged).toMatchObject({
+      text: "done",
+      mediaUrls: ["/tmp/render.png"],
+      mediaUrl: "/tmp/render.png",
+    });
+    expect(getReplyPayloadMetadata(merged)?.deliverDespiteSourceReplySuppression).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-runner/run/tool-media-payloads.ts
+++ b/src/agents/pi-embedded-runner/run/tool-media-payloads.ts
@@ -1,3 +1,4 @@
+import { copyReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import type { EmbeddedPiRunResult } from "../types.js";
 
 type EmbeddedRunPayload = NonNullable<EmbeddedPiRunResult["payloads"]>[number];
@@ -19,12 +20,12 @@ export function mergeAttemptToolMediaPayloads(params: {
   if (payloadIndex >= 0) {
     const payload = payloads[payloadIndex];
     const mergedMediaUrls = Array.from(new Set([...(payload.mediaUrls ?? []), ...mediaUrls]));
-    payloads[payloadIndex] = {
+    payloads[payloadIndex] = copyReplyPayloadMetadata(payload, {
       ...payload,
       mediaUrls: mergedMediaUrls.length ? mergedMediaUrls : undefined,
       mediaUrl: payload.mediaUrl ?? mergedMediaUrls[0],
       audioAsVoice: payload.audioAsVoice || params.toolAudioAsVoice || undefined,
-    };
+    });
     return payloads;
   }
 

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -507,7 +507,8 @@ describe("message tool agent routing", () => {
     expect(mocks.runMessageAction).not.toHaveBeenCalled();
     expect(result.details).toMatchObject({
       ok: true,
-      status: "sent",
+      status: "ok",
+      deliveryStatus: "sent",
       delivery: "webchat-session",
       channel: "webchat",
       to: "webchat-session-1",

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -490,6 +490,63 @@ describe("message tool secret scoping", () => {
 });
 
 describe("message tool agent routing", () => {
+  it("treats message-tool-only WebChat sends as same-session visible replies", async () => {
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "webchat",
+      currentChannelId: "webchat-session-1",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runMessageAction: mocks.runMessageAction as never,
+    });
+
+    const result = await tool.execute("1", {
+      action: "send",
+      message: "Actual visible reply after tools.",
+    });
+
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      ok: true,
+      status: "sent",
+      delivery: "webchat-session",
+      channel: "webchat",
+      to: "webchat-session-1",
+      message: "Actual visible reply after tools.",
+    });
+  });
+
+  it("keeps explicit external message-tool sends on the outbound path from WebChat", async () => {
+    mockSendResult({ channel: "telegram", to: "telegram:123" });
+
+    const tool = createMessageTool({
+      config: {
+        channels: {
+          telegram: {
+            token: "test-token",
+          },
+        },
+      } as never,
+      currentChannelProvider: "webchat",
+      currentChannelId: "webchat-session-1",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runMessageAction: mocks.runMessageAction as never,
+    });
+
+    await tool.execute("1", {
+      action: "send",
+      channel: "telegram",
+      target: "telegram:123",
+      message: "Send elsewhere.",
+    });
+
+    expect(mocks.runMessageAction).toHaveBeenCalledTimes(1);
+    expect(firstRunMessageActionInput()?.params).toMatchObject({
+      channel: "telegram",
+      target: "telegram:123",
+      message: "Send elsewhere.",
+    });
+  });
+
   it("derives agentId from the session key", async () => {
     mockSendResult();
 

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -516,6 +516,32 @@ describe("message tool agent routing", () => {
     });
   });
 
+  it("sanitizes same-session WebChat visible reply text", async () => {
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "webchat",
+      currentChannelId: "webchat-session-1",
+      sourceReplyDeliveryMode: "message_tool_only",
+      runMessageAction: mocks.runMessageAction as never,
+    });
+
+    const result = await tool.execute("1", {
+      action: "send",
+      message: "<think>internal scratchpad</think>Actual visible reply after tools.",
+    });
+
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      ok: true,
+      status: "ok",
+      deliveryStatus: "sent",
+      delivery: "webchat-session",
+      channel: "webchat",
+      to: "webchat-session-1",
+      message: "Actual visible reply after tools.",
+    });
+  });
+
   it("keeps explicit external message-tool sends on the outbound path from WebChat", async () => {
     mockSendResult({ channel: "telegram", to: "telegram:123" });
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -827,7 +827,8 @@ function resolveSameSessionWebchatSendResult(params: {
   const message = readMessageToolText(params.args);
   return jsonResult({
     ok: true,
-    status: "sent",
+    status: "ok",
+    deliveryStatus: "sent",
     delivery: "webchat-session",
     channel: INTERNAL_MESSAGE_CHANNEL,
     to: target ?? currentTarget ?? "current",

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -24,7 +24,7 @@ import { POLL_CREATION_PARAM_DEFS, SHARED_POLL_CREATION_PARAM_NAMES } from "../.
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
-import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listAllChannelSupportedActions, listChannelSupportedActions } from "../channel-tools.js";
 import { channelTargetSchema, channelTargetsSchema, stringEnum } from "../schema/typebox.js";
@@ -759,6 +759,82 @@ function appendMessageToolReadHint(
   return description;
 }
 
+function hasExplicitTargets(params: Record<string, unknown>): boolean {
+  return Array.isArray(params.targets)
+    ? params.targets.some((value) => normalizeOptionalString(value) !== undefined)
+    : false;
+}
+
+function readOptionalMessageToolTarget(params: Record<string, unknown>): string | undefined {
+  return (
+    readStringParam(params, "target") ??
+    readStringParam(params, "to") ??
+    readStringParam(params, "channelId")
+  );
+}
+
+function readMessageToolText(params: Record<string, unknown>): string | undefined {
+  return (
+    readStringParam(params, "message", { allowEmpty: true }) ??
+    readStringParam(params, "text", { allowEmpty: true }) ??
+    readStringParam(params, "content", { allowEmpty: true })
+  );
+}
+
+function resolveSameSessionWebchatSendResult(params: {
+  action: ChannelMessageActionName;
+  args: Record<string, unknown>;
+  currentChannelProvider?: string;
+  currentChannelId?: string;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  requireExplicitTarget?: boolean;
+}): ReturnType<typeof jsonResult> | undefined {
+  if (
+    params.action !== "send" ||
+    params.sourceReplyDeliveryMode !== "message_tool_only" ||
+    normalizeMessageChannel(params.currentChannelProvider) !== INTERNAL_MESSAGE_CHANNEL
+  ) {
+    return undefined;
+  }
+
+  const explicitChannel = normalizeMessageChannel(readStringParam(params.args, "channel"));
+  if (explicitChannel && explicitChannel !== INTERNAL_MESSAGE_CHANNEL) {
+    return undefined;
+  }
+
+  const explicitProvider = normalizeMessageChannel(readStringParam(params.args, "provider"));
+  if (explicitProvider && explicitProvider !== INTERNAL_MESSAGE_CHANNEL) {
+    return undefined;
+  }
+
+  if (hasExplicitTargets(params.args)) {
+    return undefined;
+  }
+
+  const target = readOptionalMessageToolTarget(params.args);
+  if (params.requireExplicitTarget && !target) {
+    return undefined;
+  }
+
+  const currentTarget = normalizeOptionalString(params.currentChannelId);
+  if (target && currentTarget && target !== currentTarget) {
+    return undefined;
+  }
+  if (target && !currentTarget) {
+    return undefined;
+  }
+
+  const message = readMessageToolText(params.args);
+  return jsonResult({
+    ok: true,
+    status: "sent",
+    delivery: "webchat-session",
+    channel: INTERNAL_MESSAGE_CHANNEL,
+    to: target ?? currentTarget ?? "current",
+    ...(message !== undefined ? { message } : {}),
+  });
+}
+
 export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
   const loadConfigForTool = options?.getRuntimeConfig ?? getRuntimeConfig;
   const getScopedSecretTargetsForTool =
@@ -839,6 +915,18 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         required: true,
       }) as ChannelMessageActionName;
       const requireExplicitTarget = options?.requireExplicitTarget === true;
+      const sameSessionWebchatResult = resolveSameSessionWebchatSendResult({
+        action,
+        args: params,
+        currentChannelProvider: options?.currentChannelProvider,
+        currentChannelId: options?.currentChannelId,
+        sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
+        requireExplicitTarget,
+      });
+      if (sameSessionWebchatResult) {
+        return sameSessionWebchatResult;
+      }
+
       if (requireExplicitTarget && actionNeedsExplicitTarget(action)) {
         const explicitTarget =
           (typeof params.target === "string" && params.target.trim().length > 0) ||


### PR DESCRIPTION
This PR restores the visible WebChat reply for Codex same-session `message(action="send")` calls by carrying the sanitized tool-result text into the Codex telemetry/rendering path. The safety boundary is that WebChat displays the sanitized result detail, not the raw tool arguments that may include markdown or same-session routing internals.

## Summary

This is the option-2 alternative for #81109, alongside #81110. It keeps the Codex `message` tool path available for WebChat so the model can deliberately send the visible reply after a tool-heavy turn, but now renders only the sanitized same-session message text. That preserves the personality-restoring `message` tool behavior without leaking raw reasoning-tag content from original tool arguments.

- Problem: same-session WebChat `message(action="send")` calls could be treated as external delivery or suppressed, and the first renderer version could have reused raw telemetry text.
- Why it matters: the `message` tool is the mechanism that lets Codex recover a warm, user-facing reply after tool execution instead of ending with a sterile final answer or `Sent.`.
- What changed: same-session WebChat sends return `status: "ok"`, keep semantic `deliveryStatus: "sent"`, feed sanitized result text into Codex telemetry, and render that text through source-suppression-safe reply payloads.
- What did NOT change (scope boundary): no duplicate Codex-native workspace tools, no Codex app-server filtering change, and no external channel delivery behavior change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #81109
- Alternative to #81110
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: WebChat turns configured for `message_tool_only` can use the `message` tool for the visible reply without routing through an external channel, without being suppressed by final source-reply suppression, and without rendering unsanitized reasoning-tag text.
- Real environment tested: local OpenClaw checkout at `/Volumes/LEXAR/repos/openclaw-webchat-message-renderer`, branch `fix/webchat-message-tool-renderer`, latest patch `45e0d6de92a`, using real source modules and focused Vitest coverage. This is not a full browser WebChat E2E run.
- Exact steps or command run after this patch:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/tools/message-tool.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts
pnpm exec oxfmt --check --threads=1 src/agents/tools/message-tool.ts src/agents/tools/message-tool.test.ts extensions/codex/src/app-server/dynamic-tools.ts extensions/codex/src/app-server/dynamic-tools.test.ts
git diff --check
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
[test] passed 3 Vitest shards in 9.61s
Test Files  2 passed (2), 1 passed (1), 1 passed (1)
Tests  29 passed (29), 50 passed (50), 25 passed (25)

oxfmt: All matched files use the correct format.
git diff --check: passed
```

Focused regressions now assert:

```text
same-session WebChat result.details.message === "Actual visible reply after tools."
Codex bridge telemetry.messagingToolSentTexts === ["Visible reply from Codex."]
Codex bridge telemetry target text === "Visible reply from Codex."
```

- Observed result after fix: same-session WebChat `message` sends are bridge-successful (`status: "ok"`, `deliveryStatus: "sent"`), the renderer receives source-suppression-safe payload metadata, and Codex telemetry prefers sanitized tool-result details over raw original args.
- What was not tested: full browser WebChat DOM rendering and broad repo type/lint. Those should remain GitHub CI/Testbox work per local-resource policy.
- Before evidence (optional but encouraged): ClawSweeper identified that raw `attempt.messagingToolSentTexts` could render `<think>hidden</think>Visible reply` even though `createMessageTool` sanitized its copied params. The new test locks the sanitized result path.

## Root Cause (if applicable)

- Root cause: the first renderer consumed Codex bridge messaging telemetry collected from original tool args, while `createMessageTool` strips reasoning tags on a copied params object before returning same-session result details.
- Missing detection / guardrail: coverage proved the WebChat message-tool payload existed, but did not assert reasoning-tag sanitization at the Codex bridge telemetry boundary.
- Contributing context (if known): WebChat same-session delivery is intentionally not an outbound channel send, so the safe display text must come from the sanitized tool result, not raw transport args.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/tools/message-tool.test.ts`, `extensions/codex/src/app-server/dynamic-tools.test.ts`
- Scenario the test should lock in: same-session WebChat message sends sanitize reasoning tags before display, and Codex dynamic bridge telemetry records sanitized result text.
- Why this is the smallest reliable guardrail: it covers both the source sanitizer and the bridge telemetry seam without requiring a browser WebChat E2E.
- Existing test that already covers this (if any): none before the sanitizer follow-up.
- If no new test is added, why not: N/A, new regressions are included.

## User-visible / Behavior Changes

WebChat users can receive a real visible assistant reply from the `message` tool path in `message_tool_only` mode. The rendered text is sanitized and can pass through source-reply suppression intentionally.

## Diagram (if applicable)

<!-- reviewer-map -->

```mermaid
flowchart LR
  call["message(action=send)"] --> sanitize["Message tool sanitizes visible text"]
  sanitize --> result["Tool result detail text"]
  result --> telemetry["Codex dynamic-tool telemetry"]
  telemetry --> payload["Embedded-run payload"]
  payload --> webchat["WebChat visible reply"]
  raw["Raw original args"] -. "not used for visible text" .-> telemetry
```

```text
Before:
[Codex calls message tool] -> [message tool sanitizes copied params]
  -> [Codex telemetry stores raw original args]
  -> [WebChat renderer could display raw telemetry]

After:
[Codex calls message tool] -> [message tool returns sanitized same-session result]
  -> [Codex telemetry prefers sanitized result.details.message]
  -> [WebChat renderer displays sanitized visible reply]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A. The security-sensitive review finding was about reasoning-tag text disclosure; the patch mitigates it by rendering sanitized result text.

## Repro + Verification

### Environment

- OS: macOS local development host
- Runtime/container: local Lexar-backed OpenClaw checkout
- Model/provider: not model-provider dependent
- Integration/channel (if any): WebChat same-session `message` tool path and Codex dynamic bridge
- Relevant config (redacted): `sourceReplyDeliveryMode: "message_tool_only"`, current channel `webchat`

### Steps

1. Run the focused message tool and Codex bridge tests.
2. Verify same-session result details contain sanitized message text.
3. Verify bridge telemetry records sanitized result text and classifies `status: "ok"` as success.

### Expected

- Same-session WebChat `message` send returns success semantics.
- Renderable telemetry contains sanitized visible text only.
- Source-suppression payload metadata survives.

### Actual

- Focused tests passed, 104 total checks across 3 Vitest shards.
- Formatter and whitespace checks passed.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: same-session WebChat message result, Codex bridge success classification, sanitized telemetry, payload metadata preservation.
- Edge cases checked: reasoning-tag message args, `status: "ok"` plus `deliveryStatus: "sent"`, external sends remain outside this same-session path.
- What you did **not** verify: browser DOM rendering and full GitHub CI matrix.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

ClawSweeper P2 addressed by `45e0d6de92a`: render sanitized WebChat message-tool text.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: maintainers may prefer #81110's automatic-delivery product shape instead of this message-tool renderer.
  - Mitigation: this remains explicitly framed as the option-2 alternative, with #81110 available as the narrower automatic-delivery path.

