### PR TITLE
fix(telegram): normalize announce group targets

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -65,7 +65,10 @@ import { resolveTelegramReactionLevel } from "./reaction-level.js";
 import { resolveTelegramStartupProbeTimeoutMs } from "./request-timeouts.js";
 import { getTelegramRuntime } from "./runtime.js";
 import { telegramSecurityAdapter } from "./security.js";
-import { resolveTelegramSessionConversation } from "./session-conversation.js";
+import {
+  resolveTelegramSessionConversation,
+  resolveTelegramSessionTarget,
+} from "./session-conversation.js";
 import { telegramSetupAdapter } from "./setup-core.js";
 import { telegramSetupWizard } from "./setup-surface.js";
 import {
@@ -702,6 +705,7 @@ export const telegramPlugin = createChatChannelPlugin({
         resolveTelegramDeliveryTarget({ conversationId, parentConversationId }),
       resolveSessionConversation: ({ kind, rawId }) =>
         resolveTelegramSessionConversation({ kind, rawId }),
+      resolveSessionTarget: ({ kind, id }) => resolveTelegramSessionTarget({ kind, id }),
       parseExplicitTarget: ({ raw }) => parseTelegramExplicitTarget(raw),
       inferTargetChatType: ({ to }) => parseTelegramExplicitTarget(to).chatType,
       preserveHeartbeatThreadIdForGroupRoute: true,

--- a/extensions/telegram/src/session-conversation.test.ts
+++ b/extensions/telegram/src/session-conversation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveTelegramSessionConversation } from "./session-conversation.js";
+import {
+  resolveTelegramSessionConversation,
+  resolveTelegramSessionTarget,
+} from "./session-conversation.js";
 
 describe("resolveTelegramSessionConversation", () => {
   it("owns topic session parsing and parent fallback candidates", () => {
@@ -31,5 +34,17 @@ describe("resolveTelegramSessionConversation", () => {
         rawId: "-1001",
       }),
     ).toBeNull();
+  });
+});
+
+describe("resolveTelegramSessionTarget", () => {
+  it("normalizes group session ids to numeric chat ids", () => {
+    expect(resolveTelegramSessionTarget({ kind: "group", id: "-1001" })).toBe("-1001");
+  });
+
+  it("normalizes channel session ids to lookup targets", () => {
+    expect(resolveTelegramSessionTarget({ kind: "channel", id: "@OpenClawTeam" })).toBe(
+      "@OpenClawTeam",
+    );
   });
 });

--- a/extensions/telegram/src/session-conversation.ts
+++ b/extensions/telegram/src/session-conversation.ts
@@ -1,3 +1,4 @@
+import { normalizeTelegramChatId, normalizeTelegramLookupTarget } from "./targets.js";
 import { parseTelegramTopicConversation } from "./topic-conversation.js";
 
 export function resolveTelegramSessionConversation(params: {
@@ -14,4 +15,9 @@ export function resolveTelegramSessionConversation(params: {
     baseConversationId: parsed.chatId,
     parentConversationCandidates: [parsed.chatId],
   };
+}
+
+export function resolveTelegramSessionTarget(params: { kind: "group" | "channel"; id: string }) {
+  const raw = params.kind === "group" ? `telegram:group:${params.id}` : `telegram:${params.id}`;
+  return normalizeTelegramChatId(raw) ?? normalizeTelegramLookupTarget(raw);
 }

--- a/src/test-utils/session-conversation-registry.ts
+++ b/src/test-utils/session-conversation-registry.ts
@@ -135,6 +135,8 @@ export function createSessionConversationTestRegistry() {
         },
         capabilities: { chatTypes: ["direct", "group", "thread"] },
         messaging: {
+          resolveSessionTarget: ({ kind, id }: { kind: string; id: string }) =>
+            kind === "group" ? id : `channel:${id}`,
           normalizeTarget: (raw: string) => raw.replace(/^group:/, ""),
           resolveSessionConversation: resolveTelegramSessionConversation,
         },


### PR DESCRIPTION
## Summary
- Add a Telegram-owned `messaging.resolveSessionTarget` implementation so session-derived group targets normalize before announce delivery.
- Keep core `sessions_send` generic: Telegram handles `group:<chatId>` in the Telegram plugin instead of teaching shared code channel-specific syntax.
- Update the session conversation coverage so Telegram session group ids resolve to numeric Telegram chat ids.

Fixes #81086.

## Tests
- `pnpm test extensions/telegram/src/targets.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/session-conversation.test.ts src/agents/tools/sessions-send-helpers.test.ts -- --reporter=verbose`
- `pnpm check:changed`
- `git diff --check`

## Real behavior proof

Behavior addressed: Telegram session-derived group targets normalize to a Telegram-sendable numeric chat id instead of the generic `group:<chatId>` form that Telegram rejects.

Real environment tested: ClawCode live Azure VM (`clawcode-vm`) running the PR build from `~/worktrees/openclaw-81229`, captured on commit `e2db3d10785d` before the latest rebase of the same patch. Telegram was enabled for the `ClawCode` supergroup. The gateway service was restarted from this PR worktree and confirmed active before the proof.

Exact steps or command run after this patch: Restarted the gateway from the PR worktree, sent a direct Telegram group message with `node dist/index.js message send --channel telegram --target "telegram:group:<redacted-supergroup-id>" --json`, then invoked the `sessions_send` tool against the raw `telegram:group:<id>` session key.

Evidence after fix: Direct target proof returned a Telegram-sendable numeric chat id:

```json
{
  "action": "send",
  "channel": "telegram",
  "dryRun": false,
  "handledBy": "plugin",
  "payload": {
    "ok": true,
    "messageId": "15",
    "chatId": "<redacted-numeric-supergroup-id>"
  }
}
```

Gateway confirmation from the same direct-send run:

```text
/usr/bin/node /home/azureuser/worktrees/openclaw-81229/dist/index.js gateway --port 18789
[ws] ⇄ res ✓ message.action 808ms channel=telegram
```

`sessions_send` group-session proof returned announce delivery for the raw Telegram group session key:

```json
{
  "runId": "c7e5db65-cb89-4b21-b113-2f2b79bfdc7e",
  "status": "ok",
  "sessionKey": "telegram:group:<redacted-supergroup-id>",
  "delivery": {
    "status": "pending",
    "mode": "announce"
  }
}
```

Target session message tool call, redacted:

```json
{
  "action": "send",
  "channel": "telegram",
  "target": "<redacted-numeric-supergroup-id>",
  "message": "Announcement: The proof for PR 81229 is now available. Check it out! marker: proof-81229-clean-announce-1778654546"
}
```

Telegram tool result:

```json
{
  "ok": true,
  "messageId": "21",
  "chatId": "<redacted-numeric-supergroup-id>"
}
```

Gateway confirmation from the same `sessions_send` run:

```text
[agent/embedded] embedded run tool start: runId=c7e5db65-cb89-4b21-b113-2f2b79bfdc7e tool=message
[ws] ⇄ res ✓ message.action 729ms channel=telegram
[agent/embedded] embedded run tool end: runId=c7e5db65-cb89-4b21-b113-2f2b79bfdc7e tool=message
[agent:nested] session=agent:coder:telegram:group:<redacted-supergroup-id> run=c7e5db65-cb89-4b21-b113-2f2b79bfdc7e channel=webchat Announcement: The proof for PR 81229 is now available. Check it out! marker: proof-81229-clean-announce-1778654546
```

Observed result after fix: The direct Telegram send and the reported `sessions_send` entrypoint both delivered to the real Telegram supergroup. Telegram returned `ok: true` and the expected numeric chat id, showing the session-derived group target was normalized before delivery.

What was not tested: I did not test unrelated Telegram DM targets, non-Telegram channels, or the mobile UI. The proof is scoped to the failing Telegram group announce path.

