### PR TITLE
feat(telegram): localized command menu descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Validate node exec event provenance [AI]. (#81071) Thanks @pgondhi987.
 - Gateway: keep active reply runs visible to stuck-session diagnostics and clear no-active-work recovery state, preventing stale queued lanes after compaction or tool failures. Fixes #80677. (#81302)
 - Gateway/OpenAI HTTP: return OpenAI-compatible 400 errors for invalid sampling params and provider validation failures instead of collapsing them to 500s. (#81275) Thanks @Lellansin.
+- Telegram: publish plugin and skill command description localizations to native command menus while filtering unsupported locale codes and preserving Telegram command limits. (#81351) Thanks @jzakirov.
 - Limit hook CLI tool authority [AI]. (#81065) Thanks @pgondhi987.
 - Require admin scope for node device token management [AI]. (#81067) Thanks @pgondhi987.
 - Restrict chat sender allowlist matching [AI]. (#80898) Thanks @pgondhi987.

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -156,6 +156,28 @@ describe("bot-native-command-menu", () => {
     expect(result.issues).toContain('Plugin command "/empty" is missing a description.');
   });
 
+  it("preserves plugin command description localizations for Telegram menu sync", () => {
+    const result = buildPluginTelegramMenuCommands({
+      specs: [
+        {
+          name: "valid",
+          description: "Works",
+          descriptionLocalizations: { ko: "작동함" },
+        },
+      ],
+      existingCommands: new Set<string>(),
+    });
+
+    expect(result.commands).toEqual([
+      {
+        command: "valid",
+        description: "Works",
+        descriptionLocalizations: { ko: "작동함" },
+      },
+    ]);
+    expect(result.issues).toStrictEqual([]);
+  });
+
   it("normalizes hyphenated plugin command names", () => {
     const result = buildPluginTelegramMenuCommands({
       specs: [{ name: "agent-run", description: "Run agent" }],
@@ -239,6 +261,77 @@ describe("bot-native-command-menu", () => {
     expect(setMyCommands).toHaveBeenCalledWith(commands, {
       scope: { type: "all_group_chats" },
     });
+  });
+
+  it("registers localized command descriptions per Telegram language scope", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const runtimeLog = vi.fn();
+    const commands = [
+      {
+        command: "cmd",
+        description: "Default",
+        descriptionLocalizations: {
+          ko: "한국어",
+          "en-GB": "British English is unsupported by Telegram",
+        },
+      },
+    ];
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: commands,
+      accountId: `test-localized-${Date.now()}`,
+      botIdentity: "bot-a",
+    });
+
+    await vi.waitFor(() => {
+      expect(setMyCommands).toHaveBeenCalledTimes(4);
+    });
+
+    expect(setMyCommandsPayload(setMyCommands, 0)).toEqual([
+      { command: "cmd", description: "Default" },
+    ]);
+    expect(setMyCommandsPayload(setMyCommands, 2)).toEqual([
+      { command: "cmd", description: "한국어" },
+    ]);
+    expect(setMyCommandsCall(setMyCommands, 2).at(1)).toEqual({ language_code: "ko" });
+    expect(setMyCommandsCall(setMyCommands, 3).at(1)).toEqual({
+      scope: { type: "all_group_chats" },
+      language_code: "ko",
+    });
+    expect(runtimeLog).toHaveBeenCalledWith(
+      "Telegram command menu ignored unsupported description localization codes: en-GB.",
+    );
+  });
+
+  it("caps localized command descriptions before registering Telegram variants", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      commandsToRegister: [
+        {
+          command: "long",
+          description: "Default",
+          descriptionLocalizations: { ko: "x".repeat(300) },
+        },
+      ],
+      accountId: `test-localized-cap-${Date.now()}`,
+      botIdentity: "bot-a",
+    });
+
+    await vi.waitFor(() => {
+      expect(setMyCommands).toHaveBeenCalledTimes(4);
+    });
+
+    const localizedPayload = setMyCommandsPayload(setMyCommands, 2);
+    expect(localizedPayload[0]).toMatchObject({ command: "long" });
+    expect((localizedPayload[0] as { description: string }).description).toHaveLength(256);
   });
 
   it("produces a stable hash regardless of command order (#32017)", () => {
@@ -397,6 +490,34 @@ describe("bot-native-command-menu", () => {
       "Telegram accepted 80 commands after BOT_COMMANDS_TOO_MUCH (started with 100; omitted 20). Reduce plugin/skill/custom commands to expose more menu entries.",
     );
     expect(runtimeError).not.toHaveBeenCalled();
+  });
+
+  it("registers localized variants from the accepted retry command set", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("400: Bad Request: BOT_COMMANDS_TOO_MUCH"))
+      .mockResolvedValue(undefined);
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      commandsToRegister: Array.from({ length: 100 }, (_, i) => ({
+        command: `cmd_${i}`,
+        description: `Command ${i}`,
+        descriptionLocalizations: { ko: `명령 ${i}` },
+      })),
+      accountId: `test-localized-retry-${Date.now()}`,
+      botIdentity: "bot-a",
+    });
+
+    await vi.waitFor(() => {
+      expect(setMyCommands).toHaveBeenCalledTimes(5);
+    });
+    expect(setMyCommandsPayload(setMyCommands, 0)).toHaveLength(100);
+    expect(setMyCommandsPayload(setMyCommands, 1)).toHaveLength(80);
+    expect(setMyCommandsPayload(setMyCommands, 3)).toHaveLength(80);
+    expect(setMyCommandsCall(setMyCommands, 3).at(1)).toEqual({ language_code: "ko" });
   });
 
   it.each([

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { LanguageCode } from "@grammyjs/types";
 import type { Bot } from "grammy";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -15,9 +16,10 @@ const TELEGRAM_COMMAND_RETRY_RATIO = 0.8;
 const TELEGRAM_MIN_COMMAND_DESCRIPTION_LENGTH = 1;
 const TELEGRAM_MENU_RESULT_CACHE_MAX = 128;
 
-type TelegramMenuCommand = {
+export type TelegramMenuCommand = {
   command: string;
   description: string;
+  descriptionLocalizations?: Record<string, string>;
 };
 
 type TelegramCommandMenuScope =
@@ -27,6 +29,7 @@ type TelegramCommandMenuScope =
 type TelegramPluginCommandSpec = {
   name: unknown;
   description: unknown;
+  descriptionLocalizations?: Record<string, string>;
 };
 
 const TELEGRAM_COMMAND_MENU_SCOPES: readonly TelegramCommandMenuScope[] = [
@@ -196,7 +199,11 @@ export function buildPluginTelegramMenuCommands(params: {
     }
     pluginCommandNames.add(normalized);
     existingCommands.add(normalized);
-    commands.push({ command: normalized, description });
+    const menuCommand: TelegramMenuCommand = { command: normalized, description };
+    if (spec.descriptionLocalizations) {
+      menuCommand.descriptionLocalizations = spec.descriptionLocalizations;
+    }
+    commands.push(menuCommand);
   }
 
   return { commands, issues };
@@ -324,11 +331,33 @@ function writeCachedCommandHash(
   syncedCommandHashes.set(key, hash);
 }
 
+function buildLocalizedCommandVariants(
+  commands: TelegramMenuCommand[],
+): Array<{ languageCode: string; commands: TelegramMenuCommand[] }> {
+  const locales = new Set<string>();
+  for (const cmd of commands) {
+    if (cmd.descriptionLocalizations) {
+      for (const lang of Object.keys(cmd.descriptionLocalizations)) {
+        locales.add(lang);
+      }
+    }
+  }
+  return [...locales].toSorted().map((languageCode) => ({
+    languageCode,
+    commands: commands.map((cmd) => ({
+      command: cmd.command,
+      description: cmd.descriptionLocalizations?.[languageCode] ?? cmd.description,
+    })),
+  }));
+}
+
 function formatTelegramCommandScopeOperation(
   operation: "deleteMyCommands" | "setMyCommands",
   scope: TelegramCommandMenuScope,
+  languageCode?: string,
 ): string {
-  return scope.label === "default" ? operation : `${operation}(${scope.label})`;
+  const base = scope.label === "default" ? operation : `${operation}(${scope.label})`;
+  return languageCode ? `${base}(${languageCode})` : base;
 }
 
 async function deleteTelegramMenuCommandsForScopes(params: {
@@ -359,18 +388,24 @@ async function setTelegramMenuCommandsForScopes(params: {
   bot: Bot;
   runtime: RuntimeEnv;
   commands: TelegramMenuCommand[];
+  languageCode?: string;
   shouldLog?: (err: unknown) => boolean;
 }): Promise<void> {
-  const { bot, runtime, commands, shouldLog } = params;
+  const { bot, runtime, commands, languageCode, shouldLog } = params;
   for (const scope of TELEGRAM_COMMAND_MENU_SCOPES) {
     await withTelegramApiErrorLogging({
-      operation: formatTelegramCommandScopeOperation("setMyCommands", scope),
+      operation: formatTelegramCommandScopeOperation("setMyCommands", scope, languageCode),
       runtime,
       shouldLog,
-      fn: () =>
-        scope.options
-          ? bot.api.setMyCommands(commands, scope.options)
-          : bot.api.setMyCommands(commands),
+      fn: () => {
+        const opts = {
+          ...scope.options,
+          ...(languageCode ? { language_code: languageCode as LanguageCode } : undefined),
+        };
+        return Object.keys(opts).length > 0
+          ? bot.api.setMyCommands(commands, opts)
+          : bot.api.setMyCommands(commands);
+      },
     });
   }
 }
@@ -428,8 +463,7 @@ export function syncTelegramMenuCommands(params: {
             }),
           );
         }
-        writeCachedCommandHash(accountId, botIdentity, currentHash);
-        return;
+        break;
       } catch (err) {
         if (!isBotCommandsTooMuchError(err)) {
           throw err;
@@ -449,6 +483,16 @@ export function syncTelegramMenuCommands(params: {
         retryCommands = retryCommands.slice(0, reducedCount);
       }
     }
+
+    for (const variant of buildLocalizedCommandVariants(commandsToRegister)) {
+      await setTelegramMenuCommandsForScopes({
+        bot,
+        runtime,
+        commands: variant.commands,
+        languageCode: variant.languageCode,
+      });
+    }
+    writeCachedCommandHash(accountId, botIdentity, currentHash);
   };
 
   void sync().catch((err) => {

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -14,6 +14,7 @@ const TELEGRAM_MAX_COMMANDS = 100;
 export const TELEGRAM_TOTAL_COMMAND_TEXT_BUDGET = 5700;
 const TELEGRAM_COMMAND_RETRY_RATIO = 0.8;
 const TELEGRAM_MIN_COMMAND_DESCRIPTION_LENGTH = 1;
+const TELEGRAM_MAX_COMMAND_DESCRIPTION_LENGTH = 256;
 const TELEGRAM_MENU_RESULT_CACHE_MAX = 128;
 
 export type TelegramMenuCommand = {
@@ -101,7 +102,10 @@ function fitTelegramCommandsWithinTextBudget(
     );
     let descriptionTrimmed = false;
     const fittedCommands = candidateCommands.map((command) => {
-      const description = truncateTelegramCommandText(command.description, descriptionCap);
+      const description = truncateTelegramCommandText(
+        command.description,
+        Math.min(descriptionCap, TELEGRAM_MAX_COMMAND_DESCRIPTION_LENGTH),
+      );
       if (description !== command.description) {
         descriptionTrimmed = true;
         return Object.assign({}, command, { description });
@@ -278,6 +282,7 @@ function buildTelegramMenuResultCacheKey(params: {
   for (const command of params.allCommands) {
     updateTelegramCommandDigestField(digest, command.command);
     updateTelegramCommandDigestField(digest, command.description);
+    updateTelegramCommandLocalizationDigest(digest, command.descriptionLocalizations);
   }
   return digest.digest("hex").slice(0, 16);
 }
@@ -289,6 +294,18 @@ function updateTelegramCommandDigestField(
   digest.update(String(value.length));
   digest.update(":");
   digest.update(value);
+}
+
+function updateTelegramCommandLocalizationDigest(
+  digest: ReturnType<typeof createHash>,
+  localizations: Record<string, string> | undefined,
+): void {
+  const entries = Object.entries(localizations ?? {}).toSorted(([a], [b]) => a.localeCompare(b));
+  updateTelegramCommandDigestField(digest, String(entries.length));
+  for (const [locale, description] of entries) {
+    updateTelegramCommandDigestField(digest, locale);
+    updateTelegramCommandDigestField(digest, description);
+  }
 }
 
 function rememberCappedTelegramMenuResult(
@@ -331,24 +348,74 @@ function writeCachedCommandHash(
   syncedCommandHashes.set(key, hash);
 }
 
-function buildLocalizedCommandVariants(
-  commands: TelegramMenuCommand[],
-): Array<{ languageCode: string; commands: TelegramMenuCommand[] }> {
+function normalizeTelegramLanguageCode(languageCode: string): string | null {
+  const normalized = languageCode.trim().toLowerCase();
+  return /^[a-z]{2}$/.test(normalized) ? normalized : null;
+}
+
+function readLocalizedDescription(
+  command: TelegramMenuCommand,
+  languageCode: string,
+): string | undefined {
+  for (const [rawLanguageCode, rawDescription] of Object.entries(
+    command.descriptionLocalizations ?? {},
+  )) {
+    if (normalizeTelegramLanguageCode(rawLanguageCode) !== languageCode) {
+      continue;
+    }
+    const description = normalizeOptionalString(rawDescription);
+    if (description) {
+      return description;
+    }
+  }
+  return undefined;
+}
+
+function toTelegramBotCommands(commands: TelegramMenuCommand[]): Array<{
+  command: string;
+  description: string;
+}> {
+  return commands.map((command) => ({
+    command: command.command,
+    description: command.description,
+  }));
+}
+
+function buildLocalizedCommandVariants(commands: TelegramMenuCommand[]): {
+  variants: Array<{ languageCode: string; commands: TelegramMenuCommand[] }>;
+  unsupportedLanguageCodes: string[];
+} {
   const locales = new Set<string>();
+  const unsupportedLanguageCodes = new Set<string>();
   for (const cmd of commands) {
     if (cmd.descriptionLocalizations) {
       for (const lang of Object.keys(cmd.descriptionLocalizations)) {
-        locales.add(lang);
+        const normalized = normalizeTelegramLanguageCode(lang);
+        if (normalized) {
+          locales.add(normalized);
+        } else {
+          unsupportedLanguageCodes.add(lang);
+        }
       }
     }
   }
-  return [...locales].toSorted().map((languageCode) => ({
-    languageCode,
-    commands: commands.map((cmd) => ({
+  const variants = [...locales].toSorted().map((languageCode) => {
+    const localizedCommands = commands.map((cmd) => ({
       command: cmd.command,
-      description: cmd.descriptionLocalizations?.[languageCode] ?? cmd.description,
-    })),
-  }));
+      description: readLocalizedDescription(cmd, languageCode) ?? cmd.description,
+    }));
+    return {
+      languageCode,
+      commands: fitTelegramCommandsWithinTextBudget(
+        localizedCommands,
+        TELEGRAM_TOTAL_COMMAND_TEXT_BUDGET,
+      ).commands,
+    };
+  });
+  return {
+    variants,
+    unsupportedLanguageCodes: [...unsupportedLanguageCodes].toSorted(),
+  };
 }
 
 function formatTelegramCommandScopeOperation(
@@ -398,13 +465,14 @@ async function setTelegramMenuCommandsForScopes(params: {
       runtime,
       shouldLog,
       fn: () => {
+        const botCommands = toTelegramBotCommands(commands);
         const opts = {
           ...scope.options,
           ...(languageCode ? { language_code: languageCode as LanguageCode } : undefined),
         };
         return Object.keys(opts).length > 0
-          ? bot.api.setMyCommands(commands, opts)
-          : bot.api.setMyCommands(commands);
+          ? bot.api.setMyCommands(botCommands, opts)
+          : bot.api.setMyCommands(botCommands);
       },
     });
   }
@@ -446,6 +514,7 @@ export function syncTelegramMenuCommands(params: {
     }
 
     let retryCommands = commandsToRegister;
+    let acceptedCommands: TelegramMenuCommand[] | null = null;
     const initialCommandCount = commandsToRegister.length;
     while (retryCommands.length > 0) {
       try {
@@ -463,6 +532,7 @@ export function syncTelegramMenuCommands(params: {
             }),
           );
         }
+        acceptedCommands = retryCommands;
         break;
       } catch (err) {
         if (!isBotCommandsTooMuchError(err)) {
@@ -484,7 +554,18 @@ export function syncTelegramMenuCommands(params: {
       }
     }
 
-    for (const variant of buildLocalizedCommandVariants(commandsToRegister)) {
+    if (!acceptedCommands) {
+      return;
+    }
+
+    const { variants, unsupportedLanguageCodes } = buildLocalizedCommandVariants(acceptedCommands);
+    if (unsupportedLanguageCodes.length > 0) {
+      runtime.log?.(
+        `Telegram command menu ignored unsupported description localization codes: ${unsupportedLanguageCodes.join(", ")}.`,
+      );
+    }
+
+    for (const variant of variants) {
       await setTelegramMenuCommandsForScopes({
         bot,
         runtime,

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -196,6 +196,35 @@ describe("registerTelegramNativeCommands", () => {
     });
   });
 
+  it("passes skill command description localizations into Telegram menu sync", async () => {
+    const { bot, setMyCommands } = createCommandBot();
+    listSkillCommandsForAgents.mockReturnValue([
+      {
+        name: "demo_skill",
+        skillName: "demo-skill",
+        description: "Demo skill",
+        descriptionLocalizations: { ko: "데모 스킬" },
+      },
+    ]);
+
+    registerTelegramNativeCommands(
+      createNativeCommandTestParams(
+        {
+          commands: { native: true, nativeSkills: true },
+          agents: { list: [{ id: "main", default: true }] },
+        },
+        { bot },
+      ),
+    );
+
+    const registeredCommands = await waitForRegisteredCommands(setMyCommands);
+    expect(registeredCommands).toContainEqual({
+      command: "demo_skill",
+      description: "Demo skill",
+      descriptionLocalizations: { ko: "데모 스킬" },
+    });
+  });
+
   it("truncates Telegram command registration to 100 commands", async () => {
     const customCommands = Array.from({ length: 120 }, (_, index) => ({
       command: `cmd_${index}`,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -62,6 +62,7 @@ import {
   buildCappedTelegramMenuCommands,
   buildPluginTelegramMenuCommands,
   syncTelegramMenuCommands as syncTelegramMenuCommandsRuntime,
+  type TelegramMenuCommand,
 } from "./bot-native-command-menu.js";
 import { TelegramUpdateKeyContext } from "./bot-updates.js";
 import type { TelegramBotOptions } from "./bot.types.js";
@@ -759,9 +760,9 @@ export const registerTelegramNativeCommands = ({
       return telegramCfg;
     }
   };
-  const allCommandsFull: Array<{ command: string; description: string }> = [
+  const allCommandsFull: TelegramMenuCommand[] = [
     ...nativeCommands
-      .map((command) => {
+      .map((command): TelegramMenuCommand | null => {
         const normalized = normalizeTelegramCommandName(command.name);
         if (!TELEGRAM_COMMAND_NAME_PATTERN.test(normalized)) {
           runtime.error?.(
@@ -771,12 +772,9 @@ export const registerTelegramNativeCommands = ({
           );
           return null;
         }
-        return {
-          command: normalized,
-          description: command.description,
-        };
+        return { command: normalized, description: command.description };
       })
-      .filter((cmd): cmd is { command: string; description: string } => cmd !== null),
+      .filter((cmd) => cmd !== null),
     ...(nativeEnabled ? pluginCatalog.commands : []),
     ...customCommands,
   ];

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -772,7 +772,14 @@ export const registerTelegramNativeCommands = ({
           );
           return null;
         }
-        return { command: normalized, description: command.description };
+        const menuCommand: TelegramMenuCommand = {
+          command: normalized,
+          description: command.description,
+        };
+        if (command.descriptionLocalizations) {
+          menuCommand.descriptionLocalizations = command.descriptionLocalizations;
+        }
+        return menuCommand;
       })
       .filter((cmd) => cmd !== null),
     ...(nativeEnabled ? pluginCatalog.commands : []),


### PR DESCRIPTION
## Summary

- Problem: Telegram command menus only show default-locale descriptions. Multi-language bots cannot provide localized `/command` descriptions.
- Why it matters: Telegram Bot API supports `language_code` in `setMyCommands`. The Discord extension already supports `descriptionLocalizations`. Telegram should too.
- What changed: `buildPluginTelegramMenuCommands` carries `descriptionLocalizations` from plugin command specs. New `buildLocalizedCommandVariants()` groups commands by locale and calls `setMyCommands` per locale with `language_code`.
- What did NOT change (scope boundary): Default-locale registration untouched. Commands without `descriptionLocalizations` work exactly as before.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #55239

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Telegram bot menu shows only English command descriptions regardless of user language.
- Real environment tested: Production Telegram bot (Russian-language) running OpenClaw with this patch, Linux/Docker.
- Exact steps or command run after this patch: Registered `/new` and `/help` with `descriptionLocalizations: { ru: "Новая задача", ... }`. Opened bot menu in Telegram client set to Russian locale.
- Evidence after fix: Russian descriptions appear in bot command menu for Russian-locale users. English descriptions appear for other locales. Gateway logs show `setMyCommands(ru)` calls.

```text
[telegram] setMyCommands scope=default
[telegram] setMyCommands(ru) scope=default
```

- Observed result after fix: Per-locale command menus registered via `setMyCommands` with `language_code`.
- What was not tested: Locales beyond `ru`. Command truncation retry with localized variants.

## Root Cause (if applicable)

N/A — new feature.

## Regression Test Plan (if applicable)

N/A — `buildLocalizedCommandVariants` is a pure function, existing command menu tests pass.

## User-visible / Behavior Changes

Plugins can include `descriptionLocalizations` in command specs. OpenClaw registers per-locale menus via `setMyCommands` `language_code`.

## Diagram (if applicable)

```text
Before:
command spec -> setMyCommands(commands)

After:
command spec -> setMyCommands(commands)
             -> setMyCommands(localizedCommands, {language_code: "ru"})
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — additional `setMyCommands` calls per locale (same endpoint, same auth)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Docker)
- Runtime/container: Node.js 24, OpenClaw gateway
- Integration/channel: Telegram

### Steps

1. Define a plugin command with `descriptionLocalizations: { ru: "Новая задача" }`
2. Start the gateway
3. Open bot menu on a Russian-locale Telegram client

### Expected

- Russian description shown for `ru` locale, English for others

### Actual

- Confirmed

## Evidence

- [x] Trace/log snippets — gateway logs show per-locale `setMyCommands` calls
- [x] Screenshot/recording — available on request (production bot)

## Human Verification (required)

- Verified scenarios: Russian-locale client shows localized descriptions; English-locale shows default; bot without `descriptionLocalizations` unchanged.
- Edge cases checked: Localization for some commands but not all — unlocalised commands fall back to default description.
- What you did **not** verify: >2 locales simultaneously; interaction with command truncation retry.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Additional `setMyCommands` calls per locale could hit rate limits for bots with many locales.
  - Mitigation: Calls happen only on command menu sync (startup/change). Only explicitly configured locales trigger calls.

---

> AI-assisted (Claude). Verified in production Russian-language Telegram bot.