### PR TITLE
fix(discord): backfill missed messages after reconnect

### DIFF
--- a/extensions/discord/src/monitor/listeners.ts
+++ b/extensions/discord/src/monitor/listeners.ts
@@ -5,9 +5,12 @@ import {
   InteractionCreateListener,
   MessageCreateListener,
   PresenceUpdateListener,
+  ReadyListener,
+  ResumedListener,
   ThreadUpdateListener,
 } from "../internal/discord.js";
 import { discordEventQueueLog, runDiscordListenerWithSlowLog } from "./listeners.queue.js";
+import { backfillRecentDiscordInboundMessages } from "./reconnect-backfill.js";
 export { DiscordReactionListener, DiscordReactionRemoveListener } from "./listeners.reactions.js";
 import { setPresence } from "./presence-cache.js";
 import { isThreadArchived } from "./thread-bindings.discord-api.js";
@@ -51,6 +54,56 @@ export class DiscordMessageListener extends MessageCreateListener {
         const logger = this.logger ?? discordEventQueueLog;
         logger.error(danger(`discord handler failed: ${String(err)}`));
       });
+  }
+}
+
+export class DiscordReconnectBackfillReadyListener extends ReadyListener {
+  constructor(
+    private params: {
+      accountId: string;
+      messageHandler: DiscordMessageHandler;
+      botUserId?: string;
+      logger?: Logger;
+      onEvent?: () => void;
+    },
+  ) {
+    super();
+  }
+
+  async handle(_data: unknown, client: Client) {
+    void backfillRecentDiscordInboundMessages({
+      accountId: this.params.accountId,
+      client,
+      messageHandler: this.params.messageHandler,
+      botUserId: this.params.botUserId,
+      logger: this.params.logger,
+      onEvent: this.params.onEvent,
+    });
+  }
+}
+
+export class DiscordReconnectBackfillResumedListener extends ResumedListener {
+  constructor(
+    private params: {
+      accountId: string;
+      messageHandler: DiscordMessageHandler;
+      botUserId?: string;
+      logger?: Logger;
+      onEvent?: () => void;
+    },
+  ) {
+    super();
+  }
+
+  async handle(_data: unknown, client: Client) {
+    void backfillRecentDiscordInboundMessages({
+      accountId: this.params.accountId,
+      client,
+      messageHandler: this.params.messageHandler,
+      botUserId: this.params.botUserId,
+      logger: this.params.logger,
+      onEvent: this.params.onEvent,
+    });
   }
 }
 

--- a/extensions/discord/src/monitor/message-handler.hydration.test.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Message } from "../internal/discord.js";
+import { Message, MessageType } from "../internal/discord.js";
 import {
   createFakeRestClient,
   createInternalTestClient,
@@ -53,12 +53,12 @@ describe("hydrateDiscordMessageIfNeeded", () => {
           type: 0,
           tts: false,
           pinned: false,
-          flags: 0,
+          flags: 0 as never,
         },
         type: 0,
         tts: false,
         pinned: false,
-        flags: 0,
+        flags: 0 as never,
       },
     ]);
     const message = new Message<true>(client, { id: "m1", channelId: "c1" }) as unknown as Message;
@@ -76,5 +76,160 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     expect(hydrated.mentionedUsers[0]?.globalName).toBe("Bob Builder");
     expect(hydrated.mentionedRoles).toEqual(["role1"]);
     expect(hydrated.referencedMessage?.content).toBe("earlier");
+  });
+
+  it("does not hydrate reply messages that already include referenced_message", async () => {
+    const client = createInternalTestClient();
+    const rest = createFakeRestClient([]);
+    const message = new Message(client, {
+      id: "m2",
+      channel_id: "c1",
+      content: "normal reply",
+      attachments: [],
+      embeds: [],
+      mentions: [],
+      mention_roles: [],
+      mention_everyone: false,
+      timestamp: new Date().toISOString(),
+      author: {
+        id: "u1",
+        username: "alice",
+        discriminator: "0",
+        global_name: null,
+        avatar: null,
+      },
+      message_reference: {
+        channel_id: "c1",
+        message_id: "m1",
+      },
+      referenced_message: {
+        id: "m1",
+        channel_id: "c1",
+        content: "bot reply",
+        attachments: [],
+        embeds: [],
+        mentions: [],
+        mention_roles: [],
+        mention_everyone: false,
+        timestamp: new Date().toISOString(),
+        edited_timestamp: null,
+        author: {
+          id: "bot-1",
+          username: "OpenClaw",
+          discriminator: "0",
+          global_name: null,
+          avatar: null,
+          bot: true,
+        },
+        type: 0,
+        tts: false,
+        pinned: false,
+        flags: 0 as never,
+      },
+      type: MessageType.Reply,
+      tts: false,
+      pinned: false,
+      flags: 0 as never,
+    });
+
+    const hydrated = await hydrateDiscordMessageIfNeeded({
+      client: { rest },
+      message,
+      messageChannelId: "c1",
+    });
+
+    expect(rest.calls).toHaveLength(0);
+    expect(hydrated).toBe(message);
+  });
+
+  it("hydrates reply messages that have content but are missing referenced_message", async () => {
+    const client = createInternalTestClient();
+    const rest = createFakeRestClient([
+      {
+        id: "m2",
+        channel_id: "c1",
+        content: "why did this get ignored?",
+        attachments: [],
+        embeds: [],
+        mentions: [],
+        mention_roles: [],
+        mention_everyone: false,
+        timestamp: new Date().toISOString(),
+        author: {
+          id: "u1",
+          username: "alice",
+          discriminator: "0",
+          avatar: null,
+        },
+        message_reference: {
+          channel_id: "c1",
+          message_id: "m1",
+        },
+        referenced_message: {
+          id: "m1",
+          channel_id: "c1",
+          content: "bot reply",
+          attachments: [],
+          embeds: [],
+          mentions: [],
+          mention_roles: [],
+          mention_everyone: false,
+          timestamp: new Date().toISOString(),
+          author: {
+            id: "bot-1",
+            username: "OpenClaw",
+            discriminator: "0",
+            global_name: null,
+            avatar: null,
+            bot: true,
+          },
+          type: 0,
+          tts: false,
+          pinned: false,
+          flags: 0 as never,
+        },
+        type: MessageType.Reply,
+        tts: false,
+        pinned: false,
+        flags: 0 as never,
+      },
+    ]);
+    const message = new Message(client, {
+      id: "m2",
+      channel_id: "c1",
+      content: "why did this get ignored?",
+      attachments: [],
+      embeds: [],
+      mentions: [],
+      mention_roles: [],
+      mention_everyone: false,
+      timestamp: new Date().toISOString(),
+      author: {
+        id: "u1",
+        username: "alice",
+        discriminator: "0",
+        global_name: null,
+        avatar: null,
+      },
+      message_reference: {
+        channel_id: "c1",
+        message_id: "m1",
+      },
+      referenced_message: null,
+      type: MessageType.Reply,
+      tts: false,
+      pinned: false,
+      flags: 0 as never,
+    });
+
+    const hydrated = await hydrateDiscordMessageIfNeeded({
+      client: { rest },
+      message,
+      messageChannelId: "c1",
+    });
+
+    expect(rest.calls).toHaveLength(1);
+    expect(hydrated.referencedMessage?.author?.id).toBe("bot-1");
+    expect(hydrated.messageReference?.message_id).toBe("m1");
   });
 });

--- a/extensions/discord/src/monitor/message-handler.hydration.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.ts
@@ -23,6 +23,12 @@ function mergeFetchedDiscordMessage(base: Message, fetched: APIMessage): Message
     tts: fetched.tts ?? baseRawData.tts ?? false,
     pinned: fetched.pinned ?? baseRawData.pinned ?? false,
     type: fetched.type ?? baseRawData.type ?? 0,
+    message_reference:
+      fetched.message_reference ?? baseRawData.message_reference ?? baseFallback.message_reference,
+    referenced_message:
+      fetched.referenced_message ??
+      baseRawData.referenced_message ??
+      baseFallback.referenced_message,
     message_snapshots:
       fetched.message_snapshots ?? baseRawData.message_snapshots ?? baseFallback.message_snapshots,
     sticker_items:
@@ -69,6 +75,10 @@ function readMessageFallback(message: Message): MessageFallback {
     timestamp?: unknown;
     stickers?: unknown;
     sticker_items?: unknown;
+    messageReference?: unknown;
+    message_reference?: unknown;
+    referencedMessage?: unknown;
+    referenced_message?: unknown;
     message_snapshots?: unknown;
   };
   return {
@@ -82,6 +92,11 @@ function readMessageFallback(message: Message): MessageFallback {
     mention_roles: normalizeStringArray(value.mentionedRoles),
     mention_everyone: value.mentionedEveryone === true,
     timestamp: readString(value.timestamp) ?? "1970-01-01T00:00:00.000Z",
+    message_reference:
+      normalizeApiMessageReference(value.message_reference) ??
+      normalizeApiMessageReference(value.messageReference),
+    referenced_message:
+      normalizeApiMessage(value.referenced_message) ?? normalizeApiMessage(value.referencedMessage),
     sticker_items: Array.isArray(value.sticker_items)
       ? (value.sticker_items as APIMessage["sticker_items"])
       : Array.isArray(value.stickers)
@@ -110,6 +125,16 @@ function normalizeApiUsers(value: unknown): APIUser[] {
         return user.id ? [user] : [];
       })
     : [];
+}
+
+function normalizeApiMessageReference(value: unknown): APIMessage["message_reference"] | undefined {
+  return value && typeof value === "object"
+    ? (value as APIMessage["message_reference"])
+    : undefined;
+}
+
+function normalizeApiMessage(value: unknown): APIMessage | undefined {
+  return value && typeof value === "object" ? (value as APIMessage) : undefined;
 }
 
 function normalizeApiUser(value: unknown): APIUser {
@@ -158,6 +183,13 @@ function shouldHydrateDiscordMessage(params: { message: Message }) {
     return true;
   }
   if (!currentText) {
+    return true;
+  }
+  const rawData = readMessageRawData(params.message);
+  const hasReplyReference = Boolean(
+    params.message.messageReference?.message_id || rawData.message_reference?.message_id,
+  );
+  if (hasReplyReference && !params.message.referencedMessage) {
     return true;
   }
   const hasMentionMetadata =

--- a/extensions/discord/src/monitor/provider.startup.test.ts
+++ b/extensions/discord/src/monitor/provider.startup.test.ts
@@ -76,6 +76,12 @@ vi.mock("./listeners.js", () => ({
   DiscordPresenceListener: function DiscordPresenceListener() {
     return { type: "presence" };
   },
+  DiscordReconnectBackfillReadyListener: function DiscordReconnectBackfillReadyListener() {
+    return { type: "ready" };
+  },
+  DiscordReconnectBackfillResumedListener: function DiscordReconnectBackfillResumedListener() {
+    return { type: "resumed" };
+  },
   DiscordReactionListener: function DiscordReactionListener() {
     return { type: "reaction-add" };
   },
@@ -379,7 +385,13 @@ describe("registerDiscordMonitorListeners", () => {
   it("skips reaction listeners when every configured guild disables reactions and DMs are off", () => {
     registerDiscordMonitorListeners(createListenerParams());
 
-    expect(registeredListenerTypes()).toEqual(["interaction", "message", "thread-update"]);
+    expect(registeredListenerTypes()).toEqual([
+      "interaction",
+      "message",
+      "ready",
+      "resumed",
+      "thread-update",
+    ]);
   });
 
   it("keeps reaction listeners when direct messages can emit reaction notifications", () => {

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -30,6 +30,8 @@ import {
   DiscordMessageListener,
   DiscordInteractionListener,
   DiscordPresenceListener,
+  DiscordReconnectBackfillReadyListener,
+  DiscordReconnectBackfillResumedListener,
   DiscordReactionListener,
   DiscordReactionRemoveListener,
   DiscordThreadUpdateListener,
@@ -261,6 +263,21 @@ export function registerDiscordMonitorListeners(params: {
   registerDiscordListener(
     params.client.listeners,
     new DiscordMessageListener(params.messageHandler, params.logger, params.trackInboundEvent),
+  );
+  const reconnectBackfillParams = {
+    accountId: params.accountId,
+    messageHandler: params.messageHandler,
+    botUserId: params.botUserId,
+    logger: params.logger,
+    onEvent: params.trackInboundEvent,
+  };
+  registerDiscordListener(
+    params.client.listeners,
+    new DiscordReconnectBackfillReadyListener(reconnectBackfillParams),
+  );
+  registerDiscordListener(
+    params.client.listeners,
+    new DiscordReconnectBackfillResumedListener(reconnectBackfillParams),
   );
 
   if (shouldRegisterDiscordReactionListeners(params)) {

--- a/extensions/discord/src/monitor/reconnect-backfill.test.ts
+++ b/extensions/discord/src/monitor/reconnect-backfill.test.ts
@@ -1,0 +1,226 @@
+import type { APIMessage } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createFakeRestClient } from "../internal/test-builders.test-support.js";
+import {
+  recordRecentDiscordOutboundMessage,
+  resetRecentDiscordOutboundMessagesForTest,
+} from "../recent-outbound.js";
+import {
+  createDiscordMessageHandler,
+  preflightDiscordMessageMock,
+  processDiscordMessageMock,
+} from "./message-handler.module-test-helpers.js";
+import {
+  createDiscordHandlerParams,
+  createDiscordPreflightContext,
+} from "./message-handler.test-helpers.js";
+import {
+  backfillRecentDiscordInboundMessages,
+  resetRecentDiscordBackfillsForTest,
+} from "./reconnect-backfill.js";
+
+async function flushQueueWork(): Promise<void> {
+  for (let i = 0; i < 40; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+function apiMessage(overrides: Partial<APIMessage> & Pick<APIMessage, "id">): APIMessage {
+  return {
+    channel_id: "thread-1",
+    content: "reply",
+    attachments: [],
+    embeds: [],
+    mentions: [],
+    mention_roles: [],
+    mention_everyone: false,
+    timestamp: new Date().toISOString(),
+    author: {
+      id: "user-1",
+      username: "alice",
+      discriminator: "0",
+      global_name: null,
+      avatar: null,
+    },
+    type: 0,
+    tts: false,
+    pinned: false,
+    flags: 0 as APIMessage["flags"],
+    ...overrides,
+  } as APIMessage;
+}
+
+describe("backfillRecentDiscordInboundMessages", () => {
+  beforeEach(() => {
+    resetRecentDiscordOutboundMessagesForTest();
+    resetRecentDiscordBackfillsForTest();
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+  });
+
+  it("replays user messages after recent OpenClaw outbound messages in oldest-first order", async () => {
+    const rest = createFakeRestClient([
+      [apiMessage({ id: "103", content: "second" }), apiMessage({ id: "102", content: "first" })],
+    ]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    const messageHandler = vi.fn(async (_data: unknown, _client?: unknown) => {});
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "101",
+      at: 1_000,
+    });
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "101-later",
+      at: 1_500,
+    });
+
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 2_000,
+    });
+
+    expect(rest.calls[0]).toMatchObject({
+      method: "GET",
+      query: { after: "101", limit: 50 },
+    });
+    expect(messageHandler).toHaveBeenCalledTimes(2);
+    const firstEvent = messageHandler.mock.calls[0]?.[0] as {
+      message: { id: string };
+      guild_id?: string;
+    };
+    const secondEvent = messageHandler.mock.calls[1]?.[0] as { message: { id: string } };
+    expect(firstEvent.message.id).toBe("102");
+    expect(firstEvent.guild_id).toBe("guild-1");
+    expect(secondEvent.message.id).toBe("103");
+  });
+
+  it("does not rescan the same outbound anchor during the reconnect cooldown", async () => {
+    const rest = createFakeRestClient([[apiMessage({ id: "102" })], [apiMessage({ id: "103" })]]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    const messageHandler = vi.fn(async (_data: unknown, _client?: unknown) => {});
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "101",
+      at: 1_000,
+    });
+
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 2_000,
+    });
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 2_100,
+    });
+
+    expect(rest.calls).toHaveLength(1);
+    expect(messageHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares the replay guard between REST backfill and gateway delivery", async () => {
+    const rest = createFakeRestClient([[apiMessage({ id: "102" })]]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    preflightDiscordMessageMock.mockImplementation(async () =>
+      createDiscordPreflightContext("thread-1"),
+    );
+    processDiscordMessageMock.mockResolvedValue(undefined);
+    const handler = createDiscordMessageHandler(createDiscordHandlerParams());
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "101",
+      at: 1_000,
+    });
+
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler: handler,
+      botUserId: "bot-1",
+      now: 2_000,
+    });
+    await flushQueueWork();
+    await handler(
+      {
+        channel_id: "thread-1",
+        author: { id: "user-1" },
+        message: {
+          id: "102",
+          author: { id: "user-1", bot: false },
+          content: "reply",
+          channel_id: "thread-1",
+          attachments: [],
+        },
+      } as never,
+      client,
+    );
+    await flushQueueWork();
+
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replay bot-authored messages", async () => {
+    const rest = createFakeRestClient([
+      [
+        apiMessage({
+          id: "102",
+          author: {
+            id: "bot-1",
+            username: "bot",
+            discriminator: "0",
+            global_name: null,
+            avatar: null,
+            bot: true,
+          },
+        }),
+      ],
+    ]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    const messageHandler = vi.fn(async (_data: unknown, _client?: unknown) => {});
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "101",
+      at: 1_000,
+    });
+
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 2_000,
+    });
+
+    expect(messageHandler).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/discord/src/monitor/reconnect-backfill.ts
+++ b/extensions/discord/src/monitor/reconnect-backfill.ts
@@ -1,0 +1,159 @@
+import { type APIMessage } from "discord-api-types/v10";
+import { danger } from "openclaw/plugin-sdk/runtime-env";
+import { listChannelMessages } from "../internal/api.messages.js";
+import { Guild, type Client, Message, User } from "../internal/discord.js";
+import { listRecentDiscordOutboundMessages } from "../recent-outbound.js";
+import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
+
+const RECENT_OUTBOUND_BACKFILL_WINDOW_MS = 15 * 60 * 1000;
+const RECENT_OUTBOUND_BACKFILL_LIMIT = 50;
+const RECENT_OUTBOUND_BACKFILL_COOLDOWN_MS = 30 * 1000;
+
+type Logger = ReturnType<typeof import("openclaw/plugin-sdk/runtime-env").createSubsystemLogger>;
+
+type DiscordChannelLike = {
+  guildId?: string;
+  guild_id?: string;
+};
+
+const recentBackfillByKey = new Map<string, number>();
+
+function normalize(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function compareSnowflakesAscending(a: string, b: string): number {
+  try {
+    const left = BigInt(a);
+    const right = BigInt(b);
+    return left < right ? -1 : left > right ? 1 : 0;
+  } catch {
+    return a.localeCompare(b);
+  }
+}
+
+function resolveGuildId(channel: unknown): string | undefined {
+  const candidate = channel as DiscordChannelLike | null | undefined;
+  return normalize(candidate?.guildId) ?? normalize(candidate?.guild_id);
+}
+
+function isFromBot(message: APIMessage, botUserId?: string): boolean {
+  return Boolean(botUserId && message.author?.id === botUserId);
+}
+
+function backfillKey(params: { accountId: string; channelId: string; messageId: string }) {
+  return `${params.accountId || "default"}:${params.channelId}:${params.messageId}`;
+}
+
+function shouldSkipRecentBackfill(params: {
+  accountId: string;
+  channelId: string;
+  messageId: string;
+  now: number;
+}) {
+  const key = backfillKey(params);
+  const previous = recentBackfillByKey.get(key);
+  if (previous !== undefined && params.now - previous <= RECENT_OUTBOUND_BACKFILL_COOLDOWN_MS) {
+    return true;
+  }
+  recentBackfillByKey.set(key, params.now);
+  return false;
+}
+
+function toDispatchEvent(params: {
+  client: Client;
+  channelId: string;
+  guildId?: string;
+  message: APIMessage;
+}): DiscordMessageEvent {
+  const rawMessage = {
+    ...params.message,
+    channel_id: params.channelId,
+    ...(params.guildId ? { guild_id: params.guildId } : {}),
+  } as APIMessage & {
+    member?: { roles?: string[]; nick?: string | null; nickname?: string | null };
+  };
+  const message = new Message(params.client, rawMessage);
+  return {
+    ...rawMessage,
+    id: rawMessage.id,
+    channel_id: params.channelId,
+    channelId: params.channelId,
+    message,
+    author: rawMessage.author ? new User(params.client, rawMessage.author) : null,
+    member: rawMessage.member,
+    rawMember: rawMessage.member,
+    guild: params.guildId ? new Guild<true>(params.client, params.guildId) : null,
+  } as DiscordMessageEvent;
+}
+
+export async function backfillRecentDiscordInboundMessages(params: {
+  accountId: string;
+  client: Client;
+  messageHandler: DiscordMessageHandler;
+  botUserId?: string;
+  logger?: Logger;
+  onEvent?: () => void;
+  now?: number;
+}) {
+  const now = params.now ?? Date.now();
+  const recent = listRecentDiscordOutboundMessages({
+    accountId: params.accountId,
+    maxAgeMs: RECENT_OUTBOUND_BACKFILL_WINDOW_MS,
+    now,
+  });
+  if (recent.length === 0) {
+    return;
+  }
+
+  for (const entry of recent) {
+    if (
+      shouldSkipRecentBackfill({
+        accountId: params.accountId,
+        channelId: entry.channelId,
+        messageId: entry.messageId,
+        now,
+      })
+    ) {
+      continue;
+    }
+    try {
+      const channel = await params.client.fetchChannel(entry.channelId);
+      const guildId = resolveGuildId(channel);
+      const messages = await listChannelMessages(params.client.rest, entry.channelId, {
+        after: entry.messageId,
+        limit: RECENT_OUTBOUND_BACKFILL_LIMIT,
+      });
+      const candidates = messages
+        .filter((message) => message.id && !isFromBot(message, params.botUserId))
+        .toSorted((a, b) => compareSnowflakesAscending(a.id, b.id));
+      if (candidates.length === 0) {
+        continue;
+      }
+      params.logger?.info("Discord reconnect backfill scanning recent channel messages", {
+        channelId: entry.channelId,
+        count: candidates.length,
+      });
+      for (const message of candidates) {
+        params.onEvent?.();
+        await params.messageHandler(
+          toDispatchEvent({
+            client: params.client,
+            channelId: entry.channelId,
+            guildId,
+            message,
+          }),
+          params.client,
+        );
+      }
+    } catch (err) {
+      params.logger?.error(
+        danger(`discord reconnect backfill failed for channel ${entry.channelId}: ${String(err)}`),
+      );
+    }
+  }
+}
+
+export function resetRecentDiscordBackfillsForTest() {
+  recentBackfillByKey.clear();
+}

--- a/extensions/discord/src/recent-outbound.ts
+++ b/extensions/discord/src/recent-outbound.ts
@@ -1,0 +1,82 @@
+type RecentDiscordOutboundMessage = {
+  accountId: string;
+  channelId: string;
+  messageId: string;
+  at: number;
+};
+
+// Best-effort reconnect recovery anchor: intentionally in-memory and scoped to
+// recent bot outbounds. This is not a persisted, general-purpose Discord history
+// catch-up mechanism; it covers the common "user replied after OpenClaw spoke"
+// gap when the Gateway socket silently misses events before reconnecting.
+const RECENT_OUTBOUND_MAX = 500;
+const RECENT_OUTBOUND_CHANNEL_WINDOW_MS = 15 * 60 * 1000;
+const recentOutboundByKey = new Map<string, RecentDiscordOutboundMessage>();
+
+function normalize(value: string | undefined | null): string {
+  return value?.trim() ?? "";
+}
+
+function keyFor(accountId: string, channelId: string) {
+  return `${accountId || "default"}:${channelId}`;
+}
+
+function trimRecentOutbound(now: number, maxAgeMs: number) {
+  for (const [key, entry] of recentOutboundByKey) {
+    if (now - entry.at > maxAgeMs) {
+      recentOutboundByKey.delete(key);
+    }
+  }
+  if (recentOutboundByKey.size <= RECENT_OUTBOUND_MAX) {
+    return;
+  }
+  const sorted = [...recentOutboundByKey.entries()].toSorted((a, b) => a[1].at - b[1].at);
+  for (const [key] of sorted.slice(0, recentOutboundByKey.size - RECENT_OUTBOUND_MAX)) {
+    recentOutboundByKey.delete(key);
+  }
+}
+
+export function recordRecentDiscordOutboundMessage(params: {
+  accountId?: string | null;
+  channelId?: string | null;
+  messageId?: string | null;
+  at?: number;
+}) {
+  const accountId = normalize(params.accountId) || "default";
+  const channelId = normalize(params.channelId);
+  const messageId = normalize(params.messageId);
+  if (!channelId || !messageId) {
+    return;
+  }
+  const at = params.at ?? Date.now();
+  const key = keyFor(accountId, channelId);
+  const existing = recentOutboundByKey.get(key);
+  if (existing && at - existing.at <= RECENT_OUTBOUND_CHANNEL_WINDOW_MS) {
+    trimRecentOutbound(at, 30 * 60 * 1000);
+    return;
+  }
+  recentOutboundByKey.set(key, {
+    accountId,
+    channelId,
+    messageId,
+    at,
+  });
+  trimRecentOutbound(at, 30 * 60 * 1000);
+}
+
+export function listRecentDiscordOutboundMessages(params: {
+  accountId?: string | null;
+  maxAgeMs: number;
+  now?: number;
+}): RecentDiscordOutboundMessage[] {
+  const accountId = normalize(params.accountId) || "default";
+  const now = params.now ?? Date.now();
+  trimRecentOutbound(now, params.maxAgeMs);
+  return [...recentOutboundByKey.values()].filter(
+    (entry) => entry.accountId === accountId && now - entry.at <= params.maxAgeMs,
+  );
+}
+
+export function resetRecentDiscordOutboundMessagesForTest() {
+  recentOutboundByKey.clear();
+}

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -11,6 +11,7 @@ import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { resolveDiscordAccount } from "./accounts.js";
 import { createChannelMessage, createThread, type RequestClient } from "./internal/discord.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
+import { recordRecentDiscordOutboundMessage } from "./recent-outbound.js";
 import { parseAndResolveRecipient } from "./recipient-resolution.js";
 import { createDiscordSendResult, type DiscordReceiptResultSource } from "./send.receipt.js";
 import {
@@ -284,6 +285,11 @@ export async function sendMessageDiscord(
       accountId: accountInfo.accountId,
       direction: "outbound",
     });
+    recordRecentDiscordOutboundMessage({
+      accountId: accountInfo.accountId,
+      channelId: resultChannelId,
+      messageId,
+    });
     return toDiscordSendResult(
       {
         id: messageId,
@@ -345,6 +351,11 @@ export async function sendMessageDiscord(
     channel: "discord",
     accountId: accountInfo.accountId,
     direction: "outbound",
+  });
+  recordRecentDiscordOutboundMessage({
+    accountId: accountInfo.accountId,
+    channelId: result.channel_id ?? channelId,
+    messageId: result.id,
   });
   return toDiscordSendResult(result, channelId, {
     kind: opts.mediaUrl ? "media" : opts.components || opts.embeds ? "card" : "text",

--- a/extensions/discord/src/test-support/provider.test-support.ts
+++ b/extensions/discord/src/test-support/provider.test-support.ts
@@ -506,6 +506,8 @@ vi.mock(buildDiscordSourceModuleId("monitor/listeners.js"), () => ({
   DiscordInteractionListener: function DiscordInteractionListener() {},
   DiscordMessageListener: function DiscordMessageListener() {},
   DiscordPresenceListener: function DiscordPresenceListener() {},
+  DiscordReconnectBackfillReadyListener: function DiscordReconnectBackfillReadyListener() {},
+  DiscordReconnectBackfillResumedListener: function DiscordReconnectBackfillResumedListener() {},
   DiscordReactionListener: function DiscordReactionListener() {},
   DiscordReactionRemoveListener: function DiscordReactionRemoveListener() {},
   DiscordThreadUpdateListener: function DiscordThreadUpdateListener() {},


### PR DESCRIPTION
## Summary

Fixes a Discord reliability gap where user replies can be missed when the Gateway websocket silently drops `MESSAGE_CREATE` events shortly before reconnect/resume.

The patch adds a bounded, best-effort recovery path for the common case where a user replies shortly after OpenClaw sends a Discord message:

- record recent Discord outbound channel/message anchors in memory
- on Discord Gateway `READY` / `RESUMED`, REST-fetch recent messages after those anchors
- feed recovered messages through the existing Discord `messageHandler`, preserving normal preflight, routing, replay dedupe, and session queue behavior
- add a short per-anchor cooldown so `READY` + `RESUMED` do not repeatedly rescan the same anchor
- harden reply hydration so messages with `message_reference` but missing `referenced_message` can still resolve reply-to-bot implicit mention handling

## Scope boundary

This is intentionally not a general persisted Discord history catch-up system. It is an in-memory, bounded recovery seam for recent bot-outbound channels, designed to cover the high-value "user replied after the bot spoke" failure mode without broad REST scanning.

If the process restarts, the in-memory anchors are lost; this patch does not attempt cross-process persisted recovery.

## Validation

Validated in an isolated source/stage worktree; no live gateway restart or production state was used.

- `oxfmt --check` on changed Discord files
- `oxlint --tsconfig config/tsconfig/oxlint.extensions.json` on changed Discord files
- targeted regression tests:
  - `extensions/discord/src/monitor/provider.test.ts`
  - `extensions/discord/src/monitor/reconnect-backfill.test.ts`
  - `extensions/discord/src/monitor/message-handler.hydration.test.ts`
  - `extensions/discord/src/monitor/provider.startup.test.ts`
  - `extensions/discord/src/monitor/message-handler.queue.test.ts`
  - result: 5 files / 68 tests passed
- full Discord extension shard:
  - `node scripts/test-projects.mjs extensions/discord`
  - result: 146 files / 1412 tests passed
- extensions typecheck:
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental false --pretty false`
  - result: passed

## Notes

The duplicate-delivery overlap is covered by routing both REST-recovered messages and normal Gateway messages through the same replay guard path. A regression test verifies that the same message delivered by backfill and then by the normal Gateway handler is processed once.
