### PR TITLE
Require approved node pairing for system command forwarding [AI]

### DIFF
--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -1142,6 +1142,19 @@ export const nodeHandlers: GatewayRequestHandlers = {
         return;
       }
 
+      if (commandRequiresNodePairingApproval(command)) {
+        const pairedNode = await getPairedNode(nodeId);
+        if (!pairedNode || !(pairedNode.commands ?? []).includes(command)) {
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, "node pairing approval required", {
+              details: { code: "NODE_PAIRING_APPROVAL_REQUIRED", nodeId, command },
+            }),
+          );
+          return;
+        }
+      }
       const forwardedParams = sanitizeNodeInvokeParamsForForwarding({
         nodeId,
         command,
@@ -1158,19 +1171,6 @@ export const nodeHandlers: GatewayRequestHandlers = {
           }),
         );
         return;
-      }
-      if (commandRequiresNodePairingApproval(command)) {
-        const pairedNode = await getPairedNode(nodeId);
-        if (!pairedNode || !(pairedNode.commands ?? []).includes(command)) {
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, "node pairing approval required", {
-              details: { code: "NODE_PAIRING_APPROVAL_REQUIRED", nodeId, command },
-            }),
-          );
-          return;
-        }
       }
       const policyResult = await applyPluginNodeInvokePolicy({
         context,

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -3,8 +3,10 @@ import { getRuntimeConfig } from "../../config/io.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { listDevicePairing } from "../../infra/device-pairing.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { NODE_SYSTEM_RUN_COMMANDS } from "../../infra/node-commands.js";
 import {
   approveNodePairing,
+  getPairedNode,
   listNodePairing,
   rejectNodePairing,
   removePairedNode,
@@ -79,6 +81,7 @@ const NODE_WAKE_THROTTLE_MS = 15_000;
 const NODE_WAKE_NUDGE_THROTTLE_MS = 10 * 60_000;
 const NODE_PENDING_ACTION_TTL_MS = 10 * 60_000;
 const NODE_PENDING_ACTION_MAX_PER_NODE = 64;
+const NODE_PAIRING_APPROVAL_REQUIRED_COMMANDS = new Set<string>(NODE_SYSTEM_RUN_COMMANDS);
 const TALK_PTT_COMMANDS = new Set([
   "talk.ptt.start",
   "talk.ptt.stop",
@@ -138,6 +141,10 @@ function isForbiddenBrowserProxyMutation(params: unknown): boolean {
   const method = (normalizeOptionalString(candidate.method) ?? "").toUpperCase();
   const path = normalizeOptionalString(candidate.path) ?? "";
   return Boolean(method && path && isPersistentBrowserProxyMutation(method, path));
+}
+
+function commandRequiresNodePairingApproval(command: string): boolean {
+  return NODE_PAIRING_APPROVAL_REQUIRED_COMMANDS.has(command);
 }
 
 function normalizePluginSurfaceRefreshParams(params: unknown): { surface: string } | undefined {
@@ -1151,6 +1158,19 @@ export const nodeHandlers: GatewayRequestHandlers = {
           }),
         );
         return;
+      }
+      if (commandRequiresNodePairingApproval(command)) {
+        const pairedNode = await getPairedNode(nodeId);
+        if (!pairedNode || !(pairedNode.commands ?? []).includes(command)) {
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, "node pairing approval required", {
+              details: { code: "NODE_PAIRING_APPROVAL_REQUIRED", nodeId, command },
+            }),
+          );
+          return;
+        }
       }
       const policyResult = await applyPluginNodeInvokePolicy({
         context,

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -23,7 +23,11 @@ import {
   resolveApnsAuthConfigFromEnv,
   resolveApnsRelayConfigFromEnv,
 } from "../../infra/push-apns.js";
-import { refreshRemoteNodeBins } from "../../infra/skills-remote.js";
+import {
+  clearRemoteNodeApproval,
+  recordRemoteNodeApproval,
+  refreshRemoteNodeBins,
+} from "../../infra/skills-remote.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -752,6 +756,15 @@ export const nodeHandlers: GatewayRequestHandlers = {
         { dropIfSlow: true },
       );
       const connectedNode = context.nodeRegistry.get(approvedNode.nodeId);
+      recordRemoteNodeApproval({
+        nodeId: approvedNode.nodeId,
+        displayName: approvedNode.displayName,
+        platform: approvedNode.platform,
+        deviceFamily: approvedNode.deviceFamily,
+        commands: approvedNode.commands,
+        remoteIp: approvedNode.remoteIp,
+        bins: approvedNode.bins,
+      });
       if (connectedNode) {
         void refreshRemoteNodeBins({
           nodeId: connectedNode.nodeId,
@@ -825,6 +838,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         },
         { dropIfSlow: true },
       );
+      clearRemoteNodeApproval(removed.nodeId);
       respond(true, removed, undefined);
     });
   },

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -23,6 +23,7 @@ import {
   resolveApnsAuthConfigFromEnv,
   resolveApnsRelayConfigFromEnv,
 } from "../../infra/push-apns.js";
+import { refreshRemoteNodeBins } from "../../infra/skills-remote.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -750,6 +751,22 @@ export const nodeHandlers: GatewayRequestHandlers = {
         },
         { dropIfSlow: true },
       );
+      const connectedNode = context.nodeRegistry.get(approvedNode.nodeId);
+      if (connectedNode) {
+        void refreshRemoteNodeBins({
+          nodeId: connectedNode.nodeId,
+          platform: connectedNode.platform,
+          deviceFamily: connectedNode.deviceFamily,
+          commands: connectedNode.commands,
+          cfg: context.getRuntimeConfig(),
+        }).catch((err) =>
+          context.logGateway.warn(
+            `remote bin probe failed after node pairing approval for ${approvedNode.nodeId}: ${formatErrorMessage(
+              err,
+            )}`,
+          ),
+        );
+      }
       respond(true, approved, undefined);
     });
   },

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -7,6 +7,7 @@ import {
   publicKeyRawBase64UrlFromPem,
   signDevicePayload,
 } from "../infra/device-identity.js";
+import { approveNodePairing, listNodePairing } from "../infra/node-pairing.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
 import { buildDeviceAuthPayload } from "./device-auth.js";
@@ -359,6 +360,25 @@ describe("node.invoke approval bypass", () => {
         clearTimeout(timer);
       }
     }
+    await vi.waitFor(
+      async () => {
+        const list = await listNodePairing();
+        const pending = list.pending.find(
+          (entry) => entry.nodeId === resolvedDeviceIdentity.deviceId,
+        );
+        if (!pending) {
+          throw new Error("expected pending node pairing request");
+        }
+        const approved = await approveNodePairing(pending.requestId, {
+          callerScopes: ["operator.admin"],
+        });
+        expect(approved && "node" in approved).toBe(true);
+      },
+      {
+        timeout: NODE_CONNECT_TIMEOUT_MS,
+        interval: 50,
+      },
+    );
     return client;
   };
 

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -299,6 +299,7 @@ describe("node.invoke approval bypass", () => {
     onInvoke: (payload: unknown) => void,
     deviceIdentity?: DeviceIdentity,
     commands: string[] = ["system.run"],
+    opts: { approveNodePairing?: boolean } = {},
   ) => {
     let readyResolve: (() => void) | null = null;
     const ready = new Promise<void>((resolve) => {
@@ -360,12 +361,35 @@ describe("node.invoke approval bypass", () => {
         clearTimeout(timer);
       }
     }
+    if (opts.approveNodePairing !== false) {
+      await vi.waitFor(
+        async () => {
+          const list = await listNodePairing();
+          const pending = list.pending.find(
+            (entry) => entry.nodeId === resolvedDeviceIdentity.deviceId,
+          );
+          if (!pending) {
+            throw new Error("expected pending node pairing request");
+          }
+          const approved = await approveNodePairing(pending.requestId, {
+            callerScopes: ["operator.admin"],
+          });
+          expect(approved && "node" in approved).toBe(true);
+        },
+        {
+          timeout: NODE_CONNECT_TIMEOUT_MS,
+          interval: 50,
+        },
+      );
+    }
+    return client;
+  };
+
+  const approvePendingNodePairingForTest = async (nodeId: string) => {
     await vi.waitFor(
       async () => {
         const list = await listNodePairing();
-        const pending = list.pending.find(
-          (entry) => entry.nodeId === resolvedDeviceIdentity.deviceId,
-        );
+        const pending = list.pending.find((entry) => entry.nodeId === nodeId);
         if (!pending) {
           throw new Error("expected pending node pairing request");
         }
@@ -379,7 +403,6 @@ describe("node.invoke approval bypass", () => {
         interval: 50,
       },
     );
-    return client;
   };
 
   test("rejects malformed/forbidden node.invoke payloads before forwarding", async () => {
@@ -470,6 +493,75 @@ describe("node.invoke approval bypass", () => {
         "node.invoke cannot mutate persistent browser profiles via browser.proxy",
       );
       await expectNoForwardedInvoke(() => sawInvoke);
+    } finally {
+      ws.close();
+      node.stop();
+    }
+  });
+
+  test("keeps allow-once approval available when node pairing blocks forwarding", async () => {
+    let invokeCount = 0;
+    let lastInvokeParams: Record<string, unknown> | null = null;
+    const node = await connectLinuxNode(
+      (payload) => {
+        invokeCount += 1;
+        const obj = payload as { paramsJSON?: unknown };
+        const raw = typeof obj?.paramsJSON === "string" ? obj.paramsJSON : "";
+        lastInvokeParams = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+      },
+      undefined,
+      ["system.run"],
+      { approveNodePairing: false },
+    );
+    const ws = await connectOperator(["operator.write", "operator.approvals"]);
+
+    try {
+      const nodeId = await getConnectedNodeId(ws);
+      const approvalId = await requestAllowOnceApproval(ws, "echo hi", nodeId);
+      const blocked = await rpcReq(ws, "node.invoke", {
+        nodeId,
+        command: "system.run",
+        params: {
+          command: ["echo", "hi"],
+          rawCommand: "echo hi",
+          runId: approvalId,
+          approved: true,
+          approvalDecision: "allow-once",
+        },
+        idempotencyKey: crypto.randomUUID(),
+      });
+      expect(blocked.ok).toBe(false);
+      expect(blocked.error?.message).toBe("node pairing approval required");
+      await expectNoForwardedInvoke(() => invokeCount > 0);
+
+      await approvePendingNodePairingForTest(nodeId);
+
+      const allowed = await rpcReq(ws, "node.invoke", {
+        nodeId,
+        command: "system.run",
+        params: {
+          command: ["echo", "hi"],
+          rawCommand: "echo hi",
+          runId: approvalId,
+          approved: true,
+          approvalDecision: "allow-once",
+        },
+        idempotencyKey: crypto.randomUUID(),
+      });
+      expect(allowed.ok).toBe(true);
+      await vi.waitFor(
+        () => {
+          if (!lastInvokeParams) {
+            throw new Error("expected forwarded invoke params");
+          }
+        },
+        {
+          timeout: 5_000,
+          interval: 50,
+        },
+      );
+      expect(invokeCount).toBe(1);
+      expect(lastInvokeParams?.["approvalDecision"]).toBe("allow-once");
     } finally {
       ws.close();
       node.stop();

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -419,7 +419,7 @@ describe("gateway node pairing authorization", () => {
 
       await vi.waitFor(
         () => {
-          if (probeCount !== 1 || !(getRemoteSkillEligibility()?.hasBin(bin) ?? false)) {
+          if (probeCount < 1 || !(getRemoteSkillEligibility()?.hasBin(bin) ?? false)) {
             throw new Error("expected remote bin refresh after node approval");
           }
         },

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -1,3 +1,7 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 import {
@@ -6,6 +10,7 @@ import {
   listNodePairing,
   requestNodePairing,
 } from "../infra/node-pairing.js";
+import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import {
   issueOperatorToken,
@@ -19,6 +24,7 @@ import {
   installGatewayTestHooks,
   rpcReq,
   startServerWithClient,
+  testState,
 } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
@@ -319,6 +325,121 @@ describe("gateway node pairing authorization", () => {
       started.ws.close();
       await started.server.close();
       started.envSnapshot.restore();
+    }
+  });
+
+  test("refreshes remote bins after approving a connected macOS node", async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-node-pair-skills-"));
+    const bin = `bin-${randomUUID()}`;
+    fs.mkdirSync(path.join(workspaceDir, "remote-skill"), { recursive: true });
+    fs.writeFileSync(
+      path.join(workspaceDir, "remote-skill", "SKILL.md"),
+      [
+        "---",
+        "name: remote-skill",
+        "description: Needs a remote bin",
+        `metadata: { "openclaw": { "os": ["darwin"], "requires": { "bins": ["${bin}"] } } }`,
+        "---",
+        "# Remote Skill",
+        "",
+      ].join("\n"),
+    );
+    testState.agentConfig = { workspace: workspaceDir };
+    const previousMinimalGateway = process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+    delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+    let started: Awaited<ReturnType<typeof startServerWithClient>> | undefined;
+    let probeCount = 0;
+    let nodeClient: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+    try {
+      started = await startServerWithClient("secret");
+      const activeStarted = started;
+      const pairedNode = await pairDeviceIdentity({
+        name: "node-approval-refreshes-bins",
+        role: "node",
+        scopes: [],
+        clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+        clientMode: GATEWAY_CLIENT_MODES.NODE,
+      });
+
+      await connectOk(activeStarted.ws, { token: "secret" });
+      nodeClient = await connectNodeClient({
+        port: activeStarted.port,
+        deviceIdentity: pairedNode.identity,
+        commands: ["system.run", "system.which"],
+        onEvent: (evt) => {
+          if (evt.event !== "node.invoke.request") {
+            return;
+          }
+          const payload = evt.payload as {
+            id?: unknown;
+            nodeId?: unknown;
+            command?: unknown;
+          };
+          if (payload.command !== "system.which") {
+            return;
+          }
+          const id = typeof payload.id === "string" ? payload.id : "";
+          const nodeId = typeof payload.nodeId === "string" ? payload.nodeId : "";
+          if (!id || !nodeId) {
+            return;
+          }
+          probeCount += 1;
+          void nodeClient?.request("node.invoke.result", {
+            id,
+            nodeId,
+            ok: true,
+            payloadJSON: JSON.stringify({ bins: { [bin]: `/usr/bin/${bin}` } }),
+          });
+        },
+      });
+
+      let requestId = "";
+      await vi.waitFor(
+        async () => {
+          const list = await rpcReq<{
+            pending?: Array<{ requestId?: string; nodeId?: string; commands?: string[] }>;
+          }>(activeStarted.ws, "node.pair.list", {});
+          const pending = list.payload?.pending?.find(
+            (entry) => entry.nodeId === pairedNode.identity.deviceId,
+          );
+          if (!pending?.requestId) {
+            throw new Error("expected pending node pairing request");
+          }
+          requestId = pending.requestId;
+        },
+        {
+          timeout: 5_000,
+          interval: 50,
+        },
+      );
+      expect(getRemoteSkillEligibility()?.hasBin(bin) ?? false).toBe(false);
+
+      const approve = await rpcReq(activeStarted.ws, "node.pair.approve", { requestId });
+      expect(approve.ok).toBe(true);
+
+      await vi.waitFor(
+        () => {
+          if (probeCount !== 1 || !(getRemoteSkillEligibility()?.hasBin(bin) ?? false)) {
+            throw new Error("expected remote bin refresh after node approval");
+          }
+        },
+        {
+          timeout: 5_000,
+          interval: 50,
+        },
+      );
+    } finally {
+      await nodeClient?.stopAndWait();
+      started?.ws.close();
+      await started?.server.close();
+      started?.envSnapshot.restore();
+      if (previousMinimalGateway === undefined) {
+        delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+      } else {
+        process.env.OPENCLAW_TEST_MINIMAL_GATEWAY = previousMinimalGateway;
+      }
+      testState.agentConfig = undefined;
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
     }
   });
 

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -27,6 +27,7 @@ async function connectNodeClient(params: {
   port: number;
   deviceIdentity: ReturnType<typeof loadDeviceIdentity>["identity"];
   commands: string[];
+  onEvent?: (evt: { event?: string; payload?: unknown }) => void;
 }) {
   return await connectGatewayClient({
     url: `ws://127.0.0.1:${params.port}`,
@@ -40,6 +41,7 @@ async function connectNodeClient(params: {
     scopes: [],
     commands: params.commands,
     deviceIdentity: params.deviceIdentity,
+    onEvent: params.onEvent,
     timeoutMessage: "timeout waiting for paired node to connect",
   });
 }
@@ -237,6 +239,83 @@ describe("gateway node pairing authorization", () => {
       expect(pairedNode?.nodeId).toBe("node-approve-target");
     } finally {
       pairingWs?.close();
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+
+  test("blocks system command forwarding when node approval is rejected", async () => {
+    const started = await startServerWithClient("secret");
+    const pairedNode = await pairDeviceIdentity({
+      name: "node-invoke-needs-approval",
+      role: "node",
+      scopes: [],
+      clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+      clientMode: GATEWAY_CLIENT_MODES.NODE,
+    });
+    const operator = await issueOperatorToken({
+      name: "node-invoke-pairing-write",
+      approvedScopes: ["operator.admin"],
+      tokenScopes: ["operator.pairing", "operator.write"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+
+    let sawInvoke = false;
+    let operatorWs: WebSocket | undefined;
+    let nodeClient: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+    try {
+      nodeClient = await connectNodeClient({
+        port: started.port,
+        deviceIdentity: pairedNode.identity,
+        commands: ["system.run"],
+        onEvent: (evt) => {
+          if (evt.event === "node.invoke.request") {
+            sawInvoke = true;
+          }
+        },
+      });
+
+      operatorWs = await openTrackedWs(started.port);
+      await connectOk(operatorWs, {
+        skipDefaultAuth: true,
+        deviceToken: operator.token,
+        deviceIdentityPath: operator.identityPath,
+        scopes: ["operator.pairing", "operator.write"],
+      });
+
+      const list = await rpcReq<{
+        pending?: Array<{ requestId?: string; nodeId?: string; commands?: string[] }>;
+      }>(operatorWs, "node.pair.list", {});
+      expect(list.ok).toBe(true);
+      const pending = list.payload?.pending?.find(
+        (entry) => entry.nodeId === pairedNode.identity.deviceId,
+      );
+      if (!pending?.requestId) {
+        throw new Error("expected pending node pairing request");
+      }
+      expect(pending?.commands).toEqual(["system.run"]);
+
+      const approve = await rpcReq(operatorWs, "node.pair.approve", {
+        requestId: pending.requestId,
+      });
+      expect(approve.ok).toBe(false);
+      expect(approve.error?.message).toBe("missing scope: operator.admin");
+
+      const invoke = await rpcReq(operatorWs, "node.invoke", {
+        nodeId: pairedNode.identity.deviceId,
+        command: "system.run",
+        params: { command: ["echo", "blocked"], rawCommand: "echo blocked" },
+        timeoutMs: 25,
+        idempotencyKey: "node-invoke-needs-node-approval",
+      });
+      expect(invoke.ok).toBe(false);
+      expect(invoke.error?.message).toBe("node pairing approval required");
+      expect(sawInvoke).toBe(false);
+    } finally {
+      operatorWs?.close();
+      await nodeClient?.stopAndWait();
       started.ws.close();
       await started.server.close();
       started.envSnapshot.restore();

--- a/src/infra/skills-remote.test.ts
+++ b/src/infra/skills-remote.test.ts
@@ -12,6 +12,7 @@ import {
   getRemoteSkillEligibility,
   recordRemoteNodeBins,
   recordRemoteNodeInfo,
+  recordRemoteNodeApproval,
   removeRemoteNodeInfo,
   refreshRemoteNodeBins,
   setSkillsRemoteRegistry,
@@ -46,6 +47,7 @@ describe("skills-remote", () => {
       platform: "darwin",
       commands: ["system.run"],
     });
+    recordRemoteNodeApproval({ nodeId, platform: "darwin", commands: ["system.run"] });
     recordRemoteNodeBins(nodeId, [bin]);
 
     expect(getRemoteSkillEligibility()?.hasBin(bin)).toBe(true);
@@ -71,6 +73,7 @@ describe("skills-remote", () => {
       platform: "darwin",
       commands: ["system.run"],
     });
+    recordRemoteNodeApproval({ nodeId, platform: "darwin", commands: ["system.run"] });
 
     const before = getSkillsSnapshotVersion(workspaceDir);
     removeRemoteNodeInfo(nodeId);
@@ -119,6 +122,7 @@ describe("skills-remote", () => {
         platform: "darwin",
         commands: ["system.run"],
       });
+      recordRemoteNodeApproval({ nodeId: nodeA, platform: "darwin", commands: ["system.run"] });
       recordRemoteNodeBins(nodeA, [binA]);
 
       recordRemoteNodeInfo({
@@ -126,6 +130,7 @@ describe("skills-remote", () => {
         platform: "macOS",
         commands: ["system.run"],
       });
+      recordRemoteNodeApproval({ nodeId: nodeB, platform: "macOS", commands: ["system.run"] });
       recordRemoteNodeBins(nodeB, [binB]);
 
       const eligibility = getRemoteSkillEligibility();
@@ -150,12 +155,35 @@ describe("skills-remote", () => {
         platform: "darwin",
         commands: ["system.run"],
       });
+      recordRemoteNodeApproval({ nodeId, platform: "darwin", commands: ["system.run"] });
       recordRemoteNodeBins(nodeId, [bin]);
 
       const eligibility = getRemoteSkillEligibility({ advertiseExecNode: false });
 
       expect(eligibility?.hasBin(bin)).toBe(true);
       expect(eligibility?.note).toBeUndefined();
+    } finally {
+      removeRemoteNodeInfo(nodeId);
+    }
+  });
+
+  it("hides connected mac nodes until system.run is approved", () => {
+    const nodeId = `node-${randomUUID()}`;
+    const bin = `bin-${randomUUID()}`;
+    try {
+      recordRemoteNodeInfo({
+        nodeId,
+        displayName: "Remote Mac",
+        platform: "darwin",
+        commands: ["system.run"],
+      });
+      recordRemoteNodeBins(nodeId, [bin]);
+
+      expect(getRemoteSkillEligibility()?.hasBin(bin) ?? false).toBe(false);
+
+      recordRemoteNodeApproval({ nodeId, platform: "darwin", commands: ["system.run"] });
+
+      expect(getRemoteSkillEligibility()?.hasBin(bin)).toBe(true);
     } finally {
       removeRemoteNodeInfo(nodeId);
     }

--- a/src/infra/skills-remote.test.ts
+++ b/src/infra/skills-remote.test.ts
@@ -358,6 +358,97 @@ describe("skills-remote", () => {
     }
   });
 
+  it("bumps the skills snapshot when a successful probe restores cleared bins", async () => {
+    await resetSkillsRefreshForTest();
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-remote-skills-"));
+    const nodeId = `node-${randomUUID()}`;
+    const bin = `bin-${randomUUID()}`;
+    let failProbe = false;
+    try {
+      fs.mkdirSync(path.join(workspaceDir, "remote-skill"), { recursive: true });
+      fs.writeFileSync(
+        path.join(workspaceDir, "remote-skill", "SKILL.md"),
+        [
+          "---",
+          "name: remote-skill",
+          "description: Needs a remote bin",
+          `metadata: { "openclaw": { "os": ["darwin"], "requires": { "bins": ["${bin}"] } } }`,
+          "---",
+          "# Remote Skill",
+          "",
+        ].join("\n"),
+      );
+      const cfg = {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+      } satisfies OpenClawConfig;
+      setSkillsRemoteRegistry({
+        listConnected: () => [],
+        get: () => undefined,
+        invoke: async () => {
+          if (failProbe) {
+            return {
+              ok: false,
+              error: { code: "TIMEOUT", message: "node invoke timed out" },
+            };
+          }
+          return {
+            ok: true,
+            payload: { bins: { [bin]: `/opt/homebrew/bin/${bin}` } },
+            payloadJSON: JSON.stringify({ bins: { [bin]: `/opt/homebrew/bin/${bin}` } }),
+          };
+        },
+      } as unknown as NodeRegistry);
+      recordRemoteNodeInfo({
+        nodeId,
+        displayName: "Remote Mac",
+        platform: "darwin",
+        commands: ["system.run", "system.which"],
+      });
+
+      await withStateDirEnv("openclaw-remote-skills-state-", async () => {
+        await approveRemoteProbeCommandsForTest(nodeId, ["system.run", "system.which"]);
+        await refreshRemoteNodeBins({
+          nodeId,
+          platform: "darwin",
+          commands: ["system.run", "system.which"],
+          cfg,
+          timeoutMs: 10,
+        });
+        expect(getRemoteSkillEligibility()?.hasBin(bin)).toBe(true);
+
+        failProbe = true;
+        await refreshRemoteNodeBins({
+          nodeId,
+          platform: "darwin",
+          commands: ["system.run", "system.which"],
+          cfg,
+          timeoutMs: 10,
+        });
+        expect(getRemoteSkillEligibility()?.hasBin(bin) ?? false).toBe(false);
+
+        const beforeRecovery = getSkillsSnapshotVersion(workspaceDir);
+        failProbe = false;
+        await refreshRemoteNodeBins({
+          nodeId,
+          platform: "darwin",
+          commands: ["system.run", "system.which"],
+          cfg,
+          timeoutMs: 10,
+        });
+
+        expect(getRemoteSkillEligibility()?.hasBin(bin)).toBe(true);
+        expect(getSkillsSnapshotVersion(workspaceDir)).toBeGreaterThan(beforeRecovery);
+      });
+    } finally {
+      removeRemoteNodeInfo(nodeId);
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("coalesces overlapping bin probes for the same node", async () => {
     const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-remote-skills-"));
     const nodeId = `node-${randomUUID()}`;

--- a/src/infra/skills-remote.test.ts
+++ b/src/infra/skills-remote.test.ts
@@ -57,6 +57,33 @@ describe("skills-remote", () => {
     expect(getRemoteSkillEligibility()?.hasBin(bin) ?? false).toBe(false);
   });
 
+  it("restores approved remote eligibility when a node reconnects without bin probes", () => {
+    const nodeId = `node-${randomUUID()}`;
+    try {
+      recordRemoteNodeInfo({
+        nodeId,
+        displayName: "Remote Mac",
+        platform: "darwin",
+        commands: ["system.run"],
+      });
+      recordRemoteNodeApproval({ nodeId, platform: "darwin", commands: ["system.run"] });
+      expect(getRemoteSkillEligibility()?.platforms).toEqual(["darwin"]);
+
+      removeRemoteNodeInfo(nodeId);
+      expect(getRemoteSkillEligibility()).toBeUndefined();
+
+      recordRemoteNodeInfo({
+        nodeId,
+        displayName: "Remote Mac",
+        platform: "darwin",
+        commands: ["system.run"],
+      });
+      expect(getRemoteSkillEligibility()?.platforms).toEqual(["darwin"]);
+    } finally {
+      removeRemoteNodeInfo(nodeId);
+    }
+  });
+
   it("supports idempotent remote node removal", () => {
     const nodeId = `node-${randomUUID()}`;
     expect(removeRemoteNodeInfo(nodeId)).toBeUndefined();

--- a/src/infra/skills-remote.test.ts
+++ b/src/infra/skills-remote.test.ts
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import { getSkillsSnapshotVersion, resetSkillsRefreshForTest } from "../agents/skills/refresh.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { NodeRegistry } from "../gateway/node-registry.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { approveNodePairing, requestNodePairing } from "./node-pairing.js";
 import {
   getRemoteSkillEligibility,
   recordRemoteNodeBins,
@@ -14,6 +16,21 @@ import {
   refreshRemoteNodeBins,
   setSkillsRemoteRegistry,
 } from "./skills-remote.js";
+
+async function approveRemoteProbeCommandsForTest(nodeId: string, commands: string[]) {
+  const pending = await requestNodePairing({
+    nodeId,
+    displayName: "Remote Mac",
+    platform: "darwin",
+    commands,
+  });
+  const approved = await approveNodePairing(pending.request.requestId, {
+    callerScopes: ["operator.pairing", "operator.admin"],
+  });
+  if (!approved || "status" in approved) {
+    throw new Error("Expected node pairing approval to succeed");
+  }
+}
 
 describe("skills-remote", () => {
   afterEach(() => {
@@ -156,6 +173,69 @@ describe("skills-remote", () => {
     }
   });
 
+  it("does not invoke bin probe commands before node pairing approval", async () => {
+    await resetSkillsRefreshForTest();
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-remote-skills-"));
+    const nodeId = `node-${randomUUID()}`;
+    const bin = `bin-${randomUUID()}`;
+    let invokeCount = 0;
+    try {
+      fs.mkdirSync(path.join(workspaceDir, "remote-skill"), { recursive: true });
+      fs.writeFileSync(
+        path.join(workspaceDir, "remote-skill", "SKILL.md"),
+        [
+          "---",
+          "name: remote-skill",
+          "description: Needs a remote bin",
+          `metadata: { "openclaw": { "os": ["darwin"], "requires": { "bins": ["${bin}"] } } }`,
+          "---",
+          "# Remote Skill",
+          "",
+        ].join("\n"),
+      );
+      const cfg = {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+      } satisfies OpenClawConfig;
+      setSkillsRemoteRegistry({
+        listConnected: () => [],
+        get: () => undefined,
+        invoke: async () => {
+          invokeCount += 1;
+          throw new Error("unexpected remote bin probe invoke");
+        },
+      } as unknown as NodeRegistry);
+      recordRemoteNodeInfo({
+        nodeId,
+        displayName: "Remote Mac",
+        platform: "darwin",
+        commands: ["system.run", "system.which"],
+      });
+      recordRemoteNodeBins(nodeId, [bin]);
+      const before = getSkillsSnapshotVersion(workspaceDir);
+
+      await withStateDirEnv("openclaw-remote-skills-state-", async () => {
+        await refreshRemoteNodeBins({
+          nodeId,
+          platform: "darwin",
+          commands: ["system.run", "system.which"],
+          cfg,
+          timeoutMs: 10,
+        });
+      });
+
+      expect(invokeCount).toBe(0);
+      expect(getRemoteSkillEligibility()?.hasBin(bin) ?? false).toBe(false);
+      expect(getSkillsSnapshotVersion(workspaceDir)).toBeGreaterThan(before);
+    } finally {
+      removeRemoteNodeInfo(nodeId);
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("clears stale bins when a connected node probe times out", async () => {
     await resetSkillsRefreshForTest();
     const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-remote-skills-"));
@@ -203,12 +283,15 @@ describe("skills-remote", () => {
       recordRemoteNodeBins(nodeId, [bin]);
       const before = getSkillsSnapshotVersion(workspaceDir);
 
-      await refreshRemoteNodeBins({
-        nodeId,
-        platform: "darwin",
-        commands: ["system.run", "system.which"],
-        cfg,
-        timeoutMs: 10,
+      await withStateDirEnv("openclaw-remote-skills-state-", async () => {
+        await approveRemoteProbeCommandsForTest(nodeId, ["system.run", "system.which"]);
+        await refreshRemoteNodeBins({
+          nodeId,
+          platform: "darwin",
+          commands: ["system.run", "system.which"],
+          cfg,
+          timeoutMs: 10,
+        });
       });
 
       expect(invokeCalls).toEqual(["system.which"]);
@@ -271,27 +354,30 @@ describe("skills-remote", () => {
         commands: ["system.run", "system.which"],
       });
 
-      const first = refreshRemoteNodeBins({
-        nodeId,
-        platform: "darwin",
-        commands: ["system.run", "system.which"],
-        cfg,
-        timeoutMs: 10,
-      });
-      await probeStarted;
-      const second = refreshRemoteNodeBins({
-        nodeId,
-        platform: "darwin",
-        commands: ["system.run", "system.which"],
-        cfg,
-        timeoutMs: 10,
-      });
-      if (!releaseProbe) {
-        throw new Error("Expected remote skill probe release callback to be initialized");
-      }
-      releaseProbe();
+      await withStateDirEnv("openclaw-remote-skills-state-", async () => {
+        await approveRemoteProbeCommandsForTest(nodeId, ["system.run", "system.which"]);
+        const first = refreshRemoteNodeBins({
+          nodeId,
+          platform: "darwin",
+          commands: ["system.run", "system.which"],
+          cfg,
+          timeoutMs: 10,
+        });
+        await probeStarted;
+        const second = refreshRemoteNodeBins({
+          nodeId,
+          platform: "darwin",
+          commands: ["system.run", "system.which"],
+          cfg,
+          timeoutMs: 10,
+        });
+        if (!releaseProbe) {
+          throw new Error("Expected remote skill probe release callback to be initialized");
+        }
+        releaseProbe();
 
-      await Promise.all([first, second]);
+        await Promise.all([first, second]);
+      });
       expect(invokeCount).toBe(1);
     } finally {
       removeRemoteNodeInfo(nodeId);
@@ -346,12 +432,15 @@ describe("skills-remote", () => {
       });
       const before = getSkillsSnapshotVersion(workspaceDir);
 
-      await refreshRemoteNodeBins({
-        nodeId,
-        platform: "darwin",
-        commands: ["system.run", "system.which"],
-        cfg,
-        timeoutMs: 10,
+      await withStateDirEnv("openclaw-remote-skills-state-", async () => {
+        await approveRemoteProbeCommandsForTest(nodeId, ["system.run", "system.which"]);
+        await refreshRemoteNodeBins({
+          nodeId,
+          platform: "darwin",
+          commands: ["system.run", "system.which"],
+          cfg,
+          timeoutMs: 10,
+        });
       });
 
       expect(invokeCalls).toEqual(["system.which"]);

--- a/src/infra/skills-remote.ts
+++ b/src/infra/skills-remote.ts
@@ -281,8 +281,14 @@ export function clearRemoteNodeApproval(nodeId: string) {
 
 export function removeRemoteNodeInfo(nodeId: string) {
   const existing = remoteNodes.get(nodeId);
-  remoteNodes.delete(nodeId);
-  if (existing && isEligibleRemoteMacNode(existing)) {
+  if (!existing) {
+    return;
+  }
+  const wasEligible = isEligibleRemoteMacNode(existing);
+  existing.connected = false;
+  existing.remoteIp = undefined;
+  existing.bins = new Set();
+  if (wasEligible) {
     bumpSkillsSnapshotVersion({ reason: "remote-node" });
   }
 }

--- a/src/infra/skills-remote.ts
+++ b/src/infra/skills-remote.ts
@@ -9,7 +9,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
-import { listNodePairing, updatePairedNodeMetadata } from "./node-pairing.js";
+import { getPairedNode, listNodePairing, updatePairedNodeMetadata } from "./node-pairing.js";
 
 type RemoteNodeRecord = {
   nodeId: string;
@@ -117,6 +117,11 @@ function supportsSystemRun(commands?: string[]): boolean {
 
 function supportsSystemWhich(commands?: string[]): boolean {
   return Array.isArray(commands) && commands.includes("system.which");
+}
+
+async function hasApprovedRemoteProbeCommand(nodeId: string, command: string): Promise<boolean> {
+  const pairedNode = await getPairedNode(nodeId);
+  return pairedNode?.commands?.includes(command) === true;
 }
 
 function upsertNode(record: {
@@ -346,6 +351,18 @@ async function refreshRemoteNodeBinsUncoalesced(params: {
   const command = canWhich ? "system.which" : "system.run";
   const logContext = { command, timeoutMs, requiredBinCount: binsList.length };
   try {
+    if (!(await hasApprovedRemoteProbeCommand(params.nodeId, command))) {
+      const cleared = clearRemoteNodeBins(params.nodeId);
+      log.info(
+        `remote bin probe skipped: node pairing approval required (${describeNode(
+          params.nodeId,
+        )}; command=${command} timeoutMs=${timeoutMs} requiredBins=${binsList.length})`,
+      );
+      if (cleared) {
+        bumpSkillsSnapshotVersion({ reason: "remote-node" });
+      }
+      return;
+    }
     const res = await remoteRegistry.invoke(
       canWhich
         ? {

--- a/src/infra/skills-remote.ts
+++ b/src/infra/skills-remote.ts
@@ -142,7 +142,6 @@ async function hasApprovedRemoteProbeCommand(nodeId: string, command: string): P
       platform: pairedNode.platform,
       deviceFamily: pairedNode.deviceFamily,
       remoteIp: pairedNode.remoteIp,
-      bins: pairedNode.bins,
     });
   } else {
     clearRemoteNodeApproval(nodeId);

--- a/src/infra/skills-remote.ts
+++ b/src/infra/skills-remote.ts
@@ -17,6 +17,7 @@ type RemoteNodeRecord = {
   platform?: string;
   deviceFamily?: string;
   commands?: string[];
+  approvedCommands: Set<string>;
   bins: Set<string>;
   connected: boolean;
   remoteIp?: string;
@@ -119,8 +120,33 @@ function supportsSystemWhich(commands?: string[]): boolean {
   return Array.isArray(commands) && commands.includes("system.which");
 }
 
+function supportsApprovedSystemRun(node: RemoteNodeRecord): boolean {
+  return node.approvedCommands.has("system.run");
+}
+
+function isEligibleRemoteMacNode(node: RemoteNodeRecord): boolean {
+  return (
+    node.connected &&
+    isMacPlatform(node.platform, node.deviceFamily) &&
+    supportsSystemRun(node.commands) &&
+    supportsApprovedSystemRun(node)
+  );
+}
+
 async function hasApprovedRemoteProbeCommand(nodeId: string, command: string): Promise<boolean> {
   const pairedNode = await getPairedNode(nodeId);
+  if (pairedNode) {
+    recordRemoteNodeApproval({
+      nodeId,
+      commands: pairedNode.commands,
+      platform: pairedNode.platform,
+      deviceFamily: pairedNode.deviceFamily,
+      remoteIp: pairedNode.remoteIp,
+      bins: pairedNode.bins,
+    });
+  } else {
+    clearRemoteNodeApproval(nodeId);
+  }
   return pairedNode?.commands?.includes(command) === true;
 }
 
@@ -132,10 +158,14 @@ function upsertNode(record: {
   commands?: string[];
   remoteIp?: string;
   bins?: string[];
+  approvedCommands?: string[];
   connected?: boolean;
 }) {
   const existing = remoteNodes.get(record.nodeId);
   const bins = new Set<string>(record.bins ?? existing?.bins ?? []);
+  const approvedCommands = new Set<string>(
+    record.approvedCommands ?? [...(existing?.approvedCommands ?? [])],
+  );
   remoteNodes.set(record.nodeId, {
     nodeId: record.nodeId,
     displayName: record.displayName ?? existing?.displayName,
@@ -144,6 +174,7 @@ function upsertNode(record: {
     commands: record.commands ?? existing?.commands,
     remoteIp: record.remoteIp ?? existing?.remoteIp,
     bins,
+    approvedCommands,
     connected: record.connected ?? existing?.connected ?? false,
   });
 }
@@ -172,6 +203,7 @@ export async function primeRemoteSkillsCache() {
         platform: node.platform,
         deviceFamily: node.deviceFamily,
         commands: node.commands,
+        approvedCommands: node.commands,
         remoteIp: node.remoteIp,
         bins: node.bins,
         connected: false,
@@ -208,14 +240,49 @@ export function recordRemoteNodeBins(nodeId: string, bins: string[]) {
   upsertNode({ nodeId, bins });
 }
 
+export function recordRemoteNodeApproval(node: {
+  nodeId: string;
+  displayName?: string;
+  platform?: string;
+  deviceFamily?: string;
+  commands?: string[];
+  remoteIp?: string;
+  bins?: string[];
+}) {
+  const before = remoteNodes.get(node.nodeId);
+  const wasEligible = before ? isEligibleRemoteMacNode(before) : false;
+  upsertNode({
+    nodeId: node.nodeId,
+    displayName: node.displayName,
+    platform: node.platform,
+    deviceFamily: node.deviceFamily,
+    approvedCommands: node.commands ?? [],
+    remoteIp: node.remoteIp,
+    bins: node.bins,
+  });
+  const after = remoteNodes.get(node.nodeId);
+  if (after && isEligibleRemoteMacNode(after) !== wasEligible) {
+    bumpSkillsSnapshotVersion({ reason: "remote-node" });
+  }
+}
+
+export function clearRemoteNodeApproval(nodeId: string) {
+  const existing = remoteNodes.get(nodeId);
+  if (!existing || existing.approvedCommands.size === 0) {
+    return;
+  }
+  const wasEligible = isEligibleRemoteMacNode(existing);
+  existing.approvedCommands = new Set();
+  clearRemoteNodeBins(nodeId);
+  if (wasEligible) {
+    bumpSkillsSnapshotVersion({ reason: "remote-node" });
+  }
+}
+
 export function removeRemoteNodeInfo(nodeId: string) {
   const existing = remoteNodes.get(nodeId);
   remoteNodes.delete(nodeId);
-  if (
-    existing &&
-    isMacPlatform(existing.platform, existing.deviceFamily) &&
-    supportsSystemRun(existing.commands)
-  ) {
+  if (existing && isEligibleRemoteMacNode(existing)) {
     bumpSkillsSnapshotVersion({ reason: "remote-node" });
   }
 }
@@ -410,12 +477,7 @@ async function refreshRemoteNodeBinsUncoalesced(params: {
 export function getRemoteSkillEligibility(options?: {
   advertiseExecNode?: boolean;
 }): SkillEligibilityContext["remote"] | undefined {
-  const macNodes = [...remoteNodes.values()].filter(
-    (node) =>
-      node.connected &&
-      isMacPlatform(node.platform, node.deviceFamily) &&
-      supportsSystemRun(node.commands),
-  );
+  const macNodes = [...remoteNodes.values()].filter((node) => isEligibleRemoteMacNode(node));
   if (macNodes.length === 0) {
     return undefined;
   }


### PR DESCRIPTION
## Summary

- Problem: Node system command forwarding could be reached before the node command surface had an approved pairing record.
- Why it matters: Gateway-side authorization should align operator request forwarding, direct node registry probes, and remote skill eligibility with the approved node state.
- What changed: Added approval checks before protected node system command forwarding, gated remote bin probes and remote skill eligibility on approved command state, and refreshed remote bin state after node approval.
- What did NOT change (scope boundary): Device pairing approval, operator token auth mode, non-system node commands, and command execution behavior after node approval are out of scope.

AI-assisted: Yes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: N/A
- [x] This PR addresses a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Unapproved node system command forwarding and remote skill eligibility before approved node command state.
- Real environment tested: Not run in this metadata drafting step.
- Exact steps or command run after this patch: Not run in this metadata drafting step.
- Evidence after fix: Pending.
- Observed result after fix: Pending.
- What was not tested: Live gateway and node-host runtime proof, local test execution, and broad changed checks in this metadata drafting step.
- Before evidence (optional but encouraged): N/A

## Root Cause (if applicable)

- Root cause: Gateway node command forwarding and remote bin probe paths could trust connected-node command declarations before checking the approved node-pair command state.
- Missing detection / guardrail: Coverage did not lock down protected `node.invoke`, direct registry bin probe forwarding, or remote skill cache transitions around node approval and reconnects.
- Contributing context (if known): Node device pairing and node command approval are separate states, and multiple paths can forward node system commands.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.node-invoke-approval-bypass.test.ts`, `src/gateway/server.node-pairing-authz.test.ts`, and `src/infra/skills-remote.test.ts`.
- Scenario the test should lock in: Protected node system commands and remote bin probes require approved node command state, without consuming exec approvals or leaving remote skill eligibility stale across approval, disconnect, reconnect, failed probe, and recovery transitions.
- Why this is the smallest reliable guardrail: These tests exercise the gateway authorization boundary and the directly coupled remote skill cache without requiring a full external node runtime.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Protected node system command forwarding now requires approved node command state before execution or remote skill eligibility is advertised.

## Diagram (if applicable)

```text
Before:
node connected -> declared system command -> forwarding/probe could run before approved node command state

After:
node connected -> declared system command -> approved node command state required -> forwarding/probe/remote eligibility
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: Node approval can now trigger the existing remote bin refresh path for connected nodes, and protected node system command forwarding is denied until approved command state exists. The changed execution surface is narrower because forwarding and probes are gated on the approved node command list.

## Repro + Verification

### Environment

- OS: Not captured in this metadata drafting step.
- Runtime/container: Node 22 expected.
- Model/provider: N/A
- Integration/channel (if any): Gateway node pairing, node registry, and remote skills.
- Relevant config (redacted): N/A

### Steps

1. Connect a remote node that declares protected system commands.
2. Use an operator session without admin scope to complete device pairing only.
3. Attempt protected node system command forwarding before node command approval.
4. Approve the node command surface with admin scope.
5. Verify protected forwarding, remote bin probing, and remote skill eligibility follow the approved node state.

### Expected

- Protected node system commands are rejected before node command approval.
- Exec approvals are not consumed by rejected pre-approval forwarding.
- Direct remote bin probes do not run before approval.
- Remote skill eligibility is hidden until approved state exists, then refreshed after approval and reconnect/probe recovery.

### Actual

- Covered by added regression tests; live runtime proof is pending.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Metadata drafted from the supplied branch summary and changed-file list.
- Edge cases checked: Approval-before-sanitization, direct registry probe gating, approval-time refresh, reconnect eligibility, and probe recovery cache invalidation are represented in the described test plan.
- What you did **not** verify: I did not run tests, CI, or live gateway/node-host proof in this metadata drafting step.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Remote bin-gated skills may stay hidden until approved node state and a successful probe are available.
  - Mitigation: The approval path refreshes connected nodes, and tests cover reconnect and probe recovery cache invalidation.
