### PR TITLE
fix(agents): restore prompt_cache_key emission in buildOpenAICompletionsParams

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1661,6 +1661,68 @@ describe("openai transport stream", () => {
     expect(params).toHaveProperty("tool_choice", "required");
   });
 
+  it("emits prompt_cache_key for openai-completions when supportsPromptCacheKey compat is set", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "local-model",
+        name: "Local Model",
+        api: "openai-completions",
+        provider: "openai-completions",
+        baseUrl: "http://cerebro-mac:8080/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 8192,
+        compat: { supportsPromptCacheKey: true },
+      } satisfies Model<"openai-completions">,
+      { systemPrompt: "sys", messages: [], tools: [] } as never,
+      { cacheRetention: "long", sessionId: "session-abc" } as never,
+    );
+    expect(params).toHaveProperty("prompt_cache_key", "session-abc");
+  });
+
+  it("omits prompt_cache_key for openai-completions when cacheRetention is none", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "local-model",
+        name: "Local Model",
+        api: "openai-completions",
+        provider: "openai-completions",
+        baseUrl: "http://cerebro-mac:8080/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 8192,
+        compat: { supportsPromptCacheKey: true },
+      } satisfies Model<"openai-completions">,
+      { systemPrompt: "sys", messages: [], tools: [] } as never,
+      { cacheRetention: "none", sessionId: "session-abc" } as never,
+    );
+    expect(params).not.toHaveProperty("prompt_cache_key");
+  });
+
+  it("omits prompt_cache_key for openai-completions when supportsPromptCacheKey is not set", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-4.1",
+        name: "GPT-4.1",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1047576,
+        maxTokens: 32768,
+      } satisfies Model<"openai-completions">,
+      { systemPrompt: "sys", messages: [], tools: [] } as never,
+      { cacheRetention: "long", sessionId: "session-abc" } as never,
+    );
+    expect(params).not.toHaveProperty("prompt_cache_key");
+  });
+
   it("resets stopReason to stop when finish_reason is tool_calls but tool_calls array is empty", async () => {
     const model = {
       id: "nemotron-3-super",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1383,6 +1383,7 @@ function getCompat(model: OpenAIModeModel): {
   openRouterRouting: Record<string, unknown>;
   vercelGatewayRouting: Record<string, unknown>;
   supportsStrictMode: boolean;
+  supportsPromptCacheKey: boolean;
   requiresStringContent: boolean;
   visibleReasoningDetailTypes: string[];
 } {
@@ -1417,6 +1418,7 @@ function getCompat(model: OpenAIModeModel): {
       detected.vercelGatewayRouting,
     supportsStrictMode:
       (compat.supportsStrictMode as boolean | undefined) ?? detected.supportsStrictMode,
+    supportsPromptCacheKey: compat.supportsPromptCacheKey === true,
     requiresStringContent: (compat.requiresStringContent as boolean | undefined) ?? false,
     visibleReasoningDetailTypes:
       (compat.visibleReasoningDetailTypes as string[] | undefined) ??
@@ -1496,6 +1498,7 @@ export function buildOpenAICompletionsParams(
       }
     : context;
   const messages = convertMessages(model as never, completionsContext, compat as never);
+  const cacheRetention = resolveCacheRetention(options?.cacheRetention);
   const params: Record<string, unknown> = {
     model: model.id,
     messages: compat.requiresStringContent
@@ -1506,6 +1509,9 @@ export function buildOpenAICompletionsParams(
   };
   if (compat.supportsStore) {
     params.store = false;
+  }
+  if (compat.supportsPromptCacheKey && cacheRetention !== "none" && options?.sessionId) {
+    params.prompt_cache_key = options.sessionId;
   }
   if (options?.maxTokens) {
     if (compat.maxTokensField === "max_tokens") {


### PR DESCRIPTION
## Problem

Closes #81281

The `prompt_cache_key` field stopped being sent for `openai-completions` providers in 2026.5.x. Users relying on prefix caching (oMLX, llama.cpp, etc.) saw `cached_tokens: 0` on every request and ~20x latency regression. Downgrading to 2026.3.2 immediately restored caching.

## Root cause

A refactor between 2026.3.2 and 2026.5.x dropped **two** things from `buildOpenAICompletionsParams` in `src/agents/openai-transport-stream.ts`:

1. `supportsPromptCacheKey` was removed from the `getCompat()` return type and its corresponding assignment in the return object
2. The `cacheRetention` resolution and the `prompt_cache_key` assignment block were omitted from `buildOpenAICompletionsParams`

Because the field was silently absent, no runtime error was thrown — requests just never carried the key, so the backend could never match a prefix.

## Fix

- Restore `supportsPromptCacheKey: boolean` to `getCompat()`'s return type and implementation (`compat.supportsPromptCacheKey === true`)
- Restore `const cacheRetention = resolveCacheRetention(options?.cacheRetention)` at the top of `buildOpenAICompletionsParams`
- Restore the conditional: `if (compat.supportsPromptCacheKey && cacheRetention !== "none" && options?.sessionId) { params.prompt_cache_key = options.sessionId; }`
- Add three regression tests covering: emit when flag set + cacheRetention=long, omit when cacheRetention=none, omit when flag not set

## Testing

`tsc --noEmit` passes clean. Three new unit tests directly cover the regression path.

## Notes

The Responses transport (`buildOpenAIResponsesParams`) was unaffected — it retained its `prompt_cache_key` logic throughout.