### PR TITLE
[codex] Add short plugin cache windows

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { bundledDistPluginFile } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { discoverOpenClawPlugins } from "./discovery.js";
+import { clearPluginDiscoveryCache, discoverOpenClawPlugins } from "./discovery.js";
 import { listBuiltRuntimeEntryCandidates } from "./package-entrypoints.js";
 import {
   cleanupTrackedTempDirs,
@@ -450,6 +450,8 @@ async function expectRejectedPackageExtensionEntry(params: {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
+  clearPluginDiscoveryCache();
   vi.restoreAllMocks();
   cleanupTrackedTempDirs(tempDirs);
 });
@@ -2116,7 +2118,9 @@ describe("discoverOpenClawPlugins", () => {
     const pluginPath = path.join(globalExt, "fresh.ts");
     fs.writeFileSync(pluginPath, "export default function () {}", "utf-8");
 
-    const env = buildDiscoveryEnvWithOverrides(stateDir);
+    const env = buildDiscoveryEnvWithOverrides(stateDir, {
+      OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE: "1",
+    });
     const first = discoverWithEnv({ env });
     expect(first.candidates.map((candidate) => candidate.idHint)).toContain("fresh");
 
@@ -2124,6 +2128,27 @@ describe("discoverOpenClawPlugins", () => {
 
     const second = discoverWithEnv({ env });
     expect(second.candidates.map((candidate) => candidate.idHint)).not.toContain("fresh");
+  });
+
+  it("keeps default discovery cache across short gateway poll intervals", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-12T20:00:00.000Z"));
+
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions");
+    mkdirSafe(globalExt);
+    const pluginPath = path.join(globalExt, "poll-cached.ts");
+    fs.writeFileSync(pluginPath, "export default function () {}", "utf-8");
+
+    const env = buildDiscoveryEnvWithOverrides(stateDir);
+    const first = discoverWithEnv({ env });
+    expect(first.candidates.map((candidate) => candidate.idHint)).toContain("poll-cached");
+
+    fs.rmSync(pluginPath, { force: true });
+    vi.advanceTimersByTime(1500);
+
+    const second = discoverWithEnv({ env });
+    expect(second.candidates.map((candidate) => candidate.idHint)).toContain("poll-cached");
   });
 
   it("discovers bundled and global plugins for each workspace-specific scan", () => {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -78,6 +78,85 @@ export type PluginDiscoveryResult = {
   diagnostics: PluginDiagnostic[];
 };
 
+const discoveryCache = new Map<string, { expiresAt: number; result: PluginDiscoveryResult }>();
+
+// Keep a short cache window to collapse bursty reloads and gateway poll loops.
+const DEFAULT_DISCOVERY_CACHE_MS = 30_000;
+
+export function clearPluginDiscoveryCache(): void {
+  discoveryCache.clear();
+}
+
+function resolveDiscoveryCacheMs(env: NodeJS.ProcessEnv): number {
+  const raw = env.OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS?.trim();
+  if (raw === "" || raw === "0") {
+    return 0;
+  }
+  if (!raw) {
+    return DEFAULT_DISCOVERY_CACHE_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_DISCOVERY_CACHE_MS;
+  }
+  return Math.max(0, parsed);
+}
+
+function shouldUseDiscoveryCache(env: NodeJS.ProcessEnv): boolean {
+  const disabled = env.OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE?.trim();
+  if (disabled) {
+    return false;
+  }
+  return resolveDiscoveryCacheMs(env) > 0;
+}
+
+function cloneDiscoveryResult(result: PluginDiscoveryResult): PluginDiscoveryResult {
+  return {
+    candidates: [...result.candidates],
+    diagnostics: [...result.diagnostics],
+  };
+}
+
+function serializeInstallRecords(records: Record<string, PluginInstallRecord> | undefined): string {
+  if (!records) {
+    return "";
+  }
+  return JSON.stringify(
+    Object.entries(records).toSorted(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function buildDiscoveryCacheKey(params: {
+  workspaceRoot?: string;
+  roots: ReturnType<typeof resolvePluginSourceRoots>;
+  extraPaths?: string[];
+  installRecords?: Record<string, PluginInstallRecord>;
+  ownershipUid?: number | null;
+  env: NodeJS.ProcessEnv;
+}): string {
+  const normalizedExtraPaths = (params.extraPaths ?? [])
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => resolveUserPath(entry, params.env));
+  const envRootKeys = [
+    "HOME",
+    "OPENCLAW_HOME",
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_BUNDLED_PLUGINS_DIR",
+    "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+  ];
+  const envRootValues = envRootKeys.map((key) => [key, params.env[key] ?? ""]);
+  return JSON.stringify({
+    envRootValues,
+    extraPaths: normalizedExtraPaths,
+    installRecords: serializeInstallRecords(params.installRecords),
+    ownershipUid: params.ownershipUid !== undefined ? params.ownershipUid : currentUid(),
+    roots: params.roots,
+    workspaceRoot: params.workspaceRoot ?? "",
+  });
+}
+
 function currentUid(overrideUid?: number | null): number | null {
   if (overrideUid !== undefined) {
     return overrideUid;
@@ -1135,6 +1214,23 @@ export function discoverOpenClawPlugins(params: {
   const workspaceDir = normalizeOptionalString(params.workspaceDir);
   const workspaceRoot = workspaceDir ? resolveUserPath(workspaceDir, env) : undefined;
   const roots = resolvePluginSourceRoots({ workspaceDir: workspaceRoot, env });
+  const cacheEnabled = shouldUseDiscoveryCache(env);
+  const cacheKey = cacheEnabled
+    ? buildDiscoveryCacheKey({
+        roots,
+        env,
+        ...(params.extraPaths !== undefined ? { extraPaths: params.extraPaths } : {}),
+        ...(params.installRecords !== undefined ? { installRecords: params.installRecords } : {}),
+        ...(params.ownershipUid !== undefined ? { ownershipUid: params.ownershipUid } : {}),
+        ...(workspaceRoot !== undefined ? { workspaceRoot } : {}),
+      })
+    : undefined;
+  if (cacheKey) {
+    const cached = discoveryCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cloneDiscoveryResult(cached.result);
+    }
+  }
   const scopedResult = tracePluginLifecyclePhase(
     "discovery scan",
     () => {
@@ -1310,5 +1406,11 @@ export function discoverOpenClawPlugins(params: {
   const seenDiagnostics = new Set<string>();
   mergeDiscoveryResult(result, scopedResult, seenSources, seenDiagnostics);
   mergeDiscoveryResult(result, sharedResult, seenSources, seenDiagnostics);
+  if (cacheKey) {
+    discoveryCache.set(cacheKey, {
+      expiresAt: Date.now() + resolveDiscoveryCacheMs(env),
+      result: cloneDiscoveryResult(result),
+    });
+  }
   return result;
 }

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -4,7 +4,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { collectChannelSchemaMetadata } from "../config/channel-config-metadata.js";
 import { collectBundledChannelConfigs } from "./bundled-channel-config-metadata.js";
 import type { PluginCandidate } from "./discovery.js";
-import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import {
+  clearPluginManifestRegistryCache,
+  loadPluginManifestRegistry,
+} from "./manifest-registry.js";
 import type { OpenClawPackageManifest } from "./manifest.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
@@ -363,6 +366,8 @@ function expectCachedPluginRoot(params: {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
+  clearPluginManifestRegistryCache();
   vi.restoreAllMocks();
   cleanupTrackedTempDirs(tempDirs);
 });
@@ -389,6 +394,8 @@ describe("loadPluginManifestRegistry", () => {
     });
     const env = hermeticEnv({
       OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE: "1",
+      OPENCLAW_DISABLE_PLUGIN_MANIFEST_CACHE: "1",
     });
 
     const first = loadPluginManifestRegistry({ env });
@@ -404,6 +411,45 @@ describe("loadPluginManifestRegistry", () => {
 
     const second = loadPluginManifestRegistry({ env });
     expect(second.plugins.find((plugin) => plugin.id === "cached-manifest")?.name).toBe("After");
+  });
+
+  it("keeps default registry cache across short gateway poll intervals", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-12T20:00:00.000Z"));
+
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "registry-cached");
+    mkdirSafe(pluginDir);
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export default function () {}", "utf-8");
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/registry-cached",
+        openclaw: { extensions: ["./index.js"] },
+      }),
+      "utf-8",
+    );
+    writeManifest(pluginDir, {
+      id: "registry-cached",
+      name: "Before",
+      configSchema: { type: "object" },
+    });
+    const env = hermeticEnv({
+      OPENCLAW_STATE_DIR: stateDir,
+    });
+
+    const first = loadPluginManifestRegistry({ env });
+    expect(first.plugins.find((plugin) => plugin.id === "registry-cached")?.name).toBe("Before");
+
+    writeManifest(pluginDir, {
+      id: "registry-cached",
+      name: "After",
+      configSchema: { type: "object" },
+    });
+    vi.advanceTimersByTime(1500);
+
+    const second = loadPluginManifestRegistry({ env });
+    expect(second.plugins.find((plugin) => plugin.id === "registry-cached")?.name).toBe("Before");
   });
 
   it("keeps only the higher-precedence plugin for truly distinct duplicates", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -183,6 +183,85 @@ export type PluginManifestRegistry = {
   diagnostics: PluginDiagnostic[];
 };
 
+const registryCache = new Map<string, { expiresAt: number; registry: PluginManifestRegistry }>();
+
+// Keep a short cache window to collapse bursty reloads and gateway poll loops.
+const DEFAULT_MANIFEST_CACHE_MS = 30_000;
+
+export function clearPluginManifestRegistryCache(): void {
+  registryCache.clear();
+}
+
+function resolveManifestCacheMs(env: NodeJS.ProcessEnv): number {
+  const raw = env.OPENCLAW_PLUGIN_MANIFEST_CACHE_MS?.trim();
+  if (raw === "" || raw === "0") {
+    return 0;
+  }
+  if (!raw) {
+    return DEFAULT_MANIFEST_CACHE_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_MANIFEST_CACHE_MS;
+  }
+  return Math.max(0, parsed);
+}
+
+function shouldUseManifestCache(env: NodeJS.ProcessEnv): boolean {
+  const disabled = env.OPENCLAW_DISABLE_PLUGIN_MANIFEST_CACHE?.trim();
+  if (disabled) {
+    return false;
+  }
+  return resolveManifestCacheMs(env) > 0;
+}
+
+function clonePluginManifestRegistry(registry: PluginManifestRegistry): PluginManifestRegistry {
+  return {
+    plugins: [...registry.plugins],
+    diagnostics: [...registry.diagnostics],
+  };
+}
+
+function serializeInstallRecords(records: Record<string, PluginInstallRecord> | undefined): string {
+  if (!records) {
+    return "";
+  }
+  return JSON.stringify(
+    Object.entries(records).toSorted(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function buildCacheKey(params: {
+  config: OpenClawConfig;
+  workspaceDir?: string;
+  plugins: ReturnType<typeof normalizePluginsConfigWithResolver>;
+  env: NodeJS.ProcessEnv;
+  installRecords?: Record<string, PluginInstallRecord>;
+}): string {
+  const workspaceKey = params.workspaceDir ? resolveUserPath(params.workspaceDir, params.env) : "";
+  // The manifest registry only depends on where plugins are discovered from and plugin policy.
+  const loadPaths = params.plugins.loadPaths
+    .map((p) => resolveUserPath(p, params.env))
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const envRootKeys = [
+    "HOME",
+    "OPENCLAW_HOME",
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_BUNDLED_PLUGINS_DIR",
+    "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+    "OPENCLAW_VERSION",
+  ];
+  const envRootValues = envRootKeys.map((key) => [key, params.env[key] ?? ""]);
+  return JSON.stringify({
+    envRootValues,
+    installRecords: serializeInstallRecords(params.installRecords),
+    loadPaths,
+    plugins: params.config.plugins ?? null,
+    workspaceKey,
+  });
+}
+
 export type BundledChannelConfigCollector = (params: {
   pluginDir: string;
   manifest: PluginManifest;
@@ -814,11 +893,32 @@ export function loadPluginManifestRegistry(
     diagnostics?: PluginDiagnostic[];
     installRecords?: Record<string, PluginInstallRecord>;
     bundledChannelConfigCollector?: BundledChannelConfigCollector;
+    cache?: boolean;
   } = {},
 ): PluginManifestRegistry {
   const config = params.config ?? {};
   const normalized = normalizePluginsConfigWithResolver(config.plugins);
   const env = params.env ?? process.env;
+  const cacheEnabled =
+    params.cache !== false &&
+    !params.candidates &&
+    !params.bundledChannelConfigCollector &&
+    shouldUseManifestCache(env);
+  const cacheKey = cacheEnabled
+    ? buildCacheKey({
+        config,
+        plugins: normalized,
+        env,
+        ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+        ...(params.installRecords !== undefined ? { installRecords: params.installRecords } : {}),
+      })
+    : undefined;
+  if (cacheKey) {
+    const cached = registryCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return clonePluginManifestRegistry(cached.registry);
+    }
+  }
   let installRecords = params.installRecords;
   let installRecordsLoaded = Boolean(params.installRecords);
   const getInstallRecords = (): Record<string, PluginInstallRecord> => {
@@ -1030,5 +1130,11 @@ export function loadPluginManifestRegistry(
   }
 
   const registry = { plugins: records, diagnostics: dedupePluginDiagnostics(diagnostics) };
+  if (cacheKey) {
+    registryCache.set(cacheKey, {
+      expiresAt: Date.now() + resolveManifestCacheMs(env),
+      registry: clonePluginManifestRegistry(registry),
+    });
+  }
   return registry;
 }


### PR DESCRIPTION
## Summary

- Add short in-process cache windows for plugin discovery and plugin manifest registry loads.
- Use a 30 second default window to collapse repeated gateway poll loops.
- Keep explicit environment overrides and disable flags.
- Preserve tests that expect immediate reloads by disabling the cache in those specific cases.
- Add regression coverage for short gateway poll intervals.

## Why

Gateway mode can ask for plugin data repeatedly while resolving auth, providers, and runtime metadata. Without a short in-process cache, those repeated checks can trigger synchronous filesystem work against plugin manifests and package metadata.

This PR keeps normal cache controls simple while reducing repeated plugin filesystem work during gateway polling.

## Controls

- `OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS`
- `OPENCLAW_PLUGIN_MANIFEST_CACHE_MS`
- `OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE`
- `OPENCLAW_DISABLE_PLUGIN_MANIFEST_CACHE`

Refs #81143.

## Tests

- `pnpm exec vitest run src/plugins/discovery.test.ts src/plugins/manifest-registry.test.ts`
- `pnpm exec oxfmt --check src/plugins/discovery.ts src/plugins/manifest-registry.ts src/plugins/discovery.test.ts src/plugins/manifest-registry.test.ts`
- `pnpm exec oxlint src/plugins/discovery.ts src/plugins/manifest-registry.ts src/plugins/discovery.test.ts src/plugins/manifest-registry.test.ts`
