### PR TITLE
fix(doctor): auto-archive orphan transcripts with yes

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -428,7 +428,7 @@ describe("doctor state integrity oauth dir checks", () => {
     const archivePrompt = repairPromptCalls(confirmRuntimeRepair).find((prompt) =>
       prompt.message?.includes("This only renames them to *.deleted.<timestamp>."),
     );
-    expect(archivePrompt?.requiresInteractiveConfirmation).toBe(true);
+    expect(archivePrompt?.requiresInteractiveConfirmation).toBeUndefined();
     const files = fs.readdirSync(sessionsDir);
     const archivedOrphanTranscripts = files.filter((name) =>
       name.startsWith("orphan-session.jsonl.deleted."),
@@ -436,7 +436,7 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(archivedOrphanTranscripts.length).toBeGreaterThan(0);
   });
 
-  it("does not auto-archive orphan transcripts from non-interactive repair mode", async () => {
+  it("auto-archives orphan transcripts from non-interactive repair mode", async () => {
     const cfg: OpenClawConfig = {};
     setupSessionState(cfg, process.env, process.env.HOME ?? "");
     const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
@@ -447,16 +447,16 @@ describe("doctor state integrity oauth dir checks", () => {
     );
     await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
 
-    const archivePrompt = repairPromptCalls(confirmRuntimeRepair).find(
-      (prompt) => prompt.requiresInteractiveConfirmation === true,
+    const archivePrompt = repairPromptCalls(confirmRuntimeRepair).find((prompt) =>
+      prompt.message?.includes("This only renames them to *.deleted.<timestamp>."),
     );
     expect(archivePrompt?.initialValue).toBe(false);
     const files = fs.readdirSync(sessionsDir);
-    expect(files).toContain("orphan-session.jsonl");
     const archivedOrphanTranscripts = files.filter((name) =>
       name.startsWith("orphan-session.jsonl.deleted."),
     );
-    expect(archivedOrphanTranscripts).toStrictEqual([]);
+    expect(archivedOrphanTranscripts.length).toBeGreaterThan(0);
+    expect(files).not.toContain("orphan-session.jsonl");
   });
 
   it.skipIf(process.platform === "win32")(

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -1020,7 +1020,6 @@ export async function noteStateIntegrity(
       const archiveOrphans = await prompter.confirmRuntimeRepair({
         message: `Archive ${orphanCount} in ${displaySessionsDir}? This only renames them to *.deleted.<timestamp>.`,
         initialValue: false,
-        requiresInteractiveConfirmation: true,
       });
       if (archiveOrphans) {
         let archived = 0;


### PR DESCRIPTION
## Summary
- Let the orphan transcript archival repair participate in `doctor --fix --yes` auto-approval.
- Keep the repair recoverable: transcripts are still renamed to `*.deleted.<timestamp>` instead of being removed.
- Update the state integrity regression so non-interactive repair archives orphan transcripts instead of reporting them without action.

Fixes #81222.

## Tests
- `pnpm test src/commands/doctor-state-integrity.test.ts -- --reporter=verbose`
- `pnpm check:changed`
- `git diff --check`

## Real behavior proof

**Behavior addressed:** `openclaw doctor --fix --non-interactive --yes` archives orphan transcript files instead of reporting them and leaving them in place.

**Real environment tested:** Local Windows checkout, OpenClaw built from this branch with an isolated temporary `OPENCLAW_HOME`.

**Exact steps or command run after this patch:** Created a temporary OpenClaw home, wrote an empty `sessions.json`, wrote one unreferenced `orphan-session.jsonl`, ran `node scripts/run-node.mjs doctor --fix --non-interactive --yes`, and listed the sessions directory before and after.

**Evidence after fix:** Copied terminal output from the local OpenClaw command run:

```text
OPENCLAW_HOME=C:\Users\giodl\AppData\Local\Temp\openclaw-doctor-orphan-proof-220e4bbe96cd461ca6aa8cb5369ab22c
before:
orphan-session.jsonl
sessions.json

node scripts/run-node.mjs doctor --fix --non-interactive --yes

State integrity
- Found 1 orphan transcript file ...
  Doctor can archive them safely by renaming each file to *.deleted.<timestamp>.
  Examples: orphan-session.jsonl

Doctor changes
- Archived 1 orphan transcript file ... as .deleted timestamped backups.

exit=0
after:
orphan-session.jsonl.deleted.2026-05-13T00-31-36.121Z
sessions.json
```

**Observed result after fix:** The command exited 0 and renamed the orphan transcript to a timestamped `.deleted` archive.

**What was not tested:** No live user transcript store was modified; the proof used an isolated temporary `OPENCLAW_HOME`.