### PR TITLE
fix(amazon-bedrock-mantle): dedupe the IAM token-failure diagnostic per region (#67288)

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -1,6 +1,20 @@
 // Amazon Bedrock Mantle tests cover discovery plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const discoveryDebugSpy = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/core")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "bedrock-mantle-discovery"
+        ? { ...logger, debug: discoveryDebugSpy }
+        : logger;
+    },
+  };
+});
+
 const {
   discoverMantleModels,
   generateBearerTokenFromIam,
@@ -74,6 +88,7 @@ describe("bedrock mantle discovery", () => {
   beforeEach(() => {
     process.env = { ...originalEnv };
     vi.restoreAllMocks();
+    discoveryDebugSpy.mockClear();
     resetMantleDiscoveryCacheForTest();
     resetIamTokenCacheForTest();
   });
@@ -190,6 +205,46 @@ describe("bedrock mantle discovery", () => {
     await expect(
       generateBearerTokenFromIam({ region: "us-east-1", tokenProviderFactory }),
     ).resolves.toBeUndefined();
+  });
+
+  it("logs a new IAM token failure after the credential chain recovers", async () => {
+    const tokenProviderFactory = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("first failure");
+      })
+      .mockImplementationOnce(() => async () => "recovered-token")
+      .mockImplementationOnce(() => {
+        throw new Error("later failure");
+      });
+
+    await generateBearerTokenFromIam({
+      region: "us-east-1",
+      now: () => 0,
+      tokenProviderFactory,
+    });
+    await generateBearerTokenFromIam({
+      region: "us-east-1",
+      now: () => 1,
+      tokenProviderFactory,
+    });
+    await generateBearerTokenFromIam({
+      region: "us-east-1",
+      now: () => 7200_001,
+      tokenProviderFactory,
+    });
+
+    expect(discoveryDebugSpy).toHaveBeenCalledTimes(2);
+    expect(discoveryDebugSpy).toHaveBeenNthCalledWith(
+      1,
+      "Mantle IAM token generation unavailable",
+      { region: "us-east-1", error: "first failure" },
+    );
+    expect(discoveryDebugSpy).toHaveBeenNthCalledWith(
+      2,
+      "Mantle IAM token generation unavailable",
+      { region: "us-east-1", error: "later failure" },
+    );
   });
 
   it("skips IAM token generation when plugin discovery is disabled", async () => {
@@ -594,17 +649,25 @@ describe("bedrock mantle discovery", () => {
     }
   });
 
-  it("returns null when no auth is available", async () => {
+  it("retries missing IAM credentials while logging once per region", async () => {
     const tokenProviderFactory = vi.fn(() => {
       throw new Error("no credentials");
     });
 
-    const provider = await resolveImplicitMantleProvider({
-      env: {} as NodeJS.ProcessEnv,
-      tokenProviderFactory,
-    });
+    for (const region of ["us-east-1", "us-east-1", "us-west-2"]) {
+      await expect(
+        resolveImplicitMantleProvider({
+          env: { AWS_REGION: region } as NodeJS.ProcessEnv,
+          tokenProviderFactory,
+        }),
+      ).resolves.toBeNull();
+    }
 
-    expect(provider).toBeNull();
+    expect(tokenProviderFactory).toHaveBeenCalledTimes(3);
+    expect(discoveryDebugSpy.mock.calls).toEqual([
+      ["Mantle IAM token generation unavailable", { region: "us-east-1", error: "no credentials" }],
+      ["Mantle IAM token generation unavailable", { region: "us-west-2", error: "no credentials" }],
+    ]);
   });
 
   it("uses a generated IAM token when no explicit token is set", async () => {

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -254,6 +254,96 @@ describe("bedrock mantle discovery", () => {
     );
   });
 
+  it("ignores an older failure that completes after a newer IAM token succeeds", async () => {
+    let rejectOlderFailure!: (error: Error) => void;
+    const olderFailure = new Promise<string>((_resolve, reject) => {
+      rejectOlderFailure = reject;
+    });
+    const tokenProviderFactory = vi
+      .fn()
+      .mockImplementationOnce(() => () => olderFailure)
+      .mockImplementationOnce(() => async () => "recovered-token")
+      .mockImplementationOnce(() => {
+        throw new Error("same failure");
+      });
+
+    const pendingOlderFailure = generateBearerTokenFromIam({
+      region: "us-east-1",
+      now: () => 0,
+      tokenProviderFactory,
+    });
+    await expect(
+      generateBearerTokenFromIam({
+        region: "us-east-1",
+        now: () => 1,
+        tokenProviderFactory,
+      }),
+    ).resolves.toBe("recovered-token");
+
+    rejectOlderFailure(new Error("same failure"));
+    await expect(pendingOlderFailure).resolves.toBeUndefined();
+    expect(discoveryDebugSpy).not.toHaveBeenCalled();
+
+    await generateBearerTokenFromIam({
+      region: "us-east-1",
+      now: () => 7_200_001,
+      tokenProviderFactory,
+    });
+
+    expect(discoveryDebugSpy).toHaveBeenCalledOnce();
+    expect(discoveryDebugSpy).toHaveBeenCalledWith("Mantle IAM token generation unavailable", {
+      region: "us-east-1",
+      error: "same failure",
+    });
+  });
+
+  it("ignores a newer failure that started before an older IAM token succeeds", async () => {
+    let resolveOlderSuccess!: (token: string) => void;
+    const olderSuccess = new Promise<string>((resolve) => {
+      resolveOlderSuccess = resolve;
+    });
+    let rejectNewerFailure!: (error: Error) => void;
+    const newerFailure = new Promise<string>((_resolve, reject) => {
+      rejectNewerFailure = reject;
+    });
+    const tokenProviderFactory = vi
+      .fn()
+      .mockImplementationOnce(() => () => olderSuccess)
+      .mockImplementationOnce(() => () => newerFailure)
+      .mockImplementationOnce(() => {
+        throw new Error("same failure");
+      });
+
+    const pendingOlderSuccess = generateBearerTokenFromIam({
+      region: "us-east-1",
+      now: () => 0,
+      tokenProviderFactory,
+    });
+    const pendingNewerFailure = generateBearerTokenFromIam({
+      region: "us-east-1",
+      now: () => 1,
+      tokenProviderFactory,
+    });
+
+    resolveOlderSuccess("recovered-token");
+    await expect(pendingOlderSuccess).resolves.toBe("recovered-token");
+    rejectNewerFailure(new Error("same failure"));
+    await expect(pendingNewerFailure).resolves.toBeUndefined();
+    expect(discoveryDebugSpy).not.toHaveBeenCalled();
+
+    await generateBearerTokenFromIam({
+      region: "us-east-1",
+      now: () => 7_200_001,
+      tokenProviderFactory,
+    });
+
+    expect(discoveryDebugSpy).toHaveBeenCalledOnce();
+    expect(discoveryDebugSpy).toHaveBeenCalledWith("Mantle IAM token generation unavailable", {
+      region: "us-east-1",
+      error: "same failure",
+    });
+  });
+
   it("logs when the IAM token failure cause changes before recovery", async () => {
     const tokenProviderFactory = vi
       .fn()

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -218,11 +218,11 @@ describe("bedrock mantle discovery", () => {
     const tokenProviderFactory = vi
       .fn()
       .mockImplementationOnce(() => {
-        throw new Error("first failure");
+        throw new Error("same failure");
       })
       .mockImplementationOnce(() => async () => "recovered-token")
       .mockImplementationOnce(() => {
-        throw new Error("later failure");
+        throw new Error("same failure");
       });
 
     await generateBearerTokenFromIam({
@@ -245,13 +245,46 @@ describe("bedrock mantle discovery", () => {
     expect(discoveryDebugSpy).toHaveBeenNthCalledWith(
       1,
       "Mantle IAM token generation unavailable",
-      { region: "us-east-1", error: "first failure" },
+      { region: "us-east-1", error: "same failure" },
     );
     expect(discoveryDebugSpy).toHaveBeenNthCalledWith(
       2,
       "Mantle IAM token generation unavailable",
-      { region: "us-east-1", error: "later failure" },
+      { region: "us-east-1", error: "same failure" },
     );
+  });
+
+  it("logs when the IAM token failure cause changes before recovery", async () => {
+    const tokenProviderFactory = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("credentials unavailable");
+      })
+      .mockImplementationOnce(() => {
+        throw new Error("credentials expired");
+      })
+      .mockImplementationOnce(() => {
+        throw new Error("credentials expired");
+      });
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await generateBearerTokenFromIam({
+        region: "us-east-1",
+        tokenProviderFactory,
+      });
+    }
+
+    expect(tokenProviderFactory).toHaveBeenCalledTimes(3);
+    expect(discoveryDebugSpy.mock.calls).toEqual([
+      [
+        "Mantle IAM token generation unavailable",
+        { region: "us-east-1", error: "credentials unavailable" },
+      ],
+      [
+        "Mantle IAM token generation unavailable",
+        { region: "us-east-1", error: "credentials expired" },
+      ],
+    ]);
   });
 
   it("logs an ongoing IAM token failure after debug becomes enabled", async () => {
@@ -682,7 +715,7 @@ describe("bedrock mantle discovery", () => {
     }
   });
 
-  it("retries missing IAM credentials while logging once per region", async () => {
+  it("retries identical IAM failures while logging once per region", async () => {
     const tokenProviderFactory = vi.fn(() => {
       throw new Error("no credentials");
     });

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const discoveryDebugSpy = vi.hoisted(() => vi.fn());
+const discoveryLoggerState = vi.hoisted(() => ({ debugEnabled: true }));
 vi.mock("openclaw/plugin-sdk/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/core")>();
   return {
@@ -9,7 +10,12 @@ vi.mock("openclaw/plugin-sdk/core", async (importOriginal) => {
     createSubsystemLogger: (subsystem: string) => {
       const logger = actual.createSubsystemLogger(subsystem);
       return subsystem === "bedrock-mantle-discovery"
-        ? { ...logger, debug: discoveryDebugSpy }
+        ? {
+            ...logger,
+            debug: discoveryDebugSpy,
+            isEnabled: (...args: Parameters<typeof logger.isEnabled>) =>
+              args[0] === "debug" ? discoveryLoggerState.debugEnabled : logger.isEnabled(...args),
+          }
         : logger;
     },
   };
@@ -89,6 +95,7 @@ describe("bedrock mantle discovery", () => {
     process.env = { ...originalEnv };
     vi.restoreAllMocks();
     discoveryDebugSpy.mockClear();
+    discoveryLoggerState.debugEnabled = true;
     resetMantleDiscoveryCacheForTest();
     resetIamTokenCacheForTest();
   });
@@ -245,6 +252,32 @@ describe("bedrock mantle discovery", () => {
       "Mantle IAM token generation unavailable",
       { region: "us-east-1", error: "later failure" },
     );
+  });
+
+  it("logs an ongoing IAM token failure after debug becomes enabled", async () => {
+    const tokenProviderFactory = vi.fn(() => {
+      throw new Error("no credentials");
+    });
+
+    discoveryLoggerState.debugEnabled = false;
+    await generateBearerTokenFromIam({
+      region: "us-east-1",
+      tokenProviderFactory,
+    });
+    expect(discoveryDebugSpy).not.toHaveBeenCalled();
+
+    discoveryLoggerState.debugEnabled = true;
+    await generateBearerTokenFromIam({
+      region: "us-east-1",
+      tokenProviderFactory,
+    });
+
+    expect(tokenProviderFactory).toHaveBeenCalledTimes(2);
+    expect(discoveryDebugSpy).toHaveBeenCalledOnce();
+    expect(discoveryDebugSpy).toHaveBeenCalledWith("Mantle IAM token generation unavailable", {
+      region: "us-east-1",
+      error: "no credentials",
+    });
   });
 
   it("skips IAM token generation when plugin discovery is disabled", async () => {

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -116,6 +116,8 @@ export function resolveMantleBearerToken(env: NodeJS.ProcessEnv = process.env): 
 
 /** Token cache for IAM-derived bearer tokens, keyed by region. */
 const iamTokenCache = new Map<string, { token: string; expiresAt: number }>();
+/** Regions whose current IAM token failure streak has already been logged. */
+const iamTokenFailureLogged = new Set<string>();
 const IAM_TOKEN_TTL_MS = 7200_000; // Matches the 2h token lifetime we request below.
 
 function resolveMantleRegion(env: NodeJS.ProcessEnv): string {
@@ -167,12 +169,17 @@ export async function generateBearerTokenFromIam(params: {
     if (expiresAt !== undefined) {
       iamTokenCache.set(params.region, { token, expiresAt });
     }
+    iamTokenFailureLogged.delete(params.region);
     return token;
   } catch (error) {
-    log.debug?.("Mantle IAM token generation unavailable", {
-      region: params.region,
-      error: formatErrorMessage(error),
-    });
+    // Keep retrying the credential chain, but collapse diagnostics until it recovers.
+    if (!iamTokenFailureLogged.has(params.region)) {
+      iamTokenFailureLogged.add(params.region);
+      log.debug?.("Mantle IAM token generation unavailable", {
+        region: params.region,
+        error: formatErrorMessage(error),
+      });
+    }
     return undefined;
   }
 }
@@ -225,6 +232,7 @@ export async function resolveMantleRuntimeBearerToken(params: {
 /** Clear the IAM token cache for tests. */
 export function resetIamTokenCacheForTest(): void {
   iamTokenCache.clear();
+  iamTokenFailureLogged.clear();
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -173,9 +173,9 @@ export async function generateBearerTokenFromIam(params: {
     return token;
   } catch (error) {
     // Keep retrying the credential chain, but collapse diagnostics until it recovers.
-    if (!iamTokenFailureLogged.has(params.region)) {
+    if (!iamTokenFailureLogged.has(params.region) && log.isEnabled("debug")) {
       iamTokenFailureLogged.add(params.region);
-      log.debug?.("Mantle IAM token generation unavailable", {
+      log.debug("Mantle IAM token generation unavailable", {
         region: params.region,
         error: formatErrorMessage(error),
       });

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -116,8 +116,8 @@ export function resolveMantleBearerToken(env: NodeJS.ProcessEnv = process.env): 
 
 /** Token cache for IAM-derived bearer tokens, keyed by region. */
 const iamTokenCache = new Map<string, { token: string; expiresAt: number }>();
-/** Regions whose current IAM token failure streak has already been logged. */
-const iamTokenFailureLogged = new Set<string>();
+/** Last emitted IAM token failure per region, retained until token generation succeeds. */
+const iamTokenFailureDetailByRegion = new Map<string, string>();
 const IAM_TOKEN_TTL_MS = 7200_000; // Matches the 2h token lifetime we request below.
 
 function resolveMantleRegion(env: NodeJS.ProcessEnv): string {
@@ -169,16 +169,19 @@ export async function generateBearerTokenFromIam(params: {
     if (expiresAt !== undefined) {
       iamTokenCache.set(params.region, { token, expiresAt });
     }
-    iamTokenFailureLogged.delete(params.region);
+    iamTokenFailureDetailByRegion.delete(params.region);
     return token;
   } catch (error) {
-    // Keep retrying the credential chain, but collapse diagnostics until it recovers.
-    if (!iamTokenFailureLogged.has(params.region) && log.isEnabled("debug")) {
-      iamTokenFailureLogged.add(params.region);
-      log.debug("Mantle IAM token generation unavailable", {
-        region: params.region,
-        error: formatErrorMessage(error),
-      });
+    // Keep retrying the credential chain while surfacing each distinct failure cause once.
+    if (log.isEnabled("debug")) {
+      const errorMessage = formatErrorMessage(error);
+      if (iamTokenFailureDetailByRegion.get(params.region) !== errorMessage) {
+        iamTokenFailureDetailByRegion.set(params.region, errorMessage);
+        log.debug("Mantle IAM token generation unavailable", {
+          region: params.region,
+          error: errorMessage,
+        });
+      }
     }
     return undefined;
   }
@@ -232,7 +235,7 @@ export async function resolveMantleRuntimeBearerToken(params: {
 /** Clear the IAM token cache for tests. */
 export function resetIamTokenCacheForTest(): void {
   iamTokenCache.clear();
-  iamTokenFailureLogged.clear();
+  iamTokenFailureDetailByRegion.clear();
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -118,6 +118,8 @@ export function resolveMantleBearerToken(env: NodeJS.ProcessEnv = process.env): 
 const iamTokenCache = new Map<string, { token: string; expiresAt: number }>();
 /** Last emitted IAM token failure per region, retained until token generation succeeds. */
 const iamTokenFailureDetailByRegion = new Map<string, string>();
+/** Success epoch per region; failures spanning a recovery cannot restore stale diagnostics. */
+const iamTokenSuccessEpochByRegion = new Map<string, number>();
 const IAM_TOKEN_TTL_MS = 7200_000; // Matches the 2h token lifetime we request below.
 
 function resolveMantleRegion(env: NodeJS.ProcessEnv): string {
@@ -158,6 +160,7 @@ export async function generateBearerTokenFromIam(params: {
     return cached.token;
   }
 
+  const successEpoch = iamTokenSuccessEpochByRegion.get(params.region) ?? 0;
   try {
     const getTokenProvider =
       params.tokenProviderFactory ?? (await loadMantleBearerTokenProviderFactory());
@@ -169,9 +172,16 @@ export async function generateBearerTokenFromIam(params: {
     if (expiresAt !== undefined) {
       iamTokenCache.set(params.region, { token, expiresAt });
     }
+    iamTokenSuccessEpochByRegion.set(
+      params.region,
+      (iamTokenSuccessEpochByRegion.get(params.region) ?? 0) + 1,
+    );
     iamTokenFailureDetailByRegion.delete(params.region);
     return token;
   } catch (error) {
+    if (successEpoch !== (iamTokenSuccessEpochByRegion.get(params.region) ?? 0)) {
+      return undefined;
+    }
     // Keep retrying the credential chain while surfacing each distinct failure cause once.
     if (log.isEnabled("debug")) {
       const errorMessage = formatErrorMessage(error);
@@ -236,6 +246,7 @@ export async function resolveMantleRuntimeBearerToken(params: {
 export function resetIamTokenCacheForTest(): void {
   iamTokenCache.clear();
   iamTokenFailureDetailByRegion.clear();
+  iamTokenSuccessEpochByRegion.clear();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What Problem This Solves

Fixes #67288. On hosts with no usable AWS credentials (Raspberry Pi installs, default Docker images), the `amazon-bedrock-mantle` plugin attempts IAM bearer-token generation on every implicit-discovery call and logs `[bedrock-mantle-discovery] Mantle IAM token generation unavailable` every time it fails.

## Why This Change Was Made

The fix dedupes consecutive identical formatted failure diagnostics per region instead of gating the IAM chain:

- `generateBearerTokenFromIam` keeps running the AWS default credential chain on every call. Hosts that rely on late-arriving credentials such as instance roles, IRSA, SSO, or shared profiles still start working as soon as the chain succeeds.
- Repeated identical formatted failures are quiet for that region, but a changed failure cause emits immediately.
- The last emitted detail is recorded only when debug logging actually emits, so enabling debug during an ongoing failure streak still produces one diagnostic.
- A successful token generation clears that region's last emitted detail, so the same failure logs again after recovery.
- In-flight failures that span a successful token generation cannot restore stale diagnostic state, regardless of which attempt started first.

An earlier revision short-circuited discovery when no AWS environment credentials were present. That approach was removed because it broke credential sources that are not visible in environment variables. The current diff adds no credential gate and no config surface.

**Operator-observability policy:** consecutive identical failures stay quiet, while a changed formatted failure cause is visible once per transition. This removes steady-state log flooding without hiding a new credential failure reason.

## User Impact

- Installs without AWS credentials see one diagnostic per region for consecutive identical failures instead of one per catalog refresh.
- A changed credential failure cause is logged without waiting for recovery or process restart.
- Hosts that enable debug after failures have already started still receive the next diagnostic.
- Hosts with working or late-arriving IAM chains keep retrying unchanged.
- Explicit `AWS_BEARER_TOKEN_BEDROCK` and `discovery.enabled: false` behavior is unchanged.

## Evidence

Validated commit: `256d92386ad9433c660cc8f0466c89a765124426`

### Exact-head sterile runtime proof

The proof ran in a fresh GWT at the exact PR head with an empty temporary `HOME`, nonexistent AWS config/credentials files, no AWS credential environment variables, and `AWS_EC2_METADATA_DISABLED=true`.

For real failure steps, the harness wrapped only to count invocations and delegated to the unmodified installed `@aws/bedrock-token-generator` provider. The dependency's real default credential chain produced the shown failure. A deterministic changed failure is injected twice to prove that a changed formatted cause emits once and an identical repeat stays quiet. The one redacted deterministic token is an explicit recovery event used only to prove that success resets the stored detail; the following failure delegates to the real chain again.

```text
head=256d92386ad9433c660cc8f0466c89a765124426
dependency=@aws/bedrock-token-generator@1.1.0
environment=sterile-empty-home,metadata-disabled,no-aws-credential-env
diagnostic_count_after_disabled_failure=0
logging_transition=debug-enabled
step=real-failure-debug-disabled result=undefined real_default_chain_calls=1
step=real-failure-2 result=undefined real_default_chain_calls=2
step=real-failure-3 result=undefined real_default_chain_calls=3
step=deterministic-changed-failure-1 result=undefined real_default_chain_calls=3
step=deterministic-changed-failure-2 result=undefined real_default_chain_calls=3
step=deterministic-recovery result=token-redacted real_default_chain_calls=3
step=real-failure-after-recovery result=undefined real_default_chain_calls=4
real_factory_calls=4
real_provider_calls=4
initial_failure_streak_diagnostic_count=1
after_changed_failure_diagnostic_count=2
after_recovery_diagnostic_count=2
diagnostic_count=3
diagnostic_1={"stream":"stdout","level":"debug","subsystem":"bedrock-mantle-discovery","message":"Mantle IAM token generation unavailable","region":"us-east-1","error":"Could not load credentials from any providers"}
diagnostic_2={"stream":"stdout","level":"debug","subsystem":"bedrock-mantle-discovery","message":"Mantle IAM token generation unavailable","region":"us-east-1","error":"deterministic changed credential failure"}
diagnostic_3={"stream":"stdout","level":"debug","subsystem":"bedrock-mantle-discovery","message":"Mantle IAM token generation unavailable","region":"us-east-1","error":"Could not load credentials from any providers"}
assertions={"exactHead":true,"disabledFailureSilent":true,"threeRepeatedFailures":true,"threeRealChainCallsBeforeRecovery":true,"changedFailureLoggedOnce":true,"recoverySucceeded":true,"postRecoveryRealFailure":true,"fourRealChainCallsTotal":true,"oneDiagnosticDuringInitialStreak":true,"noDiagnosticDuringRecovery":true,"diagnosticResetAfterRecovery":true,"sameRegionDiagnostics":true,"diagnosticCausesPreserved":true}
verdict=PASS
```

This proves:

- a real default-chain failure with debug disabled emits no diagnostic and does not consume the region's marker;
- enabling debug during the same failure streak makes the next real failure emit exactly once;
- three consecutive real default-chain failures in `us-east-1` still perform three provider calls;
- a changed formatted failure cause emits once, while its identical repeat stays quiet;
- deterministic recovery emits no failure diagnostic and clears the stored detail;
- the next real default-chain failure emits again even though its detail matches the pre-recovery failure.

### Dependency contract

Direct inspection of installed `@aws/bedrock-token-generator@1.1.0` confirmed:

- `dist/runtimeConfig.js` supplies `credentials: fromNodeProviderChain(...)` when no explicit credentials are provided;
- `dist/token.js` passes that credentials provider to Smithy `SignatureV4`, whose presign path resolves it;
- the installed AWS node provider chain covers environment, SSO, shared config/profile, process, web identity, and remote metadata sources.

### Automated proof

```text
node scripts/run-vitest.mjs extensions/amazon-bedrock-mantle/discovery.test.ts extensions/amazon-bedrock-mantle/index.test.ts
Test Files  2 passed (2)
Tests       45 passed (45)
```

- Two deferred completion-order regressions prove that a failure spanning a successful recovery emits nothing whether the failing attempt started first or second, and that the next identical post-expiry failure emits once.
- The sterile runtime transcript passed at the exact head.
- `git diff --check origin/main...HEAD` passed.
- Exact-head `oxfmt --check` and direct `oxlint` passed for both changed files.
- The signed four-commit series is based on `0ef19111929092718173f31b48090197e6bf9697`; the first three retain the prior range-diff result, and the fourth adds the success-epoch race fence plus both completion-order regressions.

Part of #67288.



Punchcard-Session: clear-orchard-lantern-bc
