### PR TITLE
feat(onboard): add --skip-hooks flag

### DIFF
--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -169,6 +169,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--skip-search", "Skip search provider setup")
     .option("--skip-health", "Skip health check")
     .option("--skip-ui", "Skip Control UI/TUI prompts")
+    .option("--skip-hooks", "Skip hook setup")
     .option("--node-manager <name>", "Node manager for skills: npm|pnpm|bun")
     .option("--import-from <provider>", "Migration provider to run during onboarding")
     .option("--import-source <path>", "Source agent home for --import-from")
@@ -245,6 +246,7 @@ export function registerOnboardCommand(program: Command) {
           skipSearch: Boolean(opts.skipSearch),
           skipHealth: Boolean(opts.skipHealth),
           skipUi: Boolean(opts.skipUi),
+          skipHooks: Boolean(opts.skipHooks),
           nodeManager: opts.nodeManager as NodeManagerChoice | undefined,
           importFrom: opts.importFrom as string | undefined,
           importSource: opts.importSource as string | undefined,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -79,6 +79,7 @@ export type OnboardOptions = OnboardDynamicProviderOptions & {
   skipSearch?: boolean;
   skipHealth?: boolean;
   skipUi?: boolean;
+  skipHooks?: boolean;
   nodeManager?: NodeManagerChoice;
   remoteUrl?: string;
   remoteToken?: string;

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -780,9 +780,11 @@ export async function runSetupWizard(
     });
   }
 
-  // Setup hooks (session memory on /new)
-  const { setupInternalHooks } = await import("../commands/onboard-hooks.js");
-  nextConfig = await setupInternalHooks(nextConfig, runtime, prompter);
+  if (!opts.skipHooks) {
+    // Setup hooks (session memory on /new)
+    const { setupInternalHooks } = await import("../commands/onboard-hooks.js");
+    nextConfig = await setupInternalHooks(nextConfig, runtime, prompter);
+  }
 
   nextConfig = onboardHelpers.applyWizardMetadata(nextConfig, { command: "onboard", mode });
   nextConfig = await writeWizardConfigFile(nextConfig);


### PR DESCRIPTION
## Summary

`openclaw onboard` has `--skip-channels`, `--skip-skills`, `--skip-search`, `--skip-ui`, etc., but no `--skip-hooks`. The hook-enable step (`src/commands/onboard-hooks.ts`) is unconditional, so wizard runs always pause on the "Enable hooks?" multiselect even when the operator just wants to bring up an agent fast.

This PR adds `--skip-hooks`, gating the `setupInternalHooks` call at `src/wizard/setup.ts:787` on the new flag.

## Files

- `src/cli/program/register.onboard.ts` — register the option, wire `skipHooks` into the opts object.
- `src/commands/onboard-types.ts` — add `skipHooks?: boolean` to `OnboardOptions`.
- `src/wizard/setup.ts` — skip the hook-setup block when the flag is set.

## Verification

- `pnpm lint` clean.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` clean.
- Manual: `openclaw onboard --skip-hooks` runs the wizard without the "Enable hooks?" prompt; without the flag the prompt still fires.