### PR TITLE
fix(onboard): shorten codex detect timeout to 30s and show progress spinner

### DIFF
--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -265,7 +265,10 @@ async function requestSourceCodexAppServerJson<T>(
   return await requestCodexAppServerJson<T>({
     method: params.method,
     requestParams: params.requestParams,
-    timeoutMs: 60_000,
+    // 30s is enough on a normal install; the previous 60s value let an
+    // unauth'd or stalled `codex app-server` freeze the post-install
+    // migration prompt for a full minute with no UI activity.
+    timeoutMs: 30_000,
     startOptions: options.startOptions,
     authProfileId: null,
     isolated: true,

--- a/src/wizard/setup.post-install-migration.ts
+++ b/src/wizard/setup.post-install-migration.ts
@@ -29,6 +29,10 @@ async function resolveCandidates(params: {
   config: OpenClawConfig;
   runtime: RuntimeEnv;
   installedPluginIds: readonly string[];
+  // When present, wrap each `provider.detect` call in a wizard spinner so the
+  // terminal does not appear frozen during the (potentially multi-second)
+  // codex app-server probe in `detect()`.
+  prompter?: WizardPrompter;
 }): Promise<ResolvedProviderCandidate[]> {
   if (params.installedPluginIds.length === 0) {
     return [];
@@ -64,6 +68,7 @@ async function resolveCandidates(params: {
     if (!ownership.pluginIds.some((pluginId) => installedIds.has(pluginId))) {
       continue;
     }
+    const spin = params.prompter?.progress(`Checking ${provider.label} state…`);
     try {
       const detection = await provider.detect({
         config: params.config,
@@ -71,13 +76,16 @@ async function resolveCandidates(params: {
         logger,
       });
       if (!detection.found || detection.confidence === "low") {
+        spin?.stop(`No ${provider.label} state to migrate.`);
         continue;
       }
+      spin?.stop(`Found ${provider.label} state.`);
       candidates.push({
         provider,
         ...(detection.source ? { source: detection.source } : {}),
       });
     } catch (error) {
+      spin?.stop(`${provider.label} detection failed.`);
       logger.debug?.(
         `Post-install migration detect for ${provider.id} failed: ${formatErrorMessage(error)}`,
       );
@@ -114,6 +122,12 @@ export async function offerPostInstallMigrations(
     config: params.config,
     runtime: params.runtime,
     installedPluginIds: params.installedPluginIds,
+    // Only pass the prompter when we are actually going to drive an
+    // interactive prompt below; in non-interactive / non-TTY mode the
+    // spinner has no UX value and `runtime.log` already covers feedback.
+    ...(params.nonInteractive !== true && process.stdin.isTTY && params.prompter !== undefined
+      ? { prompter: params.prompter }
+      : {}),
   });
   if (candidates.length === 0) {
     return;


### PR DESCRIPTION
## Summary

The post-install migration prompt (#81192) can take up to 60 seconds before it appears, with no visible activity on the terminal. Two narrow fixes that together turn "the wizard looks frozen" into "the wizard is clearly checking, with a known time bound."

1. **Shorten the source-side `codex app-server` timeout to 30 seconds** in `requestSourceCodexAppServerJson` (`extensions/codex/src/migration/source.ts:268`). This is the call that `provider.detect()` and `provider.plan()` make to enumerate curated-marketplace plugins. 60s is too long for an interactive prompt path; on an unauth'd or stalled `~/.codex`, the full minute was eaten before the migration prompt could fire.

2. **Wrap each provider's `detect()` call in a wizard progress spinner** in `src/wizard/setup.post-install-migration.ts`. The spinner shows `Checking Codex state…` while the probe runs, and ends with `Found Codex state.` / `No Codex state to migrate.` / `Codex detection failed.` so the operator sees outcome, not just absence. Only fires when the helper is actually going to drive an interactive prompt (TTY + prompter passed); non-interactive callers still rely on `runtime.log` and are unchanged.

## Behavior

Before (interactive wizard, post `ensureCodexRuntimePluginForModelSelection`):

```
…
Codex install complete.
                            ← up to 60s of silent terminal
? Migrate Codex at /Users/me/.codex into this agent now? (y/N)
```

After:

```
…
Codex install complete.
◇  Checking Codex state… (spinner)
◇  Found Codex state.
? Migrate Codex at /Users/me/.codex into this agent now? (y/N)
```

If `codex app-server` does not respond within 30s the spinner stops with `Codex detection failed.`, the wizard moves on, and onboarding continues — no abort.

## Files

- `extensions/codex/src/migration/source.ts` — `timeoutMs: 60_000` → `30_000` on `requestSourceCodexAppServerJson`, with a comment recording why.
- `src/wizard/setup.post-install-migration.ts` — `resolveCandidates` gains an optional `prompter` parameter and runs each `detect()` inside `prompter.progress(...)` with success / no-state / failure end labels. `offerPostInstallMigrations` only forwards the prompter when the helper is in interactive mode (`!nonInteractive && stdin.isTTY && prompter`).

## Verification

```
pnpm lint                                                              # 0 errors
pnpm tsgo:core && pnpm tsgo:core:test                                  # clean
pnpm test src/wizard/setup.post-install-migration.test.ts              # 10/10 passed
```

### Real behavior proof — interactive `bash run.sh onboard-fast`

Against the seeded fixture at `~/onboarding/codex_home`:

1. Picked `openai/gpt-5.5` so the Codex harness install ran.
2. Post-install, the spinner appeared: `◐ Checking Codex state…` — running while `codex app-server plugin/list` was in flight.
3. Spinner stopped with `Found Codex state.`; migration confirm prompt followed immediately.

## Notes

- The 30s ceiling still lets a slow but eventually-successful `plugin/list` complete; it just caps the worst case to half what it used to be. Longer-term, a filesystem-only "light" detect mode (flagged in the original PR's follow-ups) would let this drop to milliseconds — that's a separate change.
- The spinner uses the existing `WizardPrompter.progress` seam used by `src/commands/onboard-skills.ts:168`, `src/commands/onboarding-plugin-install.ts:604`, etc. No new prompter surface.
- `prompter.progress(...)` is only invoked when `prompter` is forwarded, so non-interactive / non-TTY paths see no UI change.
