### PR TITLE
feat(discord): expose message fetch action

### DIFF
--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -167,6 +167,55 @@ describe("handleDiscordMessageAction", () => {
     });
   });
 
+  it("maps fetch to Discord fetchMessage with channel and message ids", async () => {
+    const cfg = discordConfig();
+    await handleDiscordMessageAction({
+      action: "fetch",
+      params: {
+        channelId: "channel:123",
+        messageId: "msg-1",
+      },
+      cfg,
+    });
+
+    expectDiscordActionCall({
+      payload: {
+        action: "fetchMessage",
+        accountId: undefined,
+        guildId: undefined,
+        channelId: "123",
+        messageId: "msg-1",
+        messageLink: undefined,
+      },
+      cfg,
+      options: defaultActionOptions(),
+    });
+  });
+
+  it("maps fetch URL alias to Discord fetchMessage without requiring channel id", async () => {
+    const cfg = discordConfig();
+    await handleDiscordMessageAction({
+      action: "fetch",
+      params: {
+        url: "https://discord.com/channels/111/222/333",
+      },
+      cfg,
+    });
+
+    expectDiscordActionCall({
+      payload: {
+        action: "fetchMessage",
+        accountId: undefined,
+        guildId: undefined,
+        channelId: undefined,
+        messageId: undefined,
+        messageLink: "https://discord.com/channels/111/222/333",
+      },
+      cfg,
+      options: defaultActionOptions(),
+    });
+  });
+
   it("maps upload-file to Discord sendMessage with media read context", async () => {
     const mediaReadFile = vi.fn(async () => Buffer.from("image"));
     const mediaAccess = {

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -244,6 +244,24 @@ export async function handleDiscordMessageAction(
     );
   }
 
+  if (action === "fetch") {
+    const messageLink = readStringParam(params, "messageLink") ?? readStringParam(params, "url");
+    const messageId = readStringParam(params, "messageId", { required: !messageLink });
+    const channelId = messageLink ? readStringParam(params, "channelId") : resolveChannelId();
+    return await handleDiscordAction(
+      {
+        action: "fetchMessage",
+        accountId: accountId ?? undefined,
+        guildId: readStringParam(params, "guildId"),
+        channelId,
+        messageId,
+        messageLink,
+      },
+      cfg,
+      actionOptions,
+    );
+  }
+
   if (action === "edit") {
     const messageId = readStringParam(params, "messageId", { required: true });
     const content = readStringParam(params, "message", { required: true });

--- a/extensions/discord/src/actions/runtime.messaging.messages.ts
+++ b/extensions/discord/src/actions/runtime.messaging.messages.ts
@@ -41,7 +41,8 @@ export async function handleDiscordMessageManagementAction(ctx: DiscordMessaging
       if (!ctx.isActionEnabled("messages")) {
         throw new Error("Discord message reads are disabled.");
       }
-      const messageLink = readStringParam(ctx.params, "messageLink");
+      const messageLink =
+        readStringParam(ctx.params, "messageLink") ?? readStringParam(ctx.params, "url");
       let guildId = readStringParam(ctx.params, "guildId");
       let channelId = readStringParam(ctx.params, "channelId");
       let messageId = readStringParam(ctx.params, "messageId");
@@ -51,9 +52,9 @@ export async function handleDiscordMessageManagementAction(ctx: DiscordMessaging
         channelId = parsed.channelId;
         messageId = parsed.messageId;
       }
-      if (!guildId || !channelId || !messageId) {
+      if (!channelId || !messageId) {
         throw new Error(
-          "Discord message fetch requires guildId, channelId, and messageId (or a valid messageLink).",
+          "Discord message fetch requires channelId and messageId (or a valid messageLink).",
         );
       }
       const message = await discordMessagingActionRuntime.fetchMessageDiscord(

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -438,6 +438,32 @@ describe("handleDiscordMessagingAction", () => {
     expect(fetchMessageDiscord).toHaveBeenCalledWith("C1", "M1", { cfg });
   });
 
+  it("fetches a Discord message from channel and message ids without guild id", async () => {
+    await handleMessagingAction(
+      "fetchMessage",
+      { channelId: "C1", messageId: "M1" },
+      enableAllActions,
+    );
+
+    expect(fetchMessageDiscord).toHaveBeenCalledWith("C1", "M1", { cfg: DISCORD_TEST_CFG });
+  });
+
+  it("fetches a Discord message from the public url alias", async () => {
+    const result = await handleMessagingAction(
+      "fetchMessage",
+      { url: "https://discord.com/channels/111/222/333" },
+      enableAllActions,
+    );
+
+    expect(fetchMessageDiscord).toHaveBeenCalledWith("222", "333", { cfg: DISCORD_TEST_CFG });
+    expect(result.details).toMatchObject({
+      ok: true,
+      guildId: "111",
+      channelId: "222",
+      messageId: "333",
+    });
+  });
+
   it("adds normalized timestamps to listPins payloads", async () => {
     listPinsDiscord.mockResolvedValueOnce([{ id: "1", timestamp: "2026-01-15T12:00:00.000Z" }]);
 

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -62,6 +62,7 @@ describe("discordMessageActions", () => {
       "emoji-list",
       "upload-file",
       "read",
+      "fetch",
       "edit",
       "delete",
       "pin",
@@ -109,6 +110,7 @@ describe("discordMessageActions", () => {
       "emoji-list",
       "upload-file",
       "read",
+      "fetch",
       "edit",
       "delete",
       "pin",
@@ -170,6 +172,7 @@ describe("discordMessageActions", () => {
       "emoji-list",
       "upload-file",
       "read",
+      "fetch",
       "edit",
       "delete",
       "pin",
@@ -236,6 +239,7 @@ describe("discordMessageActions", () => {
       "poll",
       "upload-file",
       "read",
+      "fetch",
       "edit",
       "delete",
       "pin",
@@ -271,6 +275,7 @@ describe("discordMessageActions", () => {
       "emoji-list",
       "upload-file",
       "read",
+      "fetch",
       "edit",
       "delete",
       "pin",
@@ -318,6 +323,7 @@ describe("discordMessageActions", () => {
     expect(discovery?.actions).toContain("send");
     expect(discovery?.actions).not.toContain("upload-file");
     expect(discovery?.actions).not.toContain("read");
+    expect(discovery?.actions).not.toContain("fetch");
     expect(discovery?.actions).not.toContain("edit");
     expect(discovery?.actions).not.toContain("delete");
   });
@@ -335,11 +341,14 @@ describe("discordMessageActions", () => {
     expect(discovery?.schema).toBeUndefined();
   });
 
-  it.each(["read", "search"])("routes %s actions through gateway execution mode", (action) => {
-    expect(discordMessageActions.resolveExecutionMode?.({ action: action as never })).toBe(
-      "gateway",
-    );
-  });
+  it.each(["read", "fetch", "search"])(
+    "routes %s actions through gateway execution mode",
+    (action) => {
+      expect(discordMessageActions.resolveExecutionMode?.({ action: action as never })).toBe(
+        "gateway",
+      );
+    },
+  );
 
   it.each(["send", "upload-file", "edit", "delete", "react", "pin", "poll"])(
     "routes %s actions through local execution mode",

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -89,6 +89,7 @@ function describeDiscordMessageTool({
   if (discovery.isEnabled("messages")) {
     actions.add("upload-file");
     actions.add("read");
+    actions.add("fetch");
     actions.add("edit");
     actions.add("delete");
   }
@@ -163,7 +164,7 @@ function describeDiscordMessageTool({
 
 export const discordMessageActions: ChannelMessageActionAdapter = {
   resolveExecutionMode: ({ action }) =>
-    action === "read" || action === "search" ? "gateway" : "local",
+    action === "read" || action === "fetch" || action === "search" ? "gateway" : "local",
   describeMessageTool: describeDiscordMessageTool,
   extractToolSend: ({ args }) => {
     const action = normalizeOptionalString(args.action) ?? "";

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -271,6 +271,16 @@ function buildReactionSchema() {
 
 function buildFetchSchema() {
   return {
+    messageLink: Type.Optional(
+      Type.String({
+        description: "Provider-specific message URL to fetch, for example a Discord message link.",
+      }),
+    ),
+    url: Type.Optional(
+      Type.String({
+        description: "Alias for messageLink when fetching a single provider message by URL.",
+      }),
+    ),
     limit: Type.Optional(Type.Number()),
     pageSize: Type.Optional(Type.Number()),
     pageToken: Type.Optional(Type.String()),

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -6,6 +6,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "react",
   "reactions",
   "read",
+  "fetch",
   "edit",
   "unsend",
   "reply",

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -17,6 +17,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     react: "to",
     reactions: "to",
     read: "to",
+    fetch: "none",
     edit: "to",
     unsend: "to",
     reply: "to",


### PR DESCRIPTION
## Summary
- expose a public Discord `message` tool `action: "fetch"` for single-message lookup
- map `channelId` + `messageId` and Discord message URL forms onto the existing `fetchMessage` runtime
- advertise `fetch` under the existing Discord messages gate and route it through gateway execution

Fixes #81232

## Real behavior proof
- Behavior addressed: Discord message tool can now fetch one specific message by `channelId` + `messageId`, or by a Discord message URL, using the existing Discord `fetchMessage` runtime path.
- Real environment tested: local OpenClaw source checkout on Ubuntu 24.04 / Node 22.22.0, running the patched Discord message-action discovery and runtime parser through `pnpm exec tsx` after this patch.
- Exact steps or command run after this patch:

```sh
pnpm exec tsx -e '<script imports discordMessageActions, CHANNEL_MESSAGE_ACTION_NAMES, MESSAGE_ACTION_TARGET_MODE, and handleDiscordMessagingAction; stubs only fetchMessageDiscord to avoid contacting Discord while exercising the patched public discovery/runtime mapping>'
```

- Evidence after fix: terminal output from the patched checkout:

```json
{
  "actionInContract": true,
  "targetMode": "none",
  "advertised": true,
  "executionMode": "gateway",
  "direct": {
    "ok": true,
    "message": {
      "id": "333",
      "channel_id": "222",
      "content": "fetched-message",
      "timestamp": "2026-05-13T03:30:00.000Z",
      "timestampMs": 1778643000000,
      "timestampUtc": "2026-05-13T03:30:00.000Z"
    },
    "channelId": "222",
    "messageId": "333"
  },
  "linked": {
    "ok": true,
    "message": {
      "id": "333",
      "channel_id": "222",
      "content": "fetched-message",
      "timestamp": "2026-05-13T03:30:00.000Z",
      "timestampMs": 1778643000000,
      "timestampUtc": "2026-05-13T03:30:00.000Z"
    },
    "guildId": "111",
    "channelId": "222",
    "messageId": "333"
  }
}
```

- Observed result after fix: `fetch` is in the public message action contract, advertised by Discord discovery, routed through gateway execution, and both direct ID and URL forms reach normalized `fetchMessage` output with the expected IDs.
- What was not tested: no live Discord API call was made in this terminal proof; the Discord REST call itself was already present in the existing `fetchMessageDiscord` helper and is covered by existing focused tests.

## Audit
- Existing-helper check: reused existing internal `fetchMessage` runtime, REST helper, and message normalization.
- Shared-contract check: added `fetch` to shared message action names and target-mode metadata; public schema exposes `messageLink`/`url`.
- Gate check: Discord only advertises `fetch` when `channels.discord.actions.messages` is enabled.

## Tests
- `pnpm test extensions/discord/src/actions/runtime.test.ts extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/channel-actions.test.ts extensions/discord/src/send.messages.test.ts`
- `pnpm test src/agents/tools/message-tool.test.ts src/infra/outbound/message-action-spec.test.ts src/infra/outbound/message-action-normalization.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/channels/plugins/message-action-names.ts src/infra/outbound/message-action-spec.ts src/agents/tools/message-tool.ts extensions/discord/src/channel-actions.ts extensions/discord/src/channel-actions.test.ts extensions/discord/src/actions/handle-action.ts extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/actions/runtime.messaging.messages.ts extensions/discord/src/actions/runtime.test.ts`
- `pnpm check:changed`