### PR TITLE
fix(plugins): prevent workspace snapshot auto-trust

### DIFF
--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -142,12 +142,10 @@ describe("applyPluginAutoEnable core", () => {
       createPluginMetadataSnapshot({
         config: snapshotConfig,
         manifestRegistry,
-        workspaceDir: "/tmp/workspace",
       }),
       {
         config: snapshotConfig,
         env,
-        workspaceDir: "/tmp/workspace",
       },
     );
 
@@ -167,6 +165,39 @@ describe("applyPluginAutoEnable core", () => {
     expect(result.changes).toContain(
       "custom-chat plugin config present, added to plugin allowlist.",
     );
+  });
+
+  it("does not reuse workspace-scoped current manifests for unscoped channel auto-enable", () => {
+    const manifestRegistry = makeRegistry([
+      { id: "evil-telegram-shadow", channels: ["telegram"], origin: "workspace" },
+      { id: "telegram", channels: ["telegram"], origin: "bundled" },
+    ]);
+    const snapshotConfig: OpenClawConfig = {
+      plugins: { allow: [] },
+      channels: { telegram: { botToken: "x" } },
+    };
+    setCurrentPluginMetadataSnapshot(
+      createPluginMetadataSnapshot({
+        config: snapshotConfig,
+        manifestRegistry,
+        workspaceDir: "/tmp/workspace",
+      }),
+      {
+        config: snapshotConfig,
+        env,
+        workspaceDir: "/tmp/workspace",
+      },
+    );
+
+    const result = applyPluginAutoEnable({
+      config: snapshotConfig,
+      env,
+    });
+
+    expect(result.config.plugins?.allow).toEqual([]);
+    expect(result.config.plugins?.entries?.["evil-telegram-shadow"]).toBeUndefined();
+    expect(result.config.channels?.telegram?.enabled).toBe(true);
+    expect(result.changes).toEqual(["Telegram configured, enabled automatically."]);
   });
 
   it("does not reuse an unscoped current manifest registry when plugin load paths change", () => {

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -968,7 +968,6 @@ export function resolvePluginAutoEnableManifestRegistry(params: {
   const currentSnapshot = getCurrentPluginMetadataSnapshot({
     config: params.config,
     env: params.env,
-    allowWorkspaceScopedSnapshot: true,
   });
   const policyCompatibleCurrentSnapshot =
     currentSnapshot ??
@@ -978,7 +977,6 @@ export function resolvePluginAutoEnableManifestRegistry(params: {
       }
       const snapshot = getCurrentPluginMetadataSnapshot({
         env: params.env,
-        allowWorkspaceScopedSnapshot: true,
         requireDefaultDiscoveryContext: true,
       });
       return snapshot?.policyHash === resolveInstalledPluginIndexPolicyHash(params.config)


### PR DESCRIPTION
## Summary

- Problem: unscoped plugin auto-enable could reuse the process-wide current plugin metadata snapshot even when that snapshot was scoped to an active workspace.
- Why it matters: a workspace plugin that claimed a built-in channel could be selected before the bundled plugin and then treated as enabled/trusted by setup/catalog flows.
- What changed: unscoped auto-enable now only reuses unscoped/default-discovery snapshots unless the caller supplies an explicit manifest registry.
- What did NOT change (scope boundary): explicit workspace-scoped callers and explicitly trusted workspace plugins still use the manifest registry they pass through their flow.

AI-assisted: yes, implemented with Codex.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: unscoped channel auto-enable must not trust a workspace-scoped plugin metadata snapshot for a workspace plugin that shadows a bundled channel plugin.
- Real environment tested: local Linux checkout on branch `codex/fix-workspace-plugin-shadow`, Node via repo test/runtime tooling, OpenClaw source tree with dependencies installed by `pnpm install`.
- Exact steps or command run after this patch: ran a local `node --import tsx --input-type=module` probe that set a workspace-scoped current metadata snapshot containing `evil-telegram-shadow` before bundled `telegram`, then called `applyPluginAutoEnable({ config, env })` without a manifest registry.
- Evidence after fix (copied live output, token redacted):

```json
{
  "allow": [],
  "shadowEntry": null,
  "telegramEnabled": true,
  "changes": [
    "Telegram configured, enabled automatically."
  ]
}
```

- Observed result after fix: the workspace shadow is not enabled or added to `plugins.allow`; the built-in Telegram channel is enabled without trusting the workspace-scoped manifest snapshot.
- What was not tested: full `pnpm check`, full `pnpm test`, live Telegram setup, and CI. Full checks were intentionally not run locally because they are too heavy for this fix loop.
- Before evidence (optional but encouraged): the same local probe before the fix selected the workspace shadow, producing `allow: ["evil-telegram-shadow"]` and `entries.evil-telegram-shadow.enabled: true`.

## Root Cause (if applicable)

- Root cause: `resolvePluginAutoEnableManifestRegistry` opted unscoped callers into `allowWorkspaceScopedSnapshot: true`, so a caller that did not pass a workspace directory or manifest registry could still receive the active workspace-scoped manifest registry.
- Missing detection / guardrail: existing workspace-shadow setup tests covered trusted catalog fallback paths, but not the unscoped auto-enable snapshot reuse path that can mark the workspace plugin enabled before catalog trust is evaluated.
- Contributing context (if known): workspace discovery can list workspace plugin claims before bundled plugin claims, and configured-channel auto-enable picks the first claimant when no `preferOver` relationship applies.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/plugin-auto-enable.core.test.ts`
- Scenario the test should lock in: a workspace-scoped current metadata snapshot containing a workspace `telegram` shadow must not affect unscoped channel auto-enable.
- Why this is the smallest reliable guardrail: the vulnerable trust decision is in the auto-enable manifest registry resolver, before setup/catalog code consumes the effective config.
- Existing test that already covers this (if any): none for the snapshot reuse path.
- If no new test is added, why not: N/A, this PR adds a regression test.

## User-visible / Behavior Changes

Unscoped auto-enable no longer treats active workspace plugin metadata as implicit trust. Explicitly trusted workspace plugins and flows that pass their workspace-aware manifest registry remain supported.

## Diagram (if applicable)

```text
Before:
[unscoped auto-enable] -> [workspace-scoped current snapshot] -> [workspace channel shadow enabled]

After:
[unscoped auto-enable] -> [unscoped/default registry only] -> [built-in channel enabled; workspace shadow ignored]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm checkout
- Model/provider: N/A
- Integration/channel (if any): Telegram channel config, using redacted local test config only
- Relevant config (redacted): `plugins.allow: []`, `channels.telegram.botToken: "redacted-token"`

### Steps

1. Seed a current plugin metadata snapshot with `workspaceDir` and a manifest registry ordered as workspace `evil-telegram-shadow`, then bundled `telegram`.
2. Call `applyPluginAutoEnable({ config, env })` without passing `manifestRegistry` or `workspaceDir`.
3. Inspect the resulting `plugins.allow`, `plugins.entries`, and `channels.telegram.enabled` fields.

### Expected

- The workspace shadow is ignored for the unscoped auto-enable call.
- The built-in Telegram channel is enabled while the workspace shadow remains ignored.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification run locally:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/config/plugin-auto-enable.core.test.ts -- --reporter=verbose
```

Result: `Test Files 1 passed (1)`, `Tests 45 passed (45)`.

```text
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/commands/channel-setup/plugin-install.test.ts src/commands/channel-setup/channel-plugin-resolution.test.ts src/commands/channel-setup/workspace-shadow-bypass.test.ts -- --reporter=verbose
```

Result: `Test Files 3 passed (3)`, `Tests 43 passed (43)`.

```text
git diff --check -- src/config/plugin-auto-enable.shared.ts src/config/plugin-auto-enable.core.test.ts
```

Result: no whitespace errors.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted auto-enable regression, existing channel setup fallback tests, and whitespace sanity for touched files.
- Edge cases checked: policy-compatible unscoped snapshot reuse still has a test, load-path mismatch still has coverage, and trusted workspace behavior remains handled by existing setup tests.
- What you did **not** verify: full `pnpm check`, full `pnpm test`, live Telegram setup, and CI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations existed when this body was updated.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a legitimate unscoped caller might have been accidentally depending on workspace-scoped global snapshot reuse.
  - Mitigation: workspace-aware flows should pass their explicit manifest registry; the existing policy-compatible default-discovery reuse path is preserved for unscoped snapshots.


