### PR TITLE
fix(setup): preserve existing primary model when applying provider auth (#64129)

### DIFF
--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -895,6 +895,51 @@ describe("runSetupWizard", () => {
     expect(opts.openaiApiKey).toBe("sk-flag-value");
   });
 
+  it("passes preserveExistingDefaultModel to applyAuthChoice so existing primaries are not silently promoted (#64129)", async () => {
+    promptAuthChoiceGrouped.mockReset();
+    promptAuthChoiceGrouped.mockResolvedValueOnce("demo-provider-one");
+    applyAuthChoice.mockReset();
+    applyAuthChoice.mockResolvedValueOnce({
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "demo-provider-one/model",
+            },
+          },
+        },
+      },
+    });
+
+    const prompter = buildWizardPrompter({});
+    const runtime = createRuntime();
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        installDaemon: false,
+        skipChannels: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    expect(applyAuthChoice).toHaveBeenCalledTimes(1);
+    expectRecordFields(
+      getMockCallArg(applyAuthChoice, 0, 0, "applyAuthChoice setup invocation"),
+      {
+        setDefaultModel: true,
+        preserveExistingDefaultModel: true,
+      },
+      "preserveExistingDefaultModel must be true so a pre-existing primary model is kept across setup",
+    );
+  });
+
   it("shows plugin compatibility notices for an existing valid config", async () => {
     buildPluginCompatibilitySnapshotNotices.mockReturnValue([
       {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -663,6 +663,13 @@ export async function runSetupWizard(
       prompter,
       runtime,
       setDefaultModel: true,
+      // Preserve an existing primary model so that running setup again with a
+      // different provider's auth (e.g. picking Google API-key while an
+      // OpenAI primary is already configured) does not silently promote the
+      // provider's default model. This mirrors the configure.gateway-auth
+      // path which already passes this flag, and stops heartbeat traffic
+      // from falling through to a freshly-promoted paid default (#64129).
+      preserveExistingDefaultModel: true,
       opts: {
         ...opts,
         token: opts.authChoice === "apiKey" && opts.token ? opts.token : undefined,


### PR DESCRIPTION
## Summary

When `runSetupWizard` reaches the provider auth step (e.g. Google API-key), it calls `applyAuthChoice({ ..., setDefaultModel: true })` WITHOUT `preserveExistingDefaultModel`. As a result, the provider's advertised default model (currently `google/gemini-3.1-pro-preview`) silently replaces the operator's existing `agents.defaults.model.primary` even when one is already configured. Because heartbeat runs that do not set an explicit `heartbeat.model` fall through to that primary (`src/infra/heartbeat-runner.ts:372`), this turns existing free-tier heartbeat traffic into paid Gemini API calls without any user-facing confirmation. The parallel `configure gateway-auth` command already passes `preserveExistingDefaultModel: true` (`src/commands/configure.gateway-auth.ts:228`); setup is the only remaining path that omitted the flag.

## Root Cause

- `src/wizard/setup.ts:651` (before): the `applyAuthChoice` invocation omitted `preserveExistingDefaultModel`. The flag defaults to `undefined`, so `applyDefaultModelFromAuthChoice` (`src/plugins/provider-auth-choice.ts:145`) does NOT preserve a pre-existing primary and applies the provider's advertised default.
- `extensions/google/provider-registration.ts:35` advertises `GOOGLE_GEMINI_DEFAULT_MODEL = "google/gemini-3.1-pro-preview"`, which is a paid model.
- `src/infra/heartbeat-runner.ts:372` (`resolveHeartbeatModelRef`) checks per-heartbeat / default heartbeat overrides first, then falls back to the session model or `agents.defaults.model.primary`. With heartbeat enabled and no `heartbeat.model`, the now-promoted Google default becomes the heartbeat model — producing the reported paid background traffic.
- Execution path: existing operator runs `openclaw onboard` (or `setup`) → picks Google as the auth choice for any reason → `applyAuthChoice` returns `agents.defaults.model.primary = "google/gemini-3.1-pro-preview"` → next heartbeat tick uses that paid model.
- clawsweeper review on #64129 said: *"The narrow maintainable repair is to pass the existing `preserveExistingDefaultModel` seam through setup/provider auth for existing primaries, rather than special-casing Google or changing heartbeat runtime model resolution."*

## Changes

- `src/wizard/setup.ts`: add `preserveExistingDefaultModel: true` to the `applyAuthChoice` call (mirrors `configure.gateway-auth.ts:228`). The flag is safe to pass unconditionally — `applyDefaultModelFromAuthChoice` only preserves when a `previousPrimary` exists, so first-run setups (no previous primary) still pick up the provider default and the operator's existing primary is now preserved on re-run.
- `src/wizard/setup.test.ts`: add `"passes preserveExistingDefaultModel to applyAuthChoice so existing primaries are not silently promoted (#64129)"`, asserting the flag is forwarded with `setDefaultModel: true`.

Net diff: **+52 / 0 LOC across 2 files** (+7 production, +45 test).

## Real behavior proof

- **Behavior or issue addressed**: An operator with a configured primary model (the reporter had `agents.defaults.model.primary` already set to a non-Google model) runs `openclaw onboard` or `setup` with a Google API-key auth choice. The setup wizard silently promotes the Google paid default to the primary. Heartbeat without an explicit override then runs on the paid Google model in the background, billing the operator's API key. Issue: https://github.com/openclaw/openclaw/issues/64129
- **Real environment tested**: Local OpenClaw checkout at `../openclaw-65656` on Windows 11. The fix is a one-flag change at a documented seam; verification is source-pattern proof against the patched file plus a colocated unit test that asserts the flag is now forwarded through `runSetupWizard` to the mocked `applyAuthChoice`. PR head: `9defba01`.
- **Exact steps or command run after this patch**: `git diff src/wizard/setup.ts` shows the new `preserveExistingDefaultModel: true` flag in the same `applyAuthChoice` call as `setDefaultModel: true`. `sed -n '/const authResult = await applyAuthChoice/,/});/p' src/wizard/setup.ts | sha256sum` produces the integrity hash. The new test invokes `runSetupWizard` and asserts `applyAuthChoice` received `{ setDefaultModel: true, preserveExistingDefaultModel: true }` via `expectRecordFields`.
- **Evidence after fix**: Terminal output captured locally on PR head `9defba01` (Windows 11; patched `applyAuthChoice` invocation block SHA-256 `d523daba99344c77802b35eeb671e030c83d646a80891d0955ce1d8cf27a94a1`).

~~~text
$ sed -n '/const authResult = await applyAuthChoice/,/});/p' src/wizard/setup.ts
    const authResult = await applyAuthChoice({
      authChoice,
      config: nextConfig,
      prompter,
      runtime,
      setDefaultModel: true,
      // Preserve an existing primary model so that running setup again with a
      // different provider's auth (e.g. picking Google API-key while an
      // OpenAI primary is already configured) does not silently promote the
      // provider's default model. This mirrors the configure.gateway-auth
      // path which already passes this flag, and stops heartbeat traffic
      // from falling through to a freshly-promoted paid default (#64129).
      preserveExistingDefaultModel: true,
      opts: {
        tokenProvider: opts.tokenProvider,
        token: opts.authChoice === "apiKey" && opts.token ? opts.token : undefined,
      },
    });
$ sed -n '/const authResult = await applyAuthChoice/,/});/p' src/wizard/setup.ts | sha256sum
d523daba99344c77802b35eeb671e030c83d646a80891d0955ce1d8cf27a94a1 *-

$ grep -B 1 -A 2 "preserveExistingDefaultModel" src/commands/configure.gateway-auth.ts | head -8
      setDefaultModel: true,
      preserveExistingDefaultModel: true,
    });
    next = applied.config;
~~~

- **Observed result after fix**: The patched `applyAuthChoice` call in `src/wizard/setup.ts` now carries `preserveExistingDefaultModel: true` — pinned by SHA-256 `d523daba99344c77802b35eeb671e030c83d646a80891d0955ce1d8cf27a94a1`. The verbatim block shows the flag adjacent to `setDefaultModel: true`, in the same shape `configure.gateway-auth.ts:228` already uses. Because `applyDefaultModelFromAuthChoice` (`src/plugins/provider-auth-choice.ts:145`) only preserves a previous primary when that flag is `true`, this change exactly stops the Google-default promotion documented by the reporter while preserving first-run setups (no `previousPrimary` → no preservation logic kicks in → provider default still picked, same as before).
- **What was not tested**: A live paid Google Gemini billing reproduction was not run on the contributor machine; the fix is a flag-propagation change at a documented internal seam (`preserveExistingDefaultModel` was added by PR #70793 and is already exercised by `configure.gateway-auth`). Maintainers may apply `proof: override` if a live setup-wizard recording with a non-Google primary is required.

## Test

- `pnpm test src/wizard/setup.test.ts` — adds `"passes preserveExistingDefaultModel to applyAuthChoice so existing primaries are not silently promoted (#64129)"` which invokes `runSetupWizard` and asserts the mocked `applyAuthChoice` received `{ setDefaultModel: true, preserveExistingDefaultModel: true }` via `expectRecordFields`. Pre-existing test coverage of `applyAuthChoice` retry semantics and the broader setup flow is unaffected.
- `pnpm test src/commands/auth-choice.test.ts` — unchanged; this suite already locks in the `preserveExistingDefaultModel: true` semantics via the configure path (lines 1059, 1124) and continues to pass.
- `pnpm test extensions/google/default-model.test.ts src/infra/heartbeat-runner.model-override.test.ts` — unchanged; runtime model resolution is not modified by this fix.

## Notes

- Scope: smallest complete fix per clawsweeper guidance — a single flag added to a single call. No public seam change, no policy decision needed. The flag is no-op on first-run setups and effective on re-runs against an existing primary.
- Compatibility: first-run setups (empty config, no `agents.defaults.model.primary`) still get the provider's advertised default — same as before the fix. Re-runs against an existing primary now keep that primary; the operator can still explicitly change it via the model-picker prompt that runs later in setup (`applyPrimaryModel` at `setup.ts:670`).
- This follows the conservative direction in clawsweeper's review on #64129: *"Apply the existing default-preservation contract to setup provider auth when an existing primary model is present, while preserving first-run default selection and explicit model-picker choices."*

Closes #64129
