### PR TITLE
fix(codex): format status rate limits like usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ Docs: https://docs.openclaw.ai
 - Reject truncated exec approval commands [AI]. (#81001) Thanks @pgondhi987.
 - Enforce inline shell wrapper payload matching [AI]. (#80978) Thanks @pgondhi987.
 - fix(node-pairing): replace changed pending requests [AI]. (#80894) Thanks @pgondhi987.
+- Codex/status: align `/codex status` rate-limit wording with `/status` by showing remaining quota and compact reset durations instead of used quota and raw ISO timestamps. Thanks @MatthewSchleder.
 - Rate limit Google Chat webhook requests [AI]. (#80974) Thanks @pgondhi987.
 - Docker: mount the auth-profile secret key directory so OAuth-backed auth profiles survive container rebuilds. (#80991)
 - Onboarding: accept Codex auth profiles for canonical OpenAI model checks, avoiding false missing-auth warnings. (#80913) Thanks @rubencu.

--- a/extensions/codex/src/app-server/rate-limits.test.ts
+++ b/extensions/codex/src/app-server/rate-limits.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatCodexUsageLimitErrorMessage,
   resolveCodexUsageLimitResetAtMs,
+  summarizeCodexRateLimits,
   summarizeCodexAccountUsage,
 } from "./rate-limits.js";
 
@@ -64,5 +65,34 @@ describe("Codex rate limit blocking resets", () => {
 
     expect(resolveCodexUsageLimitResetAtMs(payload, nowMs)).toBe(weeklyReset * 1000);
     expect(summarizeCodexAccountUsage(payload, nowMs)?.blockedUntilMs).toBe(weeklyReset * 1000);
+  });
+});
+
+describe("summarizeCodexRateLimits", () => {
+  it("formats status limits like provider usage summaries", () => {
+    const nowMs = 1_700_000_000_000;
+    const nowSeconds = nowMs / 1000;
+
+    expect(
+      summarizeCodexRateLimits(
+        {
+          rateLimits: {
+            limitId: "codex",
+            limitName: "Codex",
+            primary: {
+              usedPercent: 26,
+              windowDurationMins: 300,
+              resetsAt: nowSeconds + 3 * 60 * 60,
+            },
+            secondary: {
+              usedPercent: 4,
+              windowDurationMins: 7 * 24 * 60,
+              resetsAt: nowSeconds + 7 * 24 * 60 * 60,
+            },
+          },
+        },
+        nowMs,
+      ),
+    ).toBe("Codex: primary 74% left ⏱3h · secondary 96% left ⏱7d");
   });
 });

--- a/extensions/codex/src/app-server/rate-limits.ts
+++ b/extensions/codex/src/app-server/rate-limits.ts
@@ -499,12 +499,12 @@ function formatRelativeDuration(durationMs: number): string {
 }
 
 function formatResetDuration(resetsAtMs: number, nowMs: number): string {
-  const safeMs = Math.max(ONE_SECOND_MS, resetsAtMs - nowMs);
-  const totalSeconds = Math.round(safeMs / ONE_SECOND_MS);
-  const days = Math.floor(totalSeconds / 86_400);
-  const hours = Math.floor((totalSeconds % 86_400) / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
+  const durationMs =
+    Math.round(Math.max(ONE_SECOND_MS, resetsAtMs - nowMs) / ONE_SECOND_MS) * ONE_SECOND_MS;
+  const days = Math.floor(durationMs / ONE_DAY_MS);
+  const hours = Math.floor((durationMs % ONE_DAY_MS) / ONE_HOUR_MS);
+  const minutes = Math.floor((durationMs % ONE_HOUR_MS) / ONE_MINUTE_MS);
+  const seconds = Math.floor((durationMs % ONE_MINUTE_MS) / ONE_SECOND_MS);
   if (days > 0) {
     return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
   }

--- a/extensions/codex/src/app-server/rate-limits.ts
+++ b/extensions/codex/src/app-server/rate-limits.ts
@@ -2,6 +2,7 @@ import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
 
 const CODEX_LIMIT_ID = "codex";
 const LIMIT_WINDOW_KEYS = ["primary", "secondary"] as const;
+const ONE_SECOND_MS = 1000;
 const ONE_MINUTE_MS = 60_000;
 const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
 const ONE_DAY_MS = 24 * ONE_HOUR_MS;
@@ -200,7 +201,7 @@ function summarizeRateLimitSnapshot(snapshot: JsonObject, nowMs: number): string
   const reachedType =
     readString(snapshot, "rateLimitReachedType") ?? readString(snapshot, "rate_limit_reached_type");
   const suffix = reachedType ? ` (${formatReachedType(reachedType)})` : "";
-  return `${label}: ${windows.join(", ") || "available"}${suffix}`;
+  return `${label}: ${windows.join(" · ") || "available"}${suffix}`;
 }
 
 function collectCodexRateLimitSnapshots(value: JsonValue | undefined): JsonObject[] {
@@ -331,11 +332,13 @@ function formatRateLimitWindow(key: LimitWindowKey, window: RateLimitReset, nowM
 }
 
 function formatRateLimitWindowDetails(window: RateLimitReset, nowMs: number): string {
-  const usedPercent =
-    window.usedPercent === undefined ? "usage unknown" : `${Math.round(window.usedPercent)}%`;
+  const remainingPercent =
+    window.usedPercent === undefined
+      ? "usage unknown"
+      : `${Math.max(0, 100 - Math.round(window.usedPercent))}% left`;
   const reset =
-    window.resetsAtMs > nowMs ? `, resets ${formatResetTime(window.resetsAtMs, nowMs)}` : "";
-  return `${usedPercent}${reset}`;
+    window.resetsAtMs > nowMs ? ` ⏱${formatResetDuration(window.resetsAtMs, nowMs)}` : "";
+  return `${remainingPercent}${reset}`;
 }
 
 function formatLimitLabel(snapshot: JsonObject): string {
@@ -493,6 +496,25 @@ function formatRelativeDuration(durationMs: number): string {
   }
   const days = Math.ceil(safeMs / ONE_DAY_MS);
   return `${days} ${days === 1 ? "day" : "days"}`;
+}
+
+function formatResetDuration(resetsAtMs: number, nowMs: number): string {
+  const safeMs = Math.max(ONE_SECOND_MS, resetsAtMs - nowMs);
+  const totalSeconds = Math.round(safeMs / ONE_SECOND_MS);
+  const days = Math.floor(totalSeconds / 86_400);
+  const hours = Math.floor((totalSeconds % 86_400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (days > 0) {
+    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  }
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  if (minutes > 0) {
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  return `${seconds}s`;
 }
 
 function formatWindowSignature(value: JsonValue | undefined): string {

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -638,7 +638,7 @@ describe("codex command", () => {
     });
 
     const statusResult = await handleCodexCommand(createContext("status"), { deps });
-    expectResultTextContains(statusResult, "Rate limits: Codex: primary 42%");
+    expectResultTextContains(statusResult, "Rate limits: Codex: primary 58% left");
     const accountResult = await handleCodexCommand(createContext("account"), { deps });
     expectResultTextContains(accountResult, "Codex is available.");
   });


### PR DESCRIPTION
## Summary
- Aligns `/codex status` rate-limit output with the main `/status` usage style.
- Shows remaining quota instead of used quota, e.g. `primary 74% left`.
- Replaces raw ISO reset timestamps in status summaries with compact reset durations, e.g. `⏱3h` or `⏱7d`.
- Keeps the newer current-main `/codex account` availability and paused-limit summaries intact.
- Adds a changelog entry for the user-facing `/codex status` output change.

## Real behavior proof
- **Behavior addressed:** `/codex status` rate-limit summaries now show remaining quota and compact reset durations instead of used quota and raw ISO timestamps.
- **Real environment tested:** Local OpenClaw checkout on the rebased PR branch, running the real Codex status formatter through Node/tsx against an app-server-shaped status payload.
- **Exact steps or command run after the patch:** `node --import tsx -e "import { formatCodexStatus } from \"./extensions/codex/src/command-formatters.ts\"; const now=Math.floor(Date.now()/1000); console.log(formatCodexStatus({models:{ok:true,value:{models:[{id:\"gpt-5.5\",isDefault:true}],truncated:false}},account:{ok:true,value:{account:{email:\"codex@example.com\"}}},limits:{ok:true,value:{rateLimits:{limitId:\"codex\",limitName:\"Codex\",primary:{usedPercent:26,windowDurationMins:300,resetsAt:now+3*60*60},secondary:{usedPercent:4,windowDurationMins:7*24*60,resetsAt:now+7*24*60*60},credits:null,planType:\"pro\",rateLimitReachedType:null}}},mcps:{ok:true,value:{data:[{name:\"filesystem\"}]}},skills:{ok:true,value:{data:[{name:\"repo\"}]}}}));"`
- **Evidence after fix:** Terminal output from the formatter command:

```text
Codex app-server: connected
Models: gpt-5.5
Account: codex@example.com
Rate limits: Codex: primary 74% left ⏱3h · secondary 96% left ⏱7d
MCP servers: 1
Skills: 1
```

- **Observed result after fix:** The status line reports `primary 74% left ⏱3h · secondary 96% left ⏱7d`, matching the intended remaining-quota and compact-reset wording.
- **What was not tested:** Full live `/codex status` chat round trip was not run locally; GitHub workflows will validate the rebased branch.

## Verification
- `git diff --check`
- `node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/rate-limits.ts extensions/codex/src/commands.test.ts CHANGELOG.md`
- Formatter proof command above

## Notes
- Not run locally: Vitest. GitHub workflows will validate the rebased branch.