### PR TITLE
fix(whatsapp): drain debounced inbound before close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 - Agents/exec: skip redundant heartbeat wake-ups for subagent session exec completions, preventing spurious LLM invocations on parent sessions. Fixes #66748. (#66749) Thanks @ggzeng.
 - Provider streams: keep OpenAI-compatible SSE and JSON fallback streams draining across split chunks and fail Azure Responses streams with a bounded first-event diagnostic instead of stalling. Refs #80926. (#80927) Thanks @galiniliev and @CaptainTimon.
 - Agents: rewrite generic provider internal errors with support request IDs into user-friendly transient error copy. (#49401) Thanks @y471823206.
+- WhatsApp: finish handling pending debounced inbound messages before closing the socket. (#81246) Thanks @mcaxtr.
 
 ### Changes
 

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -54,6 +54,7 @@ import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
 const RECONNECT_IN_PROGRESS_ERROR = "no active socket - reconnection in progress";
 const GROUP_META_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const INBOUND_CLOSE_DRAIN_TIMEOUT_MS = 5_000;
 export const WHATSAPP_GROUP_METADATA_CACHE_MAX_ENTRIES = 500;
 
 type WhatsAppGroupMetadataCacheEntry = {
@@ -223,7 +224,29 @@ export async function attachWebInboxToSocket(
   const self = selfIdentity.identity;
   type QueuedInboundMessage = WebInboundMessage & {
     dedupeKey?: string;
+    debounceKey?: string;
   };
+  const inboundDebounceMs = Math.max(0, Math.trunc(options.debounceMs ?? 0));
+  const pendingDebounceKeys = new Set<string>();
+  const activeInboundFlushes = new Set<Promise<void>>();
+  const buildInboundDebounceKey = (msg: WebInboundMessage): string | null => {
+    const sender = msg.sender;
+    const senderKey =
+      msg.chatType === "group"
+        ? (getPrimaryIdentityId(sender ?? null) ??
+          msg.senderJid ??
+          msg.senderE164 ??
+          msg.senderName ??
+          msg.from)
+        : msg.from;
+    if (!senderKey) {
+      return null;
+    }
+    const conversationKey = msg.chatType === "group" ? msg.chatId : msg.from;
+    return `${msg.accountId}:${conversationKey}:${senderKey}`;
+  };
+  const shouldDebounceInboundMessage = (msg: WebInboundMessage): boolean =>
+    options.shouldDebounce?.(msg) ?? true;
 
   const finalizeInboundDedupe = async (
     entries: QueuedInboundMessage[],
@@ -243,57 +266,57 @@ export async function attachWebInboxToSocket(
   };
 
   const debouncer = createInboundDebouncer<QueuedInboundMessage>({
-    debounceMs: options.debounceMs ?? 0,
-    buildKey: (msg) => {
-      const sender = msg.sender;
-      const senderKey =
-        msg.chatType === "group"
-          ? (getPrimaryIdentityId(sender ?? null) ??
-            msg.senderJid ??
-            msg.senderE164 ??
-            msg.senderName ??
-            msg.from)
-          : msg.from;
-      if (!senderKey) {
-        return null;
-      }
-      const conversationKey = msg.chatType === "group" ? msg.chatId : msg.from;
-      return `${msg.accountId}:${conversationKey}:${senderKey}`;
-    },
-    shouldDebounce: options.shouldDebounce,
+    debounceMs: inboundDebounceMs,
+    buildKey: (msg) => msg.debounceKey ?? buildInboundDebounceKey(msg),
+    shouldDebounce: shouldDebounceInboundMessage,
     onFlush: async (entries) => {
-      const last = entries.at(-1);
-      if (!last) {
-        return;
-      }
+      let finishFlush!: () => void;
+      const flushTask = new Promise<void>((resolve) => {
+        finishFlush = resolve;
+      });
+      activeInboundFlushes.add(flushTask);
       try {
-        if (entries.length === 1) {
-          await options.onMessage(last);
-          await finalizeInboundDedupe(entries);
+        const last = entries.at(-1);
+        if (!last) {
           return;
         }
-        const mentioned = new Set<string>();
+        try {
+          if (entries.length === 1) {
+            await options.onMessage(last);
+            await finalizeInboundDedupe(entries);
+            return;
+          }
+          const mentioned = new Set<string>();
+          for (const entry of entries) {
+            for (const jid of entry.mentions ?? entry.mentionedJids ?? []) {
+              mentioned.add(jid);
+            }
+          }
+          const combinedBody = entries
+            .map((entry) => entry.body)
+            .filter(Boolean)
+            .join("\n");
+          const combinedMessage: WebInboundMessage = {
+            ...last,
+            body: combinedBody,
+            mentions: mentioned.size > 0 ? Array.from(mentioned) : undefined,
+            mentionedJids: mentioned.size > 0 ? Array.from(mentioned) : undefined,
+            isBatched: true,
+          };
+          await options.onMessage(combinedMessage);
+          await finalizeInboundDedupe(entries);
+        } catch (error) {
+          await finalizeInboundDedupe(entries, error);
+          throw error;
+        }
+      } finally {
         for (const entry of entries) {
-          for (const jid of entry.mentions ?? entry.mentionedJids ?? []) {
-            mentioned.add(jid);
+          if (entry.debounceKey) {
+            pendingDebounceKeys.delete(entry.debounceKey);
           }
         }
-        const combinedBody = entries
-          .map((entry) => entry.body)
-          .filter(Boolean)
-          .join("\n");
-        const combinedMessage: WebInboundMessage = {
-          ...last,
-          body: combinedBody,
-          mentions: mentioned.size > 0 ? Array.from(mentioned) : undefined,
-          mentionedJids: mentioned.size > 0 ? Array.from(mentioned) : undefined,
-          isBatched: true,
-        };
-        await options.onMessage(combinedMessage);
-        await finalizeInboundDedupe(entries);
-      } catch (error) {
-        await finalizeInboundDedupe(entries, error);
-        throw error;
+        activeInboundFlushes.delete(flushTask);
+        finishFlush();
       }
     },
     onError: (err) => {
@@ -783,6 +806,13 @@ export async function attachWebInboxToSocket(
       mediaFileName: enriched.mediaFileName,
       dedupeKey: inbound.id ? `${options.accountId}:${inbound.remoteJid}:${inbound.id}` : undefined,
     };
+    const debounceKey = buildInboundDebounceKey(inboundMessage);
+    if (debounceKey) {
+      inboundMessage.debounceKey = debounceKey;
+      if (inboundDebounceMs > 0 && shouldDebounceInboundMessage(inboundMessage)) {
+        pendingDebounceKeys.add(debounceKey);
+      }
+    }
     if (inboundMessage.id) {
       cacheInboundMessageMeta(inboundMessage.accountId, inboundMessage.chatId, inboundMessage.id, {
         participant: inboundMessage.senderJid,
@@ -804,6 +834,7 @@ export async function attachWebInboxToSocket(
     }
   };
 
+  const pendingMessageHandlers = new Set<Promise<void>>();
   const handleMessagesUpsert = async (upsert: { type?: string; messages?: Array<WAMessage> }) => {
     if (upsert.type !== "notify" && upsert.type !== "append") {
       return;
@@ -841,6 +872,62 @@ export async function attachWebInboxToSocket(
       await enqueueInboundMessage(msg, inbound, enriched);
     }
   };
+  const handleMessagesUpsertEvent = (upsert: { type?: string; messages?: Array<WAMessage> }) => {
+    const task = handleMessagesUpsert(upsert).catch((err) => {
+      inboundLogger.error({ error: String(err) }, "messages.upsert handler error");
+      inboundConsoleLog.error(`Messages upsert handler error: ${String(err)}`);
+    });
+    pendingMessageHandlers.add(task);
+    void task.finally(() => {
+      pendingMessageHandlers.delete(task);
+    });
+  };
+  const waitForPendingMessageHandlers = async () => {
+    while (pendingMessageHandlers.size > 0) {
+      await Promise.all(Array.from(pendingMessageHandlers));
+    }
+  };
+  const drainDebouncedInboundMessages = async () => {
+    while (pendingDebounceKeys.size > 0 || activeInboundFlushes.size > 0) {
+      const debounceKeys = Array.from(pendingDebounceKeys);
+      if (debounceKeys.length > 0) {
+        await Promise.all(debounceKeys.map((key) => debouncer.flushKey(key)));
+      }
+
+      const flushes = Array.from(activeInboundFlushes);
+      if (flushes.length > 0) {
+        await Promise.allSettled(flushes);
+      }
+
+      await Promise.resolve();
+    }
+  };
+  const drainInboundBeforeSocketClose = async () => {
+    await waitForPendingMessageHandlers();
+    await drainDebouncedInboundMessages();
+  };
+  const drainInboundBeforeSocketCloseWithTimeout = async () => {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    try {
+      await Promise.race([
+        drainInboundBeforeSocketClose(),
+        new Promise<void>((_, reject) => {
+          timeout = setTimeout(() => {
+            reject(
+              new Error(
+                `Timed out draining WhatsApp inbound debounce after ${INBOUND_CLOSE_DRAIN_TIMEOUT_MS}ms`,
+              ),
+            );
+          }, INBOUND_CLOSE_DRAIN_TIMEOUT_MS);
+          timeout.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+  };
   const handleConnectionUpdate = (update: Partial<import("baileys").ConnectionState>) => {
     try {
       if (update.connection === "close") {
@@ -866,7 +953,7 @@ export async function attachWebInboxToSocket(
       removeListener?: (event: string, listener: (...args: unknown[]) => void) => void;
     },
     "messages.upsert",
-    handleMessagesUpsert as unknown as (...args: unknown[]) => void,
+    handleMessagesUpsertEvent as unknown as (...args: unknown[]) => void,
   );
   const detachConnectionUpdate = attachEmitterListener(
     sock.ev as unknown as {
@@ -930,6 +1017,11 @@ export async function attachWebInboxToSocket(
       try {
         detachMessagesUpsert();
         detachConnectionUpdate();
+        await drainInboundBeforeSocketCloseWithTimeout();
+      } catch (err) {
+        logWhatsAppVerbose(options.verbose, `Inbound close drain failed: ${String(err)}`);
+      }
+      try {
         closeInboundMonitorSocket(sock);
       } catch (err) {
         logWhatsAppVerbose(options.verbose, `Socket close failed: ${String(err)}`);

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -459,6 +459,112 @@ describe("web monitor inbox", () => {
     }
   });
 
+  it("lets a drained debounced inbound reply before closing the socket", async () => {
+    vi.useFakeTimers();
+    try {
+      const onMessage = vi.fn(async (msg) => {
+        await msg.reply("pong");
+        await msg.sendMedia({ text: "media" });
+      });
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+      });
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-close-reply-1"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "first",
+          timestamp: 1_700_000_000,
+          pushName: "Tester",
+        }),
+      );
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-close-reply-2"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "second",
+          timestamp: 1_700_000_001,
+          pushName: "Tester",
+        }),
+      );
+
+      await listener.close();
+
+      expect(onMessage).toHaveBeenCalledTimes(1);
+      expect(inboundMessage(onMessage).body).toBe("first\nsecond");
+      expect(sock.sendMessage).toHaveBeenNthCalledWith(1, "999@s.whatsapp.net", {
+        text: "pong",
+      });
+      expect(sock.sendMessage).toHaveBeenNthCalledWith(2, "999@s.whatsapp.net", {
+        text: "media",
+      });
+      expect(sock.end).toHaveBeenCalledTimes(1);
+      expect(sock.sendMessage.mock.invocationCallOrder.at(-1)).toBeLessThan(
+        sock.end.mock.invocationCallOrder.at(0),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for in-flight inbound handlers before draining on close", async () => {
+    vi.useFakeTimers();
+    try {
+      const onMessage = vi.fn(async (msg) => {
+        await msg.reply("pong");
+      });
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+      });
+      let releaseRead: (() => void) | undefined;
+      const readGate = new Promise<void>((resolve) => {
+        releaseRead = resolve;
+      });
+      const readStarted = new Promise<void>((resolve) => {
+        sock.readMessages.mockImplementationOnce(async () => {
+          resolve();
+          await readGate;
+        });
+      });
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-close-inflight"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "first",
+          timestamp: 1_700_000_000,
+          pushName: "Tester",
+        }),
+      );
+
+      await readStarted;
+      const closePromise = listener.close();
+      await Promise.resolve();
+
+      expect(sock.end).not.toHaveBeenCalled();
+
+      if (!releaseRead) {
+        throw new Error("Expected read receipt release callback to be initialized");
+      }
+      releaseRead();
+      await closePromise;
+
+      expect(onMessage).toHaveBeenCalledTimes(1);
+      expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
+        text: "pong",
+      });
+      expect(sock.end).toHaveBeenCalledTimes(1);
+      expect(sock.sendMessage.mock.invocationCallOrder.at(0)).toBeLessThan(
+        sock.end.mock.invocationCallOrder.at(0),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("retries timed-out sends on the same socket without clearing the socket ref", async () => {
     const onMessage = vi.fn(async () => undefined);
     const socketRef = createSocketRef();


### PR DESCRIPTION
## Summary

WhatsApp batches rapid inbound messages through a debounce window. When `close()` starts while a batch is still pending, OpenClaw already has those messages in memory, but the socket can be closed before the batch reaches the message handler. That means user code that replies from the debounced inbound message may run too late to use the still-open socket.

This PR keeps the fix scoped to the WhatsApp listener:

- tracks in-flight `messages.upsert` handlers so close waits until already-received inbound work has reached the debouncer
- tracks pending WhatsApp debounce keys and flushes them with the existing `flushKey()` API before closing the socket
- waits for any active inbound flush to finish before calling the socket close routine
- bounds close-time draining with a timeout so shutdown cannot hang forever

The regression coverage proves that debounced inbound `reply()` and `sendMedia()` calls run before `sock.end()`, and that close waits for an in-flight inbound handler before draining.

## Verification

- `pnpm test extensions/whatsapp/src/monitor-inbox.behavior.test.ts`
- `pnpm check:changed`
- `git diff --check`
