### PR TITLE
fix(onboard): skip config-handling prompt when no key settings detected

### DIFF
--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -39,7 +39,7 @@ export function guardCancel<T>(value: T | symbol, runtime: RuntimeEnv): T {
   return value;
 }
 
-export function summarizeExistingConfig(config: OpenClawConfig): string {
+function collectKeyConfigRows(config: OpenClawConfig): string[] {
   const rows: string[] = [];
   const defaults = config.agents?.defaults;
   if (defaults?.workspace) {
@@ -66,6 +66,15 @@ export function summarizeExistingConfig(config: OpenClawConfig): string {
   if (config.skills?.install?.nodeManager) {
     rows.push(shortenHomeInString(`skills.nodeManager: ${config.skills.install.nodeManager}`));
   }
+  return rows;
+}
+
+export function hasKeyConfigSettings(config: OpenClawConfig): boolean {
+  return collectKeyConfigRows(config).length > 0;
+}
+
+export function summarizeExistingConfig(config: OpenClawConfig): string {
+  const rows = collectKeyConfigRows(config);
   return rows.length ? rows.join("\n") : "No key settings detected.";
 }
 

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -285,7 +285,11 @@ export async function runSetupWizard(
     flow = "advanced";
   }
 
-  if (snapshot.exists) {
+  if (snapshot.exists && !onboardHelpers.hasKeyConfigSettings(baseConfig)) {
+    await prompter.note("No existing config detected.");
+  }
+
+  if (snapshot.exists && onboardHelpers.hasKeyConfigSettings(baseConfig)) {
     await prompter.note(
       onboardHelpers.summarizeExistingConfig(baseConfig),
       "Existing config detected",


### PR DESCRIPTION
## Summary
- Onboarding wizard previously showed an \"Existing config detected\" panel saying \"No key settings detected.\" followed by a \"Config handling\" select (keep/modify/reset) whenever a config file existed but had no meaningful values set.
- Now: when the config file exists but no key settings are present, show a single \"No existing config detected.\" note and continue. The existing-config panel and config-handling select still appear when there are real settings to preserve.

Adds `hasKeyConfigSettings(config)` helper alongside `summarizeExistingConfig`, sharing a private `collectKeyConfigRows` helper so they cannot drift.

## Verification
- [ ] `pnpm test src/wizard/setup.test.ts src/commands/onboard-helpers.test.ts`
- [ ] Manual: `bash run.sh reset && bash run.sh onboard` against an empty config — wizard should skip the config-handling prompt
- [ ] Manual: same with a populated config — wizard should still show the existing-config panel and select