### PR TITLE
Fix stale diagnostic lanes for reply runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: discard legacy long-poll update offsets that cannot be tied to the current bot token, so token rotation no longer leaves bots silently skipping new messages. (#80671) Thanks @sxxtony.
 - browser: enforce navigation checks for act interactions [AI]. (#81070) Thanks @pgondhi987.
 - Validate node exec event provenance [AI]. (#81071) Thanks @pgondhi987.
+- Gateway: keep active reply runs visible to stuck-session diagnostics and clear no-active-work recovery state, preventing stale queued lanes after compaction or tool failures. Fixes #80677.
 - Limit hook CLI tool authority [AI]. (#81065) Thanks @pgondhi987.
 - Require admin scope for node device token management [AI]. (#81067) Thanks @pgondhi987.
 - Restrict chat sender allowlist matching [AI]. (#80898) Thanks @pgondhi987.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: discard legacy long-poll update offsets that cannot be tied to the current bot token, so token rotation no longer leaves bots silently skipping new messages. (#80671) Thanks @sxxtony.
 - browser: enforce navigation checks for act interactions [AI]. (#81070) Thanks @pgondhi987.
 - Validate node exec event provenance [AI]. (#81071) Thanks @pgondhi987.
-- Gateway: keep active reply runs visible to stuck-session diagnostics and clear no-active-work recovery state, preventing stale queued lanes after compaction or tool failures. Fixes #80677.
+- Gateway: keep active reply runs visible to stuck-session diagnostics and clear no-active-work recovery state, preventing stale queued lanes after compaction or tool failures. Fixes #80677. (#81302)
 - Limit hook CLI tool authority [AI]. (#81065) Thanks @pgondhi987.
 - Require admin scope for node device token management [AI]. (#81067) Thanks @pgondhi987.
 - Restrict chat sender allowlist matching [AI]. (#80898) Thanks @pgondhi987.

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  getDiagnosticSessionActivitySnapshot,
+  resetDiagnosticRunActivityForTest,
+} from "../../logging/diagnostic-run-activity.js";
+import {
   __testing,
   abortActiveReplyRuns,
   createReplyOperation,
@@ -14,6 +18,7 @@ import {
 describe("reply run registry", () => {
   afterEach(() => {
     __testing.resetReplyRunRegistry();
+    resetDiagnosticRunActivityForTest();
     vi.restoreAllMocks();
   });
 
@@ -49,6 +54,39 @@ describe("reply run registry", () => {
       await vi.runOnlyPendingTimersAsync();
       vi.useRealTimers();
     }
+  });
+
+  it("mirrors active reply operations into diagnostic work state", () => {
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:telegram:direct:chat-1",
+      sessionId: "session-1",
+      resetTriggered: false,
+    });
+
+    expect(
+      getDiagnosticSessionActivitySnapshot({
+        sessionId: "session-1",
+        sessionKey: "agent:main:telegram:direct:chat-1",
+      }).activeWorkKind,
+    ).toBe("embedded_run");
+
+    operation.updateSessionId("session-2");
+
+    expect(
+      getDiagnosticSessionActivitySnapshot({
+        sessionId: "session-2",
+        sessionKey: "agent:main:telegram:direct:chat-1",
+      }).activeWorkKind,
+    ).toBe("embedded_run");
+
+    operation.complete();
+
+    expect(
+      getDiagnosticSessionActivitySnapshot({
+        sessionId: "session-2",
+        sessionKey: "agent:main:telegram:direct:chat-1",
+      }).activeWorkKind,
+    ).toBeUndefined();
   });
 
   it("clears queued operations immediately on user abort", () => {

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -1,3 +1,7 @@
+import {
+  markDiagnosticEmbeddedRunEnded,
+  markDiagnosticEmbeddedRunStarted,
+} from "../../logging/diagnostic-run-activity.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 
@@ -181,16 +185,36 @@ function getAttachedBackend(operation: ReplyOperation): ReplyBackendHandle | und
 
 function clearReplyRunState(params: { sessionKey: string; sessionId: string }): void {
   replyRunState.activeRunsByKey.delete(params.sessionKey);
-  if (replyRunState.activeSessionIdsByKey.get(params.sessionKey) === params.sessionId) {
-    replyRunState.activeSessionIdsByKey.delete(params.sessionKey);
-  } else {
-    replyRunState.activeSessionIdsByKey.delete(params.sessionKey);
-  }
+  replyRunState.activeSessionIdsByKey.delete(params.sessionKey);
   if (replyRunState.activeKeysBySessionId.get(params.sessionId) === params.sessionKey) {
     replyRunState.activeKeysBySessionId.delete(params.sessionId);
   }
   clearWaitSessionIds(params.sessionKey);
   notifyReplyRunEnded(params.sessionKey);
+}
+
+function replyRunDiagnosticWorkKey(sessionKey: string): string {
+  return `reply:${sessionKey}`;
+}
+
+function markReplyRunDiagnosticWorkStarted(params: {
+  sessionKey: string;
+  sessionId: string;
+}): void {
+  markDiagnosticEmbeddedRunStarted({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    workKey: replyRunDiagnosticWorkKey(params.sessionKey),
+  });
+}
+
+function markReplyRunDiagnosticWorkEnded(params: { sessionKey: string; sessionId: string }): void {
+  markDiagnosticEmbeddedRunEnded({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    workKey: replyRunDiagnosticWorkKey(params.sessionKey),
+    clearRunActivity: false,
+  });
 }
 
 export function createReplyOperation(params: {
@@ -222,6 +246,7 @@ export function createReplyOperation(params: {
       return;
     }
     stateCleared = true;
+    markReplyRunDiagnosticWorkEnded({ sessionKey, sessionId: currentSessionId });
     clearReplyRunState({
       sessionKey,
       sessionId: currentSessionId,
@@ -308,6 +333,7 @@ export function createReplyOperation(params: {
       replyRunState.activeSessionIdsByKey.set(sessionKey, currentSessionId);
       replyRunState.activeKeysBySessionId.set(currentSessionId, sessionKey);
       registerWaitSessionId(sessionKey, currentSessionId);
+      markReplyRunDiagnosticWorkStarted({ sessionKey, sessionId: currentSessionId });
     },
     attachBackend(handle) {
       if (result) {
@@ -372,6 +398,7 @@ export function createReplyOperation(params: {
   replyRunState.activeSessionIdsByKey.set(sessionKey, currentSessionId);
   replyRunState.activeKeysBySessionId.set(currentSessionId, sessionKey);
   registerWaitSessionId(sessionKey, currentSessionId);
+  markReplyRunDiagnosticWorkStarted({ sessionKey, sessionId: currentSessionId });
 
   return operation;
 }
@@ -530,6 +557,9 @@ export function listActiveReplyRunSessionIds(): string[] {
 
 export const __testing = {
   resetReplyRunRegistry(): void {
+    for (const [sessionKey, sessionId] of replyRunState.activeSessionIdsByKey) {
+      markReplyRunDiagnosticWorkEnded({ sessionKey, sessionId });
+    }
     replyRunState.activeRunsByKey.clear();
     replyRunState.activeSessionIdsByKey.clear();
     replyRunState.activeKeysBySessionId.clear();

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -7,7 +7,7 @@ import {
 type SessionActivity = {
   sessionId?: string;
   sessionKey?: string;
-  activeEmbeddedRun: boolean;
+  activeEmbeddedRuns: Set<string>;
   activeTools: Map<string, ActiveTool>;
   activeModelCalls: Set<string>;
   lastProgressAt: number;
@@ -81,7 +81,9 @@ function replaceSessionActivityReferences(source: SessionActivity, target: Sessi
 function mergeSessionActivity(target: SessionActivity, source: SessionActivity): void {
   target.sessionId ??= source.sessionId;
   target.sessionKey ??= source.sessionKey;
-  target.activeEmbeddedRun ||= source.activeEmbeddedRun;
+  for (const key of source.activeEmbeddedRuns) {
+    target.activeEmbeddedRuns.add(key);
+  }
   for (const [key, tool] of source.activeTools) {
     target.activeTools.set(key, tool);
   }
@@ -133,7 +135,7 @@ function resolveSessionActivity(params: {
   const created: SessionActivity = {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
-    activeEmbeddedRun: false,
+    activeEmbeddedRuns: new Set(),
     activeTools: new Map(),
     activeModelCalls: new Set(),
     lastProgressAt: Date.now(),
@@ -232,34 +234,43 @@ function recordRunCompleted(
   activityByRunId.delete(event.runId);
   activity.activeTools.clear();
   activity.activeModelCalls.clear();
-  activity.activeEmbeddedRun = false;
+  activity.activeEmbeddedRuns.clear();
   touchSessionActivity(activity, "run:completed");
 }
 
 export function markDiagnosticEmbeddedRunStarted(params: {
   sessionId: string;
   sessionKey?: string;
+  workKey?: string;
 }): void {
   const activity = resolveSessionActivity({ ...params, create: true });
   if (!activity) {
     return;
   }
-  activity.activeEmbeddedRun = true;
+  activity.activeEmbeddedRuns.add(resolveEmbeddedRunWorkKey(params));
   touchSessionActivity(activity, "embedded_run:started");
 }
 
 export function markDiagnosticEmbeddedRunEnded(params: {
   sessionId: string;
   sessionKey?: string;
+  workKey?: string;
+  clearRunActivity?: boolean;
 }): void {
   const activity = resolveSessionActivity(params);
   if (!activity) {
     return;
   }
-  activity.activeEmbeddedRun = false;
-  activity.activeTools.clear();
-  activity.activeModelCalls.clear();
+  activity.activeEmbeddedRuns.delete(resolveEmbeddedRunWorkKey(params));
+  if (params.clearRunActivity !== false) {
+    activity.activeTools.clear();
+    activity.activeModelCalls.clear();
+  }
   touchSessionActivity(activity, "embedded_run:ended");
+}
+
+function resolveEmbeddedRunWorkKey(params: { sessionId: string; workKey?: string }): string {
+  return params.workKey ?? params.sessionId;
 }
 
 export function getDiagnosticSessionActivitySnapshot(
@@ -276,7 +287,7 @@ export function getDiagnosticSessionActivitySnapshot(
     activeWorkKind = "tool_call";
   } else if (activity.activeModelCalls.size > 0) {
     activeWorkKind = "model_call";
-  } else if (activity.activeEmbeddedRun) {
+  } else if (activity.activeEmbeddedRuns.size > 0) {
     activeWorkKind = "embedded_run";
   }
 

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -2,6 +2,7 @@ import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { markDiagnosticActivity as markActivity } from "./diagnostic-runtime.js";
 import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
 import {
+  recoveryOutcomeClearsQueuedSessionState,
   recoveryOutcomeMutatesSessionState,
   recoveryOutcomeReleasedCount,
   type StuckSessionRecoveryOutcome,
@@ -107,8 +108,9 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
   state.generation = (state.generation ?? 0) + 1;
   state.lastStuckWarnAgeMs = undefined;
   state.lastLongRunningWarnAgeMs = undefined;
-  const released = recoveryOutcomeReleasedCount(params.outcome);
-  state.queueDepth = released > 0 ? 0 : Math.max(0, state.queueDepth - 1);
+  state.queueDepth = recoveryOutcomeClearsQueuedSessionState(params.outcome)
+    ? 0
+    : Math.max(0, state.queueDepth - 1);
   emitDiagnosticEvent({
     type: "session.state",
     sessionId: state.sessionId,

--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -73,7 +73,20 @@ export function recoveryOutcomeMutatesSessionState(
   if (!outcome) {
     return false;
   }
-  return outcome.status === "aborted" || outcome.status === "released";
+  return (
+    outcome.status === "aborted" ||
+    outcome.status === "released" ||
+    (outcome.status === "noop" && outcome.reason === "no_active_work")
+  );
+}
+
+export function recoveryOutcomeClearsQueuedSessionState(
+  outcome: StuckSessionRecoveryOutcome,
+): boolean {
+  return (
+    outcome.status === "released" ||
+    (outcome.status === "noop" && outcome.reason === "no_active_work")
+  );
 }
 
 export function recoveryOutcomeReleasedCount(outcome: StuckSessionRecoveryOutcome): number {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -12,6 +12,7 @@ import { withDiagnosticPhase } from "./diagnostic-phase.js";
 import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticRunProgressForTest,
+  markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
   markDiagnosticToolStartedForTest,
 } from "./diagnostic-run-activity.js";
@@ -245,6 +246,32 @@ describe("diagnostic session activity aliases", () => {
     expect(getDiagnosticSessionActivitySnapshot({ sessionId: "s1" }).activeWorkKind).toBe(
       "embedded_run",
     );
+  });
+
+  it("keeps embedded diagnostic work active until every owner ends", () => {
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+    markDiagnosticEmbeddedRunStarted({
+      sessionId: "s1",
+      sessionKey: "main",
+      workKey: "reply:main",
+    });
+
+    markDiagnosticEmbeddedRunEnded({
+      sessionId: "s1",
+      sessionKey: "main",
+      workKey: "reply:main",
+      clearRunActivity: false,
+    });
+
+    expect(getDiagnosticSessionActivitySnapshot({ sessionId: "s1", sessionKey: "main" })).toEqual(
+      expect.objectContaining({ activeWorkKind: "embedded_run" }),
+    );
+
+    markDiagnosticEmbeddedRunEnded({ sessionId: "s1", sessionKey: "main" });
+
+    expect(
+      getDiagnosticSessionActivitySnapshot({ sessionId: "s1", sessionKey: "main" }).activeWorkKind,
+    ).toBeUndefined();
   });
 });
 
@@ -641,6 +668,47 @@ describe("stuck session diagnostics threshold", () => {
       events,
       { type: "session.recovery.completed", status: "released", action: "release_lane" },
       "released recovery event",
+    );
+  });
+
+  it("clears queued diagnostic state after no-active-work recovery", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn().mockResolvedValue({
+      status: "noop",
+      action: "none",
+      reason: "no_active_work",
+      sessionId: "s1",
+      sessionKey: "main",
+    });
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+      vi.advanceTimersByTime(61_000);
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    const state = getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" });
+    expect(state.state).toBe("idle");
+    expect(state.queueDepth).toBe(0);
+    requireMatchingRecord(
+      events,
+      { type: "session.state", state: "idle", reason: "stuck_recovery:noop", queueDepth: 0 },
+      "noop state clear event",
     );
   });
 


### PR DESCRIPTION
## Summary
- Track active reply runs in diagnostic activity so queued Telegram lanes are not mistaken for idle/stuck work.
- Clear stale queued diagnostic state after `noop/no_active_work` recovery.
- Add regressions for reply-run diagnostic visibility and no-active-work queue cleanup.

## Real behavior proof

- Behavior or issue addressed: queued Telegram reply lanes could look stuck because diagnostics saw queued work without the active reply run, and no-active-work recovery could leave stale `queueDepth=1` state.
- Real environment tested: local OpenClaw gateway from this branch, real Telegram bot-to-bot group transport, real SUT Telegram bot, mock OpenAI-compatible SSE model server.
- Exact steps or command run after this patch: `node /Users/obviyus/.codex/skills/custom/telegram-e2e-bot-to-bot/scripts/run-mock-sut-e2e.mjs --text '@{sut} Please answer with OPENCLAW_E2E_OK only for diagnostic lane PR proof {run}.' --expect OPENCLAW_E2E_OK --timeout-ms 90000 --output /tmp/openclaw-80677-pr-bot-to-bot.json`
- Evidence after fix (terminal capture):

```text
sent.messageId=7651 text="@foremanclawbot Please answer with OPENCLAW_E2E_OK only for diagnostic lane PR proof QA-mp3lgbjd."
reply.messageId=7652 fromUsername=foremanclawbot replyToMessageId=7651 text="OPENCLAW_E2E_OK"
observedCount=1 rttMs=6865 mockRequests=1 drained.pendingBefore=0 drained.drained=0 drained.pendingAfter=0
```

- Observed result after fix: the live Telegram lane replied normally and threaded to the triggering message. In the queued stress run, two delayed same-lane Telegram messages both returned threaded replies while diagnostics reported active work with `queueDepth=1`; no `session.stuck` and no `queued_work_without_active_run` were emitted.
- What was not tested: a full production provider compaction overflow was not separately forced; the root diagnostic states were covered by regression tests and the real Telegram queued-lane run.

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/logging/diagnostic.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/auto-reply/reply/reply-run-registry.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/logging/diagnostic-run-activity.ts src/logging/diagnostic-session-recovery.ts src/logging/diagnostic-session-recovery-coordinator.ts src/logging/diagnostic.test.ts src/auto-reply/reply/reply-run-registry.ts src/auto-reply/reply/reply-run-registry.test.ts`
- `git diff --check origin/main...HEAD`
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed --timed`

Fixes #80677.
