### PR TITLE
fix(telegram): route plugin-bound topic messages

### DIFF
--- a/extensions/telegram/src/bot-message-context.thread-binding.test.ts
+++ b/extensions/telegram/src/bot-message-context.thread-binding.test.ts
@@ -28,10 +28,16 @@ const threadBindingSessionRuntime = {
   recordInboundSession: recordInboundSessionForThreadBindingTest,
 } satisfies TelegramTestSessionRuntime;
 
-function createBoundRoute(params: { accountId: string; sessionKey: string; agentId: string }) {
+function createBoundRoute(params: {
+  accountId: string;
+  sessionKey: string;
+  agentId: string;
+  pluginOwnedRuntimeBinding?: boolean;
+}) {
   return {
     configuredBinding: null,
     configuredBindingSessionKey: "",
+    pluginOwnedRuntimeBinding: params.pluginOwnedRuntimeBinding ?? false,
     route: {
       accountId: params.accountId,
       agentId: params.agentId,
@@ -98,6 +104,53 @@ describe("buildTelegramMessageContext thread binding override", () => {
     expect(routeArgs.senderId).toBe("42");
     expect(ctx?.ctxPayload?.SessionKey).toBe("agent:codex-acp:session-1");
     expect(ctx?.turn.record.updateLastRoute).toBeUndefined();
+  });
+
+  it("bypasses mention gating for bound forum topic messages", async () => {
+    resolveTelegramConversationRouteMock.mockReturnValue(
+      createBoundRoute({
+        accountId: "default",
+        sessionKey: "plugin-binding:openclaw-codex-app-server:session-1",
+        agentId: "main",
+        pluginOwnedRuntimeBinding: true,
+      }),
+    );
+
+    const ctx = await buildTelegramMessageContextForTest({
+      sessionRuntime: threadBindingSessionRuntime,
+      message: createForumTopicMessage(),
+      resolveGroupActivation: () => undefined,
+      resolveGroupRequireMention: () => true,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: true },
+        topicConfig: { requireMention: true },
+      }),
+    });
+
+    expect(ctx?.ctxPayload?.SessionKey).toBe("plugin-binding:openclaw-codex-app-server:session-1");
+  });
+
+  it("keeps mention gating for normal channel binding routes", async () => {
+    resolveTelegramConversationRouteMock.mockReturnValue(
+      createBoundRoute({
+        accountId: "default",
+        sessionKey: "agent:main:telegram:group:-100200300:topic:77",
+        agentId: "main",
+      }),
+    );
+
+    const ctx = await buildTelegramMessageContextForTest({
+      sessionRuntime: threadBindingSessionRuntime,
+      message: createForumTopicMessage(),
+      resolveGroupActivation: () => undefined,
+      resolveGroupRequireMention: () => true,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: true },
+        topicConfig: { requireMention: true },
+      }),
+    });
+
+    expect(ctx).toBeNull();
   });
 
   it("treats named-account bound conversations as explicit route matches", async () => {

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -242,16 +242,17 @@ export const buildTelegramMessageContext = async ({
   const freshCfg =
     loadFreshConfig?.() ??
     (runtime?.getRuntimeConfig ?? (await loadTelegramMessageContextRuntime()).getRuntimeConfig)();
-  let { route, configuredBinding, configuredBindingSessionKey } = resolveTelegramConversationRoute({
-    cfg: freshCfg,
-    accountId: account.accountId,
-    chatId,
-    isGroup,
-    resolvedThreadId,
-    replyThreadId,
-    senderId,
-    topicAgentId: topicConfig?.agentId,
-  });
+  let { route, configuredBinding, configuredBindingSessionKey, pluginOwnedRuntimeBinding } =
+    resolveTelegramConversationRoute({
+      cfg: freshCfg,
+      accountId: account.accountId,
+      chatId,
+      isGroup,
+      resolvedThreadId,
+      replyThreadId,
+      senderId,
+      topicAgentId: topicConfig?.agentId,
+    });
   const requiresExplicitAccountBinding = (
     candidate: ReturnType<typeof resolveTelegramConversationRoute>["route"],
   ): boolean =>
@@ -430,12 +431,15 @@ export const buildTelegramMessageContext = async ({
     agentId: route.agentId,
   });
   const baseRequireMention = resolveGroupRequireMention(chatId);
-  const requireMention = firstDefined(
-    topicConfig?.requireMention,
-    activationOverride,
-    telegramGroupConfig?.requireMention,
-    baseRequireMention,
-  );
+  const requireMention =
+    isGroup && pluginOwnedRuntimeBinding
+      ? false
+      : firstDefined(
+          topicConfig?.requireMention,
+          activationOverride,
+          telegramGroupConfig?.requireMention,
+          baseRequireMention,
+        );
 
   const recordChannelActivity =
     runtime?.recordChannelActivity ??

--- a/extensions/telegram/src/conversation-route.base-session-key.test.ts
+++ b/extensions/telegram/src/conversation-route.base-session-key.test.ts
@@ -5,7 +5,7 @@ import {
   type SessionBindingAdapter,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resolveTelegramConversationBaseSessionKey,
   resolveTelegramConversationRoute,
@@ -15,6 +15,10 @@ describe("resolveTelegramConversationBaseSessionKey", () => {
   const cfg: OpenClawConfig = {};
 
   beforeEach(() => {
+    conversationBindingTesting.resetSessionBindingAdaptersForTests();
+  });
+
+  afterEach(() => {
     conversationBindingTesting.resetSessionBindingAdaptersForTests();
   });
 
@@ -157,5 +161,55 @@ describe("resolveTelegramConversationBaseSessionKey", () => {
     expect(result.route.agentId).toBe("main");
     expect(result.route.sessionKey).toBe("agent:main:main");
     expect(result.route.matchedBy).toBe("default");
+    expect(result.pluginOwnedRuntimeBinding).toBe(false);
+  });
+
+  it("detects plugin-owned runtime bindings without replacing the route", () => {
+    const touch = vi.fn<NonNullable<SessionBindingAdapter["touch"]>>();
+    registerSessionBindingAdapter({
+      channel: "telegram",
+      accountId: "default",
+      listBySession: () => [],
+      resolveByConversation: () => ({
+        bindingId: "binding-plugin-owned",
+        targetSessionKey: "plugin-binding:openclaw-codex-app-server:abc123",
+        targetKind: "session",
+        conversation: {
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "-1001234567890:topic:11",
+        },
+        status: "active",
+        boundAt: 1,
+        metadata: {
+          pluginBindingOwner: "plugin",
+          pluginId: "openclaw-codex-app-server",
+          pluginRoot: "/tmp/openclaw-codex-app-server",
+        },
+      }),
+      touch,
+    });
+
+    const result = resolveTelegramConversationRoute({
+      cfg: {
+        session: {
+          dmScope: "main",
+        },
+      },
+      accountId: "default",
+      chatId: -1001234567890,
+      isGroup: true,
+      resolvedThreadId: 11,
+      replyThreadId: 11,
+      senderId: 12345,
+    });
+
+    expect(touch).toHaveBeenCalledWith("binding-plugin-owned", undefined);
+    expect(result.configuredBinding).toBeNull();
+    expect(result.configuredBindingSessionKey).toBe("");
+    expect(result.route.agentId).toBe("main");
+    expect(result.route.sessionKey).toBe("agent:main:telegram:group:-1001234567890:topic:11");
+    expect(result.route.matchedBy).toBe("default");
+    expect(result.pluginOwnedRuntimeBinding).toBe(true);
   });
 });

--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -33,6 +33,7 @@ export function resolveTelegramConversationRoute(params: {
   route: ReturnType<typeof resolveAgentRoute>;
   configuredBinding: ConfiguredBindingRouteResult["bindingResolution"];
   configuredBindingSessionKey: string;
+  pluginOwnedRuntimeBinding: boolean;
 } {
   const peerId = params.isGroup
     ? buildTelegramGroupPeerId(params.chatId, params.resolvedThreadId)
@@ -118,6 +119,9 @@ export function resolveTelegramConversationRoute(params: {
     },
   });
   route = runtimeRoute.route;
+  const pluginOwnedRuntimeBinding = Boolean(
+    runtimeRoute.bindingRecord && !runtimeRoute.boundSessionKey,
+  );
   if (runtimeRoute.bindingRecord) {
     configuredBinding = null;
     configuredBindingSessionKey = "";
@@ -132,6 +136,7 @@ export function resolveTelegramConversationRoute(params: {
     route,
     configuredBinding,
     configuredBindingSessionKey,
+    pluginOwnedRuntimeBinding,
   };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -6690,6 +6690,168 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("routes plugin-owned bindings under message-tool-only source delivery", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) =>
+        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
+    );
+    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+      status: "handled",
+      result: { handled: true },
+    });
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-message-tool-only",
+      targetSessionKey: "plugin-binding:codex:abc123",
+      targetKind: "session",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "-1001234567890:topic:11",
+        parentConversationId: "-1001234567890",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "openclaw-codex-app-server",
+        pluginRoot: "/tmp/plugin",
+      },
+    } satisfies SessionBindingRecord);
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:-1001234567890",
+      To: "telegram:-1001234567890",
+      AccountId: "default",
+      MessageThreadId: 11,
+      SessionKey: "agent:main:telegram:group:-1001234567890:topic:11",
+      ChatType: "group",
+      GroupSubject: "Dev",
+      Body: "observed message",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(result).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(sessionBindingMocks.touch).toHaveBeenCalledWith("binding-message-tool-only");
+    expect(hookMocks.runner.runInboundClaimForPluginOutcome).toHaveBeenCalledWith(
+      "openclaw-codex-app-server",
+      expect.objectContaining({
+        channel: "telegram",
+        content: "observed message",
+        threadId: 11,
+      }),
+      expect.objectContaining({
+        pluginBinding: expect.objectContaining({ bindingId: "binding-message-tool-only" }),
+      }),
+    );
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps unmentioned plugin-bound fallback from ordinary group agent dispatch", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) =>
+        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
+    );
+    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+      status: "no_handler",
+    });
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-message-tool-fallback",
+      targetSessionKey: "plugin-binding:codex:abc123",
+      targetKind: "session",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "-1001234567890:topic:11",
+        parentConversationId: "-1001234567890",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "openclaw-codex-app-server",
+        pluginRoot: "/tmp/plugin",
+      },
+    } satisfies SessionBindingRecord);
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:-1001234567890",
+      To: "telegram:-1001234567890",
+      AccountId: "default",
+      MessageThreadId: 11,
+      SessionKey: "agent:main:telegram:group:-1001234567890:topic:11",
+      ChatType: "group",
+      GroupSubject: "Dev",
+      Body: "observed message",
+      WasMentioned: false,
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(result).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(hookMocks.runner.runInboundClaimForPluginOutcome).toHaveBeenCalledWith(
+      "openclaw-codex-app-server",
+      expect.objectContaining({
+        channel: "telegram",
+        content: "observed message",
+        threadId: 11,
+      }),
+      expect.objectContaining({
+        pluginBinding: expect.objectContaining({ bindingId: "binding-message-tool-fallback" }),
+      }),
+    );
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("keeps message-tool-only source delivery private while still processing the turn", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1348,6 +1348,9 @@ export async function dispatchReplyFromConfig(
     payload: ReplyPayload,
     mode: "additive" | "terminal",
   ): Promise<boolean> => {
+    if (suppressAutomaticSourceDelivery) {
+      return false;
+    }
     const result = await routeReplyToOriginating(payload);
     if (result) {
       if (!result.ok) {
@@ -1569,10 +1572,12 @@ export async function dispatchReplyFromConfig(
       logVerbose(
         `plugin-bound inbound command escaped plugin binding (plugin=${pluginOwnedBinding.pluginId} session=${sessionKey ?? "unknown"}); falling through to command processing`,
       );
-    } else if (suppressDelivery) {
+    } else if (sendPolicyDenied || (suppressDelivery && !suppressAutomaticSourceDelivery)) {
       // Plugin-bound inbound handlers typically emit outbound replies we
-      // cannot rewind. When automatic delivery is suppressed, skip the plugin
-      // claim and fall through to normal suppressed agent processing.
+      // cannot rewind. When automatic delivery is explicitly denied, skip the
+      // plugin claim and fall through to normal suppressed agent processing.
+      // message_tool_only is the normal visible-reply mode for group chats and
+      // must still let the bound plugin own the turn unless sendPolicy denied it.
       logVerbose(
         `plugin-bound inbound skipped under ${deliverySuppressionReason} (plugin=${pluginOwnedBinding.pluginId} session=${sessionKey ?? "unknown"}); falling through to suppressed agent processing`,
       );
@@ -1615,6 +1620,19 @@ export async function dispatchReplyFromConfig(
             targetedClaimOutcome.status === "missing_plugin"
               ? "plugin-bound-fallback-missing-plugin"
               : "plugin-bound-fallback-no-handler";
+          if (
+            (chatType === "group" || chatType === "channel") &&
+            ctx.WasMentioned === false &&
+            !isExplicitSourceReplyCommand(ctx)
+          ) {
+            markIdle("plugin_binding_fallback_unmentioned");
+            recordProcessed("completed", { reason: pluginFallbackReason });
+            commitInboundDedupeIfClaimed();
+            return attachSourceReplyDeliveryMode({
+              queuedFinal: false,
+              counts: dispatcher.getQueuedCounts(),
+            });
+          }
           if (!hasShownPluginBindingFallbackNotice(pluginOwnedBinding.bindingId)) {
             const didSendNotice = await sendBindingNotice(
               { text: buildPluginBindingUnavailableText(pluginOwnedBinding) },


### PR DESCRIPTION
## Summary

- Problem: Telegram forum topics that are bound to a plugin-owned runtime binding can still be processed as ordinary group messages, so mention gating and delivery suppression can prevent the plugin from claiming the turn.
- Why it matters: a Codex Application Server binding in a Telegram topic can appear attached in `/cas_status`, but normal user messages in that topic do not reliably reach the plugin.
- What changed: plugin-owned runtime binding routes are marked as `binding.channel`, Telegram mention gating bypasses those explicit bound routes, and auto-reply dispatch still allows plugin claims when the source reply mode is `message_tool_only`.
- What did NOT change (scope boundary): no new Telegram commands, no auth changes, no persistence format changes, and no behavior change for unbound Telegram groups.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a Telegram forum topic bound to `openclaw-codex-app-server` did not deliver normal topic messages to the plugin-bound Codex thread. The binding existed, but the message could be skipped because delivery was marked `sourceReplyDeliveryMode: message_tool_only`.
- Real environment tested: AlphaClaw Docker gateway running OpenClaw 2026.5.7 with Telegram forum topic `-1003817967251:topic:11` bound to the Codex Application Server plugin.
- Exact steps or command run after this patch:
  1. Built and restarted the AlphaClaw gateway image with this patch applied.
  2. Sent a normal user message in the bound Telegram forum topic.
  3. Checked gateway logs and plugin state for the bound turn.
- Evidence after fix (redacted copied runtime log):

```text
[gateway] plugin binding dispatch {"channel":"telegram","accountId":"default","conversationId":"-1003817967251:topic:11","parentConversationId":"-1003817967251","sessionKey":"agent:niemand-code:telegram:group:-1003817967251:topic:11","hasBinding":true,"pluginId":"openclaw-codex-app-server","suppressDelivery":true,"deliverySuppressionReason":"sourceReplyDeliveryMode: message_tool_only"}
[gateway] plugin binding claim outcome handled
[gateway] codex turn start thread is unavailable; retrying on replacement thread ...
```

Plugin state then showed the binding moved to replacement Codex thread `019e1eb2-a14d-7f22-a3e0-acfd2e03e31e`, and sent-message tracking recorded Telegram message `38884`. The user confirmed the Codex response arrived in the topic.

- Observed result after fix: the plugin-owned binding claims the Telegram topic turn and sends the Codex response.
- What was not tested: other transports such as Slack, Discord, WhatsApp, or Matrix.
- Before evidence (optional but encouraged): before this patch, the same bound topic reported `/cas_status` binding metadata but normal messages produced no Codex response or fell through as ordinary OpenClaw agent turns.

## Root Cause (if applicable)

- Root cause: plugin-owned runtime binding routes did not advertise that they matched an explicit channel binding, and dispatch treated `message_tool_only` reply delivery suppression as a reason to skip plugin-owned binding claims.
- Missing detection / guardrail: tests covered base session key preservation and some suppression paths, but not the specific combination of Telegram forum topic + plugin-owned runtime binding + `message_tool_only` visible reply mode.
- Contributing context (if known): Telegram groups often use mention gating and message-tool reply mode for visible replies, while plugin-owned bound topics need to bypass the unbound group path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/reply/dispatch-from-config.test.ts`
  - `src/channels/plugins/binding-routing.test.ts`
  - `extensions/telegram/src/conversation-route.base-session-key.test.ts`
  - `extensions/telegram/src/bot-message-context.thread-binding.test.ts`
- Scenario the test should lock in: an explicitly plugin-bound Telegram topic keeps the base session key, bypasses mention gating, and still allows the plugin to claim the turn when the source reply mode is `message_tool_only`.
- Why this is the smallest reliable guardrail: it exercises the routing and dispatch decisions without needing a live Telegram bot or Codex Application Server process.
- Existing test that already covers this (if any): no single existing test covered this exact combination before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Explicitly plugin-bound Telegram group topics now route normal topic messages to the plugin binding instead of requiring an unrelated mention or falling through the ordinary group path.

## Diagram (if applicable)

```text
Before:
Telegram topic message -> plugin binding exists -> route not marked bound / message_tool_only suppression -> plugin claim skipped

After:
Telegram topic message -> plugin binding route marked binding.channel -> mention bypass -> plugin claim handled -> visible reply
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: AlphaClaw Docker gateway
- Model/provider: Codex Application Server plugin backed by Codex
- Integration/channel (if any): Telegram forum topic
- Relevant config (redacted): Telegram topic `-1003817967251:topic:11` bound to plugin id `openclaw-codex-app-server`

### Steps

1. Bind a Telegram forum topic to a plugin-owned runtime binding.
2. Configure the Telegram source for normal visible replies using `message_tool_only`.
3. Send a normal user message in the bound topic without an explicit bot mention.

### Expected

- The plugin-owned binding claims the turn and sends the response.

### Actual

- After this patch, the plugin-owned binding claims the turn and sends the response.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: live AlphaClaw Telegram forum topic bound to Codex Application Server plugin; targeted unit tests for Telegram route/session handling and auto-reply plugin dispatch.
- Edge cases checked: unbound group mention gating remains covered by existing require-mention tests; plugin claims remain skipped for real suppressed delivery reasons.
- What you did **not** verify: non-Telegram transports and a full repo-wide `pnpm build && pnpm check && pnpm test` run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: allowing plugin claims under `message_tool_only` could accidentally broaden plugin handling.
  - Mitigation: the change is limited to plugin-owned explicit runtime bindings and keeps the previous skip behavior for real delivery suppression reasons.

## Verification Commands

```bash
pnpm test src/channels/plugins/binding-routing.test.ts src/auto-reply/reply/dispatch-from-config.test.ts extensions/telegram/src/conversation-route.base-session-key.test.ts extensions/telegram/src/bot-message-context.thread-binding.test.ts extensions/telegram/src/bot-message-context.require-mention.test.ts
codex review --base origin/main
```

AI-assisted with Codex. I understand the code path and verified the live behavior described above.
