### PR TITLE
fix(cron): use stable notification session key for isolated cron announce delivery

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1040,6 +1040,8 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       session: { dmScope: "per-channel-peer" },
     } as never;
     params.agentSessionKey = "agent:main:telegram:123456";
+    // Non-isolated job should use agentSessionKey directly
+    (params.job as { sessionTarget?: string }).sessionTarget = "session:agent:main:main";
 
     const state = await dispatchCronDelivery(params);
 
@@ -1049,6 +1051,28 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       cfg: params.cfgWithAgentDefaults,
       agentId: "main",
       sessionKey: "agent:main:telegram:123456",
+    });
+  });
+
+  it("uses resolveCronNotificationSessionKey for isolated cron delivery session context", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: "hello from isolated cron" });
+    params.cfgWithAgentDefaults = {
+      session: { dmScope: "per-channel-peer" },
+    } as never;
+    params.agentSessionKey = "agent:main:cron:test-job";
+    (params.job as { sessionTarget?: string }).sessionTarget = "isolated";
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(true);
+    expect(buildOutboundSessionContext).toHaveBeenCalledWith({
+      cfg: params.cfgWithAgentDefaults,
+      agentId: "main",
+      sessionKey: "cron:test-job:failure",
     });
   });
 

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -29,6 +29,10 @@ import {
 import { shouldAttemptTtsPayload } from "../../tts/tts-config.js";
 import { createCronExecutionId } from "../run-id.js";
 import { hasScheduledNextRunAtMs } from "../service/jobs.js";
+import {
+  resolveCronDeliverySessionKey,
+  resolveCronNotificationSessionKey,
+} from "../session-target.js";
 import type { CronJob, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import { pickLastNonEmptyTextFromPayloads, pickSummaryFromOutput } from "./helpers.js";
@@ -645,7 +649,13 @@ export async function dispatchCronDelivery(
       const deliverySession = buildOutboundSessionContext({
         cfg: params.cfgWithAgentDefaults,
         agentId: params.agentId,
-        sessionKey: params.agentSessionKey,
+        sessionKey:
+          params.job.sessionTarget === "isolated"
+            ? resolveCronNotificationSessionKey({
+                jobId: params.job.id,
+                sessionKey: resolveCronDeliverySessionKey(params.job),
+              })
+            : params.agentSessionKey,
       });
 
       // Track bestEffort partial failures so we can log them and avoid


### PR DESCRIPTION
## Problem

Isolated cron sessions use a fresh agent-scoped session key (`agent:main:cron:<job-id>`) that lacks channel binding history. When `deliverViaDirect` builds the outbound session context with this temporary key, some channel adapters cannot resolve the correct delivery target, causing announce messages to fail silently in isolated cron sessions.

## Root Cause

`delivery-dispatch.ts` `deliverViaDirect` always uses `params.agentSessionKey` for the outbound session context. For isolated jobs, this key points to a brand-new session with no `lastChannel`/`lastTo` history, diverging from `delivery.ts` `sendCronAnnouncePayloadStrict` which uses `resolveCronNotificationSessionKey()` (`cron:<job-id>:failure`).

## Fix

For isolated cron jobs, use `resolveCronNotificationSessionKey()` so the session key matches the stable notification key used by the announce path in `delivery.ts`. Non-isolated jobs continue to use `agentSessionKey` directly.

```ts
sessionKey:
  params.job.sessionTarget === "isolated"
    ? resolveCronNotificationSessionKey({
        jobId: params.job.id,
        sessionKey: resolveCronDeliverySessionKey(params.job),
      })
    : params.agentSessionKey,
```

## Changes

- `src/cron/isolated-agent/delivery-dispatch.ts`: conditionally use `resolveCronNotificationSessionKey` when `job.sessionTarget === "isolated"`
- `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`: add regression test verifying isolated jobs use the notification session key; update existing test to use non-isolated `sessionTarget`

## Testing

- Regression test added: `uses resolveCronNotificationSessionKey for isolated cron delivery session context`
- Existing test updated: `builds outbound session context from the run session key under per-channel-peer scoping` now uses `sessionTarget: "session:agent:main:main"` to verify non-isolated behavior

## Real behavior proof

- Behavior or issue addressed: Fixes #80672 — announce delivery fails in isolated cron sessions due to session key mismatch

- Real environment tested: Linux container with openclaw source tree at commit f6d093e75e, Node.js v20, pnpm 11.1.0, Vitest 4.1.6

- Exact steps or command run after this patch:
  1. Applied patch to `src/cron/isolated-agent/delivery-dispatch.ts` adding conditional session key selection
  2. Updated regression test in `delivery-dispatch.double-announce.test.ts`
  3. Ran the test suite:

- Evidence after fix (terminal capture):

```
$ pnpm test src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts

 RUN  v4.1.6 /root/openclaw

 ✓  cron  src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts (51 tests) 729ms

 Test Files  1 passed (1)
      Tests  51 passed (51)
   Start at  13:03:10
   Duration  3.12s
```

- Observed result after fix: All 51 tests in the double-announce suite pass, including the new regression test that verifies isolated jobs use `cron:<job-id>:failure` as the session key. The existing per-channel-peer test was updated to use a non-isolated `sessionTarget` to preserve its original behavior verification.

- What was not tested: Live channel adapter integration (no channel credentials configured in test environment). The fix affects session context construction only; actual adapter behavior is outside the modified code path.