### PR TITLE
fix(agents): validate process actions at the schema boundary

### DIFF
--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -22,7 +22,8 @@ import {
 } from "./agent-tools.params.js";
 import { normalizeToolParameters } from "./agent-tools.schema.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
-import { execSchema } from "./bash-tools.schemas.js";
+import { createProcessTool } from "./bash-tools.process.js";
+import { execSchema, processSchema } from "./bash-tools.schemas.js";
 import {
   BEFORE_TOOL_CALL_HOOK_CONTEXT,
   BEFORE_TOOL_CALL_SOURCE_TOOL,
@@ -59,6 +60,101 @@ describe("direct exec tool schema", () => {
     expect(describeField("ask")).toContain("tools.exec.ask");
     expect(describeField("ask")).toContain("channel-origin");
     expect(describeField("ask")).toContain("ask=off");
+  });
+});
+
+describe("direct process tool schema", () => {
+  it("keeps the action enum canonical at the agent-loop boundary", () => {
+    expect(processSchema.properties.action.type).toBe("string");
+    const actionEnum = processSchema.properties.action as Type.TString & { enum?: string[] };
+    expect(actionEnum.enum?.join("|")).toBe(
+      "list|poll|log|write|send-keys|submit|paste|kill|clear|remove",
+    );
+    expect(() =>
+      validateToolArguments(createProcessTool(), {
+        type: "toolCall",
+        id: "call-invalid-process-action",
+        name: "process",
+        arguments: { action: "delete" },
+      }),
+    ).toThrow('Validation failed for tool "process"');
+  });
+
+  it("rejects unknown process actions without starting execution", async () => {
+    const processTool = createProcessTool();
+    const execute = vi.spyOn(processTool, "execute");
+    const events: AgentEvent[] = [];
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        streamCalls += 1;
+        const message =
+          streamCalls === 1
+            ? {
+                role: "assistant" as const,
+                content: [
+                  {
+                    type: "toolCall" as const,
+                    id: "call-unknown-process-action",
+                    name: "process",
+                    arguments: { action: "delete" },
+                  },
+                ],
+                api: "faux",
+                provider: "faux",
+                model: "faux-1",
+                usage: TEST_USAGE,
+                stopReason: "toolUse" as const,
+                timestamp: Date.now(),
+              }
+            : {
+                role: "assistant" as const,
+                content: [{ type: "text" as const, text: "done" }],
+                api: "faux",
+                provider: "faux",
+                model: "faux-1",
+                usage: TEST_USAGE,
+                stopReason: "stop" as const,
+                timestamp: Date.now(),
+              };
+        stream.push({ type: "done", reason: message.stopReason, message });
+      });
+      return stream;
+    };
+
+    const messages = await runAgentLoop(
+      [{ role: "user", content: "inspect processes", timestamp: Date.now() }],
+      { systemPrompt: "test", messages: [], tools: [processTool] },
+      {
+        model: {
+          id: "faux-1",
+          name: "Faux",
+          provider: "faux",
+          api: "faux",
+          baseUrl: "http://localhost:0",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128000,
+          maxTokens: 1024,
+        },
+        convertToLlm: (agentMessages) => agentMessages as never,
+      },
+      (event) => {
+        events.push(event);
+      },
+      undefined,
+      streamFn,
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    const toolResult = messages.find((message) => message.role === "toolResult");
+    expect(JSON.stringify(toolResult)).toContain('Validation failed for tool \\"process\\"');
+    expect(events.find((event) => event.type === "tool_execution_end")).toMatchObject({
+      executionStarted: false,
+      errorKind: "argument-validation",
+    });
   });
 });
 

--- a/src/agents/bash-tools.process.e2e.test.ts
+++ b/src/agents/bash-tools.process.e2e.test.ts
@@ -133,6 +133,16 @@ test.skipIf(process.platform === "win32").each([
   },
 );
 
+test("rejects malformed direct actions before requiring a session id", async () => {
+  const result = await createProcessTool().execute("invalid-process-action", {
+    action: {},
+  } as never);
+
+  expect(textContent(result)).toContain("Invalid process action");
+  expect(textContent(result)).not.toContain("sessionId is required");
+  expect(result.details).toMatchObject({ status: "failed" });
+});
+
 test.skipIf(process.platform === "win32").each([
   { name: "quiet successful exit", exitCode: 0, output: "", expectsNotification: false },
   { name: "quiet nonzero exit", exitCode: 7, output: "", expectsNotification: true },

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -56,6 +56,12 @@ const DEFAULT_LOG_TAIL_LINES = 200;
 const DEFAULT_INPUT_WAIT_IDLE_MS = 15_000;
 const MIN_INPUT_WAIT_IDLE_MS = 1_000;
 const MAX_INPUT_WAIT_IDLE_MS = 10 * 60 * 1000;
+const PROCESS_TOOL_ACTIONS = (
+  processSchema.properties.action as typeof processSchema.properties.action & {
+    enum: readonly string[];
+  }
+).enum;
+type ProcessToolAction = (typeof PROCESS_TOOL_ACTIONS)[number];
 
 function resolveLogSliceWindow(offset?: number, limit?: number) {
   const usingDefaultTail = offset === undefined && limit === undefined;
@@ -288,18 +294,14 @@ export function createProcessTool(
     description: describeProcessTool({ hasCronTool: defaults?.hasCronTool === true }),
     parameters: processSchema,
     execute: async (_toolCallId, args, signal, _onUpdate): Promise<AgentToolResult<unknown>> => {
+      const action = (args as { action?: unknown }).action;
+      if (!PROCESS_TOOL_ACTIONS.includes(action as ProcessToolAction)) {
+        return failText(
+          `Invalid process action. Expected one of: ${PROCESS_TOOL_ACTIONS.join(", ")}`,
+        );
+      }
       const params = args as {
-        action:
-          | "list"
-          | "poll"
-          | "log"
-          | "write"
-          | "send-keys"
-          | "submit"
-          | "paste"
-          | "kill"
-          | "clear"
-          | "remove";
+        action: ProcessToolAction;
         sessionId?: string;
         data?: string;
         keys?: string[];

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -5,9 +5,21 @@
  * descriptions that match runtime validation.
  */
 import { Type } from "typebox";
-import { optionalStringEnum } from "./schema/typebox.js";
+import { optionalStringEnum, stringEnum } from "./schema/typebox.js";
 
 const EXEC_TOOL_HOST_VALUES = ["auto", "sandbox", "gateway", "node"] as const;
+const PROCESS_TOOL_ACTIONS = [
+  "list",
+  "poll",
+  "log",
+  "write",
+  "send-keys",
+  "submit",
+  "paste",
+  "kill",
+  "clear",
+  "remove",
+] as const;
 
 /** Parameters accepted by the exec tool. */
 export const execSchema = Type.Object({
@@ -74,9 +86,9 @@ export const nodeExecSchema = Type.Object({
 
 /** Parameters accepted by the process-control tool. */
 export const processSchema = Type.Object({
-  action: Type.String({
+  action: stringEnum(PROCESS_TOOL_ACTIONS, {
     description: "Process action (list|poll|log|write|send-keys|submit|paste|kill|clear|remove)",
-  }),
+  }) as unknown as Type.TString,
   sessionId: Type.Optional(Type.String({ description: "Session id for actions other than list" })),
   data: Type.Optional(Type.String({ description: "Data to write for write" })),
   keys: Type.Optional(


### PR DESCRIPTION
## Summary

- Make `processSchema.action` a provider-safe flat enum backed by one canonical action tuple.
- Derive direct executor validation from that schema and reject malformed or unknown actions before any `sessionId` lookup.
- Add real `packages/agent-core` dispatch proof plus a direct executor bypass regression test.

Refs #69582.

This PR fixes only the process-action facet. Issue #69582 remains open because malformed edit-tool argument corruption is outside this branch.

## What Problem This Solves

The model-facing schema accepted any string, while the direct executor trusted a handwritten action union. Direct callers could therefore pass malformed actions and reach the misleading `sessionId is required for this action.` branch before action validation.

The schema now owns the action list. The executor reads the emitted enum values from that schema, validates raw input first, and then enters the existing action-specific flow.

## Evidence

- Redacted base and exact-head runtime trace: https://github.com/openclaw/openclaw/pull/81157#issuecomment-5268888881
- Exact base `282e6a47ae6f9fa45251960d52382ba1cd65dbcd` dispatch of `{ action: "delete" }`:
  - calls the process executor
  - reports `executionStarted: true`
  - reaches `sessionId is required for this action`
- Exact head `d2803b283ced566064cfe7ef0a299a7f46a553a8` dispatch of `{ action: "delete" }`:
  - reports `errorKind: "argument-validation"`
  - reports `executionStarted: false`
  - never calls the process executor
- Exact-head direct executor bypass of `{ action: {} }` returns `Invalid process action...` before session lookup.
- Focused proof:
  - `node scripts/run-vitest.mjs src/agents/agent-tools.schema.test.ts`
  - 67 schema tests passed
  - `node scripts/run-vitest.mjs src/agents/bash-tools.process.e2e.test.ts`
  - 9 process E2E tests passed
- Previously completed unchanged-production proof:
  - 69 adjacent process tests passed
  - Plugin SDK API baseline passed
  - current-main Testbox core and core-test typechecks passed
- Fresh exact-head max-P1 autoreview found no actionable findings with 0.97 correctness confidence.
- `git diff --check`

## Scope

- Production: +14 net lines
- Tests: +106 net lines
- No SDK, config, security, protocol, dependency, or edit-tool changes
- No Plugin SDK API baseline drift

## Credit

PR contribution: @sholomsbs33.

Original implementation author preserved in commit history:

`Co-authored-by: adone0 <vladyslav.yavorskyi@outlook.com>`

Punchcard-Session: clear-orchard-timber-c2
