### PR TITLE
feat(config): add allowFrom fallback transition foundation

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -748,6 +748,53 @@ checks that run before channel runtime loads. Bundled channels can also publish
 the same defaults through `package.json#openclaw.channel.commands` alongside
 their other package-owned channel catalog metadata.
 
+Channel packages can also publish `package.json#openclaw.channel.doctorCapabilities`
+for read-only doctor and transition checks. These fields are metadata, not user
+config. When a channel sets one fallback flag to `false`, `openclaw doctor --fix`
+infers the matching preservation copy from existing DM `allowFrom` entries to the
+canonical explicit allowlist.
+
+Valid fallback metadata fields are:
+
+| Field                                      | Values    |
+| ------------------------------------------ | --------- |
+| `groupAllowFromFallbackToAllowFrom`        | `boolean` |
+| `groupOwnerAllowFromFallbackToAllowFrom`   | `boolean` |
+| `commandGroupAllowFromFallbackToAllowFrom` | `boolean` |
+| `commandAllowFromFallbackToAllowFrom`      | `boolean` |
+| `elevatedAllowFromFallbackToAllowFrom`     | `boolean` |
+
+### Disable fallback in a channel PR
+
+Channel follow-up PRs should disable one fallback family only after the channel
+runtime consumes the matching explicit allowlist. The metadata and runtime flag
+must move together: setting only metadata makes doctor guidance wrong, and
+setting only runtime flags can remove access before `openclaw doctor --fix` can
+preserve it.
+
+Use this table as the channel PR checklist:
+
+| Fallback being removed                                                        | Runtime change in the channel                                                                                                                                            | Doctor capability metadata                        | Doctor copy target                      |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- | --------------------------------------- |
+| Normal group sender access falls back from group allowlists to DM `allowFrom` | Pass `policy.groupAllowFromFallbackToAllowFrom: false` to the shared ingress resolver and pass the explicit group sender allowlist the channel will use.                 | `groupAllowFromFallbackToAllowFrom: false`        | `channels.<id>.groupAllowFrom`          |
+| Group command senders fall back to DM or group sender allowlists              | Pass `command.commandGroupAllowFromFallbackToAllowFrom: false` and pass `command.commandGroupAllowFrom` when the channel has a command-specific sender allowlist.        | `commandGroupAllowFromFallbackToAllowFrom: false` | `channels.<id>.commandGroupAllowFrom`   |
+| Group command owners fall back to DM `allowFrom`                              | Pass `command.groupOwnerAllowFromFallbackToAllowFrom: false` and pass `command.groupOwnerAllowFrom` when the channel has a command-owner allowlist.                      | `groupOwnerAllowFromFallbackToAllowFrom: false`   | `channels.<id>.groupOwnerAllowFrom`     |
+| Text command authorization falls back to channel `allowFrom`                  | Make command authorization use explicit `commands.allowFrom` entries for this provider and keep the prepared doctor capability available to the auto-reply command path. | `commandAllowFromFallbackToAllowFrom: false`      | `commands.allowFrom.<channel-id>`       |
+| Elevated authorization falls back to channel `allowFrom`                      | Stop using the channel elevated `allowFromFallback` hook, or let shared elevated auth skip it through the prepared doctor capability.                                    | `elevatedAllowFromFallbackToAllowFrom: false`     | `tools.elevated.allowFrom.<channel-id>` |
+
+Before setting any fallback flag to `false`, verify that:
+
+- the target config key is accepted by that channel schema
+- the channel runtime reads that key on the relevant ingress or command path
+- `openclaw doctor --fix` can preserve existing access without broadening
+  account scope
+- synthetic open-DM wildcards are not being used as the source of the migration
+
+Command-only migrations must target command-specific allowlists:
+`commandGroupAllowFrom`, `groupOwnerAllowFrom`, or provider maps under
+`commands.allowFrom` and `tools.elevated.allowFrom`. Do not use normal group
+sender targets to preserve command authorization fallback.
+
 ```json
 {
   "channelConfigs": {

--- a/docs/plugins/sdk-channel-ingress.md
+++ b/docs/plugins/sdk-channel-ingress.md
@@ -58,6 +58,44 @@ Do not precompute effective allowlists, command owners, or command groups. The
 resolver derives them from raw allowlists, store callbacks, route descriptors,
 access groups, policy, and conversation kind.
 
+`allowFrom` is the direct-message allowlist. For group conversations, pass
+explicit non-DM targets when the channel has them:
+
+- `groupAllowFrom` controls normal group sender authorization.
+- `command.commandGroupAllowFrom` controls group command senders.
+- `command.groupOwnerAllowFrom` controls group command owners.
+
+`groupAllowFromFallbackToAllowFrom` controls only the shared normal group
+sender fallback. `command.commandGroupAllowFromFallbackToAllowFrom` is a
+separate command-group override; when omitted, it inherits the normal group
+fallback flag. `command.groupOwnerAllowFromFallbackToAllowFrom` controls the
+legacy group command-owner fallback and defaults to enabled for compatibility.
+
+When a channel disables one of these fallbacks, update the runtime resolver
+input and the doctor capability metadata in the same channel PR. Runtime config
+loading does not perform this repair; `openclaw doctor --fix` is the only
+preservation-copy path.
+
+Use these runtime flags before declaring the matching manifest metadata:
+
+| Fallback family               | Runtime input to set                                      | Required explicit input                                                                                              |
+| ----------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Normal group sender fallback  | `policy.groupAllowFromFallbackToAllowFrom: false`         | `groupAllowFrom` or a route sender allowlist that replaces the legacy fallback.                                      |
+| Group command-sender fallback | `command.commandGroupAllowFromFallbackToAllowFrom: false` | `command.commandGroupAllowFrom`, unless command authorization is intentionally covered by explicit `groupAllowFrom`. |
+| Group command-owner fallback  | `command.groupOwnerAllowFromFallbackToAllowFrom: false`   | `command.groupOwnerAllowFrom`, or an intentional no-owner mode such as the legacy `"none"` sentinel.                 |
+
+Provider-wide command fallback and elevated fallback are not ingress resolver
+inputs. Those paths read prepared channel capability metadata, so the channel PR
+must ensure the command or elevated authorization path already has an explicit
+target before declaring the fallback disabled.
+
+After the runtime consumes the explicit target, set the corresponding
+`package.json#openclaw.channel.doctorCapabilities` fields described in
+[Plugin manifest](/plugins/manifest#disable-fallback-in-a-channel-pr). Doctor
+infers the copy target from the disabled fallback flag, so channel PRs should
+only set the fallback metadata after the target config key is accepted by that
+channel schema and read by that channel runtime.
+
 ## Result
 
 Bundled plugins should consume modern projections directly:

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -346,6 +346,10 @@ function resolveCommandsAllowFromList(params: {
   });
 }
 
+function allowsCommandAllowFromFallback(plugin?: ChannelPlugin): boolean {
+  return plugin?.doctor?.commandAllowFromFallbackToAllowFrom !== false;
+}
+
 function resolveOwnerCandidatesForCommands(params: {
   plugin?: ChannelPlugin;
   cfg: OpenClawConfig;
@@ -653,6 +657,8 @@ export function resolveCommandAuthorization(params: {
     accountId: ctx.AccountId,
     providerId,
   });
+  const effectiveCommandsAllowFromList =
+    commandsAllowFromList ?? (allowsCommandAllowFromFallback(plugin) ? null : []);
 
   const resolvedAllowFrom = buildProviderAllowFromResolution({
     plugin,
@@ -719,7 +725,7 @@ export function resolveCommandAuthorization(params: {
     nativeCommandAuthorized,
     isOwnerForCommands,
     senderCandidates,
-    commandsAllowFromList,
+    commandsAllowFromList: effectiveCommandsAllowFromList,
     providerResolutionError,
     commandsAllowFromConfigured,
   });

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -628,6 +628,29 @@ describe("resolveCommandAuthorization", () => {
       expect(auth.isAuthorizedSender).toBe(true);
     });
 
+    it("does not fall back to channel allowFrom when command fallback is disabled", () => {
+      const entry = createAllowFromPlugin("nofallback", () => ["user:1"]);
+      registerAllowFromPlugins({
+        ...entry,
+        plugin: {
+          ...entry.plugin,
+          doctor: { commandAllowFromFallbackToAllowFrom: false },
+        },
+      });
+      const auth = resolveCommandAuthorization({
+        ctx: {
+          Provider: "nofallback",
+          Surface: "nofallback",
+          From: "nofallback:user:1",
+          SenderId: "user:1",
+        } as MsgContext,
+        cfg: { channels: { nofallback: { allowFrom: ["user:1"] } } } as OpenClawConfig,
+        commandAuthorized: true,
+      });
+
+      expect(auth.isAuthorizedSender).toBe(false);
+    });
+
     it("allows all senders when commands.allowFrom includes wildcard", () => {
       const cfg = {
         commands: {

--- a/src/auto-reply/reply/reply-elevated.test.ts
+++ b/src/auto-reply/reply/reply-elevated.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { MsgContext } from "../templating.js";
 import { resolveElevatedPermissions } from "./reply-elevated.js";
+
+const channelPluginLookup = vi.hoisted(() => vi.fn());
+const normalizeChannelIdMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  getChannelPlugin: channelPluginLookup,
+  normalizeChannelId: normalizeChannelIdMock,
+}));
 
 function buildConfig(allowFrom: string[]): OpenClawConfig {
   return {
@@ -55,11 +63,46 @@ function expectAllowFromDecision(params: {
 }
 
 describe("resolveElevatedPermissions", () => {
+  beforeEach(() => {
+    normalizeChannelIdMock.mockImplementation(
+      (raw?: string | null) => raw?.trim().toLowerCase() || null,
+    );
+  });
+
+  afterEach(() => {
+    channelPluginLookup.mockReset();
+    normalizeChannelIdMock.mockReset();
+  });
+
   it("authorizes when sender matches allowFrom", () => {
     expectAllowFromDecision({
       allowFrom: ["+15550001111"],
       allowed: true,
     });
+  });
+
+  it("uses bundled channel formatting when no plugin registry is loaded", () => {
+    channelPluginLookup.mockReturnValue({
+      config: {
+        formatAllowFrom: ({ allowFrom }: { allowFrom: Array<string | number> }) =>
+          allowFrom.flatMap((entry) => {
+            const digits = String(entry).replace(/\D/g, "");
+            return digits ? [digits] : [];
+          }),
+      },
+    });
+
+    expectAllowFromDecision({
+      allowFrom: ["15550001111"],
+      ctx: {
+        SenderId: "+1 (555) 000-1111",
+        From: undefined,
+        SenderE164: undefined,
+      },
+      allowed: true,
+    });
+
+    expect(channelPluginLookup).toHaveBeenCalledWith("whatsapp");
   });
 
   it("does not authorize when only recipient matches allowFrom", () => {
@@ -89,5 +132,80 @@ describe("resolveElevatedPermissions", () => {
         SenderUsername: "owner_username",
       },
     });
+  });
+
+  it("does not use elevated allowFrom fallback when the channel disables it", () => {
+    channelPluginLookup.mockReturnValue({
+      doctor: { elevatedAllowFromFallbackToAllowFrom: false },
+      elevated: {
+        allowFromFallback: () => ["user:1"],
+      },
+    });
+
+    const result = resolveElevatedPermissions({
+      cfg: { tools: { elevated: {} } } as OpenClawConfig,
+      agentId: "main",
+      provider: "nofallback",
+      ctx: buildContext({ Provider: "nofallback", Surface: "nofallback", SenderId: "user:1" }),
+    });
+
+    expect(result.allowed).toBe(false);
+  });
+
+  it("uses elevated allowFrom fallback when the channel keeps it enabled", () => {
+    channelPluginLookup.mockReturnValue({
+      elevated: {
+        allowFromFallback: () => ["user:1"],
+      },
+    });
+
+    const result = resolveElevatedPermissions({
+      cfg: { tools: { elevated: {} } } as OpenClawConfig,
+      agentId: "main",
+      provider: "fallback",
+      ctx: buildContext({
+        Provider: "fallback",
+        Surface: "fallback",
+        SenderId: "user:1",
+        From: undefined,
+        SenderE164: undefined,
+      }),
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("falls back to the raw provider key when registry normalization is unavailable", () => {
+    normalizeChannelIdMock.mockReturnValueOnce(null);
+    channelPluginLookup.mockReturnValue({
+      config: {
+        formatAllowFrom: ({ allowFrom }: { allowFrom: Array<string | number> }) =>
+          allowFrom.map(String),
+      },
+    });
+
+    const result = resolveElevatedPermissions({
+      cfg: {
+        tools: {
+          elevated: {
+            allowFrom: {
+              unregistered: ["sender"],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      agentId: "main",
+      provider: "unregistered",
+      ctx: buildContext({
+        Provider: "unregistered",
+        Surface: "unregistered",
+        SenderId: "sender",
+        From: undefined,
+        SenderE164: undefined,
+      }),
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(channelPluginLookup).toHaveBeenCalledWith("unregistered");
   });
 });

--- a/src/auto-reply/reply/reply-elevated.ts
+++ b/src/auto-reply/reply/reply-elevated.ts
@@ -1,5 +1,6 @@
 import { resolveAgentConfig } from "../../agents/agent-scope.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { AgentElevatedAllowFromConfig, OpenClawConfig } from "../../config/config.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
@@ -32,11 +33,9 @@ function resolveAllowFromFormatter(params: {
   cfg: OpenClawConfig;
   provider: string;
   accountId?: string;
+  plugin?: ChannelPlugin;
 }): AllowFromFormatter {
-  const normalizedProvider = normalizeChannelId(params.provider);
-  const formatAllowFrom = normalizedProvider
-    ? getChannelPlugin(normalizedProvider)?.config?.formatAllowFrom
-    : undefined;
+  const formatAllowFrom = params.plugin?.config?.formatAllowFrom;
   if (!formatAllowFrom) {
     return (values) => normalizeStringEntries(values);
   }
@@ -48,6 +47,11 @@ function resolveAllowFromFormatter(params: {
     })
       .map((entry) => normalizeOptionalString(entry) ?? "")
       .filter(Boolean);
+}
+
+function resolveProviderPlugin(provider: string): ChannelPlugin | undefined {
+  const providerKey = normalizeChannelId(provider) ?? normalizeOptionalString(provider);
+  return providerKey ? getChannelPlugin(providerKey) : undefined;
 }
 
 function isApprovedElevatedSender(params: {
@@ -199,17 +203,20 @@ export function resolveElevatedPermissions(params: {
     return { enabled, allowed: false, failures };
   }
 
-  const normalizedProvider = normalizeChannelId(params.provider);
-  const fallbackAllowFrom = normalizedProvider
-    ? getChannelPlugin(normalizedProvider)?.elevated?.allowFromFallback?.({
-        cfg: params.cfg,
-        accountId: params.ctx.AccountId,
-      })
+  const plugin = resolveProviderPlugin(params.provider);
+  const fallbackAllowFrom = plugin
+    ? plugin.doctor?.elevatedAllowFromFallbackToAllowFrom === false
+      ? undefined
+      : plugin.elevated?.allowFromFallback?.({
+          cfg: params.cfg,
+          accountId: params.ctx.AccountId,
+        })
     : undefined;
   const formatAllowFrom = resolveAllowFromFormatter({
     cfg: params.cfg,
     provider: params.provider,
     accountId: params.ctx.AccountId,
+    plugin,
   });
   const globalAllowed = isApprovedElevatedSender({
     provider: params.provider,

--- a/src/channels/message-access/runtime-types.ts
+++ b/src/channels/message-access/runtime-types.ts
@@ -106,10 +106,17 @@ export type ChannelMessageIngressCommandInput = NonNullable<
 > & {
   /** Explicit command-owner allowlist; defaults to effective DM allowlist. */
   commandOwnerAllowFrom?: Array<string | number> | null;
+  /**
+   * Explicit group command-owner allowlist; defaults to configured DM allowlist in groups.
+   * Legacy SDK callers may still pass "configured" or "none".
+   */
+  groupOwnerAllowFrom?: Array<string | number> | "configured" | "none" | null;
   /** Controls whether group command owners inherit configured DM owners. */
-  groupOwnerAllowFrom?: "configured" | "none";
+  groupOwnerAllowFromFallbackToAllowFrom?: boolean;
   /** Allows direct-message command checks to reuse effective group allowlists. */
   directGroupAllowFrom?: "effective" | "none";
+  /** Explicit group command allowlist; defaults to group sender allowlist/fallback. */
+  commandGroupAllowFrom?: Array<string | number> | null;
   /** Group command allowFrom fallback, separate from normal group sender policy. */
   commandGroupAllowFromFallbackToAllowFrom?: boolean;
 };

--- a/src/channels/message-access/runtime.ts
+++ b/src/channels/message-access/runtime.ts
@@ -564,7 +564,19 @@ function commandOwnerAllowFrom(params: {
   if (!params.isGroup) {
     return params.effectiveAllowFrom;
   }
-  return params.command?.groupOwnerAllowFrom === "none" ? [] : params.configuredAllowFrom;
+  const groupOwnerAllowFrom = params.command?.groupOwnerAllowFrom;
+  if (Array.isArray(groupOwnerAllowFrom)) {
+    return groupOwnerAllowFrom;
+  }
+  if (groupOwnerAllowFrom === "none") {
+    return [];
+  }
+  if (groupOwnerAllowFrom === "configured") {
+    return params.configuredAllowFrom;
+  }
+  return params.command?.groupOwnerAllowFromFallbackToAllowFrom === false
+    ? []
+    : params.configuredAllowFrom;
 }
 
 function commandGroupAllowFrom(params: {
@@ -623,6 +635,8 @@ export async function resolveChannelMessageIngress(
     rawGroupAllowFrom,
     rawStoreAllowFrom,
     params.command?.commandOwnerAllowFrom ?? [],
+    Array.isArray(params.command?.groupOwnerAllowFrom) ? params.command.groupOwnerAllowFrom : [],
+    params.command?.commandGroupAllowFrom ?? [],
     ...routeFacts.map((route) => route.senderAllowFrom ?? []),
   ]);
   const runtimeAccessGroupMembership = await resolveRuntimeAccessGroupMembershipFacts({
@@ -648,14 +662,17 @@ export async function resolveChannelMessageIngress(
     dmPolicy: params.policy.dmPolicy,
     groupAllowFromFallbackToAllowFrom: params.policy.groupAllowFromFallbackToAllowFrom,
   });
-  const rawCommandGroup = resolveChannelIngressEffectiveAllowFromLists({
-    allowFrom: rawAllowFrom,
-    groupAllowFrom: rawGroupAllowFrom,
-    dmPolicy: params.policy.dmPolicy,
-    groupAllowFromFallbackToAllowFrom:
-      params.command?.commandGroupAllowFromFallbackToAllowFrom ??
-      params.policy.groupAllowFromFallbackToAllowFrom,
-  });
+  const rawCommandGroupAllowFrom =
+    params.command?.commandGroupAllowFrom != null
+      ? normalizeStringEntries(params.command.commandGroupAllowFrom)
+      : resolveChannelIngressEffectiveAllowFromLists({
+          allowFrom: rawAllowFrom,
+          groupAllowFrom: rawGroupAllowFrom,
+          dmPolicy: params.policy.dmPolicy,
+          groupAllowFromFallbackToAllowFrom:
+            params.command?.commandGroupAllowFromFallbackToAllowFrom ??
+            params.policy.groupAllowFromFallbackToAllowFrom,
+        }).effectiveGroupAllowFrom;
   const isGroup = params.conversation.kind !== "direct";
   const policy: ChannelIngressPolicyInput = {
     ...params.policy,
@@ -685,7 +702,7 @@ export async function resolveChannelMessageIngress(
       commandGroup: commandGroupAllowFrom({
         command: params.command,
         isGroup,
-        effectiveCommandGroupAllowFrom: rawCommandGroup.effectiveGroupAllowFrom,
+        effectiveCommandGroupAllowFrom: rawCommandGroupAllowFrom,
       }),
     },
   });

--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -171,6 +171,7 @@ function writeExternalSetupChannelPlugin(
     manifestChannelConfig?: boolean;
     manifestChannelDescription?: string;
     manifestChannelLabel?: string;
+    packageDoctorCapabilities?: Record<string, unknown>;
     setupRequiresRuntime?: boolean;
     setupChannelId?: string;
   } = {},
@@ -194,6 +195,14 @@ function writeExternalSetupChannelPlugin(
         openclaw: {
           extensions: ["./index.cjs"],
           ...(setupEntry ? { setupEntry: "./setup-entry.cjs" } : {}),
+          ...(options.packageDoctorCapabilities
+            ? {
+                channel: {
+                  id: channelId,
+                  doctorCapabilities: options.packageDoctorCapabilities,
+                },
+              }
+            : {}),
         },
       },
       null,
@@ -730,6 +739,37 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     );
     expect(fs.existsSync(setupMarker)).toBe(false);
     expect(fs.existsSync(fullMarker)).toBe(false);
+  });
+
+  it("exposes package doctor capabilities through read-only channel plugins", () => {
+    const { pluginDir } = writeExternalSetupChannelPlugin({
+      setupEntry: false,
+      pluginId: "external-chat-plugin",
+      channelId: "external-chat",
+      packageDoctorCapabilities: {
+        groupAllowFromFallbackToAllowFrom: false,
+      },
+    });
+    const plugins = listReadOnlyChannelPluginsForConfig(
+      {
+        channels: {
+          "external-chat": { token: "configured" },
+        },
+        plugins: {
+          load: { paths: [pluginDir] },
+          allow: ["external-chat-plugin"],
+        },
+      } as never,
+      {
+        env: { ...process.env },
+        includePersistedAuthState: false,
+        includeSetupFallbackPlugins: true,
+      },
+    );
+
+    expect(plugins.find((entry) => entry.id === "external-chat")?.doctor).toMatchObject({
+      groupAllowFromFallbackToAllowFrom: false,
+    });
   });
 
   it("uses manifest channel configs before setup-only plugin loading", () => {

--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -321,6 +321,7 @@ function buildManifestChannelPlugin(params: {
   const commands = normalizeChannelCommandDefaults(
     channelConfig?.commands ?? catalogMeta?.commands,
   );
+  const doctorCapabilities = catalogMeta?.doctorCapabilities;
   return {
     id: params.channelId,
     meta: {
@@ -337,6 +338,7 @@ function buildManifestChannelPlugin(params: {
     },
     capabilities: { chatTypes: ["direct"] },
     ...(commands ? { commands } : {}),
+    ...(doctorCapabilities ? { doctor: doctorCapabilities } : {}),
     ...(channelConfig
       ? {
           configSchema: {

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -512,6 +512,10 @@ export type ChannelDoctorAdapter = {
   dmAllowFromMode?: "topOnly" | "topOrNested" | "nestedOnly";
   groupModel?: "sender" | "route" | "hybrid";
   groupAllowFromFallbackToAllowFrom?: boolean;
+  groupOwnerAllowFromFallbackToAllowFrom?: boolean;
+  commandGroupAllowFromFallbackToAllowFrom?: boolean;
+  commandAllowFromFallbackToAllowFrom?: boolean;
+  elevatedAllowFromFallbackToAllowFrom?: boolean;
   warnOnEmptyGroupSenderAllowlist?: boolean;
   legacyConfigRules?: LegacyConfigRule[];
   normalizeCompatibilityConfig?: (params: { cfg: OpenClawConfig }) => ChannelDoctorConfigMutation;

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -642,24 +642,28 @@ vi.mock("./doctor/channel-capabilities.js", () => {
     googlechat: {
       dmAllowFromMode: "nestedOnly",
       groupModel: "route",
+      supportsGroupChats: true,
       groupAllowFromFallbackToAllowFrom: false,
       warnOnEmptyGroupSenderAllowlist: false,
     },
     matrix: {
       dmAllowFromMode: "nestedOnly",
       groupModel: "sender",
+      supportsGroupChats: true,
       groupAllowFromFallbackToAllowFrom: false,
       warnOnEmptyGroupSenderAllowlist: true,
     },
     msteams: {
       dmAllowFromMode: "topOnly",
       groupModel: "hybrid",
+      supportsGroupChats: true,
       groupAllowFromFallbackToAllowFrom: false,
       warnOnEmptyGroupSenderAllowlist: true,
     },
     zalouser: {
       dmAllowFromMode: "topOnly",
       groupModel: "hybrid",
+      supportsGroupChats: true,
       groupAllowFromFallbackToAllowFrom: false,
       warnOnEmptyGroupSenderAllowlist: false,
     },
@@ -667,6 +671,7 @@ vi.mock("./doctor/channel-capabilities.js", () => {
   const fallback = {
     dmAllowFromMode: "topOnly",
     groupModel: "sender",
+    supportsGroupChats: true,
     groupAllowFromFallbackToAllowFrom: true,
     warnOnEmptyGroupSenderAllowlist: true,
   };
@@ -1052,6 +1057,17 @@ vi.mock("./doctor/shared/channel-doctor.js", () => {
       shouldSkipDefaultEmptyGroupAllowlistWarning: ({ channelName }: { channelName: string }) =>
         channelName === "googlechat" || channelName === "telegram",
     })),
+    resolveDoctorChannelCapabilities: vi.fn(() => ({
+      dmAllowFromMode: "topOnly",
+      groupModel: "sender",
+      supportsGroupChats: true,
+      groupAllowFromFallbackToAllowFrom: true,
+      groupOwnerAllowFromFallbackToAllowFrom: true,
+      commandAllowFromFallbackToAllowFrom: true,
+      elevatedAllowFromFallbackToAllowFrom: false,
+      warnOnEmptyGroupSenderAllowlist: true,
+    })),
+    resolveDoctorChannelCapabilityMetadata: vi.fn(() => undefined),
     runChannelDoctorConfigSequences: vi.fn(async () => ({ changeNotes: [], warningNotes: [] })),
     shouldSkipChannelDoctorDefaultEmptyGroupAllowlistWarning: vi.fn(
       ({ channelName }: { channelName: string }) =>

--- a/src/commands/doctor/channel-capabilities.test.ts
+++ b/src/commands/doctor/channel-capabilities.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { getDoctorChannelCapabilities } from "./channel-capabilities.js";
+import {
+  getDoctorChannelCapabilities,
+  mergeDoctorChannelCapabilities,
+} from "./channel-capabilities.js";
 
 describe("doctor channel capabilities", () => {
   it("returns nested route semantics from googlechat plugin metadata", () => {
     expect(getDoctorChannelCapabilities("googlechat")).toEqual({
       dmAllowFromMode: "nestedOnly",
       groupModel: "route",
+      supportsGroupChats: true,
       groupAllowFromFallbackToAllowFrom: false,
+      groupOwnerAllowFromFallbackToAllowFrom: true,
+      commandAllowFromFallbackToAllowFrom: true,
+      elevatedAllowFromFallbackToAllowFrom: false,
       warnOnEmptyGroupSenderAllowlist: false,
     });
   });
@@ -15,7 +22,24 @@ describe("doctor channel capabilities", () => {
     expect(getDoctorChannelCapabilities("matrix")).toEqual({
       dmAllowFromMode: "nestedOnly",
       groupModel: "sender",
+      supportsGroupChats: true,
       groupAllowFromFallbackToAllowFrom: false,
+      groupOwnerAllowFromFallbackToAllowFrom: true,
+      commandAllowFromFallbackToAllowFrom: true,
+      elevatedAllowFromFallbackToAllowFrom: false,
+      warnOnEmptyGroupSenderAllowlist: true,
+    });
+  });
+
+  it("returns command-owner fallback overrides from line plugin metadata", () => {
+    expect(getDoctorChannelCapabilities("line")).toEqual({
+      dmAllowFromMode: "topOnly",
+      groupModel: "sender",
+      supportsGroupChats: true,
+      groupAllowFromFallbackToAllowFrom: true,
+      groupOwnerAllowFromFallbackToAllowFrom: true,
+      commandAllowFromFallbackToAllowFrom: true,
+      elevatedAllowFromFallbackToAllowFrom: false,
       warnOnEmptyGroupSenderAllowlist: true,
     });
   });
@@ -24,7 +48,11 @@ describe("doctor channel capabilities", () => {
     expect(getDoctorChannelCapabilities("zalouser")).toEqual({
       dmAllowFromMode: "topOnly",
       groupModel: "hybrid",
+      supportsGroupChats: true,
       groupAllowFromFallbackToAllowFrom: false,
+      groupOwnerAllowFromFallbackToAllowFrom: true,
+      commandAllowFromFallbackToAllowFrom: true,
+      elevatedAllowFromFallbackToAllowFrom: false,
       warnOnEmptyGroupSenderAllowlist: false,
     });
   });
@@ -33,7 +61,11 @@ describe("doctor channel capabilities", () => {
     expect(getDoctorChannelCapabilities("msteams")).toEqual({
       dmAllowFromMode: "topOnly",
       groupModel: "hybrid",
+      supportsGroupChats: true,
       groupAllowFromFallbackToAllowFrom: false,
+      groupOwnerAllowFromFallbackToAllowFrom: true,
+      commandAllowFromFallbackToAllowFrom: true,
+      elevatedAllowFromFallbackToAllowFrom: false,
       warnOnEmptyGroupSenderAllowlist: true,
     });
   });
@@ -42,8 +74,45 @@ describe("doctor channel capabilities", () => {
     expect(getDoctorChannelCapabilities("external-demo")).toEqual({
       dmAllowFromMode: "topOnly",
       groupModel: "sender",
+      supportsGroupChats: true,
       groupAllowFromFallbackToAllowFrom: true,
+      groupOwnerAllowFromFallbackToAllowFrom: true,
+      commandAllowFromFallbackToAllowFrom: true,
+      elevatedAllowFromFallbackToAllowFrom: false,
       warnOnEmptyGroupSenderAllowlist: true,
     });
+  });
+
+  it("preserves explicitly declared elevated allowFrom fallback support", () => {
+    expect(
+      mergeDoctorChannelCapabilities({
+        elevatedAllowFromFallbackToAllowFrom: true,
+      }).elevatedAllowFromFallbackToAllowFrom,
+    ).toBe(true);
+  });
+
+  it("preserves explicit command fallback disable metadata", () => {
+    const capabilities = mergeDoctorChannelCapabilities({
+      groupOwnerAllowFromFallbackToAllowFrom: false,
+      commandGroupAllowFromFallbackToAllowFrom: false,
+    });
+
+    expect(capabilities.groupOwnerAllowFromFallbackToAllowFrom).toBe(false);
+    expect(capabilities.groupOwnerAllowFromFallbackToAllowFromExplicit).toBe(true);
+    expect(capabilities.commandGroupAllowFromFallbackToAllowFrom).toBe(false);
+  });
+
+  it("does not mark defaulted group-owner fallback as explicit metadata", () => {
+    expect(
+      mergeDoctorChannelCapabilities({}).groupOwnerAllowFromFallbackToAllowFromExplicit,
+    ).toBeUndefined();
+  });
+
+  it("preserves direct-only chat metadata supplied by the capability resolver", () => {
+    expect(
+      mergeDoctorChannelCapabilities(undefined, {
+        supportsGroupChats: false,
+      }).supportsGroupChats,
+    ).toBe(false);
   });
 });

--- a/src/commands/doctor/channel-capabilities.ts
+++ b/src/commands/doctor/channel-capabilities.ts
@@ -10,31 +10,79 @@ export type DoctorGroupModel = "sender" | "route" | "hybrid";
 export type DoctorChannelCapabilities = {
   dmAllowFromMode: AllowFromMode;
   groupModel: DoctorGroupModel;
+  supportsGroupChats: boolean;
   groupAllowFromFallbackToAllowFrom: boolean;
+  groupOwnerAllowFromFallbackToAllowFrom: boolean;
+  groupOwnerAllowFromFallbackToAllowFromExplicit?: boolean;
+  commandGroupAllowFromFallbackToAllowFrom?: boolean;
+  commandAllowFromFallbackToAllowFrom: boolean;
+  commandAllowFromFallbackToAllowFromExplicit?: boolean;
+  elevatedAllowFromFallbackToAllowFrom: boolean;
   warnOnEmptyGroupSenderAllowlist: boolean;
 };
 
 const DEFAULT_DOCTOR_CHANNEL_CAPABILITIES: DoctorChannelCapabilities = {
   dmAllowFromMode: "topOnly",
   groupModel: "sender",
+  supportsGroupChats: true,
   groupAllowFromFallbackToAllowFrom: true,
+  groupOwnerAllowFromFallbackToAllowFrom: true,
+  commandAllowFromFallbackToAllowFrom: true,
+  // Elevated fallback is implemented only by a channel runtime hook, so doctor
+  // must not warn unless channel metadata explicitly declares it.
+  elevatedAllowFromFallbackToAllowFrom: false,
   warnOnEmptyGroupSenderAllowlist: true,
 };
 
-function mergeDoctorChannelCapabilities(
+export function mergeDoctorChannelCapabilities(
   capabilities?: PluginPackageChannelDoctorCapabilities,
+  options: { supportsGroupChats?: boolean } = {},
 ): DoctorChannelCapabilities {
   return {
     dmAllowFromMode:
       capabilities?.dmAllowFromMode ?? DEFAULT_DOCTOR_CHANNEL_CAPABILITIES.dmAllowFromMode,
     groupModel: capabilities?.groupModel ?? DEFAULT_DOCTOR_CHANNEL_CAPABILITIES.groupModel,
+    supportsGroupChats:
+      options.supportsGroupChats ?? DEFAULT_DOCTOR_CHANNEL_CAPABILITIES.supportsGroupChats,
     groupAllowFromFallbackToAllowFrom:
       capabilities?.groupAllowFromFallbackToAllowFrom ??
       DEFAULT_DOCTOR_CHANNEL_CAPABILITIES.groupAllowFromFallbackToAllowFrom,
+    groupOwnerAllowFromFallbackToAllowFrom:
+      capabilities?.groupOwnerAllowFromFallbackToAllowFrom ??
+      DEFAULT_DOCTOR_CHANNEL_CAPABILITIES.groupOwnerAllowFromFallbackToAllowFrom,
+    ...(capabilities?.groupOwnerAllowFromFallbackToAllowFrom !== undefined
+      ? { groupOwnerAllowFromFallbackToAllowFromExplicit: true }
+      : {}),
+    ...(capabilities?.commandGroupAllowFromFallbackToAllowFrom !== undefined
+      ? {
+          commandGroupAllowFromFallbackToAllowFrom:
+            capabilities.commandGroupAllowFromFallbackToAllowFrom,
+        }
+      : {}),
+    commandAllowFromFallbackToAllowFrom:
+      capabilities?.commandAllowFromFallbackToAllowFrom ??
+      DEFAULT_DOCTOR_CHANNEL_CAPABILITIES.commandAllowFromFallbackToAllowFrom,
+    ...(capabilities?.commandAllowFromFallbackToAllowFrom !== undefined
+      ? { commandAllowFromFallbackToAllowFromExplicit: true }
+      : {}),
+    elevatedAllowFromFallbackToAllowFrom:
+      capabilities?.elevatedAllowFromFallbackToAllowFrom ??
+      DEFAULT_DOCTOR_CHANNEL_CAPABILITIES.elevatedAllowFromFallbackToAllowFrom,
     warnOnEmptyGroupSenderAllowlist:
       capabilities?.warnOnEmptyGroupSenderAllowlist ??
       DEFAULT_DOCTOR_CHANNEL_CAPABILITIES.warnOnEmptyGroupSenderAllowlist,
   };
+}
+
+function resolveSupportsGroupChats(
+  plugin:
+    | {
+        capabilities?: { chatTypes?: readonly string[] };
+      }
+    | undefined,
+): boolean | undefined {
+  const chatTypes = plugin?.capabilities?.chatTypes;
+  return Array.isArray(chatTypes) ? chatTypes.some((chatType) => chatType !== "direct") : undefined;
 }
 
 function getManifestDoctorCapabilities(
@@ -57,10 +105,11 @@ export function getDoctorChannelCapabilities(channelName?: string): DoctorChanne
   if (!channelId) {
     return DEFAULT_DOCTOR_CHANNEL_CAPABILITIES;
   }
-  const pluginDoctor =
-    getChannelPlugin(channelId)?.doctor ?? getBundledChannelPlugin(channelId)?.doctor;
-  if (pluginDoctor) {
-    return mergeDoctorChannelCapabilities(pluginDoctor);
+  const plugin = getChannelPlugin(channelId) ?? getBundledChannelPlugin(channelId);
+  if (plugin?.doctor) {
+    return mergeDoctorChannelCapabilities(plugin.doctor, {
+      supportsGroupChats: resolveSupportsGroupChats(plugin),
+    });
   }
   return mergeDoctorChannelCapabilities(getManifestDoctorCapabilities(channelId));
 }

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -9,11 +9,15 @@ const mocks = vi.hoisted(() => ({
   getInstalledPluginRecord: vi.fn(),
   isInstalledPluginEnabled: vi.fn(),
   loadInstalledPluginIndex: vi.fn(),
+  maybeRepairAllowlistPolicyAllowFrom: vi.fn(),
   maybeRepairManagedNpmOpenClawPeerLinks: vi.fn(),
+  maybeRepairOpenPolicyAllowFrom: vi.fn(),
   maybeRepairStaleManagedNpmBundledPlugins: vi.fn(),
   maybeRepairStalePluginConfig: vi.fn(),
   repairStaleOAuthProfileShadows: vi.fn(),
   repairMissingConfiguredPluginInstalls: vi.fn(),
+  resolveDoctorChannelCapabilities: vi.fn(),
+  resolveDoctorChannelCapabilityMetadata: vi.fn(),
   resolveAuthProfileOrder: vi.fn(),
   resolveProfileUnusableUntilForDisplay: vi.fn(),
 }));
@@ -85,6 +89,8 @@ vi.mock("./shared/channel-doctor.js", () => ({
     extraWarningsForAccount: () => [],
     shouldSkipDefaultEmptyGroupAllowlistWarning: () => false,
   }),
+  resolveDoctorChannelCapabilities: mocks.resolveDoctorChannelCapabilities,
+  resolveDoctorChannelCapabilityMetadata: mocks.resolveDoctorChannelCapabilityMetadata,
 }));
 
 vi.mock("./shared/empty-allowlist-scan.js", () => ({
@@ -95,10 +101,7 @@ vi.mock("./shared/empty-allowlist-scan.js", () => ({
 }));
 
 vi.mock("./shared/allowlist-policy-repair.js", () => ({
-  maybeRepairAllowlistPolicyAllowFrom: async (cfg: OpenClawConfig) => ({
-    config: cfg,
-    changes: [],
-  }),
+  maybeRepairAllowlistPolicyAllowFrom: mocks.maybeRepairAllowlistPolicyAllowFrom,
 }));
 
 vi.mock("./shared/bundled-plugin-load-paths.js", () => ({
@@ -109,10 +112,7 @@ vi.mock("./shared/bundled-plugin-load-paths.js", () => ({
 }));
 
 vi.mock("./shared/open-policy-allowfrom.js", () => ({
-  maybeRepairOpenPolicyAllowFrom: (cfg: OpenClawConfig) => ({
-    config: cfg,
-    changes: [],
-  }),
+  maybeRepairOpenPolicyAllowFrom: mocks.maybeRepairOpenPolicyAllowFrom,
 }));
 
 vi.mock("./shared/stale-plugin-config.js", () => ({
@@ -193,6 +193,14 @@ describe("doctor repair sequencing", () => {
     mocks.isInstalledPluginEnabled.mockReturnValue(false);
     mocks.loadInstalledPluginIndex.mockReturnValue({ plugins: [] });
     mocks.maybeRepairManagedNpmOpenClawPeerLinks.mockResolvedValue(false);
+    mocks.maybeRepairAllowlistPolicyAllowFrom.mockImplementation(async (cfg: OpenClawConfig) => ({
+      config: cfg,
+      changes: [],
+    }));
+    mocks.maybeRepairOpenPolicyAllowFrom.mockImplementation((cfg: OpenClawConfig) => ({
+      config: cfg,
+      changes: [],
+    }));
     mocks.maybeRepairStaleManagedNpmBundledPlugins.mockReturnValue(false);
     mocks.repairMissingConfiguredPluginInstalls.mockResolvedValue({
       changes: [],
@@ -202,6 +210,17 @@ describe("doctor repair sequencing", () => {
       changes: [],
       warnings: [],
     });
+    mocks.resolveDoctorChannelCapabilities.mockReturnValue({
+      dmAllowFromMode: "topOnly",
+      groupModel: "sender",
+      supportsGroupChats: true,
+      groupAllowFromFallbackToAllowFrom: true,
+      groupOwnerAllowFromFallbackToAllowFrom: true,
+      commandAllowFromFallbackToAllowFrom: true,
+      elevatedAllowFromFallbackToAllowFrom: false,
+      warnOnEmptyGroupSenderAllowlist: true,
+    });
+    mocks.resolveDoctorChannelCapabilityMetadata.mockReturnValue(undefined);
     mocks.resolveAuthProfileOrder.mockReturnValue([]);
     mocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(null);
     mocks.maybeRepairStalePluginConfig.mockImplementation((cfg: OpenClawConfig) => ({
@@ -274,6 +293,157 @@ describe("doctor repair sequencing", () => {
     ]);
     expect(result.warningNotes.join("\n")).not.toContain("\u001B");
     expect(result.warningNotes.join("\n")).not.toContain("\r");
+  });
+
+  it("does not treat doctor capability defaults as explicit elevated fallback metadata", async () => {
+    const result = await runDoctorRepairSequence({
+      state: {
+        cfg: {
+          channels: {
+            demo: {
+              allowFrom: ["user:1"],
+            },
+          },
+        } as OpenClawConfig,
+        candidate: {
+          channels: {
+            demo: {
+              allowFrom: ["user:1"],
+            },
+          },
+        } as OpenClawConfig,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+      env: {},
+    });
+
+    expect(mocks.resolveDoctorChannelCapabilities).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "demo",
+    );
+    expect(result.warningNotes.join("\n")).not.toContain("elevated authorization");
+    expect(result.warningNotes.join("\n")).not.toContain("tools.elevated.allowFrom.demo");
+  });
+
+  it("runs fallback transition after allowFrom policy repairs", async () => {
+    mocks.maybeRepairAllowlistPolicyAllowFrom.mockImplementationOnce(
+      async (cfg: OpenClawConfig) => ({
+        config: {
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            demo: {
+              ...cfg.channels?.demo,
+              allowFrom: ["pairing-user"],
+            },
+          },
+        },
+        changes: [
+          'channels.demo.allowFrom: restored 1 sender entry from pairing store (dmPolicy="allowlist").',
+        ],
+      }),
+    );
+    mocks.resolveDoctorChannelCapabilityMetadata.mockImplementation(
+      (_ctx: unknown, channelName: string) =>
+        channelName === "demo"
+          ? {
+              groupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    );
+
+    const result = await runDoctorRepairSequence({
+      state: {
+        cfg: {
+          channels: {
+            demo: {
+              dmPolicy: "allowlist",
+            },
+          },
+        } as OpenClawConfig,
+        candidate: {
+          channels: {
+            demo: {
+              dmPolicy: "allowlist",
+            },
+          },
+        } as OpenClawConfig,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+      env: {},
+    });
+
+    expect(result.state.candidate.channels?.demo).toMatchObject({
+      allowFrom: ["pairing-user"],
+      groupAllowFrom: ["pairing-user"],
+    });
+    expect(result.changeNotes).toStrictEqual([
+      'channels.demo.allowFrom: restored 1 sender entry from pairing store (dmPolicy="allowlist").',
+      "Copied channels.demo.allowFrom entries to channels.demo.groupAllowFrom because group-sender fallback to allowFrom is disabled.",
+    ]);
+  });
+
+  it("does not migrate open-policy wildcards generated by doctor repair", async () => {
+    mocks.maybeRepairOpenPolicyAllowFrom.mockImplementationOnce((cfg: OpenClawConfig) => ({
+      config: {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          demo: {
+            ...cfg.channels?.demo,
+            allowFrom: ["*"],
+          },
+        },
+      },
+      changes: ['channels.demo.allowFrom: added wildcard for dmPolicy="open".'],
+    }));
+    mocks.resolveDoctorChannelCapabilityMetadata.mockImplementation(
+      (_ctx: unknown, channelName: string) =>
+        channelName === "demo"
+          ? {
+              groupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    );
+
+    const result = await runDoctorRepairSequence({
+      state: {
+        cfg: {
+          channels: {
+            demo: {
+              dmPolicy: "open",
+              groupPolicy: "allowlist",
+            },
+          },
+        } as OpenClawConfig,
+        candidate: {
+          channels: {
+            demo: {
+              dmPolicy: "open",
+              groupPolicy: "allowlist",
+            },
+          },
+        } as OpenClawConfig,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+      env: {},
+    });
+
+    expect(result.state.candidate.channels?.demo).toMatchObject({
+      dmPolicy: "open",
+      groupPolicy: "allowlist",
+      allowFrom: ["*"],
+    });
+    expect(result.state.candidate.channels?.demo).not.toHaveProperty("groupAllowFrom");
+    expect(result.changeNotes).toStrictEqual([
+      'channels.demo.allowFrom: added wildcard for dmPolicy="open".',
+    ]);
   });
 
   it("repairs managed npm plugin drift before missing plugin install repair", async () => {

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -1,3 +1,4 @@
+import { applyAllowFromFallbackTransition } from "../../config/allowfrom-fallback-transition.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import { sanitizeForLog } from "../../terminal/ansi.js";
 import {
@@ -9,6 +10,8 @@ import { maybeRepairBundledPluginLoadPaths } from "./shared/bundled-plugin-load-
 import {
   createChannelDoctorEmptyAllowlistPolicyHooks,
   collectChannelDoctorRepairMutations,
+  resolveDoctorChannelCapabilityMetadata,
+  resolveDoctorChannelCapabilities,
 } from "./shared/channel-doctor.js";
 import { maybeRepairCodexRoutes } from "./shared/codex-route-warnings.js";
 import {
@@ -66,7 +69,6 @@ export async function runDoctorRepairSequence(params: {
   })) {
     applyMutation(mutation);
   }
-  applyMutation(maybeRepairOpenPolicyAllowFrom(state.candidate));
   applyMutation(maybeRepairBundledPluginLoadPaths(state.candidate, env));
   maybeRepairStaleManagedNpmBundledPlugins({
     config: state.candidate,
@@ -106,9 +108,18 @@ export async function runDoctorRepairSequence(params: {
   }
   applyMutation(maybeRepairInvalidPluginConfig(state.candidate));
   applyMutation(await maybeRepairAllowlistPolicyAllowFrom(state.candidate));
+  applyMutation(
+    applyAllowFromFallbackTransition(state.candidate, {
+      resolveCapabilities: (channelName) =>
+        resolveDoctorChannelCapabilityMetadata({ cfg: state.candidate, env }, channelName),
+    }),
+  );
+  applyMutation(maybeRepairOpenPolicyAllowFrom(state.candidate));
 
   const emptyAllowlistWarnings = scanEmptyAllowlistPolicyWarnings(state.candidate, {
     doctorFixCommand: params.doctorFixCommand,
+    resolveCapabilities: (channelName) =>
+      resolveDoctorChannelCapabilities({ cfg: state.candidate, env }, channelName),
     ...createChannelDoctorEmptyAllowlistPolicyHooks({ cfg: state.candidate, env }),
   });
   if (emptyAllowlistWarnings.length > 0) {

--- a/src/commands/doctor/shared/channel-doctor.ts
+++ b/src/commands/doctor/shared/channel-doctor.ts
@@ -12,6 +12,10 @@ import type {
 } from "../../../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { normalizeOptionalLowercaseString } from "../../../shared/string-coerce.js";
+import {
+  mergeDoctorChannelCapabilities,
+  type DoctorChannelCapabilities,
+} from "../channel-capabilities.js";
 
 type ChannelDoctorEntry = {
   doctor: ChannelDoctorAdapter;
@@ -19,6 +23,7 @@ type ChannelDoctorEntry = {
 
 type ChannelDoctorPluginCandidate = {
   id: string;
+  capabilities?: { chatTypes?: readonly string[] };
   doctor?: ChannelDoctorAdapter;
 };
 
@@ -44,6 +49,10 @@ const channelDoctorFunctionKeys = new Set<keyof ChannelDoctorAdapter>([
 
 const channelDoctorBooleanKeys = new Set<keyof ChannelDoctorAdapter>([
   "groupAllowFromFallbackToAllowFrom",
+  "groupOwnerAllowFromFallbackToAllowFrom",
+  "commandGroupAllowFromFallbackToAllowFrom",
+  "commandAllowFromFallbackToAllowFrom",
+  "elevatedAllowFromFallbackToAllowFrom",
   "warnOnEmptyGroupSenderAllowlist",
 ]);
 
@@ -170,6 +179,23 @@ function mergeDoctorAdapters(
   return Object.keys(merged).length > 0 ? (merged as ChannelDoctorAdapter) : undefined;
 }
 
+function resolveSupportsGroupChats(
+  candidates: Array<ChannelDoctorPluginCandidate | undefined>,
+): boolean | undefined {
+  let hasChatTypeMetadata = false;
+  for (const candidate of candidates) {
+    const chatTypes = candidate?.capabilities?.chatTypes;
+    if (!Array.isArray(chatTypes)) {
+      continue;
+    }
+    hasChatTypeMetadata = true;
+    if (chatTypes.some((chatType) => chatType !== "direct")) {
+      return true;
+    }
+  }
+  return hasChatTypeMetadata ? false : undefined;
+}
+
 function isValidChannelDoctorAdapterValue(
   key: keyof ChannelDoctorAdapter,
   value: unknown,
@@ -283,6 +309,42 @@ export function createChannelDoctorEmptyAllowlistPolicyHooks(
         params,
       ),
   };
+}
+
+export function resolveDoctorChannelCapabilities(
+  context: ChannelDoctorLookupContext,
+  channelId?: string,
+): DoctorChannelCapabilities {
+  if (!channelId || isChannelDoctorBlockedByConfig(channelId, context.cfg)) {
+    return mergeDoctorChannelCapabilities();
+  }
+  const readOnlyPluginsById = listReadOnlyChannelPluginsById(context);
+  const candidates = [
+    readOnlyPluginsById.get(channelId),
+    safeGetLoadedChannelPlugin(channelId),
+    safeGetBundledChannelSetupPlugin(channelId),
+    safeGetBundledChannelPlugin(channelId),
+  ];
+  const doctor = mergeDoctorAdapters(candidates.map((candidate) => candidate?.doctor));
+  return mergeDoctorChannelCapabilities(doctor, {
+    supportsGroupChats: resolveSupportsGroupChats(candidates),
+  });
+}
+
+export function resolveDoctorChannelCapabilityMetadata(
+  context: ChannelDoctorLookupContext,
+  channelId?: string,
+) {
+  if (!channelId || isChannelDoctorBlockedByConfig(channelId, context.cfg)) {
+    return undefined;
+  }
+  const readOnlyPluginsById = listReadOnlyChannelPluginsById(context);
+  return mergeDoctorAdapters([
+    readOnlyPluginsById.get(channelId)?.doctor,
+    safeGetLoadedChannelPlugin(channelId)?.doctor,
+    safeGetBundledChannelSetupPlugin(channelId)?.doctor,
+    safeGetBundledChannelPlugin(channelId)?.doctor,
+  ]);
 }
 
 export async function runChannelDoctorConfigSequences(params: {

--- a/src/commands/doctor/shared/empty-allowlist-policy.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-policy.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
+import type { DoctorChannelCapabilities } from "../channel-capabilities.js";
 import { collectEmptyAllowlistPolicyWarningsForAccount } from "./empty-allowlist-policy.js";
 
 vi.mock("../channel-capabilities.js", () => ({
   getDoctorChannelCapabilities: (channelName?: string) => ({
     dmAllowFromMode: "topOnly",
     groupModel: channelName === "discord" ? "route" : "sender",
+    supportsGroupChats: true,
     groupAllowFromFallbackToAllowFrom: channelName !== "imessage",
     warnOnEmptyGroupSenderAllowlist: channelName !== "discord",
   }),
@@ -17,6 +19,26 @@ vi.mock("./channel-doctor.js", () => ({
     channelName?: string;
   }) => channelName === "zalouser",
 }));
+
+const baseCapabilities = (
+  overrides: Partial<DoctorChannelCapabilities> = {},
+): DoctorChannelCapabilities => ({
+  dmAllowFromMode: "topOnly",
+  groupModel: "sender",
+  supportsGroupChats: true,
+  groupAllowFromFallbackToAllowFrom: true,
+  groupOwnerAllowFromFallbackToAllowFrom: true,
+  commandAllowFromFallbackToAllowFrom: true,
+  elevatedAllowFromFallbackToAllowFrom: true,
+  warnOnEmptyGroupSenderAllowlist: true,
+  ...overrides,
+});
+
+function expectFutureRemovalWarningWithoutDoctorText(warnings: string[]): void {
+  const text = warnings.join("\n");
+  expect(text).toContain("will be removed in future releases");
+  expect(text).not.toContain("doctor");
+}
 
 describe("doctor empty allowlist policy warnings", () => {
   it("warns when dm allowlist mode has no allowFrom entries", () => {
@@ -62,6 +84,261 @@ describe("doctor empty allowlist policy warnings", () => {
       channelName: "discord",
       doctorFixCommand: "openclaw doctor --fix",
       prefix: "channels.discord",
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("warns when group sender access relies on allowFrom fallback", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["user:1"], groupPolicy: "allowlist" },
+      capabilities: baseCapabilities({
+        commandGroupAllowFromFallbackToAllowFrom: false,
+        groupOwnerAllowFromFallbackToAllowFrom: false,
+      }),
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toEqual([
+      '- channels.signal.groupPolicy is "allowlist" and channels.signal.groupAllowFrom is unset, so allowFrom is currently used as the group sender allowlist fallback. This behavior will be removed in future releases; set channels.signal.groupAllowFrom explicitly.',
+    ]);
+    expectFutureRemovalWarningWithoutDoctorText(warnings);
+  });
+
+  it("warns when group command access relies on allowFrom fallback", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["user:1"] },
+      capabilities: baseCapabilities({
+        commandGroupAllowFromFallbackToAllowFrom: true,
+        groupOwnerAllowFromFallbackToAllowFrom: false,
+      }),
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toEqual([
+      "- channels.signal group command authorization currently uses allowFrom as the group command allowlist fallback because commandGroupAllowFrom is unset. This behavior will be removed in future releases; set channels.signal.commandGroupAllowFrom explicitly.",
+    ]);
+    expectFutureRemovalWarningWithoutDoctorText(warnings);
+  });
+
+  it("stays quiet for group command fallback when commandGroupAllowFrom is unsupported", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["user:1"] },
+      capabilities: baseCapabilities({
+        groupOwnerAllowFromFallbackToAllowFrom: false,
+      }),
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("stays quiet for group command fallback when groupPolicy is disabled", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["user:1"], groupPolicy: "disabled" },
+      capabilities: baseCapabilities({
+        commandAllowFromFallbackToAllowFrom: false,
+        commandGroupAllowFromFallbackToAllowFrom: true,
+        elevatedAllowFromFallbackToAllowFrom: false,
+        groupOwnerAllowFromFallbackToAllowFrom: true,
+        groupOwnerAllowFromFallbackToAllowFromExplicit: true,
+      }),
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("stays quiet for group command fallback on direct-only channels", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["user:1"] },
+      capabilities: baseCapabilities({
+        supportsGroupChats: false,
+      }),
+      channelName: "directonly",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.directonly",
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("stays quiet for command group fallback when groupAllowFrom is configured", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: {
+        allowFrom: ["dm-user"],
+        groupAllowFrom: ["group-user"],
+      },
+      capabilities: baseCapabilities({
+        commandGroupAllowFromFallbackToAllowFrom: true,
+        groupOwnerAllowFromFallbackToAllowFrom: false,
+        commandAllowFromFallbackToAllowFrom: false,
+        elevatedAllowFromFallbackToAllowFrom: false,
+      }),
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("warns when group command-owner access relies on allowFrom fallback", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["user:1"] },
+      capabilities: baseCapabilities({
+        commandGroupAllowFromFallbackToAllowFrom: false,
+        groupOwnerAllowFromFallbackToAllowFrom: true,
+        groupOwnerAllowFromFallbackToAllowFromExplicit: true,
+      }),
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toEqual([
+      "- channels.signal group command-owner authorization currently uses allowFrom as the group command-owner fallback because groupOwnerAllowFrom is unset. This behavior will be removed in future releases; set channels.signal.groupOwnerAllowFrom explicitly.",
+    ]);
+    expectFutureRemovalWarningWithoutDoctorText(warnings);
+  });
+
+  it("stays quiet for group command-owner fallback when support is only defaulted", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["user:1"] },
+      capabilities: baseCapabilities({
+        commandAllowFromFallbackToAllowFrom: false,
+        commandGroupAllowFromFallbackToAllowFrom: false,
+        elevatedAllowFromFallbackToAllowFrom: false,
+        groupOwnerAllowFromFallbackToAllowFrom: true,
+      }),
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("warns when command and elevated authorization rely on allowFrom fallback", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["user:1"] },
+      capabilities: baseCapabilities({
+        commandAllowFromFallbackToAllowFromExplicit: true,
+        commandGroupAllowFromFallbackToAllowFrom: false,
+        groupOwnerAllowFromFallbackToAllowFrom: false,
+      }),
+      cfg: { channels: { signal: {} } },
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toEqual([
+      "- channels.signal command authorization currently uses allowFrom as the command allowlist fallback because commands.allowFrom.signal is unset. This behavior will be removed in future releases; set commands.allowFrom.signal explicitly.",
+      "- channels.signal elevated authorization currently uses allowFrom as the elevated allowlist fallback because tools.elevated.allowFrom.signal is unset. This behavior will be removed in future releases; set tools.elevated.allowFrom.signal explicitly.",
+    ]);
+    expectFutureRemovalWarningWithoutDoctorText(warnings);
+  });
+
+  it("stays quiet for command fallback when support is only defaulted", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["user:1"] },
+      capabilities: baseCapabilities({
+        commandGroupAllowFromFallbackToAllowFrom: false,
+        elevatedAllowFromFallbackToAllowFrom: false,
+        groupOwnerAllowFromFallbackToAllowFrom: false,
+      }),
+      cfg: { channels: { signal: {} } },
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("stays quiet for command and elevated fallback when explicit empty provider targets are configured", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["user:1"] },
+      capabilities: baseCapabilities({
+        commandAllowFromFallbackToAllowFromExplicit: true,
+        commandGroupAllowFromFallbackToAllowFrom: false,
+        groupOwnerAllowFromFallbackToAllowFrom: false,
+      }),
+      cfg: {
+        channels: { signal: {} },
+        commands: { allowFrom: { signal: [] } },
+        tools: { elevated: { allowFrom: { signal: [] } } },
+      },
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("honors global command allowlist before warning about command fallback", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["user:1"] },
+      capabilities: baseCapabilities({
+        commandAllowFromFallbackToAllowFromExplicit: true,
+        commandGroupAllowFromFallbackToAllowFrom: false,
+        groupOwnerAllowFromFallbackToAllowFrom: false,
+        elevatedAllowFromFallbackToAllowFrom: false,
+      }),
+      cfg: {
+        channels: { signal: {} },
+        commands: { allowFrom: { "*": ["global-user"] } },
+      },
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("treats wildcard-only allowFrom entries as fallback reliance", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: { allowFrom: ["*"] },
+      capabilities: baseCapabilities({
+        commandGroupAllowFromFallbackToAllowFrom: true,
+        groupOwnerAllowFromFallbackToAllowFrom: false,
+      }),
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      prefix: "channels.signal",
+    });
+
+    expect(warnings).toEqual([
+      "- channels.signal group command authorization currently uses allowFrom as the group command allowlist fallback because commandGroupAllowFrom is unset. This behavior will be removed in future releases; set channels.signal.commandGroupAllowFrom explicitly.",
+    ]);
+    expectFutureRemovalWarningWithoutDoctorText(warnings);
+  });
+
+  it("stays quiet when explicit empty command fallback targets are configured", () => {
+    const warnings = collectEmptyAllowlistPolicyWarningsForAccount({
+      account: {
+        allowFrom: ["user:1"],
+        commandGroupAllowFrom: [],
+      },
+      capabilities: baseCapabilities({
+        commandGroupAllowFromFallbackToAllowFrom: true,
+        groupOwnerAllowFromFallbackToAllowFrom: true,
+      }),
+      channelName: "signal",
+      doctorFixCommand: "openclaw doctor --fix",
+      parent: { groupOwnerAllowFrom: [] },
+      prefix: "channels.signal",
     });
 
     expect(warnings).toStrictEqual([]);

--- a/src/commands/doctor/shared/empty-allowlist-policy.ts
+++ b/src/commands/doctor/shared/empty-allowlist-policy.ts
@@ -1,5 +1,8 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { getDoctorChannelCapabilities } from "../channel-capabilities.js";
+import {
+  getDoctorChannelCapabilities,
+  type DoctorChannelCapabilities,
+} from "../channel-capabilities.js";
 import type { DoctorAccountRecord, DoctorAllowFromList } from "../types.js";
 import { hasAllowFromEntries } from "./allowlist.js";
 import { shouldSkipChannelDoctorDefaultEmptyGroupAllowlistWarning } from "./channel-doctor.js";
@@ -11,15 +14,12 @@ type CollectEmptyAllowlistPolicyWarningsParams = {
   doctorFixCommand: string;
   parent?: DoctorAccountRecord;
   prefix: string;
+  capabilities?: DoctorChannelCapabilities;
   shouldSkipDefaultEmptyGroupAllowlistWarning?: typeof shouldSkipChannelDoctorDefaultEmptyGroupAllowlistWarning;
 };
 
-function usesSenderBasedGroupAllowlist(channelName?: string): boolean {
-  return getDoctorChannelCapabilities(channelName).warnOnEmptyGroupSenderAllowlist;
-}
-
-function allowsGroupAllowFromFallback(channelName?: string): boolean {
-  return getDoctorChannelCapabilities(channelName).groupAllowFromFallbackToAllowFrom;
+function resolveCapabilities(params: CollectEmptyAllowlistPolicyWarningsParams) {
+  return params.capabilities ?? getDoctorChannelCapabilities(params.channelName);
 }
 
 export function collectEmptyAllowlistPolicyWarningsForAccount(
@@ -60,8 +60,21 @@ export function collectEmptyAllowlistPolicyWarningsForAccount(
     (params.account.groupPolicy as string | undefined) ??
     (params.parent?.groupPolicy as string | undefined) ??
     undefined;
+  const capabilities = resolveCapabilities(params);
 
-  if (groupPolicy !== "allowlist" || !usesSenderBasedGroupAllowlist(params.channelName)) {
+  collectCommandFallbackRelianceWarnings({
+    account: params.account,
+    capabilities,
+    cfg: params.cfg,
+    effectiveAllowFrom,
+    channelName: params.channelName,
+    groupPolicy,
+    parent: params.parent,
+    prefix: params.prefix,
+    warnings,
+  });
+
+  if (groupPolicy !== "allowlist" || !capabilities.warnOnEmptyGroupSenderAllowlist) {
     return warnings;
   }
 
@@ -89,9 +102,15 @@ export function collectEmptyAllowlistPolicyWarningsForAccount(
   // Match runtime semantics: resolveGroupAllowFromSources treats empty arrays as
   // unset and falls back to allowFrom.
   const groupAllowFrom = hasAllowFromEntries(rawGroupAllowFrom) ? rawGroupAllowFrom : undefined;
-  const fallbackToAllowFrom = allowsGroupAllowFromFallback(params.channelName);
+  const fallbackToAllowFrom = capabilities.groupAllowFromFallbackToAllowFrom;
   const effectiveGroupAllowFrom =
     groupAllowFrom ?? (fallbackToAllowFrom ? effectiveAllowFrom : undefined);
+
+  if (fallbackToAllowFrom && !groupAllowFrom && hasAllowFromEntries(effectiveAllowFrom)) {
+    warnings.push(
+      `- ${params.prefix}.groupPolicy is "allowlist" and ${params.prefix}.groupAllowFrom is unset, so allowFrom is currently used as the group sender allowlist fallback. This behavior will be removed in future releases; set ${params.prefix}.groupAllowFrom explicitly.`,
+    );
+  }
 
   if (hasAllowFromEntries(effectiveGroupAllowFrom)) {
     return warnings;
@@ -108,4 +127,123 @@ export function collectEmptyAllowlistPolicyWarningsForAccount(
   }
 
   return warnings;
+}
+
+function collectCommandFallbackRelianceWarnings(params: {
+  account: DoctorAccountRecord;
+  capabilities: DoctorChannelCapabilities;
+  cfg?: OpenClawConfig;
+  effectiveAllowFrom?: DoctorAllowFromList;
+  channelName?: string;
+  groupPolicy?: string;
+  parent?: DoctorAccountRecord;
+  prefix: string;
+  warnings: string[];
+}): void {
+  if (!hasAllowFromEntries(params.effectiveAllowFrom)) {
+    return;
+  }
+  const commandGroupFallback = params.capabilities.commandGroupAllowFromFallbackToAllowFrom;
+  const commandGroupCoveredByGroupAllowFrom = hasAllowFromEntries(
+    readAllowFromTarget(params.account, params.parent, "groupAllowFrom"),
+  );
+  const shouldWarnForGroupCommands =
+    params.groupPolicy !== "disabled" &&
+    (params.capabilities.supportsGroupChats || hasGroupCommandAuthorizationConfig(params));
+  if (
+    shouldWarnForGroupCommands &&
+    commandGroupFallback &&
+    !hasExplicitAllowFromTarget(params.account, params.parent, "commandGroupAllowFrom") &&
+    !commandGroupCoveredByGroupAllowFrom
+  ) {
+    params.warnings.push(
+      `- ${params.prefix} group command authorization currently uses allowFrom as the group command allowlist fallback because commandGroupAllowFrom is unset. This behavior will be removed in future releases; set ${params.prefix}.commandGroupAllowFrom explicitly.`,
+    );
+  }
+  if (
+    shouldWarnForGroupCommands &&
+    params.capabilities.groupOwnerAllowFromFallbackToAllowFrom &&
+    params.capabilities.groupOwnerAllowFromFallbackToAllowFromExplicit === true &&
+    !hasExplicitAllowFromTarget(params.account, params.parent, "groupOwnerAllowFrom")
+  ) {
+    params.warnings.push(
+      `- ${params.prefix} group command-owner authorization currently uses allowFrom as the group command-owner fallback because groupOwnerAllowFrom is unset. This behavior will be removed in future releases; set ${params.prefix}.groupOwnerAllowFrom explicitly.`,
+    );
+  }
+  if (
+    params.cfg &&
+    params.channelName &&
+    params.capabilities.commandAllowFromFallbackToAllowFrom &&
+    params.capabilities.commandAllowFromFallbackToAllowFromExplicit === true &&
+    !hasExplicitProviderAllowFromTarget(params.cfg?.commands?.allowFrom, params.channelName, {
+      includeGlobal: true,
+    })
+  ) {
+    params.warnings.push(
+      `- ${params.prefix} command authorization currently uses allowFrom as the command allowlist fallback because commands.allowFrom.${params.channelName} is unset. This behavior will be removed in future releases; set commands.allowFrom.${params.channelName} explicitly.`,
+    );
+  }
+  if (
+    params.cfg &&
+    params.channelName &&
+    params.capabilities.elevatedAllowFromFallbackToAllowFrom &&
+    !hasExplicitProviderAllowFromTarget(params.cfg?.tools?.elevated?.allowFrom, params.channelName)
+  ) {
+    params.warnings.push(
+      `- ${params.prefix} elevated authorization currently uses allowFrom as the elevated allowlist fallback because tools.elevated.allowFrom.${params.channelName} is unset. This behavior will be removed in future releases; set tools.elevated.allowFrom.${params.channelName} explicitly.`,
+    );
+  }
+}
+
+function hasGroupCommandAuthorizationConfig(params: {
+  account: DoctorAccountRecord;
+  capabilities: DoctorChannelCapabilities;
+  parent?: DoctorAccountRecord;
+}): boolean {
+  return (
+    params.capabilities.commandGroupAllowFromFallbackToAllowFrom !== undefined ||
+    params.capabilities.groupOwnerAllowFromFallbackToAllowFromExplicit === true ||
+    Array.isArray(params.account.groupAllowFrom) ||
+    Array.isArray(params.parent?.groupAllowFrom) ||
+    Array.isArray(params.account.commandGroupAllowFrom) ||
+    Array.isArray(params.parent?.commandGroupAllowFrom) ||
+    Array.isArray(params.account.groupOwnerAllowFrom) ||
+    Array.isArray(params.parent?.groupOwnerAllowFrom)
+  );
+}
+
+function hasExplicitAllowFromTarget(
+  account: DoctorAccountRecord,
+  parent: DoctorAccountRecord | undefined,
+  key: "commandGroupAllowFrom" | "groupOwnerAllowFrom",
+): boolean {
+  return Array.isArray(account[key]) || Array.isArray(parent?.[key]);
+}
+
+function readAllowFromTarget(
+  account: DoctorAccountRecord,
+  parent: DoctorAccountRecord | undefined,
+  key: "groupAllowFrom",
+): DoctorAllowFromList | undefined {
+  const own = account[key];
+  if (Array.isArray(own)) {
+    return own as DoctorAllowFromList;
+  }
+  const inherited = parent?.[key];
+  return Array.isArray(inherited) ? (inherited as DoctorAllowFromList) : undefined;
+}
+
+function hasExplicitProviderAllowFromTarget(
+  allowFromByProvider: unknown,
+  channelName: string | undefined,
+  options: { includeGlobal?: boolean } = {},
+): boolean {
+  if (!channelName || !allowFromByProvider || typeof allowFromByProvider !== "object") {
+    return false;
+  }
+  const allowFromRecord = allowFromByProvider as Record<string, unknown>;
+  return (
+    Object.hasOwn(allowFromRecord, channelName) ||
+    (options.includeGlobal === true && Object.hasOwn(allowFromRecord, "*"))
+  );
 }

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -5,6 +5,7 @@ vi.mock("../channel-capabilities.js", () => ({
   getDoctorChannelCapabilities: (channelName?: string) => ({
     dmAllowFromMode: "topOnly",
     groupModel: "sender",
+    supportsGroupChats: true,
     groupAllowFromFallbackToAllowFrom: channelName !== "imessage",
     warnOnEmptyGroupSenderAllowlist: channelName !== "discord",
   }),

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -1,5 +1,6 @@
 import type { ChannelDoctorEmptyAllowlistAccountContext } from "../../../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { DoctorChannelCapabilities } from "../channel-capabilities.js";
 import type { DoctorAccountRecord, DoctorAllowFromList } from "../types.js";
 import { collectEmptyAllowlistPolicyWarningsForAccount } from "./empty-allowlist-policy.js";
 import { asObjectRecord } from "./object.js";
@@ -10,6 +11,7 @@ type ScanEmptyAllowlistPolicyWarningsParams = {
   shouldSkipDefaultEmptyGroupAllowlistWarning?: (
     params: ChannelDoctorEmptyAllowlistAccountContext,
   ) => boolean;
+  resolveCapabilities?: (channelName: string) => DoctorChannelCapabilities;
 };
 
 function isDisabledRecord(value: unknown): boolean {
@@ -59,6 +61,7 @@ export function scanEmptyAllowlistPolicyWarnings(
         doctorFixCommand: params.doctorFixCommand,
         parent,
         prefix,
+        capabilities: params.resolveCapabilities?.(channelName),
         shouldSkipDefaultEmptyGroupAllowlistWarning:
           params.shouldSkipDefaultEmptyGroupAllowlistWarning,
       }),

--- a/src/commands/doctor/shared/open-policy-allowfrom.test.ts
+++ b/src/commands/doctor/shared/open-policy-allowfrom.test.ts
@@ -9,6 +9,7 @@ vi.mock("../channel-capabilities.js", () => ({
     dmAllowFromMode:
       channelName === "googlechat" || channelName === "matrix" ? "nestedOnly" : "topOrNested",
     groupModel: "sender",
+    supportsGroupChats: true,
     groupAllowFromFallbackToAllowFrom: true,
     warnOnEmptyGroupSenderAllowlist: true,
   }),

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -30,7 +30,11 @@ vi.mock("../channel-capabilities.js", () => {
   const fallback = {
     dmAllowFromMode: "topOnly",
     groupModel: "sender",
+    supportsGroupChats: true,
     groupAllowFromFallbackToAllowFrom: true,
+    groupOwnerAllowFromFallbackToAllowFrom: true,
+    commandAllowFromFallbackToAllowFrom: true,
+    elevatedAllowFromFallbackToAllowFrom: true,
     warnOnEmptyGroupSenderAllowlist: true,
   };
   return {
@@ -61,6 +65,17 @@ vi.mock("./channel-doctor.js", () => ({
   createChannelDoctorEmptyAllowlistPolicyHooks: vi.fn(() => ({
     extraWarningsForAccount: () => [],
     shouldSkipDefaultEmptyGroupAllowlistWarning: () => false,
+  })),
+  resolveDoctorChannelCapabilities: vi.fn((_: unknown, channelName?: string) => ({
+    dmAllowFromMode: "topOnly",
+    groupModel: "sender",
+    supportsGroupChats: true,
+    groupAllowFromFallbackToAllowFrom: true,
+    groupOwnerAllowFromFallbackToAllowFrom: channelName !== "external",
+    commandGroupAllowFromFallbackToAllowFrom: channelName !== "external",
+    commandAllowFromFallbackToAllowFrom: true,
+    elevatedAllowFromFallbackToAllowFrom: true,
+    warnOnEmptyGroupSenderAllowlist: true,
   })),
   shouldSkipChannelDoctorDefaultEmptyGroupAllowlistWarning: vi.fn(() => false),
 }));
@@ -265,6 +280,23 @@ describe("doctor preview warnings", () => {
     );
     expect(warning).not.toContain("\u001B");
     expect(warning).not.toContain("\r");
+  });
+
+  it("uses contextual channel capabilities for preview fallback warnings", async () => {
+    const warnings = await collectDoctorPreviewWarnings({
+      cfg: {
+        channels: {
+          external: {
+            allowFrom: ["user:1"],
+          },
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    const text = warnings.join("\n");
+    expect(text).not.toContain("group command authorization currently uses allowFrom");
+    expect(text).not.toContain("group command-owner authorization currently uses allowFrom");
   });
 
   it("includes stale plugin config warnings", async () => {

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -462,7 +462,8 @@ export async function collectDoctorPreviewWarnings(params: {
   }
 
   if (hasChannelConfig) {
-    const { createChannelDoctorEmptyAllowlistPolicyHooks } = await loadChannelDoctorModule();
+    const { createChannelDoctorEmptyAllowlistPolicyHooks, resolveDoctorChannelCapabilities } =
+      await loadChannelDoctorModule();
     const { scanEmptyAllowlistPolicyWarnings } = await import("./empty-allowlist-scan.js");
     const emptyAllowlistHooks = createChannelDoctorEmptyAllowlistPolicyHooks({
       cfg: params.cfg,
@@ -471,6 +472,8 @@ export async function collectDoctorPreviewWarnings(params: {
     const emptyAllowlistWarnings = scanEmptyAllowlistPolicyWarnings(params.cfg, {
       doctorFixCommand: params.doctorFixCommand,
       extraWarningsForAccount: emptyAllowlistHooks.extraWarningsForAccount,
+      resolveCapabilities: (channelName) =>
+        resolveDoctorChannelCapabilities({ cfg: params.cfg, env }, channelName),
       shouldSkipDefaultEmptyGroupAllowlistWarning:
         emptyAllowlistHooks.shouldSkipDefaultEmptyGroupAllowlistWarning,
     }).filter(

--- a/src/config/allowfrom-fallback-transition.test.ts
+++ b/src/config/allowfrom-fallback-transition.test.ts
@@ -1,0 +1,816 @@
+import { describe, expect, it } from "vitest";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import {
+  applyAllowFromFallbackTransition,
+  classifyAllowFromFallbackTransitions,
+} from "./allowfrom-fallback-transition.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+
+const fallbackOffCapabilities = {
+  groupAllowFromFallbackToAllowFrom: false,
+  commandGroupAllowFromFallbackToAllowFrom: false,
+  groupOwnerAllowFromFallbackToAllowFrom: false,
+  commandAllowFromFallbackToAllowFrom: false,
+  elevatedAllowFromFallbackToAllowFrom: false,
+};
+
+const resolveCapabilities = (channelId: string) =>
+  channelId === "demo" ? fallbackOffCapabilities : undefined;
+
+describe("allowFrom fallback transition", () => {
+  it("copies wildcard, pattern, and accessGroup entries to each explicit target", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["*", "foo:*", "accessGroup:ops", "", "foo:*"],
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, { resolveCapabilities });
+
+    expect(result.config.channels?.demo).toMatchObject({
+      groupAllowFrom: ["*", "foo:*", "accessGroup:ops"],
+      commandGroupAllowFrom: ["*", "foo:*", "accessGroup:ops"],
+      groupOwnerAllowFrom: ["*", "foo:*", "accessGroup:ops"],
+    });
+    expect(result.config.commands?.allowFrom?.demo).toEqual(["*", "foo:*", "accessGroup:ops"]);
+    expect(result.config.tools?.elevated?.allowFrom?.demo).toEqual([
+      "*",
+      "foo:*",
+      "accessGroup:ops",
+    ]);
+    expect(result.config.channels?.demo).not.toBe(cfg.channels?.demo);
+    expect(result.changes).toHaveLength(5);
+  });
+
+  it("does not overwrite explicit targets, including empty arrays", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["user:1"],
+          groupAllowFrom: ["group:1"],
+          commandGroupAllowFrom: ["cmd:1"],
+          groupOwnerAllowFrom: [],
+        },
+      },
+      commands: { allowFrom: { demo: [] } },
+      tools: { elevated: { allowFrom: { demo: ["root:1"] } } },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, { resolveCapabilities });
+
+    expect(result.config).toBe(cfg);
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("copies allowFrom over empty groupAllowFrom because runtime treats it as fallback", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["user:1"],
+          groupAllowFrom: [],
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              groupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config.channels?.demo).toMatchObject({
+      allowFrom: ["user:1"],
+      groupAllowFrom: ["user:1"],
+    });
+    expect(result.changes).toEqual([
+      "Copied channels.demo.allowFrom entries to channels.demo.groupAllowFrom because group-sender fallback to allowFrom is disabled.",
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("copies account allowFrom over inherited empty groupAllowFrom", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          groupAllowFrom: [],
+          accounts: {
+            work: {
+              allowFrom: ["account-user"],
+            },
+          },
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              groupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    const demo = result.config.channels?.demo as
+      | { accounts?: Record<string, Record<string, unknown>> }
+      | undefined;
+    expect(demo?.accounts?.work).toMatchObject({
+      allowFrom: ["account-user"],
+      groupAllowFrom: ["account-user"],
+    });
+    expect(result.changes).toEqual([
+      "Copied channels.demo.accounts.work.allowFrom entries to channels.demo.accounts.work.groupAllowFrom because group-sender fallback to allowFrom is disabled.",
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("copies allowFrom into commandGroupAllowFrom when groupAllowFrom is empty", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["cmd-user"],
+          groupAllowFrom: [],
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              commandGroupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config.channels?.demo).toMatchObject({
+      allowFrom: ["cmd-user"],
+      groupAllowFrom: [],
+      commandGroupAllowFrom: ["cmd-user"],
+    });
+    expect(result.changes).toEqual([
+      "Copied channels.demo.allowFrom entries to channels.demo.commandGroupAllowFrom because command-group fallback to allowFrom is disabled.",
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("does not infer plugin-specific groupSenderAllowFrom as the generic target", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["sender:1"],
+          groupAllowFrom: ["room:1"],
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              groupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config).toBe(cfg);
+    expect(result.config.channels?.demo).toEqual({
+      allowFrom: ["sender:1"],
+      groupAllowFrom: ["room:1"],
+    });
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("preserves dotted account ids when applying local account migrations", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          accounts: {
+            "work.prod": {
+              allowFrom: ["account-user"],
+            },
+          },
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              groupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    const demo = result.config.channels?.demo as
+      | { accounts?: Record<string, Record<string, unknown>>; work?: unknown }
+      | undefined;
+    expect(demo?.accounts?.["work.prod"]).toMatchObject({
+      allowFrom: ["account-user"],
+      groupAllowFrom: ["account-user"],
+    });
+    expect(demo?.work).toBeUndefined();
+    expect(result.changes).toEqual([
+      "Copied channels.demo.accounts.work.prod.allowFrom entries to channels.demo.accounts.work.prod.groupAllowFrom because group-sender fallback to allowFrom is disabled.",
+    ]);
+  });
+
+  it("does not copy inherited channel allowFrom into account-local targets", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["channel-user"],
+          accounts: {
+            work: {
+              name: "Work",
+            },
+          },
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              groupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config.channels?.demo).toMatchObject({
+      allowFrom: ["channel-user"],
+      groupAllowFrom: ["channel-user"],
+      accounts: {
+        work: {
+          name: "Work",
+        },
+      },
+    });
+    expect(
+      (
+        result.config.channels?.demo as
+          | { accounts?: { work?: { groupAllowFrom?: unknown } } }
+          | undefined
+      )?.accounts?.work?.groupAllowFrom,
+    ).toBeUndefined();
+    expect(result.changes).toEqual([
+      "Copied channels.demo.allowFrom entries to channels.demo.groupAllowFrom because group-sender fallback to allowFrom is disabled.",
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("preserves explicit empty account allowlists when parent targets are migrated", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["channel-user"],
+          accounts: {
+            blocked: {
+              allowFrom: [],
+            },
+          },
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, { resolveCapabilities });
+    const demo = result.config.channels?.demo as
+      | { accounts?: Record<string, Record<string, unknown>> }
+      | undefined;
+
+    expect(result.config.channels?.demo).toMatchObject({
+      allowFrom: ["channel-user"],
+      groupAllowFrom: ["channel-user"],
+      commandGroupAllowFrom: ["channel-user"],
+      groupOwnerAllowFrom: ["channel-user"],
+    });
+    expect(demo?.accounts?.blocked).toMatchObject({
+      allowFrom: [],
+      groupAllowFrom: [],
+      commandGroupAllowFrom: [],
+      groupOwnerAllowFrom: [],
+    });
+    expect(result.changes).toEqual([
+      "Copied channels.demo.allowFrom entries to channels.demo.groupAllowFrom because group-sender fallback to allowFrom is disabled.",
+      "Copied channels.demo.allowFrom entries to channels.demo.commandGroupAllowFrom because command-group fallback to allowFrom is disabled.",
+      "Copied channels.demo.allowFrom entries to channels.demo.groupOwnerAllowFrom because group-command-owner fallback to allowFrom is disabled.",
+      "Set channels.demo.accounts.blocked.groupAllowFrom to an explicit empty allowlist because group-sender fallback to allowFrom is disabled.",
+      "Set channels.demo.accounts.blocked.commandGroupAllowFrom to an explicit empty allowlist because command-group fallback to allowFrom is disabled.",
+      "Set channels.demo.accounts.blocked.groupOwnerAllowFrom to an explicit empty allowlist because group-command-owner fallback to allowFrom is disabled.",
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("does not migrate command group allowlists when groupAllowFrom already supplies them", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["dm-user"],
+          groupAllowFrom: ["group-user"],
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              commandGroupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config).toBe(cfg);
+    expect(result.config.channels?.demo).toEqual({
+      allowFrom: ["dm-user"],
+      groupAllowFrom: ["group-user"],
+    });
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("does not warn for command group fallback when groupAllowFrom already supplies it", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["dm-user"],
+          groupAllowFrom: ["group-user"],
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              commandGroupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config).toBe(cfg);
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("copies over empty groupAllowFrom while preserving explicit empty command targets", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["dm-user"],
+          groupAllowFrom: [],
+          commandGroupAllowFrom: [],
+          groupOwnerAllowFrom: [],
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              groupAllowFromFallbackToAllowFrom: false,
+              commandGroupAllowFromFallbackToAllowFrom: false,
+              groupOwnerAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config.channels?.demo).toMatchObject({
+      allowFrom: ["dm-user"],
+      groupAllowFrom: ["dm-user"],
+      commandGroupAllowFrom: [],
+      groupOwnerAllowFrom: [],
+    });
+    expect(result.changes).toEqual([
+      "Copied channels.demo.allowFrom entries to channels.demo.groupAllowFrom because group-sender fallback to allowFrom is disabled.",
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("does not migrate command group when only group fallback is disabled", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["dm-user"],
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              groupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config.channels?.demo).toMatchObject({
+      allowFrom: ["dm-user"],
+      groupAllowFrom: ["dm-user"],
+    });
+    expect(
+      (result.config.channels?.demo as { commandGroupAllowFrom?: unknown } | undefined)
+        ?.commandGroupAllowFrom,
+    ).toBeUndefined();
+    expect(result.changes).toEqual([
+      "Copied channels.demo.allowFrom entries to channels.demo.groupAllowFrom because group-sender fallback to allowFrom is disabled.",
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("migrates command group separately when its fallback is explicitly disabled", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["dm-user"],
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              groupAllowFromFallbackToAllowFrom: false,
+              commandGroupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config.channels?.demo).toMatchObject({
+      allowFrom: ["dm-user"],
+      groupAllowFrom: ["dm-user"],
+      commandGroupAllowFrom: ["dm-user"],
+    });
+    expect(result.changes).toEqual([
+      "Copied channels.demo.allowFrom entries to channels.demo.groupAllowFrom because group-sender fallback to allowFrom is disabled.",
+      "Copied channels.demo.allowFrom entries to channels.demo.commandGroupAllowFrom because command-group fallback to allowFrom is disabled.",
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("classifies disabled plugins without mutating them", () => {
+    const cfg: OpenClawConfig = {
+      plugins: { enabled: true, entries: { disabled: { enabled: false } } },
+      channels: {
+        demo: { allowFrom: ["user:1"] },
+        missing: { allowFrom: ["user:2"] },
+        disabled: { allowFrom: ["user:3"] },
+      },
+    };
+
+    const classifications = classifyAllowFromFallbackTransitions(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              groupAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(classifications).toContainEqual(
+      expect.objectContaining({
+        channelName: "demo",
+        family: "group-sender",
+        fallbackDisabled: true,
+        target: "groupAllowFrom",
+        migrationEligible: true,
+        warningNeeded: false,
+      }),
+    );
+    expect(classifications.some((item) => item.channelName === "disabled")).toBe(false);
+  });
+
+  it("infers group owner migration target from disabled owner fallback", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: { allowFrom: ["user:1"] },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              groupOwnerAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config.channels?.demo).toMatchObject({
+      allowFrom: ["user:1"],
+      groupOwnerAllowFrom: ["user:1"],
+    });
+    expect(result.changes).toEqual([
+      "Copied channels.demo.allowFrom entries to channels.demo.groupOwnerAllowFrom because group-command-owner fallback to allowFrom is disabled.",
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("ignores stale legacy migration target metadata and uses the inferred target", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: { allowFrom: ["user:1"] },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? ({
+              groupAllowFromFallbackToAllowFrom: false,
+              legacyDmAllowFromMigrationTarget: "__proto__",
+            } as unknown as ReturnType<typeof resolveCapabilities>)
+          : undefined,
+    });
+
+    expect(result.config.channels?.demo).toMatchObject({
+      allowFrom: ["user:1"],
+      groupAllowFrom: ["user:1"],
+    });
+    expect(
+      Object.hasOwn(result.config.channels?.demo as Record<string, unknown>, "__proto__"),
+    ).toBe(false);
+    expect(result.changes).toEqual([
+      "Copied channels.demo.allowFrom entries to channels.demo.groupAllowFrom because group-sender fallback to allowFrom is disabled.",
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("uses read-only manifest doctor metadata for repair transitions", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        external: { allowFrom: ["user:1"] },
+      },
+    };
+    const result = applyAllowFromFallbackTransition(cfg, {
+      manifestRegistry: {
+        plugins: [
+          {
+            channelCatalogMeta: {
+              id: "external",
+              doctorCapabilities: {
+                groupAllowFromFallbackToAllowFrom: false,
+              },
+            },
+          } as unknown as PluginManifestRecord,
+        ],
+      },
+    });
+
+    expect(result.config.channels?.external).toMatchObject({
+      groupAllowFrom: ["user:1"],
+    });
+  });
+
+  it("skips manifest-owned transitions when the owning plugin is disabled", () => {
+    const cfg: OpenClawConfig = {
+      plugins: {
+        entries: {
+          "external-chat-plugin": { enabled: false },
+        },
+      },
+      channels: {
+        "external-chat": { allowFrom: ["user:1"] },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      manifestRegistry: {
+        plugins: [
+          {
+            id: "external-chat-plugin",
+            channelCatalogMeta: {
+              id: "external-chat",
+              doctorCapabilities: {
+                groupAllowFromFallbackToAllowFrom: false,
+              },
+            },
+          } as unknown as PluginManifestRecord,
+        ],
+      },
+    });
+
+    expect(result.config).toBe(cfg);
+    expect(result.config.channels?.["external-chat"]).toEqual({ allowFrom: ["user:1"] });
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("copies inherited multi-account command fallback allowFrom entries into provider command allowlist", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["channel-user", "foo:*"],
+          accounts: {
+            work: {
+              name: "Work",
+            },
+            personal: {
+              name: "Personal",
+            },
+            disabled: {
+              enabled: false,
+              allowFrom: ["disabled-user"],
+            },
+          },
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              commandAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config.commands?.allowFrom?.demo).toEqual(["channel-user", "foo:*"]);
+  });
+
+  it("does not overwrite explicit provider command allowlist when accounts need migration", () => {
+    const cfg: OpenClawConfig = {
+      commands: { allowFrom: { demo: ["explicit-user"] } },
+      channels: {
+        demo: {
+          accounts: {
+            work: { allowFrom: ["account-user"] },
+          },
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              commandAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config).toBe(cfg);
+    expect(result.config.commands?.allowFrom?.demo).toEqual(["explicit-user"]);
+    expect(result.changes).toEqual([]);
+  });
+
+  it("honors global command allowlist before migrating provider command allowlist", () => {
+    const cfg: OpenClawConfig = {
+      commands: { allowFrom: { "*": ["global-user"] } },
+      channels: {
+        demo: {
+          allowFrom: ["channel-user"],
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              commandAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config).toBe(cfg);
+    expect(result.config.commands?.allowFrom?.["*"]).toEqual(["global-user"]);
+    expect(result.config.commands?.allowFrom?.demo).toBeUndefined();
+    expect(result.changes).toEqual([]);
+  });
+
+  it("warns instead of unioning multi-account command fallback allowFrom entries", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["channel-user", "foo:*"],
+          accounts: {
+            work: {
+              allowFrom: ["work-user"],
+            },
+            personal: {
+              dm: { allowFrom: ["personal-user"] },
+            },
+          },
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              commandAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config).toBe(cfg);
+    expect(result.config.commands?.allowFrom?.demo).toBeUndefined();
+    expect(result.changes).toEqual([]);
+    expect(result.warnings.join("\n")).toContain("account_scoped_entries");
+  });
+
+  it("copies single-account command fallback allowFrom entries into provider command allowlist", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          allowFrom: ["channel-user"],
+          accounts: {
+            work: {
+              allowFrom: ["account-user"],
+            },
+          },
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              commandAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config.commands?.allowFrom?.demo).toEqual(["account-user"]);
+  });
+
+  it("warns instead of unioning multi-account elevated fallback allowFrom entries", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        demo: {
+          dm: { allowFrom: ["channel-dm", "accessGroup:ops"] },
+          accounts: {
+            work: {
+              allowFrom: ["account-user", "foo:*", "channel-dm"],
+            },
+            personal: {
+              dm: { allowFrom: ["*", "accessGroup:oncall"] },
+            },
+            disabled: {
+              enabled: false,
+              allowFrom: ["disabled-user"],
+            },
+          },
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              dmAllowFromMode: "topOrNested",
+              elevatedAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config).toBe(cfg);
+    expect(result.config.tools?.elevated?.allowFrom?.demo).toBeUndefined();
+    expect(result.changes).toEqual([]);
+    expect(result.warnings.join("\n")).toContain("account_scoped_entries");
+  });
+
+  it("does not overwrite explicit provider elevated allowlist when accounts need migration", () => {
+    const cfg: OpenClawConfig = {
+      tools: { elevated: { allowFrom: { demo: [] } } },
+      channels: {
+        demo: {
+          allowFrom: ["channel-user"],
+          accounts: {
+            work: { allowFrom: ["account-user"] },
+          },
+        },
+      },
+    };
+
+    const result = applyAllowFromFallbackTransition(cfg, {
+      resolveCapabilities: (channelId) =>
+        channelId === "demo"
+          ? {
+              elevatedAllowFromFallbackToAllowFrom: false,
+            }
+          : undefined,
+    });
+
+    expect(result.config).toBe(cfg);
+    expect(result.config.tools?.elevated?.allowFrom?.demo).toEqual([]);
+    expect(result.changes).toEqual([]);
+  });
+});

--- a/src/config/allowfrom-fallback-transition.ts
+++ b/src/config/allowfrom-fallback-transition.ts
@@ -1,0 +1,891 @@
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import type { PluginPackageChannelDoctorCapabilities } from "../plugins/manifest.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import { normalizeStringEntries } from "../shared/string-normalization.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+
+type ChannelRecord = Record<string, unknown>;
+
+type MigrationFamily =
+  | "group-sender"
+  | "command-group"
+  | "group-command-owner"
+  | "command-allow"
+  | "elevated-allow";
+
+type LocalTarget = "groupAllowFrom" | "groupOwnerAllowFrom" | "commandGroupAllowFrom";
+
+export type AllowFromFallbackTransitionClassification = {
+  family: MigrationFamily;
+  prefix: string;
+  recordPath: readonly string[];
+  channelName: string;
+  target?: LocalTarget | "commands.allowFrom" | "tools.elevated.allowFrom";
+  fallbackDisabled: boolean;
+  migrationEligible: boolean;
+  warningNeeded: boolean;
+  migratedEntries: string[];
+  noMutationReason?:
+    | "fallback_enabled"
+    | "missing_target"
+    | "explicit_target"
+    | "inherited_target"
+    | "account_scoped_entries"
+    | "no_dm_allowfrom"
+    | "no_migratable_entries"
+    | "disabled";
+};
+
+type EffectiveCapabilities = {
+  dmAllowFromMode: "topOnly" | "topOrNested" | "nestedOnly";
+  groupModel: "sender" | "route" | "hybrid";
+  groupAllowFromFallbackToAllowFrom: boolean;
+  groupOwnerAllowFromFallbackToAllowFrom: boolean;
+  commandGroupAllowFromFallbackToAllowFrom?: boolean;
+  commandAllowFromFallbackToAllowFrom: boolean;
+  elevatedAllowFromFallbackToAllowFrom: boolean;
+};
+
+const PSEUDO_CHANNEL_KEYS = new Set(["defaults", "modelByChannel"]);
+const DM_ALLOW_FROM_MODES: ReadonlySet<
+  NonNullable<PluginPackageChannelDoctorCapabilities["dmAllowFromMode"]>
+> = new Set(["topOnly", "topOrNested", "nestedOnly"]);
+const GROUP_MODELS: ReadonlySet<NonNullable<PluginPackageChannelDoctorCapabilities["groupModel"]>> =
+  new Set(["sender", "route", "hybrid"]);
+
+function isRecord(value: unknown): value is ChannelRecord {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function hasOwn(record: ChannelRecord | undefined, key: string): boolean {
+  return Boolean(record && Object.prototype.hasOwnProperty.call(record, key));
+}
+
+function isDisabled(record: ChannelRecord | undefined): boolean {
+  return record?.enabled === false;
+}
+
+function isPluginEntryDisabled(cfg: OpenClawConfig, pluginId: string): boolean {
+  const entries = cfg.plugins?.entries;
+  if (!isRecord(entries)) {
+    return false;
+  }
+  const exactEntry = entries[pluginId];
+  if (isRecord(exactEntry) && exactEntry.enabled === false) {
+    return true;
+  }
+  const normalizedPluginId = normalizeOptionalLowercaseString(pluginId);
+  if (!normalizedPluginId || normalizedPluginId === pluginId) {
+    return false;
+  }
+  const normalizedEntry = entries[normalizedPluginId];
+  return isRecord(normalizedEntry) && normalizedEntry.enabled === false;
+}
+
+function resolveManifestChannelOwner(
+  channelId: string,
+  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">,
+) {
+  const normalized = normalizeOptionalLowercaseString(channelId) ?? channelId;
+  return manifestRegistry?.plugins.find((record) => record.channelCatalogMeta?.id === normalized);
+}
+
+function isChannelTransitionDisabled(
+  cfg: OpenClawConfig,
+  channelName: string,
+  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">,
+): boolean {
+  if (isPluginEntryDisabled(cfg, channelName)) {
+    return true;
+  }
+  const owner = resolveManifestChannelOwner(channelName, manifestRegistry);
+  return owner ? isPluginEntryDisabled(cfg, owner.id) : false;
+}
+
+function readBooleanCapability(record: ChannelRecord, key: string): boolean | undefined {
+  return typeof record[key] === "boolean" ? record[key] : undefined;
+}
+
+function readStringCapability<T extends string>(
+  record: ChannelRecord,
+  key: string,
+  allowed: ReadonlySet<T>,
+): T | undefined {
+  const value = record[key];
+  return typeof value === "string" && allowed.has(value as T) ? (value as T) : undefined;
+}
+
+function normalizeTransitionCapabilities(
+  capabilities?: PluginPackageChannelDoctorCapabilities,
+): PluginPackageChannelDoctorCapabilities | undefined {
+  if (!isRecord(capabilities)) {
+    return undefined;
+  }
+  const normalized: PluginPackageChannelDoctorCapabilities = {};
+  const dmAllowFromMode = readStringCapability<
+    NonNullable<PluginPackageChannelDoctorCapabilities["dmAllowFromMode"]>
+  >(capabilities, "dmAllowFromMode", DM_ALLOW_FROM_MODES);
+  if (dmAllowFromMode) {
+    normalized.dmAllowFromMode = dmAllowFromMode;
+  }
+  const groupModel = readStringCapability<
+    NonNullable<PluginPackageChannelDoctorCapabilities["groupModel"]>
+  >(capabilities, "groupModel", GROUP_MODELS);
+  if (groupModel) {
+    normalized.groupModel = groupModel;
+  }
+  const groupFallback = readBooleanCapability(capabilities, "groupAllowFromFallbackToAllowFrom");
+  if (groupFallback !== undefined) {
+    normalized.groupAllowFromFallbackToAllowFrom = groupFallback;
+  }
+  const ownerFallback = readBooleanCapability(
+    capabilities,
+    "groupOwnerAllowFromFallbackToAllowFrom",
+  );
+  if (ownerFallback !== undefined) {
+    normalized.groupOwnerAllowFromFallbackToAllowFrom = ownerFallback;
+  }
+  const commandGroupFallback = readBooleanCapability(
+    capabilities,
+    "commandGroupAllowFromFallbackToAllowFrom",
+  );
+  if (commandGroupFallback !== undefined) {
+    normalized.commandGroupAllowFromFallbackToAllowFrom = commandGroupFallback;
+  }
+  const commandFallback = readBooleanCapability(
+    capabilities,
+    "commandAllowFromFallbackToAllowFrom",
+  );
+  if (commandFallback !== undefined) {
+    normalized.commandAllowFromFallbackToAllowFrom = commandFallback;
+  }
+  const elevatedFallback = readBooleanCapability(
+    capabilities,
+    "elevatedAllowFromFallbackToAllowFrom",
+  );
+  if (elevatedFallback !== undefined) {
+    normalized.elevatedAllowFromFallbackToAllowFrom = elevatedFallback;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function mergeCapabilities(
+  capabilities?: PluginPackageChannelDoctorCapabilities,
+): EffectiveCapabilities {
+  const normalized = normalizeTransitionCapabilities(capabilities);
+  return {
+    dmAllowFromMode: normalized?.dmAllowFromMode ?? "topOnly",
+    groupModel: normalized?.groupModel ?? "sender",
+    groupAllowFromFallbackToAllowFrom: normalized?.groupAllowFromFallbackToAllowFrom ?? true,
+    groupOwnerAllowFromFallbackToAllowFrom:
+      normalized?.groupOwnerAllowFromFallbackToAllowFrom ?? true,
+    ...(normalized?.commandGroupAllowFromFallbackToAllowFrom !== undefined
+      ? {
+          commandGroupAllowFromFallbackToAllowFrom:
+            normalized.commandGroupAllowFromFallbackToAllowFrom,
+        }
+      : {}),
+    commandAllowFromFallbackToAllowFrom: normalized?.commandAllowFromFallbackToAllowFrom ?? true,
+    elevatedAllowFromFallbackToAllowFrom: normalized?.elevatedAllowFromFallbackToAllowFrom ?? true,
+  };
+}
+
+function resolveManifestCapabilities(
+  channelId: string,
+  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">,
+): PluginPackageChannelDoctorCapabilities | undefined {
+  const manifest = resolveManifestChannelOwner(channelId, manifestRegistry)?.channelCatalogMeta
+    ?.doctorCapabilities;
+  return normalizeTransitionCapabilities(manifest);
+}
+
+function resolveCapabilities(params: {
+  channelId: string;
+  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
+  override?: (channelId: string) => PluginPackageChannelDoctorCapabilities | undefined;
+}): EffectiveCapabilities {
+  return mergeCapabilities(
+    params.override?.(params.channelId) ??
+      resolveManifestCapabilities(params.channelId, params.manifestRegistry),
+  );
+}
+
+function readDmAllowFrom(
+  record: ChannelRecord,
+  parent: ChannelRecord | undefined,
+  mode: EffectiveCapabilities["dmAllowFromMode"],
+): unknown {
+  const dm = isRecord(record.dm) ? record.dm : undefined;
+  const parentDm = isRecord(parent?.dm) ? parent.dm : undefined;
+  if (mode === "nestedOnly") {
+    return dm?.allowFrom ?? record.allowFrom ?? parentDm?.allowFrom ?? parent?.allowFrom;
+  }
+  return record.allowFrom ?? dm?.allowFrom ?? parent?.allowFrom ?? parentDm?.allowFrom;
+}
+
+function readOwnDmAllowFrom(
+  record: ChannelRecord,
+  mode: EffectiveCapabilities["dmAllowFromMode"],
+): unknown {
+  const dm = isRecord(record.dm) ? record.dm : undefined;
+  if (mode === "nestedOnly") {
+    return hasOwn(dm, "allowFrom") ? dm?.allowFrom : record.allowFrom;
+  }
+  return hasOwn(record, "allowFrom") ? record.allowFrom : dm?.allowFrom;
+}
+
+function normalizeMigratedEntries(raw: unknown): string[] {
+  return Array.from(new Set(Array.isArray(raw) ? normalizeStringEntries(raw) : []));
+}
+
+function enabledAccountRecords(channel: ChannelRecord): ChannelRecord[] {
+  const accounts = isRecord(channel.accounts) ? channel.accounts : undefined;
+  if (!accounts) {
+    return [];
+  }
+  return Object.values(accounts).filter(
+    (account): account is ChannelRecord => isRecord(account) && !isDisabled(account),
+  );
+}
+
+function hasAccountScopedFallbackEntries(
+  channel: ChannelRecord,
+  capabilities: EffectiveCapabilities,
+): boolean {
+  const accounts = enabledAccountRecords(channel);
+  return (
+    accounts.length > 1 &&
+    accounts.some(
+      (account) => readOwnDmAllowFrom(account, capabilities.dmAllowFromMode) !== undefined,
+    )
+  );
+}
+
+function localTargetForFamily(
+  family: MigrationFamily,
+  capabilities: EffectiveCapabilities,
+): LocalTarget | undefined {
+  if (family === "group-sender") {
+    return "groupAllowFrom";
+  }
+  if (family === "command-group") {
+    return capabilities.commandGroupAllowFromFallbackToAllowFrom === undefined
+      ? undefined
+      : "commandGroupAllowFrom";
+  }
+  if (family === "group-command-owner") {
+    return "groupOwnerAllowFrom";
+  }
+  return undefined;
+}
+
+function fallbackDisabledForFamily(
+  family: MigrationFamily,
+  capabilities: EffectiveCapabilities,
+): boolean {
+  if (family === "group-sender") {
+    return !capabilities.groupAllowFromFallbackToAllowFrom;
+  }
+  if (family === "command-group") {
+    return capabilities.commandGroupAllowFromFallbackToAllowFrom === false;
+  }
+  if (family === "group-command-owner") {
+    return !capabilities.groupOwnerAllowFromFallbackToAllowFrom;
+  }
+  if (family === "command-allow") {
+    return !capabilities.commandAllowFromFallbackToAllowFrom;
+  }
+  return !capabilities.elevatedAllowFromFallbackToAllowFrom;
+}
+
+function globalTargetForFamily(
+  family: MigrationFamily,
+  capabilities: EffectiveCapabilities,
+): "commands.allowFrom" | "tools.elevated.allowFrom" | undefined {
+  if (family === "command-allow") {
+    return capabilities.commandAllowFromFallbackToAllowFrom === false
+      ? "commands.allowFrom"
+      : undefined;
+  }
+  if (family === "elevated-allow") {
+    return capabilities.elevatedAllowFromFallbackToAllowFrom === false
+      ? "tools.elevated.allowFrom"
+      : undefined;
+  }
+  return undefined;
+}
+
+function targetExists(record: ChannelRecord, parent: ChannelRecord | undefined, target: string) {
+  return hasOwn(record, target) || hasOwn(parent, target);
+}
+
+function isLocalTarget(target: string): target is LocalTarget {
+  return (
+    target === "groupAllowFrom" ||
+    target === "groupOwnerAllowFrom" ||
+    target === "commandGroupAllowFrom"
+  );
+}
+
+function hasRuntimeCommandGroupSource(record: ChannelRecord | undefined): boolean {
+  return normalizeMigratedEntries(record?.groupAllowFrom).length > 0;
+}
+
+function hasNonEmptyRuntimeGroupSenderTarget(record: ChannelRecord | undefined): boolean {
+  return normalizeMigratedEntries(record?.groupAllowFrom).length > 0;
+}
+
+function hasExplicitRuntimeTargetForFamily(params: {
+  family: MigrationFamily;
+  record: ChannelRecord | undefined;
+}): boolean {
+  if (params.family === "group-sender") {
+    if (hasOwn(params.record, "groupSenderAllowFrom")) {
+      return true;
+    }
+    return hasNonEmptyRuntimeGroupSenderTarget(params.record);
+  }
+  if (params.family === "command-group") {
+    return (
+      hasOwn(params.record, "commandGroupAllowFrom") || hasRuntimeCommandGroupSource(params.record)
+    );
+  }
+  if (params.family === "group-command-owner") {
+    return hasOwn(params.record, "groupOwnerAllowFrom");
+  }
+  return false;
+}
+
+function classifyLocalFamily(params: {
+  family: MigrationFamily;
+  channelName: string;
+  record: ChannelRecord;
+  parent?: ChannelRecord;
+  prefix: string;
+  recordPath: readonly string[];
+  capabilities: EffectiveCapabilities;
+}): AllowFromFallbackTransitionClassification {
+  const fallbackDisabled = fallbackDisabledForFamily(params.family, params.capabilities);
+  const target = localTargetForFamily(params.family, params.capabilities);
+  const rawDmAllowFrom = params.parent
+    ? readOwnDmAllowFrom(params.record, params.capabilities.dmAllowFromMode)
+    : readDmAllowFrom(params.record, undefined, params.capabilities.dmAllowFromMode);
+  const migratedEntries = normalizeMigratedEntries(rawDmAllowFrom);
+  const commandGroupCoveredByRecord =
+    params.family === "command-group" && hasRuntimeCommandGroupSource(params.record);
+  const commandGroupCoveredByParent =
+    params.family === "command-group" && hasRuntimeCommandGroupSource(params.parent);
+  const shouldPreserveEmptyAccountOverride =
+    Boolean(params.parent) && Array.isArray(rawDmAllowFrom) && migratedEntries.length === 0;
+  if (!fallbackDisabled) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: migratedEntries.length > 0,
+      migratedEntries,
+      noMutationReason: "fallback_enabled",
+    };
+  }
+  if (commandGroupCoveredByRecord) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: false,
+      migratedEntries,
+      noMutationReason: "explicit_target",
+    };
+  }
+  const shouldCopyOverEmptyGroupAllowFrom =
+    params.family === "group-sender" &&
+    target === "groupAllowFrom" &&
+    hasOwn(params.record, target) &&
+    normalizeMigratedEntries(params.record[target]).length === 0 &&
+    migratedEntries.length > 0;
+  if (target && hasOwn(params.record, target) && !shouldCopyOverEmptyGroupAllowFrom) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: false,
+      migratedEntries,
+      noMutationReason: "explicit_target",
+    };
+  }
+  if (
+    hasExplicitRuntimeTargetForFamily({
+      family: params.family,
+      record: params.record,
+    })
+  ) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: false,
+      migratedEntries,
+      noMutationReason: "explicit_target",
+    };
+  }
+  if (target && shouldPreserveEmptyAccountOverride) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: true,
+      warningNeeded: false,
+      migratedEntries,
+    };
+  }
+  if (commandGroupCoveredByParent) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: false,
+      migratedEntries,
+      noMutationReason: "inherited_target",
+    };
+  }
+  if (
+    hasExplicitRuntimeTargetForFamily({
+      family: params.family,
+      record: params.parent,
+    })
+  ) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: false,
+      migratedEntries,
+      noMutationReason: "inherited_target",
+    };
+  }
+  if (!target) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: false,
+      migratedEntries,
+      noMutationReason: "missing_target",
+    };
+  }
+  if (
+    hasOwn(params.parent, target) &&
+    !(
+      params.family === "group-sender" &&
+      target === "groupAllowFrom" &&
+      normalizeMigratedEntries(params.parent?.[target]).length === 0 &&
+      migratedEntries.length > 0
+    )
+  ) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: false,
+      migratedEntries,
+      noMutationReason: "inherited_target",
+    };
+  }
+  if (migratedEntries.length === 0) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: false,
+      migratedEntries,
+      noMutationReason: "no_migratable_entries",
+    };
+  }
+  return {
+    family: params.family,
+    prefix: params.prefix,
+    recordPath: params.recordPath,
+    channelName: params.channelName,
+    target,
+    fallbackDisabled,
+    migrationEligible: true,
+    warningNeeded: false,
+    migratedEntries,
+  };
+}
+
+function classifyGlobalFamily(params: {
+  family: "command-allow" | "elevated-allow";
+  channelName: string;
+  record: ChannelRecord;
+  prefix: string;
+  recordPath: readonly string[];
+  capabilities: EffectiveCapabilities;
+  cfg: OpenClawConfig;
+}): AllowFromFallbackTransitionClassification {
+  const fallbackDisabled = fallbackDisabledForFamily(params.family, params.capabilities);
+  const target = globalTargetForFamily(params.family, params.capabilities);
+  const migratedEntries = collectProviderFallbackMigratedEntries(
+    params.record,
+    params.capabilities,
+  );
+  if (!fallbackDisabled || !target) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: fallbackDisabled ? false : migratedEntries.length > 0,
+      migratedEntries,
+      noMutationReason: fallbackDisabled ? "missing_target" : "fallback_enabled",
+    };
+  }
+  const map =
+    target === "commands.allowFrom"
+      ? params.cfg.commands?.allowFrom
+      : params.cfg.tools?.elevated?.allowFrom;
+  const explicitTarget =
+    isRecord(map) &&
+    (hasOwn(map, params.channelName) || (target === "commands.allowFrom" && hasOwn(map, "*")));
+  if (explicitTarget) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: false,
+      migratedEntries,
+      noMutationReason: "explicit_target",
+    };
+  }
+  if (hasAccountScopedFallbackEntries(params.record, params.capabilities)) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: migratedEntries.length > 0,
+      migratedEntries,
+      noMutationReason: "account_scoped_entries",
+    };
+  }
+  if (migratedEntries.length === 0) {
+    return {
+      family: params.family,
+      prefix: params.prefix,
+      recordPath: params.recordPath,
+      channelName: params.channelName,
+      target,
+      fallbackDisabled,
+      migrationEligible: false,
+      warningNeeded: false,
+      migratedEntries,
+      noMutationReason: "no_migratable_entries",
+    };
+  }
+  return {
+    family: params.family,
+    prefix: params.prefix,
+    recordPath: params.recordPath,
+    channelName: params.channelName,
+    target,
+    fallbackDisabled,
+    migrationEligible: true,
+    warningNeeded: false,
+    migratedEntries,
+  };
+}
+
+function collectProviderFallbackMigratedEntries(
+  channel: ChannelRecord,
+  capabilities: EffectiveCapabilities,
+): string[] {
+  const entries: string[] = [];
+  const pushEntries = (raw: unknown) => {
+    for (const entry of normalizeMigratedEntries(raw)) {
+      if (!entries.includes(entry)) {
+        entries.push(entry);
+      }
+    }
+  };
+  const accounts = enabledAccountRecords(channel);
+  if (accounts.length === 1) {
+    pushEntries(readDmAllowFrom(accounts[0], channel, capabilities.dmAllowFromMode));
+    return entries;
+  }
+  if (accounts.length > 1 && hasAccountScopedFallbackEntries(channel, capabilities)) {
+    for (const account of accounts) {
+      pushEntries(readDmAllowFrom(account, channel, capabilities.dmAllowFromMode));
+    }
+    return entries;
+  }
+  pushEntries(readDmAllowFrom(channel, undefined, capabilities.dmAllowFromMode));
+  return entries;
+}
+
+export function classifyAllowFromFallbackTransitions(
+  cfg: OpenClawConfig,
+  options: {
+    manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
+    resolveCapabilities?: (channelId: string) => PluginPackageChannelDoctorCapabilities | undefined;
+  } = {},
+): AllowFromFallbackTransitionClassification[] {
+  if (cfg.plugins?.enabled === false || !isRecord(cfg.channels)) {
+    return [];
+  }
+  const classifications: AllowFromFallbackTransitionClassification[] = [];
+  for (const [channelName, rawChannel] of Object.entries(cfg.channels)) {
+    if (PSEUDO_CHANNEL_KEYS.has(channelName) || !isRecord(rawChannel)) {
+      continue;
+    }
+    if (
+      isChannelTransitionDisabled(cfg, channelName, options.manifestRegistry) ||
+      isDisabled(rawChannel)
+    ) {
+      continue;
+    }
+    const capabilities = resolveCapabilities({
+      channelId: channelName,
+      manifestRegistry: options.manifestRegistry,
+      override: options.resolveCapabilities,
+    });
+    const prefix = `channels.${channelName}`;
+    const recordPath = ["channels", channelName];
+    for (const family of ["group-sender", "command-group", "group-command-owner"] as const) {
+      classifications.push(
+        classifyLocalFamily({
+          family,
+          channelName,
+          record: rawChannel,
+          prefix,
+          recordPath,
+          capabilities,
+        }),
+      );
+    }
+    for (const family of ["command-allow", "elevated-allow"] as const) {
+      classifications.push(
+        classifyGlobalFamily({
+          family,
+          channelName,
+          record: rawChannel,
+          prefix,
+          recordPath,
+          capabilities,
+          cfg,
+        }),
+      );
+    }
+    const accounts = isRecord(rawChannel.accounts) ? rawChannel.accounts : undefined;
+    if (!accounts) {
+      continue;
+    }
+    for (const [accountId, rawAccount] of Object.entries(accounts)) {
+      if (!isRecord(rawAccount) || isDisabled(rawAccount)) {
+        continue;
+      }
+      const accountRecordPath = [...recordPath, "accounts", accountId];
+      for (const family of ["group-sender", "command-group", "group-command-owner"] as const) {
+        classifications.push(
+          classifyLocalFamily({
+            family,
+            channelName,
+            record: rawAccount,
+            parent: rawChannel,
+            prefix: `${prefix}.accounts.${accountId}`,
+            recordPath: accountRecordPath,
+            capabilities,
+          }),
+        );
+      }
+    }
+  }
+  return classifications;
+}
+
+function ensureMutableConfig(cfg: OpenClawConfig, current: OpenClawConfig): OpenClawConfig {
+  return current === cfg ? structuredClone(cfg) : current;
+}
+
+export function applyAllowFromFallbackTransition(
+  cfg: OpenClawConfig,
+  options: {
+    manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
+    resolveCapabilities?: (channelId: string) => PluginPackageChannelDoctorCapabilities | undefined;
+  } = {},
+): { config: OpenClawConfig; changes: string[]; warnings: string[] } {
+  let next = cfg;
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  for (const item of classifyAllowFromFallbackTransitions(cfg, options)) {
+    if (!item.migrationEligible) {
+      if (shouldWarnNoMutation(item, next)) {
+        warnings.push(formatNoMutationWarning(item));
+      }
+      continue;
+    }
+    next = ensureMutableConfig(cfg, next);
+    let changed = false;
+    if (item.target === "commands.allowFrom") {
+      next.commands = { ...next.commands };
+      next.commands.allowFrom = { ...next.commands.allowFrom };
+      next.commands.allowFrom[item.channelName] = item.migratedEntries;
+      changed = true;
+    } else if (item.target === "tools.elevated.allowFrom") {
+      next.tools = { ...next.tools };
+      next.tools.elevated = { ...next.tools.elevated };
+      next.tools.elevated.allowFrom = { ...next.tools.elevated.allowFrom };
+      next.tools.elevated.allowFrom[item.channelName] = item.migratedEntries;
+      changed = true;
+    } else if (item.target && isLocalTarget(item.target)) {
+      const record = resolveRecordByPath(next, item.recordPath);
+      if (
+        record &&
+        (!targetExists(record, undefined, item.target) || shouldOverwriteLocalTarget(item, record))
+      ) {
+        record[item.target] = item.migratedEntries;
+        changed = true;
+      }
+    }
+    if (changed) {
+      changes.push(formatMutationChange(item));
+    }
+  }
+  return { config: next, changes, warnings };
+}
+
+function shouldOverwriteLocalTarget(
+  item: AllowFromFallbackTransitionClassification,
+  record: ChannelRecord,
+): boolean {
+  return (
+    item.family === "group-sender" &&
+    item.target === "groupAllowFrom" &&
+    normalizeMigratedEntries(record.groupAllowFrom).length === 0 &&
+    item.migratedEntries.length > 0
+  );
+}
+
+function shouldWarnNoMutation(
+  item: AllowFromFallbackTransitionClassification,
+  current: OpenClawConfig,
+): boolean {
+  return (
+    item.warningNeeded &&
+    item.noMutationReason !== "fallback_enabled" &&
+    item.noMutationReason !== "explicit_target" &&
+    item.noMutationReason !== "inherited_target" &&
+    !isCommandGroupCoveredByCurrentConfig(item, current)
+  );
+}
+
+function isCommandGroupCoveredByCurrentConfig(
+  item: AllowFromFallbackTransitionClassification,
+  current: OpenClawConfig,
+): boolean {
+  if (item.family !== "command-group") {
+    return false;
+  }
+  const record = resolveRecordByPath(current, item.recordPath);
+  if (hasRuntimeCommandGroupSource(record)) {
+    return true;
+  }
+  return hasRuntimeCommandGroupSource(resolveParentRecordByPath(current, item.recordPath));
+}
+
+function resolveRecordByPath(
+  cfg: OpenClawConfig,
+  pathParts: readonly string[],
+): ChannelRecord | undefined {
+  let current: unknown = cfg;
+  for (const part of pathParts) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[part];
+  }
+  return isRecord(current) ? current : undefined;
+}
+
+function resolveParentRecordByPath(
+  cfg: OpenClawConfig,
+  pathParts: readonly string[],
+): ChannelRecord | undefined {
+  const accountsIndex = pathParts.indexOf("accounts");
+  if (accountsIndex <= 0) {
+    return undefined;
+  }
+  return resolveRecordByPath(cfg, pathParts.slice(0, accountsIndex));
+}
+
+function formatTargetPath(item: AllowFromFallbackTransitionClassification): string {
+  if (item.target === "commands.allowFrom") {
+    return `commands.allowFrom.${item.channelName}`;
+  }
+  if (item.target === "tools.elevated.allowFrom") {
+    return `tools.elevated.allowFrom.${item.channelName}`;
+  }
+  return `${item.prefix}.${item.target}`;
+}
+
+function formatMutationChange(item: AllowFromFallbackTransitionClassification): string {
+  const targetPath = formatTargetPath(item);
+  if (item.migratedEntries.length === 0) {
+    return `Set ${targetPath} to an explicit empty allowlist because ${item.family} fallback to allowFrom is disabled.`;
+  }
+  return `Copied ${item.prefix}.allowFrom entries to ${targetPath} because ${item.family} fallback to allowFrom is disabled.`;
+}
+
+function formatNoMutationWarning(item: AllowFromFallbackTransitionClassification): string {
+  if (!item.target) {
+    return `- ${item.prefix} still has allowFrom entries, but ${item.family} fallback to allowFrom is disabled and no automatic migration target is declared (${item.noMutationReason}). This fallback behavior will be removed in future releases; configure an explicit allowlist for this authorization mode.`;
+  }
+  return `- ${item.prefix} still has allowFrom entries, but ${item.family} fallback to allowFrom is disabled and ${formatTargetPath(item)} was not changed (${item.noMutationReason}). This fallback behavior will be removed in future releases; set ${formatTargetPath(item)} explicitly.`;
+}

--- a/src/config/materialize.test.ts
+++ b/src/config/materialize.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { materializeRuntimeConfig } from "./materialize.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+
+describe("runtime config materialization", () => {
+  it("does not run allowFrom fallback transition during runtime materialization", () => {
+    const result = materializeRuntimeConfig(
+      {
+        channels: {
+          demo: {
+            allowFrom: ["user:1"],
+          },
+        },
+      } as OpenClawConfig,
+      "load",
+      {
+        manifestRegistry: {
+          plugins: [
+            {
+              channelCatalogMeta: {
+                id: "demo",
+                doctorCapabilities: {
+                  groupAllowFromFallbackToAllowFrom: false,
+                },
+              },
+            } as unknown as PluginManifestRecord,
+          ],
+        },
+      },
+    );
+
+    expect(result.channels?.demo).toMatchObject({
+      allowFrom: ["user:1"],
+    });
+    expect(result.channels?.demo).not.toHaveProperty("groupAllowFrom");
+  });
+});

--- a/src/plugin-sdk/channel-ingress-runtime.test.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.test.ts
@@ -84,7 +84,7 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
         useAccessGroups: true,
         allowTextCommands: true,
         hasControlCommand: true,
-        groupOwnerAllowFrom: "none",
+        groupOwnerAllowFromFallbackToAllowFrom: false,
         commandGroupAllowFromFallbackToAllowFrom: false,
       },
     });
@@ -92,6 +92,86 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
     expect(unauthorizedCommand.senderAccess.decision).toBe("allow");
     expect(unauthorizedCommand.senderAccess.reasonCode).toBe("group_policy_open");
     expect(unauthorizedCommand.commandAccess.shouldBlockControlCommand).toBe(true);
+  });
+
+  it("treats explicit empty commandGroupAllowFrom as no group command senders", async () => {
+    const command = {
+      useAccessGroups: true,
+      allowTextCommands: true,
+      hasControlCommand: true,
+      groupOwnerAllowFromFallbackToAllowFrom: false,
+    };
+    const fallbackAllowed = await resolve({
+      conversation: { kind: "group", id: "room-1" },
+      event: { kind: "message", authMode: "inbound", mayPair: false },
+      policy: {
+        dmPolicy: "allowlist",
+        groupPolicy: "open",
+        groupAllowFromFallbackToAllowFrom: false,
+      },
+      allowFrom: ["owner"],
+      command: {
+        ...command,
+        commandGroupAllowFromFallbackToAllowFrom: true,
+      },
+    });
+    expect(fallbackAllowed.commandAccess.authorized).toBe(true);
+
+    const explicitEmptyBlocked = await resolve({
+      conversation: { kind: "group", id: "room-1" },
+      event: { kind: "message", authMode: "inbound", mayPair: false },
+      policy: {
+        dmPolicy: "allowlist",
+        groupPolicy: "open",
+        groupAllowFromFallbackToAllowFrom: false,
+      },
+      allowFrom: ["owner"],
+      command: {
+        ...command,
+        commandGroupAllowFrom: [],
+        commandGroupAllowFromFallbackToAllowFrom: true,
+      },
+    });
+    expect(explicitEmptyBlocked.commandAccess.authorized).toBe(false);
+    expect(explicitEmptyBlocked.commandAccess.shouldBlockControlCommand).toBe(true);
+  });
+
+  it("accepts legacy groupOwnerAllowFrom sentinels", async () => {
+    const groupMessage = {
+      conversation: { kind: "group", id: "room-1" } as const,
+      event: { kind: "message", authMode: "inbound", mayPair: false } as const,
+      policy: {
+        dmPolicy: "allowlist",
+        groupPolicy: "open",
+        groupAllowFromFallbackToAllowFrom: false,
+      } as const,
+      allowFrom: ["owner"],
+    };
+    const command = {
+      useAccessGroups: true,
+      allowTextCommands: true,
+      hasControlCommand: true,
+      commandGroupAllowFromFallbackToAllowFrom: false,
+    };
+
+    const configured = await resolve({
+      ...groupMessage,
+      command: {
+        ...command,
+        groupOwnerAllowFrom: "configured",
+      },
+    });
+    expect(configured.commandAccess.authorized).toBe(true);
+
+    const none = await resolve({
+      ...groupMessage,
+      command: {
+        ...command,
+        groupOwnerAllowFrom: "none",
+      },
+    });
+    expect(none.commandAccess.authorized).toBe(false);
+    expect(none.commandAccess.shouldBlockControlCommand).toBe(true);
   });
 
   it("keeps normalized compatibility entries scoped to the intended identifier kind", async () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -41,6 +41,7 @@ import {
   type PluginManifestSetup,
   type PluginManifestToolMetadata,
   type PluginPackageChannel,
+  type PluginPackageChannelDoctorCapabilities,
   type PluginPackageInstall,
 } from "./manifest.js";
 import { checkMinHostVersion } from "./min-host-version.js";
@@ -254,6 +255,7 @@ export type PluginManifestRecord = {
     blurb?: string;
     preferOver?: readonly string[];
     commands?: PluginManifestChannelCommandDefaults;
+    doctorCapabilities?: PluginPackageChannelDoctorCapabilities;
   };
 };
 
@@ -581,6 +583,9 @@ function buildRecord(params: {
               ? { preferOver: params.candidate.packageManifest.channel.preferOver }
               : {}),
             ...(packageChannelCommands ? { commands: packageChannelCommands } : {}),
+            ...(params.candidate.packageManifest.channel.doctorCapabilities
+              ? { doctorCapabilities: params.candidate.packageManifest.channel.doctorCapabilities }
+              : {}),
           },
         }
       : {}),

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -1750,6 +1750,10 @@ export type PluginPackageChannelDoctorCapabilities = {
   dmAllowFromMode?: "topOnly" | "topOrNested" | "nestedOnly";
   groupModel?: "sender" | "route" | "hybrid";
   groupAllowFromFallbackToAllowFrom?: boolean;
+  groupOwnerAllowFromFallbackToAllowFrom?: boolean;
+  commandGroupAllowFromFallbackToAllowFrom?: boolean;
+  commandAllowFromFallbackToAllowFrom?: boolean;
+  elevatedAllowFromFallbackToAllowFrom?: boolean;
   warnOnEmptyGroupSenderAllowlist?: boolean;
 };
 

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDmGroupAccessWithCommandGate,
+  resolveDmGroupAccessWithLists,
+} from "./dm-policy-shared.js";
+
+describe("deprecated DM/group policy shared helper", () => {
+  it("honors the group allowFrom fallback flag", () => {
+    const base = {
+      isGroup: true,
+      dmPolicy: "allowlist",
+      groupPolicy: "allowlist",
+      allowFrom: ["user:1"],
+      isSenderAllowed: (entries: string[]) => entries.includes("user:1"),
+    };
+
+    expect(
+      resolveDmGroupAccessWithLists({
+        ...base,
+        groupAllowFromFallbackToAllowFrom: true,
+      }).decision,
+    ).toBe("allow");
+    expect(
+      resolveDmGroupAccessWithLists({
+        ...base,
+        groupAllowFromFallbackToAllowFrom: false,
+      }).decision,
+    ).toBe("block");
+  });
+
+  it("uses explicit commandGroupAllowFrom before command group fallback", () => {
+    const base = {
+      isGroup: true,
+      dmPolicy: "allowlist",
+      groupPolicy: "open",
+      allowFrom: [],
+      groupAllowFrom: ["group-user"],
+      groupAllowFromFallbackToAllowFrom: true,
+      isSenderAllowed: (entries: string[]) => entries.includes("group-user"),
+    };
+
+    expect(
+      resolveDmGroupAccessWithCommandGate({
+        ...base,
+        command: {
+          useAccessGroups: true,
+          allowTextCommands: true,
+          hasControlCommand: true,
+        },
+      }).commandAuthorized,
+    ).toBe(true);
+    expect(
+      resolveDmGroupAccessWithCommandGate({
+        ...base,
+        command: {
+          useAccessGroups: true,
+          allowTextCommands: true,
+          hasControlCommand: true,
+          commandGroupAllowFrom: [],
+        },
+      }).commandAuthorized,
+    ).toBe(false);
+  });
+});

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -251,6 +251,8 @@ export function resolveDmGroupAccessWithCommandGate(
       useAccessGroups: boolean;
       allowTextCommands: boolean;
       hasControlCommand: boolean;
+      commandGroupAllowFrom?: Array<string | number> | null;
+      commandGroupAllowFromFallbackToAllowFrom?: boolean | null;
     };
   },
 ): {
@@ -275,11 +277,16 @@ export function resolveDmGroupAccessWithCommandGate(
 
   const configuredAllowFrom = normalizeStringEntries(params.allowFrom ?? []);
   const configuredGroupAllowFrom = normalizeStringEntries(
-    resolveGroupAllowFromSources({
-      allowFrom: configuredAllowFrom,
-      groupAllowFrom: normalizeStringEntries(params.groupAllowFrom ?? []),
-      fallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
-    }),
+    params.command?.commandGroupAllowFrom != null
+      ? params.command.commandGroupAllowFrom
+      : resolveGroupAllowFromSources({
+          allowFrom: configuredAllowFrom,
+          groupAllowFrom: normalizeStringEntries(params.groupAllowFrom ?? []),
+          fallbackToAllowFrom:
+            params.command?.commandGroupAllowFromFallbackToAllowFrom ??
+            params.groupAllowFromFallbackToAllowFrom ??
+            undefined,
+        }),
   );
   // Group command authorization must not inherit DM pairing-store approvals.
   const commandDmAllowFrom = params.isGroup ? configuredAllowFrom : access.effectiveAllowFrom;


### PR DESCRIPTION
## Purpose

This PR adds the generic, dormant machinery needed to disable legacy `allowFrom` fallback per channel later. It does not disable fallback for any channel in this PR.

## User Config Impact

This PR does not add user-facing fallback flags.

Users should never set `*FallbackToAllowFrom` in their OpenClaw config. Those booleans are channel runtime/package metadata for future channel-owned PRs.

The only user config change `openclaw doctor --fix` may make is copying existing allowlist values from `allowFrom` into the explicit allowlist that already represents the same access:

- `channels.<id>.groupAllowFrom`
- `channels.<id>.commandGroupAllowFrom`
- `channels.<id>.groupOwnerAllowFrom`
- `commands.allowFrom.<channel-id>`
- `tools.elevated.allowFrom.<channel-id>`

The goal is preservation: when a later channel PR disables a fallback in code, users keep the same effective access after doctor copies the old `allowFrom` values to the correct explicit target.

## Future Channel PR Checklist

For each fallback a channel later disables, that channel PR must do both:

1. Change runtime behavior so the channel reads the explicit replacement allowlist.
2. Set the matching package doctor metadata boolean to `false`.

Doctor infers the copy target from the boolean:

| Fallback being removed later | Set metadata to `false` | Doctor copies `allowFrom` to |
| --- | --- | --- |
| Group senders use DM `allowFrom` | `groupAllowFromFallbackToAllowFrom` | `channels.<id>.groupAllowFrom` |
| Group command senders use DM/group fallback | `commandGroupAllowFromFallbackToAllowFrom` | `channels.<id>.commandGroupAllowFrom` |
| Group command owners use DM `allowFrom` | `groupOwnerAllowFromFallbackToAllowFrom` | `channels.<id>.groupOwnerAllowFrom` |
| Text commands use channel `allowFrom` | `commandAllowFromFallbackToAllowFrom` | `commands.allowFrom.<channel-id>` |
| Elevated access uses channel `allowFrom` | `elevatedAllowFromFallbackToAllowFrom` | `tools.elevated.allowFrom.<channel-id>` |

Only set a fallback boolean to `false` after the target config key is accepted by that channel schema and actually read by that channel runtime. Multi-account channels must preserve account scope; otherwise doctor warns instead of copying into a broader provider target.

## Example: future Telegram opt-out

A later Telegram PR that disables group-sender fallback would set the same capability in two places:

```ts
// Telegram runtime
createChannelIngressResolver({
  channelId: "telegram",
  accountId,
  identity: telegramIngressIdentity,
  cfg,
  groupAllowFromFallbackToAllowFrom: false,
});
```

```jsonc
// Package metadata
{
  "openclaw": {
    "channel": {
      "id": "telegram",
      "doctorCapabilities": {
        "groupAllowFromFallbackToAllowFrom": false
      }
    }
  }
}
```

The runtime flag changes live authorization behavior. The package metadata lets `openclaw doctor --fix` preserve existing configs without loading Telegram runtime.

When that future PR lands, doctor can copy:

```json
{
  "channels": {
    "telegram": {
      "allowFrom": ["123456789"]
    }
  }
}
```

to:

```json
{
  "channels": {
    "telegram": {
      "allowFrom": ["123456789"],
      "groupAllowFrom": ["123456789"]
    }
  }
}
```

This PR only adds that generic machinery; it does not set the Telegram runtime flag or package metadata.

## Summary

- Adds fallback capability metadata to plugin manifests/read-only discovery.
- Wires shared runtime paths to honor fallback-disable metadata when channels opt out later.
- Adds `openclaw doctor --fix` preservation-copy repair.
- Adds capability-aware doctor warnings for configs still relying on fallback.
- Removes separate migration-target metadata; copy targets are inferred from the disabled fallback.

## Verification

- `pnpm test src/config/allowfrom-fallback-transition.test.ts src/config/materialize.test.ts src/commands/doctor/channel-capabilities.test.ts src/commands/doctor/shared/empty-allowlist-policy.test.ts src/commands/doctor/repair-sequencing.test.ts src/channels/plugins/read-only.test.ts -- --reporter=verbose`
- `pnpm test src/commands/doctor/repair-sequencing.test.ts src/commands/doctor/shared/empty-allowlist-policy.test.ts src/commands/doctor/shared/preview-warnings.test.ts src/config/allowfrom-fallback-transition.test.ts src/config/materialize.test.ts -- --reporter=verbose`
- `pnpm test src/config/allowfrom-fallback-transition.test.ts src/config/materialize.test.ts src/commands/doctor/repair-sequencing.test.ts src/commands/doctor/shared/empty-allowlist-policy.test.ts src/commands/doctor/shared/empty-allowlist-scan.test.ts src/commands/doctor/shared/open-policy-allowfrom.test.ts src/commands/doctor/shared/preview-warnings.test.ts src/commands/doctor/channel-capabilities.test.ts src/commands/doctor-config-flow.test.ts src/auto-reply/command-control.test.ts src/auto-reply/reply/reply-elevated.test.ts src/plugin-sdk/channel-ingress-runtime.test.ts src/channels/plugins/read-only.test.ts src/security/dm-policy-shared.test.ts -- --reporter=verbose`
- `pnpm docs:list`
- `pnpm check:changed` before rebase
- `git diff --check origin/main...HEAD`

Known after rebase: `pnpm check:changed` currently fails in untouched `src/agents/pi-embedded-runner/run/helpers.test.ts` with an upstream-main `UsageAccumulator` type error. The file is identical to `origin/main`.
