### PR TITLE
fix(gateway): forward temperature and top_p through OpenAI-compatible HTTP APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - browser: enforce navigation checks for act interactions [AI]. (#81070) Thanks @pgondhi987.
 - Validate node exec event provenance [AI]. (#81071) Thanks @pgondhi987.
 - Gateway: keep active reply runs visible to stuck-session diagnostics and clear no-active-work recovery state, preventing stale queued lanes after compaction or tool failures. Fixes #80677. (#81302)
+- Gateway/OpenAI HTTP: return OpenAI-compatible 400 errors for invalid sampling params and provider validation failures instead of collapsing them to 500s. (#81275) Thanks @Lellansin.
 - Limit hook CLI tool authority [AI]. (#81065) Thanks @pgondhi987.
 - Require admin scope for node device token management [AI]. (#81067) Thanks @pgondhi987.
 - Restrict chat sender allowlist matching [AI]. (#80898) Thanks @pgondhi987.

--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -203,8 +203,10 @@ Set `stream: true` to receive Server-Sent Events (SSE):
 - `messages[*].tool_call_id` for binding tool results back to a prior tool call
 - `max_completion_tokens`: number; per-call cap for total completion tokens (reasoning tokens included). Current OpenAI Chat Completions field name; preferred when both `max_completion_tokens` and `max_tokens` are sent.
 - `max_tokens`: number; legacy alias accepted for backwards compatibility. Ignored when `max_completion_tokens` is also present.
+- `temperature`: number; best-effort sampling temperature forwarded to the upstream provider via the agent stream-param channel.
+- `top_p`: number; best-effort nucleus sampling forwarded to the upstream provider via the agent stream-param channel.
 
-When either field is set, the value is forwarded to the upstream provider via the agent stream-param channel. The actual wire field name sent to the upstream provider is chosen by the provider transport: `max_completion_tokens` for OpenAI-family endpoints, and `max_tokens` for providers that only accept the legacy name (such as Mistral and Chutes).
+When either token-cap field is set, the value is forwarded to the upstream provider via the agent stream-param channel. The actual wire field name sent to the upstream provider is chosen by the provider transport: `max_completion_tokens` for OpenAI-family endpoints, and `max_tokens` for providers that only accept the legacy name (such as Mistral and Chutes). Sampling fields (`temperature`, `top_p`) follow the same stream-param channel; the ChatGPT-based Codex Responses backend strips them server-side since it uses fixed sampling.
 
 ### Unsupported variants
 

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -74,6 +74,8 @@ The request follows the OpenResponses API with item-based input. Current support
 - `tool_choice`: filter or require client tools.
 - `stream`: enables SSE streaming.
 - `max_output_tokens`: best-effort output limit (provider dependent).
+- `temperature`: best-effort sampling temperature forwarded to the provider. Ignored by the ChatGPT-based Codex Responses backend, which uses fixed server-side sampling.
+- `top_p`: best-effort nucleus sampling forwarded to the provider. Same Codex Responses caveat as `temperature`.
 - `user`: stable session routing.
 
 Accepted but **currently ignored**:

--- a/src/agents/command/shared-types.ts
+++ b/src/agents/command/shared-types.ts
@@ -1,6 +1,7 @@
 export type AgentStreamParams = {
   /** Provider stream params override (best-effort). */
   temperature?: number;
+  topP?: number;
   maxTokens?: number;
   /** Provider fast-mode override (best-effort). */
   fastMode?: boolean;

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1374,6 +1374,35 @@ describe("openai transport stream", () => {
     expect(params.reasoning).toEqual({ effort: "high" });
   });
 
+  it("forwards temperature and top_p to chat completions request params", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+        tools: [],
+      } as never,
+      {
+        temperature: 0.4,
+        topP: 0.9,
+      },
+    );
+
+    expect(params.temperature).toBe(0.4);
+    expect(params.top_p).toBe(0.9);
+  });
+
   it("does not build OpenRouter reasoning params for Hunter Alpha when reasoning is disabled", () => {
     const params = buildOpenAICompletionsParams(
       {
@@ -1502,6 +1531,7 @@ describe("openai transport stream", () => {
         serviceTier: "auto",
         sessionId: "session-123",
         temperature: 0.2,
+        topP: 0.85,
       },
       {
         openclaw_session_id: "session-123",
@@ -1525,6 +1555,7 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("prompt_cache_retention");
     expect(params).not.toHaveProperty("service_tier");
     expect(params).not.toHaveProperty("temperature");
+    expect(params).not.toHaveProperty("top_p");
   });
 
   it("sanitizes Codex responses params after payload hooks mutate them without stripping cache identity", () => {
@@ -1538,6 +1569,7 @@ describe("openai transport stream", () => {
       prompt_cache_retention: "24h",
       service_tier: "auto",
       temperature: 0.2,
+      top_p: 0.85,
     };
 
     const sanitized = __testing.sanitizeOpenAICodexResponsesParams(
@@ -1562,6 +1594,7 @@ describe("openai transport stream", () => {
     expect(sanitized).not.toHaveProperty("prompt_cache_retention");
     expect(sanitized).not.toHaveProperty("service_tier");
     expect(sanitized).not.toHaveProperty("temperature");
+    expect(sanitized).not.toHaveProperty("top_p");
   });
 
   it("preserves custom Codex-compatible responses params", () => {
@@ -1588,6 +1621,7 @@ describe("openai transport stream", () => {
         maxTokens: 1024,
         sessionId: "session-123",
         temperature: 0.2,
+        topP: 0.85,
       },
       {
         openclaw_session_id: "session-123",
@@ -1603,6 +1637,7 @@ describe("openai transport stream", () => {
     });
     expect(params.max_output_tokens).toBe(1024);
     expect(params.temperature).toBe(0.2);
+    expect(params.top_p).toBe(0.85);
   });
 
   it("preserves custom Codex-compatible responses params after payload hooks mutate them", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -78,6 +78,7 @@ type ReplayableResponseReasoningItem = Omit<ResponseReasoningItem, "id"> & { id?
 
 type BaseStreamOptions = {
   temperature?: number;
+  topP?: number;
   maxTokens?: number;
   signal?: AbortSignal;
   apiKey?: string;
@@ -1267,6 +1268,7 @@ const OPENAI_CODEX_RESPONSES_UNSUPPORTED_PARAMS = [
   "prompt_cache_retention",
   "service_tier",
   "temperature",
+  "top_p",
 ] as const;
 
 function sanitizeOpenAICodexResponsesParams<T extends Record<string, unknown>>(
@@ -1349,6 +1351,9 @@ export function buildOpenAIResponsesParams(
   }
   if (options?.temperature !== undefined) {
     params.temperature = options.temperature;
+  }
+  if (options?.topP !== undefined) {
+    params.top_p = options.topP;
   }
   if (options?.serviceTier !== undefined && payloadPolicy.allowsServiceTier) {
     params.service_tier = options.serviceTier;
@@ -2180,6 +2185,7 @@ type OpenAIResponsesRequestParams = {
   store?: boolean;
   max_output_tokens?: number;
   temperature?: number;
+  top_p?: number;
   service_tier?: ResponseCreateParamsStreaming["service_tier"];
   tools?: FunctionTool[];
   reasoning?:
@@ -2410,6 +2416,9 @@ export function buildOpenAICompletionsParams(
   }
   if (options?.temperature !== undefined) {
     params.temperature = options.temperature;
+  }
+  if (options?.topP !== undefined) {
+    params.top_p = options.topP;
   }
   if (context.tools) {
     params.tools = convertTools(context.tools, compat, model);

--- a/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
@@ -1,0 +1,89 @@
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPiAiStreamSimpleMock } from "../../../test/helpers/agents/pi-ai-stream-simple-mock.js";
+import { __testing as extraParamsTesting, applyExtraParamsToAgent } from "./extra-params.js";
+
+vi.mock("./logger.js", () => ({
+  log: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("@earendil-works/pi-ai", () => createPiAiStreamSimpleMock());
+
+beforeEach(() => {
+  extraParamsTesting.setProviderRuntimeDepsForTest({
+    prepareProviderExtraParams: () => undefined,
+    resolveProviderExtraParamsForTransport: () => undefined,
+    wrapProviderStreamFn: () => undefined,
+  });
+});
+
+afterEach(() => {
+  extraParamsTesting.resetProviderRuntimeDepsForTest();
+});
+
+describe("createStreamFnWithExtraParams sampling overrides", () => {
+  it("forwards temperature, top_p, and maxTokens from override into the underlying streamFn options", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5.4", {
+      temperature: 0.4,
+      topP: 0.7,
+      maxTokens: 512,
+    });
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      { id: "gpt-5.4", api: "openai-completions", provider: "openai" } as never,
+      { messages: [], tools: [] } as never,
+      undefined,
+    );
+
+    expect(underlying).toHaveBeenCalledTimes(1);
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as { temperature?: number; topP?: number; maxTokens?: number } | undefined;
+    expect(callOptions?.temperature).toBe(0.4);
+    expect(callOptions?.topP).toBe(0.7);
+    expect(callOptions?.maxTokens).toBe(512);
+  });
+
+  it("lets runtime options override the wrapper sampling defaults", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5.4", { temperature: 0.4, topP: 0.7 });
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      { id: "gpt-5.4", api: "openai-completions", provider: "openai" } as never,
+      { messages: [], tools: [] } as never,
+      { topP: 0.9 } as never,
+    );
+
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as { temperature?: number; topP?: number } | undefined;
+    expect(callOptions?.temperature).toBe(0.4);
+    expect(callOptions?.topP).toBe(0.9);
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -133,6 +133,7 @@ export function resolveExtraParams(params: {
 type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
   cacheRetention?: "none" | "short" | "long";
   cachedContent?: string;
+  topP?: number;
 };
 export type SupportedTransport = AgentRuntimeTransport;
 
@@ -378,6 +379,9 @@ function createStreamFnWithExtraParams(
   const streamParams: CacheRetentionStreamOptions = {};
   if (typeof extraParams.temperature === "number") {
     streamParams.temperature = extraParams.temperature;
+  }
+  if (typeof extraParams.topP === "number") {
+    streamParams.topP = extraParams.topP;
   }
   if (typeof extraParams.maxTokens === "number") {
     streamParams.maxTokens = extraParams.maxTokens;

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -201,7 +201,8 @@ export const CreateResponseBodySchema = z
     max_output_tokens: z.number().int().positive().optional(),
     max_tool_calls: z.number().int().positive().optional(),
     user: z.string().optional(),
-    // Phase 1: ignore but accept these fields
+    // Sampling overrides forwarded to provider (best-effort; some backends like
+    // ChatGPT Codex Responses strip these — see openai-transport-stream.ts).
     temperature: z.number().optional(),
     top_p: z.number().optional(),
     metadata: z.record(z.string(), z.string()).optional(),

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -203,8 +203,8 @@ export const CreateResponseBodySchema = z
     user: z.string().optional(),
     // Sampling overrides forwarded to provider (best-effort; some backends like
     // ChatGPT Codex Responses strip these — see openai-transport-stream.ts).
-    temperature: z.number().optional(),
-    top_p: z.number().optional(),
+    temperature: z.number().min(0).max(2).optional(),
+    top_p: z.number().min(0).max(1).optional(),
     metadata: z.record(z.string(), z.string()).optional(),
     store: z.boolean().optional(),
     previous_response_id: z.string().optional(),

--- a/src/gateway/openai-compat-errors.ts
+++ b/src/gateway/openai-compat-errors.ts
@@ -1,0 +1,100 @@
+import { describeFailoverError, resolveFailoverStatus } from "../agents/failover-error.js";
+import type { FailoverReason } from "../agents/pi-embedded-helpers/types.js";
+
+export type OpenAiCompatError = {
+  status: number;
+  error: {
+    message: string;
+    type: string;
+    code?: string;
+  };
+};
+
+const ERROR_TYPE_BY_REASON: Partial<Record<FailoverReason, string>> = {
+  auth: "authentication_error",
+  auth_permanent: "permission_error",
+  billing: "insufficient_quota",
+  format: "invalid_request_error",
+  model_not_found: "invalid_request_error",
+  overloaded: "api_error",
+  rate_limit: "rate_limit_error",
+  server_error: "api_error",
+  session_expired: "invalid_request_error",
+  timeout: "api_error",
+};
+
+function statusForReason(reason: FailoverReason, status: number | undefined): number {
+  if (reason === "server_error") {
+    return status && status >= 400 && status < 500 ? status : 502;
+  }
+  if (reason === "timeout") {
+    return status && status >= 400 && status < 500 ? status : 504;
+  }
+  return status ?? resolveFailoverStatus(reason) ?? 500;
+}
+
+function messageForReason(params: {
+  reason: FailoverReason;
+  message: string;
+  rawError?: string;
+}): string {
+  if (params.reason === "server_error") {
+    return "upstream provider error";
+  }
+  if (params.reason === "timeout") {
+    return "upstream provider timeout";
+  }
+  if (params.reason === "overloaded") {
+    return "upstream provider overloaded";
+  }
+  return params.rawError?.trim() || params.message.trim() || "request failed";
+}
+
+export function resolveOpenAiCompatError(err: unknown): OpenAiCompatError | undefined {
+  const described = describeFailoverError(err);
+  const reason = described.reason;
+  if (!reason) {
+    return undefined;
+  }
+  const type = ERROR_TYPE_BY_REASON[reason];
+  if (!type) {
+    return undefined;
+  }
+  const status = statusForReason(reason, described.status);
+  const message = messageForReason({
+    reason,
+    message: described.message,
+    rawError: described.rawError,
+  });
+  return {
+    status,
+    error: {
+      message,
+      type,
+      ...(described.code ? { code: described.code } : {}),
+    },
+  };
+}
+
+export function validateOpenAiSamplingParams(params: {
+  temperature?: unknown;
+  topP?: unknown;
+}): string | undefined {
+  if (params.temperature != null) {
+    if (typeof params.temperature !== "number" || !Number.isFinite(params.temperature)) {
+      return "`temperature` must be a finite number.";
+    }
+    if (params.temperature < 0 || params.temperature > 2) {
+      return "`temperature` must be between 0 and 2.";
+    }
+  }
+  if (params.topP != null) {
+    if (typeof params.topP !== "number" || !Number.isFinite(params.topP)) {
+      return "`top_p` must be a finite number.";
+    }
+    if (params.topP < 0 || params.topP > 1) {
+      return "`top_p` must be between 0 and 1.";
+    }
+  }
+  return undefined;
+}

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { FailoverError } from "../agents/failover-error.js";
 import {
   createStubSessionHarness,
   emitAssistantTextDelta,
@@ -1368,6 +1369,65 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       expect(getStreamParams()).toBeUndefined();
       await res.text();
     }
+
+    {
+      agentCommand.mockClear();
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        temperature: 999,
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(400);
+      const json = (await res.json()) as { error?: { type?: string; message?: string } };
+      expect(json.error?.type).toBe("invalid_request_error");
+      expect(json.error?.message).toMatch(/temperature/);
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+    }
+
+    {
+      agentCommand.mockClear();
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        top_p: 5,
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(400);
+      const json = (await res.json()) as { error?: { type?: string; message?: string } };
+      expect(json.error?.type).toBe("invalid_request_error");
+      expect(json.error?.message).toMatch(/top_p/);
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+    }
+  });
+
+  it("maps provider format failures to OpenAI-compatible 400 errors", async () => {
+    const port = enabledPort;
+
+    agentCommand.mockClear();
+    agentCommand.mockRejectedValueOnce(
+      new FailoverError(
+        "LLM request failed: provider rejected the request schema or tool payload.",
+        {
+          reason: "format",
+          status: 400,
+          code: "decimal_above_max_value",
+          rawError:
+            "400 Invalid 'temperature': decimal above maximum value. Expected a value <= 2, but got 999 instead.",
+        },
+      ) as never,
+    );
+
+    const res = await postChatCompletions(port, {
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as {
+      error?: { type?: string; code?: string; message?: string };
+    };
+    expect(json.error?.type).toBe("invalid_request_error");
+    expect(json.error?.code).toBe("decimal_above_max_value");
+    expect(json.error?.message).toContain("Invalid 'temperature'");
+    expect(agentCommand).toHaveBeenCalledTimes(1);
   });
 
   it("returns 429 for repeated failed auth when gateway.auth.rateLimit is configured", async () => {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -111,7 +111,7 @@ type FirstAgentCommandOptions = {
   model?: string;
   senderIsOwner?: boolean;
   sessionKey?: string;
-  streamParams?: { maxTokens?: number };
+  streamParams?: { maxTokens?: number; temperature?: number; topP?: number };
 };
 
 function firstAgentCommandOptions() {
@@ -1319,6 +1319,53 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       });
       expect(res.status).toBe(200);
       expect(getFirstAgentMaxTokens()).toBeUndefined();
+      await res.text();
+    }
+  });
+
+  it("forwards inbound temperature and top_p into streamParams", async () => {
+    const port = enabledPort;
+    const mockAgentOnce = (payloads: Array<{ text: string }>) => {
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({ payloads } as never);
+    };
+    const getStreamParams = () => firstAgentCommandOptions()?.streamParams;
+
+    {
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        temperature: 0.3,
+        top_p: 0.95,
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getStreamParams()).toMatchObject({ temperature: 0.3, topP: 0.95 });
+      await res.text();
+    }
+
+    {
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        temperature: 0,
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      const params = getStreamParams();
+      expect(params?.temperature).toBe(0);
+      expect(params?.topP).toBeUndefined();
+      await res.text();
+    }
+
+    {
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getStreamParams()).toBeUndefined();
       await res.text();
     }
   });

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -75,6 +75,8 @@ type OpenAiChatCompletionRequest = {
   user?: unknown;
   max_tokens?: unknown;
   max_completion_tokens?: unknown;
+  temperature?: unknown;
+  top_p?: unknown;
 };
 
 const DEFAULT_OPENAI_CHAT_COMPLETIONS_BODY_BYTES = 20 * 1024 * 1024;
@@ -134,7 +136,7 @@ function buildAgentCommandInput(params: {
   messageChannel: string;
   senderIsOwner: boolean;
   abortSignal?: AbortSignal;
-  streamParams?: { maxTokens?: number };
+  streamParams?: { maxTokens?: number; temperature?: number; topP?: number };
 }) {
   return {
     message: params.prompt.message,
@@ -823,7 +825,16 @@ export async function handleOpenAiHttpRequest(
       : typeof payload.max_tokens === "number"
         ? payload.max_tokens
         : undefined;
-  const streamParams = maxTokens !== undefined ? { maxTokens } : undefined;
+  const temperature = typeof payload.temperature === "number" ? payload.temperature : undefined;
+  const topP = typeof payload.top_p === "number" ? payload.top_p : undefined;
+  const streamParams =
+    maxTokens !== undefined || temperature !== undefined || topP !== undefined
+      ? {
+          ...(maxTokens !== undefined ? { maxTokens } : {}),
+          ...(temperature !== undefined ? { temperature } : {}),
+          ...(topP !== undefined ? { topP } : {}),
+        }
+      : undefined;
 
   const { agentId, sessionKey, messageChannel } = resolveGatewayRequestContext({
     req,

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -46,6 +46,7 @@ import {
   resolveOpenAiCompatibleHttpSenderIsOwner,
 } from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
+import { resolveOpenAiCompatError, validateOpenAiSamplingParams } from "./openai-compat-errors.js";
 
 type OpenAiHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -827,6 +828,16 @@ export async function handleOpenAiHttpRequest(
         : undefined;
   const temperature = typeof payload.temperature === "number" ? payload.temperature : undefined;
   const topP = typeof payload.top_p === "number" ? payload.top_p : undefined;
+  const samplingError = validateOpenAiSamplingParams({
+    temperature: payload.temperature,
+    topP: payload.top_p,
+  });
+  if (samplingError) {
+    sendJson(res, 400, {
+      error: { message: samplingError, type: "invalid_request_error" },
+    });
+    return true;
+  }
   const streamParams =
     maxTokens !== undefined || temperature !== undefined || topP !== undefined
       ? {
@@ -986,6 +997,11 @@ export async function handleOpenAiHttpRequest(
         sendJson(res, 400, {
           error: { message: "invalid tool configuration", type: "invalid_request_error" },
         });
+        return true;
+      }
+      const mapped = resolveOpenAiCompatError(err);
+      if (mapped) {
+        sendJson(res, mapped.status, { error: mapped.error });
         return true;
       }
       sendJson(res, 500, {
@@ -1159,6 +1175,16 @@ export async function handleOpenAiHttpRequest(
         writeSse(res, {
           error: { message: "invalid tool configuration", type: "invalid_request_error" },
         });
+        writeDone(res);
+        res.end();
+        return;
+      }
+      const mapped = resolveOpenAiCompatError(err);
+      if (mapped) {
+        closed = true;
+        stopWatchingDisconnect();
+        unsubscribe();
+        writeSse(res, { error: mapped.error });
         writeDone(res);
         res.end();
         return;

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { FailoverError } from "../agents/failover-error.js";
 import { createClientToolNameConflictError } from "../agents/pi-tool-definition-adapter.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
@@ -665,6 +666,34 @@ describe("OpenResponses HTTP API (e2e)", () => {
       expect(samplingStreamParams?.topP).toBe(0.9);
       await ensureResponseConsumed(resSampling);
 
+      agentCommand.mockClear();
+      const resInvalidTemperature = await postResponses(port, {
+        model: "openclaw",
+        input: "hi",
+        temperature: 999,
+      });
+      expect(resInvalidTemperature.status).toBe(400);
+      const invalidTemperatureJson = (await resInvalidTemperature.json()) as {
+        error?: { type?: string; message?: string };
+      };
+      expect(invalidTemperatureJson.error?.type).toBe("invalid_request_error");
+      expect(invalidTemperatureJson.error?.message ?? "").toMatch(/temperature/i);
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+
+      agentCommand.mockClear();
+      const resInvalidTopP = await postResponses(port, {
+        model: "openclaw",
+        input: "hi",
+        top_p: 5,
+      });
+      expect(resInvalidTopP.status).toBe(400);
+      const invalidTopPJson = (await resInvalidTopP.json()) as {
+        error?: { type?: string; message?: string };
+      };
+      expect(invalidTopPJson.error?.type).toBe("invalid_request_error");
+      expect(invalidTopPJson.error?.message ?? "").toMatch(/top_p/i);
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+
       mockAgentOnce([{ text: "ok" }], {
         agentMeta: {
           usage: { input: 3, output: 5, cacheRead: 1, cacheWrite: 1 },
@@ -810,6 +839,38 @@ describe("OpenResponses HTTP API (e2e)", () => {
     } finally {
       // shared server
     }
+  });
+
+  it("maps provider format failures to OpenResponses 400 failed responses", async () => {
+    const port = enabledPort;
+
+    agentCommand.mockClear();
+    agentCommand.mockRejectedValueOnce(
+      new FailoverError(
+        "LLM request failed: provider rejected the request schema or tool payload.",
+        {
+          reason: "format",
+          status: 400,
+          code: "decimal_above_max_value",
+          rawError:
+            "400 Invalid 'top_p': decimal above maximum value. Expected a value <= 1, but got 5 instead.",
+        },
+      ) as never,
+    );
+
+    const res = await postResponses(port, {
+      model: "openclaw",
+      input: "hi",
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as {
+      status?: string;
+      error?: { code?: string; message?: string };
+    };
+    expect(json.status).toBe("failed");
+    expect(json.error?.code).toBe("invalid_request_error");
+    expect(json.error?.message).toContain("Invalid 'top_p'");
+    expect(agentCommand).toHaveBeenCalledTimes(1);
   });
 
   it("treats write-scoped HTTP callers as non-owner and admin-scoped callers as owner", async () => {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -650,6 +650,21 @@ describe("OpenResponses HTTP API (e2e)", () => {
       ).toBe(123);
       await ensureResponseConsumed(resMaxTokens);
 
+      mockAgentOnce([{ text: "ok" }]);
+      const resSampling = await postResponses(port, {
+        model: "openclaw",
+        input: "hi",
+        temperature: 0.2,
+        top_p: 0.9,
+      });
+      expect(resSampling.status).toBe(200);
+      const samplingStreamParams = (
+        firstAgentOpts() as { streamParams?: { temperature?: number; topP?: number } } | undefined
+      )?.streamParams;
+      expect(samplingStreamParams?.temperature).toBe(0.2);
+      expect(samplingStreamParams?.topP).toBe(0.9);
+      await ensureResponseConsumed(resSampling);
+
       mockAgentOnce([{ text: "ok" }], {
         agentMeta: {
           usage: { input: 3, output: 5, cacheRead: 1, cacheWrite: 1 },

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -55,6 +55,7 @@ import {
   type StreamingEvent,
   type Usage,
 } from "./open-responses.schema.js";
+import { resolveOpenAiCompatError } from "./openai-compat-errors.js";
 import { wrapUntrustedFileContent } from "./openresponses-file-content.js";
 import { buildAgentPrompt } from "./openresponses-prompt.js";
 import { createAssistantOutputItem, createFunctionCallOutputItem } from "./openresponses-shape.js";
@@ -810,6 +811,22 @@ export async function handleOpenResponsesHttpRequest(
         output: [],
         error: { code: "api_error", message: "internal error" },
       });
+      const mapped = resolveOpenAiCompatError(err);
+      if (mapped) {
+        const mappedResponse = createResponseResource({
+          id: responseId,
+          model,
+          status: "failed",
+          output: [],
+          error: {
+            code: mapped.error.type,
+            message: mapped.error.message,
+          },
+        });
+        rememberResponseSession();
+        sendJson(res, mapped.status, mappedResponse);
+        return true;
+      }
       rememberResponseSession();
       sendJson(res, 500, response);
     } finally {
@@ -1164,6 +1181,28 @@ export async function handleOpenResponsesHttpRequest(
         usage: finalUsage,
       });
 
+      const mapped = resolveOpenAiCompatError(err);
+      if (mapped) {
+        const mappedResponse = createResponseResource({
+          id: responseId,
+          model,
+          status: "failed",
+          output: [],
+          error: {
+            code: mapped.error.type,
+            message: mapped.error.message,
+          },
+          usage: finalUsage,
+        });
+        rememberResponseSession();
+        writeSseEvent(res, { type: "response.failed", response: mappedResponse });
+        emitAgentEvent({
+          runId: responseId,
+          stream: "lifecycle",
+          data: { phase: "error" },
+        });
+        return;
+      }
       rememberResponseSession();
       writeSseEvent(res, { type: "response.failed", response: errorResponse });
       emitAgentEvent({

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -396,7 +396,7 @@ async function runResponsesAgentCommand(params: {
   clientTools: ClientToolDefinition[];
   extraSystemPrompt: string;
   modelOverride?: string;
-  streamParams: { maxTokens: number } | undefined;
+  streamParams: { maxTokens?: number; temperature?: number; topP?: number } | undefined;
   sessionKey: string;
   runId: string;
   messageChannel: string;
@@ -673,9 +673,18 @@ export async function handleOpenResponsesHttpRequest(
   const outputItemId = `msg_${randomUUID()}`;
   const deps = createDefaultDeps();
   const abortController = new AbortController();
+  const streamMaxTokens =
+    typeof payload.max_output_tokens === "number" ? payload.max_output_tokens : undefined;
+  const streamTemperature =
+    typeof payload.temperature === "number" ? payload.temperature : undefined;
+  const streamTopP = typeof payload.top_p === "number" ? payload.top_p : undefined;
   const streamParams =
-    typeof payload.max_output_tokens === "number"
-      ? { maxTokens: payload.max_output_tokens }
+    streamMaxTokens !== undefined || streamTemperature !== undefined || streamTopP !== undefined
+      ? {
+          ...(streamMaxTokens !== undefined ? { maxTokens: streamMaxTokens } : {}),
+          ...(streamTemperature !== undefined ? { temperature: streamTemperature } : {}),
+          ...(streamTopP !== undefined ? { topP: streamTopP } : {}),
+        }
       : undefined;
 
   if (!stream) {


### PR DESCRIPTION
## Summary

- Thread `temperature` and `top_p` from inbound `POST /v1/chat/completions` and `POST /v1/responses` through `streamParams` → runtime stream wrapper → OpenAI transport, so client-supplied sampling preferences reach the upstream provider.
- Extend `AgentStreamParams` with `topP` and fix `createStreamFnWithExtraParams` in `src/agents/pi-embedded-runner/extra-params.ts` to forward `topP` to the underlying stream function — previously it only copied `temperature` / `maxTokens`, so `topP` would have been silently dropped mid-flight even with the new HTTP wiring.
- Add `top_p` to `OPENAI_CODEX_RESPONSES_UNSUPPORTED_PARAMS` so the ChatGPT-based Codex Responses backend strips it server-side, matching how `temperature` is already handled there.
- Drop the `// Phase 1: ignore but accept` comment on the OpenResponses schema fields and update both HTTP API docs to describe the new behavior (including the Codex Responses caveat).

Fixes #81274. Refs #65345 (one of the ShadowLogic findings from that audit).

Follows the same pattern as #81013, which previously wired `max_completion_tokens` / `max_tokens` through the same `streamParams` channel.

## Verification

- `pnpm test src/gateway/openai-http.test.ts` — 14/14 (new round-trip case asserting `temperature` / `top_p` land in `streamParams`)
- `pnpm test src/gateway/openresponses-http.test.ts` — 17/17 (extended `max_output_tokens` block to cover `temperature` / `top_p`)
- `pnpm test src/agents/openai-transport-stream.test.ts` — 120/120 (Codex-strip tests now also assert `top_p` is removed for the ChatGPT-based Codex Responses backend; custom-proxy test asserts `top_p` is *preserved* for non-`chatgpt.com` baseUrls; new chat-completions case asserts the sampling fields reach the request params)
- `pnpm test src/agents/pi-embedded-runner/extra-params.sampling.test.ts` — 2/2 (new file; round-trip proof that `topP` reaches the underlying stream function and that runtime options can override the wrapper)
- `pnpm test src/agents/pi-embedded-runner/extra-params.{cache-retention-default,provider-runtime,openrouter-cache-control}.test.ts` — 26/26 (no regressions in adjacent extra-params lanes)
- `pnpm check:changed` — clean (lint core + typecheck core + typecheck core tests + duplicate scan + dependency-pin guard + import-cycle guard)
- `codex review --uncommitted` — *"No correctness issues were found in the changed and untracked files."* after the wrapper fix

## Real behavior proof

- Behavior or issue addressed: OpenAI-compatible Gateway HTTP requests now forward client-supplied `temperature` and `top_p` from `POST /v1/chat/completions` through `streamParams` to the upstream OpenAI-compatible provider instead of silently dropping them. The same PR also wires `topP` through the embedded runtime wrapper and documents the Responses/Codex caveat.
- Real environment tested: Local OpenClaw managed gateway on loopback port 18789 after building PR head `ceef4b80c9450a3f227514ad2054828a20033eab` with `pnpm build` and restarting the gateway. Runtime was Node `v24.14.1`; CLI and gateway reported OpenClaw `2026.5.12-beta.1`. The default agent model was `deepseek/deepseek-v4-flash`, using the configured `deepseek:default` API-key auth profile. Gateway token and provider key were read from local OpenClaw config/auth storage and were not printed.
- Exact steps or command run after this patch: Ran `pnpm build`, then `pnpm openclaw gateway restart`, then posted three authenticated local requests to `http://127.0.0.1:18789/v1/chat/completions`: a happy-path request with `temperature: 0.42` and `top_p: 0.87`, an out-of-range `temperature: 999` probe, and an out-of-range `top_p: 5` probe. Then repeated the same three-request pattern against `http://127.0.0.1:18789/v1/responses` with `input` payloads. Finally, sent the same two out-of-range probes directly to `https://api.deepseek.com/chat/completions` with model `deepseek-chat` as a provider control.
- Evidence after fix: Live gateway output from the happy-path request:

  ```json
  {
    "name": "happy-path-sampling",
    "ok": true,
    "id": "chatcmpl_acbf80a5-2f10-47d0-a51d-ec1ef2193c70",
    "object": "chat.completion",
    "model": "openclaw",
    "status": 200,
    "choice": "Hey there, how's it going? ✨",
    "usage": {"prompt_tokens": 16918, "completion_tokens": 24, "total_tokens": 16942}
  }
  ```

  Live gateway client output from the two forwarding probes:

  ```json
  {"name":"temperature-out-of-range","ok":false,"status":500,"error":{"message":"internal error","type":"api_error"}}
  {"name":"top-p-out-of-range","ok":false,"status":500,"error":{"message":"internal error","type":"api_error"}}
  ```

  Live /v1/responses output from the same sampling checks:

  ```json
  {
    "name": "responses-happy-path-sampling",
    "ok": true,
    "id": "resp_3fc99375-8f94-4aac-93e6-88786780571a",
    "object": "response",
    "model": "openclaw",
    "status": 200,
    "outputTypes": ["message"],
    "usage": {"input_tokens": 22, "output_tokens": 21, "total_tokens": 16939}
  }
  {"name":"responses-temperature-out-of-range","ok":false,"id":"resp_a03bce88-14d9-4e60-960b-a7291e58e85d","object":"response","model":"openclaw","status":500,"error":{"code":"api_error","message":"internal error"}}
  {"name":"responses-top-p-out-of-range","ok":false,"id":"resp_48f0d32b-cdea-40c4-b324-9eb79971cf87","object":"response","model":"openclaw","status":500,"error":{"code":"api_error","message":"internal error"}}
  ```

  Redacted runtime log excerpts for the /v1/responses probes show the same provider-side field validation:

  ```text
  2026-05-13T13:34:02.857+08:00 embedded run agent end runId=resp_a03bce88-... isError=true model=deepseek-v4-flash provider=deepseek rawErrorPreview="400 Invalid temperature value, the valid range of temperature is [0, 2]"
  2026-05-13T13:34:03.630+08:00 embedded run agent end runId=resp_48f0d32b-... isError=true model=deepseek-v4-flash provider=deepseek rawErrorPreview="400 Invalid top_p value, the valid range of top_p is (0, 1.0]"
  ```

  Redacted runtime log excerpts for those same gateway requests show DeepSeek rejected the forwarded fields by name:

  ```text
  2026-05-13T13:26:05.632+08:00 embedded run agent end runId=chatcmpl_c4489521-... isError=true model=deepseek-v4-flash provider=deepseek rawErrorPreview="400 Invalid temperature value, the valid range of temperature is [0, 2]"
  2026-05-13T13:26:06.332+08:00 embedded run agent end runId=chatcmpl_d26c95e4-... isError=true model=deepseek-v4-flash provider=deepseek rawErrorPreview="400 Invalid top_p value, the valid range of top_p is (0, 1.0]"
  ```

  Direct DeepSeek control requests, bypassing the gateway, returned the same provider errors:

  ```json
  {
    "name": "direct-temperature-out-of-range",
    "status": 400,
    "error": {
      "message": "Invalid temperature value, the valid range of temperature is [0, 2]",
      "type": "invalid_request_error",
      "param": null,
      "code": "invalid_request_error"
    }
  }
  {
    "name": "direct-top-p-out-of-range",
    "status": 400,
    "error": {
      "message": "Invalid top_p value, the valid range of top_p is (0, 1.0]",
      "type": "invalid_request_error",
      "param": null,
      "code": "invalid_request_error"
    }
  }
  ```
- Observed result after fix: The valid `temperature`/`top_p` requests completed successfully through both local OpenAI-compatible gateway endpoints tested: `/v1/chat/completions` and `/v1/responses`. The invalid-value probes reached DeepSeek with those exact fields present from both endpoints: DeepSeek returned field-specific `Invalid temperature value` and `Invalid top_p value` errors in the gateway runtime logs, and direct DeepSeek control calls produced the same messages. That proves the gateway writes both sampling fields into the outbound provider request body after this patch.
- What was not tested: Live native ChatGPT Codex Responses backend behavior was not exercised in this rerun; that strip path is covered by targeted tests, including the native-baseUrl strip and custom-proxy preservation cases. The unrelated behavior where the gateway maps upstream provider 400s to a generic OpenAI-compatible `internal error` client response remains out of scope.

