### PR TITLE
fix(providers): keep self-hosted wildcard discovery with explicit config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- vLLM/SGLang: keep provider wildcard model discovery active when an explicit self-hosted provider endpoint is configured, so `agents.defaults.models["vllm/*"]` and `["sglang/*"]` can still load models from the configured `/models` endpoint. Fixes #81218.
 - Sessions: redact persisted tool result detail metadata before writing transcripts so diagnostic secrets do not survive tool output redaction. (#80444) Thanks @nimbleenigma.
 - Codex migration: make Enter activate the highlighted checkbox row before continuing, so `Skip for now` and bulk-selection rows work even when planned items start preselected.
 - fix: harden safe-bin argument validation [AI]. (#80999) Thanks @pgondhi987.

--- a/docs/providers/sglang.md
+++ b/docs/providers/sglang.md
@@ -20,7 +20,7 @@ SGLang serves open-weight models via an OpenAI-compatible HTTP API. OpenClaw con
 | Streaming usage           | Yes (`supportsStreamingUsage: true`)                         |
 | Pricing                   | Marked external-free (`modelPricing.external: false`)        |
 
-OpenClaw also **auto-discovers** available models from SGLang when you opt in with `SGLANG_API_KEY` and you do not define an explicit `models.providers.sglang` entry — see [Model discovery (implicit provider)](#model-discovery-implicit-provider) below.
+OpenClaw also **auto-discovers** available models from SGLang when you opt in with `SGLANG_API_KEY`. With the default endpoint, discovery works without an explicit `models.providers.sglang` entry. With a custom endpoint, define `models.providers.sglang.baseUrl` and add `agents.defaults.models["sglang/*"]` to keep the provider dynamic — see [Model discovery](#model-discovery) below.
 
 ## Getting started
 
@@ -61,18 +61,22 @@ OpenClaw also **auto-discovers** available models from SGLang when you opt in wi
   </Step>
 </Steps>
 
-## Model discovery (implicit provider)
+## Model discovery
 
-When `SGLANG_API_KEY` is set (or an auth profile exists) and you **do not**
-define `models.providers.sglang`, OpenClaw will query:
+When `SGLANG_API_KEY` is set (or an auth profile exists), OpenClaw can discover
+models from the default SGLang endpoint:
 
 - `GET http://127.0.0.1:30000/v1/models`
 
-and convert the returned IDs into model entries.
+and convert the returned IDs into model entries. For non-default endpoints,
+define `models.providers.sglang.baseUrl` and keep discovery enabled with a
+provider wildcard such as `agents.defaults.models["sglang/*"]`.
 
 <Note>
-If you set `models.providers.sglang` explicitly, auto-discovery is skipped and
-you must define models manually.
+If you set exact model entries such as `agents.defaults.models["sglang/my-model"]`,
+explicit `models.providers.sglang` config stays manual-only. If you set a
+provider wildcard such as `agents.defaults.models["sglang/*"]`, OpenClaw still
+queries the configured provider `baseUrl` and shows the returned models.
 </Note>
 
 ## Explicit configuration (manual models)
@@ -143,6 +147,38 @@ Use explicit config when:
     If you run SGLang without authentication, any non-empty value for
     `SGLANG_API_KEY` is sufficient to opt in to model discovery.
     </Tip>
+
+  </Accordion>
+
+  <Accordion title="Discover models from a custom endpoint">
+    Use a provider wildcard when you want OpenClaw to discover models from a
+    non-default SGLang endpoint while keeping the endpoint, auth, and request
+    policy explicit:
+
+    ```json5
+    {
+      models: {
+        providers: {
+          sglang: {
+            baseUrl: "http://192.168.1.50:30000/v1",
+            apiKey: "${SGLANG_API_KEY}",
+            api: "openai-completions",
+            request: { allowPrivateNetwork: true },
+            models: [],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          models: {
+            "sglang/*": {},
+          },
+        },
+      },
+    }
+    ```
+
+    Exact entries such as `"sglang/my-custom-model": {}` remain manual-only.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/providers/vllm.md
+++ b/docs/providers/vllm.md
@@ -8,7 +8,7 @@ title: "vLLM"
 
 vLLM can serve open-source (and some custom) models via an **OpenAI-compatible** HTTP API. OpenClaw connects to vLLM using the `openai-completions` API.
 
-OpenClaw can also **auto-discover** available models from vLLM when you opt in with `VLLM_API_KEY` (any value works if your server does not enforce auth) and you do not define an explicit `models.providers.vllm` entry.
+OpenClaw can also **auto-discover** available models from vLLM when you opt in with `VLLM_API_KEY` (any value works if your server does not enforce auth). With the default endpoint, discovery works without an explicit `models.providers.vllm` entry. With a custom endpoint, define `models.providers.vllm.baseUrl` and add `agents.defaults.models["vllm/*"]` to keep the provider dynamic.
 
 OpenClaw treats `vllm` as a local OpenAI-compatible provider that supports
 streamed usage accounting, so status/context token counts can update from
@@ -61,18 +61,18 @@ streamed usage accounting, so status/context token counts can update from
   </Step>
 </Steps>
 
-## Model discovery (implicit provider)
+## Model discovery
 
-When `VLLM_API_KEY` is set (or an auth profile exists) and you **do not** define `models.providers.vllm`, OpenClaw queries:
+When `VLLM_API_KEY` is set (or an auth profile exists), OpenClaw can discover models from the default vLLM endpoint:
 
 ```
 GET http://127.0.0.1:8000/v1/models
 ```
 
-and converts the returned IDs into model entries.
+and convert the returned IDs into model entries. For non-default endpoints, define `models.providers.vllm.baseUrl` and keep discovery enabled with a provider wildcard such as `agents.defaults.models["vllm/*"]`.
 
 <Note>
-If you set `models.providers.vllm` explicitly, auto-discovery is skipped and you must define models manually.
+If you set exact model entries such as `agents.defaults.models["vllm/my-model"]`, explicit `models.providers.vllm` config stays manual-only. If you set a provider wildcard such as `agents.defaults.models["vllm/*"]`, OpenClaw still queries the configured provider `baseUrl` and shows the returned models.
 </Note>
 
 ## Explicit configuration (manual models)
@@ -331,7 +331,41 @@ Use explicit config when:
   </Accordion>
 
   <Accordion title="No models discovered">
-    Auto-discovery requires `VLLM_API_KEY` to be set **and** no explicit `models.providers.vllm` config entry. If you have defined the provider manually, OpenClaw skips discovery and uses only your declared models.
+    Auto-discovery requires `VLLM_API_KEY` to be set. If you define the
+    provider manually, use a provider wildcard such as
+    `agents.defaults.models["vllm/*"]`; exact entries remain manual-only.
+  </Accordion>
+
+  <Accordion title="Discover models from a custom endpoint">
+    Use a provider wildcard when you want OpenClaw to discover models from a
+    non-default vLLM endpoint while keeping the endpoint, auth, and request
+    policy explicit:
+
+    ```json5
+    {
+      models: {
+        providers: {
+          vllm: {
+            baseUrl: "http://192.168.1.50:9000/v1",
+            apiKey: "${VLLM_API_KEY}",
+            api: "openai-completions",
+            request: { allowPrivateNetwork: true },
+            models: [],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          models: {
+            "vllm/*": {},
+          },
+        },
+      },
+    }
+    ```
+
+    Exact entries such as `"vllm/my-custom-model": {}` remain manual-only.
+
   </Accordion>
 
   <Accordion title="Tools render as raw text">

--- a/src/plugins/provider-self-hosted-setup.test.ts
+++ b/src/plugins/provider-self-hosted-setup.test.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   configureOpenAICompatibleSelfHostedProviderNonInteractive,
   discoverOpenAICompatibleLocalModels,
+  discoverOpenAICompatibleSelfHostedProvider,
 } from "./provider-self-hosted-setup.js";
-import type { ProviderAuthMethodNonInteractiveContext } from "./types.js";
+import type { ProviderAuthMethodNonInteractiveContext, ProviderDiscoveryContext } from "./types.js";
 
 const { fetchWithSsrFGuardMock, upsertAuthProfileWithLock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -61,6 +62,38 @@ function createContext(params: {
         key: apiKeyResult.key,
       }),
     ),
+  };
+}
+
+function createDiscoveryContext(
+  params: Partial<ProviderDiscoveryContext> = {},
+): ProviderDiscoveryContext {
+  return {
+    config: { agents: { defaults: {} } },
+    env: {},
+    resolveProviderApiKey: vi.fn(() => ({
+      apiKey: "runtime-vllm-key",
+      discoveryApiKey: "discovery-vllm-key",
+    })),
+    resolveProviderAuth: vi.fn(() => ({
+      apiKey: "runtime-vllm-key",
+      discoveryApiKey: "discovery-vllm-key",
+      mode: "api_key" as const,
+      source: "env" as const,
+    })),
+    ...params,
+  };
+}
+
+function modelConfig(id: string) {
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text" as const],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 8192,
   };
 }
 
@@ -393,6 +426,126 @@ describe("discoverOpenAICompatibleLocalModels", () => {
       timeoutMs: 5000,
     });
     expect(release).toHaveBeenCalledOnce();
+  });
+});
+
+describe("discoverOpenAICompatibleSelfHostedProvider", () => {
+  it("keeps explicit provider config manual-only without provider wildcard visibility", async () => {
+    const buildProvider = vi.fn(async () => ({
+      baseUrl: "http://127.0.0.1:8000/v1",
+      api: "openai-completions",
+      models: [{ id: "Qwen/Qwen3-32B", name: "Qwen/Qwen3-32B" }],
+    }));
+    const ctx = createDiscoveryContext({
+      config: {
+        agents: {
+          defaults: {
+            models: { "vllm/Qwen/Qwen3-32B": {} },
+          },
+        },
+        models: {
+          providers: {
+            vllm: {
+              baseUrl: "http://configured-vllm.example/v1",
+              api: "openai-completions",
+              models: [modelConfig("manual-model")],
+            },
+          },
+        },
+      },
+    });
+
+    const result = await discoverOpenAICompatibleSelfHostedProvider({
+      ctx,
+      providerId: "vllm",
+      buildProvider,
+    });
+
+    expect(result).toBeNull();
+    expect(buildProvider).not.toHaveBeenCalled();
+    expect(ctx.resolveProviderApiKey).not.toHaveBeenCalled();
+  });
+
+  it("discovers through explicit provider baseUrl when provider wildcard visibility is configured", async () => {
+    const buildProvider = vi.fn(async (params: { apiKey?: string; baseUrl?: string }) => ({
+      baseUrl: params.baseUrl ?? "http://default-vllm.example/v1",
+      api: "openai-completions",
+      models: [{ id: "Qwen/Qwen3-32B", name: "Qwen/Qwen3-32B" }],
+    }));
+    const ctx = createDiscoveryContext({
+      config: {
+        agents: {
+          defaults: {
+            models: { "vllm/*": {} },
+          },
+        },
+        models: {
+          providers: {
+            vllm: {
+              baseUrl: "http://configured-vllm.example/v1",
+              api: "openai-completions",
+              request: { allowPrivateNetwork: true },
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    const result = await discoverOpenAICompatibleSelfHostedProvider({
+      ctx,
+      providerId: "vllm",
+      buildProvider,
+    });
+
+    expect(buildProvider).toHaveBeenCalledWith({
+      apiKey: "discovery-vllm-key",
+      baseUrl: "http://configured-vllm.example/v1",
+    });
+    expect(result).toEqual({
+      provider: {
+        baseUrl: "http://configured-vllm.example/v1",
+        api: "openai-completions",
+        request: { allowPrivateNetwork: true },
+        models: [{ id: "Qwen/Qwen3-32B", name: "Qwen/Qwen3-32B" }],
+        apiKey: "runtime-vllm-key",
+      },
+    });
+  });
+
+  it("matches provider wildcard visibility through normalized provider ids", async () => {
+    const buildProvider = vi.fn(async () => ({
+      baseUrl: "http://configured-zai.example/v1",
+      api: "openai-completions",
+      models: [{ id: "zai-model", name: "Z.ai model" }],
+    }));
+    const ctx = createDiscoveryContext({
+      config: {
+        agents: {
+          defaults: {
+            models: { "z.ai/*": {} },
+          },
+        },
+        models: {
+          providers: {
+            zai: {
+              baseUrl: "http://configured-zai.example/v1",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    const result = await discoverOpenAICompatibleSelfHostedProvider({
+      ctx,
+      providerId: "zai",
+      buildProvider,
+    });
+
+    expect(result?.provider.models).toEqual([{ id: "zai-model", name: "Z.ai model" }]);
+    expect(buildProvider).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -1,5 +1,6 @@
 import type { ApiKeyCredential, AuthProfileCredential } from "../agents/auth-profiles/types.js";
 import { upsertAuthProfileWithLock } from "../agents/auth-profiles/upsert-with-lock.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "../agents/provider-id.js";
 import {
   SELF_HOSTED_DEFAULT_CONTEXT_WINDOW,
   SELF_HOSTED_DEFAULT_COST,
@@ -395,21 +396,41 @@ export async function discoverOpenAICompatibleSelfHostedProvider<
 >(params: {
   ctx: ProviderDiscoveryContext;
   providerId: string;
-  buildProvider: (params: { apiKey?: string }) => Promise<T>;
+  buildProvider: (params: { apiKey?: string; baseUrl?: string }) => Promise<T>;
 }): Promise<{ provider: T & { apiKey: string } } | null> {
-  if (params.ctx.config.models?.providers?.[params.providerId]) {
+  const configuredProvider = findNormalizedProviderValue(
+    params.ctx.config.models?.providers,
+    params.providerId,
+  );
+  if (configuredProvider && !hasProviderWildcardVisibility(params.ctx.config, params.providerId)) {
     return null;
   }
   const { apiKey, discoveryApiKey } = params.ctx.resolveProviderApiKey(params.providerId);
   if (!apiKey) {
     return null;
   }
+  const discoveredProvider = await params.buildProvider({
+    apiKey: discoveryApiKey,
+    baseUrl: configuredProvider?.baseUrl,
+  });
   return {
     provider: {
-      ...(await params.buildProvider({ apiKey: discoveryApiKey })),
+      ...configuredProvider,
+      ...discoveredProvider,
       apiKey,
     },
   };
+}
+
+function hasProviderWildcardVisibility(cfg: OpenClawConfig, providerId: string): boolean {
+  const normalizedProviderId = normalizeProviderId(providerId);
+  return Object.keys(cfg.agents?.defaults?.models ?? {}).some((key) => {
+    const trimmedKey = key.trim();
+    if (!trimmedKey.endsWith("/*")) {
+      return false;
+    }
+    return normalizeProviderId(trimmedKey.slice(0, -2)) === normalizedProviderId;
+  });
 }
 
 function buildMissingNonInteractiveModelIdMessage(params: {


### PR DESCRIPTION
Fixes #81218.

## Summary
- keep explicit self-hosted provider config manual-only unless `agents.defaults.models` includes a provider wildcard such as `vllm/*` or `sglang/*`
- when wildcard visibility is present, pass the configured provider `baseUrl` into the provider-owned catalog builder so `/models` discovery uses the explicit endpoint
- preserve configured provider options while replacing the catalog rows with discovered models

## Real behavior proof
- Behavior addressed: vLLM/SGLang provider wildcard visibility with explicit self-hosted provider config. Exact configured model entries must remain manual-only, while `provider/*` wildcard entries must discover through the configured provider endpoint.
- Real environment tested: local OpenClaw source checkout on Ubuntu 24.04 / Node 22.22.0, running the patched shared provider discovery helper through `pnpm exec tsx` after this patch.
- Exact steps or command run after this patch:

```sh
pnpm exec tsx -e '<script imports discoverOpenAICompatibleSelfHostedProvider and runs exact vs wildcard configured-provider cases>'
```

- Evidence after fix: terminal output from the patched checkout:

```json
{
  "manual": null,
  "wildcard": {
    "provider": {
      "baseUrl": "http://configured-vllm.example/v1",
      "api": "openai-completions",
      "request": {
        "allowPrivateNetwork": true
      },
      "models": [
        {
          "id": "Qwen/Qwen3-32B",
          "name": "Qwen/Qwen3-32B"
        }
      ],
      "apiKey": "runtime-key"
    }
  }
}
```

- Observed result after fix: exact configured model visibility returns `manual: null`, preserving manual-only behavior; wildcard visibility returns a provider using `baseUrl: "http://configured-vllm.example/v1"`, proving discovery now uses the explicit configured endpoint.
- What was not tested: no live vLLM/SGLang server was contacted in this terminal proof; network fetch behavior is covered by the existing guarded-fetch tests and the new regression tests exercise the catalog policy boundary.

## Audit
- Existing-helper check: reused `findNormalizedProviderValue` / `normalizeProviderId`
- Shared-helper caller check: 2 direct callers (`extensions/vllm`, `extensions/sglang`); contract preserved for manual exact model config, new path only for provider wildcard visibility
- Broader rival scan: no open rival PR found for #81218 / vLLM SGLang wildcard explicit endpoint

## Tests
- `pnpm test src/plugins/provider-self-hosted-setup.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/plugins/provider-self-hosted-setup.ts src/plugins/provider-self-hosted-setup.test.ts`
- `git diff --check`
- `pnpm check:changed`