### PR TITLE
[AI-assisted] fix(ui): prevent chat actions overlapping replies

### DIFF
--- a/ui/src/ui/chat/chat-responsive.browser.test.ts
+++ b/ui/src/ui/chat/chat-responsive.browser.test.ts
@@ -68,6 +68,19 @@ function iconSvg() {
   return `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M5 12h14"></path></svg>`;
 }
 
+function chatBubbleActionsHtml() {
+  return `
+    <div class="chat-bubble-actions">
+      <button class="btn btn--xs chat-expand-btn" type="button" aria-label="Open in canvas">
+        <span class="chat-expand-btn__icon" aria-hidden="true">${iconSvg()}</span>
+      </button>
+      <button class="btn btn--xs chat-copy-btn" type="button" aria-label="Copy as markdown">
+        <span class="chat-copy-btn__icon" aria-hidden="true">${iconSvg()}</span>
+      </button>
+    </div>
+  `;
+}
+
 function chatControlsHtml(opts: { agent?: boolean } = {}) {
   const showAgent = opts.agent !== false;
   return `
@@ -168,6 +181,7 @@ function chatHtml(opts: { sideResult?: boolean; singleAgent?: boolean } = {}) {
                     <div class="chat-avatar assistant">A</div>
                     <div class="chat-group-messages">
                       <div class="chat-bubble has-copy">
+                        ${chatBubbleActionsHtml()}
                         <div class="chat-text">
                           <p>The chat shell should stay compact and readable.</p>
                           <pre><code>const importantLongIdentifier = "control-ui-chat-responsive-regression-fixture-keeps-code-scrollable"; console.log(importantLongIdentifier);</code></pre>
@@ -224,6 +238,41 @@ async function openFixture(
     `<!doctype html><html><head><style>${readUiCss()}</style></head><body>${chatHtml(opts)}</body></html>`,
   );
   return page;
+}
+
+async function getRect(page: Page, selector: string) {
+  const rect = await page.locator(selector).evaluate((node) => {
+    const bounds = (node as HTMLElement).getBoundingClientRect();
+    return {
+      left: bounds.left,
+      right: bounds.right,
+      top: bounds.top,
+      bottom: bounds.bottom,
+      width: bounds.width,
+      height: bounds.height,
+    };
+  });
+  expectFiniteRect({ x: rect.left, y: rect.top, width: rect.width, height: rect.height });
+  return rect;
+}
+
+async function getTextContentRect(page: Page, selector: string) {
+  const rect = await page.locator(selector).evaluate((node) => {
+    const range = document.createRange();
+    range.selectNodeContents(node);
+    const bounds = range.getBoundingClientRect();
+    range.detach();
+    return {
+      left: bounds.left,
+      right: bounds.right,
+      top: bounds.top,
+      bottom: bounds.bottom,
+      width: bounds.width,
+      height: bounds.height,
+    };
+  });
+  expectFiniteRect({ x: rect.left, y: rect.top, width: rect.width, height: rect.height });
+  return rect;
 }
 
 async function openHeaderFixture(width: number, height: number, opts: { hidden?: boolean } = {}) {
@@ -325,6 +374,42 @@ describeBrowserLayout("chat responsive browser layout", () => {
       await page.close();
     }
   });
+
+  it.each([
+    [320, 568],
+    [1366, 900],
+  ] as const)(
+    "keeps short assistant text clear of bubble actions at %sx%s",
+    async (width, height) => {
+      const page = await browser.newPage({ viewport: { width, height } });
+      try {
+        await page.setContent(
+          `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+            <div class="chat-thread" role="log">
+              <div class="chat-thread-inner">
+                <div class="chat-group assistant">
+                  <div class="chat-avatar assistant">A</div>
+                  <div class="chat-group-messages">
+                    <div class="chat-bubble has-copy">
+                      ${chatBubbleActionsHtml()}
+                      <div class="chat-text"><p>Done.</p></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </body></html>`,
+        );
+        await page.locator(".chat-bubble").hover();
+
+        const text = await getTextContentRect(page, ".chat-text p");
+        const actions = await getRect(page, ".chat-bubble-actions");
+        expect(text.right).toBeLessThanOrEqual(actions.left - 1);
+      } finally {
+        await page.close();
+      }
+    },
+  );
 
   it.each(["dark", "light"] as const)(
     "keeps mobile controls inside the viewport with touch targets in %s mode",

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -481,6 +481,37 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector('[aria-label="Read aloud"]')).toBeNull();
   });
 
+  it("reserves bubble space when assistant message actions render", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(container, {
+      role: "assistant",
+      content: "Short reply",
+      timestamp: 1000,
+    });
+
+    const assistantBubble = expectElement(
+      container,
+      ".chat-group.assistant .chat-bubble",
+      HTMLElement,
+    );
+    expect(assistantBubble.classList.contains("has-copy")).toBe(true);
+    expect(assistantBubble.querySelector(".chat-bubble-actions")).toBeInstanceOf(HTMLElement);
+
+    renderGroupedMessage(
+      container,
+      {
+        role: "user",
+        content: "Short reply",
+        timestamp: 1001,
+      },
+      "user",
+    );
+
+    const userBubble = expectElement(container, ".chat-group.user .chat-bubble", HTMLElement);
+    expect(userBubble.classList.contains("has-copy")).toBe(false);
+    expect(userBubble.querySelector(".chat-bubble-actions")).toBeNull();
+  });
+
   it("positions delete confirm by message side", () => {
     const container = document.createElement("div");
     clearDeleteConfirmSkip();

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1436,6 +1436,7 @@ function renderGroupedMessage(
   const markdown = markdownBase;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
   const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
+  const hasActions = canCopyMarkdown || canExpand;
 
   // Detect pure-JSON messages and render as collapsible block
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
@@ -1444,6 +1445,7 @@ function renderGroupedMessage(
   const bubbleClasses = [
     "chat-bubble",
     isToolMessage ? "chat-bubble--tool-shell" : "",
+    hasActions ? "has-copy" : "",
     opts.isStreaming ? "streaming" : "",
     "fade-in",
   ]
@@ -1491,7 +1493,6 @@ function renderGroupedMessage(
         : "Tool output";
   const toolMessageIcon = singleToolDisplay ? icons[singleToolDisplay.icon] : icons.zap;
 
-  const hasActions = canCopyMarkdown || canExpand;
   const duplicateCount = Math.max(1, Math.floor(opts.duplicateCount ?? 1));
 
   return html`


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: short assistant replies could render underneath the in-bubble copy/open action buttons because the real grouped-chat renderer did not apply the existing reserved-space class.
- Why it matters: the Control UI/WebChat transcript should keep short replies readable when message actions are visible.
- What changed: assistant bubbles with rendered message actions now receive the existing `has-copy` class, so the existing right-side padding is applied in the real renderer.
- What did NOT change (scope boundary): no chat data, provider behavior, gateway behavior, copy behavior, or action button behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79509
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: short assistant reply text no longer sits underneath visible bubble action buttons.
- Real environment tested: local Chromium/Chrome render of the real Control UI chat CSS with an isolated WebChat-style assistant bubble fixture. No real chat history, provider, gateway, or credentials were used.
- Exact steps or command run after this patch: rendered the same short assistant bubble before/after the class fix with local Chrome and measured the horizontal gap between the text range and `.chat-bubble-actions`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
Before:
textRight: 80.61
actionsLeft: 26.61
gap: -54px
Result: actions overlap the short reply text.

After:
textRight: 80.61
actionsLeft: 82.61
gap: 2px
Result: text remains clear of the action buttons.
```

- Observed result after fix: the same short reply has visible reserved space before the action buttons.
- What was not tested: a full live OpenClaw gateway session or real provider-backed WebChat conversation.
- Before evidence (optional but encouraged): local before screenshot showed the `Done.` text hidden behind the visible action buttons; the measured gap was `-54px`.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `grouped.css` already had `.chat-bubble.has-copy { padding-right: 70px; }`, but the production grouped-chat renderer never added `has-copy` when rendering assistant message actions.
- Missing detection / guardrail: the browser fixture used `has-copy` manually, so it did not catch that the real renderer omitted the class.
- Contributing context (if known): action buttons are absolutely positioned inside `.chat-bubble`, so short inline text needs reserved space when actions are present.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/chat/grouped-render.test.ts`; `ui/src/ui/chat/chat-responsive.browser.test.ts`
- Scenario the test should lock in: assistant messages with rendered bubble actions get the reserved-space class, and short assistant text stays clear of the action buttons in the browser fixture.
- Why this is the smallest reliable guardrail: the fix is a renderer class contract plus layout behavior in the existing chat CSS fixture; no provider or gateway path is involved.
- Existing test that already covers this (if any): existing browser fixture used `has-copy`, but it did not validate the renderer-class contract.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Short assistant replies in Control UI/WebChat no longer render underneath visible copy/open action buttons.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local source checkout; local Chrome render for visual proof
- Model/provider: N/A
- Integration/channel (if any): Control UI/WebChat grouped chat rendering
- Relevant config (redacted): isolated synthetic assistant bubble fixture only

### Steps

1. Render a short assistant bubble with visible `.chat-bubble-actions`.
2. Compare the text range against the action button container.
3. Run the grouped chat renderer test to verify the real renderer applies the reserved-space class.

### Expected

- Short assistant text remains visible and does not sit underneath the action buttons.

### Actual

- Short assistant text remains visible and has a measured `2px` gap before the action buttons in the local Chrome proof.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-ui.config.ts ui/src/ui/chat/grouped-render.test.ts
Test Files  1 passed (1)
Tests  36 passed (36)

node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-ui.config.ts ui/src/ui/chat/chat-responsive.browser.test.ts
Test Files  1 skipped (1)
Tests  18 skipped (18)
Reason: local Playwright Chromium is not installed in this checkout; the test remains skip-gated by the repo.

node_modules\.bin\oxfmt.cmd --check --threads=1 ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts ui/src/ui/chat/chat-responsive.browser.test.ts
All matched files use the correct format.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: renderer adds `has-copy` for assistant message actions; user messages without actions do not get it; local Chrome fixture before/after shows overlap removed.
- Edge cases checked: mobile-width 320px visual proof and browser-test fixture also covers desktop width.
- What you did **not** verify: full live OpenClaw gateway/WebChat session with a real provider; full repo test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
