### PR TITLE
fix(memory): sanitize word-internal hyphens in qmd search queries

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -5086,6 +5086,82 @@ describe("QmdMemoryManager", () => {
       }
     });
   });
+
+  it("sanitizes word-internal hyphens before passing query to qmd", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "query") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", "[]");
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+
+    await expect(
+      manager.search("sqlite-vec backend 2026-05-04", {
+        sessionKey: "agent:main:slack:dm:u123",
+      }),
+    ).resolves.toStrictEqual([]);
+
+    const searchCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => (call[1] as string[])?.[0] === "query",
+    );
+    // Word-internal hyphens should be replaced with spaces
+    expect(searchCall?.[1]?.[1]).toBe("sqlite vec backend 2026 05 04");
+    await manager.close();
+  });
+
+  it("preserves leading hyphens as NOT operators in qmd query", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "query") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", "[]");
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+
+    await expect(
+      manager.search("-excluded term", {
+        sessionKey: "agent:main:slack:dm:u123",
+      }),
+    ).resolves.toStrictEqual([]);
+
+    const searchCall = spawnMock.mock.calls.find(
+      (call: unknown[]) => (call[1] as string[])?.[0] === "query",
+    );
+    // Leading hyphens are NOT operators and should be preserved
+    expect(searchCall?.[1]?.[1]).toBe("-excluded term");
+    await manager.close();
+  });
 });
 
 function createDeferred<T>() {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -153,6 +153,15 @@ function normalizeHanBm25Query(query: string): string {
   return trimmed;
 }
 
+/**
+ * Replace word-internal hyphens with spaces so qmd's validateSemanticQuery
+ * does not misinterpret them as NOT operators (e.g. "sqlite-vec" → "sqlite vec").
+ * Leading hyphens (actual NOT syntax) are preserved.
+ */
+function sanitizeQmdSearchQuery(query: string): string {
+  return query.replace(/(\w)-(\w)/g, "$1 $2");
+}
+
 function parseQmdStatusVectorCount(raw: string): number | null {
   for (const line of raw.split(/\r?\n/)) {
     const match = line.match(/^\s*Vectors(?:\s*[:=]\s*|\s+)(\d+)\b/i);
@@ -1103,7 +1112,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       this.logScopeDenied(opts?.sessionKey);
       return [];
     }
-    const trimmed = query.trim();
+    const trimmed = sanitizeQmdSearchQuery(query.trim());
     if (!trimmed) {
       return [];
     }


### PR DESCRIPTION
## Summary

- Problem: `memory_search` queries containing hyphenated tokens (e.g. `sqlite-vec`, `2026-05-04`, `multi-agent`) trigger qmd `validateSemanticQuery` rejection, causing the entire query to fail with zero results.
- Why it matters: Hyphenated identifiers are extremely common in dev/ops contexts (package names, dates, compound terms). Users lose semantic search entirely for these queries.
- What changed: Added `sanitizeQmdSearchQuery()` in `qmd-manager.ts` that replaces word-internal hyphens with spaces before passing queries to qmd CLI. Leading hyphens (actual NOT operators like `-excluded`) are preserved.
- What did NOT change (scope boundary): No changes to qmd binary, qmd-query-parser, or the memory_search tool interface. This is a defensive workaround at the OpenClaw layer; once qmd ships tobi/qmd#618, the sanitization becomes a no-op.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Real behavior proof

**Behavior or issue addressed**: memory_search returns zero results for queries containing word-internal hyphens because qmd validateSemanticQuery misinterprets them as NOT operators

**Real environment tested**: Linux 6.17.0-22-generic x64, Node v22.22.1, openclaw main (34ce85a83d)

**Exact steps or command run after this patch**:
```
cd /path/to/openclaw
npx vitest run extensions/memory-core/src/memory/qmd-manager.test.ts
```

**Evidence after fix**:
```
 ✓ extension-memory qmd-manager.test.ts > QmdMemoryManager > sanitizes word-internal hyphens before passing query to qmd 1ms
 ✓ extension-memory qmd-manager.test.ts > QmdMemoryManager > preserves leading hyphens as NOT operators in qmd query 1ms

 Test Files  1 passed (1)
      Tests  105 passed (105)
   Duration  3.23s
```

**Observed result after fix**: Query `"sqlite-vec backend 2026-05-04"` is sanitized to `"sqlite vec backend 2026 05 04"` before being passed to qmd CLI, avoiding the validateSemanticQuery rejection. Leading hyphens like `"-excluded term"` are preserved as legitimate NOT operators.

**What was not tested**: Live qmd binary integration (requires qmd installed with indexed collections). The fix is verified through mock-based tests that assert the sanitized query string reaches the qmd spawn call.