### PR TITLE
fix(line): pack Flex extras into Reply API slots before token is consumed (#65656)

### DIFF
--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -230,11 +230,12 @@ describe("deliverLineAutoReply", () => {
       flexMessage: { altText: "Card", contents: { type: "bubble" } },
     };
     const chunkedText = ["chunk1", "chunk2", "chunk3", "chunk4"];
+    const processLineMessageOverride = ((text: string) => ({
+      text,
+      flexMessages: [createFlexMessage("Table", { type: "bubble" })],
+    })) as LineAutoReplyDeps["processLineMessage"];
     const { deps, replyMessageLine, pushMessagesLine } = createDeps({
-      processLineMessage: (text) => ({
-        text,
-        flexMessages: [{ altText: "Table", contents: { type: "bubble" } }],
-      }),
+      processLineMessage: processLineMessageOverride,
       chunkMarkdownText: () => chunkedText,
     });
 

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -81,7 +81,11 @@ describe("deliverLineAutoReply", () => {
     };
   }
 
-  it("uses reply token for text before sending rich messages", async () => {
+  it("packs rich + text into a single Reply API call when no quick replies (#65656)", async () => {
+    // Without quick replies, the Reply API can carry up to 5 messages on
+    // the same token; bundling rich/media with text avoids the free-plan
+    // 429 Push API quota error. The previous split (text->Reply, Flex->Push)
+    // would silently drop the table message on exhausted Push quota.
     const lineData = {
       flexMessage: { altText: "Card", contents: { type: "bubble" } },
     };
@@ -96,16 +100,12 @@ describe("deliverLineAutoReply", () => {
 
     expect(result.replyTokenUsed).toBe(true);
     expect(replyMessageLine).toHaveBeenCalledTimes(1);
-    expect(replyMessageLine).toHaveBeenCalledWith("token", [{ type: "text", text: "hello" }], {
-      cfg: LINE_TEST_CFG,
-      accountId: "acc",
-    });
-    expect(pushMessagesLine).toHaveBeenCalledTimes(1);
-    expect(pushMessagesLine).toHaveBeenCalledWith(
-      "line:user:1",
-      [createFlexMessage("Card", { type: "bubble" })],
+    expect(replyMessageLine).toHaveBeenCalledWith(
+      "token",
+      [createFlexMessage("Card", { type: "bubble" }), { type: "text", text: "hello" }],
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
+    expect(pushMessagesLine).not.toHaveBeenCalled();
     expect(createQuickReplyItems).not.toHaveBeenCalled();
   });
 
@@ -221,6 +221,74 @@ describe("deliverLineAutoReply", () => {
     const pushOrder = pushMessagesLine.mock.invocationCallOrder[0];
     const replyOrder = replyMessageLine.mock.invocationCallOrder[0];
     expect(pushOrder).toBeLessThan(replyOrder);
+  });
+
+  it("overflows past the 5-slot Reply API limit to Push API (#65656)", async () => {
+    // Total: 2 Flex + 4 text chunks = 6 messages.
+    // Reply API max is 5 → 5 go in Reply, 1 overflows to Push.
+    const lineData = {
+      flexMessage: { altText: "Card", contents: { type: "bubble" } },
+    };
+    const chunkedText = ["chunk1", "chunk2", "chunk3", "chunk4"];
+    const { deps, replyMessageLine, pushMessagesLine } = createDeps({
+      processLineMessage: (text) => ({
+        text,
+        flexMessages: [{ altText: "Table", contents: { type: "bubble" } }],
+      }),
+      chunkMarkdownText: () => chunkedText,
+    });
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: "hello", channelData: { line: lineData } },
+      lineData,
+      deps,
+    });
+
+    expect(result.replyTokenUsed).toBe(true);
+    expect(replyMessageLine).toHaveBeenCalledTimes(1);
+    // 2 Flex + first 3 text chunks fit; chunk4 overflows.
+    expect(replyMessageLine).toHaveBeenCalledWith(
+      "token",
+      [
+        createFlexMessage("Card", { type: "bubble" }),
+        createFlexMessage("Table", { type: "bubble" }),
+        { type: "text", text: "chunk1" },
+        { type: "text", text: "chunk2" },
+        { type: "text", text: "chunk3" },
+      ],
+      { cfg: LINE_TEST_CFG, accountId: "acc" },
+    );
+    expect(pushMessagesLine).toHaveBeenCalledTimes(1);
+    expect(pushMessagesLine).toHaveBeenCalledWith(
+      "line:user:1",
+      [{ type: "text", text: "chunk4" }],
+      { cfg: LINE_TEST_CFG, accountId: "acc" },
+    );
+  });
+
+  it("falls back to Push API for the whole batch when Reply API errors (#65656)", async () => {
+    const lineData = {
+      flexMessage: { altText: "Card", contents: { type: "bubble" } },
+    };
+    const failingReplyMessageLine = vi.fn(async () => {
+      throw new Error("reply quota exhausted");
+    });
+    const { deps, pushMessagesLine } = createDeps({
+      replyMessageLine: failingReplyMessageLine as LineAutoReplyDeps["replyMessageLine"],
+    });
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: "hello", channelData: { line: lineData } },
+      lineData,
+      deps,
+    });
+
+    expect(result.replyTokenUsed).toBe(true);
+    expect(failingReplyMessageLine).toHaveBeenCalledTimes(1);
+    // Failure pushed both rich + text via Push API.
+    expect(pushMessagesLine).toHaveBeenCalled();
   });
 
   it("falls back to push when reply token delivery fails", async () => {

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -139,30 +139,84 @@ export async function deliverLineAutoReply(params: {
   if (chunks.length > 0) {
     const hasRichOrMedia = richMessages.length > 0 || mediaMessages.length > 0;
     if (hasQuickReplies && hasRichOrMedia) {
+      // Quick replies must attach to the LAST message in the reply batch.
+      // To keep them visible, the original flow sends rich/media on the Push
+      // API FIRST and then attaches the quick reply to the trailing text in
+      // the Reply API. Preserve that quick-reply ordering.
       try {
         await sendLineMessages([...richMessages, ...mediaMessages], false);
       } catch (err) {
         deps.onReplyError?.(err);
       }
-    }
-    const { replyTokenUsed: nextReplyTokenUsed } = await deps.sendLineReplyChunks({
-      to,
-      chunks,
-      quickReplies: lineData.quickReplies,
-      replyToken,
-      replyTokenUsed,
-      cfg: params.cfg,
-      accountId,
-      replyMessageLine: deps.replyMessageLine,
-      pushMessageLine: deps.pushMessageLine,
-      pushTextMessageWithQuickReplies: deps.pushTextMessageWithQuickReplies,
-      createTextMessageWithQuickReplies: deps.createTextMessageWithQuickReplies,
-    });
-    replyTokenUsed = nextReplyTokenUsed;
-    if (!hasQuickReplies || !hasRichOrMedia) {
-      await sendLineMessages(richMessages, false);
-      if (mediaMessages.length > 0) {
-        await sendLineMessages(mediaMessages, false);
+      const { replyTokenUsed: nextReplyTokenUsed } = await deps.sendLineReplyChunks({
+        to,
+        chunks,
+        quickReplies: lineData.quickReplies,
+        replyToken,
+        replyTokenUsed,
+        cfg: params.cfg,
+        accountId,
+        replyMessageLine: deps.replyMessageLine,
+        pushMessageLine: deps.pushMessageLine,
+        pushTextMessageWithQuickReplies: deps.pushTextMessageWithQuickReplies,
+        createTextMessageWithQuickReplies: deps.createTextMessageWithQuickReplies,
+      });
+      replyTokenUsed = nextReplyTokenUsed;
+    } else if (replyToken && !replyTokenUsed && hasRichOrMedia) {
+      // No quick replies, but we have rich/media + text. Pack everything that
+      // fits into the single 5-slot Reply API call (LINE max) before the
+      // reply token is consumed; push only the overflow. This avoids the
+      // free-plan 429 on Push API when text reaches via Reply and rich
+      // messages would otherwise fall to Push (#65656).
+      const REPLY_API_MAX = 5;
+      const richAndMedia: messagingApi.Message[] = [...richMessages, ...mediaMessages];
+      const textChunkMessages: messagingApi.Message[] = chunks.map((chunk) => ({
+        type: "text",
+        text: chunk,
+      }));
+      const replyBatch = [...richAndMedia, ...textChunkMessages].slice(0, REPLY_API_MAX);
+      const overflow = [...richAndMedia, ...textChunkMessages].slice(REPLY_API_MAX);
+      try {
+        await deps.replyMessageLine(replyToken, replyBatch, {
+          cfg: params.cfg,
+          accountId,
+        });
+        replyTokenUsed = true;
+        if (overflow.length > 0) {
+          await pushLineMessages(overflow);
+        }
+      } catch (err) {
+        deps.onReplyError?.(err);
+        // Fall back to the original split: reply-chunks for text, push for rich/media.
+        replyTokenUsed = true;
+        await pushLineMessages(replyBatch);
+        if (overflow.length > 0) {
+          await pushLineMessages(overflow);
+        }
+      }
+    } else {
+      // Either no rich/media (text-only) or reply token already used: keep
+      // the existing reply-chunks path. If rich/media exist when reply token
+      // is already used (e.g. error fallback), push them after the text.
+      const { replyTokenUsed: nextReplyTokenUsed } = await deps.sendLineReplyChunks({
+        to,
+        chunks,
+        quickReplies: lineData.quickReplies,
+        replyToken,
+        replyTokenUsed,
+        cfg: params.cfg,
+        accountId,
+        replyMessageLine: deps.replyMessageLine,
+        pushMessageLine: deps.pushMessageLine,
+        pushTextMessageWithQuickReplies: deps.pushTextMessageWithQuickReplies,
+        createTextMessageWithQuickReplies: deps.createTextMessageWithQuickReplies,
+      });
+      replyTokenUsed = nextReplyTokenUsed;
+      if (hasRichOrMedia) {
+        await sendLineMessages(richMessages, false);
+        if (mediaMessages.length > 0) {
+          await sendLineMessages(mediaMessages, false);
+        }
       }
     }
   } else {


### PR DESCRIPTION
## What Problem This Solves
LINE auto-reply could consume the reply token on plain text and then send table/Flex/media extras through Push API. On free plans with Push quota exhausted, rich content was dropped with a 429 while the user only saw the explanatory text.

## Evidence
The PR body documents the current-main execution path in `extensions/line/src/auto-reply-delivery.ts`: text chunks used Reply API first, then rich/media used Push API with `allowReplyToken: false`. The fix packs all rich/media/text messages into the single quota-free Reply API call up to LINE's 5-message token limit, and only pushes overflow.

---

## Summary

LINE auto-reply previously sent text via the Reply API (max 5 messages per token, quota-free) and then sent Flex/media via the Push API (subject to the free-plan 200/month quota). Once Push quota was exhausted, table-derived Flex Messages were silently dropped with `HTTPFetchError: 429`, so users saw only the explanatory text. This change packs all rich + media + text into a single Reply API call up to the 5-message limit, then pushes only the overflow.

## Root Cause

- `extensions/line/src/auto-reply-delivery.ts:138` (before): when `chunks.length > 0`, `deliverLineAutoReply` always called `sendLineReplyChunks` first (text via Reply API) and then `sendLineMessages(richMessages, false)` / `sendLineMessages(mediaMessages, false)` afterwards (rich/media via Push API). With `allowReplyToken: false` and an already-consumed reply token, those calls reach `pushMessagesLine` unconditionally.
- LINE Messaging API contract: Reply API accepts up to 5 messages on a single token (quota-free); Push API consumes the monthly quota. Reporter on a free plan with Push quota exhausted sees `HTTPFetchError: 429 -` and the table is missing from the chat.
- Execution path: `processLineMessage()` extracts table markdown → `flexMessages: [TableFlex]` (`extensions/line/src/markdown-to-line.ts:340`) → `deliverLineAutoReply` builds `richMessages` from both `lineData.flexMessage` and `processed.flexMessages` (`auto-reply-delivery.ts:99-128`) → text chunks consume the reply token → rich `Push API` call hits 429 → Flex silently dropped.
- clawsweeper review on #65656: *"This is a narrow, valid LINE plugin bug with a clear source path, focused regression tests, no protected labels, and no open merged or pending fix PR."* and *"The narrow maintainable fix is to batch eligible rich/media messages into the same Reply API call before sendLineReplyChunks consumes the token, then push only overflow."*

## Changes

- `extensions/line/src/auto-reply-delivery.ts`: split the chunks-present branch into three sub-cases:
  - When quick replies AND rich/media exist: keep the existing order (rich/media via Push first, then text via Reply with attached `quickReply`), so the quick-reply UI stays attached to the last visible bubble.
  - When reply token is unused AND rich/media exist (the common #65656 case): build a combined `[...richMessages, ...mediaMessages, ...textChunkMessages]`, take the first 5 for a single `replyMessageLine` call, and push only the overflow. On Reply API error, fall back to pushing the entire batch so messages still reach the user.
  - Otherwise (text-only OR reply token already used): keep the prior `sendLineReplyChunks` code path unchanged; if rich/media exist with an already-consumed token, push them after the text as before.
- `extensions/line/src/auto-reply-delivery.test.ts`: update the existing `"uses reply token for text before sending rich messages"` test to assert the bundled Reply API call (the old assertion pinned the buggy split). Add `"overflows past the 5-slot Reply API limit to Push API (#65656)"` (2 Flex + 4 text → 5 in Reply, 1 in Push) and `"falls back to Push API for the whole batch when Reply API errors (#65656)"`.

Net diff: **+150 / −28 LOC across 2 files**.

## Real behavior proof

- Behavior addressed: On the LINE free Messaging API plan with Push quota exhausted, any agent reply that returns text + a Markdown table delivers only the text; the table Flex Message is silently dropped because the runtime routes it through `pushMessagesLine` AFTER the Reply API consumes the token. Reporter confirmed the workaround is to ask the agent to return raw Markdown pipe-table format (bypasses `processLineMessage`'s table-to-Flex extraction). Issue: https://github.com/openclaw/openclaw/issues/65656
- Real environment tested: Local OpenClaw checkout at `../openclaw-65656` on Windows 11 + Node 22.14. The smoke script reads the **patched production file `extensions/line/src/auto-reply-delivery.ts` directly from the worktree**, slices the patched `deliverLineAutoReply` body (offset-pinned), prints its SHA-256, and exercises it through `node --experimental-strip-types` with `vi.fn`-style stubs for the LINE SDK side effects. No mocks of the function itself; the function bytes that ship in the PR are what runs. PR head: `6ad1934e`.
- Exact steps or command run after this patch: `git checkout fix/line-reply-flex-batching && node --experimental-strip-types ./smoke-pr65656.mts`. The smoke imports the sliced production function, attaches inline `replyMessageLine` / `pushMessagesLine` stubs that log their invocations, and drives two scenarios: the reporter's exact `text + 1 Flex` case (Scenario 1) and a `2 Flex + 4 text` overflow case (Scenario 2).
- Evidence after fix: Terminal output captured locally on PR head `6ad1934e` (Windows 11 + Node 22.14; patched `deliverLineAutoReply` 7636 bytes, SHA-256 `74f91738983d8134e0b814694052297eca8dc9533db1db9df436f76a39c4f12b`).

~~~text
$ node --experimental-strip-types ./smoke-pr65656.mts
=== Patched deliverLineAutoReply — bytes from extensions/line/src/auto-reply-delivery.ts ===
offset: 1804 -> 9440 ( 7636 bytes)
SHA-256: 74f91738983d8134e0b814694052297eca8dc9533db1db9df436f76a39c4f12b

=== Scenario 1: Flex + text fits in single Reply API (the #65656 reproducer) ===
  replyMessageLine called with: 2 messages
  messages: [{"type":"flex","altText":"Card","contents":{"type":"bubble"}},{"type":"text","text":"hello"}]

=== Scenario 2: 2 Flex + 4 text overflows the 5-slot limit ===
  replyMessageLine called with: 5 messages
  messages: [{"type":"flex","altText":"Card","contents":{"type":"bubble"}},{"type":"flex","altText":"Table","contents":{"type":"bubble"}},{"type":"text","text":"chunk1"},{"type":"text","text":"chunk2"},{"type":"text","text":"chunk3"}]
  pushMessagesLine called with: 1 messages
  messages: [{"type":"text","text":"chunk4"}]
~~~

- Observed result after fix: For the reporter's scenario (Scenario 1) — 1 Flex + 1 text — the runtime makes a **single** `replyMessageLine` call carrying BOTH messages on the same reply token. `pushMessagesLine` is never invoked, so there is no Push API quota consumption and no `429` failure path. The table Flex is delivered alongside the text as required. For the overflow scenario (Scenario 2) — 2 Flex + 4 text = 6 total messages — the Reply API gets the first 5 (`[Flex, Flex, chunk1, chunk2, chunk3]`) and only `chunk4` overflows to `pushMessagesLine`. This proves both that the bug is fixed for the common case AND that the 5-slot Reply API limit is respected when there are too many messages. SHA-256 `74f91738983d8134e0b814694052297eca8dc9533db1db9df436f76a39c4f12b` pins the proof to the exact source bytes this PR ships.
- What was not tested: A live exhausted-quota LINE Messaging API account was not exercised on the contributor machine (would need a paid/free LINE bot with the 200 monthly Push messages already consumed). The fix is a delivery-layer ordering change inside `deliverLineAutoReply`; downstream `replyMessageLine` / `pushMessagesLine` adapters are unchanged, and the LINE SDK serialises `messagingApi.Message[]` verbatim, so the only behavioural change is which API receives which messages. Maintainers may apply `proof: override` if a live LINE recording is required; the reporter's issue already includes a real 429 log from a free-plan account.

## Test

- `pnpm test extensions/line/src/auto-reply-delivery.test.ts` — 4 existing cases + 2 new regression cases for #65656 (overflow + Reply API failure fallback). The pre-existing `"uses reply token for text before sending rich messages"` test was updated to assert the corrected single-Reply-API call (its previous assertion pinned the buggy split).
- `pnpm test extensions/line/src/reply-chunks.test.ts` — unchanged; the new code path bypasses `sendLineReplyChunks` only when there is no quick reply AND there is rich/media, so the reply-chunks helper is exercised exactly as before in its existing test scenarios.

## Notes

- Scope: single issue, single file production change plus colocated test updates. No new public seam, no signature change on `sendLineReplyChunks` (existing callers / `outbound.ts` / `bot-message-context` paths are untouched).
- Compatibility: when quick replies exist, the prior ordering is preserved verbatim so existing quick-reply UX (visible attached to the last bubble) does not regress. The reply-chunks helper still handles text-only and already-used-token cases unchanged.
- Failure semantics: if `replyMessageLine` throws (e.g. an invalid token), the new branch pushes the entire batch (rich + text) so the user still receives every message, mirroring the existing `pushLineMessages` fallback semantics in the same function.
- This follows the conservative direction in clawsweeper's review on #65656: *"The narrow maintainable fix is to batch eligible rich/media messages into the same Reply API call before sendLineReplyChunks consumes the token, then push only overflow; the closed allowReplyToken-only PR was not sufficient."*

Closes #65656
