### PR TITLE
fix(progress-draft): only trigger onToolStart on phase=start to remove duplicate tool lines

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -3749,4 +3749,50 @@ describe("runAgentTurnWithFallback", () => {
       modelOverrideFallbackOriginModel: "claude-opus",
     });
   });
+
+  describe("onToolStart phase filtering", () => {
+    it("only calls onToolStart on phase=start, not phase=update or phase=end", async () => {
+      const onToolStart = vi.fn();
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+        // Simulate a tool_execution_start
+        await params.onAgentEvent?.({
+          stream: "tool",
+          data: { phase: "start", name: "exec", toolCallId: "tc-1", args: { command: "ls" } },
+        });
+        // Followed by multiple tool_execution_update (partial results)
+        await params.onAgentEvent?.({
+          stream: "tool",
+          data: { phase: "update", name: "exec", toolCallId: "tc-1" },
+        });
+        await params.onAgentEvent?.({
+          stream: "tool",
+          data: { phase: "update", name: "exec", toolCallId: "tc-1" },
+        });
+        // And a tool_execution_end
+        await params.onAgentEvent?.({
+          stream: "tool",
+          data: { phase: "end", name: "exec", toolCallId: "tc-1" },
+        });
+        return { payloads: [{ text: "done" }], meta: {} };
+      });
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback({
+        ...createMinimalRunAgentTurnParams({
+          opts: { onToolStart } satisfies GetReplyOptions,
+        }),
+      });
+
+      expect(result.kind).toBe("success");
+      // onToolStart should only be called once — for phase=start
+      expect(onToolStart).toHaveBeenCalledTimes(1);
+      expect(onToolStart).toHaveBeenCalledWith({
+        name: "exec",
+        phase: "start",
+        args: { command: "ls" },
+        detailMode: undefined,
+      });
+    });
+  });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1780,10 +1780,15 @@ export async function runAgentTurnWithFallback(params: {
                   }
                   // Trigger typing when tools start executing.
                   // Must await to ensure typing indicator starts before tool summaries are emitted.
+                  // Only trigger on "start" phase. Upstream also emits "update" phases
+                  // (per-partial-result and final commit) for the same toolUseId. Letting
+                  // those flow into onToolStart causes duplicate, interleaved progress-draft
+                  // lines in Telegram/Discord because draft-preview dedupe only collapses
+                  // adjacent identical lines, so repeated start/update cycles accumulate.
                   if (evt.stream === "tool") {
                     const phase = readStringValue(evt.data.phase) ?? "";
                     const name = readStringValue(evt.data.name);
-                    if (phase === "start" || phase === "update") {
+                    if (phase === "start") {
                       const toolStartProgressPromise = params.opts?.onToolStart?.({
                         name,
                         phase,


### PR DESCRIPTION
## Summary

- **Problem:** `onToolStart` is triggered on both `phase === "start"` and `phase === "update"` for the same tool call, producing duplicate, interleaved progress-draft lines in Telegram/Discord
- **Why it matters:** Users see garbled progress like `🛠️ Exec → 🛠️ Exec: cmd → 🛠️ Exec → 🛠️ Exec: cmd → completed` instead of a single clean line that updates to `completed`
- **What changed:** Restrict `onToolStart` callback to `phase === "start"` only in `agent-runner-execution.ts`
- **What did NOT change (scope boundary):** The upstream `emitAgentEvent` path for `"update"` phases is untouched — item/command/patch streams that legitimately consume updates still receive them. Only the `onToolStart` channel-progress callback is gated.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Root Cause

- **Root cause:** `agent-runner-execution.ts` routes `stream === "tool"` events with `phase === "start" || phase === "update"` into the `onToolStart` callback. Upstream (`pi-embedded-subscribe.handlers.tools.ts`) emits `"update"` events per partial result without `args`. The progress-draft renderer formats args-less events as bare `🛠️ Exec`, which alternates with the args-rich `🛠️ Exec: cmd …` line. Channel draft-preview dedupe (`draft-preview.ts`) only collapses adjacent identical lines, so A/B/A/B patterns accumulate.
- **Missing detection / guardrail:** No test asserted how many times `onToolStart` fires for a multi-phase tool event sequence.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test: `src/auto-reply/reply/agent-runner-execution.test.ts` — new `onToolStart phase filtering` describe block
- Scenario: emit `start → update → update → end` for the same tool; assert `onToolStart` called exactly once with `phase: "start"`
- Why this is the smallest reliable guardrail: The bug is a simple condition overreach; a single unit test locking in the call count is sufficient.

## User-visible / Behavior Changes

- Telegram and Discord progress drafts no longer show duplicate/interleaved tool-call lines. Each tool call renders a single line that transitions to `completed`.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] Verified on live Telegram + Discord instance for ~24 hours with the fork patch applied — duplicate lines eliminated

## Human Verification

- Verified on two channels (Telegram + Discord) with multi-tool exec turns
- Edge cases checked: single-tool turns, multi-tool parallel turns, heartbeat turns
- Not verified: Slack, Mattermost, Teams (same code path, same dedupe logic)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** A tool that never emits `phase === "start"` (only `"update"`) would not appear in progress drafts.
  - **Mitigation:** Source inspection confirms `handleToolExecutionStart` always fires before `handleToolExecutionUpdate` for the same `toolCallId`. The `"start"` event is the entry point; `"update"` is supplementary.


## Real behavior proof

- Behavior or issue addressed: Tool progress draft lines render as duplicate/interleaved (`🛠️ Exec` alternating with `🛠️ Exec: cmd …`) for the same tool call in Telegram and Discord, instead of a single line that updates to `completed`.
- Real environment tested: Self-hosted OpenClaw gateway running the fork branch with this patch applied; live Telegram direct chat (`agent:main:telegram:direct:<redacted>`) and a Discord server. Node v24.14.0 on Ubuntu 24.04. The fork has had this patch in production for ~24h covering many real multi-tool turns (exec, read, write, web_search, etc.).
- Exact steps or command run after this patch:
  1. Apply the patch to `src/auto-reply/reply/agent-runner-execution.ts` on a live gateway, rebuild and restart.
  2. From Telegram, send a normal request that triggers a long-running exec (e.g., `print text -> show first 20 lines`).
  3. Watch the progress-draft message stream as the tool runs and completes.
- Evidence after fix (copied live output, redacted as needed):

  Before (upstream, observed in real chat):

  ```
  Krilling...
  🛠️ Exec: print text -> show first 20 lines (+1 steps)
  🛠️ Exec
  🛠️ Exec: print text -> show first 20 lines (+1 steps)
  🛠️ Exec
  🛠️ Exec: print text -> show first 20 lines (+1 steps)
  🛠️ Exec: completed; command print text -> show first 20 lines (+1 steps)
  ```
Screenshot:
<img width="397" height="375" alt="image" src="https://github.com/user-attachments/assets/baf1931c-9aac-4cda-9893-a1a4d988c139" />

  After (with this patch, observed in real chat):

  ```
  Krilling...
  🛠️ Exec: print text -> show first 20 lines (+1 steps)
  🛠️ Exec: completed; command print text -> show first 20 lines (+1 steps)
  ```

<img width="397" height="225" alt="image" src="https://github.com/user-attachments/assets/ed89536d-1049-4f59-8897-ef3bd45da141" />

- Observed result after fix: Each tool call renders exactly one progress-draft line that transitions to a single `completed` line. No more A/B/A/B duplication. Verified across many real Telegram and Discord turns over ~24h on the fork; no regressions seen in typing indicator, status reactions, or live exec output (those flow through `onItemEvent` / `command` streams, which this patch does not touch — see follow-up comment for the consumer-by-consumer audit).
- What was not tested: Slack, Mattermost, Microsoft Teams, Matrix, Feishu, WhatsApp on a live instance. All of these consume the same `onToolStart` callback through the same shared draft-preview renderer, so the fix applies uniformly, but I did not have live channels to verify visually.
- Before evidence (optional): See the "Before" terminal block above — copied from a real Telegram session against an unpatched gateway.
