### PR TITLE
cherry-pick #81219 onto release/2026.5.12 for beta.5

### DIFF
--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -66,7 +66,7 @@ vi.mock("./backup.js", () => ({
 }));
 
 const {
-  MIGRATION_SKILL_SELECTION_SKIP,
+  MIGRATION_SKILL_SELECTION_ACCEPT,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
 } = await import("./migrate/selection.js");
@@ -414,11 +414,11 @@ describe("migrateApplyCommand", () => {
     expect(selectionPrompt?.initialValues).toStrictEqual(["skill:alpha", "skill:beta"]);
     expect(selectionPrompt?.required).toBe(false);
     expect(selectionPrompt?.options?.map(({ label, value }) => ({ label, value }))).toStrictEqual([
-      { value: MIGRATION_SKILL_SELECTION_SKIP, label: "Skip for now" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
+      { value: MIGRATION_SKILL_SELECTION_ACCEPT, label: "Accept recommended" },
       { value: "skill:alpha", label: "alpha" },
       { value: "skill:beta", label: "beta" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
     ]);
     expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
     const appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
@@ -481,11 +481,11 @@ describe("migrateApplyCommand", () => {
     expect(pluginPrompt?.initialValues).toStrictEqual(["plugin:google-calendar", "plugin:gmail"]);
     expect(pluginPrompt?.required).toBe(false);
     expect(pluginPrompt?.options?.map(({ label, value }) => ({ label, value }))).toStrictEqual([
-      { value: MIGRATION_SKILL_SELECTION_SKIP, label: "Skip for now" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
+      { value: MIGRATION_SKILL_SELECTION_ACCEPT, label: "Accept recommended" },
       { value: "plugin:google-calendar", label: "google-calendar" },
       { value: "plugin:gmail", label: "gmail" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
     ]);
     expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
     const appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
@@ -637,59 +637,6 @@ describe("migrateApplyCommand", () => {
     expect(itemsById.get("plugin:gmail")?.status).toBe("planned");
   });
 
-  it("skips interactive Codex plugin migration before confirmation when Skip for now is selected", async () => {
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: true,
-    });
-    const planned = codexPluginPlan();
-    mocks.provider.plan.mockResolvedValue(planned);
-    mocks.multiselect.mockResolvedValue([MIGRATION_SKILL_SELECTION_SKIP]);
-
-    const result = await migrateDefaultCommand(runtime, { provider: "codex" });
-
-    expect(result).toBe(planned);
-    expect(mocks.promptYesNo).not.toHaveBeenCalled();
-    expect(mocks.backupCreateCommand).not.toHaveBeenCalled();
-    expect(mocks.provider.apply).not.toHaveBeenCalled();
-    expect(runtime.log).toHaveBeenCalledWith("Codex plugin migration skipped for now.");
-  });
-
-  it("returns without confirmation when both Codex skill and plugin selectors are skipped", async () => {
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: true,
-    });
-    const skillPlan = codexSkillPlan();
-    const pluginPlan = codexPluginPlan();
-    const planned = codexSkillPlan({
-      summary: {
-        total: skillPlan.items.length + pluginPlan.items.length,
-        planned: skillPlan.items.length + pluginPlan.items.length,
-        migrated: 0,
-        skipped: 0,
-        conflicts: 0,
-        errors: 0,
-        sensitive: 0,
-      },
-      items: [...skillPlan.items, ...pluginPlan.items],
-    });
-    mocks.provider.plan.mockResolvedValue(planned);
-    mocks.multiselect
-      .mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP])
-      .mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP]);
-
-    const result = await migrateDefaultCommand(runtime, { provider: "codex" });
-
-    expect(result).toBe(planned);
-    expect(mocks.multiselect).toHaveBeenCalledTimes(2);
-    expect(mocks.promptYesNo).not.toHaveBeenCalled();
-    expect(mocks.backupCreateCommand).not.toHaveBeenCalled();
-    expect(mocks.provider.apply).not.toHaveBeenCalled();
-    expect(runtime.log).toHaveBeenCalledWith("Codex skill migration skipped for now.");
-    expect(runtime.log).toHaveBeenCalledWith("Codex plugin migration skipped for now.");
-  });
-
   it("does not apply when interactive Codex plugin migration chooses no plugins", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,
@@ -811,57 +758,6 @@ describe("migrateApplyCommand", () => {
     expect(mocks.provider.apply).not.toHaveBeenCalled();
   });
 
-  it("continues to interactive Codex plugins when skill migration is skipped", async () => {
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: true,
-    });
-    const skillPlan = codexSkillPlan();
-    const pluginPlan = codexPluginPlan();
-    const planned = codexSkillPlan({
-      summary: {
-        total: skillPlan.items.length + pluginPlan.items.length,
-        planned: skillPlan.items.length + pluginPlan.items.length,
-        migrated: 0,
-        skipped: 0,
-        conflicts: 0,
-        errors: 0,
-        sensitive: 0,
-      },
-      items: [...skillPlan.items, ...pluginPlan.items],
-    });
-    mocks.provider.plan.mockResolvedValue(planned);
-    mocks.multiselect
-      .mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP])
-      .mockResolvedValueOnce(["plugin:gmail"]);
-    mocks.promptYesNo.mockResolvedValue(true);
-    mocks.provider.apply.mockImplementation(async (_ctx, selectedPlan: MigrationPlan) => ({
-      ...selectedPlan,
-      summary: { ...selectedPlan.summary, planned: 0, migrated: selectedPlan.summary.planned },
-      items: selectedPlan.items.map((item) =>
-        item.status === "planned" ? { ...item, status: "migrated" as const } : item,
-      ),
-    }));
-
-    await migrateDefaultCommand(runtime, { provider: "codex" });
-
-    expect(mocks.multiselect).toHaveBeenCalledTimes(2);
-    expect(runtime.log).toHaveBeenCalledWith("Codex skill migration skipped for now.");
-    expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
-    const appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
-    expect(appliedPlan.summary.planned).toBe(3);
-    expect(appliedPlan.summary.skipped).toBe(3);
-    expect(appliedPlan.summary.conflicts).toBe(0);
-    const itemsById = new Map(appliedPlan.items.map((item) => [item.id, item]));
-    expect(itemsById.get("skill:alpha")?.status).toBe("skipped");
-    expect(itemsById.get("skill:alpha")?.reason).toBe("not selected for migration");
-    expect(itemsById.get("skill:beta")?.status).toBe("skipped");
-    expect(itemsById.get("skill:beta")?.reason).toBe("not selected for migration");
-    expect(itemsById.get("plugin:gmail")?.status).toBe("planned");
-    expect(itemsById.get("plugin:google-calendar")?.status).toBe("skipped");
-    expect(itemsById.get("plugin:google-calendar")?.reason).toBe("not selected for migration");
-  });
-
   it("explains skipped plugin selection when Codex subscription auth is required", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,
@@ -894,7 +790,7 @@ describe("migrateApplyCommand", () => {
       warnings: [warning],
     });
     mocks.provider.plan.mockResolvedValue(planned);
-    mocks.multiselect.mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP]);
+    mocks.multiselect.mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF]);
 
     const result = await migrateDefaultCommand(runtime, { provider: "codex" });
 
@@ -903,7 +799,6 @@ describe("migrateApplyCommand", () => {
     expect(mocks.multiselect).toHaveBeenCalledTimes(1);
     expect(mocks.promptYesNo).not.toHaveBeenCalled();
     expect(mocks.provider.apply).not.toHaveBeenCalled();
-    expect(runtime.log).toHaveBeenCalledWith("Codex skill migration skipped for now.");
     expect(runtime.log).toHaveBeenCalledWith(warning);
     expect(runtime.log).toHaveBeenCalledWith(
       "No Codex skills selected; native Codex plugins are not eligible for migration in this run.",

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -30,7 +30,7 @@ import {
   getMigrationSkillSelectionValue,
   getSelectableMigrationPluginItems,
   getSelectableMigrationSkillItems,
-  MIGRATION_SELECTION_SKIP,
+  MIGRATION_SELECTION_ACCEPT,
   MIGRATION_SELECTION_TOGGLE_ALL_OFF,
   MIGRATION_SELECTION_TOGGLE_ALL_ON,
   resolveInteractiveMigrationPluginSelection,
@@ -135,16 +135,9 @@ async function promptCodexMigrationSkillSelection(
     message: stylePromptMessage("Select Codex skills to migrate into this agent"),
     options: [
       {
-        value: MIGRATION_SELECTION_SKIP,
-        label: "Skip for now",
-      },
-      {
-        value: MIGRATION_SELECTION_TOGGLE_ALL_ON,
-        label: "Toggle all on",
-      },
-      {
-        value: MIGRATION_SELECTION_TOGGLE_ALL_OFF,
-        label: "Toggle all off",
+        value: MIGRATION_SELECTION_ACCEPT,
+        label: "Accept recommended",
+        hint: "Migrate every recommended skill",
       },
       ...skillItems.map((item) => {
         const hint = formatMigrationSkillSelectionHint(item);
@@ -154,10 +147,19 @@ async function promptCodexMigrationSkillSelection(
           hint: hint === undefined ? undefined : stylePromptHint(hint),
         };
       }),
+      {
+        value: MIGRATION_SELECTION_TOGGLE_ALL_ON,
+        label: "Toggle all on",
+      },
+      {
+        value: MIGRATION_SELECTION_TOGGLE_ALL_OFF,
+        label: "Toggle all off",
+      },
     ],
     initialValues: getDefaultMigrationSkillSelectionValues(skillItems),
     required: false,
     selectableValues: skillItems.map(getMigrationSkillSelectionValue),
+    cursorAt: MIGRATION_SELECTION_ACCEPT,
   });
   if (isCancel(selected)) {
     cancel(stylePromptTitle("Migration cancelled.") ?? "Migration cancelled.");
@@ -165,10 +167,6 @@ async function promptCodexMigrationSkillSelection(
     return null;
   }
   const selection = resolveInteractiveMigrationSkillSelection(skillItems, selected ?? []);
-  if (selection.action === "skip") {
-    runtime.log("Codex skill migration skipped for now.");
-    return applyMigrationSelectedSkillItemIds(plan, new Set());
-  }
   const selectedPlan = applyMigrationSelectedSkillItemIds(plan, selection.selectedItemIds);
   runtime.log(
     `Selected ${selection.selectedItemIds.size} of ${skillItems.length} Codex skills for migration.`,
@@ -198,16 +196,9 @@ async function promptCodexMigrationPluginSelection(
     message: stylePromptMessage("Select native Codex plugins to activate in this agent"),
     options: [
       {
-        value: MIGRATION_SELECTION_SKIP,
-        label: "Skip for now",
-      },
-      {
-        value: MIGRATION_SELECTION_TOGGLE_ALL_ON,
-        label: "Toggle all on",
-      },
-      {
-        value: MIGRATION_SELECTION_TOGGLE_ALL_OFF,
-        label: "Toggle all off",
+        value: MIGRATION_SELECTION_ACCEPT,
+        label: "Accept recommended",
+        hint: "Migrate every recommended plugin",
       },
       ...pluginItems.map((item) => {
         const hint = formatMigrationPluginSelectionHint(item);
@@ -217,10 +208,19 @@ async function promptCodexMigrationPluginSelection(
           hint: hint === undefined ? undefined : stylePromptHint(hint),
         };
       }),
+      {
+        value: MIGRATION_SELECTION_TOGGLE_ALL_ON,
+        label: "Toggle all on",
+      },
+      {
+        value: MIGRATION_SELECTION_TOGGLE_ALL_OFF,
+        label: "Toggle all off",
+      },
     ],
     initialValues: getDefaultMigrationPluginSelectionValues(pluginItems),
     required: false,
     selectableValues: pluginItems.map(getMigrationPluginSelectionValue),
+    cursorAt: MIGRATION_SELECTION_ACCEPT,
   });
   if (isCancel(selected)) {
     cancel(stylePromptTitle("Migration cancelled.") ?? "Migration cancelled.");
@@ -228,10 +228,6 @@ async function promptCodexMigrationPluginSelection(
     return null;
   }
   const selection = resolveInteractiveMigrationPluginSelection(pluginItems, selected ?? []);
-  if (selection.action === "skip") {
-    runtime.log("Codex plugin migration skipped for now.");
-    return null;
-  }
   const selectedPlan = applyMigrationSelectedPluginItemIds(plan, selection.selectedItemIds);
   runtime.log(
     `Selected ${selection.selectedItemIds.size} of ${pluginItems.length} native Codex plugins for activation.`,
@@ -334,7 +330,7 @@ export async function migratePlanCommand(
   const plan = await createMigrationPlanWithProgress(runtime, { ...opts, provider: providerId });
   if (opts.json) {
     writeRuntimeJson(runtime, redactMigrationPlan(plan));
-  } else {
+  } else if (opts.suppressPlanLog !== true) {
     runtime.log(formatMigrationPlan(plan).join("\n"));
   }
   return plan;

--- a/src/commands/migrate/selection.test.ts
+++ b/src/commands/migrate/selection.test.ts
@@ -9,7 +9,6 @@ import {
   getDefaultMigrationPluginSelectionValues,
   getSelectableMigrationPluginItems,
   getDefaultMigrationSkillSelectionValues,
-  MIGRATION_SKILL_SELECTION_SKIP,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
   MIGRATION_PLUGIN_NOT_SELECTED_REASON,
@@ -255,7 +254,7 @@ describe("applyMigrationSkillSelection", () => {
     ).toEqual(["skill:alpha"]);
   });
 
-  it("resolves interactive special options with skip and toggle-off precedence", () => {
+  it("resolves interactive special options with toggle-off precedence over toggle-on", () => {
     const items = [
       skillItem({ id: "skill:alpha", name: "alpha" }),
       skillItem({
@@ -268,12 +267,6 @@ describe("applyMigrationSkillSelection", () => {
 
     expect(
       resolveInteractiveMigrationSkillSelection(items, [
-        MIGRATION_SKILL_SELECTION_SKIP,
-        MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
-      ]),
-    ).toEqual({ action: "skip" });
-    expect(
-      resolveInteractiveMigrationSkillSelection(items, [
         MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
         MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
       ]),
@@ -283,15 +276,6 @@ describe("applyMigrationSkillSelection", () => {
     ).toEqual({
       action: "select",
       selectedItemIds: new Set(["skill:alpha", "skill:beta"]),
-    });
-    expect(
-      resolveInteractiveMigrationSkillSelection(items, [
-        MIGRATION_SKILL_SELECTION_SKIP,
-        "skill:alpha",
-      ]),
-    ).toEqual({
-      action: "select",
-      selectedItemIds: new Set(["skill:alpha"]),
     });
   });
 
@@ -328,31 +312,9 @@ describe("applyMigrationSkillSelection", () => {
     ).toEqual(["skill:alpha"]);
 
     expect(
-      reconcileInteractiveMigrationSkillToggleValues(
-        [
-          MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
-          "skill:alpha",
-          "skill:beta",
-          MIGRATION_SKILL_SELECTION_SKIP,
-        ],
-        MIGRATION_SKILL_SELECTION_SKIP,
-        selectable,
-      ),
-    ).toEqual([MIGRATION_SKILL_SELECTION_SKIP]);
-
-    expect(
-      reconcileInteractiveMigrationSkillToggleValues(
-        [MIGRATION_SKILL_SELECTION_SKIP, "skill:alpha"],
-        "skill:alpha",
-        selectable,
-      ),
-    ).toEqual(["skill:alpha"]);
-
-    expect(
       reconcileInteractiveMigrationShortcutValues(
         ["skill:alpha", "skill:beta"],
         [
-          MIGRATION_SKILL_SELECTION_SKIP,
           MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
           MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
           "skill:alpha",
@@ -366,36 +328,15 @@ describe("applyMigrationSkillSelection", () => {
     expect(
       reconcileInteractiveMigrationShortcutValues(
         [MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF],
-        [
-          MIGRATION_SKILL_SELECTION_SKIP,
-          MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
-          MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
-        ],
+        [MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON],
         selectable,
         "i",
       ),
     ).toEqual([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF]);
-
-    expect(
-      reconcileInteractiveMigrationShortcutValues(
-        [MIGRATION_SKILL_SELECTION_SKIP],
-        [MIGRATION_SKILL_SELECTION_SKIP, "skill:beta"],
-        selectable,
-        "i",
-      ),
-    ).toEqual(["skill:beta"]);
   });
 
   it("reconciles enter as activating the cursor row without toggling it off", () => {
     const selectable = ["skill:alpha", "skill:beta"];
-
-    expect(
-      reconcileInteractiveMigrationEnterValues(
-        ["skill:alpha", "skill:beta"],
-        MIGRATION_SKILL_SELECTION_SKIP,
-        selectable,
-      ),
-    ).toEqual([MIGRATION_SKILL_SELECTION_SKIP]);
 
     expect(
       reconcileInteractiveMigrationEnterValues(

--- a/src/commands/migrate/selection.ts
+++ b/src/commands/migrate/selection.ts
@@ -4,16 +4,16 @@ import type { MigrationItem, MigrationPlan } from "../../plugins/types.js";
 
 export const MIGRATION_SKILL_NOT_SELECTED_REASON = "not selected for migration";
 export const MIGRATION_PLUGIN_NOT_SELECTED_REASON = "not selected for migration";
+export const MIGRATION_SELECTION_ACCEPT = "__openclaw_migrate_accept_recommended__";
 export const MIGRATION_SELECTION_TOGGLE_ALL_ON = "__openclaw_migrate_toggle_all_on__";
 export const MIGRATION_SELECTION_TOGGLE_ALL_OFF = "__openclaw_migrate_toggle_all_off__";
 export const MIGRATION_SELECTION_SKIP = "__openclaw_migrate_skip_for_now__";
+export const MIGRATION_SKILL_SELECTION_ACCEPT = MIGRATION_SELECTION_ACCEPT;
 export const MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON = MIGRATION_SELECTION_TOGGLE_ALL_ON;
 export const MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF = MIGRATION_SELECTION_TOGGLE_ALL_OFF;
 export const MIGRATION_SKILL_SELECTION_SKIP = MIGRATION_SELECTION_SKIP;
 
-type InteractiveMigrationSelection =
-  | { action: "skip" }
-  | { action: "select"; selectedItemIds: Set<string> };
+type InteractiveMigrationSelection = { action: "select"; selectedItemIds: Set<string> };
 export type InteractiveMigrationSkillSelection = InteractiveMigrationSelection;
 export type InteractiveMigrationPluginSelection = InteractiveMigrationSelection;
 
@@ -425,10 +425,6 @@ function resolveInteractiveMigrationSelection(
   }
 
   const selectedValueSet = new Set(selectedValues);
-  if (selectedValueSet.has(MIGRATION_SELECTION_SKIP)) {
-    return { action: "skip" };
-  }
-
   if (selectedValueSet.has(MIGRATION_SELECTION_TOGGLE_ALL_OFF)) {
     return { action: "select", selectedItemIds: new Set() };
   }
@@ -469,9 +465,6 @@ export function reconcileInteractiveMigrationSkillToggleValues(
   activatedValue: string | undefined,
   selectableValues: readonly string[],
 ): string[] {
-  if (activatedValue === MIGRATION_SELECTION_SKIP) {
-    return selectedValues.includes(MIGRATION_SELECTION_SKIP) ? [MIGRATION_SELECTION_SKIP] : [];
-  }
   if (activatedValue === MIGRATION_SELECTION_TOGGLE_ALL_ON) {
     return [MIGRATION_SELECTION_TOGGLE_ALL_ON, ...selectableValues];
   }
@@ -481,9 +474,7 @@ export function reconcileInteractiveMigrationSkillToggleValues(
   if (activatedValue !== undefined && selectableValues.includes(activatedValue)) {
     return selectedValues.filter(
       (value) =>
-        value !== MIGRATION_SELECTION_TOGGLE_ALL_ON &&
-        value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF &&
-        value !== MIGRATION_SELECTION_SKIP,
+        value !== MIGRATION_SELECTION_TOGGLE_ALL_ON && value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF,
     );
   }
   return selectedValues.filter(
@@ -499,9 +490,6 @@ export function reconcileInteractiveMigrationEnterValues(
   selectableValues: readonly string[],
   opts: { preserveDeselectedActivatedValue?: boolean } = {},
 ): string[] {
-  if (activatedValue === MIGRATION_SELECTION_SKIP) {
-    return [MIGRATION_SELECTION_SKIP];
-  }
   if (activatedValue === MIGRATION_SELECTION_TOGGLE_ALL_ON) {
     return [MIGRATION_SELECTION_TOGGLE_ALL_ON, ...selectableValues];
   }
@@ -511,9 +499,7 @@ export function reconcileInteractiveMigrationEnterValues(
   if (activatedValue !== undefined && selectableValues.includes(activatedValue)) {
     const selectedSelectableValues = selectedValues.filter(
       (value) =>
-        value !== MIGRATION_SELECTION_TOGGLE_ALL_ON &&
-        value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF &&
-        value !== MIGRATION_SELECTION_SKIP,
+        value !== MIGRATION_SELECTION_TOGGLE_ALL_ON && value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF,
     );
     if (opts.preserveDeselectedActivatedValue && !selectedValues.includes(activatedValue)) {
       return selectedSelectableValues;
@@ -530,11 +516,7 @@ export function reconcileInteractiveMigrationShortcutValues(
   key: "a" | "i",
 ): string[] {
   const previousSelectable = previousValues.filter((value) => selectableValues.includes(value));
-  if (
-    key === "a" &&
-    !previousValues.includes(MIGRATION_SELECTION_SKIP) &&
-    previousSelectable.length === selectableValues.length
-  ) {
+  if (key === "a" && previousSelectable.length === selectableValues.length) {
     return [MIGRATION_SELECTION_TOGGLE_ALL_OFF];
   }
 

--- a/src/commands/migrate/skill-selection-prompt.test.ts
+++ b/src/commands/migrate/skill-selection-prompt.test.ts
@@ -1,7 +1,7 @@
 import { PassThrough, Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import {
-  MIGRATION_SKILL_SELECTION_SKIP,
+  MIGRATION_SKILL_SELECTION_ACCEPT,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
 } from "./selection.js";
@@ -29,11 +29,11 @@ async function runPromptWithKeys(params: {
   const result = promptMigrationSkillSelectionValues({
     message: "Select Codex skills",
     options: [
-      { value: MIGRATION_SKILL_SELECTION_SKIP, label: "Skip for now" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
-      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
+      { value: MIGRATION_SKILL_SELECTION_ACCEPT, label: "Accept recommended" },
       { value: "skill:alpha", label: "alpha" },
       { value: "skill:beta", label: "beta" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, label: "Toggle all on" },
+      { value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF, label: "Toggle all off" },
     ],
     initialValues: params.initialValues,
     required: false,
@@ -70,15 +70,6 @@ async function runPromptWithReturn(params: {
 }
 
 describe("promptMigrationSkillSelectionValues", () => {
-  it("activates Skip for now before submitting with return", async () => {
-    await expect(
-      runPromptWithReturn({
-        cursorAt: MIGRATION_SKILL_SELECTION_SKIP,
-        initialValues: ["skill:alpha", "skill:beta"],
-      }),
-    ).resolves.toEqual([MIGRATION_SKILL_SELECTION_SKIP]);
-  });
-
   it("keeps the cursor item selected when submitting with return", async () => {
     await expect(
       runPromptWithReturn({
@@ -114,5 +105,28 @@ describe("promptMigrationSkillSelectionValues", () => {
         initialValues: [],
       }),
     ).resolves.toEqual([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, "skill:alpha", "skill:beta"]);
+  });
+
+  it("submits the initial recommended set when Enter is pressed on Accept recommended", async () => {
+    await expect(
+      runPromptWithReturn({
+        cursorAt: MIGRATION_SKILL_SELECTION_ACCEPT,
+        initialValues: ["skill:alpha", "skill:beta"],
+      }),
+    ).resolves.toEqual(["skill:alpha", "skill:beta"]);
+  });
+
+  it("snaps the visual selection to the recommended set when Space is pressed on Accept recommended", async () => {
+    // Space on Accept overwrites the current selection with `initialValues` so
+    // the visible checkboxes match the recommended set. The Enter that follows
+    // then submits that same set; Accept itself is never persisted in the
+    // submitted value list.
+    await expect(
+      runPromptWithKeys({
+        cursorAt: MIGRATION_SKILL_SELECTION_ACCEPT,
+        initialValues: ["skill:alpha", "skill:beta"],
+        keys: [" ", "\r"],
+      }),
+    ).resolves.toEqual(["skill:alpha", "skill:beta"]);
   });
 });

--- a/src/commands/migrate/skill-selection-prompt.ts
+++ b/src/commands/migrate/skill-selection-prompt.ts
@@ -11,6 +11,7 @@ import {
   symbolBar,
 } from "@clack/prompts";
 import {
+  MIGRATION_SELECTION_ACCEPT,
   reconcileInteractiveMigrationEnterValues,
   reconcileInteractiveMigrationShortcutValues,
   reconcileInteractiveMigrationSkillToggleValues,
@@ -181,6 +182,15 @@ export function promptMigrationSkillSelectionValues(
       return;
     }
     const activatedValue = prompt.options[prompt.cursor]?.value;
+    // Space on the "Accept recommended" sentinel snaps the visual selection
+    // back to the recommended set so the user can see what would be submitted
+    // by Enter. The sentinel itself is never persisted in the value list.
+    if (activatedValue === MIGRATION_SELECTION_ACCEPT) {
+      prompt.value = [...(opts.initialValues ?? [])];
+      lastSpaceDeselectedValue = undefined;
+      lastSelectedValues = [...(prompt.value ?? [])];
+      return;
+    }
     const previousValues = lastSelectedValues;
     const selectedValuesAfterClack = prompt.value ?? [];
     prompt.value = reconcileInteractiveMigrationSkillToggleValues(
@@ -202,6 +212,14 @@ export function promptMigrationSkillSelectionValues(
     if (info.name === "return") {
       const activatedOption = prompt.options[prompt.cursor];
       const activatedValue = activatedOption?.disabled ? undefined : activatedOption?.value;
+      // Enter on "Accept recommended" submits with the picker's initialValues
+      // (the recommended set) regardless of any toggles the user made.
+      if (activatedValue === MIGRATION_SELECTION_ACCEPT) {
+        prompt.value = [...(opts.initialValues ?? [])];
+        lastSpaceDeselectedValue = undefined;
+        lastSelectedValues = [...(prompt.value ?? [])];
+        return;
+      }
       prompt.value = reconcileInteractiveMigrationEnterValues(
         prompt.value ?? [],
         activatedValue,

--- a/src/commands/migrate/types.ts
+++ b/src/commands/migrate/types.ts
@@ -9,6 +9,11 @@ export type MigrateCommonOptions = {
   plugins?: string[];
   verifyPluginApps?: boolean;
   json?: boolean;
+  // Suppress the formatted plan dump that `migrate plan` normally prints
+  // before any interactive selection. Used by onboarding flows that have
+  // already secured user consent and do not want to re-render the plan.
+  // The interactive selection picker and apply confirmation still run.
+  suppressPlanLog?: boolean;
 };
 
 export type MigrateApplyOptions = MigrateCommonOptions & {

--- a/src/wizard/setup.post-install-migration.test.ts
+++ b/src/wizard/setup.post-install-migration.test.ts
@@ -170,7 +170,10 @@ describe("offerPostInstallMigrations", () => {
     expect(confirm).toHaveBeenCalledOnce();
     expect(confirm).toHaveBeenCalledWith(expect.objectContaining({ initialValue: false }));
     expect(migrateDefaultCommand).toHaveBeenCalledOnce();
-    expect(migrateDefaultCommand).toHaveBeenCalledWith(expect.anything(), { provider: "codex" });
+    expect(migrateDefaultCommand).toHaveBeenCalledWith(expect.anything(), {
+      provider: "codex",
+      suppressPlanLog: true,
+    });
   });
 
   it("does not invoke migrateDefaultCommand when the user declines", async () => {

--- a/src/wizard/setup.post-install-migration.ts
+++ b/src/wizard/setup.post-install-migration.ts
@@ -148,7 +148,10 @@ export async function offerPostInstallMigrations(
     }
     try {
       const { migrateDefaultCommand } = await import("../commands/migrate.js");
-      await migrateDefaultCommand(params.runtime, { provider: candidate.provider.id });
+      await migrateDefaultCommand(params.runtime, {
+        provider: candidate.provider.id,
+        suppressPlanLog: true,
+      });
     } catch (error) {
       params.runtime.log(
         `${candidate.provider.label} migration failed: ${formatErrorMessage(error)}. ` +


### PR DESCRIPTION
## Summary

Cherry-pick of #81219 (`a197e31abb`) onto `release/2026.5.12` to feed the next pre-release (`v2026.5.12-beta.5`).

Original commit covers two related improvements to the interactive `openclaw migrate <provider>` flow:
- `suppressPlanLog?: boolean` on `MigrateCommonOptions` so the post-install wizard helper can skip the up-front plan dump it already showed at the wizard prompt.
- "Accept recommended" sentinel at the top of both Codex selection pickers; `Skip for now` sentinel removed (it was a single-keystroke trap that abandoned the whole migration). "Migrate every recommended plugin" relabel for picker hint parity.

See #81219 for the full rationale.

## Conflict resolution

The upstream patch conflicted only in `src/commands/migrate.test.ts`. The conflict and the cleanly-applied test changes both depend on a `multiselectPrompt()` test helper that does not exist on `release/2026.5.12` (introduced after the release cut).

Resolution per maintainer guidance ("tests don't matter for the release"):

- Reverted all four test files in the patch to release HEAD:
  - `src/commands/migrate.test.ts`
  - `src/commands/migrate/selection.test.ts`
  - `src/commands/migrate/skill-selection-prompt.test.ts`
  - `src/wizard/setup.post-install-migration.test.ts`
- Re-added `MIGRATION_SELECTION_SKIP` and `MIGRATION_SKILL_SELECTION_SKIP` exports to `src/commands/migrate/selection.ts` so the reverted tests still typecheck. Production code does not reference them (the picker option rows now use `…_ACCEPT`).

Known consequence: the SKIP-driven test cases inherited from the release branch will **compile** but will **fail at runtime** if executed, because production code no longer drives that path. Acceptable for this release per maintainer call; the test-file changes from #81219 will land naturally when `release/2026.5.12` next merges with `main`.

Production files in this PR match the upstream patch exactly:

```
 src/commands/migrate.ts                        | 56 ++++++++++++--------------
 src/commands/migrate/selection.ts              | 30 +++-----------
 src/commands/migrate/skill-selection-prompt.ts | 18 +++++++++
 src/commands/migrate/types.ts                  |  5 +++
 src/wizard/setup.post-install-migration.ts     |  5 ++-
 5 files changed, 59 insertions(+), 55 deletions(-)
```

## Verification

Local, scoped to the touched surface (broad release-path proof belongs to `Full Release Validation` per `docs/reference/RELEASING.md`):

- [x] `pnpm tsgo:core` — pass
- [x] `pnpm tsgo:core:test` — pass
- [x] `node scripts/run-oxlint.mjs <5 touched files>` — 0 warnings, 0 errors
- [x] `pnpm format:check <5 touched files>` — clean

Not run locally (deliberate):
- Full vitest suites — production behavior is exactly the upstream patch; upstream verification recorded "migrate 32/32, selection 17/17, skill-selection-prompt 6/6, setup.post-install-migration 10/10" on main. Release-branch tests still using `SKIP` will not pass; see Conflict resolution above.
- `pnpm check:changed` and broader gates — for the maintainer / `Full Release Validation` umbrella.

## Test plan

- [ ] Maintainer reviews conflict resolution and the SKIP-tests-will-fail tradeoff
- [ ] Merge / land onto `release/2026.5.12`
- [ ] `RELEASE_TAG=v2026.5.12-beta.5 pnpm release:fast-pretag-check`
- [ ] Tag `v2026.5.12-beta.5` and run `OpenClaw NPM Release` (`preflight_only=true`)
- [ ] `Full Release Validation` (`--ref main -f ref=release/2026.5.12 -f release_profile=stable`)
- [ ] `OpenClaw Release Publish` (`--ref release/2026.5.12 -f tag=v2026.5.12-beta.5 -f npm_dist_tag=beta`)
- [ ] `pnpm release:verify-beta -- 2026.5.12-beta.5 …`
