### PR TITLE
Prepack npm git update specs before install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Pi: treat accepted embedded `sessions_spawn` child-session handoffs as terminal progress so parent turns no longer report false non-deliverable failures. (#85054) Thanks @samzong.
 - CLI/models: resolve `openclaw models set` aliases from the runtime config while keeping authored aliases ahead of runtime-only defaults. (#83262) Thanks @IWhatsskill.
 - WhatsApp: update Baileys to `7.0.0-rc13` and drop the obsolete logger type patch.
-- Install/update: reject OpenClaw GitHub source package targets early and point moving-main users at the dev/git install path instead of the broken npm source-install flow.
+- CLI/update: pre-pack GitHub/git package update targets before the staged npm install, restoring `openclaw update --tag main` for one-off package updates. (#81296) Thanks @fuller-stack-dev.
 - Gateway: mirror successful same-source message-tool sends into session transcripts so delivered replies stay in later history/context. (#84837) Thanks @iFiras-Max1.
 - Media generation: keep image, music, and video completion delivery from duplicating or losing task ownership when generated media finishes through active session replies. (#84006) Thanks @fuller-stack-dev.
 - Infra/json: retry transient `File changed during read` races while loading JSON state so config and state reads recover instead of failing the turn. (#84285)

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -23,6 +23,7 @@ openclaw update wizard
 openclaw update --channel beta
 openclaw update --channel dev
 openclaw update --tag beta
+openclaw update --tag main
 openclaw update --dry-run
 openclaw update --no-restart
 openclaw update --yes
@@ -34,7 +35,7 @@ openclaw --update
 
 - `--no-restart`: skip restarting the Gateway service after a successful update. Package-manager updates that do restart the Gateway verify the restarted service reports the expected updated version before the command succeeds.
 - `--channel <stable|beta|dev>`: set the update channel (git + npm; persisted in config).
-- `--tag <dist-tag|version|spec>`: override the package target for this update only. Use `--channel dev`, not `--tag main`, for the moving GitHub `main` checkout.
+- `--tag <dist-tag|version|spec>`: override the package target for this update only. For package installs, `main` maps to `github:openclaw/openclaw#main`; GitHub/git source specs are packed into a temporary tarball before the staged global npm install.
 - `--dry-run`: preview planned update actions (channel/tag/target/restart flow) without writing config, installing, syncing plugins, or restarting.
 - `--json`: print machine-readable `UpdateRunResult` JSON, including
   `postUpdate.plugins.warnings` when corrupt or unloadable managed plugins need

--- a/docs/install/development-channels.md
+++ b/docs/install/development-channels.md
@@ -65,6 +65,9 @@ openclaw update --channel dev
 
 # Install a specific npm package spec
 openclaw update --tag openclaw@2026.4.1-beta.1
+
+# Install from GitHub main once without persisting the channel
+openclaw update --tag main
 ```
 
 Notes:
@@ -72,9 +75,10 @@ Notes:
 - `--tag` applies to **package (npm) installs only**. Git installs ignore it.
 - The tag is not persisted. Your next `openclaw update` uses your configured
   channel as usual.
-- OpenClaw does not support npm GitHub source installs for `openclaw/openclaw`.
-  Use `--channel dev` or `--install-method git --version main` for the moving
-  `main` checkout.
+- For package installs, OpenClaw pre-packs GitHub/git source specs into a
+  temporary tarball before the staged npm install. Use `--channel dev` or
+  `--install-method git --version main` when you want the moving `main`
+  checkout as your persistent install.
 - Downgrade protection: if the target version is older than your current version,
   OpenClaw prompts for confirmation (skip with `--yes`).
 - `--channel beta` is different from `--tag beta`: the channel flow can fall back

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -34,9 +34,10 @@ installer has its own `--verbose` flag, but that flag is not part of
 the beta tag is missing or older than the latest stable release. Use `--tag beta`
 if you want the raw npm beta dist-tag for a one-off package update.
 
-Use `--channel dev` for the moving GitHub `main` checkout. Package updates do
-not support npm GitHub source installs for `openclaw/openclaw`; target a
-published dist-tag, exact version, or built tarball instead.
+Use `--channel dev` for a persistent moving GitHub `main` checkout. For package
+updates, `--tag main` maps to `github:openclaw/openclaw#main` for one run, and
+GitHub/git source specs are packed into a temporary tarball before the staged
+npm install.
 
 For managed plugins, beta-channel fallback is a warning: the core update can
 still succeed while a plugin uses its recorded default/latest release because no

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -412,8 +412,17 @@ describe("update-cli", () => {
   const packagePackCommandCall = () =>
     commandCalls().find(([argv]) => argv[0] === "npm" && argv[1] === "pack");
 
-  const isNpmGitPackageSpec = (spec: string) =>
-    /^github:/i.test(spec) || /^git(?:\+|:)/i.test(spec);
+  const stripOpenClawPackageAlias = (spec: string) => {
+    const trimmed = spec.trim();
+    return trimmed.toLowerCase().startsWith("openclaw@")
+      ? trimmed.slice("openclaw@".length)
+      : trimmed;
+  };
+
+  const isNpmGitPackageSpec = (spec: string) => {
+    const target = stripOpenClawPackageAlias(spec);
+    return /^github:/i.test(target) || /^git(?:\+|:)/i.test(target);
+  };
 
   const doctorCommandCall = () =>
     commandCalls().find(
@@ -2143,6 +2152,30 @@ describe("update-cli", () => {
       expectedSpec: "openclaw@next",
     },
     {
+      name: "main shorthand",
+      run: async () => {
+        mockPackageInstallStatus(createCaseDir("openclaw-update"));
+        await updateCommand({ yes: true, tag: "main" });
+      },
+      expectedSpec: "github:openclaw/openclaw#main",
+    },
+    {
+      name: "explicit git package spec",
+      run: async () => {
+        mockPackageInstallStatus(createCaseDir("openclaw-update"));
+        await updateCommand({ yes: true, tag: "github:openclaw/openclaw#main" });
+      },
+      expectedSpec: "github:openclaw/openclaw#main",
+    },
+    {
+      name: "aliased git package spec",
+      run: async () => {
+        mockPackageInstallStatus(createCaseDir("openclaw-update"));
+        await updateCommand({ yes: true, tag: "OpenClaw@github:openclaw/openclaw#main" });
+      },
+      expectedSpec: "OpenClaw@github:openclaw/openclaw#main",
+    },
+    {
       name: "OPENCLAW_UPDATE_PACKAGE_SPEC override",
       run: async () => {
         mockPackageInstallStatus(createCaseDir("openclaw-update"));
@@ -2165,22 +2198,6 @@ describe("update-cli", () => {
       vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(process.cwd());
       await run();
       expectPackageInstallSpec(expectedSpec);
-    },
-  );
-
-  it.each(["main", "github:openclaw/openclaw#main", "openclaw@github:openclaw/openclaw#main"])(
-    "rejects OpenClaw GitHub source package updates: %s",
-    async (tag) => {
-      mockPackageInstallStatus(createCaseDir("openclaw-update"));
-
-      await updateCommand({ yes: true, tag });
-
-      expect(packageInstallCommandCall()).toBeUndefined();
-      expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
-      const errors = vi.mocked(defaultRuntime.error).mock.calls.map((call) => String(call[0]));
-      expect(errors.join("\n")).toContain("Unsupported package update target");
-      expect(errors.join("\n")).toContain("openclaw/openclaw");
-      expect(errors.join("\n")).toContain("openclaw update --channel dev");
     },
   );
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -432,9 +432,12 @@ describe("update-cli", () => {
     let isHttpGitUrl = false;
     try {
       const url = new URL(target);
+      const pathname = url.pathname.replace(/\/+$/u, "");
+      const pathParts = pathname.split("/").filter(Boolean);
       isHttpGitUrl =
         (url.protocol === "https:" || url.protocol === "http:") &&
-        url.pathname.replace(/\/+$/u, "").endsWith(".git");
+        (pathname.endsWith(".git") ||
+          (url.hostname.toLowerCase() === "github.com" && pathParts.length === 2));
     } catch {
       isHttpGitUrl = false;
     }
@@ -2206,6 +2209,25 @@ describe("update-cli", () => {
         await updateCommand({ yes: true, tag: "https://github.com/openclaw/openclaw.git#main" });
       },
       expectedSpec: "https://github.com/openclaw/openclaw.git#main",
+    },
+    {
+      name: "hosted GitHub URL package spec without git suffix",
+      run: async () => {
+        mockPackageInstallStatus(createCaseDir("openclaw-update"));
+        await updateCommand({ yes: true, tag: "https://github.com/openclaw/openclaw#main" });
+      },
+      expectedSpec: "https://github.com/openclaw/openclaw#main",
+    },
+    {
+      name: "aliased hosted GitHub URL package spec without git suffix",
+      run: async () => {
+        mockPackageInstallStatus(createCaseDir("openclaw-update"));
+        await updateCommand({
+          yes: true,
+          tag: "openclaw@https://github.com/openclaw/openclaw#main",
+        });
+      },
+      expectedSpec: "https://github.com/openclaw/openclaw#main",
     },
     {
       name: "GitHub shorthand package spec",

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -409,6 +409,12 @@ describe("update-cli", () => {
   const packageInstallCommandCall = () =>
     commandCalls().find(([argv]) => argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g");
 
+  const packagePackCommandCall = () =>
+    commandCalls().find(([argv]) => argv[0] === "npm" && argv[1] === "pack");
+
+  const isNpmGitPackageSpec = (spec: string) =>
+    /^github:/i.test(spec) || /^git(?:\+|:)/i.test(spec);
+
   const doctorCommandCall = () =>
     commandCalls().find(
       ([argv]) => argv[2] === "doctor" && argv[3] === "--non-interactive" && argv[4] === "--fix",
@@ -490,12 +496,32 @@ describe("update-cli", () => {
 
   const expectPackageInstallSpec = (spec: string) => {
     expect(runGatewayUpdate).not.toHaveBeenCalled();
+    let installSpec = spec;
+    if (isNpmGitPackageSpec(spec)) {
+      const packCall = packagePackCommandCall();
+      expect(packCall?.[0]).toEqual([
+        "npm",
+        "pack",
+        spec,
+        "--pack-destination",
+        expect.any(String),
+        "--json",
+        "--loglevel=error",
+      ]);
+      const packDir = packCall?.[0][4];
+      if (!packDir) {
+        throw new Error("Expected package pack directory");
+      }
+      installSpec = path.join(packDir, "openclaw-9999.0.0.tgz");
+    } else {
+      expect(packagePackCommandCall()).toBeUndefined();
+    }
     const call = packageInstallCommandCall();
     expect(call?.[0]).toEqual([
       "npm",
       "i",
       "-g",
-      spec,
+      installSpec,
       "--no-fund",
       "--no-audit",
       "--loglevel=error",
@@ -655,13 +681,21 @@ describe("update-cli", () => {
         latestVersion: "1.2.3",
       },
     });
-    vi.mocked(runCommandWithTimeout).mockResolvedValue({
-      stdout: "",
-      stderr: "",
-      code: 0,
-      signal: null,
-      killed: false,
-      termination: "exit",
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (argv[0] === "npm" && argv[1] === "pack") {
+        const destination = argv[argv.indexOf("--pack-destination") + 1];
+        if (destination) {
+          await fs.writeFile(path.join(destination, "openclaw-9999.0.0.tgz"), "packed\n", "utf8");
+        }
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
     });
     vi.spyOn(updateCliShared, "readPackageName").mockImplementation(readPackageName);
     vi.spyOn(updateCliShared, "readPackageVersion").mockImplementation(readPackageVersion);

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -421,7 +421,31 @@ describe("update-cli", () => {
 
   const isNpmGitPackageSpec = (spec: string) => {
     const target = stripOpenClawPackageAlias(spec);
-    return /^github:/i.test(target) || /^git(?:\+|:)/i.test(target);
+    const [repo] = target.split("#", 1);
+    const isGitHubShorthand =
+      !!repo &&
+      !repo.startsWith(".") &&
+      !repo.startsWith("/") &&
+      !repo.startsWith("@") &&
+      repo.split("/").length === 2 &&
+      repo.split("/").every((part) => /^[^\s/:@]+$/u.test(part));
+    let isHttpGitUrl = false;
+    try {
+      const url = new URL(target);
+      isHttpGitUrl =
+        (url.protocol === "https:" || url.protocol === "http:") &&
+        url.pathname.replace(/\/+$/u, "").endsWith(".git");
+    } catch {
+      isHttpGitUrl = false;
+    }
+    return (
+      /^github:/i.test(target) ||
+      /^git(?:\+|:)/i.test(target) ||
+      /^ssh:\/\//i.test(target) ||
+      /^[^@\s]+@[^:\s]+:[^#\s]+(?:#.*)?$/u.test(target) ||
+      isHttpGitUrl ||
+      isGitHubShorthand
+    );
   };
 
   const doctorCommandCall = () =>
@@ -2174,6 +2198,30 @@ describe("update-cli", () => {
         await updateCommand({ yes: true, tag: "OpenClaw@github:openclaw/openclaw#main" });
       },
       expectedSpec: "OpenClaw@github:openclaw/openclaw#main",
+    },
+    {
+      name: "full git URL package spec",
+      run: async () => {
+        mockPackageInstallStatus(createCaseDir("openclaw-update"));
+        await updateCommand({ yes: true, tag: "https://github.com/openclaw/openclaw.git#main" });
+      },
+      expectedSpec: "https://github.com/openclaw/openclaw.git#main",
+    },
+    {
+      name: "GitHub shorthand package spec",
+      run: async () => {
+        mockPackageInstallStatus(createCaseDir("openclaw-update"));
+        await updateCommand({ yes: true, tag: "openclaw/openclaw#main" });
+      },
+      expectedSpec: "openclaw/openclaw#main",
+    },
+    {
+      name: "SCP-style SSH package spec",
+      run: async () => {
+        mockPackageInstallStatus(createCaseDir("openclaw-update"));
+        await updateCommand({ yes: true, tag: "git@github.com:openclaw/openclaw.git#main" });
+      },
+      expectedSpec: "git@github.com:openclaw/openclaw.git#main",
     },
     {
       name: "OPENCLAW_UPDATE_PACKAGE_SPEC override",

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -58,6 +58,7 @@ export function registerUpdateCli(program: Command) {
         ["openclaw update --channel beta", "Switch to beta channel (git + npm)"],
         ["openclaw update --channel dev", "Switch to dev channel (git + npm)"],
         ["openclaw update --tag beta", "One-off update to a dist-tag or version"],
+        ["openclaw update --tag main", "One-off package update from GitHub main"],
         ["openclaw update --dry-run", "Preview actions without changing anything"],
         ["openclaw update --no-restart", "Update without restarting the service"],
         ["openclaw update --json", "Output result as JSON"],
@@ -77,7 +78,7 @@ ${theme.heading("Switch channels:")}
   - Use --channel stable|beta|dev to persist the update channel in config
   - Run openclaw update status to see the active channel and source
   - Use --tag <dist-tag|version|spec> for a one-off package update without persisting
-  - Use --channel dev, not --tag main, for the moving GitHub main checkout
+  - Use --tag main for a one-off package update from GitHub main
 
 ${theme.heading("Non-interactive:")}
   - Use --yes to accept downgrade prompts

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -74,7 +74,6 @@ import {
   createGlobalInstallEnv,
   cleanupGlobalRenameDirs,
   globalInstallArgs,
-  isOpenClawSourcePackageInstallSpec,
   resolveGlobalInstallTarget,
   resolveGlobalInstallSpec,
   resolvePnpmGlobalDirFromGlobalRoot,
@@ -1023,14 +1022,6 @@ async function resolvePackageRuntimePreflightError(params: {
       : "Upgrade Node to 22.19+ or Node 24, then rerun `openclaw update`.",
     "Bare `npm i -g openclaw` can silently install an older compatible release.",
     "After upgrading Node, use `npm i -g openclaw@latest`.",
-  ].join("\n");
-}
-
-function formatUnsupportedOpenClawSourcePackageTargetMessage(target: string): string {
-  return [
-    `Unsupported package update target: ${target}.`,
-    "OpenClaw package updates use published npm artifacts or built tarballs; npm GitHub source installs for openclaw/openclaw do not reliably produce an installable package.",
-    "Use `openclaw update --channel dev` for the moving main checkout, or target `latest`, `beta`, an exact version, or a built `.tgz` package spec.",
   ].join("\n");
 }
 
@@ -3150,11 +3141,6 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       tag,
       env: process.env,
     });
-    if (isOpenClawSourcePackageInstallSpec(packageInstallSpec)) {
-      defaultRuntime.error(formatUnsupportedOpenClawSourcePackageTargetMessage(packageInstallSpec));
-      defaultRuntime.exit(1);
-      return;
-    }
   }
 
   if (opts.dryRun) {

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -337,6 +337,86 @@ describe("runGlobalPackageUpdateSteps", () => {
     });
   });
 
+  it.each([
+    {
+      name: "full git url",
+      sourceSpec: "https://github.com/openclaw/openclaw.git#main",
+    },
+    {
+      name: "GitHub shorthand",
+      sourceSpec: "openclaw/openclaw#main",
+    },
+    {
+      name: "SCP-style SSH",
+      sourceSpec: "git@github.com:openclaw/openclaw.git#main",
+    },
+  ] as const)(
+    "packs additional npm git source spec forms before install: $name",
+    async ({ sourceSpec }) => {
+      await withTempDir({ prefix: "openclaw-package-update-npm-pack-variant-" }, async (base) => {
+        const globalRoot = path.join(base, "prefix", "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+
+        let tarball: string | undefined;
+        const runStep = vi.fn(async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+          if (name === "global update pack") {
+            const destination = argv[argv.indexOf("--pack-destination") + 1];
+            if (!destination) {
+              throw new Error("missing pack destination");
+            }
+            expect(argv.slice(0, 3)).toEqual(["npm", "pack", sourceSpec]);
+            tarball = path.join(destination, "openclaw-2.0.0.tgz");
+            await fs.writeFile(tarball, "packed\n", "utf8");
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          }
+          if (name !== "global update" || !tarball) {
+            throw new Error(`unexpected step ${name}`);
+          }
+          expect(argv).toContain(tarball);
+          const stagePrefix = argv[argv.indexOf("--prefix") + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          await writePackageRoot(
+            path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+            "2.0.0",
+          );
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        });
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: sourceSpec,
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep).toBeNull();
+        expect(result.steps.map((step) => step.name)).toEqual([
+          "global update pack",
+          "global update",
+          "global install swap",
+        ]);
+      });
+    },
+  );
+
   it("swaps staged npm package roots through the copy fallback when rename crosses devices", async () => {
     await withTempDir({ prefix: "openclaw-package-update-exdev-" }, async (base) => {
       const prefix = path.join(base, "prefix");

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -249,6 +249,7 @@ describe("runGlobalPackageUpdateSteps", () => {
       const prefix = path.join(base, "prefix");
       const globalRoot = path.join(prefix, "lib", "node_modules");
       const packageRoot = path.join(globalRoot, "openclaw");
+      const sourceSpec = "OpenClaw@github:openclaw/openclaw#release/2026.5.12";
       await writePackageRoot(packageRoot, "1.0.0");
 
       let packDir: string | undefined;
@@ -257,7 +258,7 @@ describe("runGlobalPackageUpdateSteps", () => {
           expect(argv).toEqual([
             "npm",
             "pack",
-            "github:openclaw/openclaw#release/2026.5.12",
+            sourceSpec,
             "--pack-destination",
             expect.any(String),
             "--json",
@@ -314,7 +315,7 @@ describe("runGlobalPackageUpdateSteps", () => {
 
       const result = await runGlobalPackageUpdateSteps({
         installTarget: createNpmTarget(globalRoot),
-        installSpec: "github:openclaw/openclaw#release/2026.5.12",
+        installSpec: sourceSpec,
         packageName: "openclaw",
         packageRoot,
         runCommand: createRootRunner(globalRoot),

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -343,6 +343,14 @@ describe("runGlobalPackageUpdateSteps", () => {
       sourceSpec: "https://github.com/openclaw/openclaw.git#main",
     },
     {
+      name: "hosted GitHub URL without git suffix",
+      sourceSpec: "https://github.com/openclaw/openclaw#main",
+    },
+    {
+      name: "aliased hosted GitHub URL without git suffix",
+      sourceSpec: "openclaw@https://github.com/openclaw/openclaw#main",
+    },
+    {
       name: "GitHub shorthand",
       sourceSpec: "openclaw/openclaw#main",
     },

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -244,6 +244,98 @@ describe("runGlobalPackageUpdateSteps", () => {
     });
   });
 
+  it("packs npm GitHub specs before installing into the staged prefix", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-npm-pack-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+
+      let packDir: string | undefined;
+      const runStep = vi.fn(async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+        if (name === "global update pack") {
+          expect(argv).toEqual([
+            "npm",
+            "pack",
+            "github:openclaw/openclaw#release/2026.5.12",
+            "--pack-destination",
+            expect.any(String),
+            "--json",
+            "--loglevel=error",
+          ]);
+          const destination = argv[4];
+          if (!destination) {
+            throw new Error("missing pack destination");
+          }
+          packDir = destination;
+          await fs.writeFile(path.join(destination, "openclaw-2.0.0.tgz"), "packed\n", "utf8");
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        }
+        if (name !== "global update") {
+          throw new Error(`unexpected step ${name}`);
+        }
+        const prefixIndex = argv.indexOf("--prefix");
+        const stagePrefix = argv[prefixIndex + 1];
+        if (!stagePrefix || !packDir) {
+          throw new Error("missing staged prefix or pack dir");
+        }
+        expect(argv).toEqual([
+          "npm",
+          "i",
+          "-g",
+          "--prefix",
+          stagePrefix,
+          path.join(packDir, "openclaw-2.0.0.tgz"),
+          "--no-fund",
+          "--no-audit",
+          "--loglevel=error",
+          "--min-release-age=0",
+        ]);
+        await writePackageRoot(path.join(stagePrefix, "lib", "node_modules", "openclaw"), "2.0.0");
+        await fs.mkdir(path.join(stagePrefix, "bin"), { recursive: true });
+        await fs.symlink(
+          "../lib/node_modules/openclaw/dist/index.js",
+          path.join(stagePrefix, "bin", "openclaw"),
+        );
+        return {
+          name,
+          command: argv.join(" "),
+          cwd: cwd ?? process.cwd(),
+          durationMs: 1,
+          exitCode: 0,
+        };
+      });
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "github:openclaw/openclaw#release/2026.5.12",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).toBeNull();
+      expect(result.afterVersion).toBe("2.0.0");
+      expect(result.steps.map((step) => step.name)).toEqual([
+        "global update pack",
+        "global update",
+        "global install swap",
+      ]);
+      if (!packDir) {
+        throw new Error("expected npm pack directory");
+      }
+      await expectPathMissing(packDir);
+    });
+  });
+
   it("swaps staged npm package roots through the copy fallback when rename crosses devices", async () => {
     await withTempDir({ prefix: "openclaw-package-update-exdev-" }, async (base) => {
       const prefix = path.join(base, "prefix");

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -128,7 +128,12 @@ function isHttpGitUrlSpec(spec: string): boolean {
     if (url.protocol !== "https:" && url.protocol !== "http:") {
       return false;
     }
-    return url.pathname.replace(/\/+$/u, "").endsWith(".git");
+    const pathname = url.pathname.replace(/\/+$/u, "");
+    if (pathname.endsWith(".git")) {
+      return true;
+    }
+    const parts = pathname.split("/").filter(Boolean);
+    return url.hostname.toLowerCase() === "github.com" && parts.length === 2;
   } catch {
     return false;
   }

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -122,12 +122,37 @@ function stripPackageAlias(spec: string, packageName: string): string {
     : trimmed;
 }
 
+function isHttpGitUrlSpec(spec: string): boolean {
+  try {
+    const url = new URL(spec);
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return false;
+    }
+    return url.pathname.replace(/\/+$/u, "").endsWith(".git");
+  } catch {
+    return false;
+  }
+}
+
+function isGitHubShorthandSpec(spec: string): boolean {
+  const [repo] = spec.split("#", 1);
+  if (!repo || repo.startsWith(".") || repo.startsWith("/") || repo.startsWith("@")) {
+    return false;
+  }
+  const parts = repo.split("/");
+  return parts.length === 2 && parts.every((part) => /^[^\s/:@]+$/u.test(part));
+}
+
 function isNpmGitSourceInstallSpec(spec: string, packageName: string): boolean {
   const target = stripPackageAlias(spec, packageName);
   return (
     /^github:/i.test(target) ||
     /^git\+(?:ssh|https|http|file):/i.test(target) ||
-    /^git:/i.test(target)
+    /^git:/i.test(target) ||
+    /^ssh:\/\//i.test(target) ||
+    /^[^@\s]+@[^:\s]+:[^#\s]+(?:#.*)?$/u.test(target) ||
+    isHttpGitUrlSpec(target) ||
+    isGitHubShorthandSpec(target)
   );
 }
 

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -117,7 +117,9 @@ function resolveStagedNpmTargetLayout(
 function stripPackageAlias(spec: string, packageName: string): string {
   const trimmed = spec.trim();
   const prefix = `${packageName.trim()}@`;
-  return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length).trim() : trimmed;
+  return trimmed.toLowerCase().startsWith(prefix.toLowerCase())
+    ? trimmed.slice(prefix.length).trim()
+    : trimmed;
 }
 
 function isNpmGitSourceInstallSpec(spec: string, packageName: string): boolean {

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { pathExists } from "./fs-safe.js";
 import { readPackageVersion } from "./package-json.js";
@@ -50,6 +51,8 @@ type NpmBinShimBackup = {
     hadExisting: boolean;
   }>;
 };
+
+const NPM_PACK_QUIET_FLAGS = ["--json", "--loglevel=error"] as const;
 
 function formatError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -111,6 +114,21 @@ function resolveStagedNpmTargetLayout(
   return null;
 }
 
+function stripPackageAlias(spec: string, packageName: string): string {
+  const trimmed = spec.trim();
+  const prefix = `${packageName.trim()}@`;
+  return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length).trim() : trimmed;
+}
+
+function isNpmGitSourceInstallSpec(spec: string, packageName: string): boolean {
+  const target = stripPackageAlias(spec, packageName);
+  return (
+    /^github:/i.test(target) ||
+    /^git\+(?:ssh|https|http|file):/i.test(target) ||
+    /^git:/i.test(target)
+  );
+}
+
 async function createStagedNpmInstall(
   installTarget: ResolvedGlobalInstallTarget,
   packageName: string,
@@ -133,6 +151,87 @@ async function createStagedNpmInstall(
       globalRoot: layout.globalRoot,
       packageRoot: path.join(layout.globalRoot, packageName),
     },
+  };
+}
+
+async function findPackedTarball(packDir: string): Promise<string | null> {
+  const entries = await fs.readdir(packDir).catch((): string[] => []);
+  const tarballs = entries.filter((entry) => entry.endsWith(".tgz"));
+  if (tarballs.length !== 1) {
+    return null;
+  }
+  return path.join(packDir, tarballs[0] ?? "");
+}
+
+async function prepareNpmGitSourceInstallSpec(params: {
+  installTarget: ResolvedGlobalInstallTarget;
+  installSpec: string;
+  packageName: string;
+  runStep: PackageUpdateStepRunner;
+  timeoutMs: number;
+  env?: NodeJS.ProcessEnv;
+  installCwd?: string;
+}): Promise<{
+  installSpec: string;
+  packDir: string | null;
+  steps: PackageUpdateStepResult[];
+  failedStep: PackageUpdateStepResult | null;
+}> {
+  if (
+    params.installTarget.manager !== "npm" ||
+    !isNpmGitSourceInstallSpec(params.installSpec, params.packageName)
+  ) {
+    return { installSpec: params.installSpec, packDir: null, steps: [], failedStep: null };
+  }
+
+  const packDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-pack-"));
+  const packStep = await params.runStep({
+    name: "global update pack",
+    argv: [
+      params.installTarget.command,
+      "pack",
+      params.installSpec,
+      "--pack-destination",
+      packDir,
+      ...NPM_PACK_QUIET_FLAGS,
+    ],
+    cwd: params.installCwd,
+    env: params.env,
+    timeoutMs: params.timeoutMs,
+  });
+  if (packStep.exitCode !== 0) {
+    return {
+      installSpec: params.installSpec,
+      packDir,
+      steps: [packStep],
+      failedStep: packStep,
+    };
+  }
+
+  const tarball = await findPackedTarball(packDir);
+  if (!tarball) {
+    const failedStep: PackageUpdateStepResult = {
+      name: "global update pack verify",
+      command: `find packed tarball in ${packDir}`,
+      cwd: packDir,
+      durationMs: 0,
+      exitCode: 1,
+      stdoutTail: null,
+      stderrTail: `expected exactly one .tgz from npm pack ${params.installSpec}`,
+    };
+    return {
+      installSpec: params.installSpec,
+      packDir,
+      steps: [packStep, failedStep],
+      failedStep,
+    };
+  }
+
+  return {
+    installSpec: tarball,
+    packDir,
+    steps: [packStep],
+    failedStep: null,
   };
 }
 
@@ -367,6 +466,7 @@ export async function runGlobalPackageUpdateSteps(params: {
   const installCwd = params.installCwd === undefined ? {} : { cwd: params.installCwd };
   const installEnv = params.env === undefined ? {} : { env: params.env };
   let stagedInstall: StagedNpmInstall | null = null;
+  let packedInstallDir: string | null = null;
 
   try {
     const preparedInstall = await prepareStagedNpmInstall(params.installTarget, params.packageName);
@@ -380,7 +480,28 @@ export async function runGlobalPackageUpdateSteps(params: {
       };
     }
 
+    const steps: PackageUpdateStepResult[] = [];
     const installCommandTarget = stagedInstall?.installTarget ?? params.installTarget;
+    const preparedSpec = await prepareNpmGitSourceInstallSpec({
+      installTarget: installCommandTarget,
+      installSpec: params.installSpec,
+      packageName: params.packageName,
+      runStep: params.runStep,
+      timeoutMs: params.timeoutMs,
+      env: params.env,
+      installCwd: params.installCwd,
+    });
+    packedInstallDir = preparedSpec.packDir;
+    steps.push(...preparedSpec.steps);
+    if (preparedSpec.failedStep) {
+      return {
+        steps,
+        verifiedPackageRoot: params.packageRoot ?? null,
+        afterVersion: null,
+        failedStep: preparedSpec.failedStep,
+      };
+    }
+
     const installLocation =
       stagedInstall?.prefix ??
       (installCommandTarget.manager === "pnpm"
@@ -388,13 +509,18 @@ export async function runGlobalPackageUpdateSteps(params: {
         : null);
     const updateStep = await params.runStep({
       name: "global update",
-      argv: globalInstallArgs(installCommandTarget, params.installSpec, undefined, installLocation),
+      argv: globalInstallArgs(
+        installCommandTarget,
+        preparedSpec.installSpec,
+        undefined,
+        installLocation,
+      ),
       ...installCwd,
       ...installEnv,
       timeoutMs: params.timeoutMs,
     });
 
-    const steps = [updateStep];
+    steps.push(updateStep);
     let finalInstallStep = updateStep;
     if (updateStep.exitCode !== 0) {
       await cleanupStagedNpmInstall(stagedInstall);
@@ -416,7 +542,7 @@ export async function runGlobalPackageUpdateSteps(params: {
 
       const fallbackArgv = globalInstallFallbackArgs(
         stagedInstall?.installTarget ?? params.installTarget,
-        params.installSpec,
+        preparedSpec.installSpec,
         undefined,
         stagedInstall?.prefix,
       );
@@ -520,5 +646,8 @@ export async function runGlobalPackageUpdateSteps(params: {
     };
   } finally {
     await cleanupStagedNpmInstall(stagedInstall);
+    if (packedInstallDir) {
+      await removePathBestEffort(packedInstallDir);
+    }
   }
 }

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -26,7 +26,6 @@ import {
   globalInstallFallbackArgs,
   isExplicitPackageInstallSpec,
   isMainPackageTarget,
-  isOpenClawSourcePackageInstallSpec,
   OPENCLAW_MAIN_PACKAGE_SPEC,
   resolveGlobalInstallCommand,
   resolveGlobalPackageRoot,
@@ -248,24 +247,6 @@ describe("update global helpers", () => {
     expect(canResolveRegistryVersionForPackageTarget("main")).toBe(false);
     expect(canResolveRegistryVersionForPackageTarget("github:openclaw/openclaw#main")).toBe(false);
     expect(canResolveRegistryVersionForPackageTarget("/tmp/openclaw-main.tgz")).toBe(false);
-  });
-
-  it("classifies OpenClaw GitHub source package specs as unsupported package targets", () => {
-    expect(isOpenClawSourcePackageInstallSpec("main")).toBe(true);
-    expect(isOpenClawSourcePackageInstallSpec("github:openclaw/openclaw#main")).toBe(true);
-    expect(isOpenClawSourcePackageInstallSpec("openclaw@github:openclaw/openclaw#main")).toBe(true);
-    expect(isOpenClawSourcePackageInstallSpec("OpenClaw@github:openclaw/openclaw#main")).toBe(true);
-    expect(
-      isOpenClawSourcePackageInstallSpec("git+https://github.com/openclaw/openclaw.git#main"),
-    ).toBe(true);
-    expect(isOpenClawSourcePackageInstallSpec("https://example.com/openclaw-main.tgz")).toBe(false);
-    expect(
-      isOpenClawSourcePackageInstallSpec(
-        "https://github.com/openclaw/openclaw/releases/download/v2026.5.20/openclaw.tgz",
-      ),
-    ).toBe(false);
-    expect(isOpenClawSourcePackageInstallSpec("github:other/openclaw#main")).toBe(false);
-    expect(isOpenClawSourcePackageInstallSpec("beta")).toBe(false);
   });
 
   it("detects install managers from resolved roots and on-disk presence", async () => {

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -94,27 +94,6 @@ function stripPrimaryPackageAlias(spec: string): string {
     : normalized;
 }
 
-export function isOpenClawSourcePackageInstallSpec(value: string): boolean {
-  if (isMainPackageTarget(value)) {
-    return true;
-  }
-  const target = stripPrimaryPackageAlias(value);
-  const normalizedTarget = normalizeLowercaseStringOrEmpty(target);
-  if (!normalizedTarget) {
-    return false;
-  }
-  if (/^github:openclaw\/openclaw(?:$|[#/])/u.test(normalizedTarget)) {
-    return true;
-  }
-  const gitUrl = normalizedTarget.replace(/^git\+/u, "");
-  return (
-    /^https?:\/\/github\.com\/openclaw\/openclaw(?:\.git)?(?:$|[?#])/u.test(gitUrl) ||
-    /^ssh:\/\/git@github\.com[:/]openclaw\/openclaw(?:\.git)?(?:$|[?#])/u.test(gitUrl) ||
-    /^git:\/\/github\.com\/openclaw\/openclaw(?:\.git)?(?:$|[?#])/u.test(gitUrl) ||
-    /^git@github\.com:openclaw\/openclaw(?:\.git)?(?:$|[?#])/u.test(gitUrl)
-  );
-}
-
 function isPnpmOpenClawSourceInstallSpec(spec: string): boolean {
   const target = stripPrimaryPackageAlias(spec);
   return (

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -286,9 +286,16 @@ describe("runGatewayUpdate", () => {
     return { nodeModules, pkgRoot };
   }
 
+  type InstallCommandExpectation = string | ((argv: string[]) => boolean);
+
   const npmFreshnessArg = "--min-release-age=0";
   const normalizeNpmFreshnessArgs = (argv: string[]) =>
     argv.map((arg) => (/^--before=\d{4}-\d{2}-\d{2}T/u.test(arg) ? npmFreshnessArg : arg));
+
+  const installCommandMatches = (expected: InstallCommandExpectation, argv: string[]) => {
+    const normalizedArgv = normalizeNpmFreshnessArgs(argv);
+    return typeof expected === "string" ? normalizedArgv.join(" ") === expected : expected(normalizedArgv);
+  };
 
   const npmGlobalInstallCommand = (spec: string, extraArgs: string[] = []) =>
     [
@@ -1655,7 +1662,7 @@ describe("runGatewayUpdate", () => {
   });
 
   async function runNpmGlobalUpdateCase(params: {
-    expectedInstallCommand: string;
+    expectedInstallCommand: InstallCommandExpectation;
     channel?: "stable" | "beta";
     tag?: string;
   }): Promise<{ calls: string[]; result: Awaited<ReturnType<typeof runGatewayUpdate>> }> {
@@ -1689,7 +1696,7 @@ describe("runGatewayUpdate", () => {
     pkgRoot: string;
     npmRootOutput?: string;
     pnpmRootOutput?: string;
-    installCommand: string;
+    installCommand: InstallCommandExpectation;
     gitRootMode?: "not-git" | "missing";
     onInstall?: (options?: {
       env?: NodeJS.ProcessEnv;
@@ -1719,18 +1726,30 @@ describe("runGatewayUpdate", () => {
         }
         return { stdout: "", stderr: "", code: 1 };
       }
-      if (key === params.installCommand) {
+      if (argv[0] === "npm" && argv[1] === "pack") {
+        const destination = argv[argv.indexOf("--pack-destination") + 1];
+        if (!destination) {
+          return { stdout: "", stderr: "missing pack destination", code: 1 };
+        }
+        await fs.writeFile(path.join(destination, "openclaw-2.0.0.tgz"), "packed\n", "utf-8");
+        return {
+          stdout: JSON.stringify([{ filename: "openclaw-2.0.0.tgz" }]),
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (installCommandMatches(params.installCommand, argv)) {
         await params.onInstall?.(options);
         return { stdout: "ok", stderr: "", code: 0 };
       }
       const prefixIndex = argv.indexOf("--prefix");
       const installPrefix = prefixIndex >= 0 ? argv[prefixIndex + 1] : undefined;
       if (installPrefix) {
-        const normalizedInstallCommand = normalizeNpmFreshnessArgs([
+        const installCommandArgv = [
           ...argv.slice(0, prefixIndex),
           ...argv.slice(prefixIndex + 2),
-        ]).join(" ");
-        if (normalizedInstallCommand === params.installCommand) {
+        ];
+        if (installCommandMatches(params.installCommand, installCommandArgv)) {
           const packageRoot =
             process.platform === "win32"
               ? path.join(installPrefix, "node_modules", "openclaw")
@@ -1777,17 +1796,27 @@ describe("runGatewayUpdate", () => {
     expect(calls).toContain(expectedInstallCommand);
   });
 
-  it("rejects global npm updates from the GitHub main package spec", async () => {
+  it("updates global npm installs from the GitHub main package spec", async () => {
+    const sourceSpec = "github:openclaw/openclaw#main";
     const { calls, result } = await runNpmGlobalUpdateCase({
-      expectedInstallCommand: npmGlobalInstallCommand("github:openclaw/openclaw#main"),
+      expectedInstallCommand: (argv) =>
+        argv[0] === "npm" &&
+        argv[1] === "i" &&
+        argv[2] === "-g" &&
+        path.basename(argv[3] ?? "") === "openclaw-2.0.0.tgz" &&
+        argv.slice(4).join(" ") === "--no-fund --no-audit --loglevel=error --min-release-age=0",
       tag: "main",
     });
 
-    expect(result.status).toBe("error");
+    expect(result.status).toBe("ok");
     expect(result.mode).toBe("npm");
-    expect(result.reason).toBe("unsupported-package-target");
-    expect(result.steps[0]?.name).toBe("package target validation");
-    expect(calls).not.toContain(npmGlobalInstallCommand("github:openclaw/openclaw#main"));
+    expect(result.steps.map((step) => step.name)).toContain("global update pack");
+    expect(
+      calls.some((call) => call.startsWith(`npm pack ${sourceSpec} --pack-destination `)),
+    ).toBe(true);
+    const installCall = calls.find((call) => call.includes("openclaw-2.0.0.tgz"));
+    expect(installCall).toContain("--no-fund --no-audit --loglevel=error --min-release-age=0");
+    expect(installCall).not.toContain(sourceSpec);
   });
 
   it("runs doctor after global npm updates before reporting success", async () => {

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -294,7 +294,9 @@ describe("runGatewayUpdate", () => {
 
   const installCommandMatches = (expected: InstallCommandExpectation, argv: string[]) => {
     const normalizedArgv = normalizeNpmFreshnessArgs(argv);
-    return typeof expected === "string" ? normalizedArgv.join(" ") === expected : expected(normalizedArgv);
+    return typeof expected === "string"
+      ? normalizedArgv.join(" ") === expected
+      : expected(normalizedArgv);
   };
 
   const npmGlobalInstallCommand = (spec: string, extraArgs: string[] = []) =>
@@ -1745,11 +1747,11 @@ describe("runGatewayUpdate", () => {
       const prefixIndex = argv.indexOf("--prefix");
       const installPrefix = prefixIndex >= 0 ? argv[prefixIndex + 1] : undefined;
       if (installPrefix) {
-        const installCommandArgv = [
+        const normalizedInstallCommand = normalizeNpmFreshnessArgs([
           ...argv.slice(0, prefixIndex),
           ...argv.slice(prefixIndex + 2),
-        ];
-        if (installCommandMatches(params.installCommand, installCommandArgv)) {
+        ]);
+        if (installCommandMatches(params.installCommand, normalizedInstallCommand)) {
           const packageRoot =
             process.platform === "win32"
               ? path.join(installPrefix, "node_modules", "openclaw")

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -25,7 +25,6 @@ import {
   cleanupGlobalRenameDirs,
   createGlobalInstallEnv,
   detectGlobalInstallManagerForRoot,
-  isOpenClawSourcePackageInstallSpec,
   resolveGlobalInstallTarget,
   resolveGlobalInstallSpec,
   type GlobalInstallManager,
@@ -1449,30 +1448,6 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       tag,
       env: globalInstallEnv,
     });
-    if (isOpenClawSourcePackageInstallSpec(spec)) {
-      const durationMs = Date.now() - startedAt;
-      return {
-        status: "error",
-        mode: globalManager,
-        root: pkgRoot,
-        reason: "unsupported-package-target",
-        before: { version: beforeVersion },
-        after: { version: beforeVersion },
-        steps: [
-          {
-            name: "package target validation",
-            command: `validate package target ${spec}`,
-            cwd: pkgRoot,
-            durationMs,
-            exitCode: 1,
-            stdoutTail: null,
-            stderrTail:
-              "OpenClaw package updates use published npm artifacts or built tarballs; use the dev channel for GitHub main.",
-          },
-        ],
-        durationMs,
-      };
-    }
     const packageUpdate = await runGlobalPackageUpdateSteps({
       installTarget,
       installSpec: spec,


### PR DESCRIPTION
## Summary
- pre-pack npm GitHub/git source update specs into a temporary tarball before the staged global install
- install the packed tarball into the existing staged npm prefix and keep cleanup best-effort
- add coverage for the pack step, tarball install argv, staged swap, and temporary pack dir cleanup

## Why
`npm i -g --prefix <stage> github:openclaw/openclaw#release/2026.5.12` currently fails on macOS with `spawn /bin/sh ENOENT` while running nested dependency preinstall scripts. Reproducing the flow showed that `npm pack github:...` succeeds, and installing the resulting tarball with the same prefix succeeds. The updater already stages npm installs, so this keeps the staged swap behavior but feeds npm a packed tarball for git source specs.

## Verification
- `pnpm exec oxfmt --check --threads=1 src/infra/package-update-steps.ts src/infra/package-update-steps.test.ts src/infra/update-runner.test.ts src/cli/update-cli.test.ts`
  - `All matched files use the correct format.`
- `pnpm test src/infra/package-update-steps.test.ts src/infra/update-runner.test.ts src/cli/update-cli.test.ts -- --reporter=verbose`
  - `[test] passed 2 Vitest shards in 56.70s`
  - `src/infra/package-update-steps.test.ts`: `9 passed`
  - `src/infra/update-runner.test.ts`: `44 passed`
  - `src/cli/update-cli.test.ts`: `108 passed`
- `pnpm tsgo:core`
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `git diff --check`
  - no output

## Manual reproduction
- Failing before workaround: `NPM_CONFIG_SCRIPT_SHELL=/bin/sh npm i -g --prefix /tmp/openclaw-npm-stage-repro github:openclaw/openclaw#release/2026.5.12 --no-fund --no-audit --loglevel=error`
- Passing path: `npm pack github:openclaw/openclaw#release/2026.5.12`, then `npm i -g --prefix /tmp/openclaw-npm-tar-install ./openclaw-2026.5.12-beta.3.tgz --no-fund --no-audit --loglevel=error`

## Real behavior proof
- **Behavior or issue addressed**: npm-managed OpenClaw updates from a GitHub/git source spec fail when `npm i -g --prefix <stage> github:...` tries to run lifecycle scripts directly from the git spec.
- **Real environment tested**: macOS Darwin 25.3.0, Node v23.11.1, npm 10.9.2, OpenClaw GitHub ref `github:openclaw/openclaw#release/2026.5.12`.
- **Exact steps or command run after this patch**: Reproduced the updater's new sequence manually: `NPM_CONFIG_SCRIPT_SHELL=/bin/sh npm pack github:openclaw/openclaw#release/2026.5.12 --json`, then `NPM_CONFIG_SCRIPT_SHELL=/bin/sh npm i -g --prefix /tmp/openclaw-npm-tar-install-XXXXXX /tmp/openclaw-npm-pack-repro-XXXXXX/openclaw-2026.5.12-beta.3.tgz --no-fund --no-audit --loglevel=error`.
- **Evidence after fix**: Copied live terminal output from the tarball path:

```text
> openclaw@2026.5.12-beta.3 prepare
> command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath git-hooks || exit 0

[
  {
    "id": "openclaw@2026.5.12-beta.3",
    "name": "openclaw",
    "version": "2026.5.12-beta.3",
    "filename": "openclaw-2026.5.12-beta.3.tgz",
    "entryCount": 809
  }
]

added 578 packages in 5s
```

- **Observed result after fix**: Packing the GitHub source ref produced `openclaw-2026.5.12-beta.3.tgz`, and installing that tarball into a staged npm prefix completed with exit code 0. The direct GitHub install path failed beforehand with `npm error syscall spawn /bin/sh` and `npm error enoent spawn /bin/sh ENOENT`.
- **What was not tested**: I did not run a full `openclaw update` using this branch-built CLI; the real setup proof covers the npm package-manager sequence this patch adds.


## Maintainer conflict-resolution update
- Resolved merge conflicts against `origin/main` at `e399a92e6cc93f1bb3190e490658a2aec627b16e`.
- Kept the PR behavior as the current contract: npm GitHub/git update specs are pre-packed before the staged global npm install, including aliased specs such as `OpenClaw@github:...`.
- Updated CLI help, update docs, install-channel docs, and the changelog entry that had temporarily documented the early-reject fallback.

### Current-head verification
- `pnpm docs:list`
  - completed and listed docs, including `docs/cli/update.md`, `docs/install/development-channels.md`, and `docs/install/updating.md`
- `pnpm exec oxfmt --check --threads=1 src/infra/package-update-steps.ts src/infra/package-update-steps.test.ts src/infra/update-runner.test.ts src/infra/update-runner.ts src/infra/update-global.ts src/infra/update-global.test.ts src/cli/update-cli.test.ts src/cli/update-cli.ts src/cli/update-cli/update-command.ts`
  - `All matched files use the correct format.`
- `node scripts/run-vitest.mjs src/infra/package-update-steps.test.ts src/infra/update-runner.test.ts src/cli/update-cli.test.ts src/infra/update-global.test.ts --reporter=verbose`
  - `Test Files 4 passed (4)`
  - `Tests 199 passed (199)`
- `git diff --check`
  - no output
- What was not retested: no full branch-built live `openclaw update` run was performed during conflict resolution; the original real npm pack/install proof above is retained.
