### PR TITLE
fix(xai): gate reasoning effort to supported models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sessions: preserve fresh post-compaction token snapshots across stale usage updates, preventing repeated auto-compaction after every message. Fixes #82576. (#82578) Thanks @njuboy11.
 - Agents/OpenAI Responses: log redacted diagnostics for detail-less `response.failed` events while preserving failed response ids, so operators can correlate provider-side failures. Fixes #82558.
 - Agents/OpenRouter: strip non-replayable Anthropic/xAI reasoning provenance tags from follow-up requests, preventing poisoned thinking signatures from breaking second turns. Fixes #82335. (#82380) Thanks @hclsys.
+- Providers/xAI: send configurable reasoning effort only for Grok 4.3, preserving xAI's default low reasoning while omitting unsupported controls for Grok 4.20 reasoning models. (#81227) Thanks @jason-allen-oneal.
 - Agents/auth: redact OAuth refresh failure causes against in-memory, attempted, and reloaded credentials before generic token masking while ensuring failed ACP dispatch cleanup closes initialized runtimes.
 - Google/Gemini CLI OAuth: add provider-owned refresh support for `google-gemini-cli` so expired Gemini CLI tokens refresh in OpenClaw instead of falling through to the generic unknown-provider path. Fixes #42541. Thanks @jason-allen-oneal.
 - Telegram: cache successful startup bot identity by account and token fingerprint for up to 24 hours, so restarts can skip redundant `getMe` probes during Telegram API slow periods without permanently pinning renamed bots. Refs #82525.

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -203,8 +203,8 @@ describe("xai provider plugin", () => {
 
     const normalized = provider.normalizeResolvedModel?.({
       provider: "xai",
-      modelId: "grok-4-1-fast",
-      model: createProviderModel({ id: "grok-4-1-fast" }),
+      modelId: "grok-4.3",
+      model: createProviderModel({ id: "grok-4.3" }),
     } as never);
     expect(normalized?.thinkingLevelMap).toEqual({
       off: null,
@@ -213,6 +213,19 @@ describe("xai provider plugin", () => {
       medium: "medium",
       high: "high",
       xhigh: "high",
+    });
+    const olderReasoningModel = provider.normalizeResolvedModel?.({
+      provider: "xai",
+      modelId: "grok-4-1-fast",
+      model: createProviderModel({ id: "grok-4-1-fast" }),
+    } as never);
+    expect(olderReasoningModel?.thinkingLevelMap).toEqual({
+      off: null,
+      minimal: null,
+      low: null,
+      medium: null,
+      high: null,
+      xhigh: null,
     });
     const normalizedCompat = normalized?.compat as
       | {

--- a/extensions/xai/runtime-model-compat.test.ts
+++ b/extensions/xai/runtime-model-compat.test.ts
@@ -9,6 +9,10 @@ describe("xai runtime model compat", () => {
       reasoning: true,
     });
 
+    expect(model.compat).toMatchObject({
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: ["low", "medium", "high"],
+    });
     expect(model.thinkingLevelMap).toEqual({
       off: null,
       minimal: "low",

--- a/extensions/xai/runtime-model-compat.test.ts
+++ b/extensions/xai/runtime-model-compat.test.ts
@@ -35,4 +35,22 @@ describe("xai runtime model compat", () => {
       xhigh: null,
     });
   });
+
+  it("does not advertise configurable reasoning effort for older xAI reasoning models", () => {
+    const model = applyXaiRuntimeModelCompat({
+      id: "grok-4.20-beta-latest-reasoning",
+      provider: "xai",
+      reasoning: true,
+    });
+
+    expect(model.compat).toMatchObject({ supportsReasoningEffort: false });
+    expect(model.thinkingLevelMap).toEqual({
+      off: null,
+      minimal: null,
+      low: null,
+      medium: null,
+      high: null,
+      xhigh: null,
+    });
+  });
 });

--- a/extensions/xai/runtime-model-compat.ts
+++ b/extensions/xai/runtime-model-compat.ts
@@ -28,7 +28,7 @@ const XAI_REASONING_EFFORTS = {
   xhigh: "high",
 } satisfies NonNullable<XaiRuntimeModelCompat["thinkingLevelMap"]>;
 
-const XAI_SUPPORTED_REASONING_EFFORTS = ["none", "low", "medium", "high"] as const;
+const XAI_SUPPORTED_REASONING_EFFORTS = ["low", "medium", "high"] as const;
 
 function normalizeXaiCompatModelId(id: unknown): string {
   return typeof id === "string" ? id.trim().toLowerCase() : "";

--- a/extensions/xai/runtime-model-compat.ts
+++ b/extensions/xai/runtime-model-compat.ts
@@ -2,6 +2,7 @@ import { applyXaiModelCompat } from "./model-compat.js";
 
 type XaiRuntimeModelCompat = {
   compat?: unknown;
+  id?: unknown;
   reasoning?: unknown;
   thinkingLevelMap?: XaiThinkingLevelMap;
 };
@@ -27,15 +28,45 @@ const XAI_REASONING_EFFORTS = {
   xhigh: "high",
 } satisfies NonNullable<XaiRuntimeModelCompat["thinkingLevelMap"]>;
 
+const XAI_SUPPORTED_REASONING_EFFORTS = ["none", "low", "medium", "high"] as const;
+
+function normalizeXaiCompatModelId(id: unknown): string {
+  return typeof id === "string" ? id.trim().toLowerCase() : "";
+}
+
+function supportsConfigurableXaiReasoningEffort(model: XaiRuntimeModelCompat): boolean {
+  const id = normalizeXaiCompatModelId(model.id);
+  return model.reasoning === true && (id === "grok-4.3" || id.startsWith("grok-4.3-"));
+}
+
+function resolveXaiReasoningEffortCompat(model: XaiRuntimeModelCompat): Record<string, unknown> {
+  if (supportsConfigurableXaiReasoningEffort(model)) {
+    return {
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: [...XAI_SUPPORTED_REASONING_EFFORTS],
+    };
+  }
+  return { supportsReasoningEffort: false };
+}
+
 export function applyXaiRuntimeModelCompat<T extends XaiRuntimeModelCompat>(
   model: T,
-): T & { thinkingLevelMap: XaiThinkingLevelMap } {
+): T & { compat: Record<string, unknown>; thinkingLevelMap: XaiThinkingLevelMap } {
   const withCompat = applyXaiModelCompat(model);
+  const supportsReasoningEffort = supportsConfigurableXaiReasoningEffort(withCompat);
+  const existingCompat =
+    withCompat.compat && typeof withCompat.compat === "object"
+      ? (withCompat.compat as Record<string, unknown>)
+      : {};
   return {
     ...withCompat,
+    compat: {
+      ...existingCompat,
+      ...resolveXaiReasoningEffortCompat(withCompat),
+    },
     thinkingLevelMap: {
       ...withCompat.thinkingLevelMap,
-      ...(withCompat.reasoning ? XAI_REASONING_EFFORTS : XAI_UNSUPPORTED_REASONING_EFFORTS),
+      ...(supportsReasoningEffort ? XAI_REASONING_EFFORTS : XAI_UNSUPPORTED_REASONING_EFFORTS),
     },
   };
 }

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -197,6 +197,35 @@ describe("xai stream wrappers", () => {
     expect(payload.reasoning_effort).toBe("high");
   });
 
+  it("strips reasoning controls when compat disables reasoning effort", () => {
+    const payload: Record<string, unknown> = {
+      reasoning: { effort: "high" },
+      reasoningEffort: "high",
+      reasoning_effort: "high",
+    };
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      options?.onPayload?.(payload, model);
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = createXaiToolPayloadCompatibilityWrapper(baseStreamFn);
+
+    void wrapped(
+      {
+        api: "openai-responses",
+        provider: "xai",
+        id: "grok-4.20-beta-latest-reasoning",
+        reasoning: true,
+        compat: { supportsReasoningEffort: false },
+      } as unknown as Model<"openai-responses">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(payload).not.toHaveProperty("reasoning");
+    expect(payload).not.toHaveProperty("reasoningEffort");
+    expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
   it("keeps native xAI Responses thinking efforts before pi-ai dispatches payloads", async () => {
     const payload = await captureXaiResponsesPayloadWithThinking();
 

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -42,8 +42,12 @@ function supportsExplicitImageInput(model: { input?: unknown }): boolean {
   return Array.isArray(model.input) && model.input.includes("image");
 }
 
-function supportsReasoningControls(model: { reasoning?: unknown }): boolean {
-  return model.reasoning === true;
+function supportsReasoningControls(model: { compat?: unknown; reasoning?: unknown }): boolean {
+  const compat =
+    model.compat && typeof model.compat === "object"
+      ? (model.compat as { supportsReasoningEffort?: unknown })
+      : undefined;
+  return model.reasoning === true && compat?.supportsReasoningEffort !== false;
 }
 
 const TOOL_RESULT_IMAGE_REPLAY_TEXT = "Attached image(s) from tool result:";

--- a/src/agents/openai-reasoning-effort.test.ts
+++ b/src/agents/openai-reasoning-effort.test.ts
@@ -88,4 +88,15 @@ describe("OpenAI reasoning effort support", () => {
     expect(resolveOpenAISupportedReasoningEfforts(model)).toEqual([]);
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "high" })).toBeUndefined();
   });
+
+  it("does not turn disabled reasoning into a fallback effort when compat omits none", () => {
+    const model = {
+      provider: "xai",
+      id: "grok-4.3",
+      compat: { supportedReasoningEfforts: ["low", "medium", "high"] },
+    };
+
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "none" })).toBeUndefined();
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "high" })).toBe("high");
+  });
 });

--- a/src/agents/openai-reasoning-effort.test.ts
+++ b/src/agents/openai-reasoning-effort.test.ts
@@ -77,4 +77,15 @@ describe("OpenAI reasoning effort support", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("honors compat metadata that disables reasoning effort payloads", () => {
+    const model = {
+      provider: "xai",
+      id: "grok-4.20-beta-latest-reasoning",
+      compat: { supportsReasoningEffort: false },
+    };
+
+    expect(resolveOpenAISupportedReasoningEfforts(model)).toEqual([]);
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "high" })).toBeUndefined();
+  });
 });

--- a/src/agents/openai-reasoning-effort.ts
+++ b/src/agents/openai-reasoning-effort.ts
@@ -39,6 +39,9 @@ function readCompatReasoningEfforts(compat: unknown): OpenAIApiReasoningEffort[]
   if (!compat || typeof compat !== "object") {
     return undefined;
   }
+  if ((compat as { supportsReasoningEffort?: unknown }).supportsReasoningEffort === false) {
+    return [];
+  }
   const raw = (compat as { supportedReasoningEfforts?: unknown }).supportedReasoningEfforts;
   if (!Array.isArray(raw)) {
     return undefined;

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1774,6 +1774,68 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("include");
   });
 
+  it("preserves xAI Grok 4.3 default reasoning by omitting default none", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "grok-4.3",
+        name: "Grok 4.3",
+        api: "openai-responses",
+        provider: "xai",
+        baseUrl: "https://api.x.ai/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+        compat: {
+          supportsReasoningEffort: true,
+          supportedReasoningEfforts: ["low", "medium", "high"],
+        },
+      } as unknown as Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    ) as { reasoning?: unknown; include?: string[] };
+
+    expect(params).not.toHaveProperty("reasoning");
+    expect(params).not.toHaveProperty("include");
+  });
+
+  it("passes explicit xAI Grok 4.3 reasoning effort through", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "grok-4.3",
+        name: "Grok 4.3",
+        api: "openai-responses",
+        provider: "xai",
+        baseUrl: "https://api.x.ai/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+        compat: {
+          supportsReasoningEffort: true,
+          supportedReasoningEfforts: ["low", "medium", "high"],
+        },
+      } as unknown as Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        reasoning: "high",
+      } as never,
+    ) as { reasoning?: unknown; include?: string[] };
+
+    expect(params.reasoning).toEqual({ effort: "high", summary: "auto" });
+    expect(params.include).toEqual(["reasoning.encrypted_content"]);
+  });
+
   it("keeps developer role for native OpenAI reasoning responses models", () => {
     const params = buildOpenAIResponsesParams(
       {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1745,6 +1745,35 @@ describe("openai transport stream", () => {
     expect(params.input?.[0]?.role).toBe("system");
   });
 
+  it("omits Responses reasoning params when model compat disables reasoning effort", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "grok-4.20-beta-latest-reasoning",
+        name: "Grok 4.20 Beta Latest (Reasoning)",
+        api: "openai-responses",
+        provider: "xai",
+        baseUrl: "https://api.x.ai/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 2_000_000,
+        maxTokens: 30_000,
+        compat: { supportsReasoningEffort: false },
+      } as unknown as Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        reasoning: "high",
+      } as never,
+    ) as { reasoning?: unknown; include?: string[] };
+
+    expect(params).not.toHaveProperty("reasoning");
+    expect(params).not.toHaveProperty("include");
+  });
+
   it("keeps developer role for native OpenAI reasoning responses models", () => {
     const params = buildOpenAIResponsesParams(
       {


### PR DESCRIPTION
## Summary
- honor compat.supportsReasoningEffort=false when building OpenAI-compatible reasoning payloads
- mark xAI runtime models as configurable only for grok-4.3, matching xAI docs
- strip reasoning controls from xAI payload wrappers when compat disables reasoning effort

## Root cause
xAI's docs now scope the configurable reasoning_effort parameter to grok-4.3. Older xAI reasoning model IDs such as grok-4.20-beta-latest-reasoning and grok-4-1-fast can be reasoning-capable but still reject configurable reasoning_effort payloads. OpenClaw treated reasoning=true as permission to emit reasoning effort controls, so xAI requests could fail suddenly with provider validation errors.

## Test Plan
- pnpm tsgo:test:src
- pnpm tsgo:test:extensions
- OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run src/agents/openai-reasoning-effort.test.ts src/agents/openai-transport-stream.test.ts extensions/xai

## Real behavior proof
- **Behavior addressed**: Older xAI reasoning models such as `grok-4.20-beta-latest-reasoning` must not receive unsupported configurable reasoning-effort controls when OpenClaw users request high thinking. The fix should omit `reasoning`, `reasoning_effort`, `reasoningEffort`, and `include: ["reasoning.encrypted_content"]` for those models.
- **Real environment tested**: Local OpenClaw checkout at PR commit `7312f56`, Node 22, repository dependencies installed, built CLI verified with `pnpm openclaw --help`. The xAI plugin catalog in this checkout lists the affected model family (`xai/grok-4.20-0309-reasoning`) and the only configurable-effort model documented by xAI (`xai/grok-4.3`).
- **Exact steps or command run after this patch**: Captured the xAI Responses outgoing payload immediately before provider dispatch using OpenClaw's xAI runtime compat and Responses stream path, with `grok-4.20-beta-latest-reasoning` and high thinking requested:

  ```text
  OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run extensions/xai/payload-proof.test.ts --reporter verbose
  ```

- **Evidence after fix**: Terminal capture / console output from the outgoing payload capture:

  ```text
  XAI_OUTGOING_PAYLOAD_PROOF {
    "model": "grok-4.20-beta-latest-reasoning",
    "supportsReasoningEffort": false,
    "requestedThinking": "high",
    "payloadHasReasoning": false,
    "payloadHasReasoningEffort": false,
    "payloadHasCamelReasoningEffort": false,
    "payloadInclude": null,
    "payloadKeys": [
      "input",
      "max_output_tokens",
      "model",
      "prompt_cache_key",
      "prompt_cache_retention",
      "store",
      "stream"
    ]
  }
  ```



  Live xAI network verification was also run with the user's xAI API key. This made exactly two requests to `https://api.x.ai/v1/responses` using `max_output_tokens: 16`; the key and Authorization header were not logged or saved. The control request reproduced the provider rejection when unsupported reasoning controls are present, and the fixed request succeeded when those controls are omitted:

  ```json
  {
    "requestCount": 2,
    "control_bad_with_reasoning_controls": {
      "request": {
        "model": "grok-4.20-beta-latest-reasoning",
        "requestKeys": ["include", "input", "max_output_tokens", "model", "reasoning"],
        "hasReasoning": true,
        "hasReasoningEffort": false,
        "hasCamelReasoningEffort": false,
        "include": ["reasoning.encrypted_content"],
        "maxOutputTokens": 16
      },
      "response": {
        "httpStatus": 400,
        "ok": false
      }
    },
    "fixed_without_reasoning_controls": {
      "request": {
        "model": "grok-4.20-beta-latest-reasoning",
        "requestKeys": ["input", "max_output_tokens", "model"],
        "hasReasoning": false,
        "hasReasoningEffort": false,
        "hasCamelReasoningEffort": false,
        "include": null,
        "maxOutputTokens": 16
      },
      "response": {
        "httpStatus": 200,
        "ok": true,
        "responseModel": "grok-4.20-0309-reasoning",
        "usage": {
          "input_tokens": 129,
          "output_tokens": 554,
          "total_tokens": 683
        }
      }
    }
  }
  ```

- **Observed result after fix**: The patched xAI runtime marks `grok-4.20-beta-latest-reasoning` with `supportsReasoningEffort: false`, and the outgoing provider payload no longer contains any unsupported `reasoning`, `reasoning_effort`, `reasoningEffort`, or `include: ["reasoning.encrypted_content"]` controls even when high thinking is requested.
- **What was not tested**: A full end-to-end production workflow was not run from this local checkout. The proof now combines the OpenClaw dispatch-boundary payload capture with a two-request paid live xAI provider check showing the old unsupported payload is rejected and the fixed payload is accepted.

Supplemental verification still passes:

```text
$ pnpm tsgo:test:src
$ pnpm tsgo:test:extensions
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run src/agents/openai-reasoning-effort.test.ts src/agents/openai-transport-stream.test.ts extensions/xai
Test Files  23 passed (23)
Tests  381 passed (381)
```


