### PR TITLE
fix(webchat): preserve leading message whitespace

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -609,6 +609,42 @@ describe("handleSendChat", () => {
     vi.unstubAllGlobals();
   });
 
+  it("submits WebChat drafts without trimming leading diagram whitespace", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return { status: "started" };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const diagram = [
+      "+5V --+-- R68 3.3K --+-- TP175",
+      "      |               +-- R122 10K",
+      "      +-- R122 10K --+-- TP128",
+    ].join("\n");
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: diagram,
+      sessionKey: "agent:main",
+    });
+
+    await handleSendChat(host);
+
+    const payload = findRequestPayload(
+      request as unknown as MockCallSource,
+      "chat.send",
+      "chat send payload",
+    );
+    expect(payload.message).toBe(diagram);
+    expect(host.chatMessages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: diagram }],
+        timestamp: expect.any(Number),
+      },
+    ]);
+    expect(host.chatMessage).toBe("");
+  });
+
   it("cancels button-triggered /new resets when confirmation is declined", async () => {
     const confirm = vi.fn(() => false);
     vi.stubGlobal("confirm", confirm);

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -194,7 +194,7 @@ function enqueueChatMessage(
     ...host.chatQueue,
     {
       id: generateUUID(),
-      text: trimmed,
+      text,
       createdAt: Date.now(),
       attachments: hasAttachments ? cloneChatAttachmentsMetadata(attachments ?? []) : undefined,
       refreshSessions,
@@ -219,7 +219,7 @@ function enqueuePendingRunMessage(
     ...host.chatQueue,
     {
       id: generateUUID(),
-      text: trimmed,
+      text,
       createdAt: Date.now(),
       kind: "steered",
       attachments: hasAttachments ? cloneChatAttachmentsMetadata(attachments ?? []) : undefined,
@@ -299,7 +299,7 @@ function chatSubmitKey(
   return JSON.stringify([
     kind,
     host.sessionKey,
-    message.trim(),
+    message,
     attachments.map(attachmentSubmitSignature),
   ]);
 }
@@ -521,30 +521,31 @@ export async function handleSendChat(
     return;
   }
   const previousDraft = host.chatMessage;
-  const message = (messageOverride ?? host.chatMessage).trim();
+  const message = messageOverride ?? host.chatMessage;
+  const trimmedMessage = message.trim();
   const submittedSessionKey = host.sessionKey;
   const attachments = host.chatAttachments ?? [];
   const attachmentsToSend = messageOverride == null ? snapshotChatAttachments(attachments) : [];
   const hasAttachments = attachmentsToSend.length > 0;
 
-  if (!message && !hasAttachments) {
+  if (!trimmedMessage && !hasAttachments) {
     return;
   }
 
-  if (messageOverride != null && opts?.confirmReset && !confirmChatResetCommand(message)) {
+  if (messageOverride != null && opts?.confirmReset && !confirmChatResetCommand(trimmedMessage)) {
     return;
   }
 
-  if (isChatStopCommand(message)) {
+  if (isChatStopCommand(trimmedMessage)) {
     if (messageOverride == null) {
-      recordNonTranscriptInputHistory(host, message);
+      recordNonTranscriptInputHistory(host, trimmedMessage);
     }
     await handleAbortChat(host);
     return;
   }
 
-  if (isBtwCommand(message)) {
-    const submitKey = chatSubmitKey(host, "btw", message, attachmentsToSend);
+  if (isBtwCommand(trimmedMessage)) {
+    const submitKey = chatSubmitKey(host, "btw", trimmedMessage, attachmentsToSend);
     await withChatSubmitGuard(host, submitKey, async () => {
       const modelSwitchReady = waitForPendingChatModelSwitch(host, submittedSessionKey);
       if (modelSwitchReady !== true && !(await modelSwitchReady)) {
@@ -558,9 +559,9 @@ export async function handleSendChat(
           ? clearSubmittedComposerState(host, previousDraft, attachmentsToSend)
           : {};
       if (messageOverride == null) {
-        recordNonTranscriptInputHistory(host, message);
+        recordNonTranscriptInputHistory(host, trimmedMessage);
       }
-      await sendDetachedBtwMessage(host, message, {
+      await sendDetachedBtwMessage(host, trimmedMessage, {
         previousDraft: cleared.previousDraft,
         attachments: hasAttachments ? attachmentsToSend : undefined,
         previousAttachments: cleared.previousAttachments,
@@ -570,16 +571,16 @@ export async function handleSendChat(
   }
 
   // Intercept local slash commands (/status, /model, /compact, etc.)
-  const parsed = parseSlashCommand(message);
+  const parsed = parseSlashCommand(trimmedMessage);
   if (parsed?.command.executeLocal) {
     if (isChatBusy(host) && shouldQueueLocalSlashCommand(parsed.command.key)) {
       if (messageOverride == null) {
-        recordNonTranscriptInputHistory(host, message);
+        recordNonTranscriptInputHistory(host, trimmedMessage);
         host.chatMessage = "";
         host.chatAttachments = [];
         resetChatInputHistoryNavigation(host);
       }
-      enqueueChatMessage(host, message, undefined, isChatResetCommand(message), {
+      enqueueChatMessage(host, trimmedMessage, undefined, isChatResetCommand(trimmedMessage), {
         args: parsed.args,
         name: parsed.command.key,
       });
@@ -587,7 +588,7 @@ export async function handleSendChat(
     }
     const prevDraft = messageOverride == null ? previousDraft : undefined;
     if (messageOverride == null) {
-      recordNonTranscriptInputHistory(host, message);
+      recordNonTranscriptInputHistory(host, trimmedMessage);
       host.chatMessage = "";
       host.chatAttachments = [];
       resetChatInputHistoryNavigation(host);
@@ -599,7 +600,7 @@ export async function handleSendChat(
     return;
   }
 
-  const refreshSessions = isChatResetCommand(message);
+  const refreshSessions = isChatResetCommand(trimmedMessage);
   const submitKey = chatSubmitKey(host, "message", message, attachmentsToSend);
   await withChatSubmitGuard(host, submitKey, async () => {
     const modelSwitchReady = waitForPendingChatModelSwitch(host, submittedSessionKey);

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -865,6 +865,27 @@ describe("sendChatMessage", () => {
     expect(state.chatMessages).toHaveLength(1);
   });
 
+  it("preserves leading whitespace in WebChat message text", async () => {
+    const request = vi.fn().mockResolvedValue({ runId: "run-1", status: "started" });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+    const diagram = [
+      "+5V --+-- R68 3.3K --+-- TP175",
+      "      |               +-- R122 10K",
+      "      +-- R122 10K --+-- TP128",
+    ].join("\n");
+
+    const result = await sendChatMessage(state, diagram);
+
+    expect(result).toMatch(UUID_V4_RE);
+    const [requestMethod, requestParams] = requireFirstRequestCall(request);
+    expect(requestMethod).toBe("chat.send");
+    expect(requireRecord(requestParams).message).toBe(diagram);
+    expectTextChatMessage(state.chatMessages[0], "user", diagram);
+  });
+
   it("passes the backing session id from history when sending after reconnect", async () => {
     const request = vi
       .fn()

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -470,9 +470,10 @@ export async function sendChatMessage(
   if (!state.client || !state.connected) {
     return null;
   }
-  const msg = message.trim();
+  const msg = message;
+  const hasText = msg.trim().length > 0;
   const hasAttachments = attachments && attachments.length > 0;
-  if (!msg && !hasAttachments) {
+  if (!hasText && !hasAttachments) {
     return null;
   }
   if (state.chatSending) {
@@ -494,7 +495,7 @@ export async function sendChatMessage(
       mimeType?: string;
     };
   }> = [];
-  if (msg) {
+  if (hasText) {
     contentBlocks.push({ type: "text", text: msg });
   }
   // Add image previews to the message for display
@@ -571,9 +572,10 @@ export async function sendDetachedChatMessage(
   if (!state.client || !state.connected) {
     return null;
   }
-  const msg = message.trim();
+  const msg = message;
+  const hasText = msg.trim().length > 0;
   const hasAttachments = attachments && attachments.length > 0;
-  if (!msg && !hasAttachments) {
+  if (!hasText && !hasAttachments) {
     return null;
   }
   state.lastError = null;
@@ -595,9 +597,10 @@ export async function sendSteerChatMessage(
   if (!state.client || !state.connected) {
     return null;
   }
-  const msg = message.trim();
+  const msg = message;
+  const hasText = msg.trim().length > 0;
   const hasAttachments = attachments && attachments.length > 0;
-  if (!msg && !hasAttachments) {
+  if (!hasText && !hasAttachments) {
     return null;
   }
   state.lastError = null;


### PR DESCRIPTION
## Summary

- Problem: WebChat trims composer text before optimistic display and `chat.send`, so pasted code blocks lose leading indentation and ASCII diagrams break.
- What changed: keep the submitted message string intact through `handleSendChat`, queued sends, optimistic WebChat message rendering, and `chat.send`; use trimmed text only for blank-message guards and slash/stop/BTW command detection.
- What did NOT change: server-side control-character sanitization, attachment handling, slash-command parsing semantics, or gateway transcript/history projection.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #81339
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `handleSendChat()` used `(messageOverride ?? host.chatMessage).trim()` as the submitted message, and `sendChatMessage()` trimmed again before optimistic display and RPC submission.
- Missing guardrail: WebChat controller/host tests did not cover leading indentation in a multi-line user message.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target tests:
  - `ui/src/ui/controllers/chat.test.ts`: controller preserves the exact submitted text in optimistic display and `chat.send` payload.
  - `ui/src/ui/app-chat.test.ts`: host `handleSendChat()` preserves a multi-line indented draft through the WebChat send path.
- Scenario the tests lock in: a pasted diagram containing leading spaces on continuation lines is submitted exactly as typed.
- Why this is the smallest reliable guardrail: these are the two places that previously called `.trim()` on WebChat message content before submission.

## User-visible / Behavior Changes

WebChat preserves leading whitespace in sent text, including code blocks and diagram lines. Whitespace-only messages are still rejected unless attachments are present.

## Diagram (if applicable)

```text
Before:
composer draft -> trim() -> optimistic message + chat.send -> leading columns lost

After:
composer draft -> blank/command checks use trim()
               -> optimistic message + chat.send use original text
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Real behavior proof

- **Behavior or issue addressed:** WebChat send path now preserves leading spaces in multi-line diagram text for both the optimistic user message and the `chat.send` payload.
- **Real environment tested:** Local OpenClaw checkout on Linux with Node v22.22.0, executing the real `ui/src/ui/controllers/chat.ts` send path from this branch.
- **Exact steps or command run after this patch:** Ran `pnpm exec tsx` against `sendChatMessage()` with a pasted multi-line diagram containing six leading spaces on continuation lines, capturing the actual `chat.send` request payload and optimistic message state.
- **Evidence after fix:** Console output from the live command:

```json
{
  "sentSecondLine": "      |               +-- R122 10K",
  "optimisticSecondLine": "      |               +-- R122 10K",
  "sentLeadingSpaces": 6,
  "optimisticLeadingSpaces": 6
}
```

- **Observed result after fix:** The second diagram line retained six leading spaces in both surfaces that previously received trimmed text: the outgoing `chat.send` payload and the optimistic WebChat user message.
- **What was not tested:** Full browser screenshot was not captured; the exercised path is the real WebChat controller path used by the browser host.

## Repro + Verification

### Environment

- OS: Linux dev checkout
- Runtime/container: local Node/pnpm repo checkout
- Model/provider: N/A
- Integration/channel: WebChat UI
- Relevant config (redacted): N/A

### Steps

1. Submit a WebChat draft containing:

```text
+5V --+-- R68 3.3K --+-- TP175
      |               +-- R122 10K
      +-- R122 10K --+-- TP128
```

2. Inspect the optimistic WebChat user message.
3. Inspect the `chat.send` RPC payload.

### Expected

- Continuation lines keep the six leading spaces.
- `chat.send` receives the exact submitted text.
- Whitespace-only messages without attachments still do not send.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing source path before + passing after
- [x] Console output from the real WebChat controller send path
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Source proof before fix:
  - `ui/src/ui/app-chat.ts` used `(messageOverride ?? host.chatMessage).trim()` as the submitted `message`.
  - `ui/src/ui/controllers/chat.ts` used `const msg = message.trim()` before optimistic display and `requestChatSend()`.
- Automated proof after fix:
  - `pnpm test ui/src/ui/controllers/chat.test.ts ui/src/ui/app-chat.test.ts`
  - Result: 2 files passed, 102 tests passed.
- The new regression tests assert the exact sent string and exact optimistic message text, including leading spaces on diagram continuation lines.

## Next step before merge

Review the small UI send-path diff and let CI run.