### PR TITLE
fix(windows): suppress persistent cmd window from scheduled-task node launch

### DIFF
--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -273,7 +273,11 @@ function buildTaskScript({
     }
   }
   const command = programArguments.map(quoteCmdScriptArg).join(" ");
-  lines.push(command);
+  // Use start /b so the launched process runs in the background. Without it,
+  // cmd.exe blocks on the long-running node process and the console window
+  // persists in the taskbar / screen (Windows)
+  const launched = `start "" /b ${command}`;
+  lines.push(launched);
   return `${lines.join("\r\n")}\r\n`;
 }
 
@@ -1071,3 +1075,4 @@ export async function readScheduledTaskRuntime(
     ...(derived.detail ? { detail: derived.detail } : {}),
   };
 }
+


### PR DESCRIPTION
## Problem

On Windows, openclaw node install creates a Scheduled Task that runs the 
ode.cmd script at login. Because uildTaskScript() runs the node process directly, cmd.exe blocks until the node process exits - leaving a persistent visible cmd window in the taskbar.

Fixes #81254

## Root cause

uildTaskScript() pushes the raw 
ode.exe args... line as the final command in the generated .cmd script. When this script runs via Windows Scheduled Task with /IT (interactive), cmd.exe blocks on the long-running node process, keeping the console window open and visible.

## Fix

Wrap the final command with start "" /b so the launched process runs in the same console's background. cmd.exe completes the batch file and exits immediately. The window closes after a brief appearance instead of persisting.

This mirrors the same approach used in launchFallbackTaskScript() which already uses windowsHide: true via Node.js spawn, and is consistent with the startup folder fallback's start "" /min pattern.

## Testing

- [ ] On Windows 11: openclaw node install, sign out/in, verify no persistent visible cmd window in taskbar
- [ ] openclaw node status still shows running
- [ ] openclaw node stop / openclaw node start still work