### PR TITLE
fix(devices): refresh paired device last-seen metadata

### DIFF
--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -689,7 +689,9 @@ export function registerControlUiAndPairingSuite(): void {
 
   test("device token auth matrix", async () => {
     const { server, ws, port, prevToken } = await startControlUiServerWithClient("secret");
-    const { deviceToken, deviceIdentityPath } = await ensurePairedDeviceTokenForCurrentIdentity(ws);
+    const { identity, deviceToken, deviceIdentityPath } =
+      await ensurePairedDeviceTokenForCurrentIdentity(ws);
+    const { getPairedDevice } = await import("../infra/device-pairing.js");
     ws.close();
 
     const scenarios: Array<{
@@ -772,6 +774,9 @@ export function registerControlUiAndPairingSuite(): void {
           ws2.close();
         }
       }
+      const paired = await getPairedDevice(identity.deviceId);
+      expect(paired?.lastSeenReason).toBe("connect");
+      expect(typeof paired?.lastSeenAtMs).toBe("number");
     } finally {
       await server.close();
       restoreGatewayToken(prevToken);

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1113,6 +1113,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           const clientAccessMetadata = {
             displayName: connectParams.client.displayName,
             remoteIp: reportedClientIp,
+            lastSeenAtMs: Date.now(),
+            lastSeenReason: "connect",
           };
           const requirePairing = async (
             reason: ConnectPairingRequiredReason,

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -789,6 +789,26 @@ describe("device pairing tokens", () => {
     });
   });
 
+  test("device token verification refreshes paired device last-seen metadata", async () => {
+    const { baseDir, token } = await setupOperatorToken(["operator.read"]);
+    const beforeVerifyAtMs = Date.now();
+
+    await expect(
+      verifyDeviceToken({
+        deviceId: "device-1",
+        token,
+        role: "operator",
+        scopes: ["operator.read"],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    const paired = await getPairedDevice("device-1", baseDir);
+    expect(paired?.lastSeenReason).toBe("device-token-auth");
+    expect(typeof paired?.lastSeenAtMs).toBe("number");
+    expect(paired?.lastSeenAtMs ?? 0).toBeGreaterThanOrEqual(beforeVerifyAtMs);
+  });
+
   test("generates base64url device tokens with 256-bit entropy output length", async () => {
     const baseDir = await makeDevicePairingDir();
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -976,9 +976,12 @@ export async function verifyDeviceToken(params: {
     if (!roleScopesAllow({ role, requestedScopes, allowedScopes: entry.scopes })) {
       return { ok: false, reason: "scope-mismatch" };
     }
-    entry.lastUsedAtMs = Date.now();
+    const now = Date.now();
+    entry.lastUsedAtMs = now;
     device.tokens ??= {};
     device.tokens[role] = entry;
+    device.lastSeenAtMs = now;
+    device.lastSeenReason = "device-token-auth";
     state.pairedByDeviceId[device.deviceId] = device;
     await persistState(state, params.baseDir, "paired");
     return entry.issuer ? { ok: true, issuer: entry.issuer } : { ok: true };


### PR DESCRIPTION
## Summary

- Fixes #81169.
- Refreshes paired-device `lastSeenAtMs` and `lastSeenReason` when accepted device-token auth succeeds.
- Marks successful paired WebSocket reconnects as `lastSeenReason: "connect"` through the existing paired metadata update path.
- Preserves current main's paired-platform refresh behavior and does not change pairing approval, token verification, scopes, or config.

## Real behavior proof

Behavior addressed: Accepted paired-device auth now refreshes device-level last-seen metadata so stale paired clients can be audited.

Real environment tested: Local OpenClaw source checkout at PR head on macOS, using isolated temporary pairing state from the focused Vitest/gateway harness.

Exact steps or command run after this patch: Ran the focused paired-device auth and gateway reconnect tests after applying the patch.

Evidence after fix: Terminal output from the focused tests:

```text
$ node scripts/run-vitest.mjs src/infra/device-pairing.test.ts --reporter=verbose
✓ device token verification refreshes paired device last-seen metadata
Test Files  1 passed (1)
Tests  54 passed (54)

$ node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts --reporter=verbose
✓ device token auth matrix
Test Files  1 passed (1)
Tests  29 passed (29)
```

Observed result after fix: The pairing test confirmed accepted device-token verification writes numeric `lastSeenAtMs` and `lastSeenReason: "device-token-auth"`; the gateway auth matrix confirmed a successful reconnect writes `lastSeenReason: "connect"` with numeric `lastSeenAtMs`.

What was not tested: No physical mobile client or installed user pairing state was used; the proof uses OpenClaw's isolated pairing and gateway harnesses.

## Verification

- `pnpm exec oxfmt --check --threads=1 src/infra/device-pairing.ts src/gateway/server/ws-connection/message-handler.ts src/infra/device-pairing.test.ts src/gateway/server.auth.control-ui.suite.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs src/infra/device-pairing.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts --reporter=verbose`
- `pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean: no accepted/actionable findings)
