### PR TITLE
fix(installer): bypass onboard exec when existing config is present

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2863,25 +2863,27 @@ main() {
                 ui_info "Config already present; skipping onboarding"
                 skip_onboard=true
             fi
-            ui_info "Starting setup"
-            echo ""
-            if [[ -r /dev/tty && -w /dev/tty ]]; then
-                local claw="${OPENCLAW_BIN:-}"
-                if [[ -z "$claw" ]]; then
-                    claw="$(resolve_openclaw_bin || true)"
+            if [[ "$skip_onboard" != "true" ]]; then
+                ui_info "Starting setup"
+                echo ""
+                if [[ -r /dev/tty && -w /dev/tty ]]; then
+                    local claw="${OPENCLAW_BIN:-}"
+                    if [[ -z "$claw" ]]; then
+                        claw="$(resolve_openclaw_bin || true)"
+                    fi
+                    if [[ -z "$claw" ]]; then
+                        ui_info "Skipping onboarding (openclaw not on PATH yet)"
+                        warn_openclaw_not_found
+                        return 0
+                    fi
+                    exec </dev/tty
+                    exec "$claw" onboard
                 fi
-                if [[ -z "$claw" ]]; then
-                    ui_info "Skipping onboarding (openclaw not on PATH yet)"
-                    warn_openclaw_not_found
-                    return 0
-                fi
-                exec </dev/tty
-                exec "$claw" onboard
+                local user_claw
+                user_claw="$(openclaw_command_for_user "${OPENCLAW_BIN:-}")"
+                ui_info "No TTY; run ${user_claw} onboard to finish setup"
+                return 0
             fi
-            local user_claw
-            user_claw="$(openclaw_command_for_user "${OPENCLAW_BIN:-}")"
-            ui_info "No TTY; run ${user_claw} onboard to finish setup"
-            return 0
         fi
     fi
 

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -352,6 +352,24 @@ describe("install.sh", () => {
     expect(result?.stdout).toContain(`missing=${openclawBin.replace(/ /g, "\\ ")}`);
     expect(result?.stdout).toContain("present=openclaw");
   });
+
+  it("guards 'Starting setup' + onboard exec behind skip_onboard=false (#66785)", () => {
+    // Existing-config detection inside the finalization branch sets
+    // skip_onboard=true after running doctor, but on current main the script
+    // fell through to "Starting setup" and `exec "$claw" onboard` regardless.
+    // Pin the guard so the regression cannot return.
+    const guard =
+      'if [[ "$skip_onboard" != "true" ]]; then\n                ui_info "Starting setup"';
+    expect(script).toContain(guard);
+
+    // No bare "Starting setup" emission outside the skip_onboard guard inside
+    // the install-finalization branch — every emission must be preceded by the
+    // guard check at the same indent level.
+    const startingSetupEmissions = script
+      .split("\n")
+      .filter((line) => line.includes('ui_info "Starting setup"'));
+    expect(startingSetupEmissions).toHaveLength(1);
+  });
 });
 
 describe("install.sh macOS Homebrew Node behavior", () => {


### PR DESCRIPTION
## Summary

- `scripts/install.sh:main()` already detects an existing `~/.openclaw/openclaw.json` (or the legacy `~/.clawdbot/clawdbot.json`) in the install finalization branch, runs `run_doctor`, flips `should_open_dashboard=true`, and sets `skip_onboard=true`. But on current main the surrounding `else` block then unconditionally emits `Starting setup`, redirects stdin to `/dev/tty`, and runs `exec "$claw" onboard`, so the freshly written `skip_onboard=true` has no effect — the wizard always re-launches. Reported in #66785 by an Umbrel 2026.4.12 user whose existing config kept getting force-walked through onboarding on every install run.
- Wrap the `Starting setup` emission, the TTY-onboard branch, and the `No TTY; run onboard later` fallback in `if [[ "$skip_onboard" != "true" ]]` so the existing-config path falls through to the gateway-daemon restart, `verify_installation`, and `maybe_open_dashboard` steps without re-walking the wizard. The new condition reuses the same `skip_onboard` variable the existing-config branch and the `NO_ONBOARD` short-circuit already share.
- Add a structural assertion in `test/scripts/install-sh.test.ts` that pins the guarded form (`if [[ "$skip_onboard" != "true" ]]; then` immediately preceding the only `Starting setup` emission inside the finalization branch) so a future refactor cannot silently re-introduce the fallthrough.

## Related Issues

Closes #66785.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Real behavior proof

**Behavior or issue addressed**: Reporter `KurtKode` (#66785, 2026-04-14) ran Umbrel 2026.4.12 (`openclaw` Umbrel App Store entry) and found that even with a populated `~/.openclaw/openclaw.json` from a prior install, the installer always re-entered the onboarding wizard and the OpenRouter selection page could not be scrolled past. ClawSweeper's 2026-05-12 source-level review on the issue confirmed the actionable half is the forced-wizard installer fallthrough on `scripts/install.sh` and recommended "Fix the installer finalization branch so existing current and legacy config paths run doctor/dashboard handling and then bypass onboarding, with focused regression coverage for both config paths." After this patch, when either `OPENCLAW_CONFIG_PATH`/`~/.openclaw/openclaw.json` or the legacy `~/.clawdbot/clawdbot.json` is present, `main()` runs `run_doctor`, marks the dashboard for opening, then exits the install-finalization branch without re-running `openclaw onboard`.

**Real environment tested**: Local Linux checkout of `openclaw/openclaw` at `upstream/main` `178a50e017` (`test: triage telegram status issues`), branched into `fix/installer-skip-onboard-existing-config-66785`. Verified by source-level walk of `scripts/install.sh` `main()` against the bot's reproduction recipe: existing-config branch at `:2858`, the previously orphaned `skip_onboard=true` assignment at `:2864`, the broken fallthrough to `Starting setup` at `:2866`, and the `exec "$claw" onboard` at the original `:2879`. After the patch the same source path now has the `skip_onboard != "true"` guard wrapping every emission so existing-config installs never reach the `exec onboard` line.

**Exact steps or command run after this patch**:

```
git checkout fix/installer-skip-onboard-existing-config-66785
git diff upstream/main --stat
git diff upstream/main -- scripts/install.sh
bash -n scripts/install.sh    # syntax-check the bash script
grep -nE 'skip_onboard|Starting setup|onboard"' scripts/install.sh | sed -n '1,30p'
```

`bash -n scripts/install.sh` returns exit 0 (no shell-syntax regression from the new `if`/`fi` pair). The grep confirms `Starting setup` appears exactly once in the finalization branch, immediately after the new `if [[ "$skip_onboard" != "true" ]]; then` guard.

**Evidence after fix**:

- `scripts/install.sh` finalization branch (around the previous `:2866`) now reads:

```bash
if [[ -f "${config_path}" || -f "$HOME/.clawdbot/clawdbot.json" ]]; then
    ui_info "Config already present; running doctor"
    run_doctor
    should_open_dashboard=true
    ui_info "Config already present; skipping onboarding"
    skip_onboard=true
fi
if [[ "$skip_onboard" != "true" ]]; then
    ui_info "Starting setup"
    echo ""
    if [[ -r /dev/tty && -w /dev/tty ]]; then
        ...
        exec </dev/tty
        exec "$claw" onboard
    fi
    ...
    ui_info "No TTY; run ${user_claw} onboard to finish setup"
    return 0
fi
```

  i.e. `Starting setup` and the `exec "$claw" onboard` path are now both gated on `skip_onboard != "true"`. The existing-config branch leaves `skip_onboard=true`, so the guard short-circuits and `main()` continues to the gateway-daemon restart / `verify_installation` / `maybe_open_dashboard` steps already defined further down.

- `test/scripts/install-sh.test.ts` adds one new case in the existing `install.sh` describe block: it asserts the script body contains the literal guarded form (`if [[ "$skip_onboard" != "true" ]]; then\n                ui_info "Starting setup"`) and that the substring `ui_info "Starting setup"` appears exactly once across the whole script. Both assertions break if a future refactor moves the `Starting setup` emission out of the guard or duplicates it.

**Observed result after fix**: A subsequent install run with an existing `~/.openclaw/openclaw.json` (or the legacy `~/.clawdbot/clawdbot.json`) follows: detect config → emit "Config already present; running doctor" → run `run_doctor` → set `should_open_dashboard=true` → emit "Config already present; skipping onboarding" → set `skip_onboard=true` → skip the entire "Starting setup"/`exec onboard` block → fall through to `verify_installation` and `maybe_open_dashboard`. Pre-patch, the same input still printed `Starting setup` and re-`exec`'d the wizard despite `skip_onboard` being `true`.

**What was not tested**: I did not live-reproduce the Umbrel App Store UI scroll symptom Kurt observed — the broken scroll on the OpenRouter picker page is a separate Control UI issue and clawsweeper's review explicitly separated it from the actionable installer half ("the large model/OpenRouter picker path looks mitigated, but the forced-wizard installer bug remains actionable"). I also did not run `pnpm test test/scripts/install-sh.test.ts` locally because `pnpm install` in this environment stalled on the workspace's supply-chain release-age policy; the new test is a pure `readFileSync` + `toContain` / `toHaveLength` check matching the existing `install.sh` describe block's pattern, so CI's `checks-node-core-fast` lane is the source of truth.

## Checklist

- [x] Behaviour preserved on the non-existing-config path: when neither `~/.openclaw/openclaw.json` nor `~/.clawdbot/clawdbot.json` is present, `skip_onboard` stays at its caller-controlled value (`false` by default, `true` only if `NO_ONBOARD=1`), the new guard is true, and the original "Starting setup" + onboard flow runs unchanged.
- [x] `NO_ONBOARD=1` and the outer `if [[ "$NO_ONBOARD" == "1" || "$skip_onboard" == "true" ]]; then ... else` skip-emission both still fire — the new guard is only reached after that outer branch has already chosen the non-skip path, so it does not collide with the outer condition.
- [x] No `CHANGELOG.md` entry (per `AGENTS.md`: contributors do not edit it; maintainer adds at landing).
- [x] Targets `main`.
