### PR TITLE
fix(ai): redact text tool results before provider replay

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -352,7 +352,6 @@ src/agents/bash-tools.exec-host-gateway.ts
 src/agents/bash-tools.exec-host-node.test.ts
 src/agents/bash-tools.exec-runtime.ts
 src/agents/bash-tools.exec.approval-id.test.ts
-src/agents/bash-tools.process.ts
 src/agents/btw.test.ts
 src/agents/btw.ts
 src/agents/cli-auth-epoch.test.ts

--- a/packages/ai/src/providers/tool-result-text.test.ts
+++ b/packages/ai/src/providers/tool-result-text.test.ts
@@ -1,10 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { configureAiTransportHost, getAiTransportHost } from "../host.js";
 import {
   describeToolResultMediaPlaceholder,
   extractToolResultText,
   hasMediaPayload,
   isImageWithMediaPayload,
 } from "./tool-result-text.js";
+
+const initialTransportHost = getAiTransportHost();
+const fakeSecret = ["qa", "-tool-result-secret-", "a1b2c3d4"].join("");
+const safeNonce = "QA_SAFE_NONCE_A1B2C3D4";
+afterEach(() => {
+  configureAiTransportHost(initialTransportHost);
+});
+function installFakeSecretRedactor(): void {
+  configureAiTransportHost({
+    ...initialTransportHost,
+    redactToolPayloadText: (text) => text.replaceAll(fakeSecret, "[redacted]"),
+  });
+}
 
 describe("hasMediaPayload", () => {
   it("requires non-empty inline data instead of media metadata", () => {
@@ -30,6 +44,50 @@ describe("isImageWithMediaPayload", () => {
 });
 
 describe("extractToolResultText", () => {
+  it("redacts secrets in valid JSON text while preserving safe fields", () => {
+    installFakeSecretRedactor();
+    const text = extractToolResultText([
+      {
+        type: "text",
+        text: JSON.stringify({
+          password: fakeSecret,
+          nonce: safeNonce,
+          status: "completed",
+        }),
+      },
+    ]);
+
+    expect(JSON.parse(text)).toEqual({
+      password: "[redacted]",
+      nonce: safeNonce,
+      status: "completed",
+    });
+    expect(text).not.toContain(fakeSecret);
+  });
+
+  it("redacts secrets in plain text while preserving safe evidence", () => {
+    installFakeSecretRedactor();
+    const text = extractToolResultText([
+      {
+        type: "text",
+        text: [
+          `password=${fakeSecret}`,
+          `nonce=${safeNonce}`,
+          "status=completed",
+          "cwd=/workspace",
+          "exitCode=0",
+        ].join("\n"),
+      },
+    ]);
+
+    expect(text).toContain("password=[redacted]");
+    expect(text).toContain(`nonce=${safeNonce}`);
+    expect(text).toContain("status=completed");
+    expect(text).toContain("cwd=/workspace");
+    expect(text).toContain("exitCode=0");
+    expect(text).not.toContain(fakeSecret);
+  });
+
   it("keeps media-only blocks out of provider replay text", () => {
     const text = extractToolResultText([
       { type: "text", text: "summary" },

--- a/packages/ai/src/providers/tool-result-text.ts
+++ b/packages/ai/src/providers/tool-result-text.ts
@@ -181,7 +181,7 @@ export function extractToolResultBlockText(block: unknown): string | undefined {
   }
   if (record.type === "text") {
     const text = typeof record.text === "string" ? record.text : "";
-    return text ? sanitizeSurrogates(text) : undefined;
+    return text ? sanitizeSurrogates(redactStructuredTextValue(text)) : undefined;
   }
   const structured = stringifyStructuredBlock(record);
   return structured ? sanitizeSurrogates(truncateProviderToolText(structured)) : undefined;

--- a/src/agents/bash-process-references.ts
+++ b/src/agents/bash-process-references.ts
@@ -5,7 +5,10 @@
  */
 import { truncateUtf16Safe } from "../utils.js";
 import { listRunningSessions } from "./bash-process-registry.js";
-import { deriveSessionName } from "./bash-tools.shared.js";
+import {
+  deriveRedactedProcessSessionName,
+  redactProcessSessionText,
+} from "./bash-tools.process-redaction.js";
 
 const DEFAULT_ACTIVE_PROCESS_LIMIT = 8;
 const MAX_COMMAND_LABEL_CHARS = 140;
@@ -22,6 +25,7 @@ export type ActiveProcessSessionReference = {
   name: string;
   tail?: string;
   truncated: boolean;
+  redacted?: true;
 };
 
 function truncate(value: string, maxChars: number): string {
@@ -54,19 +58,29 @@ export function listActiveProcessSessionReferences(params: {
     .filter((session) => session.scopeKey === scopeKey)
     .toSorted((left, right) => right.startedAt - left.startedAt)
     .slice(0, limit)
-    .map((session) => ({
-      sessionId: session.id,
-      status: "running" as const,
-      pid: session.pid ?? session.child?.pid,
-      startedAt: session.startedAt,
-      runtimeMs: Math.max(0, now - session.startedAt),
-      cwd: session.cwd,
-      command: session.command,
-      name: truncate(
-        deriveSessionName(session.command) || session.command,
+    .map((session) => {
+      const command = redactProcessSessionText(session.command);
+      const name = truncate(
+        deriveRedactedProcessSessionName(session.command) ?? command,
         MAX_COMMAND_LABEL_CHARS,
-      ),
-      tail: session.tail,
-      truncated: session.truncated,
-    }));
+      );
+      const tail = redactProcessSessionText(session.tail);
+      const redacted = command !== session.command || tail !== session.tail;
+      const reference: ActiveProcessSessionReference = {
+        sessionId: session.id,
+        status: "running" as const,
+        pid: session.pid ?? session.child?.pid,
+        startedAt: session.startedAt,
+        runtimeMs: Math.max(0, now - session.startedAt),
+        cwd: session.cwd,
+        command,
+        name,
+        tail,
+        truncated: session.truncated,
+      };
+      if (redacted) {
+        reference.redacted = true;
+      }
+      return reference;
+    });
 }

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -12,9 +12,13 @@ import type { ProcessSupervisor } from "../process/supervisor/index.js";
 import type { SpawnInput } from "../process/supervisor/types.js";
 import { captureEnv } from "../test-utils/env.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
+import { prependRedactionWarning } from "./bash-tools.exec-output.js";
 import { createExecTool } from "./bash-tools.exec-run.js";
+import { buildExecForegroundResult, buildExecRunningResult } from "./bash-tools.exec-support.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import { getBashShellConfig } from "./shell-utils.js";
+
+const EXEC_REDACTION_WARNING = prependRedactionWarning("", true).trimEnd();
 
 const supervisorMock = vi.hoisted(() => ({
   spawn: vi.fn<ProcessSupervisor["spawn"]>(),
@@ -32,6 +36,7 @@ const defaultShell = isWin
   ? undefined
   : process.env.OPENCLAW_TEST_SHELL || getBashShellConfig().shell;
 const tempDirs = createTempDirTracker();
+const fakeSecretOutput = "OPENAI_API_KEY=sk-proj-redaction-canary-1234567890";
 
 function requireTextContent(
   result: Awaited<ReturnType<ReturnType<typeof createExecTool>["execute"]>>,
@@ -247,6 +252,102 @@ describe("exec foreground failures", () => {
     expect(details.aggregated).toBe("");
     expect(details.durationMs).toBeTypeOf("number");
     expect(details.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("redacts secret-shaped stdout before returning foreground results", () => {
+    const result = buildExecForegroundResult({
+      outcome: {
+        status: "completed",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 1,
+        aggregated: `${fakeSecretOutput}\n`,
+        timedOut: false,
+      },
+    });
+
+    const text = (result.content[0] as { text?: string }).text ?? "";
+    const details = result.details as { aggregated?: string; redacted?: boolean };
+    expect(text).not.toContain(fakeSecretOutput);
+    expect(details.aggregated).not.toContain(fakeSecretOutput);
+    expect(text).toContain("OPENAI_API_KEY=sk-pro…7890");
+    expect(details.aggregated).toContain("OPENAI_API_KEY=***");
+    expect(text).toContain(EXEC_REDACTION_WARNING);
+    expect(details.redacted).toBe(true);
+  });
+
+  it("redacts secret-shaped warning text before returning foreground results", () => {
+    const result = buildExecForegroundResult({
+      warningText: `Warning: ${fakeSecretOutput}`,
+      outcome: {
+        status: "completed",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 1,
+        aggregated: "ok\n",
+        timedOut: false,
+      },
+    });
+
+    const text = (result.content[0] as { text?: string }).text ?? "";
+    expect(text).not.toContain(fakeSecretOutput);
+    expect(text).toContain("OPENAI_API_KEY=sk-pro…7890");
+    expect(text).toContain(EXEC_REDACTION_WARNING);
+    expect((result.details as { redacted?: boolean }).redacted).toBe(true);
+  });
+
+  it("redacts secret-shaped output from background exec details tail", () => {
+    const result = buildExecRunningResult({
+      sessionId: "sess-redact-background",
+      pid: 12345,
+      startedAt: Date.now(),
+      cwd: "/tmp",
+      tail: `${fakeSecretOutput}\n`,
+    });
+
+    const text = (result.content[0] as { text?: string }).text ?? "";
+    const details = result.details as { status?: string; tail?: string; redacted?: boolean };
+    expect(details.status).toBe("running");
+    expect(details.tail).not.toContain(fakeSecretOutput);
+    expect(details.tail).toContain("OPENAI_API_KEY=***");
+    expect(text).toContain(EXEC_REDACTION_WARNING);
+    expect(details.redacted).toBe(true);
+  });
+
+  it("redacts secret-shaped warning text before returning background exec results", () => {
+    const result = buildExecRunningResult({
+      warningText: `Warning: ${fakeSecretOutput}\n\n`,
+      sessionId: "sess-redact-background-warning",
+      pid: 12345,
+      startedAt: Date.now(),
+      cwd: "/tmp",
+      tail: "still running\n",
+    });
+
+    const text = (result.content[0] as { text?: string }).text ?? "";
+    expect(text).not.toContain(fakeSecretOutput);
+    expect(text).toContain("OPENAI_API_KEY=sk-pro…7890");
+    expect(text).toContain(EXEC_REDACTION_WARNING);
+    expect((result.details as { redacted?: boolean }).redacted).toBe(true);
+    expect(text).toContain("7890\n\nCommand still running");
+    expect(text).toContain("Command still running");
+  });
+
+  it("does not mark unredacted foreground results", () => {
+    const result = buildExecForegroundResult({
+      outcome: {
+        status: "completed",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 1,
+        aggregated: "plain output\n",
+        timedOut: false,
+      },
+    });
+
+    const text = (result.content[0] as { text?: string }).text ?? "";
+    expect(text).not.toContain(EXEC_REDACTION_WARNING);
+    expect((result.details as { redacted?: boolean }).redacted).toBeUndefined();
   });
 
   it("rejects invalid host values before launching a command", async () => {

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -42,11 +42,13 @@ import {
   invokeNodeSystemRun,
 } from "./bash-tools.exec-host-node-failure.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
-import { renderExecUpdateText } from "./bash-tools.exec-output.js";
+import { formatNodeRunToolResult } from "./bash-tools.exec-node-result.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { callGatewayTool } from "./tools/gateway.js";
 import { listNodes, resolveNodeIdFromList } from "./tools/nodes-utils.js";
+
+export { formatNodeRunToolResult } from "./bash-tools.exec-node-result.js";
 
 type NodeExecutionTarget = {
   nodeId: string;
@@ -233,44 +235,6 @@ export function shouldSkipNodeApprovalPrepare(params: {
   return (
     params.hostSecurity === "full" && params.hostAsk === "off" && params.strictInlineEval !== true
   );
-}
-
-/** Formats a raw `node.invoke system.run` response as an exec tool result. */
-export function formatNodeRunToolResult(params: {
-  raw: unknown;
-  startedAt: number;
-  cwd: string | undefined;
-  warnings?: string[];
-}): AgentToolResult<ExecToolDetails> {
-  const payload =
-    params.raw && typeof params.raw === "object"
-      ? (params.raw as { payload?: unknown }).payload
-      : undefined;
-  const payloadObj =
-    payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
-  const stdout = typeof payloadObj.stdout === "string" ? payloadObj.stdout : "";
-  const stderr = typeof payloadObj.stderr === "string" ? payloadObj.stderr : "";
-  const errorText = typeof payloadObj.error === "string" ? payloadObj.error : "";
-  const success = typeof payloadObj.success === "boolean" ? payloadObj.success : false;
-  const exitCode = typeof payloadObj.exitCode === "number" ? payloadObj.exitCode : null;
-  return {
-    content: [
-      {
-        type: "text",
-        text: renderExecUpdateText({
-          tailText: stdout || stderr || errorText,
-          warnings: params.warnings ?? [],
-        }),
-      },
-    ],
-    details: {
-      status: success ? "completed" : "failed",
-      exitCode,
-      durationMs: Date.now() - params.startedAt,
-      aggregated: [stdout, stderr, errorText].filter(Boolean).join("\n"),
-      cwd: params.cwd,
-    } satisfies ExecToolDetails,
-  };
 }
 
 /** Resolves the node id, platform, argv, env, and timeout for a node-host exec. */

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -11,6 +11,9 @@ import type { ExecAllowlistEntry } from "../infra/exec-approvals.types.js";
 import { createDeferred } from "../test-utils/deferred.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS } from "../utils/timer-delay.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
+import { prependRedactionWarning } from "./bash-tools.exec-output.js";
+
+const EXEC_REDACTION_WARNING = prependRedactionWarning("", true).trimEnd();
 
 type StrictInlineEvalBoundary =
   typeof import("./bash-tools.exec-host-shared.js").enforceStrictInlineEvalApprovalBoundary;
@@ -74,6 +77,7 @@ const INLINE_EVAL_HIT = {
   flag: "-c",
   argv: ["python3", "-c", "print(1)"],
 };
+const fakeSecretOutput = "OPENAI_API_KEY=sk-proj-redaction-canary-1234567890";
 
 const preparedPlan = vi.hoisted(() => ({
   argv: ["bun", "./script.ts"],
@@ -3756,6 +3760,91 @@ describe("executeNodeHostCommand", () => {
       "exec host=node requires a connected node (node-1 is currently disconnected)",
     );
     expect(callGatewayToolMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["stdout", { stdout: `${fakeSecretOutput}\n`, stderr: "", error: "" }],
+    ["stderr", { stdout: "", stderr: `${fakeSecretOutput}\n`, error: "" }],
+    ["error", { stdout: "", stderr: "", error: `${fakeSecretOutput}\n` }],
+  ] as const)("redacts secret-shaped node %s before returning results", async (_field, payload) => {
+    callGatewayToolMock.mockImplementationOnce(
+      async (method: string, _options: unknown, params: MockNodeInvokeParams | undefined) => {
+        if (method === "node.invoke" && params?.command === "system.run") {
+          return {
+            payload: {
+              success: true,
+              stdout: payload.stdout,
+              stderr: payload.stderr,
+              error: payload.error,
+              exitCode: 0,
+              timedOut: false,
+            },
+          };
+        }
+        throw new Error(`unexpected node invoke command: ${String(params?.command)}`);
+      },
+    );
+
+    const result = await executeNodeHostCommand({
+      command: "echo fake-secret",
+      workdir: "/tmp/work",
+      env: {},
+      security: "full",
+      ask: "off",
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+    });
+
+    const text = (result.content[0] as { text?: string }).text ?? "";
+    const details = result.details as { aggregated?: string };
+    expect(text).not.toContain(fakeSecretOutput);
+    expect(details.aggregated).not.toContain(fakeSecretOutput);
+    expect(text).toContain("OPENAI_API_KEY=sk-pro…7890");
+    expect(details.aggregated).toContain("OPENAI_API_KEY=***");
+    expect(text).toContain(EXEC_REDACTION_WARNING);
+    expect((result.details as { redacted?: boolean }).redacted).toBe(true);
+  });
+
+  it("redacts secret-shaped node warnings before returning results", async () => {
+    callGatewayToolMock.mockImplementationOnce(
+      async (method: string, _options: unknown, params: MockNodeInvokeParams | undefined) => {
+        if (method === "node.invoke" && params?.command === "system.run") {
+          return {
+            payload: {
+              success: true,
+              stdout: "ok\n",
+              stderr: "",
+              error: "",
+              exitCode: 0,
+              timedOut: false,
+            },
+          };
+        }
+        throw new Error(`unexpected node invoke command: ${String(params?.command)}`);
+      },
+    );
+
+    const result = await executeNodeHostCommand({
+      command: "echo fake-secret",
+      workdir: "/tmp/work",
+      env: {},
+      security: "full",
+      ask: "off",
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [`warning leaked ${fakeSecretOutput}`],
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+    });
+
+    const text = (result.content[0] as { text?: string }).text ?? "";
+    expect(text).not.toContain(fakeSecretOutput);
+    expect(text).toContain("OPENAI_API_KEY=sk-pro…7890");
+    expect(text).toContain(EXEC_REDACTION_WARNING);
+    expect((result.details as { redacted?: boolean }).redacted).toBe(true);
   });
 
   it("returns a non-empty placeholder for silent node exec results", async () => {

--- a/src/agents/bash-tools.exec-node-result.ts
+++ b/src/agents/bash-tools.exec-node-result.ts
@@ -1,0 +1,56 @@
+import {
+  redactExecDetails,
+  redactExecOutputText,
+  renderExecUpdateText,
+  withRedactionMarker,
+} from "./bash-tools.exec-output.js";
+import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import type { AgentToolResult } from "./runtime/index.js";
+
+/** Formats a raw `node.invoke system.run` response as an exec tool result. */
+export function formatNodeRunToolResult(params: {
+  raw: unknown;
+  startedAt: number;
+  cwd: string | undefined;
+  warnings?: string[];
+}): AgentToolResult<ExecToolDetails> {
+  const payload =
+    params.raw && typeof params.raw === "object"
+      ? (params.raw as { payload?: unknown }).payload
+      : undefined;
+  const payloadObj =
+    payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const stdout = typeof payloadObj.stdout === "string" ? payloadObj.stdout : "";
+  const stderr = typeof payloadObj.stderr === "string" ? payloadObj.stderr : "";
+  const errorText = typeof payloadObj.error === "string" ? payloadObj.error : "";
+  const output = redactExecOutputText(stdout || stderr || errorText);
+  const aggregated = redactExecOutputText([stdout, stderr, errorText].filter(Boolean).join("\n"));
+  const warnings = (params.warnings ?? []).map((warning) => redactExecOutputText(warning));
+  const success = typeof payloadObj.success === "boolean" ? payloadObj.success : false;
+  const exitCode = typeof payloadObj.exitCode === "number" ? payloadObj.exitCode : null;
+  const details = redactExecDetails({
+    status: success ? "completed" : "failed",
+    exitCode,
+    durationMs: Date.now() - params.startedAt,
+    aggregated: aggregated.text,
+    cwd: params.cwd,
+  } satisfies ExecToolDetails);
+  const redacted =
+    output.redacted ||
+    aggregated.redacted ||
+    warnings.some((warning) => warning.redacted) ||
+    details.redacted;
+  return {
+    content: [
+      {
+        type: "text",
+        text: renderExecUpdateText({
+          tailText: output.text,
+          warnings: warnings.map((warning) => warning.text),
+          redacted,
+        }),
+      },
+    ],
+    details: withRedactionMarker(details.details, redacted),
+  };
+}

--- a/src/agents/bash-tools.exec-output.ts
+++ b/src/agents/bash-tools.exec-output.ts
@@ -3,21 +3,100 @@
  * Keeps no-output placeholders and warning placement consistent across exec
  * progress, polling, and completion surfaces.
  */
+import { redactSecrets, redactToolPayloadText } from "../logging/redact.js";
 import type { TerminationReason } from "../process/supervisor/types.js";
 
 const EXEC_NO_OUTPUT_PLACEHOLDER = "(no output)";
+const EXEC_REDACTION_WARNING =
+  "Warning: redacted secret-shaped output; masked values are not real source data and must not be written back.";
 const EXEC_TIMEOUT_RETRY_GUIDANCE =
   "The command was terminated, but external side effects may already have completed. Verify the resulting state before retrying. Do not automatically rerun non-idempotent commands. Use a higher timeout only when the command is known to be safe to retry.";
 
+type RedactedText = {
+  text: string;
+  redacted: boolean;
+};
+
+export function redactExecOutputText(value: string): RedactedText {
+  const text = redactToolPayloadText(value);
+  return { text, redacted: text !== value };
+}
+
+export function redactExecDetails<T>(details: T): { details: T; redacted: boolean } {
+  const redactedDetails = redactSecrets(details);
+  return {
+    details: redactedDetails,
+    redacted: JSON.stringify(redactedDetails) !== JSON.stringify(details),
+  };
+}
+
+export function withRedactionMarker<T extends Record<string, unknown>>(
+  details: T,
+  redacted: boolean,
+): T & { redacted?: true } {
+  return redacted ? ({ ...details, redacted: true } as T & { redacted: true }) : details;
+}
+
+export function prependRedactionWarning(text: string, redacted: boolean): string {
+  return redacted ? `${EXEC_REDACTION_WARNING}\n\n${text}` : text;
+}
+
+export function buildExecUpdateResult(params: {
+  tailText: string;
+  tail: string;
+  warnings?: string[];
+  status: "running";
+  sessionId: string;
+  pid?: number;
+  startedAt: number;
+  cwd?: string;
+}) {
+  const tailText = redactExecOutputText(params.tailText);
+  const tail = redactExecOutputText(params.tail);
+  const warnings = params.warnings?.map((warning) => redactExecOutputText(warning)) ?? [];
+  const details = redactExecDetails({
+    status: params.status,
+    sessionId: params.sessionId,
+    pid: params.pid,
+    startedAt: params.startedAt,
+    cwd: params.cwd,
+    tail: tail.text,
+  });
+  const redacted =
+    tailText.redacted ||
+    tail.redacted ||
+    warnings.some((warning) => warning.redacted) ||
+    details.redacted;
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: renderExecUpdateText({
+          tailText: tailText.text,
+          warnings: warnings.map((warning) => warning.text),
+          redacted,
+        }),
+      },
+    ],
+    details: withRedactionMarker(details.details, redacted),
+  };
+}
 /** Render command output with a stable placeholder for empty output. */
 export function renderExecOutputText(value: string | undefined): string {
   return value || EXEC_NO_OUTPUT_PLACEHOLDER;
 }
 
 /** Render the text shown in exec progress updates, including warnings first. */
-export function renderExecUpdateText(params: { tailText?: string; warnings: string[] }): string {
+export function renderExecUpdateText(params: {
+  tailText?: string;
+  warnings: string[];
+  redacted?: boolean;
+}): string {
   const warningText = params.warnings.length ? `${params.warnings.join("\n")}\n\n` : "";
-  return warningText + renderExecOutputText(params.tailText);
+  return prependRedactionWarning(
+    warningText + renderExecOutputText(params.tailText),
+    Boolean(params.redacted),
+  );
 }
 
 /** Add retry-safety guidance only for supervisor timeout exits. */

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -46,6 +46,7 @@ import {
 } from "./bash-tools.exec-script-preflight.js";
 import {
   buildExecForegroundResult,
+  buildExecRunningResult,
   createExecHostResolver,
   resolveExecReviewerDefaults,
 } from "./bash-tools.exec-support.js";
@@ -603,24 +604,16 @@ export function createExecTool(
 
         const resolveRunning = () => {
           cleanupToolRunListeners();
-          resolve({
-            content: [
-              {
-                type: "text",
-                text: `${getWarningText()}Command still running (session ${run.session.id}, pid ${
-                  run.session.pid ?? "n/a"
-                }). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.`,
-              },
-            ],
-            details: {
-              status: "running",
+          resolve(
+            buildExecRunningResult({
+              warningText: getWarningText(),
               sessionId: run.session.id,
               pid: run.session.pid ?? undefined,
               startedAt: run.startedAt,
               cwd: run.session.cwd,
               tail: run.session.tail,
-            },
-          });
+            }),
+          );
         };
 
         const onYieldNow = () => {

--- a/src/agents/bash-tools.exec-runtime-redaction.test.ts
+++ b/src/agents/bash-tools.exec-runtime-redaction.test.ts
@@ -1,0 +1,157 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
+import { prependRedactionWarning, renderExecUpdateText } from "./bash-tools.exec-output.js";
+import { runExecProcess } from "./bash-tools.exec-runtime.js";
+
+const EXEC_REDACTION_WARNING = prependRedactionWarning("", true).trimEnd();
+const supervisorMock = vi.hoisted(() => ({ spawn: vi.fn() }));
+
+vi.mock("../process/supervisor/index.js", () => ({
+  getProcessSupervisor: () => ({ spawn: supervisorMock.spawn }),
+}));
+
+beforeEach(() => {
+  resetProcessRegistryForTests();
+  supervisorMock.spawn.mockReset();
+});
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+});
+
+describe("renderExecUpdateText", () => {
+  it("uses a non-empty placeholder when an exec update has no output", () => {
+    expect(renderExecUpdateText({ tailText: "", warnings: [] })).toBe("(no output)");
+  });
+
+  it("preserves non-empty exec output", () => {
+    expect(renderExecUpdateText({ tailText: "hello", warnings: [] })).toBe("hello");
+  });
+
+  it("keeps warnings while still avoiding empty output text", () => {
+    expect(renderExecUpdateText({ tailText: "", warnings: ["Warning: retrying"] })).toBe(
+      "Warning: retrying\n\n(no output)",
+    );
+  });
+
+  it("combines warnings with non-empty output", () => {
+    expect(renderExecUpdateText({ tailText: "hello", warnings: ["Warning: retrying"] })).toBe(
+      "Warning: retrying\n\nhello",
+    );
+  });
+
+  it("adds a visible warning when output was redacted", () => {
+    expect(renderExecUpdateText({ tailText: "hello", warnings: [], redacted: true })).toBe(
+      `${EXEC_REDACTION_WARNING}\n\nhello`,
+    );
+  });
+});
+
+describe("runExecProcess live updates", () => {
+  it("redacts secret-shaped stdout in update text and details tail", async () => {
+    const fakeSecretOutput = "OPENAI_API_KEY=sk-proj-redaction-canary-1234567890";
+    const updates: Array<{ content: Array<{ type: string; text?: string }>; details: unknown }> =
+      [];
+    supervisorMock.spawn.mockImplementationOnce(
+      async (input: { onStdout?: (chunk: string) => void }) => ({
+        runId: "run-redact-live-update",
+        startedAtMs: Date.now(),
+        pid: 123,
+        stdin: undefined,
+        wait: async () => {
+          input.onStdout?.(`${fakeSecretOutput}\n`);
+          await new Promise((resolve) => {
+            setImmediate(resolve);
+          });
+          return {
+            reason: "exit" as const,
+            exitCode: 0,
+            exitSignal: null,
+            durationMs: 10,
+            stdout: "",
+            stderr: "",
+            timedOut: false,
+            noOutputTimedOut: false,
+          };
+        },
+        cancel: vi.fn(),
+      }),
+    );
+    const run = await runExecProcess({
+      command: "printf secret",
+      workdir: "/tmp",
+      env: {},
+      usePty: false,
+      warnings: [],
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+      notifyOnExit: false,
+      notifyOnExitEmptySuccess: false,
+      timeoutSec: null,
+      onUpdate: (update) => updates.push(update),
+    });
+    await run.promise;
+    const update = expectDefined(updates[0], "updates[0] test invariant");
+    const text = (update.content[0] as { text?: string }).text ?? "";
+    const details = update.details as { tail?: string; redacted?: boolean };
+    expect(text).not.toContain(fakeSecretOutput);
+    expect(details.tail).not.toContain(fakeSecretOutput);
+    expect(text).toContain("OPENAI_API_KEY=sk-pro…7890");
+    expect(details.tail).toContain("OPENAI_API_KEY=***");
+    expect(text).toContain(EXEC_REDACTION_WARNING);
+    expect(details.redacted).toBe(true);
+  });
+
+  it("redacts secret-shaped warnings in update text", async () => {
+    const fakeSecretOutput = "OPENAI_API_KEY=sk-proj-redaction-canary-1234567890";
+    const updates: Array<{ content: Array<{ type: string; text?: string }>; details: unknown }> =
+      [];
+    supervisorMock.spawn.mockImplementationOnce(
+      async (input: { onStdout?: (chunk: string) => void }) => ({
+        runId: "run-redact-live-warning",
+        startedAtMs: Date.now(),
+        pid: 123,
+        stdin: undefined,
+        wait: async () => {
+          input.onStdout?.("ready\n");
+          await new Promise((resolve) => {
+            setImmediate(resolve);
+          });
+          return {
+            reason: "exit" as const,
+            exitCode: 0,
+            exitSignal: null,
+            durationMs: 10,
+            stdout: "",
+            stderr: "",
+            timedOut: false,
+            noOutputTimedOut: false,
+          };
+        },
+        cancel: vi.fn(),
+      }),
+    );
+    const run = await runExecProcess({
+      command: "printf ready",
+      workdir: "/tmp",
+      env: {},
+      usePty: false,
+      warnings: [`Warning: ${fakeSecretOutput}`],
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+      notifyOnExit: false,
+      notifyOnExitEmptySuccess: false,
+      timeoutSec: null,
+      onUpdate: (update) => updates.push(update),
+    });
+    await run.promise;
+    const update = expectDefined(updates[0], "updates[0] test invariant");
+    const text = (update.content[0] as { text?: string }).text ?? "";
+    expect(text).not.toContain(fakeSecretOutput);
+    expect(text).toContain("OPENAI_API_KEY=sk-pro…7890");
+    expect(text).toContain(EXEC_REDACTION_WARNING);
+    expect((update.details as { redacted?: boolean }).redacted).toBe(true);
+    expect(text).toContain("ready");
+  });
+});

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -45,7 +45,7 @@ import {
   markExited,
   tail,
 } from "./bash-process-registry.js";
-import { appendExecTimeoutRetryGuidance, renderExecUpdateText } from "./bash-tools.exec-output.js";
+import { appendExecTimeoutRetryGuidance, buildExecUpdateResult } from "./bash-tools.exec-output.js";
 import {
   buildDockerExecArgs,
   chunkString,
@@ -671,8 +671,7 @@ export async function runExecProcess(opts: {
     if (session.backgrounded || session.exited || updatesDisabled) {
       return;
     }
-    const tailText = session.tail || session.aggregated;
-    // Note: opts.onUpdate() is provided by agent runtime's agent-loop and
+    // Note: opts.onUpdate() is provided by pi-agent-core's agent-loop and
     // internally pushes Promise.resolve(emit(event)) into an updateEvents
     // array.  Because emit → processEvents is async, any failure (e.g.
     // activeRun cleared) produces a *rejected Promise*, not a synchronous
@@ -681,19 +680,18 @@ export async function runExecProcess(opts: {
     // chain on process exit (Layer 1) and by `disableUpdates()` on abort
     // signal (Layer 2) — both of which prevent this call from ever being
     // reached after the agent run has ended.
-    opts.onUpdate({
-      content: [
-        { type: "text", text: renderExecUpdateText({ tailText, warnings: opts.warnings }) },
-      ],
-      details: {
+    opts.onUpdate(
+      buildExecUpdateResult({
         status: "running",
         sessionId,
         pid: session.pid ?? undefined,
         startedAt,
         cwd: session.cwd,
+        tailText: session.tail || session.aggregated,
         tail: session.tail,
-      },
-    });
+        warnings: opts.warnings,
+      }),
+    );
   };
 
   // One parser per stream so ESC sequences split across chunks are not mangled.

--- a/src/agents/bash-tools.exec-support.ts
+++ b/src/agents/bash-tools.exec-support.ts
@@ -2,7 +2,13 @@ import type { ExecHost } from "../infra/exec-approvals.js";
 import { requireValidExecTarget } from "../infra/exec-approvals.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
-import { renderExecOutputText } from "./bash-tools.exec-output.js";
+import {
+  prependRedactionWarning,
+  redactExecDetails,
+  redactExecOutputText,
+  renderExecOutputText,
+  withRedactionMarker,
+} from "./bash-tools.exec-output.js";
 import type { ExecToolArgs } from "./bash-tools.exec-request-preparation.js";
 import { type ExecProcessOutcome, resolveExecTarget } from "./bash-tools.exec-runtime.js";
 import type { ExecToolDefaults, ExecToolDetails } from "./bash-tools.exec-types.js";
@@ -14,31 +20,91 @@ export function buildExecForegroundResult(params: {
   cwd?: string;
   warningText?: string;
 }): AgentToolResult<ExecToolDetails> {
-  const warningText = params.warningText?.trim() ? `${params.warningText}\n\n` : "";
+  const originalWarningText = params.warningText?.trimEnd();
+  const warning = originalWarningText?.trim()
+    ? redactExecOutputText(originalWarningText).text.trimEnd()
+    : "";
+  const warningText = warning ? `${warning}\n\n` : "";
+  const aggregatedResult = redactExecOutputText(params.outcome.aggregated);
+  const aggregated = aggregatedResult.text;
+  const warningRedacted = Boolean(originalWarningText?.trim()) && warning !== originalWarningText;
   if (params.outcome.status === "failed") {
-    return failedTextResult(`${warningText}${params.outcome.reason}`, {
+    const reasonResult = redactExecOutputText(params.outcome.reason);
+    const rawDetails = {
       status: "failed",
       exitCode: params.outcome.exitCode ?? null,
       exitSignal: params.outcome.exitSignal,
       failureKind: params.outcome.failureKind,
       exitReason: params.outcome.exitReason,
       durationMs: params.outcome.durationMs,
-      aggregated: params.outcome.aggregated,
+      aggregated,
       timedOut: params.outcome.timedOut,
       noOutputTimedOut: params.outcome.noOutputTimedOut,
       cwd: params.cwd,
-    });
+    } satisfies ExecToolDetails;
+    const details = redactExecDetails(rawDetails);
+    const redacted =
+      warningRedacted || aggregatedResult.redacted || reasonResult.redacted || details.redacted;
+    return failedTextResult(
+      prependRedactionWarning(`${warningText}${reasonResult.text}`, redacted),
+      withRedactionMarker(details.details, redacted),
+    );
   }
-  return textResult(`${warningText}${renderExecOutputText(params.outcome.aggregated)}`, {
+  const rawDetails = {
     status: "completed",
     exitCode: params.outcome.exitCode,
     exitSignal: params.outcome.exitSignal,
     exitReason: params.outcome.exitReason,
     durationMs: params.outcome.durationMs,
-    aggregated: params.outcome.aggregated,
+    aggregated,
     noOutputTimedOut: params.outcome.noOutputTimedOut,
     cwd: params.cwd,
-  });
+  } satisfies ExecToolDetails;
+  const details = redactExecDetails(rawDetails);
+  const redacted = warningRedacted || aggregatedResult.redacted || details.redacted;
+  return textResult(
+    prependRedactionWarning(`${warningText}${renderExecOutputText(aggregated)}`, redacted),
+    withRedactionMarker(details.details, redacted),
+  );
+}
+
+export function buildExecRunningResult(params: {
+  warningText?: string;
+  sessionId: string;
+  pid?: number;
+  startedAt: number;
+  cwd?: string;
+  tail: string;
+}): AgentToolResult<ExecToolDetails> {
+  const originalWarningText = params.warningText?.trimEnd();
+  const warning = originalWarningText?.trim()
+    ? redactExecOutputText(originalWarningText).text.trimEnd()
+    : "";
+  const warningText = warning ? `${warning}\n\n` : "";
+  const warningRedacted = Boolean(originalWarningText?.trim()) && warning !== originalWarningText;
+  const tail = redactExecOutputText(params.tail);
+  const rawDetails = {
+    status: "running",
+    sessionId: params.sessionId,
+    pid: params.pid,
+    startedAt: params.startedAt,
+    cwd: params.cwd,
+    tail: tail.text,
+  } satisfies ExecToolDetails;
+  const details = redactExecDetails(rawDetails);
+  const redacted = warningRedacted || tail.redacted || details.redacted;
+  return {
+    content: [
+      {
+        type: "text",
+        text: prependRedactionWarning(
+          `${warningText}Command still running (session ${params.sessionId}, pid ${params.pid ?? "n/a"}). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.`,
+          redacted,
+        ),
+      },
+    ],
+    details: withRedactionMarker(details.details, redacted),
+  };
 }
 
 export function resolveExecReviewerDefaults(params: {

--- a/src/agents/bash-tools.process-helpers.ts
+++ b/src/agents/bash-tools.process-helpers.ts
@@ -1,0 +1,161 @@
+import { createAbortError as createNamedAbortError } from "../infra/abort-signal.js";
+import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
+import type { ProcessSession } from "./bash-process-registry.js";
+import { prependRedactionWarning } from "./bash-tools.exec-output.js";
+import {
+  deriveRedactedProcessSessionName,
+  redactProcessToolDetailsWithCommand,
+} from "./bash-tools.process-redaction.js";
+import type { WritableStdin } from "./bash-tools.process-send-keys.js";
+import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
+import type { AgentToolResult } from "./runtime/index.js";
+
+export const DEFAULT_INPUT_WAIT_IDLE_MS = 15_000;
+export const MIN_INPUT_WAIT_IDLE_MS = 1_000;
+export const MAX_INPUT_WAIT_IDLE_MS = 10 * 60 * 1000;
+
+const DEFAULT_LOG_TAIL_LINES = 200;
+const MAX_POLL_WAIT_MS = 30_000;
+const INTEGER_STRING_PATTERN = /^[+-]?\d+$/u;
+
+export type RunningSessionRuntime = {
+  stdinWritable: boolean;
+  waitingForInput: boolean;
+  idleMs: number;
+  lastOutputAt: number;
+};
+
+export function resolveLogSliceWindow(offset?: number, limit?: number) {
+  const usingDefaultTail = offset === undefined && limit === undefined;
+  const effectiveLimit =
+    typeof limit === "number" && Number.isFinite(limit)
+      ? limit
+      : usingDefaultTail
+        ? DEFAULT_LOG_TAIL_LINES
+        : undefined;
+  return { effectiveOffset: offset, effectiveLimit, usingDefaultTail };
+}
+
+export function defaultTailNote(totalLines: number, usingDefaultTail: boolean) {
+  if (!usingDefaultTail || totalLines <= DEFAULT_LOG_TAIL_LINES) {
+    return "";
+  }
+  return `\n\n[showing last ${DEFAULT_LOG_TAIL_LINES} of ${totalLines} lines; pass offset/limit to page]`;
+}
+
+export function resolveSessionStdin(session: ProcessSession): WritableStdin | undefined {
+  return (session.stdin ?? session.child?.stdin) as WritableStdin | undefined;
+}
+
+export function isWritableStdin(stdin: WritableStdin | undefined): stdin is WritableStdin {
+  if (!stdin || stdin.destroyed) {
+    return false;
+  }
+  if (stdin.writable === false || stdin.writableEnded === true || stdin.writableFinished === true) {
+    return false;
+  }
+  return true;
+}
+
+export function runningSessionInputDetails(runtime: RunningSessionRuntime) {
+  return {
+    stdinWritable: runtime.stdinWritable,
+    waitingForInput: runtime.waitingForInput,
+    idleMs: runtime.idleMs,
+    lastOutputAt: runtime.lastOutputAt,
+  };
+}
+
+export function resolvePollWaitMs(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.min(MAX_POLL_WAIT_MS, Math.floor(value)));
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!INTEGER_STRING_PATTERN.test(trimmed)) {
+      return 0;
+    }
+    const parsed = Number(trimmed);
+    if (Number.isSafeInteger(parsed)) {
+      return Math.max(0, Math.min(MAX_POLL_WAIT_MS, parsed));
+    }
+  }
+  return 0;
+}
+
+export function failText(text: string): AgentToolResult<unknown> {
+  return {
+    content: [{ type: "text", text }],
+    details: { status: "failed" },
+  };
+}
+
+export function runningProcessSessionResult(
+  sessionId: string,
+  session: ProcessSession,
+  text: string,
+): AgentToolResult<unknown> {
+  const details = redactProcessToolDetailsWithCommand(
+    { status: "running", sessionId, name: deriveRedactedProcessSessionName(session.command) },
+    session.command,
+  );
+  return {
+    content: [{ type: "text", text: prependRedactionWarning(text, details.redacted === true) }],
+    details,
+  };
+}
+
+export function recordPollRetrySuggestion(
+  sessionId: string,
+  hasNewOutput: boolean,
+): number | undefined {
+  try {
+    const sessionState = getDiagnosticSessionState({ sessionId });
+    return recordCommandPoll(sessionState, sessionId, hasNewOutput);
+  } catch {
+    return undefined;
+  }
+}
+
+export function resetPollRetrySuggestion(sessionId: string): void {
+  try {
+    const sessionState = getDiagnosticSessionState({ sessionId });
+    resetCommandPollCount(sessionState, sessionId);
+  } catch {
+    // Ignore diagnostics state failures for process tool behavior.
+  }
+}
+
+function createAbortError(reason: unknown): Error {
+  if (reason instanceof Error) {
+    return reason;
+  }
+  return createNamedAbortError(typeof reason === "string" ? reason : "Aborted");
+}
+
+export async function sleepPollInterval(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    throw createAbortError(signal.reason);
+  }
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      if (onAbort) {
+        signal?.removeEventListener("abort", onAbort);
+      }
+    };
+    const onResolve = () => {
+      cleanup();
+      resolve();
+    };
+    const onAbort: (() => void) | undefined = () => {
+      cleanup();
+      reject(createAbortError(signal?.reason));
+    };
+    const timer: ReturnType<typeof setTimeout> | undefined = setTimeout(onResolve, ms);
+    timer.unref?.();
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/src/agents/bash-tools.process-redaction.ts
+++ b/src/agents/bash-tools.process-redaction.ts
@@ -1,0 +1,43 @@
+import { redactSecrets, redactToolPayloadText } from "../logging/redact.js";
+import {
+  redactExecDetails,
+  redactExecOutputText,
+  withRedactionMarker,
+} from "./bash-tools.exec-output.js";
+import { deriveSessionName } from "./bash-tools.shared.js";
+
+export function redactProcessSessionText(text: string): string {
+  return redactSecrets(redactToolPayloadText(text));
+}
+
+export function deriveRedactedProcessSessionName(command: string): string | undefined {
+  return redactSecrets(deriveSessionName(redactToolPayloadText(command)));
+}
+
+export function redactProcessToolDetails<T extends Record<string, unknown>>(
+  details: T,
+): T & { redacted?: true } {
+  const result = redactExecDetails(details);
+  const nestedRedacted = JSON.stringify(result.details).includes('"redacted":true');
+  return withRedactionMarker(result.details, result.redacted || nestedRedacted);
+}
+
+export function redactProcessToolDetailsWithCommand<T extends Record<string, unknown>>(
+  details: T,
+  command: string,
+  redacted = false,
+): T & { redacted?: true } {
+  return withRedactionMarker(
+    redactProcessToolDetails(details),
+    redacted || processSessionNameWasRedacted(command),
+  );
+}
+
+export function redactProcessText(text: string, suffix = "") {
+  const redacted = redactExecOutputText(text);
+  return { text: redacted.text + suffix, redacted: redacted.redacted };
+}
+
+function processSessionNameWasRedacted(command: string): boolean {
+  return deriveRedactedProcessSessionName(command) !== deriveSessionName(command);
+}

--- a/src/agents/bash-tools.process-send-keys.test.ts
+++ b/src/agents/bash-tools.process-send-keys.test.ts
@@ -4,7 +4,12 @@
  */
 import { expect, test } from "vitest";
 import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+import { prependRedactionWarning } from "./bash-tools.exec-output.js";
 import { handleProcessSendKeys, type WritableStdin } from "./bash-tools.process-send-keys.js";
+
+const EXEC_REDACTION_WARNING = prependRedactionWarning("", true).trimEnd();
+const fakeSecretOutput = "OPENAI_API_KEY=sk-proj-redaction-canary-1234567890";
+const fakeFlagSecret = "sk-proj-redaction-canary-abcdefghijklmnopqrstuvwxyz1234567890";
 
 function createWritableStdinStub(): WritableStdin {
   return {
@@ -53,6 +58,99 @@ test("process send-keys still sends non-cursor keys while mode is unknown", asyn
   });
 
   expect((result.details as { status?: string }).status).toBe("running");
+});
+
+test("process send-keys redacts secret-shaped command-derived details name", async () => {
+  const result = await handleProcessSendKeys({
+    sessionId: "sess-redact-send-keys-name",
+    session: createProcessSessionFixture({
+      id: "sess-redact-send-keys-name",
+      command: `echo ${fakeSecretOutput}`,
+      backgrounded: true,
+    }),
+    stdin: createWritableStdinStub(),
+    keys: ["Enter"],
+  });
+  const details = result.details as { name?: string; redacted?: boolean };
+
+  expect((result.content[0] as { text?: string }).text).not.toContain(fakeSecretOutput);
+  expect((result.content[0] as { text?: string }).text).toContain(EXEC_REDACTION_WARNING);
+  expect(JSON.stringify(details)).not.toContain(fakeSecretOutput);
+  expect(details.name).toContain("OPENAI_API_KEY=");
+  expect(details.redacted).toBe(true);
+});
+
+test("process send-keys redacts secret-shaped flag values before deriving details name", async () => {
+  const result = await handleProcessSendKeys({
+    sessionId: "sess-redact-send-keys-flag-name",
+    session: createProcessSessionFixture({
+      id: "sess-redact-send-keys-flag-name",
+      command: `tool --api-key ${fakeFlagSecret}`,
+      backgrounded: true,
+    }),
+    stdin: createWritableStdinStub(),
+    keys: ["Enter"],
+  });
+  const details = result.details as { name?: string; redacted?: boolean };
+
+  expect((result.content[0] as { text?: string }).text).toContain(EXEC_REDACTION_WARNING);
+  expect(JSON.stringify(details)).not.toContain(fakeFlagSecret);
+  expect(JSON.stringify(details)).not.toContain("abcdefghijklmnopqrstuvwxyz1234567890");
+  expect(details.name).toContain("sk-pro…7890");
+  expect(details.redacted).toBe(true);
+});
+
+test("process send-keys leaves unredacted command details unmarked", async () => {
+  const result = await handleProcessSendKeys({
+    sessionId: "sess-unredacted-send-keys",
+    session: createProcessSessionFixture({
+      id: "sess-unredacted-send-keys",
+      command: "cat",
+      backgrounded: true,
+    }),
+    stdin: createWritableStdinStub(),
+    keys: ["Enter"],
+  });
+
+  expect((result.content[0] as { text?: string }).text).not.toContain(EXEC_REDACTION_WARNING);
+  expect((result.details as { redacted?: boolean }).redacted).toBeUndefined();
+});
+
+test("process send-keys does not mark a secret omitted from the derived name", async () => {
+  const result = await handleProcessSendKeys({
+    sessionId: "sess-hidden-secret-send-keys",
+    session: createProcessSessionFixture({
+      id: "sess-hidden-secret-send-keys",
+      command: `tool target --api-key ${fakeFlagSecret}`,
+      backgrounded: true,
+    }),
+    stdin: createWritableStdinStub(),
+    keys: ["Enter"],
+  });
+
+  expect((result.content[0] as { text?: string }).text).not.toContain(EXEC_REDACTION_WARNING);
+  expect(JSON.stringify(result)).not.toContain(fakeFlagSecret);
+  expect((result.details as { redacted?: boolean }).redacted).toBeUndefined();
+});
+
+test("process send-keys redacts secret-shaped encoder warnings", async () => {
+  const result = await handleProcessSendKeys({
+    sessionId: "sess-redact-send-keys-warning",
+    session: createProcessSessionFixture({
+      id: "sess-redact-send-keys-warning",
+      command: "cat",
+      backgrounded: true,
+    }),
+    stdin: createWritableStdinStub(),
+    keys: ["Enter"],
+    hex: [fakeFlagSecret],
+  });
+  const text = (result.content[0] as { text?: string }).text ?? "";
+
+  expect(text).toContain(EXEC_REDACTION_WARNING);
+  expect(text).not.toContain(fakeFlagSecret);
+  expect(text).toContain("sk-pro…7890");
+  expect((result.details as { redacted?: boolean }).redacted).toBe(true);
 });
 
 test("process send-keys reports the UTF-8 byte count", async () => {

--- a/src/agents/bash-tools.process-send-keys.ts
+++ b/src/agents/bash-tools.process-send-keys.ts
@@ -4,7 +4,12 @@
  * live process stdin.
  */
 import type { ProcessSession } from "./bash-process-registry.js";
-import { deriveSessionName } from "./bash-tools.shared.js";
+import { prependRedactionWarning } from "./bash-tools.exec-output.js";
+import {
+  deriveRedactedProcessSessionName,
+  redactProcessText,
+  redactProcessToolDetailsWithCommand,
+} from "./bash-tools.process-redaction.js";
 import { encodeKeySequence, hasCursorModeSensitiveKeys } from "./pty-keys.js";
 import type { AgentToolResult } from "./runtime/index.js";
 
@@ -70,19 +75,26 @@ export async function handleProcessSendKeys(params: {
     return failText("No key data provided.");
   }
   await writeProcessStdin(params.stdin, data);
+  const text = redactProcessText(
+    `Sent ${Buffer.byteLength(data, "utf8")} bytes to session ${params.sessionId}.` +
+      (warnings.length ? `\nWarnings:\n- ${warnings.join("\n- ")}` : ""),
+  );
+  const details = redactProcessToolDetailsWithCommand(
+    {
+      status: "running",
+      sessionId: params.sessionId,
+      name: deriveRedactedProcessSessionName(params.session.command),
+    },
+    params.session.command,
+    text.redacted,
+  );
   return {
     content: [
       {
         type: "text",
-        text:
-          `Sent ${Buffer.byteLength(data, "utf8")} bytes to session ${params.sessionId}.` +
-          (warnings.length ? `\nWarnings:\n- ${warnings.join("\n- ")}` : ""),
+        text: prependRedactionWarning(text.text, details.redacted === true),
       },
     ],
-    details: {
-      status: "running",
-      sessionId: params.sessionId,
-      name: deriveSessionName(params.session.command),
-    },
+    details,
   };
 }

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -7,23 +7,43 @@ import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-sessio
 import { addSession, appendOutput, markExited } from "./bash-process-registry.js";
 import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
+import { prependRedactionWarning } from "./bash-tools.exec-output.js";
 import { createProcessTool } from "./bash-tools.process.js";
 import { processSchema } from "./bash-tools.schemas.js";
+
+const EXEC_REDACTION_WARNING = prependRedactionWarning("", true).trimEnd();
+
+const fakeSecretOutput = "OPENAI_API_KEY=sk-proj-redaction-canary-1234567890";
+const fakeFlagSecret = "sk-proj-redaction-canary-abcdefghijklmnopqrstuvwxyz1234567890";
+
+function resultText(result: Awaited<ReturnType<ReturnType<typeof createProcessTool>["execute"]>>) {
+  return (result.content[0] as { text?: string }).text ?? "";
+}
 
 afterEach(() => {
   resetProcessRegistryForTests();
   resetDiagnosticSessionStateForTest();
 });
 
-function createProcessSessionHarness(sessionId: string) {
+function createProcessSessionHarness(sessionId: string, command = "test") {
   const processTool = createProcessTool();
   const session = createProcessSessionFixture({
     id: sessionId,
-    command: "test",
+    command,
     backgrounded: true,
   });
   addSession(session);
   return { processTool, session };
+}
+
+function attachWritableStdin(session: ReturnType<typeof createProcessSessionFixture>) {
+  session.stdin = {
+    write(_data: string, cb?: (err?: Error | null) => void) {
+      cb?.();
+    },
+    end() {},
+    destroyed: false,
+  };
 }
 
 async function pollSession(
@@ -104,6 +124,41 @@ test("process poll accepts string timeout values", async () => {
   });
 });
 
+test("process poll ignores partial string timeout values", async () => {
+  vi.useFakeTimers();
+  try {
+    const { processTool } = createProcessSessionHarness("sess-partial-timeout");
+
+    const pollPromise = pollSession(processTool, "toolcall", "sess-partial-timeout", "10ms");
+
+    await expect(pollPromise).resolves.toMatchObject({
+      details: expect.objectContaining({ status: "running" }),
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("process poll ignores unsafe integer string timeout values", async () => {
+  vi.useFakeTimers();
+  try {
+    const { processTool } = createProcessSessionHarness("sess-unsafe-integer-timeout");
+
+    const pollPromise = pollSession(
+      processTool,
+      "toolcall",
+      "sess-unsafe-integer-timeout",
+      "999999999999999999999999",
+    );
+
+    await expect(pollPromise).resolves.toMatchObject({
+      details: expect.objectContaining({ status: "running" }),
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 test("process poll warns when the session times out while poll is waiting", async () => {
   vi.useFakeTimers();
   try {
@@ -181,6 +236,177 @@ test("process poll aborts while waiting for completion", async () => {
     expect((err as Error).name).toBe("AbortError");
   } finally {
     vi.useRealTimers();
+  }
+});
+
+test("process poll redacts secret-shaped output before returning results", async () => {
+  const sessionId = "sess-redact-poll";
+  const { processTool, session } = createProcessSessionHarness(sessionId);
+
+  appendOutput(session, "stdout", `${fakeSecretOutput}\n`);
+  markExited(session, 0, null, "completed");
+
+  const poll = await pollSession(processTool, "toolcall-redact-poll", sessionId);
+  const details = poll.details as { aggregated?: string };
+  expect(resultText(poll)).not.toContain(fakeSecretOutput);
+  expect(details.aggregated).not.toContain(fakeSecretOutput);
+  expect(resultText(poll)).toContain("OPENAI_API_KEY=sk-pro…7890");
+  expect(details.aggregated).toContain("OPENAI_API_KEY=sk-pro…7890");
+  expect(resultText(poll)).toContain(EXEC_REDACTION_WARNING);
+  expect((poll.details as { redacted?: boolean }).redacted).toBe(true);
+});
+
+test("process log redacts secret-shaped output before returning results", async () => {
+  const sessionId = "sess-redact-log";
+  const { processTool, session } = createProcessSessionHarness(sessionId);
+
+  appendOutput(session, "stdout", `${fakeSecretOutput}\n`);
+  const log = await processTool.execute("toolcall-redact-log", {
+    action: "log",
+    sessionId,
+  });
+
+  expect(resultText(log)).not.toContain(fakeSecretOutput);
+  expect(resultText(log)).toContain("OPENAI_API_KEY=sk-pro…7890");
+  expect(resultText(log)).toContain(EXEC_REDACTION_WARNING);
+  expect((log.details as { redacted?: boolean }).redacted).toBe(true);
+});
+
+test("process poll and log mark command-only redaction for running sessions", async () => {
+  const sessionId = "sess-redact-running-command";
+  const command = `tool --api-key ${fakeFlagSecret}`;
+  const { processTool } = createProcessSessionHarness(sessionId, command);
+
+  const polled = await pollSession(processTool, "toolcall-redact-running-poll", sessionId);
+  const logged = await processTool.execute("toolcall-redact-running-log", {
+    action: "log",
+    sessionId,
+  });
+
+  for (const result of [polled, logged]) {
+    expect(resultText(result)).toContain(EXEC_REDACTION_WARNING);
+    expect(resultText(result)).not.toContain(fakeFlagSecret);
+    expect(JSON.stringify(result.details)).not.toContain(fakeFlagSecret);
+    expect((result.details as { redacted?: boolean }).redacted).toBe(true);
+  }
+});
+
+test("process poll and log mark command-only redaction for finished sessions", async () => {
+  const sessionId = "sess-redact-finished-command";
+  const command = `tool --api-key ${fakeFlagSecret}`;
+  const { processTool, session } = createProcessSessionHarness(sessionId, command);
+  markExited(session, 0, null, "completed");
+
+  const polled = await pollSession(processTool, "toolcall-redact-finished-poll", sessionId);
+  const logged = await processTool.execute("toolcall-redact-finished-log", {
+    action: "log",
+    sessionId,
+  });
+
+  for (const result of [polled, logged]) {
+    expect(resultText(result)).toContain(EXEC_REDACTION_WARNING);
+    expect(resultText(result)).not.toContain(fakeFlagSecret);
+    expect(JSON.stringify(result.details)).not.toContain(fakeFlagSecret);
+    expect((result.details as { redacted?: boolean }).redacted).toBe(true);
+  }
+});
+
+test("process list redacts secret-shaped command and tail details", async () => {
+  const sessionId = "sess-redact-list";
+  const processTool = createProcessTool();
+  const session = createProcessSessionFixture({
+    id: sessionId,
+    command: `echo ${fakeSecretOutput}`,
+    backgrounded: true,
+  });
+  addSession(session);
+  appendOutput(session, "stdout", `${fakeSecretOutput}\n`);
+
+  const listed = await processTool.execute("toolcall-redact-list", {
+    action: "list",
+  });
+  const details = listed.details as { sessions?: Array<{ command?: string; tail?: string }> };
+  const listedSession = details.sessions?.find((entry) =>
+    entry.command?.includes("OPENAI_API_KEY"),
+  );
+
+  expect(resultText(listed)).not.toContain(fakeSecretOutput);
+  expect(JSON.stringify(details)).not.toContain(fakeSecretOutput);
+  expect(resultText(listed)).toContain("OPENAI_API_KEY=");
+  expect(listedSession?.command).toContain("OPENAI_API_KEY=***");
+  expect(listedSession?.tail).toContain("OPENAI_API_KEY=***");
+  expect(resultText(listed)).toContain(EXEC_REDACTION_WARNING);
+  expect((listed.details as { redacted?: boolean }).redacted).toBe(true);
+});
+
+test("process write redacts secret-shaped command-derived details name", async () => {
+  const sessionId = "sess-redact-write-name";
+  const processTool = createProcessTool();
+  const session = createProcessSessionFixture({
+    id: sessionId,
+    command: `echo ${fakeSecretOutput}`,
+    backgrounded: true,
+  });
+  attachWritableStdin(session);
+  addSession(session);
+
+  const written = await processTool.execute("toolcall-redact-write-name", {
+    action: "write",
+    sessionId,
+    data: "input\n",
+  });
+  const details = written.details as { name?: string };
+
+  expect(resultText(written)).not.toContain(fakeSecretOutput);
+  expect(JSON.stringify(details)).not.toContain(fakeSecretOutput);
+  expect(details.name).toContain("OPENAI_API_KEY=");
+  expect(resultText(written)).toContain(EXEC_REDACTION_WARNING);
+  expect((written.details as { redacted?: boolean }).redacted).toBe(true);
+});
+
+test("process poll leaves unredacted output unmarked", async () => {
+  const sessionId = "sess-unredacted-poll";
+  const { processTool, session } = createProcessSessionHarness(sessionId);
+
+  appendOutput(session, "stdout", "plain output\n");
+  markExited(session, 0, null, "completed");
+
+  const poll = await pollSession(processTool, "toolcall-unredacted-poll", sessionId);
+
+  expect(resultText(poll)).not.toContain(EXEC_REDACTION_WARNING);
+  expect((poll.details as { redacted?: boolean }).redacted).toBeUndefined();
+});
+
+test("process list, poll, log, and write redact secret-shaped flag values before deriving details name", async () => {
+  const sessionId = "sess-redact-flag-name";
+  const processTool = createProcessTool();
+  const session = createProcessSessionFixture({
+    id: sessionId,
+    command: `tool --api-key ${fakeFlagSecret}`,
+    backgrounded: true,
+  });
+  attachWritableStdin(session);
+  addSession(session);
+
+  const listed = await processTool.execute("toolcall-redact-flag-list", {
+    action: "list",
+  });
+  const polled = await pollSession(processTool, "toolcall-redact-flag-poll", sessionId);
+  const logged = await processTool.execute("toolcall-redact-flag-log", {
+    action: "log",
+    sessionId,
+  });
+  const written = await processTool.execute("toolcall-redact-flag-write", {
+    action: "write",
+    sessionId,
+    data: "input\n",
+  });
+
+  for (const result of [listed, polled, logged, written]) {
+    const serialized = JSON.stringify(result.details);
+    expect(serialized).not.toContain(fakeFlagSecret);
+    expect(serialized).not.toContain("abcdefghijklmnopqrstuvwxyz1234567890");
+    expect(serialized).toContain("sk-pro…7890");
   }
 });
 

--- a/src/agents/bash-tools.process.supervisor.test.ts
+++ b/src/agents/bash-tools.process.supervisor.test.ts
@@ -3,6 +3,10 @@
  * Verifies managed session cancellation, process-tree fallback, and registry state.
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { prependRedactionWarning } from "./bash-tools.exec-output.js";
+
+const EXEC_REDACTION_WARNING = prependRedactionWarning("", true).trimEnd();
+const fakeFlagSecret = "sk-proj-redaction-canary-abcdefghijklmnopqrstuvwxyz1234567890";
 
 const { supervisorMock } = vi.hoisted(() => ({
   supervisorMock: {
@@ -48,6 +52,13 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
     throw new Error(`expected ${label}`);
   }
   return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`expected ${label}`);
+  }
+  return value;
 }
 
 function expectSessionState(sessionId: string, expected: { exited?: boolean }) {
@@ -154,6 +165,33 @@ describe("process tool supervisor cancellation", () => {
     expectFinishedSessionState("sess-fallback", { status: "failed", exitSignal: "SIGKILL" });
     expectTextContent(result.content[0], "Killed session sess-fallback.");
   });
+
+  it.each(["kill", "remove"] as const)(
+    "%s marks command-only redaction in agent-visible results",
+    async (action) => {
+      const sessionId = `sess-redact-${action}`;
+      supervisorMock.getRecord.mockReturnValue({ runId: sessionId, state: "running" });
+      addSession(
+        createProcessSessionFixture({
+          id: sessionId,
+          command: `tool --api-key ${fakeFlagSecret}`,
+          backgrounded: true,
+        }),
+      );
+      const processTool = createProcessTool();
+
+      const result = await processTool.execute("toolcall", { action, sessionId });
+      const text = requireString(
+        requireRecord(result.content[0], "tool content").text,
+        "tool content text",
+      );
+
+      expect(text).toContain(EXEC_REDACTION_WARNING);
+      expect(text).not.toContain(fakeFlagSecret);
+      expect(JSON.stringify(result.details)).not.toContain(fakeFlagSecret);
+      expect(requireRecord(result.details, "result details").redacted).toBe(true);
+    },
+  );
 
   it.each(["kill", "remove"] as const)(
     "refuses %s while sandbox finalization owns the terminal transition",

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -3,9 +3,7 @@
  * Lists, polls, logs, writes to, sends keys to, pastes into, kills, clears,
  * and removes background exec sessions.
  */
-import { createAbortError as createNamedAbortError } from "../infra/abort-signal.js";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
-import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
 import { killProcessTree } from "../process/kill-tree.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import {
@@ -20,22 +18,42 @@ import {
   setJobTtlMs,
 } from "./bash-process-registry.js";
 import { describeProcessTool } from "./bash-tools.descriptions.js";
-import { appendExecTimeoutRetryGuidance } from "./bash-tools.exec-output.js";
 import {
-  handleProcessSendKeys,
-  type WritableStdin,
-  writeProcessStdin,
-} from "./bash-tools.process-send-keys.js";
+  appendExecTimeoutRetryGuidance,
+  prependRedactionWarning,
+} from "./bash-tools.exec-output.js";
+import {
+  DEFAULT_INPUT_WAIT_IDLE_MS,
+  MAX_INPUT_WAIT_IDLE_MS,
+  MIN_INPUT_WAIT_IDLE_MS,
+  type RunningSessionRuntime,
+  defaultTailNote,
+  failText,
+  isWritableStdin,
+  recordPollRetrySuggestion,
+  resetPollRetrySuggestion,
+  resolveLogSliceWindow,
+  resolvePollWaitMs,
+  resolveSessionStdin,
+  runningProcessSessionResult,
+  runningSessionInputDetails,
+  sleepPollInterval,
+} from "./bash-tools.process-helpers.js";
+import {
+  deriveRedactedProcessSessionName,
+  redactProcessText,
+  redactProcessToolDetails,
+  redactProcessToolDetailsWithCommand,
+} from "./bash-tools.process-redaction.js";
+import { handleProcessSendKeys, writeProcessStdin } from "./bash-tools.process-send-keys.js";
 import { processSchema } from "./bash-tools.schemas.js";
 import {
   clampWithDefault,
-  deriveSessionName,
   pad,
   readEnvInt,
   sliceLogLines,
   truncateMiddle,
 } from "./bash-tools.shared.js";
-import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
 import { encodePaste } from "./pty-keys.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { PROCESS_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
@@ -49,136 +67,8 @@ export type ProcessToolDefaults = {
   scopeKey?: string;
 };
 
-const DEFAULT_LOG_TAIL_LINES = 200;
-const DEFAULT_INPUT_WAIT_IDLE_MS = 15_000;
-const MIN_INPUT_WAIT_IDLE_MS = 1_000;
-const MAX_INPUT_WAIT_IDLE_MS = 10 * 60 * 1000;
-
-function resolveLogSliceWindow(offset?: number, limit?: number) {
-  const usingDefaultTail = offset === undefined && limit === undefined;
-  const effectiveLimit =
-    typeof limit === "number" && Number.isFinite(limit)
-      ? limit
-      : usingDefaultTail
-        ? DEFAULT_LOG_TAIL_LINES
-        : undefined;
-  return { effectiveOffset: offset, effectiveLimit, usingDefaultTail };
-}
-
-function defaultTailNote(totalLines: number, usingDefaultTail: boolean) {
-  if (!usingDefaultTail || totalLines <= DEFAULT_LOG_TAIL_LINES) {
-    return "";
-  }
-  return `\n\n[showing last ${DEFAULT_LOG_TAIL_LINES} of ${totalLines} lines; pass offset/limit to page]`;
-}
-
-const MAX_POLL_WAIT_MS = 30_000;
-
-type RunningSessionRuntime = {
-  stdinWritable: boolean;
-  waitingForInput: boolean;
-  idleMs: number;
-  lastOutputAt: number;
-};
-
-function resolveSessionStdin(session: ProcessSession): WritableStdin | undefined {
-  return (session.stdin ?? session.child?.stdin) as WritableStdin | undefined;
-}
-
-function isWritableStdin(stdin: WritableStdin | undefined): stdin is WritableStdin {
-  if (!stdin || stdin.destroyed) {
-    return false;
-  }
-  if (stdin.writable === false || stdin.writableEnded === true || stdin.writableFinished === true) {
-    return false;
-  }
-  return true;
-}
-
-function runningSessionInputDetails(runtime: RunningSessionRuntime) {
-  return {
-    stdinWritable: runtime.stdinWritable,
-    waitingForInput: runtime.waitingForInput,
-    idleMs: runtime.idleMs,
-    lastOutputAt: runtime.lastOutputAt,
-  };
-}
-
-function resolvePollWaitMs(value: unknown) {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return Math.max(0, Math.min(MAX_POLL_WAIT_MS, Math.floor(value)));
-  }
-  if (typeof value === "string" && /^[+-]?\d+$/.test(value.trim())) {
-    const parsed = Number(value.trim());
-    if (Number.isSafeInteger(parsed)) {
-      return Math.max(0, Math.min(MAX_POLL_WAIT_MS, parsed));
-    }
-  }
-  return 0;
-}
-
-function failText(text: string): AgentToolResult<unknown> {
-  return {
-    content: [
-      {
-        type: "text",
-        text,
-      },
-    ],
-    details: { status: "failed" },
-  };
-}
-
-function recordPollRetrySuggestion(sessionId: string, hasNewOutput: boolean): number | undefined {
-  try {
-    const sessionState = getDiagnosticSessionState({ sessionId });
-    return recordCommandPoll(sessionState, sessionId, hasNewOutput);
-  } catch {
-    return undefined;
-  }
-}
-
-function resetPollRetrySuggestion(sessionId: string): void {
-  try {
-    const sessionState = getDiagnosticSessionState({ sessionId });
-    resetCommandPollCount(sessionState, sessionId);
-  } catch {
-    // Ignore diagnostics state failures for process tool behavior.
-  }
-}
-
-function createAbortError(reason: unknown): Error {
-  if (reason instanceof Error) {
-    return reason;
-  }
-  return createNamedAbortError(typeof reason === "string" ? reason : "Aborted");
-}
-
-async function sleepPollInterval(ms: number, signal?: AbortSignal): Promise<void> {
-  if (signal?.aborted) {
-    throw createAbortError(signal.reason);
-  }
-  await new Promise<void>((resolve, reject) => {
-    const cleanup = () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-      if (onAbort) {
-        signal?.removeEventListener("abort", onAbort);
-      }
-    };
-    const onResolve = () => {
-      cleanup();
-      resolve();
-    };
-    const onAbort: (() => void) | undefined = () => {
-      cleanup();
-      reject(createAbortError(signal?.reason));
-    };
-    const timer: ReturnType<typeof setTimeout> | undefined = setTimeout(onResolve, ms);
-    timer.unref?.();
-    signal?.addEventListener("abort", onAbort, { once: true });
-  });
+function redactProcessSessionName(command: string): string | undefined {
+  return deriveRedactedProcessSessionName(command);
 }
 
 /** Build the process-control tool with optional cleanup, scope, and input-idle defaults. */
@@ -275,7 +165,7 @@ export function createProcessTool(
           .filter((s) => isInScope(s))
           .map((s) => {
             const runtime = describeRunningSession(s);
-            return {
+            return redactProcessToolDetails({
               sessionId: s.id,
               status: "running",
               pid: s.pid ?? undefined,
@@ -283,31 +173,33 @@ export function createProcessTool(
               runtimeMs: Date.now() - s.startedAt,
               cwd: s.cwd,
               command: s.command,
-              name: deriveSessionName(s.command),
+              name: redactProcessSessionName(s.command),
               tail: s.tail,
               truncated: s.truncated,
               stdinWritable: runtime.stdinWritable,
               waitingForInput: runtime.waitingForInput,
               idleMs: runtime.idleMs,
               lastOutputAt: runtime.lastOutputAt,
-            };
+            });
           });
         const finished = listFinishedSessions()
           .filter((s) => isInScope(s))
-          .map((s) => ({
-            sessionId: s.id,
-            status: s.status,
-            startedAt: s.startedAt,
-            endedAt: s.endedAt,
-            runtimeMs: s.endedAt - s.startedAt,
-            cwd: s.cwd,
-            command: s.command,
-            name: deriveSessionName(s.command),
-            tail: s.tail,
-            truncated: s.truncated,
-            exitCode: s.exitCode ?? undefined,
-            exitSignal: s.exitSignal ?? undefined,
-          }));
+          .map((s) =>
+            redactProcessToolDetails({
+              sessionId: s.id,
+              status: s.status,
+              startedAt: s.startedAt,
+              endedAt: s.endedAt,
+              runtimeMs: s.endedAt - s.startedAt,
+              cwd: s.cwd,
+              command: s.command,
+              name: redactProcessSessionName(s.command),
+              tail: s.tail,
+              truncated: s.truncated,
+              exitCode: s.exitCode ?? undefined,
+              exitSignal: s.exitSignal ?? undefined,
+            }),
+          );
         const lines = [...running, ...finished]
           .toSorted((a, b) => b.startedAt - a.startedAt)
           .map((s) => {
@@ -317,14 +209,21 @@ export function createProcessTool(
               formatDurationCompact(s.runtimeMs) ?? "n/a"
             }${marker} :: ${label}`;
           });
+        const redacted = [...running, ...finished].some((session) => session.redacted === true);
         return {
           content: [
             {
               type: "text",
-              text: lines.join("\n") || "No running or recent sessions.",
+              text: prependRedactionWarning(
+                lines.join("\n") || "No running or recent sessions.",
+                redacted,
+              ),
             },
           ],
-          details: { status: "completed", sessions: [...running, ...finished] },
+          details: redactProcessToolDetails({
+            status: "completed",
+            sessions: [...running, ...finished],
+          }),
         };
       }
 
@@ -374,42 +273,22 @@ export function createProcessTool(
         return { ok: true as const, session: scopedSession, stdin };
       };
 
-      const runningSessionResult = (
-        sessionLocal: ProcessSession,
-        text: string,
-      ): AgentToolResult<unknown> => ({
-        content: [{ type: "text", text }],
-        details: {
-          status: "running",
-          sessionId: params.sessionId,
-          name: deriveSessionName(sessionLocal.command),
-        },
-      });
-
       switch (params.action) {
         case "poll": {
           if (!scopedSession) {
             if (scopedFinished) {
               resetPollRetrySuggestion(params.sessionId);
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: appendExecTimeoutRetryGuidance(
-                      (scopedFinished.tail ||
-                        `(no output recorded${
-                          scopedFinished.truncated ? " — truncated to cap" : ""
-                        })`) +
-                        `\n\nProcess exited with ${
-                          scopedFinished.exitSignal
-                            ? `signal ${scopedFinished.exitSignal}`
-                            : `code ${scopedFinished.exitCode ?? 0}`
-                        }.`,
-                      scopedFinished.exitReason,
-                    ),
-                  },
-                ],
-                details: {
+              const text = redactProcessText(
+                scopedFinished.tail ||
+                  `(no output recorded${scopedFinished.truncated ? " — truncated to cap" : ""})`,
+                `\n\nProcess exited with ${
+                  scopedFinished.exitSignal
+                    ? `signal ${scopedFinished.exitSignal}`
+                    : `code ${scopedFinished.exitCode ?? 0}`
+                }.`,
+              );
+              const details = redactProcessToolDetailsWithCommand(
+                {
                   status: scopedFinished.status === "completed" ? "completed" : "failed",
                   sessionId: params.sessionId,
                   exitCode: scopedFinished.exitCode ?? undefined,
@@ -428,8 +307,22 @@ export function createProcessTool(
                     ? { noOutputTimedOut: scopedFinished.noOutputTimedOut }
                     : {}),
                   aggregated: scopedFinished.aggregated,
-                  name: deriveSessionName(scopedFinished.command),
+                  name: redactProcessSessionName(scopedFinished.command),
                 },
+                scopedFinished.command,
+                text.redacted,
+              );
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: prependRedactionWarning(
+                      appendExecTimeoutRetryGuidance(text.text, scopedFinished.exitReason),
+                      text.redacted || details.redacted === true,
+                    ),
+                  },
+                ],
+                details,
               };
             }
             resetPollRetrySuggestion(params.sessionId);
@@ -474,22 +367,16 @@ export function createProcessTool(
             resetPollRetrySuggestion(params.sessionId);
           }
           const runtime = exited ? undefined : describeRunningSession(scopedSession);
-          return {
-            content: [
-              {
-                type: "text",
-                text: appendExecTimeoutRetryGuidance(
-                  (output || "(no new output)") +
-                    (exited
-                      ? `\n\nProcess exited with ${
-                          exitSignal ? `signal ${exitSignal}` : `code ${exitCode}`
-                        }.`
-                      : buildInputWaitHint(runtime) || "\n\nProcess still running."),
-                  exited ? scopedSession.exitReason : undefined,
-                ),
-              },
-            ],
-            details: {
+          const text = redactProcessText(
+            output || "(no new output)",
+            exited
+              ? `\n\nProcess exited with ${
+                  exitSignal ? `signal ${exitSignal}` : `code ${exitCode}`
+                }.`
+              : buildInputWaitHint(runtime) || "\n\nProcess still running.",
+          );
+          const details = redactProcessToolDetailsWithCommand(
+            {
               status,
               sessionId: params.sessionId,
               exitCode: exited ? exitCode : undefined,
@@ -508,10 +395,27 @@ export function createProcessTool(
                 ? { noOutputTimedOut: scopedSession.noOutputTimedOut }
                 : {}),
               aggregated: scopedSession.aggregated,
-              name: deriveSessionName(scopedSession.command),
+              name: redactProcessSessionName(scopedSession.command),
               ...(runtime ? runningSessionInputDetails(runtime) : {}),
               ...(typeof retryInMs === "number" ? { retryInMs } : {}),
             },
+            scopedSession.command,
+            text.redacted,
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text: prependRedactionWarning(
+                  appendExecTimeoutRetryGuidance(
+                    text.text,
+                    exited ? scopedSession.exitReason : undefined,
+                  ),
+                  text.redacted || details.redacted === true,
+                ),
+              },
+            ],
+            details,
           };
         }
 
@@ -536,24 +440,35 @@ export function createProcessTool(
             );
             const runtime = describeRunningSession(scopedSession);
             const logDefaultTailNote = defaultTailNote(totalLines, window.usingDefaultTail);
-            return {
-              content: [
-                {
-                  type: "text",
-                  text:
-                    (slice || "(no output yet)") + logDefaultTailNote + buildInputWaitHint(runtime),
-                },
-              ],
-              details: {
+            const text = redactProcessText(
+              slice || "(no output yet)",
+              logDefaultTailNote + buildInputWaitHint(runtime),
+            );
+            const details = redactProcessToolDetailsWithCommand(
+              {
                 status: scopedSession.exited ? "completed" : "running",
                 sessionId: params.sessionId,
                 total: totalLines,
                 totalLines,
                 totalChars,
                 truncated: scopedSession.truncated,
-                name: deriveSessionName(scopedSession.command),
+                name: redactProcessSessionName(scopedSession.command),
                 ...runningSessionInputDetails(runtime),
               },
+              scopedSession.command,
+              text.redacted,
+            );
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: prependRedactionWarning(
+                    text.text,
+                    text.redacted || details.redacted === true,
+                  ),
+                },
+              ],
+              details,
             };
           }
           if (scopedFinished) {
@@ -565,11 +480,9 @@ export function createProcessTool(
             );
             const status = scopedFinished.status === "completed" ? "completed" : "failed";
             const logDefaultTailNote = defaultTailNote(totalLines, window.usingDefaultTail);
-            return {
-              content: [
-                { type: "text", text: (slice || "(no output recorded)") + logDefaultTailNote },
-              ],
-              details: {
+            const text = redactProcessText(slice || "(no output recorded)", logDefaultTailNote);
+            const details = redactProcessToolDetailsWithCommand(
+              {
                 status,
                 sessionId: params.sessionId,
                 total: totalLines,
@@ -578,8 +491,22 @@ export function createProcessTool(
                 truncated: scopedFinished.truncated,
                 exitCode: scopedFinished.exitCode ?? undefined,
                 exitSignal: scopedFinished.exitSignal ?? undefined,
-                name: deriveSessionName(scopedFinished.command),
+                name: redactProcessSessionName(scopedFinished.command),
               },
+              scopedFinished.command,
+              text.redacted,
+            );
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: prependRedactionWarning(
+                    text.text,
+                    text.redacted || details.redacted === true,
+                  ),
+                },
+              ],
+              details,
             };
           }
           return {
@@ -602,7 +529,8 @@ export function createProcessTool(
           if (params.eof) {
             resolved.stdin.end();
           }
-          return runningSessionResult(
+          return runningProcessSessionResult(
+            params.sessionId,
             resolved.session,
             `Wrote ${Buffer.byteLength(params.data ?? "", "utf8")} bytes to session ${params.sessionId}${
               params.eof ? " (stdin closed)" : ""
@@ -631,7 +559,8 @@ export function createProcessTool(
             return resolved.result;
           }
           await writeProcessStdin(resolved.stdin, "\r");
-          return runningSessionResult(
+          return runningProcessSessionResult(
+            params.sessionId,
             resolved.session,
             `Submitted session ${params.sessionId} (sent CR).`,
           );
@@ -655,7 +584,8 @@ export function createProcessTool(
             };
           }
           await writeProcessStdin(resolved.stdin, payload);
-          return runningSessionResult(
+          return runningProcessSessionResult(
+            params.sessionId,
             resolved.session,
             `Pasted ${params.text?.length ?? 0} chars to session ${params.sessionId}.`,
           );
@@ -682,19 +612,24 @@ export function createProcessTool(
             markExited(scopedSession, null, "SIGKILL", "failed");
           }
           resetPollRetrySuggestion(params.sessionId);
+          const text = canceled
+            ? `Termination requested for session ${params.sessionId}.`
+            : `Killed session ${params.sessionId}.`;
+          const details = redactProcessToolDetailsWithCommand(
+            {
+              status: "failed",
+              name: redactProcessSessionName(scopedSession.command),
+            },
+            scopedSession.command,
+          );
           return {
             content: [
               {
                 type: "text",
-                text: canceled
-                  ? `Termination requested for session ${params.sessionId}.`
-                  : `Killed session ${params.sessionId}.`,
+                text: prependRedactionWarning(text, details.redacted === true),
               },
             ],
-            details: {
-              status: "failed",
-              name: scopedSession ? deriveSessionName(scopedSession.command) : undefined,
-            },
+            details,
           };
         }
 
@@ -739,19 +674,24 @@ export function createProcessTool(
               deleteSession(params.sessionId);
             }
             resetPollRetrySuggestion(params.sessionId);
+            const text = canceled
+              ? `Removed session ${params.sessionId} (termination requested).`
+              : `Removed session ${params.sessionId}.`;
+            const details = redactProcessToolDetailsWithCommand(
+              {
+                status: "failed",
+                name: redactProcessSessionName(scopedSession.command),
+              },
+              scopedSession.command,
+            );
             return {
               content: [
                 {
                   type: "text",
-                  text: canceled
-                    ? `Removed session ${params.sessionId} (termination requested).`
-                    : `Removed session ${params.sessionId}.`,
+                  text: prependRedactionWarning(text, details.redacted === true),
                 },
               ],
-              details: {
-                status: "failed",
-                name: scopedSession ? deriveSessionName(scopedSession.command) : undefined,
-              },
+              details,
             };
           }
           if (scopedFinished) {
@@ -784,4 +724,3 @@ export function createProcessTool(
 
 /** Shared process-control tool instance used by the default Bash tool barrel. */
 export const processTool = createProcessTool();
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -247,6 +247,31 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     }
   });
 
+  it("redacts scoped active process session references for compaction", () => {
+    const fakeSecretOutput = "OPENAI_API_KEY=sk-proj-redaction-canary-1234567890";
+    const active = createProcessSessionFixture({
+      id: "sess-active-secret",
+      command: `node worker.js --token ${fakeSecretOutput}`,
+      backgrounded: true,
+    });
+    active.scopeKey = "agent:main:thread:1";
+    active.tail = `last output ${fakeSecretOutput}`;
+    addSession(active);
+
+    const result = buildEmbeddedCompactionRuntimeContext({
+      sessionKey: "agent:main:thread:1",
+      workspaceDir: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      config: {} as unknown as OpenClawConfig,
+    });
+
+    const serialized = JSON.stringify(result.activeProcessSessions);
+    expect(serialized).not.toContain(fakeSecretOutput);
+    expect(serialized).toContain("OPENAI_API_KEY=***");
+    expect(serialized).toContain('"command":"node worker.js --token ***"');
+    expect(serialized).toContain('"redacted":true');
+  });
+
   it("omits active process session references when no safe scope is available", () => {
     const active = createProcessSessionFixture({
       id: "sess-active",

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -3328,6 +3328,44 @@ describe("buildAfterTurnRuntimeContext", () => {
     }
   });
 
+  it("redacts sessionId-scoped active process sessions for after-turn context", () => {
+    resetProcessRegistryForTests();
+    try {
+      const fakeSecretOutput = "OPENAI_API_KEY=sk-proj-redaction-canary-1234567890";
+      const active = createProcessSessionFixture({
+        id: "sess-session-secret",
+        command: `node worker.js --token ${fakeSecretOutput}`,
+        backgrounded: true,
+      });
+      active.scopeKey = "session-123";
+      active.tail = `last output ${fakeSecretOutput}`;
+      addSession(active);
+
+      const legacy = buildAfterTurnRuntimeContext({
+        attempt: {
+          sessionId: "session-123",
+          config: {} as OpenClawConfig,
+          skillsSnapshot: undefined,
+          provider: "openai",
+          modelId: "gpt-5.4",
+          thinkLevel: "off",
+          reasoningLevel: "on",
+        },
+        workspaceDir: "/tmp/workspace",
+        agentDir: "/tmp/agent",
+        activeAgentId: "main",
+      });
+
+      const serialized = JSON.stringify(legacy.activeProcessSessions);
+      expect(serialized).not.toContain(fakeSecretOutput);
+      expect(serialized).toContain("OPENAI_API_KEY=***");
+      expect(serialized).toContain('"command":"node worker.js --token ***"');
+      expect(serialized).toContain('"redacted":true');
+    } finally {
+      resetProcessRegistryForTests();
+    }
+  });
+
   it("uses primary model when compaction.model is not set", () => {
     const runtimeAuthPlan = {
       providerForAuth: "openai",

--- a/src/llm/tool-result-redaction.test.ts
+++ b/src/llm/tool-result-redaction.test.ts
@@ -1,75 +1,164 @@
-import { extractToolResultText } from "@openclaw/ai/internal/shared";
-// Proves the OpenClaw redaction contract applies to provider tool-result
-// replay text once the stream facade installs the AI transport host ports.
-import { describe, expect, it } from "vitest";
-// Importing the facade installs the OpenClaw AI transport host ports.
-import "./stream.js";
+import { Agent, type AgentTool } from "openclaw/plugin-sdk/agent-core";
+import { type Model, streamSimple } from "openclaw/plugin-sdk/llm";
+import { Type } from "typebox";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { jsonResult } from "../agents/tools/common.js";
 
-describe("tool result redaction via AI transport host", () => {
-  it("redacts structured secret fields with the shared tool-payload contract", () => {
-    const text = extractToolResultText([
-      {
-        type: "json",
-        apiToken: "api-token-value-1234567890",
-        privateKey: "private-key-value-1234567890",
-        private_key: "private-key-snake-1234567890",
-        key: "generic-key-value-1234567890",
-        keyMaterial: "key-material-value-1234567890",
-        bearerToken: "bearer-token-value-1234567890",
-        bearer_token: "bearer-token-snake-value-1234567890",
-        jwt: "jwt-value-1234567890",
-        session: "session-value-1234567890",
-        code: "code-value-1234567890",
-        error: { code: "ERR_VISIBLE_PROVIDER_CODE" },
-        oauth: { code: "OPAQUEPROVIDERCODE1234567890" },
-        providerError: { error: { code: "ERR_VISIBLE_PROVIDER_NESTED_CODE" } },
-        signature: "signature-value-1234567890",
-        cookie: "cookie-value-1234567890",
-        "set-cookie": "set-cookie-value-1234567890",
-        paymentCredential: "payment-credential-value-1234567890",
-        cardNumber: 4111111111111111,
-        cvc: 123,
-        text: '{"apiToken":"api-token-in-text-1234567890","code":"oauth-code-in-text-1234567890","safe":"ok"}',
-        credential: "live-credential-value",
-        appSecret: "app-secret-value",
-        rawSecret: "raw-secret-value",
-        nested: {
-          token: "nested-token-value",
-          visible: "safe-value",
+const openAiMockState = vi.hoisted(() => ({
+  requests: 0,
+}));
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    chat = {
+      completions: {
+        create: () => {
+          const request = openAiMockState.requests++;
+          const usage = { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 };
+          const chunks =
+            request === 0
+              ? [
+                  {
+                    id: "chatcmpl-tool",
+                    choices: [
+                      {
+                        index: 0,
+                        delta: {
+                          role: "assistant",
+                          tool_calls: [
+                            {
+                              index: 0,
+                              id: "call_exec",
+                              type: "function",
+                              function: { name: "exec", arguments: "{}" },
+                            },
+                          ],
+                        },
+                        finish_reason: null,
+                      },
+                    ],
+                  },
+                  {
+                    id: "chatcmpl-tool",
+                    choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+                    usage,
+                  },
+                ]
+              : [
+                  {
+                    id: "chatcmpl-final",
+                    choices: [
+                      {
+                        index: 0,
+                        delta: { role: "assistant", content: "done" },
+                        finish_reason: null,
+                      },
+                    ],
+                  },
+                  {
+                    id: "chatcmpl-final",
+                    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+                    usage,
+                  },
+                ];
+          return {
+            withResponse: async () => ({
+              data: (async function* () {
+                for (const chunk of chunks) {
+                  yield chunk;
+                }
+              })(),
+              response: new Response(null, { status: 200 }),
+            }),
+          };
         },
       },
-    ]);
+    };
+  },
+}));
 
-    expect(text).toContain('"credential":"');
-    expect(text).toContain('"appSecret":"');
-    expect(text).toContain('"rawSecret":"');
-    expect(text).toContain('"token":"');
-    expect(text).toContain('"visible":"safe-value"');
-    expect(text).toContain('"code":"ERR_VISIBLE_PROVIDER_CODE"');
-    expect(text).toContain('"code":"ERR_VISIBLE_PROVIDER_NESTED_CODE"');
-    expect(text).not.toContain("api-token-value-1234567890");
-    expect(text).not.toContain("private-key-value-1234567890");
-    expect(text).not.toContain("private-key-snake-1234567890");
-    expect(text).not.toContain("generic-key-value-1234567890");
-    expect(text).not.toContain("key-material-value-1234567890");
-    expect(text).not.toContain("bearer-token-value-1234567890");
-    expect(text).not.toContain("bearer-token-snake-value-1234567890");
-    expect(text).not.toContain("jwt-value-1234567890");
-    expect(text).not.toContain("session-value-1234567890");
-    expect(text).not.toContain("code-value-1234567890");
-    expect(text).not.toContain("OPAQUEPROVIDERCODE1234567890");
-    expect(text).not.toContain("signature-value-1234567890");
-    expect(text).not.toContain("cookie-value-1234567890");
-    expect(text).not.toContain("set-cookie-value-1234567890");
-    expect(text).not.toContain("payment-credential-value-1234567890");
-    expect(text).not.toContain("4111111111111111");
-    expect(text).not.toContain('"cvc":123');
-    expect(text).not.toContain("api-token-in-text-1234567890");
-    expect(text).not.toContain("oauth-code-in-text-1234567890");
-    expect(text).toContain('\\"safe\\":\\"ok\\"');
-    expect(text).not.toContain("live-credential-value");
-    expect(text).not.toContain("app-secret-value");
-    expect(text).not.toContain("raw-secret-value");
-    expect(text).not.toContain("nested-token-value");
+const model = {
+  id: "provider-replay-test",
+  name: "Provider replay test",
+  api: "openai-completions",
+  provider: "openai",
+  baseUrl: "https://api.openai.test/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 16_000,
+  maxTokens: 1024,
+} satisfies Model<"openai-completions">;
+
+const fakeSecret = ["qa", "-provider-secret-", "a1b2c3d4e5f6"].join("");
+const safePayload = {
+  password: fakeSecret,
+  nonce: "QA_SAFE_NONCE_A1B2C3D4",
+  status: "completed",
+  cwd: "/workspace",
+  exitCode: 0,
+};
+
+beforeEach(() => {
+  openAiMockState.requests = 0;
+});
+
+describe("tool result redaction via AI transport host", () => {
+  it("redacts real Agent tool output before the provider continuation request", async () => {
+    const providerPayloads: unknown[] = [];
+    const execute = vi.fn(async () => ({
+      content: jsonResult(safePayload).content,
+      details: safePayload,
+    }));
+    const tool = {
+      name: "exec",
+      label: "exec",
+      description: "Return deterministic command evidence.",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute,
+    } satisfies AgentTool;
+    const agent = new Agent({
+      initialState: {
+        model,
+        tools: [tool],
+      },
+      streamFn: streamSimple,
+      getApiKey: () => "test-api-key",
+      onPayload: (payload) => {
+        providerPayloads.push(structuredClone(payload));
+      },
+    });
+
+    await agent.prompt("Run the exec tool once, then answer done.");
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(providerPayloads).toHaveLength(2);
+    expect(openAiMockState.requests).toBe(2);
+
+    const initialRequest = JSON.stringify(providerPayloads[0]);
+    const continuationRequest = JSON.stringify(providerPayloads[1]);
+    const continuationMessages = (
+      providerPayloads[1] as { messages?: Array<{ content?: unknown; role?: string }> }
+    ).messages;
+    const toolContent = continuationMessages?.find((message) => message.role === "tool")?.content;
+    expect(typeof toolContent).toBe("string");
+    expect(initialRequest).not.toContain(fakeSecret);
+    expect(initialRequest).not.toContain(safePayload.nonce);
+    expect(continuationRequest).not.toContain(fakeSecret);
+    expect(toolContent).toContain('"password"');
+    expect(toolContent).toMatch(/password[^]*?(?:\*\*\*|…|redacted)/i);
+    expect(toolContent).toContain(safePayload.nonce);
+    expect(toolContent).toContain(safePayload.status);
+    expect(toolContent).toContain(safePayload.cwd);
+    expect(toolContent).toContain(String(safePayload.exitCode));
+
+    const toolResults = agent.state.messages.filter((message) => message.role === "toolResult");
+    const finalMessages = agent.state.messages.filter(
+      (message) =>
+        message.role === "assistant" &&
+        message.stopReason === "stop" &&
+        message.content.some((block) => block.type === "text" && block.text === "done"),
+    );
+    expect(toolResults).toHaveLength(1);
+    expect(finalMessages).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Fixes #71211

## Summary

- redact text tool-result blocks at the shared `@openclaw/ai` provider replay boundary
- retain the contributor's exec, process, and node-host redaction coverage
- preserve safe tool evidence such as nonce, status, cwd, exit code, field names, and redaction markers

## What Problem This Solves

Structured tool-result blocks already passed through structured-text redaction before provider replay. Explicit `type: "text"` blocks only sanitized Unicode, so secret-shaped stdout or stderr could enter the next provider request unchanged.

## Canonical Fix

The maintainer repair applies the same structured-text redactor in `extractToolResultBlockText`, the shared boundary used by supported providers. This avoids provider-specific branches and does not change config, protocol, persistence, event, or channel contracts.

The canonical maintainer commit is exactly three files:

- `packages/ai/src/providers/tool-result-text.ts`
- `packages/ai/src/providers/tool-result-text.test.ts`
- `src/llm/tool-result-redaction.test.ts`

Production delta for that commit is net zero (`+1/-1`). Test delta is `+217/-70`.

## Contributor preservation

The contributor branch was actively refreshed during maintainer validation. Its latest commit and authorship remain intact; the canonical provider-boundary repair is a separate fast-forward maintainer commit with explicit co-author credit.

## Evidence

- final head local: `node scripts/run-vitest.mjs packages/ai/src/providers/tool-result-text.test.ts` - 15/15 passed
- final head local: `node scripts/run-vitest.mjs src/llm/tool-result-redaction.test.ts` - 1/1 passed with a real Agent/provider two-request continuation
- Blacksmith Testbox: `node scripts/tsdown-build.mjs --config tsdown.ai.config.ts` - passed
- Blacksmith Testbox: both focused files - 16/16 passed
- Blacksmith Testbox: scoped `pnpm check:changed` - passed, including core/core-test typecheck, formatting, lint, import-cycle, boundary, schema, and database-first guards
- Sol-high autoreview: clean; TruffleHog clean
- `git diff --check` and scoped `oxfmt --check`: passed

The Testbox-validated candidate and final pushed head have identical source trees; the final identity-only recomposition was followed by both focused local test runs.

## ClawSweeper Rank-up Moves

- **Explicit approval of redacted-by-default agent output:** pending. Review is requested from @steipete and @openclaw/openclaw-secops, and this remains required before merge.
- **Rebase onto current main and rerun exact-head proof:** the contributor commit was preserved without rewriting after repeated concurrent branch refreshes, so this optional rebase move was not applied. Instead, GitHub reports the PR mergeable against current main, exact-head CI is running on the PR merge candidate, and the content-identical source tree passed the scoped Testbox changed gate against current `origin/main`.

## Security review

Please review the provider replay boundary and the retained exec/process redaction surfaces: @steipete @openclaw/openclaw-secops.

AI-assisted: yes; maintainer-reviewed and validated.
