### PR TITLE
[AI-assisted] fix(agents): normalize array tool schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: add permissive item schemas to array tool parameters before provider submission, preventing OpenAI-compatible schema validation from rejecting plugin tools that omit `items`. Fixes #81175. (#81217) Thanks @JARVIS-Glasses.
 - Agents: escalate LLM idle watchdog timeouts through profile rotation and configured model fallback instead of leaving agent turns stuck after a silent model stream. Fixes #76877. (#80449) Thanks @jimdawdy-hub.
 - ACPX: stop forwarding unsupported timeout config options to Claude ACP while preserving OpenClaw's own turn timeout. (#80812) Thanks @sxxtony.
 - Session transcripts: redact sensitive message content in the centralized JSONL append path so CLI turns, gateway transcript injection, transcript mirrors, and guarded tool results use the same configured redaction behavior. Fixes #73565. Refs #73563. (#79645) Thanks @Ziy1-Tan.

--- a/src/agents/pi-tools-parameter-schema.ts
+++ b/src/agents/pi-tools-parameter-schema.ts
@@ -144,6 +144,86 @@ function isTrulyEmptySchema(schemaRecord: Record<string, unknown>): boolean {
   return Object.keys(schemaRecord).length === 0;
 }
 
+function normalizeArraySchemasMissingItems(schema: unknown): unknown {
+  if (!isSchemaRecord(schema)) {
+    return schema;
+  }
+
+  let changed = false;
+  const nextSchema: Record<string, unknown> = { ...schema };
+  if (nextSchema.type === "array" && nextSchema.items === undefined) {
+    nextSchema.items = {};
+    changed = true;
+  }
+
+  const normalizeSchemaValue = (key: string): void => {
+    if (!(key in nextSchema)) {
+      return;
+    }
+    const value = nextSchema[key];
+    if (Array.isArray(value)) {
+      const normalized = value.map(normalizeArraySchemasMissingItems);
+      if (normalized.some((entry, index) => entry !== value[index])) {
+        nextSchema[key] = normalized;
+        changed = true;
+      }
+      return;
+    }
+
+    const normalized = normalizeArraySchemasMissingItems(value);
+    if (normalized !== value) {
+      nextSchema[key] = normalized;
+      changed = true;
+    }
+  };
+
+  for (const key of [
+    "items",
+    "contains",
+    "additionalProperties",
+    "propertyNames",
+    "not",
+    "if",
+    "then",
+    "else",
+  ]) {
+    normalizeSchemaValue(key);
+  }
+
+  for (const key of ["anyOf", "oneOf", "allOf", "prefixItems"]) {
+    normalizeSchemaValue(key);
+  }
+
+  for (const key of [
+    "properties",
+    "patternProperties",
+    "dependentSchemas",
+    "$defs",
+    "definitions",
+  ]) {
+    const value = nextSchema[key];
+    if (!isSchemaRecord(value)) {
+      continue;
+    }
+    let entriesChanged = false;
+    const normalizedEntries: Array<[string, unknown]> = Object.entries(value).map(
+      ([entryKey, entryValue]) => {
+        const normalizedEntryValue = normalizeArraySchemasMissingItems(entryValue);
+        if (normalizedEntryValue !== entryValue) {
+          entriesChanged = true;
+        }
+        return [entryKey, normalizedEntryValue];
+      },
+    );
+    if (entriesChanged) {
+      nextSchema[key] = Object.fromEntries(normalizedEntries);
+      changed = true;
+    }
+  }
+
+  return changed ? nextSchema : schema;
+}
+
 export function normalizeToolParameterSchema(
   schema: unknown,
   options?: { modelProvider?: string; modelId?: string; modelCompat?: ModelCompatConfig },
@@ -169,13 +249,14 @@ export function normalizeToolParameterSchema(
   const unsupportedToolSchemaKeywords = resolveUnsupportedToolSchemaKeywords(options?.modelCompat);
 
   function applyProviderCleaning(s: unknown): TSchema {
+    const normalizedSchema = normalizeArraySchemasMissingItems(s);
     if (isGeminiProvider && !isAnthropicProvider) {
-      return cleanSchemaForGemini(s);
+      return cleanSchemaForGemini(normalizedSchema);
     }
     if (unsupportedToolSchemaKeywords.size > 0) {
-      return stripUnsupportedSchemaKeywords(s, unsupportedToolSchemaKeywords) as TSchema;
+      return stripUnsupportedSchemaKeywords(normalizedSchema, unsupportedToolSchemaKeywords) as TSchema;
     }
-    return s as TSchema;
+    return normalizedSchema as TSchema;
   }
 
   const conditionalKey = getTopLevelConditionalKey(schemaRecord);

--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -71,6 +71,44 @@ describe("normalizeToolParameterSchema", () => {
     expect(normalizeToolParameterSchema(schema)).toEqual(schema);
   });
 
+  it("adds permissive items schemas to arrays missing items", () => {
+    expect(
+      normalizeToolParameterSchema({
+        type: "object",
+        properties: {
+          entity_hints: { type: "array", description: "Optional entity hints" },
+          nested: {
+            type: "object",
+            properties: {
+              ids: { type: "array" },
+            },
+          },
+          alternatives: {
+            anyOf: [{ type: "array" }, { type: "string" }],
+          },
+        },
+      }),
+    ).toEqual({
+      type: "object",
+      properties: {
+        entity_hints: {
+          type: "array",
+          description: "Optional entity hints",
+          items: {},
+        },
+        nested: {
+          type: "object",
+          properties: {
+            ids: { type: "array", items: {} },
+          },
+        },
+        alternatives: {
+          anyOf: [{ type: "array", items: {} }, { type: "string" }],
+        },
+      },
+    });
+  });
+
   it("inlines local $ref before removing unsupported keywords", () => {
     const cleaned = cleanToolSchemaForGemini({
       type: "object",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: OpenAI rejects function/tool schemas when an array schema omits `items`, for example `entity_hints: { type: "array" }`.
- Why it matters: A single invalid array schema can make OpenAI-facing tool submission fail with invalid function parameters / `array schema missing items`.
- What changed: Tool-parameter schema normalization now recursively adds permissive `items: {}` to array schemas that omit `items`.
- What did NOT change (scope boundary): Existing array schemas with explicit `items` are preserved; no provider credentials, network calls, runtime execution, UI, config, or changelog behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #81175
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: OpenAI tool-schema normalization now emits explicit `items: {}` for arrays that previously omitted `items`.
- Real environment tested: Local OpenClaw checkout on Windows, rebased on current `origin/main`; no live provider credentials used.
- Exact steps or command run after this patch:

```powershell
node --import tsx --input-type=module -e "import { normalizeOpenAIStrictToolParameters } from './src/agents/openai-tool-schema.ts'; const schema = { type: 'object', properties: { entity_hints: { type: 'array', description: 'Optional entity hints' }, nested: { type: 'object', properties: { ids: { type: 'array' } } } } }; const normalized = normalizeOpenAIStrictToolParameters(schema, false); console.log(JSON.stringify(normalized, null, 2));"
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "type": "object",
  "properties": {
    "entity_hints": {
      "type": "array",
      "description": "Optional entity hints",
      "items": {}
    },
    "nested": {
      "type": "object",
      "properties": {
        "ids": {
          "type": "array",
          "items": {}
        }
      }
    }
  }
}
```

- Observed result after fix: The real OpenAI tool-schema normalization path emits `items: {}` for both the top-level `entity_hints` array property and the nested `ids` array property.
- What was not tested: A live OpenAI API request and a running gateway/provider session were not tested.
- Before evidence (optional but encouraged): Not captured. Issue #81175 contains the reported pre-fix failure: `array schema missing items` for `entity_hints`.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `normalizeToolParameterSchema` repaired missing top-level/object fields but did not repair array schemas that declared `type: "array"` without an explicit `items` schema.
- Missing detection / guardrail: There was no regression test covering OpenAI-incompatible arrays without `items`.
- Contributing context (if known): OpenAI requires explicit array item schemas for function/tool parameters.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-tools.schema.test.ts`
- Scenario the test should lock in: Arrays missing `items` are normalized to include permissive `items: {}`, including nested arrays and arrays inside `anyOf`.
- Why this is the smallest reliable guardrail: The behavior lives in `normalizeToolParameterSchema`, so a focused unit test covers the normalization contract directly.
- Existing test that already covers this (if any): None found.
- If no new test is added, why not: N/A; a regression test was added.

## User-visible / Behavior Changes

Tool schemas with arrays that omit `items` are normalized before provider submission, reducing OpenAI invalid schema failures. No UI, config, or command behavior changes.

## Diagram (if applicable)

N/A

```text
Before:
OpenAI-facing tool schema with entity_hints: { type: "array" }
  -> provider submission
  -> OpenAI schema validation error: array schema missing items

After:
OpenAI-facing tool schema with entity_hints: { type: "array" }
  -> normalizeToolParameterSchema
  -> entity_hints: { type: "array", items: {} }
  -> provider submission receives explicit array items schema
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local checkout
- Runtime/container: Local Node.js with repo dependencies installed via pnpm 11.1.0
- Model/provider: OpenAI tool-schema normalization path; no live provider request
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Rebase the branch on current `origin/main`.
2. Run the targeted regression test.
3. Run the local OpenAI tool-schema normalization proof command.

### Expected

- Arrays with `type: "array"` and no `items` are emitted with `items: {}`.

### Actual

- `entity_hints` and nested `ids` arrays were emitted with `items: {}`.
- Targeted regression test passed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Final branch status, targeted regression test result, OpenAI tool-schema normalization proof output, privacy/secret check result, and PR body were reviewed before submission.
- Edge cases checked: The regression test covers nested arrays and arrays inside `anyOf`, so the recursive normalization path is checked beyond the direct `entity_hints` case.
- What you did **not** verify: Live OpenAI API request, live gateway run, and full repo test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: A downstream validator may treat explicit `items: {}` differently from omitted `items`.
  - Mitigation: `items: {}` is the permissive JSON Schema form for arbitrary array entries and avoids guessing a stricter item type.
