### PR TITLE
fix(google): handle compressed Vertex ADC token refresh responses

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -2,6 +2,7 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { gzipSync } from "node:zlib";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -955,6 +956,64 @@ describe("google transport stream", () => {
     expect(result.provider).toBe("google-vertex");
     expect(result.stopReason).toBe("stop");
     expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+  });
+
+  it("refreshes authorized_user ADC from a compressed token response", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-gzip-"));
+    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
+    await writeFile(
+      credentialsPath,
+      JSON.stringify({
+        type: "authorized_user",
+        client_id: "client-id",
+        client_secret: "client-secret",
+        refresh_token: "gzip-refresh-token",
+      }),
+      "utf8",
+    );
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    const tokenFetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        gzipSync(JSON.stringify({ access_token: "ya29.gzip-token", expires_in: 3600 })),
+        {
+          status: 200,
+          headers: {
+            "content-encoding": "gzip",
+            "content-type": "application/json",
+          },
+        },
+      ),
+    );
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gcp-vertex-credentials",
+          fetch: tokenFetchMock,
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    expect(tokenFetchMock).toHaveBeenCalledTimes(1);
+    const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+    expectHeaders(requireRequestInit(guardedCall, "guarded fetch"), {
+      Authorization: "Bearer ya29.gzip-token",
+    });
   });
 
   it("does not reuse authorized_user ADC tokens with unsafe expiry lifetimes", async () => {

--- a/extensions/google/vertex-adc.ts
+++ b/extensions/google/vertex-adc.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { gunzipSync } from "node:zlib";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -27,6 +28,13 @@ type GoogleVertexAuthorizedUserToken = {
 type GoogleVertexAdcToken = {
   token: string;
   expiresAtMs: number;
+};
+
+type GoogleOauthTokenResponsePayload = {
+  access_token?: unknown;
+  expires_in?: unknown;
+  error?: unknown;
+  error_description?: unknown;
 };
 
 const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
@@ -238,15 +246,16 @@ async function refreshGoogleVertexAuthorizedUserAccessToken(params: {
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body,
   });
-  const payload = (await response.json().catch(() => undefined)) as
-    | { access_token?: unknown; expires_in?: unknown; error?: unknown; error_description?: unknown }
-    | undefined;
+  const payload = await readGoogleOauthTokenResponsePayload(response);
   if (!response.ok) {
     const description = normalizeOptionalString(payload?.error_description);
     const code = normalizeOptionalString(payload?.error);
     throw new Error(
       `Google Vertex ADC token refresh failed: ${response.status}${code ? ` ${code}` : ""}${description ? ` (${description})` : ""}`,
     );
+  }
+  if (!payload) {
+    throw new Error("Google Vertex ADC token refresh response could not be parsed as JSON.");
   }
   const token = normalizeOptionalString(payload?.access_token);
   if (!token) {
@@ -263,6 +272,45 @@ async function refreshGoogleVertexAuthorizedUserAccessToken(params: {
     };
   }
   return token;
+}
+
+async function readGoogleOauthTokenResponsePayload(
+  response: Response,
+): Promise<GoogleOauthTokenResponsePayload | undefined> {
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const text = decodeGoogleOauthTokenResponseBody(bytes, response.headers.get("content-encoding"));
+  if (!text.trim()) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as GoogleOauthTokenResponsePayload;
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeGoogleOauthTokenResponseBody(bytes: Buffer, contentEncoding: string | null): string {
+  if (shouldGunzipGoogleOauthTokenResponse(bytes, contentEncoding)) {
+    try {
+      return gunzipSync(bytes).toString("utf8");
+    } catch {
+      return bytes.toString("utf8");
+    }
+  }
+  return bytes.toString("utf8");
+}
+
+function shouldGunzipGoogleOauthTokenResponse(
+  bytes: Buffer,
+  contentEncoding: string | null,
+): boolean {
+  if (bytes[0] === 0x1f && bytes[1] === 0x8b) {
+    return true;
+  }
+  return (contentEncoding ?? "")
+    .split(",")
+    .map((encoding) => encoding.trim().toLowerCase())
+    .includes("gzip");
 }
 
 async function resolveGoogleVertexAccessTokenViaGoogleAuth(): Promise<string> {


### PR DESCRIPTION
## Summary

- Decode Google Vertex ADC OAuth token refresh bodies from raw bytes before parsing JSON.
- Gunzip compressed token responses while preserving custom fetchImpl token refresh behavior.
- Cover compressed token responses and custom fetchImpl token refresh behavior in Google transport tests.

Related: #79752, #80764, #80788

## Real behavior proof

- Behavior or issue addressed: Google Vertex ADC token refresh could receive a gzip-compressed OAuth response. The old `response.json()` path swallowed the parse failure and later reported `Google Vertex ADC token refresh response did not include an access_token` even though local ADC credentials were valid.
- Real environment tested: Local OpenClaw Enterprise gateway on macOS using Application Default Credentials from `GOOGLE_APPLICATION_CREDENTIALS=/Users/antonio/.config/gcloud/application_default_credentials.json`, `GOOGLE_CLOUD_PROJECT=taptap-ai-search`, `GOOGLE_CLOUD_LOCATION=global`, and real model route `google-vertex/gemini-3.1-pro-preview`.
- Exact steps or command run after this patch: Ran `/opt/homebrew/opt/node/bin/node /Users/antonio/Desktop/projects/openclaw/dist/index.js --profile enterprise agent --session-id openclaw_ops_smoke_vertex_gzip --message "Reply exactly: OK" --json --timeout 90` against the local Enterprise runtime.
- Evidence after fix: Copied live terminal output showed an assistant payload of `OK` through provider `google-vertex`, model `gemini-3.1-pro-preview`, with duration about 6887 ms. A final default route smoke test also returned `OK` after setting `google-vertex/gemini-3.1-pro-preview` as fallback.
- Observed result after fix: The real OpenClaw Enterprise request completed successfully through Google Vertex ADC instead of failing with missing `access_token`.
- What was not tested: I did not include secrets, OAuth token values, ADC file contents, or a live service-account JSON flow.

## Tests

- Rebased onto upstream/main `bf22893cb6`.
- `node scripts/test-projects.mjs extensions/google/transport-stream.test.ts --reporter verbose` passed, 55 tests, including `refreshes authorized_user ADC from a compressed token response`.
- `./node_modules/.bin/oxfmt --check extensions/google/vertex-adc.ts extensions/google/transport-stream.test.ts` passed, 2 files.
- `git diff --check upstream/main...HEAD` passed.
