### PR TITLE
feat(migrate): suppress plan log on embedding, add "Accept recommended" affordance, remove "Skip for now"

### DIFF
--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -66,7 +66,7 @@ vi.mock("./backup.js", () => ({
 }));
 
 const {
-  MIGRATION_SKILL_SELECTION_SKIP,
+  MIGRATION_SKILL_SELECTION_ACCEPT,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
 } = await import("./migrate/selection.js");
@@ -444,11 +444,11 @@ describe("migrateApplyCommand", () => {
     expect(selectionPrompt.initialValues).toStrictEqual(["skill:alpha", "skill:beta"]);
     expect(selectionPrompt.required).toBe(false);
     expect(selectionPrompt.options?.map(({ label, value }) => ({ label, value }))).toStrictEqual([
-      { value: MIGRATION_SKILL_SELECTION_SKIP, label: "Skip for now" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
+      { value: MIGRATION_SKILL_SELECTION_ACCEPT, label: "Accept recommended" },
       { value: "skill:alpha", label: "alpha" },
       { value: "skill:beta", label: "beta" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
     ]);
     expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
     const appliedPlan = firstAppliedPlan();
@@ -504,11 +504,11 @@ describe("migrateApplyCommand", () => {
     expect(pluginPrompt.initialValues).toStrictEqual(["plugin:google-calendar", "plugin:gmail"]);
     expect(pluginPrompt.required).toBe(false);
     expect(pluginPrompt.options?.map(({ label, value }) => ({ label, value }))).toStrictEqual([
-      { value: MIGRATION_SKILL_SELECTION_SKIP, label: "Skip for now" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
+      { value: MIGRATION_SKILL_SELECTION_ACCEPT, label: "Accept recommended" },
       { value: "plugin:google-calendar", label: "google-calendar" },
       { value: "plugin:gmail", label: "gmail" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
     ]);
     expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
     const appliedPlan = firstAppliedPlan();
@@ -652,59 +652,6 @@ describe("migrateApplyCommand", () => {
     expect(itemsById.get("plugin:gmail")?.status).toBe("planned");
   });
 
-  it("skips interactive Codex plugin migration before confirmation when Skip for now is selected", async () => {
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: true,
-    });
-    const planned = codexPluginPlan();
-    mocks.provider.plan.mockResolvedValue(planned);
-    mocks.multiselect.mockResolvedValue([MIGRATION_SKILL_SELECTION_SKIP]);
-
-    const result = await migrateDefaultCommand(runtime, { provider: "codex" });
-
-    expect(result).toBe(planned);
-    expect(mocks.promptYesNo).not.toHaveBeenCalled();
-    expect(mocks.backupCreateCommand).not.toHaveBeenCalled();
-    expect(mocks.provider.apply).not.toHaveBeenCalled();
-    expect(runtime.log).toHaveBeenCalledWith("Codex plugin migration skipped for now.");
-  });
-
-  it("returns without confirmation when both Codex skill and plugin selectors are skipped", async () => {
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: true,
-    });
-    const skillPlan = codexSkillPlan();
-    const pluginPlan = codexPluginPlan();
-    const planned = codexSkillPlan({
-      summary: {
-        total: skillPlan.items.length + pluginPlan.items.length,
-        planned: skillPlan.items.length + pluginPlan.items.length,
-        migrated: 0,
-        skipped: 0,
-        conflicts: 0,
-        errors: 0,
-        sensitive: 0,
-      },
-      items: [...skillPlan.items, ...pluginPlan.items],
-    });
-    mocks.provider.plan.mockResolvedValue(planned);
-    mocks.multiselect
-      .mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP])
-      .mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP]);
-
-    const result = await migrateDefaultCommand(runtime, { provider: "codex" });
-
-    expect(result).toBe(planned);
-    expect(mocks.multiselect).toHaveBeenCalledTimes(2);
-    expect(mocks.promptYesNo).not.toHaveBeenCalled();
-    expect(mocks.backupCreateCommand).not.toHaveBeenCalled();
-    expect(mocks.provider.apply).not.toHaveBeenCalled();
-    expect(runtime.log).toHaveBeenCalledWith("Codex skill migration skipped for now.");
-    expect(runtime.log).toHaveBeenCalledWith("Codex plugin migration skipped for now.");
-  });
-
   it("does not apply when interactive Codex plugin migration chooses no plugins", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,
@@ -819,105 +766,6 @@ describe("migrateApplyCommand", () => {
     expect(skillOptionsByValue.get("skill:beta")?.label).toBe("beta");
     expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
     expect(mocks.provider.apply).not.toHaveBeenCalled();
-  });
-
-  it("continues to interactive Codex plugins when skill migration is skipped", async () => {
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: true,
-    });
-    const skillPlan = codexSkillPlan();
-    const pluginPlan = codexPluginPlan();
-    const planned = codexSkillPlan({
-      summary: {
-        total: skillPlan.items.length + pluginPlan.items.length,
-        planned: skillPlan.items.length + pluginPlan.items.length,
-        migrated: 0,
-        skipped: 0,
-        conflicts: 0,
-        errors: 0,
-        sensitive: 0,
-      },
-      items: [...skillPlan.items, ...pluginPlan.items],
-    });
-    mocks.provider.plan.mockResolvedValue(planned);
-    mocks.multiselect
-      .mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP])
-      .mockResolvedValueOnce(["plugin:gmail"]);
-    mocks.promptYesNo.mockResolvedValue(true);
-    mocks.provider.apply.mockImplementation(async (_ctx, selectedPlan: MigrationPlan) => ({
-      ...selectedPlan,
-      summary: { ...selectedPlan.summary, planned: 0, migrated: selectedPlan.summary.planned },
-      items: selectedPlan.items.map((item) =>
-        item.status === "planned" ? { ...item, status: "migrated" as const } : item,
-      ),
-    }));
-
-    await migrateDefaultCommand(runtime, { provider: "codex" });
-
-    expect(mocks.multiselect).toHaveBeenCalledTimes(2);
-    expect(runtime.log).toHaveBeenCalledWith("Codex skill migration skipped for now.");
-    expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
-    const appliedPlan = firstAppliedPlan();
-    expect(appliedPlan.summary.planned).toBe(3);
-    expect(appliedPlan.summary.skipped).toBe(3);
-    expect(appliedPlan.summary.conflicts).toBe(0);
-    const itemsById = new Map(appliedPlan.items.map((item) => [item.id, item]));
-    expect(itemsById.get("skill:alpha")?.status).toBe("skipped");
-    expect(itemsById.get("skill:alpha")?.reason).toBe("not selected for migration");
-    expect(itemsById.get("skill:beta")?.status).toBe("skipped");
-    expect(itemsById.get("skill:beta")?.reason).toBe("not selected for migration");
-    expect(itemsById.get("plugin:gmail")?.status).toBe("planned");
-    expect(itemsById.get("plugin:google-calendar")?.status).toBe("skipped");
-    expect(itemsById.get("plugin:google-calendar")?.reason).toBe("not selected for migration");
-  });
-
-  it("explains skipped plugin selection when Codex subscription auth is required", async () => {
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: true,
-    });
-    const skillPlan = codexSkillPlan();
-    const warning =
-      "Codex app-backed plugin migration requires the Codex app-server source account to be logged in with a ChatGPT subscription account.";
-    const planned = codexSkillPlan({
-      summary: {
-        total: skillPlan.items.length + 1,
-        planned: skillPlan.summary.planned,
-        migrated: 0,
-        skipped: 1,
-        conflicts: 0,
-        errors: 0,
-        sensitive: 0,
-      },
-      items: [
-        ...skillPlan.items,
-        {
-          id: "plugin:gmail:1",
-          kind: "manual",
-          action: "manual",
-          status: "skipped",
-          reason: "codex_subscription_required",
-          details: { pluginName: "gmail" },
-        },
-      ],
-      warnings: [warning],
-    });
-    mocks.provider.plan.mockResolvedValue(planned);
-    mocks.multiselect.mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP]);
-
-    const result = await migrateDefaultCommand(runtime, { provider: "codex" });
-
-    expect(result.summary.planned).toBe(1);
-    expect(result.summary.skipped).toBe(3);
-    expect(mocks.multiselect).toHaveBeenCalledTimes(1);
-    expect(mocks.promptYesNo).not.toHaveBeenCalled();
-    expect(mocks.provider.apply).not.toHaveBeenCalled();
-    expect(runtime.log).toHaveBeenCalledWith("Codex skill migration skipped for now.");
-    expect(runtime.log).toHaveBeenCalledWith(warning);
-    expect(runtime.log).toHaveBeenCalledWith(
-      "No Codex skills selected; native Codex plugins are not eligible for migration in this run.",
-    );
   });
 
   it("does not apply archive-only Codex migration work after Toggle all off", async () => {

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -30,7 +30,7 @@ import {
   getMigrationSkillSelectionValue,
   getSelectableMigrationPluginItems,
   getSelectableMigrationSkillItems,
-  MIGRATION_SELECTION_SKIP,
+  MIGRATION_SELECTION_ACCEPT,
   MIGRATION_SELECTION_TOGGLE_ALL_OFF,
   MIGRATION_SELECTION_TOGGLE_ALL_ON,
   resolveInteractiveMigrationPluginSelection,
@@ -135,16 +135,9 @@ async function promptCodexMigrationSkillSelection(
     message: stylePromptMessage("Select Codex skills to migrate into this agent"),
     options: [
       {
-        value: MIGRATION_SELECTION_SKIP,
-        label: "Skip for now",
-      },
-      {
-        value: MIGRATION_SELECTION_TOGGLE_ALL_ON,
-        label: "Toggle all on",
-      },
-      {
-        value: MIGRATION_SELECTION_TOGGLE_ALL_OFF,
-        label: "Toggle all off",
+        value: MIGRATION_SELECTION_ACCEPT,
+        label: "Accept recommended",
+        hint: "Migrate every recommended skill",
       },
       ...skillItems.map((item) => {
         const hint = formatMigrationSkillSelectionHint(item);
@@ -154,10 +147,19 @@ async function promptCodexMigrationSkillSelection(
           hint: hint === undefined ? undefined : stylePromptHint(hint),
         };
       }),
+      {
+        value: MIGRATION_SELECTION_TOGGLE_ALL_ON,
+        label: "Toggle all on",
+      },
+      {
+        value: MIGRATION_SELECTION_TOGGLE_ALL_OFF,
+        label: "Toggle all off",
+      },
     ],
     initialValues: getDefaultMigrationSkillSelectionValues(skillItems),
     required: false,
     selectableValues: skillItems.map(getMigrationSkillSelectionValue),
+    cursorAt: MIGRATION_SELECTION_ACCEPT,
   });
   if (isCancel(selected)) {
     cancel(stylePromptTitle("Migration cancelled.") ?? "Migration cancelled.");
@@ -165,10 +167,6 @@ async function promptCodexMigrationSkillSelection(
     return null;
   }
   const selection = resolveInteractiveMigrationSkillSelection(skillItems, selected ?? []);
-  if (selection.action === "skip") {
-    runtime.log("Codex skill migration skipped for now.");
-    return applyMigrationSelectedSkillItemIds(plan, new Set());
-  }
   const selectedPlan = applyMigrationSelectedSkillItemIds(plan, selection.selectedItemIds);
   runtime.log(
     `Selected ${selection.selectedItemIds.size} of ${skillItems.length} Codex skills for migration.`,
@@ -198,16 +196,9 @@ async function promptCodexMigrationPluginSelection(
     message: stylePromptMessage("Select native Codex plugins to activate in this agent"),
     options: [
       {
-        value: MIGRATION_SELECTION_SKIP,
-        label: "Skip for now",
-      },
-      {
-        value: MIGRATION_SELECTION_TOGGLE_ALL_ON,
-        label: "Toggle all on",
-      },
-      {
-        value: MIGRATION_SELECTION_TOGGLE_ALL_OFF,
-        label: "Toggle all off",
+        value: MIGRATION_SELECTION_ACCEPT,
+        label: "Accept recommended",
+        hint: "Migrate every recommended plugin",
       },
       ...pluginItems.map((item) => {
         const hint = formatMigrationPluginSelectionHint(item);
@@ -217,10 +208,19 @@ async function promptCodexMigrationPluginSelection(
           hint: hint === undefined ? undefined : stylePromptHint(hint),
         };
       }),
+      {
+        value: MIGRATION_SELECTION_TOGGLE_ALL_ON,
+        label: "Toggle all on",
+      },
+      {
+        value: MIGRATION_SELECTION_TOGGLE_ALL_OFF,
+        label: "Toggle all off",
+      },
     ],
     initialValues: getDefaultMigrationPluginSelectionValues(pluginItems),
     required: false,
     selectableValues: pluginItems.map(getMigrationPluginSelectionValue),
+    cursorAt: MIGRATION_SELECTION_ACCEPT,
   });
   if (isCancel(selected)) {
     cancel(stylePromptTitle("Migration cancelled.") ?? "Migration cancelled.");
@@ -228,10 +228,6 @@ async function promptCodexMigrationPluginSelection(
     return null;
   }
   const selection = resolveInteractiveMigrationPluginSelection(pluginItems, selected ?? []);
-  if (selection.action === "skip") {
-    runtime.log("Codex plugin migration skipped for now.");
-    return null;
-  }
   const selectedPlan = applyMigrationSelectedPluginItemIds(plan, selection.selectedItemIds);
   runtime.log(
     `Selected ${selection.selectedItemIds.size} of ${pluginItems.length} native Codex plugins for activation.`,
@@ -334,7 +330,7 @@ export async function migratePlanCommand(
   const plan = await createMigrationPlanWithProgress(runtime, { ...opts, provider: providerId });
   if (opts.json) {
     writeRuntimeJson(runtime, redactMigrationPlan(plan));
-  } else {
+  } else if (opts.suppressPlanLog !== true) {
     runtime.log(formatMigrationPlan(plan).join("\n"));
   }
   return plan;

--- a/src/commands/migrate/selection.test.ts
+++ b/src/commands/migrate/selection.test.ts
@@ -9,7 +9,6 @@ import {
   getDefaultMigrationPluginSelectionValues,
   getSelectableMigrationPluginItems,
   getDefaultMigrationSkillSelectionValues,
-  MIGRATION_SKILL_SELECTION_SKIP,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
   MIGRATION_PLUGIN_NOT_SELECTED_REASON,
@@ -255,7 +254,7 @@ describe("applyMigrationSkillSelection", () => {
     ).toEqual(["skill:alpha"]);
   });
 
-  it("resolves interactive special options with skip and toggle-off precedence", () => {
+  it("resolves interactive special options with toggle-off precedence over toggle-on", () => {
     const items = [
       skillItem({ id: "skill:alpha", name: "alpha" }),
       skillItem({
@@ -268,12 +267,6 @@ describe("applyMigrationSkillSelection", () => {
 
     expect(
       resolveInteractiveMigrationSkillSelection(items, [
-        MIGRATION_SKILL_SELECTION_SKIP,
-        MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
-      ]),
-    ).toEqual({ action: "skip" });
-    expect(
-      resolveInteractiveMigrationSkillSelection(items, [
         MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
         MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
       ]),
@@ -283,15 +276,6 @@ describe("applyMigrationSkillSelection", () => {
     ).toEqual({
       action: "select",
       selectedItemIds: new Set(["skill:alpha", "skill:beta"]),
-    });
-    expect(
-      resolveInteractiveMigrationSkillSelection(items, [
-        MIGRATION_SKILL_SELECTION_SKIP,
-        "skill:alpha",
-      ]),
-    ).toEqual({
-      action: "select",
-      selectedItemIds: new Set(["skill:alpha"]),
     });
   });
 
@@ -328,31 +312,9 @@ describe("applyMigrationSkillSelection", () => {
     ).toEqual(["skill:alpha"]);
 
     expect(
-      reconcileInteractiveMigrationSkillToggleValues(
-        [
-          MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
-          "skill:alpha",
-          "skill:beta",
-          MIGRATION_SKILL_SELECTION_SKIP,
-        ],
-        MIGRATION_SKILL_SELECTION_SKIP,
-        selectable,
-      ),
-    ).toEqual([MIGRATION_SKILL_SELECTION_SKIP]);
-
-    expect(
-      reconcileInteractiveMigrationSkillToggleValues(
-        [MIGRATION_SKILL_SELECTION_SKIP, "skill:alpha"],
-        "skill:alpha",
-        selectable,
-      ),
-    ).toEqual(["skill:alpha"]);
-
-    expect(
       reconcileInteractiveMigrationShortcutValues(
         ["skill:alpha", "skill:beta"],
         [
-          MIGRATION_SKILL_SELECTION_SKIP,
           MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
           MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
           "skill:alpha",
@@ -366,36 +328,15 @@ describe("applyMigrationSkillSelection", () => {
     expect(
       reconcileInteractiveMigrationShortcutValues(
         [MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF],
-        [
-          MIGRATION_SKILL_SELECTION_SKIP,
-          MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
-          MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
-        ],
+        [MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON],
         selectable,
         "i",
       ),
     ).toEqual([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF]);
-
-    expect(
-      reconcileInteractiveMigrationShortcutValues(
-        [MIGRATION_SKILL_SELECTION_SKIP],
-        [MIGRATION_SKILL_SELECTION_SKIP, "skill:beta"],
-        selectable,
-        "i",
-      ),
-    ).toEqual(["skill:beta"]);
   });
 
   it("reconciles enter as activating the cursor row without toggling it off", () => {
     const selectable = ["skill:alpha", "skill:beta"];
-
-    expect(
-      reconcileInteractiveMigrationEnterValues(
-        ["skill:alpha", "skill:beta"],
-        MIGRATION_SKILL_SELECTION_SKIP,
-        selectable,
-      ),
-    ).toEqual([MIGRATION_SKILL_SELECTION_SKIP]);
 
     expect(
       reconcileInteractiveMigrationEnterValues(

--- a/src/commands/migrate/selection.ts
+++ b/src/commands/migrate/selection.ts
@@ -4,16 +4,14 @@ import type { MigrationItem, MigrationPlan } from "../../plugins/types.js";
 
 export const MIGRATION_SKILL_NOT_SELECTED_REASON = "not selected for migration";
 export const MIGRATION_PLUGIN_NOT_SELECTED_REASON = "not selected for migration";
+export const MIGRATION_SELECTION_ACCEPT = "__openclaw_migrate_accept_recommended__";
 export const MIGRATION_SELECTION_TOGGLE_ALL_ON = "__openclaw_migrate_toggle_all_on__";
 export const MIGRATION_SELECTION_TOGGLE_ALL_OFF = "__openclaw_migrate_toggle_all_off__";
-export const MIGRATION_SELECTION_SKIP = "__openclaw_migrate_skip_for_now__";
+export const MIGRATION_SKILL_SELECTION_ACCEPT = MIGRATION_SELECTION_ACCEPT;
 export const MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON = MIGRATION_SELECTION_TOGGLE_ALL_ON;
 export const MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF = MIGRATION_SELECTION_TOGGLE_ALL_OFF;
-export const MIGRATION_SKILL_SELECTION_SKIP = MIGRATION_SELECTION_SKIP;
 
-type InteractiveMigrationSelection =
-  | { action: "skip" }
-  | { action: "select"; selectedItemIds: Set<string> };
+type InteractiveMigrationSelection = { action: "select"; selectedItemIds: Set<string> };
 export type InteractiveMigrationSkillSelection = InteractiveMigrationSelection;
 export type InteractiveMigrationPluginSelection = InteractiveMigrationSelection;
 
@@ -425,10 +423,6 @@ function resolveInteractiveMigrationSelection(
   }
 
   const selectedValueSet = new Set(selectedValues);
-  if (selectedValueSet.has(MIGRATION_SELECTION_SKIP)) {
-    return { action: "skip" };
-  }
-
   if (selectedValueSet.has(MIGRATION_SELECTION_TOGGLE_ALL_OFF)) {
     return { action: "select", selectedItemIds: new Set() };
   }
@@ -469,9 +463,6 @@ export function reconcileInteractiveMigrationSkillToggleValues(
   activatedValue: string | undefined,
   selectableValues: readonly string[],
 ): string[] {
-  if (activatedValue === MIGRATION_SELECTION_SKIP) {
-    return selectedValues.includes(MIGRATION_SELECTION_SKIP) ? [MIGRATION_SELECTION_SKIP] : [];
-  }
   if (activatedValue === MIGRATION_SELECTION_TOGGLE_ALL_ON) {
     return [MIGRATION_SELECTION_TOGGLE_ALL_ON, ...selectableValues];
   }
@@ -481,9 +472,7 @@ export function reconcileInteractiveMigrationSkillToggleValues(
   if (activatedValue !== undefined && selectableValues.includes(activatedValue)) {
     return selectedValues.filter(
       (value) =>
-        value !== MIGRATION_SELECTION_TOGGLE_ALL_ON &&
-        value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF &&
-        value !== MIGRATION_SELECTION_SKIP,
+        value !== MIGRATION_SELECTION_TOGGLE_ALL_ON && value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF,
     );
   }
   return selectedValues.filter(
@@ -499,9 +488,6 @@ export function reconcileInteractiveMigrationEnterValues(
   selectableValues: readonly string[],
   opts: { preserveDeselectedActivatedValue?: boolean } = {},
 ): string[] {
-  if (activatedValue === MIGRATION_SELECTION_SKIP) {
-    return [MIGRATION_SELECTION_SKIP];
-  }
   if (activatedValue === MIGRATION_SELECTION_TOGGLE_ALL_ON) {
     return [MIGRATION_SELECTION_TOGGLE_ALL_ON, ...selectableValues];
   }
@@ -511,9 +497,7 @@ export function reconcileInteractiveMigrationEnterValues(
   if (activatedValue !== undefined && selectableValues.includes(activatedValue)) {
     const selectedSelectableValues = selectedValues.filter(
       (value) =>
-        value !== MIGRATION_SELECTION_TOGGLE_ALL_ON &&
-        value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF &&
-        value !== MIGRATION_SELECTION_SKIP,
+        value !== MIGRATION_SELECTION_TOGGLE_ALL_ON && value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF,
     );
     if (opts.preserveDeselectedActivatedValue && !selectedValues.includes(activatedValue)) {
       return selectedSelectableValues;
@@ -530,11 +514,7 @@ export function reconcileInteractiveMigrationShortcutValues(
   key: "a" | "i",
 ): string[] {
   const previousSelectable = previousValues.filter((value) => selectableValues.includes(value));
-  if (
-    key === "a" &&
-    !previousValues.includes(MIGRATION_SELECTION_SKIP) &&
-    previousSelectable.length === selectableValues.length
-  ) {
+  if (key === "a" && previousSelectable.length === selectableValues.length) {
     return [MIGRATION_SELECTION_TOGGLE_ALL_OFF];
   }
 

--- a/src/commands/migrate/skill-selection-prompt.test.ts
+++ b/src/commands/migrate/skill-selection-prompt.test.ts
@@ -1,7 +1,7 @@
 import { PassThrough, Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import {
-  MIGRATION_SKILL_SELECTION_SKIP,
+  MIGRATION_SKILL_SELECTION_ACCEPT,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
 } from "./selection.js";
@@ -29,11 +29,11 @@ async function runPromptWithKeys(params: {
   const result = promptMigrationSkillSelectionValues({
     message: "Select Codex skills",
     options: [
-      { value: MIGRATION_SKILL_SELECTION_SKIP, label: "Skip for now" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
+      { value: MIGRATION_SKILL_SELECTION_ACCEPT, label: "Accept recommended" },
       { value: "skill:alpha", label: "alpha" },
       { value: "skill:beta", label: "beta" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
     ],
     initialValues: params.initialValues,
     required: false,
@@ -70,15 +70,6 @@ async function runPromptWithReturn(params: {
 }
 
 describe("promptMigrationSkillSelectionValues", () => {
-  it("activates Skip for now before submitting with return", async () => {
-    await expect(
-      runPromptWithReturn({
-        cursorAt: MIGRATION_SKILL_SELECTION_SKIP,
-        initialValues: ["skill:alpha", "skill:beta"],
-      }),
-    ).resolves.toEqual([MIGRATION_SKILL_SELECTION_SKIP]);
-  });
-
   it("keeps the cursor item selected when submitting with return", async () => {
     await expect(
       runPromptWithReturn({
@@ -114,5 +105,28 @@ describe("promptMigrationSkillSelectionValues", () => {
         initialValues: [],
       }),
     ).resolves.toEqual([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, "skill:alpha", "skill:beta"]);
+  });
+
+  it("submits the initial recommended set when Enter is pressed on Accept recommended", async () => {
+    await expect(
+      runPromptWithReturn({
+        cursorAt: MIGRATION_SKILL_SELECTION_ACCEPT,
+        initialValues: ["skill:alpha", "skill:beta"],
+      }),
+    ).resolves.toEqual(["skill:alpha", "skill:beta"]);
+  });
+
+  it("snaps the visual selection to the recommended set when Space is pressed on Accept recommended", async () => {
+    // Space on Accept overwrites the current selection with `initialValues` so
+    // the visible checkboxes match the recommended set. The Enter that follows
+    // then submits that same set; Accept itself is never persisted in the
+    // submitted value list.
+    await expect(
+      runPromptWithKeys({
+        cursorAt: MIGRATION_SKILL_SELECTION_ACCEPT,
+        initialValues: ["skill:alpha", "skill:beta"],
+        keys: [" ", "\r"],
+      }),
+    ).resolves.toEqual(["skill:alpha", "skill:beta"]);
   });
 });

--- a/src/commands/migrate/skill-selection-prompt.ts
+++ b/src/commands/migrate/skill-selection-prompt.ts
@@ -11,6 +11,7 @@ import {
   symbolBar,
 } from "@clack/prompts";
 import {
+  MIGRATION_SELECTION_ACCEPT,
   reconcileInteractiveMigrationEnterValues,
   reconcileInteractiveMigrationShortcutValues,
   reconcileInteractiveMigrationSkillToggleValues,
@@ -181,6 +182,15 @@ export function promptMigrationSkillSelectionValues(
       return;
     }
     const activatedValue = prompt.options[prompt.cursor]?.value;
+    // Space on the "Accept recommended" sentinel snaps the visual selection
+    // back to the recommended set so the user can see what would be submitted
+    // by Enter. The sentinel itself is never persisted in the value list.
+    if (activatedValue === MIGRATION_SELECTION_ACCEPT) {
+      prompt.value = [...(opts.initialValues ?? [])];
+      lastSpaceDeselectedValue = undefined;
+      lastSelectedValues = [...(prompt.value ?? [])];
+      return;
+    }
     const previousValues = lastSelectedValues;
     const selectedValuesAfterClack = prompt.value ?? [];
     prompt.value = reconcileInteractiveMigrationSkillToggleValues(
@@ -202,6 +212,14 @@ export function promptMigrationSkillSelectionValues(
     if (info.name === "return") {
       const activatedOption = prompt.options[prompt.cursor];
       const activatedValue = activatedOption?.disabled ? undefined : activatedOption?.value;
+      // Enter on "Accept recommended" submits with the picker's initialValues
+      // (the recommended set) regardless of any toggles the user made.
+      if (activatedValue === MIGRATION_SELECTION_ACCEPT) {
+        prompt.value = [...(opts.initialValues ?? [])];
+        lastSpaceDeselectedValue = undefined;
+        lastSelectedValues = [...(prompt.value ?? [])];
+        return;
+      }
       prompt.value = reconcileInteractiveMigrationEnterValues(
         prompt.value ?? [],
         activatedValue,

--- a/src/commands/migrate/types.ts
+++ b/src/commands/migrate/types.ts
@@ -9,6 +9,11 @@ export type MigrateCommonOptions = {
   plugins?: string[];
   verifyPluginApps?: boolean;
   json?: boolean;
+  // Suppress the formatted plan dump that `migrate plan` normally prints
+  // before any interactive selection. Used by onboarding flows that have
+  // already secured user consent and do not want to re-render the plan.
+  // The interactive selection picker and apply confirmation still run.
+  suppressPlanLog?: boolean;
 };
 
 export type MigrateApplyOptions = MigrateCommonOptions & {

--- a/src/wizard/setup.post-install-migration.test.ts
+++ b/src/wizard/setup.post-install-migration.test.ts
@@ -170,7 +170,10 @@ describe("offerPostInstallMigrations", () => {
     expect(confirm).toHaveBeenCalledOnce();
     expect(confirm).toHaveBeenCalledWith(expect.objectContaining({ initialValue: false }));
     expect(migrateDefaultCommand).toHaveBeenCalledOnce();
-    expect(migrateDefaultCommand).toHaveBeenCalledWith(expect.anything(), { provider: "codex" });
+    expect(migrateDefaultCommand).toHaveBeenCalledWith(expect.anything(), {
+      provider: "codex",
+      suppressPlanLog: true,
+    });
   });
 
   it("does not invoke migrateDefaultCommand when the user declines", async () => {

--- a/src/wizard/setup.post-install-migration.ts
+++ b/src/wizard/setup.post-install-migration.ts
@@ -148,7 +148,10 @@ export async function offerPostInstallMigrations(
     }
     try {
       const { migrateDefaultCommand } = await import("../commands/migrate.js");
-      await migrateDefaultCommand(params.runtime, { provider: candidate.provider.id });
+      await migrateDefaultCommand(params.runtime, {
+        provider: candidate.provider.id,
+        suppressPlanLog: true,
+      });
     } catch (error) {
       params.runtime.log(
         `${candidate.provider.label} migration failed: ${formatErrorMessage(error)}. ` +


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/1db6ad60-e787-48a6-a1aa-37eda0fe68d1


Improvements to the interactive `openclaw migrate <provider>` flow, surfaced by the onboarding post-install migration prompt that landed in #81192.

1. **New `suppressPlanLog` option on `MigrateCommonOptions`.** Callers that have already secured user consent (notably the onboarding migration prompt) can drive `migrate <provider>` without the redundant up-front plan dump. The interactive selection picker and the "Apply this migration now?" confirm still run; only the standalone-CLI plan preview is silenced. Wired from `src/wizard/setup.post-install-migration.ts` so the wizard no longer shows the plan ahead of its own consent gate.

2. **New "Accept recommended" sentinel at the top of the selection pickers**, with "Toggle all on" and "Toggle all off" moved to the bottom. The cursor starts on "Accept recommended" so pressing Enter at the default position submits the picker's `initialValues` (the recommended set) — matching the visual state of the checkboxes. Pressing Space on the Accept row snaps the visible checkboxes back to the recommended set so the user can see exactly what would be submitted; the user can then Enter to commit or continue toggling individual rows.

3. **Removed the "Skip for now" sentinel entirely.** It was a single-keystroke trap: with the picker cursor wrapping from Accept to Skip via up-arrow (or via accidental down-arrows), Enter on Skip wiped `prompt.value` to `[MIGRATION_SELECTION_SKIP]` and abandoned the whole migration — including any items the user had already confirmed in the previous picker. To exit without migrating, users now navigate to "Toggle all off" (or use the `a` / `i` keyboard shortcuts) to clear the selection; the apply phase then sees no planned work and skips itself via the existing `shouldSkipCodexApplyAfterInteractiveSelection` path.

4. **Plugin selection hint relabelled** from `"Activate every recommended plugin"` to `"Migrate every recommended plugin"` to match the skill hint and the prompt's own verb.

## Before / after — Codex skill picker layout

Before:

```
[ ] Skip for now
[ ] Toggle all on
[ ] Toggle all off
[x] alpha
[x] beta
```

After:

```
[ ] Accept recommended       <- cursor lands here; Enter submits recommended (alpha + beta)
[x] alpha
[x] beta
[ ] Toggle all on
[ ] Toggle all off
```

Enter / Space on "Toggle all on", "Toggle all off", and individual skill rows behaves as before. The `a` (toggle all) and `i` (invert) keyboard shortcuts are unchanged.

## Files

- `src/commands/migrate/types.ts` — `suppressPlanLog?: boolean` on `MigrateCommonOptions`.
- `src/commands/migrate.ts` — `migratePlanCommand` skips the plan log when `opts.suppressPlanLog === true`; both selection pickers add "Accept recommended" at the top, drop the "Skip for now" row, keep Toggle on/off at the bottom, and set `cursorAt: MIGRATION_SELECTION_ACCEPT`; plugin-hint text updated; dead `if (selection.action === "skip")` blocks removed from both pickers.
- `src/commands/migrate/selection.ts` — new `MIGRATION_SELECTION_ACCEPT` constant (and `MIGRATION_SKILL_SELECTION_ACCEPT` alias); `MIGRATION_SELECTION_SKIP` / `MIGRATION_SKILL_SELECTION_SKIP` constants removed; `{ action: "skip" }` variant removed from `InteractiveMigrationSelection`; SKIP branches stripped from `resolveInteractiveMigrationSelection`, `reconcileInteractiveMigrationSkillToggleValues`, `reconcileInteractiveMigrationEnterValues`, and `reconcileInteractiveMigrationShortcutValues`.
- `src/commands/migrate/skill-selection-prompt.ts` — Enter on the Accept sentinel sets `prompt.value` to `opts.initialValues` and submits; Space on the Accept sentinel sets `prompt.value` to `opts.initialValues` and stays on the row, snapping the visible checkboxes back to the recommended state.
- `src/commands/migrate/skill-selection-prompt.test.ts` — Accept sentinel coverage; Skip row dropped from picker fixture; Skip-cursor test removed.
- `src/commands/migrate/selection.test.ts` — Skip sub-assertions trimmed from resolve / reconcile tests; "skip + toggle-off precedence" renamed.
- `src/commands/migrate.test.ts` — four Skip-driven scenarios removed (plugin-only skip, both-pickers skip, skip-skills-continue-to-plugins, Codex subscription warning + skip).
- `src/wizard/setup.post-install-migration.ts` — passes `suppressPlanLog: true` when handing off to `migrateDefaultCommand` from the post-install migration offer.
- `src/wizard/setup.post-install-migration.test.ts` — call-args assertion expects the new option.

## Verification

```
pnpm lint                                                              # 0 errors
pnpm tsgo:core && pnpm tsgo:core:test                                  # clean
pnpm test src/commands/migrate.test.ts                                 # 32/32 passed
pnpm test src/commands/migrate/selection.test.ts                       # 17/17 passed
pnpm test src/commands/migrate/skill-selection-prompt.test.ts          # 6/6 passed
pnpm test src/wizard/setup.post-install-migration.test.ts              # 10/10 passed
```

### Real behavior proof — interactive `bash run.sh onboard-fast`

Verified locally against the seeded `~/onboarding/codex_home` fixture:

1. Picked `openai/gpt-5.5` so `ensureCodexRuntimePluginForModelSelection` ran.
2. Wizard prompt fired: `Migrate Codex at /Users/sjf/onboarding/codex_home into this agent now?` (y).
3. No plan dump.
4. Codex selection picker fired with the new layout — cursor on "Accept recommended", all skills pre-selected, no Skip row in sight. Pressed Enter → submitted the recommended set.
5. Plugin picker fired with the same layout. Enter on Accept → submitted recommended plugins.
6. `Apply this migration now?` (y).
7. Progress label + post-apply summary printed.

## Notes

- `suppressPlanLog` is a single new boolean on an existing options type; no breaking change to the CLI surface or to `migrateDefaultCommand` callers that do not pass it.
- The Skip removal is a real UX behavior change for the standalone `openclaw migrate <provider>` CLI too. Users who want to exit without migrating now toggle the selection empty (e.g. "Toggle all off") — the apply phase already handles "nothing planned" by skipping cleanly.
- `shouldSkipCodexApplyAfterInteractiveSelection`, `hasCodexSubscriptionRequiredPlugin`, `readCodexSubscriptionWarning`, and `logNoCodexSelection` are preserved — they handle the "user produced no selectable work" case (via Toggle all off, individual deselect, or empty initial set) which is still a valid path.
