### PR TITLE
[AI-assisted] fix(acp): surface JSON-RPC error details

### DIFF
--- a/src/acp/runtime/error-text.test.ts
+++ b/src/acp/runtime/error-text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { formatAcpRuntimeErrorText } from "./error-text.js";
-import { AcpRuntimeError } from "./errors.js";
+import { AcpRuntimeError, toAcpRuntimeError } from "./errors.js";
 
 describe("formatAcpRuntimeErrorText", () => {
   it("adds actionable next steps for known ACP runtime error codes", () => {
@@ -16,6 +16,27 @@ describe("formatAcpRuntimeErrorText", () => {
     const text = formatAcpRuntimeErrorText(new AcpRuntimeError("ACP_TURN_FAILED", "turn failed"));
     expect(text).toBe(
       "ACP error (ACP_TURN_FAILED): turn failed\nnext: Retry, or use `/acp cancel` and send the message again.",
+    );
+  });
+
+  it("includes JSON-RPC details when formatting normalized ACP runtime errors", () => {
+    const sourceError = new Error("Internal error") as Error & {
+      code: number;
+      data: { details: string };
+    };
+    sourceError.code = -32603;
+    sourceError.data = { details: "unknown config option: timeout" };
+
+    const text = formatAcpRuntimeErrorText(
+      toAcpRuntimeError({
+        error: sourceError,
+        fallbackCode: "ACP_TURN_FAILED",
+        fallbackMessage: "fallback",
+      }),
+    );
+
+    expect(text).toBe(
+      "ACP error (ACP_TURN_FAILED): Internal error: unknown config option: timeout\nnext: Retry, or use `/acp cancel` and send the message again.",
     );
   });
 });

--- a/src/acp/runtime/errors.test.ts
+++ b/src/acp/runtime/errors.test.ts
@@ -3,6 +3,7 @@ import {
   AcpRuntimeError,
   formatAcpErrorChain,
   isAcpRuntimeError,
+  toAcpRuntimeError,
   withAcpRuntimeErrorBoundary,
 } from "./errors.js";
 
@@ -52,6 +53,7 @@ describe("withAcpRuntimeErrorBoundary", () => {
   it("preserves ACP runtime codes from foreign package errors", async () => {
     class ForeignAcpRuntimeError extends Error {
       readonly code = "ACP_BACKEND_MISSING" as const;
+      readonly data = { details: "backend package was not installed" };
     }
 
     const foreignError = new ForeignAcpRuntimeError("backend missing");
@@ -68,9 +70,30 @@ describe("withAcpRuntimeErrorBoundary", () => {
 
     expect(error.name).toBe("AcpRuntimeError");
     expect(error.code).toBe("ACP_BACKEND_MISSING");
-    expect(error.message).toBe("backend missing");
+    expect(error.message).toBe("backend missing: backend package was not installed");
     expect(error.cause).toBe(foreignError);
     expect(isAcpRuntimeError(foreignError)).toBe(true);
+  });
+
+  it("surfaces details from numeric ACP JSON-RPC errors", () => {
+    const sourceError = new Error("Internal error") as Error & {
+      code: number;
+      data: { details: string };
+    };
+    sourceError.name = "RequestError";
+    sourceError.code = -32603;
+    sourceError.data = { details: "unknown config option: timeout" };
+
+    const error = toAcpRuntimeError({
+      error: sourceError,
+      fallbackCode: "ACP_TURN_FAILED",
+      fallbackMessage: "fallback",
+    });
+
+    expect(error.name).toBe("AcpRuntimeError");
+    expect(error.code).toBe("ACP_TURN_FAILED");
+    expect(error.message).toBe("Internal error: unknown config option: timeout");
+    expect(error.cause).toBe(sourceError);
   });
 });
 

--- a/src/acp/runtime/errors.ts
+++ b/src/acp/runtime/errors.ts
@@ -43,6 +43,36 @@ function getForeignAcpRuntimeError(value: unknown): {
   };
 }
 
+function readForeignErrorDetails(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const data = (value as { data?: unknown }).data;
+  if (!data || typeof data !== "object") {
+    return undefined;
+  }
+  const details = (data as { details?: unknown }).details;
+  if (typeof details === "string") {
+    return details.trim() || undefined;
+  }
+  if (details instanceof Error) {
+    return details.message.trim() || details.name.trim() || undefined;
+  }
+  if (details === undefined || details === null) {
+    return undefined;
+  }
+  return stringifyNonErrorCause(details).trim() || undefined;
+}
+
+function appendForeignErrorDetails(message: string, error: unknown): string {
+  const normalizedMessage = message.trim() || "ACP runtime error";
+  const details = readForeignErrorDetails(error);
+  if (!details || normalizedMessage.includes(details)) {
+    return normalizedMessage;
+  }
+  return redactSensitiveText(`${normalizedMessage}: ${details}`);
+}
+
 export function isAcpRuntimeError(value: unknown): value is AcpRuntimeError {
   return value instanceof AcpRuntimeError || getForeignAcpRuntimeError(value) !== null;
 }
@@ -57,14 +87,22 @@ export function toAcpRuntimeError(params: {
   }
   const foreignAcpRuntimeError = getForeignAcpRuntimeError(params.error);
   if (foreignAcpRuntimeError) {
-    return new AcpRuntimeError(foreignAcpRuntimeError.code, foreignAcpRuntimeError.message, {
-      cause: params.error,
-    });
+    return new AcpRuntimeError(
+      foreignAcpRuntimeError.code,
+      appendForeignErrorDetails(foreignAcpRuntimeError.message, params.error),
+      {
+        cause: params.error,
+      },
+    );
   }
   if (params.error instanceof Error) {
-    return new AcpRuntimeError(params.fallbackCode, params.error.message, {
-      cause: params.error,
-    });
+    return new AcpRuntimeError(
+      params.fallbackCode,
+      appendForeignErrorDetails(params.error.message, params.error),
+      {
+        cause: params.error,
+      },
+    );
   }
   return new AcpRuntimeError(params.fallbackCode, params.fallbackMessage, {
     cause: params.error,


### PR DESCRIPTION
## Summary
- Preserve `data.details` from foreign ACP/JSON-RPC errors when normalizing them to `AcpRuntimeError`.
- Keep numeric JSON-RPC errors on the existing fallback ACP code while adding the backend diagnostic to the visible message.
- Add regression coverage for normalized error text and foreign ACP runtime errors.

Fixes #81126.

## Verification
- `corepack pnpm format -- src/acp/runtime/errors.ts src/acp/runtime/errors.test.ts src/acp/runtime/error-text.test.ts`
- `corepack pnpm test src/acp/runtime/errors.test.ts src/acp/runtime/error-text.test.ts`
- `corepack pnpm check:changed`
- `git diff --check`

## Proof
Source-level reproduction: a RequestError-shaped error with `code: -32603`, message `Internal error`, and `data.details: "unknown config option: timeout"` now formats as `ACP error (ACP_TURN_FAILED): Internal error: unknown config option: timeout`, instead of dropping the detail string.