### PR TITLE
fix(commitments): serialize load-modify-save with in-process queue + cross-process file lock

### DIFF
--- a/src/commitments/store-writer.ts
+++ b/src/commitments/store-writer.ts
@@ -1,0 +1,135 @@
+// Per-store-path mutation gate for the commitments store. Mirrors the
+// in-process queue + cross-process file-lock pattern in
+// src/plugin-sdk/persistent-dedupe.ts (issue #81145).
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { type FileLockOptions, withFileLock } from "../plugin-sdk/file-lock.js";
+
+type CommitmentsStoreWriterTask = {
+  fn: () => Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+};
+
+type CommitmentsStoreWriterQueue = {
+  running: boolean;
+  pending: CommitmentsStoreWriterTask[];
+  drainPromise: Promise<void> | null;
+};
+
+const WRITER_QUEUES = new Map<string, CommitmentsStoreWriterQueue>();
+
+// Matches src/plugin-sdk/persistent-dedupe.ts so both lock-protected stores share tuning.
+const DEFAULT_COMMITMENTS_LOCK_OPTIONS: FileLockOptions = {
+  retries: {
+    retries: 6,
+    factor: 1.35,
+    minTimeout: 8,
+    maxTimeout: 180,
+    randomize: true,
+  },
+  stale: 60_000,
+};
+
+function getOrCreateWriterQueue(storePath: string): CommitmentsStoreWriterQueue {
+  const existing = WRITER_QUEUES.get(storePath);
+  if (existing) {
+    return existing;
+  }
+  const created: CommitmentsStoreWriterQueue = {
+    running: false,
+    pending: [],
+    drainPromise: null,
+  };
+  WRITER_QUEUES.set(storePath, created);
+  return created;
+}
+
+async function drainCommitmentsStoreWriterQueue(storePath: string): Promise<void> {
+  const queue = WRITER_QUEUES.get(storePath);
+  if (!queue) {
+    return;
+  }
+  if (queue.drainPromise) {
+    await queue.drainPromise;
+    return;
+  }
+  queue.running = true;
+  queue.drainPromise = (async () => {
+    try {
+      while (queue.pending.length > 0) {
+        const task = queue.pending.shift();
+        if (!task) {
+          continue;
+        }
+        let result: unknown;
+        let failed: unknown;
+        let hasFailure = false;
+        try {
+          result = await task.fn();
+        } catch (err) {
+          hasFailure = true;
+          failed = err;
+        }
+        if (hasFailure) {
+          task.reject(failed);
+          continue;
+        }
+        task.resolve(result);
+      }
+    } finally {
+      queue.running = false;
+      queue.drainPromise = null;
+      if (queue.pending.length === 0) {
+        WRITER_QUEUES.delete(storePath);
+      } else {
+        queueMicrotask(() => {
+          void drainCommitmentsStoreWriterQueue(storePath);
+        });
+      }
+    }
+  })();
+  await queue.drainPromise;
+}
+
+// The advisory lockfile lives next to the data file; create the parent dir up
+// front so acquireFileLock does not ENOENT before the user fn ever runs.
+async function ensureCommitmentsStoreDir(storePath: string): Promise<void> {
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+}
+
+export async function runExclusiveCommitmentsStoreWrite<T>(
+  storePath: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!storePath || typeof storePath !== "string") {
+    throw new Error(
+      `runExclusiveCommitmentsStoreWrite: storePath must be a non-empty string, got ${JSON.stringify(
+        storePath,
+      )}`,
+    );
+  }
+  const queue = getOrCreateWriterQueue(storePath);
+  return await new Promise<T>((resolve, reject) => {
+    const task: CommitmentsStoreWriterTask = {
+      fn: async () => {
+        await ensureCommitmentsStoreDir(storePath);
+        return await withFileLock(storePath, DEFAULT_COMMITMENTS_LOCK_OPTIONS, fn);
+      },
+      resolve: (value) => resolve(value as T),
+      reject,
+    };
+    queue.pending.push(task);
+    void drainCommitmentsStoreWriterQueue(storePath);
+  });
+}
+
+export function clearCommitmentsStoreWriterQueuesForTest(): void {
+  for (const queue of WRITER_QUEUES.values()) {
+    for (const task of queue.pending) {
+      task.reject(new Error("commitments store writer queue cleared for test"));
+    }
+  }
+  WRITER_QUEUES.clear();
+}

--- a/src/commitments/store.test.ts
+++ b/src/commitments/store.test.ts
@@ -6,6 +6,8 @@ import {
   listCommitments,
   listDueCommitmentsForSession,
   loadCommitmentStore,
+  markCommitmentsAttempted,
+  markCommitmentsStatus,
   saveCommitmentStore,
 } from "./store.js";
 import type { CommitmentRecord } from "./types.js";
@@ -188,5 +190,64 @@ describe("commitment store delivery selection", () => {
     expect(expiredCommitments).toHaveLength(1);
     expect(expiredCommitments[0]?.id).toBe("cm_interview");
     expect(expiredCommitments[0]?.status).toBe("expired");
+  });
+
+  it("serializes concurrent markCommitmentsStatus on disjoint ids without losing a write (#13)", async () => {
+    await useTempStateDir();
+    await saveCommitmentStore(undefined, {
+      version: 1,
+      commitments: [
+        commitment({ id: "cm_raceA", dedupeKey: "race-A" }),
+        commitment({ id: "cm_raceB", dedupeKey: "race-B" }),
+      ],
+    });
+
+    await Promise.all([
+      markCommitmentsStatus({ ids: ["cm_raceA"], status: "dismissed", nowMs }),
+      markCommitmentsStatus({ ids: ["cm_raceB"], status: "dismissed", nowMs }),
+    ]);
+
+    const after = await loadCommitmentStore();
+    const byId = Object.fromEntries(after.commitments.map((c) => [c.id, c.status]));
+    expect(byId.cm_raceA).toBe("dismissed");
+    expect(byId.cm_raceB).toBe("dismissed");
+  });
+
+  it("serializes concurrent markCommitmentsAttempted bumps without losing the counter (#13)", async () => {
+    await useTempStateDir();
+    await saveCommitmentStore(undefined, {
+      version: 1,
+      commitments: [commitment({ id: "cm_race_attempts", attempts: 0 })],
+    });
+
+    await Promise.all(
+      Array.from({ length: 5 }, () =>
+        markCommitmentsAttempted({ ids: ["cm_race_attempts"], nowMs }),
+      ),
+    );
+
+    const after = await loadCommitmentStore();
+    expect(after.commitments[0]?.attempts).toBe(5);
+  });
+
+  it("serializes a markCommitmentsStatus dismiss against a concurrent attempted bump (#13)", async () => {
+    await useTempStateDir();
+    await saveCommitmentStore(undefined, {
+      version: 1,
+      commitments: [
+        commitment({ id: "cm_dismiss_target", dedupeKey: "dismiss-target" }),
+        commitment({ id: "cm_attempt_target", dedupeKey: "attempt-target", attempts: 2 }),
+      ],
+    });
+
+    await Promise.all([
+      markCommitmentsStatus({ ids: ["cm_dismiss_target"], status: "dismissed", nowMs }),
+      markCommitmentsAttempted({ ids: ["cm_attempt_target"], nowMs }),
+    ]);
+
+    const after = await loadCommitmentStore();
+    const byId = Object.fromEntries(after.commitments.map((c) => [c.id, c]));
+    expect(byId.cm_dismiss_target?.status).toBe("dismissed");
+    expect(byId.cm_attempt_target?.attempts).toBe(3);
   });
 });

--- a/src/commitments/store.ts
+++ b/src/commitments/store.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_COMMITMENT_MAX_PER_HEARTBEAT,
   resolveCommitmentsConfig,
 } from "./config.js";
+import { runExclusiveCommitmentsStoreWrite } from "./store-writer.js";
 import type {
   CommitmentCandidate,
   CommitmentExtractionItem,
@@ -243,12 +244,24 @@ function expireStaleCommitmentsInStore(store: CommitmentStoreFile, nowMs: number
   return changed;
 }
 
-async function loadCommitmentStoreWithExpiredMarked(nowMs: number): Promise<CommitmentStoreFile> {
+// Unchecked variant — runs without queue protection. Callers that already hold
+// the commitments-store writer queue must use this to avoid re-entry deadlock.
+async function loadAndMarkExpiredUnchecked(
+  nowMs: number,
+): Promise<{ store: CommitmentStoreFile; needsSave: boolean }> {
   const { store, hadLegacySourceText } = await loadCommitmentStoreInternal();
-  if (expireStaleCommitmentsInStore(store, nowMs) || hadLegacySourceText) {
-    await saveCommitmentStore(undefined, store);
-  }
-  return store;
+  const expireChanged = expireStaleCommitmentsInStore(store, nowMs);
+  return { store, needsSave: expireChanged || hadLegacySourceText };
+}
+
+async function loadCommitmentStoreWithExpiredMarked(nowMs: number): Promise<CommitmentStoreFile> {
+  return await runExclusiveCommitmentsStoreWrite(resolveCommitmentStorePath(), async () => {
+    const { store, needsSave } = await loadAndMarkExpiredUnchecked(nowMs);
+    if (needsSave) {
+      await saveCommitmentStore(undefined, store);
+    }
+    return store;
+  });
 }
 
 export async function listPendingCommitmentsForScope(params: {
@@ -289,47 +302,48 @@ export async function upsertInferredCommitments(params: {
     return [];
   }
   const nowMs = params.nowMs ?? Date.now();
-  const store = await loadCommitmentStoreWithExpiredMarked(nowMs);
-  const created: CommitmentRecord[] = [];
   const scopeKey = buildCommitmentScopeKey(params.item);
-
-  for (const entry of params.candidates) {
-    const dedupeKey = entry.candidate.dedupeKey.trim();
-    const existingIndex = store.commitments.findIndex(
-      (commitment) =>
-        buildCommitmentScopeKey(commitment) === scopeKey &&
-        commitment.dedupeKey === dedupeKey &&
-        isActiveStatus(commitment.status),
-    );
-    if (existingIndex >= 0) {
-      const existing = store.commitments[existingIndex];
-      store.commitments[existingIndex] = {
-        ...existing,
-        reason: entry.candidate.reason.trim() || existing.reason,
-        suggestedText: entry.candidate.suggestedText.trim() || existing.suggestedText,
-        confidence: Math.max(existing.confidence, entry.candidate.confidence),
-        dueWindow: {
-          earliestMs: Math.min(existing.dueWindow.earliestMs, entry.earliestMs),
-          latestMs: Math.max(existing.dueWindow.latestMs, entry.latestMs),
-          timezone: entry.timezone,
-        },
-        updatedAtMs: nowMs,
-      };
-      continue;
+  return await runExclusiveCommitmentsStoreWrite(resolveCommitmentStorePath(), async () => {
+    const { store } = await loadAndMarkExpiredUnchecked(nowMs);
+    const created: CommitmentRecord[] = [];
+    for (const entry of params.candidates) {
+      const dedupeKey = entry.candidate.dedupeKey.trim();
+      const existingIndex = store.commitments.findIndex(
+        (commitment) =>
+          buildCommitmentScopeKey(commitment) === scopeKey &&
+          commitment.dedupeKey === dedupeKey &&
+          isActiveStatus(commitment.status),
+      );
+      if (existingIndex >= 0) {
+        const existing = store.commitments[existingIndex];
+        store.commitments[existingIndex] = {
+          ...existing,
+          reason: entry.candidate.reason.trim() || existing.reason,
+          suggestedText: entry.candidate.suggestedText.trim() || existing.suggestedText,
+          confidence: Math.max(existing.confidence, entry.candidate.confidence),
+          dueWindow: {
+            earliestMs: Math.min(existing.dueWindow.earliestMs, entry.earliestMs),
+            latestMs: Math.max(existing.dueWindow.latestMs, entry.latestMs),
+            timezone: entry.timezone,
+          },
+          updatedAtMs: nowMs,
+        };
+        continue;
+      }
+      const record = candidateToRecord({
+        item: params.item,
+        candidate: entry.candidate,
+        nowMs,
+        earliestMs: entry.earliestMs,
+        latestMs: entry.latestMs,
+        timezone: entry.timezone,
+      });
+      store.commitments.push(record);
+      created.push(record);
     }
-    const record = candidateToRecord({
-      item: params.item,
-      candidate: entry.candidate,
-      nowMs,
-      earliestMs: entry.earliestMs,
-      latestMs: entry.latestMs,
-      timezone: entry.timezone,
-    });
-    store.commitments.push(record);
-    created.push(record);
-  }
-  await saveCommitmentStore(undefined, store);
-  return created;
+    await saveCommitmentStore(undefined, store);
+    return created;
+  });
 }
 
 function countSentCommitmentsForSession(params: {
@@ -441,23 +455,25 @@ export async function markCommitmentsAttempted(params: {
   }
   const idSet = new Set(params.ids);
   const nowMs = params.nowMs ?? Date.now();
-  const store = await loadCommitmentStore();
-  let changed = false;
-  store.commitments = store.commitments.map((commitment) => {
-    if (!idSet.has(commitment.id)) {
-      return commitment;
+  await runExclusiveCommitmentsStoreWrite(resolveCommitmentStorePath(), async () => {
+    const store = await loadCommitmentStore();
+    let changed = false;
+    store.commitments = store.commitments.map((commitment) => {
+      if (!idSet.has(commitment.id)) {
+        return commitment;
+      }
+      changed = true;
+      return {
+        ...commitment,
+        attempts: commitment.attempts + 1,
+        lastAttemptAtMs: nowMs,
+        updatedAtMs: nowMs,
+      };
+    });
+    if (changed) {
+      await saveCommitmentStore(undefined, store);
     }
-    changed = true;
-    return {
-      ...commitment,
-      attempts: commitment.attempts + 1,
-      lastAttemptAtMs: nowMs,
-      updatedAtMs: nowMs,
-    };
   });
-  if (changed) {
-    await saveCommitmentStore(undefined, store);
-  }
 }
 
 export async function markCommitmentsStatus(params: {
@@ -471,25 +487,27 @@ export async function markCommitmentsStatus(params: {
   }
   const idSet = new Set(params.ids);
   const nowMs = params.nowMs ?? Date.now();
-  const store = await loadCommitmentStore();
-  let changed = false;
-  store.commitments = store.commitments.map((commitment) => {
-    if (!idSet.has(commitment.id) || !isActiveStatus(commitment.status)) {
-      return commitment;
+  await runExclusiveCommitmentsStoreWrite(resolveCommitmentStorePath(), async () => {
+    const store = await loadCommitmentStore();
+    let changed = false;
+    store.commitments = store.commitments.map((commitment) => {
+      if (!idSet.has(commitment.id) || !isActiveStatus(commitment.status)) {
+        return commitment;
+      }
+      changed = true;
+      return {
+        ...commitment,
+        status: params.status,
+        updatedAtMs: nowMs,
+        ...(params.status === "sent" ? { sentAtMs: nowMs } : {}),
+        ...(params.status === "dismissed" ? { dismissedAtMs: nowMs } : {}),
+        ...(params.status === "expired" ? { expiredAtMs: nowMs } : {}),
+      };
+    });
+    if (changed) {
+      await saveCommitmentStore(undefined, store);
     }
-    changed = true;
-    return {
-      ...commitment,
-      status: params.status,
-      updatedAtMs: nowMs,
-      ...(params.status === "sent" ? { sentAtMs: nowMs } : {}),
-      ...(params.status === "dismissed" ? { dismissedAtMs: nowMs } : {}),
-      ...(params.status === "expired" ? { expiredAtMs: nowMs } : {}),
-    };
   });
-  if (changed) {
-    await saveCommitmentStore(undefined, store);
-  }
 }
 
 export async function listCommitments(params?: {


### PR DESCRIPTION
## Summary

- Problem: `markCommitmentsAttempted`, `markCommitmentsStatus`, `upsertInferredCommitments`, and the auto-expire pass inside `loadCommitmentStoreWithExpiredMarked` each did an independent load-modify-save against `~/.openclaw/commitments/commitments.json` with no serialization. Two callers that overlapped in one event-loop tick — or that ran in two different processes (gateway daemon heartbeat vs standalone `openclaw commitments dismiss` CLI) — silently lost whichever save committed first. A Promise.all repro against the exported store functions loses a write 20/20 times on `v2026.5.10-beta.1`.
- Why it matters: silent data-loss class. `openclaw commitments dismiss` can revert under a concurrent heartbeat tick; a commitment whose `sent` status was overwritten by a stale snapshot gets re-delivered on the next tick; `attempts` counters can roll back past the configured `maxPerDay` cap.
- What changed: new `src/commitments/store-writer.ts` exporting `runExclusiveCommitmentsStoreWrite(storePath, fn)`. The helper layers a per-store-path in-process FIFO writer queue on top of `withFileLock(storePath, ...)`, mirroring the pattern in `src/plugin-sdk/persistent-dedupe.ts` (the only other store with the same write-contention class). Every mutator (`markCommitmentsAttempted`, `markCommitmentsStatus`, `upsertInferredCommitments`) and the queued public `loadCommitmentStoreWithExpiredMarked` now run inside that gate. The expire pass is factored into a private `loadAndMarkExpiredUnchecked` so `upsertInferredCommitments` can reuse it without re-entering its own queue slot. The in-process queue serializes same-process writers (CLI dispatch, heartbeat `Promise.all`, the now-queued auto-expire pass); the file lock serializes cross-process writers (gateway daemon vs CLI).
- What did NOT change (scope boundary):
  - `loadCommitmentStore`, `saveCommitmentStore`, `resolveCommitmentStorePath`, and all other read-only helpers (`listPendingCommitmentsForScope`, `listDueCommitmentsForSession`, `listDueCommitmentSessionKeys`, `listCommitments`). The first two are still bare load/save primitives used inside the queue; the read helpers now route through the queued `loadCommitmentStoreWithExpiredMarked` so their auto-expire save is also protected, but their return shape and call signatures are unchanged.
  - Mutator signatures. All three mutators still return `Promise<void>` / `Promise<CommitmentRecord[]>` exactly as before. Every existing call site at `src/infra/heartbeat-runner.ts:1568,1702,1730,1780,1826,1929` and `src/commands/commitments.ts:155` is untouched.
  - `expireStaleCommitmentsInStore` / commitment record shape / store schema. Only the mutation gate changed.
  - The session-store writer queue at `src/config/sessions/store-writer.ts`. Considered hoisting the queue to a shared `src/infra/per-store-writer-queue.ts` (the report's Option 2) but kept the helper local to `src/commitments/` to keep the blast radius scoped to one store.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #81145
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: concurrent `markCommitmentsStatus` / `markCommitmentsAttempted` / `upsertInferredCommitments` calls silently lose each other's mutations because the commitments store has no write serialization.
- Real environment tested: Ubuntu 24.04 (Linux 6.8.0-110-generic), Node 22.22.2, openclaw `v2026.5.10-beta.1` (issue-filing commit `152ea9af34`); patched-branch checks against PR head `1c68d071ab`.
- Exact steps or command run after this patch:
  1. Apply this PR locally and build (`pnpm install && pnpm build`).
  2. Run `pnpm test src/commitments/store.test.ts` — the three new `#13`-tagged regression tests assert that two concurrent disjoint dismisses both persist, that five concurrent `markCommitmentsAttempted` bumps land all 5, and that a `dismiss` racing an `attempted` bump converge.
  3. Run `pnpm test src/infra/heartbeat-runner.commitments.test.ts` — existing heartbeat coverage of the mutator surface continues to pass (acceptance criterion called out by the clawsweeper review on #81145).
  4. Run the Promise.all repro from the issue body (saved at `qa-reports/13-commitments-race-no-lock/programmatic-repro.log`) against the patched build — both dismisses now persist on every trial.
- Evidence after fix: full live capture posted at https://github.com/openclaw/openclaw/pull/81153#issuecomment-4434704632 — same 20-trial `Promise.all` script run BEFORE on `v2026.5.10-beta.1` (`152ea9af34`) showed **20/20 trials lost a write**; same script run AFTER on PR head `1c68d071ab` shows **0/20 lost, 20/20 clean**. Verbatim verdict line: `Result: 0/20 trials lost a write (20/20 clean)`. Vitest: `pnpm test src/commitments/store.test.ts` → 8/8 pass (5 prior + 3 new `#13` regression tests); `pnpm test src/commitments/` → 20/20 pass; `pnpm test src/infra/heartbeat-runner.commitments.test.ts` → 7/7 pass. Before-fix capture is also in the Before evidence block below.
- Observed result after fix: every two-writer Promise.all converges to the expected end state. `openclaw commitments dismiss` invoked while the gateway daemon's heartbeat is bumping `attempts` no longer silently reverts (cross-process advisory lock wins); two concurrent in-process heartbeat dispatches no longer interleave (in-process queue wins); `upsertInferredCommitments` racing a status update no longer drops the newly-inferred entries. `stampConfigVersion`-style auto-stamping on the store is unchanged because `saveCommitmentStore` itself is untouched.
- What was not tested:
  - The session-store and cron-store mutation paths. They are out of scope; this PR only touches commitments.
  - Cross-process behavior under a stuck advisory lock older than the 60s stale window. The default `withFileLock` options match `src/plugin-sdk/persistent-dedupe.ts` (`stale: 60_000`, 6 retries with backoff up to 180ms) — a held-too-long lock will be reclaimed; no separate test exercises that branch here.
- Before evidence (optional but encouraged): Promise.all repro on `v2026.5.10-beta.1` (commit `152ea9af34`), 20 trials, every trial loses one of two disjoint dismisses (full capture in `qa-reports/13-commitments-race-no-lock/programmatic-repro.log`):

  ```
  trial 1: A=pending B=dismissed
  trial 2: A=pending B=dismissed
  trial 3: A=pending B=dismissed
  …
  trial 20: A=dismissed B=pending

  20/20 trials lost a write
  ```

## Root Cause (if applicable)

- Root cause: `src/commitments/store.ts` mutators followed the shape `const store = await loadCommitmentStore(); ...mutate...; await saveCommitmentStore(undefined, store);` with no lock or queue. `privateFileStore.writeJson` atomically renames the file, so individual writes are never torn — but atomic-rename only protects against partial reads, not against last-writer-wins data loss between two read-modify-save cycles whose reads happen before the first cycle's save commits. Same defect class as the session-store contention that was fixed by `runExclusiveSessionStoreWrite` in `src/config/sessions/store-writer.ts`, just on a different store that never got the same retrofit. Cross-process callers (gateway daemon heartbeat vs `openclaw commitments dismiss` CLI) additionally need an OS-level advisory lock because an in-process queue alone can't serialize between Node processes.
- Missing detection / guardrail: existing commitments tests cover enablement, delivery limits, expiry, legacy-field cleanup, and listing — none exercise concurrent writers. No contract test in the repo asserts that `markCommitmentsStatus` is safe under `Promise.all`.
- Contributing context: the session-store has had `runExclusiveSessionStoreWrite` for some time; the persistent-dedupe helper at `src/plugin-sdk/persistent-dedupe.ts:149` documents the same in-process-queue-plus-file-lock pattern. The commitments store predates that work and was never retrofitted.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/commitments/store.test.ts`
- Scenario the test should lock in:
  - Two concurrent `markCommitmentsStatus({status: "dismissed"})` calls on disjoint ids both persist.
  - Five concurrent `markCommitmentsAttempted` calls on the same id land all five increments (counter ends at +5, not +1).
  - A `markCommitmentsStatus` dismiss racing a `markCommitmentsAttempted` bump on a different id converges to both mutations applied.
- Why this is the smallest reliable guardrail: it pins the only contract the new gate is supposed to enforce (concurrent same-process writers serialize correctly) against the exact code path the bug-report repro hit. The bot's `heartbeat-runner.commitments.test.ts` acceptance criterion is exercised by the existing 7 tests there.
- Existing test that already covers this: none — the existing commitments tests cover correctness of single-writer behavior, not concurrent writers.
- If no new test is added, why not: N/A; three regression tests are added in this PR (all tagged `#13`).

## User-visible / Behavior Changes

- No external API change. The three mutators and the queued `loadCommitmentStoreWithExpiredMarked` have the same return shape. The only externally observable behavior change is that races between mutators no longer drop writes; correct-single-writer flows are unchanged.

## Diagram (if applicable)

```text
Before:
caller A ─→ load(S0) ─→ mutate(A) ─→ save(S1_A) ─────→ disk: {A:dismissed, B:pending}
caller B ─────→ load(S0) ─→ mutate(B) ─→ save(S1_B) ─→ disk: {A:pending,   B:dismissed}   ← A's dismiss is gone

After (single process):
caller A → [queue slot 1] → withFileLock → load → mutate(A) → save → release ─→ disk: {A:dismissed, B:pending}
caller B → [queue slot 2] ───────────────────── waits ──────────────────────── → withFileLock → load → mutate(B) → save → disk: {A:dismissed, B:dismissed}

After (two processes, e.g. gateway daemon + CLI):
proc A → [queue A] → withFileLock(commitments.json) → load → mutate → save → release lock ─→ disk: {A:dismissed, B:pending}
proc B → [queue B] ──────────── advisory lock retries (8ms..180ms, ×6) ──────── → load → mutate → save → disk: {A:dismissed, B:dismissed}
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Linux 6.8.0-110-generic)
- Runtime/container: Node 22.22.2
- Model/provider: Not applicable
- Integration/channel (if any): Not applicable
- Relevant config (redacted): any `~/.openclaw/commitments/commitments.json` with at least two pending commitments. The bug is in the store mutator path, not in the config surface.

### Steps

1. On a fresh checkout of this branch (`fix/commitments-store-writer-queue`, head `1c68d071ab`), run `pnpm install && pnpm build`.
2. Seed a temp commitments store with two pending commitments.
3. Issue two concurrent `markCommitmentsStatus({status: "dismissed"})` calls on disjoint ids via `Promise.all`.
4. Read the store back; both should be `dismissed`.

### Expected

- Both commitments end as `dismissed`. No write is lost.
- Repeating five concurrent `markCommitmentsAttempted` on the same id leaves `attempts === 5`, not `attempts === 1`.

### Actual

- Before this PR: 20/20 trials lose one of the two dismisses (see Before evidence above).
- After this PR: each trial converges to the expected state; the three new regression tests in `src/commitments/store.test.ts` lock this in.

## Evidence

- [x] Failing test/log before + passing after — three new vitest assertions in `src/commitments/store.test.ts` tagged `(#13)` plus the BEFORE/AFTER Promise.all comparison in the evidence comment.
- [x] Trace/log snippets — full verbatim BEFORE (20/20 LOSS) and AFTER (0/20 LOSS, 20/20 OK) captures attached at https://github.com/openclaw/openclaw/pull/81153#issuecomment-4434704632.
- [ ] Screenshot/recording — N/A; live terminal capture is the appropriate medium for this defect and is attached above.
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/commitments/store.test.ts` — 8/8 pass on the patched branch (5 prior + 3 new `#13` regression tests).
  - `pnpm test src/commitments/` — 20/20 pass across `store.test.ts`, `runtime.test.ts`, `extraction.test.ts`, `commitments-full-chain.integration.test.ts`.
  - `pnpm test src/infra/heartbeat-runner.commitments.test.ts` — 7/7 pass (the acceptance lane the clawsweeper review on #81145 called out).
  - Source-level confirmation: every former bare `loadCommitmentStore() → mutate → saveCommitmentStore(...)` site is now wrapped in `runExclusiveCommitmentsStoreWrite(resolveCommitmentStorePath(), async () => { ... })`. The unchecked `loadAndMarkExpiredUnchecked` helper is the only callsite that does not queue — and it is called only from inside an already-queued task in `upsertInferredCommitments`, avoiding re-entry deadlock.
- Edge cases checked:
  - Re-entry into the queue is avoided by routing `upsertInferredCommitments` through `loadAndMarkExpiredUnchecked` (no inner queue) rather than the queued `loadCommitmentStoreWithExpiredMarked`.
  - First-ever mutator on a fresh state dir: `ensureCommitmentsStoreDir(storePath)` runs `fs.mkdir({recursive: true})` before lock acquisition so the advisory lockfile creation does not ENOENT.
  - Test cleanup: `clearCommitmentsStoreWriterQueuesForTest` exported for future tests that need to drain the queue between cases (not used yet; tests pass without it because each test scopes `OPENCLAW_STATE_DIR` to a fresh tmp dir).
- What I did not verify:
  - Cross-process race behavior under a real gateway daemon + CLI two-process repro on this host; the in-test repro covers same-process, and the cross-process layer is structurally identical to `src/plugin-sdk/persistent-dedupe.ts`'s pattern which is exercised in production.
  - Behavior when the advisory lockfile is held longer than `stale: 60_000` ms. The default options match `persistent-dedupe.ts` (reclaim after 60s, 6 retries with backoff up to 180ms). Same trade-offs as the dedupe helper.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes (mutator signatures unchanged; only the internal serialization gate changes).
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a held advisory lock from a crashed prior process could delay a subsequent mutator by up to the stale window (60s).
  - Mitigation: matches the existing `persistent-dedupe.ts` policy. `withFileLock` reclaims locks whose owning pid is dead or whose lockfile is older than 60s. Worst case is one mutator stall, not a permanent deadlock.
- Risk: layered queue-plus-lock latency adds overhead vs the prior bare load-save.
  - Mitigation: in the contention-free path the queue is a single resolved promise and the file lock acquires immediately. Steady-state cost is one extra fs operation per mutation. Heartbeat tick budget is well above this.

