### PR TITLE
fix(heartbeat): respect HEARTBEAT.md PAUSED state to prevent credit burn (#81186)

### DIFF
--- a/src/infra/heartbeat-runner.paused-respect.test.ts
+++ b/src/infra/heartbeat-runner.paused-respect.test.ts
@@ -1,0 +1,221 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { type HeartbeatDeps, runHeartbeatOnce } from "./heartbeat-runner.js";
+import { telegramMessagingForTest } from "./outbound/targets.test-helpers.js";
+
+let previousRegistry: ReturnType<typeof getActivePluginRegistry> | null = null;
+let testRegistry: ReturnType<typeof getActivePluginRegistry> | null = null;
+let fixtureRoot = "";
+let fixtureCount = 0;
+
+const createCaseDir = async (prefix: string) => {
+  const dir = path.join(fixtureRoot, `${prefix}-${fixtureCount++}`);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+};
+
+beforeAll(async () => {
+  previousRegistry = getActivePluginRegistry();
+
+  const telegramPlugin = createOutboundTestPlugin({
+    id: "telegram",
+    outbound: {
+      deliveryMode: "direct",
+      sendText: async ({ to, text, deps, accountId }) => {
+        if (!deps?.["telegram"]) {
+          throw new Error("sendTelegram missing");
+        }
+        const res = await (deps["telegram"] as Function)(to, text, {
+          verbose: false,
+          accountId: accountId ?? undefined,
+        });
+        return { channel: "telegram", messageId: res.messageId, chatId: res.chatId };
+      },
+      sendMedia: async ({ to, text, mediaUrl, deps, accountId }) => {
+        if (!deps?.["telegram"]) {
+          throw new Error("sendTelegram missing");
+        }
+        const res = await (deps["telegram"] as Function)(to, text, {
+          verbose: false,
+          accountId: accountId ?? undefined,
+          mediaUrl,
+        });
+        return { channel: "telegram", messageId: res.messageId, chatId: res.chatId };
+      },
+    },
+    messaging: telegramMessagingForTest,
+  });
+  telegramPlugin.config = {
+    ...telegramPlugin.config,
+    listAccountIds: (cfg) => Object.keys(cfg.channels?.telegram?.accounts ?? {}),
+    resolveAllowFrom: ({ cfg, accountId }) => {
+      const channel = cfg.channels?.telegram;
+      const normalized = accountId?.trim();
+      if (normalized && channel?.accounts?.[normalized]?.allowFrom) {
+        return channel.accounts[normalized].allowFrom?.map((entry) => String(entry)) ?? [];
+      }
+      return channel?.allowFrom?.map((entry) => String(entry)) ?? [];
+    },
+  };
+
+  testRegistry = createTestRegistry([
+    { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
+  ]);
+  setActivePluginRegistry(testRegistry);
+
+  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-paused-"));
+});
+
+afterAll(async () => {
+  if (fixtureRoot) {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  }
+  if (previousRegistry) {
+    setActivePluginRegistry(previousRegistry);
+  }
+});
+
+describe("runHeartbeatOnce — HEARTBEAT.md PAUSED sentinel (#81186)", () => {
+  const createHeartbeatDeps = (
+    sendTelegram: (
+      to: string,
+      text: string,
+      opts?: unknown,
+    ) => Promise<{ messageId: string; chatId: string }>,
+    options?: {
+      getReplyFromConfig?: HeartbeatDeps["getReplyFromConfig"];
+    },
+  ): HeartbeatDeps => ({
+    telegram: sendTelegram,
+    getQueueSize: () => 0,
+    nowMs: () => 0,
+    webAuthExists: async () => true,
+    hasActiveWebListener: () => true,
+    ...(options?.getReplyFromConfig ? { getReplyFromConfig: options.getReplyFromConfig } : null),
+  });
+
+  async function runPausedScenario(params: { heartbeatContent: string }) {
+    const tmpDir = await createCaseDir("hb-paused");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const workspaceDir = path.join(tmpDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    await fs.writeFile(path.join(workspaceDir, "HEARTBEAT.md"), params.heartbeatContent, "utf-8");
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          heartbeat: { every: "5m", target: "telegram" },
+        },
+      },
+      channels: { telegram: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sid",
+          updatedAt: Date.now(),
+          lastChannel: "telegram",
+          lastTo: "-100123",
+        },
+      }),
+    );
+
+    const sendTelegram = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; chatId: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", chatId: "-100123" });
+
+    const replySpy = vi.fn().mockResolvedValue({ text: "Checked logs and PRs" });
+
+    const res = await runHeartbeatOnce({
+      cfg,
+      source: "interval",
+      intent: "scheduled",
+      reason: "interval",
+      deps: createHeartbeatDeps(sendTelegram, { getReplyFromConfig: replySpy }),
+    });
+
+    return { res, sendTelegram, replySpy };
+  }
+
+  it("skips heartbeat when HEARTBEAT.md contains 'PAUSED'", async () => {
+    const { res, sendTelegram } = await runPausedScenario({
+      heartbeatContent: "PAUSED",
+    });
+
+    expect(res.status).toBe("skipped");
+    if (res.status === "skipped") {
+      expect(res.reason).toBe("heartbeat-paused");
+    }
+    expect(sendTelegram).toHaveBeenCalledTimes(0);
+  });
+
+  it("skips heartbeat when HEARTBEAT.md contains 'paused' (lowercase)", async () => {
+    const { res, sendTelegram } = await runPausedScenario({
+      heartbeatContent: "paused",
+    });
+
+    expect(res.status).toBe("skipped");
+    if (res.status === "skipped") {
+      expect(res.reason).toBe("heartbeat-paused");
+    }
+    expect(sendTelegram).toHaveBeenCalledTimes(0);
+  });
+
+  it("skips heartbeat when HEARTBEAT.md contains 'Paused' (mixed case)", async () => {
+    const { res, sendTelegram } = await runPausedScenario({
+      heartbeatContent: "Paused",
+    });
+
+    expect(res.status).toBe("skipped");
+    if (res.status === "skipped") {
+      expect(res.reason).toBe("heartbeat-paused");
+    }
+    expect(sendTelegram).toHaveBeenCalledTimes(0);
+  });
+
+  it("skips heartbeat when HEARTBEAT.md contains '  PAUSED  ' (with whitespace)", async () => {
+    const { res, sendTelegram } = await runPausedScenario({
+      heartbeatContent: "  PAUSED  ",
+    });
+
+    expect(res.status).toBe("skipped");
+    if (res.status === "skipped") {
+      expect(res.reason).toBe("heartbeat-paused");
+    }
+    expect(sendTelegram).toHaveBeenCalledTimes(0);
+  });
+
+  it("runs heartbeat normally when HEARTBEAT.md contains actionable tasks", async () => {
+    const { res, sendTelegram } = await runPausedScenario({
+      heartbeatContent: "# HEARTBEAT.md\n\n- Check server logs\n",
+    });
+
+    expect(res.status).toBe("ran");
+    expect(sendTelegram).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips heartbeat with empty-heartbeat-file reason for effectively empty content", async () => {
+    const { res, sendTelegram } = await runPausedScenario({
+      heartbeatContent: "# HEARTBEAT.md\n\n## Tasks\n\n",
+    });
+
+    expect(res.status).toBe("skipped");
+    if (res.status === "skipped") {
+      expect(res.reason).toBe("empty-heartbeat-file");
+    }
+    expect(sendTelegram).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -808,7 +808,7 @@ type HeartbeatWakePayloadFlags = {
   isWakePayload: boolean;
 };
 
-type HeartbeatSkipReason = "empty-heartbeat-file";
+type HeartbeatSkipReason = "empty-heartbeat-file" | "heartbeat-paused";
 
 function buildCommitmentDeliveryKey(commitment: CommitmentRecord): string {
   return [
@@ -990,6 +990,15 @@ async function resolveHeartbeatPreflight(params: {
   let heartbeatFileContent: string | undefined;
   try {
     heartbeatFileContent = await fs.readFile(heartbeatFilePath, "utf-8");
+    const normalizedContent = heartbeatFileContent.trim().toLowerCase();
+    if (normalizedContent === "paused") {
+      return {
+        ...basePreflight,
+        skipReason: "heartbeat-paused",
+        tasks: [],
+        heartbeatFileContent,
+      };
+    }
     const tasks = parseHeartbeatTasks(heartbeatFileContent);
     if (
       isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) &&


### PR DESCRIPTION
## Summary

Default 30-minute heartbeat fires continuously when agent is idle, burning ~2,500 credits/day. When users explicitly set HEARTBEAT.md to `PAUSED` to stop this, the scheduler ignores the sentinel and continues firing.

### Problem

- HEARTBEAT.md is the user-facing control for heartbeat behavior
- Setting it to `PAUSED` is the documented/intuitive way to disable heartbeat polling
- The heartbeat preflight reads the file but only checks for "effectively empty" content — it does not recognize the explicit `PAUSED` sentinel
- Result: heartbeat tasks continue to be dispatched, agent turns execute, credits are consumed

### Root Cause

`src/infra/heartbeat-runner.ts` `resolveHeartbeatPreflight()` reads `HEARTBEAT.md` and checks `isHeartbeatContentEffectivelyEmpty(heartbeatFileContent)`, but there is no branch for the `PAUSED` state. The scheduler falls through to normal dispatch.

### Fix

Add an early-return immediately after reading the file:

```ts
const normalizedContent = heartbeatFileContent.trim().toLowerCase();
if (normalizedContent === "paused") {
  return {
    ...basePreflight,
    skipReason: "heartbeat-paused",
    tasks: [],
    heartbeatFileContent,
  };
}
```

This is placed before the `isHeartbeatContentEffectivelyEmpty()` check so `PAUSED` (which is not empty) is handled correctly. The `skipReason` is emitted as a diagnostic event and logged, making the behavior observable.

### Testing

- Added behavior test: `src/infra/heartbeat-runner.paused-respect.test.ts`
- Tests call `runHeartbeatOnce()` with a real `HEARTBEAT.md` file containing `PAUSED` and assert the result is `{ status: "skipped", reason: "heartbeat-paused" }` with zero Telegram calls
- Covers case variations: `PAUSED`, `paused`, `Paused`, and `  PAUSED  ` (whitespace)
- Also verifies normal heartbeat still runs with actionable tasks, and empty content still skips with `empty-heartbeat-file` reason

## Real behavior proof

- Behavior or issue addressed: Fixes #81186 — HEARTBEAT.md PAUSED sentinel ignored, causing credit burn

- Real environment tested: Linux container with openclaw source tree at commit f6d093e75e, Node.js v22, pnpm 11.1.0, Vitest 4.1.6

- Exact steps or command run after this patch:
  1. Applied patch to `src/infra/heartbeat-runner.ts` adding PAUSED check after file read
  2. Updated `HeartbeatSkipReason` type to include `"heartbeat-paused"` (fixes TypeScript compilation)
  3. Replaced source-code-inspection test with behavior test `src/infra/heartbeat-runner.paused-respect.test.ts`
  4. Ran the test suite:

```
$ pnpm test src/infra/heartbeat-runner.paused-respect.test.ts

 RUN  v4.1.6 /tmp/openclaw-fork

 ✓  infra  src/infra/heartbeat-runner.paused-respect.test.ts (6 tests) 240ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

- Evidence after fix (terminal capture):

```
$ pnpm test src/infra/heartbeat-runner.paused-respect.test.ts
[test] starting test/vitest/vitest.infra.config.ts

 RUN  v4.1.6 /tmp/openclaw-fork

 ✓  infra  src/infra/heartbeat-runner.paused-respect.test.ts (6 tests) 240ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  14:17:30
   Duration  7.27s
```

- Observed result after fix: All 6 behavior tests pass. When HEARTBEAT.md contains "PAUSED" (any case), `runHeartbeatOnce()` returns `status: "skipped"` with `reason: "heartbeat-paused"` and `sendTelegram` is never called. When the file contains actionable tasks, the heartbeat runs normally. When the file is effectively empty, it skips with `empty-heartbeat-file` reason.

- What was not tested: Live provider API call suppression (no API keys configured in test environment). The fix prevents dispatch at the scheduler level, so no provider calls are attempted.
