### PR TITLE
fix(commands): preserve multiline slash skill args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 - Agents: rewrite generic provider internal errors with support request IDs into user-friendly transient error copy. (#49401) Thanks @y471823206.
 - WhatsApp: finish handling pending debounced inbound messages before closing the socket. (#81246) Thanks @mcaxtr.
 - CLI/commitments: write `--json` output to stdout instead of diagnostic logs so automation can parse commitment list and dismiss results. (#81215) Thanks @giodl73-repo.
+- Auto-reply: preserve multiline slash skill arguments after command-head normalization, so `/skill` and direct skill commands receive full multiline payloads. Fixes #79155. (#81305) Thanks @web3blind.
 
 ### Changes
 

--- a/src/auto-reply/commands-registry-normalize.ts
+++ b/src/auto-reply/commands-registry-normalize.ts
@@ -83,7 +83,7 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
   const textAliasMap = getTextAliasMap();
   const exact = textAliasMap.get(lowered);
   if (exact) {
-    return exact.acceptsArgs ? withMultilineTail(exact.canonical) : exact.canonical;
+    return exact.key === "skill" ? withMultilineTail(exact.canonical) : exact.canonical;
   }
 
   const tokenMatch = commandBody.match(/^\/([^\s]+)(?:\s+([\s\S]+))?$/);
@@ -97,13 +97,13 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
     return withMultilineTail(commandBody);
   }
   if (rest && !tokenSpec.acceptsArgs) {
-    return withMultilineTail(commandBody);
+    return commandBody;
   }
   const normalizedRest = rest?.trimStart();
   const normalizedHead = normalizedRest
     ? `${tokenSpec.canonical} ${normalizedRest}`
     : tokenSpec.canonical;
-  return tokenSpec.acceptsArgs ? withMultilineTail(normalizedHead) : normalizedHead;
+  return tokenSpec.key === "skill" ? withMultilineTail(normalizedHead) : normalizedHead;
 }
 
 export function getCommandDetection(_cfg?: OpenClawConfig): CommandDetection {

--- a/src/auto-reply/commands-registry-normalize.ts
+++ b/src/auto-reply/commands-registry-normalize.ts
@@ -57,6 +57,9 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
 
   const newline = trimmed.indexOf("\n");
   const singleLine = newline === -1 ? trimmed : trimmed.slice(0, newline).trim();
+  const multilineTail = newline === -1 ? "" : trimmed.slice(newline);
+  const withMultilineTail = (commandHead: string) =>
+    multilineTail ? `${commandHead}${multilineTail}` : commandHead;
 
   const colonMatch = singleLine.match(/^\/([^\s:]+)\s*:(.*)$/);
   const normalized = colonMatch
@@ -80,24 +83,27 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
   const textAliasMap = getTextAliasMap();
   const exact = textAliasMap.get(lowered);
   if (exact) {
-    return exact.canonical;
+    return exact.acceptsArgs ? withMultilineTail(exact.canonical) : exact.canonical;
   }
 
   const tokenMatch = commandBody.match(/^\/([^\s]+)(?:\s+([\s\S]+))?$/);
   if (!tokenMatch) {
-    return commandBody;
+    return withMultilineTail(commandBody);
   }
   const [, token, rest] = tokenMatch;
   const tokenKey = `/${normalizeLowercaseStringOrEmpty(token)}`;
   const tokenSpec = textAliasMap.get(tokenKey);
   if (!tokenSpec) {
-    return commandBody;
+    return withMultilineTail(commandBody);
   }
   if (rest && !tokenSpec.acceptsArgs) {
-    return commandBody;
+    return withMultilineTail(commandBody);
   }
   const normalizedRest = rest?.trimStart();
-  return normalizedRest ? `${tokenSpec.canonical} ${normalizedRest}` : tokenSpec.canonical;
+  const normalizedHead = normalizedRest
+    ? `${tokenSpec.canonical} ${normalizedRest}`
+    : tokenSpec.canonical;
+  return tokenSpec.acceptsArgs ? withMultilineTail(normalizedHead) : normalizedHead;
 }
 
 export function getCommandDetection(_cfg?: OpenClawConfig): CommandDetection {

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -234,19 +234,18 @@ describe("commands registry", () => {
     expect(requireNativeSpec(listNativeCommandSpecs(), "side").acceptsArgs).toBe(true);
   });
 
-  it("preserves multiline args while normalizing arg-accepting command heads", () => {
-    expect(normalizeCommandBody("/side\nfirst line\nsecond line")).toBe(
-      "/btw\nfirst line\nsecond line",
-    );
-    expect(normalizeCommandBody("/side first line\nsecond line")).toBe(
-      "/btw first line\nsecond line",
-    );
+  it("preserves multiline args for skill command heads", () => {
     expect(normalizeCommandBody("/skill demo-skill\nfirst line\nsecond line")).toBe(
       "/skill demo-skill\nfirst line\nsecond line",
     );
     expect(normalizeCommandBody("/demo_skill\nfirst line\nsecond line")).toBe(
       "/demo_skill\nfirst line\nsecond line",
     );
+  });
+
+  it("keeps non-skill alias normalization single-line", () => {
+    expect(normalizeCommandBody("/side\nfirst line\nsecond line")).toBe("/btw");
+    expect(normalizeCommandBody("/side first line\nsecond line")).toBe("/btw first line");
   });
 
   it("keeps multiline args after telegram-style bot mention cleanup", () => {

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -234,6 +234,29 @@ describe("commands registry", () => {
     expect(requireNativeSpec(listNativeCommandSpecs(), "side").acceptsArgs).toBe(true);
   });
 
+  it("preserves multiline args while normalizing arg-accepting command heads", () => {
+    expect(normalizeCommandBody("/side\nfirst line\nsecond line")).toBe(
+      "/btw\nfirst line\nsecond line",
+    );
+    expect(normalizeCommandBody("/side first line\nsecond line")).toBe(
+      "/btw first line\nsecond line",
+    );
+    expect(normalizeCommandBody("/skill demo-skill\nfirst line\nsecond line")).toBe(
+      "/skill demo-skill\nfirst line\nsecond line",
+    );
+    expect(normalizeCommandBody("/demo_skill\nfirst line\nsecond line")).toBe(
+      "/demo_skill\nfirst line\nsecond line",
+    );
+  });
+
+  it("keeps multiline args after telegram-style bot mention cleanup", () => {
+    expect(
+      normalizeCommandBody("/skill@openclaw demo-skill\nfirst line\nsecond line", {
+        botUsername: "openclaw",
+      }),
+    ).toBe("/skill demo-skill\nfirst line\nsecond line");
+  });
+
   it("filters commands based on config flags", () => {
     const disabled = listChatCommandsForConfig({
       commands: { config: false, plugins: false, debug: false },

--- a/src/auto-reply/reply/commands-context.test.ts
+++ b/src/auto-reply/reply/commands-context.test.ts
@@ -51,6 +51,30 @@ describe("buildCommandContext", () => {
     expect(result.commandBodyNormalized).toBe("/reset soft re-read persona files");
   });
 
+  it("preserves multiline slash skill args through command context", () => {
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      From: "user",
+      To: "bot",
+      BotUsername: "openclaw",
+      Body: "/skill@openclaw demo-skill\nfirst line\nsecond line",
+      RawBody: "/skill@openclaw demo-skill\nfirst line\nsecond line",
+      CommandBody: "/skill@openclaw demo-skill\nfirst line\nsecond line",
+      BodyForCommands: "/skill@openclaw demo-skill\nfirst line\nsecond line",
+    });
+
+    const result = buildCommandContext({
+      ctx,
+      cfg: {} as OpenClawConfig,
+      isGroup: false,
+      triggerBodyNormalized: "/skill@openclaw demo-skill\nfirst line\nsecond line",
+      commandAuthorized: true,
+    });
+
+    expect(result.commandBodyNormalized).toBe("/skill demo-skill\nfirst line\nsecond line");
+  });
+
   it("maps explicit gateway origin into command context", () => {
     const ctx = buildTestCtx({
       Provider: "internal",

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -178,7 +178,10 @@ export function matchesMentionWithExplicit(params: {
   return explicit || params.mentionRegexes.some((re) => re.test(textToCheck));
 }
 
-export function stripStructuralPrefixes(text: string): string {
+export function stripStructuralPrefixes(
+  text: string,
+  options?: { preserveLineBreaks?: boolean },
+): string {
   if (!text) {
     return "";
   }
@@ -188,12 +191,18 @@ export function stripStructuralPrefixes(text: string): string {
     ? text.slice(text.indexOf(CURRENT_MESSAGE_MARKER) + CURRENT_MESSAGE_MARKER.length).trimStart()
     : text;
 
-  return afterMarker
+  const cleaned = afterMarker
     .replace(/\[[^\]]+\]\s*/g, "")
-    .replace(/^[ \t]*[A-Za-z0-9+()\-_. ]+:\s*/gm, "")
-    .replace(/\\n/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+    .replace(/^[ \t]*[A-Za-z0-9+()\-_. ]+:\s*/gm, "");
+  if (options?.preserveLineBreaks) {
+    return cleaned
+      .replace(/\\n/g, "\n")
+      .replace(/[^\S\n]+/g, " ")
+      .replace(/ *\n */g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+  }
+  return cleaned.replace(/\\n/g, " ").replace(/\s+/g, " ").trim();
 }
 
 export function stripMentions(

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -752,6 +752,29 @@ describe("initSessionState RawBody", () => {
     expect(result.triggerBodyNormalized).toBe("/NEW KeepThisCase");
   });
 
+  it("preserves multiline skill command args through session command setup", async () => {
+    const root = await makeCaseDir("openclaw-rawbody-skill-multiline-");
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Provider: "telegram",
+        Surface: "telegram",
+        BotUsername: "openclaw",
+        BodyForCommands: "/skill@openclaw demo-skill\nfirst line\nsecond line",
+        ChatType: "direct",
+        SessionKey: "agent:main:telegram:dm:s1",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.triggerBodyNormalized).toBe(
+      "/skill@openclaw demo-skill\nfirst line\nsecond line",
+    );
+  });
+
   it("drops cached skills snapshot when /new rotates an existing session", async () => {
     const root = await makeCaseDir("openclaw-rawbody-reset-skills-");
     const storePath = path.join(root, "sessions.json");

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -105,6 +105,14 @@ function resolveExplicitSessionEndReason(matchedResetTriggerLower?: string): Rep
   return matchedResetTriggerLower === "/reset" ? "reset" : "new";
 }
 
+function shouldPreserveCommandLineBreaks(commandSource: string): boolean {
+  const trimmed = commandSource.trimStart();
+  return (
+    /^\/skill(?:@|[\s:]|$)/i.test(trimmed) ||
+    /^\/[a-z0-9]+_[a-z0-9_]*(?:@[^\s]+)?(?:[\s:]|$)/i.test(trimmed)
+  );
+}
+
 function resolveSessionDefaultAccountId(params: {
   cfg: OpenClawConfig;
   channelRaw?: string;
@@ -335,7 +343,9 @@ export async function initSessionState(params: {
   // IMPORTANT: do NOT lowercase the entire command body.
   // Users often pass case-sensitive arguments (e.g. filesystem paths on Linux).
   // Command parsing downstream lowercases only the command token for matching.
-  const triggerBodyNormalized = stripStructuralPrefixes(commandSource).trim();
+  const triggerBodyNormalized = stripStructuralPrefixes(commandSource, {
+    preserveLineBreaks: shouldPreserveCommandLineBreaks(commandSource),
+  }).trim();
 
   // Use CommandBody/RawBody for reset trigger matching (clean message without structural context).
   const rawBody = commandSource;

--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -171,6 +171,24 @@ describe("resolveSkillCommandInvocation", () => {
     expect(invocation?.args).toBe("do the thing");
   });
 
+  it("preserves multiline args for direct skill commands", () => {
+    const invocation = resolveSkillCommandInvocation({
+      commandBodyNormalized: "/demo_skill\nfirst line\nsecond line",
+      skillCommands: [{ name: "demo_skill", skillName: "demo-skill", description: "Demo" }],
+    });
+    expect(invocation?.command.skillName).toBe("demo-skill");
+    expect(invocation?.args).toBe("first line\nsecond line");
+  });
+
+  it("preserves multiline args for /skill dispatch", () => {
+    const invocation = resolveSkillCommandInvocation({
+      commandBodyNormalized: "/skill demo_skill\nfirst line\nsecond line",
+      skillCommands: [{ name: "demo_skill", skillName: "demo-skill", description: "Demo" }],
+    });
+    expect(invocation?.command.skillName).toBe("demo-skill");
+    expect(invocation?.args).toBe("first line\nsecond line");
+  });
+
   it("normalizes /skill lookup names", () => {
     const invocation = resolveSkillCommandInvocation({
       commandBodyNormalized: "/skill demo-skill",


### PR DESCRIPTION
## Summary

- Fixes #79155 by preserving multiline payload text after the first slash-command line during command body normalization.
- Keeps command-head normalization intact for aliases, colon syntax, and Telegram-style `@bot` suffix cleanup.
- Adds regression coverage for `/skill`, direct skill commands, alias normalization, Telegram bot mentions, and the command-context path.
- Prior related PR #79174 was closed unmerged; this PR keeps the fix focused and adds broader dispatch-path coverage.

## Review routing

@steipete @jesse-merhi — ClawSweeper pointed to this command/skill-command surface as likely related ownership/history, so mentioning you for faster routing. This is routing context, not fault assignment.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #79155
- Related #79174
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: multiline slash-command payloads such as `/skill demo-skill\nline 1\nline 2` were truncated in `normalizeCommandBody()` before skill dispatch could receive the full args string.
- Real environment tested: local OpenClaw source checkout, Node v22.22.0, pnpm 11.1.0.
- Exact steps or command run after this patch:

```bash
pnpm test src/auto-reply/commands-registry.test.ts src/auto-reply/skill-commands.test.ts src/auto-reply/reply/commands-context.test.ts src/auto-reply/reply/get-reply.fast-path.test.ts
pnpm exec oxfmt --check --threads=1 src/auto-reply/commands-registry-normalize.ts src/auto-reply/commands-registry.test.ts src/auto-reply/skill-commands.test.ts src/auto-reply/reply/commands-context.test.ts src/auto-reply/reply/session.ts src/auto-reply/reply/get-reply-fast-path.ts CHANGELOG.md
pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/commands-registry-normalize.ts src/auto-reply/commands-registry.test.ts src/auto-reply/reply/commands-context.test.ts src/auto-reply/skill-commands.test.ts
```

- Evidence after fix:
  - Targeted tests passed: 3 files / 65 auto-reply tests plus 1 unit-fast command-context file / 4 tests.
  - Formatting check passed.
  - Targeted oxlint on changed files passed with 0 warnings and 0 errors.
- Observed result after fix:
  - `normalizeCommandBody("/skill demo-skill\nfirst line\nsecond line")` preserves the newline tail.
  - `resolveSkillCommandInvocation()` receives `first line\nsecond line` as args for `/skill` dispatch.
  - Direct skill commands such as `/demo_skill\nfirst line\nsecond line` also preserve multiline args.
  - Telegram-style `/skill@openclaw demo-skill\n...` normalizes to `/skill demo-skill\n...` through command context.
- What was not tested: a live Telegram gateway run with real Bot API delivery. The added tests cover the central normalizer, skill dispatch parser, and command-context path used before downstream handling.

## Root Cause (if applicable)

`normalizeCommandBody()` split slash-command input at the first real newline and normalized only the command head. The newline tail was never reattached, so downstream command and skill parsers could not receive multiline args even though they already support `[\s\S]` args.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/commands-registry.test.ts`
  - `src/auto-reply/skill-commands.test.ts`
  - `src/auto-reply/reply/commands-context.test.ts`
- Scenario the test should lock in: multiline args survive command-head normalization and reach `/skill` and direct skill-command invocation.
- Why this is the smallest reliable guardrail: the bug happened in shared command normalization before channel-specific or skill-specific handling.

## User-visible / Behavior Changes

Slash commands that accept args can now receive multiline payload text when the payload starts after the command head on following lines.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No` — existing arg-accepting commands receive the full args they already parse.)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v22.22.0, pnpm 11.1.0
- Model/provider: N/A
- Integration/channel: command context path with Telegram-style bot mention covered by test
- Relevant config: N/A

### Steps

1. Normalize `/skill demo-skill\nfirst line\nsecond line`.
2. Resolve the normalized command with `resolveSkillCommandInvocation()`.
3. Build command context for `/skill@openclaw demo-skill\nfirst line\nsecond line`.

### Expected

The command head is normalized, and multiline args are preserved as `first line\nsecond line`.

### Actual

After this patch, targeted tests confirm the expected behavior.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run locally:

- `pnpm test src/auto-reply/commands-registry.test.ts src/auto-reply/skill-commands.test.ts src/auto-reply/reply/commands-context.test.ts src/auto-reply/reply/get-reply.fast-path.test.ts` — passed.
- `pnpm exec oxfmt --check --threads=1 ...` — passed.
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json <changed files>` — passed.
- `pnpm check:changed` — attempted; typecheck lanes passed, but the full core lint lane was SIGKILLed by this local environment while running `oxlint-tsgolint` headless. Targeted oxlint on changed files passed.

## Human Verification (required)

- Verified scenarios: command alias normalization, `/skill` multiline args, direct skill-command multiline args, Telegram-style bot mention cleanup, command-context normalization.
- Edge cases checked: command with args on the same first line plus additional newline tail; command with payload starting on the next line.
- What you did not verify: live Telegram Bot API delivery against a real bot token.

## Review Conversations

- [x] I checked for existing PRs before opening this one; prior related PR #79174 is closed and unmerged.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: preserving multiline tails could expose downstream handlers to args they were already designed to accept but previously did not receive due to the regression.
  - Mitigation: only arg-accepting aliases reattach tails when canonicalizing; regression tests cover `/skill`, direct skill commands, alias handling, and command context.
