### PR TITLE
feat(plugin-sdk): export plugin hook types

### DIFF
--- a/package.json
+++ b/package.json
@@ -499,6 +499,10 @@
       "types": "./dist/plugin-sdk/host-runtime.d.ts",
       "default": "./dist/plugin-sdk/host-runtime.js"
     },
+    "./plugin-sdk/types": {
+      "types": "./dist/plugin-sdk/types.d.ts",
+      "default": "./dist/plugin-sdk/types.js"
+    },
     "./plugin-sdk/process-runtime": {
       "types": "./dist/plugin-sdk/process-runtime.d.ts",
       "default": "./dist/plugin-sdk/process-runtime.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -101,6 +101,7 @@
   "agent-harness-runtime",
   "hook-runtime",
   "host-runtime",
+  "types",
   "process-runtime",
   "windows-spawn",
   "acp-runtime",

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -7,6 +7,7 @@ import {
   abortEmbeddedPiRun,
   clearActiveEmbeddedRun,
   queueEmbeddedPiMessageWithOutcome,
+  resolveActiveEmbeddedRunSessionId,
   setActiveEmbeddedRun,
   type EmbeddedPiQueueMessageOptions,
 } from "../agents/pi-embedded-runner/runs.js";
@@ -105,7 +106,12 @@ export { resolveModelAuthMode } from "../agents/model-auth.js";
 export { supportsModelTools } from "../agents/model-tool-support.js";
 export { resolveAttemptSpawnWorkspaceDir } from "../agents/pi-embedded-runner/run/attempt.thread-helpers.js";
 export { buildEmbeddedAttemptToolRunContext } from "../agents/pi-embedded-runner/run/attempt.tool-run-context.js";
-export { abortEmbeddedPiRun as abortAgentHarnessRun, clearActiveEmbeddedRun, setActiveEmbeddedRun };
+export {
+  abortEmbeddedPiRun as abortAgentHarnessRun,
+  clearActiveEmbeddedRun,
+  resolveActiveEmbeddedRunSessionId,
+  setActiveEmbeddedRun,
+};
 
 /**
  * @deprecated Active-run queueing is an internal runtime concern. Use current

--- a/src/plugin-sdk/types.ts
+++ b/src/plugin-sdk/types.ts
@@ -1,0 +1,1 @@
+export * from "../plugins/types.js";


### PR DESCRIPTION
## Summary

- Problem: External plugins cannot import plugin hook types without reaching into internal source paths, which breaks on any internal refactor.
- Why it matters: Typed hook interfaces are essential for plugins that register lifecycle hooks (before-tool-call, LLM input/output, etc.). Without a public entrypoint, plugins depend on fragile internal paths.
- What changed: Added `openclaw/plugin-sdk/types` entrypoint that re-exports `src/plugins/types.js`. Exported `resolveActiveEmbeddedRunSessionId` from `agent-harness-runtime` for embedded run session resolution.
- What did NOT change (scope boundary): No runtime behavior changes. No new dependencies. Only type/export surface additions.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] API / contracts

## Linked Issue/PR

N/A

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Plugin hook types are not importable from the public SDK surface.
- Real environment tested: Production Telegram bot plugin running OpenClaw, imports hook types for typed event handling.
- Exact steps or command run after this patch:

\`\`\`ts
import type { PluginHookMap } from "openclaw/plugin-sdk/types";
\`\`\`

then \`pnpm tsc --noEmit\`.

- Evidence after fix:

\`\`\`text
$ pnpm tsc --noEmit
# exits 0, no errors
\`\`\`

Before this patch: \`Cannot find module 'openclaw/plugin-sdk/types' or its corresponding type declarations.\`

- Observed result after fix: TypeScript resolves all hook types from \`openclaw/plugin-sdk/types\` without errors.
- What was not tested: Runtime behavior (type-only change).

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A — additive type export. Verified by \`pnpm tsc\` in consuming plugin.

## User-visible / Behavior Changes

None. Type-only additions to the SDK surface.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js 24 + TypeScript
- Integration/channel: Telegram (plugin consumer)

### Steps

1. In an external plugin, add \`import type { PluginHookMap } from "openclaw/plugin-sdk/types"\`
2. Run \`pnpm tsc --noEmit\`

### Expected

- TypeScript resolves the import without errors

### Actual

- TypeScript resolves the import without errors

## Evidence

- [x] Trace/log snippets — \`tsc --noEmit\` passes in consuming plugin

## Human Verification (required)

- Verified scenarios: Plugin builds successfully with hook type imports from new entrypoint.
- Edge cases checked: Import resolution with both \`types\` and \`default\` conditions in \`exports\` map.
- What you did **not** verify: Runtime behavior (type-only change).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.

---

> AI-assisted (Claude). I understand what the code does — it's 4 lines of export wiring.