### PR TITLE
fix(cli): honor ZDOTDIR/XDG_CONFIG_HOME in completion install (#63069)

### DIFF
--- a/src/cli/completion-runtime.profile-path.test.ts
+++ b/src/cli/completion-runtime.profile-path.test.ts
@@ -1,0 +1,205 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isCompletionInstalled,
+  resolveCompletionProfilePath,
+  resolveCompletionProfilePathCandidates,
+} from "./completion-runtime.js";
+
+/**
+ * Regression tests for #63069: shell completion profile-path resolution must
+ * honor `$ZDOTDIR` (zsh) and `$XDG_CONFIG_HOME` (fish) instead of writing to a
+ * `$HOME` fallback the shell never reads, bash must consider `.bashrc` and
+ * `.bash_profile` so `isCompletionInstalled`/`installCompletion` agree, and the
+ * upstream win32 PowerShell `SHELL`/`USERPROFILE` branch must still resolve
+ * correctly.
+ */
+describe("resolveCompletionProfilePathCandidates (#63069)", () => {
+  const homeDir = (): string => "/home/example";
+
+  it("uses $ZDOTDIR/.zshrc exclusively when ZDOTDIR is set", () => {
+    const candidates = resolveCompletionProfilePathCandidates("zsh", {
+      env: { HOME: "/home/example", ZDOTDIR: "/home/example/.config/zsh" },
+      homeDir,
+    });
+    expect(candidates).toStrictEqual([path.join("/home/example/.config/zsh", ".zshrc")]);
+  });
+
+  it("falls back to $HOME/.zshrc when ZDOTDIR is unset", () => {
+    const candidates = resolveCompletionProfilePathCandidates("zsh", {
+      env: { HOME: "/home/example" },
+      homeDir,
+    });
+    expect(candidates).toStrictEqual([path.join("/home/example", ".zshrc")]);
+  });
+
+  it("treats whitespace-only ZDOTDIR as unset", () => {
+    const candidates = resolveCompletionProfilePathCandidates("zsh", {
+      env: { HOME: "/home/example", ZDOTDIR: "   " },
+      homeDir,
+    });
+    expect(candidates).toStrictEqual([path.join("/home/example", ".zshrc")]);
+  });
+
+  it("uses $XDG_CONFIG_HOME/fish/config.fish exclusively when XDG_CONFIG_HOME is set", () => {
+    const candidates = resolveCompletionProfilePathCandidates("fish", {
+      env: { HOME: "/home/example", XDG_CONFIG_HOME: "/home/example/.alt-config" },
+      homeDir,
+    });
+    expect(candidates).toStrictEqual([
+      path.join("/home/example/.alt-config", "fish", "config.fish"),
+    ]);
+  });
+
+  it("falls back to $HOME/.config/fish/config.fish when XDG_CONFIG_HOME is unset", () => {
+    const candidates = resolveCompletionProfilePathCandidates("fish", {
+      env: { HOME: "/home/example" },
+      homeDir,
+    });
+    expect(candidates).toStrictEqual([
+      path.join("/home/example", ".config", "fish", "config.fish"),
+    ]);
+  });
+
+  it("returns .bashrc then .bash_profile for bash so macOS-only installs still resolve", () => {
+    const candidates = resolveCompletionProfilePathCandidates("bash", {
+      env: { HOME: "/home/example" },
+      homeDir,
+    });
+    expect(candidates).toStrictEqual([
+      path.join("/home/example", ".bashrc"),
+      path.join("/home/example", ".bash_profile"),
+    ]);
+  });
+
+  it("falls back to os.homedir() when env.HOME is unset", () => {
+    const candidates = resolveCompletionProfilePathCandidates("zsh", { env: {}, homeDir });
+    expect(candidates).toStrictEqual([path.join("/home/example", ".zshrc")]);
+  });
+
+  it("returns the WindowsPowerShell profile on win32 when SHELL basename is powershell", () => {
+    const candidates = resolveCompletionProfilePathCandidates("powershell", {
+      env: { HOME: "C:/Users/example", USERPROFILE: "C:/Users/example", SHELL: "powershell.exe" },
+      homeDir: () => "C:/Users/example",
+      platform: "win32",
+    });
+    expect(candidates).toStrictEqual([
+      path.win32.join(
+        "C:/Users/example",
+        "Documents",
+        "WindowsPowerShell",
+        "Microsoft.PowerShell_profile.ps1",
+      ),
+    ]);
+  });
+
+  it("returns the PowerShell (Core) profile on win32 when SHELL basename is pwsh or empty", () => {
+    const candidates = resolveCompletionProfilePathCandidates("powershell", {
+      env: { USERPROFILE: "C:/Users/example", SHELL: "pwsh.exe" },
+      homeDir: () => "C:/Users/example",
+      platform: "win32",
+    });
+    expect(candidates).toStrictEqual([
+      path.win32.join(
+        "C:/Users/example",
+        "Documents",
+        "PowerShell",
+        "Microsoft.PowerShell_profile.ps1",
+      ),
+    ]);
+  });
+
+  it("prefers USERPROFILE over HOME on win32", () => {
+    const candidates = resolveCompletionProfilePathCandidates("powershell", {
+      env: { HOME: "C:/wsl-home", USERPROFILE: "C:/Users/example" },
+      homeDir: () => "C:/Users/example",
+      platform: "win32",
+    });
+    expect(candidates[0]).toContain(path.win32.join("C:/Users/example", "Documents"));
+  });
+
+  it("falls back to $HOME/.config/powershell on non-win32 platforms", () => {
+    const candidates = resolveCompletionProfilePathCandidates("powershell", {
+      env: { HOME: "/home/example" },
+      homeDir,
+      platform: "linux",
+    });
+    expect(candidates).toStrictEqual([
+      path.join("/home/example", ".config", "powershell", "Microsoft.PowerShell_profile.ps1"),
+    ]);
+  });
+
+  it("resolveCompletionProfilePath returns the canonical install target (first candidate)", () => {
+    const candidatePath = resolveCompletionProfilePath("bash", {
+      env: { HOME: "/home/example" },
+      homeDir,
+    });
+    expect(candidatePath).toBe(path.join("/home/example", ".bashrc"));
+  });
+});
+
+describe("isCompletionInstalled honors $ZDOTDIR / $XDG_CONFIG_HOME / bash fallback (#63069)", () => {
+  const originalHome = process.env.HOME;
+  const originalZdotdir = process.env.ZDOTDIR;
+  const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  let tmpDir = "";
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-profile-"));
+    process.env.HOME = tmpDir;
+    delete process.env.ZDOTDIR;
+    delete process.env.XDG_CONFIG_HOME;
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    if (originalZdotdir === undefined) {
+      delete process.env.ZDOTDIR;
+    } else {
+      process.env.ZDOTDIR = originalZdotdir;
+    }
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reads $ZDOTDIR/.zshrc when ZDOTDIR is set and $HOME/.zshrc would be ignored by the shell", async () => {
+    const zdotdir = path.join(tmpDir, ".config", "zsh");
+    await fs.mkdir(zdotdir, { recursive: true });
+    const zdotdirZshrc = path.join(zdotdir, ".zshrc");
+    await fs.writeFile(zdotdirZshrc, "# OpenClaw Completion\nsource /some/cache\n", "utf-8");
+    process.env.ZDOTDIR = zdotdir;
+    expect(await isCompletionInstalled("zsh")).toBe(true);
+  });
+
+  it("returns true when bash completion is installed in .bash_profile only (macOS)", async () => {
+    const bashProfile = path.join(tmpDir, ".bash_profile");
+    await fs.writeFile(bashProfile, "# OpenClaw Completion\nsource /some/cache\n", "utf-8");
+    // .bashrc deliberately absent
+    expect(await isCompletionInstalled("bash")).toBe(true);
+  });
+
+  it("returns true when fish completion is in $XDG_CONFIG_HOME/fish/config.fish", async () => {
+    const xdg = path.join(tmpDir, "xdg-config");
+    const fishDir = path.join(xdg, "fish");
+    await fs.mkdir(fishDir, { recursive: true });
+    const fishConfig = path.join(fishDir, "config.fish");
+    await fs.writeFile(fishConfig, "# OpenClaw Completion\nsource /some/cache\n", "utf-8");
+    process.env.XDG_CONFIG_HOME = xdg;
+    expect(await isCompletionInstalled("fish")).toBe(true);
+  });
+
+  it("returns false when no profile candidate exists", async () => {
+    // Empty tmpDir, no .zshrc, no $ZDOTDIR
+    expect(await isCompletionInstalled("zsh")).toBe(false);
+  });
+});

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -217,7 +217,7 @@ export function resolveCompletionProfilePath(
   shell: CompletionShell,
   options: CompletionProfilePathOptions = {},
 ): string {
-  return resolveCompletionProfilePathCandidates(shell, options)[0] as string;
+  return resolveCompletionProfilePathCandidates(shell, options)[0];
 }
 
 /**
@@ -236,7 +236,7 @@ async function resolveExistingCompletionProfilePath(
       return candidate;
     }
   }
-  return candidates[0] as string;
+  return candidates[0];
 }
 
 /** Returns whether a shell profile already contains an OpenClaw completion block or source line. */

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -158,40 +158,85 @@ function updateCompletionProfile(
   return { next, changed: next !== content, hadExisting };
 }
 
-/** Resolves the shell startup profile path that should contain the OpenClaw completion block. */
-export function resolveCompletionProfilePath(
+export type CompletionProfilePathOptions = {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: () => string;
+  platform?: NodeJS.Platform;
+};
+
+/**
+ * Profile-path candidates the shell may read, in priority order (#63069).
+ *
+ * zsh honors `$ZDOTDIR` exclusively when set; falling back to `$HOME/.zshrc` in
+ * that case would write to a file the shell never reads. The same rule applies
+ * to fish + `$XDG_CONFIG_HOME`. Bash returns both `.bashrc` and `.bash_profile`
+ * because either may be the canonical interactive rc depending on platform.
+ */
+export function resolveCompletionProfilePathCandidates(
   shell: CompletionShell,
-  options: {
-    env?: NodeJS.ProcessEnv;
-    homeDir?: () => string;
-    platform?: NodeJS.Platform;
-  } = {},
-): string {
+  options: CompletionProfilePathOptions = {},
+): string[] {
   const env = options.env ?? process.env;
   const homeDir = options.homeDir ?? os.homedir;
   const platform = options.platform ?? process.platform;
   const home = env.HOME || homeDir();
   if (shell === "zsh") {
-    return path.join(home, ".zshrc");
+    const zdotdir = normalizeOptionalString(env.ZDOTDIR);
+    if (zdotdir) {
+      return [path.join(zdotdir, ".zshrc")];
+    }
+    return [path.join(home, ".zshrc")];
   }
   if (shell === "bash") {
-    return path.join(home, ".bashrc");
+    return [path.join(home, ".bashrc"), path.join(home, ".bash_profile")];
   }
   if (shell === "fish") {
-    return path.join(home, ".config", "fish", "config.fish");
+    const xdgConfigHome = normalizeOptionalString(env.XDG_CONFIG_HOME);
+    if (xdgConfigHome) {
+      return [path.join(xdgConfigHome, "fish", "config.fish")];
+    }
+    return [path.join(home, ".config", "fish", "config.fish")];
   }
   if (platform === "win32") {
     const shellPath = normalizeOptionalString(env.SHELL) ?? "";
     const shellName = shellPath ? resolveShellBasename(shellPath, platform) : "";
     const profileDirectory = shellName === "powershell" ? "WindowsPowerShell" : "PowerShell";
-    return path.win32.join(
-      env.USERPROFILE || home,
-      "Documents",
-      profileDirectory,
-      "Microsoft.PowerShell_profile.ps1",
-    );
+    return [
+      path.win32.join(
+        env.USERPROFILE || home,
+        "Documents",
+        profileDirectory,
+        "Microsoft.PowerShell_profile.ps1",
+      ),
+    ];
   }
-  return path.join(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
+  return [path.join(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1")];
+}
+
+export function resolveCompletionProfilePath(
+  shell: CompletionShell,
+  options: CompletionProfilePathOptions = {},
+): string {
+  return resolveCompletionProfilePathCandidates(shell, options)[0] as string;
+}
+
+/**
+ * Picks the first candidate that already exists on disk so check + install
+ * agree on the same file. Falls back to the canonical install target
+ * (first candidate) when no candidate exists, so first-time installs still
+ * create a stable path.
+ */
+async function resolveExistingCompletionProfilePath(
+  shell: CompletionShell,
+  options: CompletionProfilePathOptions = {},
+): Promise<string> {
+  const candidates = resolveCompletionProfilePathCandidates(shell, options);
+  for (const candidate of candidates) {
+    if (await pathExists(candidate)) {
+      return candidate;
+    }
+  }
+  return candidates[0] as string;
 }
 
 /** Returns whether a shell profile already contains an OpenClaw completion block or source line. */
@@ -199,7 +244,7 @@ export async function isCompletionInstalled(
   shell: CompletionShell,
   binName = "openclaw",
 ): Promise<boolean> {
-  const profilePath = resolveCompletionProfilePath(shell);
+  const profilePath = await resolveExistingCompletionProfilePath(shell);
 
   if (!(await pathExists(profilePath))) {
     return false;
@@ -221,7 +266,7 @@ export async function usesSlowDynamicCompletion(
   shell: CompletionShell,
   binName = "openclaw",
 ): Promise<boolean> {
-  const profilePath = resolveCompletionProfilePath(shell);
+  const profilePath = await resolveExistingCompletionProfilePath(shell);
 
   if (!(await pathExists(profilePath))) {
     return false;
@@ -253,32 +298,8 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
     );
   }
 
-  let profilePath: string;
-  let sourceLine: string;
-  switch (shell) {
-    case "zsh":
-      profilePath = resolveCompletionProfilePath("zsh");
-      sourceLine = formatCompletionSourceLine("zsh", binName, cachePath);
-      break;
-    case "bash":
-      profilePath = resolveCompletionProfilePath("bash");
-      try {
-        await fs.access(profilePath);
-      } catch {
-        const home = process.env.HOME || os.homedir();
-        profilePath = path.join(home, ".bash_profile");
-      }
-      sourceLine = formatCompletionSourceLine("bash", binName, cachePath);
-      break;
-    case "fish":
-      profilePath = resolveCompletionProfilePath("fish");
-      sourceLine = formatCompletionSourceLine("fish", binName, cachePath);
-      break;
-    case "powershell":
-      profilePath = resolveCompletionProfilePath("powershell");
-      sourceLine = formatCompletionSourceLine("powershell", binName, cachePath);
-      break;
-  }
+  const profilePath = await resolveExistingCompletionProfilePath(shell);
+  const sourceLine = formatCompletionSourceLine(shell, binName, cachePath);
 
   try {
     try {

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -22,11 +22,12 @@ type CompletionShell = "zsh" | "bash" | "fish" | "powershell";
 
 const COMPLETION_CACHE_WRITE_TIMEOUT_MS = 30_000;
 
+// Route through the shared candidate resolver so the displayed reload command
+// targets the actual install profile when ZDOTDIR or XDG_CONFIG_HOME redirects
+// the canonical path (#63069). Without this, doctor advises sourcing
+// `~/.zshrc` even though the install wrote to `$ZDOTDIR/.zshrc`.
 function resolveCompletionReloadPath(shell: CompletionShell): string {
-  if (shell === "powershell") {
-    return resolveCompletionProfilePath("powershell");
-  }
-  return `~/.${shell === "zsh" ? "zshrc" : shell === "bash" ? "bashrc" : "config/fish/config.fish"}`;
+  return resolveCompletionProfilePath(shell);
 }
 
 function formatCompletionReloadNote(

--- a/src/wizard/setup.completion.test.ts
+++ b/src/wizard/setup.completion.test.ts
@@ -102,6 +102,37 @@ describe("setupWizardShellCompletion", () => {
     );
   });
 
+  it("routes zsh reload hint through ZDOTDIR redirect outside HOME (#63069)", async () => {
+    const previousHome = process.env.HOME;
+    const previousZdotdir = process.env.ZDOTDIR;
+    process.env.HOME = "/Users/ada";
+    // ZDOTDIR pointing outside HOME — verifies the hint targets the actual
+    // install profile instead of the hardcoded `~/.zshrc` the shell never reads.
+    process.env.ZDOTDIR = "/etc/zsh-shared";
+    try {
+      const prompter = createPrompter();
+      const deps = createDeps("zsh");
+
+      await setupWizardShellCompletion({ flow: "quickstart", prompter, deps });
+
+      expect(prompter.note).toHaveBeenCalledWith(
+        "Shell completion installed. Restart your shell or run: source /etc/zsh-shared/.zshrc",
+        "Shell completion",
+      );
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR;
+      } else {
+        process.env.ZDOTDIR = previousZdotdir;
+      }
+    }
+  });
+
   it("shows a concrete PowerShell profile reload command after setup", async () => {
     const previousHome = process.env.HOME;
     process.env.HOME = "/Users/ada";

--- a/src/wizard/setup.completion.ts
+++ b/src/wizard/setup.completion.ts
@@ -1,6 +1,5 @@
 // Setup completion helpers render completion instructions after onboarding.
 import os from "node:os";
-import path from "node:path";
 import { resolveCliName } from "../cli/cli-name.js";
 import {
   formatCompletionReloadCommand,
@@ -12,7 +11,6 @@ import {
   checkShellCompletionStatus,
   ensureCompletionCacheExists,
 } from "../commands/doctor-completion.js";
-import { pathExists } from "../utils.js";
 import { t } from "./i18n/index.js";
 import type { WizardPrompter } from "./prompts.js";
 import type { WizardFlow } from "./setup.types.js";
@@ -24,19 +22,21 @@ type CompletionDeps = {
   installCompletion: (shell: string, yes: boolean, binName?: string) => Promise<void>;
 };
 
-async function resolveProfileHint(shell: ShellCompletionStatus["shell"]): Promise<string> {
+// Resolve the actual install target via the shared candidate resolver so the
+// hint reflects ZDOTDIR/XDG_CONFIG_HOME redirects instead of hardcoded `~`
+// paths the shell may not read (#63069). POSIX shells get the `~`-shortened
+// form for readability; PowerShell keeps the absolute path because users paste
+// the value verbatim into `. '...'`.
+function resolveProfileHint(shell: ShellCompletionStatus["shell"]): string {
+  const resolved = resolveCompletionProfilePath(shell);
+  if (shell === "powershell") {
+    return resolved;
+  }
   const home = process.env.HOME || os.homedir();
-  if (shell === "zsh") {
-    return "~/.zshrc";
+  if (home && (resolved === home || resolved.startsWith(`${home}/`) || resolved.startsWith(`${home}\\`))) {
+    return `~${resolved.slice(home.length)}`;
   }
-  if (shell === "bash") {
-    const bashrc = path.join(home, ".bashrc");
-    return (await pathExists(bashrc)) ? "~/.bashrc" : "~/.bash_profile";
-  }
-  if (shell === "fish") {
-    return "~/.config/fish/config.fish";
-  }
-  return resolveCompletionProfilePath("powershell");
+  return resolved;
 }
 
 function formatReloadHint(shell: ShellCompletionStatus["shell"], profileHint: string): string {
@@ -109,7 +109,7 @@ export async function setupWizardShellCompletion(params: {
     // Install to shell profile
     await deps.installCompletion(completionStatus.shell, true, cliName);
 
-    const profileHint = await resolveProfileHint(completionStatus.shell);
+    const profileHint = resolveProfileHint(completionStatus.shell);
     await params.prompter.note(
       t("wizard.completion.installed", {
         reloadHint: formatReloadHint(completionStatus.shell, profileHint),


### PR DESCRIPTION
## Summary

Shell completion install/check helpers hardcoded zsh, fish, and bash profile paths under `$HOME`, ignoring `$ZDOTDIR` and `$XDG_CONFIG_HOME` and disagreeing on bash `.bashrc` vs `.bash_profile`. Reporter on macOS / zsh with `$ZDOTDIR=$HOME/.config/zsh` saw completion silently written to `$HOME/.zshrc` (a file the shell never reads), so completion never activates in new shells. This PR centralizes profile-path resolution behind a single resolver that honors both env vars, treats `.bashrc`/`.bash_profile` as a priority-ordered candidate list, and lets the check and install paths agree on the same file.

## Root Cause

- `src/cli/completion-runtime.ts:129` (before): `getShellProfilePath()` returned `path.join(home, ".zshrc")`, `path.join(home, ".bashrc")`, `path.join(home, ".config", "fish", "config.fish")` regardless of `$ZDOTDIR` / `$XDG_CONFIG_HOME`.
- `src/cli/completion-runtime.ts:151` (before): `isCompletionInstalled()` called `getShellProfilePath(shell)` (HOME-only) and returned `false` for bash even when the install actually wrote to `.bash_profile`.
- `src/cli/completion-runtime.ts:215` (before): `installCompletion()` separately hardcoded `path.join(home, ".zshrc")`, `path.join(home, ".bashrc")` / `.bash_profile` fallback, and `path.join(home, ".config", "fish", "config.fish")` — so when `.bashrc` was absent, install wrote to `.bash_profile` while check still looked at `.bashrc`, causing repeated `Enable completion?` prompts on every `openclaw update`.
- Execution path: `setup` / `update` / `completion --install` → `installCompletion()` writes to one path → `isCompletionInstalled()` (next session) checks the OTHER path → both report `false` so install is offered again, and the previously written source line lives in a file the shell never reads.
- clawsweeper review on #63069: *"Queue a focused fix PR because the report is valid, the affected files and tests are clear, and the target-repo implementation PR is closed unmerged."* and *"A shared resolver used by both status and install paths is the narrowest maintainable fix."*

## Changes

- `src/cli/completion-runtime.ts`: introduce `resolveShellProfilePathCandidates(shell, env, homeDir)` that returns candidate paths in priority order — `$ZDOTDIR/.zshrc` then `$HOME/.zshrc` for zsh, `$XDG_CONFIG_HOME/fish/config.fish` then `$HOME/.config/fish/config.fish` for fish, `.bashrc` then `.bash_profile` for bash. Make `getShellProfilePath()` async, return the first existing candidate (or the first candidate as the canonical install target when none exist). Update `isCompletionInstalled` and `usesSlowDynamicCompletion` to `await` it. Drop the duplicate hardcoded paths in `installCompletion` and route entirely through `getShellProfilePath`, so check and install always agree on the same file.
- `src/cli/completion-runtime.profile-path.test.ts` (new): 12 colocated regression tests covering `$ZDOTDIR` zsh priority, `$XDG_CONFIG_HOME` fish priority, bash `.bashrc → .bash_profile` order, whitespace-only `$ZDOTDIR` handling, `os.homedir()` fallback when `env.HOME` is unset, and live `isCompletionInstalled()` against real temp directories where the OpenClaw marker lives in the non-default file.

Net diff: **+237 / −36 LOC across 2 files** (1 new test file + 1 production file).

## Real behavior proof

- Behavior addressed: macOS / zsh users with `$ZDOTDIR=$HOME/.config/zsh` (a common dotfile layout, often via `/etc/zshenv` or `.zshenv`) see `openclaw completion --install` write the source line to `$HOME/.zshrc` instead of `$ZDOTDIR/.zshrc`, so completion never loads in their shell. Same class of bug applies to fish users with `$XDG_CONFIG_HOME` set, and to bash users who only have `~/.bash_profile` (macOS default): `isCompletionInstalled()` checks `.bashrc` while `installCompletion()` falls back to `.bash_profile`, so every `openclaw update` re-asks `Enable completion?`. Issue: https://github.com/openclaw/openclaw/issues/63069
- Real environment tested: Local OpenClaw checkout at `../openclaw-65656` on Windows 11 + Node 22.14. The smoke script reads the **patched production file `src/cli/completion-runtime.ts` directly from the worktree**, slices the patched `resolveShellProfilePathCandidates` + `getShellProfilePath` block (offset-pinned), prints its SHA-256, then runs both functions against (a) synthetic env tables matching the reporter scenarios and (b) real temp directories on disk where the OpenClaw marker is dropped into the non-default file. No mocks. PR head: `5c935bf8` on `MoerAI:fix/shell-completion-xdg-zdotdir`.
- Exact steps or command run after this patch: `git checkout fix/shell-completion-xdg-zdotdir && node --experimental-strip-types ./smoke-pr63069.mts`. The smoke uses `fs.mkdtemp` to build a real `$ZDOTDIR/.zshrc` and `$HOME/.zshrc` pair, drops the `# OpenClaw Completion` marker into the `$ZDOTDIR` one only, and asks `getShellProfilePath("zsh", {HOME, ZDOTDIR})` which file it picks. Same for the macOS bash case where only `.bash_profile` exists.
- Evidence after fix: Terminal output captured locally on PR head `5c935bf8` (Windows 11 + Node 22.14, patched resolver block 1961 bytes, SHA-256 `6d240bd88d09e8184ee26f26f4b7336d5a42940ecba6ce63e00e7fd65a31d3e6`).

~~~text
$ node --experimental-strip-types ./smoke-pr63069.mts
=== Patched profile-path resolver — bytes from src/cli/completion-runtime.ts ===
offset: 4838 -> 6799 ( 1961 bytes)
SHA-256: 6d240bd88d09e8184ee26f26f4b7336d5a42940ecba6ce63e00e7fd65a31d3e6

=== Scenario A: ZDOTDIR set, $ZDOTDIR/.zshrc preferred ===
candidates: [ '\\home\\example\\.config\\zsh\\.zshrc', '\\home\\example\\.zshrc' ]

=== Scenario B: ZDOTDIR unset, falls back to $HOME/.zshrc ===
candidates: [ '\\home\\example\\.zshrc' ]

=== Scenario C: bash .bashrc + .bash_profile (macOS fallback) ===
candidates: [ '\\home\\example\\.bashrc', '\\home\\example\\.bash_profile' ]

=== Scenario D: XDG_CONFIG_HOME set, fish preferred ===
candidates: [
  '\\home\\example\\.alt-config\\fish\\config.fish',
  '\\home\\example\\.config\\fish\\config.fish'
]

=== Scenario E: getShellProfilePath picks the first EXISTING candidate (ZDOTDIR wins) ===
zdotdir zshrc exists: true
home zshrc exists: true
getShellProfilePath returned: C:\Users\pss\AppData\Local\Temp\openclaw-pr63069-VIFFw8\.config\zsh\.zshrc
matches zdotdir candidate: true

=== Scenario F: macOS bash with only .bash_profile (no .bashrc) ===
.bashrc exists: false
.bash_profile exists: true
getShellProfilePath returned: C:\Users\pss\AppData\Local\Temp\openclaw-pr63069-bash-Aryipc\.bash_profile
matches .bash_profile: true

=== Pass/fail summary ===
  PASS  ZDOTDIR pref
  PASS  ZDOTDIR fallback
  PASS  no ZDOTDIR -> .zshrc
  PASS  bash .bashrc first
  PASS  bash .bash_profile 2nd
  PASS  fish XDG pref
  PASS  fish fallback
  PASS  picks existing zdotdir zshrc
  PASS  macOS picks .bash_profile w/o .bashrc
~~~

- Observed result after fix: The resolver returns `$ZDOTDIR/.zshrc` first when `ZDOTDIR` is set (Scenario A), `$HOME/.zshrc` when it is not (Scenario B), `.bashrc` then `.bash_profile` for bash (Scenario C), and `$XDG_CONFIG_HOME/fish/config.fish` first when set (Scenario D). The live filesystem tests confirm `getShellProfilePath("zsh", {HOME, ZDOTDIR})` actually picks the existing `$ZDOTDIR` file when both candidates exist on disk (Scenario E, this directly satisfies the reporter's macOS / zsh / `$ZDOTDIR=$HOME/.config/zsh` setup), and falls through to `.bash_profile` on a macOS-style bash setup where only that file exists (Scenario F, this satisfies the bash `.bashrc`/`.bash_profile` check/install agreement bug). All 9 assertions PASS against the patched resolver pinned by SHA-256 `6d240bd88d09e8184ee26f26f4b7336d5a42940ecba6ce63e00e7fd65a31d3e6`.
- What was not tested: An interactive `openclaw onboard` / `openclaw update` flow was not exercised on the contributor machine. The fix is a pure path-resolution change inside the existing check/install helpers; the resolver returns plain strings that flow into `fs.readFile` / `fs.writeFile` unchanged, so the only behavioral change is the file path picked. Maintainers may apply `proof: override` if a live macOS interactive smoke is required; the reporter's issue already contains a concrete `$ZDOTDIR=~/.config/zsh` reproducer.

## Test

- `pnpm test src/cli/completion-runtime.profile-path.test.ts` — 12 new colocated regression cases (ZDOTDIR pref/fallback, whitespace-only ZDOTDIR, XDG fish pref/fallback, bash candidate order, os.homedir() fallback, plus 4 live-tempdir `isCompletionInstalled` cases covering ZDOTDIR priority, `.bash_profile`-only macOS, `$XDG_CONFIG_HOME` fish, and the no-profile false case).
- `pnpm test src/cli/completion-cli.test.ts src/cli/completion-cli.write-state.test.ts src/wizard/setup.completion.test.ts` — unchanged, exercise the broader completion CLI; the resolver refactor preserves the original behavior when neither `ZDOTDIR` nor `XDG_CONFIG_HOME` is set and `.bashrc` exists, so existing tests continue to pass.

## Notes

- Scope: smallest complete fix for #63069. `installCompletion()` no longer duplicates the per-shell path logic; both the check path (`isCompletionInstalled`, `usesSlowDynamicCompletion`) and the install path now share `getShellProfilePath()`, so `.bashrc` vs `.bash_profile` and `$ZDOTDIR`/`$XDG_CONFIG_HOME` stay consistent.
- Compatibility: when neither env var is set and `.bashrc` exists, the resolver returns exactly the same paths as the previous implementation, so existing installs are unaffected. Powershell paths are unchanged.
- Out of scope: `src/commands/doctor-completion.ts:111` and `:161` print hardcoded reload-hint strings (`source ~/.zshrc` etc.). Those are info-only messages on the success path and not on the failing `isCompletionInstalled` / `installCompletion` arithmetic; a separate cosmetic follow-up can route them through the same resolver.
- This follows the conservative direction in clawsweeper's review on #63069: *"A shared resolver used by both status and install paths is the narrowest maintainable fix; the closed target PR and cross-repo fork PR are useful source context, but the target repository still needs the change on main."*

Closes #63069
