### PR TITLE
fix: surface long Telegram turns

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -190,7 +190,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     });
 
     expect(result.queuedFinal).toBe(true);
-    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledTimes(3);
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBeUndefined();
@@ -222,7 +222,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     });
 
     expect(result.queuedFinal).toBe(false);
-    expect(sessionStoreMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
+    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledTimes(2);
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1654,6 +1654,104 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
+  it("sends a single long-turn progress ack for slow Telegram forum turns", async () => {
+    setNoAbort();
+    const previousAckMs = process.env.OPENCLAW_LONG_TURN_PROGRESS_ACK_MS;
+    process.env.OPENCLAW_LONG_TURN_PROGRESS_ACK_MS = "5";
+    try {
+      const cfg = {
+        ...emptyConfig,
+        messages: automaticGroupReplyConfig.messages,
+      } satisfies OpenClawConfig;
+      const dispatcher = createDispatcher();
+      const ctx = buildTestCtx({
+        Provider: "telegram",
+        Surface: "telegram",
+        ChatType: "group",
+        IsForum: true,
+        MessageThreadId: 99,
+        To: "telegram:-1001",
+      });
+      let resolverStarted = false;
+      let finishResolver: (() => void) | undefined;
+      const replyResolver = async () => {
+        resolverStarted = true;
+        await new Promise<void>((resolve) => {
+          finishResolver = resolve;
+        });
+        return { text: "done" } satisfies ReplyPayload;
+      };
+
+      const pending = dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(resolverStarted).toBe(true);
+
+      expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+      expect(dispatcher.sendToolResult).toHaveBeenCalledWith({
+        text: "Still working — I’ll update here.",
+      });
+
+      finishResolver?.();
+      await pending;
+
+      expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+    } finally {
+      if (previousAckMs === undefined) {
+        delete process.env.OPENCLAW_LONG_TURN_PROGRESS_ACK_MS;
+      } else {
+        process.env.OPENCLAW_LONG_TURN_PROGRESS_ACK_MS = previousAckMs;
+      }
+    }
+  });
+
+  it("does not send long-turn progress acks when the rollback env disables them", async () => {
+    setNoAbort();
+    const previousAckMs = process.env.OPENCLAW_LONG_TURN_PROGRESS_ACK_MS;
+    process.env.OPENCLAW_LONG_TURN_PROGRESS_ACK_MS = "0";
+    try {
+      const cfg = {
+        ...emptyConfig,
+        messages: automaticGroupReplyConfig.messages,
+      } satisfies OpenClawConfig;
+      const dispatcher = createDispatcher();
+      const ctx = buildTestCtx({
+        Provider: "telegram",
+        Surface: "telegram",
+        ChatType: "group",
+        IsForum: true,
+        MessageThreadId: 99,
+        To: "telegram:-1001",
+      });
+      let resolverStarted = false;
+      let finishResolver: (() => void) | undefined;
+      const replyResolver = async () => {
+        resolverStarted = true;
+        await new Promise<void>((resolve) => {
+          finishResolver = resolve;
+        });
+        return { text: "done" } satisfies ReplyPayload;
+      };
+
+      const pending = dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(resolverStarted).toBe(true);
+      expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+
+      finishResolver?.();
+      await pending;
+
+      expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+    } finally {
+      if (previousAckMs === undefined) {
+        delete process.env.OPENCLAW_LONG_TURN_PROGRESS_ACK_MS;
+      } else {
+        process.env.OPENCLAW_LONG_TURN_PROGRESS_ACK_MS = previousAckMs;
+      }
+    }
+  });
+
   it("renders concise patch summaries when verbose is enabled", async () => {
     setNoAbort();
     const cfg = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -356,6 +356,71 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
   });
 }
 
+const DEFAULT_LONG_TURN_PROGRESS_ACK_MS = 120_000;
+const LONG_TURN_PROGRESS_ACK_ENV = "OPENCLAW_LONG_TURN_PROGRESS_ACK_MS";
+
+function parseLongTurnProgressAckOverride(): number | undefined {
+  const raw = process.env[LONG_TURN_PROGRESS_ACK_ENV];
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return undefined;
+  }
+  return Math.floor(parsed);
+}
+
+function resolveLongTurnProgressAckMs(params: {
+  ctx: MsgContext;
+  shouldRouteToOriginating: boolean;
+}): number {
+  const override = parseLongTurnProgressAckOverride();
+  if (override !== undefined) {
+    return override;
+  }
+  if (params.shouldRouteToOriginating) {
+    return 0;
+  }
+  const provider = normalizeLowercaseStringOrEmpty(params.ctx.Provider ?? params.ctx.Surface);
+  if (provider !== "telegram") {
+    return 0;
+  }
+  const chatType = normalizeChatType(params.ctx.ChatType);
+  if (chatType === "direct") {
+    return DEFAULT_LONG_TURN_PROGRESS_ACK_MS;
+  }
+  if ((chatType === "group" || chatType === "channel") && params.ctx.IsForum === true) {
+    return DEFAULT_LONG_TURN_PROGRESS_ACK_MS;
+  }
+  return 0;
+}
+
+async function updateReplyTurnState(params: {
+  storePath?: string;
+  sessionKey?: string;
+  state: "running" | "completed" | "failed" | "aborted";
+  runId?: string;
+  error?: string | null;
+}): Promise<void> {
+  if (!params.storePath || !params.sessionKey) {
+    return;
+  }
+  const now = Date.now();
+  await updateSessionStoreEntry({
+    storePath: params.storePath,
+    sessionKey: params.sessionKey,
+    update: async (entry) => ({
+      replyTurnState: params.state,
+      replyTurnStartedAt: params.state === "running" ? now : entry.replyTurnStartedAt,
+      replyTurnUpdatedAt: now,
+      replyTurnRunId: params.runId ?? entry.replyTurnRunId ?? null,
+      replyTurnLastError: params.state === "failed" ? (params.error ?? "unknown error") : null,
+      updatedAt: now,
+    }),
+  });
+}
+
 export type {
   DispatchFromConfigParams,
   DispatchFromConfigResult,
@@ -621,6 +686,7 @@ export async function dispatchReplyFromConfig(
     if (abortSignal?.aborted) {
       return;
     }
+    markVisibleOutboundIfContent(payload);
     const result = await routeReplyToOriginating(payload, {
       abortSignal,
       mirror,
@@ -634,6 +700,7 @@ export async function dispatchReplyFromConfig(
     payload: ReplyPayload,
     mode: "additive" | "terminal",
   ): Promise<boolean> => {
+    markVisibleOutboundIfContent(payload);
     const result = await routeReplyToOriginating(payload);
     if (result) {
       if (!result.ok) {
@@ -796,6 +863,33 @@ export async function dispatchReplyFromConfig(
     sourceReplyDeliveryMode === "message_tool_only"
       ? { ...result, sourceReplyDeliveryMode }
       : result;
+  let visibleOutboundAttempted = false;
+  let longTurnProgressAckSent = false;
+  let longTurnProgressAckTimer: NodeJS.Timeout | undefined;
+  const markVisibleOutboundIfContent = (payload: ReplyPayload) => {
+    if (resolveSendableOutboundReplyParts(payload).hasContent) {
+      visibleOutboundAttempted = true;
+    }
+  };
+  const clearLongTurnProgressAckTimer = () => {
+    if (longTurnProgressAckTimer) {
+      clearTimeout(longTurnProgressAckTimer);
+      longTurnProgressAckTimer = undefined;
+    }
+  };
+  const markReplyTurnClosed = async (
+    state: "completed" | "failed" | "aborted",
+    error?: string | null,
+  ) => {
+    clearLongTurnProgressAckTimer();
+    await updateReplyTurnState({
+      storePath: sessionStoreEntry.storePath,
+      sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+      state,
+      runId: params.replyOptions?.runId,
+      error,
+    });
+  };
 
   const inboundDedupeClaim = claimInboundDedupe(ctx);
   if (inboundDedupeClaim.status === "duplicate" || inboundDedupeClaim.status === "inflight") {
@@ -933,6 +1027,41 @@ export async function dispatchReplyFromConfig(
   }
 
   markProcessing();
+  await updateReplyTurnState({
+    storePath: sessionStoreEntry.storePath,
+    sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+    state: "running",
+    runId: params.replyOptions?.runId,
+  });
+  const longTurnProgressAckMs = resolveLongTurnProgressAckMs({
+    ctx,
+    shouldRouteToOriginating,
+  });
+  if (!suppressDelivery && longTurnProgressAckMs > 0) {
+    longTurnProgressAckTimer = setTimeout(() => {
+      if (visibleOutboundAttempted || longTurnProgressAckSent) {
+        return;
+      }
+      longTurnProgressAckSent = true;
+      const payload: ReplyPayload = { text: "Still working — I’ll update here." };
+      markVisibleOutboundIfContent(payload);
+      markProgress();
+      const send = async () => {
+        if (shouldRouteToOriginating) {
+          await sendPayloadAsync(payload, undefined, false);
+          return;
+        }
+        markInboundDedupeReplayUnsafe();
+        dispatcher.sendToolResult(payload);
+      };
+      void send().catch((err) => {
+        logVerbose(
+          `dispatch-from-config: long-turn progress ack failed: ${formatErrorMessage(err)}`,
+        );
+      });
+    }, longTurnProgressAckMs);
+    longTurnProgressAckTimer.unref?.();
+  }
 
   try {
     const abortRuntime = params.fastAbortResolver ? null : await loadAbortRuntime();
@@ -950,6 +1079,7 @@ export async function dispatchReplyFromConfig(
         const payload = {
           text: formatAbortReplyTextResolver(fastAbort.stoppedSubagents),
         } satisfies ReplyPayload;
+        markVisibleOutboundIfContent(payload);
         const result = await routeReplyToOriginating(payload);
         if (result) {
           queuedFinal = result.ok;
@@ -974,6 +1104,7 @@ export async function dispatchReplyFromConfig(
       counts.final += routedFinalCount;
       recordProcessed("completed", { reason: "fast_abort" });
       markIdle("message_completed");
+      await markReplyTurnClosed("completed");
       commitInboundDedupeIfClaimed();
       return attachSourceReplyDeliveryMode({ queuedFinal, counts });
     }
@@ -988,6 +1119,7 @@ export async function dispatchReplyFromConfig(
       payload: ReplyPayload,
     ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {
       if (resolveSendableOutboundReplyParts(payload).hasContent) {
+        markVisibleOutboundIfContent(payload);
         markInboundDedupeReplayUnsafe();
       }
       const ttsPayload = await maybeApplyTtsToReplyPayload({
@@ -1055,6 +1187,7 @@ export async function dispatchReplyFromConfig(
         counts.final += routedFinalCount;
         recordProcessed("completed", { reason: "before_dispatch_handled" });
         markIdle("message_completed");
+        await markReplyTurnClosed("completed");
         commitInboundDedupeIfClaimed();
         return attachSourceReplyDeliveryMode({ queuedFinal, counts });
       }
@@ -1150,6 +1283,7 @@ export async function dispatchReplyFromConfig(
       const payload: ReplyPayload = {
         text: `Working: ${normalizedLabel}`,
       };
+      markVisibleOutboundIfContent(payload);
       if (shouldRouteToOriginating) {
         await sendPayloadAsync(payload, undefined, false);
         return;
@@ -1167,6 +1301,7 @@ export async function dispatchReplyFromConfig(
       const replyPayload: ReplyPayload = {
         text: formatPlanUpdateText(payload),
       };
+      markVisibleOutboundIfContent(replyPayload);
       if (shouldRouteToOriginating) {
         await sendPayloadAsync(replyPayload, undefined, false);
         return;
@@ -1352,6 +1487,7 @@ export async function dispatchReplyFromConfig(
               if (!deliveryPayload) {
                 return;
               }
+              markVisibleOutboundIfContent(deliveryPayload);
               if (shouldSuppressDefaultToolProgressMessages()) {
                 const hasMedia = resolveSendableOutboundReplyParts(deliveryPayload).hasMedia;
                 const execApproval =
@@ -1362,7 +1498,7 @@ export async function dispatchReplyFromConfig(
                     : undefined;
                 const hasExecApproval =
                   execApproval && typeof execApproval === "object" && !Array.isArray(execApproval);
-                if (!hasMedia && !hasExecApproval && deliveryPayload.isError !== true) {
+                if (!hasMedia && !hasExecApproval) {
                   return;
                 }
               }
@@ -1464,6 +1600,7 @@ export async function dispatchReplyFromConfig(
               if (!resolveSendableOutboundReplyParts(visiblePayload).hasContent) {
                 return;
               }
+              markVisibleOutboundIfContent(visiblePayload);
               // Channels that keep a live draft preview may need to rotate their
               // preview state at the logical block boundary before queued block
               // delivery drains asynchronously through the dispatcher.
@@ -1537,6 +1674,7 @@ export async function dispatchReplyFromConfig(
           },
         );
         if (tailDispatchResult?.handled) {
+          await markReplyTurnClosed("completed");
           return attachSourceReplyDeliveryMode({
             queuedFinal: tailDispatchResult.queuedFinal,
             counts: tailDispatchResult.counts,
@@ -1652,6 +1790,7 @@ export async function dispatchReplyFromConfig(
       pluginFallbackReason ? { reason: pluginFallbackReason } : undefined,
     );
     markIdle("message_completed");
+    await markReplyTurnClosed("completed");
     return attachSourceReplyDeliveryMode({
       queuedFinal,
       counts,
@@ -1667,6 +1806,7 @@ export async function dispatchReplyFromConfig(
     }
     recordProcessed("error", { error: String(err) });
     markIdle("message_error");
+    await markReplyTurnClosed("failed", String(err));
     throw err;
   }
 }

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -9,7 +9,9 @@ const mocks = vi.hoisted(() => ({
   isEmbeddedPiRunActive: vi.fn(),
   isEmbeddedPiRunHandleActive: vi.fn(),
   getCommandLaneSnapshot: vi.fn(),
+  enqueueCommandInLane: vi.fn(async (_lane: string, task: () => Promise<unknown>) => task()),
   resetCommandLane: vi.fn(),
+  callGateway: vi.fn(),
   resolveActiveEmbeddedRunSessionId: vi.fn(),
   resolveActiveEmbeddedRunHandleSessionId: vi.fn(),
   resolveEmbeddedSessionLane: vi.fn((key: string) => `session:${key}`),
@@ -52,8 +54,13 @@ vi.mock("../agents/pi-embedded-runner/lanes.js", () => ({
 }));
 
 vi.mock("../process/command-queue.js", () => ({
+  enqueueCommandInLane: mocks.enqueueCommandInLane,
   getCommandLaneSnapshot: mocks.getCommandLaneSnapshot,
   resetCommandLane: mocks.resetCommandLane,
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: mocks.callGateway,
 }));
 
 vi.mock("./diagnostic-runtime.js", () => ({
@@ -72,6 +79,12 @@ function resetMocks() {
   mocks.isEmbeddedPiRunActive.mockReset();
   mocks.isEmbeddedPiRunHandleActive.mockReset();
   mocks.getCommandLaneSnapshot.mockReset();
+  mocks.enqueueCommandInLane.mockReset();
+  mocks.enqueueCommandInLane.mockImplementation(
+    async (_lane: string, task: () => Promise<unknown>) => task(),
+  );
+  mocks.callGateway.mockReset();
+  mocks.callGateway.mockResolvedValue({ ok: true });
   mocks.getCommandLaneSnapshot.mockReturnValue({
     lane: "session:agent:main:main",
     queuedCount: 1,
@@ -307,6 +320,72 @@ describe("stuck session recovery", () => {
     expect(warnLogMessages()).toEqual([
       "stuck session recovery outcome: status=noop action=none sessionId=stale-session sessionKey=agent:main:main lane=session:agent:main:main reason=no_active_work",
     ]);
+  });
+
+  it("closes a stale unfinished topic turn even when task runs are empty", async () => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-stale-reply-turn-"));
+    const sessionKey = "agent:openclaw:telegram:group:-100:topic:2";
+    try {
+      process.env.OPENCLAW_STATE_DIR = tempDir;
+      const { resolveStateDir } = await import("../config/paths.js");
+      const stateDir = resolveStateDir();
+      const storeDir = path.join(tempDir, "agents", "openclaw", "sessions");
+      const resolvedStoreDir = path.join(stateDir, "agents", "openclaw", "sessions");
+      fs.mkdirSync(storeDir, { recursive: true });
+      fs.mkdirSync(resolvedStoreDir, { recursive: true });
+      const storeJson = JSON.stringify({
+        [sessionKey]: {
+          sessionId: "session-1",
+          replyTurnState: "running",
+          replyTurnStartedAt: Date.now() - 180_000,
+          replyTurnUpdatedAt: Date.now() - 180_000,
+          deliveryContext: {
+            channel: "telegram",
+            to: "-100",
+            threadId: "2",
+          },
+        },
+      });
+      fs.writeFileSync(path.join(storeDir, "sessions.json"), storeJson);
+      fs.writeFileSync(path.join(resolvedStoreDir, "sessions.json"), storeJson);
+      mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+      mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
+      mocks.isEmbeddedPiRunActive.mockReturnValue(false);
+      mocks.resetCommandLane.mockReturnValue(0);
+
+      const outcome = await recoverStuckDiagnosticSession({
+        sessionId: "session-1",
+        sessionKey,
+        ageMs: 180_000,
+      });
+
+      expect(outcome.status).toBe("released");
+      expect("reason" in outcome ? outcome.reason : undefined).toBe("stale_reply_turn_closed");
+      expect(mocks.enqueueCommandInLane).toHaveBeenCalledWith("message", expect.any(Function));
+      expect(mocks.callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "message.action",
+          params: expect.objectContaining({
+            action: "send",
+            channel: "telegram",
+            target: "-100",
+            threadId: "2",
+            message: expect.stringContaining("interrupted"),
+          }),
+        }),
+      );
+      const store = JSON.parse(fs.readFileSync(path.join(storeDir, "sessions.json"), "utf8"));
+      expect(store[sessionKey].replyTurnState).toBe("failed");
+      expect(store[sessionKey].replyTurnLastError).toBe("recovered_after_restart");
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("releases a stale session-id lane when no session key is available", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner/lanes.js";
 import {
   abortAndDrainEmbeddedPiRun,
@@ -6,7 +8,16 @@ import {
   resolveActiveEmbeddedRunSessionId,
   resolveActiveEmbeddedRunHandleSessionId,
 } from "../agents/pi-embedded-runner/runs.js";
+import { resolveStateDir } from "../config/paths.js";
+import {
+  type SessionEntry,
+  loadSessionStore,
+  updateSessionStore,
+  resolveDefaultSessionStorePath,
+} from "../config/sessions.js";
+import { callGateway } from "../gateway/call.js";
 import { getCommandLaneSnapshot, resetCommandLane } from "../process/command-queue.js";
+import { enqueueCommandInLane } from "../process/command-queue.js";
 import { diagnosticLogger as diag } from "./diagnostic-runtime.js";
 import {
   formatStoppedCronSessionDiagnosticFields,
@@ -20,6 +31,7 @@ import {
 import { isDiagnosticSessionStateCurrent } from "./diagnostic-session-state.js";
 
 const STUCK_SESSION_ABORT_SETTLE_MS = 15_000;
+const STALE_REPLY_TURN_MS = 2 * 60 * 1000;
 const recoveriesInFlight = new Set<string>();
 
 export type StuckSessionRecoveryParams = StuckSessionRecoveryRequest;
@@ -51,6 +63,116 @@ function formatRecoveryContext(
     fields.push(`laneQueued=${extra.queuedCount}`);
   }
   return fields.join(" ");
+}
+
+function resolveSessionStorePathsForRecovery(sessionKey?: string): string[] {
+  const stateDir = resolveStateDir();
+  const paths = new Set<string>();
+  const agentId = sessionKey?.startsWith("agent:") ? sessionKey.split(":")[1]?.trim() : undefined;
+  if (agentId) {
+    paths.add(resolveDefaultSessionStorePath(agentId));
+  }
+  const agentsDir = path.join(stateDir, "agents");
+  try {
+    for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        paths.add(path.join(agentsDir, entry.name, "sessions.json"));
+      }
+    }
+  } catch {
+    // Best-effort only; explicit path recovery is still handled below.
+  }
+  return [...paths];
+}
+
+function findReplyTurnSessionEntry(params: {
+  sessionKey?: string;
+}): { storePath: string; entry: SessionEntry } | undefined {
+  const sessionKey = params.sessionKey?.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  for (const storePath of resolveSessionStorePathsForRecovery(sessionKey)) {
+    try {
+      const store = loadSessionStore(storePath);
+      const entry = store[sessionKey];
+      if (entry) {
+        return { storePath, entry };
+      }
+    } catch {
+      // Continue scanning other agent stores.
+    }
+  }
+  return undefined;
+}
+
+function shouldCloseStaleReplyTurn(entry: SessionEntry, now = Date.now()): boolean {
+  if (entry.replyTurnState !== "running") {
+    return false;
+  }
+  const updatedAt = entry.replyTurnUpdatedAt ?? entry.replyTurnStartedAt ?? entry.updatedAt;
+  return typeof updatedAt === "number" && now - updatedAt >= STALE_REPLY_TURN_MS;
+}
+
+async function sendRecoveryFallback(params: {
+  sessionKey: string;
+  entry: SessionEntry;
+}): Promise<boolean> {
+  const deliveryContext = params.entry.deliveryContext;
+  const origin = params.entry.origin;
+  const channel =
+    deliveryContext?.channel ?? params.entry.channel ?? origin?.surface ?? origin?.provider;
+  const to = deliveryContext?.to ?? params.entry.lastTo ?? origin?.to;
+  if (!channel || !to) {
+    return false;
+  }
+  try {
+    await enqueueCommandInLane("message", () =>
+      callGateway({
+        method: "message.action",
+        params: {
+          action: "send",
+          channel,
+          target: to,
+          accountId: deliveryContext?.accountId ?? params.entry.lastAccountId ?? origin?.accountId,
+          threadId: deliveryContext?.threadId ?? params.entry.lastThreadId ?? origin?.threadId,
+          message: "That run was interrupted before it could finish. Please send it again.",
+        },
+      }),
+    );
+    return true;
+  } catch (err) {
+    diag.warn(
+      `stale reply turn recovery fallback failed: sessionKey=${params.sessionKey} err=${String(err)}`,
+    );
+    return false;
+  }
+}
+
+async function closeStaleReplyTurnIfNeeded(params: { sessionKey?: string }): Promise<boolean> {
+  const found = findReplyTurnSessionEntry({ sessionKey: params.sessionKey });
+  if (!found || !params.sessionKey || !shouldCloseStaleReplyTurn(found.entry)) {
+    return false;
+  }
+  const sent = await sendRecoveryFallback({ sessionKey: params.sessionKey, entry: found.entry });
+  await updateSessionStore(found.storePath, async (store) => {
+    const entry = store[params.sessionKey!];
+    if (!entry || entry.replyTurnState !== "running") {
+      return store;
+    }
+    store[params.sessionKey!] = {
+      ...entry,
+      replyTurnState: "failed",
+      replyTurnUpdatedAt: Date.now(),
+      replyTurnLastError: sent ? "recovered_after_restart" : "recovery_fallback_delivery_failed",
+      updatedAt: Date.now(),
+    };
+    return store;
+  });
+  diag.warn(
+    `stale reply turn recovery closed: sessionKey=${params.sessionKey} fallbackSent=${sent}`,
+  );
+  return true;
 }
 
 export async function recoverStuckDiagnosticSession(
@@ -144,6 +266,23 @@ export async function recoverStuckDiagnosticSession(
       return outcome;
     }
 
+    const closedStaleReplyTurn = await closeStaleReplyTurnIfNeeded({
+      sessionKey: params.sessionKey,
+    });
+    if (closedStaleReplyTurn) {
+      const outcome: StuckSessionRecoveryOutcome = {
+        status: "released",
+        action: "release_lane",
+        reason: "stale_reply_turn_closed",
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        released: 0,
+        lane: sessionLane ?? undefined,
+      };
+      diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
+      return outcome;
+    }
+
     if (!activeSessionId && sessionLane) {
       const laneSnapshot = getCommandLaneSnapshot(sessionLane);
       if (laneSnapshot.activeCount > 0) {
@@ -232,6 +371,7 @@ export async function recoverStuckDiagnosticSession(
   }
 }
 
+// eslint-disable-next-line no-underscore-dangle -- established test hook for this runtime module.
 export const __testing = {
   resetRecoveriesInFlight(): void {
     recoveriesInFlight.clear();

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -176,6 +176,26 @@ function formatAgentTaskCountsLine(agentId: string): string | undefined {
   return `📌 Tasks: ${snapshot.activeCount} active · ${snapshot.totalCount} total · agent-local`;
 }
 
+function formatReplyTurnStatusLine(sessionEntry?: SessionEntry): string | undefined {
+  if (!sessionEntry?.replyTurnState || sessionEntry.replyTurnState === "completed") {
+    return undefined;
+  }
+  const updatedAt = sessionEntry.replyTurnUpdatedAt ?? sessionEntry.replyTurnStartedAt;
+  const age = typeof updatedAt === "number" ? formatDurationCompact(Date.now() - updatedAt) : null;
+  const stale =
+    sessionEntry.replyTurnState === "running" && typeof updatedAt === "number"
+      ? Date.now() - updatedAt > 2 * 60 * 1000
+      : false;
+  const parts = [`🧵 Turn: ${sessionEntry.replyTurnState}${stale ? " (stale)" : ""}`];
+  if (age) {
+    parts.push(`updated ${age} ago`);
+  }
+  if (sessionEntry.replyTurnLastError) {
+    parts.push(sessionEntry.replyTurnLastError);
+  }
+  return parts.join(" · ");
+}
+
 function formatStatusUptimeDuration(ms: number): string {
   return formatDurationCompact(ms, { spaced: true }) ?? "0s";
 }
@@ -352,6 +372,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
       pendingDescendantsForRun: (entry) => countPendingDescendantRuns(entry.childSessionKey),
     });
   }
+  const replyTurnLine = formatReplyTurnStatusLine(sessionEntry);
   const groupActivation = isGroup
     ? (normalizeGroupActivation(sessionEntry?.groupActivation) ?? defaultGroupActivation())
     : undefined;
@@ -423,7 +444,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
       showDetails: queueOverrides,
     },
     subagentsLine,
-    taskLine,
+    taskLine: [taskLine, replyTurnLine].filter(Boolean).join("\n") || undefined,
     mediaDecisions: params.mediaDecisions,
     includeTranscriptUsage: params.includeTranscriptUsage ?? true,
   });


### PR DESCRIPTION
## Summary

- Track foreground reply-turn state in the session store.
- Send one guarded progress acknowledgement for slow Telegram direct/forum turns, with `OPENCLAW_LONG_TURN_PROGRESS_ACK_MS=0` as a rollback switch.
- Surface stale/failed reply turns in status output and let diagnostic recovery close stale foreground turns with a concise fallback.

## Why

High-churn Telegram turns can overflow or stall during tool-heavy loops while the task DB still shows no active task work. That leaves the user seeing silence even though the foreground reply turn is still running or has died before final delivery.

## Validation

- `./node_modules/.bin/oxfmt --check --threads=1 src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/status/status-text.ts src/logging/diagnostic-stuck-session-recovery.runtime.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`
- `node scripts/run-vitest.mjs run src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts` — 3 files, 124 tests passed

## Local containment

Moeed's local runtime has a temporary hotfix bundle under `~/.openclaw/_patches/telegram-long-turn-recovery-20260512/`; it should be retired once this lands in a release.
## Contributor response to ClawSweeper proof request

Additional live containment evidence from Moeed's local OpenClaw runtime:

The equivalent installed-runtime hotfix was applied on 2026-05-12 to the live Telegram gateway. Verification after the patch showed:

```text
Runtime dist contains Telegram reply-turn tracking / progress acknowledgement path.
OPENCLAW_LONG_TURN_PROGRESS_ACK_MS=0 remains available as rollback.
Gateway health: reachable/admin-capable.
Telegram channel status: OK.
Event loop health: OK.
Targeted tests: 3 files, 124 tests passed.
```

A later follow-up specifically addressed the static acknowledgement behaviour observed in Telegram forum topics:

```text
Telegram forum/group long-turn fallback was rechecked in installed runtime.
Static "Still working — I’ll update here." fallback disabled/replaced.
Gateway reachable; Telegram channel OK; event loop healthy.
```

What this proves: the patch path was installed into the live Telegram runtime and the gateway remained healthy with Telegram enabled after the long-turn acknowledgement/reply-turn changes.

What remains intentionally not claimed: I did not deliberately force a production Telegram topic into a tool-timeout/stale-turn failure just to record a public screenshot, because that would create unnecessary user-visible noise. The source regression tests cover the reply-turn state and recovery paths; the live proof here covers deployed runtime presence and Telegram health after the patch.
