### PR TITLE
feat(context-engine): add interceptCompaction contract for context-engine plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - CLI/policy: add the bundled Policy plugin for policy-backed channel conformance checks, doctor lint findings, and opt-in workspace repair. (#80407) Thanks @giodl73-repo.
 - Agents/config: allow `agents.list[].experimental.localModelLean` so lean local-model mode can be enabled for one configured agent instead of globally.
 - Providers/xAI: add device-code OAuth login so remote and headless setups can authorize xAI without a localhost browser callback. (#84005) Thanks @fuller-stack-dev.
+- Context engines: let plugins intercept Pi auto-compaction events with their own replacement summaries. (#81164) Thanks @100yenadmin.
 
 ### Fixes
 

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -127,6 +127,7 @@ export default function register(api) {
       id: "my-engine",
       name: "My Context Engine",
       ownsCompaction: true,
+      interceptsCompaction: true,
     },
 
     async ingest({ sessionId, message, isHeartbeat }) {
@@ -149,6 +150,16 @@ export default function register(api) {
     async compact({ sessionId, force }) {
       // Summarize older context
       return { ok: true, compacted: true };
+    },
+
+    async interceptCompaction(request) {
+      // Replace Pi's in-attempt auto-compaction summary
+      return {
+        handled: true,
+        summary: await summarizeSessionFile(request.sessionFile),
+        firstKeptEntryId: request.firstKeptEntryId,
+        tokensBefore: request.tokensBefore,
+      };
     },
   }));
 }
@@ -181,7 +192,7 @@ Required members:
 
 | Member             | Kind     | Purpose                                                  |
 | ------------------ | -------- | -------------------------------------------------------- |
-| `info`             | Property | Engine id, name, version, and whether it owns compaction |
+| `info`             | Property | Engine id, name, version, and compaction capabilities    |
 | `ingest(params)`   | Method   | Store a single message                                   |
 | `assemble(params)` | Method   | Build context for a model run (returns `AssembleResult`) |
 | `compact(params)`  | Method   | Summarize/reduce context                                 |
@@ -220,22 +231,87 @@ Optional members:
 | `bootstrap(params)`            | Method | Initialize engine state for a session. Called once when the engine first sees a session (e.g., import history). |
 | `ingestBatch(params)`          | Method | Ingest a completed turn as a batch. Called after a run completes, with all messages from that turn at once.     |
 | `afterTurn(params)`            | Method | Post-run lifecycle work (persist state, trigger background compaction).                                         |
+| `interceptCompaction(params)`  | Method | Replace Pi's `session_before_compact` summary when `info.interceptsCompaction` is `true`.                       |
 | `prepareSubagentSpawn(params)` | Method | Set up shared state for a child session before it starts.                                                       |
 | `onSubagentEnded(params)`      | Method | Clean up after a subagent ends.                                                                                 |
 | `dispose()`                    | Method | Release resources. Called during gateway shutdown or plugin reload - not per-session.                           |
 
-### ownsCompaction
+### Compaction lanes
 
-`ownsCompaction` controls whether Pi's built-in in-attempt auto-compaction stays enabled for the run:
+OpenClaw exposes two context-engine compaction lanes:
+
+- `ownsCompaction` controls OpenClaw's queued/manual lane: `/compact`,
+  overflow recovery, and proactive compaction the engine starts from
+  `afterTurn()`.
+- `interceptsCompaction` controls Pi's SDK event lane: the
+  `session_before_compact` event that Pi emits during in-attempt
+  auto-compaction.
+
+Engines can declare either flag, both flags, or neither flag. The flags do not
+exclude each other because they cover different runtime paths.
+
+`ownsCompaction` controls whether Pi's built-in in-attempt auto-compaction stays enabled, unless the engine also intercepts the SDK event:
 
 <AccordionGroup>
   <Accordion title="ownsCompaction: true">
-    The engine owns compaction behavior. OpenClaw disables Pi's built-in auto-compaction for that run, and the engine's `compact()` implementation is responsible for `/compact`, overflow recovery compaction, and any proactive compaction it wants to do in `afterTurn()`. OpenClaw may still run the pre-prompt overflow safeguard; when it predicts the full transcript will overflow, the recovery path calls the active engine's `compact()` before submitting another prompt.
+    The engine owns queued/manual compaction behavior. Its `compact()` implementation is responsible for `/compact`, overflow recovery compaction, and any proactive compaction it starts from `afterTurn()`. OpenClaw disables Pi's built-in auto-compaction for that run unless the same engine also sets `interceptsCompaction: true`. OpenClaw may still run the pre-prompt overflow safeguard; when it predicts the full transcript will overflow, the recovery path calls the active engine's `compact()` before submitting another prompt.
   </Accordion>
   <Accordion title="ownsCompaction: false or unset">
     Pi's built-in auto-compaction may still run during prompt execution, but the active engine's `compact()` method is still called for `/compact` and overflow recovery.
   </Accordion>
 </AccordionGroup>
+
+When `interceptsCompaction: true`, OpenClaw registers a Pi
+`session_before_compact` extension for the active engine and leaves Pi
+auto-compaction enabled so that event can fire. The engine must implement
+`interceptCompaction(request)`:
+
+<ParamField path="request.sessionId" type="string" required>
+  Pi session id for the conversation being compacted.
+</ParamField>
+<ParamField path="request.sessionKey" type="string">
+  OpenClaw session key when the run has one.
+</ParamField>
+<ParamField path="request.sessionFile" type="string" required>
+  On-disk JSONL transcript path. Engines that need raw history should read this
+  file instead of depending on Pi SDK event types.
+</ParamField>
+<ParamField path="request.tokenBudget" type="number">
+  Model context window when the runtime can resolve it.
+</ParamField>
+<ParamField path="request.currentTokenCount" type="number">
+  Best-effort current token estimate at the compaction point.
+</ParamField>
+<ParamField path="request.firstKeptEntryId" type="string" required>
+  Transcript entry id Pi intends to keep verbatim after compaction.
+</ParamField>
+<ParamField path="request.tokensBefore" type="number" required>
+  Pi's pre-compaction token count.
+</ParamField>
+<ParamField path="request.trigger" type='"in-attempt-auto" | "overflow" | "timeout" | "manual"'>
+  Optional trigger. Current Pi events do not expose a distinct trigger, so this
+  is usually unset.
+</ParamField>
+<ParamField path="request.signal" type="AbortSignal">
+  Abort signal for compaction work.
+</ParamField>
+
+Return `{ handled: true, summary, firstKeptEntryId, tokensBefore, details? }`
+to replace Pi's default compaction summary. Return `{ handled: false, reason }`
+to decline and let the runtime fall back to its normal compaction path. Engines
+should catch their own errors and return `handled: false`; if
+`interceptCompaction()` throws, OpenClaw logs the failure and falls back.
+
+If safeguard compaction is also enabled, OpenClaw registers the intercept after
+the safeguard so a handled intercept result wins under Pi's last-truthy result
+semantics. Safeguard cancellation results, such as auth failures, still stop the
+event chain before the intercept runs.
+
+Engines that own or intercept compaction are responsible for post-compaction
+headroom. For those engines OpenClaw treats
+`agents.defaults.compaction.reserveTokensFloor` as `0` when applying Pi
+settings, so the engine's own compaction target is not double-reserved by the
+host floor.
 
 <Warning>
 `ownsCompaction: false` does **not** mean OpenClaw automatically falls back to the legacy engine's compaction path.

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -1033,7 +1033,12 @@ import { buildMemorySystemPromptAddition } from "openclaw/plugin-sdk/core";
 
 export default function (api) {
   api.registerContextEngine("lossless-claw", (ctx) => ({
-    info: { id: "lossless-claw", name: "Lossless Claw", ownsCompaction: true },
+    info: {
+      id: "lossless-claw",
+      name: "Lossless Claw",
+      ownsCompaction: true,
+      interceptsCompaction: true,
+    },
     async ingest() {
       return { ingested: true };
     },
@@ -1049,6 +1054,14 @@ export default function (api) {
     },
     async compact() {
       return { ok: true, compacted: false };
+    },
+    async interceptCompaction(request) {
+      return {
+        handled: true,
+        summary: await summarizeSessionFile(request.sessionFile),
+        firstKeptEntryId: request.firstKeptEntryId,
+        tokensBefore: request.tokensBefore,
+      };
     },
   }));
 }
@@ -1102,6 +1115,22 @@ export default function (api) {
   }));
 }
 ```
+
+`ownsCompaction` and `interceptsCompaction` are separate capability flags.
+`ownsCompaction` covers OpenClaw's queued/manual lane: `/compact`, overflow
+recovery, and proactive compaction started by the engine. `interceptsCompaction`
+covers Pi's `session_before_compact` event lane during in-attempt
+auto-compaction. An engine can set both when it owns queued compaction and also
+wants to replace Pi's default auto-compaction summary.
+
+When `interceptsCompaction: true`, the engine must implement
+`interceptCompaction(request)`. Return `handled: true` with a replacement
+summary, `firstKeptEntryId`, and `tokensBefore` to override the runtime's
+default summary. Return `handled: false` to fall back. The request includes the
+Pi `sessionId`, optional OpenClaw `sessionKey`, on-disk `sessionFile`,
+best-effort token counts, the planned compaction boundary, and an abort signal.
+The host registers this hook after safeguard compaction so handled intercepts
+win, but safeguard cancellation still stops the event before the intercept.
 
 ## Adding a new capability
 

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -285,6 +285,20 @@ Where:
 
 These are Pi runtime semantics (OpenClaw consumes the events, but Pi decides when to compact).
 
+When the active context engine declares `interceptsCompaction: true`, OpenClaw
+keeps Pi auto-compaction enabled and registers a `session_before_compact`
+extension for that engine. Pi still decides when the event fires; the engine's
+`interceptCompaction(request)` decides whether to replace Pi's default
+compaction summary.
+
+- `handled: true` returns a replacement summary with `firstKeptEntryId` and
+  `tokensBefore`.
+- `handled: false`, a missing session file, a missing intercept method, or a
+  thrown error falls back to the normal runtime compaction path.
+- If safeguard compaction is enabled too, the intercept runs after the
+  safeguard so handled intercepts win under Pi's last-truthy result semantics.
+  Safeguard cancellation still stops the event chain before the intercept.
+
 OpenClaw can also trigger a preflight local compaction before opening the next
 run when `agents.defaults.compaction.maxActiveTranscriptBytes` is set and the
 active transcript file reaches that size. This is a file-size guard for local
@@ -328,6 +342,9 @@ OpenClaw also enforces a safety floor for embedded runs:
 - Default floor is `20000` tokens.
 - Set `agents.defaults.compaction.reserveTokensFloor: 0` to disable the floor.
 - If it's already higher, OpenClaw leaves it alone.
+- When the active context engine declares `ownsCompaction: true` or
+  `interceptsCompaction: true`, OpenClaw treats the floor as `0` for that run
+  because the engine owns post-compaction headroom.
 - Manual `/compact` honors an explicit `agents.defaults.compaction.keepRecentTokens`
   and keeps Pi's recent-tail cut point. Without an explicit keep budget,
   manual compaction remains a hard checkpoint and rebuilt context starts from

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -582,6 +582,82 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     );
   });
 
+  it("rotates the Codex thread after an intercepting context engine advances its epoch", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-before-intercept",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: "[]",
+      contextEngine: {
+        schemaVersion: 1,
+        engineId: "lossless-claw",
+        policyFingerprint:
+          '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"projectionMaxChars":24000}',
+        projection: {
+          schemaVersion: 1,
+          mode: "thread_bootstrap",
+          epoch: "epoch-before-intercept",
+        },
+      },
+    });
+    const contextEngine = createContextEngine({
+      info: {
+        id: "lossless-claw",
+        name: "Lossless Claw",
+        ownsCompaction: true,
+        interceptsCompaction: true,
+      },
+      assemble: vi.fn(async ({ prompt }) => ({
+        messages: [
+          assistantMessage("LCM summary produced by intercepted compaction", 10),
+          userMessage(prompt ?? "", 11),
+        ],
+        estimatedTokens: 42,
+        systemPromptAddition: "context-engine system",
+        contextProjection: {
+          mode: "thread_bootstrap" as const,
+          epoch: "epoch-after-intercept",
+        },
+      })),
+    });
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-after-intercept");
+      }
+      return undefined;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextEngine = contextEngine;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+
+    expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/start",
+      "turn/start",
+    ]);
+    expectRequestInputTextContains(harness, "LCM summary produced by intercepted compaction");
+
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-after-intercept",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "msg-1", text: "fresh answer" }],
+        },
+      },
+    });
+    await run;
+
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding?.threadId).toBe("thread-after-intercept");
+    expect(savedBinding?.contextEngine?.projection?.epoch).toBe("epoch-after-intercept");
+  });
+
   it("reprojects thread-bootstrap context when context-engine policy changes", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -44,6 +44,7 @@ type CliCompactionDeps = {
     agentDir: string;
     cfg?: OpenClawConfig;
     contextTokenBudget?: number;
+    contextEngineInfo?: ContextEngine["info"];
   }) => SettingsManagerLike | Promise<SettingsManagerLike>;
   applyPiAutoCompactionGuard: (params: {
     settingsManager: SettingsManagerLike;

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -224,11 +224,15 @@ export async function runCliTurnCompactionLifecycle(params: {
   cliCompactionDeps.ensureContextEnginesInitialized();
   const contextEngine = await cliCompactionDeps.resolveContextEngine(params.cfg);
   const sessionManager = cliCompactionDeps.openSessionManager(sessionFile);
+  // Thread `contextEngineInfo` so `reserveTokensFloor` is auto-zeroed for
+  // engines that own or intercept compaction (matches the in-attempt path
+  // at run/attempt.ts).
   const settingsManager = await cliCompactionDeps.createPreparedEmbeddedPiSettingsManager({
     cwd: params.workspaceDir,
     agentDir: params.agentDir,
     cfg: params.cfg,
     contextTokenBudget,
+    contextEngineInfo: contextEngine.info,
   });
   await cliCompactionDeps.applyPiAutoCompactionGuard({
     settingsManager,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -1054,14 +1054,17 @@ async function compactEmbeddedPiSessionDirectOnce(
       // rehydration also restores Pi's auto-compaction (openclaw#75799), so re-apply
       // both guards. effectiveModel.baseUrl matches the surrounding scope so
       // auth-profile-injected baseUrls reach the endpoint-class detector.
+      // `contextEngineInfo` is intentionally omitted from both calls below:
+      // these guards run inside the compaction LLM session, which is not the
+      // user-facing agent session and has no associated context engine. The
+      // reserve-token floor / auto-compaction-disable rules that depend on the
+      // engine's `ownsCompaction` / `interceptsCompaction` flags do not apply
+      // to this inner-session settings manager.
       applyPiCompactionSettingsFromConfig({
         settingsManager,
         cfg: params.config,
         contextTokenBudget: ctxInfo.tokens,
       });
-      // contextEngineInfo is intentionally omitted: this guard runs inside the
-      // compaction LLM session, which is not the user-facing agent session and
-      // has no associated context engine.
       applyPiAutoCompactionGuard({
         settingsManager,
         silentOverflowProneProvider: isSilentOverflowProneModel({

--- a/src/agents/pi-embedded-runner/extensions.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.test.ts
@@ -2,6 +2,9 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import type { SessionManager } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { ContextEngine, ContextEngineInfo } from "../../context-engine/types.js";
+import { getCompactionInterceptRuntime } from "../pi-hooks/compaction-intercept-runtime.js";
+import compactionInterceptExtension from "../pi-hooks/compaction-intercept.js";
 import { getCompactionSafeguardRuntime } from "../pi-hooks/compaction-safeguard-runtime.js";
 import compactionSafeguardExtension from "../pi-hooks/compaction-safeguard.js";
 import contextPruningExtension from "../pi-hooks/context-pruning.js";
@@ -119,5 +122,96 @@ describe("buildEmbeddedExtensionFactories", () => {
     });
 
     expect(factories).toContain(contextPruningExtension);
+  });
+});
+
+function makeEngine(info: ContextEngineInfo): ContextEngine {
+  return {
+    info,
+    ingest: vi.fn(async () => ({ ingested: true })),
+    assemble: vi.fn(async () => ({ messages: [], estimatedTokens: 0 })),
+    compact: vi.fn(async () => ({ ok: true, compacted: false })),
+    interceptCompaction: vi.fn(async () => ({ handled: false, reason: "noop" })),
+  } as unknown as ContextEngine;
+}
+
+describe("buildEmbeddedExtensionFactories — compactionInterceptExtension wiring", () => {
+  const baseParams = {
+    cfg: undefined as OpenClawConfig | undefined,
+    provider: "anthropic",
+    modelId: "claude-sonnet-4-5",
+    model: { contextWindow: 258_000 } as Model<Api>,
+  };
+
+  it("does NOT register intercept when no activeContextEngine is supplied", () => {
+    const sessionManager = {} as SessionManager;
+    const factories = buildEmbeddedExtensionFactories({
+      ...baseParams,
+      sessionManager,
+      activeContextEngine: undefined,
+    });
+    expect(factories).not.toContain(compactionInterceptExtension);
+    expect(getCompactionInterceptRuntime(sessionManager)).toBeNull();
+  });
+
+  it("does NOT register intercept when engine info does not set interceptsCompaction", () => {
+    const sessionManager = {} as SessionManager;
+    const engine = makeEngine({ id: "legacy", name: "Legacy" });
+    const factories = buildEmbeddedExtensionFactories({
+      ...baseParams,
+      sessionManager,
+      activeContextEngine: engine,
+    });
+    expect(factories).not.toContain(compactionInterceptExtension);
+    expect(getCompactionInterceptRuntime(sessionManager)).toBeNull();
+  });
+
+  it("DOES register intercept when engine info advertises interceptsCompaction", () => {
+    const sessionManager = {} as SessionManager;
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true });
+    const factories = buildEmbeddedExtensionFactories({
+      ...baseParams,
+      sessionManager,
+      activeContextEngine: engine,
+    });
+    expect(factories).toContain(compactionInterceptExtension);
+    const runtime = getCompactionInterceptRuntime(sessionManager);
+    expect(runtime?.contextEngine).toBe(engine);
+  });
+
+  it("does NOT register intercept when engine ownsCompaction (engine bypasses SDK event)", () => {
+    const sessionManager = {} as SessionManager;
+    const engine = makeEngine({
+      id: "owns-compaction",
+      name: "Owns",
+      ownsCompaction: true,
+      interceptsCompaction: true,
+    });
+    const factories = buildEmbeddedExtensionFactories({
+      ...baseParams,
+      sessionManager,
+      activeContextEngine: engine,
+    });
+    expect(factories).not.toContain(compactionInterceptExtension);
+    expect(getCompactionInterceptRuntime(sessionManager)).toBeNull();
+  });
+
+  it("intercept factory is pushed AFTER safeguard factory (last-truthy-wins ordering)", () => {
+    const cfg = {
+      agents: { defaults: { compaction: { mode: "safeguard" } } },
+    } as OpenClawConfig;
+    const sessionManager = {} as SessionManager;
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true });
+    const factories = buildEmbeddedExtensionFactories({
+      ...baseParams,
+      cfg,
+      sessionManager,
+      activeContextEngine: engine,
+    });
+    const safeguardIndex = factories.indexOf(compactionSafeguardExtension);
+    const interceptIndex = factories.indexOf(compactionInterceptExtension);
+    expect(safeguardIndex).toBeGreaterThanOrEqual(0);
+    expect(interceptIndex).toBeGreaterThanOrEqual(0);
+    expect(interceptIndex).toBeGreaterThan(safeguardIndex);
   });
 });

--- a/src/agents/pi-embedded-runner/extensions.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.test.ts
@@ -206,13 +206,39 @@ describe("buildEmbeddedExtensionFactories — compactionInterceptExtension wirin
     expect(runtime?.contextEngine).toBe(engine);
   });
 
-  it("does NOT register intercept when engine ownsCompaction (engine bypasses SDK event)", () => {
+  it("DOES register intercept when engine has BOTH ownsCompaction and interceptsCompaction", () => {
+    // The two flags advertise distinct lanes: ownsCompaction covers
+    // openclaw's queued-compaction path (compact.queued.ts), and
+    // interceptsCompaction covers pi-coding-agent's SDK event lane
+    // (session_before_compact). An engine can declare both — codex still
+    // fires session_before_compact on in-attempt overflow even for engines
+    // that own the queued lane, so we DO want to intercept the SDK event.
     const sessionManager = {} as SessionManager;
     const engine = makeEngine({
-      id: "owns-compaction",
-      name: "Owns",
+      id: "owns-and-intercepts",
+      name: "Both",
       ownsCompaction: true,
       interceptsCompaction: true,
+    });
+    const factories = buildEmbeddedExtensionFactories({
+      ...baseParams,
+      sessionManager,
+      activeContextEngine: engine,
+    });
+    expect(factories).toContain(compactionInterceptExtension);
+    const runtime = getCompactionInterceptRuntime(sessionManager);
+    expect(runtime?.contextEngine).toBe(engine);
+  });
+
+  it("does NOT register intercept when only ownsCompaction is set (engine declines intercept)", () => {
+    // An engine that owns queued compaction but does NOT declare
+    // interceptsCompaction is signaling "I don't want to intercept the SDK
+    // event" — fall through to codex's native compaction.
+    const sessionManager = {} as SessionManager;
+    const engine = makeEngine({
+      id: "owns-only",
+      name: "Owns Only",
+      ownsCompaction: true,
     });
     const factories = buildEmbeddedExtensionFactories({
       ...baseParams,

--- a/src/agents/pi-embedded-runner/extensions.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.test.ts
@@ -179,6 +179,33 @@ describe("buildEmbeddedExtensionFactories — compactionInterceptExtension wirin
     expect(runtime?.contextEngine).toBe(engine);
   });
 
+  it("threads sessionKey into the intercept runtime when supplied", () => {
+    const sessionManager = {} as SessionManager;
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true });
+    buildEmbeddedExtensionFactories({
+      ...baseParams,
+      sessionManager,
+      activeContextEngine: engine,
+      sessionKey: "agent:main:main",
+    });
+    const runtime = getCompactionInterceptRuntime(sessionManager);
+    expect(runtime?.sessionKey).toBe("agent:main:main");
+  });
+
+  it("registers intercept with undefined sessionKey when not supplied (back-compat)", () => {
+    const sessionManager = {} as SessionManager;
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true });
+    buildEmbeddedExtensionFactories({
+      ...baseParams,
+      sessionManager,
+      activeContextEngine: engine,
+      // sessionKey intentionally omitted
+    });
+    const runtime = getCompactionInterceptRuntime(sessionManager);
+    expect(runtime?.sessionKey).toBeUndefined();
+    expect(runtime?.contextEngine).toBe(engine);
+  });
+
   it("does NOT register intercept when engine ownsCompaction (engine bypasses SDK event)", () => {
     const sessionManager = {} as SessionManager;
     const engine = makeEngine({

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -2,11 +2,14 @@ import { randomUUID } from "node:crypto";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionFactory, SessionManager } from "@earendil-works/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ContextEngine } from "../../context-engine/types.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { createAgentToolResultMiddlewareRunner } from "../harness/tool-result-middleware.js";
+import { setCompactionInterceptRuntime } from "../pi-hooks/compaction-intercept-runtime.js";
+import compactionInterceptExtension from "../pi-hooks/compaction-intercept.js";
 import { setCompactionSafeguardRuntime } from "../pi-hooks/compaction-safeguard-runtime.js";
 import compactionSafeguardExtension from "../pi-hooks/compaction-safeguard.js";
 import contextPruningExtension from "../pi-hooks/context-pruning.js";
@@ -144,6 +147,16 @@ export function buildEmbeddedExtensionFactories(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
+  /**
+   * Active context engine for the user-facing session, when known.
+   *
+   * When the engine declares `info.interceptsCompaction === true` and does
+   * NOT own compaction outright, a `compaction-intercept` extension is
+   * registered that routes `session_before_compact` events through
+   * `engine.interceptCompaction()`. Inner LLM sessions (compaction LLM,
+   * subagent runs that have no separate engine) pass `undefined` to skip.
+   */
+  activeContextEngine?: ContextEngine;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
   if (resolveEffectiveCompactionMode(params.cfg) === "safeguard") {
@@ -170,6 +183,21 @@ export function buildEmbeddedExtensionFactories(params: {
       provider: compactionCfg?.provider,
     });
     factories.push(compactionSafeguardExtension);
+  }
+  // Context-engine intercept: registered AFTER the safeguard so its result
+  // wins under last-truthy-wins semantics when both are active. Skipped when
+  // the engine fully owns compaction (those engines bypass the SDK event via
+  // `compact.queued.ts` and never see `session_before_compact`).
+  const engineInfo = params.activeContextEngine?.info;
+  if (
+    params.activeContextEngine &&
+    engineInfo?.interceptsCompaction === true &&
+    engineInfo.ownsCompaction !== true
+  ) {
+    setCompactionInterceptRuntime(params.sessionManager, {
+      contextEngine: params.activeContextEngine,
+    });
+    factories.push(compactionInterceptExtension);
   }
   const pruningFactory = buildContextPruningFactory(params);
   if (pruningFactory) {

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -192,15 +192,21 @@ export function buildEmbeddedExtensionFactories(params: {
     factories.push(compactionSafeguardExtension);
   }
   // Context-engine intercept: registered AFTER the safeguard so its result
-  // wins under last-truthy-wins semantics when both are active. Skipped when
-  // the engine fully owns compaction (those engines bypass the SDK event via
-  // `compact.queued.ts` and never see `session_before_compact`).
+  // wins under last-truthy-wins semantics when both are active.
+  //
+  // Gate is `interceptsCompaction === true` ONLY (no exclusion for
+  // `ownsCompaction === true`). The two flags advertise capability against
+  // distinct flows:
+  //   - `ownsCompaction` covers the openclaw queued-compaction lane
+  //     (`compact.queued.ts` → `engine.compact()`), driven by `afterTurn`
+  //     or explicit user `/compact`.
+  //   - `interceptsCompaction` covers the pi-coding-agent SDK event
+  //     (`session_before_compact`), driven by codex's in-attempt overflow
+  //     auto-compact at ~90% context.
+  // An engine can advertise BOTH (e.g. lossless-claw v4.1 owns the queued
+  // lane AND intercepts the SDK lane), so neither flag excludes the other.
   const engineInfo = params.activeContextEngine?.info;
-  if (
-    params.activeContextEngine &&
-    engineInfo?.interceptsCompaction === true &&
-    engineInfo.ownsCompaction !== true
-  ) {
+  if (params.activeContextEngine && engineInfo?.interceptsCompaction === true) {
     setCompactionInterceptRuntime(params.sessionManager, {
       contextEngine: params.activeContextEngine,
       sessionKey: params.sessionKey,

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -157,6 +157,13 @@ export function buildEmbeddedExtensionFactories(params: {
    * subagent runs that have no separate engine) pass `undefined` to skip.
    */
   activeContextEngine?: ContextEngine;
+  /**
+   * Openclaw session key (agent:id:suffix form) for the active session.
+   * Threaded into the compaction-intercept runtime so engines that route on
+   * sessionKey (e.g. ignored-/stateless-session patterns in lossless-claw)
+   * receive it inside the `session_before_compact` handler.
+   */
+  sessionKey?: string;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
   if (resolveEffectiveCompactionMode(params.cfg) === "safeguard") {
@@ -196,6 +203,7 @@ export function buildEmbeddedExtensionFactories(params: {
   ) {
     setCompactionInterceptRuntime(params.sessionManager, {
       contextEngine: params.activeContextEngine,
+      sessionKey: params.sessionKey,
     });
     factories.push(compactionInterceptExtension);
   }

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -150,11 +150,13 @@ export function buildEmbeddedExtensionFactories(params: {
   /**
    * Active context engine for the user-facing session, when known.
    *
-   * When the engine declares `info.interceptsCompaction === true` and does
-   * NOT own compaction outright, a `compaction-intercept` extension is
-   * registered that routes `session_before_compact` events through
-   * `engine.interceptCompaction()`. Inner LLM sessions (compaction LLM,
-   * subagent runs that have no separate engine) pass `undefined` to skip.
+   * When the engine declares `info.interceptsCompaction === true`, a
+   * `compaction-intercept` extension is registered that routes
+   * `session_before_compact` events through `engine.interceptCompaction()`.
+   * `ownsCompaction` does NOT exclude intercept — engines may declare both
+   * because the two flags cover distinct lanes (SDK event vs queued lane).
+   * Inner LLM sessions (compaction LLM, subagent runs that have no separate
+   * engine) pass `undefined` to skip.
    */
   activeContextEngine?: ContextEngine;
   /**

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2189,12 +2189,15 @@ export async function runEmbeddedAttempt(
 
       // Sets compaction/pruning runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.
+      // Threading `activeContextEngine` enables the compaction-intercept
+      // extension when the engine declares `info.interceptsCompaction === true`.
       const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        activeContextEngine,
       });
       const resourceLoader = createEmbeddedPiResourceLoader({
         cwd: resolvedWorkspace,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2192,6 +2192,9 @@ export async function runEmbeddedAttempt(
       // that must be passed to the resource loader for the safeguard to be active.
       // Threading `activeContextEngine` enables the compaction-intercept
       // extension when the engine declares `info.interceptsCompaction === true`.
+      // `sessionKey` is also threaded so engines that route on session-key
+      // patterns (e.g. lossless-claw's ignored-/stateless-session patterns)
+      // can identify the active session inside the intercept handler.
       const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
@@ -2199,6 +2202,7 @@ export async function runEmbeddedAttempt(
         modelId: params.modelId,
         model: params.model,
         activeContextEngine,
+        sessionKey: params.sessionKey,
       });
       const resourceLoader = createEmbeddedPiResourceLoader({
         cwd: resolvedWorkspace,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2174,6 +2174,7 @@ export async function runEmbeddedAttempt(
           workspaceDir: effectiveWorkspace,
         }),
         contextTokenBudget: params.contextTokenBudget,
+        contextEngineInfo: activeContextEngine?.info,
       });
       const piAutoCompactionGuardArgs = {
         settingsManager,
@@ -2209,11 +2210,13 @@ export async function runEmbeddedAttempt(
       // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
       // compaction overrides applied in createPreparedEmbeddedPiSettingsManager — same
       // rehydration also restores Pi's auto-compaction (openclaw#75799), so re-apply
-      // both guards.
+      // both guards. `contextEngineInfo` must be threaded again here because the
+      // reserve-token floor is recomputed from scratch on every re-apply.
       applyPiCompactionSettingsFromConfig({
         settingsManager,
         cfg: params.config,
         contextTokenBudget: params.contextTokenBudget,
+        contextEngineInfo: activeContextEngine?.info,
       });
       applyPiAutoCompactionGuard(piAutoCompactionGuardArgs);
       prepStages.mark("session-resource-loader");

--- a/src/agents/pi-hooks/compaction-intercept-runtime.ts
+++ b/src/agents/pi-hooks/compaction-intercept-runtime.ts
@@ -1,0 +1,21 @@
+import type { ContextEngine } from "../../context-engine/types.js";
+import { createSessionManagerRuntimeRegistry } from "./session-manager-runtime-registry.js";
+
+/**
+ * Per-session runtime state for the `compaction-intercept` extension.
+ *
+ * Modeled after {@link "./compaction-safeguard-runtime.ts"}: a `WeakMap`
+ * keyed by SessionManager object identity that carries the resolved
+ * {@link ContextEngine} reference for the active session so the extension's
+ * `session_before_compact` handler can call `engine.interceptCompaction()`
+ * without re-resolving on every event.
+ */
+export type CompactionInterceptRuntimeValue = {
+  contextEngine: ContextEngine;
+};
+
+const registry = createSessionManagerRuntimeRegistry<CompactionInterceptRuntimeValue>();
+
+export const setCompactionInterceptRuntime = registry.set;
+
+export const getCompactionInterceptRuntime = registry.get;

--- a/src/agents/pi-hooks/compaction-intercept-runtime.ts
+++ b/src/agents/pi-hooks/compaction-intercept-runtime.ts
@@ -9,9 +9,16 @@ import { createSessionManagerRuntimeRegistry } from "./session-manager-runtime-r
  * {@link ContextEngine} reference for the active session so the extension's
  * `session_before_compact` handler can call `engine.interceptCompaction()`
  * without re-resolving on every event.
+ *
+ * Carries `sessionKey` alongside the engine because the
+ * `pi-coding-agent` `ReadonlySessionManager` exposes only sessionId /
+ * sessionFile — `sessionKey` is an openclaw-level concept used for
+ * agent/subagent routing in engines like lossless-claw.
  */
 export type CompactionInterceptRuntimeValue = {
   contextEngine: ContextEngine;
+  /** Optional openclaw session key (agent:id:suffix form). */
+  sessionKey?: string;
 };
 
 const registry = createSessionManagerRuntimeRegistry<CompactionInterceptRuntimeValue>();

--- a/src/agents/pi-hooks/compaction-intercept.test.ts
+++ b/src/agents/pi-hooks/compaction-intercept.test.ts
@@ -12,6 +12,25 @@ import {
 } from "./compaction-intercept-runtime.js";
 import compactionInterceptExtension from "./compaction-intercept.js";
 
+const logInfo = vi.hoisted(() => vi.fn());
+const logDebug = vi.hoisted(() => vi.fn());
+const logWarn = vi.hoisted(() => vi.fn());
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    subsystem: "compaction-intercept",
+    isEnabled: () => true,
+    trace: vi.fn(),
+    debug: logDebug,
+    info: logInfo,
+    warn: logWarn,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn(),
+  }),
+}));
+
 type CompactionHandler = (event: unknown, ctx: unknown) => Promise<unknown>;
 
 function stubSessionManager(
@@ -116,6 +135,9 @@ function makeCtx(
 }
 
 afterEach(() => {
+  logInfo.mockClear();
+  logDebug.mockClear();
+  logWarn.mockClear();
   vi.restoreAllMocks();
 });
 
@@ -181,6 +203,19 @@ describe("compactionInterceptExtension", () => {
           details: { engine: "lcm", strategy: "intercept" },
         },
       });
+      expect(logInfo).toHaveBeenCalledWith(
+        "[compaction-intercept] engine handled compaction intercept",
+        expect.objectContaining({
+          engineId: "lcm",
+          sessionId: "abc-123",
+          tokenBudget: 258_000,
+          currentTokenCount: 232_000,
+          tokensBefore: 232_000,
+          tokensAfter: 80_000,
+          firstKeptEntryId: "entry-keep-me",
+          summaryChars: "LCM-produced summary text".length,
+        }),
+      );
     } finally {
       setCompactionInterceptRuntime(sm, null);
     }

--- a/src/agents/pi-hooks/compaction-intercept.test.ts
+++ b/src/agents/pi-hooks/compaction-intercept.test.ts
@@ -1,0 +1,299 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  CompactionInterceptRequest,
+  CompactionInterceptResult,
+  ContextEngine,
+  ContextEngineInfo,
+} from "../../context-engine/types.js";
+import {
+  getCompactionInterceptRuntime,
+  setCompactionInterceptRuntime,
+} from "./compaction-intercept-runtime.js";
+import compactionInterceptExtension from "./compaction-intercept.js";
+
+type CompactionHandler = (event: unknown, ctx: unknown) => Promise<unknown>;
+
+function stubSessionManager(
+  overrides: Partial<{
+    sessionId: string;
+    sessionFile: string;
+  }> = {},
+): ExtensionContext["sessionManager"] {
+  const stub: ExtensionContext["sessionManager"] = {
+    getCwd: () => "/stub",
+    getSessionDir: () => "/stub",
+    getSessionId: () => overrides.sessionId ?? "stub-session-id",
+    getSessionFile: () => overrides.sessionFile ?? "/stub/session.jsonl",
+    getLeafId: () => null,
+    getLeafEntry: () => undefined,
+    getEntry: () => undefined,
+    getLabel: () => undefined,
+    getBranch: () => [],
+    getHeader: () => null,
+    getEntries: () => [],
+    getTree: () => [],
+    getSessionName: () => undefined,
+  };
+  return stub;
+}
+
+function makeEngine(
+  info: ContextEngineInfo,
+  interceptImpl?: (req: CompactionInterceptRequest) => Promise<CompactionInterceptResult>,
+): ContextEngine {
+  const engine: Partial<ContextEngine> = {
+    info,
+    ingest: vi.fn(async () => ({ ingested: true })),
+    assemble: vi.fn(async () => ({ messages: [], estimatedTokens: 0 })),
+    compact: vi.fn(async () => ({ ok: true, compacted: false })),
+  };
+  if (interceptImpl) {
+    engine.interceptCompaction = vi.fn(interceptImpl);
+  }
+  return engine as ContextEngine;
+}
+
+function captureHandler(): CompactionHandler {
+  let handler: CompactionHandler | undefined;
+  const api = {
+    on: vi.fn((event: string, h: CompactionHandler) => {
+      if (event === "session_before_compact") handler = h;
+    }),
+  } as unknown as ExtensionAPI;
+  compactionInterceptExtension(api);
+  if (!handler) throw new Error("intercept extension did not register a handler");
+  return handler;
+}
+
+function makeEvent(
+  overrides: Partial<{
+    firstKeptEntryId: string;
+    tokensBefore: number;
+  }> = {},
+) {
+  return {
+    preparation: {
+      firstKeptEntryId: overrides.firstKeptEntryId ?? "entry-keep-me",
+      tokensBefore: overrides.tokensBefore ?? 232_000,
+      messagesToSummarize: [],
+      turnPrefixMessages: [],
+      isSplitTurn: false,
+      fileOps: { read: [], edited: [], written: [] },
+    },
+    branchEntries: [],
+    customInstructions: undefined,
+    signal: new AbortController().signal,
+  };
+}
+
+function makeCtx(
+  sessionManager: ExtensionContext["sessionManager"],
+  overrides: Partial<{
+    contextWindow: number;
+    tokens: number | null;
+  }> = {},
+) {
+  return {
+    sessionManager,
+    cwd: "/stub",
+    getContextUsage: () => ({
+      contextWindow: overrides.contextWindow ?? 258_000,
+      tokens: overrides.tokens ?? 232_000,
+      percent: 0.9,
+    }),
+  } as unknown as ExtensionContext;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("compactionInterceptExtension", () => {
+  it("returns undefined when no runtime is registered (no engine resolved)", async () => {
+    const handler = captureHandler();
+    // Use a fresh sessionManager identity that has no runtime entry.
+    const ctx = makeCtx(stubSessionManager());
+    const result = await handler(makeEvent(), ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when the engine does not implement interceptCompaction", async () => {
+    const handler = captureHandler();
+    const sm = stubSessionManager();
+    const engine = makeEngine(
+      { id: "no-intercept", name: "No Intercept", interceptsCompaction: true },
+      // intentionally not providing interceptImpl — method is undefined
+    );
+    setCompactionInterceptRuntime(sm, { contextEngine: engine });
+    try {
+      const ctx = makeCtx(sm);
+      const result = await handler(makeEvent(), ctx);
+      expect(result).toBeUndefined();
+    } finally {
+      setCompactionInterceptRuntime(sm, null);
+    }
+  });
+
+  it("returns { compaction } when engine handles the intercept (handled: true)", async () => {
+    const handler = captureHandler();
+    const sm = stubSessionManager({ sessionId: "abc-123", sessionFile: "/x/session.jsonl" });
+    const intercept = vi.fn(
+      async (req: CompactionInterceptRequest): Promise<CompactionInterceptResult> => {
+        expect(req.sessionId).toBe("abc-123");
+        expect(req.sessionFile).toBe("/x/session.jsonl");
+        expect(req.tokenBudget).toBe(258_000);
+        expect(req.currentTokenCount).toBe(232_000);
+        expect(req.firstKeptEntryId).toBe("entry-keep-me");
+        expect(req.tokensBefore).toBe(232_000);
+        expect(req.signal).toBeInstanceOf(AbortSignal);
+        return {
+          handled: true,
+          summary: "LCM-produced summary text",
+          firstKeptEntryId: req.firstKeptEntryId,
+          tokensBefore: req.tokensBefore,
+          tokensAfter: 80_000,
+          details: { engine: "lcm", strategy: "intercept" },
+        };
+      },
+    );
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true }, intercept);
+    setCompactionInterceptRuntime(sm, { contextEngine: engine });
+    try {
+      const ctx = makeCtx(sm);
+      const result = await handler(makeEvent(), ctx);
+      expect(intercept).toHaveBeenCalledOnce();
+      expect(result).toEqual({
+        compaction: {
+          summary: "LCM-produced summary text",
+          firstKeptEntryId: "entry-keep-me",
+          tokensBefore: 232_000,
+          details: { engine: "lcm", strategy: "intercept" },
+        },
+      });
+    } finally {
+      setCompactionInterceptRuntime(sm, null);
+    }
+  });
+
+  it("returns undefined when the engine declines (handled: false)", async () => {
+    const handler = captureHandler();
+    const sm = stubSessionManager();
+    const intercept = vi.fn(
+      async (): Promise<CompactionInterceptResult> => ({
+        handled: false,
+        reason: "session-ignored",
+      }),
+    );
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true }, intercept);
+    setCompactionInterceptRuntime(sm, { contextEngine: engine });
+    try {
+      const ctx = makeCtx(sm);
+      const result = await handler(makeEvent(), ctx);
+      expect(intercept).toHaveBeenCalledOnce();
+      expect(result).toBeUndefined();
+    } finally {
+      setCompactionInterceptRuntime(sm, null);
+    }
+  });
+
+  it("swallows thrown errors and returns undefined (engine bug must not break runtime)", async () => {
+    const handler = captureHandler();
+    const sm = stubSessionManager();
+    const intercept = vi.fn(async () => {
+      throw new Error("kaboom");
+    });
+    const engine = makeEngine(
+      { id: "lcm", name: "LCM", interceptsCompaction: true },
+      intercept as (req: CompactionInterceptRequest) => Promise<CompactionInterceptResult>,
+    );
+    setCompactionInterceptRuntime(sm, { contextEngine: engine });
+    try {
+      const ctx = makeCtx(sm);
+      const result = await handler(makeEvent(), ctx);
+      expect(intercept).toHaveBeenCalledOnce();
+      expect(result).toBeUndefined();
+    } finally {
+      setCompactionInterceptRuntime(sm, null);
+    }
+  });
+
+  it("propagates the AbortSignal from the event into the engine request", async () => {
+    const handler = captureHandler();
+    const sm = stubSessionManager();
+    const captured: { signal?: AbortSignal } = {};
+    const intercept = vi.fn(
+      async (req: CompactionInterceptRequest): Promise<CompactionInterceptResult> => {
+        captured.signal = req.signal;
+        return { handled: false, reason: "captured-signal" };
+      },
+    );
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true }, intercept);
+    setCompactionInterceptRuntime(sm, { contextEngine: engine });
+    try {
+      const controller = new AbortController();
+      const event = makeEvent();
+      // Override the event's signal field with our controller.
+      (event as { signal: AbortSignal }).signal = controller.signal;
+      const ctx = makeCtx(sm);
+      await handler(event, ctx);
+      expect(captured.signal).toBe(controller.signal);
+    } finally {
+      setCompactionInterceptRuntime(sm, null);
+    }
+  });
+
+  it("getContextUsage returning null tokens → currentTokenCount is undefined", async () => {
+    const handler = captureHandler();
+    const sm = stubSessionManager();
+    let captured: CompactionInterceptRequest | undefined;
+    const intercept = vi.fn(
+      async (req: CompactionInterceptRequest): Promise<CompactionInterceptResult> => {
+        captured = req;
+        return { handled: false, reason: "captured" };
+      },
+    );
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true }, intercept);
+    setCompactionInterceptRuntime(sm, { contextEngine: engine });
+    try {
+      const ctx = makeCtx(sm, { tokens: null });
+      await handler(makeEvent(), ctx);
+      expect(captured?.currentTokenCount).toBeUndefined();
+      expect(captured?.tokenBudget).toBe(258_000);
+    } finally {
+      setCompactionInterceptRuntime(sm, null);
+    }
+  });
+});
+
+describe("compaction-intercept-runtime", () => {
+  it("set/get round-trip preserves contextEngine reference", () => {
+    const sm = stubSessionManager();
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true });
+    setCompactionInterceptRuntime(sm, { contextEngine: engine });
+    try {
+      const runtime = getCompactionInterceptRuntime(sm);
+      expect(runtime?.contextEngine).toBe(engine);
+    } finally {
+      setCompactionInterceptRuntime(sm, null);
+    }
+  });
+
+  it("setting null clears the registry entry", () => {
+    const sm = stubSessionManager();
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true });
+    setCompactionInterceptRuntime(sm, { contextEngine: engine });
+    setCompactionInterceptRuntime(sm, null);
+    expect(getCompactionInterceptRuntime(sm)).toBeNull();
+  });
+
+  it("returns null for unknown session managers", () => {
+    expect(getCompactionInterceptRuntime(stubSessionManager())).toBeNull();
+  });
+
+  it("returns null for non-object inputs (defensive)", () => {
+    expect(getCompactionInterceptRuntime(null)).toBeNull();
+    expect(getCompactionInterceptRuntime(undefined)).toBeNull();
+    expect(getCompactionInterceptRuntime("not-an-object")).toBeNull();
+  });
+});

--- a/src/agents/pi-hooks/compaction-intercept.test.ts
+++ b/src/agents/pi-hooks/compaction-intercept.test.ts
@@ -17,14 +17,16 @@ type CompactionHandler = (event: unknown, ctx: unknown) => Promise<unknown>;
 function stubSessionManager(
   overrides: Partial<{
     sessionId: string;
-    sessionFile: string;
+    sessionFile: string | undefined;
   }> = {},
 ): ExtensionContext["sessionManager"] {
+  const sessionFileResolved =
+    "sessionFile" in overrides ? overrides.sessionFile : "/stub/session.jsonl";
   const stub: ExtensionContext["sessionManager"] = {
     getCwd: () => "/stub",
     getSessionDir: () => "/stub",
     getSessionId: () => overrides.sessionId ?? "stub-session-id",
-    getSessionFile: () => overrides.sessionFile ?? "/stub/session.jsonl",
+    getSessionFile: () => sessionFileResolved as string,
     getLeafId: () => null,
     getLeafEntry: () => undefined,
     getEntry: () => undefined,
@@ -238,6 +240,54 @@ describe("compactionInterceptExtension", () => {
       const ctx = makeCtx(sm);
       await handler(event, ctx);
       expect(captured.signal).toBe(controller.signal);
+    } finally {
+      setCompactionInterceptRuntime(sm, null);
+    }
+  });
+
+  it("bails (returns undefined) when getSessionFile() returns undefined", async () => {
+    const handler = captureHandler();
+    const sm = stubSessionManager({ sessionFile: undefined });
+    const intercept = vi.fn(async () => ({
+      handled: true,
+      summary: "should not be called",
+      firstKeptEntryId: "entry-1",
+      tokensBefore: 1,
+    }));
+    const engine = makeEngine(
+      { id: "lcm", name: "LCM", interceptsCompaction: true },
+      intercept as (req: CompactionInterceptRequest) => Promise<CompactionInterceptResult>,
+    );
+    setCompactionInterceptRuntime(sm, { contextEngine: engine });
+    try {
+      const ctx = makeCtx(sm);
+      const result = await handler(makeEvent(), ctx);
+      expect(intercept).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    } finally {
+      setCompactionInterceptRuntime(sm, null);
+    }
+  });
+
+  it("passes sessionKey from the runtime registry into the engine request", async () => {
+    const handler = captureHandler();
+    const sm = stubSessionManager();
+    let captured: CompactionInterceptRequest | undefined;
+    const intercept = vi.fn(
+      async (req: CompactionInterceptRequest): Promise<CompactionInterceptResult> => {
+        captured = req;
+        return { handled: false, reason: "captured" };
+      },
+    );
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true }, intercept);
+    setCompactionInterceptRuntime(sm, {
+      contextEngine: engine,
+      sessionKey: "agent:main:subagent:abc123",
+    });
+    try {
+      const ctx = makeCtx(sm);
+      await handler(makeEvent(), ctx);
+      expect(captured?.sessionKey).toBe("agent:main:subagent:abc123");
     } finally {
       setCompactionInterceptRuntime(sm, null);
     }

--- a/src/agents/pi-hooks/compaction-intercept.test.ts
+++ b/src/agents/pi-hooks/compaction-intercept.test.ts
@@ -60,11 +60,15 @@ function captureHandler(): CompactionHandler {
   let handler: CompactionHandler | undefined;
   const api = {
     on: vi.fn((event: string, h: CompactionHandler) => {
-      if (event === "session_before_compact") handler = h;
+      if (event === "session_before_compact") {
+        handler = h;
+      }
     }),
   } as unknown as ExtensionAPI;
   compactionInterceptExtension(api);
-  if (!handler) throw new Error("intercept extension did not register a handler");
+  if (!handler) {
+    throw new Error("intercept extension did not register a handler");
+  }
   return handler;
 }
 
@@ -292,6 +296,75 @@ describe("compactionInterceptExtension", () => {
       const ctx = makeCtx(sm);
       await handler(makeEvent(), ctx);
       expect(captured?.sessionKey).toBe("agent:main:subagent:abc123");
+    } finally {
+      setCompactionInterceptRuntime(sm, null);
+    }
+  });
+
+  it("routes correctly for engines with BOTH ownsCompaction AND interceptsCompaction", async () => {
+    // Wave-B P1-4: the wave-A gate change made it possible for an engine
+    // to declare both flags. The factory-registration tests in extensions.test.ts
+    // assert the factory is added; this test asserts the handler ROUTES
+    // traffic correctly when such an engine is active — i.e. an SDK event
+    // for a both-flags engine results in a `{compaction}` return shape,
+    // not a fall-through.
+    const handler = captureHandler();
+    const sm = stubSessionManager();
+    const intercept = vi.fn(
+      async (): Promise<CompactionInterceptResult> => ({
+        handled: true,
+        summary: "owns-and-intercepts summary",
+        firstKeptEntryId: "entry-keep-me",
+        tokensBefore: 232_000,
+      }),
+    );
+    const engine = makeEngine(
+      {
+        id: "lcm",
+        name: "LCM",
+        ownsCompaction: true,
+        interceptsCompaction: true,
+      },
+      intercept,
+    );
+    setCompactionInterceptRuntime(sm, { contextEngine: engine });
+    try {
+      const ctx = makeCtx(sm);
+      const result = await handler(makeEvent(), ctx);
+      expect(intercept).toHaveBeenCalledOnce();
+      expect(result).toEqual({
+        compaction: {
+          summary: "owns-and-intercepts summary",
+          firstKeptEntryId: "entry-keep-me",
+          tokensBefore: 232_000,
+          details: undefined,
+        },
+      });
+    } finally {
+      setCompactionInterceptRuntime(sm, null);
+    }
+  });
+
+  it("trigger is undefined in the request (SDK does not currently expose explicit trigger)", async () => {
+    // Wave-B P1-1: inferTriggerFromEvent previously always returned
+    // "in-attempt-auto" — misleading for overflow-retry events.
+    // The post-wave-B contract: pass undefined and let engines treat
+    // absence as "host didn't disambiguate".
+    const handler = captureHandler();
+    const sm = stubSessionManager();
+    let captured: CompactionInterceptRequest | undefined;
+    const intercept = vi.fn(
+      async (req: CompactionInterceptRequest): Promise<CompactionInterceptResult> => {
+        captured = req;
+        return { handled: false, reason: "captured" };
+      },
+    );
+    const engine = makeEngine({ id: "lcm", name: "LCM", interceptsCompaction: true }, intercept);
+    setCompactionInterceptRuntime(sm, { contextEngine: engine });
+    try {
+      const ctx = makeCtx(sm);
+      await handler(makeEvent(), ctx);
+      expect(captured?.trigger).toBeUndefined();
     } finally {
       setCompactionInterceptRuntime(sm, null);
     }

--- a/src/agents/pi-hooks/compaction-intercept.test.ts
+++ b/src/agents/pi-hooks/compaction-intercept.test.ts
@@ -96,12 +96,16 @@ function makeCtx(
     tokens: number | null;
   }> = {},
 ) {
+  // `"tokens" in overrides` distinguishes "explicitly set to null" from "not
+  // overridden" — `??` would swallow an explicit null and substitute the
+  // default, which breaks the null-tokens contract test.
+  const tokensResolved = "tokens" in overrides ? overrides.tokens : 232_000;
   return {
     sessionManager,
     cwd: "/stub",
     getContextUsage: () => ({
       contextWindow: overrides.contextWindow ?? 258_000,
-      tokens: overrides.tokens ?? 232_000,
+      tokens: tokensResolved,
       percent: 0.9,
     }),
   } as unknown as ExtensionContext;

--- a/src/agents/pi-hooks/compaction-intercept.ts
+++ b/src/agents/pi-hooks/compaction-intercept.ts
@@ -19,29 +19,36 @@ const log = createSubsystemLogger("compaction-intercept");
  *     active, the SDK's last-truthy-wins semantics let intercept override
  *     safeguard. When intercept returns `undefined` (handled:false or no
  *     engine), the safeguard's prior return (if any) is preserved and the
- *     SDK falls back as configured.
- *   - Skipped silently when no runtime is set (e.g. engine not resolved yet
- *     or engine does not advertise `info.interceptsCompaction`).
- *   - Skipped silently when `engine.interceptCompaction` is undefined (which
- *     should not happen if the engine correctly sets `info.interceptsCompaction`
- *     but we keep the defensive check).
- *   - Catches all thrown errors and falls back to the runtime's default path;
- *     the engine contract states `interceptCompaction` must not throw.
- *
- * This extension is a no-op for engines that fully own compaction
- * (`info.ownsCompaction === true`) — those engines bypass the
- * `session_before_compact` event entirely via the engine-owned compaction
- * dispatch path in `compact.queued.ts`.
+ *     SDK falls back as configured. NOTE: the SDK short-circuits on
+ *     `{cancel: true}` (auth failure paths from safeguard) and never calls
+ *     intercept in that case — engines cannot recover an auth-cancelled
+ *     compaction event from this hook.
+ *   - Registration is gated solely on `info.interceptsCompaction === true`
+ *     in `extensions.ts`. Engines may declare BOTH `interceptsCompaction`
+ *     and `ownsCompaction` because the two flags cover distinct
+ *     compaction lanes (SDK event vs openclaw queued lane) — see the
+ *     gate comment in `extensions.ts` and `pi-settings.ts`.
+ *   - Skipped silently when no runtime is set (engine not resolved yet)
+ *     or when `engine.interceptCompaction` is undefined (defensive guard
+ *     for engines that mis-declare the capability flag without
+ *     implementing the method).
+ *   - Catches all thrown errors and falls back to the runtime's default
+ *     path; the engine contract states `interceptCompaction` must not
+ *     throw across the call boundary.
  */
 export default function compactionInterceptExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
     const runtime = getCompactionInterceptRuntime(ctx.sessionManager);
     const engine = runtime?.contextEngine;
-    const interceptFn = engine?.interceptCompaction;
-    // Bind all three locals separately so TypeScript narrows each one in
-    // isolation — chained optional access on the property `engine.interceptCompaction`
-    // doesn't propagate to subsequent independent property reads on `engine`.
-    if (!runtime || !engine || !interceptFn) {
+    if (!engine || typeof engine.interceptCompaction !== "function") {
+      // Three skip cases collapse into one guard:
+      //   1. no runtime registered for this session (e.g. inner LLM session)
+      //   2. runtime present but no engine threaded through
+      //   3. engine present but doesn't implement interceptCompaction
+      // The `typeof === "function"` form narrows `engine.interceptCompaction`
+      // to a non-undefined function while satisfying the typescript/unbound-method
+      // lint rule (which would fire on a plain `!engine.interceptCompaction`
+      // truthy access).
       return undefined;
     }
 
@@ -66,11 +73,13 @@ export default function compactionInterceptExtension(api: ExtensionAPI): void {
     const currentTokenCount =
       typeof contextUsage?.tokens === "number" ? contextUsage.tokens : undefined;
 
-    // Resolve trigger from the SDK event when available. The pi-coding-agent
-    // event currently does not carry an explicit trigger field; engines may
-    // use the absence of trigger as "unknown source" and apply default policy.
-    // Reserved for forward compatibility with future SDK extensions.
-    const trigger = inferTriggerFromEvent(event);
+    // The pi-coding-agent SDK event does not currently carry an explicit
+    // trigger field — codex's in-attempt-auto, overflow-retry, and manual
+    // /compact all dispatch into the same `session_before_compact` handler
+    // chain. Engines that condition on `request.trigger` should treat
+    // `undefined` as "host couldn't disambiguate" and apply default cadence.
+    // When the SDK surface grows to expose a real trigger, plumb it here.
+    const trigger: CompactionInterceptRequest["trigger"] = undefined;
 
     const request: CompactionInterceptRequest = {
       sessionId,
@@ -86,7 +95,9 @@ export default function compactionInterceptExtension(api: ExtensionAPI): void {
 
     let result: CompactionInterceptResult;
     try {
-      result = await interceptFn.call(engine, request);
+      // Call on the engine directly (preserves `this` binding without
+      // triggering the unbound-method lint rule).
+      result = await engine.interceptCompaction(request);
     } catch (error) {
       log.warn(
         `[compaction-intercept] engine.interceptCompaction threw — falling back to default compaction path. ${String(error)}`,
@@ -94,8 +105,8 @@ export default function compactionInterceptExtension(api: ExtensionAPI): void {
       return undefined;
     }
 
-    if (!result || result.handled !== true) {
-      if (result && result.handled === false) {
+    if (!result || !result.handled) {
+      if (result && !result.handled) {
         log.debug(`[compaction-intercept] engine declined intercept: ${result.reason}`);
       }
       return undefined;
@@ -110,19 +121,4 @@ export default function compactionInterceptExtension(api: ExtensionAPI): void {
       },
     };
   });
-}
-
-/**
- * Best-effort trigger inference from the SDK event. The current
- * pi-coding-agent event surface does not carry an explicit trigger; the
- * presence of a `previousSummary` indicates a redistill / re-compact while
- * its absence indicates a fresh-compact. Engines may use this signal for
- * cadence routing — overflow/in-attempt-auto/manual all collapse to
- * `"in-attempt-auto"` from the openclaw side until the SDK surface grows.
- */
-function inferTriggerFromEvent(
-  event: { preparation?: { previousSummary?: string } } | undefined,
-): "in-attempt-auto" | "overflow" | "timeout" | "manual" | undefined {
-  if (!event || !event.preparation) return undefined;
-  return "in-attempt-auto";
 }

--- a/src/agents/pi-hooks/compaction-intercept.ts
+++ b/src/agents/pi-hooks/compaction-intercept.ts
@@ -43,11 +43,20 @@ export default function compactionInterceptExtension(api: ExtensionAPI): void {
 
     // Extract the runtime-level identifiers from the session manager so the
     // engine can route on sessionId/sessionFile without needing the SDK event
-    // type directly. `sessionKey` is an openclaw-level concept not surfaced
-    // by ReadonlySessionManager — engines that need it can derive it from
-    // sessionFile path conventions or fall back to sessionId-only routing.
+    // type directly. `sessionKey` (an openclaw-level concept) is carried
+    // through the runtime registry because ReadonlySessionManager does not
+    // expose it.
     const sessionId = ctx.sessionManager.getSessionId();
     const sessionFile = ctx.sessionManager.getSessionFile();
+    if (typeof sessionFile !== "string" || sessionFile.length === 0) {
+      // pi-coding-agent's getSessionFile() returns string | undefined for
+      // not-yet-persisted sessions. Without a session file the engine
+      // cannot read raw history; bail and let the runtime fall back.
+      log.debug(
+        "[compaction-intercept] session has no on-disk file; falling back to default compaction path",
+      );
+      return undefined;
+    }
     const contextUsage = ctx.getContextUsage();
     const tokenBudget = contextUsage?.contextWindow;
     const currentTokenCount =
@@ -55,6 +64,7 @@ export default function compactionInterceptExtension(api: ExtensionAPI): void {
 
     const request: CompactionInterceptRequest = {
       sessionId,
+      sessionKey: runtime.sessionKey,
       sessionFile,
       tokenBudget,
       currentTokenCount,

--- a/src/agents/pi-hooks/compaction-intercept.ts
+++ b/src/agents/pi-hooks/compaction-intercept.ts
@@ -1,0 +1,92 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {
+  CompactionInterceptRequest,
+  CompactionInterceptResult,
+} from "../../context-engine/types.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { getCompactionInterceptRuntime } from "./compaction-intercept-runtime.js";
+
+const log = createSubsystemLogger("compaction-intercept");
+
+/**
+ * Extension factory that bridges the pi-coding-agent `session_before_compact`
+ * event to a context-engine plugin's optional
+ * {@link import("../../context-engine/types.js").ContextEngine.interceptCompaction}
+ * method.
+ *
+ * Wiring:
+ *   - Registered AFTER `compactionSafeguardExtension` so that when both are
+ *     active, the SDK's last-truthy-wins semantics let intercept override
+ *     safeguard. When intercept returns `undefined` (handled:false or no
+ *     engine), the safeguard's prior return (if any) is preserved and the
+ *     SDK falls back as configured.
+ *   - Skipped silently when no runtime is set (e.g. engine not resolved yet
+ *     or engine does not advertise `info.interceptsCompaction`).
+ *   - Skipped silently when `engine.interceptCompaction` is undefined (which
+ *     should not happen if the engine correctly sets `info.interceptsCompaction`
+ *     but we keep the defensive check).
+ *   - Catches all thrown errors and falls back to the runtime's default path;
+ *     the engine contract states `interceptCompaction` must not throw.
+ *
+ * This extension is a no-op for engines that fully own compaction
+ * (`info.ownsCompaction === true`) — those engines bypass the
+ * `session_before_compact` event entirely via the engine-owned compaction
+ * dispatch path in `compact.queued.ts`.
+ */
+export default function compactionInterceptExtension(api: ExtensionAPI): void {
+  api.on("session_before_compact", async (event, ctx) => {
+    const runtime = getCompactionInterceptRuntime(ctx.sessionManager);
+    const engine = runtime?.contextEngine;
+    if (!engine?.interceptCompaction) {
+      return undefined;
+    }
+
+    // Extract the runtime-level identifiers from the session manager so the
+    // engine can route on sessionId/sessionFile without needing the SDK event
+    // type directly. `sessionKey` is an openclaw-level concept not surfaced
+    // by ReadonlySessionManager — engines that need it can derive it from
+    // sessionFile path conventions or fall back to sessionId-only routing.
+    const sessionId = ctx.sessionManager.getSessionId();
+    const sessionFile = ctx.sessionManager.getSessionFile();
+    const contextUsage = ctx.getContextUsage();
+    const tokenBudget = contextUsage?.contextWindow;
+    const currentTokenCount =
+      typeof contextUsage?.tokens === "number" ? contextUsage.tokens : undefined;
+
+    const request: CompactionInterceptRequest = {
+      sessionId,
+      sessionFile,
+      tokenBudget,
+      currentTokenCount,
+      firstKeptEntryId: event.preparation.firstKeptEntryId,
+      tokensBefore: event.preparation.tokensBefore,
+      signal: event.signal,
+    };
+
+    let result: CompactionInterceptResult;
+    try {
+      result = await engine.interceptCompaction(request);
+    } catch (error) {
+      log.warn(
+        `[compaction-intercept] engine.interceptCompaction threw — falling back to default compaction path. ${String(error)}`,
+      );
+      return undefined;
+    }
+
+    if (!result || result.handled !== true) {
+      if (result && result.handled === false) {
+        log.debug(`[compaction-intercept] engine declined intercept: ${result.reason}`);
+      }
+      return undefined;
+    }
+
+    return {
+      compaction: {
+        summary: result.summary,
+        firstKeptEntryId: result.firstKeptEntryId,
+        tokensBefore: result.tokensBefore,
+        details: result.details,
+      },
+    };
+  });
+}

--- a/src/agents/pi-hooks/compaction-intercept.ts
+++ b/src/agents/pi-hooks/compaction-intercept.ts
@@ -37,7 +37,11 @@ export default function compactionInterceptExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
     const runtime = getCompactionInterceptRuntime(ctx.sessionManager);
     const engine = runtime?.contextEngine;
-    if (!engine?.interceptCompaction) {
+    const interceptFn = engine?.interceptCompaction;
+    // Bind all three locals separately so TypeScript narrows each one in
+    // isolation — chained optional access on the property `engine.interceptCompaction`
+    // doesn't propagate to subsequent independent property reads on `engine`.
+    if (!runtime || !engine || !interceptFn) {
       return undefined;
     }
 
@@ -62,6 +66,12 @@ export default function compactionInterceptExtension(api: ExtensionAPI): void {
     const currentTokenCount =
       typeof contextUsage?.tokens === "number" ? contextUsage.tokens : undefined;
 
+    // Resolve trigger from the SDK event when available. The pi-coding-agent
+    // event currently does not carry an explicit trigger field; engines may
+    // use the absence of trigger as "unknown source" and apply default policy.
+    // Reserved for forward compatibility with future SDK extensions.
+    const trigger = inferTriggerFromEvent(event);
+
     const request: CompactionInterceptRequest = {
       sessionId,
       sessionKey: runtime.sessionKey,
@@ -70,12 +80,13 @@ export default function compactionInterceptExtension(api: ExtensionAPI): void {
       currentTokenCount,
       firstKeptEntryId: event.preparation.firstKeptEntryId,
       tokensBefore: event.preparation.tokensBefore,
+      trigger,
       signal: event.signal,
     };
 
     let result: CompactionInterceptResult;
     try {
-      result = await engine.interceptCompaction(request);
+      result = await interceptFn.call(engine, request);
     } catch (error) {
       log.warn(
         `[compaction-intercept] engine.interceptCompaction threw — falling back to default compaction path. ${String(error)}`,
@@ -99,4 +110,19 @@ export default function compactionInterceptExtension(api: ExtensionAPI): void {
       },
     };
   });
+}
+
+/**
+ * Best-effort trigger inference from the SDK event. The current
+ * pi-coding-agent event surface does not carry an explicit trigger; the
+ * presence of a `previousSummary` indicates a redistill / re-compact while
+ * its absence indicates a fresh-compact. Engines may use this signal for
+ * cadence routing — overflow/in-attempt-auto/manual all collapse to
+ * `"in-attempt-auto"` from the openclaw side until the SDK surface grows.
+ */
+function inferTriggerFromEvent(
+  event: { preparation?: { previousSummary?: string } } | undefined,
+): "in-attempt-auto" | "overflow" | "timeout" | "manual" | undefined {
+  if (!event || !event.preparation) return undefined;
+  return "in-attempt-auto";
 }

--- a/src/agents/pi-hooks/compaction-intercept.ts
+++ b/src/agents/pi-hooks/compaction-intercept.ts
@@ -112,6 +112,18 @@ export default function compactionInterceptExtension(api: ExtensionAPI): void {
       return undefined;
     }
 
+    log.info("[compaction-intercept] engine handled compaction intercept", {
+      engineId: engine.info.id,
+      sessionId,
+      sessionKey: runtime.sessionKey,
+      tokenBudget,
+      currentTokenCount,
+      tokensBefore: result.tokensBefore,
+      tokensAfter: result.tokensAfter,
+      firstKeptEntryId: result.firstKeptEntryId,
+      summaryChars: result.summary.length,
+    });
+
     return {
       compaction: {
         summary: result.summary,

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -1,5 +1,6 @@
 import { SettingsManager } from "@earendil-works/pi-coding-agent";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ContextEngineInfo } from "../context-engine/types.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import {
   buildEmbeddedPiSettingsSnapshot,
@@ -52,6 +53,12 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
   pluginMetadataSnapshot?: PluginMetadataSnapshot;
   /** Resolved context window budget so reserve-token floor can be capped for small models. */
   contextTokenBudget?: number;
+  /**
+   * Active context engine info. When the engine owns or intercepts
+   * compaction, the reserve-token floor is auto-zeroed because the engine
+   * takes responsibility for post-compaction headroom.
+   */
+  contextEngineInfo?: ContextEngineInfo;
 }): SettingsManager {
   const settingsManager = createRuntimeEmbeddedPiSettingsManager(
     createEmbeddedPiSettingsManager(params),
@@ -60,6 +67,7 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
     settingsManager,
     cfg: params.cfg,
     contextTokenBudget: params.contextTokenBudget,
+    contextEngineInfo: params.contextEngineInfo,
   });
   return settingsManager;
 }

--- a/src/agents/pi-settings.test.ts
+++ b/src/agents/pi-settings.test.ts
@@ -615,6 +615,55 @@ describe("shouldDisablePiAutoCompaction", () => {
   it("returns true for silent-overflow-prone providers", () => {
     expect(shouldDisablePiAutoCompaction({ silentOverflowProneProvider: true })).toBe(true);
   });
+
+  // openclaw#81164 — when the engine intercepts compaction via the pi-coding-agent
+  // SDK `session_before_compact` event, Pi's threshold check MUST keep running so
+  // the event still emits. Disabling Pi here would silently turn the engine's
+  // intercept extension into dead code.
+  it("returns false when an engine that owns compaction ALSO declares interceptsCompaction", () => {
+    expect(
+      shouldDisablePiAutoCompaction({
+        contextEngineInfo: {
+          id: "lossless-claw",
+          name: "Lossless Claw",
+          ownsCompaction: true,
+          interceptsCompaction: true,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false in safeguard mode when the engine declares interceptsCompaction", () => {
+    expect(
+      shouldDisablePiAutoCompaction({
+        contextEngineInfo: {
+          id: "lossless-claw",
+          name: "Lossless Claw",
+          ownsCompaction: true,
+          interceptsCompaction: true,
+        },
+        compactionMode: "safeguard",
+      }),
+    ).toBe(false);
+  });
+
+  it("still returns true for silent-overflow-prone providers even when interceptsCompaction is set", () => {
+    // Silent-overflow protection is a hard safety guarantee — the provider can
+    // truncate the prompt without warning, so Pi's auto-compaction must stay
+    // disabled regardless of the engine's intercept opt-in. The engine's
+    // own preemptive compaction is expected to keep the prompt under the cap.
+    expect(
+      shouldDisablePiAutoCompaction({
+        contextEngineInfo: {
+          id: "lossless-claw",
+          name: "Lossless Claw",
+          ownsCompaction: true,
+          interceptsCompaction: true,
+        },
+        silentOverflowProneProvider: true,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("applyPiAutoCompactionGuard", () => {

--- a/src/agents/pi-settings.test.ts
+++ b/src/agents/pi-settings.test.ts
@@ -105,6 +105,125 @@ describe("applyPiCompactionSettingsFromConfig", () => {
     });
   });
 
+  describe("contextEngineInfo gating (auto-zero reserveTokensFloor)", () => {
+    it("auto-zeroes the floor when engine info advertises interceptsCompaction", () => {
+      const settingsManager = {
+        getCompactionReserveTokens: () => 0,
+        getCompactionKeepRecentTokens: () => 20_000,
+        applyOverrides: vi.fn(),
+      };
+      const result = applyPiCompactionSettingsFromConfig({
+        settingsManager,
+        cfg: {
+          agents: {
+            defaults: { compaction: { reserveTokensFloor: 20_000 } },
+          },
+        },
+        contextEngineInfo: {
+          id: "lcm",
+          name: "LCM",
+          interceptsCompaction: true,
+        },
+      });
+      // With the floor zeroed, the current reserve (0) is already at/above
+      // the effective floor (0), so no override is applied.
+      expect(result.didOverride).toBe(false);
+      expect(result.compaction.reserveTokens).toBe(0);
+      expect(settingsManager.applyOverrides).not.toHaveBeenCalled();
+    });
+
+    it("auto-zeroes the floor when engine info has ownsCompaction (legacy gate path)", () => {
+      const settingsManager = {
+        getCompactionReserveTokens: () => 0,
+        getCompactionKeepRecentTokens: () => 20_000,
+        applyOverrides: vi.fn(),
+      };
+      const result = applyPiCompactionSettingsFromConfig({
+        settingsManager,
+        cfg: {
+          agents: {
+            defaults: { compaction: { reserveTokensFloor: 20_000 } },
+          },
+        },
+        contextEngineInfo: {
+          id: "owner",
+          name: "Owner",
+          ownsCompaction: true,
+        },
+      });
+      expect(result.didOverride).toBe(false);
+      expect(result.compaction.reserveTokens).toBe(0);
+    });
+
+    it("does NOT zero the floor when engine info lacks both flags", () => {
+      const settingsManager = {
+        getCompactionReserveTokens: () => 0,
+        getCompactionKeepRecentTokens: () => 20_000,
+        applyOverrides: vi.fn(),
+      };
+      const result = applyPiCompactionSettingsFromConfig({
+        settingsManager,
+        cfg: {
+          agents: {
+            defaults: { compaction: { reserveTokensFloor: 20_000 } },
+          },
+        },
+        contextEngineInfo: { id: "legacy", name: "Legacy" },
+      });
+      expect(result.didOverride).toBe(true);
+      expect(result.compaction.reserveTokens).toBe(20_000);
+    });
+
+    it("does NOT zero the floor when contextEngineInfo is omitted (back-compat)", () => {
+      const settingsManager = {
+        getCompactionReserveTokens: () => 0,
+        getCompactionKeepRecentTokens: () => 20_000,
+        applyOverrides: vi.fn(),
+      };
+      const result = applyPiCompactionSettingsFromConfig({
+        settingsManager,
+        cfg: {
+          agents: {
+            defaults: { compaction: { reserveTokensFloor: 20_000 } },
+          },
+        },
+        // contextEngineInfo intentionally omitted
+      });
+      expect(result.didOverride).toBe(true);
+      expect(result.compaction.reserveTokens).toBe(20_000);
+    });
+
+    it("auto-zero overrides an explicit reserveTokens configuration", () => {
+      // When the engine intercepts, the floor is 0 and the explicit
+      // reserveTokens config is honored (no floor bump applies).
+      const settingsManager = {
+        getCompactionReserveTokens: () => 16_384,
+        getCompactionKeepRecentTokens: () => 20_000,
+        applyOverrides: vi.fn(),
+      };
+      const result = applyPiCompactionSettingsFromConfig({
+        settingsManager,
+        cfg: {
+          agents: {
+            defaults: {
+              compaction: { reserveTokens: 5_000, reserveTokensFloor: 20_000 },
+            },
+          },
+        },
+        contextEngineInfo: {
+          id: "lcm",
+          name: "LCM",
+          interceptsCompaction: true,
+        },
+      });
+      // Explicit reserveTokens (5K) > 0 floor → 5K wins.
+      expect(result.compaction.reserveTokens).toBe(5_000);
+      expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
+        compaction: { reserveTokens: 5_000 },
+      });
+    });
+  });
+
   it("applies keepRecentTokens when explicitly configured", () => {
     const settingsManager = {
       getCompactionReserveTokens: () => 20_000,

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -65,11 +65,34 @@ function toPositiveInt(value: unknown): number | undefined {
   return Math.floor(value);
 }
 
+/**
+ * True when the active context engine takes responsibility for headroom after
+ * compaction — either by fully owning the compaction lifecycle
+ * (`ownsCompaction === true`) or by intercepting the runtime's
+ * `session_before_compact` event and supplying its own assembly
+ * (`interceptsCompaction === true`).
+ *
+ * Both cases mean the engine, not Pi's `reserveTokensFloor`, decides how
+ * much headroom the next prompt has — so the floor should be auto-zeroed
+ * to avoid double-reserving (LCM's `compactionTargetFraction = 0.35` already
+ * leaves ~65% of the context window free post-compaction, far more than the
+ * 20K-token default floor would reserve).
+ */
+function engineOwnsPostCompactHeadroom(info?: ContextEngineInfo): boolean {
+  return info?.ownsCompaction === true || info?.interceptsCompaction === true;
+}
+
 export function applyPiCompactionSettingsFromConfig(params: {
   settingsManager: PiSettingsManagerLike;
   cfg?: OpenClawConfig;
   /** When known, the resolved context window budget for the current model. */
   contextTokenBudget?: number;
+  /**
+   * Active context engine info. When present and the engine owns or
+   * intercepts compaction, the host treats `reserveTokensFloor` as 0 because
+   * the engine is responsible for post-compaction headroom.
+   */
+  contextEngineInfo?: ContextEngineInfo;
 }): {
   didOverride: boolean;
   compaction: { reserveTokens: number; keepRecentTokens: number };
@@ -80,7 +103,9 @@ export function applyPiCompactionSettingsFromConfig(params: {
 
   const configuredReserveTokens = toNonNegativeInt(compactionCfg?.reserveTokens);
   const configuredKeepRecentTokens = toPositiveInt(compactionCfg?.keepRecentTokens);
-  let reserveTokensFloor = resolveCompactionReserveTokensFloor(params.cfg);
+  let reserveTokensFloor = engineOwnsPostCompactHeadroom(params.contextEngineInfo)
+    ? 0
+    : resolveCompactionReserveTokensFloor(params.cfg);
 
   // Cap the floor to a safe fraction of the context window so that
   // small-context models (e.g. Ollama with 16 K tokens) are not starved of

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -224,15 +224,23 @@ export function isSilentOverflowProneModel(model: {
  * or an active model that is silent-overflow-prone (openclaw#75799).
  * Default-mode runs against ordinary providers keep Pi's auto-compaction as
  * the existing baseline.
+ *
+ * EXCEPTION: when the engine declares `interceptsCompaction === true`, we MUST
+ * leave Pi's auto-compaction enabled so the threshold check in Pi still fires
+ * the `session_before_compact` event — that event is the hook the engine
+ * registers an extension against to take over compaction losslessly. Disabling
+ * Pi here would silently turn the engine's intercept extension into dead code
+ * (openclaw#81164).
  */
 export function shouldDisablePiAutoCompaction(params: {
   contextEngineInfo?: ContextEngineInfo;
   compactionMode?: AgentCompactionMode;
   silentOverflowProneProvider?: boolean;
 }): boolean {
+  const intercepts = params.contextEngineInfo?.interceptsCompaction === true;
   return (
-    params.contextEngineInfo?.ownsCompaction === true ||
-    params.compactionMode === "safeguard" ||
+    (params.contextEngineInfo?.ownsCompaction === true && !intercepts) ||
+    (params.compactionMode === "safeguard" && !intercepts) ||
     params.silentOverflowProneProvider === true
   );
 }

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -72,11 +72,25 @@ function toPositiveInt(value: unknown): number | undefined {
  * `session_before_compact` event and supplying its own assembly
  * (`interceptsCompaction === true`).
  *
- * Both cases mean the engine, not Pi's `reserveTokensFloor`, decides how
- * much headroom the next prompt has — so the floor should be auto-zeroed
- * to avoid double-reserving (LCM's `compactionTargetFraction = 0.35` already
- * leaves ~65% of the context window free post-compaction, far more than the
- * 20K-token default floor would reserve).
+ * **Why both flags?** These flags advertise capability against distinct
+ * compaction lanes:
+ *   - `ownsCompaction` covers the openclaw queued-compaction lane
+ *     (`compact.queued.ts` → `engine.compact()`), driven by `afterTurn`
+ *     or explicit user `/compact`. Engines that own this lane control
+ *     their own compaction trigger and post-compact assembly entirely.
+ *   - `interceptsCompaction` covers the pi-coding-agent SDK event lane
+ *     (`session_before_compact`), driven by codex's in-attempt overflow.
+ *     Engines that intercept this event also produce post-compact
+ *     assemblies, just via a different trigger.
+ * In BOTH cases the engine — not Pi's `reserveTokensFloor` — decides how
+ * much headroom the next prompt gets, so we auto-zero the floor to avoid
+ * double-reserving (e.g. lossless-claw's `compactionTargetFraction = 0.35`
+ * already leaves ~65% of the context window free post-compaction, far more
+ * than the 20K-token default floor would reserve).
+ *
+ * The merged gate is intentional: any engine in EITHER lane manages its
+ * own headroom strategy. If we ever introduce a third lane (or split these
+ * back apart), this predicate is the single place to update.
  */
 function engineOwnsPostCompactHeadroom(info?: ContextEngineInfo): boolean {
   return info?.ownsCompaction === true || info?.interceptsCompaction === true;

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -61,6 +61,69 @@ export type CompactResult = {
   };
 };
 
+/**
+ * Request payload for {@link ContextEngine.interceptCompaction}.
+ *
+ * Mirrors the fields the runtime supplies when emitting the
+ * `session_before_compact` event in {@link
+ * https://github.com/mariozechner/pi-coding-agent | pi-coding-agent} so engines
+ * can produce a replacement compaction without depending on the SDK event type
+ * directly.
+ */
+export type CompactionInterceptRequest = {
+  /** Session id of the conversation to intercept compaction for. */
+  sessionId: string;
+  /** Optional session key (agent:id:suffix form). */
+  sessionKey?: string;
+  /** On-disk path to the session jsonl. */
+  sessionFile: string;
+  /** Total context window in tokens (when known). */
+  tokenBudget?: number;
+  /** Best-effort current token estimate at the time of compaction. */
+  currentTokenCount?: number;
+  /** First entry id the runtime intends to keep verbatim (compaction boundary). */
+  firstKeptEntryId: string;
+  /** Pre-compaction token count reported by the runtime. */
+  tokensBefore: number;
+  /**
+   * Trigger source for the compaction request. Useful for routing/diagnostics
+   * (e.g. honoring different cadence policies for overflow vs in-attempt-auto).
+   */
+  trigger?: "in-attempt-auto" | "overflow" | "timeout" | "manual";
+  /** Abort signal honored before and during compaction. */
+  signal?: AbortSignal;
+};
+
+/**
+ * Result payload for {@link ContextEngine.interceptCompaction}.
+ *
+ * `handled: true` provides a replacement compaction that the runtime uses in
+ * place of its default GPT-driven path. `handled: false` opts out and the
+ * runtime falls back to its default (codex compaction or safeguard
+ * summarization, depending on configuration).
+ */
+export type CompactionInterceptResult =
+  | {
+      /** True when the engine produced a replacement compaction. */
+      handled: true;
+      /** Summary text to use in place of the runtime's default compaction. */
+      summary: string;
+      /** First entry id retained after compaction. */
+      firstKeptEntryId: string;
+      /** Token count before compaction (echoed from request). */
+      tokensBefore: number;
+      /** Estimated token count after compaction (diagnostic, optional). */
+      tokensAfter?: number;
+      /** Optional engine-specific diagnostic payload. */
+      details?: unknown;
+    }
+  | {
+      /** False when the engine declines to intercept; the caller falls back. */
+      handled: false;
+      /** Short reason code for diagnostics (e.g. "session-ignored"). */
+      reason: string;
+    };
+
 export type IngestResult = {
   /** Whether the message was ingested (false if duplicate or no-op) */
   ingested: boolean;
@@ -86,6 +149,20 @@ export type ContextEngineInfo = {
   version?: string;
   /** True when the engine manages its own compaction lifecycle. */
   ownsCompaction?: boolean;
+  /**
+   * True when the engine implements {@link ContextEngine.interceptCompaction}
+   * and intends to override the runtime's default `session_before_compact`
+   * compaction path with its own assembly.
+   *
+   * Distinct from {@link ownsCompaction}: engines that fully own compaction
+   * never see the runtime event at all, while engines that intercept run
+   * alongside the runtime and only replace the summarization step.
+   *
+   * The host treats this as authoritative for capability gating (e.g. it
+   * auto-zeroes Pi's `reserveTokensFloor` headroom reserve when this is true,
+   * because the engine takes responsibility for post-compaction headroom).
+   */
+  interceptsCompaction?: boolean;
   /**
    * Controls how turn-triggered maintenance should be executed.
    *
@@ -326,6 +403,26 @@ export interface ContextEngine {
      */
     abortSignal?: AbortSignal;
   }): Promise<CompactResult>;
+
+  /**
+   * Intercept the runtime's `session_before_compact` event and produce a
+   * replacement compaction summary in place of the default GPT-driven path.
+   *
+   * Engines that implement this MUST set `info.interceptsCompaction = true`
+   * so the host can apply intercept-aware capability gating (e.g. zeroing
+   * Pi's `reserveTokensFloor` headroom reserve).
+   *
+   * Return `{ handled: true, ... }` to supply a replacement compaction
+   * (runtime uses the summary, skips its default path). Return
+   * `{ handled: false, reason }` to opt out (runtime falls back to its
+   * default — codex compaction or safeguard summarization).
+   *
+   * This method MUST never throw across the call boundary — defensive
+   * engines should catch internal errors and return
+   * `{ handled: false, reason: "..." }`. The host treats a thrown error as
+   * `handled: false` and falls back to its default path.
+   */
+  interceptCompaction?(params: CompactionInterceptRequest): Promise<CompactionInterceptResult>;
 
   /**
    * Prepare context-engine-managed subagent state before the child run starts.

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -154,9 +154,18 @@ export type ContextEngineInfo = {
    * and intends to override the runtime's default `session_before_compact`
    * compaction path with its own assembly.
    *
-   * Distinct from {@link ownsCompaction}: engines that fully own compaction
-   * never see the runtime event at all, while engines that intercept run
-   * alongside the runtime and only replace the summarization step.
+   * This flag and {@link ownsCompaction} cover DISTINCT compaction lanes —
+   * engines may declare either, both, or neither:
+   *   - `ownsCompaction` → the openclaw queued-compaction lane
+   *     (`compact.queued.ts` → `engine.compact()`), driven by `afterTurn`
+   *     or explicit `/compact`. Engines fully own timing and assembly.
+   *   - `interceptsCompaction` → the pi-coding-agent SDK event lane
+   *     (`session_before_compact`), driven by codex's in-attempt overflow
+   *     auto-compact (~90% context). Engines replace the codex GPT
+   *     summarization with their own.
+   * Codex still fires `session_before_compact` on in-attempt overflow even
+   * when an engine owns the queued lane, so declaring both is correct for
+   * engines that want to handle both flows (e.g. lossless-claw v4.1).
    *
    * The host treats this as authoritative for capability gating (e.g. it
    * auto-zeroes Pi's `reserveTokensFloor` headroom reserve when this is true,

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -118,6 +118,8 @@ export type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.j
 export type {
   AssembleResult,
   BootstrapResult,
+  CompactionInterceptRequest,
+  CompactionInterceptResult,
   CompactResult,
   ContextEngine,
   ContextEngineInfo,


### PR DESCRIPTION
TLDR - lets other context systems turn off/replace codex compaction (when it calls to compact it uses them versus its native).

## Summary

Adds an optional `interceptCompaction(request)` method to the `ContextEngine` plugin contract so engines can replace the runtime's default `session_before_compact` GPT-driven summarization with their own assembly — without leaving the runtime's compaction lifecycle.

Motivating use case: [lossless-claw](https://github.com/Martian-Engineering/lossless-claw/pull/665) assembles a lossless raw + summary pyramid on disk and wants to swap in its assembled context whenever pi-coding-agent would otherwise trigger codex's GPT compaction. With the contract added here, lossless-claw can keep its plugin scope narrow (one new method on the engine) instead of forking or monkey-patching the runtime.

## Architecture — two compaction lanes, two capability flags

OpenClaw + pi-coding-agent expose two distinct compaction flows that this PR makes explicit:

```
┌──────────────────────────────────────────────────────────────────────────┐
│                     OpenClaw queued-compaction lane                       │
│              ┌──────────────┐   afterTurn /        │
│              │ engine plugin│ ◄─/compact / explicit│
│              │.compact(…)   │   queue              │
│              └──────────────┘                      │
│   Gate: info.ownsCompaction === true                                      │
│   Where: src/agents/pi-embedded-runner/compact.queued.ts                  │
│   Engine: full control of timing, target, assembly                        │
└──────────────────────────────────────────────────────────────────────────┘

┌──────────────────────────────────────────────────────────────────────────┐
│             pi-coding-agent SDK session_before_compact lane               │
│                                                                           │
│  codex hits 90%      ┌─────────────────────┐    ┌──────────────────────┐ │
│  context (auto-      │ session_before_     │ ─► │ compactionInterceptExt│ │
│  compact threshold)  │ compact emit        │    │ (this PR)             │ │
│                      └─────────────────────┘    └──────────┬───────────┘ │
│                                                            ▼               │
│                                              engine.interceptCompaction()  │
│                                                  │                         │
│                                  handled: true  ─┴─►  use {summary}        │
│                                  handled: false ────►  fall through to     │
│                                                       safeguard/codex GPT  │
│                                                                           │
│  Gate: info.interceptsCompaction === true                                 │
│  Where: src/agents/pi-hooks/compaction-intercept.{ts,-runtime.ts}         │
│  Engine: replacement summary only; trigger is owned by the SDK           │
└──────────────────────────────────────────────────────────────────────────┘
```

Engines may declare BOTH flags (lossless-claw does): codex still fires `session_before_compact` on in-attempt overflow even when the engine owns the openclaw queued lane.

## What's in this PR

| # | File | Change |
|---|---|---|
| 1 | `src/context-engine/types.ts` | New `CompactionInterceptRequest` / `CompactionInterceptResult` types, new `info.interceptsCompaction?: boolean` flag, new optional `interceptCompaction?(...)` method on `ContextEngine`. Re-exported via plugin-sdk. |
| 2 | `src/agents/pi-hooks/compaction-intercept-runtime.ts` (new) | Per-session runtime registry (WeakMap keyed by SessionManager identity) carrying the resolved engine + optional `sessionKey`. Modeled on `compaction-safeguard-runtime.ts`. |
| 3 | `src/agents/pi-hooks/compaction-intercept.ts` (new) | The new `ExtensionFactory`. Defensive against: no runtime, no engine, engine without method, undefined sessionFile, thrown errors. Returns `{compaction: {...}}` on `handled:true` or `undefined` on fall-through. |
| 4 | `src/agents/pi-embedded-runner/extensions.ts` | `buildEmbeddedExtensionFactories` accepts optional `activeContextEngine` + `sessionKey`. Pushes the new factory AFTER safeguard so SDK last-truthy-wins lets intercept override safeguard's fallback. Gate is `info.interceptsCompaction === true` only — no exclusion for `ownsCompaction`. |
| 5 | `src/agents/pi-settings.ts` | Two related changes: (a) New `engineOwnsPostCompactHeadroom` predicate. `applyPiCompactionSettingsFromConfig` gains optional `contextEngineInfo` and auto-zeroes `reserveTokensFloor` when `ownsCompaction \|\| interceptsCompaction` (without auto-zero, an engine like lossless-claw targeting ~65% post-compact headroom would have an additional 20K-token floor reserved on top). (b) `shouldDisablePiAutoCompaction` carves out an `interceptsCompaction === true` exception so Pi's threshold check stays enabled and the `session_before_compact` event still emits — without this the intercept extension is dead code. The silent-overflow branch deliberately ignores the exception (provider can truncate without warning regardless). |
| 6 | `src/agents/pi-embedded-runner/run/attempt.ts` | Threads `activeContextEngine?.info` + `params.sessionKey` at both the initial prepared-settings build and the post-`resourceLoader.reload()` re-apply. |
| 7 | `src/agents/command/cli-compaction.ts` | Threads `contextEngineInfo` so the `/compact` CLI path matches. The test-injectable `CliCompactionDeps` shape gains the new field. |
| 8 | Inner compaction-LLM session (`pi-embedded-runner/compact.ts:992`) | Intentionally NOT threaded — that session has no user-facing engine; the existing comment block is expanded to cover both calls. |
| 9 | Tests | New `compaction-intercept.test.ts` (~18 cases). Extended `extensions.test.ts` (~10 cases). Extended `pi-settings.test.ts` (~8 cases covering both the auto-zero gate and the `shouldDisablePiAutoCompaction` exception). |

## Behavior changes

- **None by default.** The contract is opt-in: engines that don't declare `info.interceptsCompaction = true` see zero behavior change. The new ExtensionFactory is a no-op when no such engine is active.
- **For opt-in engines:** `session_before_compact` routes through `engine.interceptCompaction()`. On `handled:true`, the engine's summary replaces the codex GPT call. On `handled:false` or thrown errors, the runtime falls back to its default. The SDK short-circuits on `{cancel:true}` returns (auth-failure cases from safeguard) and intercept is not called in those cases — documented limitation.
- **Reserve-token floor auto-zero:** for engines declaring `interceptsCompaction` or `ownsCompaction`, Pi's `reserveTokensFloor` is treated as 0 because the engine takes responsibility for post-compaction headroom.
- **Pi auto-compaction stays on for intercepting engines:** when an engine declares `interceptsCompaction === true`, Pi's `_checkCompaction` is NOT force-disabled (it would normally be when `ownsCompaction === true` or `mode === "safeguard"`). The threshold check is the only emit point for `session_before_compact`; disabling it would silently turn the intercept extension into dead code. The silent-overflow-prone branch is intentionally exempt — that lane is a hard safety guarantee.

## Compatibility

- Plugin SDK is private (`packages/plugin-sdk/package.json` is `"private": true`), so no version bump. Third-party plugins importing the new types from `openclaw/plugin-sdk` see them automatically once this lands.
- New `ContextEngine.interceptCompaction?` method is **optional** — existing engines (legacy, custom plugins) don't need any changes. New `info.interceptsCompaction` flag is also optional.
- SDK `{cancel: true}` short-circuit limitation: when the safeguard returns cancel (auth/model failure), intercept is not called. This is the correct degradation for the auth case — intercept can't summarize without a model either — but is documented in `compaction-intercept.ts` so future readers understand the ordering tradeoff.

## Adversarial review

Four independent adversarial review waves were performed by separate research agents reading the source code from scratch. Findings addressed in order:

- **Wave A** (commit `058997508ab`): 1 P0 architecture-killer (gate exclusion blocking the only legitimate consumer), 3 P0 CI compile/lint failures, 3 P1 polish items.
- **Wave B** (commit `b97b9e32e45`): 1 P0 lint cascade (`!== true` / `=== false` against discriminated-union booleans, `unbound-method`, `curly`) and 3 P1 items: misleading `trigger` field always-returns, stale docstrings claiming "no-op for ownsCompaction" (contradicting wave-A gate change), missing handler-routing test for both-flags engines.
- **Wave 3** (commit `049d7d640a5`): 2 stale docstrings in `types.ts` and `extensions.ts` left over from the wave-A gate change.
- **Wave 4** (commit `fe7455a9d9e`): runtime smoke-test against lossless-claw discovered that the intercept extension was registered correctly but the underlying `session_before_compact` event never emitted. Root cause: `shouldDisablePiAutoCompaction` in `pi-settings.ts` was force-disabling Pi auto-compaction whenever `ownsCompaction === true` (and engines like lossless-claw declare both flags), so Pi's `shouldCompact()` short-circuited on `!settings.enabled` before the threshold was ever evaluated and the event never fired. Fix: carve out an exception so `interceptsCompaction === true` keeps Pi auto-compaction enabled. The silent-overflow branch remains gated only on `silentOverflowProneProvider` because that lane is a hard provider-truncation guarantee. New test cases cover the carve-out.

All findings addressed in dedicated commits with cross-references in commit messages.


## Real behavior proof

Behavior addressed: context-engine plugins that declare both `ownsCompaction: true` and `interceptsCompaction: true` must keep Pi auto-compaction enabled so Pi can emit `session_before_compact`, while still letting the plugin replace the default GPT-driven compaction summary through `engine.interceptCompaction(request)`.

Real environment tested: local OpenClaw dev install with `/opt/homebrew/lib/node_modules/openclaw` symlinked into the PR-branch source tree, all PR commits applied, Gateway restarted through `launchctl bootout` / `launchctl bootstrap`, and the `lossless-claw` context-engine plugin loaded. `lossless-claw` is the both-flags engine this PR is for (`ownsCompaction: true`, `interceptsCompaction: true`; see Martian-Engineering/lossless-claw#665).

Exact steps or command run after this patch:

```sh
grep -A4 '^function shouldDisablePiAutoCompaction' dist/pi-settings-BNY3tGnv.js
curl -s http://localhost:18789/healthz
ps -p "$(launchctl list | awk '/ai\\.openclaw\\.gateway$/ {print $1}')" -o pid,etime,command
tail -F ~/.openclaw/logs/gateway.log | grep -E '(listening|lossless-claw)'
grep -c '"type":"session_before_compact"' ~/.openclaw/agents/main/sessions/<uuid>.trajectory.jsonl
pnpm exec vitest run src/agents/pi-settings.test.ts --pool=forks
```

Evidence after fix:

```text
$ grep -A4 '^function shouldDisablePiAutoCompaction' dist/pi-settings-BNY3tGnv.js
function shouldDisablePiAutoCompaction(params) {
        const intercepts = params.contextEngineInfo?.interceptsCompaction === true;
        return params.contextEngineInfo?.ownsCompaction === true && !intercepts
                || params.compactionMode === "safeguard" && !intercepts
                || params.silentOverflowProneProvider === true;
}

$ curl -s http://localhost:18789/healthz
{"ok":true,"status":"live"}

$ ps -p $(launchctl list | awk '/ai\.openclaw\.gateway$/ {print $1}') -o pid,etime,command
75484   04:41 /opt/homebrew/opt/node/bin/node /opt/homebrew/lib/node_modules/openclaw/dist/index.js gateway --port 18789

$ tail -F ~/.openclaw/logs/gateway.log | grep -E '(listening|lossless-claw)'
2026-05-14T00:01:10.403+07:00 [gateway] http server listening
  (7 plugins: acpx, browser, codex, cortex, gbrain, lossless-claw, telegram; 10.9s)
2026-05-14T00:01:12.770+07:00 [plugins] loading lossless-claw
  from /Volumes/LEXAR/repos/lossless-claw/dist/index.js

$ grep -c '"type":"session_before_compact"' ~/.openclaw/agents/main/sessions/<uuid>.trajectory.jsonl
0

$ pnpm exec vitest run src/agents/pi-settings.test.ts --pool=forks
 ✓ |agents-core|    pi-settings.test.ts (43 tests) 40ms
 ✓ |agents-support| pi-settings.test.ts (43 tests) 27ms

  Test Files  2 passed (2)
  Tests       86 passed (86)
```

Observed result after fix: the compiled Gateway bundle contains the new `interceptsCompaction` exception, Gateway boots successfully with `lossless-claw` loaded, and the table-driven runtime tests pass for the exact both-flags case that previously disabled Pi auto-compaction. Before this fix, the same live setup ran for 24 hours of Eva-channel usage with the intercept extension registered but unreachable: 0 `compaction-intercept` log lines, 0 `session_before_compact` events in the 27.5 MB trajectory, 0 rows in lossless-claw's `compaction_events` SQLite table, and 0 `Generating new conversation summary` markers in codex rollout files. The root cause was deterministic: `shouldDisablePiAutoCompaction({ ownsCompaction: true })` returned `true`, `setCompactionEnabled(false)` ran, and Pi short-circuited before evaluating the threshold that emits `session_before_compact`.

What was not tested: the next live high-context Eva turn has not yet crossed the 90% `openai-codex/gpt-5.5` threshold after the fix, so the final wild-fire `compaction-intercept` Gateway log line is still pending. A monitor is tailing `~/.openclaw/logs/gateway.log`; this PR will be updated when that event emits.
