### PR TITLE
fix: normalize Codex app-server runtime attribution

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3446,6 +3446,70 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
   });
 
+  it("records canonical OpenAI models as Codex-runtime when app-server owns the turn", async () => {
+    vi.stubEnv("OPENCLAW_TRAJECTORY", "1");
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.provider = "openai";
+    params.modelId = "gpt-5.5";
+    params.model = {
+      ...createCodexTestModel("openai"),
+      id: "gpt-5.5",
+      name: "gpt-5.5",
+      api: "openai-responses",
+    } as EmbeddedRunAttemptParams["model"];
+    params.runtimePlan = {
+      ...createCodexRuntimePlanFixture(),
+      observability: {
+        resolvedRef: "openai/gpt-5.5",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        harnessId: "codex",
+      },
+    };
+    const harness = createAppServerHarness(async (method) => {
+      if (method === "thread/start") {
+        return {
+          ...threadStartResult(),
+          model: "gpt-5.5",
+        };
+      }
+      if (method === "turn/start") {
+        return {
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            items: [{ type: "agentMessage", id: "msg-1", text: "done from codex" }],
+          },
+        };
+      }
+      return {};
+    });
+
+    const result = await runCodexAppServerAttempt(params);
+
+    expect(harness.requests.map((entry) => entry.method)).toContain("turn/start");
+    expect(result.lastAssistant?.provider).toBe("openai-codex");
+    expect(result.lastAssistant?.api).toBe("openai-codex-responses");
+    expect(result.lastAssistant?.model).toBe("gpt-5.5");
+    expect(result.assistantTexts).toEqual(["done from codex"]);
+
+    const trajectory = await fs.readFile(
+      `${sessionFile.slice(0, -".jsonl".length)}.trajectory.jsonl`,
+      "utf8",
+    );
+    const events = trajectory
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { provider?: string; modelApi?: string; type?: string });
+    expect(events.some((event) => event.type === "session.started")).toBe(true);
+    for (const event of events) {
+      expect(event.provider).toBe("openai-codex");
+      expect(event.modelApi).toBe("openai-codex-responses");
+    }
+  });
+
   it("surfaces Codex-native image generation saved paths as reply media", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -150,6 +150,10 @@ const CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS = 30 * 60_000;
 const CODEX_NATIVE_HOOK_RELAY_MIN_TTL_MS = 30 * 60_000;
 const CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS = 5 * 60_000;
 const CODEX_STEER_ALL_DEBOUNCE_MS = 500;
+const OPENAI_PROVIDER_ID = "openai";
+const OPENAI_RESPONSES_API = "openai-responses";
+const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
+const OPENAI_CODEX_RESPONSES_API = "openai-codex-responses";
 const LOG_FIELD_MAX_LENGTH = 160;
 const CODEX_NATIVE_PROJECT_DOC_BASENAMES = new Set(["agents.md"]);
 const CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS =
@@ -211,6 +215,34 @@ function emitCodexAppServerEvent(
 
 function collectTerminalAssistantText(result: EmbeddedRunAttemptResult): string {
   return result.assistantTexts.join("\n\n").trim();
+}
+
+function normalizeRuntimeId(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function shouldUseOpenAICodexRuntimeAttribution(params: EmbeddedRunAttemptParams): boolean {
+  return (
+    normalizeRuntimeId(params.model.provider) === OPENAI_PROVIDER_ID &&
+    normalizeRuntimeId(params.model.api) === OPENAI_RESPONSES_API
+  );
+}
+
+function withCodexAppServerRuntimeAttribution<TParams extends EmbeddedRunAttemptParams>(
+  params: TParams,
+): TParams {
+  if (!shouldUseOpenAICodexRuntimeAttribution(params)) {
+    return params;
+  }
+  return {
+    ...params,
+    provider: OPENAI_CODEX_PROVIDER_ID,
+    model: {
+      ...params.model,
+      provider: OPENAI_CODEX_PROVIDER_ID,
+      api: OPENAI_CODEX_RESPONSES_API,
+    },
+  } as TParams;
 }
 
 type CodexSteeringQueueOptions = {
@@ -481,6 +513,7 @@ export async function runCodexAppServerAttempt(
     sessionKey: sandboxSessionKey,
     ...(startupAuthProfileId ? { authProfileId: startupAuthProfileId } : {}),
   };
+  const codexRuntimeParams = withCodexAppServerRuntimeAttribution(runtimeParams);
   const startupAuthAccountCacheKey = await resolveCodexAppServerAuthAccountCacheKey({
     authProfileId: startupAuthProfileId,
     authProfileStore: params.authProfileStore,
@@ -497,7 +530,7 @@ export async function runCodexAppServerAttempt(
     : undefined;
   let yieldDetected = false;
   const tools = await buildDynamicTools({
-    params,
+    params: codexRuntimeParams,
     resolvedWorkspace,
     effectiveWorkspace,
     sandboxSessionKey,
@@ -542,7 +575,7 @@ export async function runCodexAppServerAttempt(
       sessionKey: sandboxSessionKey,
       sessionFile: params.sessionFile,
       runtimeContext: buildHarnessContextEngineRuntimeContext({
-        attempt: runtimeParams,
+        attempt: codexRuntimeParams,
         workspaceDir: effectiveWorkspace,
         agentDir,
         tokenBudget: params.contextTokenBudget,
@@ -554,7 +587,7 @@ export async function runCodexAppServerAttempt(
     historyMessages =
       (await readMirroredSessionHistoryMessages(params.sessionFile)) ?? historyMessages;
   }
-  const baseDeveloperInstructions = buildDeveloperInstructions(params);
+  const baseDeveloperInstructions = buildDeveloperInstructions(codexRuntimeParams);
   // Build the workspace bootstrap block before finalizing developer
   // instructions so persona files (SOUL.md, IDENTITY.md, ...) reach Codex
   // through the explicit `developerInstructions` field.
@@ -635,7 +668,7 @@ export async function runCodexAppServerAttempt(
     ctx: hookContext,
   });
   const systemPromptReport = buildCodexSystemPromptReport({
-    attempt: params,
+    attempt: codexRuntimeParams,
     sessionKey: sandboxSessionKey,
     workspaceDir: effectiveWorkspace,
     developerInstructions: promptBuild.developerInstructions,
@@ -643,7 +676,7 @@ export async function runCodexAppServerAttempt(
     tools: toolBridge.specs,
   });
   const trajectoryRecorder = createCodexTrajectoryRecorder({
-    attempt: params,
+    attempt: codexRuntimeParams,
     cwd: effectiveWorkspace,
     developerInstructions: promptBuild.developerInstructions,
     prompt: promptBuild.prompt,
@@ -738,7 +771,7 @@ export async function runCodexAppServerAttempt(
           });
           const startupThread = await startOrResumeThread({
             client: startupClient,
-            params: runtimeParams,
+            params: codexRuntimeParams,
             cwd: effectiveWorkspace,
             dynamicTools: toolBridge.specs,
             appServer: pluginAppServer,
@@ -831,7 +864,7 @@ export async function runCodexAppServerAttempt(
     toolCount: toolBridge.specs.length,
   });
   recordCodexTrajectoryContext(trajectoryRecorder, {
-    attempt: params,
+    attempt: codexRuntimeParams,
     cwd: effectiveWorkspace,
     developerInstructions: promptBuild.developerInstructions,
     prompt: promptBuild.prompt,
@@ -1534,7 +1567,7 @@ export async function runCodexAppServerAttempt(
     prompt: promptBuild.prompt,
     imagesCount: params.images?.length ?? 0,
   });
-  projector = new CodexAppServerEventProjector(params, thread.threadId, activeTurnId, {
+  projector = new CodexAppServerEventProjector(codexRuntimeParams, thread.threadId, activeTurnId, {
     nativePostToolUseRelayEnabled:
       nativeHookRelay?.allowedEvents.includes("post_tool_use") === true,
   });
@@ -1634,7 +1667,7 @@ export async function runCodexAppServerAttempt(
     }
     const finalPromptErrorSource = timedOut ? "prompt" : result.promptErrorSource;
     recordCodexTrajectoryCompletion(trajectoryRecorder, {
-      attempt: params,
+      attempt: codexRuntimeParams,
       result,
       threadId: thread.threadId,
       turnId: activeTurnId,
@@ -1692,7 +1725,7 @@ export async function runCodexAppServerAttempt(
         prePromptMessageCount,
         tokenBudget: params.contextTokenBudget,
         runtimeContext: buildHarnessContextEngineRuntimeContextFromUsage({
-          attempt: runtimeParams,
+          attempt: codexRuntimeParams,
           workspaceDir: effectiveWorkspace,
           agentDir,
           tokenBudget: params.contextTokenBudget,


### PR DESCRIPTION
This PR makes Codex app-server run attribution line up with the runtime that actually owns the turn: canonical OpenAI model metadata can still be visible to the user, but local reports classify the run as `openai-codex` / `openai-codex-responses`. That keeps diagnostics and parity reports from confusing Codex-owned turns with the generic OpenAI provider path.

## Summary

This PR fixes a narrow but confusing Codex beta attribution bug. Users can select the canonical model id `openai/gpt-5.5` while `agentRuntime: codex` correctly routes the turn through the Codex app-server harness. Before this patch, that Codex-owned turn still wrote local transcript and trajectory metadata as the public OpenAI runtime (`openai` / `openai-responses`), which made logs, diagnostics, and follow-up debugging look like the Pi/OpenAI Responses path owned the turn. The fix keeps the visible model id unchanged and normalizes only the Codex-owned local runtime attribution.

- Problem: Codex app-server-owned records for canonical OpenAI beta config were stamped as `provider: openai`, `api/modelApi: openai-responses`.
- Why it matters: maintainers debugging beta.5 Codex behavior need local transcript, trajectory, context-engine, prompt-report, and dynamic-tool records to identify the actual runtime family.
- What changed: Codex app-server runtime metadata now resolves to `openai-codex` / `openai-codex-responses` when `runtimePlan.observability.harnessId === "codex"` owns a canonical OpenAI model turn.
- What did NOT change (scope boundary): no model picker display change, no doctor migration change, no timeout/watchdog change, no auth/profile routing change, and no production dynamic-tool filtering change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #79413
- Related #81114
- Related #81152
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: canonical OpenAI model config with Codex runtime (`openai/gpt-5.5` + `agentRuntime: codex`) previously entered `runCodexAppServerAttempt` with public OpenAI metadata, so local Codex transcript/trajectory rows were recorded as `provider: openai`, `modelApi: openai-responses` even though Codex app-server owned the turn.
- Real environment tested: local Lexar-backed OpenClaw checkout at `/Volumes/LEXAR/repos/openclaw-codex-runtime-attribution`, commit `e2a2a46bc0e`, Node/pnpm repo defaults, real `runCodexAppServerAttempt` source path with the existing Codex app-server fake-client harness. This is not a live OAuth/frontier app-server run.
- Exact steps or command run after this patch:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/codex/src/app-server/run-attempt.test.ts -t "records canonical OpenAI models as Codex-runtime"
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
Before fix: expected 'openai' to be 'openai-codex'
After fix:
Test Files  1 passed (1)
Tests  1 passed | 102 skipped (103)
```

The regression drives the real `runCodexAppServerAttempt` path with a completed Codex turn, enables trajectory capture, and asserts:

```text
lastAssistant.provider === "openai-codex"
lastAssistant.api === "openai-codex-responses"
every trajectory event provider === "openai-codex"
every trajectory event modelApi === "openai-codex-responses"
```

- Observed result after fix: the assistant transcript and trajectory sidecar for the canonical beta schema are attributed to the Codex runtime family (`openai-codex` / `openai-codex-responses`) while preserving the visible model id (`gpt-5.5`).
- What was not tested: live OAuth/frontier Codex app-server behavior, Telegram end-to-end recovery, and the separate progress-aware timeout path from #81152. This PR fixes the confirmed attribution bug but does not claim to fully close #81114 by itself.
- Before evidence (optional but encouraged): the focused regression failed before the implementation with `expected 'openai' to be 'openai-codex'`, proving the pre-patch transcript attribution was wrong for Codex-owned turns.

## Root Cause (if applicable)

- Root cause: `runCodexAppServerAttempt` reused model metadata from the public OpenAI canonical model entry after the Codex harness had already been selected, so local Codex-owned records inherited `provider: openai` and `api: openai-responses`.
- Missing detection / guardrail: existing Codex app-server tests covered successful turn projection but did not assert runtime-family attribution for canonical `openai/*` model ids running under `runtimePlan.observability.harnessId: codex`.
- Contributing context (if known): beta.5 intentionally allows canonical model ids and Codex harness selection to be represented separately. That split is correct, but the local record attribution needed to follow the selected harness rather than the public model catalog provider.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/run-attempt.test.ts`
- Scenario the test should lock in: canonical beta schema (`provider: openai`, `api: openai-responses`, `runtimePlan.observability.harnessId: codex`) records assistant transcript and trajectory metadata as `openai-codex` / `openai-codex-responses`.
- Why this is the smallest reliable guardrail: it drives the real `runCodexAppServerAttempt` projection path with the fake Codex app-server client, without needing live OAuth or frontier traffic to verify local metadata normalization.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A, a focused regression test is included.

## User-visible / Behavior Changes

Local diagnostics become clearer for Codex beta runs: transcript, trajectory, context-engine, prompt-report, and dynamic-tool metadata identify the Codex runtime family instead of looking like the public OpenAI Responses runtime owned the turn. The user-facing model id remains `gpt-5.5`.

## Diagram (if applicable)

<!-- reviewer-map -->

```mermaid
flowchart LR
  appserver["Codex app-server turn"] --> model["Visible model: openai/gpt-5.x"]
  appserver --> runtime["Runtime owner: openai-codex"]
  runtime --> projector["Event projector"]
  runtime --> trajectory["Trajectory/report rows"]
  model -. "preserved for display" .-> projector
```

```text
Before:
[config: openai/gpt-5.5 + agentRuntime=codex]
  -> [Codex app-server owns the turn]
  -> [local records stamped provider=openai, api=openai-responses]
  -> [debugging points at the wrong runtime family]

After:
[config: openai/gpt-5.5 + agentRuntime=codex]
  -> [Codex app-server owns the turn]
  -> [local records stamped provider=openai-codex, api=openai-codex-responses]
  -> [debugging and parity artifacts identify the actual runtime family]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local development host
- Runtime/container: local Lexar-backed OpenClaw checkout, Node/pnpm repo defaults
- Model/provider: canonical beta schema `openai/gpt-5.5` with `runtimePlan.observability.harnessId: codex`
- Integration/channel (if any): Codex app-server run-attempt projection path with fake app-server client
- Relevant config (redacted): no secrets required; test constructs the runtime plan in-process

### Steps

1. Run the focused regression command from the repository root.
2. Verify assistant transcript metadata uses `openai-codex` / `openai-codex-responses`.
3. Verify trajectory sidecar events use the same Codex runtime family.
4. Run the full app-server run-attempt test file and the auth-profile runtime contract file.

### Expected

- Codex-owned transcript and trajectory records use `openai-codex` / `openai-codex-responses`.
- The visible model id remains `gpt-5.5`.
- Existing Codex app-server and auth-profile contract tests keep passing.

### Actual

- Focused regression passed.
- Full `run-attempt.test.ts` passed on warmed full-file run.
- `auth-profile-runtime-contract.test.ts` passed.
- Formatting and whitespace checks passed.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/codex/src/app-server/run-attempt.test.ts -t "records canonical OpenAI models as Codex-runtime"
# passed: 1 test, 102 skipped

OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/codex/src/app-server/run-attempt.test.ts
# passed: 103 tests

OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
# passed: 3 tests

pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts
# passed

git diff --check
# passed
```

Note: one cold local full-file run hit the existing slow Tool Search dynamic-tool test timeout at 120s; the same test passed by itself in 71s, and the warmed full-file rerun passed in 78s. Broad proof should still come from GitHub CI/Testbox per repo local-resource policy.

## Human Verification (required)

- Verified scenarios: focused canonical beta attribution regression; full Codex app-server run-attempt suite; auth-profile runtime contract suite; formatting; whitespace.
- Edge cases checked: canonical model id remains `gpt-5.5`; Codex runtime family attribution applies to assistant transcript and trajectory events; native Codex thread provider/auth selection is not changed by this patch.
- What you did **not** verify: live OAuth/frontier Codex app-server traffic, Telegram end-to-end recovery, and the separate progress-aware timeout proposal in #81152.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Current state: no review threads are open as of this PR body update; ClawSweeper has posted only the review-start placeholder.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a future model-provider path might need public OpenAI attribution even while the Codex harness owns local app-server records.
  - Mitigation: the helper is scoped to Codex app-server-owned local attribution and covered by a regression for the beta schema that triggered the issue; it does not mutate visible model id or native auth/thread selection.

- Risk: this could be mistaken for a complete #81114 timeout fix.
  - Mitigation: the PR body explicitly keeps #81114 open for live/OAuth confirmation and keeps #81152 separate for the progress-aware timeout/watchdog path.

