### PR TITLE
fix: make Codex app-server timeout progress-aware

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1396,6 +1396,46 @@ describe("runCodexAppServerAttempt", () => {
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
+  it("does not count non-turn app-server requests as turn attempt progress", async () => {
+    const harness = createStartedThreadHarness();
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 100;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 500,
+      turnAssistantCompletionIdleTimeoutMs: 500,
+      turnTerminalIdleTimeoutMs: 500,
+    });
+    await harness.waitForMethod("turn/start");
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    await harness.handleServerRequest({
+      id: "request-account-refresh",
+      method: "account/nonTurnRefresh",
+      params: {},
+    });
+
+    const result = await run;
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+    const warnCall = warn.mock.calls.find(
+      ([message]) => message === "codex app-server turn idle timed out waiting for progress",
+    );
+    const warnData = warnCall?.[1] as
+      | { lastActivityReason?: string; timeoutMs?: number }
+      | undefined;
+    expect(warnData?.timeoutMs).toBe(100);
+    expect(warnData?.lastActivityReason).toBe("turn:start");
+    expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(true);
+  });
+
   it("does not count account rate-limit updates as turn completion activity", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     let handleRequest:

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1294,7 +1294,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(queueActiveRunMessageForTest("session-1", "after timeout")).toBe(false);
   });
 
-  it("closes the app-server client when the active turn exceeds the attempt timeout", async () => {
+  it("closes the app-server client when the active turn goes idle past the attempt timeout", async () => {
     const close = vi.fn();
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {
@@ -1327,7 +1327,9 @@ describe("runCodexAppServerAttempt", () => {
 
     expect(result.aborted).toBe(true);
     expect(result.timedOut).toBe(true);
-    expect(result.promptError).toBe("codex app-server attempt timed out");
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
     expect(request).toHaveBeenCalledWith(
       "turn/interrupt",
       {
@@ -1338,6 +1340,60 @@ describe("runCodexAppServerAttempt", () => {
     );
     expect(close).toHaveBeenCalledTimes(1);
     expect(queueActiveRunMessageForTest("session-1", "after timeout")).toBe(false);
+  });
+
+  it("keeps a progressing active turn alive beyond the original attempt timeout", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 100;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 300,
+      turnAssistantCompletionIdleTimeoutMs: 300,
+      turnTerminalIdleTimeoutMs: 300,
+    });
+    await harness.waitForMethod("turn/start");
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    await harness.notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "message",
+          id: "raw-progress-1",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Still working." }],
+        },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    await harness.notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "message",
+          id: "raw-progress-2",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Almost done." }],
+        },
+      },
+    });
+
+    expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+
+    const result = await run;
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
   it("does not count account rate-limit updates as turn completion activity", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -870,6 +870,9 @@ export async function runCodexAppServerAttempt(
   let turnAssistantCompletionIdleWatchArmed = false;
   let turnAssistantCompletionLastActivityAt = Date.now();
   let turnAssistantCompletionLastActivityDetails: Record<string, unknown> | undefined;
+  const turnAttemptIdleTimeoutMs = Math.max(100, Math.floor(params.timeoutMs));
+  let turnAttemptIdleTimer: ReturnType<typeof setTimeout> | undefined;
+  let turnAttemptIdleWatchArmed = false;
   let turnTerminalIdleTimer: ReturnType<typeof setTimeout> | undefined;
   let turnTerminalIdleWatchArmed = false;
   let turnCompletionLastActivityAt = Date.now();
@@ -896,6 +899,13 @@ export async function runCodexAppServerAttempt(
     if (turnAssistantCompletionIdleTimer) {
       clearTimeout(turnAssistantCompletionIdleTimer);
       turnAssistantCompletionIdleTimer = undefined;
+    }
+  };
+
+  const clearTurnAttemptIdleTimer = () => {
+    if (turnAttemptIdleTimer) {
+      clearTimeout(turnAttemptIdleTimer);
+      turnAttemptIdleTimer = undefined;
     }
   };
 
@@ -941,6 +951,44 @@ export async function runCodexAppServerAttempt(
     }
     completed = true;
     resolveCompletion?.();
+  };
+
+  const fireTurnAttemptIdleTimeout = () => {
+    if (
+      completed ||
+      runAbortController.signal.aborted ||
+      !turnAttemptIdleWatchArmed ||
+      activeAppServerTurnRequests > 0
+    ) {
+      return;
+    }
+    const idleMs = Math.max(0, Date.now() - turnCompletionLastActivityAt);
+    if (idleMs < turnAttemptIdleTimeoutMs) {
+      scheduleTurnAttemptIdleWatch();
+      return;
+    }
+    timedOut = true;
+    turnCompletionIdleTimedOut = true;
+    turnCompletionIdleTimeoutMessage =
+      "codex app-server turn idle timed out waiting for turn/completed";
+    projector?.markTimedOut();
+    trajectoryRecorder?.recordEvent("turn.progress_idle_timeout", {
+      threadId: thread.threadId,
+      turnId,
+      idleMs,
+      timeoutMs: turnAttemptIdleTimeoutMs,
+      lastActivityReason: turnCompletionLastActivityReason,
+      ...turnCompletionLastActivityDetails,
+    });
+    embeddedAgentLog.warn("codex app-server turn idle timed out waiting for progress", {
+      threadId: thread.threadId,
+      turnId,
+      idleMs,
+      timeoutMs: turnAttemptIdleTimeoutMs,
+      lastActivityReason: turnCompletionLastActivityReason,
+      ...turnCompletionLastActivityDetails,
+    });
+    runAbortController.abort("turn_progress_idle_timeout");
   };
 
   const fireTurnCompletionIdleTimeout = () => {
@@ -1046,6 +1094,22 @@ export async function runCodexAppServerAttempt(
     turnAssistantCompletionIdleTimer.unref?.();
   }
 
+  function scheduleTurnAttemptIdleWatch() {
+    clearTurnAttemptIdleTimer();
+    if (
+      completed ||
+      runAbortController.signal.aborted ||
+      !turnAttemptIdleWatchArmed ||
+      activeAppServerTurnRequests > 0
+    ) {
+      return;
+    }
+    const elapsedMs = Math.max(0, Date.now() - turnCompletionLastActivityAt);
+    const delayMs = Math.max(1, turnAttemptIdleTimeoutMs - elapsedMs);
+    turnAttemptIdleTimer = setTimeout(fireTurnAttemptIdleTimeout, delayMs);
+    turnAttemptIdleTimer.unref?.();
+  }
+
   function scheduleTurnTerminalIdleWatch() {
     clearTurnTerminalIdleTimer();
     if (
@@ -1080,6 +1144,7 @@ export async function runCodexAppServerAttempt(
       turnCompletionIdleWatchArmed = true;
       turnCompletionIdleWatchPinnedByTerminalError = false;
     }
+    scheduleTurnAttemptIdleWatch();
     scheduleTurnCompletionIdleWatch();
     scheduleTurnTerminalIdleWatch();
   };
@@ -1572,17 +1637,9 @@ export async function runCodexAppServerAttempt(
     abort: () => runAbortController.abort("aborted"),
   };
   setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
+  turnAttemptIdleWatchArmed = true;
   turnTerminalIdleWatchArmed = true;
   touchTurnCompletionActivity("turn:start");
-
-  const timeout = setTimeout(
-    () => {
-      timedOut = true;
-      projector?.markTimedOut();
-      runAbortController.abort("timeout");
-    },
-    Math.max(100, params.timeoutMs),
-  );
 
   const abortListener = () => {
     const shouldRetireClient = timedOut;
@@ -1765,7 +1822,7 @@ export async function runCodexAppServerAttempt(
       await steeringQueue?.flushPending();
     }
     userInputBridge?.cancelPending();
-    clearTimeout(timeout);
+    clearTurnAttemptIdleTimer();
     clearTurnCompletionIdleTimer();
     clearTurnAssistantCompletionIdleTimer();
     clearTurnTerminalIdleTimer();

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -878,6 +878,9 @@ export async function runCodexAppServerAttempt(
   let turnCompletionLastActivityAt = Date.now();
   let turnCompletionLastActivityReason = "startup";
   let turnCompletionLastActivityDetails: Record<string, unknown> | undefined;
+  let turnAttemptLastProgressAt = Date.now();
+  let turnAttemptLastProgressReason = "startup";
+  let turnAttemptLastProgressDetails: Record<string, unknown> | undefined;
   let activeAppServerTurnRequests = 0;
   const activeTurnItemIds = new Set<string>();
 
@@ -962,7 +965,7 @@ export async function runCodexAppServerAttempt(
     ) {
       return;
     }
-    const idleMs = Math.max(0, Date.now() - turnCompletionLastActivityAt);
+    const idleMs = Math.max(0, Date.now() - turnAttemptLastProgressAt);
     if (idleMs < turnAttemptIdleTimeoutMs) {
       scheduleTurnAttemptIdleWatch();
       return;
@@ -977,16 +980,16 @@ export async function runCodexAppServerAttempt(
       turnId,
       idleMs,
       timeoutMs: turnAttemptIdleTimeoutMs,
-      lastActivityReason: turnCompletionLastActivityReason,
-      ...turnCompletionLastActivityDetails,
+      lastActivityReason: turnAttemptLastProgressReason,
+      ...turnAttemptLastProgressDetails,
     });
     embeddedAgentLog.warn("codex app-server turn idle timed out waiting for progress", {
       threadId: thread.threadId,
       turnId,
       idleMs,
       timeoutMs: turnAttemptIdleTimeoutMs,
-      lastActivityReason: turnCompletionLastActivityReason,
-      ...turnCompletionLastActivityDetails,
+      lastActivityReason: turnAttemptLastProgressReason,
+      ...turnAttemptLastProgressDetails,
     });
     runAbortController.abort("turn_progress_idle_timeout");
   };
@@ -1104,7 +1107,7 @@ export async function runCodexAppServerAttempt(
     ) {
       return;
     }
-    const elapsedMs = Math.max(0, Date.now() - turnCompletionLastActivityAt);
+    const elapsedMs = Math.max(0, Date.now() - turnAttemptLastProgressAt);
     const delayMs = Math.max(1, turnAttemptIdleTimeoutMs - elapsedMs);
     turnAttemptIdleTimer = setTimeout(fireTurnAttemptIdleTimeout, delayMs);
     turnAttemptIdleTimer.unref?.();
@@ -1126,13 +1129,24 @@ export async function runCodexAppServerAttempt(
     turnTerminalIdleTimer.unref?.();
   }
 
+  function scheduleTurnProgressWatches() {
+    scheduleTurnAttemptIdleWatch();
+    scheduleTurnCompletionIdleWatch();
+    scheduleTurnTerminalIdleWatch();
+  }
+
   const touchTurnCompletionActivity = (
     reason: string,
-    options?: { arm?: boolean; details?: Record<string, unknown> },
+    options?: { arm?: boolean; details?: Record<string, unknown>; attemptProgress?: boolean },
   ) => {
     turnCompletionLastActivityAt = Date.now();
     turnCompletionLastActivityReason = reason;
     turnCompletionLastActivityDetails = options?.details;
+    if (options?.attemptProgress) {
+      turnAttemptLastProgressAt = turnCompletionLastActivityAt;
+      turnAttemptLastProgressReason = reason;
+      turnAttemptLastProgressDetails = options.details;
+    }
     emitTrustedDiagnosticEvent({
       type: "run.progress",
       runId: params.runId,
@@ -1144,9 +1158,7 @@ export async function runCodexAppServerAttempt(
       turnCompletionIdleWatchArmed = true;
       turnCompletionIdleWatchPinnedByTerminalError = false;
     }
-    scheduleTurnAttemptIdleWatch();
-    scheduleTurnCompletionIdleWatch();
-    scheduleTurnTerminalIdleWatch();
+    scheduleTurnProgressWatches();
   };
 
   const disarmTurnCompletionIdleWatch = () => {
@@ -1252,6 +1264,7 @@ export async function runCodexAppServerAttempt(
     if (isCurrentTurnNotification) {
       touchTurnCompletionActivity(`notification:${notification.method}`, {
         details: describeNotificationActivity(notification),
+        attemptProgress: true,
       });
       reportCodexExecutionNotification(notification);
     }
@@ -1337,8 +1350,8 @@ export async function runCodexAppServerAttempt(
     activeAppServerTurnRequests += 1;
     clearTurnCompletionIdleTimer();
     disarmTurnAssistantCompletionIdleWatch();
-    touchTurnCompletionActivity(`request:${request.method}`);
     let armCompletionWatchOnResponse = false;
+    let requestCountsAsTurnActivity = false;
     try {
       if (request.method === "account/chatgptAuthTokens/refresh") {
         return refreshCodexAppServerAuthTokens({
@@ -1352,6 +1365,7 @@ export async function runCodexAppServerAttempt(
       }
       if (request.method === "mcpServer/elicitation/request") {
         armCompletionWatchOnResponse = true;
+        requestCountsAsTurnActivity = true;
         return handleCodexAppServerElicitationRequest({
           requestParams: request.params,
           paramsForRun: params,
@@ -1363,6 +1377,7 @@ export async function runCodexAppServerAttempt(
       }
       if (request.method === "item/tool/requestUserInput") {
         armCompletionWatchOnResponse = true;
+        requestCountsAsTurnActivity = true;
         return userInputBridge?.handleRequest({
           id: request.id,
           params: request.params,
@@ -1371,6 +1386,7 @@ export async function runCodexAppServerAttempt(
       if (request.method !== "item/tool/call") {
         if (isCodexAppServerApprovalRequest(request.method)) {
           armCompletionWatchOnResponse = true;
+          requestCountsAsTurnActivity = true;
           return handleApprovalRequest({
             method: request.method,
             params: request.params,
@@ -1387,6 +1403,7 @@ export async function runCodexAppServerAttempt(
         return undefined;
       }
       armCompletionWatchOnResponse = true;
+      requestCountsAsTurnActivity = true;
       trajectoryRecorder?.recordEvent("tool.call", {
         threadId: call.threadId,
         turnId: call.turnId,
@@ -1464,9 +1481,14 @@ export async function runCodexAppServerAttempt(
       return response as JsonValue;
     } finally {
       activeAppServerTurnRequests = Math.max(0, activeAppServerTurnRequests - 1);
-      touchTurnCompletionActivity(`request:${request.method}:response`, {
-        arm: armCompletionWatchOnResponse,
-      });
+      if (requestCountsAsTurnActivity) {
+        touchTurnCompletionActivity(`request:${request.method}:response`, {
+          arm: armCompletionWatchOnResponse,
+          attemptProgress: true,
+        });
+      } else {
+        scheduleTurnProgressWatches();
+      }
     }
   });
 
@@ -1639,7 +1661,7 @@ export async function runCodexAppServerAttempt(
   setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
   turnAttemptIdleWatchArmed = true;
   turnTerminalIdleWatchArmed = true;
-  touchTurnCompletionActivity("turn:start");
+  touchTurnCompletionActivity("turn:start", { attemptProgress: true });
 
   const abortListener = () => {
     const shouldRetireClient = timedOut;


### PR DESCRIPTION
This PR makes the Codex app-server watchdog match how users experience long-running turns: real current-turn progress keeps the turn alive, while unrelated app-server chatter cannot mask a stuck accepted turn. It is intentionally narrow so reviewers can evaluate the timeout behavior without mixing in runtime attribution or subagent cascade fixes.

## Summary

This PR fixes the source-reproducible Codex app-server timeout bug where an accepted turn could be aborted by a fixed post-`turn/start` wall-clock deadline even while the current turn was still producing progress. The follow-up patch also resolves ClawSweeper's key correctness concern: unrelated app-server request traffic no longer resets the attempt-progress watchdog.

- Problem: the original Codex app-server attempt timeout was absolute after `turn/start`, and the first progress-aware version could be reset by non-turn requests.
- Why it matters: beta Codex turns can legitimately run longer than the initial attempt timeout while streaming current-turn notifications or handling turn-scoped tools; unrelated keepalives must not hide a dead turn.
- What changed: the attempt watchdog now tracks a separate `turnAttemptLastProgress*` timestamp, reset only by current-turn notifications, `turn/start`, and turn-scoped request responses.
- What did NOT change (scope boundary): no startup timeout change, no dynamic tool RPC timeout change, no Pi/embedded-runner timeout change, no model namespace/runtime-attribution change, and no subagent cascade fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Refs #81114
- Related #81180
- [x] This PR fixes a bug or regression

## Scope Note After Latest #81114 Comment

The later #81114 workaround report (`2026.5.12-beta.1`, `openai/gpt-5.x` + `agentRuntime: codex` vs `openai-codex/gpt-5.x`) appears to describe a distinct model-identity/runtime-attribution path. This PR fixes the source-reproducible accepted-turn progress timeout that ClawSweeper identified, but it should not by itself close every #81114 operator report without live OAuth/frontier confirmation.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: accepted Codex app-server turns should remain alive past the original `params.timeoutMs` only when the current turn is actually progressing, and unrelated non-turn app-server requests must not reset that progress watchdog.
- Real environment tested: local Lexar-backed OpenClaw checkout at `/Volumes/LEXAR/repos/openclaw-codex-progress-timeout`, branch `fix/codex-app-server-progress-timeout`, latest patch `e61981b25c8`, using the repo-supported Vitest app-server harness and real `runCodexAppServerAttempt` source path with a fake app-server client. This is not a live OAuth/frontier run.
- Exact steps or command run after this patch:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/codex/src/app-server/run-attempt.test.ts
pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts src/agents/pi-embedded-runner/run.ts
git diff --check
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
[test] passed 1 Vitest shard in 77.79s
Test Files  1 passed (1)
Tests  104 passed (104)

oxfmt: All matched files use the correct format.
git diff --check: passed
```

Focused regressions now prove both sides:

```text
keeps a progressing active turn alive beyond the original attempt timeout
non-turn app-server requests do not count as turn attempt progress
```

- Observed result after fix: current-turn progress notifications keep the accepted turn alive past the original 100ms deadline; unrelated `account/nonTurnRefresh` request traffic does not reset progress, and the watchdog times out with `lastActivityReason: "turn:start"`.
- What was not tested: live OAuth/frontier Codex app-server behavior and the separate parent/subagent cascade after a timeout. This PR targets the accepted-turn progress timeout that can start that cascade.
- Before evidence (optional but encouraged): ClawSweeper identified that the first progress-aware helper reset from shared request activity, including non-turn app-server requests.

## Root Cause (if applicable)

- Root cause: Codex accepted-turn liveness used a fixed post-start deadline, then the initial watchdog fix tied attempt progress to the shared completion-activity timestamp that non-turn request paths could update.
- Missing detection / guardrail: coverage proved current-turn notifications kept a turn alive, but did not prove non-turn app-server requests could not extend a dead accepted turn.
- Contributing context (if known): app-server request handling includes both turn-scoped tool/approval/user-input requests and account/global requests; those cannot share the same progress timestamp.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/run-attempt.test.ts`
- Scenario the test should lock in: current-turn notifications and turn-scoped request responses reset attempt progress; non-turn app-server requests do not.
- Why this is the smallest reliable guardrail: it uses the real run-attempt path and fake app-server client to deterministically control turn notifications and server requests.
- Existing test that already covers this (if any): current-turn progress coverage existed after the first patch; non-turn request coverage is new.
- If no new test is added, why not: N/A, a new regression is included.

## User-visible / Behavior Changes

Codex app-server turns that are still making current-turn progress are less likely to be killed by a stale absolute timeout. Dead turns are still interrupted after `params.timeoutMs` of no actual turn progress.

## Diagram (if applicable)

<!-- reviewer-map -->

```mermaid
flowchart LR
  user["User starts Codex turn"] --> start["turn/start accepted"]
  start --> progress{"Current-turn progress?"}
  progress -->|notification or turn-scoped response| reset["Reset attempt watchdog"]
  progress -->|no progress| timeout["Timeout after idle window"]
  other["Account/global app-server request"] -. "does not reset" .-> timeout
  reset --> progress
```

```text
Current-turn progress:
[turn/start] -> [current-turn notification/tool response] -> [attempt watchdog reset]
  -> [turn can continue beyond original deadline]

Non-turn traffic:
[turn/start] -> [account/global app-server request] -> [attempt watchdog NOT reset]
  -> [dead accepted turn still times out]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local development host
- Runtime/container: local Lexar-backed OpenClaw checkout
- Model/provider: Codex app-server run-attempt path, not model-provider dependent
- Integration/channel (if any): Codex app-server fake-client harness
- Relevant config (redacted): `params.timeoutMs = 100` in focused progress/idle tests

### Steps

1. Run the full `run-attempt.test.ts` shard.
2. Confirm the current-turn progress test completes normally without `turn/interrupt`.
3. Confirm the non-turn request test still times out and reports `lastActivityReason: "turn:start"`.

### Expected

- Current-turn progress extends the attempt.
- Non-turn request traffic does not extend the attempt.
- Full app-server run-attempt suite passes.

### Actual

- `run-attempt.test.ts` passed: 104/104 tests.
- Formatter and whitespace checks passed.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: current-turn progress beyond original deadline, non-turn request non-progress, full app-server run-attempt shard.
- Edge cases checked: active request rescheduling, watchdog diagnostic `lastActivityReason`, turn interrupt on dead attempt.
- What you did **not** verify: live OAuth/frontier Codex app-server session and subagent cascade recovery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

ClawSweeper P2 addressed by `e61981b25c8`: keep the attempt watchdog scoped to turn progress.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: fake-client proof does not fully substitute for a live OAuth/frontier app-server proof.
  - Mitigation: the PR is source-reproducible and covered by deterministic run-attempt tests; live proof remains a follow-up gate before claiming #81114 fully closed.

