### PR TITLE
[AI-assisted] fix(gateway): clarify invalid config recovery hints

### DIFF
--- a/src/cli/config-recovery-hints.ts
+++ b/src/cli/config-recovery-hints.ts
@@ -1,0 +1,8 @@
+import { formatCliCommand } from "./command-format.js";
+
+export function formatInvalidConfigRecoveryHint(): string {
+  return [
+    `Run "${formatCliCommand("openclaw doctor --fix")}" to repair, then retry.`,
+    "If startup is still blocked, inspect the adjacent .bak backup before restoring it manually.",
+  ].join("\n");
+}

--- a/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
@@ -15,6 +15,10 @@ const newerConfigHints = [
   "Set OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1 only for an intentional downgrade or recovery action.",
 ];
 const newerConfigHintItems = newerConfigHints.map((text) => ({ kind: "generic", text }));
+const invalidConfigRecoveryHint = [
+  'Run "openclaw doctor --fix" to repair, then retry.',
+  "If startup is still blocked, inspect the adjacent .bak backup before restoring it manually.",
+].join("\n");
 
 function expectLatestRuntimeJson(payload: unknown) {
   expect(defaultRuntime.writeJson.mock.calls.at(-1)?.[0]).toEqual(payload);
@@ -92,6 +96,14 @@ describe("runServiceRestart config pre-flight (#35862)", () => {
     await expect(runServiceRestart(createServiceRunArgs())).rejects.toThrow("__exit__:1");
 
     expect(service.restart).not.toHaveBeenCalled();
+    expectLatestRuntimeJson({
+      action: "restart",
+      ok: false,
+      error: `Gateway aborted: config is invalid.\nagents.defaults.pdfModel: Unrecognized key\n${invalidConfigRecoveryHint}`,
+      hints: undefined,
+      hintItems: undefined,
+      warnings: undefined,
+    });
   });
 
   it("blocks restart from an older binary when config was written by a newer one", async () => {
@@ -162,6 +174,14 @@ describe("runServiceStart config pre-flight (#35862)", () => {
     await expect(runServiceStart(createServiceRunArgs())).rejects.toThrow("__exit__:1");
 
     expect(service.restart).not.toHaveBeenCalled();
+    expectLatestRuntimeJson({
+      action: "start",
+      ok: false,
+      error: `Gateway aborted: config is invalid.\nagents.defaults.pdfModel: Unrecognized key\n${invalidConfigRecoveryHint}`,
+      hints: undefined,
+      hintItems: undefined,
+      warnings: undefined,
+    });
   });
 
   it("aborts before not-loaded start recovery when config is invalid", async () => {

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -19,6 +19,7 @@ import {
 import { isWSL } from "../../infra/wsl.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
+import { formatInvalidConfigRecoveryHint } from "../config-recovery-hints.js";
 import { resolveGatewayTokenForDriftCheck } from "./gateway-token-drift.js";
 import {
   buildDaemonServiceSnapshot,
@@ -254,7 +255,7 @@ export async function runServiceStart(params: {
       fail(
         preflight.hints
           ? `${params.serviceNoun} start blocked: ${preflight.message}`
-          : `${params.serviceNoun} aborted: config is invalid.\n${preflight.message}\nFix the config and retry, or run "openclaw doctor" to repair.`,
+          : `${params.serviceNoun} aborted: config is invalid.\n${preflight.message}\n${formatInvalidConfigRecoveryHint()}`,
         preflight.hints,
       );
       return;
@@ -498,7 +499,7 @@ export async function runServiceRestart(params: {
       fail(
         preflight.hints
           ? `${params.serviceNoun} restart blocked: ${preflight.message}`
-          : `${params.serviceNoun} aborted: config is invalid.\n${preflight.message}\nFix the config and retry, or run "openclaw doctor" to repair.`,
+          : `${params.serviceNoun} aborted: config is invalid.\n${preflight.message}\n${formatInvalidConfigRecoveryHint()}`,
         preflight.hints,
       );
       return false;

--- a/src/gateway/server-startup-config.recovery.test.ts
+++ b/src/gateway/server-startup-config.recovery.test.ts
@@ -450,7 +450,7 @@ describe("gateway startup config validation", () => {
         log: { info: vi.fn(), warn: vi.fn() },
       }),
     ).rejects.toThrow(
-      `Invalid config at ${configPath}.\ngateway.mode: Expected 'local' or 'remote'\nRun "openclaw doctor --fix" to repair, then retry.`,
+      `Invalid config at ${configPath}.\ngateway.mode: Expected 'local' or 'remote'\nRun "openclaw doctor --fix" to repair, then retry.\nIf startup is still blocked, inspect the adjacent .bak backup before restoring it manually.`,
     );
   });
 

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -1,4 +1,4 @@
-import { formatCliCommand } from "../cli/command-format.js";
+import { formatInvalidConfigRecoveryHint } from "../cli/config-recovery-hints.js";
 import {
   type ReadConfigFileSnapshotWithPluginMetadataResult,
   readConfigFileSnapshotWithPluginMetadata,
@@ -224,9 +224,7 @@ export function assertValidGatewayStartupConfigSnapshot(
     snapshot.issues.length > 0
       ? formatConfigIssueLines(snapshot.issues, "", { normalizeRoot: true }).join("\n")
       : "Unknown validation issue.";
-  const doctorHint = options.includeDoctorHint
-    ? `\nRun "${formatCliCommand("openclaw doctor --fix")}" to repair, then retry.`
-    : "";
+  const doctorHint = options.includeDoctorHint ? `\n${formatInvalidConfigRecoveryHint()}` : "";
   throw new Error(`Invalid config at ${snapshot.path}.\n${issues}${doctorHint}`);
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: invalid-config startup errors gave incomplete recovery guidance; the gateway path did not mention the adjacent `.bak` backup, and daemon start/restart still pointed at generic `openclaw doctor`.
- Why it matters: when config validation blocks startup, users need the exact repair command and a safe pointer to the backup file before they try manual recovery.
- What changed: added one shared invalid-config recovery hint and used it for gateway startup plus daemon start/restart preflight failures.
- What did NOT change (scope boundary): no automatic restore, config mutation, service install behavior, network calls, or secret handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40652
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: invalid gateway config startup validation now prints the exact `openclaw doctor --fix` repair command and a `.bak` backup recovery pointer.
- Real environment tested: local OpenClaw source checkout on Windows, using the real gateway startup config validation path. No service was started.
- Exact steps or command run after this patch: ran a local `node --import tsx --input-type=module` proof that imports `assertValidGatewayStartupConfigSnapshot` and validates an invalid gateway config snapshot.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
Invalid config at /tmp/openclaw.json.
gateway.mode: Expected 'local' or 'remote'
Run "openclaw doctor --fix" to repair, then retry.
If startup is still blocked, inspect the adjacent .bak backup before restoring it manually.
```

- Observed result after fix: the startup error includes both the direct repair command and the `.bak` backup guidance.
- What was not tested: full live gateway service startup/restart with an installed service.
- Before evidence (optional but encouraged): existing tests showed the old gateway message stopped after `Run "openclaw doctor --fix" to repair, then retry.`, and daemon start/restart used generic `openclaw doctor` guidance.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: invalid-config recovery wording lived in separate gateway and daemon paths, so the daemon path stayed generic and the gateway startup path never included backup guidance.
- Missing detection / guardrail: tests asserted startup failure, but did not lock in the full recovery hint expected by the issue.
- Contributing context (if known): config backup rotation already creates adjacent `.bak` files, but the startup failure text did not point users to that recovery option.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-startup-config.recovery.test.ts`; `src/cli/daemon-cli/lifecycle-core.config-guard.test.ts`
- Scenario the test should lock in: invalid gateway config startup failures and daemon start/restart preflight failures include the shared recovery hint.
- Why this is the smallest reliable guardrail: the behavior is deterministic error text from validation/preflight paths, so focused tests cover it without launching a real service.
- Existing test that already covers this (if any): existing invalid-config tests existed, but they did not cover the new `.bak` guidance.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Invalid-config startup errors now include:

```text
Run "openclaw doctor --fix" to repair, then retry.
If startup is still blocked, inspect the adjacent .bak backup before restoring it manually.
```

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node.js source checkout
- Model/provider: N/A
- Integration/channel (if any): Gateway/CLI startup config validation
- Relevant config (redacted): synthetic invalid gateway config snapshot with `gateway.mode` invalid

### Steps

1. Import `assertValidGatewayStartupConfigSnapshot` from `src/gateway/server-startup-config.ts`.
2. Pass an invalid config snapshot with `includeDoctorHint: true`.
3. Observe the thrown startup validation message.

### Expected

- The error includes `openclaw doctor --fix` and `.bak` backup recovery guidance.

### Actual

- The error includes `openclaw doctor --fix` and `.bak` backup recovery guidance.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-startup-config.recovery.test.ts
Test Files  1 passed (1)
Tests  10 passed (10)

node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
Test Files  1 passed (1)
Tests  9 passed (9)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: gateway startup validation error text; daemon start and restart invalid-config preflight JSON errors; targeted regression tests.
- Edge cases checked: direct gateway startup path and daemon lifecycle start/restart path both use the shared hint.
- What you did **not** verify: full live gateway service startup/restart with an installed service; full repo test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
