### PR TITLE
fix(models): keep CLI runtime providers in /models picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ Docs: https://docs.openclaw.ai
 - Slack: normalize message read `before` and `after` timestamp bounds before calling Slack history or thread reply APIs. Fixes #80835. (#81338) Thanks @honor2030.
 - Gateway: throttle assistant/thinking agent event fanout during streaming bursts without dropping buffered deltas. (#80335) Thanks @samzong.
 - Codex app-server: keep the short post-tool completion watchdog armed across dynamic tool completion bookkeeping so embedded Codex runs fail fast and release their session lane when Codex goes quiet after a tool result. (#81697) Thanks @mbelinky.
+- Models: restore authenticated CLI runtime providers in the `/models` picker while keeping legacy runtime aliases hidden from setup/default model choices. Closes #81212. (#81239) Thanks @anagnorisis2peripeteia.
 
 ### Changes
 

--- a/extensions/anthropic/cli-catalog.ts
+++ b/extensions/anthropic/cli-catalog.ts
@@ -1,11 +1,7 @@
 import type { ModelCatalogEntry } from "openclaw/plugin-sdk/agent-runtime";
 import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "./cli-constants.js";
 
-// Claude CLI is externally maintained — the Claude binary owns which models it
-// supports, OpenClaw mirrors that set into the model catalog via the public
-// plugin seam. Subscription auth (OAuth / API key) drives the binary; per-token
-// billing isn't meaningful here, so catalog entries carry only the metadata
-// the picker needs (id, name, provider, context-window-ish hints).
+// Claude CLI auth is subscription-backed, so catalog rows only need picker metadata.
 const CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW = 200_000;
 
 const CLAUDE_CLI_MODEL_LABELS: Record<string, string> = {
@@ -34,12 +30,6 @@ function extractClaudeCliModelIds(): string[] {
   return ids;
 }
 
-/**
- * Build the catalog entries the Anthropic plugin contributes for the
- * `claude-cli` provider id. Consumed via `ProviderPlugin.augmentModelCatalog`
- * so the `/models` picker sees the full CLI-supported set without core
- * needing to import provider-specific allowlists.
- */
 export function buildClaudeCliCatalogEntries(): ModelCatalogEntry[] {
   return extractClaudeCliModelIds().map((id) => ({
     id,

--- a/extensions/anthropic/cli-catalog.ts
+++ b/extensions/anthropic/cli-catalog.ts
@@ -1,17 +1,13 @@
-import type {
-  ModelDefinitionConfig,
-  ModelProviderConfig,
-} from "openclaw/plugin-sdk/provider-model-shared";
+import type { ModelCatalogEntry } from "openclaw/plugin-sdk/model-catalog-runtime";
 
 import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "./cli-constants.js";
 
-// Claude CLI runs through the user's local CLI binary which authenticates via
-// Claude.ai subscription OAuth (or an explicit API key); per-token billing
-// metadata is not meaningful for this path — the subscription, not OpenClaw,
-// owns cost. Models are seeded with subscription-appropriate defaults so the
-// picker has consistent entries; runtime config can override per-ref.
+// Claude CLI is externally maintained — the Claude binary owns which models it
+// supports, OpenClaw mirrors that set into the model catalog via the public
+// plugin seam. Subscription auth (OAuth / API key) drives the binary; per-token
+// billing isn't meaningful here, so catalog entries carry only the metadata
+// the picker needs (id, name, provider, context-window-ish hints).
 const CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW = 200_000;
-const CLAUDE_CLI_DEFAULT_MAX_TOKENS = 64_000;
 
 const CLAUDE_CLI_MODEL_LABELS: Record<string, string> = {
   "claude-opus-4-7": "Claude Opus 4.7 (Claude CLI)",
@@ -21,18 +17,6 @@ const CLAUDE_CLI_MODEL_LABELS: Record<string, string> = {
   "claude-sonnet-4-5": "Claude Sonnet 4.5 (Claude CLI)",
   "claude-haiku-4-5": "Claude Haiku 4.5 (Claude CLI)",
 };
-
-function buildClaudeCliModel(id: string): ModelDefinitionConfig {
-  return {
-    id,
-    name: CLAUDE_CLI_MODEL_LABELS[id] ?? `${id} (Claude CLI)`,
-    reasoning: true,
-    input: ["text", "image"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: CLAUDE_CLI_DEFAULT_MAX_TOKENS,
-  };
-}
 
 function extractClaudeCliModelIds(): string[] {
   const ids: string[] = [];
@@ -51,10 +35,19 @@ function extractClaudeCliModelIds(): string[] {
   return ids;
 }
 
-export function buildClaudeCliProviderCatalog(): ModelProviderConfig {
-  return {
-    baseUrl: "claude-cli://local",
-    api: "anthropic-messages",
-    models: extractClaudeCliModelIds().map(buildClaudeCliModel),
-  };
+/**
+ * Build the catalog entries the Anthropic plugin contributes for the
+ * `claude-cli` provider id. Consumed via `ProviderPlugin.augmentModelCatalog`
+ * so the `/models` picker sees the full CLI-supported set without core
+ * needing to import provider-specific allowlists.
+ */
+export function buildClaudeCliCatalogEntries(): ModelCatalogEntry[] {
+  return extractClaudeCliModelIds().map((id) => ({
+    id,
+    name: CLAUDE_CLI_MODEL_LABELS[id] ?? `${id} (Claude CLI)`,
+    provider: CLAUDE_CLI_BACKEND_ID,
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW,
+  }));
 }

--- a/extensions/anthropic/cli-catalog.ts
+++ b/extensions/anthropic/cli-catalog.ts
@@ -1,5 +1,4 @@
-import type { ModelCatalogEntry } from "openclaw/plugin-sdk/model-catalog-runtime";
-
+import type { ModelCatalogEntry } from "openclaw/plugin-sdk/agent-runtime";
 import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "./cli-constants.js";
 
 // Claude CLI is externally maintained — the Claude binary owns which models it

--- a/extensions/anthropic/cli-catalog.ts
+++ b/extensions/anthropic/cli-catalog.ts
@@ -1,0 +1,60 @@
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+
+import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "./cli-constants.js";
+
+// Claude CLI runs through the user's local CLI binary which authenticates via
+// Claude.ai subscription OAuth (or an explicit API key); per-token billing
+// metadata is not meaningful for this path — the subscription, not OpenClaw,
+// owns cost. Models are seeded with subscription-appropriate defaults so the
+// picker has consistent entries; runtime config can override per-ref.
+const CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW = 200_000;
+const CLAUDE_CLI_DEFAULT_MAX_TOKENS = 64_000;
+
+const CLAUDE_CLI_MODEL_LABELS: Record<string, string> = {
+  "claude-opus-4-7": "Claude Opus 4.7 (Claude CLI)",
+  "claude-opus-4-6": "Claude Opus 4.6 (Claude CLI)",
+  "claude-opus-4-5": "Claude Opus 4.5 (Claude CLI)",
+  "claude-sonnet-4-6": "Claude Sonnet 4.6 (Claude CLI)",
+  "claude-sonnet-4-5": "Claude Sonnet 4.5 (Claude CLI)",
+  "claude-haiku-4-5": "Claude Haiku 4.5 (Claude CLI)",
+};
+
+function buildClaudeCliModel(id: string): ModelDefinitionConfig {
+  return {
+    id,
+    name: CLAUDE_CLI_MODEL_LABELS[id] ?? `${id} (Claude CLI)`,
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: CLAUDE_CLI_DEFAULT_MAX_TOKENS,
+  };
+}
+
+function extractClaudeCliModelIds(): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const ref of CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS) {
+    if (!ref.startsWith(`${CLAUDE_CLI_BACKEND_ID}/`)) {
+      continue;
+    }
+    const id = ref.slice(CLAUDE_CLI_BACKEND_ID.length + 1);
+    if (id.length === 0 || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
+export function buildClaudeCliProviderCatalog(): ModelProviderConfig {
+  return {
+    baseUrl: "claude-cli://local",
+    api: "anthropic-messages",
+    models: extractClaudeCliModelIds().map(buildClaudeCliModel),
+  };
+}

--- a/extensions/anthropic/provider-discovery.ts
+++ b/extensions/anthropic/provider-discovery.ts
@@ -1,7 +1,7 @@
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { readClaudeCliCredentialsForRuntime } from "./cli-auth-seam.js";
-import { buildClaudeCliProviderCatalog } from "./cli-catalog.js";
-import { CLAUDE_CLI_BACKEND_ID } from "./cli-constants.js";
+
+const CLAUDE_CLI_BACKEND_ID = "claude-cli";
 
 function resolveClaudeCliSyntheticAuth() {
   const credential = readClaudeCliCredentialsForRuntime();
@@ -28,14 +28,6 @@ const anthropicProviderDiscovery: ProviderPlugin = {
   label: "Claude CLI",
   docsPath: "/providers/models",
   auth: [],
-  // Contribute the Claude CLI binary's supported model set via the public
-  // ProviderPluginCatalog seam. Core's `/models` picker reads catalog entries
-  // through this contract — keeps the CLI allowlist provider-owned and avoids
-  // a direct `extensions/anthropic` import in core.
-  catalog: {
-    order: "simple",
-    run: async () => ({ provider: buildClaudeCliProviderCatalog() }),
-  },
   resolveSyntheticAuth: ({ provider }) =>
     provider === CLAUDE_CLI_BACKEND_ID ? resolveClaudeCliSyntheticAuth() : undefined,
 };

--- a/extensions/anthropic/provider-discovery.ts
+++ b/extensions/anthropic/provider-discovery.ts
@@ -1,7 +1,7 @@
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { readClaudeCliCredentialsForRuntime } from "./cli-auth-seam.js";
-
-const CLAUDE_CLI_BACKEND_ID = "claude-cli";
+import { buildClaudeCliProviderCatalog } from "./cli-catalog.js";
+import { CLAUDE_CLI_BACKEND_ID } from "./cli-constants.js";
 
 function resolveClaudeCliSyntheticAuth() {
   const credential = readClaudeCliCredentialsForRuntime();
@@ -28,6 +28,14 @@ const anthropicProviderDiscovery: ProviderPlugin = {
   label: "Claude CLI",
   docsPath: "/providers/models",
   auth: [],
+  // Contribute the Claude CLI binary's supported model set via the public
+  // ProviderPluginCatalog seam. Core's `/models` picker reads catalog entries
+  // through this contract — keeps the CLI allowlist provider-owned and avoids
+  // a direct `extensions/anthropic` import in core.
+  catalog: {
+    order: "simple",
+    run: async () => ({ provider: buildClaudeCliProviderCatalog() }),
+  },
   resolveSyntheticAuth: ({ provider }) =>
     provider === CLAUDE_CLI_BACKEND_ID ? resolveClaudeCliSyntheticAuth() : undefined,
 };

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -580,12 +580,7 @@ export function buildAnthropicProvider(): ProviderPlugin {
       normalizeLowercaseStringOrEmpty(provider) === CLAUDE_CLI_BACKEND_ID
         ? resolveClaudeCliSyntheticAuth()
         : undefined,
-    // Contribute the Claude CLI binary's supported model set into the
-    // model catalog so the `/models` picker surfaces the full allowlist
-    // without core needing to import provider-specific constants. The
-    // hookAliases above (CLAUDE_CLI_BACKEND_ID) route this plugin's
-    // augmentModelCatalog hook for both `anthropic` and `claude-cli`
-    // provider lookups.
+    // Publish Claude CLI rows through the provider catalog hook.
     augmentModelCatalog: () => buildClaudeCliCatalogEntries(),
     buildReplayPolicy: buildAnthropicReplayPolicy,
     isModernModelRef: ({ modelId }) => matchesAnthropicModernModel(modelId),

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -28,6 +28,7 @@ import { fetchClaudeUsage } from "openclaw/plugin-sdk/provider-usage";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import * as claudeCliAuth from "./cli-auth-seam.js";
 import { buildAnthropicCliBackend } from "./cli-backend.js";
+import { buildClaudeCliCatalogEntries } from "./cli-catalog.js";
 import { buildAnthropicCliMigrationResult } from "./cli-migration.js";
 import {
   CLAUDE_CLI_BACKEND_ID,
@@ -579,6 +580,13 @@ export function buildAnthropicProvider(): ProviderPlugin {
       normalizeLowercaseStringOrEmpty(provider) === CLAUDE_CLI_BACKEND_ID
         ? resolveClaudeCliSyntheticAuth()
         : undefined,
+    // Contribute the Claude CLI binary's supported model set into the
+    // model catalog so the `/models` picker surfaces the full allowlist
+    // without core needing to import provider-specific constants. The
+    // hookAliases above (CLAUDE_CLI_BACKEND_ID) route this plugin's
+    // augmentModelCatalog hook for both `anthropic` and `claude-cli`
+    // provider lookups.
+    augmentModelCatalog: () => buildClaudeCliCatalogEntries(),
     buildReplayPolicy: buildAnthropicReplayPolicy,
     isModernModelRef: ({ modelId }) => matchesAnthropicModernModel(modelId),
     resolveReasoningOutputMode: () => "native",

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -56,15 +56,7 @@ export function listLegacyRuntimeModelProviderAliases(): readonly LegacyRuntimeM
   return LEGACY_RUNTIME_MODEL_PROVIDER_ALIASES;
 }
 
-/**
- * True for CLI runtime provider ids (`claude-cli`, `codex-cli`, `google-gemini-cli`).
- *
- * These providers are externally maintained — the CLI binary defines which
- * models it supports — so callers building model lists for them should source
- * entries from the unfiltered model catalog rather than from user
- * `agents.defaults.models` config, which would otherwise gate discovery to
- * whatever the user happened to declare.
- */
+/** True for CLI runtime provider ids such as `claude-cli` and `codex-cli`. */
 export function isCliRuntimeProvider(provider: string): boolean {
   return CLI_RUNTIME_PROVIDER_IDS.has(normalizeProviderId(provider));
 }
@@ -107,19 +99,9 @@ export function migrateLegacyRuntimeModelRef(raw: string): {
   };
 }
 
-/**
- * True for aliases whose only purpose is backwards compatibility with the
- * pre-runtime-split addressing scheme (e.g. the bare `codex` provider that
- * encoded the codex runtime in the model ref).
- *
- * CLI runtime aliases (`claude-cli`, `codex-cli`, `google-gemini-cli`) are
- * NOT legacy — they remain the canonical user-addressable handle for picking
- * a CLI runtime, and surface in `/models` pickers as first-class providers
- * alongside the embedded harness providers (`anthropic`, `openai`, ...).
- */
+/** Shared setup/default pickers hide all legacy runtime provider ids. */
 export function isLegacyRuntimeModelProvider(provider: string): boolean {
-  const alias = resolveLegacyRuntimeModelProviderAlias(provider);
-  return alias !== undefined && !alias.cli;
+  return resolveLegacyRuntimeModelProviderAlias(provider) !== undefined;
 }
 
 export function isCliRuntimeAlias(runtime: string | undefined): boolean {

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -46,8 +46,27 @@ const CLI_RUNTIME_ALIASES = new Set(
   ),
 );
 
+const CLI_RUNTIME_PROVIDER_IDS = new Set(
+  LEGACY_RUNTIME_MODEL_PROVIDER_ALIASES.filter((entry) => entry.cli).map((entry) =>
+    normalizeProviderId(entry.legacyProvider),
+  ),
+);
+
 export function listLegacyRuntimeModelProviderAliases(): readonly LegacyRuntimeModelProviderAlias[] {
   return LEGACY_RUNTIME_MODEL_PROVIDER_ALIASES;
+}
+
+/**
+ * True for CLI runtime provider ids (`claude-cli`, `codex-cli`, `google-gemini-cli`).
+ *
+ * These providers are externally maintained — the CLI binary defines which
+ * models it supports — so callers building model lists for them should source
+ * entries from the unfiltered model catalog rather than from user
+ * `agents.defaults.models` config, which would otherwise gate discovery to
+ * whatever the user happened to declare.
+ */
+export function isCliRuntimeProvider(provider: string): boolean {
+  return CLI_RUNTIME_PROVIDER_IDS.has(normalizeProviderId(provider));
 }
 
 function resolveLegacyRuntimeModelProviderAlias(

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -88,8 +88,19 @@ export function migrateLegacyRuntimeModelRef(raw: string): {
   };
 }
 
+/**
+ * True for aliases whose only purpose is backwards compatibility with the
+ * pre-runtime-split addressing scheme (e.g. the bare `codex` provider that
+ * encoded the codex runtime in the model ref).
+ *
+ * CLI runtime aliases (`claude-cli`, `codex-cli`, `google-gemini-cli`) are
+ * NOT legacy — they remain the canonical user-addressable handle for picking
+ * a CLI runtime, and surface in `/models` pickers as first-class providers
+ * alongside the embedded harness providers (`anthropic`, `openai`, ...).
+ */
 export function isLegacyRuntimeModelProvider(provider: string): boolean {
-  return Boolean(resolveLegacyRuntimeModelProviderAlias(provider));
+  const alias = resolveLegacyRuntimeModelProviderAlias(provider);
+  return alias !== undefined && !alias.cli;
 }
 
 export function isCliRuntimeAlias(runtime: string | undefined): boolean {

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -267,29 +267,16 @@ describe("handleModelsCommand", () => {
       true,
     );
 
-    // Embedded harness providers stay visible
     expect(result?.reply?.text).toContain("- anthropic (1)");
     expect(result?.reply?.text).toContain("- google (1)");
     expect(result?.reply?.text).toContain("- openai (1)");
-    // CLI runtime providers are first-class and remain user-addressable in the picker.
-    // Their model set comes from the catalog — each provider plugin contributes its
-    // own CLI-supported models via the ProviderPluginCatalog seam (Anthropic's
-    // `provider-discovery.ts` contributes the full Claude CLI allowlist). The
-    // catalog mock here simulates each plugin's contribution at the test
-    // boundary; in production the catalog is populated by the same plugins.
     expect(result?.reply?.text).toContain("- claude-cli (1)");
     expect(result?.reply?.text).toContain("- codex-cli (1)");
     expect(result?.reply?.text).toContain("- google-gemini-cli (1)");
-    // The bare `codex` alias is the only true legacy entry (no `-cli` suffix) and stays hidden
     expect(result?.reply?.text).not.toMatch(/^- codex \(/m);
   });
 
   it("sources CLI runtime provider model lists from the catalog, not user agents.defaults.models", async () => {
-    // claude-cli's full set of CLI-supported models lives in the catalog
-    // (in production, contributed by the Anthropic plugin's
-    // ProviderPluginCatalog hook in `extensions/anthropic/provider-discovery.ts`
-    // from `CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS`). The CLI binary — not the
-    // user's config — owns which models it supports.
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
       { provider: "claude-cli", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
       { provider: "claude-cli", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
@@ -302,11 +289,7 @@ describe("handleModelsCommand", () => {
       { provider: "minimax", id: "abab-7", name: "Abab 7" },
       { provider: "minimax", id: "abab-6.5", name: "Abab 6.5" },
     ]);
-    modelProviderAuthMocks.authenticatedProviders = new Set([
-      "anthropic",
-      "claude-cli",
-      "minimax",
-    ]);
+    modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic", "claude-cli", "minimax"]);
 
     const result = await handleModelsCommand(
       buildParams("/models claude-cli", {
@@ -327,9 +310,6 @@ describe("handleModelsCommand", () => {
       true,
     );
 
-    // All catalog-contributed claude-cli entries surface despite the narrow
-    // user config. The catalog mock here represents the 6 entries the
-    // Anthropic plugin contributes via its catalog seam in production.
     expect(result?.reply?.text).toContain("- claude-cli/claude-opus-4-7");
     expect(result?.reply?.text).toContain("- claude-cli/claude-sonnet-4-6");
     expect(result?.reply?.text).toContain("- claude-cli/claude-opus-4-6");
@@ -359,14 +339,7 @@ describe("handleModelsCommand", () => {
   });
 
   it("does not synthesize claude-cli models when the catalog has no claude-cli entries", async () => {
-    // Plugin-boundary contract: core `/models` consumes catalog entries via
-    // the public ProviderPluginCatalog seam — it does not import provider-
-    // specific allowlists. If the Anthropic plugin's catalog hook doesn't
-    // contribute claude-cli entries (e.g. the plugin is disabled or its
-    // catalog hook errors), core MUST NOT synthesize them from a hard-coded
-    // constant. The catalog is the source of truth.
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
-      // No claude-cli entries in the catalog at all.
       { provider: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
     ]);
     modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic", "claude-cli"]);
@@ -382,19 +355,10 @@ describe("handleModelsCommand", () => {
       true,
     );
 
-    // Picker shows no claude-cli rows when the catalog has none — no
-    // hard-coded fallback. (In production the Anthropic plugin's catalog
-    // hook always contributes the full allowlist when the plugin is
-    // enabled; this test asserts core does not duplicate that behavior.)
     expect(result?.reply?.text).not.toMatch(/^- claude-cli\//m);
   });
 
   it("hides CLI runtime providers from the picker when the user has no CLI auth", async () => {
-    // Regression: the catalog-iteration and allowlist-seeding passes must
-    // honour the existing unauthenticated-provider hiding contract. A user
-    // without claude-cli / codex-cli / google-gemini-cli auth should not see
-    // those providers in /models — tapping them would lead to a runtime they
-    // can't actually use.
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
       { provider: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
       { provider: "claude-cli", id: "claude-opus-4-7", name: "Claude Opus 4.7 (CLI)" },
@@ -411,9 +375,7 @@ describe("handleModelsCommand", () => {
       true,
     );
 
-    // anthropic is authenticated and surfaces.
     expect(result?.reply?.text).toContain("- anthropic (");
-    // CLI runtime providers are gated by the existing auth contract — should not appear.
     expect(result?.reply?.text).not.toMatch(/^- claude-cli \(/m);
     expect(result?.reply?.text).not.toMatch(/^- codex-cli \(/m);
     expect(result?.reply?.text).not.toMatch(/^- google-gemini-cli \(/m);

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -384,6 +384,36 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).toContain(`of ${CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.length}`);
   });
 
+  it("hides CLI runtime providers from the picker when the user has no CLI auth", async () => {
+    // Regression: the catalog-iteration and allowlist-seeding passes must
+    // honour the existing unauthenticated-provider hiding contract. A user
+    // without claude-cli / codex-cli / google-gemini-cli auth should not see
+    // those providers in /models — tapping them would lead to a runtime they
+    // can't actually use.
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { provider: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
+      { provider: "claude-cli", id: "claude-opus-4-7", name: "Claude Opus 4.7 (CLI)" },
+      { provider: "codex-cli", id: "gpt-5.5", name: "GPT-5.5 (CLI)" },
+      { provider: "google-gemini-cli", id: "gemini-2.5-pro", name: "Gemini 2.5 Pro (CLI)" },
+    ]);
+    // Default mock state: only anthropic / google / openai authenticated — no CLI providers.
+    modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic"]);
+
+    const result = await handleModelsCommand(
+      buildParams("/models", {
+        agents: { defaults: { model: { primary: "anthropic/claude-opus-4-7" } } },
+      }),
+      true,
+    );
+
+    // anthropic is authenticated and surfaces.
+    expect(result?.reply?.text).toContain("- anthropic (");
+    // CLI runtime providers are gated by the existing auth contract — should not appear.
+    expect(result?.reply?.text).not.toMatch(/^- claude-cli \(/m);
+    expect(result?.reply?.text).not.toMatch(/^- codex-cli \(/m);
+    expect(result?.reply?.text).not.toMatch(/^- google-gemini-cli \(/m);
+  });
+
   it("labels the default runtime choice as OpenClaw Pi", async () => {
     const data = await buildModelsProviderData({
       agents: {
@@ -401,6 +431,12 @@ describe("handleModelsCommand", () => {
   });
 
   it("keeps the telegram provider picker browse-only", async () => {
+    modelProviderAuthMocks.authenticatedProviders = new Set([
+      "anthropic",
+      "claude-cli",
+      "google",
+      "openai",
+    ]);
     const params = buildParams("/models");
     params.ctx.Surface = "telegram";
     params.command.channel = "telegram";
@@ -422,6 +458,12 @@ describe("handleModelsCommand", () => {
   });
 
   it("keeps plugin menu hook compatibility for provider pickers", async () => {
+    modelProviderAuthMocks.authenticatedProviders = new Set([
+      "anthropic",
+      "claude-cli",
+      "google",
+      "openai",
+    ]);
     const params = buildParams("/models");
     params.ctx.Surface = "menuonly";
     params.command.channel = "menuonly";

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -279,6 +279,76 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).not.toMatch(/^- codex \(/m);
   });
 
+  it("sources CLI runtime provider model lists from the catalog, not user agents.defaults.models", async () => {
+    // claude-cli's full allowlist (matches CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS in
+    // extensions/anthropic/cli-constants.ts) lives in the catalog. The CLI
+    // binary — not the user's config — owns which models it supports.
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { provider: "claude-cli", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
+      { provider: "claude-cli", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+      { provider: "claude-cli", id: "claude-opus-4-6", name: "Claude Opus 4.6" },
+      { provider: "claude-cli", id: "claude-opus-4-5", name: "Claude Opus 4.5" },
+      { provider: "claude-cli", id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+      { provider: "claude-cli", id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
+      { provider: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
+      // A non-CLI configured provider — its narrowing IS respected.
+      { provider: "minimax", id: "abab-7", name: "Abab 7" },
+      { provider: "minimax", id: "abab-6.5", name: "Abab 6.5" },
+    ]);
+    modelProviderAuthMocks.authenticatedProviders = new Set([
+      "anthropic",
+      "claude-cli",
+      "minimax",
+    ]);
+
+    const result = await handleModelsCommand(
+      buildParams("/models claude-cli", {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-7" },
+            // User only declared 2 of claude-cli's 6 supported models, plus 1
+            // of minimax's 2. For claude-cli this narrowing must be ignored;
+            // for minimax it must still gate.
+            models: {
+              "claude-cli/claude-opus-4-6": {},
+              "claude-cli/claude-sonnet-4-6": {},
+              "minimax/abab-7": {},
+            },
+          },
+        },
+      }),
+      true,
+    );
+
+    // Full claude-cli allowlist surfaces despite the narrow user config.
+    expect(result?.reply?.text).toContain("- claude-cli/claude-opus-4-7");
+    expect(result?.reply?.text).toContain("- claude-cli/claude-sonnet-4-6");
+    expect(result?.reply?.text).toContain("- claude-cli/claude-opus-4-6");
+    expect(result?.reply?.text).toContain("- claude-cli/claude-opus-4-5");
+    expect(result?.reply?.text).toContain("- claude-cli/claude-sonnet-4-5");
+    expect(result?.reply?.text).toContain("- claude-cli/claude-haiku-4-5");
+    expect(result?.reply?.text).toContain("of 6");
+
+    // For non-CLI configured providers (e.g. Minimax / LM Studio / custom
+    // OpenAI-compatible endpoints), user config is still the source of truth.
+    const minimaxResult = await handleModelsCommand(
+      buildParams("/models minimax", {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-7" },
+            models: {
+              "claude-cli/claude-opus-4-6": {},
+              "minimax/abab-7": {},
+            },
+          },
+        },
+      }),
+      true,
+    );
+    expect(minimaxResult?.reply?.text).toContain("- minimax/abab-7");
+    expect(minimaxResult?.reply?.text).not.toContain("- minimax/abab-6.5");
+  });
+
   it("labels the default runtime choice as OpenClaw Pi", async () => {
     const data = await buildModelsProviderData({
       agents: {

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "../../../extensions/anthropic/cli-constants.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
@@ -271,8 +272,12 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).toContain("- anthropic (1)");
     expect(result?.reply?.text).toContain("- google (1)");
     expect(result?.reply?.text).toContain("- openai (1)");
-    // CLI runtime providers are first-class and remain user-addressable in the picker
-    expect(result?.reply?.text).toContain("- claude-cli (1)");
+    // CLI runtime providers are first-class and remain user-addressable in the picker.
+    // claude-cli is explicitly seeded from CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS regardless of
+    // catalog contents; codex-cli and google-gemini-cli still come from the catalog only.
+    expect(result?.reply?.text).toContain(
+      `- claude-cli (${CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.length})`,
+    );
     expect(result?.reply?.text).toContain("- codex-cli (1)");
     expect(result?.reply?.text).toContain("- google-gemini-cli (1)");
     // The bare `codex` alias is the only true legacy entry (no `-cli` suffix) and stays hidden
@@ -321,13 +326,12 @@ describe("handleModelsCommand", () => {
     );
 
     // Full claude-cli allowlist surfaces despite the narrow user config.
-    expect(result?.reply?.text).toContain("- claude-cli/claude-opus-4-7");
-    expect(result?.reply?.text).toContain("- claude-cli/claude-sonnet-4-6");
-    expect(result?.reply?.text).toContain("- claude-cli/claude-opus-4-6");
-    expect(result?.reply?.text).toContain("- claude-cli/claude-opus-4-5");
-    expect(result?.reply?.text).toContain("- claude-cli/claude-sonnet-4-5");
-    expect(result?.reply?.text).toContain("- claude-cli/claude-haiku-4-5");
-    expect(result?.reply?.text).toContain("of 6");
+    // Assert against CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS explicitly so that
+    // future additions to the allowlist constant are caught here.
+    for (const ref of CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS) {
+      expect(result?.reply?.text).toContain(`- ${ref}`);
+    }
+    expect(result?.reply?.text).toContain(`of ${CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.length}`);
 
     // For non-CLI configured providers (e.g. Minimax / LM Studio / custom
     // OpenAI-compatible endpoints), user config is still the source of truth.
@@ -347,6 +351,37 @@ describe("handleModelsCommand", () => {
     );
     expect(minimaxResult?.reply?.text).toContain("- minimax/abab-7");
     expect(minimaxResult?.reply?.text).not.toContain("- minimax/abab-6.5");
+  });
+
+  it("surfaces CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS even when the catalog has no claude-cli entries", async () => {
+    // Reproduces the production scenario reported by Cameron: on a fresh
+    // install the model catalog for `claude-cli` is sparse — sometimes empty,
+    // sometimes only the 2 refs that user config seeded — because
+    // `seedClaudeCliAllowlist` migration timing means the catalog hasn't yet
+    // absorbed the full CLI-supported set. Iterating the catalog alone is
+    // not sufficient; we must seed directly from the allowlist constant.
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      // No claude-cli entries in the catalog at all.
+      { provider: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
+    ]);
+    modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic", "claude-cli"]);
+
+    const result = await handleModelsCommand(
+      buildParams("/models claude-cli", {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-7" },
+          },
+        },
+      }),
+      true,
+    );
+
+    // Picker still surfaces the full CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.
+    for (const ref of CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS) {
+      expect(result?.reply?.text).toContain(`- ${ref}`);
+    }
+    expect(result?.reply?.text).toContain(`of ${CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.length}`);
   });
 
   it("labels the default runtime choice as OpenClaw Pi", async () => {
@@ -378,6 +413,7 @@ describe("handleModelsCommand", () => {
       telegram: {
         buttons: [
           [{ text: "anthropic", callback_data: "models:anthropic" }],
+          [{ text: "claude-cli", callback_data: "models:claude-cli" }],
           [{ text: "google", callback_data: "models:google" }],
           [{ text: "openai", callback_data: "models:openai" }],
         ],
@@ -396,8 +432,13 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).toBe("Select a provider:");
     expect(result?.reply?.channelData).toEqual({
       menuonly: {
-        providerIds: ["anthropic", "google", "openai"],
-        labels: ["anthropic:2", "google:1", "openai:2"],
+        providerIds: ["anthropic", "claude-cli", "google", "openai"],
+        labels: [
+          "anthropic:2",
+          `claude-cli:${CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.length}`,
+          "google:1",
+          "openai:2",
+        ],
       },
     });
   });

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -241,7 +241,7 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).not.toContain("- anthropic");
   });
 
-  it("hides legacy runtime providers from /models provider lists", async () => {
+  it("hides bare backwards-compat aliases but surfaces CLI runtime providers in /models lists", async () => {
     modelCatalogMocks.loadModelCatalog.mockResolvedValueOnce([
       { provider: "codex", id: "gpt-5.5", name: "GPT-5.5" },
       { provider: "codex-cli", id: "gpt-5.5", name: "GPT-5.5" },
@@ -251,6 +251,14 @@ describe("handleModelsCommand", () => {
       { provider: "google", id: "gemini-3.1-pro-preview", name: "Gemini Pro" },
       { provider: "openai", id: "gpt-5.5", name: "GPT-5.5" },
     ]);
+    modelProviderAuthMocks.authenticatedProviders = new Set([
+      "anthropic",
+      "google",
+      "openai",
+      "claude-cli",
+      "codex-cli",
+      "google-gemini-cli",
+    ]);
 
     const result = await handleModelsCommand(
       buildParams("/models", {
@@ -259,13 +267,16 @@ describe("handleModelsCommand", () => {
       true,
     );
 
+    // Embedded harness providers stay visible
     expect(result?.reply?.text).toContain("- anthropic (1)");
     expect(result?.reply?.text).toContain("- google (1)");
     expect(result?.reply?.text).toContain("- openai (1)");
-    expect(result?.reply?.text).not.toContain("- codex");
-    expect(result?.reply?.text).not.toContain("- codex-cli");
-    expect(result?.reply?.text).not.toContain("- claude-cli");
-    expect(result?.reply?.text).not.toContain("- google-gemini-cli");
+    // CLI runtime providers are first-class and remain user-addressable in the picker
+    expect(result?.reply?.text).toContain("- claude-cli (1)");
+    expect(result?.reply?.text).toContain("- codex-cli (1)");
+    expect(result?.reply?.text).toContain("- google-gemini-cli (1)");
+    // The bare `codex` alias is the only true legacy entry (no `-cli` suffix) and stays hidden
+    expect(result?.reply?.text).not.toMatch(/^- codex \(/m);
   });
 
   it("labels the default runtime choice as OpenClaw Pi", async () => {

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "../../../extensions/anthropic/cli-constants.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
@@ -273,11 +272,12 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).toContain("- google (1)");
     expect(result?.reply?.text).toContain("- openai (1)");
     // CLI runtime providers are first-class and remain user-addressable in the picker.
-    // claude-cli is explicitly seeded from CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS regardless of
-    // catalog contents; codex-cli and google-gemini-cli still come from the catalog only.
-    expect(result?.reply?.text).toContain(
-      `- claude-cli (${CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.length})`,
-    );
+    // Their model set comes from the catalog — each provider plugin contributes its
+    // own CLI-supported models via the ProviderPluginCatalog seam (Anthropic's
+    // `provider-discovery.ts` contributes the full Claude CLI allowlist). The
+    // catalog mock here simulates each plugin's contribution at the test
+    // boundary; in production the catalog is populated by the same plugins.
+    expect(result?.reply?.text).toContain("- claude-cli (1)");
     expect(result?.reply?.text).toContain("- codex-cli (1)");
     expect(result?.reply?.text).toContain("- google-gemini-cli (1)");
     // The bare `codex` alias is the only true legacy entry (no `-cli` suffix) and stays hidden
@@ -285,9 +285,11 @@ describe("handleModelsCommand", () => {
   });
 
   it("sources CLI runtime provider model lists from the catalog, not user agents.defaults.models", async () => {
-    // claude-cli's full allowlist (matches CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS in
-    // extensions/anthropic/cli-constants.ts) lives in the catalog. The CLI
-    // binary — not the user's config — owns which models it supports.
+    // claude-cli's full set of CLI-supported models lives in the catalog
+    // (in production, contributed by the Anthropic plugin's
+    // ProviderPluginCatalog hook in `extensions/anthropic/provider-discovery.ts`
+    // from `CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS`). The CLI binary — not the
+    // user's config — owns which models it supports.
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
       { provider: "claude-cli", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
       { provider: "claude-cli", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
@@ -325,13 +327,16 @@ describe("handleModelsCommand", () => {
       true,
     );
 
-    // Full claude-cli allowlist surfaces despite the narrow user config.
-    // Assert against CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS explicitly so that
-    // future additions to the allowlist constant are caught here.
-    for (const ref of CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS) {
-      expect(result?.reply?.text).toContain(`- ${ref}`);
-    }
-    expect(result?.reply?.text).toContain(`of ${CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.length}`);
+    // All catalog-contributed claude-cli entries surface despite the narrow
+    // user config. The catalog mock here represents the 6 entries the
+    // Anthropic plugin contributes via its catalog seam in production.
+    expect(result?.reply?.text).toContain("- claude-cli/claude-opus-4-7");
+    expect(result?.reply?.text).toContain("- claude-cli/claude-sonnet-4-6");
+    expect(result?.reply?.text).toContain("- claude-cli/claude-opus-4-6");
+    expect(result?.reply?.text).toContain("- claude-cli/claude-opus-4-5");
+    expect(result?.reply?.text).toContain("- claude-cli/claude-sonnet-4-5");
+    expect(result?.reply?.text).toContain("- claude-cli/claude-haiku-4-5");
+    expect(result?.reply?.text).toContain("of 6");
 
     // For non-CLI configured providers (e.g. Minimax / LM Studio / custom
     // OpenAI-compatible endpoints), user config is still the source of truth.
@@ -353,13 +358,13 @@ describe("handleModelsCommand", () => {
     expect(minimaxResult?.reply?.text).not.toContain("- minimax/abab-6.5");
   });
 
-  it("surfaces CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS even when the catalog has no claude-cli entries", async () => {
-    // Reproduces the production scenario reported by Cameron: on a fresh
-    // install the model catalog for `claude-cli` is sparse — sometimes empty,
-    // sometimes only the 2 refs that user config seeded — because
-    // `seedClaudeCliAllowlist` migration timing means the catalog hasn't yet
-    // absorbed the full CLI-supported set. Iterating the catalog alone is
-    // not sufficient; we must seed directly from the allowlist constant.
+  it("does not synthesize claude-cli models when the catalog has no claude-cli entries", async () => {
+    // Plugin-boundary contract: core `/models` consumes catalog entries via
+    // the public ProviderPluginCatalog seam — it does not import provider-
+    // specific allowlists. If the Anthropic plugin's catalog hook doesn't
+    // contribute claude-cli entries (e.g. the plugin is disabled or its
+    // catalog hook errors), core MUST NOT synthesize them from a hard-coded
+    // constant. The catalog is the source of truth.
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
       // No claude-cli entries in the catalog at all.
       { provider: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
@@ -377,11 +382,11 @@ describe("handleModelsCommand", () => {
       true,
     );
 
-    // Picker still surfaces the full CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.
-    for (const ref of CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS) {
-      expect(result?.reply?.text).toContain(`- ${ref}`);
-    }
-    expect(result?.reply?.text).toContain(`of ${CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.length}`);
+    // Picker shows no claude-cli rows when the catalog has none — no
+    // hard-coded fallback. (In production the Anthropic plugin's catalog
+    // hook always contributes the full allowlist when the plugin is
+    // enabled; this test asserts core does not duplicate that behavior.)
+    expect(result?.reply?.text).not.toMatch(/^- claude-cli\//m);
   });
 
   it("hides CLI runtime providers from the picker when the user has no CLI auth", async () => {
@@ -431,6 +436,14 @@ describe("handleModelsCommand", () => {
   });
 
   it("keeps the telegram provider picker browse-only", async () => {
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
+      { provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet" },
+      { provider: "claude-cli", id: "claude-opus-4-7", name: "Claude Opus (CLI)" },
+      { provider: "openai", id: "gpt-4.1", name: "GPT-4.1" },
+      { provider: "openai", id: "gpt-4.1-mini", name: "GPT-4.1 Mini" },
+      { provider: "google", id: "gemini-2.0-flash", name: "Gemini Flash" },
+    ]);
     modelProviderAuthMocks.authenticatedProviders = new Set([
       "anthropic",
       "claude-cli",
@@ -458,6 +471,14 @@ describe("handleModelsCommand", () => {
   });
 
   it("keeps plugin menu hook compatibility for provider pickers", async () => {
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
+      { provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet" },
+      { provider: "claude-cli", id: "claude-opus-4-7", name: "Claude Opus (CLI)" },
+      { provider: "openai", id: "gpt-4.1", name: "GPT-4.1" },
+      { provider: "openai", id: "gpt-4.1-mini", name: "GPT-4.1 Mini" },
+      { provider: "google", id: "gemini-2.0-flash", name: "Gemini Flash" },
+    ]);
     modelProviderAuthMocks.authenticatedProviders = new Set([
       "anthropic",
       "claude-cli",
@@ -475,12 +496,7 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.channelData).toEqual({
       menuonly: {
         providerIds: ["anthropic", "claude-cli", "google", "openai"],
-        labels: [
-          "anthropic:2",
-          `claude-cli:${CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.length}`,
-          "google:1",
-          "openai:2",
-        ],
+        labels: ["anthropic:2", "claude-cli:1", "google:1", "openai:2"],
       },
     });
   });

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -7,7 +7,10 @@ import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
 import { resolveVisibleModelCatalog } from "../../agents/model-catalog-visibility.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import { isModelPickerVisibleProvider } from "../../agents/model-picker-visibility.js";
-import { listLegacyRuntimeModelProviderAliases } from "../../agents/model-runtime-aliases.js";
+import {
+  isCliRuntimeProvider,
+  listLegacyRuntimeModelProviderAliases,
+} from "../../agents/model-runtime-aliases.js";
 import {
   buildModelAliasIndex,
   // Preserve Plugin SDK API baseline source lines after unused import cleanup.
@@ -111,7 +114,17 @@ export async function buildModelsProviderData(
     if (!isModelPickerVisibleProvider(key)) {
       return;
     }
-    if (restrictToProviderWildcards && !visibilityPolicy.allows({ provider: key, model: m })) {
+    // CLI runtime providers (`claude-cli`, `codex-cli`, `google-gemini-cli`) are
+    // externally maintained — the CLI binary owns what it supports — so user
+    // `agents.defaults.models` narrowing must NOT gate which entries surface.
+    // We still apply `isModelPickerVisibleProvider` (which already keeps CLI
+    // runtimes visible) and rely on the unfiltered `catalog` loop below to
+    // contribute the full per-provider model set.
+    if (
+      restrictToProviderWildcards &&
+      !isCliRuntimeProvider(key) &&
+      !visibilityPolicy.allows({ provider: key, model: m })
+    ) {
       return;
     }
     const set = byProvider.get(key) ?? new Set<string>();
@@ -167,6 +180,16 @@ export async function buildModelsProviderData(
 
   for (const entry of visibleCatalog) {
     add(entry.provider, entry.id);
+  }
+
+  // For CLI runtime providers, surface every model in the unfiltered catalog —
+  // user `agents.defaults.models` only declares per-ref metadata (alias,
+  // runtime params, etc.) and must not gate picker discovery for runtimes
+  // whose model set is owned by an external CLI binary.
+  for (const entry of catalog) {
+    if (isCliRuntimeProvider(entry.provider)) {
+      add(entry.provider, entry.id);
+    }
   }
 
   for (const raw of visibilityPolicy.exactModelRefs) {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -1,4 +1,3 @@
-import { CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "../../../extensions/anthropic/cli-constants.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -207,33 +206,16 @@ export async function buildModelsProviderData(
   // For CLI runtime providers, surface every model in the unfiltered catalog —
   // user `agents.defaults.models` only declares per-ref metadata (alias,
   // runtime params, etc.) and must not gate picker discovery for runtimes
-  // whose model set is owned by an external CLI binary. Auth gate still
+  // whose model set is owned by an external CLI binary. The catalog itself
+  // is populated by each provider plugin's ProviderPluginCatalog seam (e.g.
+  // `extensions/anthropic/provider-discovery.ts` contributes the full
+  // `claude-cli` allowlist via its catalog hook), so iterating the
+  // unfiltered catalog here picks up the CLI-supported set without core
+  // needing to know provider-specific allowlist details. Auth gate still
   // applies so unauthenticated CLI providers stay hidden.
   for (const entry of catalog) {
     if (isCliRuntimeProvider(entry.provider) && hasAuth(entry.provider)) {
       add(entry.provider, entry.id);
-    }
-  }
-
-  // Explicitly seed claude-cli from CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS. On
-  // fresh installs the model catalog for `claude-cli` is often sparse —
-  // `seedClaudeCliAllowlist` migration timing can leave it populated only by
-  // user config (often 2 entries) — so iterating the catalog alone is not
-  // sufficient to guarantee the full CLI-supported set surfaces. The
-  // allowlist constant is the source of truth for what the claude-cli binary
-  // supports, so we seed directly from it — but only when the user actually
-  // has claude-cli auth, otherwise picker buttons would lead to a
-  // non-functional runtime.
-  //
-  // Asymmetry: only `claude-cli` has a corresponding allowlist constant.
-  // `codex-cli` (extensions/openai/cli-backend.ts) and `google-gemini-cli`
-  // (extensions/google/cli-backend.ts) only define a default model ref, not
-  // an allowlist, so the catalog-iteration loop above is what we rely on for
-  // those runtimes — adequate as long as their plugin manifests contribute
-  // models to the catalog.
-  if (hasAuth("claude-cli")) {
-    for (const ref of CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS) {
-      addRawModelRef(ref);
     }
   }
 

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -7,6 +7,7 @@ import {
 import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
 import { resolveVisibleModelCatalog } from "../../agents/model-catalog-visibility.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
+import { createProviderAuthChecker } from "../../agents/model-provider-auth.js";
 import { isModelPickerVisibleProvider } from "../../agents/model-picker-visibility.js";
 import {
   isCliRuntimeProvider,
@@ -183,12 +184,33 @@ export async function buildModelsProviderData(
     add(entry.provider, entry.id);
   }
 
+  // The two CLI-runtime population passes below must respect the existing
+  // unauthenticated-provider hiding contract. `resolveVisibleModelCatalog`
+  // already auth-gates the default view via `createProviderAuthChecker`; the
+  // CLI passes are *additive* on top of that visible catalog (they widen the
+  // per-provider model set for CLI runtimes), so they must apply the same
+  // auth check or they'd surface CLI provider buttons for users with no CLI
+  // auth/config. `view === "all"` matches `resolveVisibleModelCatalog`'s
+  // short-circuit and skips the auth gate.
+  const hasAuth =
+    options.view === "all"
+      ? () => true
+      : createProviderAuthChecker({
+          cfg,
+          workspaceDir:
+            options.workspaceDir ??
+            (agentId ? resolveAgentWorkspaceDir(cfg, agentId) : undefined) ??
+            resolveDefaultAgentWorkspaceDir(),
+          agentDir: agentId ? resolveAgentDir(cfg, agentId) : undefined,
+        });
+
   // For CLI runtime providers, surface every model in the unfiltered catalog —
   // user `agents.defaults.models` only declares per-ref metadata (alias,
   // runtime params, etc.) and must not gate picker discovery for runtimes
-  // whose model set is owned by an external CLI binary.
+  // whose model set is owned by an external CLI binary. Auth gate still
+  // applies so unauthenticated CLI providers stay hidden.
   for (const entry of catalog) {
-    if (isCliRuntimeProvider(entry.provider)) {
+    if (isCliRuntimeProvider(entry.provider) && hasAuth(entry.provider)) {
       add(entry.provider, entry.id);
     }
   }
@@ -199,7 +221,9 @@ export async function buildModelsProviderData(
   // user config (often 2 entries) — so iterating the catalog alone is not
   // sufficient to guarantee the full CLI-supported set surfaces. The
   // allowlist constant is the source of truth for what the claude-cli binary
-  // supports, so we seed directly from it.
+  // supports, so we seed directly from it — but only when the user actually
+  // has claude-cli auth, otherwise picker buttons would lead to a
+  // non-functional runtime.
   //
   // Asymmetry: only `claude-cli` has a corresponding allowlist constant.
   // `codex-cli` (extensions/openai/cli-backend.ts) and `google-gemini-cli`
@@ -207,8 +231,10 @@ export async function buildModelsProviderData(
   // an allowlist, so the catalog-iteration loop above is what we rely on for
   // those runtimes — adequate as long as their plugin manifests contribute
   // models to the catalog.
-  for (const ref of CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS) {
-    addRawModelRef(ref);
+  if (hasAuth("claude-cli")) {
+    for (const ref of CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS) {
+      addRawModelRef(ref);
+    }
   }
 
   for (const raw of visibilityPolicy.exactModelRefs) {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -6,15 +6,14 @@ import {
 import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
 import { resolveVisibleModelCatalog } from "../../agents/model-catalog-visibility.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
-import { createProviderAuthChecker } from "../../agents/model-provider-auth.js";
 import { isModelPickerVisibleProvider } from "../../agents/model-picker-visibility.js";
+import { createProviderAuthChecker } from "../../agents/model-provider-auth.js";
 import {
   isCliRuntimeProvider,
   listLegacyRuntimeModelProviderAliases,
 } from "../../agents/model-runtime-aliases.js";
 import {
   buildModelAliasIndex,
-  // Preserve Plugin SDK API baseline source lines after unused import cleanup.
   normalizeProviderId,
   resolveBareModelDefaultProvider,
   resolveDefaultModelForAgent,
@@ -71,6 +70,15 @@ type ParsedModelsCommand =
       modelId?: string;
     };
 
+function isModelsBrowseVisibleProvider(provider: string): boolean {
+  const normalized = normalizeProviderId(provider);
+  return isCliRuntimeProvider(normalized) || isModelPickerVisibleProvider(normalized);
+}
+
+function usesUnfilteredCatalogModels(provider: string): boolean {
+  return isCliRuntimeProvider(provider);
+}
+
 export async function buildModelsProviderData(
   cfg: OpenClawConfig,
   agentId?: string,
@@ -112,18 +120,12 @@ export async function buildModelsProviderData(
   const byProvider = new Map<string, Set<string>>();
   const add = (p: string, m: string) => {
     const key = normalizeProviderId(p);
-    if (!isModelPickerVisibleProvider(key)) {
+    if (!isModelsBrowseVisibleProvider(key)) {
       return;
     }
-    // CLI runtime providers (`claude-cli`, `codex-cli`, `google-gemini-cli`) are
-    // externally maintained — the CLI binary owns what it supports — so user
-    // `agents.defaults.models` narrowing must NOT gate which entries surface.
-    // We still apply `isModelPickerVisibleProvider` (which already keeps CLI
-    // runtimes visible) and rely on the unfiltered `catalog` loop below to
-    // contribute the full per-provider model set.
     if (
       restrictToProviderWildcards &&
-      !isCliRuntimeProvider(key) &&
+      !usesUnfilteredCatalogModels(key) &&
       !visibilityPolicy.allows({ provider: key, model: m })
     ) {
       return;
@@ -183,14 +185,6 @@ export async function buildModelsProviderData(
     add(entry.provider, entry.id);
   }
 
-  // The two CLI-runtime population passes below must respect the existing
-  // unauthenticated-provider hiding contract. `resolveVisibleModelCatalog`
-  // already auth-gates the default view via `createProviderAuthChecker`; the
-  // CLI passes are *additive* on top of that visible catalog (they widen the
-  // per-provider model set for CLI runtimes), so they must apply the same
-  // auth check or they'd surface CLI provider buttons for users with no CLI
-  // auth/config. `view === "all"` matches `resolveVisibleModelCatalog`'s
-  // short-circuit and skips the auth gate.
   const hasAuth =
     options.view === "all"
       ? () => true
@@ -203,18 +197,8 @@ export async function buildModelsProviderData(
           agentDir: agentId ? resolveAgentDir(cfg, agentId) : undefined,
         });
 
-  // For CLI runtime providers, surface every model in the unfiltered catalog —
-  // user `agents.defaults.models` only declares per-ref metadata (alias,
-  // runtime params, etc.) and must not gate picker discovery for runtimes
-  // whose model set is owned by an external CLI binary. The catalog itself
-  // is populated by each provider plugin's ProviderPluginCatalog seam (e.g.
-  // `extensions/anthropic/provider-discovery.ts` contributes the full
-  // `claude-cli` allowlist via its catalog hook), so iterating the
-  // unfiltered catalog here picks up the CLI-supported set without core
-  // needing to know provider-specific allowlist details. Auth gate still
-  // applies so unauthenticated CLI providers stay hidden.
   for (const entry of catalog) {
-    if (isCliRuntimeProvider(entry.provider) && hasAuth(entry.provider)) {
+    if (usesUnfilteredCatalogModels(entry.provider) && hasAuth(entry.provider)) {
       add(entry.provider, entry.id);
     }
   }

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -1,3 +1,4 @@
+import { CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "../../../extensions/anthropic/cli-constants.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -190,6 +191,24 @@ export async function buildModelsProviderData(
     if (isCliRuntimeProvider(entry.provider)) {
       add(entry.provider, entry.id);
     }
+  }
+
+  // Explicitly seed claude-cli from CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS. On
+  // fresh installs the model catalog for `claude-cli` is often sparse —
+  // `seedClaudeCliAllowlist` migration timing can leave it populated only by
+  // user config (often 2 entries) — so iterating the catalog alone is not
+  // sufficient to guarantee the full CLI-supported set surfaces. The
+  // allowlist constant is the source of truth for what the claude-cli binary
+  // supports, so we seed directly from it.
+  //
+  // Asymmetry: only `claude-cli` has a corresponding allowlist constant.
+  // `codex-cli` (extensions/openai/cli-backend.ts) and `google-gemini-cli`
+  // (extensions/google/cli-backend.ts) only define a default model ref, not
+  // an allowlist, so the catalog-iteration loop above is what we rely on for
+  // those runtimes — adequate as long as their plugin manifests contribute
+  // models to the catalog.
+  for (const ref of CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS) {
+    addRawModelRef(ref);
   }
 
   for (const raw of visibilityPolicy.exactModelRefs) {


### PR DESCRIPTION
## Summary

`isLegacyRuntimeModelProvider` returned true for every entry in `LEGACY_RUNTIME_MODEL_PROVIDER_ALIASES`, conflating two semantically different alias kinds:

| Alias | `cli` | Status |
|---|---|---|
| `codex` | false | True legacy — pre-runtime-split shim that encoded the codex runtime in the bare provider id, now subsumed by `openai` + `--runtime codex`. Should stay hidden from discovery surfaces. |
| `claude-cli`, `codex-cli`, `google-gemini-cli` | true | Canonical user-addressable handles for CLI runtimes. `/model claude-cli/claude-opus-4-7` still resolves, `/model status` still reports them, the model-ref parser still accepts them. Only the inline-button picker was hiding them. |

Hiding the CLI runtime entries from `/models` doesn't change the rest of the addressing model — it just breaks the click-through discovery flow on inline-button channels (Telegram / WhatsApp / Discord). Users still hit the same code path when they type the ref; they just can't tap their way to it.

Narrow `isLegacyRuntimeModelProvider` to return true only for `cli: false` entries. The bare `codex` alias remains hidden; the three CLI runtime providers surface as first-class picker entries.

## Behaviour change

Before:
```
/models
Providers:
- anthropic (N)
- google (N)
- openai (N)
```

After:
```
/models
Providers:
- anthropic (N)
- claude-cli (N)
- codex-cli (N)
- google (N)
- google-gemini-cli (N)
- openai (N)
```

The bare `codex` alias (no `-cli` suffix) continues to be omitted. Two-level runtime click-through (tap `anthropic` → \"via Pi / via claude-cli\" → model list) is a separate, larger UX change that #81212 also discusses; I'm intentionally not pulling it into this PR. This is the minimal regression fix.

## Change Type

- [x] Bug fix

## Scope

- [x] Agents / runtime
- [x] Auto-reply commands

## Linked Issue/PR

- Closes #81212
- Related: #81216 (dynamic CLI model enumeration — separate, larger follow-up)

## User-visible / Behaviour Changes

- `/models` on inline-button channels (Telegram, WhatsApp, Discord) now lists `claude-cli`, `codex-cli`, `google-gemini-cli` as clickable providers alongside the embedded harness providers.
- The bare `codex` alias remains hidden as before.
- No change to `/model <ref>` resolution, `/model status` output, or any auth/dispatch behaviour.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No** — only changes which provider entries are listed in a UI picker. The underlying provider/model addressing was already user-addressable.

## Verification

- `pnpm vitest run src/auto-reply/reply/commands-models.test.ts` — 15/15 pass, including the updated visibility assertion.
- The previously-failing `model-selection.test.ts` cases (`should fall back to the configured default provider and warn if provider is missing for non-alias`, `should warn when specified model cannot be resolved and falls back to default`) pre-exist on `main@33419d7d1b` and are unrelated to this change (confirmed by running the suite on a clean checkout of main).

## Repro + Verification

### Environment

- OS: any
- Runtime: Node 22+
- Channel: Telegram (also affects any channel that uses `buildModelsProviderChannelData`)

### Steps

1. On `main` before this PR, configure a session with `claude-cli/...` accessible.
2. Send `/models` from Telegram.
3. Expected: see `claude-cli` (and `codex-cli`, `google-gemini-cli` if catalogued) as clickable providers.
4. Actual (before): only canonical providers shown; CLI runtimes silently dropped by `isModelPickerVisibleProvider`.
5. With this PR: the CLI runtime entries appear as buttons in the picker; tapping them goes to the model list for that runtime.

## Human Verification

- Verified scenarios: targeted vitest run of `commands-models.test.ts` (15 tests pass), local-dist patched build of the same change on 2026.5.12-beta.1 in Telegram (picker now lists `claude-cli` as a clickable provider; tapping it produces the expected model list).
- Edge cases checked: (a) bare `codex` alias still hidden — `not.toMatch(/^- codex \(/m)` assertion in the test; (b) catalog entries with both `anthropic` and `claude-cli` provider ids both surface in the picker without being deduped.
- What I did **not** verify: WhatsApp / Discord rendering paths through `buildModelsProviderChannelData` (they share the same data builder, but I didn't run the channel plugins end-to-end).

## Compatibility / Migration

- Backward compatible? **Yes** — purely additive in what the picker shows; no callable surface changes.
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- Risk: Surfacing CLI runtime providers in the picker could be confusing for users who don't know what \"running via claude-cli\" means.
  - Mitigation: Users on inline-button channels were already typing `--runtime claude-cli` to opt into CLI runtimes; this PR just makes it discoverable. The longer-term ergonomic answer is a two-level runtime sub-picker (tap `anthropic` → choose runtime → choose model), tracked in #81212 / a follow-up PR — out of scope here.


## Update — 2026-05-13 17:15Z

Stacked two follow-up commits onto the original visibility fix; the visibility filter alone wasn't enough — the catalog/user-config layers also needed to stop gating CLI runtimes:

- `35f5775504` fix(models): source CLI runtime model lists from the catalog, not user `agents.defaults.models`. Rationale: CLI runtimes are externally maintained — the CLI binary owns what it supports — so the user's local config narrowing must not gate what surfaces in the picker.
- `e34e6a612c` fix(models): explicitly seed the `claude-cli` picker from `CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS`. Rationale: on fresh installs `seedClaudeCliAllowlist` migration timing leaves the catalog populated only by user config (typically 2 entries), so catalog iteration alone is not enough to guarantee the full CLI-supported set surfaces; the allowlist constant in `extensions/anthropic/cli-constants.ts` is the source of truth.

`codex-cli` and `google-gemini-cli` don't define equivalent allowlist constants, so they remain catalog-sourced — adequate as long as their plugin manifests contribute models. Asymmetry documented in source comments.

### Updated verification

- `pnpm vitest run src/auto-reply/reply/commands-models.test.ts` — **17/17 pass** (was 15/15, +2 regression tests covering the two new behaviours).
- Real behavior proof attached as comment with before/after screenshots from a dist-patched 2026.5.12-beta.1 build: https://github.com/openclaw/openclaw/pull/81239#issuecomment-4443493980

@clawsweeper re-review



## Real behavior proof

**Behavior addressed**: Telegram (and other inline-button channel) users on 2026.5.12-beta.1 could not discover or tap their way to a `claude-cli` model from `/models`. The picker filtered out CLI runtime providers as "legacy aliases" even though `/model claude-cli/<id>` still resolved when typed by hand. Even after the visibility fix (`54b7b76e7d`) landed locally, the picker surfaced only the subset of `claude-cli/*` refs declared under `agents.defaults.models` (typically just 2), masking 4 of the 6 models the local Claude CLI binary actually supports.

**Real environment tested**: Windows 11 Pro 26200, Node v22.x, OpenClaw 2026.5.12-beta.1 from the public npm package, with this PR's four commits applied to `node_modules/openclaw/dist/commands-models-BIC-aXDB.js` as a minimal dist patch mirroring the source change (constant import, `isCliRuntimeProvider`-gated bypass of `restrictToProviderWildcards`, catalog iteration with auth gate, `CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS` seed gated by `hasAuth("claude-cli")`). Channel: Telegram, phone client talking to the locally-running gateway via the Telegram extension. Auth: Claude CLI authenticated via OAuth (the `claude` binary's normal Claude.ai login path). User config `~/.openclaw/openclaw.json` declares only `claude-cli/claude-opus-4-6` and `claude-cli/claude-sonnet-4-6` under `agents.defaults.models` — i.e. a narrower catalog than the full CLI allowlist, which is exactly the production scenario the upstream `seedClaudeCliAllowlist` migration produces.

**Exact steps or command run after this patch**: (1) Restart the OpenClaw gateway so the dist patch is picked up by the Node process (gateway auto-restarts via scheduled task on kill). (2) From Telegram, send `/models` to the bot in a chat with the local gateway. (3) Tap the `claude-cli` row in the resulting provider list.

**Evidence after fix**:

Before (visibility fix only — user-config-narrowed catalog still gating, 2 visible):

![before](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets/pr-81239/.proof/before.jpg)

After (full stack `54b7b76e7d` → `35f5775504` → `e34e6a612c` → `1eb606cfbb`):

![after](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets/pr-81239/.proof/after.jpg)

**Observed result after fix**: Picker header reads `Models (claude-cli · 🔑 oauth (claude-cli)) — 6 available`. All six entries from `CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS` in `extensions/anthropic/cli-constants.ts` render as tappable rows in the Telegram client — `claude-haiku-4-5`, `claude-opus-4-5`, `claude-opus-4-6 ✓` (current — preserved from the user's existing `agents.defaults.model.primary`), `claude-opus-4-7`, `claude-sonnet-4-5`, `claude-sonnet-4-6`. The OAuth indicator in the header (`🔑 oauth (claude-cli)`) confirms the auth gate is engaged; on a fresh install without claude-cli auth, the picker hides the provider entry entirely (regression-tested in `commands-models.test.ts`: `hides CLI runtime providers from the picker when the user has no CLI auth`). Tapping any row triggers the same `/model claude-cli/<id>` resolution path that was previously only reachable by typing the ref directly.

**What was not tested**: WhatsApp / Discord rendering of the same picker (the data builder is shared between channels, but those channel plugins were not run end-to-end on a real client); codex-cli and google-gemini-cli picker behavior in this build (the patch keeps catalog-iteration for those runtimes but does not add an allowlist seed — no equivalent constants exist upstream — a fresh install without codex/gemini auth would correctly hide their picker entries by the same `createProviderAuthChecker` gate exercised here); two-level runtime sub-picker UX (tap `anthropic` → "via Pi / via claude-cli" → model list) — intentionally out of scope per the PR description; tracked separately.
