### PR TITLE
fix(providers): discover wildcard self-hosted endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Limit hook CLI tool authority [AI]. (#81065) Thanks @pgondhi987.
 - Require admin scope for node device token management [AI]. (#81067) Thanks @pgondhi987.
+- vLLM/SGLang: keep provider wildcard discovery dynamic for explicit self-hosted endpoints, so `agents.defaults.models["provider/*"]` can query a configured `models.providers.<provider>.baseUrl` instead of forcing manual model lists. Fixes #81218.
 - Restrict chat sender allowlist matching [AI]. (#80898) Thanks @pgondhi987.
 - Sessions: redact persisted tool result detail metadata before writing transcripts so diagnostic secrets do not survive tool output redaction. (#80444) Thanks @nimbleenigma.
 - Codex migration: make Enter activate the highlighted checkbox row before continuing, so `Skip for now` and bulk-selection rows work even when planned items start preselected.

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -160,6 +160,9 @@ With that policy, `/model`, `/models`, and model pickers show the discovered
 catalog for those providers only. New models from the selected providers can
 appear without editing the allowlist. Exact `provider/model` entries can be mixed
 with `provider/*` entries when you need one specific model from another provider.
+For self-hosted providers such as vLLM and SGLang, `provider/*` also keeps
+discovery dynamic when `models.providers.<provider>` is present only to set
+transport details such as `baseUrl`.
 
 Example allowlist config:
 

--- a/docs/providers/sglang.md
+++ b/docs/providers/sglang.md
@@ -6,7 +6,11 @@ read_when:
 title: "SGLang"
 ---
 
-SGLang serves open-weight models via an OpenAI-compatible HTTP API. OpenClaw connects to SGLang using the `openai-completions` provider family with auto-discovery of available models.
+SGLang serves open-weight models via an OpenAI-compatible HTTP API. OpenClaw
+connects to SGLang using the `openai-completions` provider family with
+auto-discovery of available models. Use `agents.defaults.models["sglang/*"]`
+when you want discovery from a configured SGLang endpoint instead of manually
+listing every model.
 
 | Property                  | Value                                                        |
 | ------------------------- | ------------------------------------------------------------ |
@@ -20,7 +24,8 @@ SGLang serves open-weight models via an OpenAI-compatible HTTP API. OpenClaw con
 | Streaming usage           | Yes (`supportsStreamingUsage: true`)                         |
 | Pricing                   | Marked external-free (`modelPricing.external: false`)        |
 
-OpenClaw also **auto-discovers** available models from SGLang when you opt in with `SGLANG_API_KEY` and you do not define an explicit `models.providers.sglang` entry — see [Model discovery (implicit provider)](#model-discovery-implicit-provider) below.
+OpenClaw also **auto-discovers** available models from SGLang when you opt in
+with `SGLANG_API_KEY`; see [Model discovery](#model-discovery) below.
 
 ## Getting started
 
@@ -61,7 +66,7 @@ OpenClaw also **auto-discovers** available models from SGLang when you opt in wi
   </Step>
 </Steps>
 
-## Model discovery (implicit provider)
+## Model discovery
 
 When `SGLANG_API_KEY` is set (or an auth profile exists) and you **do not**
 define `models.providers.sglang`, OpenClaw will query:
@@ -71,8 +76,10 @@ define `models.providers.sglang`, OpenClaw will query:
 and convert the returned IDs into model entries.
 
 <Note>
-If you set `models.providers.sglang` explicitly, auto-discovery is skipped and
-you must define models manually.
+If you set `models.providers.sglang` explicitly, OpenClaw treats that provider
+as manual by default. Add `agents.defaults.models["sglang/*"]` when the explicit
+entry is only transport config, such as a custom `baseUrl`, and you still want
+model discovery from that endpoint.
 </Note>
 
 ## Explicit configuration (manual models)
@@ -82,6 +89,31 @@ Use explicit config when:
 - SGLang runs on a different host/port.
 - You want to pin `contextWindow`/`maxTokens` values.
 - Your server requires a real API key (or you want to control headers).
+
+To keep dynamic discovery with an explicit endpoint, configure the provider
+transport and add the provider wildcard to the agent model allowlist:
+
+```json5
+{
+  agents: {
+    defaults: {
+      models: {
+        "sglang/*": {},
+      },
+    },
+  },
+  models: {
+    providers: {
+      sglang: {
+        baseUrl: "http://sglang-router.example/v1",
+        apiKey: "${SGLANG_API_KEY}",
+        api: "openai-completions",
+        models: [],
+      },
+    },
+  },
+}
+```
 
 ```json5
 {

--- a/docs/providers/vllm.md
+++ b/docs/providers/vllm.md
@@ -8,7 +8,10 @@ title: "vLLM"
 
 vLLM can serve open-source (and some custom) models via an **OpenAI-compatible** HTTP API. OpenClaw connects to vLLM using the `openai-completions` API.
 
-OpenClaw can also **auto-discover** available models from vLLM when you opt in with `VLLM_API_KEY` (any value works if your server does not enforce auth) and you do not define an explicit `models.providers.vllm` entry.
+OpenClaw can also **auto-discover** available models from vLLM when you opt in
+with `VLLM_API_KEY` (any value works if your server does not enforce auth). Use
+`agents.defaults.models["vllm/*"]` when you want discovery from a configured
+vLLM endpoint instead of manually listing every model.
 
 OpenClaw treats `vllm` as a local OpenAI-compatible provider that supports
 streamed usage accounting, so status/context token counts can update from
@@ -61,9 +64,10 @@ streamed usage accounting, so status/context token counts can update from
   </Step>
 </Steps>
 
-## Model discovery (implicit provider)
+## Model discovery
 
-When `VLLM_API_KEY` is set (or an auth profile exists) and you **do not** define `models.providers.vllm`, OpenClaw queries:
+When `VLLM_API_KEY` is set (or an auth profile exists) and you **do not** define
+`models.providers.vllm`, OpenClaw queries:
 
 ```
 GET http://127.0.0.1:8000/v1/models
@@ -72,7 +76,10 @@ GET http://127.0.0.1:8000/v1/models
 and converts the returned IDs into model entries.
 
 <Note>
-If you set `models.providers.vllm` explicitly, auto-discovery is skipped and you must define models manually.
+If you set `models.providers.vllm` explicitly, OpenClaw treats that provider as
+manual by default. Add `agents.defaults.models["vllm/*"]` when the explicit entry
+is only transport config, such as a custom `baseUrl`, and you still want model
+discovery from that endpoint.
 </Note>
 
 ## Explicit configuration (manual models)
@@ -83,6 +90,31 @@ Use explicit config when:
 - You want to pin `contextWindow` or `maxTokens` values
 - Your server requires a real API key (or you want to control headers)
 - You connect to a trusted loopback, LAN, or Tailscale vLLM endpoint
+
+To keep dynamic discovery with an explicit endpoint, configure the provider
+transport and add the provider wildcard to the agent model allowlist:
+
+```json5
+{
+  agents: {
+    defaults: {
+      models: {
+        "vllm/*": {},
+      },
+    },
+  },
+  models: {
+    providers: {
+      vllm: {
+        baseUrl: "http://vllm-router.example/v1",
+        apiKey: "${VLLM_API_KEY}",
+        api: "openai-completions",
+        models: [],
+      },
+    },
+  },
+}
+```
 
 ```json5
 {
@@ -331,7 +363,10 @@ Use explicit config when:
   </Accordion>
 
   <Accordion title="No models discovered">
-    Auto-discovery requires `VLLM_API_KEY` to be set **and** no explicit `models.providers.vllm` config entry. If you have defined the provider manually, OpenClaw skips discovery and uses only your declared models.
+    Auto-discovery requires `VLLM_API_KEY` to be set. If you have defined
+    `models.providers.vllm` manually, OpenClaw uses only your declared models
+    unless `agents.defaults.models` contains `"vllm/*"` to keep that provider
+    dynamic.
   </Accordion>
 
   <Accordion title="Tools render as raw text">

--- a/src/plugins/provider-self-hosted-setup.test.ts
+++ b/src/plugins/provider-self-hosted-setup.test.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   configureOpenAICompatibleSelfHostedProviderNonInteractive,
   discoverOpenAICompatibleLocalModels,
+  discoverOpenAICompatibleSelfHostedProvider,
 } from "./provider-self-hosted-setup.js";
-import type { ProviderAuthMethodNonInteractiveContext } from "./types.js";
+import type { ProviderAuthMethodNonInteractiveContext, ProviderDiscoveryContext } from "./types.js";
 
 const { fetchWithSsrFGuardMock, upsertAuthProfileWithLock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -67,6 +68,29 @@ function createContext(params: {
 function readPrimaryModel(config: Awaited<ReturnType<typeof configureSelfHostedTestProvider>>) {
   const model = config?.agents?.defaults?.model;
   return model && typeof model === "object" ? model.primary : undefined;
+}
+
+function createDiscoveryContext(params: {
+  config: ProviderDiscoveryContext["config"];
+  apiKey?: string;
+  discoveryApiKey?: string;
+}): ProviderDiscoveryContext {
+  const apiKey = params.apiKey ?? "SELF_HOSTED_API_KEY";
+  const discoveryApiKey = params.discoveryApiKey ?? "self-hosted-test-key";
+  return {
+    config: params.config,
+    env: {},
+    resolveProviderApiKey: vi.fn(() => ({
+      apiKey,
+      discoveryApiKey,
+    })),
+    resolveProviderAuth: vi.fn(() => ({
+      apiKey,
+      discoveryApiKey,
+      mode: "api_key" as const,
+      source: "env" as const,
+    })),
+  };
 }
 
 async function configureSelfHostedTestProvider(params: {
@@ -393,6 +417,143 @@ describe("discoverOpenAICompatibleLocalModels", () => {
       timeoutMs: 5000,
     });
     expect(release).toHaveBeenCalledOnce();
+  });
+});
+
+describe("discoverOpenAICompatibleSelfHostedProvider", () => {
+  it("keeps explicit provider config manual when no provider wildcard is allowed", async () => {
+    const buildProvider = vi.fn(async () => ({ models: [{ id: "dynamic-model" }] }));
+    const ctx = createDiscoveryContext({
+      config: {
+        models: {
+          providers: {
+            vllm: {
+              baseUrl: "http://router.example/v1",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "vllm/manual-model": {},
+            },
+          },
+        },
+      },
+    });
+
+    await expect(
+      discoverOpenAICompatibleSelfHostedProvider({
+        ctx,
+        providerId: "vllm",
+        buildProvider,
+      }),
+    ).resolves.toBeNull();
+    expect(buildProvider).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { providerId: "vllm", apiKey: "VLLM_API_KEY", discoveryApiKey: "vllm-test-key" },
+    { providerId: "sglang", apiKey: "SGLANG_API_KEY", discoveryApiKey: "sglang-test-key" },
+  ])(
+    "discovers from an explicit $providerId endpoint when the provider wildcard is allowed",
+    async ({ providerId, apiKey, discoveryApiKey }) => {
+      const buildProvider = vi.fn(
+        async ({ apiKey, baseUrl }: { apiKey?: string; baseUrl?: string }) => ({
+          baseUrl,
+          api: "openai-completions",
+          models: [{ id: "dynamic-model" }],
+          discoveryApiKey: apiKey,
+        }),
+      );
+      const explicitBaseUrl = `http://${providerId}-router.example/v1`;
+      const ctx = createDiscoveryContext({
+        config: {
+          models: {
+            providers: {
+              [providerId]: {
+                baseUrl: explicitBaseUrl,
+                api: "openai-completions",
+                models: [],
+              },
+            },
+          },
+          agents: {
+            defaults: {
+              models: {
+                [`${providerId}/*`]: {},
+              },
+            },
+          },
+        },
+        apiKey,
+        discoveryApiKey,
+      });
+
+      await expect(
+        discoverOpenAICompatibleSelfHostedProvider({
+          ctx,
+          providerId,
+          buildProvider,
+        }),
+      ).resolves.toEqual({
+        provider: {
+          baseUrl: explicitBaseUrl,
+          api: "openai-completions",
+          models: [{ id: "dynamic-model" }],
+          discoveryApiKey,
+          apiKey,
+        },
+      });
+      expect(buildProvider).toHaveBeenCalledWith({
+        apiKey: discoveryApiKey,
+        baseUrl: explicitBaseUrl,
+      });
+    },
+  );
+
+  it("uses provider defaults when the wildcard has no explicit endpoint", async () => {
+    const buildProvider = vi.fn(
+      async ({ apiKey, baseUrl }: { apiKey?: string; baseUrl?: string }) => ({
+        baseUrl: baseUrl ?? "http://127.0.0.1:8000/v1",
+        api: "openai-completions",
+        models: [{ id: "dynamic-model" }],
+        discoveryApiKey: apiKey,
+      }),
+    );
+    const ctx = createDiscoveryContext({
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "vllm/*": {},
+            },
+          },
+        },
+      },
+    });
+
+    await expect(
+      discoverOpenAICompatibleSelfHostedProvider({
+        ctx,
+        providerId: "vllm",
+        buildProvider,
+      }),
+    ).resolves.toEqual({
+      provider: {
+        baseUrl: "http://127.0.0.1:8000/v1",
+        api: "openai-completions",
+        models: [{ id: "dynamic-model" }],
+        discoveryApiKey: "self-hosted-test-key",
+        apiKey: "SELF_HOSTED_API_KEY",
+      },
+    });
+    expect(buildProvider).toHaveBeenCalledWith({
+      apiKey: "self-hosted-test-key",
+      baseUrl: undefined,
+    });
   });
 });
 

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -1,5 +1,6 @@
 import type { ApiKeyCredential, AuthProfileCredential } from "../agents/auth-profiles/types.js";
 import { upsertAuthProfileWithLock } from "../agents/auth-profiles/upsert-with-lock.js";
+import { normalizeProviderId } from "../agents/provider-id.js";
 import {
   SELF_HOSTED_DEFAULT_CONTEXT_WINDOW,
   SELF_HOSTED_DEFAULT_COST,
@@ -395,9 +396,10 @@ export async function discoverOpenAICompatibleSelfHostedProvider<
 >(params: {
   ctx: ProviderDiscoveryContext;
   providerId: string;
-  buildProvider: (params: { apiKey?: string }) => Promise<T>;
+  buildProvider: (params: { apiKey?: string; baseUrl?: string }) => Promise<T>;
 }): Promise<{ provider: T & { apiKey: string } } | null> {
-  if (params.ctx.config.models?.providers?.[params.providerId]) {
+  const configuredProvider = params.ctx.config.models?.providers?.[params.providerId];
+  if (configuredProvider && !hasProviderWildcardModel(params.ctx.config, params.providerId)) {
     return null;
   }
   const { apiKey, discoveryApiKey } = params.ctx.resolveProviderApiKey(params.providerId);
@@ -406,10 +408,32 @@ export async function discoverOpenAICompatibleSelfHostedProvider<
   }
   return {
     provider: {
-      ...(await params.buildProvider({ apiKey: discoveryApiKey })),
+      ...(await params.buildProvider({
+        apiKey: discoveryApiKey,
+        baseUrl:
+          typeof configuredProvider?.baseUrl === "string" ? configuredProvider.baseUrl : undefined,
+      })),
       apiKey,
     },
   };
+}
+
+function hasProviderWildcardModel(config: OpenClawConfig, providerId: string): boolean {
+  const models = config.agents?.defaults?.models;
+  if (!models) {
+    return false;
+  }
+  const normalizedProvider = normalizeProviderId(providerId);
+  return Object.keys(models).some((key) => {
+    const slash = key.indexOf("/");
+    if (slash <= 0) {
+      return false;
+    }
+    return (
+      normalizeProviderId(key.slice(0, slash)) === normalizedProvider &&
+      key.slice(slash + 1) === "*"
+    );
+  });
 }
 
 function buildMissingNonInteractiveModelIdMessage(params: {


### PR DESCRIPTION
## Summary

Closes #81218.

Provider wildcard visibility should keep self-hosted providers dynamic, even when the provider has explicit transport config. This PR updates the shared vLLM/SGLang discovery helper so:

- exact `agents.defaults.models["provider/model"]` entries keep explicit `models.providers.<provider>` configs manual;
- `agents.defaults.models["provider/*"]` allows discovery to run from the configured provider endpoint;
- the explicit `models.providers.<provider>.baseUrl` is passed into the provider builder so discovery queries the intended router/server;
- vLLM, SGLang, and model-selection docs explain the wildcard + explicit endpoint pattern.

## Motivation

Self-hosted vLLM/SGLang deployments often need `models.providers.<provider>.baseUrl` for a router, Docker host, k8s service, or remote endpoint. Today that explicit provider entry disables discovery completely, even when `agents.defaults.models` says `vllm/*` or `sglang/*` should remain dynamic. Users then have to manually edit config each time the self-hosted endpoint advertises a new model.

The provider wildcard is already the OpenClaw model for "this provider is allowed, keep its catalog dynamic." This keeps that contract working for explicit self-hosted endpoints.

## What changed

- Updated `discoverOpenAICompatibleSelfHostedProvider` to distinguish exact manual model entries from provider wildcard entries.
- Passed configured `baseUrl` through to provider builders when wildcard discovery is enabled.
- Added focused regression coverage for:
  - explicit provider config without wildcard remains manual;
  - `vllm/*` discovers from the configured vLLM endpoint;
  - `sglang/*` discovers from the configured SGLang endpoint;
  - wildcard discovery without explicit endpoint still uses provider defaults.
- Updated vLLM, SGLang, and model-selection docs.

## Real behavior proof

- Behavior or issue addressed: `agents.defaults.models["vllm/*"]` and `agents.defaults.models["sglang/*"]` now keep discovery dynamic even when `models.providers.<provider>.baseUrl` is configured.
- Real environment tested: Windows 11 local OpenClaw source checkout at `C:\src\openclaw-core`, Node/pnpm dev workflow, branch based on current `origin/main`.
- Exact steps or command run after this patch: Started a local OpenAI-compatible HTTP server with `node --import tsx`, then called OpenClaw's shared self-hosted discovery helper for `vllm/*` and `sglang/*` against `http://127.0.0.1:<port>/v1/models`.
- Evidence after fix: copied live output from the local OpenAI-compatible catalog proof:

```text
vllm: proof-model-a
sglang: proof-model-a
requests: GET /v1/models Bearer vllm-discovery-key | GET /props Bearer vllm-discovery-key | GET /v1/models Bearer sglang-discovery-key | GET /props Bearer sglang-discovery-key
```

- Observed result after fix: The shared self-hosted discovery helper calls the provider builder with the configured `baseUrl` for `vllm/*` and `sglang/*`, while exact manual entries still return `null` and leave the declared provider models untouched. The local OpenAI-compatible proof confirms the configured endpoint is actually queried over HTTP for both providers.
- What was not tested: No full vLLM or SGLang process was started locally; the HTTP proof exercised their shared OpenAI-compatible `/v1/models` catalog contract at the OpenClaw discovery seam.

## Verification

```bash
pnpm test src/plugins/provider-self-hosted-setup.test.ts -- --reporter=verbose
pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/plugins/provider-self-hosted-setup.ts src/plugins/provider-self-hosted-setup.test.ts docs/providers/vllm.md docs/providers/sglang.md docs/concepts/models.md
pnpm check:changed
pnpm check:test-types
git diff --check
```

`pnpm format:docs:check` currently fails for me on Windows before checking docs with `TypeError: Cannot read properties of undefined (reading 'trim')` in `scripts/format-docs.mjs`; direct `oxfmt --check` over the touched docs passes.

## Risk

Low. The default/manual behavior is preserved unless the agent model allowlist contains an explicit `provider/*` wildcard. The change lives in the shared self-hosted discovery helper used by vLLM and SGLang.