### PR TITLE
[Feat] Add Control UI i18n baseline report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Control UI/i18n: add a `pnpm ui:i18n:report` baseline report for hardcoded-copy focus areas and locale fallback metadata. (#81320) Thanks @samzong.
 - Maintainer tooling: add a repo-local `codex-review` skill for Codex closeout reviews, including local dirty-work and PR-branch review helpers that rerun until no accepted/actionable findings remain and avoid unsupported inline prompts with `--base`.
 - Maintainer tooling: fail CI when pull requests add package patch files or pnpm patched dependencies, preserving the upstream-and-bump dependency workflow.
 - Amazon Bedrock: externalize the Bedrock and Bedrock Mantle provider packages so core installs no longer pull AWS SDK dependencies unless those providers are installed.

--- a/package.json
+++ b/package.json
@@ -1743,6 +1743,7 @@
     "ui:build": "node scripts/ui.js build",
     "ui:dev": "node scripts/ui.js dev",
     "ui:i18n:check": "node --import tsx scripts/control-ui-i18n.ts check",
+    "ui:i18n:report": "node --import tsx scripts/control-ui-i18n-report.ts",
     "ui:i18n:sync": "node --import tsx scripts/control-ui-i18n.ts sync --write",
     "ui:install": "node scripts/ui.js install"
   },

--- a/scripts/control-ui-i18n-report.ts
+++ b/scripts/control-ui-i18n-report.ts
@@ -1,0 +1,421 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { TranslationMap } from "../ui/src/i18n/lib/types.ts";
+
+const ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const I18N_ASSETS_DIR = path.join(ROOT, "ui/src/i18n/.i18n");
+const LOCALES_DIR = path.join(ROOT, "ui/src/i18n/locales");
+const RAW_COPY_BASELINE_PATH = path.join(I18N_ASSETS_DIR, "raw-copy-baseline.json");
+const SOURCE_LOCALE_PATH = path.join(LOCALES_DIR, "en.ts");
+const DEFAULT_TOP = 10;
+const LOCALE_LABELS: Record<string, string> = {
+  ar: "Arabic",
+  de: "German",
+  es: "Spanish",
+  fa: "Persian",
+  fr: "French",
+  id: "Indonesian",
+  it: "Italian",
+  "ja-JP": "Japanese",
+  ko: "Korean",
+  nl: "Dutch",
+  pl: "Polish",
+  "pt-BR": "Brazilian Portuguese",
+  th: "Thai",
+  tr: "Turkish",
+  uk: "Ukrainian",
+  vi: "Vietnamese",
+  "zh-CN": "Simplified Chinese",
+  "zh-TW": "Traditional Chinese",
+};
+const PATH_LABELS: Record<string, string> = {
+  "ui/src/ui/chat/chat-queue.ts": "Chat queue",
+  "ui/src/ui/chat/grouped-render.ts": "Chat message groups",
+  "ui/src/ui/chat/side-result-render.ts": "Chat tool result panel",
+  "ui/src/ui/chat/tool-cards.ts": "Chat tool cards",
+  "ui/src/ui/views/agents-panels-overview.ts": "Agents overview panel",
+  "ui/src/ui/views/agents-panels-tools-skills.ts": "Agents tools and skills panel",
+  "ui/src/ui/views/agents-utils.ts": "Agents shared UI helpers",
+  "ui/src/ui/views/chat.ts": "Chat page",
+  "ui/src/ui/views/config-form.render.ts": "Config form",
+  "ui/src/ui/views/config-quick.ts": "Quick config page",
+  "ui/src/ui/views/config.ts": "Config page",
+  "ui/src/ui/views/cron.ts": "Cron page",
+  "ui/src/ui/views/usage-query.ts": "Usage filters",
+  "ui/src/ui/views/usage-render-details.ts": "Usage detail view",
+  "ui/src/ui/views/usage-render-overview.ts": "Usage overview",
+};
+
+type RawCopyKind = "html-attribute" | "html-text" | "object-property";
+
+export type RawCopyBaselineEntry = {
+  count: number;
+  kind: RawCopyKind;
+  name: string;
+  path: string;
+  text: string;
+};
+
+type RawCopyBaseline = {
+  entries: RawCopyBaselineEntry[];
+  version: number;
+};
+
+type LocaleMeta = {
+  fallbackKeys: string[];
+  generatedAt: string;
+  locale: string;
+  model: string;
+  provider: string;
+  sourceHash: string;
+  totalKeys: number;
+  translatedKeys: number;
+  workflow: number;
+};
+
+type ReportArgs = {
+  locale?: string;
+  surface?: string;
+  top: number;
+};
+
+export type RawCopySummary = {
+  entries: number;
+  occurrences: number;
+  topPaths: Array<{ count: number; path: string }>;
+};
+
+export type LocaleSummary = {
+  fallbackKeysInScope: string[];
+  meta: LocaleMeta;
+  sameAsEnglishKeys: string[];
+};
+
+type ReportInput = {
+  locale?: LocaleSummary;
+  rawCopy: RawCopySummary;
+  surface?: string;
+};
+
+export function parseArgs(argv: string[]): ReportArgs {
+  const args: ReportArgs = { top: DEFAULT_TOP };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--surface") {
+      args.surface = readOptionValue(argv, (index += 1), arg);
+      continue;
+    }
+    if (arg === "--locale") {
+      args.locale = readOptionValue(argv, (index += 1), arg);
+      continue;
+    }
+    if (arg === "--top") {
+      const raw = readOptionValue(argv, (index += 1), arg);
+      const top = Number.parseInt(raw, 10);
+      if (!Number.isSafeInteger(top) || top < 1) {
+        throw new Error(`--top must be a positive integer: ${raw}`);
+      }
+      args.top = top;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}\n${usage()}`);
+  }
+  return args;
+}
+
+function readOptionValue(argv: string[], index: number, flag: string) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+export function filterRawCopyEntries(entries: RawCopyBaselineEntry[], surface?: string) {
+  if (!surface) {
+    return entries;
+  }
+  const normalized = normalizeToken(surface);
+  return entries.filter((entry) => pathTokens(entry.path).some((token) => token === normalized));
+}
+
+export function summarizeRawCopy(entries: RawCopyBaselineEntry[], top: number): RawCopySummary {
+  const byPath = new Map<string, number>();
+  let occurrences = 0;
+
+  for (const entry of entries) {
+    occurrences += entry.count;
+    byPath.set(entry.path, (byPath.get(entry.path) ?? 0) + entry.count);
+  }
+
+  const rankedPaths = [...byPath.entries()]
+    .map(([entryPath, count]) => ({ count, path: entryPath }))
+    .toSorted(compareCountThenName((entry) => entry.path));
+
+  return {
+    entries: entries.length,
+    occurrences,
+    topPaths: rankedPaths.slice(0, top),
+  };
+}
+
+function compareCountThenName<T>(nameOf: (value: T) => string) {
+  return (left: T & { count: number }, right: T & { count: number }) =>
+    right.count - left.count || nameOf(left).localeCompare(nameOf(right));
+}
+
+function pathTokens(repoPath: string) {
+  return repoPath
+    .split("/")
+    .flatMap((part) => part.replace(/\.[^.]+$/, "").split(/[^A-Za-z0-9]+/))
+    .filter(Boolean)
+    .map(normalizeToken);
+}
+
+function normalizeToken(value: string) {
+  return value.trim().toLowerCase();
+}
+
+export function flattenTranslations(
+  value: TranslationMap,
+  prefix = "",
+  out = new Map<string, string>(),
+) {
+  for (const [key, nested] of Object.entries(value)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof nested === "string") {
+      out.set(fullKey, nested);
+      continue;
+    }
+    flattenTranslations(nested, fullKey, out);
+  }
+  return out;
+}
+
+export function computeSameAsEnglishKeys(source: Map<string, string>, target: Map<string, string>) {
+  return [...target.entries()]
+    .filter(([key, value]) => source.get(key) === value)
+    .map(([key]) => key)
+    .toSorted();
+}
+
+export function filterTranslationKeysBySurface(keys: string[], surface?: string) {
+  if (!surface) {
+    return keys;
+  }
+  const normalized = normalizeToken(surface);
+  return keys.filter((key) => key.split(".").some((part) => normalizeToken(part) === normalized));
+}
+
+export function formatReport(input: ReportInput) {
+  const lines = [
+    "Control UI i18n baseline report",
+    `Scope: ${formatSurfaceLabel(input.surface)}, ${
+      input.locale ? formatLocaleLabel(input.locale.meta.locale) : "no locale selected"
+    }`,
+    "Based on: current raw-copy baseline and locale metadata. Not a drift check.",
+    "",
+    "Current i18n state",
+    `  Hardcoded UI text outside i18n: ${input.rawCopy.entries} pieces in code, ${input.rawCopy.occurrences} total occurrences.`,
+    ...formatLocaleState(input.locale),
+    "",
+    "Current issue",
+    ...formatIssueLines(input),
+    "",
+    "Focus modules",
+    ...formatTopPathLines(input.rawCopy.topPaths),
+    "",
+    "Next steps",
+    ...formatNextStepLines(input),
+  ];
+
+  return `${lines.join("\n")}\n`;
+}
+
+function formatLocaleState(locale?: LocaleSummary) {
+  if (!locale) {
+    return ["  Existing translation keys: not checked. Add --locale <code> to include them."];
+  }
+  return [
+    `  Existing ${locale.meta.locale} translation keys (all Control UI): ${locale.meta.translatedKeys}/${locale.meta.totalKeys} filled, ${formatFallbackCount(locale.meta.fallbackKeys.length)}.`,
+  ];
+}
+
+function formatIssueLines(input: ReportInput) {
+  const scope = input.surface ? formatSurfaceLabel(input.surface) : "Control UI";
+  const lines: string[] = [];
+
+  if (input.rawCopy.entries === 0) {
+    lines.push(`  No hardcoded UI text found in ${scope}.`);
+  } else {
+    lines.push(`  ${scope} still has UI text written directly in code.`);
+  }
+
+  if (!input.locale) {
+    lines.push("  Locale-specific gaps were not checked.");
+    return lines;
+  }
+
+  if (
+    input.locale.fallbackKeysInScope.length === 0 &&
+    input.locale.sameAsEnglishKeys.length === 0
+  ) {
+    lines.push(`  No ${input.locale.meta.locale} locale problems found in this scope.`);
+    return lines;
+  }
+
+  if (input.locale.fallbackKeysInScope.length > 0) {
+    lines.push(
+      `  ${input.locale.meta.locale} has ${formatMissingKeyCount(input.locale.fallbackKeysInScope.length)}.`,
+    );
+  }
+  if (input.locale.sameAsEnglishKeys.length > 0) {
+    lines.push(
+      `  ${formatSameAsEnglishIssue(input.locale.sameAsEnglishKeys.length, input.locale.meta.locale)}.`,
+    );
+  }
+  return lines;
+}
+
+function formatNextStepLines(input: ReportInput) {
+  if (input.rawCopy.entries === 0) {
+    return ["  No module work needed for hardcoded text in this scope."];
+  }
+  return [
+    "  Move text from the focus modules into translation keys.",
+    "  Do not hand-edit generated locale, translation memory, or i18n metadata files.",
+    "  Run pnpm ui:i18n:sync after adding translation keys.",
+  ];
+}
+
+function formatTopPathLines(entries: Array<{ count: number; path: string }>) {
+  if (entries.length === 0) {
+    return ["  none"];
+  }
+  return entries.map((entry) => `  ${entry.count} ${formatPathLabel(entry.path)}: ${entry.path}`);
+}
+
+function formatMissingKeyCount(count: number) {
+  return `${count} missing ${count === 1 ? "key" : "keys"}`;
+}
+
+function formatFallbackCount(count: number) {
+  return `${count} ${count === 1 ? "fallback" : "fallbacks"}`;
+}
+
+function formatSameAsEnglishIssue(count: number, locale: string) {
+  if (count === 1) {
+    return `1 ${locale} translation still matches English and needs review`;
+  }
+  return `${count} ${locale} translations still match English and need review`;
+}
+
+function formatSurfaceLabel(surface?: string) {
+  if (!surface) {
+    return "all Control UI";
+  }
+  return toTitleWords(surface);
+}
+
+function formatLocaleLabel(locale: string) {
+  const label = LOCALE_LABELS[locale];
+  return label ? `${label} (${locale})` : locale;
+}
+
+function formatPathLabel(repoPath: string) {
+  return PATH_LABELS[repoPath] ?? toTitleWords(path.basename(repoPath).replace(/\.[^.]+$/, ""));
+}
+
+function toTitleWords(value: string) {
+  return value
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+async function loadRawCopyBaseline(): Promise<RawCopyBaseline> {
+  const parsed = JSON.parse(await readFile(RAW_COPY_BASELINE_PATH, "utf8")) as RawCopyBaseline;
+  if (!Array.isArray(parsed.entries)) {
+    throw new Error("raw-copy baseline is missing entries");
+  }
+  return parsed;
+}
+
+async function loadLocaleMeta(locale: string): Promise<LocaleMeta> {
+  const metaPath = path.join(I18N_ASSETS_DIR, `${locale}.meta.json`);
+  if (!existsSync(metaPath)) {
+    throw new Error(`unknown locale metadata: ${locale}`);
+  }
+  return JSON.parse(await readFile(metaPath, "utf8")) as LocaleMeta;
+}
+
+async function loadLocaleMap(locale: string): Promise<TranslationMap> {
+  const filePath = locale === "en" ? SOURCE_LOCALE_PATH : path.join(LOCALES_DIR, `${locale}.ts`);
+  if (!existsSync(filePath)) {
+    throw new Error(`unknown locale file: ${locale}`);
+  }
+  const exportName = locale.replaceAll("-", "_");
+  const mod = (await import(pathToFileURL(filePath).href)) as Record<string, TranslationMap>;
+  const map = mod[exportName];
+  if (!map) {
+    throw new Error(`locale ${locale} does not export ${exportName}`);
+  }
+  return map;
+}
+
+async function buildReport(args: ReportArgs) {
+  const baseline = await loadRawCopyBaseline();
+  const entries = filterRawCopyEntries(baseline.entries, args.surface);
+  const input: ReportInput = {
+    rawCopy: summarizeRawCopy(entries, args.top),
+    surface: args.surface,
+  };
+
+  if (args.locale) {
+    const [meta, source, target] = await Promise.all([
+      loadLocaleMeta(args.locale),
+      loadLocaleMap("en"),
+      loadLocaleMap(args.locale),
+    ]);
+    input.locale = {
+      fallbackKeysInScope: filterTranslationKeysBySurface(meta.fallbackKeys, args.surface),
+      meta,
+      sameAsEnglishKeys: filterTranslationKeysBySurface(
+        computeSameAsEnglishKeys(flattenTranslations(source), flattenTranslations(target)),
+        args.surface,
+      ),
+    };
+  }
+
+  return formatReport(input);
+}
+
+function usage() {
+  return [
+    "usage: node --import tsx scripts/control-ui-i18n-report.ts [--surface <name>] [--locale <locale>] [--top <n>]",
+    "example: pnpm ui:i18n:report --surface chat --locale zh-CN --top 20",
+  ].join("\n");
+}
+
+function isCliEntrypoint() {
+  const entrypoint = process.argv[1];
+  return Boolean(entrypoint && import.meta.url === pathToFileURL(path.resolve(entrypoint)).href);
+}
+
+if (isCliEntrypoint()) {
+  const cliArgs = process.argv.slice(2);
+  if (cliArgs.includes("--help") || cliArgs.includes("-h")) {
+    process.stdout.write(`${usage()}\n`);
+    process.exit(0);
+  }
+
+  try {
+    process.stdout.write(await buildReport(parseArgs(cliArgs)));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/control-ui-i18n-report.ts
+++ b/scripts/control-ui-i18n-report.ts
@@ -30,6 +30,7 @@ const LOCALE_LABELS: Record<string, string> = {
   "zh-CN": "Simplified Chinese",
   "zh-TW": "Traditional Chinese",
 };
+const REPORT_LOCALES = new Set(Object.keys(LOCALE_LABELS));
 const PATH_LABELS: Record<string, string> = {
   "ui/src/ui/chat/chat-queue.ts": "Chat queue",
   "ui/src/ui/chat/grouped-render.ts": "Chat message groups",
@@ -108,13 +109,16 @@ export function parseArgs(argv: string[]): ReportArgs {
       continue;
     }
     if (arg === "--locale") {
-      args.locale = readOptionValue(argv, (index += 1), arg);
+      args.locale = parseLocale(readOptionValue(argv, (index += 1), arg));
       continue;
     }
     if (arg === "--top") {
       const raw = readOptionValue(argv, (index += 1), arg);
+      if (!/^[1-9][0-9]*$/.test(raw)) {
+        throw new Error(`--top must be a positive integer: ${raw}`);
+      }
       const top = Number.parseInt(raw, 10);
-      if (!Number.isSafeInteger(top) || top < 1) {
+      if (!Number.isSafeInteger(top)) {
         throw new Error(`--top must be a positive integer: ${raw}`);
       }
       args.top = top;
@@ -131,6 +135,13 @@ function readOptionValue(argv: string[], index: number, flag: string) {
     throw new Error(`${flag} requires a value`);
   }
   return value;
+}
+
+function parseLocale(locale: string) {
+  if (!REPORT_LOCALES.has(locale)) {
+    throw new Error(`unknown locale: ${locale}`);
+  }
+  return locale;
 }
 
 export function filterRawCopyEntries(entries: RawCopyBaselineEntry[], surface?: string) {
@@ -167,9 +178,13 @@ function compareCountThenName<T>(nameOf: (value: T) => string) {
 }
 
 function pathTokens(repoPath: string) {
-  return repoPath
-    .split("/")
-    .flatMap((part) => part.replace(/\.[^.]+$/, "").split(/[^A-Za-z0-9]+/))
+  return repoPath.split("/").flatMap((part) => surfaceTokens(part.replace(/\.[^.]+$/, "")));
+}
+
+function surfaceTokens(value: string) {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[^A-Za-z0-9]+/)
     .filter(Boolean)
     .map(normalizeToken);
 }
@@ -206,7 +221,9 @@ export function filterTranslationKeysBySurface(keys: string[], surface?: string)
     return keys;
   }
   const normalized = normalizeToken(surface);
-  return keys.filter((key) => key.split(".").some((part) => normalizeToken(part) === normalized));
+  return keys.filter((key) =>
+    key.split(".").some((part) => surfaceTokens(part).some((token) => token === normalized)),
+  );
 }
 
 export function formatReport(input: ReportInput) {

--- a/scripts/control-ui-i18n-report.ts
+++ b/scripts/control-ui-i18n-report.ts
@@ -2,13 +2,10 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import type { TranslationMap } from "../ui/src/i18n/lib/types.ts";
 
 const ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const I18N_ASSETS_DIR = path.join(ROOT, "ui/src/i18n/.i18n");
-const LOCALES_DIR = path.join(ROOT, "ui/src/i18n/locales");
 const RAW_COPY_BASELINE_PATH = path.join(I18N_ASSETS_DIR, "raw-copy-baseline.json");
-const SOURCE_LOCALE_PATH = path.join(LOCALES_DIR, "en.ts");
 const DEFAULT_TOP = 10;
 const LOCALE_LABELS: Record<string, string> = {
   ar: "Arabic",
@@ -91,7 +88,6 @@ export type RawCopySummary = {
 export type LocaleSummary = {
   fallbackKeysInScope: string[];
   meta: LocaleMeta;
-  sameAsEnglishKeys: string[];
 };
 
 type ReportInput = {
@@ -193,29 +189,6 @@ function normalizeToken(value: string) {
   return value.trim().toLowerCase();
 }
 
-export function flattenTranslations(
-  value: TranslationMap,
-  prefix = "",
-  out = new Map<string, string>(),
-) {
-  for (const [key, nested] of Object.entries(value)) {
-    const fullKey = prefix ? `${prefix}.${key}` : key;
-    if (typeof nested === "string") {
-      out.set(fullKey, nested);
-      continue;
-    }
-    flattenTranslations(nested, fullKey, out);
-  }
-  return out;
-}
-
-export function computeSameAsEnglishKeys(source: Map<string, string>, target: Map<string, string>) {
-  return [...target.entries()]
-    .filter(([key, value]) => source.get(key) === value)
-    .map(([key]) => key)
-    .toSorted();
-}
-
 export function filterTranslationKeysBySurface(keys: string[], surface?: string) {
   if (!surface) {
     return keys;
@@ -275,24 +248,14 @@ function formatIssueLines(input: ReportInput) {
     return lines;
   }
 
-  if (
-    input.locale.fallbackKeysInScope.length === 0 &&
-    input.locale.sameAsEnglishKeys.length === 0
-  ) {
+  if (input.locale.fallbackKeysInScope.length === 0) {
     lines.push(`  No ${input.locale.meta.locale} locale problems found in this scope.`);
     return lines;
   }
 
-  if (input.locale.fallbackKeysInScope.length > 0) {
-    lines.push(
-      `  ${input.locale.meta.locale} has ${formatMissingKeyCount(input.locale.fallbackKeysInScope.length)}.`,
-    );
-  }
-  if (input.locale.sameAsEnglishKeys.length > 0) {
-    lines.push(
-      `  ${formatSameAsEnglishIssue(input.locale.sameAsEnglishKeys.length, input.locale.meta.locale)}.`,
-    );
-  }
+  lines.push(
+    `  ${input.locale.meta.locale} has ${formatMissingKeyCount(input.locale.fallbackKeysInScope.length)}.`,
+  );
   return lines;
 }
 
@@ -320,13 +283,6 @@ function formatMissingKeyCount(count: number) {
 
 function formatFallbackCount(count: number) {
   return `${count} ${count === 1 ? "fallback" : "fallbacks"}`;
-}
-
-function formatSameAsEnglishIssue(count: number, locale: string) {
-  if (count === 1) {
-    return `1 ${locale} translation still matches English and needs review`;
-  }
-  return `${count} ${locale} translations still match English and need review`;
 }
 
 function formatSurfaceLabel(surface?: string) {
@@ -369,20 +325,6 @@ async function loadLocaleMeta(locale: string): Promise<LocaleMeta> {
   return JSON.parse(await readFile(metaPath, "utf8")) as LocaleMeta;
 }
 
-async function loadLocaleMap(locale: string): Promise<TranslationMap> {
-  const filePath = locale === "en" ? SOURCE_LOCALE_PATH : path.join(LOCALES_DIR, `${locale}.ts`);
-  if (!existsSync(filePath)) {
-    throw new Error(`unknown locale file: ${locale}`);
-  }
-  const exportName = locale.replaceAll("-", "_");
-  const mod = (await import(pathToFileURL(filePath).href)) as Record<string, TranslationMap>;
-  const map = mod[exportName];
-  if (!map) {
-    throw new Error(`locale ${locale} does not export ${exportName}`);
-  }
-  return map;
-}
-
 async function buildReport(args: ReportArgs) {
   const baseline = await loadRawCopyBaseline();
   const entries = filterRawCopyEntries(baseline.entries, args.surface);
@@ -392,18 +334,10 @@ async function buildReport(args: ReportArgs) {
   };
 
   if (args.locale) {
-    const [meta, source, target] = await Promise.all([
-      loadLocaleMeta(args.locale),
-      loadLocaleMap("en"),
-      loadLocaleMap(args.locale),
-    ]);
+    const meta = await loadLocaleMeta(args.locale);
     input.locale = {
       fallbackKeysInScope: filterTranslationKeysBySurface(meta.fallbackKeys, args.surface),
       meta,
-      sameAsEnglishKeys: filterTranslationKeysBySurface(
-        computeSameAsEnglishKeys(flattenTranslations(source), flattenTranslations(target)),
-        args.surface,
-      ),
     };
   }
 

--- a/src/scripts/control-ui-i18n-report.test.ts
+++ b/src/scripts/control-ui-i18n-report.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeSameAsEnglishKeys,
+  filterRawCopyEntries,
+  filterTranslationKeysBySurface,
+  flattenTranslations,
+  formatReport,
+  summarizeRawCopy,
+  type RawCopyBaselineEntry,
+} from "../../scripts/control-ui-i18n-report.ts";
+import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
+
+const entries: RawCopyBaselineEntry[] = [
+  {
+    count: 2,
+    kind: "html-text",
+    name: "text",
+    path: "ui/src/ui/chat/render.ts",
+    text: "Send",
+  },
+  {
+    count: 1,
+    kind: "object-property",
+    name: "label",
+    path: "ui/src/ui/views/agents-panels-tools.ts",
+    text: "Tools",
+  },
+  {
+    count: 4,
+    kind: "html-attribute",
+    name: "title",
+    path: "ui/src/ui/views/config-form.render.ts",
+    text: "Open config",
+  },
+];
+
+describe("control-ui-i18n report helpers", () => {
+  it("filters raw-copy entries by path surface token", () => {
+    expect(filterRawCopyEntries(entries, "agents")).toEqual([entries[1]]);
+    expect(filterRawCopyEntries(entries, "config")).toEqual([entries[2]]);
+    expect(filterRawCopyEntries(entries, "missing")).toEqual([]);
+  });
+
+  it("summarizes raw-copy occurrences deterministically", () => {
+    expect(summarizeRawCopy(entries, 2)).toEqual({
+      entries: 3,
+      occurrences: 7,
+      topPaths: [
+        { count: 4, path: "ui/src/ui/views/config-form.render.ts" },
+        { count: 2, path: "ui/src/ui/chat/render.ts" },
+      ],
+    });
+  });
+
+  it("flattens locale maps and reports same-as-English keys", () => {
+    const source: TranslationMap = {
+      actions: { send: "Send", stop: "Stop" },
+      brand: "OpenClaw",
+    };
+    const target: TranslationMap = {
+      actions: { send: "发送", stop: "Stop" },
+      brand: "OpenClaw",
+    };
+
+    expect(
+      computeSameAsEnglishKeys(flattenTranslations(source), flattenTranslations(target)),
+    ).toEqual(["actions.stop", "brand"]);
+  });
+
+  it("filters same-as-English keys by translation key surface token", () => {
+    expect(
+      filterTranslationKeysBySurface(
+        ["agents.tabs.cronJobs", "chat.composer.send", "usage.common.emptyValue"],
+        "chat",
+      ),
+    ).toEqual(["chat.composer.send"]);
+  });
+
+  it("formats pasteable report text", () => {
+    const report = formatReport({
+      locale: {
+        fallbackKeysInScope: ["actions.cancel"],
+        meta: {
+          fallbackKeys: ["actions.cancel"],
+          generatedAt: "2026-05-13T00:00:00.000Z",
+          locale: "zh-CN",
+          model: "gpt-5.5",
+          provider: "openai",
+          sourceHash: "hash",
+          totalKeys: 3,
+          translatedKeys: 2,
+          workflow: 1,
+        },
+        sameAsEnglishKeys: ["brand"],
+      },
+      rawCopy: summarizeRawCopy(entries, 1),
+      surface: "chat",
+    });
+
+    expect(report).toContain("Control UI i18n baseline report\n");
+    expect(report).toContain("Scope: Chat, Simplified Chinese (zh-CN)\n");
+    expect(report).toContain(
+      "Based on: current raw-copy baseline and locale metadata. Not a drift check.\n",
+    );
+    expect(report).toContain(
+      "Hardcoded UI text outside i18n: 3 pieces in code, 7 total occurrences.\n",
+    );
+    expect(report).toContain(
+      "Existing zh-CN translation keys (all Control UI): 2/3 filled, 1 fallback.\n",
+    );
+    expect(report).toContain("Chat still has UI text written directly in code.\n");
+    expect(report).toContain("zh-CN has 1 missing key.\n");
+    expect(report).toContain("1 zh-CN translation still matches English and needs review.\n");
+    expect(report).toContain("4 Config form: ui/src/ui/views/config-form.render.ts\n");
+    expect(report).toContain("Move text from the focus modules into translation keys.\n");
+    expect(report).toContain(
+      "Do not hand-edit generated locale, translation memory, or i18n metadata files.\n",
+    );
+    expect(report).toContain("Run pnpm ui:i18n:sync after adding translation keys.\n");
+    expect(report).not.toContain("raw-copy entries");
+  });
+
+  it("keeps fallback-key issues scoped to the selected surface", () => {
+    const report = formatReport({
+      locale: {
+        fallbackKeysInScope: [],
+        meta: {
+          fallbackKeys: ["usage.common.emptyValue"],
+          generatedAt: "2026-05-13T00:00:00.000Z",
+          locale: "zh-CN",
+          model: "gpt-5.5",
+          provider: "openai",
+          sourceHash: "hash",
+          totalKeys: 3,
+          translatedKeys: 2,
+          workflow: 1,
+        },
+        sameAsEnglishKeys: [],
+      },
+      rawCopy: summarizeRawCopy(entries, 1),
+      surface: "chat",
+    });
+
+    expect(report).toContain(
+      "Existing zh-CN translation keys (all Control UI): 2/3 filled, 1 fallback.\n",
+    );
+    expect(report).toContain("No zh-CN locale problems found in this scope.\n");
+    expect(report).not.toContain("zh-CN has 1 missing key.\n");
+  });
+});

--- a/src/scripts/control-ui-i18n-report.test.ts
+++ b/src/scripts/control-ui-i18n-report.test.ts
@@ -5,6 +5,7 @@ import {
   filterTranslationKeysBySurface,
   flattenTranslations,
   formatReport,
+  parseArgs,
   summarizeRawCopy,
   type RawCopyBaselineEntry,
 } from "../../scripts/control-ui-i18n-report.ts";
@@ -35,6 +36,23 @@ const entries: RawCopyBaselineEntry[] = [
 ];
 
 describe("control-ui-i18n report helpers", () => {
+  it("rejects invalid numeric limits", () => {
+    expect(() => parseArgs(["--top", "3abc"])).toThrow("--top must be a positive integer");
+    expect(() => parseArgs(["--top", "1.5"])).toThrow("--top must be a positive integer");
+    expect(() => parseArgs(["--top", "0"])).toThrow("--top must be a positive integer");
+    expect(() => parseArgs(["--top", "999999999999999999999999999"])).toThrow(
+      "--top must be a positive integer",
+    );
+  });
+
+  it("rejects locale path traversal before filesystem access", () => {
+    expect(parseArgs(["--locale", "zh-CN"])).toMatchObject({ locale: "zh-CN" });
+    expect(() => parseArgs(["--locale", "../zh-CN"])).toThrow("unknown locale");
+    expect(() => parseArgs(["--locale", "../../../../scripts/control-ui-i18n-report"])).toThrow(
+      "unknown locale",
+    );
+  });
+
   it("filters raw-copy entries by path surface token", () => {
     expect(filterRawCopyEntries(entries, "agents")).toEqual([entries[1]]);
     expect(filterRawCopyEntries(entries, "config")).toEqual([entries[2]]);
@@ -70,10 +88,26 @@ describe("control-ui-i18n report helpers", () => {
   it("filters same-as-English keys by translation key surface token", () => {
     expect(
       filterTranslationKeysBySurface(
-        ["agents.tabs.cronJobs", "chat.composer.send", "usage.common.emptyValue"],
+        [
+          "agents.tabs.cronJobs",
+          "chat.composer.send",
+          "sessionsView.thinking",
+          "usage.common.emptyValue",
+        ],
         "chat",
       ),
     ).toEqual(["chat.composer.send"]);
+    expect(
+      filterTranslationKeysBySurface(
+        [
+          "agents.tabs.cronJobs",
+          "chat.composer.send",
+          "sessionsView.thinking",
+          "usage.common.emptyValue",
+        ],
+        "sessions",
+      ),
+    ).toEqual(["sessionsView.thinking"]);
   });
 
   it("formats pasteable report text", () => {

--- a/src/scripts/control-ui-i18n-report.test.ts
+++ b/src/scripts/control-ui-i18n-report.test.ts
@@ -1,15 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
-  computeSameAsEnglishKeys,
   filterRawCopyEntries,
   filterTranslationKeysBySurface,
-  flattenTranslations,
   formatReport,
   parseArgs,
   summarizeRawCopy,
   type RawCopyBaselineEntry,
 } from "../../scripts/control-ui-i18n-report.ts";
-import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 
 const entries: RawCopyBaselineEntry[] = [
   {
@@ -70,22 +67,7 @@ describe("control-ui-i18n report helpers", () => {
     });
   });
 
-  it("flattens locale maps and reports same-as-English keys", () => {
-    const source: TranslationMap = {
-      actions: { send: "Send", stop: "Stop" },
-      brand: "OpenClaw",
-    };
-    const target: TranslationMap = {
-      actions: { send: "发送", stop: "Stop" },
-      brand: "OpenClaw",
-    };
-
-    expect(
-      computeSameAsEnglishKeys(flattenTranslations(source), flattenTranslations(target)),
-    ).toEqual(["actions.stop", "brand"]);
-  });
-
-  it("filters same-as-English keys by translation key surface token", () => {
+  it("filters translation keys by surface token", () => {
     expect(
       filterTranslationKeysBySurface(
         [
@@ -125,7 +107,6 @@ describe("control-ui-i18n report helpers", () => {
           translatedKeys: 2,
           workflow: 1,
         },
-        sameAsEnglishKeys: ["brand"],
       },
       rawCopy: summarizeRawCopy(entries, 1),
       surface: "chat",
@@ -144,7 +125,7 @@ describe("control-ui-i18n report helpers", () => {
     );
     expect(report).toContain("Chat still has UI text written directly in code.\n");
     expect(report).toContain("zh-CN has 1 missing key.\n");
-    expect(report).toContain("1 zh-CN translation still matches English and needs review.\n");
+    expect(report).not.toContain("matches English");
     expect(report).toContain("4 Config form: ui/src/ui/views/config-form.render.ts\n");
     expect(report).toContain("Move text from the focus modules into translation keys.\n");
     expect(report).toContain(
@@ -169,7 +150,6 @@ describe("control-ui-i18n report helpers", () => {
           translatedKeys: 2,
           workflow: 1,
         },
-        sameAsEnglishKeys: [],
       },
       rawCopy: summarizeRawCopy(entries, 1),
       surface: "chat",

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -86,6 +86,8 @@ describe("production lint suppressions", () => {
       "extensions/feishu/src/bitable.ts|typescript/no-unnecessary-type-parameters|1",
       "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
       "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
+      "extensions/telegram/src/telegram-ingress-worker.runtime.ts|unicorn/require-post-message-target-origin|1",
+      "extensions/telegram/src/telegram-ingress-worker.ts|unicorn/require-post-message-target-origin|1",
       "scripts/e2e/mcp-channels-harness.ts|unicorn/prefer-add-event-listener|1",
       "scripts/lib/extension-package-boundary.ts|typescript/no-unnecessary-type-parameters|1",
       "scripts/lib/plugin-npm-release.ts|typescript/no-unnecessary-type-parameters|1",

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -11,6 +11,7 @@ This directory owns Control UI-specific guidance that should not live in the rep
   - `ui/src/i18n/lib/types.ts`
   - `ui/src/i18n/lib/registry.ts`
 - Pipeline: update English strings and locale wiring here, then run `pnpm ui:i18n:sync` and commit the regenerated locale bundles plus `.i18n` metadata.
+- Prioritization report: `pnpm ui:i18n:report [--surface <name>] [--locale <locale>] [--top <n>]` shows current hardcoded-copy focus areas and locale fallback metadata. It is not a drift gate; use `pnpm ui:i18n:check` for that.
 - If locale outputs drift, regenerate them. Do not manually translate or hand-maintain generated locale files by default.
 
 ## Scope


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: Control UI i18n contributors had no concise command for reading the checked-in raw-copy baseline and locale metadata as a prioritization report.
- Why it matters: Translation work can be split by surface without manually grepping hardcoded copy or touching generated locale artifacts.
- What changed: Added `pnpm ui:i18n:report` with optional `--surface`, `--locale`, and `--top` filters, plus focused helper tests.
- What did NOT change (scope boundary): This does not rescan source, update locale bundles, change runtime i18n behavior, or replace `ui:i18n:sync` / `ui:i18n:check`.
- AI-assisted: Yes, Codex helped implement and verify this PR.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

No linked issue.

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Contributors can run a concise Control UI i18n baseline report without regenerating locale artifacts.
- Real environment tested: Local OpenClaw checkout on Darwin 25.4.0 arm64, Node v24.14.0, pnpm 11.1.0.
- Exact steps or command run after this patch: `pnpm ui:i18n:report --surface chat --locale zh-CN --top 3`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ node --import tsx scripts/control-ui-i18n-report.ts --surface chat --locale zh-CN --top 3
Control UI i18n baseline report
Scope: Chat, Simplified Chinese (zh-CN)
Based on: current raw-copy baseline and locale metadata. Not a drift check.

Current i18n state
  Hardcoded UI text outside i18n: 81 pieces in code, 92 total occurrences.
  Existing zh-CN translation keys (all Control UI): 1108/1108 filled, 0 fallbacks.

Current issue
  Chat still has UI text written directly in code.
  No zh-CN locale problems found in this scope.

Focus modules
  54 Chat page: ui/src/ui/views/chat.ts
  12 Chat message groups: ui/src/ui/chat/grouped-render.ts
  7 Chat tool cards: ui/src/ui/chat/tool-cards.ts

Next steps
  Move text from the focus modules into translation keys.
  Do not hand-edit generated locale, translation memory, or i18n metadata files.
  Run pnpm ui:i18n:sync after adding translation keys.
```

- Observed result after fix: The command prints current baseline state, the main i18n issue, focus modules, and next steps without scanning source or editing generated files.
- What was not tested: Full `pnpm check`; browser UI visual proof is not applicable because this is a CLI/reporting tool.
- Before evidence (optional but encouraged): Before this PR, `package.json` had `ui:i18n:sync` and `ui:i18n:check`, but no `ui:i18n:report` script.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: N/A.
- Missing detection / guardrail: N/A.
- Contributing context (if known): N/A.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/scripts/control-ui-i18n-report.test.ts`
- Scenario the test should lock in: surface filtering, raw-copy aggregation, same-as-English detection, scoped fallback issue reporting, and concise report formatting.
- Why this is the smallest reliable guardrail: The new behavior is a deterministic report over checked-in baseline and locale metadata.
- Existing test that already covers this (if any): N/A; this PR adds the focused test file.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Adds a contributor-facing package script:

```bash
pnpm ui:i18n:report [--surface <name>] [--locale <locale>] [--top <n>]
```

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: The new command is local dev tooling that reads checked-in `ui/src/i18n/.i18n/raw-copy-baseline.json`, locale metadata, and locale modules. It does not write files, call the network, or read secrets.

## Repro + Verification

### Environment

- OS: Darwin 25.4.0 arm64
- Runtime/container: Local Node v24.14.0 with pnpm 11.1.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm ui:i18n:report --surface chat --locale zh-CN --top 3`.
2. Run `pnpm test src/scripts/control-ui-i18n-report.test.ts`.
3. Run `node scripts/check-changed.mjs`.
4. Run `pnpm changed:lanes --json`.

### Expected

- The report command prints a concise baseline report.
- The focused report tests pass.
- Changed-file checks pass for the touched lanes.
- Changed-lane discovery stays limited to `coreTests` and `tooling`.

### Actual

- `pnpm ui:i18n:report --surface chat --locale zh-CN --top 3` passed and printed the copied output above.
- `pnpm test src/scripts/control-ui-i18n-report.test.ts` passed: 1 test file, 6 tests.
- `node scripts/check-changed.mjs` passed.
- `pnpm changed:lanes --json` reported `coreTests: true`, `tooling: true`, and all broad/runtime lanes false.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Report output for `chat` + `zh-CN`; helper tests; changed-file checks; lane discovery.
- Edge cases checked: scoped fallback issue reporting, no-locale output path, same-as-English detection, deterministic path ranking, positive integer validation for `--top` through tests and CLI behavior.
- What you did **not** verify: Full `pnpm check`; no browser visual proof because no browser UI changed.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations exist yet for this PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The report can be mistaken for a drift gate.
  - Mitigation: The output explicitly says it is based on the current raw-copy baseline and locale metadata, and is not a drift check.
- Risk: Contributors may hand-edit generated locale artifacts after seeing next steps.
  - Mitigation: The report tells users not to hand-edit generated locale, translation memory, or i18n metadata files, and to run `pnpm ui:i18n:sync` after adding translation keys.
