### PR TITLE
fix(gateway): render webchat audio as URL attachments instead of base64 content blocks

### DIFF
--- a/src/gateway/server-methods/chat-webchat-media.test.ts
+++ b/src/gateway/server-methods/chat-webchat-media.test.ts
@@ -33,15 +33,12 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     expect(blocks).toHaveLength(1);
     const block = blocks[0] as {
       type?: string;
-      source?: { type?: string; media_type?: string; data?: string };
+      attachment?: { url?: string; kind?: string; label?: string; mimeType?: string };
     };
-    expect(block.type).toBe("audio");
-    expect(block.source?.type).toBe("base64");
-    expect(block.source?.media_type).toBe("audio/mpeg");
-    expect(block.source?.data?.includes("data:")).toBe(false);
-    expect(Buffer.from(block.source?.data ?? "", "base64")).toEqual(
-      Buffer.from([0xff, 0xfb, 0x90, 0x00]),
-    );
+    expect(block.type).toBe("attachment");
+    expect(block.attachment?.kind).toBe("audio");
+    expect(block.attachment?.url).toContain("clip.mp3");
+    expect(block.attachment?.mimeType).toBe("audio/mpeg");
   });
 
   it("suppresses reasoning payload audio", async () => {
@@ -113,7 +110,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     );
 
     expect(blocks).toHaveLength(1);
-    expect((blocks[0] as { type?: string }).type).toBe("audio");
+    expect((blocks[0] as { type?: string }).type).toBe("attachment");
   });
 
   it("drops tool-result file:// URLs with remote hosts before touching the filesystem", async () => {
@@ -171,7 +168,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     ]);
 
     expect(blocks).toHaveLength(1);
-    expect((blocks[0] as { type?: string }).type).toBe("audio");
+    expect((blocks[0] as { type?: string }).type).toBe("attachment");
   });
 
   it("skips local audio when the opened file stat is over the cap", async () => {

--- a/src/gateway/server-methods/chat-webchat-media.ts
+++ b/src/gateway/server-methods/chat-webchat-media.ts
@@ -103,18 +103,15 @@ async function readLocalAudioContentBlockForEmbedding(
     if (opened.stat.size > MAX_WEBCHAT_AUDIO_BYTES) {
       return null;
     }
-    const buf = await opened.handle.readFile();
-    if (buf.length > MAX_WEBCHAT_AUDIO_BYTES) {
-      return null;
-    }
     return {
       path: opened.realPath,
       block: {
-        type: "audio",
-        source: {
-          type: "base64",
-          media_type: mimeTypeForPath(opened.realPath),
-          data: buf.toString("base64"),
+        type: "attachment",
+        attachment: {
+          url: opened.realPath,
+          kind: "audio",
+          label: path.basename(opened.realPath),
+          mimeType: mimeTypeForPath(opened.realPath),
         },
       },
     };


### PR DESCRIPTION
## Summary

The Control UI message parser (`JT` function in the chat message handler) only renders content blocks of type `attachment` (with URL-based `kind: "audio"/"image"/"video"/"document"`), `canvas`, and `text`. Audio content blocks with `type: "audio"` and base64 source data were silently dropped — no `<audio>` element was created, no play button appeared, and audio never played.

This change modifies `readLocalAudioContentBlockForEmbedding` to return `type: "attachment"` objects with local file path URLs instead of `type: "audio"` base64 content blocks. The Control UI's media ticket system resolves local paths into playable URLs (via `/__openclaw__/assistant-media?source=...&mediaTicket=...`), enabling proper `<audio controls>` rendering.

## Changes

**`chat-webchat-media.ts`:**
- `readLocalAudioContentBlockForEmbedding` now returns `{ type: "attachment", attachment: { url, kind: "audio", label, mimeType } }` instead of `{ type: "audio", source: { type: "base64", ... } }`
- Removed the `readFile` + base64 encode step (no longer needed — file is not embedded inline)
- The 15MB file size check for `buf.length` is also removed (stat size check remains)

**`chat-webchat-media.test.ts`:**
- Updated 3 test assertions from `type: "audio"` with base64 source to `type: "attachment"` with attachment object

## Benefits

- Audio attachments now render with play controls in webchat
- Eliminates base64 payload overhead in WebSocket messages (was embedding up to 15MB of audio data per message)
- Consistent rendering path for all audio in webchat (auto-TTS and `/tts` command use the same attachment format)
- Backward compatible: old base64 content blocks are still handled by `chat-display-projection.ts` sanitization for any persisted messages

## Real behavior proof

**Setup:** OpenClaw 2026.5.7 with local Qwen3-TTS (OpenAI-compatible API) on CUDA, auto-TTS enabled (`messages.tts.auto: "always"`).

**Before:** Auto-TTS audio produced `{ type: "audio", source: { type: "base64", data: "..." } }` content blocks. The Control UI's `JT` function processes content arrays and handles `type: "attachment"`, `type: "canvas"`, and `type: "text"`, but falls through on unrecognized types. The `type: "audio"` block became `{ type: "audio", text: undefined, ... }` — no URL, no play button, no sound.

**After:** Audio is produced as `{ type: "attachment", attachment: { url: "/path/to/file.mp3", kind: "audio", ... } }`. The Control UI's attachment renderer handles this: `GT()` detects `kind: "audio"`, `GP()` generates a media ticket URL, and `<audio controls>` renders with the resolved URL.

**Observed:** Webchat shows audio player with play button, audio plays successfully on click.

## Companion PR

This pairs with #81203 (trustedLocalMedia flag for auto-TTS): that PR gets audio into the embedding pipeline, and this PR ensures the Control UI can actually render it.