### PR TITLE
docs: clarify local-prefix managed Node runtime

### DIFF
--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -187,7 +187,7 @@ by default, plus git-checkout installs under the same prefix flow.
 
 <Steps>
   <Step title="Install local Node runtime">
-    Downloads a pinned supported Node LTS tarball (the version is embedded in the script and updated independently) to `<prefix>/tools/node-v<version>` and verifies SHA-256.
+    Downloads a pinned supported Node LTS tarball (default: Node `22.22.0`) to `<prefix>/tools/node-v<version>` and verifies SHA-256. This managed local-prefix runtime can intentionally differ from the shell/global Node used by the main installer, which defaults to Node 24.
   </Step>
   <Step title="Ensure Git">
     If Git is missing, attempts install via apt/dnf/yum on Linux or Homebrew on macOS.
@@ -234,23 +234,27 @@ by default, plus git-checkout installs under the same prefix flow.
   </Tab>
 </Tabs>
 
+<Note>
+`install-cli.sh` is the local-prefix installer. It uses its own managed Node under `<prefix>/tools/` and currently defaults that runtime to Node `22.22.0`, even though the main installer and general docs recommend Node 24 for normal/global installs. If OpenClaw-adjacent native tools are loaded by this local-prefix gateway, install or rebuild them with the managed Node runtime rather than assuming your shell/global `node` is the one OpenClaw will use.
+</Note>
+
 <AccordionGroup>
   <Accordion title="Flags reference">
 
-| Flag                        | Description                                                                     |
-| --------------------------- | ------------------------------------------------------------------------------- |
-| `--prefix <path>`           | Install prefix (default: `~/.openclaw`)                                         |
-| `--install-method npm\|git` | Choose install method (default: `npm`). Alias: `--method`                       |
-| `--npm`                     | Shortcut for npm method                                                         |
-| `--git`, `--github`         | Shortcut for git method                                                         |
-| `--git-dir <path>`          | Git checkout directory (default: `~/openclaw`). Alias: `--dir`                  |
-| `--version <ver>`           | OpenClaw version or dist-tag (default: `latest`)                                |
-| `--node-version <ver>`      | Node version (default: `22.22.0`)                                               |
-| `--json`                    | Emit NDJSON events                                                              |
-| `--onboard`                 | Run `openclaw onboard` after install                                            |
-| `--no-onboard`              | Skip onboarding (default)                                                       |
-| `--set-npm-prefix`          | On Linux, force npm prefix to `~/.npm-global` if current prefix is not writable |
-| `--help`                    | Show usage (`-h`)                                                               |
+| Flag                        | Description                                                                                  |
+| --------------------------- | -------------------------------------------------------------------------------------------- |
+| `--prefix <path>`           | Install prefix (default: `~/.openclaw`)                                                      |
+| `--install-method npm\|git` | Choose install method (default: `npm`). Alias: `--method`                                    |
+| `--npm`                     | Shortcut for npm method                                                                      |
+| `--git`, `--github`         | Shortcut for git method                                                                      |
+| `--git-dir <path>`          | Git checkout directory (default: `~/openclaw`). Alias: `--dir`                               |
+| `--version <ver>`           | OpenClaw version or dist-tag (default: `latest`)                                             |
+| `--node-version <ver>`      | Managed local-prefix Node version (default: `22.22.0`; may differ from shell/global Node 24) |
+| `--json`                    | Emit NDJSON events                                                                           |
+| `--onboard`                 | Run `openclaw onboard` after install                                                         |
+| `--no-onboard`              | Skip onboarding (default)                                                                    |
+| `--set-npm-prefix`          | On Linux, force npm prefix to `~/.npm-global` if current prefix is not writable              |
+| `--help`                    | Show usage (`-h`)                                                                            |
 
   </Accordion>
 
@@ -261,7 +265,7 @@ by default, plus git-checkout installs under the same prefix flow.
 | `OPENCLAW_PREFIX=<path>`                    | Install prefix                                |
 | `OPENCLAW_INSTALL_METHOD=git\|npm`          | Install method                                |
 | `OPENCLAW_VERSION=<ver>`                    | OpenClaw version or dist-tag                  |
-| `OPENCLAW_NODE_VERSION=<ver>`               | Node version                                  |
+| `OPENCLAW_NODE_VERSION=<ver>`               | Managed local-prefix Node version             |
 | `OPENCLAW_GIT_DIR=<path>`                   | Git checkout directory for git installs       |
 | `OPENCLAW_GIT_UPDATE=0\|1`                  | Toggle git updates for existing checkouts     |
 | `OPENCLAW_NO_ONBOARD=1`                     | Skip onboarding                               |

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -520,12 +520,13 @@ install_node() {
     current_major="$("$(node_bin)" -v 2>/dev/null | tr -d 'v' | cut -d'.' -f1 || echo "")"
     if [[ -n "$current_major" && "$current_major" -ge 22 ]]; then
       emit_json "{\"event\":\"step\",\"name\":\"node\",\"status\":\"skip\",\"path\":\"${dir//\"/\\\\\\\"}\"}"
+      log "Using existing managed Node at ${dir}; this local-prefix runtime may differ from your shell/global node."
       return
     fi
   fi
 
   emit_json "{\"event\":\"step\",\"name\":\"node\",\"status\":\"start\",\"version\":\"${NODE_VERSION}\"}"
-  log "Installing Node ${NODE_VERSION} (user-space)..."
+  log "Installing managed Node ${NODE_VERSION} for the local-prefix runtime (this may differ from your shell/global node)..."
 
   mkdir -p "${PREFIX}/tools"
   tmp="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- Clarify that `install-cli.sh` uses a managed local-prefix Node runtime that currently defaults to 22.22.0.
- Call out that this can intentionally differ from shell/global Node 24.
- Update install output wording so users see the managed-runtime distinction during install or update.

Closes #79558.

## Verification
- `git diff --check`
- `bash -n scripts/install-cli.sh`
- `pnpm docs:check-mdx`
- `pnpm docs:list`
- `pnpm docs:check-links`

## Real behavior proof
- **Behavior or issue addressed:** The local-prefix installer now tells users that it is using a managed Node runtime, and that this runtime may differ from their shell/global Node.
- **Real environment tested:** Local OpenClaw checkout on Linux arm64 with Node v22.21.1, running the patched `scripts/install-cli.sh` from this PR branch.
- **Exact steps or command run after this patch:**

```bash
proof_tmp=$(mktemp -d)
mkdir -p "$proof_tmp/tools/node-v22.22.0/bin"
ln -s "$(command -v node)" "$proof_tmp/tools/node-v22.22.0/bin/node"
OPENCLAW_PREFIX="$proof_tmp" OPENCLAW_INSTALL_CLI_SH_NO_RUN=1 bash -c 'source scripts/install-cli.sh; install_node'
rm -rf "$proof_tmp"
```

- **Evidence after fix:** Console output from the patched installer helper:

```text
Using existing managed Node at /tmp/tmp.znUwhmDIh5/tools/node-v22.22.0; this local-prefix runtime may differ from your shell/global node.
```

- **Observed result after fix:** The real installer path now surfaces the managed local-prefix Node distinction when reusing an existing managed Node, instead of silently skipping the Node step.
- **What was not tested:** I did not perform a full destructive/replacing install into a real `~/.openclaw` prefix; the proof uses a temporary local prefix to exercise the changed installer branch safely.
