### PR TITLE
[AI-assisted] fix: skip context engine preparation for isolated subagent spawns

### DIFF
--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -443,3 +443,74 @@ describe("spawnSubagentDirect seam flow", () => {
     ).toBe(false);
   });
 });
+
+describe("isolated context engine skip", () => {
+  let spawnIsolated: typeof import("./subagent-spawn.js").spawnSubagentDirect;
+  let resetIsolated: typeof import("./subagent-registry.js").resetSubagentRegistryForTests;
+  const resolveContextEngineSpy = vi.fn(async () => ({
+    prepareSubagentSpawn: vi.fn(async () => ({ rollback: vi.fn() })),
+  }));
+  const ensureContextEnginesSpy = vi.fn();
+
+  beforeAll(async () => {
+    const callGateway = vi.fn();
+    const updateStore = vi.fn();
+    const registerRun = vi.fn();
+    const resolveAgent = vi.fn(
+      (cfg: { agents?: { list?: Array<{ id?: string }> } }, agentId: string) =>
+        cfg.agents?.list?.find((agent) => agent.id === agentId),
+    );
+    installAcceptedSubagentGatewayMock(callGateway);
+    updateStore.mockImplementation(
+      async (
+        _storePath: string,
+        mutator: (store: Record<string, Record<string, unknown>>) => unknown,
+      ) => {
+        const store: Record<string, Record<string, unknown>> = {};
+        await mutator(store);
+        return store;
+      },
+    );
+    ({ resetSubagentRegistryForTests: resetIsolated, spawnSubagentDirect: spawnIsolated } =
+      await loadSubagentSpawnModuleForTest({
+        callGatewayMock: callGateway,
+        getRuntimeConfig: () =>
+          createSubagentSpawnTestConfig(os.tmpdir(), {
+            agents: {
+              defaults: { workspace: os.tmpdir() },
+              list: [{ id: "main", workspace: os.tmpdir() }],
+            },
+          }),
+        updateSessionStoreMock: updateStore,
+        registerSubagentRunMock: registerRun,
+        resolveAgentConfig: resolveAgent,
+        resolveSubagentSpawnModelSelection: () => "openai-codex/gpt-5.4",
+        resolveSandboxRuntimeStatus: () => ({ sandboxed: false }),
+        ensureContextEnginesInitializedMock: ensureContextEnginesSpy,
+        resolveContextEngineMock: resolveContextEngineSpy,
+        sessionStorePath: "/tmp/subagent-spawn-isolated-test-store.json",
+      }));
+  });
+
+  beforeEach(() => {
+    resetIsolated();
+    resolveContextEngineSpy.mockClear();
+    ensureContextEnginesSpy.mockClear();
+  });
+
+  it("does not invoke context engine preparation for isolated subagent spawns", async () => {
+    const result = await spawnIsolated(
+      {
+        task: "Reply only with: OK",
+        context: "isolated",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(resolveContextEngineSpy).not.toHaveBeenCalled();
+    expect(ensureContextEnginesSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -441,6 +441,15 @@ async function prepareContextEngineSubagentSpawn(params: {
 }): Promise<
   { status: "ok"; preparation?: SubagentSpawnPreparation } | { status: "error"; error: string }
 > {
+  // Isolated subagent spawns should not inherit context-engine state.
+  // Preparing the context engine for isolated runs injects large inherited
+  // payloads that bloat lightweight spawns and cause runaway CPU on local
+  // inference runtimes (e.g. Ollama).  Short-circuit here to keep isolated
+  // runs truly lightweight.
+  if (params.context.mode === "isolated") {
+    return { status: "ok", preparation: undefined };
+  }
+
   try {
     subagentSpawnDeps.ensureContextEnginesInitialized();
     const engine = await subagentSpawnDeps.resolveContextEngine(params.cfg);


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: Isolated lightweight subagent spawns (`context="isolated"`, `lightContext=true`) unnecessarily invoked `prepareContextEngineSubagentSpawn()`, injecting large inherited context payloads into what should be zero-context runs. This caused runaway CPU utilization on local inference runtimes (e.g. Ollama), stalled inference, and embedded runtime fallback behavior.
- Why it matters: Multi-agent deployments using local Ollama runtimes with `sessions_spawn()` became unstable after OpenClaw 2026.5.7, breaking lightweight subagent orchestration workflows.
- What changed: Added an early return in `prepareContextEngineSubagentSpawn()` when `params.context.mode === "isolated"`, returning `{ status: "ok", preparation: undefined }` immediately. Added a regression test verifying the context engine is never invoked for isolated spawns.
- What did NOT change (scope boundary): Fork-mode and default-context spawns still invoke the full context engine preparation pipeline. No changes to `prepareSpawnContext()`, `resolveSubagentContextMode()`, or any other spawn orchestration logic.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Agents

## Linked Issue/PR
- Closes #81214
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `prepareContextEngineSubagentSpawn()` was called unconditionally for all spawn modes, including `"isolated"`. For isolated runs, the context engine resolves and prepares parent context state that the child will never use, inflating payloads sent to local inference runtimes.
- Missing detection / guardrail: No test verified that isolated spawns bypass context engine preparation. The existing `prepareSpawnContext()` already short-circuits for isolated mode (line 334), but the downstream `prepareContextEngineSubagentSpawn()` call at line 1089 was not guarded.
- Contributing context (if known): The regression likely arrived with subagent policy enforcement changes between 2026.4.27 and 2026.5.7 that restructured the spawn pipeline without preserving the isolated-mode optimization.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/subagent-spawn.test.ts`
- Scenario the test should lock in: When spawning a subagent with `context: "isolated"`, `resolveContextEngine` and `ensureContextEnginesInitialized` must not be called.
- Why this is the smallest reliable guardrail: Directly asserts the skip behavior at the function boundary without requiring a full gateway integration test or live Ollama runtime.
- Existing test that already covers this (if any): N/A — no prior test checked context engine invocation for isolated spawns.
- If no new test is added, why not: N/A — new test added.

## User-visible / Behavior Changes
- Isolated subagent spawns no longer cause excessive CPU utilization or payload expansion on local inference runtimes.
- No change to fork-mode or default-context subagent behavior.

## Security Impact (required)
- New permissions/capabilities? No
- This fix removes an unnecessary code path for isolated spawns, reducing the attack surface for context injection. No new permissions, capabilities, or trust boundaries are affected.
