### PR TITLE
fix(speech-core): add trustedLocalMedia to auto-TTS payload

### DIFF
--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -1847,6 +1847,7 @@ export async function maybeApplyTtsToPayload(params: {
     return {
       ...nextPayload,
       mediaUrl: result.audioPath,
+      trustedLocalMedia: true,
       audioAsVoice: result.audioAsVoice || params.payload.audioAsVoice,
       spokenText: textForAudio,
     };


### PR DESCRIPTION
## Summary

Auto-TTS (`maybeApplyTtsToPayload`) returns audio payloads without `trustedLocalMedia: true`, but the webchat embedding pipeline (`resolveLocalAudioFileForEmbedding` in `chat-webchat-media.ts`) requires this flag to serve local audio files to the Control UI. Without it, auto-TTS audio is silently dropped and never reaches webchat clients.

The `/tts` slash command already sets `trustedLocalMedia: true` in its media details (see `tts-tool.ts` line 99), so auto-TTS should match.

## Fix

Single line: add `trustedLocalMedia: true` to the auto-TTS return payload in `maybeApplyTtsToPayload`.

## Real behavior proof

**Setup:** OpenClaw 2026.5.7 with local Qwen3-TTS (OpenAI-compatible API) on CUDA, auto-TTS enabled (`messages.tts.auto: "always"`).

**Before:** Auto-TTS audio payloads lacked `trustedLocalMedia: true`. The `resolveLocalAudioFileForEmbedding` check (`payload.trustedLocalMedia !== true`) returned `null`, silently dropping audio from webchat messages. Telegram voice messages worked fine (different delivery path).

**After:** With the flag set, `resolveLocalAudioFileForEmbedding` proceeds, the local audio file is resolved, and audio reaches the Control UI for embedding.

**Observed:** Webchat audio playback works end-to-end after this change (combined with the companion content-block rendering fix in #2 below).

## Companion PR

This pairs with #2 (webchat audio content block rendering): the `trustedLocalMedia` flag gets audio into the embedding pipeline, and the content-block format change ensures the Control UI can actually render it.