### PR TITLE
Allow pnpm source updates to build OpenClaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - Agents: rewrite generic provider internal errors with support request IDs into user-friendly transient error copy. (#49401) Thanks @y471823206.
 - WhatsApp: finish handling pending debounced inbound messages before closing the socket. (#81246) Thanks @mcaxtr.
 - CLI/commitments: write `--json` output to stdout instead of diagnostic logs so automation can parse commitment list and dismiss results. (#81215) Thanks @giodl73-repo.
+- Update: allow pnpm GitHub-source OpenClaw updates to approve the OpenClaw package build, so source installs complete their prepare/prepack lifecycle. (#81294) Thanks @fuller-stack-dev.
 
 ### Changes
 

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -570,6 +570,22 @@ describe("update global helpers", () => {
       "-g",
       "openclaw@latest",
     ]);
+    expect(globalInstallArgs("pnpm", "github:openclaw/openclaw#release/2026.5.12")).toEqual([
+      "pnpm",
+      "add",
+      "-g",
+      "--allow-build=openclaw",
+      "github:openclaw/openclaw#release/2026.5.12",
+    ]);
+    expect(
+      globalInstallArgs("pnpm", "openclaw@git+https://github.com/openclaw/openclaw.git"),
+    ).toEqual([
+      "pnpm",
+      "add",
+      "-g",
+      "--allow-build=openclaw",
+      "openclaw@git+https://github.com/openclaw/openclaw.git",
+    ]);
     expect(globalInstallArgs("bun", "openclaw@latest")).toEqual([
       "bun",
       "add",
@@ -598,6 +614,22 @@ describe("update global helpers", () => {
       "--global-dir",
       "/opt/pnpm-global",
       "openclaw@latest",
+    ]);
+    expect(
+      globalInstallArgs(
+        "pnpm",
+        "github:openclaw/openclaw#release/2026.5.12",
+        null,
+        "/opt/pnpm-global",
+      ),
+    ).toEqual([
+      "pnpm",
+      "add",
+      "-g",
+      "--global-dir",
+      "/opt/pnpm-global",
+      "--allow-build=openclaw",
+      "github:openclaw/openclaw#release/2026.5.12",
     ]);
   });
 

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -46,6 +46,7 @@ const NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS = [
   "--omit=optional",
   ...NPM_GLOBAL_INSTALL_QUIET_FLAGS,
 ] as const;
+const PNPM_OPENCLAW_BUILD_ALLOWLIST_FLAG = `--allow-build=${PRIMARY_PACKAGE_NAME}`;
 const FIRST_PACKAGED_DIST_INVENTORY_VERSION = { major: 2026, minor: 4, patch: 15 };
 const OMITTED_PRIVATE_QA_BUNDLED_PLUGIN_ROOTS = new Set([
   "dist/extensions/qa-channel",
@@ -84,6 +85,21 @@ export function isExplicitPackageInstallSpec(value: string): boolean {
     trimmed.includes("://") ||
     trimmed.includes("#") ||
     /^(?:file|github|git\+ssh|git\+https|git\+http|git\+file|npm):/i.test(trimmed)
+  );
+}
+
+function stripPrimaryPackageAlias(spec: string): string {
+  const normalized = normalizePackageTarget(spec);
+  const prefix = `${PRIMARY_PACKAGE_NAME}@`;
+  return normalized.startsWith(prefix) ? normalized.slice(prefix.length).trim() : normalized;
+}
+
+function isPnpmOpenClawSourceInstallSpec(spec: string): boolean {
+  const target = stripPrimaryPackageAlias(spec);
+  return (
+    /^github:/i.test(target) ||
+    /^git\+(?:ssh|https|http|file):/i.test(target) ||
+    /^git:/i.test(target)
   );
 }
 
@@ -715,6 +731,7 @@ export function globalInstallArgs(
       "add",
       "-g",
       ...(installPrefix ? ["--global-dir", installPrefix] : []),
+      ...(isPnpmOpenClawSourceInstallSpec(spec) ? [PNPM_OPENCLAW_BUILD_ALLOWLIST_FLAG] : []),
       spec,
     ];
   }


### PR DESCRIPTION
## Summary
- add `--allow-build=openclaw` when pnpm globally installs OpenClaw from GitHub/git source specs
- keep registry installs unchanged
- cover GitHub and aliased git specs, including custom pnpm global dirs

## Why
`openclaw update --tag github:openclaw/openclaw#release/2026.5.12` can resolve to a pnpm-managed install, but pnpm refuses to prepare git-hosted packages with lifecycle/build scripts unless the package is approved for build. A manual retry with `pnpm add -g ... --allow-build=openclaw` succeeds.

## Test
- `pnpm test src/infra/update-global.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/infra/update-global.ts src/infra/update-global.test.ts`

## Real behavior proof
- **Behavior or issue addressed**: pnpm-managed OpenClaw source updates need to approve the OpenClaw git-hosted package build so the package can run its prepare/prepack lifecycle.
- **Real environment tested**: macOS Darwin 25.3.0, Node v23.11.1, pnpm 11.1.0, OpenClaw GitHub ref `github:openclaw/openclaw#release/2026.5.12`.
- **Exact steps or command run after this patch**: Ran the same pnpm global add shape with the new approval flag: `pnpm add -g openclaw@github:openclaw/openclaw#release/2026.5.12 --global-bin-dir /Users/jason/Library/pnpm --allow-build=openclaw`.
- **Evidence after fix**: Copied live terminal output from the successful retry:

```text
... pnpm-install: Done in 7.3s using pnpm v11.1.0
... prepack: [build-all] check-plugin-sdk-exports
... prepack: OK: All 4 required plugin-sdk exports verified.
... prepack: prepack: using existing prepared artifacts.
... prepack: [build-smoke] bundled channel entry smoke passed packageRoot=/var/folders/.../node_modules/openclaw channel=9 setup=6 legacySetup=0
... prepack: Done
... node_modules/openclaw preinstall: Done
... node_modules/openclaw postinstall: Done
```

- **Observed result after fix**: The pnpm GitHub-source package build was allowed and completed through prepack, preinstall, and postinstall. The prior command without the approval flag stopped with `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` before the source package could be prepared.
- **What was not tested**: I did not run a full `openclaw update` using this branch-built CLI; the real setup proof covers the package-manager command this patch changes.