### PR TITLE
feat(telegram): web_app button support in inline keyboard

### DIFF
--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -12,6 +12,7 @@ type TelegramInlineButton = {
   text: string;
   callback_data?: string;
   url?: string;
+  web_app?: { url: string };
   style?: TelegramButtonStyle;
 };
 

--- a/extensions/telegram/src/inline-keyboard.ts
+++ b/extensions/telegram/src/inline-keyboard.ts
@@ -17,6 +17,11 @@ function toInlineKeyboardButton(
       ? { text: button.text, callback_data: button.callback_data, style: button.style }
       : { text: button.text, callback_data: button.callback_data };
   }
+  if (button.web_app?.url) {
+    return button.style
+      ? { text: button.text, web_app: { url: button.web_app.url }, style: button.style }
+      : { text: button.text, web_app: { url: button.web_app.url } };
+  }
   return undefined;
 }
 

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -353,6 +353,42 @@ describe("buildInlineKeyboard", () => {
         },
       },
       {
+        name: "passes web_app buttons through",
+        input: [
+          [
+            {
+              text: "Launch",
+              web_app: { url: "https://example.com/app" },
+            },
+          ],
+        ],
+        expected: {
+          inline_keyboard: [
+            [
+              {
+                text: "Launch",
+                web_app: { url: "https://example.com/app" },
+              },
+            ],
+          ],
+        },
+      },
+      {
+        name: "prefers callback_data over web_app when both are present",
+        input: [
+          [
+            {
+              text: "Both",
+              callback_data: "cmd:both",
+              web_app: { url: "https://example.com/app" },
+            },
+          ],
+        ],
+        expected: {
+          inline_keyboard: [[{ text: "Both", callback_data: "cmd:both" }]],
+        },
+      },
+      {
         name: "filters invalid buttons and empty rows",
         input: [
           [


### PR DESCRIPTION
## Summary

- Problem: Telegram inline keyboards support `url` and `callback_data` buttons, but `web_app` is missing.
- Why it matters: `web_app` is a standard Telegram Bot API button type for opening Mini Apps. Without it, bots cannot use this Telegram feature through OpenClaw.
- What changed: Added `web_app` field to `TelegramInlineButton` type and handling in `toInlineKeyboardButton`. Added 2 test cases.
- What did NOT change (scope boundary): No changes to `url`/`callback_data` behavior, reply keyboard, or button-type conversion from `InteractiveReply`.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

N/A

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Bots cannot open Telegram Mini Apps from inline keyboard responses.
- Real environment tested: Production Telegram bot running OpenClaw, sends `web_app` inline keyboard buttons to open a skill-map Mini App.
- Exact steps or command run after this patch: Bot sends inline keyboard with `web_app: { url: "https://spru.io/#/skill-map" }` button. Tapped in Telegram.
- Evidence after fix: Mini App opens correctly from inline keyboard button in Telegram. Existing `url` and `callback_data` buttons unaffected.
- Observed result after fix: `web_app` buttons render in Telegram and open the Mini App URL when tapped.
- What was not tested: `web_app` with `style` field (Telegram ignores style on web_app buttons).

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

- [x] Unit test
- Target test or file: `extensions/telegram/src/send.test.ts`
- Scenario: `web_app` buttons pass through; `callback_data` takes priority when both present.

## User-visible / Behavior Changes

Plugins can include `web_app: { url: "https://..." }` in inline keyboard button definitions. Telegram renders these as Mini App buttons.

## Diagram (if applicable)

```text
Before:
plugin sends web_app button -> toInlineKeyboardButton returns undefined -> button dropped

After:
plugin sends web_app button -> { text, web_app: { url } } -> Telegram shows Mini App button
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Docker)
- Runtime/container: Node.js 24
- Integration/channel: Telegram

### Steps

1. Plugin sends inline keyboard with `web_app: { url: "https://your-app.example.com" }` button
2. Tap the button in Telegram

### Expected

- Mini App opens

### Actual

- Mini App opens correctly

## Evidence

- [x] Failing test/log before + passing after — 2 new test cases pass

## Human Verification (required)

- Verified scenarios: `web_app` button renders and opens Mini App; existing buttons unaffected; priority order preserved (`callback_data` > `web_app`).
- Edge cases checked: Button with both `callback_data` and `web_app` — `callback_data` wins.
- What you did **not** verify: `web_app` + `style` rendering.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.

---

> AI-assisted (Claude). Verified in production Telegram bot.