### PR TITLE
feat(telegram): support native draft streaming previews

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -300,19 +300,39 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 ## Feature reference
 
 <AccordionGroup>
-  <Accordion title="Live stream preview (message edits)">
+  <Accordion title="Live stream preview">
     OpenClaw can stream partial replies in real time:
 
-    - direct chats: preview message + `editMessageText`
+    - default transport: preview message + `editMessageText`
+    - optional native Telegram drafts in DMs: `sendMessageDraft` during generation, then a normal final message
     - groups/topics: preview message + `editMessageText`
 
     Requirement:
 
     - `channels.telegram.streaming` is `off | partial | block | progress` (default: `partial`)
+    - `streaming.nativeTransport: true` enables Telegram's native `sendMessageDraft` preview transport when Telegram accepts it
+    - if native drafts fail or are unsupported for the chat, OpenClaw falls back to the default message-edit preview transport for that turn
     - `progress` keeps one editable status draft for tool progress, clears it at completion, and sends the final answer as a normal message
     - `streaming.preview.toolProgress` controls whether tool/progress updates reuse the same edited preview message (default: `true` when preview streaming is active)
     - `streaming.preview.commandText` controls command/exec detail inside those tool-progress lines: `raw` (default, preserves released behavior) or `status` (tool label only)
     - legacy `channels.telegram.streamMode` and boolean `streaming` values are detected; run `openclaw doctor --fix` to migrate them to `channels.telegram.streaming.mode`
+
+    To opt into native Telegram draft previews where supported, set:
+
+    ```json
+    {
+      "channels": {
+        "telegram": {
+          "streaming": {
+            "mode": "partial",
+            "nativeTransport": true
+          }
+        }
+      }
+    }
+    ```
+
+    Native drafts are ephemeral Telegram UI previews, so OpenClaw still sends the completed answer with normal `sendMessage` final delivery.
 
     Tool-progress preview updates are the short status lines shown while tools run, for example command execution, file reads, planning updates, or patch summaries. Telegram keeps these enabled by default to match released OpenClaw behavior from `v2026.4.22` and later. To keep the edited preview for answer text but hide tool-progress lines, set:
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -96,6 +96,7 @@ import {
   type LaneDeliveryResult,
   type LaneName,
 } from "./lane-delivery.js";
+import { resolveTelegramNativeDraftStreamingEnabled } from "./preview-streaming.js";
 import {
   createTelegramReasoningStepState,
   splitTelegramReasoningText,
@@ -544,6 +545,9 @@ export const dispatchTelegramMessage = async ({
       ? (replyQuoteMessageId ?? msg.message_id)
       : undefined;
   const draftMinInitialChars = streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS;
+  const draftStreamTransport = resolveTelegramNativeDraftStreamingEnabled(telegramCfg)
+    ? "native-draft"
+    : "message";
   const progressSeed = `${route.accountId}:${chatId}:${threadSpec.id ?? ""}`;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
@@ -552,6 +556,7 @@ export const dispatchTelegramMessage = async ({
           api: bot.api,
           chatId,
           maxChars: draftMaxChars,
+          transport: draftStreamTransport,
           thread: threadSpec,
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -7,6 +7,7 @@ type TelegramDraftStreamParams = Parameters<typeof createTelegramDraftStream>[0]
 function createMockDraftApi(sendMessageImpl?: () => Promise<{ message_id: number }>) {
   return {
     sendMessage: vi.fn(sendMessageImpl ?? (async () => ({ message_id: 17 }))),
+    sendMessageDraft: vi.fn().mockResolvedValue(true),
     editMessageText: vi.fn().mockResolvedValue(true),
     deleteMessage: vi.fn().mockResolvedValue(true),
   };
@@ -76,6 +77,77 @@ describe("createTelegramDraftStream", () => {
     await stream.flush();
 
     expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "Hello again");
+  });
+
+  it("uses native Telegram message drafts when requested", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      transport: "native-draft",
+      draftIdFactory: () => 12345,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+    stream.update("Hello again");
+    await stream.flush();
+
+    expect(api.sendMessageDraft).toHaveBeenNthCalledWith(1, 123, 12345, "Hello", {});
+    expect(api.sendMessageDraft).toHaveBeenNthCalledWith(2, 123, 12345, "Hello again", {});
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(api.editMessageText).not.toHaveBeenCalled();
+    expect(stream.messageId()).toBeUndefined();
+  });
+
+  it("passes rendered parse mode to native Telegram message drafts", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      transport: "native-draft",
+      draftIdFactory: () => 12345,
+      renderText: (text) => ({ text: `<i>${text}</i>`, parseMode: "HTML" }),
+    });
+
+    stream.update("hello");
+    await stream.flush();
+
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 12345, "<i>hello</i>", {
+      parse_mode: "HTML",
+    });
+  });
+
+  it("falls back to message previews when native Telegram message drafts fail", async () => {
+    const api = createMockDraftApi();
+    api.sendMessageDraft.mockRejectedValueOnce(new Error("draft unsupported"));
+    const stream = createDraftStream(api, {
+      transport: "native-draft",
+      draftIdFactory: () => 12345,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+    stream.update("Hello again");
+    await stream.flush();
+
+    expect(api.sendMessageDraft).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined);
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "Hello again");
+  });
+
+  it("rotates native Telegram message draft ids for new preview messages", async () => {
+    const api = createMockDraftApi();
+    const draftIds = [111, 222];
+    const stream = createDraftStream(api, {
+      transport: "native-draft",
+      draftIdFactory: () => draftIds.shift() ?? 333,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+    stream.forceNewMessage();
+    stream.update("Next");
+    await stream.flush();
+
+    expect(api.sendMessageDraft).toHaveBeenNthCalledWith(1, 123, 111, "Hello", {});
+    expect(api.sendMessageDraft).toHaveBeenNthCalledWith(2, 123, 222, "Next", {});
   });
 
   it("waits for in-flight updates before final flush edit", async () => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -13,6 +13,12 @@ const DEFAULT_THROTTLE_MS = 1000;
 const THREAD_NOT_FOUND_RE = /400:\s*Bad Request:\s*message thread not found/i;
 
 type TelegramSendMessageParams = Parameters<Bot["api"]["sendMessage"]>[2];
+type TelegramSendMessageDraftParams = Parameters<Bot["api"]["sendMessageDraft"]>[3];
+type TelegramDraftStreamTransport = "message" | "native-draft";
+
+function createTelegramNativeDraftId(): number {
+  return Math.max(1, Math.floor(Math.random() * 0x7fffffff));
+}
 
 function hasNumericMessageThreadId(
   params: TelegramSendMessageParams | undefined,
@@ -89,6 +95,8 @@ export function createTelegramDraftStream(params: {
   api: Bot["api"];
   chatId: Parameters<Bot["api"]["sendMessage"]>[0];
   maxChars?: number;
+  transport?: TelegramDraftStreamTransport;
+  draftIdFactory?: () => number;
   thread?: TelegramThreadSpec | null;
   replyToMessageId?: number;
   throttleMs?: number;
@@ -130,6 +138,8 @@ export function createTelegramDraftStream(params: {
   let previewRevision = 0;
   let generation = 0;
   let deliveredTextOffset = 0;
+  let nativeDraftId = Math.trunc(params.draftIdFactory?.() ?? createTelegramNativeDraftId());
+  let nativeDraftTransportDisabled = params.transport !== "native-draft";
   let resetStreamToNewMessage: (options?: { keepPending?: boolean; resetOffset?: boolean }) => void;
   type PreviewSendParams = {
     renderedText: string;
@@ -223,6 +233,22 @@ export function createTelegramDraftStream(params: {
     return true;
   };
 
+  const sendNativeDraftTransportPreview = async ({
+    renderedText,
+    renderedParseMode,
+  }: PreviewSendParams): Promise<boolean> => {
+    if (typeof chatId !== "number") {
+      throw new Error("native Telegram message drafts require a numeric private chat id");
+    }
+    const draftParams: TelegramSendMessageDraftParams = {
+      ...threadParams,
+      ...(renderedParseMode ? { parse_mode: renderedParseMode } : {}),
+    };
+    streamVisibleSinceMs ??= Date.now();
+    await params.api.sendMessageDraft(chatId, nativeDraftId, renderedText, draftParams);
+    return true;
+  };
+
   const sendOrEditStreamMessage = async (text: string): Promise<boolean> => {
     if (streamState.stopped && !streamState.final) {
       return false;
@@ -281,7 +307,12 @@ export function createTelegramDraftStream(params: {
     }
     const sendGeneration = generation;
 
-    if (typeof streamMessageId !== "number" && minInitialChars != null && !streamState.final) {
+    if (
+      typeof streamMessageId !== "number" &&
+      streamVisibleSinceMs == null &&
+      minInitialChars != null &&
+      !streamState.final
+    ) {
       if (renderedText.length < minInitialChars) {
         return false;
       }
@@ -290,11 +321,32 @@ export function createTelegramDraftStream(params: {
     lastSentText = renderedText;
     lastSentParseMode = renderedParseMode;
     try {
-      const sent = await sendMessageTransportPreview({
-        renderedText,
-        renderedParseMode,
-        sendGeneration,
-      });
+      let sent: boolean;
+      if (!nativeDraftTransportDisabled) {
+        try {
+          sent = await sendNativeDraftTransportPreview({
+            renderedText,
+            renderedParseMode,
+            sendGeneration,
+          });
+        } catch (err) {
+          nativeDraftTransportDisabled = true;
+          params.warn?.(
+            `telegram native draft preview failed; falling back to message edits: ${formatErrorMessage(err)}`,
+          );
+          sent = await sendMessageTransportPreview({
+            renderedText,
+            renderedParseMode,
+            sendGeneration,
+          });
+        }
+      } else {
+        sent = await sendMessageTransportPreview({
+          renderedText,
+          renderedParseMode,
+          sendGeneration,
+        });
+      }
       if (sent) {
         previewRevision += 1;
         lastDeliveredText = trimmed;
@@ -322,6 +374,8 @@ export function createTelegramDraftStream(params: {
     streamVisibleSinceMs = undefined;
     lastSentText = "";
     lastSentParseMode = undefined;
+    nativeDraftId = Math.trunc(params.draftIdFactory?.() ?? createTelegramNativeDraftId());
+    nativeDraftTransportDisabled = params.transport !== "native-draft";
     if (options?.resetOffset !== false) {
       deliveredTextOffset = 0;
     }

--- a/extensions/telegram/src/preview-streaming.ts
+++ b/extensions/telegram/src/preview-streaming.ts
@@ -1,4 +1,5 @@
 import {
+  resolveChannelStreamingNativeTransport,
   resolveChannelPreviewStreamMode,
   type StreamingMode,
 } from "openclaw/plugin-sdk/channel-streaming";
@@ -12,4 +13,13 @@ export function resolveTelegramPreviewStreamMode(
   } = {},
 ): TelegramPreviewStreamMode {
   return resolveChannelPreviewStreamMode(params, "partial");
+}
+
+export function resolveTelegramNativeDraftStreamingEnabled(
+  params: {
+    nativeStreaming?: unknown;
+    streaming?: unknown;
+  } = {},
+): boolean {
+  return resolveChannelStreamingNativeTransport(params) === true;
 }

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -95,7 +95,7 @@ export type ChannelDeliveryStreamingConfig = Pick<ChannelStreamingConfig, "chunk
 
 export type ChannelPreviewStreamingConfig = Pick<
   ChannelStreamingConfig,
-  "mode" | "chunkMode" | "preview" | "progress" | "block"
+  "mode" | "chunkMode" | "preview" | "progress" | "block" | "nativeTransport"
 >;
 
 export type SlackChannelStreamingConfig = Pick<


### PR DESCRIPTION
## Summary

- add optional Telegram native draft preview transport via `sendMessageDraft`
- keep current `sendMessage`/`editMessageText` preview transport as the default and fallback
- expose the opt-in through `streaming.nativeTransport: true`
- document the Telegram config and final-delivery behavior

## Behavior

When native transport is enabled, Telegram draft previews are updated during generation with a stable `draft_id`. Because Telegram drafts are ephemeral UI state, OpenClaw still sends the completed answer with normal final delivery. If `sendMessageDraft` fails or is unsupported for a chat, the turn falls back to the existing message-edit preview path.

## Real behavior proof

- **Behavior or issue addressed:** Telegram supports native fluid streaming UI for bots through `sendMessageDraft`, but OpenClaw's Telegram plugin only used persistent preview messages with `sendMessage` + `editMessageText`. This PR wires `sendMessageDraft` into the Telegram plugin as an opt-in preview transport while keeping the existing message-edit transport as the default fallback.
- **Real environment tested:** Real Telegram Bot API against a real private Telegram chat using the OpenClaw Telegram bot token from my local OpenClaw setup. Token, chat id, and full URL were redacted.
- **Exact steps or command run after this patch:** From the local OpenClaw workspace, I verified the target Bot API behavior with a redacted live command sequence equivalent to:

  ```bash
  TOKEN=$(cat /root/.openclaw/secrets/telegram-default-token)
  CHAT_ID=<redacted-private-chat-id>
  DRAFT_ID=481286593
  curl -sS "https://api.telegram.org/bot${TOKEN}/sendMessageDraft" \
    -d chat_id="$CHAT_ID" \
    -d draft_id="$DRAFT_ID" \
    -d text="Teste SOFIA: começando streaming nativo…"
  curl -sS "https://api.telegram.org/bot${TOKEN}/sendMessageDraft" \
    -d chat_id="$CHAT_ID" \
    -d draft_id="$DRAFT_ID" \
    -d text="Teste SOFIA: streaming nativo atualizando com o mesmo draft_id…"
  curl -sS "https://api.telegram.org/bot${TOKEN}/sendMessage" \
    -d chat_id="$CHAT_ID" \
    -d text="✅ Teste finalizado: sendMessageDraft funcionou e esta é a mensagem persistente final."
  ```

  I repeated the same live check with a second non-zero `draft_id` before opening this PR. The branch validation also exercises the patched OpenClaw transport and fallback paths with focused tests.
- **Evidence after fix:** Terminal output from the live command, with token/chat id redacted:

  ```text
  $ curl -sS https://api.telegram.org/bot<redacted>/sendMessageDraft -d chat_id=<redacted> -d draft_id=481286593 -d text='Teste SOFIA: começando streaming nativo…'
  {"ok":true,"result":true}
  $ curl -sS https://api.telegram.org/bot<redacted>/sendMessageDraft -d chat_id=<redacted> -d draft_id=481286593 -d text='Teste SOFIA: streaming nativo atualizando com o mesmo draft_id…'
  {"ok":true,"result":true}
  $ curl -sS https://api.telegram.org/bot<redacted>/sendMessage -d chat_id=<redacted> -d text='✅ Teste finalizado: sendMessageDraft funcionou e esta é a mensagem persistente final.'
  {"ok":true,"result":{"message_id":2821,"from":{"id":8602155719,"is_bot":true,"first_name":"Sofia","username":"SofiaTCBot"},"chat":{"id":<redacted>,"type":"private"},"date":<redacted>,"text":"✅ Teste finalizado: sendMessageDraft funcionou e esta é a mensagem persistente final."}}
  ```

  Live Telegram output observed in the actual private chat after the Bot API calls:

  ```text
  Teste SOFIA: começando streaming nativo…
  Teste SOFIA: streaming nativo atualizando com o mesmo draft_id…
  ✅ Teste finalizado: sendMessageDraft funcionou e esta é a mensagem persistente final.
  Teste 2 SOFIA: draft nativo iniciado…
  ✅ Teste 2 finalizado: sendMessageDraft funcionou de novo; esta é a mensagem persistente final.
  ```

  The two `sendMessageDraft` updates with the same `draft_id` rendered as Telegram's native fluid draft animation in the client, then the final `sendMessage` persisted the completed answer.
- **Observed result after fix:** `sendMessageDraft` accepted repeated updates with the same non-zero `draft_id`, Telegram displayed the native animated draft preview, and the final persistent answer was delivered with normal `sendMessage`. In the patched code, `streaming.nativeTransport: true` selects this native draft transport, and failures fall back to the existing message-edit preview path.
- **What was not tested:** I did not install this PR branch into a production OpenClaw daemon or enable it on a public Telegram group/topic. Group/topic behavior intentionally keeps the existing message-edit fallback unless Telegram accepts native drafts for that chat.

## Validation

- `pnpm vitest run extensions/telegram/src/draft-stream.test.ts --config test/vitest/vitest.extension-telegram.config.ts` — 35 passed
- `pnpm vitest run src/plugin-sdk/channel-streaming.test.ts --config test/vitest/vitest.plugin-sdk.config.ts` — 17 passed
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- `pnpm exec oxlint extensions/telegram/src/draft-stream.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/preview-streaming.ts src/config/types.base.ts`
- `pnpm exec oxfmt --check extensions/telegram/src/draft-stream.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/preview-streaming.ts src/config/types.base.ts docs/channels/telegram.md`
- `pnpm check:docs`
- `git diff --check`
