### PR TITLE
Use agent identity name in runtime prompt

### DIFF
--- a/src/agents/system-prompt-params.test.ts
+++ b/src/agents/system-prompt-params.test.ts
@@ -13,9 +13,15 @@ async function makeRepoRoot(root: string): Promise<void> {
   await fs.mkdir(path.join(root, ".git"), { recursive: true });
 }
 
-function buildParams(params: { config?: OpenClawConfig; workspaceDir?: string; cwd?: string }) {
+function buildParams(params: {
+  config?: OpenClawConfig;
+  agentId?: string;
+  workspaceDir?: string;
+  cwd?: string;
+}) {
   return buildSystemPromptParams({
     config: params.config,
+    agentId: params.agentId ?? "main",
     workspaceDir: params.workspaceDir,
     cwd: params.cwd,
     runtime: {
@@ -29,6 +35,34 @@ function buildParams(params: { config?: OpenClawConfig; workspaceDir?: string; c
 }
 
 describe("buildSystemPromptParams repo root", () => {
+  it("threads configured agent identity name into runtime info", async () => {
+    const workspaceDir = await makeTempDir("agent-identity");
+    const config: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", identity: { name: "Runt" } }],
+      },
+    };
+
+    const { runtimeInfo } = buildParams({ config, workspaceDir });
+
+    expect(runtimeInfo.agentId).toBe("main");
+    expect(runtimeInfo.agentName).toBe("Runt");
+  });
+
+  it("resolves agent identity name through normalized agent ids", async () => {
+    const workspaceDir = await makeTempDir("agent-identity-normalized");
+    const config: OpenClawConfig = {
+      agents: {
+        list: [{ id: "Work", identity: { name: "Runt" } }],
+      },
+    };
+
+    const { runtimeInfo } = buildParams({ config, agentId: "work", workspaceDir });
+
+    expect(runtimeInfo.agentId).toBe("work");
+    expect(runtimeInfo.agentName).toBe("Runt");
+  });
+
   it("detects repo root from workspaceDir", async () => {
     const temp = await makeTempDir("workspace");
     const repoRoot = path.join(temp, "repo");

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { findGitRoot } from "../infra/git-root.js";
+import { readStringValue } from "../shared/string-coerce.js";
+import { resolveAgentConfig } from "./agent-scope-config.js";
 import type { ActiveProcessSessionReference } from "./bash-process-references.js";
 import {
   formatUserTime,
@@ -12,6 +14,7 @@ import {
 
 type RuntimeInfoInput = {
   agentId?: string;
+  agentName?: string;
   host: string;
   os: string;
   arch: string;
@@ -37,7 +40,7 @@ type SystemPromptRuntimeParams = {
 export function buildSystemPromptParams(params: {
   config?: OpenClawConfig;
   agentId?: string;
-  runtime: Omit<RuntimeInfoInput, "agentId">;
+  runtime: Omit<RuntimeInfoInput, "agentId" | "agentName">;
   workspaceDir?: string;
   cwd?: string;
 }): SystemPromptRuntimeParams {
@@ -53,12 +56,21 @@ export function buildSystemPromptParams(params: {
     runtimeInfo: {
       agentId: params.agentId,
       ...params.runtime,
+      agentName: resolveRuntimeAgentName(params.config, params.agentId),
       repoRoot,
     },
     userTimezone,
     userTime,
     userTimeFormat,
   };
+}
+
+function resolveRuntimeAgentName(config: OpenClawConfig | undefined, agentId: string | undefined) {
+  if (!config || !agentId) {
+    return undefined;
+  }
+  const identityName = readStringValue(resolveAgentConfig(config, agentId)?.identity?.name)?.trim();
+  return identityName || undefined;
 }
 
 function resolveRepoRoot(params: {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -124,6 +124,15 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
+  it("uses configured identity name in the runtime agent display", () => {
+    const line = buildRuntimeLine({ agentId: "main", agentName: "Runt", host: "test-host" });
+
+    expect(line).toContain("agent=Runt");
+    expect(line).toContain("agent_id=main");
+    expect(line).toContain("host=test-host");
+    expect(line).not.toContain("agent=main");
+  });
+
   it("omits extended sections in minimal prompt mode", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -708,6 +708,7 @@ export function buildAgentSystemPrompt(params: {
   nativeCommandGuidanceLines?: string[];
   runtimeInfo?: {
     agentId?: string;
+    agentName?: string;
     host?: string;
     os?: string;
     arch?: string;
@@ -1337,6 +1338,7 @@ function buildActiveProcessSessionReferenceLines(
 export function buildRuntimeLine(
   runtimeInfo?: {
     agentId?: string;
+    agentName?: string;
     host?: string;
     os?: string;
     arch?: string;
@@ -1352,8 +1354,14 @@ export function buildRuntimeLine(
   defaultThinkLevel?: ThinkLevel,
 ): string {
   const normalizedRuntimeCapabilities = normalizePromptCapabilityIds(runtimeCapabilities);
+  const agentName = runtimeInfo?.agentName?.trim();
+  const agentId = runtimeInfo?.agentId?.trim();
+  const agentDisplay = agentName || agentId;
   return `Runtime: ${[
-    runtimeInfo?.agentId ? `agent=${runtimeInfo.agentId}` : "",
+    agentDisplay ? `agent=${sanitizeForPromptLiteral(agentDisplay)}` : "",
+    agentName && agentId && agentName !== agentId
+      ? `agent_id=${sanitizeForPromptLiteral(agentId)}`
+      : "",
     runtimeInfo?.host ? `host=${runtimeInfo.host}` : "",
     runtimeInfo?.repoRoot ? `repo=${runtimeInfo.repoRoot}` : "",
     runtimeInfo?.os


### PR DESCRIPTION
## Summary
- Thread configured `agents.list[].identity.name` into runtime prompt params.
- Render the identity name as `agent=...` in the Runtime line, while retaining the slot id as `agent_id=...` when different.
- Cover the prompt-param plumbing and Runtime line formatting.

Fixes #81269.

## Verification
- `node --import tsx - <<'NODE' ...` runtime identity smoke
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/system-prompt-params.test.ts`
- `pnpm exec oxfmt --check src/agents/system-prompt.ts src/agents/system-prompt-params.ts src/agents/system-prompt.test.ts src/agents/system-prompt-params.test.ts`
- `pnpm exec oxlint src/agents/system-prompt.ts src/agents/system-prompt-params.ts src/agents/system-prompt.test.ts src/agents/system-prompt-params.test.ts`
- `git diff --check`
- `pnpm tsgo:core`

Note: `src/agents/system-prompt.test.ts` is excluded by the current scoped Vitest config when passed directly, so the `buildRuntimeLine` behavior is covered by the smoke assertion plus oxlint, format, and typecheck.

## Real behavior proof
- **Behavior or issue addressed:** The generated Runtime line should use the configured agent identity name for the visible `agent=...` value instead of always showing the technical slot id such as `main`. The slot id remains available as `agent_id=...` for debugging.
- **Real environment tested:** Local OpenClaw checkout on Linux, running Node/tsx against the changed runtime prompt modules.
- **Exact steps or command run after this patch:** Ran this after the patch:

```text
$ node --import tsx - <<'NODE'
import { buildRuntimeLine } from './src/agents/system-prompt.ts';
import { buildSystemPromptParams } from './src/agents/system-prompt-params.ts';
const runtimeLine = buildRuntimeLine({ agentId: 'main', agentName: 'Runt', host: 'test-host', model: 'test-model' });
const params = buildSystemPromptParams({
  agentId: 'main',
  config: { agents: { list: [{ id: 'main', identity: { name: 'Runt' } }] } },
  runtime: { host: 'test-host', os: 'test-os', arch: 'test-arch', node: 'test-node', model: 'test-model' },
});
console.log(runtimeLine);
console.log(JSON.stringify({ agentId: params.runtimeInfo.agentId, agentName: params.runtimeInfo.agentName }));
NODE
```

- **Evidence after fix:** Terminal output from the command above:

```text
Runtime: agent=Runt | agent_id=main | host=test-host | model=test-model | thinking=off
{"agentId":"main","agentName":"Runt"}
```

- **Observed result after fix:** The copied live output shows `agent=Runt` while preserving `agent_id=main`, confirming the configured identity name is used in the Runtime display and the technical slot id remains present separately.
- **What was not tested:** I did not run a full interactive OpenClaw chat session or screenshot the UI; this proof is a live local runtime prompt module invocation from the changed branch.
