### PR TITLE
fix(cli): route commitments --json output to stdout via writeRuntimeJson (#81183)

### DIFF
--- a/src/commands/commitments.test.ts
+++ b/src/commands/commitments.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CommitmentRecord } from "../commitments/types.js";
-import type { RuntimeEnv } from "../runtime.js";
+import type { OutputRuntimeEnv, RuntimeEnv } from "../runtime.js";
 import { stripAnsi } from "../terminal/ansi.js";
-import { commitmentsListCommand } from "./commitments.js";
+import { commitmentsDismissCommand, commitmentsListCommand } from "./commitments.js";
 
 const mocks = vi.hoisted(() => ({
   listCommitments: vi.fn(),
@@ -33,6 +33,32 @@ function createRuntime(): { runtime: RuntimeEnv; logs: string[] } {
       log: (message: unknown) => logs.push(String(message)),
       error: vi.fn(),
       exit: vi.fn(),
+    },
+  };
+}
+
+function createOutputRuntime(): {
+  runtime: OutputRuntimeEnv;
+  logs: string[];
+  stdout: string[];
+  jsonWrites: unknown[];
+} {
+  const logs: string[] = [];
+  const stdout: string[] = [];
+  const jsonWrites: unknown[] = [];
+  return {
+    logs,
+    stdout,
+    jsonWrites,
+    runtime: {
+      log: (message: unknown) => logs.push(String(message)),
+      error: vi.fn(),
+      exit: vi.fn(),
+      writeStdout: (chunk: string) => stdout.push(chunk),
+      writeJson: (value: unknown, space = 2) => {
+        jsonWrites.push(value);
+        stdout.push(JSON.stringify(value, null, space > 0 ? space : undefined) + "\n");
+      },
     },
   };
 }
@@ -82,5 +108,56 @@ describe("commitments command", () => {
       "ID               Status     Kind             Due                      Scope                        Suggested text",
       "cm_escape        pending    event_check_in   2026-04-30T17:00:00.000Z main/telegram/+15551234567   How did it go?\\nspoofed",
     ]);
+  });
+
+  it("writes list --json payload through writeJson (stdout), not runtime.log (regression for #81183)", async () => {
+    const { runtime, logs, stdout, jsonWrites } = createOutputRuntime();
+
+    await commitmentsListCommand({ json: true }, runtime);
+
+    expect(jsonWrites).toHaveLength(1);
+    const payload = jsonWrites[0] as Record<string, unknown>;
+    expect(payload.count).toBe(1);
+    expect(payload.status).toBe("pending");
+    expect(payload.store).toBe("/tmp/openclaw-commitments.json");
+    expect(Array.isArray(payload.commitments)).toBe(true);
+    expect(logs).toEqual([]);
+    expect(stdout).toHaveLength(1);
+    expect(JSON.parse(stdout[0])).toEqual(payload);
+  });
+
+  it("writes list --json --all payload through writeJson with null status", async () => {
+    const { runtime, jsonWrites } = createOutputRuntime();
+
+    await commitmentsListCommand({ json: true, all: true }, runtime);
+
+    expect(jsonWrites).toHaveLength(1);
+    const payload = jsonWrites[0] as Record<string, unknown>;
+    expect(payload.status).toBeNull();
+  });
+
+  it("writes dismiss --json payload through writeJson (stdout), not runtime.log (regression for #81183)", async () => {
+    mocks.markCommitmentsStatus.mockResolvedValue(undefined);
+    const { runtime, logs, stdout, jsonWrites } = createOutputRuntime();
+
+    await commitmentsDismissCommand({ ids: ["cm_abc"], json: true }, runtime);
+
+    expect(jsonWrites).toEqual([{ dismissed: ["cm_abc"] }]);
+    expect(logs).toEqual([]);
+    expect(stdout).toHaveLength(1);
+    expect(JSON.parse(stdout[0])).toEqual({ dismissed: ["cm_abc"] });
+  });
+
+  it("falls back to runtime.log when runtime does not expose writeJson (back-compat)", async () => {
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsListCommand({ json: true }, runtime);
+
+    // Plain RuntimeEnv mocks have no writeJson; writeRuntimeJson falls back to
+    // runtime.log so older callers and the existing test runtime still work.
+    expect(logs).toHaveLength(1);
+    const parsed = JSON.parse(logs[0]) as Record<string, unknown>;
+    expect(parsed.count).toBe(1);
+    expect(parsed.store).toBe("/tmp/openclaw-commitments.json");
   });
 });

--- a/src/commands/commitments.ts
+++ b/src/commands/commitments.ts
@@ -7,7 +7,7 @@ import {
 import type { CommitmentRecord, CommitmentStatus } from "../commitments/types.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { info } from "../globals.js";
-import type { RuntimeEnv } from "../runtime.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { sanitizeTerminalText } from "../terminal/safe-text.js";
 import { isRich, theme } from "../terminal/theme.js";
@@ -104,19 +104,16 @@ export async function commitmentsListCommand(
   ).filter((commitment) => opts.all || status || isActiveCommitment(commitment));
 
   if (opts.json) {
-    runtime.log(
-      JSON.stringify(
-        {
-          count: commitments.length,
-          status: status ?? (opts.all ? null : "pending"),
-          agentId: normalizeOptionalString(opts.agent) ?? null,
-          store: resolveCommitmentStorePath(),
-          commitments,
-        },
-        null,
-        2,
-      ),
-    );
+    // Use writeRuntimeJson (writes directly to stdout) instead of runtime.log
+    // (which goes through the console.log patch that redirects everything to
+    // stderr in --json mode). See #81183.
+    writeRuntimeJson(runtime, {
+      count: commitments.length,
+      status: status ?? (opts.all ? null : "pending"),
+      agentId: normalizeOptionalString(opts.agent) ?? null,
+      store: resolveCommitmentStorePath(),
+      commitments,
+    });
     return;
   }
 
@@ -159,7 +156,9 @@ export async function commitmentsDismissCommand(
     nowMs: Date.now(),
   });
   if (opts.json) {
-    runtime.log(JSON.stringify({ dismissed: ids }, null, 2));
+    // See #81183 — writeRuntimeJson bypasses the console.log -> stderr patch
+    // active in --json mode so the payload actually lands on stdout.
+    writeRuntimeJson(runtime, { dismissed: ids });
     return;
   }
   runtime.log(info(`Dismissed commitments: ${ids.join(", ")}`));


### PR DESCRIPTION
Fixes #81183.

## Summary

`openclaw commitments --json`, `openclaw commitments list --json`, `openclaw commitments list --all --json`, and `openclaw commitments dismiss <id> --json` all produced **empty stdout (0 bytes)** and emitted the full JSON payload to **stderr** instead, while exiting 0. Any shell pipeline like `openclaw commitments list --json | jq .` parsed empty input and failed silently. The four working sibling commands cited in the issue body (`agents list --json`, `cron list --json`, `tasks list --json`, `skills list --json`) write JSON via `writeRuntimeJson(runtime, value)`, which goes directly to `process.stdout.write` and bypasses the `console.log` patch that redirects everything to stderr in `--json` mode (`forceConsoleToStderr` in `src/logging/console.ts`).

Commitments' JSON paths were using `runtime.log(JSON.stringify(...))`, which routed through the same console patch and got caught by the stderr redirect.

Changes:

- `src/commands/commitments.ts` — replace the two `runtime.log(JSON.stringify(..., null, 2))` calls (the `list` branch at the original line 107 and the `dismiss` branch at the original line 162) with `writeRuntimeJson(runtime, ...)`. Imports `writeRuntimeJson` from `../runtime.js` alongside the existing `RuntimeEnv` type-only import.
- `src/commands/commitments.test.ts` — add 4 regression tests using a new `createOutputRuntime()` helper that exposes `writeStdout` + `writeJson` (matching the production `OutputRuntimeEnv` shape), asserting the JSON payload goes through `writeJson` (stdout) rather than `runtime.log` (stderr in `--json` mode) for both `list` and `dismiss`. A fallback test confirms back-compat for callers that only expose `runtime.log`.

## Real behavior proof

- **Behavior or issue addressed**: `openclaw commitments [list|dismiss] --json` produced empty stdout (0 bytes) and emitted the JSON payload to stderr while exiting 0, breaking `… | jq` pipelines silently. The four working sibling JSON commands all use `writeRuntimeJson` for the same reason this fix adopts.
- **Real environment tested**: Local source checkout, fresh branch off `upstream/main`, `pnpm build` against the working tree, Node v22.22.2 via nvm, pnpm 10.33.0, Linux x86_64 (Ubuntu noble). Real CLI invocation via `node openclaw.mjs <args>`, exactly the steps from the bug report.
- **Exact steps or command run after this patch**:

  ```
  pnpm build
  mkdir -p ~/.openclaw/commitments
  node -e '...seed one commitment with id cm_evi...'
  for inv in "commitments --json" \
             "commitments list --json" \
             "commitments list --all --json" \
             "commitments dismiss cm_evi --json"; do
    node openclaw.mjs $inv 1>/tmp/cmout 2>/tmp/cmerr
    echo "exit=$? stdout=$(wc -c </tmp/cmout)b stderr=$(wc -c </tmp/cmerr)b"
    python3 -c "import json; json.load(open('/tmp/cmout'))" && echo "stdout JSON parseable"
  done
  ```

- **Evidence after fix**: Verbatim terminal output from running the exact four invocations from the issue's repro:

  ```text
  === commitments --json ===
  exit=0 stdout=688b stderr=0b
    ✓ stdout JSON parseable
  {
    "count": 1,
    "status": "pending",

  === commitments list --json ===
  exit=0 stdout=688b stderr=0b
    ✓ stdout JSON parseable
  {
    "count": 1,
    "status": "pending",

  === commitments list --all --json ===
  exit=0 stdout=683b stderr=0b
    ✓ stdout JSON parseable
  {
    "count": 1,
    "status": null,

  === commitments dismiss cm_evi --json ===
  exit=0 stdout=38b stderr=0b
    ✓ stdout JSON parseable
  {
    "dismissed": [
      "cm_evi"
  ```

  Regression sanity — bare table output (non-json) unchanged:

  ```text
  === commitments (table) ===
  Commitments: 1
  Store: /home/orin/.openclaw/commitments/commitments.json
  Status filter: pending
  ID               Status     Kind             Due                      Scope                        Suggested text
  cm_evi           pending    follow_up        2026-05-12T22:02:11.680Z qa/slack/qa                  qa
  exit=0
  ```

- **Observed result after fix**: All four `--json` invocations now exit 0 with **stdout containing the JSON payload (688/688/683/38 bytes)** and **stderr empty (0 bytes)** — exactly the inverse of the pre-fix behavior the bug report documented. `… | jq .` pipelines work because stdout is now valid JSON. Table/text output (`openclaw commitments`, `openclaw commitments list`) is unchanged.
- **What was not tested**: A live invocation through an installed `npm install -g openclaw` global binary; the proof above uses the in-tree wrapper `node openclaw.mjs` which exercises the same `runCli` dispatch path the installed binary runs against the built dist.

## Verification

```
pnpm test src/commands/commitments.test.ts
# Tests 5 passed (5)   ← 1 existing + 4 new regression cases for #81183

pnpm exec oxfmt --check --threads=1 src/commands/commitments.ts src/commands/commitments.test.ts
# clean

pnpm tsgo:core
# exit 0

pnpm check:changed
# (see CI)
```
