### PR TITLE
feat(plugins): expose tools in LLM input hook event

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3407,6 +3407,7 @@ export async function runEmbeddedAttempt(
                     normalizeMessagesForLlmBoundary(activeSession.messages),
                   ),
                   imagesCount: imageResult.images.length,
+                  tools: tools,
                 },
                 {
                   runId: params.runId,

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -217,6 +217,7 @@ export type PluginHookLlmInputEvent = {
   prompt: string;
   historyMessages: unknown[];
   imagesCount: number;
+  tools?: unknown[];
 };
 
 export type PluginHookModelCallBaseEvent = {

--- a/src/plugins/wired-hooks-llm.test.ts
+++ b/src/plugins/wired-hooks-llm.test.ts
@@ -98,6 +98,7 @@ describe("llm hook runner methods", () => {
         prompt: "hello",
         historyMessages: [],
         imagesCount: 0,
+        tools: [],
       },
     },
     {


### PR DESCRIPTION
## Summary

- Problem: The `llm_input` hook exposes `prompt`, `historyMessages`, and `imagesCount`, but `tools` is missing.
- Why it matters: Plugins that observe or modify the full LLM call context cannot see which tools are available for the call.
- What changed: Added optional `tools?: unknown[]` field to `PluginHookLlmInputEvent` and passed the existing `tools` variable through in the embedded runner.
- What did NOT change (scope boundary): No other hook types, no runtime behavior, no breaking changes. 3 lines total.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR

N/A

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `llm_input` hook missing `tools` prevents plugins from seeing the full LLM call context.
- Real environment tested: Production Telegram bot plugin with `llm_input` hook, OpenClaw gateway on Linux/Docker.
- Exact steps or command run after this patch: Registered an `llm_input` hook, sent a message triggering an LLM call with tools enabled, logged `event.tools`.
- Evidence after fix:

```text
# Before patch:
event.tools = undefined

# After patch:
event.tools = [{ type: "function", function: { name: "web_search", ... } }, ...]
```

- Observed result after fix: `event.tools` contains the tool definitions array on every LLM call.
- What was not tested: Other hook types (unchanged).

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

- [x] Unit test
- Target test or file: `src/plugins/wired-hooks-llm.test.ts` — extended the existing `runLlmInput` fixture with `tools: []`.

## User-visible / Behavior Changes

None. Optional field — existing hooks that don't reference it are unaffected.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Docker)
- Runtime/container: Node.js 24, OpenClaw gateway
- Integration/channel: Telegram

### Steps

1. Register a plugin hook for `llm_input`
2. Send a message that triggers an LLM call with tools
3. Inspect `event.tools` in the hook

### Expected

- `event.tools` contains the tool definitions array

### Actual

- Confirmed: `event.tools` is populated

## Evidence

- [x] Failing test/log before + passing after — test fixture updated, existing tests pass

## Human Verification (required)

- Verified scenarios: Hook receives tools in production environment, calls with zero tools yield empty array.
- Edge cases checked: Calls without hooks registered (no change).
- What you did **not** verify: Other hook types (unchanged).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.

---

> AI-assisted (Claude). 3-line change, understood and verified.