### PR TITLE
fix(plugins): preserve npm fallback integrity

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -405,7 +405,19 @@ describe("update-cli", () => {
 
   const syncPluginCall = (index = 0) => {
     const calls = syncPluginsForUpdateChannel.mock.calls as unknown as Array<
-      [{ channel?: string; config?: OpenClawConfig }]
+      [
+        {
+          channel?: string;
+          config?: OpenClawConfig;
+          onIntegrityDrift?: (drift: {
+            pluginId: string;
+            spec: string;
+            expectedIntegrity: string;
+            actualIntegrity: string;
+            resolvedSpec?: string;
+          }) => Promise<boolean>;
+        },
+      ]
     >;
     return calls[index]?.[0];
   };
@@ -1199,6 +1211,9 @@ describe("update-cli", () => {
         await updateCommand({ restart: false });
       },
     );
+
+    const syncCall = syncPluginCall();
+    expect(syncCall?.onIntegrityDrift).toBeTypeOf("function");
 
     const updateCall = npmPluginUpdateCall() as
       | {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1191,24 +1191,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
     params.configSnapshot.sourceConfig,
     pluginInstallRecords,
   );
-  const syncResult = await syncPluginsForUpdateChannel({
-    config: syncConfig,
-    channel: params.channel,
-    workspaceDir: params.root,
-    externalizedBundledPluginBridges: await listPersistedBundledPluginLocationBridges({
-      workspaceDir: params.root,
-    }),
-    logger: pluginLogger,
-  });
-  for (const error of syncResult.summary.errors) {
-    warnings.push(createPostUpdatePluginWarning({ reason: error }));
-  }
-  let pluginConfig = syncResult.config;
   const integrityDrifts: PostCorePluginUpdateResult["integrityDrifts"] = [];
-  const pluginUpdateOutcomes: PluginUpdateOutcome[] = [];
-  let pluginsChanged = syncResult.changed;
-  let npmPluginsChanged = false;
-
   const onPluginIntegrityDrift = async (drift: PluginUpdateIntegrityDriftParams) => {
     integrityDrifts.push({
       pluginId: drift.pluginId,
@@ -1232,6 +1215,23 @@ export async function updatePluginsAfterCoreUpdate(params: {
     }
     return false;
   };
+  const syncResult = await syncPluginsForUpdateChannel({
+    config: syncConfig,
+    channel: params.channel,
+    workspaceDir: params.root,
+    externalizedBundledPluginBridges: await listPersistedBundledPluginLocationBridges({
+      workspaceDir: params.root,
+    }),
+    logger: pluginLogger,
+    onIntegrityDrift: onPluginIntegrityDrift,
+  });
+  for (const error of syncResult.summary.errors) {
+    warnings.push(createPostUpdatePluginWarning({ reason: error }));
+  }
+  let pluginConfig = syncResult.config;
+  const pluginUpdateOutcomes: PluginUpdateOutcome[] = [];
+  let pluginsChanged = syncResult.changed;
+  let npmPluginsChanged = false;
 
   const collectMissingPayloadWarnings = async (
     records: Record<string, PluginInstallRecord>,
@@ -1285,6 +1285,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
     config: pluginConfig,
     timeoutMs: params.timeoutMs,
     updateChannel: params.channel,
+    // Bridge sync already updated these ids, including pinned fallback integrity checks.
     skipIds: new Set([...syncResult.summary.switchedToNpm, ...missingPayloadIds]),
     skipDisabledPlugins: true,
     syncOfficialPluginInstalls: true,

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -3125,6 +3125,139 @@ describe("syncPluginsForUpdateChannel", () => {
     expect(npmInstallCall()?.trustedSourceLinkedOfficialInstall).toBe(true);
   });
 
+  it("preserves expected integrity for ClawHub-to-npm fallback reinstalls", async () => {
+    resolveBundledPluginSourcesMock.mockReturnValue(new Map());
+    installPluginFromClawHubMock.mockResolvedValue({
+      ok: false,
+      code: "package_not_found",
+      error: "Package not found on ClawHub.",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "legacy-chat",
+        targetDir: "/tmp/openclaw-plugins/legacy-chat",
+        version: "2.0.0",
+      }),
+    );
+    const onIntegrityDrift = vi.fn(async () => false);
+
+    await syncPluginsForUpdateChannel({
+      channel: "stable",
+      externalizedBundledPluginBridges: [
+        {
+          bundledPluginId: "legacy-chat",
+          preferredSource: "clawhub",
+          clawhubSpec: "clawhub:legacy-chat@2026.5.1-beta.2",
+          npmSpec: "@openclaw/legacy-chat@2.0.0",
+          channelIds: ["legacy-chat"],
+        },
+      ],
+      config: {
+        channels: {
+          "legacy-chat": {
+            enabled: true,
+          },
+        },
+        plugins: {
+          installs: {
+            "legacy-chat": {
+              source: "npm",
+              spec: "@openclaw/legacy-chat@2.0.0",
+              integrity: "sha512-original",
+              installPath: "/tmp/openclaw-plugins/legacy-chat",
+            },
+          },
+        },
+      },
+      onIntegrityDrift,
+    });
+
+    expect(npmInstallCall()?.spec).toBe("@openclaw/legacy-chat@2.0.0");
+    expect(npmInstallCall()?.expectedPluginId).toBe("legacy-chat");
+    expect(npmInstallCall()?.expectedIntegrity).toBe("sha512-original");
+    expect(npmInstallCall()?.onIntegrityDrift).toBeTypeOf("function");
+    const driftHandler = npmInstallCall()?.onIntegrityDrift;
+    if (typeof driftHandler !== "function") {
+      throw new Error("Expected fallback npm install to include an integrity drift handler");
+    }
+    await expect(
+      driftHandler({
+        spec: "@openclaw/legacy-chat@2.0.0",
+        expectedIntegrity: "sha512-original",
+        actualIntegrity: "sha512-replaced",
+        resolution: {
+          name: "@openclaw/legacy-chat",
+          version: "2.0.0",
+          resolvedSpec: "@openclaw/legacy-chat@2.0.0",
+          integrity: "sha512-replaced",
+          resolvedAt: "2026-05-12T00:00:00.000Z",
+        },
+      }),
+    ).resolves.toBe(false);
+    expect(onIntegrityDrift).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginId: "legacy-chat",
+        spec: "@openclaw/legacy-chat@2.0.0",
+        expectedIntegrity: "sha512-original",
+        actualIntegrity: "sha512-replaced",
+        resolvedSpec: "@openclaw/legacy-chat@2.0.0",
+        resolvedVersion: "2.0.0",
+        dryRun: false,
+      }),
+    );
+  });
+
+  it("does not reuse fallback npm integrity when the fallback spec changes", async () => {
+    resolveBundledPluginSourcesMock.mockReturnValue(new Map());
+    installPluginFromClawHubMock.mockResolvedValue({
+      ok: false,
+      code: "package_not_found",
+      error: "Package not found on ClawHub.",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "legacy-chat",
+        targetDir: "/tmp/openclaw-plugins/legacy-chat",
+        version: "2.0.1",
+      }),
+    );
+
+    await syncPluginsForUpdateChannel({
+      channel: "stable",
+      externalizedBundledPluginBridges: [
+        {
+          bundledPluginId: "legacy-chat",
+          preferredSource: "clawhub",
+          clawhubSpec: "clawhub:legacy-chat@2026.5.1-beta.2",
+          npmSpec: "@openclaw/legacy-chat@2.0.1",
+          channelIds: ["legacy-chat"],
+        },
+      ],
+      config: {
+        channels: {
+          "legacy-chat": {
+            enabled: true,
+          },
+        },
+        plugins: {
+          installs: {
+            "legacy-chat": {
+              source: "npm",
+              spec: "@openclaw/legacy-chat@2.0.0",
+              integrity: "sha512-original",
+              installPath: "/tmp/openclaw-plugins/legacy-chat",
+            },
+          },
+        },
+      },
+    });
+
+    expect(npmInstallCall()?.spec).toBe("@openclaw/legacy-chat@2.0.1");
+    expect(npmInstallCall()?.expectedPluginId).toBe("legacy-chat");
+    expect(npmInstallCall()?.expectedIntegrity).toBeUndefined();
+    expect(npmInstallCall()?.onIntegrityDrift).toBeTypeOf("function");
+  });
+
   it("moves ClawHub-preferred externalized plugin fallbacks back to ClawHub", async () => {
     resolveBundledPluginSourcesMock.mockReturnValue(new Map());
     installPluginFromClawHubMock.mockResolvedValue(

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1568,6 +1568,7 @@ export async function syncPluginsForUpdateChannel(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   logger?: PluginUpdateLogger;
+  onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
   externalizedBundledPluginBridges?: readonly ExternalizedBundledPluginBridge[];
 }): Promise<PluginChannelSyncResult> {
   const env = params.env ?? process.env;
@@ -1681,6 +1682,11 @@ export async function syncPluginsForUpdateChannel(params: {
         targetPluginId,
         npmSpec,
       });
+      // Only bind recorded integrity to the exact fallback artifact it came from.
+      const fallbackExpectedIntegrity =
+        existing?.record.source === "npm" && existing.record.spec === npmSpec
+          ? expectedIntegrityForUpdate(existing.record.spec, existing.record.integrity)
+          : undefined;
       let installSource = preferredSource;
       let installSpec = preferredSource === "clawhub" ? clawhubSpec : npmSpec;
       let result:
@@ -1713,6 +1719,13 @@ export async function syncPluginsForUpdateChannel(params: {
             mode: "update",
             expectedPluginId: targetPluginId,
             trustedSourceLinkedOfficialInstall,
+            expectedIntegrity: fallbackExpectedIntegrity,
+            onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
+              pluginId: targetPluginId,
+              dryRun: false,
+              logger,
+              onIntegrityDrift: params.onIntegrityDrift,
+            }),
             logger,
           });
         }


### PR DESCRIPTION
## Summary

- Problem: ClawHub-preferred plugin bridge sync could fall back to npm without carrying the pinned npm fallback record's stored integrity into `installPluginFromNpmSpec`.
- Why it matters: a changed artifact for the same pinned npm fallback spec could be accepted in the sync path, then skipped by the later integrity-checked npm updater because the plugin was recorded in `switchedToNpm`.
- What changed: ClawHub-to-npm fallback reinstalls now compute `expectedIntegrity` from the existing npm fallback record and use the same fail-closed integrity drift handler as normal npm plugin updates.
- What did NOT change (scope boundary): unpinned npm fallback specs still do not get recorded-integrity enforcement, matching the existing normal updater behavior.

AI-assisted: yes, implemented with Codex.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: pinned npm fallback records for ClawHub-preferred externalized bundled plugins now retain integrity drift enforcement when bridge sync falls back from ClawHub to npm.
- Real environment tested: local Linux checkout on branch `codex/fix-npm-fallback-integrity`, Node/pnpm repo test tooling.
- Exact steps or command run after this patch: ran targeted Vitest files covering plugin update sync and the post-core update CLI path.
- Evidence after fix (copied live output):

```text
pnpm test src/plugins/update.test.ts src/cli/update-cli.test.ts -- --reporter=verbose

[test] passed 2 Vitest shards in 22.95s
```

- Observed result after fix: the new `syncPluginsForUpdateChannel` regression shows the npm fallback reinstall receives `expectedIntegrity: "sha512-original"` and an integrity drift handler, and the CLI test shows post-core sync receives the fail-closed handler.
- What was not tested: full `pnpm check`, full `pnpm test`, live ClawHub, live npm registry drift, and a running gateway loading a changed plugin artifact.
- Before evidence (optional but encouraged): static review of the previous path showed `installPluginFromNpmSpec` in ClawHub-to-npm sync fallback was called without `expectedIntegrity` or `onIntegrityDrift`, while the later regular npm updater skipped `switchedToNpm` ids.

## Root Cause (if applicable)

- Root cause: the bridge sync fallback path reinstalled an existing npm fallback record through `installPluginFromNpmSpec` without mirroring the integrity parameters used by `updateNpmInstalledPlugins`.
- Missing detection / guardrail: existing tests covered ClawHub-to-npm fallback and normal npm updater integrity drift separately, but not the bridge sync fallback reinstall path for an already-installed pinned npm fallback record.
- Contributing context (if known): the CLI records successful sync fallbacks in `summary.switchedToNpm`, and the subsequent regular npm updater intentionally skips those plugin ids.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/update.test.ts` and `src/cli/update-cli.test.ts`
- Scenario the test should lock in: a ClawHub-preferred bridge with an existing exact pinned npm fallback record and stored integrity must pass that integrity and a fail-closed handler into npm fallback reinstall.
- Why this is the smallest reliable guardrail: the vulnerable decision is in plugin update sync argument construction and CLI handler wiring, before any live registry or runtime plugin load is needed.
- Existing test that already covers this (if any): none for the combined sync fallback + stored integrity path.
- If no new test is added, why not: N/A, this PR adds regression coverage.

## User-visible / Behavior Changes

Pinned npm fallback plugin updates now fail closed on integrity drift in the bridge sync path, matching the regular npm plugin updater. Operators may see the existing integrity drift warning/abort instead of a silent fallback reinstall if the registry serves a different artifact for the same pinned spec.

## Diagram (if applicable)

```text
Before:
[ClawHub unavailable] -> [npm fallback reinstall] -> [no expectedIntegrity] -> [switchedToNpm skips regular updater]

After:
[ClawHub unavailable] -> [npm fallback reinstall + expectedIntegrity] -> [same fail-closed drift handler]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm checkout
- Model/provider: N/A
- Integration/channel (if any): plugin update sync for ClawHub-preferred bridge fallback
- Relevant config (redacted): test fixture with `plugins.installs.legacy-chat.source = "npm"`, pinned spec `@openclaw/legacy-chat@2.0.0`, and stored integrity `sha512-original`

### Steps

1. Mock ClawHub install to return `package_not_found` for a ClawHub-preferred bridge.
2. Seed config with an existing exact pinned npm fallback install record containing stored integrity.
3. Run `syncPluginsForUpdateChannel` and inspect the npm installer arguments.
4. Run the post-core update CLI test path and inspect handler wiring into sync.

### Expected

- The npm fallback reinstall receives `expectedIntegrity` from the existing npm install record.
- The npm fallback reinstall receives an integrity drift handler that aborts by default.
- The post-core update command passes its fail-closed integrity handler into sync before regular npm update skips `switchedToNpm` ids.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification run locally:

```text
pnpm test src/plugins/update.test.ts src/cli/update-cli.test.ts -- --reporter=verbose
```

Result: `Test Files 2 passed (2)`, `Tests 163 passed (163)`.

```text
git diff --check -- src/plugins/update.ts src/plugins/update.test.ts src/cli/update-cli/update-command.ts src/cli/update-cli.test.ts
```

Result: no whitespace errors.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ClawHub-to-npm fallback reinstall for an existing pinned npm fallback record, integrity handler forwarding, and existing plugin update/CLI update tests.
- Edge cases checked: normal npm updater integrity behavior remains covered; ClawHub integrity mismatch still fails without npm fallback; official ClawHub-to-npm fallback trust flag remains covered.
- What you did **not** verify: full `pnpm check`, full `pnpm test`, live ClawHub, live npm registry drift, and gateway runtime execution of a changed plugin artifact.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations existed when this PR was opened.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: exact pinned npm fallback installs with changed registry integrity now abort during sync instead of silently reinstalling.
  - Mitigation: this matches the existing regular npm updater integrity policy; operators can intentionally reinstall only after deciding they trust the new artifact.


## Additional Real Behavior Proof

After the bot review, I ran a non-mocked plugin sync proof against real ClawHub and npm metadata. The proof used a temporary ClawHub-preferred bridge whose ClawHub package does not exist, an existing exact pinned npm fallback record for `is-number@7.0.0`, and a deliberately wrong stored integrity value. This exercises the real bridge sync path, the real ClawHub missing-package fallback, real `npm view` metadata resolution, and the fail-closed integrity drift handler.

Command shape used locally:

```text
node --import tsx --input-type=module <<'EOF'
# calls syncPluginsForUpdateChannel with:
# - clawhubSpec: clawhub:<temporary missing package>
# - npmSpec: is-number@7.0.0
# - existing npm install record integrity: sha512-deliberately-wrong-proof-integrity
# - onIntegrityDrift returning false
EOF
```

Copied output, with the temporary proof id preserved and no secrets present:

```json
{
  "proofId": "integrity-proof-1778621231077",
  "changed": false,
  "warnings": [
    "ClawHub clawhub:integrity-proof-1778621231077 unavailable for integrity-proof-1778621231077; falling back to npm is-number@7.0.0."
  ],
  "errors": [
    "Failed to update integrity-proof-1778621231077: aborted: npm package integrity drift detected for is-number@7.0.0"
  ],
  "switchedToNpm": [],
  "driftEvents": [
    {
      "pluginId": "integrity-proof-1778621231077",
      "spec": "is-number@7.0.0",
      "resolvedSpec": "is-number@7.0.0",
      "resolvedVersion": "7.0.0",
      "expectedIntegrity": "sha512-deliberately-wrong-proof-integrity",
      "actualIntegrityPrefix": "sha512-41Cifkg6e8T",
      "dryRun": false
    }
  ],
  "loggerWarnings": [
    "ClawHub clawhub:integrity-proof-1778621231077 unavailable for integrity-proof-1778621231077; falling back to npm is-number@7.0.0."
  ],
  "loggerErrors": [
    "Failed to update integrity-proof-1778621231077: aborted: npm package integrity drift detected for is-number@7.0.0"
  ],
  "installRecord": {
    "source": "npm",
    "spec": "is-number@7.0.0",
    "integrity": "sha512-deliberately-wrong-proof-integrity",
    "installPath": "/tmp/integrity-proof-1778621231077"
  }
}
```

Observed result: the fallback reaches real npm metadata, reports the expected integrity drift, aborts the update, leaves `changed: false`, and does not add the plugin id to `switchedToNpm`.
