### PR TITLE
codex: plumb session reasoningLevel into codex model_reasoning_summary

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -122,7 +122,13 @@ describe("Codex app-server reasoning summary plumbing", () => {
     expect(request.config).toMatchObject({ model_reasoning_summary: "auto" });
   });
 
-  it("sets model_reasoning_summary=none on thread/start when reasoningLevel=off", () => {
+  // openclaw defaults a missing reasoningLevel to "off" at several callsites
+  // (commands-btw, directive-handling, get-reply-directives), so we cannot
+  // distinguish "user explicitly set off" from "openclaw filled in a default".
+  // To avoid clobbering a user's `~/.codex/config.toml` setting from a default
+  // value, the extension does NOT emit model_reasoning_summary for "off".
+  // Users wanting summaries off should set it in codex config.toml directly.
+  it("omits model_reasoning_summary on thread/start when reasoningLevel=off (default-or-explicit; preserves codex config.toml)", () => {
     const request = buildThreadStartParams(
       createAttemptParams({ provider: "openai", reasoningLevel: "off" }),
       {
@@ -132,7 +138,7 @@ describe("Codex app-server reasoning summary plumbing", () => {
         developerInstructions: "test instructions",
       },
     );
-    expect(request.config).toMatchObject({ model_reasoning_summary: "none" });
+    expect(request.config).not.toHaveProperty("model_reasoning_summary");
   });
 
   it("plumbs model_reasoning_summary on thread/resume as well", () => {
@@ -171,16 +177,16 @@ describe("Codex app-server reasoning summary plumbing", () => {
   });
 
   describe("resolveCodexReasoningSummary", () => {
-    it("maps off → none", () => {
-      expect(resolveCodexReasoningSummary("off")).toBe("none");
-    });
     it("maps on → auto", () => {
       expect(resolveCodexReasoningSummary("on")).toBe("auto");
     });
     it("maps stream → auto", () => {
       expect(resolveCodexReasoningSummary("stream")).toBe("auto");
     });
-    it("returns undefined for unset (preserves codex defaults)", () => {
+    it("returns undefined for off (cannot distinguish explicit-off from openclaw default)", () => {
+      expect(resolveCodexReasoningSummary("off")).toBeUndefined();
+    });
+    it("returns undefined for unset (preserves codex config.toml defaults)", () => {
       expect(resolveCodexReasoningSummary(undefined)).toBeUndefined();
     });
     it("returns undefined for unknown values (forwards-compat)", () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildThreadResumeParams,
   buildThreadStartParams,
+  resolveCodexReasoningSummary,
   resolveReasoningEffort,
 } from "./thread-lifecycle.js";
 
@@ -11,6 +12,7 @@ function createAttemptParams(params: {
   authProfileId?: string;
   authProfileProvider?: string;
   authProfileProviders?: Record<string, string>;
+  reasoningLevel?: string;
 }): EmbeddedRunAttemptParams {
   const authProfileProviders =
     params.authProfileProviders ??
@@ -21,6 +23,7 @@ function createAttemptParams(params: {
     provider: params.provider,
     modelId: "gpt-5.4",
     authProfileId: params.authProfileId,
+    reasoningLevel: params.reasoningLevel,
     authProfileStore: {
       version: 1,
       profiles: Object.fromEntries(
@@ -78,6 +81,110 @@ describe("Codex app-server native code mode config", () => {
     expect(request.config).toEqual({
       "features.code_mode": true,
       "features.code_mode_only": true,
+    });
+  });
+});
+
+describe("Codex app-server reasoning summary plumbing", () => {
+  it("omits model_reasoning_summary when reasoningLevel is unset (preserves user's codex config.toml)", () => {
+    const request = buildThreadStartParams(createAttemptParams({ provider: "openai" }), {
+      cwd: "/repo",
+      dynamicTools: [],
+      appServer: createAppServerOptions() as never,
+      developerInstructions: "test instructions",
+    });
+    expect(request.config).not.toHaveProperty("model_reasoning_summary");
+  });
+
+  it("sets model_reasoning_summary=auto on thread/start when reasoningLevel=stream", () => {
+    const request = buildThreadStartParams(
+      createAttemptParams({ provider: "openai", reasoningLevel: "stream" }),
+      {
+        cwd: "/repo",
+        dynamicTools: [],
+        appServer: createAppServerOptions() as never,
+        developerInstructions: "test instructions",
+      },
+    );
+    expect(request.config).toMatchObject({ model_reasoning_summary: "auto" });
+  });
+
+  it("sets model_reasoning_summary=auto on thread/start when reasoningLevel=on", () => {
+    const request = buildThreadStartParams(
+      createAttemptParams({ provider: "openai", reasoningLevel: "on" }),
+      {
+        cwd: "/repo",
+        dynamicTools: [],
+        appServer: createAppServerOptions() as never,
+        developerInstructions: "test instructions",
+      },
+    );
+    expect(request.config).toMatchObject({ model_reasoning_summary: "auto" });
+  });
+
+  it("sets model_reasoning_summary=none on thread/start when reasoningLevel=off", () => {
+    const request = buildThreadStartParams(
+      createAttemptParams({ provider: "openai", reasoningLevel: "off" }),
+      {
+        cwd: "/repo",
+        dynamicTools: [],
+        appServer: createAppServerOptions() as never,
+        developerInstructions: "test instructions",
+      },
+    );
+    expect(request.config).toMatchObject({ model_reasoning_summary: "none" });
+  });
+
+  it("plumbs model_reasoning_summary on thread/resume as well", () => {
+    const request = buildThreadResumeParams(
+      createAttemptParams({ provider: "openai", reasoningLevel: "stream" }),
+      {
+        threadId: "thread-1",
+        appServer: createAppServerOptions() as never,
+        developerInstructions: "test instructions",
+      },
+    );
+    expect(request.config).toMatchObject({ model_reasoning_summary: "auto" });
+  });
+
+  it("does not clobber other config entries when injecting reasoning summary", () => {
+    const request = buildThreadStartParams(
+      createAttemptParams({ provider: "openai", reasoningLevel: "stream" }),
+      {
+        cwd: "/repo",
+        dynamicTools: [],
+        appServer: createAppServerOptions() as never,
+        developerInstructions: "test instructions",
+        config: {
+          "features.codex_hooks": true,
+          apps: { _default: { enabled: false } },
+        },
+      },
+    );
+    expect(request.config).toEqual({
+      "features.codex_hooks": true,
+      apps: { _default: { enabled: false } },
+      "features.code_mode": true,
+      "features.code_mode_only": true,
+      model_reasoning_summary: "auto",
+    });
+  });
+
+  describe("resolveCodexReasoningSummary", () => {
+    it("maps off → none", () => {
+      expect(resolveCodexReasoningSummary("off")).toBe("none");
+    });
+    it("maps on → auto", () => {
+      expect(resolveCodexReasoningSummary("on")).toBe("auto");
+    });
+    it("maps stream → auto", () => {
+      expect(resolveCodexReasoningSummary("stream")).toBe("auto");
+    });
+    it("returns undefined for unset (preserves codex defaults)", () => {
+      expect(resolveCodexReasoningSummary(undefined)).toBeUndefined();
+    });
+    it("returns undefined for unknown values (forwards-compat)", () => {
+      expect(resolveCodexReasoningSummary("future-value")).toBeUndefined();
     });
   });
 });

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -300,6 +300,10 @@ export function buildThreadStartParams(
     agentDir: params.agentDir,
     config: params.config,
   });
+  const reasoningPatch = reasoningSummaryConfigPatch(params.reasoningLevel);
+  const mergedConfig = reasoningPatch
+    ? (mergeCodexThreadConfigs(options.config, reasoningPatch) ?? reasoningPatch)
+    : options.config;
   return {
     model: params.modelId,
     ...(modelProvider ? { modelProvider } : {}),
@@ -309,7 +313,7 @@ export function buildThreadStartParams(
     sandbox: options.appServer.sandbox,
     ...(options.appServer.serviceTier ? { serviceTier: options.appServer.serviceTier } : {}),
     serviceName: "OpenClaw",
-    config: buildCodexRuntimeThreadConfig(options.config),
+    config: buildCodexRuntimeThreadConfig(mergedConfig),
     developerInstructions: options.developerInstructions ?? buildDeveloperInstructions(params),
     dynamicTools: options.dynamicTools,
     experimentalRawEvents: true,
@@ -334,6 +338,10 @@ export function buildThreadResumeParams(
     agentDir: params.agentDir,
     config: params.config,
   });
+  const reasoningPatch = reasoningSummaryConfigPatch(params.reasoningLevel);
+  const mergedConfig = reasoningPatch
+    ? (mergeCodexThreadConfigs(options.config, reasoningPatch) ?? reasoningPatch)
+    : options.config;
   return {
     threadId: options.threadId,
     model: params.modelId,
@@ -342,7 +350,7 @@ export function buildThreadResumeParams(
     approvalsReviewer: options.appServer.approvalsReviewer,
     sandbox: options.appServer.sandbox,
     ...(options.appServer.serviceTier ? { serviceTier: options.appServer.serviceTier } : {}),
-    config: buildCodexRuntimeThreadConfig(options.config),
+    config: buildCodexRuntimeThreadConfig(mergedConfig),
     developerInstructions: options.developerInstructions ?? buildDeveloperInstructions(params),
     persistExtendedHistory: true,
   };
@@ -354,6 +362,46 @@ export function buildCodexRuntimeThreadConfig(config: JsonObject | undefined): J
       ...CODEX_CODE_MODE_THREAD_CONFIG,
     }
   );
+}
+
+// Map the openclaw session-level `reasoningLevel` preference (off/on/stream)
+// to the codex `model_reasoning_summary` config value (none/auto/concise/detailed).
+//
+// Without this, codex's app-server falls back to its built-in default of
+// `summary = "none"` — codex still *thinks*, but never emits
+// `item/reasoning/summaryTextDelta` notifications, so openclaw's
+// `CodexAppServerEventProjector` (which already handles those deltas) has
+// nothing to forward to the chat client. End result: long codex turns appear
+// silent to the user until the final answer arrives.
+//
+// The pi-embedded runtime already does the equivalent mapping via
+// `openai-transport-stream.ts` — this brings the codex app-server path to
+// parity.
+//
+// Returns `undefined` when reasoningLevel is unset so codex preserves whatever
+// `model_reasoning_summary` is configured in the user's `~/.codex/config.toml`.
+// Returns `undefined` for unknown values (forwards-compat with future enum
+// additions).
+export function resolveCodexReasoningSummary(
+  reasoningLevel: string | undefined,
+): "auto" | "none" | undefined {
+  if (!reasoningLevel) {
+    return undefined;
+  }
+  switch (reasoningLevel) {
+    case "off":
+      return "none";
+    case "on":
+    case "stream":
+      return "auto";
+    default:
+      return undefined;
+  }
+}
+
+function reasoningSummaryConfigPatch(reasoningLevel: string | undefined): JsonObject | undefined {
+  const summary = resolveCodexReasoningSummary(reasoningLevel);
+  return summary === undefined ? undefined : { model_reasoning_summary: summary };
 }
 
 export function buildTurnStartParams(

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -364,10 +364,10 @@ export function buildCodexRuntimeThreadConfig(config: JsonObject | undefined): J
   );
 }
 
-// Map the openclaw session-level `reasoningLevel` preference (off/on/stream)
-// to the codex `model_reasoning_summary` config value (none/auto/concise/detailed).
+// Map the openclaw session-level `reasoningLevel` preference to the codex
+// `model_reasoning_summary` config value, on positive opt-in only.
 //
-// Without this, codex's app-server falls back to its built-in default of
+// Without this, the codex app-server falls back to its built-in default of
 // `summary = "none"` — codex still *thinks*, but never emits
 // `item/reasoning/summaryTextDelta` notifications, so openclaw's
 // `CodexAppServerEventProjector` (which already handles those deltas) has
@@ -378,19 +378,20 @@ export function buildCodexRuntimeThreadConfig(config: JsonObject | undefined): J
 // `openai-transport-stream.ts` — this brings the codex app-server path to
 // parity.
 //
-// Returns `undefined` when reasoningLevel is unset so codex preserves whatever
-// `model_reasoning_summary` is configured in the user's `~/.codex/config.toml`.
-// Returns `undefined` for unknown values (forwards-compat with future enum
-// additions).
+// Important: openclaw defaults a missing `reasoningLevel` to `"off"` at
+// several callsites (commands-btw, directive-handling, get-reply-directives,
+// etc.), so by the time the value reaches this extension we cannot
+// distinguish "user explicitly set off" from "openclaw filled in a default".
+// We therefore only emit `model_reasoning_summary` for the positive opt-ins
+// (`"on"`, `"stream"`). For everything else — including `"off"` and unset —
+// we return `undefined` so codex's own default (or whatever the user has set
+// in `~/.codex/config.toml`) wins. Users who want to actively suppress
+// summaries can set `model_reasoning_summary = "none"` in their codex
+// config.toml; this extension will not override that.
 export function resolveCodexReasoningSummary(
   reasoningLevel: string | undefined,
-): "auto" | "none" | undefined {
-  if (!reasoningLevel) {
-    return undefined;
-  }
+): "auto" | undefined {
   switch (reasoningLevel) {
-    case "off":
-      return "none";
     case "on":
     case "stream":
       return "auto";


### PR DESCRIPTION
## Problem

The codex app-server defaults `model_reasoning_summary` to `"none"` when it isnt explicitly configured. As a result codex still produces reasoning items internally (visible in its rollout `.jsonl`) but never emits `item/reasoning/summaryTextDelta` notifications. That leaves `CodexAppServerEventProjector.handleReasoningDelta` with nothing to project — long codex turns appear silent in any UI subscribed to the gateway until the final answer arrives.

The pi-embedded runtime already maps session reasoning preferences into `reasoning.summary` via `openai-transport-stream.ts`. This brings the codex app-server path to parity.

## Repro before this change

1. Configure an agent with `agentRuntime.id: "codex"`.
2. `sessions.patch` `{ reasoningLevel: "stream" }`.
3. Send a prompt that requires multi-step reasoning.
4. Inspect `~/.openclaw/agents/<id>/agent/codex-home/sessions/.../rollout-*.jsonl`: reasoning items are present but every one has `"summary": []`. The session trajectory has zero reasoning events.

## Change

- New helper `resolveCodexReasoningSummary(level)`:
  - `"off"` → `"none"`
  - `"on"` / `"stream"` → `"auto"`
  - unset / unknown → `undefined` (preserves the user's `~/.codex/config.toml` or codex's own default; no behavior change for callers that haven't opted in)
- `buildThreadStartParams` and `buildThreadResumeParams` merge `{ model_reasoning_summary }` into the thread config patch (same plumbing as `features.code_mode`).

## Tests

8 new tests in `thread-lifecycle.test.ts` covering each mapping, the unset/unknown passthrough cases, the no-clobber merge with other config keys, and the thread/resume parity path. All 35 tests in the file pass.

## Compatibility

- No schema change. `reasoningLevel` is already accepted by the `sessions.patch` schema; this only makes the codex extension honor it.
- Default behavior unchanged for sessions where `reasoningLevel` is unset — codex's own default (and any user `~/.codex/config.toml`) still wins.
- No protocol or wire-format changes; `model_reasoning_summary` is a config key codex already understands


## PR-path real behavior proof — controlled before/after on the same prompt

Captured live on an LXC running `openclaw 2026.5.7` / `@openclaw/codex 2026.5.7` / `@openai/codex 0.128.0`, model `gpt-5.5` via ChatGPT subscription OAuth. Token / email / hostname / full UUIDs redacted.

### Setup invariants (both runs)

```sh
$ cat ~/.openclaw/agents/coder/agent/codex-home/config.toml
[projects."/home/devuser/.openclaw/workspace-coder"]
trust_level = "trusted"
# (no model_reasoning_summary set — the only thing that can produce summaries
#  is the extension's thread/start config)
```

- Same agent (`agent:coder:main`, `agentRuntime.id: "codex"`)
- Same prompt: `"What is 17 times 23? Briefly explain your reasoning."`
- Same `sessions.patch` payload: `{ thinkingLevel: "medium", reasoningLevel: "stream" }`
- Binding cleared and gateway restarted between runs so each takes the `thread/start` path

---

### BEFORE — stock `@openclaw/codex 2026.5.7` bundle

Bundle confirmation:
```sh
$ grep -c 'resolveCodexReasoningSummary\|model_reasoning_summary\|reasoningSummary' \
    ~/.openclaw/npm/node_modules/@openclaw/codex/dist/thread-lifecycle-CzllX4PU.js
0
```

Live gateway WS run:
```
2026-05-13T13:01:33.540Z <- connect.challenge
2026-05-13T13:01:33.542Z -> connect (sent)
2026-05-13T13:01:33.574Z <- connect ok
2026-05-13T13:01:33.574Z -> sessions.patch { reasoningLevel: stream, thinkingLevel: medium }
2026-05-13T13:01:34.229Z <- sessions.patch ok
2026-05-13T13:01:34.229Z -> chat.send
2026-05-13T13:01:34.237Z <- chat.send ok runId=before-…
```

Session pref persisted (gateway state):
```json
{ "thinkingLevel": "medium", "reasoningLevel": "stream" }
```

Codex `turn_context` (in the rollout):
```json
{ "model": "gpt-5.5", "effort": "medium", "summary": "none" }
```

Rollout event-type counts:
```
   4  reasoning            (all 4 with "summary": [])
   1  turn_context
   1  agent_message
   0  summary_text
```

**Net effect**: `sessions.patch reasoningLevel: "stream"` is accepted and persisted on the openclaw side, but the codex extension never plumbs it into the codex `thread/start` config — codex defaults `summary` to `"none"`, emits reasoning items with empty summary arrays, **zero `summary_text` events**, **zero `item/reasoning/summaryTextDelta` notifications** for `CodexAppServerEventProjector.handleReasoningDelta` to forward. Net silence to subscribers.

---

### AFTER — bundle patched with this PR's logic

Bundle patched in place to apply the diff from this PR (helper + `buildThreadStartParams` config merge); a one-line `process.stderr.write("[pr-patch] reasoningLevel=… summary=… pid=…")` probe added inside `reasoningSummaryConfigPatch` to prove the helper fires at runtime.

```sh
$ grep -c 'resolveCodexReasoningSummary\|model_reasoning_summary' \
    ~/.openclaw/npm/node_modules/@openclaw/codex/dist/thread-lifecycle-CzllX4PU.js
3
$ node -c ~/.openclaw/npm/node_modules/@openclaw/codex/dist/thread-lifecycle-CzllX4PU.js && echo syntax OK
syntax OK
```

Live gateway WS run (same payload, same prompt):
```
2026-05-13T13:03:00.445Z <- connect.challenge
2026-05-13T13:03:00.447Z -> connect (sent)
2026-05-13T13:03:00.483Z <- connect ok
2026-05-13T13:03:00.484Z -> sessions.patch { reasoningLevel: stream, thinkingLevel: medium }
2026-05-13T13:03:01.040Z <- sessions.patch ok
2026-05-13T13:03:01.041Z -> chat.send
2026-05-13T13:03:01.049Z <- chat.send ok runId=after-…
```

Gateway journal — PR helper probe fires with the session pref:
```
May 13 13:03:24 warm-… node[63576]: [pr-patch] reasoningLevel=stream summary=auto pid=63576
```

Codex `turn_context`:
```json
{ "model": "gpt-5.5", "effort": "medium", "summary": "auto" }
```

Rollout event-type counts:
```
   2  reasoning            (1 of 2 with non-empty summary)
   1  summary_text         <-- NEW
   1  turn_context
   1  agent_message
```

Captured `summary_text` content (excerpt, from the reasoning item):
```
**Checking for BOOTSTRAP**

I need to find out if BOOTSTRAP exists, especially since it seems like rg
isn't available. We didn't check with find yet, but maybe just checking if
BOOTSTRAP is there will be enough. I've noticed that the exec returned a
failure with rg. I might need to check the files using ls. This task seems
simple, but I must determine if BOOTSTRAP exists before proceeding with
any follow-up actions or deletions.
```

Final assistant answer (unchanged between runs):
```
17 × 23 = 391.

Reasoning: 17 × 20 = 340, and 17 × 3 = 51. Add them: 340 + 51 = 391.
```

---

### Side-by-side

| | session pref accepted | codex `turn_context.summary` | reasoning items / empty | `summary_text` events |
|---|---|---|---|---|
| BEFORE (stock bundle) | ✓ | `"none"` | 4 / 4 empty | **0** |
| AFTER (PR-patched bundle) | ✓ | `"auto"` | 2 / 1 empty | **1** |

The `item/reasoning/summaryTextDelta` stream this AFTER run produces is what `CodexAppServerEventProjector.handleReasoningDelta` (`extensions/codex/src/app-server/event-projector.ts`, also visible in the installed bundle at `run-attempt-BaT_FcTv.js:1173`) already forwards as reasoning deltas to subscribed clients — no projector change needed.

### Notes

- Probe + bundle patch were applied only for proof capture on this LXC; the PR source contains the same logic at `extensions/codex/src/app-server/thread-lifecycle.ts` (commits `6cec5562` + `8a7388dd`).
- Codex's `"auto"` mode is non-deterministic — the model decides whether a given turn warrants emitting summary text. On trivial prompts it sometimes opts out (we observed this on a couple of math turns). `"auto"` was chosen to match the existing pi-embedded behavior (`src/agents/openai-transport-stream.ts:1380: summary: options?.reasoningSummary || "auto"`). Forcing `"detailed"` in the patched bundle confirmed the path also produces summary text on those same trivial prompts.
- The follow-up commit (`8a7388dd`) responds to the previous review by dropping the `"off"` → `"none"` mapping, so the PR no longer clobbers a user's `~/.codex/config.toml` from openclaw's `"off"` default.


if you need more detailed logs, let me know. I can add.


