### PR TITLE
fix(acp): preserve numeric RequestError details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACP: preserve redacted numeric JSON-RPC `RequestError` details in runtime failure text, so backend diagnostics are visible instead of only `Internal error`. Fixes #81126. (#81188) Thanks @vyctorbrzezowski.
 - Security/Windows ACL audit: classify Anonymous Logon, Guests, Interactive, Local, and Network SIDs as world-equivalent principals so broadly writable paths stay critical instead of being downgraded to group-writable. Fixes #74350. (#74383) Thanks @dwc1997.
 - Media-understanding: retry transient remote attachment fetch failures before audio or vision processing, so Discord voice notes are not lost after one network/CDN blip. Fixes #74316. Thanks @vyctorbrzezowski and @gabrielexito-stack.
 - Control UI: order timestamped live stream and tool items before untimestamped history fallbacks, keeping chat history in visible time order. Fixes #80759. (#81016) Thanks @akrimm702.

--- a/src/acp/runtime/error-text.test.ts
+++ b/src/acp/runtime/error-text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { formatAcpRuntimeErrorText } from "./error-text.js";
-import { AcpRuntimeError } from "./errors.js";
+import { formatAcpRuntimeErrorText, toAcpRuntimeErrorText } from "./error-text.js";
+import { AcpRuntimeError, toAcpRuntimeError } from "./errors.js";
 
 describe("formatAcpRuntimeErrorText", () => {
   it("adds actionable next steps for known ACP runtime error codes", () => {
@@ -16,6 +16,51 @@ describe("formatAcpRuntimeErrorText", () => {
     const text = formatAcpRuntimeErrorText(new AcpRuntimeError("ACP_TURN_FAILED", "turn failed"));
     expect(text).toBe(
       "ACP error (ACP_TURN_FAILED): turn failed\nnext: Retry, or use `/acp cancel` and send the message again.",
+    );
+  });
+
+  it("surfaces redacted numeric RequestError details in runtime failure text", () => {
+    const token = "sk-abcdefghijklmnopqrstuvwxyz123456";
+    const requestError = Object.assign(new Error("Internal error"), {
+      name: "RequestError",
+      code: -32603,
+      data: {
+        details: `Unknown config option: timeout; token=${token}`,
+      },
+    });
+
+    const text = formatAcpRuntimeErrorText(
+      toAcpRuntimeError({
+        error: requestError,
+        fallbackCode: "ACP_TURN_FAILED",
+        fallbackMessage: "fallback",
+      }),
+    );
+
+    expect(text).toContain(
+      "ACP error (ACP_TURN_FAILED): Internal error: Unknown config option: timeout",
+    );
+    expect(text).toContain("next: Retry");
+    expect(text).not.toContain(token);
+  });
+
+  it("applies the same RequestError details normalization through text conversion", () => {
+    const requestError = Object.assign(new Error("Internal error"), {
+      name: "RequestError",
+      code: -32603,
+      data: {
+        details: "Unknown config option: timeout",
+      },
+    });
+
+    const text = toAcpRuntimeErrorText({
+      error: requestError,
+      fallbackCode: "ACP_TURN_FAILED",
+      fallbackMessage: "fallback",
+    });
+
+    expect(text).toContain(
+      "ACP error (ACP_TURN_FAILED): Internal error: Unknown config option: timeout",
     );
   });
 });

--- a/src/acp/runtime/errors.test.ts
+++ b/src/acp/runtime/errors.test.ts
@@ -3,6 +3,7 @@ import {
   AcpRuntimeError,
   formatAcpErrorChain,
   isAcpRuntimeError,
+  toAcpRuntimeError,
   withAcpRuntimeErrorBoundary,
 } from "./errors.js";
 
@@ -71,6 +72,65 @@ describe("withAcpRuntimeErrorBoundary", () => {
     expect(error.message).toBe("backend missing");
     expect(error.cause).toBe(foreignError);
     expect(isAcpRuntimeError(foreignError)).toBe(true);
+  });
+
+  it("preserves redacted RequestError details from numeric ACP errors", () => {
+    const token = "sk-abcdefghijklmnopqrstuvwxyz123456";
+    const requestError = Object.assign(new Error("Internal error"), {
+      name: "RequestError",
+      code: -32603,
+      data: {
+        details: `unknown config option: timeout; token=${token}`,
+      },
+    });
+
+    const error = toAcpRuntimeError({
+      error: requestError,
+      fallbackCode: "ACP_TURN_FAILED",
+      fallbackMessage: "fallback",
+    });
+
+    expect(error.code).toBe("ACP_TURN_FAILED");
+    expect(error.message).toContain("Internal error: unknown config option: timeout");
+    expect(error.message).not.toContain(token);
+    expect(error.cause).toBe(requestError);
+  });
+
+  it("keeps foreign OpenClaw ACP string code behavior unchanged", () => {
+    const foreignError = Object.assign(new Error("backend missing"), {
+      code: "ACP_BACKEND_MISSING",
+      data: {
+        details: "extra backend diagnostic",
+      },
+    });
+
+    const error = toAcpRuntimeError({
+      error: foreignError,
+      fallbackCode: "ACP_TURN_FAILED",
+      fallbackMessage: "fallback",
+    });
+
+    expect(error.code).toBe("ACP_BACKEND_MISSING");
+    expect(error.message).toBe("backend missing");
+    expect(error.cause).toBe(foreignError);
+  });
+
+  it("keeps generic non-RequestError messages unchanged", () => {
+    const sourceError = Object.assign(new Error("boom"), {
+      data: {
+        details: "extra diagnostic",
+      },
+    });
+
+    const error = toAcpRuntimeError({
+      error: sourceError,
+      fallbackCode: "ACP_TURN_FAILED",
+      fallbackMessage: "fallback",
+    });
+
+    expect(error.code).toBe("ACP_TURN_FAILED");
+    expect(error.message).toBe("boom");
+    expect(error.cause).toBe(sourceError);
   });
 });
 

--- a/src/acp/runtime/errors.ts
+++ b/src/acp/runtime/errors.ts
@@ -43,6 +43,31 @@ function getForeignAcpRuntimeError(value: unknown): {
   };
 }
 
+function readAcpRequestErrorDetails(value: Error): string | undefined {
+  const code = (value as { code?: unknown }).code;
+  if (typeof code !== "number") {
+    return undefined;
+  }
+  const data = (value as { data?: unknown }).data;
+  if (!data || typeof data !== "object") {
+    return undefined;
+  }
+  const details = (data as { details?: unknown }).details;
+  if (details === undefined || details === null) {
+    return undefined;
+  }
+  const rendered = redactSensitiveText(stringifyNonErrorCause(details)).trim();
+  return rendered.length > 0 ? rendered : undefined;
+}
+
+function messageWithAcpRequestErrorDetails(error: Error): string {
+  const details = readAcpRequestErrorDetails(error);
+  if (!details || error.message.includes(details)) {
+    return error.message;
+  }
+  return `${error.message}: ${details}`;
+}
+
 export function isAcpRuntimeError(value: unknown): value is AcpRuntimeError {
   return value instanceof AcpRuntimeError || getForeignAcpRuntimeError(value) !== null;
 }
@@ -62,9 +87,13 @@ export function toAcpRuntimeError(params: {
     });
   }
   if (params.error instanceof Error) {
-    return new AcpRuntimeError(params.fallbackCode, params.error.message, {
-      cause: params.error,
-    });
+    return new AcpRuntimeError(
+      params.fallbackCode,
+      messageWithAcpRequestErrorDetails(params.error),
+      {
+        cause: params.error,
+      },
+    );
   }
   return new AcpRuntimeError(params.fallbackCode, params.fallbackMessage, {
     cause: params.error,


### PR DESCRIPTION
## Summary

- Problem: numeric ACP/JSON-RPC `RequestError` values can carry the actionable cause in `data.details`, while the visible message is only `Internal error`.
- Why it matters: OpenClaw surfaced `ACP_TURN_FAILED: Internal error` and dropped the backend diagnostic needed to understand the rejection.
- What changed: `toAcpRuntimeError` now appends a redacted diagnostic from numeric `error.data.details` while keeping the fallback ACP code.
- What did NOT change (scope boundary): known OpenClaw ACP string codes, ACP option handling, backend-specific behavior, and generic non-RequestError wrapping stay unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #81126
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: ACP runtime error text no longer drops `data.details` from numeric JSON-RPC `RequestError` values.
- Real environment tested: source-level OpenClaw ACP runtime normalization on macOS with the repository test harness.
- Exact steps or command run after this patch: `pnpm test src/acp/runtime/errors.test.ts src/acp/runtime/error-text.test.ts -- --reporter=verbose`
- Evidence after fix: regression coverage now formats a `RequestError`-shaped error with `code: -32603`, `message: "Internal error"`, and `data.details: "Unknown config option: timeout"` as `ACP error (ACP_TURN_FAILED): Internal error: Unknown config option: timeout`; a secret-shaped token in the detail is redacted.
- Observed result after fix: focused ACP runtime tests pass and verify the diagnostic is visible without leaking the raw token.
- What was not tested: live ACP backend roundtrip.
- Before evidence: the added regression covers the pre-fix shape where `data.details` was not included in the normalized runtime error message.

## Root Cause (if applicable)

- Root cause: OpenClaw only recognized foreign ACP runtime errors with OpenClaw string codes; numeric JSON-RPC errors fell back to `error.message`, which is often the generic `Internal error` string.
- Missing detection / guardrail: no regression covered numeric ACP/JSON-RPC `RequestError` values carrying useful diagnostics under `data.details`.
- Contributing context (if known): `@agentclientprotocol/sdk@0.21.0` defines `RequestError` with numeric `code` and optional `data`; internal errors use code `-32603`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/acp/runtime/errors.test.ts`, `src/acp/runtime/error-text.test.ts`
- Scenario the test should lock in: numeric `RequestError` details are preserved in formatted ACP runtime text after redaction.
- Why this is the smallest reliable guardrail: the bug is in ACP runtime error normalization and formatting, so direct unit coverage exercises the exact boundary.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

ACP runtime failures backed by numeric JSON-RPC `RequestError` values can now show a redacted diagnostic after the generic error message.

## Diagram (if applicable)

```text
Before:
numeric RequestError -> "Internal error" -> ACP_TURN_FAILED with no detail

After:
numeric RequestError + data.details -> redacted "Internal error: <detail>" -> ACP_TURN_FAILED
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ repository test harness
- Model/provider: N/A
- Integration/channel (if any): ACP runtime error normalization
- Relevant config (redacted): N/A

### Steps

1. Construct a `RequestError`-shaped error with `code: -32603`, `message: "Internal error"`, and `data.details: "Unknown config option: timeout"`.
2. Normalize it through `toAcpRuntimeError` with fallback code `ACP_TURN_FAILED`.
3. Format it with `formatAcpRuntimeErrorText`.

### Expected

- The formatted ACP runtime error includes `Internal error: Unknown config option: timeout`.
- Secret-shaped content inside details is redacted.
- foreign OpenClaw ACP string-code errors keep their existing message behavior.

### Actual

- Before this patch, the formatted message only surfaced `Internal error`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: numeric RequestError details are surfaced; secret-shaped details are redacted; known OpenClaw ACP string codes remain unchanged; generic non-RequestError messages remain unchanged.
- Edge cases checked: missing/non-object `data`, absent `details`, already-included detail text, and non-numeric errors do not add extra text.
- What you did **not** verify: live ACP backend roundtrip.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: upstream diagnostics can contain sensitive text.
  - Mitigation: details are rendered through the existing ACP error stringification path and `redactSensitiveText` before becoming user-visible.

## Verification

- `codex review --base origin/main` (no actionable findings; no review fixes required)
- `pnpm exec oxfmt --check --threads=1 src/acp/runtime/errors.ts src/acp/runtime/errors.test.ts src/acp/runtime/error-text.test.ts`
- `pnpm test src/acp/runtime/errors.test.ts src/acp/runtime/error-text.test.ts -- --reporter=verbose`
- `pnpm test src/agents/command/attempt-execution.error-propagation.test.ts src/auto-reply/reply/dispatch-acp.test.ts -- --reporter=verbose`
- `pnpm check:changed`
- `git diff --check`

