### PR TITLE
Harden package portability checks

### DIFF
--- a/scripts/check-openclaw-package-tarball.mjs
+++ b/scripts/check-openclaw-package-tarball.mjs
@@ -13,6 +13,7 @@ import {
   collectPackageDistImportErrors,
   expandPackageDistImportClosure,
 } from "./lib/package-dist-imports.mjs";
+import { collectPackageLocalAbsolutePathContentErrors } from "./lib/package-local-path-scan.mjs";
 
 function usage() {
   return "Usage: node scripts/check-openclaw-package-tarball.mjs <openclaw.tgz>";
@@ -258,6 +259,13 @@ errors.push(
     files: normalized,
     readText: readTarEntry,
     imports: packageDistImports ?? undefined,
+  }),
+);
+errors.push(
+  ...collectPackageLocalAbsolutePathContentErrors({
+    files: normalized,
+    readText: readTarEntry,
+    forbiddenRoots: [process.cwd(), process.env.OPENCLAW_PACKAGE_LOCAL_PATH_ROOT ?? ""],
   }),
 );
 

--- a/scripts/lib/package-local-path-scan.mjs
+++ b/scripts/lib/package-local-path-scan.mjs
@@ -1,0 +1,88 @@
+const DEFAULT_TEXT_DIST_FILE_RE = /^dist\/.*\.(?:cjs|d\.ts|js|json|mjs)$/u;
+const DEFAULT_LOCAL_PATH_PATTERNS = [
+  { label: "/Users/", pattern: /\/Users\/[^"'`\s<>()]+/gu },
+  { label: "/home/", pattern: /\/home\/[^"'`\s<>()]+/gu },
+  { label: "/private/var/", pattern: /\/private\/var\/[^"'`\s<>()]+/gu },
+  { label: "C:\\Users\\", pattern: /[A-Za-z]:\\Users\\[^"'`\s<>()]+/gu },
+];
+
+function normalizePackagePath(value) {
+  return value.replace(/\\/gu, "/").replace(/^package\//u, "");
+}
+
+function normalizeSearchPath(value) {
+  return value.replace(/\\/gu, "/").replace(/\/+$/u, "");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function normalizeMatch(value) {
+  return value.length > 160 ? `${value.slice(0, 157)}...` : value;
+}
+
+function isDefaultScannablePackagePath(relativePath) {
+  return DEFAULT_TEXT_DIST_FILE_RE.test(relativePath) && !relativePath.includes("/node_modules/");
+}
+
+function isIntentionalExampleOrPlatformPath(value) {
+  return (
+    value.startsWith("/home/linuxbrew/.linuxbrew") ||
+    value.startsWith("/home/package-manager") ||
+    value.startsWith("/home/user/") ||
+    value.startsWith("/home/.../") ||
+    value.startsWith("/Users/*/") ||
+    value.startsWith("/Users/alice/") ||
+    value === "/private/var/run" ||
+    value.startsWith("/private/var/run/")
+  );
+}
+
+export function collectPackageLocalAbsolutePathContentErrors(params) {
+  const files = [...new Set(params.files.map(normalizePackagePath))].toSorted((left, right) =>
+    left.localeCompare(right),
+  );
+  const scannablePath =
+    params.scannablePath ?? ((relativePath) => isDefaultScannablePackagePath(relativePath));
+  const roots = [...new Set((params.forbiddenRoots ?? []).map(normalizeSearchPath))]
+    .filter(Boolean)
+    .filter((root) => root.length > 1)
+    .toSorted((left, right) => right.length - left.length);
+  const rootPatterns = roots.map((root) => ({
+    label: "current repo root",
+    pattern: new RegExp(`${escapeRegExp(root)}(?:/[^"'\\s<>()]*)?`, "gu"),
+  }));
+  const patterns = [...DEFAULT_LOCAL_PATH_PATTERNS, ...rootPatterns];
+  const errors = [];
+
+  for (const relativePath of files) {
+    if (!scannablePath(relativePath)) {
+      continue;
+    }
+    let source;
+    try {
+      source = params.readText(relativePath);
+    } catch {
+      continue;
+    }
+    const matches = new Set();
+    for (const { pattern } of patterns) {
+      pattern.lastIndex = 0;
+      for (const match of source.matchAll(pattern)) {
+        if (match[0] && !isIntentionalExampleOrPlatformPath(match[0])) {
+          matches.add(normalizeMatch(match[0]));
+        }
+      }
+    }
+    if (matches.size > 0) {
+      errors.push(
+        `${relativePath} contains local absolute path reference(s): ${[...matches]
+          .toSorted((left, right) => left.localeCompare(right))
+          .join(", ")}`,
+      );
+    }
+  }
+
+  return errors;
+}

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -32,6 +32,7 @@ import {
   listBundledPluginPackArtifacts,
 } from "./lib/bundled-plugin-build-entries.mjs";
 import { collectPackUnpackedSizeErrors as collectNpmPackUnpackedSizeErrors } from "./lib/npm-pack-budget.mjs";
+import { collectPackageLocalAbsolutePathContentErrors } from "./lib/package-local-path-scan.mjs";
 import { collectBundledPluginPackageDependencySpecs } from "./lib/plugin-package-dependencies.mjs";
 import { listPluginSdkDistArtifacts } from "./lib/plugin-sdk-entries.mjs";
 import {
@@ -576,8 +577,9 @@ export function collectForbiddenPackContentPaths(
   paths: Iterable<string>,
   rootDir = process.cwd(),
 ): string[] {
+  const pathList = [...paths];
   const textPathPattern = /\.(?:[cm]?js|d\.ts|json|md|mjs|cjs)$/u;
-  return [...paths]
+  const privateQaPaths = pathList
     .filter((packedPath) => {
       if (!forbiddenPrivateQaContentScanPrefixes.some((prefix) => packedPath.startsWith(prefix))) {
         return false;
@@ -594,6 +596,17 @@ export function collectForbiddenPackContentPaths(
       return forbiddenPrivateQaContentMarkers.some((marker) => content.includes(marker));
     })
     .toSorted((left, right) => left.localeCompare(right));
+  const localPathContentErrors = collectPackageLocalAbsolutePathContentErrors({
+    files: pathList,
+    forbiddenRoots: [rootDir],
+    readText(relativePath: string) {
+      return readFileSync(resolve(rootDir, relativePath), "utf8");
+    },
+  });
+  const localPathPaths = localPathContentErrors.map((error) => error.split(" contains ", 1)[0]);
+  return [...new Set([...privateQaPaths, ...localPathPaths])].toSorted((left, right) =>
+    left.localeCompare(right),
+  );
 }
 
 export { collectPackUnpackedSizeErrors } from "./lib/npm-pack-budget.mjs";

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -469,6 +469,57 @@ describe("collectForbiddenPackPaths", () => {
       rmSync(tempRoot, { recursive: true, force: true });
     }
   });
+
+  it("blocks local absolute paths from packaged dist content", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "openclaw-release-local-paths-"));
+
+    try {
+      mkdirSync(join(tempRoot, "dist", "web"), { recursive: true });
+      writeFileSync(
+        join(tempRoot, "dist", "web", "qr-image.js"),
+        [
+          'const staleBuildRoot = "/Users/steipete/Projects/clawdis/dist/web/qr-image.js";',
+          'const staleDependency = "/home/builder/openclaw/node_modules/pkg/package.json";',
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      writeFileSync(join(tempRoot, "dist", "ok.js"), "export const ok = true;\n", "utf8");
+      writeFileSync(
+        join(tempRoot, "README.md"),
+        "docs may mention /home/node container paths without being dist runtime output\n",
+        "utf8",
+      );
+
+      expect(
+        collectForbiddenPackContentPaths(
+          ["dist/web/qr-image.js", "dist/ok.js", "README.md"],
+          tempRoot,
+        ),
+      ).toEqual(["dist/web/qr-image.js"]);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks the current package root from packaged dist content", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "openclaw-release-root-path-"));
+
+    try {
+      mkdirSync(join(tempRoot, "dist"), { recursive: true });
+      writeFileSync(
+        join(tempRoot, "dist", "entry.js"),
+        `export const root = ${JSON.stringify(`${tempRoot}/dist/entry.js`)};\n`,
+        "utf8",
+      );
+
+      expect(collectForbiddenPackContentPaths(["dist/entry.js"], tempRoot)).toEqual([
+        "dist/entry.js",
+      ]);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("collectMissingPackPaths", () => {


### PR DESCRIPTION
Summary
- add a shared package-local-path scanner for packaged dist text artifacts
- wire the scanner into release pack validation and tarball integrity checks
- add regression coverage for stale /Users, /home, and current package-root paths in dist output while leaving documented placeholder examples alone

Verification
- corepack pnpm test test/release-check.test.ts
- corepack pnpm build
- corepack pnpm --dir ui build
- node --import tsx scripts/release-check.ts with a temporary pnpm shim on PATH
- npm pack --json --ignore-scripts --pack-destination "$packdir" && node scripts/check-openclaw-package-tarball.mjs "$tarball"
- installed the packed tarball into a temp prefix outside the source tree and ran openclaw --version
- installed the packed tarball into a temp prefix outside the source tree and ran openclaw qr --url ws://127.0.0.1:18789 --token issue-58-token

Notes
- The current tree already uses qrcode instead of qrcode-terminal for QR rendering, and qrcode is declared as a root runtime dependency.
- Full pnpm release:check could not be invoked directly because this machine lacks a global pnpm shim; running the underlying preflight with a temporary shim exposed pre-existing generated-baseline drift in docs/.generated/config-baseline.sha256 and docs/.generated/plugin-sdk-api-baseline.sha256, unrelated to this packaging change. The package release check itself passed with the shim.

Fixes #58
