### PR TITLE
fix(agents): drain pending log writes before creating second relay for same streamLogPath

### DIFF
--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -6,9 +6,20 @@ const requestHeartbeatMock = vi.fn();
 const readAcpSessionEntryMock = vi.fn();
 const resolveSessionFilePathMock = vi.fn();
 const resolveSessionFilePathOptionsMock = vi.fn();
+const mkdirMock = vi.fn();
+const appendRegularFileMock = vi.fn();
 
 vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+}));
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return { ...actual, mkdir: (...args: unknown[]) => mkdirMock(...args) };
+});
+
+vi.mock("../infra/regular-file.js", () => ({
+  appendRegularFile: (...args: unknown[]) => appendRegularFileMock(...args),
 }));
 
 vi.mock("../infra/heartbeat-wake.js", async () => {
@@ -89,6 +100,10 @@ describe("startAcpSpawnParentStreamRelay", () => {
     resolveSessionFilePathMock.mockReset();
     resolveSessionFilePathOptionsMock.mockReset();
     resolveSessionFilePathOptionsMock.mockImplementation((value: unknown) => value);
+    mkdirMock.mockReset();
+    mkdirMock.mockResolvedValue(undefined);
+    appendRegularFileMock.mockReset();
+    appendRegularFileMock.mockResolvedValue(undefined);
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-04T01:00:00.000Z"));
   });
@@ -478,5 +493,63 @@ describe("startAcpSpawnParentStreamRelay", () => {
     expect(sessionId).toBe("sess-123");
     expect(entry.sessionId).toBe("sess-123");
     expect(options.storePath).toBe("/tmp/openclaw/agents/codex/sessions/sessions.json");
+  });
+
+  describe("drain", () => {
+    it("resolves immediately when no log writes are pending", async () => {
+      const relay = startAcpSpawnParentStreamRelay({
+        runId: "drain-idle-run",
+        parentSessionKey: "agent:main:main",
+        childSessionKey: "agent:codex:acp:child-drain-idle",
+        agentId: "codex",
+        logPath: "/tmp/drain-idle-test.jsonl",
+      });
+
+      await expect(relay.drain()).resolves.toBeUndefined();
+      relay.dispose();
+    });
+
+    it("does not resolve until pending appendRegularFile calls complete", async () => {
+      let resolveWrite!: () => void;
+      const writeBlock = new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      });
+      appendRegularFileMock.mockReturnValueOnce(writeBlock);
+
+      const relay = startAcpSpawnParentStreamRelay({
+        runId: "drain-block-run",
+        parentSessionKey: "agent:main:main",
+        childSessionKey: "agent:codex:acp:child-drain-block",
+        agentId: "codex",
+        logPath: "/tmp/drain-block-test.jsonl",
+      });
+
+      emitAgentEvent({
+        runId: "drain-block-run",
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 0, endedAt: 100 },
+      });
+
+      // 4 hops: queueMicrotask → .then callback → await mkdir → await appendRegularFile
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+
+      // Guard: appendRegularFile must be in-flight before we test drain ordering.
+      expect(appendRegularFileMock).toHaveBeenCalledOnce();
+
+      let drained = false;
+      const drainDone = relay.drain().then(() => {
+        drained = true;
+      });
+
+      // write chain still pending — drain must not resolve before it settles
+      await Promise.resolve();
+      expect(drained).toBe(false);
+
+      resolveWrite();
+      await drainDone;
+      expect(drained).toBe(true);
+
+      relay.dispose();
+    });
   });
 });

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -531,7 +531,9 @@ describe("startAcpSpawnParentStreamRelay", () => {
       });
 
       // 4 hops: queueMicrotask → .then callback → await mkdir → await appendRegularFile
-      for (let i = 0; i < 5; i++) await Promise.resolve();
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+      }
 
       // Guard: appendRegularFile must be in-flight before we test drain ordering.
       expect(appendRegularFileMock).toHaveBeenCalledOnce();

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -104,6 +104,7 @@ export function startAcpSpawnParentStreamRelay(params: {
   if (!runId || !parentSessionKey) {
     return {
       dispose: () => {},
+      drain: () => Promise.resolve(),
       notifyStarted: () => {},
     };
   }
@@ -151,6 +152,10 @@ export function startAcpSpawnParentStreamRelay(params: {
       .catch(() => {
         // Best-effort diagnostics; never break relay flow.
       });
+  };
+  const drain = async () => {
+    flushLogBuffer();
+    await logWriteChain;
   };
   const scheduleLogFlush = () => {
     if (!logPath || logFlushScheduled) {
@@ -432,11 +437,13 @@ export function startAcpSpawnParentStreamRelay(params: {
 
   return {
     dispose,
+    drain,
     notifyStarted: emitStartNotice,
   };
 }
 
 export type AcpSpawnParentRelayHandle = {
   dispose: () => void;
+  drain: () => Promise<void>;
   notifyStarted: () => void;
 };

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1451,6 +1451,8 @@ export async function spawnAcpDirect(
 
   if (effectiveStreamToParent && parentSessionKey) {
     if (parentRelay && childRunId !== childIdem) {
+      // Drain pending log writes before creating a second relay with the same logPath.
+      await parentRelay.drain();
       parentRelay.dispose();
       // Defensive fallback if gateway returns a runId that differs from idempotency key.
       parentRelay = startAcpSpawnParentStreamRelay({


### PR DESCRIPTION
## Summary

- Problem: When the gateway returns a `runId` that differs from the idempotency key, `acp-spawn.ts` disposes the first relay and immediately constructs a second one with the same `streamLogPath`. `dispose()` calls `flushLogBuffer()` fire-and-forget — the first relay's `logWriteChain` may still be resolving `appendRegularFile` when the second relay begins its own chain. Two independent chains append to the same file without coordination.
- Why it matters: The `.catch(() => { // Best-effort diagnostics })` at `acp-spawn-parent-stream.ts:152` handles fs-write errors, not ordering between two concurrent `logWriteChain` instances on the same path.
- What changed: Added `drain(): Promise<void>` to `AcpSpawnParentRelayHandle`. It queues a final buffer flush and awaits `logWriteChain` to settle. The relay-reassignment branch in `acp-spawn.ts` now `await parentRelay.drain()` before `parentRelay.dispose()` and the second relay construction. The no-op guard stub also gets `drain: () => Promise.resolve()`.
- What did NOT change: `dispose()` signature and all three internal call sites (`:319`, `:403`, `:417`) are untouched. `drain` is purely additive to the handle type.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Real behavior proof

- Behavior addressed: First relay's `logWriteChain` racing with second relay's chain on the same `streamLogPath` in the defensive fallback branch of `acp-spawn.ts`.
- Real environment tested: The race occurs only when the gateway returns a `runId !== idempotencyKey` — a defensive fallback path not reliably triggerable in a standard environment. The unit test directly exercises the Promise-ordering contract the bug exploits: `appendRegularFile` is mocked to block, `drain()` is verified to not resolve until the mock unblocks.
- Exact steps or command run after fix: `pnpm test -- src/agents/acp-spawn-parent-stream.test.ts` → 12/12 pass.
- Evidence after fix:
```
✓ startAcpSpawnParentStreamRelay > drain > resolves immediately when no log writes are pending 2ms
✓ startAcpSpawnParentStreamRelay > drain > does not resolve until pending appendRegularFile calls complete 1ms

Test Files  1 passed (1)
      Tests  12 passed (12)
   Duration  1.97s
```
- Observed result after fix: Both drain() tests pass. `drain()` returns when `logWriteChain` is already settled and blocks until the mocked `appendRegularFile` call resolves. The `expect(appendRegularFileMock).toHaveBeenCalledOnce()` guard confirms the mock is in-flight before ordering is tested.
- What was not tested: A live environment with a gateway returning a mismatched `runId`. The race window requires a specific unexpected gateway response to trigger.

## Root Cause

- Root cause: `dispose()` calls `flushLogBuffer()` fire-and-forget (returns void). The relay-reassignment site in `acp-spawn.ts` did not wait for the write chain to settle before constructing a replacement relay with the same log path.
- Missing detection / guardrail: No test covered the path where `parentRelay.dispose()` is followed immediately by `startAcpSpawnParentStreamRelay({..., logPath: streamLogPath})` with an in-flight write chain.
- Contributing context: The `.catch()` is intentional best-effort for error tolerance — preserved.

## Regression Test Plan

- Coverage level: Unit test
- Target test: `src/agents/acp-spawn-parent-stream.test.ts`, `describe("drain")`
- Scenario 1: `drain()` resolves immediately when `logWriteChain = Promise.resolve()` (no pending writes).
- Scenario 2: `drain()` does not resolve until a controlled `appendRegularFile` mock settles.
- Why this is the smallest reliable guardrail: The race is not reliably reproducible in a live environment without instrumentation. The tests directly exercise the Promise-ordering contract.
- If no new test is added, why not: Tests are added.

## User-visible / Behavior Changes

None — diagnostics log path is internal tooling.

## Diagram

Before:
parentRelay.dispose() -> [flushLogBuffer fire-and-forget]
parentRelay = new relay(logPath) -> [second chain starts immediately]
=> two logWriteChain instances writing to the same file concurrently

After:
await parentRelay.drain() -> [flushLogBuffer + await logWriteChain]
parentRelay.dispose()
parentRelay = new relay(logPath) -> [starts only after first chain settles]

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] Failing test/log before + passing after: two new tests in `acp-spawn-parent-stream.test.ts`, 12/12 pass.

## Human Verification

- Verified scenarios: Source trace confirmed against `origin/main` HEAD `3eaefda824` twice (author + Codex adversarial pass); all 3 internal `dispose()` callers at `:319`, `:403`, `:417` confirmed as not creating a second relay; guard assertion verifies `appendRegularFile` is in-flight before drain ordering is tested; no-op guard stub updated to satisfy updated type.
- Edge cases checked: `drain()` idle (resolves immediately); double-flush after `drain()` + `dispose()` is a no-op.
- What you did not verify: Live environment with mismatched `runId`.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — `drain` is additive.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `await parentRelay.drain()` adds sequential delay at the reassignment site. Normal path (`childRunId === childIdem`) never enters this branch.
  - Mitigation: Delay bounded by a single `appendRegularFile` call — same latency that was already occurring silently, now sequential.
- Risk: Events arriving between `drain()` completion and `dispose()` are still flushed fire-and-forget (existing behavior, not introduced here).
  - Mitigation: Window is two synchronous operations in the same frame — sub-microsecond. Documented for future reference.
