### PR TITLE
[codex] Add Control UI gateway request timeouts

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -219,6 +219,7 @@ function createAppServerHarness(
           handleServerRequest = handler;
           return () => undefined;
         },
+        close: vi.fn(),
       } as never;
     },
   );
@@ -1296,6 +1297,7 @@ describe("runCodexAppServerAttempt", () => {
 
   it("closes the app-server client when the active turn exceeds the attempt timeout", async () => {
     const close = vi.fn();
+    const onRunAgentEvent = vi.fn();
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {
         return threadStartResult("thread-1");
@@ -1322,6 +1324,7 @@ describe("runCodexAppServerAttempt", () => {
       path.join(tempDir, "workspace"),
     );
     params.timeoutMs = 100;
+    params.onAgentEvent = onRunAgentEvent;
 
     const result = await runCodexAppServerAttempt(params);
 
@@ -1337,6 +1340,18 @@ describe("runCodexAppServerAttempt", () => {
       { timeoutMs: 5_000 },
     );
     expect(close).toHaveBeenCalledTimes(1);
+    expect(onRunAgentEvent).toHaveBeenCalledWith({
+      stream: "codex_app_server.lifecycle",
+      data: expect.objectContaining({
+        phase: "turn_timeout_client_retired",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        reason: "timeout",
+        timeoutMs: 100,
+        clearedSharedClient: false,
+        closedNonCurrentClient: true,
+      }),
+    });
     expect(queueActiveRunMessageForTest("session-1", "after timeout")).toBe(false);
   });
 
@@ -2021,7 +2036,7 @@ describe("runCodexAppServerAttempt", () => {
     });
   });
 
-  it("does not release the session after only a raw assistant response item", async () => {
+  it("releases the session after a raw assistant response item stalls without turn completion", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {
@@ -2078,11 +2093,188 @@ describe("runCodexAppServerAttempt", () => {
       aborted: result.aborted,
       timedOut: result.timedOut,
       promptError: result.promptError,
+      assistantTexts: result.assistantTexts,
     }).toEqual({
-      aborted: true,
-      timedOut: true,
-      promptError: "codex app-server turn idle timed out waiting for turn/completed",
+      aborted: false,
+      timedOut: false,
+      promptError: null,
+      assistantTexts: ["Done."],
     });
+    expect(request).toHaveBeenCalledWith(
+      "turn/interrupt",
+      {
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      { timeoutMs: 5_000 },
+    );
+  });
+
+  it("releases after raw assistant completion clears its active assistant item", async () => {
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+    __testing.setCodexAppServerClientFactoryForTests(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: () => () => undefined,
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 200;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnAssistantCompletionIdleTimeoutMs: 5,
+      turnTerminalIdleTimeoutMs: 50,
+    });
+    await vi.waitFor(
+      () =>
+        expect(request).toHaveBeenCalledWith("turn/start", expect.anything(), expect.anything()),
+      { interval: 1 },
+    );
+    await notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { type: "message", id: "raw-final-1", role: "assistant", status: "inProgress" },
+      },
+    });
+    await notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "message",
+          id: "raw-final-1",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Done." }],
+        },
+      },
+    });
+
+    const result = await run;
+    expect({
+      aborted: result.aborted,
+      timedOut: result.timedOut,
+      promptError: result.promptError,
+      assistantTexts: result.assistantTexts,
+    }).toEqual({
+      aborted: false,
+      timedOut: false,
+      promptError: null,
+      assistantTexts: ["Done."],
+    });
+  });
+
+  it("keeps raw assistant completion release armed across late assistant notifications", async () => {
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+    __testing.setCodexAppServerClientFactoryForTests(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: () => () => undefined,
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 200;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnAssistantCompletionIdleTimeoutMs: 5,
+      turnTerminalIdleTimeoutMs: 50,
+    });
+    await vi.waitFor(
+      () =>
+        expect(request).toHaveBeenCalledWith("turn/start", expect.anything(), expect.anything()),
+      { interval: 1 },
+    );
+    await notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "message",
+          id: "raw-final-1",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Done." }],
+        },
+      },
+    });
+    await notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { type: "message", id: "raw-final-1", role: "assistant", status: "inProgress" },
+      },
+    });
+    await notify({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "raw-final-1",
+        delta: "Done.",
+      },
+    });
+
+    const result = await run;
+    expect({
+      aborted: result.aborted,
+      timedOut: result.timedOut,
+      promptError: result.promptError,
+      assistantTexts: result.assistantTexts,
+    }).toEqual({
+      aborted: false,
+      timedOut: false,
+      promptError: null,
+      assistantTexts: ["Done.Done."],
+    });
+    await vi.waitFor(
+      () =>
+        expect(request).toHaveBeenCalledWith(
+          "turn/interrupt",
+          {
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+          { timeoutMs: 5_000 },
+        ),
+      { interval: 1 },
+    );
   });
 
   it("keeps waiting when a current-turn item is still active", async () => {
@@ -4524,6 +4716,7 @@ describe("runCodexAppServerAttempt", () => {
           return () => undefined;
         },
         addRequestHandler: () => () => undefined,
+        close: vi.fn(),
       } as never;
     });
 
@@ -4573,6 +4766,7 @@ describe("runCodexAppServerAttempt", () => {
           return () => undefined;
         },
         addRequestHandler: () => () => undefined,
+        close: vi.fn(),
       } as never;
     });
 
@@ -4594,6 +4788,115 @@ describe("runCodexAppServerAttempt", () => {
       ["thread/resume"],
       ["thread/resume", "turn/start"],
     ]);
+  });
+
+  it("reports exhausted startup close retries when the failed client is no longer shared", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const onRunAgentEvent = vi.fn();
+    const requests: string[][] = [];
+    let closeCount = 0;
+    let starts = 0;
+    __testing.setCodexAppServerClientFactoryForTests(async () => {
+      starts += 1;
+      const methods: string[] = [];
+      requests.push(methods);
+      return {
+        request: vi.fn(async (method: string) => {
+          methods.push(method);
+          if (method === "thread/resume") {
+            throw new Error("codex app-server client is closed");
+          }
+          return {};
+        }),
+        close: () => {
+          closeCount += 1;
+        },
+        addNotificationHandler: () => () => undefined,
+        addRequestHandler: () => () => undefined,
+      } as never;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.onAgentEvent = onRunAgentEvent;
+
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow(
+      "codex app-server client is closed",
+    );
+
+    expect(starts).toBe(3);
+    expect(closeCount).toBe(3);
+    expect(requests).toEqual([["thread/resume"], ["thread/resume"], ["thread/resume"]]);
+    expect(warn).toHaveBeenCalledWith(
+      "codex app-server connection closed during startup; restarting app-server and retrying",
+      expect.objectContaining({
+        attempt: 1,
+        nextAttempt: 2,
+        maxAttempts: 3,
+        clearedSharedClient: false,
+        closedNonCurrentClient: true,
+      }),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "codex app-server connection closed during startup; restarting app-server and retrying",
+      expect.objectContaining({
+        attempt: 2,
+        nextAttempt: 3,
+        maxAttempts: 3,
+        clearedSharedClient: false,
+        closedNonCurrentClient: true,
+      }),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "codex app-server connection closed during startup; retries exhausted",
+      expect.objectContaining({
+        attempt: 3,
+        maxAttempts: 3,
+        clearedSharedClient: false,
+        closedNonCurrentClient: true,
+      }),
+    );
+    const lifecycleEvents = onRunAgentEvent.mock.calls.map(([event]) => event) as Array<{
+      data?: {
+        attempt?: number;
+        closedNonCurrentClient?: boolean;
+        failureClass?: string;
+        phase?: string;
+      };
+      stream?: string;
+    }>;
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stream: "codex_app_server.lifecycle",
+          data: expect.objectContaining({
+            phase: "startup_retry",
+            attempt: 1,
+            failureClass: "app_server_client_closed",
+            closedNonCurrentClient: true,
+          }),
+        }),
+        expect.objectContaining({
+          stream: "codex_app_server.lifecycle",
+          data: expect.objectContaining({
+            phase: "startup_retry",
+            attempt: 2,
+            failureClass: "app_server_client_closed",
+            closedNonCurrentClient: true,
+          }),
+        }),
+        expect.objectContaining({
+          stream: "codex_app_server.lifecycle",
+          data: expect.objectContaining({
+            phase: "startup_retries_exhausted",
+            attempt: 3,
+            failureClass: "app_server_client_closed",
+            closedNonCurrentClient: true,
+          }),
+        }),
+      ]),
+    );
   });
 
   it("passes native hook relay config on thread start and resume", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -113,7 +113,11 @@ import {
 } from "./rate-limits.js";
 import { readCodexAppServerBinding, type CodexAppServerThreadBinding } from "./session-binding.js";
 import { readCodexMirroredSessionHistoryMessages } from "./session-history.js";
-import { clearSharedCodexAppServerClientIfCurrent } from "./shared-client.js";
+import {
+  createIsolatedCodexAppServerClient,
+  retainSharedCodexAppServerClient,
+  retireSharedCodexAppServerClient,
+} from "./shared-client.js";
 import {
   areCodexDynamicToolFingerprintsCompatible,
   buildDeveloperInstructions,
@@ -174,6 +178,12 @@ type CodexBootstrapFile = CodexBootstrapContext["bootstrapFiles"][number];
 type CodexSystemPromptReport = NonNullable<EmbeddedRunAttemptResult["systemPromptReport"]>;
 type CodexToolReportEntry = CodexSystemPromptReport["tools"]["entries"][number];
 type CodexWorkspaceBootstrapContext = CodexBootstrapContext & { instructions?: string };
+type ActiveCodexTurnItem = {
+  type?: string;
+  role?: string;
+  phase?: string;
+  assistantLike: boolean;
+};
 
 const testClientFactoryStorage = new AsyncLocalStorage<CodexAppServerClientFactory | undefined>();
 const clientFactory = defaultCodexAppServerClientFactory;
@@ -181,6 +191,10 @@ let openClawCodingToolsFactoryForTests: OpenClawCodingToolsFactory | undefined;
 
 function resolveCodexAppServerClientFactory(): CodexAppServerClientFactory {
   return testClientFactoryStorage.getStore() ?? clientFactory;
+}
+
+function hasCodexAppServerClientFactoryForTests(): boolean {
+  return testClientFactoryStorage.getStore() !== undefined;
 }
 
 function emitCodexAppServerEvent(
@@ -651,6 +665,8 @@ export async function runCodexAppServerAttempt(
   });
   let client: CodexAppServerClient;
   let thread: CodexAppServerThreadBinding;
+  let clientIsolated = false;
+  let releaseSharedClientLease: (() => void) | undefined;
   let trajectoryEndRecorded = false;
   let nativeHookRelay: NativeHookRelayRegistrationHandle | undefined;
   let startupClientForCleanup: CodexAppServerClient | undefined;
@@ -716,18 +732,34 @@ export async function runCodexAppServerAttempt(
             approvalPolicy: withMcpElicitationsApprovalPolicy(appServer.approvalPolicy),
           }
         : appServer;
-    ({ client, thread } = await withCodexStartupTimeout({
+    ({
+      client,
+      thread,
+      isolated: clientIsolated,
+    } = await withCodexStartupTimeout({
       timeoutMs: startupTimeoutMs,
       signal: runAbortController.signal,
       operation: async () => {
         let attemptedClient: CodexAppServerClient | undefined;
+        let attemptedClientIsolated = false;
+        let isolateAfterStartupClose = false;
         const startupAttempt = async () => {
-          const startupClient = await attemptClientFactory(
-            appServer.start,
-            startupAuthProfileId,
-            agentDir,
-            params.config,
-          );
+          const useIsolatedRetry =
+            isolateAfterStartupClose && !hasCodexAppServerClientFactoryForTests();
+          attemptedClientIsolated = useIsolatedRetry;
+          const startupClient = useIsolatedRetry
+            ? await createIsolatedCodexAppServerClient({
+                startOptions: appServer.start,
+                authProfileId: startupAuthProfileId,
+                agentDir,
+                config: params.config,
+              })
+            : await attemptClientFactory(
+                appServer.start,
+                startupAuthProfileId,
+                agentDir,
+                params.config,
+              );
           attemptedClient = startupClient;
           startupClientForCleanup = startupClient;
           await ensureCodexComputerUse({
@@ -763,7 +795,7 @@ export async function runCodexAppServerAttempt(
                 }
               : undefined,
           });
-          return { client: startupClient, thread: startupThread };
+          return { client: startupClient, thread: startupThread, isolated: useIsolatedRetry };
         };
         for (
           let attempt = 1;
@@ -780,30 +812,58 @@ export async function runCodexAppServerAttempt(
               throw error;
             }
             const failedClient = attemptedClient;
-            const clearedSharedClient = clearSharedCodexAppServerClientIfCurrent(failedClient);
+            const retirement = retireCodexAppServerClient(failedClient);
             if (startupClientForCleanup === failedClient) {
               startupClientForCleanup = undefined;
             }
             attemptedClient = undefined;
+            isolateAfterStartupClose = true;
             if (attempt >= CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS) {
+              emitCodexAppServerEvent(params, {
+                stream: "codex_app_server.lifecycle",
+                data: {
+                  phase: "startup_retries_exhausted",
+                  attempt,
+                  maxAttempts: CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS,
+                  failureClass: "app_server_client_closed",
+                  isolatedRetry: attemptedClientIsolated,
+                  ...retirement,
+                },
+              });
               embeddedAgentLog.warn(
                 "codex app-server connection closed during startup; retries exhausted",
                 {
                   attempt,
                   maxAttempts: CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS,
-                  clearedSharedClient,
+                  isolatedRetry: attemptedClientIsolated,
+                  ...retirement,
                   error: formatErrorMessage(error),
                 },
               );
               throw error;
             }
+            emitCodexAppServerEvent(params, {
+              stream: "codex_app_server.lifecycle",
+              data: {
+                phase: "startup_retry",
+                attempt,
+                nextAttempt: attempt + 1,
+                maxAttempts: CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS,
+                failureClass: "app_server_client_closed",
+                nextAttemptIsolated: !hasCodexAppServerClientFactoryForTests(),
+                isolatedRetry: attemptedClientIsolated,
+                ...retirement,
+              },
+            });
             embeddedAgentLog.warn(
               "codex app-server connection closed during startup; restarting app-server and retrying",
               {
                 attempt,
                 nextAttempt: attempt + 1,
                 maxAttempts: CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS,
-                clearedSharedClient,
+                nextAttemptIsolated: !hasCodexAppServerClientFactoryForTests(),
+                isolatedRetry: attemptedClientIsolated,
+                ...retirement,
                 error: formatErrorMessage(error),
               },
             );
@@ -812,6 +872,9 @@ export async function runCodexAppServerAttempt(
         throw new Error("codex app-server startup retry loop exited unexpectedly");
       },
     }));
+    releaseSharedClientLease = clientIsolated
+      ? () => client.close()
+      : retainSharedCodexAppServerClient(client);
     startupClientForCleanup = undefined;
     emitCodexAppServerEvent(params, {
       stream: "codex_app_server.lifecycle",
@@ -819,8 +882,9 @@ export async function runCodexAppServerAttempt(
     });
   } catch (error) {
     nativeHookRelay?.unregister();
-    clearSharedCodexAppServerClientIfCurrent(startupClientForCleanup);
+    retireCodexAppServerClient(startupClientForCleanup);
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);
+    releaseSharedClientLease?.();
     throw error;
   }
   trajectoryRecorder?.recordEvent("session.started", {
@@ -876,7 +940,7 @@ export async function runCodexAppServerAttempt(
   let turnCompletionLastActivityReason = "startup";
   let turnCompletionLastActivityDetails: Record<string, unknown> | undefined;
   let activeAppServerTurnRequests = 0;
-  const activeTurnItemIds = new Set<string>();
+  const activeTurnItems = new Map<string, ActiveCodexTurnItem>();
 
   const clearTurnCompletionIdleTimer = () => {
     if (turnCompletionIdleTimer) {
@@ -903,7 +967,7 @@ export async function runCodexAppServerAttempt(
     if (completed || runAbortController.signal.aborted || !turnAssistantCompletionIdleWatchArmed) {
       return;
     }
-    if (activeAppServerTurnRequests > 0 || activeTurnItemIds.size > 0) {
+    if (activeAppServerTurnRequests > 0 || hasBlockingActiveTurnItems(activeTurnItems)) {
       scheduleTurnAssistantCompletionIdleWatch();
       return;
     }
@@ -1059,7 +1123,6 @@ export async function runCodexAppServerAttempt(
     const elapsedMs = Math.max(0, Date.now() - turnCompletionLastActivityAt);
     const delayMs = Math.max(1, turnTerminalIdleTimeoutMs - elapsedMs);
     turnTerminalIdleTimer = setTimeout(fireTurnTerminalIdleTimeout, delayMs);
-    turnTerminalIdleTimer.unref?.();
   }
 
   const touchTurnCompletionActivity = (
@@ -1191,13 +1254,13 @@ export async function runCodexAppServerAttempt(
       reportCodexExecutionNotification(notification);
     }
     if (isCurrentTurnNotification) {
-      updateActiveTurnItemIds(notification, activeTurnItemIds);
+      updateActiveTurnItems(notification, activeTurnItems);
     }
     const unblockedAssistantCompletionRelease =
       isCurrentTurnNotification &&
       turnAssistantCompletionIdleWatchArmed &&
       notification.method === "item/completed" &&
-      activeTurnItemIds.size === 0;
+      !hasBlockingActiveTurnItems(activeTurnItems);
     if (isCurrentTurnNotification && notification.method === "error") {
       if (isRetryableErrorNotification(notification.params)) {
         disarmTurnCompletionIdleWatch();
@@ -1207,7 +1270,11 @@ export async function runCodexAppServerAttempt(
       disarmTurnAssistantCompletionIdleWatch();
     } else if (isTurnCompletion) {
       disarmTurnAssistantCompletionIdleWatch();
-    } else if (isCurrentTurnNotification && isCompletedAssistantNotification(notification)) {
+    } else if (
+      isCurrentTurnNotification &&
+      (isCompletedAssistantNotification(notification) ||
+        isRawCompletedAssistantNotification(notification))
+    ) {
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
     } else if (unblockedAssistantCompletionRelease) {
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
@@ -1592,10 +1659,21 @@ export async function runCodexAppServerAttempt(
       timeoutMs: shouldRetireClient ? CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS : undefined,
     });
     if (shouldRetireClient) {
-      retireCodexAppServerClientAfterTimedOutTurn(client, {
+      const retirement = retireCodexAppServerClientAfterTimedOutTurn(client, {
         threadId: thread.threadId,
         turnId: activeTurnId,
         reason: String(runAbortController.signal.reason ?? "timeout"),
+      });
+      emitCodexAppServerEvent(params, {
+        stream: "codex_app_server.lifecycle",
+        data: {
+          phase: "turn_timeout_client_retired",
+          threadId: thread.threadId,
+          turnId: activeTurnId,
+          reason: String(runAbortController.signal.reason ?? "timeout"),
+          timeoutMs: params.timeoutMs,
+          ...retirement,
+        },
       });
     }
     resolveCompletion?.();
@@ -1776,6 +1854,7 @@ export async function runCodexAppServerAttempt(
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);
     steeringQueue?.cancel();
     clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
+    releaseSharedClientLease?.();
   }
 }
 
@@ -2093,6 +2172,19 @@ function interruptCodexTurnBestEffort(
   }
 }
 
+function retireCodexAppServerClient(client: CodexAppServerClient | undefined): {
+  clearedSharedClient: boolean;
+  closedNonCurrentClient: boolean;
+  deferredSharedClientRetirement: boolean;
+} {
+  const retirement = retireSharedCodexAppServerClient(client);
+  return {
+    clearedSharedClient: retirement.clearedSharedClient,
+    closedNonCurrentClient: !retirement.clearedSharedClient && retirement.closedClient,
+    deferredSharedClientRetirement: retirement.deferredSharedClientRetirement,
+  };
+}
+
 function retireCodexAppServerClientAfterTimedOutTurn(
   client: CodexAppServerClient,
   params: {
@@ -2100,20 +2192,18 @@ function retireCodexAppServerClientAfterTimedOutTurn(
     turnId: string;
     reason: string;
   },
-): void {
-  const clearedSharedClient = clearSharedCodexAppServerClientIfCurrent(client);
-  if (!clearedSharedClient) {
-    const close = (client as { close?: () => void }).close;
-    if (typeof close === "function") {
-      close.call(client);
-    }
-  }
+): {
+  clearedSharedClient: boolean;
+  closedNonCurrentClient: boolean;
+} {
+  const retirement = retireCodexAppServerClient(client);
   embeddedAgentLog.warn("codex app-server client retired after timed-out turn", {
     threadId: params.threadId,
     turnId: params.turnId,
     reason: params.reason,
-    clearedSharedClient,
+    ...retirement,
   });
+  return retirement;
 }
 
 type DynamicToolBuildParams = {
@@ -2566,22 +2656,70 @@ function describeNotificationActivity(
   };
 }
 
-function updateActiveTurnItemIds(
+function updateActiveTurnItems(
   notification: CodexServerNotification,
-  activeItemIds: Set<string>,
+  activeItems: Map<string, ActiveCodexTurnItem>,
 ): void {
-  if (notification.method !== "item/started" && notification.method !== "item/completed") {
+  if (
+    notification.method !== "item/started" &&
+    notification.method !== "item/completed" &&
+    notification.method !== "rawResponseItem/completed"
+  ) {
     return;
   }
   const itemId = readNotificationItemId(notification);
-  if (!itemId) {
-    return;
-  }
   if (notification.method === "item/started") {
-    activeItemIds.add(itemId);
+    if (!itemId) {
+      return;
+    }
+    activeItems.set(itemId, readActiveTurnItem(notification));
     return;
   }
-  activeItemIds.delete(itemId);
+  if (itemId) {
+    activeItems.delete(itemId);
+  }
+  if (
+    isCompletedAssistantNotification(notification) ||
+    isRawCompletedAssistantNotification(notification)
+  ) {
+    clearAssistantLikeActiveTurnItems(activeItems);
+  }
+}
+
+function readActiveTurnItem(notification: CodexServerNotification): ActiveCodexTurnItem {
+  const item = isJsonObject(notification.params)
+    ? isJsonObject(notification.params.item)
+      ? notification.params.item
+      : undefined
+    : undefined;
+  const type = item ? readString(item, "type") : undefined;
+  const role = item ? readString(item, "role") : undefined;
+  const phase = item ? readString(item, "phase") : undefined;
+  return {
+    type,
+    role,
+    phase,
+    assistantLike:
+      (type === "agentMessage" && phase !== "commentary") ||
+      (type === "message" && role === "assistant"),
+  };
+}
+
+function clearAssistantLikeActiveTurnItems(activeItems: Map<string, ActiveCodexTurnItem>): void {
+  for (const [itemId, item] of activeItems) {
+    if (item.assistantLike) {
+      activeItems.delete(itemId);
+    }
+  }
+}
+
+function hasBlockingActiveTurnItems(activeItems: Map<string, ActiveCodexTurnItem>): boolean {
+  for (const item of activeItems.values()) {
+    if (!item.assistantLike) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function isCompletedAssistantNotification(notification: CodexServerNotification): boolean {
@@ -2599,15 +2737,26 @@ function isCompletedAssistantNotification(notification: CodexServerNotification)
   );
 }
 
+function isRawCompletedAssistantNotification(notification: CodexServerNotification): boolean {
+  if (!isJsonObject(notification.params)) {
+    return false;
+  }
+  if (notification.method !== "rawResponseItem/completed") {
+    return false;
+  }
+  const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
+  return Boolean(item && readString(item, "role") === "assistant");
+}
+
 function shouldDisarmAssistantCompletionIdleWatch(notification: CodexServerNotification): boolean {
   if (!isJsonObject(notification.params)) {
     return false;
   }
   if (notification.method === "item/started") {
-    return true;
+    return !readActiveTurnItem(notification).assistantLike;
   }
   if (notification.method === "item/agentMessage/delta") {
-    return true;
+    return false;
   }
   return false;
 }

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -40,6 +40,8 @@ let clearSharedCodexAppServerClient: typeof import("./shared-client.js").clearSh
 let clearSharedCodexAppServerClientIfCurrent: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrent;
 let createIsolatedCodexAppServerClient: typeof import("./shared-client.js").createIsolatedCodexAppServerClient;
 let getSharedCodexAppServerClient: typeof import("./shared-client.js").getSharedCodexAppServerClient;
+let retainSharedCodexAppServerClient: typeof import("./shared-client.js").retainSharedCodexAppServerClient;
+let retireSharedCodexAppServerClient: typeof import("./shared-client.js").retireSharedCodexAppServerClient;
 let resetSharedCodexAppServerClientForTests: typeof import("./shared-client.js").resetSharedCodexAppServerClientForTests;
 
 async function sendInitializeResult(
@@ -112,6 +114,8 @@ describe("shared Codex app-server client", () => {
       clearSharedCodexAppServerClientIfCurrent,
       createIsolatedCodexAppServerClient,
       getSharedCodexAppServerClient,
+      retainSharedCodexAppServerClient,
+      retireSharedCodexAppServerClient,
       resetSharedCodexAppServerClientForTests,
     } = await import("./shared-client.js"));
   });
@@ -170,6 +174,51 @@ describe("shared Codex app-server client", () => {
 
     await expect(secondList).resolves.toEqual({ models: [] });
     expect(startSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears a leased shared app-server immediately but defers closing it until the lease releases", async () => {
+    const first = createClientHarness();
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+
+    const firstClientPromise = getSharedCodexAppServerClient({ timeoutMs: 1000 });
+    await sendInitializeResult(first, "openclaw/0.125.0 (macOS; test)");
+    const firstClient = await firstClientPromise;
+    const release = retainSharedCodexAppServerClient(firstClient);
+
+    expect(retireSharedCodexAppServerClient(firstClient)).toEqual({
+      clearedSharedClient: true,
+      closedClient: false,
+      deferredSharedClientRetirement: true,
+    });
+    expect(first.process.stdin.destroyed).toBe(false);
+
+    const secondClientPromise = getSharedCodexAppServerClient({ timeoutMs: 1000 });
+    await sendInitializeResult(second, "openclaw/0.125.0 (macOS; test)");
+    const secondClient = await secondClientPromise;
+    expect(secondClient).toBe(second.client);
+    expect(startSpy).toHaveBeenCalledTimes(2);
+
+    release();
+    expect(first.process.stdin.destroyed).toBe(true);
+    expect(second.process.stdin.destroyed).toBe(false);
+  });
+
+  it("tolerates retiring a non-current app-server client without close", () => {
+    const client = {
+      request: vi.fn(),
+      addNotificationHandler: () => () => undefined,
+      addRequestHandler: () => () => undefined,
+    } as never;
+
+    expect(retireSharedCodexAppServerClient(client)).toEqual({
+      clearedSharedClient: false,
+      closedClient: false,
+      deferredSharedClientRetirement: false,
+    });
   });
 
   it("does not wait for isolated initialize after a timeout closes the client", async () => {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -17,6 +17,8 @@ type SharedCodexAppServerClientState = {
   client?: CodexAppServerClient;
   promise?: Promise<CodexAppServerClient>;
   key?: string;
+  leases?: WeakMap<CodexAppServerClient, number>;
+  retireWhenIdle?: WeakSet<CodexAppServerClient>;
 };
 
 const SHARED_CODEX_APP_SERVER_CLIENT_STATE = Symbol.for("openclaw.codexAppServerClientState");
@@ -161,6 +163,10 @@ export function clearSharedCodexAppServerClient(): void {
   state.client = undefined;
   state.promise = undefined;
   state.key = undefined;
+  if (client) {
+    state.leases?.delete(client);
+    state.retireWhenIdle?.delete(client);
+  }
   client?.close();
 }
 
@@ -177,7 +183,102 @@ export function clearSharedCodexAppServerClientIfCurrent(
   state.client = undefined;
   state.promise = undefined;
   state.key = undefined;
+  state.leases?.delete(client);
+  state.retireWhenIdle?.delete(client);
   client.close();
+  return true;
+}
+
+export function retainSharedCodexAppServerClient(
+  client: CodexAppServerClient | undefined,
+): () => void {
+  if (!client) {
+    return () => undefined;
+  }
+  const state = getSharedCodexAppServerClientState();
+  if (state.client !== client) {
+    return () => undefined;
+  }
+  state.leases ??= new WeakMap();
+  state.retireWhenIdle ??= new WeakSet();
+  state.leases.set(client, (state.leases.get(client) ?? 0) + 1);
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const currentCount = state.leases?.get(client) ?? 0;
+    if (currentCount <= 1) {
+      state.leases?.delete(client);
+      if (state.retireWhenIdle?.has(client)) {
+        state.retireWhenIdle.delete(client);
+        closeCodexAppServerClientIfAvailable(client);
+      }
+      return;
+    }
+    state.leases?.set(client, currentCount - 1);
+  };
+}
+
+export function retireSharedCodexAppServerClient(client: CodexAppServerClient | undefined): {
+  clearedSharedClient: boolean;
+  closedClient: boolean;
+  deferredSharedClientRetirement: boolean;
+} {
+  if (!client) {
+    return {
+      clearedSharedClient: false,
+      closedClient: false,
+      deferredSharedClientRetirement: false,
+    };
+  }
+  const state = getSharedCodexAppServerClientState();
+  const leaseCount = state.leases?.get(client) ?? 0;
+  const deferClose = leaseCount > 0;
+  if (state.client === client) {
+    state.client = undefined;
+    state.promise = undefined;
+    state.key = undefined;
+    if (deferClose) {
+      state.retireWhenIdle ??= new WeakSet();
+      state.retireWhenIdle.add(client);
+      return {
+        clearedSharedClient: true,
+        closedClient: false,
+        deferredSharedClientRetirement: true,
+      };
+    }
+    const closedClient = closeCodexAppServerClientIfAvailable(client);
+    return {
+      clearedSharedClient: true,
+      closedClient,
+      deferredSharedClientRetirement: false,
+    };
+  }
+  if (deferClose) {
+    state.retireWhenIdle ??= new WeakSet();
+    state.retireWhenIdle.add(client);
+    return {
+      clearedSharedClient: false,
+      closedClient: false,
+      deferredSharedClientRetirement: true,
+    };
+  }
+  const closedClient = closeCodexAppServerClientIfAvailable(client);
+  return {
+    clearedSharedClient: false,
+    closedClient,
+    deferredSharedClientRetirement: false,
+  };
+}
+
+function closeCodexAppServerClientIfAvailable(client: CodexAppServerClient): boolean {
+  const close = (client as { close?: () => void }).close;
+  if (typeof close !== "function") {
+    return false;
+  }
+  close.call(client);
   return true;
 }
 
@@ -190,6 +291,10 @@ export async function clearSharedCodexAppServerClientAndWait(options?: {
   state.client = undefined;
   state.promise = undefined;
   state.key = undefined;
+  if (client) {
+    state.leases?.delete(client);
+    state.retireWhenIdle?.delete(client);
+  }
   await client?.closeAndWait(options);
 }
 

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -94,8 +94,12 @@ vi.mock("./device-identity.ts", () => ({
   signDevicePayload: signDevicePayloadMock,
 }));
 
-const { CONTROL_UI_OPERATOR_SCOPES, GatewayBrowserClient, shouldRetryWithDeviceToken } =
-  await import("./gateway.ts");
+const {
+  CONTROL_UI_OPERATOR_SCOPES,
+  GatewayBrowserClient,
+  GatewayRequestTimeoutError,
+  shouldRetryWithDeviceToken,
+} = await import("./gateway.ts");
 
 type ConnectFrame = {
   id?: string;
@@ -533,6 +537,152 @@ describe("GatewayBrowserClient", () => {
       ok: false,
       errorCode: "CONFIG_ERROR",
     });
+  });
+
+  it("times out unanswered gateway requests and records bounded timing", async () => {
+    vi.useFakeTimers();
+    const onRequestTiming = vi.fn();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+      requestTimeoutMs: 25,
+      onRequestTiming,
+    });
+
+    const { ws, connectFrame } = await startConnect(client);
+    ws.emitMessage({
+      type: "res",
+      id: connectFrame.id,
+      ok: true,
+      payload: {
+        type: "hello-ok",
+        protocol: 3,
+        auth: { role: "operator", scopes: [] },
+      },
+    });
+    onRequestTiming.mockClear();
+
+    const request = client.request("sessions.list", { includeGlobal: true });
+    const caught = request.catch((error: unknown) => error);
+    const frame = JSON.parse(ws.sent.at(-1) ?? "{}") as { id?: string; method?: string };
+
+    await vi.advanceTimersByTimeAsync(24);
+    expect(onRequestTiming).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(caught).resolves.toBeInstanceOf(GatewayRequestTimeoutError);
+    await expect(caught).resolves.toMatchObject({
+      method: "sessions.list",
+      timeoutMs: 25,
+    });
+    expect(onRequestTiming).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: frame.id,
+        method: "sessions.list",
+        ok: false,
+        errorCode: "CLIENT_TIMEOUT",
+      }),
+    );
+
+    ws.emitMessage({
+      type: "res",
+      id: frame.id,
+      ok: true,
+      payload: { sessions: [] },
+    });
+    expect(onRequestTiming).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears request timeout timers when a gateway response arrives", async () => {
+    vi.useFakeTimers();
+    const onRequestTiming = vi.fn();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+      requestTimeoutMs: 25,
+      onRequestTiming,
+    });
+
+    const { ws, connectFrame } = await startConnect(client);
+    ws.emitMessage({
+      type: "res",
+      id: connectFrame.id,
+      ok: true,
+      payload: {
+        type: "hello-ok",
+        protocol: 3,
+        auth: { role: "operator", scopes: [] },
+      },
+    });
+    onRequestTiming.mockClear();
+
+    const request = client.request("sessions.list", { includeGlobal: true });
+    const frame = JSON.parse(ws.sent.at(-1) ?? "{}") as { id?: string; method?: string };
+    ws.emitMessage({
+      type: "res",
+      id: frame.id,
+      ok: true,
+      payload: { sessions: [] },
+    });
+
+    await expect(request).resolves.toEqual({ sessions: [] });
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(onRequestTiming).toHaveBeenCalledTimes(1);
+    expect(onRequestTiming).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: frame.id,
+        method: "sessions.list",
+        ok: true,
+      }),
+    );
+  });
+
+  it("lets server-declared timeout requests run past the default client timeout", async () => {
+    vi.useFakeTimers();
+    const onRequestTiming = vi.fn();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+      requestTimeoutMs: 10,
+      onRequestTiming,
+    });
+
+    const { ws, connectFrame } = await startConnect(client);
+    ws.emitMessage({
+      type: "res",
+      id: connectFrame.id,
+      ok: true,
+      payload: {
+        type: "hello-ok",
+        protocol: 3,
+        auth: { role: "operator", scopes: [] },
+      },
+    });
+    onRequestTiming.mockClear();
+
+    const request = client.request("channels.login", { channel: "whatsapp", timeoutMs: 50 });
+    const frame = JSON.parse(ws.sent.at(-1) ?? "{}") as { id?: string; method?: string };
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(onRequestTiming).not.toHaveBeenCalled();
+
+    ws.emitMessage({
+      type: "res",
+      id: frame.id,
+      ok: true,
+      payload: { ok: true },
+    });
+
+    await expect(request).resolves.toEqual({ ok: true });
+    expect(onRequestTiming).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: frame.id,
+        method: "channels.login",
+        ok: true,
+      }),
+    );
   });
 
   it("prefers explicit shared auth over cached device tokens", async () => {

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -65,6 +65,18 @@ export class GatewayRequestError extends Error {
   }
 }
 
+export class GatewayRequestTimeoutError extends Error {
+  readonly method: string;
+  readonly timeoutMs: number;
+
+  constructor(params: { method: string; timeoutMs: number }) {
+    super(`gateway request timed out after ${params.timeoutMs}ms: ${params.method}`);
+    this.name = "GatewayRequestTimeoutError";
+    this.method = params.method;
+    this.timeoutMs = params.timeoutMs;
+  }
+}
+
 export function resolveGatewayErrorDetailCode(
   error: { details?: unknown } | null | undefined,
 ): string | null {
@@ -152,6 +164,8 @@ type Pending = {
   reject: (err: unknown) => void;
   method: string;
   startedAtMs: number;
+  timeoutId: number | null;
+  timeoutMs: number;
 };
 
 type SelectedConnectAuth = {
@@ -244,6 +258,7 @@ export type GatewayBrowserClientOptions = {
   onClose?: (info: { code: number; reason: string; error?: GatewayErrorInfo }) => void;
   onGap?: (info: { expected: number; received: number }) => void;
   onRequestTiming?: (timing: GatewayRequestTiming) => void;
+  requestTimeoutMs?: number;
 };
 
 export type GatewayEventListener = (evt: GatewayEventFrame) => void;
@@ -258,12 +273,19 @@ export type GatewayRequestTiming = {
   errorCode?: string;
 };
 
+export type GatewayRequestOptions = {
+  timeoutMs?: number;
+};
+
 // 4008 = application-defined code (browser rejects 1008 "Policy Violation")
 const CONNECT_FAILED_CLOSE_CODE = 4008;
 const STARTUP_RETRY_CLOSE_CODE = 4013;
 const BROWSER_WEBSOCKET_CLOSE_CODE = 1006;
 const BROWSER_WEBSOCKET_CONSTRUCTOR_ERROR_CODE = "BROWSER_WEBSOCKET_CONSTRUCTOR_ERROR";
 const BROWSER_WEBSOCKET_SECURITY_ERROR_CODE = "BROWSER_WEBSOCKET_SECURITY_ERROR";
+const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000;
+const REQUEST_TIMEOUT_SERVER_GRACE_MS = 5_000;
+const MAX_BROWSER_TIMEOUT_MS = 2_147_483_647;
 
 function buildGatewayConnectAuth(
   selectedAuth: SelectedConnectAuth,
@@ -519,6 +541,7 @@ export class GatewayBrowserClient {
 
   private flushPending(err: Error) {
     for (const [id, p] of this.pending) {
+      this.clearRequestTimer(p);
       this.emitRequestTiming(id, p, false, "CLIENT_CLOSED");
       p.reject(err);
     }
@@ -546,6 +569,39 @@ export class GatewayBrowserClient {
     } catch (err) {
       console.error("[gateway] request timing handler error:", err);
     }
+  }
+
+  private clearRequestTimer(pending: Pending): void {
+    if (pending.timeoutId !== null) {
+      window.clearTimeout(pending.timeoutId);
+      pending.timeoutId = null;
+    }
+  }
+
+  private resolveRequestTimeoutMs(params: unknown, options?: GatewayRequestOptions): number {
+    const explicitTimeoutMs = options?.timeoutMs;
+    if (typeof explicitTimeoutMs === "number" && Number.isFinite(explicitTimeoutMs)) {
+      return Math.min(Math.max(1, Math.floor(explicitTimeoutMs)), MAX_BROWSER_TIMEOUT_MS);
+    }
+    const paramsTimeoutMs =
+      params && typeof params === "object" && "timeoutMs" in params
+        ? (params as { timeoutMs?: unknown }).timeoutMs
+        : undefined;
+    if (
+      typeof paramsTimeoutMs === "number" &&
+      Number.isFinite(paramsTimeoutMs) &&
+      paramsTimeoutMs > 0
+    ) {
+      return Math.min(
+        Math.floor(paramsTimeoutMs) + REQUEST_TIMEOUT_SERVER_GRACE_MS,
+        MAX_BROWSER_TIMEOUT_MS,
+      );
+    }
+    const defaultTimeoutMs = this.opts.requestTimeoutMs;
+    if (typeof defaultTimeoutMs === "number" && Number.isFinite(defaultTimeoutMs)) {
+      return Math.min(Math.max(1, Math.floor(defaultTimeoutMs)), MAX_BROWSER_TIMEOUT_MS);
+    }
+    return DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS;
   }
 
   private buildConnectClient(): GatewayConnectClientInfo {
@@ -775,6 +831,7 @@ export class GatewayBrowserClient {
         return;
       }
       this.pending.delete(res.id);
+      this.clearRequestTimer(pending);
       if (res.ok) {
         this.emitRequestTiming(res.id, pending, true);
         pending.resolve(res.payload);
@@ -828,17 +885,22 @@ export class GatewayBrowserClient {
     };
   }
 
-  request<T = unknown>(method: string, params?: unknown): Promise<T> {
+  request<T = unknown>(
+    method: string,
+    params?: unknown,
+    options?: GatewayRequestOptions,
+  ): Promise<T> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       return Promise.reject(new Error("gateway not connected"));
     }
-    return this.requestOnSocket(this.ws, method, params);
+    return this.requestOnSocket(this.ws, method, params, options);
   }
 
   private requestOnSocket<T = unknown>(
     ws: WebSocket,
     method: string,
     params?: unknown,
+    options?: GatewayRequestOptions,
   ): Promise<T> {
     if (this.ws !== ws || ws.readyState !== WebSocket.OPEN) {
       return Promise.reject(new Error("gateway not connected"));
@@ -846,8 +908,25 @@ export class GatewayBrowserClient {
     const id = generateUUID();
     const frame = { type: "req", id, method, params };
     const startedAtMs = this.nowMs();
+    const timeoutMs = this.resolveRequestTimeoutMs(params, options);
     const p = new Promise<T>((resolve, reject) => {
-      this.pending.set(id, { resolve: (v) => resolve(v as T), reject, method, startedAtMs });
+      const pending: Pending = {
+        resolve: (v) => resolve(v as T),
+        reject,
+        method,
+        startedAtMs,
+        timeoutId: null,
+        timeoutMs,
+      };
+      pending.timeoutId = window.setTimeout(() => {
+        if (!this.pending.delete(id)) {
+          return;
+        }
+        this.clearRequestTimer(pending);
+        this.emitRequestTiming(id, pending, false, "CLIENT_TIMEOUT");
+        reject(new GatewayRequestTimeoutError({ method, timeoutMs }));
+      }, timeoutMs);
+      this.pending.set(id, pending);
     });
     ws.send(JSON.stringify(frame));
     return p;


### PR DESCRIPTION
Summary
- Add client-side request timeouts to the Control UI gateway RPC path.
- Keep longer server-declared timeouts alive with grace while timing out unanswered default requests.
- Record bounded CLIENT_TIMEOUT timing and clear timers on responses/flushes.

Verification at current head
- Current head SHA: 95659193b66d613b5d7587f054260f8d87e12298
- CI=true pnpm test ui/src/ui/gateway.node.test.ts -- --reporter=verbose
- CI=true pnpm exec oxfmt --check --threads=1 ui/src/ui/gateway.ts ui/src/ui/gateway.node.test.ts
- git diff --check upstream/main..HEAD -- ui/src/ui/gateway.ts ui/src/ui/gateway.node.test.ts
- pnpm changed:lanes --base upstream/main --head HEAD --json
- CI=true pnpm check:changed --base upstream/main --head HEAD

## Real behavior proof

- Behavior or issue addressed: Control UI Gateway RPC client requests now have bounded client-side timeouts, clear timeout timers after Gateway responses, and emit request timing without request params. This proof covers both the successful real Gateway request path and the central unanswered-open-WebSocket timeout path.
- Real environment tested: Real OpenClaw Gateway started from current head SHA 95659193b66d613b5d7587f054260f8d87e12298 on loopback with isolated local state and token auth; real `ui/src/ui/gateway.ts` `GatewayBrowserClient` connected through an actual WebSocket transport using browser-equivalent Origin plus WebCrypto device identity/signing. Additional timeout-specific proof used the same real `GatewayBrowserClient` against an actual local `ws` WebSocketServer that completed `hello-ok`, kept the socket open, and intentionally never answered one request.
- Exact steps or command run after this patch: Started `pnpm openclaw gateway run --allow-unconfigured --port 18977 --bind loopback --auth token --token <redacted> --compact --cli-backend-logs`; checked `curl http://127.0.0.1:18977/healthz`; checked `HOME=<isolated> pnpm openclaw gateway health --url ws://127.0.0.1:18977 --token <redacted> --json`; ran a Node/tsx browser-shaped harness importing `GatewayBrowserClient` from `ui/src/ui/gateway.ts` and requesting `health` with a 5000ms timeout. Then ran a second Node/tsx browser-shaped no-response harness at the same head SHA: actual `GatewayBrowserClient`, actual local `ws` WebSocketServer, Origin `http://127.0.0.1:18988`, generated WebCrypto device identity, `connect` answered with `hello-ok`, and `proof.neverResponds` deliberately left unanswered with `timeoutMs: 75` while the socket stayed open.
- Evidence after fix: Copied live output from the real local Gateway/WebSocket/Control UI client run, with token, isolated home path, and generated device identity redacted:

```json
{
  "branchSha": "95659193b66d613b5d7587f054260f8d87e12298",
  "gatewayUrl": "ws://127.0.0.1:18977",
  "origin": "http://127.0.0.1:18977",
  "auth": "token(redacted)",
  "browserIdentity": "generated-and-signed(redacted)",
  "hello": {
    "type": "hello-ok",
    "protocol": 4,
    "role": "operator",
    "scopeCount": 5,
    "hasDeviceToken": true
  },
  "health": {
    "ok": true,
    "pluginCount": 8,
    "channelCount": 0,
    "agentCount": 1
  },
  "timingMethods": [
    {
      "method": "connect",
      "ok": true,
      "errorCode": null,
      "durationMs": 18
    },
    {
      "method": "health",
      "ok": true,
      "errorCode": null,
      "durationMs": 134
    }
  ],
  "clientConnectedBeforeStop": true,
  "closeInfo": null,
  "eventNames": [
    {
      "event": "health",
      "seq": 1
    }
  ]
}
```

Copied live output from the no-response timeout harness, with token and generated device identity redacted:

```json
{
  "branchSha": "95659193b66d613b5d7587f054260f8d87e12298",
  "gatewayUrl": "ws://127.0.0.1:45491",
  "transport": "actual ws WebSocketServer + actual GatewayBrowserClient",
  "browserShape": {
    "origin": "http://127.0.0.1:18988",
    "webCryptoIdentity": "generated-and-signed(redacted)",
    "auth": "token(redacted)"
  },
  "hello": {
    "type": "hello-ok",
    "protocol": 4,
    "role": "operator",
    "scopeCount": 1,
    "hasDeviceToken": true
  },
  "unansweredRequest": {
    "id": "c3605a03-bb26-40f3-894d-0be17a69f6a8",
    "method": "proof.neverResponds",
    "params": {
      "scenario": "unanswered-open-websocket"
    },
    "serverAction": "intentionally left unanswered while socket stayed open"
  },
  "timeoutError": {
    "name": "GatewayRequestTimeoutError",
    "message": "gateway request timed out after 75ms: proof.neverResponds",
    "instanceOfGatewayRequestTimeoutError": true,
    "method": "proof.neverResponds",
    "timeoutMs": 75
  },
  "timingMethods": [
    {
      "method": "connect",
      "ok": true,
      "errorCode": null,
      "durationMs": 1.788
    },
    {
      "method": "proof.neverResponds",
      "ok": false,
      "errorCode": "CLIENT_TIMEOUT",
      "durationMs": 76.298
    }
  ],
  "timeoutTiming": {
    "method": "proof.neverResponds",
    "ok": false,
    "errorCode": "CLIENT_TIMEOUT",
    "durationMs": 76.298
  },
  "connectTiming": {
    "method": "connect",
    "ok": true,
    "errorCode": null,
    "durationMs": 1.788
  },
  "observedElapsedMs": 77,
  "connectedAfterTimeout": true,
  "serverMessageSummary": [
    {
      "event": "connection",
      "origin": "http://127.0.0.1:18988",
      "url": "/"
    },
    {
      "event": "message",
      "type": "req",
      "id": "e01940c1-0588-4299-bccb-7596c217ca15",
      "method": "connect",
      "paramsKeys": [
        "auth",
        "caps",
        "client",
        "device",
        "locale",
        "maxProtocol",
        "minProtocol",
        "role",
        "scopes",
        "userAgent"
      ]
    },
    {
      "event": "message",
      "type": "req",
      "id": "c3605a03-bb26-40f3-894d-0be17a69f6a8",
      "method": "proof.neverResponds",
      "paramsKeys": [
        "scenario"
      ]
    }
  ]
}
```

- Observed result after fix: The real Gateway browser client completed `hello-ok` with protocol 4 as operator, received a device token, successfully read live Gateway `health`, emitted successful `connect` and `health` timings, and the temporary Gateway was stopped afterward. The no-response harness then kept an actual WebSocket open, deliberately did not answer `proof.neverResponds`, and the actual `GatewayBrowserClient` rejected with `GatewayRequestTimeoutError` after the 75ms client timeout while emitting a single `CLIENT_TIMEOUT` timing and remaining connected before stop.
- What was not tested: No deploy, canary, Testbox, release validation, Golden Run success, end-to-end product flow, or MVP score movement. The no-response proof uses an actual local WebSocket server to create the unanswered-request condition; it is not a deployed Gateway canary or release proof.

Historical pre-rebase proof retained for traceability: The earlier real setup proof was captured before the branch was rebased, at SHA e906ef282a95277a4355efd42c2d8ea0ac441d92 on port 18976. It is retained only as historical traceability and should not be treated as the current PR head proof. Historical observed result: the browser client completed `hello-ok` with protocol 3 as operator, received a device token, successfully read live Gateway `health`, emitted successful `connect` and `health` timings, and the temporary Gateway was stopped afterward.

Calibration notes: A query-side CLI attempt without the isolated `HOME` read the operator's real local config and failed on unrelated stale model IDs; rerunning the same health check with isolated local state succeeded. Raw Node socket, missing Origin, and missing WebCrypto identity attempts were rejected during earlier calibration, so the live proof used a browser-shaped client path.

Release evidence and claim ceiling
- This real behavior proof is bounded to a local real OpenClaw Gateway/WebSocket/Control UI client path plus a local actual-WebSocket no-response timeout harness at the current PR head SHA.
- It does not prove deploy, canary, Testbox, release validation, Golden Run success, end-to-end product flow, or MVP score movement.
- No changelog entry is included yet because this branch was intentionally kept to the bounded two-file Card 6 patch.
