### PR TITLE
fix(discord): backfill missed messages after reconnect

### DIFF
--- a/extensions/discord/src/monitor/listeners.ts
+++ b/extensions/discord/src/monitor/listeners.ts
@@ -6,9 +6,23 @@ import {
   InteractionCreateListener,
   MessageCreateListener,
   PresenceUpdateListener,
+  ReadyListener,
+  ResumedListener,
   ThreadUpdateListener,
 } from "../internal/discord.js";
 import { discordEventQueueLog, runDiscordListenerWithSlowLog } from "./listeners.queue.js";
+import type {
+  DiscordInteractionEvent,
+  DiscordMessageEvent,
+  DiscordMessageHandler,
+} from "./listeners.types.js";
+export type {
+  DiscordInteractionEvent,
+  DiscordMessageEvent,
+  DiscordMessageHandler,
+} from "./listeners.types.js";
+import { recordRecentDiscordInboundMessage } from "../recent-inbound.js";
+import { backfillRecentDiscordInboundMessages } from "./reconnect-backfill.js";
 export { DiscordReactionListener, DiscordReactionRemoveListener } from "./listeners.reactions.js";
 import { setPresence } from "./presence-cache.js";
 import { isThreadArchived } from "./thread-bindings.discord-api.js";
@@ -16,14 +30,28 @@ import { closeDiscordThreadSessions } from "./thread-session-close.js";
 
 type Logger = ReturnType<typeof import("openclaw/plugin-sdk/runtime-env").createSubsystemLogger>;
 
-export type DiscordMessageEvent = Parameters<MessageCreateListener["handle"]>[0];
-export type DiscordInteractionEvent = Parameters<InteractionCreateListener["handle"]>[0];
+function readDiscordMessageId(data: DiscordMessageEvent): string | undefined {
+  const candidate = data as DiscordMessageEvent & { message?: { id?: unknown } };
+  return typeof candidate.message?.id === "string" && candidate.message.id.trim()
+    ? candidate.message.id.trim()
+    : typeof candidate.id === "string" && candidate.id.trim()
+      ? candidate.id.trim()
+      : undefined;
+}
 
-export type DiscordMessageHandler = (
-  data: DiscordMessageEvent,
-  client: Client,
-  options?: { abortSignal?: AbortSignal },
-) => Promise<void>;
+function readDiscordChannelId(data: DiscordMessageEvent): string | undefined {
+  const candidate = data as DiscordMessageEvent & {
+    channelId?: unknown;
+    message?: { channel_id?: unknown };
+  };
+  return typeof candidate.channel_id === "string" && candidate.channel_id.trim()
+    ? candidate.channel_id.trim()
+    : typeof candidate.channelId === "string" && candidate.channelId.trim()
+      ? candidate.channelId.trim()
+      : typeof candidate.message?.channel_id === "string" && candidate.message.channel_id.trim()
+        ? candidate.message.channel_id.trim()
+        : undefined;
+}
 
 export function registerDiscordListener(listeners: Array<object>, listener: object) {
   if (listeners.some((existing) => existing.constructor === listener.constructor)) {
@@ -38,6 +66,7 @@ export class DiscordMessageListener extends MessageCreateListener {
     private handler: DiscordMessageHandler,
     private logger?: Logger,
     private onEvent?: () => void,
+    private accountId?: string,
   ) {
     super();
   }
@@ -48,10 +77,67 @@ export class DiscordMessageListener extends MessageCreateListener {
     // Per-session ordering is owned by the message run queue.
     void Promise.resolve()
       .then(() => this.handler(data, client))
+      .then(() => {
+        recordRecentDiscordInboundMessage({
+          accountId: this.accountId,
+          channelId: readDiscordChannelId(data),
+          messageId: readDiscordMessageId(data),
+        });
+      })
       .catch((err: unknown) => {
         const logger = this.logger ?? discordEventQueueLog;
         logger.error(danger(`discord handler failed: ${String(err)}`));
       });
+  }
+}
+
+export class DiscordReconnectBackfillReadyListener extends ReadyListener {
+  constructor(
+    private params: {
+      accountId: string;
+      messageHandler: DiscordMessageHandler;
+      botUserId?: string;
+      logger?: Logger;
+      onEvent?: () => void;
+    },
+  ) {
+    super();
+  }
+
+  async handle(_data: unknown, client: Client) {
+    void backfillRecentDiscordInboundMessages({
+      accountId: this.params.accountId,
+      client,
+      messageHandler: this.params.messageHandler,
+      botUserId: this.params.botUserId,
+      logger: this.params.logger,
+      onEvent: this.params.onEvent,
+    });
+  }
+}
+
+export class DiscordReconnectBackfillResumedListener extends ResumedListener {
+  constructor(
+    private params: {
+      accountId: string;
+      messageHandler: DiscordMessageHandler;
+      botUserId?: string;
+      logger?: Logger;
+      onEvent?: () => void;
+    },
+  ) {
+    super();
+  }
+
+  async handle(_data: unknown, client: Client) {
+    void backfillRecentDiscordInboundMessages({
+      accountId: this.params.accountId,
+      client,
+      messageHandler: this.params.messageHandler,
+      botUserId: this.params.botUserId,
+      logger: this.params.logger,
+      onEvent: this.params.onEvent,
+    });
   }
 }
 

--- a/extensions/discord/src/monitor/listeners.types.ts
+++ b/extensions/discord/src/monitor/listeners.types.ts
@@ -1,0 +1,14 @@
+import type {
+  Client,
+  InteractionCreateListener,
+  MessageCreateListener,
+} from "../internal/discord.js";
+
+export type DiscordMessageEvent = Parameters<MessageCreateListener["handle"]>[0];
+export type DiscordInteractionEvent = Parameters<InteractionCreateListener["handle"]>[0];
+
+export type DiscordMessageHandler = (
+  data: DiscordMessageEvent,
+  client: Client,
+  options?: { abortSignal?: AbortSignal },
+) => Promise<void>;

--- a/extensions/discord/src/monitor/message-handler.hydration.test.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.test.ts
@@ -48,7 +48,7 @@ function createDefaultReplyPayload(overrides = {}) {
   });
 }
 
-function createReferencedMessagePayload(content: string) {
+function createReferencedMessagePayload(content: string, overrides = {}) {
   return createMessagePayload({
     id: "m0",
     content,
@@ -58,6 +58,7 @@ function createReferencedMessagePayload(content: string) {
       discriminator: "0",
       avatar: null,
     },
+    ...overrides,
   });
 }
 
@@ -180,5 +181,91 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     });
 
     expect(rest.calls).toHaveLength(0);
+  });
+
+  it("does not hydrate reply messages that already include referenced_message", async () => {
+    const client = createInternalTestClient();
+    const rest = createFakeRestClient([]);
+    const message = new Message(
+      client,
+      createDefaultReplyPayload({
+        id: "m2",
+        content: "normal reply",
+        message_reference: {
+          type: MessageReferenceType.Default,
+          channel_id: "c1",
+          message_id: "m1",
+        },
+        referenced_message: createReferencedMessagePayload("bot reply", {
+          id: "m1",
+          author: {
+            id: "bot-1",
+            username: "OpenClaw",
+            discriminator: "0",
+            global_name: null,
+            avatar: null,
+            bot: true,
+          },
+        }),
+      }),
+    );
+
+    const hydrated = await hydrateDiscordMessageIfNeeded({
+      client: { rest },
+      message,
+      messageChannelId: "c1",
+    });
+
+    expect(rest.calls).toHaveLength(0);
+    expect(hydrated).toBe(message);
+  });
+
+  it("hydrates reply messages that have content but are missing referenced_message", async () => {
+    const client = createInternalTestClient();
+    const rest = createFakeRestClient([
+      createDefaultReplyPayload({
+        id: "m2",
+        content: "why did this get ignored?",
+        message_reference: {
+          type: MessageReferenceType.Default,
+          channel_id: "c1",
+          message_id: "m1",
+        },
+        referenced_message: createReferencedMessagePayload("bot reply", {
+          id: "m1",
+          author: {
+            id: "bot-1",
+            username: "OpenClaw",
+            discriminator: "0",
+            global_name: null,
+            avatar: null,
+            bot: true,
+          },
+        }),
+      }),
+    ]);
+    const message = new Message(
+      client,
+      createDefaultReplyPayload({
+        id: "m2",
+        content: "why did this get ignored?",
+        message_reference: {
+          type: MessageReferenceType.Default,
+          channel_id: "c1",
+          message_id: "m1",
+        },
+        referenced_message: null,
+      }),
+    );
+
+    const hydrated = await hydrateDiscordMessageIfNeeded({
+      client: { rest },
+      message,
+      messageChannelId: "c1",
+    });
+
+    expect(rest.calls).toHaveLength(1);
+    expect(hydrated.referencedMessage?.author?.id).toBe("bot-1");
+    expect(hydrated.messageReference?.message_id).toBe("m1");
   });
 });

--- a/extensions/discord/src/monitor/message-handler.hydration.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.ts
@@ -29,6 +29,12 @@ function mergeFetchedDiscordMessage(base: Message, fetched: APIMessage): Message
     tts: fetched.tts ?? baseRawData.tts ?? false,
     pinned: fetched.pinned ?? baseRawData.pinned ?? false,
     type: fetched.type ?? baseRawData.type ?? 0,
+    message_reference:
+      fetched.message_reference ?? baseRawData.message_reference ?? baseFallback.message_reference,
+    referenced_message:
+      fetched.referenced_message ??
+      baseRawData.referenced_message ??
+      baseFallback.referenced_message,
     message_snapshots:
       fetched.message_snapshots ?? baseRawData.message_snapshots ?? baseFallback.message_snapshots,
     sticker_items:
@@ -75,6 +81,10 @@ function readMessageFallback(message: Message): MessageFallback {
     timestamp?: unknown;
     stickers?: unknown;
     sticker_items?: unknown;
+    messageReference?: unknown;
+    message_reference?: unknown;
+    referencedMessage?: unknown;
+    referenced_message?: unknown;
     message_snapshots?: unknown;
   };
   return {
@@ -88,6 +98,11 @@ function readMessageFallback(message: Message): MessageFallback {
     mention_roles: normalizeStringArray(value.mentionedRoles),
     mention_everyone: value.mentionedEveryone === true,
     timestamp: readString(value.timestamp) ?? "1970-01-01T00:00:00.000Z",
+    message_reference:
+      normalizeApiMessageReference(value.message_reference) ??
+      normalizeApiMessageReference(value.messageReference),
+    referenced_message:
+      normalizeApiMessage(value.referenced_message) ?? normalizeApiMessage(value.referencedMessage),
     sticker_items: Array.isArray(value.sticker_items)
       ? (value.sticker_items as APIMessage["sticker_items"])
       : Array.isArray(value.stickers)
@@ -112,6 +127,16 @@ function normalizeApiUsers(value: unknown): APIUser[] {
         return user.id ? [user] : [];
       })
     : [];
+}
+
+function normalizeApiMessageReference(value: unknown): APIMessage["message_reference"] | undefined {
+  return value && typeof value === "object"
+    ? (value as APIMessage["message_reference"])
+    : undefined;
+}
+
+function normalizeApiMessage(value: unknown): APIMessage | undefined {
+  return value && typeof value === "object" ? (value as APIMessage) : undefined;
 }
 
 function normalizeApiUser(value: unknown): APIUser {
@@ -163,6 +188,13 @@ function shouldHydrateDiscordMessage(params: { message: Message }) {
     return true;
   }
   if (!currentText) {
+    return true;
+  }
+  const rawData = readMessageRawData(params.message);
+  const hasReplyReference = Boolean(
+    params.message.messageReference?.message_id || rawData.message_reference?.message_id,
+  );
+  if (hasReplyReference && !params.message.referencedMessage) {
     return true;
   }
   const hasMentionMetadata =

--- a/extensions/discord/src/monitor/provider.startup.test.ts
+++ b/extensions/discord/src/monitor/provider.startup.test.ts
@@ -77,6 +77,12 @@ vi.mock("./listeners.js", () => ({
   DiscordPresenceListener: function DiscordPresenceListener() {
     return { type: "presence" };
   },
+  DiscordReconnectBackfillReadyListener: function DiscordReconnectBackfillReadyListener() {
+    return { type: "ready" };
+  },
+  DiscordReconnectBackfillResumedListener: function DiscordReconnectBackfillResumedListener() {
+    return { type: "resumed" };
+  },
   DiscordReactionListener: function DiscordReactionListener() {
     return { type: "reaction-add" };
   },
@@ -380,7 +386,13 @@ describe("registerDiscordMonitorListeners", () => {
   it("skips reaction listeners when every configured guild disables reactions and DMs are off", () => {
     registerDiscordMonitorListeners(createListenerParams());
 
-    expect(registeredListenerTypes()).toEqual(["interaction", "message", "thread-update"]);
+    expect(registeredListenerTypes()).toEqual([
+      "interaction",
+      "message",
+      "ready",
+      "resumed",
+      "thread-update",
+    ]);
   });
 
   it("keeps reaction listeners when direct messages can emit reaction notifications", () => {

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -31,6 +31,8 @@ import {
   DiscordMessageListener,
   DiscordInteractionListener,
   DiscordPresenceListener,
+  DiscordReconnectBackfillReadyListener,
+  DiscordReconnectBackfillResumedListener,
   DiscordReactionListener,
   DiscordReactionRemoveListener,
   DiscordThreadUpdateListener,
@@ -261,7 +263,27 @@ export function registerDiscordMonitorListeners(params: {
   );
   registerDiscordListener(
     params.client.listeners,
-    new DiscordMessageListener(params.messageHandler, params.logger, params.trackInboundEvent),
+    new DiscordMessageListener(
+      params.messageHandler,
+      params.logger,
+      params.trackInboundEvent,
+      params.accountId,
+    ),
+  );
+  const reconnectBackfillParams = {
+    accountId: params.accountId,
+    messageHandler: params.messageHandler,
+    botUserId: params.botUserId,
+    logger: params.logger,
+    onEvent: params.trackInboundEvent,
+  };
+  registerDiscordListener(
+    params.client.listeners,
+    new DiscordReconnectBackfillReadyListener(reconnectBackfillParams),
+  );
+  registerDiscordListener(
+    params.client.listeners,
+    new DiscordReconnectBackfillResumedListener(reconnectBackfillParams),
   );
 
   if (shouldRegisterDiscordReactionListeners(params)) {

--- a/extensions/discord/src/monitor/reconnect-backfill.test.ts
+++ b/extensions/discord/src/monitor/reconnect-backfill.test.ts
@@ -1,0 +1,461 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { APIMessage } from "discord-api-types/v10";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFakeRestClient } from "../internal/test-builders.test-support.js";
+import {
+  clearRecentDiscordInboundPersistenceForTest,
+  recordRecentDiscordInboundMessage,
+  resetRecentDiscordInboundMessagesForTest,
+} from "../recent-inbound.js";
+import {
+  clearRecentDiscordOutboundPersistenceForTest,
+  listRecentDiscordOutboundMessages,
+  recordRecentDiscordOutboundMessage,
+  resetRecentDiscordOutboundMessagesForTest,
+} from "../recent-outbound.js";
+import {
+  createDiscordMessageHandler,
+  preflightDiscordMessageMock,
+  processDiscordMessageMock,
+} from "./message-handler.module-test-helpers.js";
+import {
+  createDiscordHandlerParams,
+  createDiscordPreflightContext,
+} from "./message-handler.test-helpers.js";
+import {
+  backfillRecentDiscordInboundMessages,
+  getRecentDiscordBackfillCooldownCountForTest,
+  resetRecentDiscordBackfillsForTest,
+} from "./reconnect-backfill.js";
+
+async function flushQueueWork(): Promise<void> {
+  for (let i = 0; i < 40; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+function apiMessage(overrides: Partial<APIMessage> & Pick<APIMessage, "id">): APIMessage {
+  return {
+    channel_id: "thread-1",
+    content: "reply",
+    attachments: [],
+    embeds: [],
+    mentions: [],
+    mention_roles: [],
+    mention_everyone: false,
+    timestamp: new Date().toISOString(),
+    author: {
+      id: "user-1",
+      username: "alice",
+      discriminator: "0",
+      global_name: null,
+      avatar: null,
+    },
+    type: 0,
+    tts: false,
+    pinned: false,
+    flags: 0 as APIMessage["flags"],
+    ...overrides,
+  } as APIMessage;
+}
+
+const previousRecentOutboundStorePath = process.env.OPENCLAW_DISCORD_RECENT_OUTBOUND_STORE_PATH;
+const previousRecentInboundStorePath = process.env.OPENCLAW_DISCORD_RECENT_INBOUND_STORE_PATH;
+const recentOutboundStorePath = path.join(
+  os.tmpdir(),
+  `openclaw-discord-recent-outbound-${process.pid}.json`,
+);
+const recentInboundStorePath = path.join(
+  os.tmpdir(),
+  `openclaw-discord-recent-inbound-${process.pid}.json`,
+);
+
+describe("backfillRecentDiscordInboundMessages", () => {
+  beforeEach(() => {
+    process.env.OPENCLAW_DISCORD_RECENT_OUTBOUND_STORE_PATH = recentOutboundStorePath;
+    process.env.OPENCLAW_DISCORD_RECENT_INBOUND_STORE_PATH = recentInboundStorePath;
+    clearRecentDiscordOutboundPersistenceForTest();
+    clearRecentDiscordInboundPersistenceForTest();
+    resetRecentDiscordOutboundMessagesForTest();
+    resetRecentDiscordInboundMessagesForTest();
+    resetRecentDiscordBackfillsForTest();
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+  });
+
+  afterEach(() => {
+    clearRecentDiscordOutboundPersistenceForTest();
+    clearRecentDiscordInboundPersistenceForTest();
+    resetRecentDiscordOutboundMessagesForTest();
+    resetRecentDiscordInboundMessagesForTest();
+    if (previousRecentOutboundStorePath === undefined) {
+      delete process.env.OPENCLAW_DISCORD_RECENT_OUTBOUND_STORE_PATH;
+    } else {
+      process.env.OPENCLAW_DISCORD_RECENT_OUTBOUND_STORE_PATH = previousRecentOutboundStorePath;
+    }
+    if (previousRecentInboundStorePath === undefined) {
+      delete process.env.OPENCLAW_DISCORD_RECENT_INBOUND_STORE_PATH;
+    } else {
+      process.env.OPENCLAW_DISCORD_RECENT_INBOUND_STORE_PATH = previousRecentInboundStorePath;
+    }
+  });
+
+  it("replays user messages after recent OpenClaw outbound messages in oldest-first order", async () => {
+    const rest = createFakeRestClient([
+      [apiMessage({ id: "103", content: "second" }), apiMessage({ id: "102", content: "first" })],
+    ]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    const messageHandler = vi.fn(async (_data: unknown, _client?: unknown) => {});
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "101",
+      at: 1_000,
+    });
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "101-later",
+      at: 1_500,
+    });
+
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 2_000,
+    });
+
+    expect(rest.calls[0]).toMatchObject({
+      method: "GET",
+      query: { after: "101", limit: 50 },
+    });
+    expect(messageHandler).toHaveBeenCalledTimes(2);
+    const firstEvent = messageHandler.mock.calls[0]?.[0] as {
+      message: { id: string };
+      guild_id?: string;
+    };
+    const secondEvent = messageHandler.mock.calls[1]?.[0] as { message: { id: string } };
+    expect(firstEvent.message.id).toBe("102");
+    expect(firstEvent.guild_id).toBe("guild-1");
+    expect(secondEvent.message.id).toBe("103");
+  });
+
+  it("persists recent outbound anchors across full process restarts", async () => {
+    const rest = createFakeRestClient([[apiMessage({ id: "202", content: "missed" })]]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    const messageHandler = vi.fn(async (_data: unknown, _client?: unknown) => {});
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "201",
+      at: 1_000,
+    });
+
+    expect(fs.existsSync(recentOutboundStorePath)).toBe(true);
+    resetRecentDiscordOutboundMessagesForTest();
+
+    expect(
+      listRecentDiscordOutboundMessages({ accountId: "default", maxAgeMs: 60_000, now: 2_000 }),
+    ).toEqual([
+      {
+        accountId: "default",
+        channelId: "thread-1",
+        messageId: "201",
+        at: 1_000,
+      },
+    ]);
+
+    resetRecentDiscordOutboundMessagesForTest();
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 2_000,
+    });
+
+    expect(rest.calls[0]).toMatchObject({
+      method: "GET",
+      query: { after: "201", limit: 50 },
+    });
+    expect(messageHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replay inbound messages already processed before a restart", async () => {
+    const rest = createFakeRestClient([[apiMessage({ id: "202", content: "already handled" })]]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    const messageHandler = vi.fn(async (_data: unknown, _client?: unknown) => {});
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "201",
+      at: 1_000,
+    });
+    recordRecentDiscordInboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "202",
+      at: 1_500,
+    });
+
+    resetRecentDiscordOutboundMessagesForTest();
+    resetRecentDiscordInboundMessagesForTest();
+    const stats = await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 2_000,
+    });
+
+    expect(rest.calls[0]).toMatchObject({
+      method: "GET",
+      query: { after: "201", limit: 50 },
+    });
+    expect(messageHandler).not.toHaveBeenCalled();
+    expect(stats).toMatchObject({
+      candidates: 1,
+      skippedAlreadyProcessed: 1,
+      replayed: 0,
+    });
+  });
+
+  it("reports reconnect backfill outcome stats", async () => {
+    const rest = createFakeRestClient([[apiMessage({ id: "302" })]]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    const messageHandler = vi.fn(async (_data: unknown, _client?: unknown) => {});
+    const logger = { info: vi.fn(), error: vi.fn() };
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "301",
+      at: 1_000,
+    });
+
+    const stats = await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      logger: logger as never,
+      now: 2_000,
+    });
+
+    expect(stats).toMatchObject({
+      anchorsAvailable: 1,
+      anchorsScanned: 1,
+      channelsScanned: 1,
+      candidates: 1,
+      replayed: 1,
+      errors: 0,
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      "Discord reconnect backfill complete",
+      expect.objectContaining({ anchorsAvailable: 1, replayed: 1 }),
+    );
+  });
+
+  it("does not rescan the same outbound anchor during the reconnect cooldown", async () => {
+    const rest = createFakeRestClient([[apiMessage({ id: "102" })], [apiMessage({ id: "103" })]]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    const messageHandler = vi.fn(async (_data: unknown, _client?: unknown) => {});
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "101",
+      at: 1_000,
+    });
+
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 2_000,
+    });
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 2_100,
+    });
+
+    expect(rest.calls).toHaveLength(1);
+    expect(messageHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("prunes expired cooldown entries for outbound anchors outside the backfill window", async () => {
+    const rest = createFakeRestClient([
+      [apiMessage({ id: "102" })],
+      [apiMessage({ id: "902002" })],
+    ]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    const messageHandler = vi.fn(async (_data: unknown, _client?: unknown) => {});
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "101",
+      at: 1_000,
+    });
+
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 2_000,
+    });
+
+    expect(getRecentDiscordBackfillCooldownCountForTest()).toBe(1);
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "902001",
+      at: 902_000,
+    });
+
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 903_000,
+    });
+
+    expect(rest.calls).toHaveLength(2);
+    expect(rest.calls[1]).toMatchObject({
+      method: "GET",
+      query: { after: "902001", limit: 50 },
+    });
+    expect(getRecentDiscordBackfillCooldownCountForTest()).toBe(1);
+  });
+
+  it("shares the replay guard between REST backfill and gateway delivery", async () => {
+    const rest = createFakeRestClient([[apiMessage({ id: "102" })]]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    const handlerParams = createDiscordHandlerParams();
+    preflightDiscordMessageMock.mockImplementation(async () => ({
+      ...createDiscordPreflightContext("thread-1"),
+      cfg: handlerParams.cfg,
+      discordConfig: handlerParams.discordConfig,
+      accountId: handlerParams.accountId,
+      token: handlerParams.token,
+      runtime: handlerParams.runtime,
+      guildHistories: handlerParams.guildHistories,
+      historyLimit: handlerParams.historyLimit,
+      mediaMaxBytes: handlerParams.mediaMaxBytes,
+      textLimit: handlerParams.textLimit,
+      replyToMode: handlerParams.replyToMode,
+      threadBindings: handlerParams.threadBindings,
+      client,
+    }));
+    processDiscordMessageMock.mockResolvedValue(undefined);
+    const handler = createDiscordMessageHandler(handlerParams);
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "101",
+      at: 1_000,
+    });
+
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler: handler,
+      botUserId: "bot-1",
+      now: 2_000,
+    });
+    await flushQueueWork();
+    await handler(
+      {
+        channel_id: "thread-1",
+        author: { id: "user-1" },
+        message: {
+          id: "102",
+          author: { id: "user-1", bot: false },
+          content: "reply",
+          channel_id: "thread-1",
+          attachments: [],
+        },
+      } as never,
+      client,
+    );
+    await flushQueueWork();
+
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replay bot-authored messages", async () => {
+    const rest = createFakeRestClient([
+      [
+        apiMessage({
+          id: "102",
+          author: {
+            id: "bot-1",
+            username: "bot",
+            discriminator: "0",
+            global_name: null,
+            avatar: null,
+            bot: true,
+          },
+        }),
+      ],
+    ]);
+    const client = {
+      rest,
+      fetchChannel: vi.fn(async () => ({ id: "thread-1", guildId: "guild-1" })),
+    } as never;
+    const messageHandler = vi.fn(async (_data: unknown, _client?: unknown) => {});
+
+    recordRecentDiscordOutboundMessage({
+      accountId: "default",
+      channelId: "thread-1",
+      messageId: "101",
+      at: 1_000,
+    });
+
+    await backfillRecentDiscordInboundMessages({
+      accountId: "default",
+      client,
+      messageHandler,
+      botUserId: "bot-1",
+      now: 2_000,
+    });
+
+    expect(messageHandler).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/discord/src/monitor/reconnect-backfill.ts
+++ b/extensions/discord/src/monitor/reconnect-backfill.ts
@@ -1,0 +1,236 @@
+import type { APIMessage } from "discord-api-types/v10";
+import { danger } from "openclaw/plugin-sdk/runtime-env";
+import { listChannelMessages } from "../internal/api.messages.js";
+import { Guild, type Client, Message, User } from "../internal/discord.js";
+import {
+  hasRecentDiscordInboundMessage,
+  recordRecentDiscordInboundMessage,
+} from "../recent-inbound.js";
+import { listRecentDiscordOutboundMessages } from "../recent-outbound.js";
+import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.types.js";
+
+const RECENT_OUTBOUND_BACKFILL_WINDOW_MS = 2 * 60 * 60 * 1000;
+const RECENT_OUTBOUND_BACKFILL_LIMIT = 50;
+const RECENT_OUTBOUND_BACKFILL_COOLDOWN_MS = 30 * 1000;
+
+type Logger = ReturnType<typeof import("openclaw/plugin-sdk/runtime-env").createSubsystemLogger>;
+
+type DiscordChannelLike = {
+  guildId?: string;
+  guild_id?: string;
+};
+
+type DiscordReconnectBackfillStats = {
+  anchorsAvailable: number;
+  anchorsScanned: number;
+  skippedCooldown: number;
+  channelsScanned: number;
+  candidates: number;
+  skippedAlreadyProcessed: number;
+  replayed: number;
+  errors: number;
+};
+
+const recentBackfillByKey = new Map<string, number>();
+
+function normalize(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function compareSnowflakesAscending(a: string, b: string): number {
+  try {
+    const left = BigInt(a);
+    const right = BigInt(b);
+    return left < right ? -1 : left > right ? 1 : 0;
+  } catch {
+    return a.localeCompare(b);
+  }
+}
+
+function resolveGuildId(channel: unknown): string | undefined {
+  const candidate = channel as DiscordChannelLike | null | undefined;
+  return normalize(candidate?.guildId) ?? normalize(candidate?.guild_id);
+}
+
+function isFromBot(message: APIMessage, botUserId?: string): boolean {
+  return Boolean(botUserId && message.author?.id === botUserId);
+}
+
+function backfillKey(params: { accountId: string; channelId: string; messageId: string }) {
+  return `${params.accountId || "default"}:${params.channelId}:${params.messageId}`;
+}
+
+function pruneExpiredRecentBackfillCooldowns(now: number) {
+  for (const [key, previous] of recentBackfillByKey) {
+    if (now - previous > RECENT_OUTBOUND_BACKFILL_COOLDOWN_MS) {
+      recentBackfillByKey.delete(key);
+    }
+  }
+}
+
+function shouldSkipRecentBackfill(params: {
+  accountId: string;
+  channelId: string;
+  messageId: string;
+  now: number;
+}) {
+  pruneExpiredRecentBackfillCooldowns(params.now);
+  const key = backfillKey(params);
+  const previous = recentBackfillByKey.get(key);
+  if (previous !== undefined && params.now - previous <= RECENT_OUTBOUND_BACKFILL_COOLDOWN_MS) {
+    return true;
+  }
+  recentBackfillByKey.set(key, params.now);
+  return false;
+}
+
+function toDispatchEvent(params: {
+  client: Client;
+  channelId: string;
+  guildId?: string;
+  message: APIMessage;
+}): DiscordMessageEvent {
+  const rawMessage = {
+    ...params.message,
+    channel_id: params.channelId,
+    ...(params.guildId ? { guild_id: params.guildId } : {}),
+  } as APIMessage & {
+    member?: { roles?: string[]; nick?: string | null; nickname?: string | null };
+  };
+  const message = new Message(params.client, rawMessage);
+  return {
+    ...rawMessage,
+    id: rawMessage.id,
+    channel_id: params.channelId,
+    channelId: params.channelId,
+    message,
+    author: rawMessage.author ? new User(params.client, rawMessage.author) : null,
+    member: rawMessage.member,
+    rawMember: rawMessage.member,
+    guild: params.guildId ? new Guild<true>(params.client, params.guildId) : null,
+  } as DiscordMessageEvent;
+}
+
+function createEmptyStats(anchorsAvailable: number): DiscordReconnectBackfillStats {
+  return {
+    anchorsAvailable,
+    anchorsScanned: 0,
+    skippedCooldown: 0,
+    channelsScanned: 0,
+    candidates: 0,
+    skippedAlreadyProcessed: 0,
+    replayed: 0,
+    errors: 0,
+  };
+}
+
+function logBackfillStats(params: { logger?: Logger; stats: DiscordReconnectBackfillStats }) {
+  const { stats } = params;
+  if (stats.anchorsAvailable === 0) {
+    return;
+  }
+  params.logger?.info("Discord reconnect backfill complete", stats);
+}
+
+export async function backfillRecentDiscordInboundMessages(params: {
+  accountId: string;
+  client: Client;
+  messageHandler: DiscordMessageHandler;
+  botUserId?: string;
+  logger?: Logger;
+  onEvent?: () => void;
+  now?: number;
+}) {
+  const now = params.now ?? Date.now();
+  const recent = listRecentDiscordOutboundMessages({
+    accountId: params.accountId,
+    maxAgeMs: RECENT_OUTBOUND_BACKFILL_WINDOW_MS,
+    now,
+  });
+  const stats = createEmptyStats(recent.length);
+  if (recent.length === 0) {
+    return stats;
+  }
+
+  for (const entry of recent) {
+    if (
+      shouldSkipRecentBackfill({
+        accountId: params.accountId,
+        channelId: entry.channelId,
+        messageId: entry.messageId,
+        now,
+      })
+    ) {
+      stats.skippedCooldown += 1;
+      continue;
+    }
+    stats.anchorsScanned += 1;
+    try {
+      const channel = await params.client.fetchChannel(entry.channelId);
+      const guildId = resolveGuildId(channel);
+      const messages = await listChannelMessages(params.client.rest, entry.channelId, {
+        after: entry.messageId,
+        limit: RECENT_OUTBOUND_BACKFILL_LIMIT,
+      });
+      stats.channelsScanned += 1;
+      const candidates = messages
+        .filter((message) => message.id && !isFromBot(message, params.botUserId))
+        .toSorted((a, b) => compareSnowflakesAscending(a.id, b.id));
+      stats.candidates += candidates.length;
+      if (candidates.length === 0) {
+        continue;
+      }
+      params.logger?.info("Discord reconnect backfill scanning recent channel messages", {
+        channelId: entry.channelId,
+        after: entry.messageId,
+        count: candidates.length,
+      });
+      for (const message of candidates) {
+        if (
+          hasRecentDiscordInboundMessage({
+            accountId: params.accountId,
+            channelId: entry.channelId,
+            messageId: message.id,
+            maxAgeMs: RECENT_OUTBOUND_BACKFILL_WINDOW_MS,
+            now,
+          })
+        ) {
+          stats.skippedAlreadyProcessed += 1;
+          continue;
+        }
+        params.onEvent?.();
+        await params.messageHandler(
+          toDispatchEvent({
+            client: params.client,
+            channelId: entry.channelId,
+            guildId,
+            message,
+          }),
+          params.client,
+        );
+        recordRecentDiscordInboundMessage({
+          accountId: params.accountId,
+          channelId: entry.channelId,
+          messageId: message.id,
+          at: now,
+        });
+        stats.replayed += 1;
+      }
+    } catch (err) {
+      stats.errors += 1;
+      params.logger?.error(
+        danger(`discord reconnect backfill failed for channel ${entry.channelId}: ${String(err)}`),
+      );
+    }
+  }
+  logBackfillStats({ logger: params.logger, stats });
+  return stats;
+}
+
+export function resetRecentDiscordBackfillsForTest() {
+  recentBackfillByKey.clear();
+}
+
+export function getRecentDiscordBackfillCooldownCountForTest() {
+  return recentBackfillByKey.size;
+}

--- a/extensions/discord/src/recent-inbound.ts
+++ b/extensions/discord/src/recent-inbound.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+
+type RecentDiscordInboundMessage = {
+  accountId: string;
+  channelId: string;
+  messageId: string;
+  at: number;
+};
+
+// Best-effort reconnect recovery dedupe: records recent inbound Discord message
+// ids that reached the normal message handler, so persisted outbound-anchor
+// backfill does not replay already-processed messages after a process restart.
+const RECENT_INBOUND_MAX = 2000;
+const RECENT_INBOUND_PERSIST_WINDOW_MS = 2 * 60 * 60 * 1000;
+const RECENT_INBOUND_STORE_VERSION = 1;
+const RECENT_INBOUND_STORE_PATH_ENV = "OPENCLAW_DISCORD_RECENT_INBOUND_STORE_PATH";
+const RECENT_INBOUND_DISABLE_PERSISTENCE_ENV =
+  "OPENCLAW_DISCORD_RECENT_INBOUND_DISABLE_PERSISTENCE";
+const recentInboundByKey = new Map<string, RecentDiscordInboundMessage>();
+let persistenceLoadedMaxAgeMs = 0;
+
+function normalize(value: string | undefined | null): string {
+  return value?.trim() ?? "";
+}
+
+function keyFor(accountId: string, channelId: string, messageId: string) {
+  return `${accountId || "default"}:${channelId}:${messageId}`;
+}
+
+function normalizeTimestamp(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+function normalizePersistedEntry(value: unknown): RecentDiscordInboundMessage | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as Partial<RecentDiscordInboundMessage>;
+  const accountId = normalize(record.accountId) || "default";
+  const channelId = normalize(record.channelId);
+  const messageId = normalize(record.messageId);
+  const at = normalizeTimestamp(record.at);
+  if (!channelId || !messageId || at === null) {
+    return null;
+  }
+  return { accountId, channelId, messageId, at };
+}
+
+function resolveRecentInboundStorePath(): string | null {
+  if (process.env[RECENT_INBOUND_DISABLE_PERSISTENCE_ENV] === "1") {
+    return null;
+  }
+  const override = process.env[RECENT_INBOUND_STORE_PATH_ENV]?.trim();
+  if (override) {
+    return path.resolve(override);
+  }
+  // Vitest should not write into a developer's real state dir unless a test
+  // explicitly opts in with OPENCLAW_DISCORD_RECENT_INBOUND_STORE_PATH.
+  if (process.env.NODE_ENV === "test") {
+    return null;
+  }
+  return path.join(resolveStateDir(process.env), "discord", "recent-inbound.json");
+}
+
+function readPersistedRecentInbound(now: number, maxAgeMs: number): RecentDiscordInboundMessage[] {
+  const storePath = resolveRecentInboundStorePath();
+  if (!storePath) {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(storePath, "utf8")) as unknown;
+  } catch {
+    return [];
+  }
+  const entries = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { entries?: unknown }).entries)
+      ? (parsed as { entries: unknown[] }).entries
+      : [];
+  return entries
+    .map(normalizePersistedEntry)
+    .filter((entry): entry is RecentDiscordInboundMessage => Boolean(entry))
+    .filter((entry) => now - entry.at <= maxAgeMs)
+    .toSorted((a, b) => a.at - b.at);
+}
+
+function loadPersistedRecentInbound(now: number, maxAgeMs: number) {
+  if (persistenceLoadedMaxAgeMs >= maxAgeMs) {
+    return;
+  }
+  persistenceLoadedMaxAgeMs = maxAgeMs;
+  for (const entry of readPersistedRecentInbound(now, maxAgeMs)) {
+    recentInboundByKey.set(keyFor(entry.accountId, entry.channelId, entry.messageId), entry);
+  }
+}
+
+function trimRecentInbound(now: number, maxAgeMs: number) {
+  for (const [key, entry] of recentInboundByKey) {
+    if (now - entry.at > maxAgeMs) {
+      recentInboundByKey.delete(key);
+    }
+  }
+  if (recentInboundByKey.size <= RECENT_INBOUND_MAX) {
+    return;
+  }
+  const sorted = [...recentInboundByKey.entries()].toSorted((a, b) => a[1].at - b[1].at);
+  for (const [key] of sorted.slice(0, recentInboundByKey.size - RECENT_INBOUND_MAX)) {
+    recentInboundByKey.delete(key);
+  }
+}
+
+function persistRecentInbound(now: number) {
+  const storePath = resolveRecentInboundStorePath();
+  if (!storePath) {
+    return;
+  }
+  try {
+    trimRecentInbound(now, RECENT_INBOUND_PERSIST_WINDOW_MS);
+    const entries = [...recentInboundByKey.values()]
+      .filter((entry) => now - entry.at <= RECENT_INBOUND_PERSIST_WINDOW_MS)
+      .toSorted((a, b) => a.at - b.at);
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    const tmpPath = `${storePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(
+      tmpPath,
+      `${JSON.stringify({ version: RECENT_INBOUND_STORE_VERSION, entries }, null, 2)}\n`,
+      "utf8",
+    );
+    fs.renameSync(tmpPath, storePath);
+  } catch {
+    // Best-effort resilience cache only. Inbound Discord handling must not fail
+    // because this optional replay guard could not be persisted.
+  }
+}
+
+export function recordRecentDiscordInboundMessage(params: {
+  accountId?: string | null;
+  channelId?: string | null;
+  messageId?: string | null;
+  at?: number;
+}) {
+  const accountId = normalize(params.accountId) || "default";
+  const channelId = normalize(params.channelId);
+  const messageId = normalize(params.messageId);
+  if (!channelId || !messageId) {
+    return;
+  }
+  const at = params.at ?? Date.now();
+  loadPersistedRecentInbound(at, RECENT_INBOUND_PERSIST_WINDOW_MS);
+  recentInboundByKey.set(keyFor(accountId, channelId, messageId), {
+    accountId,
+    channelId,
+    messageId,
+    at,
+  });
+  trimRecentInbound(at, RECENT_INBOUND_PERSIST_WINDOW_MS);
+  persistRecentInbound(at);
+}
+
+export function hasRecentDiscordInboundMessage(params: {
+  accountId?: string | null;
+  channelId?: string | null;
+  messageId?: string | null;
+  maxAgeMs?: number;
+  now?: number;
+}): boolean {
+  const accountId = normalize(params.accountId) || "default";
+  const channelId = normalize(params.channelId);
+  const messageId = normalize(params.messageId);
+  if (!channelId || !messageId) {
+    return false;
+  }
+  const maxAgeMs = params.maxAgeMs ?? RECENT_INBOUND_PERSIST_WINDOW_MS;
+  const now = params.now ?? Date.now();
+  loadPersistedRecentInbound(now, maxAgeMs);
+  trimRecentInbound(now, maxAgeMs);
+  return recentInboundByKey.has(keyFor(accountId, channelId, messageId));
+}
+
+export function resetRecentDiscordInboundMessagesForTest() {
+  recentInboundByKey.clear();
+  persistenceLoadedMaxAgeMs = 0;
+}
+
+export function clearRecentDiscordInboundPersistenceForTest() {
+  const storePath = resolveRecentInboundStorePath();
+  if (!storePath) {
+    return;
+  }
+  try {
+    fs.rmSync(storePath, { force: true });
+  } catch {
+    // test helper only
+  }
+}

--- a/extensions/discord/src/recent-outbound.ts
+++ b/extensions/discord/src/recent-outbound.ts
@@ -1,0 +1,214 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+
+type RecentDiscordOutboundMessage = {
+  accountId: string;
+  channelId: string;
+  messageId: string;
+  at: number;
+};
+
+// Best-effort reconnect recovery anchor: scoped to recent bot outbounds.
+// Unlike the first in-memory-only version, this store is persisted so a full
+// Gateway restart can still catch user replies that Discord delivered while the
+// old process was wedged/starved. This is still deliberately bounded; it is not
+// a general-purpose Discord history sync.
+const RECENT_OUTBOUND_MAX = 500;
+const RECENT_OUTBOUND_CHANNEL_WINDOW_MS = 15 * 60 * 1000;
+const RECENT_OUTBOUND_PERSIST_WINDOW_MS = 2 * 60 * 60 * 1000;
+const RECENT_OUTBOUND_STORE_VERSION = 1;
+const RECENT_OUTBOUND_STORE_PATH_ENV = "OPENCLAW_DISCORD_RECENT_OUTBOUND_STORE_PATH";
+const RECENT_OUTBOUND_DISABLE_PERSISTENCE_ENV =
+  "OPENCLAW_DISCORD_RECENT_OUTBOUND_DISABLE_PERSISTENCE";
+const recentOutboundByKey = new Map<string, RecentDiscordOutboundMessage>();
+let persistenceLoadedMaxAgeMs = 0;
+
+function normalize(value: string | undefined | null): string {
+  return value?.trim() ?? "";
+}
+
+function keyFor(accountId: string, channelId: string) {
+  return `${accountId || "default"}:${channelId}`;
+}
+
+function normalizeTimestamp(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+function normalizePersistedEntry(value: unknown): RecentDiscordOutboundMessage | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as Partial<RecentDiscordOutboundMessage>;
+  const accountId = normalize(record.accountId) || "default";
+  const channelId = normalize(record.channelId);
+  const messageId = normalize(record.messageId);
+  const at = normalizeTimestamp(record.at);
+  if (!channelId || !messageId || at === null) {
+    return null;
+  }
+  return { accountId, channelId, messageId, at };
+}
+
+function resolveRecentOutboundStorePath(): string | null {
+  if (process.env[RECENT_OUTBOUND_DISABLE_PERSISTENCE_ENV] === "1") {
+    return null;
+  }
+  const override = process.env[RECENT_OUTBOUND_STORE_PATH_ENV]?.trim();
+  if (override) {
+    return path.resolve(override);
+  }
+  // Vitest should not write into a developer's real state dir unless a test
+  // explicitly opts in with OPENCLAW_DISCORD_RECENT_OUTBOUND_STORE_PATH.
+  if (process.env.NODE_ENV === "test") {
+    return null;
+  }
+  return path.join(resolveStateDir(process.env), "discord", "recent-outbound.json");
+}
+
+function readPersistedRecentOutbound(
+  now: number,
+  maxAgeMs: number,
+): RecentDiscordOutboundMessage[] {
+  const storePath = resolveRecentOutboundStorePath();
+  if (!storePath) {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(storePath, "utf8")) as unknown;
+  } catch {
+    return [];
+  }
+  const entries = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { entries?: unknown }).entries)
+      ? (parsed as { entries: unknown[] }).entries
+      : [];
+  return entries
+    .map(normalizePersistedEntry)
+    .filter((entry): entry is RecentDiscordOutboundMessage => Boolean(entry))
+    .filter((entry) => now - entry.at <= maxAgeMs)
+    .toSorted((a, b) => a.at - b.at);
+}
+
+function loadPersistedRecentOutbound(now: number, maxAgeMs: number) {
+  if (persistenceLoadedMaxAgeMs >= maxAgeMs) {
+    return;
+  }
+  persistenceLoadedMaxAgeMs = maxAgeMs;
+  for (const entry of readPersistedRecentOutbound(now, maxAgeMs)) {
+    const key = keyFor(entry.accountId, entry.channelId);
+    const existing = recentOutboundByKey.get(key);
+    // Prefer the oldest still-valid anchor for a channel so a startup catch-up
+    // scans across the largest bounded gap after a full process restart.
+    if (!existing || entry.at < existing.at) {
+      recentOutboundByKey.set(key, entry);
+    }
+  }
+}
+
+function trimRecentOutbound(now: number, maxAgeMs: number) {
+  for (const [key, entry] of recentOutboundByKey) {
+    if (now - entry.at > maxAgeMs) {
+      recentOutboundByKey.delete(key);
+    }
+  }
+  if (recentOutboundByKey.size <= RECENT_OUTBOUND_MAX) {
+    return;
+  }
+  const sorted = [...recentOutboundByKey.entries()].toSorted((a, b) => a[1].at - b[1].at);
+  for (const [key] of sorted.slice(0, recentOutboundByKey.size - RECENT_OUTBOUND_MAX)) {
+    recentOutboundByKey.delete(key);
+  }
+}
+
+function persistRecentOutbound(now: number) {
+  const storePath = resolveRecentOutboundStorePath();
+  if (!storePath) {
+    return;
+  }
+  try {
+    trimRecentOutbound(now, RECENT_OUTBOUND_PERSIST_WINDOW_MS);
+    const entries = [...recentOutboundByKey.values()]
+      .filter((entry) => now - entry.at <= RECENT_OUTBOUND_PERSIST_WINDOW_MS)
+      .toSorted((a, b) => a.at - b.at);
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    const tmpPath = `${storePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(
+      tmpPath,
+      `${JSON.stringify({ version: RECENT_OUTBOUND_STORE_VERSION, entries }, null, 2)}\n`,
+      "utf8",
+    );
+    fs.renameSync(tmpPath, storePath);
+  } catch {
+    // Best-effort resilience cache only. Outbound Discord sends must not fail
+    // because this optional recovery anchor could not be persisted.
+  }
+}
+
+export function recordRecentDiscordOutboundMessage(params: {
+  accountId?: string | null;
+  channelId?: string | null;
+  messageId?: string | null;
+  at?: number;
+}) {
+  const accountId = normalize(params.accountId) || "default";
+  const channelId = normalize(params.channelId);
+  const messageId = normalize(params.messageId);
+  if (!channelId || !messageId) {
+    return;
+  }
+  const at = params.at ?? Date.now();
+  loadPersistedRecentOutbound(at, RECENT_OUTBOUND_PERSIST_WINDOW_MS);
+  const key = keyFor(accountId, channelId);
+  const existing = recentOutboundByKey.get(key);
+  if (existing && at - existing.at <= RECENT_OUTBOUND_CHANNEL_WINDOW_MS) {
+    trimRecentOutbound(at, RECENT_OUTBOUND_PERSIST_WINDOW_MS);
+    persistRecentOutbound(at);
+    return;
+  }
+  recentOutboundByKey.set(key, {
+    accountId,
+    channelId,
+    messageId,
+    at,
+  });
+  trimRecentOutbound(at, RECENT_OUTBOUND_PERSIST_WINDOW_MS);
+  persistRecentOutbound(at);
+}
+
+export function listRecentDiscordOutboundMessages(params: {
+  accountId?: string | null;
+  maxAgeMs: number;
+  now?: number;
+}): RecentDiscordOutboundMessage[] {
+  const accountId = normalize(params.accountId) || "default";
+  const now = params.now ?? Date.now();
+  loadPersistedRecentOutbound(now, params.maxAgeMs);
+  trimRecentOutbound(now, params.maxAgeMs);
+  return [...recentOutboundByKey.values()].filter(
+    (entry) => entry.accountId === accountId && now - entry.at <= params.maxAgeMs,
+  );
+}
+
+export function resetRecentDiscordOutboundMessagesForTest() {
+  recentOutboundByKey.clear();
+  persistenceLoadedMaxAgeMs = 0;
+}
+
+export function clearRecentDiscordOutboundPersistenceForTest() {
+  const storePath = resolveRecentOutboundStorePath();
+  if (!storePath) {
+    return;
+  }
+  try {
+    fs.rmSync(storePath, { force: true });
+  } catch {
+    // test helper only
+  }
+}

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -12,6 +12,7 @@ import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { resolveDiscordAccount } from "./accounts.js";
 import { createChannelMessage, createThread, type RequestClient } from "./internal/discord.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
+import { recordRecentDiscordOutboundMessage } from "./recent-outbound.js";
 import { parseAndResolveChannelRecipient } from "./recipient-resolution.js";
 import { createDiscordSendResult, type DiscordReceiptResultSource } from "./send.receipt.js";
 import {
@@ -305,6 +306,11 @@ export async function sendMessageDiscord(
       accountId: accountInfo.accountId,
       direction: "outbound",
     });
+    recordRecentDiscordOutboundMessage({
+      accountId: accountInfo.accountId,
+      channelId: resultChannelId,
+      messageId,
+    });
     return toDiscordSendResult(
       {
         id: messageId,
@@ -368,6 +374,11 @@ export async function sendMessageDiscord(
     channel: "discord",
     accountId: accountInfo.accountId,
     direction: "outbound",
+  });
+  recordRecentDiscordOutboundMessage({
+    accountId: accountInfo.accountId,
+    channelId: result.channel_id ?? channelId,
+    messageId: result.id,
   });
   return toDiscordSendResult(result, channelId, {
     kind: opts.mediaUrl ? "media" : opts.components || opts.embeds ? "card" : "text",

--- a/extensions/discord/src/test-support/provider.test-support.ts
+++ b/extensions/discord/src/test-support/provider.test-support.ts
@@ -507,6 +507,8 @@ vi.mock(buildDiscordSourceModuleId("monitor/listeners.js"), () => ({
   DiscordInteractionListener: function DiscordInteractionListener() {},
   DiscordMessageListener: function DiscordMessageListener() {},
   DiscordPresenceListener: function DiscordPresenceListener() {},
+  DiscordReconnectBackfillReadyListener: function DiscordReconnectBackfillReadyListener() {},
+  DiscordReconnectBackfillResumedListener: function DiscordReconnectBackfillResumedListener() {},
   DiscordReactionListener: function DiscordReactionListener() {},
   DiscordReactionRemoveListener: function DiscordReactionRemoveListener() {},
   DiscordThreadUpdateListener: function DiscordThreadUpdateListener() {},


### PR DESCRIPTION
Replaces #81211, which was closed automatically because the author temporarily exceeded the active PR queue limit. The active queue has since been reduced.

## Summary

Fixes a Discord reliability gap where user replies can be missed when the Gateway websocket silently drops `MESSAGE_CREATE` events shortly before reconnect/resume.

The patch adds a bounded, best-effort recovery path for the common case where a user replies shortly after OpenClaw sends a Discord message:

- record recent Discord outbound channel/message anchors in memory
- on Discord Gateway `READY` / `RESUMED`, REST-fetch recent messages after those anchors
- feed recovered messages through the existing Discord `messageHandler`, preserving normal preflight, routing, replay dedupe, and session queue behavior
- add a short per-anchor cooldown so `READY` + `RESUMED` do not repeatedly rescan the same anchor
- harden reply hydration so messages with `message_reference` but missing `referenced_message` can still resolve reply-to-bot implicit mention handling

## Scope boundary

This is intentionally not a general persisted Discord history catch-up system. It is an in-memory, bounded recovery seam for recent bot-outbound channels, designed to cover the high-value "user replied after the bot spoke" failure mode without broad REST scanning.

If the process restarts, the in-memory anchors are lost; this patch does not attempt cross-process persisted recovery.

## Validation

Validated in an isolated source/stage worktree; no live gateway restart or production state was used.

- `oxfmt --check` on changed Discord files
- `oxlint --tsconfig config/tsconfig/oxlint.extensions.json` on changed Discord files
- targeted regression tests:
  - `extensions/discord/src/monitor/provider.test.ts`
  - `extensions/discord/src/monitor/reconnect-backfill.test.ts`
  - `extensions/discord/src/monitor/message-handler.hydration.test.ts`
  - `extensions/discord/src/monitor/provider.startup.test.ts`
  - `extensions/discord/src/monitor/message-handler.queue.test.ts`
  - result: 5 files / 68 tests passed
- full Discord extension shard:
  - `node scripts/test-projects.mjs extensions/discord`
  - result: 146 files / 1412 tests passed
- extensions typecheck:
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental false --pretty false`
  - result: passed

## Notes

The duplicate-delivery overlap is covered by routing both REST-recovered messages and normal Gateway messages through the same replay guard path. A regression test verifies that the same message delivered by backfill and then by the normal Gateway handler is processed once.


## Reopen/resubmit note

This replacement keeps the same branch and scope as #81211:

- Discord missed inbound recovery after gateway reconnect.
- Bounded recent-outbound REST backfill.
- Reply hydration hardening.

Validation from the original PR preparation remains applicable:

- targeted formatter/lint passed
- targeted regression: 5 files / 68 tests passed
- full Discord extension shard: 146 files / 1412 tests passed
- extensions `tsgo` passed under guarded heavy-run

No live Gateway/runtime activation was used for this PR.

## Real behavior proof

- **Behavior addressed**: Discord Gateway websocket reconnect/resume can miss recent inbound `MESSAGE_CREATE` events, especially when a user replies shortly after the bot sends a message. This patch adds bounded recent-outbound REST backfill and reply hydration hardening so those missed replies can be recovered through the existing Discord message handling path.
- **Real setup tested**: Isolated OpenClaw source checkout at current PR head `06ff7efc51e3b591de00733361987c5770b21a59`. The after-fix behavior was exercised with a local Node proof harness using synthetic Discord/Gateway/REST seams, Discord-shaped REST payloads, READY/RESUMED reconnect entry points, recent outbound anchors, reply-reference hydration payloads, and the same message-handler/replay-dedupe contract. No production live Gateway/runtime/config/state was used, and no live Discord channel was used.
- **Exact steps or command run after this patch**:

```text
current PR head: 06ff7efc51e3b591de00733361987c5770b21a59
node discord-reconnect-backfill-nonprod-proof.mjs \
  --repo <isolated-source-checkout> \
  --head 06ff7efc51e3b591de00733361987c5770b21a59
git diff --check "$(git merge-base upstream/main HEAD)"..HEAD
git grep -n -E '^(<<<<<<<|=======|>>>>>>>)($| )' -- ':!pnpm-lock.yaml' ':!*.snap'
```

- **Evidence after fix**:

```text
discord reconnect backfill non-production proof
head=06ff7efc51e3b591de00733361987c5770b21a59
environment=isolated source checkout; synthetic Discord/Gateway/REST harness; no production Gateway/runtime/config/state; no live Discord channel
source assertions=16/16
- READY listener class is wired to reconnect backfill
- RESUMED listener class is wired to reconnect backfill
- monitor startup registers READY backfill listener
- monitor startup registers RESUMED backfill listener
- outbound sends record recent Discord anchors
- recent outbound anchors are in-memory, bounded, and account-filtered
- backfill reads recent outbound anchors
- backfill REST-fetches after the outbound anchor with bounded limit
- backfill filters bot-authored messages
- backfill sorts recovered messages oldest-first
- backfill routes recovered messages through the provided messageHandler
- backfill prunes expired cooldown entries before skip checks
- reply hydration fetches when reply reference lacks referenced_message
- committed regression covers replay guard shared by backfill and gateway delivery
- committed regression covers reconnect cooldown skip
- committed regression covers expired cooldown pruning
behavior transcript:
- outbound anchor recorded: channel=thread-A message=101 account=default
- second outbound inside channel window ignored: message=101-later kept first anchor=101
- READY REST backfill call: after=101 limit=50
- RESUMED immediately after READY: skipped by reconnect cooldown; no duplicate REST call
- REST payload order: 103, 102, 104; bot-authored payload 104 ignored
- dispatched through existing handler order: 102 -> 103
- reply hydration fetched references for: 102->bot-A, 103->bot-A
- duplicate normal Gateway delivery for 102: replay-dedupe
- cooldown entries after READY/RESUMED: 1
- expired cooldown prune/later anchor: after=902001; cooldown entries after prune=1
result=PASS
source hashes:
- reconnect: sha256:567234410d22e371
- listeners: sha256:dc74f995b4583506
- startup: sha256:4db47064f198e848
- hydration: sha256:46fa4c0c4cd6307b
- outbound: sha256:388d4723f40dfe5d
- recent-outbound: sha256:cc355aa6e3e5d524
- reconnect-test: sha256:426f70b6ceb8d128

git diff --check "$(git merge-base upstream/main HEAD)"..HEAD: OK
conflict marker scan: OK no conflict markers
```

Supplemental current-head repository validation is green on GitHub for this PR at head `06ff7efc51e3b591de00733361987c5770b21a59`: `check`, `check-additional`, `checks-node-channels`, `check-lint`, `check-test-types`, `check-prod-types`, `checks-fast-contracts-channels`, `build-smoke`, and the latest `Real behavior proof` run completed successfully.

- **Observed result after fix**: The non-production reconnect scenario recovered user messages after the recent bot outbound anchor with `after=101` and `limit=50`, skipped an immediate RESUMED rescan via reconnect cooldown, filtered the bot-authored payload, dispatched recovered user messages through the existing handler in oldest-first order (`102 -> 103`), hydrated missing reply references back to the bot-authored message (`102->bot-A`, `103->bot-A`), rejected a later duplicate normal Gateway delivery of message `102` via the shared replay-dedupe path, and pruned an expired cooldown entry before processing a later anchor. Source assertions also confirm both READY and RESUMED listeners call the reconnect backfill and that monitor startup registers both listeners.
- **What was not tested**: No production live Gateway restart, live Discord channel, persisted cross-process catch-up, or broad unbounded history scan was exercised. This PR intentionally covers bounded in-memory recent-outbound recovery only; if maintainers require a true live Discord reconnect proof, that needs an explicit live-test lane or maintainer `proof: override` because this contributor-side validation avoided live runtime/config/state.
