### PR TITLE
fix(imessage): avoid visible media placeholder text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iMessage: stop sending visible `<media:image>` placeholder text for media-only native image sends while preserving the internal echo key that prevents self-echo duplicate replies. (#81209) Thanks @homer-byte.
 - Agents/sessions: create configured agent main sessions before first `sessions_send` or gateway send, so agent-to-agent messages no longer fail when the target agent has not started yet.
 - gateway: pass Talk session scope to resolver [AI]. (#81379) Thanks @pgondhi987.
 - Gateway protocol: require v4 clients and stream explicit chat `deltaText`/`replace` frames so SDK clients can consume assistant updates without local diffing. (#80725) Thanks @samzong.

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -237,11 +237,12 @@ describe("deliverReplies", () => {
     });
   });
 
-  it("records the actual sent placeholder for media-only replies", async () => {
+  it("records the internal echo key for media-only replies", async () => {
     const remember = vi.fn();
     sendMessageIMessageMock.mockResolvedValueOnce({
       messageId: "imsg-media-1",
-      sentText: "<media:image>",
+      sentText: "",
+      echoText: "<media:image>",
     });
 
     await deliverReplies({

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -58,7 +58,10 @@ export async function deliverReplies(params: {
         // not before. The window between send completion and cache write is sub-millisecond;
         // the next SQLite inbound poll is 1-2s away, so no echo can arrive before the
         // cache entry exists.
-        sentMessageCache?.remember(scope, { text: sent.sentText, messageId: sent.messageId });
+        sentMessageCache?.remember(scope, {
+          text: sent.echoText ?? sent.sentText,
+          messageId: sent.messageId,
+        });
       },
       sendMedia: async ({ mediaUrl, caption }) => {
         const sent = await sendMessageIMessage(target, caption ?? "", {
@@ -70,7 +73,7 @@ export async function deliverReplies(params: {
           replyToId: payload.replyToId,
         });
         sentMessageCache?.remember(scope, {
-          text: sent.sentText || undefined,
+          text: sent.echoText ?? (sent.sentText || undefined),
           messageId: sent.messageId,
         });
       },
@@ -94,7 +97,7 @@ export function createIMessageEchoCachingSend(params: {
     });
     const scope = `${params.accountId ?? opts.accountId ?? ""}:${target}`;
     params.sentMessageCache?.remember(scope, {
-      text: sent.sentText || undefined,
+      text: sent.echoText ?? (sent.sentText || undefined),
       messageId: sent.messageId,
     });
     return sent;

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -31,6 +31,7 @@ describe("sendMessageIMessage receipts", () => {
 
     expect(result.messageId).toBe("p:0/imsg-1");
     expect(result.sentText).toBe("hello");
+    expect(result.echoText).toBe("hello");
     expect(result.receipt.primaryPlatformMessageId).toBe("p:0/imsg-1");
     expect(result.receipt.platformMessageIds).toEqual(["p:0/imsg-1"]);
     expect(result.receipt.replyToId).toBe("reply-1");
@@ -71,6 +72,7 @@ describe("sendMessageIMessage receipts", () => {
 
     expect(result.messageId).toBe("12345");
     expect(result.sentText).toBe("");
+    expect(result.echoText).toBe("<media:image>");
     expect(result.receipt.primaryPlatformMessageId).toBe("12345");
     expect(result.receipt.platformMessageIds).toEqual(["12345"]);
     expect(client.request).toHaveBeenCalledWith(
@@ -115,6 +117,7 @@ describe("sendMessageIMessage receipts", () => {
     });
 
     expect(result.sentText).toBe("literal <media:image> text");
+    expect(result.echoText).toBe("literal <media:image> text");
     expect(client.request).toHaveBeenCalledWith(
       "send",
       expect.objectContaining({

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -70,9 +70,18 @@ describe("sendMessageIMessage receipts", () => {
     });
 
     expect(result.messageId).toBe("12345");
-    expect(result.sentText).toBe("<media:image>");
+    expect(result.sentText).toBe("");
     expect(result.receipt.primaryPlatformMessageId).toBe("12345");
     expect(result.receipt.platformMessageIds).toEqual(["12345"]);
+    expect(client.request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({
+        chat_guid: "chat-1",
+        file: "/tmp/image.png",
+        text: "",
+      }),
+      expect.any(Object),
+    );
     expect(result.receipt.raw).toEqual([
       {
         channel: "imessage",
@@ -95,6 +104,25 @@ describe("sendMessageIMessage receipts", () => {
       },
     ]);
     expect(result.receipt.sentAt).toBeGreaterThan(0);
+  });
+
+  it("preserves literal media placeholder text when no attachment is sent", async () => {
+    const client = createClient({ guid: "p:0/imsg-text" });
+
+    const result = await sendMessageIMessage("chat_id:42", "literal <media:image> text", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+    });
+
+    expect(result.sentText).toBe("literal <media:image> text");
+    expect(client.request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({
+        chat_id: 42,
+        text: "literal <media:image> text",
+      }),
+      expect.any(Object),
+    );
   });
 
   it("does not treat compatibility ok responses as visible platform ids", async () => {

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -6,7 +6,7 @@ import {
 } from "openclaw/plugin-sdk/channel-message";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
-import { resolveOutboundAttachmentFromUrl } from "openclaw/plugin-sdk/media-runtime";
+import { kindFromMime, resolveOutboundAttachmentFromUrl } from "openclaw/plugin-sdk/media-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
@@ -47,6 +47,7 @@ type IMessageSendOpts = {
 type IMessageSendResult = {
   messageId: string;
   sentText: string;
+  echoText?: string;
   receipt: MessageReceipt;
 };
 
@@ -91,6 +92,17 @@ function resolveMessageId(result: Record<string, unknown> | null | undefined): s
     (typeof result.message_id === "number" ? String(result.message_id) : null) ||
     (typeof result.id === "number" ? String(result.id) : null);
   return raw ? raw.trim() : null;
+}
+
+function resolveOutboundEchoText(text: string, mediaContentType?: string): string | undefined {
+  if (text.trim()) {
+    return text;
+  }
+  const kind = kindFromMime(mediaContentType ?? undefined);
+  if (!kind) {
+    return undefined;
+  }
+  return kind === "image" ? "<media:image>" : `<media:${kind}>`;
 }
 
 function createIMessageSendReceipt(params: {
@@ -175,6 +187,7 @@ export async function sendMessageIMessage(
         : 16 * 1024 * 1024;
   let message = text ?? "";
   let filePath: string | undefined;
+  let mediaContentType: string | undefined;
 
   if (opts.mediaUrl?.trim()) {
     const resolveAttachmentFn = opts.resolveAttachmentImpl ?? resolveOutboundAttachmentFromUrl;
@@ -183,6 +196,7 @@ export async function sendMessageIMessage(
       readFile: opts.mediaReadFile,
     });
     filePath = resolved.path;
+    mediaContentType = resolved.contentType ?? undefined;
   }
 
   if (!message.trim() && !filePath) {
@@ -211,6 +225,7 @@ export async function sendMessageIMessage(
   if (!message.trim() && !filePath) {
     throw new Error("iMessage send requires text or media");
   }
+  const echoText = resolveOutboundEchoText(message, filePath ? mediaContentType : undefined);
   const resolvedReplyToId = sanitizeReplyToId(opts.replyToId);
   const params: Record<string, unknown> = {
     text: message,
@@ -253,7 +268,7 @@ export async function sendMessageIMessage(
     if (echoScope) {
       rememberPersistedIMessageEcho({
         scope: echoScope,
-        text: message,
+        text: echoText,
         messageId: resolvedId ?? undefined,
       });
     }
@@ -280,6 +295,7 @@ export async function sendMessageIMessage(
     return {
       messageId,
       sentText: message,
+      ...(echoText ? { echoText } : {}),
       receipt: createIMessageSendReceipt({
         messageId,
         target,

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -6,7 +6,6 @@ import {
 } from "openclaw/plugin-sdk/channel-message";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
-import { kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import { resolveOutboundAttachmentFromUrl } from "openclaw/plugin-sdk/media-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
@@ -92,17 +91,6 @@ function resolveMessageId(result: Record<string, unknown> | null | undefined): s
     (typeof result.message_id === "number" ? String(result.message_id) : null) ||
     (typeof result.id === "number" ? String(result.id) : null);
   return raw ? raw.trim() : null;
-}
-
-function resolveDeliveredIMessageText(text: string, mediaContentType?: string): string {
-  if (text.trim()) {
-    return text;
-  }
-  const kind = kindFromMime(mediaContentType ?? undefined);
-  if (!kind) {
-    return text;
-  }
-  return kind === "image" ? "<media:image>" : `<media:${kind}>`;
 }
 
 function createIMessageSendReceipt(params: {
@@ -195,7 +183,6 @@ export async function sendMessageIMessage(
       readFile: opts.mediaReadFile,
     });
     filePath = resolved.path;
-    message = resolveDeliveredIMessageText(message, resolved.contentType ?? undefined);
   }
 
   if (!message.trim() && !filePath) {


### PR DESCRIPTION
## Summary
- stop synthesizing literal `<media:image>` / `<media:...>` text for iMessage media-only sends
- send attachment-only iMessages with empty text plus the file path instead
- add regression coverage for media-only sends and literal `<media:image>` text when no attachment is present

## User problem
When OpenClaw sends an image over native iMessage, the recipient can see the actual image plus a visible `<media:image>` placeholder in the conversation. In Rich's real iMessage thread this made image sends look duplicated, with the placeholder text appearing between two image previews.

That placeholder is useful as an internal inbound/context marker, but it should not be fabricated as outbound user-visible text when a real file is already being sent.

## Fix
`sendMessageIMessage` now keeps media-only outbound text empty after resolving the attachment. The RPC still receives the `file` path, so the image is delivered, but OpenClaw no longer sends a synthetic `<media:image>` text body alongside it.

Literal user text such as `literal <media:image> text` is still preserved when no attachment is sent.

## Real behavior proof
- **Behavior or issue addressed**: Native iMessage image sends from OpenClaw can show the image plus a visible `<media:image>` placeholder, creating duplicate-looking image delivery in the Messages thread.
- **Real environment tested**: Local OpenClaw checkout on macOS 26/Darwin 25.4.0, branch `fix/imessage-media-only-no-placeholder`, executing the patched `extensions/imessage/src/send.ts` outbound iMessage helper with the real package/test runtime and an instrumented iMessage RPC client.
- **Exact steps or command run after this patch**:

```bash
cd /Users/openclaw/.openclaw/workspace-homer/tmp/openclaw-imessage-media-placeholder-fix
pnpm exec tsx --conditions=development --tsconfig test/tsconfig/tsconfig.extensions.test.json <<'NODE'
import { sendMessageIMessage } from './extensions/imessage/src/send.ts';
const calls = [];
const client = {
  async request(method, params) {
    calls.push({ method, params });
    return { guid: 'local-after-fix-proof' };
  },
  async stop() {},
};
const result = await sendMessageIMessage('chat_guid:local-proof-chat', '', {
  config: { channels: { imessage: { accounts: { default: {} } } } },
  client,
  mediaUrl: '/tmp/proof-image.png',
  resolveAttachmentImpl: async () => ({ path: '/tmp/proof-image.png', contentType: 'image/png' }),
});
console.log(JSON.stringify({
  sentText: result.sentText,
  rpcMethod: calls[0]?.method,
  rpcText: calls[0]?.params?.text,
  rpcFile: calls[0]?.params?.file,
  receiptKind: result.receipt.parts[0]?.kind,
}, null, 2));
NODE
```

- **Evidence after fix**: Terminal output from the command above:

```json
{
  "sentText": "",
  "rpcMethod": "send",
  "rpcText": "",
  "rpcFile": "/tmp/proof-image.png",
  "receiptKind": "media"
}
```

- **Observed result after fix**: The patched iMessage send path now calls the outbound RPC with `file: "/tmp/proof-image.png"` and `text: ""`; it no longer sends the synthetic `<media:image>` body while still producing a media receipt.
- **What was not tested**: A live end-to-end iMessage send from a Gateway running this branch was not performed. The reported before behavior came from Rich's real iMessage thread; the after-fix proof exercises the patched outbound send helper and captures the RPC payload that would be sent.

## Tests
- `pnpm exec oxfmt --check --threads=1 extensions/imessage/src/send.ts extensions/imessage/src/send.test.ts`
- `pnpm exec oxlint extensions/imessage/src/send.ts extensions/imessage/src/send.test.ts`
- `pnpm test extensions/imessage/src/send.test.ts`
- `pnpm test extensions/imessage` → 354 passed
- `pnpm check:changed`
