### PR TITLE
[AI-assisted] Fix ACP bound thread follow-up delivery

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2106,6 +2106,152 @@ describe("dispatchReplyFromConfig", () => {
     expect(finalPayload?.text).toBe("hello world");
   });
 
+  it("delivers follow-up replies from parent-owned ACP sessions in their bound Discord thread", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const runtime = createAcpRuntime([
+      { type: "text_delta", text: "thread follow-up" },
+      { type: "done" },
+    ]);
+    acpMocks.readAcpSessionEntry.mockReturnValue({
+      sessionKey: "agent:codex-acp:session-1",
+      storeSessionKey: "agent:codex-acp:session-1",
+      cfg: {},
+      storePath: "/tmp/mock-sessions.json",
+      entry: {},
+      acp: {
+        backend: "acpx",
+        agent: "codex",
+        runtimeSessionName: "runtime:1",
+        mode: "persistent",
+        state: "idle",
+        lastActivityAt: Date.now(),
+      },
+    });
+    acpMocks.requireAcpRuntimeBackend.mockReturnValue({
+      id: "acpx",
+      runtime,
+    });
+    sessionStoreMocks.currentEntry = {
+      sessionId: "acp-session-id",
+      updatedAt: Date.now(),
+      acp: {
+        backend: "acpx",
+        agent: "codex",
+        runtimeSessionName: "runtime:1",
+        mode: "persistent",
+        state: "idle",
+        lastActivityAt: Date.now(),
+      },
+      spawnedBy: "agent:main:discord:channel:parent",
+      deliveryContext: {
+        channel: "discord",
+        accountId: "main",
+        to: "channel:thread-1",
+        threadId: "thread-1",
+      },
+    };
+
+    const cfg = {
+      acp: {
+        enabled: true,
+        dispatch: { enabled: true },
+        stream: { deliveryMode: "live", coalesceIdleMs: 0, maxChunkChars: 128 },
+      },
+    } as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      OriginatingChannel: "discord",
+      OriginatingTo: "channel:thread-1",
+      AccountId: "main",
+      SessionKey: "agent:codex-acp:session-1",
+      MessageThreadId: "thread-1",
+      BodyForAgent: "follow up in the bound thread",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "fallback" }) as ReplyPayload);
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(mocks.routeReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).toHaveBeenCalledWith({ text: "thread follow-up" });
+    expect(firstFinalReplyPayload(dispatcher)?.text).toBe("thread follow-up");
+  });
+
+  it("still suppresses parent-owned ACP replies outside the child delivery thread", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const runtime = createAcpRuntime([
+      { type: "text_delta", text: "hidden child output" },
+      { type: "done" },
+    ]);
+    acpMocks.readAcpSessionEntry.mockReturnValue({
+      sessionKey: "agent:codex-acp:session-1",
+      storeSessionKey: "agent:codex-acp:session-1",
+      cfg: {},
+      storePath: "/tmp/mock-sessions.json",
+      entry: {},
+      acp: {
+        backend: "acpx",
+        agent: "codex",
+        runtimeSessionName: "runtime:1",
+        mode: "persistent",
+        state: "idle",
+        lastActivityAt: Date.now(),
+      },
+    });
+    acpMocks.requireAcpRuntimeBackend.mockReturnValue({
+      id: "acpx",
+      runtime,
+    });
+    sessionStoreMocks.currentEntry = {
+      sessionId: "acp-session-id",
+      updatedAt: Date.now(),
+      acp: {
+        backend: "acpx",
+        agent: "codex",
+        runtimeSessionName: "runtime:1",
+        mode: "persistent",
+        state: "idle",
+        lastActivityAt: Date.now(),
+      },
+      spawnedBy: "agent:main:discord:channel:parent",
+      deliveryContext: {
+        channel: "discord",
+        accountId: "main",
+        to: "channel:thread-1",
+        threadId: "thread-1",
+      },
+    };
+
+    const cfg = {
+      acp: {
+        enabled: true,
+        dispatch: { enabled: true },
+        stream: { deliveryMode: "live", coalesceIdleMs: 0, maxChunkChars: 128 },
+      },
+    } as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      OriginatingChannel: "discord",
+      OriginatingTo: "channel:other-thread",
+      AccountId: "main",
+      SessionKey: "agent:codex-acp:session-1",
+      MessageThreadId: "other-thread",
+      BodyForAgent: "follow up somewhere else",
+    });
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver: vi.fn() });
+
+    expect(mocks.routeReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("emits lifecycle end for ACP turns using the current run id", async () => {
     setNoAbort();
     const runtime = createAcpRuntime([{ type: "text_delta", text: "done" }, { type: "done" }]);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -118,6 +118,42 @@ function loadRouteReplyRuntime() {
   return routeReplyRuntimeLoader.load();
 }
 
+function isDirectAcpChildDeliveryTurn(params: {
+  ctx: FinalizedMsgContext;
+  entry?: SessionEntry | null;
+}): boolean {
+  const deliveryContext = params.entry?.deliveryContext;
+  const deliveryChannel = normalizeMessageChannel(deliveryContext?.channel);
+  const turnChannel = normalizeMessageChannel(
+    params.ctx.OriginatingChannel ?? params.ctx.Provider ?? params.ctx.Surface,
+  );
+  if (!deliveryChannel || !turnChannel || deliveryChannel !== turnChannel) {
+    return false;
+  }
+
+  const deliveryAccountId = normalizeOptionalString(deliveryContext?.accountId);
+  const turnAccountId = normalizeOptionalString(params.ctx.AccountId);
+  if (deliveryAccountId && turnAccountId && deliveryAccountId !== turnAccountId) {
+    return false;
+  }
+
+  const deliveryThreadId =
+    deliveryContext?.threadId != null
+      ? normalizeOptionalString(String(deliveryContext.threadId))
+      : undefined;
+  const turnThreadId =
+    params.ctx.MessageThreadId != null
+      ? normalizeOptionalString(String(params.ctx.MessageThreadId))
+      : undefined;
+  if (deliveryThreadId && turnThreadId && deliveryThreadId === turnThreadId) {
+    return true;
+  }
+
+  const deliveryTo = normalizeOptionalString(deliveryContext?.to);
+  const turnTo = normalizeOptionalString(params.ctx.OriginatingTo);
+  return Boolean(deliveryTo && turnTo && deliveryTo === turnTo);
+}
+
 function loadGetReplyFromConfigRuntime() {
   return getReplyFromConfigRuntimeLoader.load();
 }
@@ -504,7 +540,12 @@ export async function dispatchReplyFromConfig(
   // flow when the provider handles its own messages.
   //
   // Debug: `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts`
-  const suppressAcpChildUserDelivery = isParentOwnedBackgroundAcpSession(sessionStoreEntry.entry);
+  const suppressAcpChildUserDelivery =
+    isParentOwnedBackgroundAcpSession(sessionStoreEntry.entry) &&
+    !isDirectAcpChildDeliveryTurn({
+      ctx,
+      entry: sessionStoreEntry.entry,
+    });
   const normalizedRouteReplyChannel = normalizeMessageChannel(replyRoute.channel);
   const normalizedProviderChannel = normalizeMessageChannel(ctx.Provider);
   const normalizedSurfaceChannel = normalizeMessageChannel(ctx.Surface);


### PR DESCRIPTION
## Summary

- Problem: follow-up messages sent inside a Discord Thread bound to a spawned ACP runtime session could run the ACP turn but suppress the child session's visible reply.
- Why it matters: `/acp spawn ... --thread` creates a user-facing thread; follow-up turns in that same thread should behave like direct interaction with that ACP session.
- What changed: parent-owned ACP sessions now keep user-delivery suppression only outside their own bound delivery context. A turn from the child session's bound channel/account/thread or target is treated as direct child delivery.
- What did NOT change (scope boundary): this does not change parent-owned background behavior for unrelated conversations, ACP spawning, Discord thread creation, or channel adapter binding.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Discord Thread follow-up messages to a spawned ACP runtime session were processed, but ACP output was not returned to the bound Discord Thread after the initial spawn response.
- Real environment tested: local OpenClaw gateway service with Discord main bot account, ACP `claude` runtime agent, cwd `/home/qiqi/developer/codebank/com/ai`.
- Exact steps or command run after this patch: spawned/bound an ACP session to a real Discord Thread, then sent an initial prompt and a follow-up prompt in that same Thread.
- Evidence after fix (copied live output):
  - Discord Thread id: `1504020691337613322`
  - ACP session: `agent:claude:acp:e8523aac-bf91-41f8-9852-17367846d15d`
  - Initial reply appeared in the Thread: `SPAWN_BOOT_OK_OC_ACP_THREAD_REALCTX_1521`
  - Follow-up reply appeared in the same Thread: `FOLLOWUP_OK_OC_ACP_THREAD_REALCTX_1521`
  - The ACP turn reported cwd as `/home/qiqi/developer/codebank/com/ai`.
- Observed result after fix: the initial spawn response and the first follow-up response both returned to the bound Discord Thread.
- What was not tested: Discord adapter thread creation failure cases, nested thread creation, other channel adapters, and ACP runtimes other than the live `claude` setup above.
- Before evidence (optional but encouraged): before the patch, the ACP runtime produced the follow-up reply in console/runtime logs, but the bound Discord Thread received no visible ACP reply after the initial session binding messages.

## Root Cause (if applicable)

- Root cause: spawned ACP runtime sessions include parent ownership metadata (`spawnedBy` / parent-owned background semantics). `dispatch-from-config` used that classification to suppress user delivery for all turns from that child session, including turns that originated inside the child session's own bound Discord Thread.
- Missing detection / guardrail: there was no distinction between an unrelated parent-owned background turn and a direct turn coming from the child ACP session's own saved delivery context.
- Contributing context (if known): ACP child sessions are correctly suppressed when they are only background work for a parent session, but Discord thread-bound ACP sessions are also intended to be directly interactive from the bound Thread.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-from-config.test.ts`
- Scenario the test should lock in: a parent-owned ACP session delivers replies when the inbound turn matches its bound Discord Thread, and remains suppressed outside that thread.
- Why this is the smallest reliable guardrail: the bug is in dispatch suppression policy, so the narrow unit test can cover the delivery decision without requiring a live Discord adapter.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A; two regression tests were added.

## User-visible / Behavior Changes

Discord Thread-bound spawned ACP runtime sessions now return follow-up ACP replies in their own bound Thread instead of silently suppressing them as parent-owned background output.

## Diagram (if applicable)

```text
Before:
Discord Thread message -> bound spawned ACP session -> parent-owned suppression -> no Thread reply

After:
Discord Thread message -> bound spawned ACP session -> delivery context match -> ACP reply appears in Thread
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: WSL/Linux local development environment
- Runtime/container: local OpenClaw gateway service
- Model/provider: ACP `claude` runtime agent
- Integration/channel (if any): Discord bot + Discord Thread
- Relevant config (redacted): Discord `main` account with ACP runtime agents configured; ACP cwd `/home/qiqi/developer/codebank/com/ai`

### Steps

1. Start the local OpenClaw gateway with Discord and ACP runtime agents configured.
2. Spawn/bind a `claude` ACP session to a Discord Thread.
3. Send an initial prompt in the Thread and confirm a reply appears.
4. Send a follow-up prompt in the same Thread and confirm the follow-up reply appears.

### Expected

- The bound Discord Thread receives visible replies for follow-up ACP turns from the spawned ACP session.

### Actual

- After the patch, the bound Discord Thread received both `SPAWN_BOOT_OK_OC_ACP_THREAD_REALCTX_1521` and `FOLLOWUP_OK_OC_ACP_THREAD_REALCTX_1521`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts` -> 108 tests passed.
- `node_modules/.bin/oxfmt --check src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts` -> all matched files use the correct format.
- `git diff --check` -> passed.
- `codex review --base origin/main` was attempted, but failed before producing findings with: `ERROR: Selected model is at capacity. Please try a different model.`

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios: direct ACP child delivery from the bound Discord Thread; suppression outside the child delivery thread; target dispatch test file passes.
- Edge cases checked: account/channel/thread context must match before bypassing parent-owned ACP child suppression; unrelated thread remains suppressed.
- What I did **not** verify: all channel adapters, nested Discord thread creation/bind failures, and non-Discord ACP thread-bound sessions.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: parent-owned ACP sessions could become visible in a context where they should remain background-only.
  - Mitigation: the bypass requires the current turn to match the child session's saved delivery channel and either its thread id or delivery target; account mismatch still blocks the bypass.

AI-assisted: this PR was prepared with an AI coding assistant and manually verified with focused tests plus the live Discord/ACP behavior proof above.