### PR TITLE
fix: treat enabled:true as meaningful channel config

### DIFF
--- a/src/config/channel-configured-shared.ts
+++ b/src/config/channel-configured-shared.ts
@@ -15,7 +15,15 @@ export function hasMeaningfulChannelConfigShallow(value: unknown): boolean {
   if (!isRecord(value)) {
     return false;
   }
-  return Object.keys(value).some((key) => key !== "enabled");
+  const keys = Object.keys(value);
+  if (keys.length === 0) {
+    return false;
+  }
+  // enabled:true alone should be enough to signal that the channel is configured.
+  if (keys.length === 1 && keys[0] === "enabled" && value.enabled === true) {
+    return true;
+  }
+  return keys.some((key) => key !== "enabled");
 }
 
 export function isStaticallyChannelConfigured(

--- a/src/config/channel-configured.test.ts
+++ b/src/config/channel-configured.test.ts
@@ -44,6 +44,22 @@ describe("isChannelConfigured", () => {
     ).toBe(true);
   });
 
+  it("treats enabled:true alone as meaningful channel config", () => {
+    expect(
+      isChannelConfigured(
+        {
+          channels: {
+            "openclaw-weixin": {
+              enabled: true,
+            },
+          },
+        },
+        "openclaw-weixin",
+        {},
+      ),
+    ).toBe(true);
+  });
+
   it("does not treat persisted Matrix credentials as configured channel state", () => {
     expect(
       isChannelConfigured({}, "matrix", { OPENCLAW_STATE_DIR: "state-with-matrix-creds" }),


### PR DESCRIPTION
## Summary

When `channels.openclaw-weixin` is configured with only `enabled: true`, the gateway fails to load the channel with error: `invalid channels.start channel`.

### Root Cause

`hasMeaningfulChannelConfigShallow()` in `src/config/channel-configured-shared.ts` only checked for keys other than `enabled`. When the config was `{ enabled: true }`, it returned `false`, causing the channel to not be recognized as configured. This prevented the channel plugin from being auto-enabled on gateway startup.

### Fix

`enabled: true` alone is now treated as a meaningful config signal. This matches the documented workaround of adding `accounts: {}` — both paths now result in the channel being recognized as configured.

### Changes

- `src/config/channel-configured-shared.ts`: Updated `hasMeaningfulChannelConfigShallow()` to treat `{ enabled: true }` as meaningful config
- `src/config/channel-configured.test.ts`: Added test case for `enabled: true` alone

Fixes #81323