### PR TITLE
fix: extend planning-only retry guard to Ollama and handle plan-only tool calls with no text

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -1281,7 +1281,7 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
-  it("does not apply planning-only or ack fast paths to Ollama runs", () => {
+  it("applies planning-only retry guard to Ollama runs with planning prose", () => {
     const retryInstruction = resolvePlanningOnlyRetryInstruction({
       provider: "ollama",
       modelId: "gemma4:31b",
@@ -1298,8 +1298,81 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
       prompt: "go ahead",
     });
 
+    expect(retryInstruction).toContain("Do not restate the plan");
+    expect(ackInstruction).not.toBeNull();
+  });
+
+  it("triggers planning-only retry for Ollama when update_plan is called with no text", () => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      provider: "ollama",
+      modelId: "glm-5.1:cloud",
+      prompt: "Please inspect the code, make the change, and run the checks.",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "update_plan", meta: "status=updated" }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "ollama",
+          model: "glm-5.1:cloud",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        itemLifecycle: {
+          startedCount: 1,
+          completedCount: 1,
+          activeCount: 0,
+        },
+      }),
+    });
+
+    expect(retryInstruction).toContain("Act now");
+  });
+
+  it("triggers planning-only retry for Ollama when update_plan is called with planning prose", () => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      provider: "ollama",
+      modelId: "glm-5.1:cloud",
+      prompt: "Please inspect the code, make the change, and run the checks.",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["I'll capture the steps, then take the first tool action."],
+        toolMetas: [{ toolName: "update_plan", meta: "status=updated" }],
+        itemLifecycle: {
+          startedCount: 1,
+          completedCount: 1,
+          activeCount: 0,
+        },
+      }),
+    });
+
+    expect(retryInstruction).toContain("Act now");
+  });
+
+  it("does not trigger planning-only retry for Ollama when update_plan plus an action tool are called", () => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      provider: "ollama",
+      modelId: "glm-5.1:cloud",
+      prompt: "Please inspect the code, make the change, and run the checks.",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [
+          { toolName: "update_plan", meta: "status=updated" },
+          { toolName: "read", meta: "path=/src/foo.ts" },
+        ],
+        itemLifecycle: {
+          startedCount: 2,
+          completedCount: 2,
+          activeCount: 0,
+        },
+      }),
+    });
+
     expect(retryInstruction).toBeNull();
-    expect(ackInstruction).toBeNull();
   });
 
   it("retries signed reasoning-only Ollama turns with a visible-answer continuation instruction", () => {

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -605,10 +605,17 @@ function shouldApplyPlanningOnlyRetryGuard(params: {
   if (params.executionContract === "strict-agentic") {
     return true;
   }
-  return isIncompleteTurnRecoverySupportedProviderModel({
-    provider: params.provider,
-    modelId: params.modelId,
-  });
+  if (
+    isIncompleteTurnRecoverySupportedProviderModel({
+      provider: params.provider,
+      modelId: params.modelId,
+    })
+  ) {
+    return true;
+  }
+  return OLLAMA_INCOMPLETE_TURN_PROVIDER_ID_PATTERN.test(
+    normalizeLowercaseStringOrEmpty(params.provider ?? ""),
+  );
 }
 
 function shouldApplyNonVisibleTurnRetryGuard(params: {
@@ -859,14 +866,19 @@ export function resolvePlanningOnlyRetryInstruction(params: {
   }
 
   const text = (params.attempt.assistantTexts ?? []).join("\n\n").trim();
-  if (!text || text.length > PLANNING_ONLY_MAX_VISIBLE_TEXT || text.includes("```")) {
+  // A model that calls only update_plan with no accompanying text (e.g. Ollama/GLM)
+  // is still a planning-only turn — skip text-matching checks for it.
+  const planOnlyTurnWithNoText =
+    !text && planOnlyToolMetaCount > 0 && !hasNonPlanToolActivity(params.attempt.toolMetas);
+  if ((!text && !planOnlyTurnWithNoText) || text.length > PLANNING_ONLY_MAX_VISIBLE_TEXT || text.includes("```")) {
     return null;
   }
-  const hasStructuredPlanningFormat = hasStructuredPlanningOnlyFormat(text);
-  if (!PLANNING_ONLY_PROMISE_RE.test(text) && !hasStructuredPlanningFormat) {
+  const hasStructuredPlanningFormat = !planOnlyTurnWithNoText && hasStructuredPlanningOnlyFormat(text);
+  if (!planOnlyTurnWithNoText && !PLANNING_ONLY_PROMISE_RE.test(text) && !hasStructuredPlanningFormat) {
     return null;
   }
   if (
+    !planOnlyTurnWithNoText &&
     !hasStructuredPlanningFormat &&
     !singleActionNarrative &&
     !PLANNING_ONLY_ACTION_VERB_RE.test(text)


### PR DESCRIPTION
## Problem

When GLM-5.1 (or any Ollama model) calls the `update_plan` tool, it stops generating — `stopReason: "stop"` with no subsequent text. Two gaps in OpenClaw's retry logic prevented recovery:

1. **`shouldApplyPlanningOnlyRetryGuard()` did not cover Ollama.**  The function only returned `true` for strict-agentic (GPT-5 family) and Gemini models. Ollama models fell through — no "act now" retry was ever triggered.

2. **`resolvePlanningOnlyRetryInstruction()` required visible text.**  When a model calls only `update_plan` with no accompanying text, the function returned `null` (no retry).

## Fix

### Patch 1 — extend `shouldApplyPlanningOnlyRetryGuard` to Ollama

`src/agents/pi-embedded-runner/run/incomplete-turn.ts`

Adds `OLLAMA_INCOMPLETE_TURN_PROVIDER_ID_PATTERN` check to `shouldApplyPlanningOnlyRetryGuard`, mirroring the existing check already present in `shouldApplyNonVisibleTurnRetryGuard`.

### Patch 2 — handle plan-only tool calls with no text

When the assistant called only `update_plan` and produced no visible text, the text-matching guards in `resolvePlanningOnlyRetryInstruction` now detect this as a `planOnlyTurnWithNoText` case and skip text-matching, returning the standard retry instruction directly.

## Tests

Four new test cases added to `run.incomplete-turn.test.ts`:

- Ollama calls only `update_plan` with no text, `stopReason=stop` → retry triggered
- Ollama calls `update_plan` + planning prose → retry triggered
- Ollama calls `update_plan` + action tool (`read`) → no retry (non-plan tool activity detected)
- Existing "does not apply planning-only paths to Ollama" test updated to assert the guard now fires correctly

All 190 tests pass.

## Files changed

- `src/agents/pi-embedded-runner/run/incomplete-turn.ts` — two targeted patches
- `src/agents/pi-embedded-runner/run.incomplete-turn.test.ts` — updated + new tests