### PR TITLE
fix: improve Codex migration selector enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex migration: make Enter activate the highlighted checkbox row before continuing, so `Skip for now` and bulk-selection rows work even when planned items start preselected.
 - fix: harden safe-bin argument validation [AI]. (#80999) Thanks @pgondhi987.
 - fix: scan plugin runtime entries during install [AI]. (#80998) Thanks @pgondhi987.
 - Codex harness: keep auth-profile-backed media tools such as `image_generate` available when OpenAI auth lives in the agent's auth-profile store instead of environment variables.

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -129,7 +129,8 @@ your personal Codex CLI state by default.
 Running `openclaw migrate codex` in an interactive terminal previews the full
 plan, then opens checkbox selectors before the final apply confirmation. Skill
 copy items are prompted first. Use `Toggle all on` or `Toggle all off` for bulk
-selection; planned skills start checked, conflict skills start unchecked, and
+selection. Press Space to toggle rows, or press Enter to activate the highlighted
+row and continue. Planned skills start checked, conflict skills start unchecked, and
 `Skip for now` skips skill copies for this run while still continuing to plugin
 selection. When source-installed curated Codex plugins are migratable and
 `--plugin` was not supplied, migration then prompts for native Codex plugin

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -9,6 +9,11 @@ const mocks = vi.hoisted(() => ({
   clackCancel: vi.fn(),
   clackIsCancel: vi.fn(),
   multiselect: vi.fn(),
+  progress: {
+    setLabel: vi.fn(),
+    setPercent: vi.fn(),
+    tick: vi.fn(),
+  },
   promptYesNo: vi.fn(),
   provider: {
     id: "hermes",
@@ -16,7 +21,12 @@ const mocks = vi.hoisted(() => ({
     plan: vi.fn(),
     apply: vi.fn(),
   },
+  withProgress: vi.fn(),
 }));
+
+mocks.withProgress.mockImplementation(
+  async (_opts: unknown, run: (progress: unknown) => unknown) => await run(mocks.progress),
+);
 
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => ({}),
@@ -29,6 +39,10 @@ vi.mock("../config/paths.js", () => ({
 
 vi.mock("../cli/prompt.js", () => ({
   promptYesNo: mocks.promptYesNo,
+}));
+
+vi.mock("../cli/progress.js", () => ({
+  withProgress: mocks.withProgress,
 }));
 
 vi.mock("@clack/prompts", () => ({
@@ -254,6 +268,10 @@ describe("migrateApplyCommand", () => {
     });
     mocks.provider.plan.mockReset();
     mocks.provider.apply.mockReset();
+    mocks.withProgress.mockClear();
+    mocks.progress.setLabel.mockClear();
+    mocks.progress.setPercent.mockClear();
+    mocks.progress.tick.mockClear();
     mocks.multiselect.mockReset();
     mocks.clackCancel.mockReset();
     mocks.clackIsCancel.mockReset();
@@ -337,6 +355,23 @@ describe("migrateApplyCommand", () => {
 
     expect(result).toBe(planned);
     expect(mocks.provider.plan).toHaveBeenCalledTimes(1);
+    expect(mocks.withProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ indeterminate: true, label: "Scanning codex migration…" }),
+      expect.any(Function),
+    );
+  });
+
+  it("does not wrap JSON planning in progress output", async () => {
+    const planned = codexPluginPlan();
+    mocks.provider.plan.mockResolvedValue(planned);
+
+    const result = await migratePlanCommand(runtime, {
+      provider: "codex",
+      json: true,
+    });
+
+    expect(result).toBe(planned);
+    expect(mocks.withProgress).not.toHaveBeenCalled();
   });
 
   it("passes --verify-plugin-apps into Codex apply planning and apply contexts", async () => {
@@ -1208,6 +1243,7 @@ describe("migrateApplyCommand", () => {
     await migrateDefaultCommand(jsonRuntime, { provider: "hermes", yes: true, json: true });
 
     expect(logs).toHaveLength(1);
+    expect(mocks.withProgress).not.toHaveBeenCalled();
     const logPayload = JSON.parse(logs[0] ?? "{}") as {
       backupPath?: unknown;
       items?: Array<{
@@ -1278,6 +1314,7 @@ describe("migrateApplyCommand", () => {
     await migrateDefaultCommand(runtime, { provider: "hermes", yes: true });
 
     expect(mocks.provider.plan).toHaveBeenCalledTimes(1);
+    expect(mocks.withProgress).toHaveBeenCalledTimes(2);
     expect(typeof firstApplyContext()).toBe("object");
     expect(firstAppliedPlan()).toBe(planned);
   });

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,5 +1,6 @@
 import { cancel, isCancel } from "@clack/prompts";
 import { formatCliCommand } from "../cli/command-format.js";
+import { withProgress } from "../cli/progress.js";
 import { promptYesNo } from "../cli/prompt.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { redactMigrationPlan } from "../plugin-sdk/migration.js";
@@ -84,6 +85,26 @@ function selectMigrationItems(plan: MigrationPlan, opts: MigrateCommonOptions): 
     applyMigrationPluginSelection(applyMigrationSkillSelection(plan, opts.skills), opts.plugins),
     opts,
   );
+}
+
+async function createMigrationPlanWithProgress(
+  runtime: RuntimeEnv,
+  opts: MigrateCommonOptions & { provider: string },
+): Promise<MigrationPlan> {
+  const createPlan = async (): Promise<MigrationPlan> => await createMigrationPlan(runtime, opts);
+  if (opts.json) {
+    return selectMigrationItems(await createPlan(), opts);
+  }
+  const plan = await withProgress(
+    { label: `Scanning ${opts.provider} migration…`, indeterminate: true },
+    async (progress) => {
+      progress.setLabel("Reading migration source…");
+      const plan = await createPlan();
+      progress.tick();
+      return plan;
+    },
+  );
+  return selectMigrationItems(plan, opts);
 }
 
 function assertVerifyPluginAppsProvider(providerId: string, opts: MigrateCommonOptions): void {
@@ -310,10 +331,7 @@ export async function migratePlanCommand(
     );
   }
   assertVerifyPluginAppsProvider(providerId, opts);
-  const plan = selectMigrationItems(
-    await createMigrationPlan(runtime, { ...opts, provider: providerId }),
-    opts,
-  );
+  const plan = await createMigrationPlanWithProgress(runtime, { ...opts, provider: providerId });
   if (opts.json) {
     writeRuntimeJson(runtime, redactMigrationPlan(plan));
   } else {

--- a/src/commands/migrate/apply.ts
+++ b/src/commands/migrate/apply.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs/promises";
+import { withProgress } from "../../cli/progress.js";
+import type { ProgressReporter } from "../../cli/progress.js";
 import { resolveStateDir } from "../../config/paths.js";
 import type { MigrationApplyResult, MigrationProviderPlugin } from "../../plugins/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
@@ -49,45 +51,74 @@ export async function runMigrationApply(params: {
   providerId: string;
   provider: MigrationProviderPlugin;
 }): Promise<MigrationApplyResult> {
-  const preflightPlan =
-    params.opts.preflightPlan ??
-    (await params.provider.plan(
-      buildMigrationContext({
-        source: params.opts.source,
-        includeSecrets: params.opts.includeSecrets,
-        overwrite: params.opts.overwrite,
-        providerOptions: buildMigrationProviderOptions(params.opts),
-        runtime: params.runtime,
-        json: params.opts.json,
-      }),
-    ));
-  const selectedPlan = applyMigrationPluginSelection(
-    applyMigrationSkillSelection(preflightPlan, params.opts.skills),
-    params.opts.plugins,
-  );
-  assertConflictFreePlan(selectedPlan, params.providerId);
-  const stateDir = resolveStateDir();
-  const reportDir = buildMigrationReportDir(params.providerId, stateDir);
-  const backupPath = params.opts.noBackup
-    ? undefined
-    : await createPreMigrationBackup({ output: params.opts.backupOutput });
-  await fs.mkdir(reportDir, { recursive: true });
-  const ctx = buildMigrationContext({
-    source: params.opts.source,
-    includeSecrets: params.opts.includeSecrets,
-    overwrite: params.opts.overwrite,
-    providerOptions: buildMigrationProviderOptions(params.opts),
-    runtime: params.runtime,
-    backupPath,
-    reportDir,
-    json: params.opts.json,
-  });
-  const result = await params.provider.apply(ctx, selectedPlan);
-  const withBackup = {
-    ...result,
-    backupPath: result.backupPath ?? backupPath,
-    reportDir: result.reportDir ?? reportDir,
+  const applyMigration = async (progress?: ProgressReporter) => {
+    const total = (params.opts.preflightPlan ? 0 : 1) + (params.opts.noBackup ? 0 : 1) + 1;
+    let completed = 0;
+    const tick = () => {
+      completed += 1;
+      progress?.setPercent((completed / total) * 100);
+    };
+    if (!params.opts.preflightPlan) {
+      progress?.setLabel("Preparing migration plan…");
+    }
+    const preflightPlan =
+      params.opts.preflightPlan ??
+      (await params.provider.plan(
+        buildMigrationContext({
+          source: params.opts.source,
+          includeSecrets: params.opts.includeSecrets,
+          overwrite: params.opts.overwrite,
+          providerOptions: buildMigrationProviderOptions(params.opts),
+          runtime: params.runtime,
+          json: params.opts.json,
+        }),
+      ));
+    if (!params.opts.preflightPlan) {
+      tick();
+    }
+    const selectedPlan = applyMigrationPluginSelection(
+      applyMigrationSkillSelection(preflightPlan, params.opts.skills),
+      params.opts.plugins,
+    );
+    assertConflictFreePlan(selectedPlan, params.providerId);
+    const stateDir = resolveStateDir();
+    const reportDir = buildMigrationReportDir(params.providerId, stateDir);
+    if (!params.opts.noBackup) {
+      progress?.setLabel("Preparing migration backup…");
+    }
+    const backupPath = params.opts.noBackup
+      ? undefined
+      : await createPreMigrationBackup({ output: params.opts.backupOutput });
+    if (!params.opts.noBackup) {
+      tick();
+    }
+    await fs.mkdir(reportDir, { recursive: true });
+    const ctx = buildMigrationContext({
+      source: params.opts.source,
+      includeSecrets: params.opts.includeSecrets,
+      overwrite: params.opts.overwrite,
+      providerOptions: buildMigrationProviderOptions(params.opts),
+      runtime: params.runtime,
+      backupPath,
+      reportDir,
+      json: params.opts.json,
+    });
+    progress?.setLabel("Applying migration…");
+    const result = await params.provider.apply(ctx, selectedPlan);
+    tick();
+    const withBackup = {
+      ...result,
+      backupPath: result.backupPath ?? backupPath,
+      reportDir: result.reportDir ?? reportDir,
+    };
+    return withBackup;
   };
+  const withBackup = params.opts.json
+    ? await applyMigration()
+    : await withProgress(
+        { label: `Applying ${params.providerId} migration…` },
+        async (progress) => await applyMigration(progress),
+      );
   writeApplyResult(params.runtime, params.opts, withBackup);
   assertApplySucceeded(withBackup);
   return withBackup;

--- a/src/commands/migrate/selection.test.ts
+++ b/src/commands/migrate/selection.test.ts
@@ -422,6 +422,12 @@ describe("applyMigrationSkillSelection", () => {
     ).toEqual(["skill:alpha"]);
 
     expect(
+      reconcileInteractiveMigrationEnterValues(["skill:beta"], "skill:alpha", selectable, {
+        preserveDeselectedActivatedValue: true,
+      }),
+    ).toEqual(["skill:beta"]);
+
+    expect(
       reconcileInteractiveMigrationEnterValues(["skill:alpha"], undefined, selectable),
     ).toEqual(["skill:alpha"]);
   });

--- a/src/commands/migrate/selection.test.ts
+++ b/src/commands/migrate/selection.test.ts
@@ -14,6 +14,7 @@ import {
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
   MIGRATION_PLUGIN_NOT_SELECTED_REASON,
   MIGRATION_SKILL_NOT_SELECTED_REASON,
+  reconcileInteractiveMigrationEnterValues,
   reconcileInteractiveMigrationShortcutValues,
   reconcileInteractiveMigrationSkillToggleValues,
   resolveInteractiveMigrationPluginSelection,
@@ -383,6 +384,46 @@ describe("applyMigrationSkillSelection", () => {
         "i",
       ),
     ).toEqual(["skill:beta"]);
+  });
+
+  it("reconciles enter as activating the cursor row without toggling it off", () => {
+    const selectable = ["skill:alpha", "skill:beta"];
+
+    expect(
+      reconcileInteractiveMigrationEnterValues(
+        ["skill:alpha", "skill:beta"],
+        MIGRATION_SKILL_SELECTION_SKIP,
+        selectable,
+      ),
+    ).toEqual([MIGRATION_SKILL_SELECTION_SKIP]);
+
+    expect(
+      reconcileInteractiveMigrationEnterValues(
+        ["skill:alpha"],
+        MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
+        selectable,
+      ),
+    ).toEqual([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, "skill:alpha", "skill:beta"]);
+
+    expect(
+      reconcileInteractiveMigrationEnterValues(
+        ["skill:alpha"],
+        MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
+        selectable,
+      ),
+    ).toEqual([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF]);
+
+    expect(
+      reconcileInteractiveMigrationEnterValues(["skill:alpha"], "skill:beta", selectable),
+    ).toEqual(["skill:alpha", "skill:beta"]);
+
+    expect(
+      reconcileInteractiveMigrationEnterValues(["skill:alpha"], "skill:alpha", selectable),
+    ).toEqual(["skill:alpha"]);
+
+    expect(
+      reconcileInteractiveMigrationEnterValues(["skill:alpha"], undefined, selectable),
+    ).toEqual(["skill:alpha"]);
   });
 
   it("rejects unknown explicit skill selectors with available choices", () => {

--- a/src/commands/migrate/selection.ts
+++ b/src/commands/migrate/selection.ts
@@ -493,6 +493,36 @@ export function reconcileInteractiveMigrationSkillToggleValues(
   );
 }
 
+export function reconcileInteractiveMigrationEnterValues(
+  selectedValues: readonly string[],
+  activatedValue: string | undefined,
+  selectableValues: readonly string[],
+): string[] {
+  if (activatedValue === MIGRATION_SELECTION_SKIP) {
+    return [MIGRATION_SELECTION_SKIP];
+  }
+  if (activatedValue === MIGRATION_SELECTION_TOGGLE_ALL_ON) {
+    return [MIGRATION_SELECTION_TOGGLE_ALL_ON, ...selectableValues];
+  }
+  if (activatedValue === MIGRATION_SELECTION_TOGGLE_ALL_OFF) {
+    return [MIGRATION_SELECTION_TOGGLE_ALL_OFF];
+  }
+  if (activatedValue !== undefined && selectableValues.includes(activatedValue)) {
+    return Array.from(
+      new Set([
+        ...selectedValues.filter(
+          (value) =>
+            value !== MIGRATION_SELECTION_TOGGLE_ALL_ON &&
+            value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF &&
+            value !== MIGRATION_SELECTION_SKIP,
+        ),
+        activatedValue,
+      ]),
+    );
+  }
+  return [...selectedValues];
+}
+
 export function reconcileInteractiveMigrationShortcutValues(
   previousValues: readonly string[],
   selectedValues: readonly string[],

--- a/src/commands/migrate/selection.ts
+++ b/src/commands/migrate/selection.ts
@@ -497,6 +497,7 @@ export function reconcileInteractiveMigrationEnterValues(
   selectedValues: readonly string[],
   activatedValue: string | undefined,
   selectableValues: readonly string[],
+  opts: { preserveDeselectedActivatedValue?: boolean } = {},
 ): string[] {
   if (activatedValue === MIGRATION_SELECTION_SKIP) {
     return [MIGRATION_SELECTION_SKIP];
@@ -508,17 +509,16 @@ export function reconcileInteractiveMigrationEnterValues(
     return [MIGRATION_SELECTION_TOGGLE_ALL_OFF];
   }
   if (activatedValue !== undefined && selectableValues.includes(activatedValue)) {
-    return Array.from(
-      new Set([
-        ...selectedValues.filter(
-          (value) =>
-            value !== MIGRATION_SELECTION_TOGGLE_ALL_ON &&
-            value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF &&
-            value !== MIGRATION_SELECTION_SKIP,
-        ),
-        activatedValue,
-      ]),
+    const selectedSelectableValues = selectedValues.filter(
+      (value) =>
+        value !== MIGRATION_SELECTION_TOGGLE_ALL_ON &&
+        value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF &&
+        value !== MIGRATION_SELECTION_SKIP,
     );
+    if (opts.preserveDeselectedActivatedValue && !selectedValues.includes(activatedValue)) {
+      return selectedSelectableValues;
+    }
+    return Array.from(new Set([...selectedSelectableValues, activatedValue]));
   }
   return [...selectedValues];
 }

--- a/src/commands/migrate/skill-selection-prompt.test.ts
+++ b/src/commands/migrate/skill-selection-prompt.test.ts
@@ -1,0 +1,85 @@
+import { PassThrough, Writable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import {
+  MIGRATION_SKILL_SELECTION_SKIP,
+  MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
+  MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
+} from "./selection.js";
+import { promptMigrationSkillSelectionValues } from "./skill-selection-prompt.js";
+
+function createPromptOutput(): NodeJS.WriteStream {
+  const output = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+  Object.defineProperty(output, "columns", {
+    configurable: true,
+    value: 100,
+  });
+  return output as NodeJS.WriteStream;
+}
+
+async function runPromptWithReturn(params: {
+  cursorAt: string;
+  initialValues?: string[];
+}): Promise<string[] | symbol | undefined> {
+  const input = new PassThrough() as unknown as NodeJS.ReadStream;
+  const result = promptMigrationSkillSelectionValues({
+    message: "Select Codex skills",
+    options: [
+      { value: MIGRATION_SKILL_SELECTION_SKIP, label: "Skip for now" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
+      { value: "skill:alpha", label: "alpha" },
+      { value: "skill:beta", label: "beta" },
+    ],
+    initialValues: params.initialValues,
+    required: false,
+    cursorAt: params.cursorAt,
+    selectableValues: ["skill:alpha", "skill:beta"],
+    input,
+    output: createPromptOutput(),
+    withGuide: false,
+  });
+  setTimeout(() => input.write("\r"), 0);
+  return await result;
+}
+
+describe("promptMigrationSkillSelectionValues", () => {
+  it("activates Skip for now before submitting with return", async () => {
+    await expect(
+      runPromptWithReturn({
+        cursorAt: MIGRATION_SKILL_SELECTION_SKIP,
+        initialValues: ["skill:alpha", "skill:beta"],
+      }),
+    ).resolves.toEqual([MIGRATION_SKILL_SELECTION_SKIP]);
+  });
+
+  it("keeps the cursor item selected when submitting with return", async () => {
+    await expect(
+      runPromptWithReturn({
+        cursorAt: "skill:alpha",
+        initialValues: ["skill:alpha"],
+      }),
+    ).resolves.toEqual(["skill:alpha"]);
+  });
+
+  it("activates Toggle all off before submitting with return", async () => {
+    await expect(
+      runPromptWithReturn({
+        cursorAt: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
+        initialValues: ["skill:alpha", "skill:beta"],
+      }),
+    ).resolves.toEqual([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF]);
+  });
+
+  it("activates Toggle all on before submitting with return", async () => {
+    await expect(
+      runPromptWithReturn({
+        cursorAt: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
+        initialValues: [],
+      }),
+    ).resolves.toEqual([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, "skill:alpha", "skill:beta"]);
+  });
+});

--- a/src/commands/migrate/skill-selection-prompt.test.ts
+++ b/src/commands/migrate/skill-selection-prompt.test.ts
@@ -20,9 +20,10 @@ function createPromptOutput(): NodeJS.WriteStream {
   return output as NodeJS.WriteStream;
 }
 
-async function runPromptWithReturn(params: {
+async function runPromptWithKeys(params: {
   cursorAt: string;
   initialValues?: string[];
+  keys: string[];
 }): Promise<string[] | symbol | undefined> {
   const input = new PassThrough() as unknown as NodeJS.ReadStream;
   const result = promptMigrationSkillSelectionValues({
@@ -42,8 +43,30 @@ async function runPromptWithReturn(params: {
     output: createPromptOutput(),
     withGuide: false,
   });
-  setTimeout(() => input.write("\r"), 0);
+  params.keys.forEach((key, index) => {
+    setTimeout(
+      () => {
+        if (key === " ") {
+          input.emit("keypress", " ", { name: "space" });
+          return;
+        }
+        if (key === "\r") {
+          input.emit("keypress", "\r", { name: "return" });
+          return;
+        }
+        input.write(key);
+      },
+      20 + index * 20,
+    );
+  });
   return await result;
+}
+
+async function runPromptWithReturn(params: {
+  cursorAt: string;
+  initialValues?: string[];
+}): Promise<string[] | symbol | undefined> {
+  return await runPromptWithKeys({ ...params, keys: ["\r"] });
 }
 
 describe("promptMigrationSkillSelectionValues", () => {
@@ -63,6 +86,16 @@ describe("promptMigrationSkillSelectionValues", () => {
         initialValues: ["skill:alpha"],
       }),
     ).resolves.toEqual(["skill:alpha"]);
+  });
+
+  it("preserves a cursor item deselected with space before return", async () => {
+    await expect(
+      runPromptWithKeys({
+        cursorAt: "skill:alpha",
+        initialValues: ["skill:alpha", "skill:beta"],
+        keys: [" ", "\r"],
+      }),
+    ).resolves.toEqual(["skill:beta"]);
   });
 
   it("activates Toggle all off before submitting with return", async () => {

--- a/src/commands/migrate/skill-selection-prompt.ts
+++ b/src/commands/migrate/skill-selection-prompt.ts
@@ -11,6 +11,7 @@ import {
   symbolBar,
 } from "@clack/prompts";
 import {
+  reconcileInteractiveMigrationEnterValues,
   reconcileInteractiveMigrationShortcutValues,
   reconcileInteractiveMigrationSkillToggleValues,
 } from "./selection.js";
@@ -186,7 +187,18 @@ export function promptMigrationSkillSelectionValues(
     lastSelectedValues = [...(prompt.value ?? [])];
   });
 
-  prompt.on("key", (key) => {
+  prompt.on("key", (key, info) => {
+    if (info.name === "return") {
+      const activatedOption = prompt.options[prompt.cursor];
+      const activatedValue = activatedOption?.disabled ? undefined : activatedOption?.value;
+      prompt.value = reconcileInteractiveMigrationEnterValues(
+        prompt.value ?? [],
+        activatedValue,
+        opts.selectableValues,
+      );
+      lastSelectedValues = [...(prompt.value ?? [])];
+      return;
+    }
     if (key !== "a" && key !== "i") {
       return;
     }

--- a/src/commands/migrate/skill-selection-prompt.ts
+++ b/src/commands/migrate/skill-selection-prompt.ts
@@ -173,17 +173,28 @@ export function promptMigrationSkillSelectionValues(
     },
   });
   let lastSelectedValues = [...(prompt.value ?? [])];
+  let lastSpaceDeselectedValue: string | undefined;
 
   prompt.on("cursor", (key) => {
     if (key !== "space") {
+      lastSpaceDeselectedValue = undefined;
       return;
     }
     const activatedValue = prompt.options[prompt.cursor]?.value;
+    const previousValues = lastSelectedValues;
+    const selectedValuesAfterClack = prompt.value ?? [];
     prompt.value = reconcileInteractiveMigrationSkillToggleValues(
-      prompt.value ?? [],
+      selectedValuesAfterClack,
       activatedValue,
       opts.selectableValues,
     );
+    lastSpaceDeselectedValue =
+      activatedValue !== undefined &&
+      opts.selectableValues.includes(activatedValue) &&
+      previousValues.includes(activatedValue) &&
+      !(prompt.value ?? []).includes(activatedValue)
+        ? activatedValue
+        : undefined;
     lastSelectedValues = [...(prompt.value ?? [])];
   });
 
@@ -195,7 +206,14 @@ export function promptMigrationSkillSelectionValues(
         prompt.value ?? [],
         activatedValue,
         opts.selectableValues,
+        {
+          preserveDeselectedActivatedValue:
+            activatedValue !== undefined &&
+            activatedValue === lastSpaceDeselectedValue &&
+            !(prompt.value ?? []).includes(activatedValue),
+        },
       );
+      lastSpaceDeselectedValue = undefined;
       lastSelectedValues = [...(prompt.value ?? [])];
       return;
     }
@@ -208,6 +226,7 @@ export function promptMigrationSkillSelectionValues(
       opts.selectableValues,
       key,
     );
+    lastSpaceDeselectedValue = undefined;
     lastSelectedValues = [...(prompt.value ?? [])];
   });
 


### PR DESCRIPTION
## Summary
- Make Enter activate highlighted Codex migration command rows like `Skip for now`, `Toggle all on`, and `Toggle all off` before submitting.
- Preserve an ordinary migration row that the user explicitly deselected with Space before pressing Enter.
- Add CLI progress around non-JSON migration planning/apply work while keeping progress out of JSON output and prompt rendering.
- Document selector key behavior and add focused prompt-wrapper coverage.

## Real behavior proof
- Behavior or issue addressed: `openclaw migrate codex` multi-select prompts now treat Enter as activation for highlighted command rows before advancing, while preserving ordinary rows the user explicitly deselects with Space before Enter. Non-JSON migration planning/apply paths show CLI progress while work is running.
- Real environment tested: Local OpenClaw checkout on macOS from branch `codex/migrate-enter-progress` at `80428252738f480b7d8d8ab149ddead21f236afe`, using the real `pnpm openclaw --profile dev migrate codex` command in a TTY against `/Users/kevinlin/.codex` and `/Users/kevinlin/.openclaw/workspace-dev`.
- Exact steps or command run after this patch: Ran `pnpm openclaw --profile dev migrate codex`, waited for the live plan and skill selector, moved the cursor to the preselected `ag-bootstrap` ordinary skill row, pressed Space, then pressed Enter.
- Evidence after fix: Terminal capture from the real command:

```text
◆  Select Codex skills to migrate into this agent
│  ◻ Skip for now
│  ◻ Toggle all on
│  ◻ Toggle all off
│  ◻ ag-bootstrap (Codex CLI skill)
│  ◼ ag-dir (Codex CLI skill)
│  ◼ ag-judge (Codex CLI skill)
...

◇  Select Codex skills to migrate into this agent
│  ag-dir, ag-judge, ag-learn, ag-ledger, ag-task, agent-browser, audit, babysit-pr, claw-integ, claw-repro,
│  create-task, debug-test-failure, dendron, dendron.changelog, dendron.gather-tasks, dendron.meet,
│  dendron.review, dendron.weekly-review, dendron.wins, dev.add-license, dev.bootstrap.typescript,
│  dev.can-make-public, dev.code, dev.codex, dev.conventional-commits, dev.diagram, dev.do, dev.llm-session,
│  dev.loop, dev.new, dev.review, dev.shortcuts, dev.worktrees, devtools, docstyle, docx, docy, endday,
│  fast-mode, fin, find-links, gen-notifier, hingy, hn-title, icon-gen, imagekit-upload, integ, land, linear,
│  link, mature, mdsearch, me.context, mem, meta.skill-optimizer, meta.summarize, notion, op, oz.gif,
│  oz.prepday, pdf, planloop, prepday, prepweek, proj, proj.report, proofread, relationship-review, sc,
│  schemas, secrets, showboat, showboat-v2, slack-notify, spec-simulate, specy, statsig, sudocode, sw-ctrl,
│  sw-loop, tech-doc-writer, tmp.detect-abuse, tool, video2image, workon, xlsx
Selected 86 of 87 Codex skills for migration.
```

Earlier current-branch TTY proof also showed Enter on highlighted `Skip for now` producing `Codex skill migration skipped for now.` and `Codex plugin migration skipped for now.`, and the migration scan spinner rendering as `Reading migration source…`.
- Observed result after fix: Space deselected the highlighted ordinary `ag-bootstrap` row; pressing Enter submitted the remaining 86 of 87 skills and did not re-add `ag-bootstrap`. The special `Skip for now` Enter activation and migration progress spinner behavior remain covered by the same live TTY flow.
- What was not tested: No additional gaps.

## Verification
- [x] `pnpm test src/commands/migrate/selection.test.ts src/commands/migrate/skill-selection-prompt.test.ts src/commands/migrate.test.ts`
- [x] `pnpm format:check CHANGELOG.md docs/cli/migrate.md src/commands/migrate.ts src/commands/migrate/apply.ts src/commands/migrate/selection.ts src/commands/migrate/skill-selection-prompt.ts src/commands/migrate.test.ts src/commands/migrate/selection.test.ts src/commands/migrate/skill-selection-prompt.test.ts`
- [x] `pnpm docs:check-mdx docs/cli/migrate.md`
- [x] `pnpm check:changed`

