### PR TITLE
fix(acpx): strip provider API keys from child harness env

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -456,9 +456,12 @@ Auth is selected in this order:
    still required.
 
 When OpenClaw sees a ChatGPT subscription-style Codex auth profile, it removes
-`CODEX_API_KEY` and `OPENAI_API_KEY` from the spawned Codex child process. That
-keeps Gateway-level API keys available for embeddings or direct OpenAI models
-without making native Codex app-server turns bill through the API by accident.
+Codex-auth bridge variables (`ACPX_AUTH_CODEX_API_KEY`,
+`ACPX_AUTH_OPENAI_API_KEY`, `CODEX_API_KEY`, and `OPENAI_API_KEY`) from spawned
+ACP child processes. That keeps Gateway-level API keys available for embeddings
+or direct OpenAI models without making native Codex app-server turns bill
+through the API by accident, and without stripping provider-specific CLI auth,
+path/home values, acceptance variables, or intentional provider flags.
 Explicit Codex API-key profiles and local stdio env-key fallback use app-server
 login instead of inherited child-process env. WebSocket app-server connections
 do not receive Gateway env API-key fallback; use an explicit auth profile or the

--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -218,6 +218,15 @@ or flag value should remain one argv token:
 - `agents.<id>.command` is the executable or existing command string for that ACP agent.
 - `agents.<id>.args` is optional. Each array item is shell-quoted before OpenClaw passes it through the current acpx command-string registry.
 
+Gemini CLI auth note: OpenClaw's generated `gemini` ACP wrapper strips
+`GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_GENAI_USE_GCA`, and
+`GOOGLE_GENAI_USE_VERTEXAI` from the child environment by default so unrelated
+Gateway/provider credentials are not inherited accidentally. If you intentionally
+run Gemini CLI with API-key or Vertex environment auth, set
+`OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV=1` in the environment for that ACP
+launch along with the Gemini auth variables. The preserve flag is consumed by the
+OpenClaw wrapper and is not forwarded to the Gemini child process.
+
 See [Plugins](/tools/plugin).
 
 ### Automatic dependency install

--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -218,14 +218,12 @@ or flag value should remain one argv token:
 - `agents.<id>.command` is the executable or existing command string for that ACP agent.
 - `agents.<id>.args` is optional. Each array item is shell-quoted before OpenClaw passes it through the current acpx command-string registry.
 
-Gemini CLI auth note: OpenClaw's generated `gemini` ACP wrapper strips
-`GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_GENAI_USE_GCA`, and
-`GOOGLE_GENAI_USE_VERTEXAI` from the child environment by default so unrelated
-Gateway/provider credentials are not inherited accidentally. If you intentionally
-run Gemini CLI with API-key or Vertex environment auth, set
-`OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV=1` in the environment for that ACP
-launch along with the Gemini auth variables. The preserve flag is consumed by the
-OpenClaw wrapper and is not forwarded to the Gemini child process.
+ACP auth environment note: OpenClaw-generated ACP wrappers strip only the
+Codex-auth bridge variables (`ACPX_AUTH_CODEX_API_KEY`,
+`ACPX_AUTH_OPENAI_API_KEY`, `CODEX_API_KEY`, and `OPENAI_API_KEY`) from spawned
+provider children. Provider-specific environment auth, path/home values,
+acceptance variables, and intentional provider flags remain inherited by the
+provider CLI.
 
 See [Plugins](/tools/plugin).
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -95,21 +95,22 @@ should call those tools directly.
 With the `acpx` backend, use these harness ids as `/acp spawn <id>`
 or `sessions_spawn({ runtime: "acp", agentId: "<id>" })` targets:
 
-| Harness id | Typical backend                                | Notes                                                                               |
-| ---------- | ---------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `claude`   | Claude Code ACP adapter                        | Requires Claude Code auth on the host.                                              |
-| `codex`    | Codex ACP adapter                              | Explicit ACP fallback only when native `/codex` is unavailable or ACP is requested. |
-| `copilot`  | GitHub Copilot ACP adapter                     | Requires Copilot CLI/runtime auth.                                                  |
-| `cursor`   | Cursor CLI ACP (`cursor-agent acp`)            | Override the acpx command if a local install exposes a different ACP entrypoint.    |
-| `droid`    | Factory Droid CLI                              | Requires Factory/Droid auth or `FACTORY_API_KEY` in the harness environment.        |
-| `gemini`   | Gemini CLI ACP adapter                         | Requires Gemini CLI auth or API key setup.                                          |
-| `iflow`    | iFlow CLI                                      | Adapter availability and model control depend on the installed CLI.                 |
-| `kilocode` | Kilo Code CLI                                  | Adapter availability and model control depend on the installed CLI.                 |
-| `kimi`     | Kimi/Moonshot CLI                              | Requires Kimi/Moonshot auth on the host.                                            |
-| `kiro`     | Kiro CLI                                       | Adapter availability and model control depend on the installed CLI.                 |
-| `opencode` | OpenCode ACP adapter                           | Requires OpenCode CLI/provider auth.                                                |
-| `openclaw` | OpenClaw Gateway bridge through `openclaw acp` | Lets an ACP-aware harness talk back to an OpenClaw Gateway session.                 |
-| `qwen`     | Qwen Code / Qwen CLI                           | Requires Qwen-compatible auth on the host.                                          |
+| Harness id | Typical backend                                | Notes                                                                                      |
+| ---------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `claude`   | Claude Code ACP adapter                        | Requires Claude Code auth on the host.                                                     |
+| `codex`    | Codex ACP adapter                              | Explicit ACP fallback only when native `/codex` is unavailable or ACP is requested.        |
+| `copilot`  | GitHub Copilot ACP adapter                     | Requires Copilot CLI/runtime auth.                                                         |
+| `cursor`   | Cursor CLI ACP (`cursor-agent acp`)            | Override the acpx command if a local install exposes a different ACP entrypoint.           |
+| `droid`    | Factory Droid CLI                              | Requires Factory/Droid auth or `FACTORY_API_KEY` in the harness environment.               |
+| `gemini`   | Gemini CLI ACP adapter                         | Requires Gemini CLI auth, or API-key/Vertex env auth with the explicit ACPX preserve flag. |
+| `iflow`    | iFlow CLI                                      | Adapter availability and model control depend on the installed CLI.                        |
+| `kilocode` | Kilo Code CLI                                  | Adapter availability and model control depend on the installed CLI.                        |
+| `kimi`     | Kimi/Moonshot CLI                              | Requires Kimi/Moonshot auth on the host.                                                   |
+| `kiro`     | Kiro CLI                                       | Adapter availability and model control depend on the installed CLI.                        |
+| `opencode` | OpenCode ACP adapter                           | Requires OpenCode CLI/provider auth.                                                       |
+| `openclaw` | OpenClaw Gateway bridge through `openclaw acp` | Lets an ACP-aware harness talk back to an OpenClaw Gateway session.                        |
+| `pi`       | Pi/embedded OpenClaw runtime                   | Used for OpenClaw-native harness experiments.                                              |
+| `qwen`     | Qwen Code / Qwen CLI                           | Requires Qwen-compatible auth on the host.                                                 |
 
 Custom acpx agent aliases can be configured in acpx itself, but OpenClaw
 policy still checks `acp.allowedAgents` and any

--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -109,6 +109,40 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   expect((error as NodeJS.ErrnoException).code).toBe("ENOENT");
 }
 
+async function writeVersionedFakeGeminiBin(
+  root: string,
+  versionOutput: string,
+): Promise<{ binDir: string; geminiBinPath: string }> {
+  const binDir = path.join(root, "bin");
+  await fs.mkdir(binDir, { recursive: true });
+  const geminiBinPath = path.join(binDir, "gemini");
+  await fs.writeFile(
+    geminiBinPath,
+    [
+      "#!/usr/bin/env node",
+      "if (process.argv[2] === '--version') {",
+      `  console.log(${JSON.stringify(versionOutput)});`,
+      "  process.exit(0);",
+      "}",
+      "console.log(",
+      "  JSON.stringify({",
+      "    argv: process.argv.slice(2),",
+      "    geminiApiKey: process.env.GEMINI_API_KEY ?? null,",
+      "    googleApiKey: process.env.GOOGLE_API_KEY ?? null,",
+      "    googleGenaiUseGca: process.env.GOOGLE_GENAI_USE_GCA ?? null,",
+      "    googleGenaiUseVertexai: process.env.GOOGLE_GENAI_USE_VERTEXAI ?? null,",
+      `    preserveFlag: process.env.${GEMINI_AUTH_ENV_PRESERVE_FLAG} ?? null,`,
+      "    inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null,",
+      "  }),",
+      ");",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.chmod(geminiBinPath, 0o755);
+  return { binDir, geminiBinPath };
+}
+
 afterEach(async () => {
   vi.restoreAllMocks();
   restoreEnv("ANTHROPIC_API_KEY");
@@ -673,6 +707,115 @@ describe("prepareAcpxCodexAuthConfig", () => {
       inheritedProbe?: unknown;
     };
     expect(launched.argv).toEqual(["--acp"]);
+    expect(launched.geminiApiKey).toBe("child-gemini-secret");
+    expect(launched.googleApiKey).toBe("child-google-secret");
+    expect(launched.googleGenaiUseGca).toBe("child-gca-selector");
+    expect(launched.googleGenaiUseVertexai).toBe("child-vertex-selector");
+    expect(launched.preserveFlag).toBeNull();
+    expect(launched.inheritedProbe).toBe("preserved");
+    expect(process.env.GEMINI_API_KEY).toBe("parent-gemini-secret");
+    expect(process.env.GOOGLE_API_KEY).toBe("parent-google-secret");
+    expect(process.env.GOOGLE_GENAI_USE_GCA).toBe("parent-gca-selector");
+    expect(process.env.GOOGLE_GENAI_USE_VERTEXAI).toBe("parent-vertex-selector");
+    expect(process.env.OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV).toBe("parent-preserve-flag");
+  });
+
+  it("keeps modern Gemini CLI on --acp while stripping provider auth env", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedGeminiPaths(stateDir);
+    const { binDir } = await writeVersionedFakeGeminiBin(root, "0.33.0");
+    process.env.GEMINI_API_KEY = "parent-gemini-secret";
+    process.env.GOOGLE_API_KEY = "parent-google-secret";
+    process.env.GOOGLE_GENAI_USE_GCA = "parent-gca-selector";
+    process.env.GOOGLE_GENAI_USE_VERTEXAI = "parent-vertex-selector";
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+    });
+
+    const { stdout } = await execFileAsync(process.execPath, [generated.wrapperPath], {
+      cwd: root,
+      env: {
+        ...process.env,
+        GEMINI_API_KEY: "child-gemini-secret",
+        GOOGLE_API_KEY: "child-google-secret",
+        GOOGLE_GENAI_USE_GCA: "child-gca-selector",
+        GOOGLE_GENAI_USE_VERTEXAI: "child-vertex-selector",
+        OPENCLAW_ACPX_ENV_PROBE: "preserved",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+    const launched = JSON.parse(stdout.trim()) as {
+      argv?: unknown;
+      geminiApiKey?: unknown;
+      googleApiKey?: unknown;
+      googleGenaiUseGca?: unknown;
+      googleGenaiUseVertexai?: unknown;
+      preserveFlag?: unknown;
+      inheritedProbe?: unknown;
+    };
+    expect(launched.argv).toEqual(["--acp"]);
+    expect(launched.geminiApiKey).toBeNull();
+    expect(launched.googleApiKey).toBeNull();
+    expect(launched.googleGenaiUseGca).toBeNull();
+    expect(launched.googleGenaiUseVertexai).toBeNull();
+    expect(launched.preserveFlag).toBeNull();
+    expect(launched.inheritedProbe).toBe("preserved");
+    expect(process.env.GEMINI_API_KEY).toBe("parent-gemini-secret");
+    expect(process.env.GOOGLE_API_KEY).toBe("parent-google-secret");
+    expect(process.env.GOOGLE_GENAI_USE_GCA).toBe("parent-gca-selector");
+    expect(process.env.GOOGLE_GENAI_USE_VERTEXAI).toBe("parent-vertex-selector");
+  });
+
+  it("uses --experimental-acp for older Gemini CLI while preserving explicit env opt-in", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedGeminiPaths(stateDir);
+    const { binDir } = await writeVersionedFakeGeminiBin(root, "0.32.9");
+    process.env.GEMINI_API_KEY = "parent-gemini-secret";
+    process.env.GOOGLE_API_KEY = "parent-google-secret";
+    process.env.GOOGLE_GENAI_USE_GCA = "parent-gca-selector";
+    process.env.GOOGLE_GENAI_USE_VERTEXAI = "parent-vertex-selector";
+    process.env.OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV = "parent-preserve-flag";
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+    });
+
+    const { stdout } = await execFileAsync(process.execPath, [generated.wrapperPath], {
+      cwd: root,
+      env: {
+        ...process.env,
+        GEMINI_API_KEY: "child-gemini-secret",
+        GOOGLE_API_KEY: "child-google-secret",
+        GOOGLE_GENAI_USE_GCA: "child-gca-selector",
+        GOOGLE_GENAI_USE_VERTEXAI: "child-vertex-selector",
+        OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV: "true",
+        OPENCLAW_ACPX_ENV_PROBE: "preserved",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+    const launched = JSON.parse(stdout.trim()) as {
+      argv?: unknown;
+      geminiApiKey?: unknown;
+      googleApiKey?: unknown;
+      googleGenaiUseGca?: unknown;
+      googleGenaiUseVertexai?: unknown;
+      preserveFlag?: unknown;
+      inheritedProbe?: unknown;
+    };
+    expect(launched.argv).toEqual(["--experimental-acp"]);
     expect(launched.geminiApiKey).toBe("child-gemini-secret");
     expect(launched.googleApiKey).toBe("child-google-secret");
     expect(launched.googleGenaiUseGca).toBe("child-gca-selector");

--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -11,6 +11,7 @@ import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./
 
 const execFileAsync = promisify(execFile);
 const tempDirs: string[] = [];
+const GEMINI_AUTH_ENV_PRESERVE_FLAG = "OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV";
 const previousEnv = {
   ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
   CODEX_HOME: process.env.CODEX_HOME,
@@ -18,6 +19,7 @@ const previousEnv = {
   GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
   GOOGLE_GENAI_USE_GCA: process.env.GOOGLE_GENAI_USE_GCA,
   GOOGLE_GENAI_USE_VERTEXAI: process.env.GOOGLE_GENAI_USE_VERTEXAI,
+  OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV: process.env.OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV,
   OPENCLAW_AGENT_DIR: process.env.OPENCLAW_AGENT_DIR,
 };
 
@@ -115,6 +117,7 @@ afterEach(async () => {
   restoreEnv("GOOGLE_API_KEY");
   restoreEnv("GOOGLE_GENAI_USE_GCA");
   restoreEnv("GOOGLE_GENAI_USE_VERTEXAI");
+  restoreEnv("OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV");
   restoreEnv("OPENCLAW_AGENT_DIR");
   for (const dir of tempDirs.splice(0)) {
     await fs.rm(dir, { recursive: true, force: true });
@@ -548,6 +551,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
         "    googleApiKey: process.env.GOOGLE_API_KEY ?? null,",
         "    googleGenaiUseGca: process.env.GOOGLE_GENAI_USE_GCA ?? null,",
         "    googleGenaiUseVertexai: process.env.GOOGLE_GENAI_USE_VERTEXAI ?? null,",
+        `    preserveFlag: process.env.${GEMINI_AUTH_ENV_PRESERVE_FLAG} ?? null,`,
         "    inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null,",
         "  }),",
         ");",
@@ -588,6 +592,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
       googleApiKey?: unknown;
       googleGenaiUseGca?: unknown;
       googleGenaiUseVertexai?: unknown;
+      preserveFlag?: unknown;
       inheritedProbe?: unknown;
     };
     expect(launched.argv).toEqual(["--acp"]);
@@ -595,11 +600,90 @@ describe("prepareAcpxCodexAuthConfig", () => {
     expect(launched.googleApiKey).toBeNull();
     expect(launched.googleGenaiUseGca).toBeNull();
     expect(launched.googleGenaiUseVertexai).toBeNull();
+    expect(launched.preserveFlag).toBeNull();
     expect(launched.inheritedProbe).toBe("preserved");
     expect(process.env.GEMINI_API_KEY).toBe("parent-gemini-secret");
     expect(process.env.GOOGLE_API_KEY).toBe("parent-google-secret");
     expect(process.env.GOOGLE_GENAI_USE_GCA).toBe("parent-gca-selector");
     expect(process.env.GOOGLE_GENAI_USE_VERTEXAI).toBe("parent-vertex-selector");
+  });
+
+  it("preserves Gemini provider auth env when the explicit wrapper opt-in is set", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedGeminiPaths(stateDir);
+    const binDir = path.join(root, "bin");
+    await fs.mkdir(binDir, { recursive: true });
+    const geminiBinPath = path.join(binDir, "gemini");
+    await fs.writeFile(
+      geminiBinPath,
+      [
+        "#!/usr/bin/env node",
+        "console.log(",
+        "  JSON.stringify({",
+        "    argv: process.argv.slice(2),",
+        "    geminiApiKey: process.env.GEMINI_API_KEY ?? null,",
+        "    googleApiKey: process.env.GOOGLE_API_KEY ?? null,",
+        "    googleGenaiUseGca: process.env.GOOGLE_GENAI_USE_GCA ?? null,",
+        "    googleGenaiUseVertexai: process.env.GOOGLE_GENAI_USE_VERTEXAI ?? null,",
+        `    preserveFlag: process.env.${GEMINI_AUTH_ENV_PRESERVE_FLAG} ?? null,`,
+        "    inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null,",
+        "  }),",
+        ");",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.chmod(geminiBinPath, 0o755);
+    process.env.GEMINI_API_KEY = "parent-gemini-secret";
+    process.env.GOOGLE_API_KEY = "parent-google-secret";
+    process.env.GOOGLE_GENAI_USE_GCA = "parent-gca-selector";
+    process.env.GOOGLE_GENAI_USE_VERTEXAI = "parent-vertex-selector";
+    process.env.OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV = "parent-preserve-flag";
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+    });
+
+    const { stdout } = await execFileAsync(process.execPath, [generated.wrapperPath], {
+      cwd: root,
+      env: {
+        ...process.env,
+        GEMINI_API_KEY: "child-gemini-secret",
+        GOOGLE_API_KEY: "child-google-secret",
+        GOOGLE_GENAI_USE_GCA: "child-gca-selector",
+        GOOGLE_GENAI_USE_VERTEXAI: "child-vertex-selector",
+        OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV: "1",
+        OPENCLAW_ACPX_ENV_PROBE: "preserved",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+    const launched = JSON.parse(stdout.trim()) as {
+      argv?: unknown;
+      geminiApiKey?: unknown;
+      googleApiKey?: unknown;
+      googleGenaiUseGca?: unknown;
+      googleGenaiUseVertexai?: unknown;
+      preserveFlag?: unknown;
+      inheritedProbe?: unknown;
+    };
+    expect(launched.argv).toEqual(["--acp"]);
+    expect(launched.geminiApiKey).toBe("child-gemini-secret");
+    expect(launched.googleApiKey).toBe("child-google-secret");
+    expect(launched.googleGenaiUseGca).toBe("child-gca-selector");
+    expect(launched.googleGenaiUseVertexai).toBe("child-vertex-selector");
+    expect(launched.preserveFlag).toBeNull();
+    expect(launched.inheritedProbe).toBe("preserved");
+    expect(process.env.GEMINI_API_KEY).toBe("parent-gemini-secret");
+    expect(process.env.GOOGLE_API_KEY).toBe("parent-google-secret");
+    expect(process.env.GOOGLE_GENAI_USE_GCA).toBe("parent-gca-selector");
+    expect(process.env.GOOGLE_GENAI_USE_VERTEXAI).toBe("parent-vertex-selector");
+    expect(process.env.OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV).toBe("parent-preserve-flag");
   });
 
   it("does not copy source Codex auth", async () => {

--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -12,7 +12,10 @@ import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./
 const execFileAsync = promisify(execFile);
 const tempDirs: string[] = [];
 const previousEnv = {
+  ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
   CODEX_HOME: process.env.CODEX_HOME,
+  GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+  GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
   OPENCLAW_AGENT_DIR: process.env.OPENCLAW_AGENT_DIR,
 };
 
@@ -56,12 +59,26 @@ function generatedClaudePaths(stateDir: string): {
   };
 }
 
+function generatedGeminiPaths(stateDir: string): {
+  wrapperPath: string;
+} {
+  const baseDir = path.join(stateDir, "acpx");
+  return {
+    wrapperPath: path.join(baseDir, "gemini-acp-wrapper.mjs"),
+  };
+}
+
 function expectCodexWrapperCommand(command: string | undefined, wrapperPath: string): void {
   expect(command).toContain(quoteArg(process.execPath));
   expect(command).toContain(quoteArg(wrapperPath));
 }
 
 function expectClaudeWrapperCommand(command: string | undefined, wrapperPath: string): void {
+  expect(command).toContain(quoteArg(process.execPath));
+  expect(command).toContain(quoteArg(wrapperPath));
+}
+
+function expectGeminiWrapperCommand(command: string | undefined, wrapperPath: string): void {
   expect(command).toContain(quoteArg(process.execPath));
   expect(command).toContain(quoteArg(wrapperPath));
 }
@@ -90,7 +107,10 @@ async function expectPathMissing(targetPath: string): Promise<void> {
 
 afterEach(async () => {
   vi.restoreAllMocks();
+  restoreEnv("ANTHROPIC_API_KEY");
   restoreEnv("CODEX_HOME");
+  restoreEnv("GEMINI_API_KEY");
+  restoreEnv("GOOGLE_API_KEY");
   restoreEnv("OPENCLAW_AGENT_DIR");
   for (const dir of tempDirs.splice(0)) {
     await fs.rm(dir, { recursive: true, force: true });
@@ -104,6 +124,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
     const stateDir = path.join(root, "state");
     const generated = generatedCodexPaths(stateDir);
     const generatedClaude = generatedClaudePaths(stateDir);
+    const generatedGemini = generatedGeminiPaths(stateDir);
     const installedBinPath = path.join(
       root,
       "node_modules",
@@ -126,8 +147,10 @@ describe("prepareAcpxCodexAuthConfig", () => {
 
     expectCodexWrapperCommand(resolved.agents.codex, generated.wrapperPath);
     expectClaudeWrapperCommand(resolved.agents.claude, generatedClaude.wrapperPath);
+    expectGeminiWrapperCommand(resolved.agents.gemini, generatedGemini.wrapperPath);
     await expect(fs.access(generated.wrapperPath)).resolves.toBeUndefined();
     await expect(fs.access(generatedClaude.wrapperPath)).resolves.toBeUndefined();
+    await expect(fs.access(generatedGemini.wrapperPath)).resolves.toBeUndefined();
     const wrapper = await fs.readFile(generated.wrapperPath, "utf8");
     expect(wrapper).toContain(JSON.stringify(installedBinPath));
     expect(wrapper).toContain("defaultArgs = [installedBinPath]");
@@ -139,6 +162,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
     const stateDir = path.join(root, "state");
     const generatedCodex = generatedCodexPaths(stateDir);
     const generatedClaude = generatedClaudePaths(stateDir);
+    const generatedGemini = generatedGeminiPaths(stateDir);
     const chmodError = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
     const chmodSpy = vi.spyOn(fs, "chmod").mockRejectedValue(chmodError);
     const pluginConfig = resolveAcpxPluginConfig({
@@ -153,10 +177,13 @@ describe("prepareAcpxCodexAuthConfig", () => {
 
     expect(chmodSpy).toHaveBeenCalledWith(generatedCodex.wrapperPath, 0o755);
     expect(chmodSpy).toHaveBeenCalledWith(generatedClaude.wrapperPath, 0o755);
+    expect(chmodSpy).toHaveBeenCalledWith(generatedGemini.wrapperPath, 0o755);
     expectCodexWrapperCommand(resolved.agents.codex, generatedCodex.wrapperPath);
     expectClaudeWrapperCommand(resolved.agents.claude, generatedClaude.wrapperPath);
+    expectGeminiWrapperCommand(resolved.agents.gemini, generatedGemini.wrapperPath);
     await expect(fs.access(generatedCodex.wrapperPath)).resolves.toBeUndefined();
     await expect(fs.access(generatedClaude.wrapperPath)).resolves.toBeUndefined();
+    await expect(fs.access(generatedGemini.wrapperPath)).resolves.toBeUndefined();
   });
 
   it("falls back to the current Codex ACP package range when the local adapter is unavailable", async () => {
@@ -460,6 +487,98 @@ describe("prepareAcpxCodexAuthConfig", () => {
     expect(launched.codexHome).toBeNull();
   });
 
+  it("strips Claude provider API keys only from the spawned ACP child env", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedClaudePaths(stateDir);
+    const installedBinPath = path.join(root, "claude-agent-acp-bin.js");
+    await fs.writeFile(
+      installedBinPath,
+      "console.log(JSON.stringify({ anthropicApiKey: process.env.ANTHROPIC_API_KEY ?? null, inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null }));\n",
+      "utf8",
+    );
+    process.env.ANTHROPIC_API_KEY = "parent-secret";
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledClaudeAcpBinPath: async () => installedBinPath,
+    });
+
+    const { stdout } = await execFileAsync(process.execPath, [generated.wrapperPath], {
+      cwd: root,
+      env: {
+        ...process.env,
+        ANTHROPIC_API_KEY: "child-secret",
+        OPENCLAW_ACPX_ENV_PROBE: "preserved",
+      },
+    });
+    const launched = JSON.parse(stdout.trim()) as {
+      anthropicApiKey?: unknown;
+      inheritedProbe?: unknown;
+    };
+    expect(launched.anthropicApiKey).toBeNull();
+    expect(launched.inheritedProbe).toBe("preserved");
+    expect(process.env.ANTHROPIC_API_KEY).toBe("parent-secret");
+  });
+
+  it("strips Gemini provider API keys only from the spawned ACP child env", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedGeminiPaths(stateDir);
+    const binDir = path.join(root, "bin");
+    await fs.mkdir(binDir, { recursive: true });
+    const geminiBinPath = path.join(binDir, "gemini");
+    await fs.writeFile(
+      geminiBinPath,
+      [
+        "#!/usr/bin/env node",
+        "console.log(JSON.stringify({ argv: process.argv.slice(2), geminiApiKey: process.env.GEMINI_API_KEY ?? null, googleApiKey: process.env.GOOGLE_API_KEY ?? null, inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null }));",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.chmod(geminiBinPath, 0o755);
+    process.env.GEMINI_API_KEY = "parent-gemini-secret";
+    process.env.GOOGLE_API_KEY = "parent-google-secret";
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+    });
+
+    const { stdout } = await execFileAsync(process.execPath, [generated.wrapperPath], {
+      cwd: root,
+      env: {
+        ...process.env,
+        GEMINI_API_KEY: "child-gemini-secret",
+        GOOGLE_API_KEY: "child-google-secret",
+        OPENCLAW_ACPX_ENV_PROBE: "preserved",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+    const launched = JSON.parse(stdout.trim()) as {
+      argv?: unknown;
+      geminiApiKey?: unknown;
+      googleApiKey?: unknown;
+      inheritedProbe?: unknown;
+    };
+    expect(launched.argv).toEqual(["--acp"]);
+    expect(launched.geminiApiKey).toBeNull();
+    expect(launched.googleApiKey).toBeNull();
+    expect(launched.inheritedProbe).toBe("preserved");
+    expect(process.env.GEMINI_API_KEY).toBe("parent-gemini-secret");
+    expect(process.env.GOOGLE_API_KEY).toBe("parent-google-secret");
+  });
+
   it("does not copy source Codex auth", async () => {
     const root = await makeTempDir();
     const sourceCodexHome = path.join(root, "source-codex");
@@ -663,21 +782,21 @@ describe("prepareAcpxCodexAuthConfig", () => {
       stderrScript,
       `const chunks = [
         "token=sk-test",
-        "secret1234567890\\n",
+        "secret1234567890\n",
         "Authorization: Bearer bearer-secret",
-        "-token-1234567890\\n",
-        '{"client_secret":"json-secret-1234567890","api_key":"json-api-key-1234567890"}\\n',
-        "client-secret: kebab-secret-1234567890\\n",
+        "-token-1234567890\n",
+        '{"client_secret":"json-secret-1234567890","api_key":"json-api-key-1234567890"}\n',
+        "client-secret: kebab-secret-1234567890\n",
         "standalone sk-live-secret",
-        "1234567890\\n",
+        "1234567890\n",
         "url=https://example.test/callback?token=query-secret",
-        "-1234567890\\n",
+        "-1234567890\n",
         "github_pat_1234567890",
-        "abcdefghijklmnopqrstuvwxyz\\n",
-        "-----BEGIN PRIVATE KEY-----\\nprivate-secret-body\\n",
-        "-----END PRIVATE KEY-----\\n",
+        "abcdefghijklmnopqrstuvwxyz\n",
+        "-----BEGIN PRIVATE KEY-----\nprivate-secret-body\n",
+        "-----END PRIVATE KEY-----\n",
         "tail-token=tail-secret-1234567890",
-        "\\n-----BEGIN PRIVATE KEY-----\\ntruncated-private-secret",
+        "\n-----BEGIN PRIVATE KEY-----\ntruncated-private-secret",
       ];
       let index = 0;
       function writeNext() {
@@ -749,6 +868,31 @@ describe("prepareAcpxCodexAuthConfig", () => {
     await expectPathMissing(path.join(stateDir, "acpx", "codex-acp-wrapper.stderr.log"));
   });
 
+  it("normalizes an explicitly configured Gemini ACP command to the local env-stripping wrapper", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedGeminiPaths(stateDir);
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {
+        agents: {
+          gemini: {
+            command: "gemini --acp --model gemini-3.1-pro-preview",
+          },
+        },
+      },
+      workspaceDir: root,
+    });
+
+    const resolved = await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+    });
+
+    expectGeminiWrapperCommand(resolved.agents.gemini, generated.wrapperPath);
+    expect(resolved.agents.gemini).toContain("--acp");
+    expect(resolved.agents.gemini).toContain("--model");
+    expect(resolved.agents.gemini).toContain("gemini-3.1-pro-preview");
+  });
   it("leaves a custom Claude agent command alone", async () => {
     const root = await makeTempDir();
     const stateDir = path.join(root, "state");

--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -16,6 +16,8 @@ const previousEnv = {
   CODEX_HOME: process.env.CODEX_HOME,
   GEMINI_API_KEY: process.env.GEMINI_API_KEY,
   GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+  GOOGLE_GENAI_USE_GCA: process.env.GOOGLE_GENAI_USE_GCA,
+  GOOGLE_GENAI_USE_VERTEXAI: process.env.GOOGLE_GENAI_USE_VERTEXAI,
   OPENCLAW_AGENT_DIR: process.env.OPENCLAW_AGENT_DIR,
 };
 
@@ -111,6 +113,8 @@ afterEach(async () => {
   restoreEnv("CODEX_HOME");
   restoreEnv("GEMINI_API_KEY");
   restoreEnv("GOOGLE_API_KEY");
+  restoreEnv("GOOGLE_GENAI_USE_GCA");
+  restoreEnv("GOOGLE_GENAI_USE_VERTEXAI");
   restoreEnv("OPENCLAW_AGENT_DIR");
   for (const dir of tempDirs.splice(0)) {
     await fs.rm(dir, { recursive: true, force: true });
@@ -526,7 +530,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
     expect(process.env.ANTHROPIC_API_KEY).toBe("parent-secret");
   });
 
-  it("strips Gemini provider API keys only from the spawned ACP child env", async () => {
+  it("strips Gemini provider auth env only from the spawned ACP child env", async () => {
     const root = await makeTempDir();
     const stateDir = path.join(root, "state");
     const generated = generatedGeminiPaths(stateDir);
@@ -537,7 +541,16 @@ describe("prepareAcpxCodexAuthConfig", () => {
       geminiBinPath,
       [
         "#!/usr/bin/env node",
-        "console.log(JSON.stringify({ argv: process.argv.slice(2), geminiApiKey: process.env.GEMINI_API_KEY ?? null, googleApiKey: process.env.GOOGLE_API_KEY ?? null, inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null }));",
+        "console.log(",
+        "  JSON.stringify({",
+        "    argv: process.argv.slice(2),",
+        "    geminiApiKey: process.env.GEMINI_API_KEY ?? null,",
+        "    googleApiKey: process.env.GOOGLE_API_KEY ?? null,",
+        "    googleGenaiUseGca: process.env.GOOGLE_GENAI_USE_GCA ?? null,",
+        "    googleGenaiUseVertexai: process.env.GOOGLE_GENAI_USE_VERTEXAI ?? null,",
+        "    inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null,",
+        "  }),",
+        ");",
         "",
       ].join("\n"),
       "utf8",
@@ -545,6 +558,8 @@ describe("prepareAcpxCodexAuthConfig", () => {
     await fs.chmod(geminiBinPath, 0o755);
     process.env.GEMINI_API_KEY = "parent-gemini-secret";
     process.env.GOOGLE_API_KEY = "parent-google-secret";
+    process.env.GOOGLE_GENAI_USE_GCA = "parent-gca-selector";
+    process.env.GOOGLE_GENAI_USE_VERTEXAI = "parent-vertex-selector";
     const pluginConfig = resolveAcpxPluginConfig({
       rawConfig: {},
       workspaceDir: root,
@@ -561,6 +576,8 @@ describe("prepareAcpxCodexAuthConfig", () => {
         ...process.env,
         GEMINI_API_KEY: "child-gemini-secret",
         GOOGLE_API_KEY: "child-google-secret",
+        GOOGLE_GENAI_USE_GCA: "child-gca-selector",
+        GOOGLE_GENAI_USE_VERTEXAI: "child-vertex-selector",
         OPENCLAW_ACPX_ENV_PROBE: "preserved",
         PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -569,14 +586,20 @@ describe("prepareAcpxCodexAuthConfig", () => {
       argv?: unknown;
       geminiApiKey?: unknown;
       googleApiKey?: unknown;
+      googleGenaiUseGca?: unknown;
+      googleGenaiUseVertexai?: unknown;
       inheritedProbe?: unknown;
     };
     expect(launched.argv).toEqual(["--acp"]);
     expect(launched.geminiApiKey).toBeNull();
     expect(launched.googleApiKey).toBeNull();
+    expect(launched.googleGenaiUseGca).toBeNull();
+    expect(launched.googleGenaiUseVertexai).toBeNull();
     expect(launched.inheritedProbe).toBe("preserved");
     expect(process.env.GEMINI_API_KEY).toBe("parent-gemini-secret");
     expect(process.env.GOOGLE_API_KEY).toBe("parent-google-secret");
+    expect(process.env.GOOGLE_GENAI_USE_GCA).toBe("parent-gca-selector");
+    expect(process.env.GOOGLE_GENAI_USE_VERTEXAI).toBe("parent-vertex-selector");
   });
 
   it("does not copy source Codex auth", async () => {
@@ -782,21 +805,21 @@ describe("prepareAcpxCodexAuthConfig", () => {
       stderrScript,
       `const chunks = [
         "token=sk-test",
-        "secret1234567890\n",
+        "secret1234567890\\n",
         "Authorization: Bearer bearer-secret",
-        "-token-1234567890\n",
-        '{"client_secret":"json-secret-1234567890","api_key":"json-api-key-1234567890"}\n',
-        "client-secret: kebab-secret-1234567890\n",
+        "-token-1234567890\\n",
+        '{"client_secret":"json-secret-1234567890","api_key":"json-api-key-1234567890"}\\n',
+        "client-secret: kebab-secret-1234567890\\n",
         "standalone sk-live-secret",
-        "1234567890\n",
+        "1234567890\\n",
         "url=https://example.test/callback?token=query-secret",
-        "-1234567890\n",
+        "-1234567890\\n",
         "github_pat_1234567890",
-        "abcdefghijklmnopqrstuvwxyz\n",
-        "-----BEGIN PRIVATE KEY-----\nprivate-secret-body\n",
-        "-----END PRIVATE KEY-----\n",
+        "abcdefghijklmnopqrstuvwxyz\\n",
+        "-----BEGIN PRIVATE KEY-----\\nprivate-secret-body\\n",
+        "-----END PRIVATE KEY-----\\n",
         "tail-token=tail-secret-1234567890",
-        "\n-----BEGIN PRIVATE KEY-----\ntruncated-private-secret",
+        "\\n-----BEGIN PRIVATE KEY-----\\ntruncated-private-secret",
       ];
       let index = 0;
       function writeNext() {

--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -6,20 +6,23 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { prepareAcpxCodexAuthConfig } from "./codex-auth-bridge.js";
+import { splitCommandParts } from "./command-line.js";
 import { resolveAcpxPluginConfig } from "./config.js";
 import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./process-lease.js";
 
 const execFileAsync = promisify(execFile);
 const tempDirs: string[] = [];
-const GEMINI_AUTH_ENV_PRESERVE_FLAG = "OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV";
 const previousEnv = {
+  ACPX_AUTH_CODEX_API_KEY: process.env.ACPX_AUTH_CODEX_API_KEY,
+  ACPX_AUTH_OPENAI_API_KEY: process.env.ACPX_AUTH_OPENAI_API_KEY,
   ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+  CODEX_API_KEY: process.env.CODEX_API_KEY,
   CODEX_HOME: process.env.CODEX_HOME,
   GEMINI_API_KEY: process.env.GEMINI_API_KEY,
   GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
   GOOGLE_GENAI_USE_GCA: process.env.GOOGLE_GENAI_USE_GCA,
   GOOGLE_GENAI_USE_VERTEXAI: process.env.GOOGLE_GENAI_USE_VERTEXAI,
-  OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV: process.env.OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   OPENCLAW_AGENT_DIR: process.env.OPENCLAW_AGENT_DIR,
 };
 
@@ -131,7 +134,10 @@ async function writeVersionedFakeGeminiBin(
       "    googleApiKey: process.env.GOOGLE_API_KEY ?? null,",
       "    googleGenaiUseGca: process.env.GOOGLE_GENAI_USE_GCA ?? null,",
       "    googleGenaiUseVertexai: process.env.GOOGLE_GENAI_USE_VERTEXAI ?? null,",
-      `    preserveFlag: process.env.${GEMINI_AUTH_ENV_PRESERVE_FLAG} ?? null,`,
+      "    codexApiKey: process.env.CODEX_API_KEY ?? null,",
+      "    openaiApiKey: process.env.OPENAI_API_KEY ?? null,",
+      "    acpxAuthCodexApiKey: process.env.ACPX_AUTH_CODEX_API_KEY ?? null,",
+      "    acpxAuthOpenaiApiKey: process.env.ACPX_AUTH_OPENAI_API_KEY ?? null,",
       "    inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null,",
       "  }),",
       ");",
@@ -145,13 +151,16 @@ async function writeVersionedFakeGeminiBin(
 
 afterEach(async () => {
   vi.restoreAllMocks();
+  restoreEnv("ACPX_AUTH_CODEX_API_KEY");
+  restoreEnv("ACPX_AUTH_OPENAI_API_KEY");
   restoreEnv("ANTHROPIC_API_KEY");
+  restoreEnv("CODEX_API_KEY");
   restoreEnv("CODEX_HOME");
   restoreEnv("GEMINI_API_KEY");
   restoreEnv("GOOGLE_API_KEY");
   restoreEnv("GOOGLE_GENAI_USE_GCA");
   restoreEnv("GOOGLE_GENAI_USE_VERTEXAI");
-  restoreEnv("OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV");
+  restoreEnv("OPENAI_API_KEY");
   restoreEnv("OPENCLAW_AGENT_DIR");
   for (const dir of tempDirs.splice(0)) {
     await fs.rm(dir, { recursive: true, force: true });
@@ -528,14 +537,30 @@ describe("prepareAcpxCodexAuthConfig", () => {
     expect(launched.codexHome).toBeNull();
   });
 
-  it("strips Claude provider API keys only from the spawned ACP child env", async () => {
+  it("preserves Claude provider env while stripping toxic Codex bridge env", async () => {
     const root = await makeTempDir();
     const stateDir = path.join(root, "state");
     const generated = generatedClaudePaths(stateDir);
     const installedBinPath = path.join(root, "claude-agent-acp-bin.js");
     await fs.writeFile(
       installedBinPath,
-      "console.log(JSON.stringify({ anthropicApiKey: process.env.ANTHROPIC_API_KEY ?? null, inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null }));\n",
+      [
+        "console.log(",
+        "  JSON.stringify({",
+        "    acpxAuthCodexApiKey: process.env.ACPX_AUTH_CODEX_API_KEY ?? null,",
+        "    acpxAuthOpenaiApiKey: process.env.ACPX_AUTH_OPENAI_API_KEY ?? null,",
+        "    anthropicApiKey: process.env.ANTHROPIC_API_KEY ?? null,",
+        "    codeAcceptEnv: process.env.CLAUDE_CODE_ACCEPT ?? null,",
+        "    codexApiKey: process.env.CODEX_API_KEY ?? null,",
+        "    home: process.env.HOME ?? null,",
+        "    openaiApiKey: process.env.OPENAI_API_KEY ?? null,",
+        "    path: process.env.PATH ?? null,",
+        "    customFlag: process.env.PROVIDER_CUSTOM_FLAG ?? null,",
+        "    inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null,",
+        "  }),",
+        ");",
+        "",
+      ].join("\n"),
       "utf8",
     );
     process.env.ANTHROPIC_API_KEY = "parent-secret";
@@ -550,24 +575,49 @@ describe("prepareAcpxCodexAuthConfig", () => {
       resolveInstalledClaudeAcpBinPath: async () => installedBinPath,
     });
 
+    const childPath = `${root}${path.delimiter}${process.env.PATH ?? ""}`;
     const { stdout } = await execFileAsync(process.execPath, [generated.wrapperPath], {
       cwd: root,
       env: {
         ...process.env,
+        ACPX_AUTH_CODEX_API_KEY: "bridge-codex-secret",
+        ACPX_AUTH_OPENAI_API_KEY: "bridge-openai-secret",
         ANTHROPIC_API_KEY: "child-secret",
+        CLAUDE_CODE_ACCEPT: "yes",
+        CODEX_API_KEY: "codex-secret",
+        HOME: root,
+        OPENAI_API_KEY: "openai-secret",
         OPENCLAW_ACPX_ENV_PROBE: "preserved",
+        PATH: childPath,
+        PROVIDER_CUSTOM_FLAG: "intentional",
       },
     });
     const launched = JSON.parse(stdout.trim()) as {
+      acpxAuthCodexApiKey?: unknown;
+      acpxAuthOpenaiApiKey?: unknown;
       anthropicApiKey?: unknown;
+      codeAcceptEnv?: unknown;
+      codexApiKey?: unknown;
+      home?: unknown;
+      openaiApiKey?: unknown;
+      path?: unknown;
+      customFlag?: unknown;
       inheritedProbe?: unknown;
     };
-    expect(launched.anthropicApiKey).toBeNull();
+    expect(launched.acpxAuthCodexApiKey).toBeNull();
+    expect(launched.acpxAuthOpenaiApiKey).toBeNull();
+    expect(launched.anthropicApiKey).toBe("child-secret");
+    expect(launched.codeAcceptEnv).toBe("yes");
+    expect(launched.codexApiKey).toBeNull();
+    expect(launched.home).toBe(root);
+    expect(launched.openaiApiKey).toBeNull();
+    expect(launched.path).toBe(childPath);
+    expect(launched.customFlag).toBe("intentional");
     expect(launched.inheritedProbe).toBe("preserved");
     expect(process.env.ANTHROPIC_API_KEY).toBe("parent-secret");
   });
 
-  it("strips Gemini provider auth env only from the spawned ACP child env", async () => {
+  it("strips only toxic Codex bridge env from the spawned Gemini ACP child env", async () => {
     const root = await makeTempDir();
     const stateDir = path.join(root, "state");
     const generated = generatedGeminiPaths(stateDir);
@@ -585,7 +635,10 @@ describe("prepareAcpxCodexAuthConfig", () => {
         "    googleApiKey: process.env.GOOGLE_API_KEY ?? null,",
         "    googleGenaiUseGca: process.env.GOOGLE_GENAI_USE_GCA ?? null,",
         "    googleGenaiUseVertexai: process.env.GOOGLE_GENAI_USE_VERTEXAI ?? null,",
-        `    preserveFlag: process.env.${GEMINI_AUTH_ENV_PRESERVE_FLAG} ?? null,`,
+        "    codexApiKey: process.env.CODEX_API_KEY ?? null,",
+        "    openaiApiKey: process.env.OPENAI_API_KEY ?? null,",
+        "    acpxAuthCodexApiKey: process.env.ACPX_AUTH_CODEX_API_KEY ?? null,",
+        "    acpxAuthOpenaiApiKey: process.env.ACPX_AUTH_OPENAI_API_KEY ?? null,",
         "    inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null,",
         "  }),",
         ");",
@@ -614,8 +667,12 @@ describe("prepareAcpxCodexAuthConfig", () => {
         ...process.env,
         GEMINI_API_KEY: "child-gemini-secret",
         GOOGLE_API_KEY: "child-google-secret",
+        ACPX_AUTH_CODEX_API_KEY: "bridge-codex-secret",
+        ACPX_AUTH_OPENAI_API_KEY: "bridge-openai-secret",
+        CODEX_API_KEY: "codex-secret",
         GOOGLE_GENAI_USE_GCA: "child-gca-selector",
         GOOGLE_GENAI_USE_VERTEXAI: "child-vertex-selector",
+        OPENAI_API_KEY: "openai-secret",
         OPENCLAW_ACPX_ENV_PROBE: "preserved",
         PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -626,84 +683,10 @@ describe("prepareAcpxCodexAuthConfig", () => {
       googleApiKey?: unknown;
       googleGenaiUseGca?: unknown;
       googleGenaiUseVertexai?: unknown;
-      preserveFlag?: unknown;
-      inheritedProbe?: unknown;
-    };
-    expect(launched.argv).toEqual(["--acp"]);
-    expect(launched.geminiApiKey).toBeNull();
-    expect(launched.googleApiKey).toBeNull();
-    expect(launched.googleGenaiUseGca).toBeNull();
-    expect(launched.googleGenaiUseVertexai).toBeNull();
-    expect(launched.preserveFlag).toBeNull();
-    expect(launched.inheritedProbe).toBe("preserved");
-    expect(process.env.GEMINI_API_KEY).toBe("parent-gemini-secret");
-    expect(process.env.GOOGLE_API_KEY).toBe("parent-google-secret");
-    expect(process.env.GOOGLE_GENAI_USE_GCA).toBe("parent-gca-selector");
-    expect(process.env.GOOGLE_GENAI_USE_VERTEXAI).toBe("parent-vertex-selector");
-  });
-
-  it("preserves Gemini provider auth env when the explicit wrapper opt-in is set", async () => {
-    const root = await makeTempDir();
-    const stateDir = path.join(root, "state");
-    const generated = generatedGeminiPaths(stateDir);
-    const binDir = path.join(root, "bin");
-    await fs.mkdir(binDir, { recursive: true });
-    const geminiBinPath = path.join(binDir, "gemini");
-    await fs.writeFile(
-      geminiBinPath,
-      [
-        "#!/usr/bin/env node",
-        "console.log(",
-        "  JSON.stringify({",
-        "    argv: process.argv.slice(2),",
-        "    geminiApiKey: process.env.GEMINI_API_KEY ?? null,",
-        "    googleApiKey: process.env.GOOGLE_API_KEY ?? null,",
-        "    googleGenaiUseGca: process.env.GOOGLE_GENAI_USE_GCA ?? null,",
-        "    googleGenaiUseVertexai: process.env.GOOGLE_GENAI_USE_VERTEXAI ?? null,",
-        `    preserveFlag: process.env.${GEMINI_AUTH_ENV_PRESERVE_FLAG} ?? null,`,
-        "    inheritedProbe: process.env.OPENCLAW_ACPX_ENV_PROBE ?? null,",
-        "  }),",
-        ");",
-        "",
-      ].join("\n"),
-      "utf8",
-    );
-    await fs.chmod(geminiBinPath, 0o755);
-    process.env.GEMINI_API_KEY = "parent-gemini-secret";
-    process.env.GOOGLE_API_KEY = "parent-google-secret";
-    process.env.GOOGLE_GENAI_USE_GCA = "parent-gca-selector";
-    process.env.GOOGLE_GENAI_USE_VERTEXAI = "parent-vertex-selector";
-    process.env.OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV = "parent-preserve-flag";
-    const pluginConfig = resolveAcpxPluginConfig({
-      rawConfig: {},
-      workspaceDir: root,
-    });
-
-    await prepareAcpxCodexAuthConfig({
-      pluginConfig,
-      stateDir,
-    });
-
-    const { stdout } = await execFileAsync(process.execPath, [generated.wrapperPath], {
-      cwd: root,
-      env: {
-        ...process.env,
-        GEMINI_API_KEY: "child-gemini-secret",
-        GOOGLE_API_KEY: "child-google-secret",
-        GOOGLE_GENAI_USE_GCA: "child-gca-selector",
-        GOOGLE_GENAI_USE_VERTEXAI: "child-vertex-selector",
-        OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV: "1",
-        OPENCLAW_ACPX_ENV_PROBE: "preserved",
-        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-      },
-    });
-    const launched = JSON.parse(stdout.trim()) as {
-      argv?: unknown;
-      geminiApiKey?: unknown;
-      googleApiKey?: unknown;
-      googleGenaiUseGca?: unknown;
-      googleGenaiUseVertexai?: unknown;
-      preserveFlag?: unknown;
+      codexApiKey?: unknown;
+      openaiApiKey?: unknown;
+      acpxAuthCodexApiKey?: unknown;
+      acpxAuthOpenaiApiKey?: unknown;
       inheritedProbe?: unknown;
     };
     expect(launched.argv).toEqual(["--acp"]);
@@ -711,16 +694,18 @@ describe("prepareAcpxCodexAuthConfig", () => {
     expect(launched.googleApiKey).toBe("child-google-secret");
     expect(launched.googleGenaiUseGca).toBe("child-gca-selector");
     expect(launched.googleGenaiUseVertexai).toBe("child-vertex-selector");
-    expect(launched.preserveFlag).toBeNull();
+    expect(launched.codexApiKey).toBeNull();
+    expect(launched.openaiApiKey).toBeNull();
+    expect(launched.acpxAuthCodexApiKey).toBeNull();
+    expect(launched.acpxAuthOpenaiApiKey).toBeNull();
     expect(launched.inheritedProbe).toBe("preserved");
     expect(process.env.GEMINI_API_KEY).toBe("parent-gemini-secret");
     expect(process.env.GOOGLE_API_KEY).toBe("parent-google-secret");
     expect(process.env.GOOGLE_GENAI_USE_GCA).toBe("parent-gca-selector");
     expect(process.env.GOOGLE_GENAI_USE_VERTEXAI).toBe("parent-vertex-selector");
-    expect(process.env.OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV).toBe("parent-preserve-flag");
   });
 
-  it("keeps modern Gemini CLI on --acp while stripping provider auth env", async () => {
+  it("keeps modern Gemini CLI on --acp while preserving provider auth env", async () => {
     const root = await makeTempDir();
     const stateDir = path.join(root, "state");
     const generated = generatedGeminiPaths(stateDir);
@@ -745,8 +730,12 @@ describe("prepareAcpxCodexAuthConfig", () => {
         ...process.env,
         GEMINI_API_KEY: "child-gemini-secret",
         GOOGLE_API_KEY: "child-google-secret",
+        ACPX_AUTH_CODEX_API_KEY: "bridge-codex-secret",
+        ACPX_AUTH_OPENAI_API_KEY: "bridge-openai-secret",
+        CODEX_API_KEY: "codex-secret",
         GOOGLE_GENAI_USE_GCA: "child-gca-selector",
         GOOGLE_GENAI_USE_VERTEXAI: "child-vertex-selector",
+        OPENAI_API_KEY: "openai-secret",
         OPENCLAW_ACPX_ENV_PROBE: "preserved",
         PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -757,15 +746,21 @@ describe("prepareAcpxCodexAuthConfig", () => {
       googleApiKey?: unknown;
       googleGenaiUseGca?: unknown;
       googleGenaiUseVertexai?: unknown;
-      preserveFlag?: unknown;
+      codexApiKey?: unknown;
+      openaiApiKey?: unknown;
+      acpxAuthCodexApiKey?: unknown;
+      acpxAuthOpenaiApiKey?: unknown;
       inheritedProbe?: unknown;
     };
     expect(launched.argv).toEqual(["--acp"]);
-    expect(launched.geminiApiKey).toBeNull();
-    expect(launched.googleApiKey).toBeNull();
-    expect(launched.googleGenaiUseGca).toBeNull();
-    expect(launched.googleGenaiUseVertexai).toBeNull();
-    expect(launched.preserveFlag).toBeNull();
+    expect(launched.geminiApiKey).toBe("child-gemini-secret");
+    expect(launched.googleApiKey).toBe("child-google-secret");
+    expect(launched.googleGenaiUseGca).toBe("child-gca-selector");
+    expect(launched.googleGenaiUseVertexai).toBe("child-vertex-selector");
+    expect(launched.codexApiKey).toBeNull();
+    expect(launched.openaiApiKey).toBeNull();
+    expect(launched.acpxAuthCodexApiKey).toBeNull();
+    expect(launched.acpxAuthOpenaiApiKey).toBeNull();
     expect(launched.inheritedProbe).toBe("preserved");
     expect(process.env.GEMINI_API_KEY).toBe("parent-gemini-secret");
     expect(process.env.GOOGLE_API_KEY).toBe("parent-google-secret");
@@ -773,7 +768,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
     expect(process.env.GOOGLE_GENAI_USE_VERTEXAI).toBe("parent-vertex-selector");
   });
 
-  it("uses --experimental-acp for older Gemini CLI while preserving explicit env opt-in", async () => {
+  it("uses --experimental-acp for older Gemini CLI while preserving provider auth env", async () => {
     const root = await makeTempDir();
     const stateDir = path.join(root, "state");
     const generated = generatedGeminiPaths(stateDir);
@@ -782,7 +777,6 @@ describe("prepareAcpxCodexAuthConfig", () => {
     process.env.GOOGLE_API_KEY = "parent-google-secret";
     process.env.GOOGLE_GENAI_USE_GCA = "parent-gca-selector";
     process.env.GOOGLE_GENAI_USE_VERTEXAI = "parent-vertex-selector";
-    process.env.OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV = "parent-preserve-flag";
     const pluginConfig = resolveAcpxPluginConfig({
       rawConfig: {},
       workspaceDir: root,
@@ -799,9 +793,12 @@ describe("prepareAcpxCodexAuthConfig", () => {
         ...process.env,
         GEMINI_API_KEY: "child-gemini-secret",
         GOOGLE_API_KEY: "child-google-secret",
+        ACPX_AUTH_CODEX_API_KEY: "bridge-codex-secret",
+        ACPX_AUTH_OPENAI_API_KEY: "bridge-openai-secret",
+        CODEX_API_KEY: "codex-secret",
         GOOGLE_GENAI_USE_GCA: "child-gca-selector",
         GOOGLE_GENAI_USE_VERTEXAI: "child-vertex-selector",
-        OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV: "true",
+        OPENAI_API_KEY: "openai-secret",
         OPENCLAW_ACPX_ENV_PROBE: "preserved",
         PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -812,7 +809,10 @@ describe("prepareAcpxCodexAuthConfig", () => {
       googleApiKey?: unknown;
       googleGenaiUseGca?: unknown;
       googleGenaiUseVertexai?: unknown;
-      preserveFlag?: unknown;
+      codexApiKey?: unknown;
+      openaiApiKey?: unknown;
+      acpxAuthCodexApiKey?: unknown;
+      acpxAuthOpenaiApiKey?: unknown;
       inheritedProbe?: unknown;
     };
     expect(launched.argv).toEqual(["--experimental-acp"]);
@@ -820,13 +820,15 @@ describe("prepareAcpxCodexAuthConfig", () => {
     expect(launched.googleApiKey).toBe("child-google-secret");
     expect(launched.googleGenaiUseGca).toBe("child-gca-selector");
     expect(launched.googleGenaiUseVertexai).toBe("child-vertex-selector");
-    expect(launched.preserveFlag).toBeNull();
+    expect(launched.codexApiKey).toBeNull();
+    expect(launched.openaiApiKey).toBeNull();
+    expect(launched.acpxAuthCodexApiKey).toBeNull();
+    expect(launched.acpxAuthOpenaiApiKey).toBeNull();
     expect(launched.inheritedProbe).toBe("preserved");
     expect(process.env.GEMINI_API_KEY).toBe("parent-gemini-secret");
     expect(process.env.GOOGLE_API_KEY).toBe("parent-google-secret");
     expect(process.env.GOOGLE_GENAI_USE_GCA).toBe("parent-gca-selector");
     expect(process.env.GOOGLE_GENAI_USE_VERTEXAI).toBe("parent-vertex-selector");
-    expect(process.env.OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV).toBe("parent-preserve-flag");
   });
 
   it("does not copy source Codex auth", async () => {
@@ -1118,7 +1120,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
     await expectPathMissing(path.join(stateDir, "acpx", "codex-acp-wrapper.stderr.log"));
   });
 
-  it("normalizes an explicitly configured Gemini ACP command to the local env-stripping wrapper", async () => {
+  it("normalizes an explicitly configured Gemini ACP command to the local env-stripping wrapper without duplicating ACP flags", async () => {
     const root = await makeTempDir();
     const stateDir = path.join(root, "state");
     const generated = generatedGeminiPaths(stateDir);
@@ -1139,10 +1141,39 @@ describe("prepareAcpxCodexAuthConfig", () => {
     });
 
     expectGeminiWrapperCommand(resolved.agents.gemini, generated.wrapperPath);
-    expect(resolved.agents.gemini).toContain("--acp");
-    expect(resolved.agents.gemini).toContain("--model");
-    expect(resolved.agents.gemini).toContain("gemini-3.1-pro-preview");
+    const commandParts = splitCommandParts(resolved.agents.gemini ?? "");
+    expect(commandParts.filter((part) => part === "--acp")).toHaveLength(0);
+    expect(commandParts).toContain("--model");
+    expect(commandParts).toContain("gemini-3.1-pro-preview");
   });
+
+  it("removes legacy Gemini ACP flags from configured commands before wrapper launch", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedGeminiPaths(stateDir);
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {
+        agents: {
+          gemini: {
+            command: "gemini --experimental-acp --model gemini-3.1-pro-preview",
+          },
+        },
+      },
+      workspaceDir: root,
+    });
+
+    const resolved = await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+    });
+
+    expectGeminiWrapperCommand(resolved.agents.gemini, generated.wrapperPath);
+    const commandParts = splitCommandParts(resolved.agents.gemini ?? "");
+    expect(commandParts.filter((part) => part === "--experimental-acp")).toHaveLength(0);
+    expect(commandParts).toContain("--model");
+    expect(commandParts).toContain("gemini-3.1-pro-preview");
+  });
+
   it("leaves a custom Claude agent command alone", async () => {
     const root = await makeTempDir();
     const stateDir = path.join(root, "state");

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -26,7 +26,10 @@ const CODEX_ACP_BIN = "codex-acp";
 const CLAUDE_ACP_PACKAGE = "@agentclientprotocol/claude-agent-acp";
 const CLAUDE_ACP_BIN = "claude-agent-acp";
 const GEMINI_ACP_BIN = "gemini";
-const GEMINI_ACP_ARGS = ["--acp"];
+const GEMINI_ACP_ARG = "--acp";
+const GEMINI_LEGACY_ACP_ARG = "--experimental-acp";
+const GEMINI_STABLE_ACP_MIN_VERSION = [0, 33, 0] as const;
+const GEMINI_ACP_ARGS = [GEMINI_ACP_ARG];
 const RUN_CONFIGURED_COMMAND_SENTINEL = "--openclaw-run-configured";
 const OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV = "OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV";
 const requireFromHere = createRequire(import.meta.url);
@@ -260,11 +263,12 @@ function buildAdapterWrapperScript(params: {
   stderrLogFileNamePrefix?: string;
   stripEnvVars?: string[];
   preserveStrippedEnvVarsFlag?: string;
+  postCommandSetupScript?: string;
 }): string {
   return `#!/usr/bin/env node
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const providerEnvVarsToStrip = new Set([
@@ -479,7 +483,7 @@ if (installedBinPath) {
 }
 const command =
   configuredArgs[0] === "${RUN_CONFIGURED_COMMAND_SENTINEL}" ? configuredArgs[1] : defaultCommand;
-const args =
+let args =
   configuredArgs[0] === "${RUN_CONFIGURED_COMMAND_SENTINEL}"
     ? configuredArgs.slice(2)
     : [...defaultArgs, ...configuredArgs];
@@ -489,6 +493,7 @@ if (!command) {
   process.exit(1);
 }
 
+${params.postCommandSetupScript ?? ""}
 const child = spawn(command, args, {
   detached: process.platform !== "win32",
   env,
@@ -638,6 +643,62 @@ function buildClaudeAcpWrapperScript(installedBinPath?: string): string {
   });
 }
 
+function buildGeminiAcpFlagCompatibilityScript(): string {
+  return `
+const geminiStableAcpArg = ${quoteCommandPart(GEMINI_ACP_ARG)};
+const geminiLegacyAcpArg = ${quoteCommandPart(GEMINI_LEGACY_ACP_ARG)};
+const geminiStableAcpMinVersion = ${JSON.stringify(GEMINI_STABLE_ACP_MIN_VERSION)};
+
+function parseGeminiCliVersion(text) {
+  const match = String(text ?? "").match(/(?:^|\\D)(\\d+)\\.(\\d+)\\.(\\d+)(?:[-+][0-9A-Za-z.-]+)?(?:$|\\D)/);
+  if (!match) {
+    return undefined;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareSemverTuple(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    const delta = left[index] - right[index];
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+  return 0;
+}
+
+function shouldUseLegacyGeminiAcpArg() {
+  try {
+    const result = spawnSync(command, ["--version"], {
+      env,
+      encoding: "utf8",
+      timeout: 3_000,
+      windowsHide: true,
+    });
+    const versionText = [result.stdout, result.stderr].filter(Boolean).join("\\n");
+    const version = parseGeminiCliVersion(versionText);
+    return version ? compareSemverTuple(version, geminiStableAcpMinVersion) < 0 : false;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeGeminiAcpArgs(argsToNormalize) {
+  if (!argsToNormalize.includes(geminiStableAcpArg)) {
+    return argsToNormalize;
+  }
+  if (!shouldUseLegacyGeminiAcpArg()) {
+    return argsToNormalize;
+  }
+  return argsToNormalize.map((arg) =>
+    arg === geminiStableAcpArg ? geminiLegacyAcpArg : arg,
+  );
+}
+
+args = normalizeGeminiAcpArgs(args);
+`;
+}
+
 function buildGeminiAcpWrapperScript(): string {
   return buildAdapterWrapperScript({
     displayName: BUILT_IN_ACP_HARNESS_METADATA.gemini.displayName,
@@ -647,6 +708,7 @@ function buildGeminiAcpWrapperScript(): string {
     envSetup: `const env = createChildEnv(process.env);`,
     stripEnvVars: BUILT_IN_ACP_HARNESS_METADATA.gemini.stripEnvVars,
     preserveStrippedEnvVarsFlag: BUILT_IN_ACP_HARNESS_METADATA.gemini.preserveStrippedEnvVarsFlag,
+    postCommandSetupScript: buildGeminiAcpFlagCompatibilityScript(),
   });
 }
 

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -28,6 +28,7 @@ const CLAUDE_ACP_BIN = "claude-agent-acp";
 const GEMINI_ACP_BIN = "gemini";
 const GEMINI_ACP_ARGS = ["--acp"];
 const RUN_CONFIGURED_COMMAND_SENTINEL = "--openclaw-run-configured";
+const OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV = "OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV";
 const requireFromHere = createRequire(import.meta.url);
 
 type PackageManifest = {
@@ -39,6 +40,7 @@ type PackageManifest = {
 type BuiltInAcpHarnessMetadata = {
   displayName: string;
   stripEnvVars?: string[];
+  preserveStrippedEnvVarsFlag?: string;
 };
 
 const BUILT_IN_ACP_HARNESS_METADATA = {
@@ -54,6 +56,7 @@ const BUILT_IN_ACP_HARNESS_METADATA = {
       "GOOGLE_GENAI_USE_GCA",
       "GOOGLE_GENAI_USE_VERTEXAI",
     ],
+    preserveStrippedEnvVarsFlag: OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV,
   },
 } satisfies Record<string, BuiltInAcpHarnessMetadata>;
 
@@ -256,6 +259,7 @@ function buildAdapterWrapperScript(params: {
   envSetup: string;
   stderrLogFileNamePrefix?: string;
   stripEnvVars?: string[];
+  preserveStrippedEnvVarsFlag?: string;
 }): string {
   return `#!/usr/bin/env node
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -266,11 +270,24 @@ import { fileURLToPath } from "node:url";
 const providerEnvVarsToStrip = new Set([
   ${(params.stripEnvVars ?? []).map(quoteCommandPart).join(",\n  ")}
 ]);
+const preserveStrippedEnvVarsFlag = ${params.preserveStrippedEnvVarsFlag ? quoteCommandPart(params.preserveStrippedEnvVarsFlag) : "undefined"};
+
+function isTruthyEnvFlag(value) {
+  return /^(?:1|true|yes|on)$/i.test(String(value ?? "").trim());
+}
 
 function createChildEnv(sourceEnv) {
   const childEnv = { ...sourceEnv };
-  for (const name of providerEnvVarsToStrip) {
-    delete childEnv[name];
+  const preserveStrippedEnvVars = preserveStrippedEnvVarsFlag
+    ? isTruthyEnvFlag(sourceEnv[preserveStrippedEnvVarsFlag])
+    : false;
+  if (preserveStrippedEnvVarsFlag) {
+    delete childEnv[preserveStrippedEnvVarsFlag];
+  }
+  if (!preserveStrippedEnvVars) {
+    for (const name of providerEnvVarsToStrip) {
+      delete childEnv[name];
+    }
   }
   return childEnv;
 }
@@ -629,6 +646,7 @@ function buildGeminiAcpWrapperScript(): string {
     defaultArgs: GEMINI_ACP_ARGS,
     envSetup: `const env = createChildEnv(process.env);`,
     stripEnvVars: BUILT_IN_ACP_HARNESS_METADATA.gemini.stripEnvVars,
+    preserveStrippedEnvVarsFlag: BUILT_IN_ACP_HARNESS_METADATA.gemini.preserveStrippedEnvVarsFlag,
   });
 }
 

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -25,6 +25,8 @@ const CODEX_ACP_PACKAGE = "@zed-industries/codex-acp";
 const CODEX_ACP_BIN = "codex-acp";
 const CLAUDE_ACP_PACKAGE = "@agentclientprotocol/claude-agent-acp";
 const CLAUDE_ACP_BIN = "claude-agent-acp";
+const GEMINI_ACP_BIN = "gemini";
+const GEMINI_ACP_ARGS = ["--acp"];
 const RUN_CONFIGURED_COMMAND_SENTINEL = "--openclaw-run-configured";
 const requireFromHere = createRequire(import.meta.url);
 
@@ -33,6 +35,22 @@ type PackageManifest = {
   bin?: unknown;
   dependencies?: Record<string, unknown>;
 };
+
+type BuiltInAcpHarnessMetadata = {
+  displayName: string;
+  stripEnvVars?: string[];
+};
+
+const BUILT_IN_ACP_HARNESS_METADATA = {
+  claude: {
+    displayName: "Claude",
+    stripEnvVars: ["ANTHROPIC_API_KEY"],
+  },
+  gemini: {
+    displayName: "Gemini",
+    stripEnvVars: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+  },
+} satisfies Record<string, BuiltInAcpHarnessMetadata>;
 
 function readSelfManifest(): PackageManifest {
   const manifestPath = path.join(resolveAcpxPluginRoot(import.meta.url), "package.json");
@@ -225,17 +243,32 @@ function renderDiagnosticRedactionRuleSpecs(): string {
 
 function buildAdapterWrapperScript(params: {
   displayName: string;
-  packageSpec: string;
+  packageSpec?: string;
   binName: string;
   installedBinPath?: string;
+  defaultCommand?: string;
+  defaultArgs?: string[];
   envSetup: string;
   stderrLogFileNamePrefix?: string;
+  stripEnvVars?: string[];
 }): string {
   return `#!/usr/bin/env node
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+
+const providerEnvVarsToStrip = new Set([
+  ${(params.stripEnvVars ?? []).map(quoteCommandPart).join(",\n  ")}
+]);
+
+function createChildEnv(sourceEnv) {
+  const childEnv = { ...sourceEnv };
+  for (const name of providerEnvVarsToStrip) {
+    delete childEnv[name];
+  }
+  return childEnv;
+}
 
 ${params.envSetup}
 const stderrLogFileNamePrefix = ${params.stderrLogFileNamePrefix ? JSON.stringify(params.stderrLogFileNamePrefix) : "undefined"};
@@ -412,12 +445,15 @@ let defaultArgs;
 if (installedBinPath) {
   defaultCommand = process.execPath;
   defaultArgs = [installedBinPath];
-} else if (npmCliPath) {
+} else if (${params.packageSpec ? "true" : "false"} && npmCliPath) {
   defaultCommand = process.execPath;
-  defaultArgs = [npmCliPath, "exec", "--yes", "--package", "${params.packageSpec}", "--", "${params.binName}"];
-} else {
+  defaultArgs = [npmCliPath, "exec", "--yes", "--package", "${params.packageSpec ?? ""}", "--", "${params.binName}"];
+} else if (${params.packageSpec ? "true" : "false"}) {
   defaultCommand = process.platform === "win32" ? "npx.cmd" : "npx";
-  defaultArgs = ["--yes", "--package", "${params.packageSpec}", "--", "${params.binName}"];
+  defaultArgs = ["--yes", "--package", "${params.packageSpec ?? ""}", "--", "${params.binName}"];
+} else {
+  defaultCommand = ${params.defaultCommand ? quoteCommandPart(params.defaultCommand) : quoteCommandPart(params.binName)};
+  defaultArgs = [${(params.defaultArgs ?? []).map(quoteCommandPart).join(", ")}];
 }
 const command =
   configuredArgs[0] === "${RUN_CONFIGURED_COMMAND_SENTINEL}" ? configuredArgs[1] : defaultCommand;
@@ -562,7 +598,7 @@ if (shouldWriteCodexApiKeyAuth) {
   );
 }
 const env = {
-  ...process.env,
+  ...createChildEnv(process.env),
   CODEX_HOME: codexHome,
 };`,
   });
@@ -575,9 +611,19 @@ function buildClaudeAcpWrapperScript(installedBinPath?: string): string {
     packageSpec: `${CLAUDE_ACP_PACKAGE}@${CLAUDE_ACP_PACKAGE_VERSION}`,
     binName: CLAUDE_ACP_BIN,
     installedBinPath,
-    envSetup: `const env = {
-  ...process.env,
-};`,
+    envSetup: `const env = createChildEnv(process.env);`,
+    stripEnvVars: BUILT_IN_ACP_HARNESS_METADATA.claude.stripEnvVars,
+  });
+}
+
+function buildGeminiAcpWrapperScript(): string {
+  return buildAdapterWrapperScript({
+    displayName: BUILT_IN_ACP_HARNESS_METADATA.gemini.displayName,
+    binName: GEMINI_ACP_BIN,
+    defaultCommand: GEMINI_ACP_BIN,
+    defaultArgs: GEMINI_ACP_ARGS,
+    envSetup: `const env = createChildEnv(process.env);`,
+    stripEnvVars: BUILT_IN_ACP_HARNESS_METADATA.gemini.stripEnvVars,
   });
 }
 
@@ -637,6 +683,16 @@ async function writeClaudeAcpWrapper(baseDir: string, installedBinPath?: string)
   await fs.mkdir(baseDir, { recursive: true });
   const wrapperPath = path.join(baseDir, "claude-agent-acp-wrapper.mjs");
   await fs.writeFile(wrapperPath, buildClaudeAcpWrapperScript(installedBinPath), {
+    encoding: "utf8",
+  });
+  await makeGeneratedWrapperExecutableIfPossible(wrapperPath);
+  return wrapperPath;
+}
+
+async function writeGeminiAcpWrapper(baseDir: string): Promise<string> {
+  await fs.mkdir(baseDir, { recursive: true });
+  const wrapperPath = path.join(baseDir, "gemini-acp-wrapper.mjs");
+  await fs.writeFile(wrapperPath, buildGeminiAcpWrapperScript(), {
     encoding: "utf8",
   });
   await makeGeneratedWrapperExecutableIfPossible(wrapperPath);
@@ -728,6 +784,30 @@ function buildClaudeAcpWrapperCommand(wrapperPath: string, configuredCommand?: s
   return configuredCommand?.trim() || buildWrapperCommand(wrapperPath);
 }
 
+function buildDirectAcpWrapperCommand(params: {
+  wrapperPath: string;
+  configuredCommand?: string;
+  binName: string;
+}): string {
+  const trimmed = params.configuredCommand?.trim();
+  if (!trimmed) {
+    return buildWrapperCommand(params.wrapperPath);
+  }
+  const parts = splitCommandParts(trimmed);
+  if (isAcpBinName(parts[0] ?? "", params.binName)) {
+    return buildWrapperCommand(params.wrapperPath, parts.slice(1));
+  }
+  return trimmed;
+}
+
+function buildGeminiAcpWrapperCommand(wrapperPath: string, configuredCommand?: string): string {
+  return buildDirectAcpWrapperCommand({
+    wrapperPath,
+    configuredCommand,
+    binName: GEMINI_ACP_BIN,
+  });
+}
+
 /** Prepare ACPX agent commands and isolated auth homes for Codex/Claude adapters. */
 export async function prepareAcpxCodexAuthConfig(params: {
   pluginConfig: ResolvedAcpxPluginConfig;
@@ -750,8 +830,10 @@ export async function prepareAcpxCodexAuthConfig(params: {
   )();
   const wrapperPath = await writeCodexAcpWrapper(codexBaseDir, installedCodexBinPath);
   const claudeWrapperPath = await writeClaudeAcpWrapper(codexBaseDir, installedClaudeBinPath);
+  const geminiWrapperPath = await writeGeminiAcpWrapper(codexBaseDir);
   const configuredCodexCommand = params.pluginConfig.agents.codex;
   const configuredClaudeCommand = params.pluginConfig.agents.claude;
+  const configuredGeminiCommand = params.pluginConfig.agents.gemini;
 
   return {
     ...params.pluginConfig,
@@ -759,6 +841,7 @@ export async function prepareAcpxCodexAuthConfig(params: {
       ...params.pluginConfig.agents,
       codex: buildCodexAcpWrapperCommand(wrapperPath, configuredCodexCommand),
       claude: buildClaudeAcpWrapperCommand(claudeWrapperPath, configuredClaudeCommand),
+      gemini: buildGeminiAcpWrapperCommand(geminiWrapperPath, configuredGeminiCommand),
     },
   };
 }

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -48,7 +48,12 @@ const BUILT_IN_ACP_HARNESS_METADATA = {
   },
   gemini: {
     displayName: "Gemini",
-    stripEnvVars: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+    stripEnvVars: [
+      "GEMINI_API_KEY",
+      "GOOGLE_API_KEY",
+      "GOOGLE_GENAI_USE_GCA",
+      "GOOGLE_GENAI_USE_VERTEXAI",
+    ],
   },
 } satisfies Record<string, BuiltInAcpHarnessMetadata>;
 

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -31,7 +31,12 @@ const GEMINI_LEGACY_ACP_ARG = "--experimental-acp";
 const GEMINI_STABLE_ACP_MIN_VERSION = [0, 33, 0] as const;
 const GEMINI_ACP_ARGS = [GEMINI_ACP_ARG];
 const RUN_CONFIGURED_COMMAND_SENTINEL = "--openclaw-run-configured";
-const OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV = "OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV";
+const CODEX_AUTH_BRIDGE_ENV_VARS_TO_STRIP = [
+  "ACPX_AUTH_CODEX_API_KEY",
+  "ACPX_AUTH_OPENAI_API_KEY",
+  "CODEX_API_KEY",
+  "OPENAI_API_KEY",
+] as const;
 const requireFromHere = createRequire(import.meta.url);
 
 type PackageManifest = {
@@ -42,24 +47,17 @@ type PackageManifest = {
 
 type BuiltInAcpHarnessMetadata = {
   displayName: string;
-  stripEnvVars?: string[];
-  preserveStrippedEnvVarsFlag?: string;
+  alwaysStripEnvVars?: readonly string[];
 };
 
 const BUILT_IN_ACP_HARNESS_METADATA = {
   claude: {
     displayName: "Claude",
-    stripEnvVars: ["ANTHROPIC_API_KEY"],
+    alwaysStripEnvVars: CODEX_AUTH_BRIDGE_ENV_VARS_TO_STRIP,
   },
   gemini: {
     displayName: "Gemini",
-    stripEnvVars: [
-      "GEMINI_API_KEY",
-      "GOOGLE_API_KEY",
-      "GOOGLE_GENAI_USE_GCA",
-      "GOOGLE_GENAI_USE_VERTEXAI",
-    ],
-    preserveStrippedEnvVarsFlag: OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV,
+    alwaysStripEnvVars: CODEX_AUTH_BRIDGE_ENV_VARS_TO_STRIP,
   },
 } satisfies Record<string, BuiltInAcpHarnessMetadata>;
 
@@ -261,8 +259,7 @@ function buildAdapterWrapperScript(params: {
   defaultArgs?: string[];
   envSetup: string;
   stderrLogFileNamePrefix?: string;
-  stripEnvVars?: string[];
-  preserveStrippedEnvVarsFlag?: string;
+  alwaysStripEnvVars?: readonly string[];
   postCommandSetupScript?: string;
 }): string {
   return `#!/usr/bin/env node
@@ -271,27 +268,13 @@ import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-const providerEnvVarsToStrip = new Set([
-  ${(params.stripEnvVars ?? []).map(quoteCommandPart).join(",\n  ")}
+const envVarsToAlwaysStrip = new Set([
+  ${(params.alwaysStripEnvVars ?? []).map(quoteCommandPart).join(",\n  ")}
 ]);
-const preserveStrippedEnvVarsFlag = ${params.preserveStrippedEnvVarsFlag ? quoteCommandPart(params.preserveStrippedEnvVarsFlag) : "undefined"};
-
-function isTruthyEnvFlag(value) {
-  return /^(?:1|true|yes|on)$/i.test(String(value ?? "").trim());
-}
-
 function createChildEnv(sourceEnv) {
   const childEnv = { ...sourceEnv };
-  const preserveStrippedEnvVars = preserveStrippedEnvVarsFlag
-    ? isTruthyEnvFlag(sourceEnv[preserveStrippedEnvVarsFlag])
-    : false;
-  if (preserveStrippedEnvVarsFlag) {
-    delete childEnv[preserveStrippedEnvVarsFlag];
-  }
-  if (!preserveStrippedEnvVars) {
-    for (const name of providerEnvVarsToStrip) {
-      delete childEnv[name];
-    }
+  for (const name of envVarsToAlwaysStrip) {
+    delete childEnv[name];
   }
   return childEnv;
 }
@@ -594,6 +577,7 @@ function buildCodexAcpWrapperScript(installedBinPath?: string): string {
     binName: CODEX_ACP_BIN,
     installedBinPath,
     stderrLogFileNamePrefix: "codex-acp-wrapper.stderr",
+    alwaysStripEnvVars: CODEX_AUTH_BRIDGE_ENV_VARS_TO_STRIP,
     envSetup: `const codexHome = fileURLToPath(new URL("./codex-home/", import.meta.url));
 const codexAuthPath = fileURLToPath(new URL("./codex-home/auth.json", import.meta.url));
 const codexApiKey = (process.env.CODEX_API_KEY || process.env.OPENAI_API_KEY || "").trim();
@@ -639,7 +623,7 @@ function buildClaudeAcpWrapperScript(installedBinPath?: string): string {
     binName: CLAUDE_ACP_BIN,
     installedBinPath,
     envSetup: `const env = createChildEnv(process.env);`,
-    stripEnvVars: BUILT_IN_ACP_HARNESS_METADATA.claude.stripEnvVars,
+    alwaysStripEnvVars: BUILT_IN_ACP_HARNESS_METADATA.claude.alwaysStripEnvVars,
   });
 }
 
@@ -706,8 +690,7 @@ function buildGeminiAcpWrapperScript(): string {
     defaultCommand: GEMINI_ACP_BIN,
     defaultArgs: GEMINI_ACP_ARGS,
     envSetup: `const env = createChildEnv(process.env);`,
-    stripEnvVars: BUILT_IN_ACP_HARNESS_METADATA.gemini.stripEnvVars,
-    preserveStrippedEnvVarsFlag: BUILT_IN_ACP_HARNESS_METADATA.gemini.preserveStrippedEnvVarsFlag,
+    alwaysStripEnvVars: BUILT_IN_ACP_HARNESS_METADATA.gemini.alwaysStripEnvVars,
     postCommandSetupScript: buildGeminiAcpFlagCompatibilityScript(),
   });
 }
@@ -873,6 +856,7 @@ function buildDirectAcpWrapperCommand(params: {
   wrapperPath: string;
   configuredCommand?: string;
   binName: string;
+  dropConfiguredArgs?: readonly string[];
 }): string {
   const trimmed = params.configuredCommand?.trim();
   if (!trimmed) {
@@ -880,7 +864,8 @@ function buildDirectAcpWrapperCommand(params: {
   }
   const parts = splitCommandParts(trimmed);
   if (isAcpBinName(parts[0] ?? "", params.binName)) {
-    return buildWrapperCommand(params.wrapperPath, parts.slice(1));
+    const configuredArgs = parts.slice(1).filter((arg) => !params.dropConfiguredArgs?.includes(arg));
+    return buildWrapperCommand(params.wrapperPath, configuredArgs);
   }
   return trimmed;
 }
@@ -890,6 +875,7 @@ function buildGeminiAcpWrapperCommand(wrapperPath: string, configuredCommand?: s
     wrapperPath,
     configuredCommand,
     binName: GEMINI_ACP_BIN,
+    dropConfiguredArgs: [GEMINI_ACP_ARG, GEMINI_LEGACY_ACP_ARG],
   });
 }
 

--- a/extensions/acpx/src/process-reaper.ts
+++ b/extensions/acpx/src/process-reaper.ts
@@ -15,6 +15,7 @@ const requireFromHere = createRequire(import.meta.url);
 const GENERATED_WRAPPER_BASENAMES = new Set([
   "codex-acp-wrapper.mjs",
   "claude-agent-acp-wrapper.mjs",
+  "gemini-acp-wrapper.mjs",
 ]);
 const OPENCLAW_PLUGIN_DEPS_MARKER = "/plugin-runtime-deps/";
 const OWNED_ACP_PACKAGE_NAMES = [

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -204,7 +204,8 @@ function extractGeneratedWrapperPath(command: string | undefined): string {
     parts.find(
       (part) =>
         basename(part) === "codex-acp-wrapper.mjs" ||
-        basename(part) === "claude-agent-acp-wrapper.mjs",
+        basename(part) === "claude-agent-acp-wrapper.mjs" ||
+        basename(part) === "gemini-acp-wrapper.mjs",
     ) ?? ""
   );
 }

--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -219,6 +219,7 @@ WRAP
       run_setup_command npm install -g @google/gemini-cli
     fi
     if [ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GOOGLE_API_KEY:-}" ]; then
+      export OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV="${OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV:-1}"
       gemini_auth_type="gemini-api-key"
       if [ -z "${GEMINI_API_KEY:-}" ] && [ -n "${GOOGLE_API_KEY:-}" ]; then
         gemini_auth_type="vertex-ai"
@@ -400,6 +401,9 @@ for ACP_AGENT in "${ACP_AGENTS[@]}"; do
     -e OPENCLAW_LIVE_ACP_BIND_ANTHROPIC_API_KEY_OLD="${ANTHROPIC_API_KEY_OLD:-}" \
     -e GEMINI_API_KEY \
     -e GOOGLE_API_KEY \
+    -e GOOGLE_GENAI_USE_GCA \
+    -e GOOGLE_GENAI_USE_VERTEXAI \
+    -e OPENCLAW_ACPX_PRESERVE_GEMINI_AUTH_ENV \
     -e FACTORY_API_KEY \
     -e OPENAI_API_KEY \
     -e CODEX_API_KEY \


### PR DESCRIPTION
## Summary
- add built-in ACP harness metadata for provider API-key env vars that must be stripped before launching provider-owned child harnesses
- route the built-in Claude and Gemini ACP aliases through generated wrappers that delete only those provider API-key env vars from the spawned child process env
- keep the parent process env unchanged and keep Codex behavior as-is except for using the shared wrapper env-copy helper

Fixes #69260

## Notes
- Claude strips `ANTHROPIC_API_KEY` before launching `claude-agent-acp`.
- Gemini strips `GEMINI_API_KEY` and `GOOGLE_API_KEY` before launching `gemini --acp`.
- The strip list is applied inside the generated wrapper only, after copying `process.env`; unrelated env vars still pass through.
- Custom non-built-in commands are left alone. A broader user-configurable auth-contract schema and doctor/readiness warnings can be follow-ups if maintainers want that larger surface.

## Real behavior proof

- Behavior or issue addressed: generated ACPX child wrappers should prevent provider API-key and Gemini selector env fallback for built-in Claude and Gemini harnesses while preserving unrelated env and leaving the parent process env untouched.
- Real environment tested: disposable source checkout on Linux at PR head `21f655c6a7e61cea2a30158e813d7a7e8101d1de`, using generated OpenClaw ACPX wrappers and local child commands that print their received env.
- Exact steps or command run after this patch: generated Claude and Gemini wrappers from this branch, then ran a direct Node probe (`node --import tsx probe-acpx-env-strip.ts`) that launched the generated wrappers with dummy provider API-key env vars plus dummy Gemini selector env vars in the child environment, and captured child stdout plus parent env after launch.
- Evidence after fix (console output):

```text
Claude child stdout: {"ANTHROPIC_API_KEY":null,"OPENCLAW_ACPX_ENV_PROBE":"preserved"}
Gemini child stdout: {"argv":["--acp"],"GEMINI_API_KEY":null,"GOOGLE_API_KEY":null,"GOOGLE_GENAI_USE_GCA":null,"GOOGLE_GENAI_USE_VERTEXAI":null,"OPENCLAW_ACPX_ENV_PROBE":"preserved"}
Parent env after child launches: {"ANTHROPIC_API_KEY":"parent-dummy-anthropic","GEMINI_API_KEY":"parent-dummy-gemini","GOOGLE_API_KEY":"parent-dummy-google","GOOGLE_GENAI_USE_GCA":"parent-dummy-gca-selector","GOOGLE_GENAI_USE_VERTEXAI":"parent-dummy-vertex-selector"}
```

- Observed result after fix: child ACP harness env no longer contains provider API-key variables (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`) or Gemini selector variables (`GOOGLE_GENAI_USE_GCA`, `GOOGLE_GENAI_USE_VERTEXAI`); unrelated env still reaches the child; Gemini keeps the default `--acp` launch args; and the parent env remains available/non-mutated after both launches.
- What was not tested: no live provider login/session was exercised; doctor/readiness warnings and explicit API-key opt-in UX are intentionally deferred.

## Validation
- `git diff --check`
- `corepack pnpm exec oxfmt --check --threads=1 extensions/acpx/src/codex-auth-bridge.ts extensions/acpx/src/codex-auth-bridge.test.ts extensions/acpx/src/runtime.ts extensions/acpx/src/process-reaper.ts`
- `corepack pnpm exec vitest run --config test/vitest/vitest.extension-acpx.config.ts extensions/acpx`
- `corepack pnpm lint:extensions`
