### PR TITLE
fix(changelog): reject bot/app handles as Thanks attribution and require explicit human credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: keep the short post-tool completion watchdog armed across dynamic tool completion bookkeeping so embedded Codex runs fail fast and release their session lane when Codex goes quiet after a tool result. (#81697) Thanks @mbelinky.
 - Models: restore authenticated CLI runtime providers in the `/models` picker while keeping legacy runtime aliases hidden from setup/default model choices. Closes #81212. (#81239) Thanks @anagnorisis2peripeteia.
 - Agents/cron: honor a cron payload's explicit `timeoutSeconds` for the LLM idle watchdog even when it numerically equals `agents.defaults.timeoutSeconds`, preserving explicit per-run timeout intent and preventing stalled streaming replies from being cut to the implicit 120s cap. (#79426) Thanks @legolaz8451.
+- Changelog gates: reject bot/app handles as `Thanks` attribution and require explicit human credit for ClawSweeper-authored changelog entries. (#81357) Thanks @hxy91819.
 
 ### Changes
 
@@ -8650,7 +8651,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Commands: keep webchat command authorization on the internal `webchat` context instead of inferring another provider from channel allowlists, fixing dropped `/new`/`/status` commands in Control UI when channel allowlists are configured. (#7189) Thanks @karlisbergmanis-lv.
 - Control UI: prevent stored XSS via assistant name/avatar by removing inline script injection, serving bootstrap config as JSON, and enforcing `script-src 'self'`. Thanks @Adam55A-code.
 - Agents/Security: sanitize workspace paths before embedding into LLM prompts (strip Unicode control/format chars) to prevent instruction injection via malicious directory names. Thanks @aether-ai-agent.
-- Agents/Sandbox: clarify system prompt path guidance so sandbox `bash/exec` uses container paths (for example `/workspace`) while file tools keep host-bridge mapping, avoiding first-attempt path misses from host-only absolute paths in sandbox command execution. (#17693) Thanks @app/juniordevbot.
+- Agents/Sandbox: clarify system prompt path guidance so sandbox `bash/exec` uses container paths (for example `/workspace`) while file tools keep host-bridge mapping, avoiding first-attempt path misses from host-only absolute paths in sandbox command execution. (#17693)
 - Agents/Context: apply configured model `contextWindow` overrides after provider discovery so `lookupContextTokens()` honors operator config values (including discovery-failure paths). (#17404) Thanks @michaelbship and @vignesh07.
 - Agents/Context: derive `lookupContextTokens()` from auth-available model metadata and keep the smallest discovered context window for duplicate model ids, preventing cross-provider cache collisions from overestimating session context limits. (#17586) Thanks @githabideri and @vignesh07.
 - Agents/OpenAI: force `store=true` for direct OpenAI Responses/Codex runs to preserve multi-turn server-side conversation state, while leaving proxy/non-OpenAI endpoints unchanged. (#16803) Thanks @mark9232 and @vignesh07.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,7 +244,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: keep the short post-tool completion watchdog armed across dynamic tool completion bookkeeping so embedded Codex runs fail fast and release their session lane when Codex goes quiet after a tool result. (#81697) Thanks @mbelinky.
 - Models: restore authenticated CLI runtime providers in the `/models` picker while keeping legacy runtime aliases hidden from setup/default model choices. Closes #81212. (#81239) Thanks @anagnorisis2peripeteia.
 - Agents/cron: honor a cron payload's explicit `timeoutSeconds` for the LLM idle watchdog even when it numerically equals `agents.defaults.timeoutSeconds`, preserving explicit per-run timeout intent and preventing stalled streaming replies from being cut to the implicit 120s cap. (#79426) Thanks @legolaz8451.
-- Changelog gates: reject bot/app handles as `Thanks` attribution and require explicit human credit for ClawSweeper-authored changelog entries. (#81357) Thanks @hxy91819.
+- Changelog gates: reject bot/app handles as `Thanks` attribution and require explicit human credit for bot/app-authored changelog entries. (#81357) Thanks @hxy91819.
 
 ### Changes
 

--- a/scripts/check-changelog-attributions.mjs
+++ b/scripts/check-changelog-attributions.mjs
@@ -6,12 +6,22 @@ import { fileURLToPath } from "node:url";
 
 export const FORBIDDEN_CHANGELOG_THANKS_HANDLES = ["codex", "openclaw", "steipete", "clawsweeper"];
 
-const THANKS_HANDLE_PATTERN = /\bThanks\b[^\n]*@([-_/A-Za-z0-9]+(?:\[bot\])?)/iu;
+const THANKS_PATTERN = /\bThanks\b/iu;
+const THANKED_HANDLE_PATTERN = /@([-_/A-Za-z0-9]+(?:\[bot\])?)/giu;
 
-export function isForbiddenChangelogThanksHandle(handle) {
+export function isForbiddenChangelogThanksHandle(handle, options = {}) {
+  const { strictBotHandle = false } = options;
   const normalized = handle.toLowerCase();
   if (normalized === "null" || normalized.startsWith("app/")) {
     return true;
+  }
+  if (strictBotHandle && normalized.includes("clawsweeper")) {
+    return (
+      normalized === "clawsweeper" ||
+      normalized === "clawsweeper[bot]" ||
+      normalized === "openclaw-clawsweeper" ||
+      normalized === "openclaw-clawsweeper[bot]"
+    );
   }
   return FORBIDDEN_CHANGELOG_THANKS_HANDLES.some((forbidden) =>
     forbidden === "clawsweeper" ? normalized.includes(forbidden) : normalized === forbidden,
@@ -22,18 +32,26 @@ export function findForbiddenChangelogThanks(content) {
   return content
     .split(/\r?\n/u)
     .map((text, index) => {
-      const match = text.match(THANKS_HANDLE_PATTERN);
-      if (!match || !isForbiddenChangelogThanksHandle(match[1])) {
+      if (!THANKS_PATTERN.test(text)) {
         return null;
       }
-      return { line: index + 1, handle: match[1].toLowerCase(), text };
+      for (const match of text.matchAll(THANKED_HANDLE_PATTERN)) {
+        if (isForbiddenChangelogThanksHandle(match[1])) {
+          return { line: index + 1, handle: match[1].toLowerCase(), text };
+        }
+      }
+      return null;
     })
     .filter(Boolean);
 }
 
 export async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--is-forbidden-handle") {
-    process.exitCode = isForbiddenChangelogThanksHandle(argv[1] ?? "") ? 0 : 1;
+    process.exitCode = isForbiddenChangelogThanksHandle(argv[1] ?? "", {
+      strictBotHandle: true,
+    })
+      ? 0
+      : 1;
     return;
   }
 

--- a/scripts/check-changelog-attributions.mjs
+++ b/scripts/check-changelog-attributions.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const FORBIDDEN_CHANGELOG_THANKS_HANDLES = ["codex", "openclaw", "steipete", "clawsweeper"];
+export const FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES = ["app/"];
 
 const THANKS_PATTERN = /\bThanks\b/iu;
 const THANKED_HANDLE_PATTERN = /@([-_/A-Za-z0-9]+(?:\[bot\])?)/giu;
@@ -12,7 +13,10 @@ const THANKED_HANDLE_PATTERN = /@([-_/A-Za-z0-9]+(?:\[bot\])?)/giu;
 export function isForbiddenChangelogThanksHandle(handle, options = {}) {
   const { strictBotHandle = false } = options;
   const normalized = handle.toLowerCase();
-  if (normalized === "null" || normalized.startsWith("app/")) {
+  if (normalized === "" || normalized === "null") {
+    return true;
+  }
+  if (FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
     return true;
   }
   if (strictBotHandle && normalized.includes("clawsweeper")) {

--- a/scripts/check-changelog-attributions.mjs
+++ b/scripts/check-changelog-attributions.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const FORBIDDEN_CHANGELOG_THANKS_EXACT_HANDLES = [
+  // Shell metadata can serialize a missing GitHub login as the literal string "null".
   "null",
   "codex",
   "openclaw",
@@ -23,6 +24,7 @@ export function isForbiddenChangelogThanksHandle(handle, options = {}) {
   const { strictBotHandle = false } = options;
   const normalized = handle.toLowerCase();
   if (normalized === "") {
+    // Empty input is not a GitHub handle, but the shell query path may pass it through.
     return true;
   }
   if (
@@ -32,6 +34,7 @@ export function isForbiddenChangelogThanksHandle(handle, options = {}) {
     return true;
   }
   if (strictBotHandle) {
+    // PR-author checks should not reject a real human whose login merely contains a bot keyword.
     return false;
   }
   return false;
@@ -44,6 +47,7 @@ export function findForbiddenChangelogThanks(content) {
       if (!THANKS_PATTERN.test(text)) {
         return null;
       }
+      // A single changelog line may thank multiple handles; scan all of them.
       for (const match of text.matchAll(THANKED_HANDLE_PATTERN)) {
         if (isForbiddenChangelogThanksHandle(match[1])) {
           return { line: index + 1, handle: match[1].toLowerCase(), text };

--- a/scripts/check-changelog-attributions.mjs
+++ b/scripts/check-changelog-attributions.mjs
@@ -14,6 +14,7 @@ export const FORBIDDEN_CHANGELOG_THANKS_HANDLES = [
   "openclaw-clawsweeper[bot]",
 ];
 export const FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES = ["app/"];
+export const FORBIDDEN_CHANGELOG_THANKS_HANDLE_SUFFIXES = ["[bot]"];
 export const CHANGELOG_THANKS_REQUIRE_HUMAN_CREDIT_HANDLES = [
   "clawsweeper",
   "openclaw-clawsweeper",
@@ -21,6 +22,7 @@ export const CHANGELOG_THANKS_REQUIRE_HUMAN_CREDIT_HANDLES = [
   "openclaw-clawsweeper[bot]",
 ];
 export const CHANGELOG_THANKS_REQUIRE_HUMAN_CREDIT_HANDLE_PREFIXES = ["app/"];
+export const CHANGELOG_THANKS_REQUIRE_HUMAN_CREDIT_HANDLE_SUFFIXES = ["[bot]"];
 
 const THANKS_PATTERN = /\bThanks\b/iu;
 const THANKED_HANDLE_PATTERN = /@([-_/A-Za-z0-9]+(?:\[bot\])?)/giu;
@@ -34,7 +36,8 @@ export function isForbiddenChangelogThanksHandle(handle, options = {}) {
   }
   if (
     FORBIDDEN_CHANGELOG_THANKS_HANDLES.includes(normalized) ||
-    FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+    FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES.some((prefix) => normalized.startsWith(prefix)) ||
+    FORBIDDEN_CHANGELOG_THANKS_HANDLE_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
   ) {
     return true;
   }
@@ -54,6 +57,9 @@ export function requiresExplicitHumanChangelogThanks(handle) {
     CHANGELOG_THANKS_REQUIRE_HUMAN_CREDIT_HANDLES.includes(normalized) ||
     CHANGELOG_THANKS_REQUIRE_HUMAN_CREDIT_HANDLE_PREFIXES.some((prefix) =>
       normalized.startsWith(prefix),
+    ) ||
+    CHANGELOG_THANKS_REQUIRE_HUMAN_CREDIT_HANDLE_SUFFIXES.some((suffix) =>
+      normalized.endsWith(suffix),
     )
   );
 }

--- a/scripts/check-changelog-attributions.mjs
+++ b/scripts/check-changelog-attributions.mjs
@@ -14,6 +14,13 @@ export const FORBIDDEN_CHANGELOG_THANKS_HANDLES = [
   "openclaw-clawsweeper[bot]",
 ];
 export const FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES = ["app/"];
+export const CHANGELOG_THANKS_REQUIRE_HUMAN_CREDIT_HANDLES = [
+  "clawsweeper",
+  "openclaw-clawsweeper",
+  "clawsweeper[bot]",
+  "openclaw-clawsweeper[bot]",
+];
+export const CHANGELOG_THANKS_REQUIRE_HUMAN_CREDIT_HANDLE_PREFIXES = ["app/"];
 
 const THANKS_PATTERN = /\bThanks\b/iu;
 const THANKED_HANDLE_PATTERN = /@([-_/A-Za-z0-9]+(?:\[bot\])?)/giu;
@@ -36,6 +43,19 @@ export function isForbiddenChangelogThanksHandle(handle, options = {}) {
     return false;
   }
   return false;
+}
+
+export function requiresExplicitHumanChangelogThanks(handle) {
+  const normalized = handle.toLowerCase();
+  if (normalized === "" || normalized === "null") {
+    return false;
+  }
+  return (
+    CHANGELOG_THANKS_REQUIRE_HUMAN_CREDIT_HANDLES.includes(normalized) ||
+    CHANGELOG_THANKS_REQUIRE_HUMAN_CREDIT_HANDLE_PREFIXES.some((prefix) =>
+      normalized.startsWith(prefix),
+    )
+  );
 }
 
 export function findForbiddenChangelogThanks(content) {
@@ -63,6 +83,11 @@ export async function main(argv = process.argv.slice(2)) {
     })
       ? 0
       : 1;
+    return;
+  }
+
+  if (argv[0] === "--requires-explicit-human-thanks") {
+    process.exitCode = requiresExplicitHumanChangelogThanks(argv[1] ?? "") ? 0 : 1;
     return;
   }
 

--- a/scripts/check-changelog-attributions.mjs
+++ b/scripts/check-changelog-attributions.mjs
@@ -4,8 +4,19 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const FORBIDDEN_CHANGELOG_THANKS_HANDLES = ["codex", "openclaw", "steipete", "clawsweeper"];
+export const FORBIDDEN_CHANGELOG_THANKS_EXACT_HANDLES = [
+  "",
+  "null",
+  "codex",
+  "openclaw",
+  "steipete",
+  "clawsweeper",
+  "openclaw-clawsweeper",
+  "clawsweeper[bot]",
+  "openclaw-clawsweeper[bot]",
+];
 export const FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES = ["app/"];
+export const FORBIDDEN_CHANGELOG_THANKS_HANDLE_SUBSTRINGS = ["clawsweeper"];
 
 const THANKS_PATTERN = /\bThanks\b/iu;
 const THANKED_HANDLE_PATTERN = /@([-_/A-Za-z0-9]+(?:\[bot\])?)/giu;
@@ -13,22 +24,17 @@ const THANKED_HANDLE_PATTERN = /@([-_/A-Za-z0-9]+(?:\[bot\])?)/giu;
 export function isForbiddenChangelogThanksHandle(handle, options = {}) {
   const { strictBotHandle = false } = options;
   const normalized = handle.toLowerCase();
-  if (normalized === "" || normalized === "null") {
+  if (
+    FORBIDDEN_CHANGELOG_THANKS_EXACT_HANDLES.includes(normalized) ||
+    FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+  ) {
     return true;
   }
-  if (FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
-    return true;
+  if (strictBotHandle) {
+    return false;
   }
-  if (strictBotHandle && normalized.includes("clawsweeper")) {
-    return (
-      normalized === "clawsweeper" ||
-      normalized === "clawsweeper[bot]" ||
-      normalized === "openclaw-clawsweeper" ||
-      normalized === "openclaw-clawsweeper[bot]"
-    );
-  }
-  return FORBIDDEN_CHANGELOG_THANKS_HANDLES.some((forbidden) =>
-    forbidden === "clawsweeper" ? normalized.includes(forbidden) : normalized === forbidden,
+  return FORBIDDEN_CHANGELOG_THANKS_HANDLE_SUBSTRINGS.some((substring) =>
+    normalized.includes(substring),
   );
 }
 
@@ -73,7 +79,11 @@ export async function main(argv = process.argv.slice(2)) {
     console.error(`- ${relativePath}:${violation.line} uses Thanks @${violation.handle}`);
   }
   console.error(
-    `Use a credited external GitHub username instead of ${FORBIDDEN_CHANGELOG_THANKS_HANDLES.map((handle) => `@${handle}`).join(", ")}.`,
+    `Use a credited external GitHub username instead of ${FORBIDDEN_CHANGELOG_THANKS_EXACT_HANDLES.filter(
+      Boolean,
+    )
+      .map((handle) => `@${handle}`)
+      .join(", ")}.`,
   );
   process.exitCode = 1;
 }

--- a/scripts/check-changelog-attributions.mjs
+++ b/scripts/check-changelog-attributions.mjs
@@ -4,9 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const FORBIDDEN_CHANGELOG_THANKS_EXACT_HANDLES = [
-  // Shell metadata can serialize a missing GitHub login as the literal string "null".
-  "null",
+export const FORBIDDEN_CHANGELOG_THANKS_HANDLES = [
   "codex",
   "openclaw",
   "steipete",
@@ -23,12 +21,12 @@ const THANKED_HANDLE_PATTERN = /@([-_/A-Za-z0-9]+(?:\[bot\])?)/giu;
 export function isForbiddenChangelogThanksHandle(handle, options = {}) {
   const { strictBotHandle = false } = options;
   const normalized = handle.toLowerCase();
-  if (normalized === "") {
-    // Empty input is not a GitHub handle, but the shell query path may pass it through.
+  if (normalized === "" || normalized === "null") {
+    // Empty/null input is not a GitHub handle, but the shell query path may pass it through.
     return true;
   }
   if (
-    FORBIDDEN_CHANGELOG_THANKS_EXACT_HANDLES.includes(normalized) ||
+    FORBIDDEN_CHANGELOG_THANKS_HANDLES.includes(normalized) ||
     FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES.some((prefix) => normalized.startsWith(prefix))
   ) {
     return true;
@@ -82,11 +80,9 @@ export async function main(argv = process.argv.slice(2)) {
     console.error(`- ${relativePath}:${violation.line} uses Thanks @${violation.handle}`);
   }
   console.error(
-    `Use a credited external GitHub username instead of ${FORBIDDEN_CHANGELOG_THANKS_EXACT_HANDLES.filter(
-      Boolean,
-    )
-      .map((handle) => `@${handle}`)
-      .join(", ")}.`,
+    `Use a credited external GitHub username instead of ${FORBIDDEN_CHANGELOG_THANKS_HANDLES.map(
+      (handle) => `@${handle}`,
+    ).join(", ")}.`,
   );
   process.exitCode = 1;
 }

--- a/scripts/check-changelog-attributions.mjs
+++ b/scripts/check-changelog-attributions.mjs
@@ -4,9 +4,23 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const FORBIDDEN_CHANGELOG_THANKS_HANDLES = ["codex", "openclaw", "steipete"];
+export const FORBIDDEN_CHANGELOG_THANKS_HANDLES = [
+  "codex",
+  "openclaw",
+  "steipete",
+  "clawsweeper",
+  "openclaw-clawsweeper",
+  "app/clawsweeper",
+  "app/openclaw-clawsweeper",
+  "clawsweeper[bot]",
+  "openclaw-clawsweeper[bot]",
+];
 
-const HANDLE_PATTERN = FORBIDDEN_CHANGELOG_THANKS_HANDLES.join("|");
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+const HANDLE_PATTERN = FORBIDDEN_CHANGELOG_THANKS_HANDLES.map(escapeRegExp).join("|");
 const FORBIDDEN_THANKS_PATTERN = new RegExp(
   `\\bThanks\\b[^\\n]*@(${HANDLE_PATTERN})(?=\\b|[^A-Za-z0-9-])`,
   "iu",

--- a/scripts/check-changelog-attributions.mjs
+++ b/scripts/check-changelog-attributions.mjs
@@ -4,34 +4,26 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const FORBIDDEN_CHANGELOG_THANKS_HANDLES = [
-  "codex",
-  "openclaw",
-  "steipete",
-  "clawsweeper",
-  "openclaw-clawsweeper",
-  "app/clawsweeper",
-  "app/openclaw-clawsweeper",
-  "clawsweeper[bot]",
-  "openclaw-clawsweeper[bot]",
-];
+export const FORBIDDEN_CHANGELOG_THANKS_HANDLES = ["codex", "openclaw", "steipete", "clawsweeper"];
 
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+const THANKS_HANDLE_PATTERN = /\bThanks\b[^\n]*@([-_/A-Za-z0-9]+(?:\[bot\])?)/iu;
+
+function isForbiddenThanksHandle(handle) {
+  const normalized = handle.toLowerCase();
+  return FORBIDDEN_CHANGELOG_THANKS_HANDLES.some((forbidden) =>
+    forbidden === "clawsweeper" ? normalized.includes(forbidden) : normalized === forbidden,
+  );
 }
-
-const HANDLE_PATTERN = FORBIDDEN_CHANGELOG_THANKS_HANDLES.map(escapeRegExp).join("|");
-const FORBIDDEN_THANKS_PATTERN = new RegExp(
-  `\\bThanks\\b[^\\n]*@(${HANDLE_PATTERN})(?=\\b|[^A-Za-z0-9-])`,
-  "iu",
-);
 
 export function findForbiddenChangelogThanks(content) {
   return content
     .split(/\r?\n/u)
     .map((text, index) => {
-      const match = text.match(FORBIDDEN_THANKS_PATTERN);
-      return match ? { line: index + 1, handle: match[1].toLowerCase(), text } : null;
+      const match = text.match(THANKS_HANDLE_PATTERN);
+      if (!match || !isForbiddenThanksHandle(match[1])) {
+        return null;
+      }
+      return { line: index + 1, handle: match[1].toLowerCase(), text };
     })
     .filter(Boolean);
 }

--- a/scripts/check-changelog-attributions.mjs
+++ b/scripts/check-changelog-attributions.mjs
@@ -5,7 +5,6 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const FORBIDDEN_CHANGELOG_THANKS_EXACT_HANDLES = [
-  "",
   "null",
   "codex",
   "openclaw",
@@ -16,7 +15,6 @@ export const FORBIDDEN_CHANGELOG_THANKS_EXACT_HANDLES = [
   "openclaw-clawsweeper[bot]",
 ];
 export const FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES = ["app/"];
-export const FORBIDDEN_CHANGELOG_THANKS_HANDLE_SUBSTRINGS = ["clawsweeper"];
 
 const THANKS_PATTERN = /\bThanks\b/iu;
 const THANKED_HANDLE_PATTERN = /@([-_/A-Za-z0-9]+(?:\[bot\])?)/giu;
@@ -24,6 +22,9 @@ const THANKED_HANDLE_PATTERN = /@([-_/A-Za-z0-9]+(?:\[bot\])?)/giu;
 export function isForbiddenChangelogThanksHandle(handle, options = {}) {
   const { strictBotHandle = false } = options;
   const normalized = handle.toLowerCase();
+  if (normalized === "") {
+    return true;
+  }
   if (
     FORBIDDEN_CHANGELOG_THANKS_EXACT_HANDLES.includes(normalized) ||
     FORBIDDEN_CHANGELOG_THANKS_HANDLE_PREFIXES.some((prefix) => normalized.startsWith(prefix))
@@ -33,9 +34,7 @@ export function isForbiddenChangelogThanksHandle(handle, options = {}) {
   if (strictBotHandle) {
     return false;
   }
-  return FORBIDDEN_CHANGELOG_THANKS_HANDLE_SUBSTRINGS.some((substring) =>
-    normalized.includes(substring),
-  );
+  return false;
 }
 
 export function findForbiddenChangelogThanks(content) {

--- a/scripts/check-changelog-attributions.mjs
+++ b/scripts/check-changelog-attributions.mjs
@@ -8,8 +8,11 @@ export const FORBIDDEN_CHANGELOG_THANKS_HANDLES = ["codex", "openclaw", "steipet
 
 const THANKS_HANDLE_PATTERN = /\bThanks\b[^\n]*@([-_/A-Za-z0-9]+(?:\[bot\])?)/iu;
 
-function isForbiddenThanksHandle(handle) {
+export function isForbiddenChangelogThanksHandle(handle) {
   const normalized = handle.toLowerCase();
+  if (normalized === "null" || normalized.startsWith("app/")) {
+    return true;
+  }
   return FORBIDDEN_CHANGELOG_THANKS_HANDLES.some((forbidden) =>
     forbidden === "clawsweeper" ? normalized.includes(forbidden) : normalized === forbidden,
   );
@@ -20,7 +23,7 @@ export function findForbiddenChangelogThanks(content) {
     .split(/\r?\n/u)
     .map((text, index) => {
       const match = text.match(THANKS_HANDLE_PATTERN);
-      if (!match || !isForbiddenThanksHandle(match[1])) {
+      if (!match || !isForbiddenChangelogThanksHandle(match[1])) {
         return null;
       }
       return { line: index + 1, handle: match[1].toLowerCase(), text };
@@ -29,6 +32,11 @@ export function findForbiddenChangelogThanks(content) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
+  if (argv[0] === "--is-forbidden-handle") {
+    process.exitCode = isForbiddenChangelogThanksHandle(argv[1] ?? "") ? 0 : 1;
+    return;
+  }
+
   const changelogPath = argv[0] ?? "CHANGELOG.md";
   const absolutePath = path.resolve(process.cwd(), changelogPath);
   const content = fs.readFileSync(absolutePath, "utf8");

--- a/scripts/pr-lib/changelog.sh
+++ b/scripts/pr-lib/changelog.sh
@@ -173,6 +173,23 @@ changelog_thanks_required_for_contributor() {
   return 0
 }
 
+changelog_entry_has_explicit_human_thanks() {
+  local lines="$1"
+  local pr_pattern="$2"
+
+  local pr_lines
+  pr_lines=$(printf '%s\n' "$lines" | rg -in "$pr_pattern" || true)
+  if [ -z "$pr_lines" ]; then
+    return 1
+  fi
+
+  if ! printf '%s\n' "$pr_lines" | rg -i '\bthanks[[:space:]]+@[-_A-Za-z0-9]+(\[bot\])?' >/dev/null; then
+    return 1
+  fi
+
+  ! printf '%s\n' "$pr_lines" | rg -i '\bthanks\b[^\n]*@(codex|openclaw|steipete|(app/)?clawsweeper(\[bot\])?|(app/)?openclaw-clawsweeper(\[bot\])?)($|[^-A-Za-z0-9])' >/dev/null
+}
+
 validate_changelog_entry_for_pr() {
   local pr="$1"
   local contrib="$2"
@@ -339,7 +356,13 @@ END {
     return 0
   fi
 
-  echo "changelog validated: found PR #$pr (no eligible human contributor handle, skipping thanks check)"
+  if ! changelog_entry_has_explicit_human_thanks "$added_lines" "$pr_pattern"; then
+    echo "CHANGELOG.md update for bot/app/non-creditable author $contrib must include an explicit human Thanks @handle on the PR #$pr entry line."
+    echo "Choose the credited original contributor, or stop for maintainer input if authorship is unclear."
+    exit 1
+  fi
+
+  echo "changelog validated: found PR #$pr + explicit human thanks for bot/app/non-creditable author $contrib"
 }
 
 validate_changelog_merge_hygiene() {

--- a/scripts/pr-lib/changelog.sh
+++ b/scripts/pr-lib/changelog.sh
@@ -175,6 +175,12 @@ changelog_thanks_required_for_contributor() {
   return 0
 }
 
+changelog_explicit_human_thanks_required_for_contributor() {
+  local contrib="${1:-}"
+  [ -n "$contrib" ] || return 1
+  node "$(changelog_attribution_script)" --requires-explicit-human-thanks "$contrib"
+}
+
 validate_changelog_entry_for_pr() {
   local pr="$1"
   local contrib="$2"
@@ -338,6 +344,11 @@ END {
       exit 1
     fi
     echo "changelog validated: found PR #$pr + thanks @$contrib"
+    return 0
+  fi
+
+  if ! changelog_explicit_human_thanks_required_for_contributor "$contrib"; then
+    echo "changelog validated: found PR #$pr (no eligible human contributor handle, skipping thanks check)"
     return 0
   fi
 

--- a/scripts/pr-lib/changelog.sh
+++ b/scripts/pr-lib/changelog.sh
@@ -1,3 +1,11 @@
+changelog_helper_root() {
+  cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd
+}
+
+changelog_attribution_script() {
+  printf '%s\n' "$(changelog_helper_root)/scripts/check-changelog-attributions.mjs"
+}
+
 normalize_pr_changelog_entries() {
   local pr="$1"
   local changelog_path="CHANGELOG.md"
@@ -156,19 +164,13 @@ EOF_NODE
 }
 
 validate_changelog_attribution_policy() {
-  node scripts/check-changelog-attributions.mjs CHANGELOG.md
+  node "$(changelog_attribution_script)" CHANGELOG.md
 }
 
 changelog_thanks_required_for_contributor() {
   local contrib="${1:-}"
-  local normalized
-  normalized=$(printf '%s' "$contrib" | tr '[:upper:]' '[:lower:]')
-
-  case "$normalized" in
-    ""|"null"|"app/"*|"codex"|"openclaw"|"steipete"|*clawsweeper*)
-      return 1
-      ;;
-  esac
+  [ -n "$contrib" ] || return 1
+  node "$(changelog_attribution_script)" --is-forbidden-handle "$contrib" && return 1
 
   return 0
 }

--- a/scripts/pr-lib/changelog.sh
+++ b/scripts/pr-lib/changelog.sh
@@ -165,29 +165,12 @@ changelog_thanks_required_for_contributor() {
   normalized=$(printf '%s' "$contrib" | tr '[:upper:]' '[:lower:]')
 
   case "$normalized" in
-    ""|"null"|"app/"*|"codex"|"openclaw"|"clawsweeper"|"openclaw-clawsweeper"|"clawsweeper[bot]"|"openclaw-clawsweeper[bot]"|"steipete")
+    ""|"null"|"app/"*|"codex"|"openclaw"|"steipete"|*clawsweeper*)
       return 1
       ;;
   esac
 
   return 0
-}
-
-changelog_entry_has_explicit_human_thanks() {
-  local lines="$1"
-  local pr_pattern="$2"
-
-  local pr_lines
-  pr_lines=$(printf '%s\n' "$lines" | rg -in "$pr_pattern" || true)
-  if [ -z "$pr_lines" ]; then
-    return 1
-  fi
-
-  if ! printf '%s\n' "$pr_lines" | rg -i '\bthanks[[:space:]]+@[-_A-Za-z0-9]+(\[bot\])?' >/dev/null; then
-    return 1
-  fi
-
-  ! printf '%s\n' "$pr_lines" | rg -i '\bthanks\b[^\n]*@(codex|openclaw|steipete|(app/)?clawsweeper(\[bot\])?|(app/)?openclaw-clawsweeper(\[bot\])?)($|[^-A-Za-z0-9])' >/dev/null
 }
 
 validate_changelog_entry_for_pr() {
@@ -356,13 +339,15 @@ END {
     return 0
   fi
 
-  if ! changelog_entry_has_explicit_human_thanks "$added_lines" "$pr_pattern"; then
+  local with_pr_and_any_thanks
+  with_pr_and_any_thanks=$(printf '%s\n' "$added_lines" | rg -in "$pr_pattern" | rg -i '\bthanks[[:space:]]+@' || true)
+  if [ -z "$with_pr_and_any_thanks" ]; then
     echo "CHANGELOG.md update for bot/app/non-creditable author $contrib must include an explicit human Thanks @handle on the PR #$pr entry line."
     echo "Choose the credited original contributor, or stop for maintainer input if authorship is unclear."
     exit 1
   fi
 
-  echo "changelog validated: found PR #$pr + explicit human thanks for bot/app/non-creditable author $contrib"
+  echo "changelog validated: found PR #$pr + explicit thanks for bot/app/non-creditable author $contrib"
 }
 
 validate_changelog_merge_hygiene() {

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   findForbiddenChangelogThanks,
   isForbiddenChangelogThanksHandle,
+  requiresExplicitHumanChangelogThanks,
 } from "../../scripts/check-changelog-attributions.mjs";
 
 const changelogScriptPath = path.join(process.cwd(), "scripts", "pr-lib", "changelog.sh");
@@ -46,7 +47,7 @@ function validateChangelogEntry(repo: string, contrib: string): string {
     repo,
     "bash",
     [
-      "-lc",
+      "-c",
       'source "$OPENCLAW_PR_CHANGELOG_SH"; validate_changelog_entry_for_pr 123 "$OPENCLAW_TEST_CONTRIB"',
     ],
     {
@@ -114,6 +115,13 @@ describe("check-changelog-attributions", () => {
     expect(
       isForbiddenChangelogThanksHandle("human-clawsweeper-fan", { strictBotHandle: true }),
     ).toBe(false);
+
+    expect(requiresExplicitHumanChangelogThanks("clawsweeper")).toBe(true);
+    expect(requiresExplicitHumanChangelogThanks("clawsweeper[bot]")).toBe(true);
+    expect(requiresExplicitHumanChangelogThanks("app/clawsweeper")).toBe(true);
+    expect(requiresExplicitHumanChangelogThanks("human-clawsweeper-fan")).toBe(false);
+    expect(requiresExplicitHumanChangelogThanks("steipete")).toBe(false);
+    expect(requiresExplicitHumanChangelogThanks("")).toBe(false);
   });
 
   it("requires explicit human thanks for bot PR changelog entries", () => {
@@ -140,6 +148,15 @@ describe("check-changelog-attributions", () => {
     }
   });
 
+  it("keeps non-bot forbidden contributors on the no-thanks fallback", () => {
+    const repo = createRepoWithPrChangelogDiff("- Maintainer repair (#123).");
+    try {
+      expect(validateChangelogEntry(repo, "steipete")).toContain("skipping thanks check");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
   it("keeps PR changelog gates on the same attribution policy", () => {
     const commonLib = readFileSync("scripts/pr-lib/common.sh", "utf8");
     const changelogLib = readFileSync("scripts/pr-lib/changelog.sh", "utf8");
@@ -151,7 +168,9 @@ describe("check-changelog-attributions", () => {
     expect(commonLib).toContain("resolve_contributor_coauthor_email");
     expect(changelogLib).toContain("changelog_attribution_script");
     expect(changelogLib).toContain("--is-forbidden-handle");
+    expect(changelogLib).toContain("--requires-explicit-human-thanks");
     expect(changelogLib).toContain("changelog_thanks_required_for_contributor");
+    expect(changelogLib).toContain("changelog_explicit_human_thanks_required_for_contributor");
     expect(changelogLib).toContain("Choose the credited original contributor");
     expect(gates).toContain("validate_changelog_attribution_policy");
     expect(prepareCore).toContain("resolve_contributor_coauthor_email");

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -67,7 +67,7 @@ describe("check-changelog-attributions", () => {
       { line: 2, handle: "openclaw", text: "- Org-owned fix. Thanks @openclaw." },
       { line: 3, handle: "steipete", text: "- Maintainer-owned fix. Thanks @steipete." },
       { line: 4, handle: "openclaw", text: "- Mixed credit. Thanks @contributor and @OpenClaw." },
-      { line: 5, handle: "clawsweeper", text: "- Bot repair. Thanks @clawsweeper[bot]." },
+      { line: 5, handle: "clawsweeper[bot]", text: "- Bot repair. Thanks @clawsweeper[bot]." },
       { line: 6, handle: "app/clawsweeper", text: "- App repair. Thanks @app/clawsweeper." },
     ]);
   });
@@ -95,42 +95,10 @@ describe("check-changelog-attributions", () => {
     }
   });
 
-  it("rejects bot thanks as explicit human credit for bot PR changelog entries", () => {
-    const repo = initChangelogRepo("- Bot repair (#123). Thanks @clawsweeper[bot].");
-    try {
-      let output = "";
-      try {
-        validateChangelogEntry(repo, "clawsweeper[bot]");
-      } catch (error) {
-        output = String((error as { stdout?: unknown }).stdout ?? error);
-      }
-      expect(output).toContain("must include an explicit human Thanks @handle");
-    } finally {
-      rmSync(repo, { recursive: true, force: true });
-    }
-  });
-
-  it("rejects app bot thanks as explicit human credit for bot PR changelog entries", () => {
-    const repo = initChangelogRepo(
-      "- Session transcripts: redact sensitive message content in the centralized JSONL append path so CLI turns, gateway transcript injection, transcript mirrors, and guarded tool results use the same configured redaction behavior. Fixes #73565. Refs #73563. (#123) Thanks @app/clawsweeper.",
-    );
-    try {
-      let output = "";
-      try {
-        validateChangelogEntry(repo, "clawsweeper[bot]");
-      } catch (error) {
-        output = String((error as { stdout?: unknown }).stdout ?? error);
-      }
-      expect(output).toContain("must include an explicit human Thanks @handle");
-    } finally {
-      rmSync(repo, { recursive: true, force: true });
-    }
-  });
-
   it("accepts explicit human thanks for bot PR changelog entries", () => {
     const repo = initChangelogRepo("- Bot repair (#123). Thanks @Ziy1-Tan.");
     try {
-      expect(validateChangelogEntry(repo, "clawsweeper[bot]")).toContain("explicit human thanks");
+      expect(validateChangelogEntry(repo, "clawsweeper[bot]")).toContain("explicit thanks");
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }
@@ -147,10 +115,9 @@ describe("check-changelog-attributions", () => {
     expect(commonLib).toContain("resolve_contributor_coauthor_email");
     expect(changelogLib).toContain("node scripts/check-changelog-attributions.mjs CHANGELOG.md");
     expect(changelogLib).toContain("changelog_thanks_required_for_contributor");
-    expect(changelogLib).toContain("changelog_entry_has_explicit_human_thanks");
     expect(changelogLib).toContain("Choose the credited original contributor");
     expect(changelogLib).toContain('"app/"*');
-    expect(changelogLib).toContain('"clawsweeper"');
+    expect(changelogLib).toContain("*clawsweeper*");
     expect(gates).toContain("validate_changelog_attribution_policy");
     expect(prepareCore).toContain("resolve_contributor_coauthor_email");
     expect(mergeLib).toContain("pr_contributor_allows_human_trailers");

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -83,11 +83,27 @@ describe("check-changelog-attributions", () => {
     ).toStrictEqual([]);
   });
 
+  it("checks every thanked handle on a changelog line", () => {
+    expect(
+      findForbiddenChangelogThanks("- Mixed credit (#123). Thanks @openclaw and @alice."),
+    ).toEqual([
+      {
+        line: 1,
+        handle: "openclaw",
+        text: "- Mixed credit (#123). Thanks @openclaw and @alice.",
+      },
+    ]);
+  });
+
   it("uses one attribution predicate for scanner and shell checks", () => {
     expect(isForbiddenChangelogThanksHandle("codex")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("app/clawsweeper")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("openclaw-clawsweeper[bot]")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("Ziy1-Tan")).toBe(false);
+    expect(isForbiddenChangelogThanksHandle("human-clawsweeper-fan")).toBe(true);
+    expect(
+      isForbiddenChangelogThanksHandle("human-clawsweeper-fan", { strictBotHandle: true }),
+    ).toBe(false);
   });
 
   it("requires explicit human thanks for bot PR changelog entries", () => {

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -65,6 +65,7 @@ describe("check-changelog-attributions", () => {
       "- Maintainer-owned fix. Thanks @steipete.",
       "- Mixed credit. Thanks @contributor and @OpenClaw.",
       "- Bot repair. Thanks @clawsweeper[bot].",
+      "- Dependency bump. Thanks @dependabot[bot].",
       "- App repair. Thanks @app/clawsweeper.",
     ].join("\n");
 
@@ -74,7 +75,8 @@ describe("check-changelog-attributions", () => {
       { line: 3, handle: "steipete", text: "- Maintainer-owned fix. Thanks @steipete." },
       { line: 4, handle: "openclaw", text: "- Mixed credit. Thanks @contributor and @OpenClaw." },
       { line: 5, handle: "clawsweeper[bot]", text: "- Bot repair. Thanks @clawsweeper[bot]." },
-      { line: 6, handle: "app/clawsweeper", text: "- App repair. Thanks @app/clawsweeper." },
+      { line: 6, handle: "dependabot[bot]", text: "- Dependency bump. Thanks @dependabot[bot]." },
+      { line: 7, handle: "app/clawsweeper", text: "- App repair. Thanks @app/clawsweeper." },
     ]);
   });
 
@@ -110,6 +112,10 @@ describe("check-changelog-attributions", () => {
     expect(isForbiddenChangelogThanksHandle("clawsweeper[bot]")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("openclaw-clawsweeper")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("openclaw-clawsweeper[bot]")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("dependabot[bot]")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("dependabot[bot]", { strictBotHandle: true })).toBe(
+      true,
+    );
     expect(isForbiddenChangelogThanksHandle("alice")).toBe(false);
     expect(isForbiddenChangelogThanksHandle("human-clawsweeper-fan")).toBe(false);
     expect(
@@ -118,6 +124,7 @@ describe("check-changelog-attributions", () => {
 
     expect(requiresExplicitHumanChangelogThanks("clawsweeper")).toBe(true);
     expect(requiresExplicitHumanChangelogThanks("clawsweeper[bot]")).toBe(true);
+    expect(requiresExplicitHumanChangelogThanks("dependabot[bot]")).toBe(true);
     expect(requiresExplicitHumanChangelogThanks("app/clawsweeper")).toBe(true);
     expect(requiresExplicitHumanChangelogThanks("human-clawsweeper-fan")).toBe(false);
     expect(requiresExplicitHumanChangelogThanks("steipete")).toBe(false);
@@ -129,7 +136,7 @@ describe("check-changelog-attributions", () => {
     try {
       let output = "";
       try {
-        validateChangelogEntry(repo, "clawsweeper[bot]");
+        validateChangelogEntry(repo, "dependabot[bot]");
       } catch (error) {
         output = String((error as { stdout?: unknown }).stdout ?? error);
       }
@@ -142,7 +149,7 @@ describe("check-changelog-attributions", () => {
   it("accepts explicit human thanks for bot PR changelog entries", () => {
     const repo = createRepoWithPrChangelogDiff("- Bot repair (#123). Thanks @alice.");
     try {
-      expect(validateChangelogEntry(repo, "clawsweeper[bot]")).toContain("explicit thanks");
+      expect(validateChangelogEntry(repo, "dependabot[bot]")).toContain("explicit thanks");
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -96,8 +96,16 @@ describe("check-changelog-attributions", () => {
   });
 
   it("uses one attribution predicate for scanner and shell checks", () => {
+    expect(isForbiddenChangelogThanksHandle("")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("null")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("app/any-bot")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("codex")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("openclaw")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("steipete")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("app/clawsweeper")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("clawsweeper")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("clawsweeper[bot]")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("openclaw-clawsweeper")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("openclaw-clawsweeper[bot]")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("Ziy1-Tan")).toBe(false);
     expect(isForbiddenChangelogThanksHandle("human-clawsweeper-fan")).toBe(true);

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -109,7 +109,7 @@ describe("check-changelog-attributions", () => {
     expect(isForbiddenChangelogThanksHandle("clawsweeper[bot]")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("openclaw-clawsweeper")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("openclaw-clawsweeper[bot]")).toBe(true);
-    expect(isForbiddenChangelogThanksHandle("Ziy1-Tan")).toBe(false);
+    expect(isForbiddenChangelogThanksHandle("alice")).toBe(false);
     expect(isForbiddenChangelogThanksHandle("human-clawsweeper-fan")).toBe(false);
     expect(
       isForbiddenChangelogThanksHandle("human-clawsweeper-fan", { strictBotHandle: true }),
@@ -132,7 +132,7 @@ describe("check-changelog-attributions", () => {
   });
 
   it("accepts explicit human thanks for bot PR changelog entries", () => {
-    const repo = createRepoWithPrChangelogDiff("- Bot repair (#123). Thanks @Ziy1-Tan.");
+    const repo = createRepoWithPrChangelogDiff("- Bot repair (#123). Thanks @alice.");
     try {
       expect(validateChangelogEntry(repo, "clawsweeper[bot]")).toContain("explicit thanks");
     } finally {

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -108,7 +108,7 @@ describe("check-changelog-attributions", () => {
     expect(isForbiddenChangelogThanksHandle("openclaw-clawsweeper")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("openclaw-clawsweeper[bot]")).toBe(true);
     expect(isForbiddenChangelogThanksHandle("Ziy1-Tan")).toBe(false);
-    expect(isForbiddenChangelogThanksHandle("human-clawsweeper-fan")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("human-clawsweeper-fan")).toBe(false);
     expect(
       isForbiddenChangelogThanksHandle("human-clawsweeper-fan", { strictBotHandle: true }),
     ).toBe(false);

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -18,7 +18,7 @@ function run(cwd: string, command: string, args: string[], env?: NodeJS.ProcessE
   }).trim();
 }
 
-function initChangelogRepo(entry: string): string {
+function createRepoWithPrChangelogDiff(entry: string): string {
   const repo = mkdtempSync(path.join(os.tmpdir(), "openclaw-changelog-credit-"));
   run(repo, "git", ["init", "-q", "--initial-branch=main"]);
   run(repo, "git", ["config", "user.email", "test@example.com"]);
@@ -27,6 +27,8 @@ function initChangelogRepo(entry: string): string {
   run(repo, "git", ["add", "CHANGELOG.md"]);
   run(repo, "git", ["commit", "-qm", "seed"]);
   const baseSha = run(repo, "git", ["rev-parse", "HEAD"]);
+  // validate_changelog_entry_for_pr reads origin/main...HEAD, so the test
+  // fixture needs a real base ref plus a feature-branch changelog diff.
   run(repo, "git", ["update-ref", "refs/remotes/origin/main", baseSha]);
   run(repo, "git", ["checkout", "-qb", "feature"]);
   writeFileSync(
@@ -115,7 +117,7 @@ describe("check-changelog-attributions", () => {
   });
 
   it("requires explicit human thanks for bot PR changelog entries", () => {
-    const repo = initChangelogRepo("- Bot repair (#123).");
+    const repo = createRepoWithPrChangelogDiff("- Bot repair (#123).");
     try {
       let output = "";
       try {
@@ -130,7 +132,7 @@ describe("check-changelog-attributions", () => {
   });
 
   it("accepts explicit human thanks for bot PR changelog entries", () => {
-    const repo = initChangelogRepo("- Bot repair (#123). Thanks @Ziy1-Tan.");
+    const repo = createRepoWithPrChangelogDiff("- Bot repair (#123). Thanks @Ziy1-Tan.");
     try {
       expect(validateChangelogEntry(repo, "clawsweeper[bot]")).toContain("explicit thanks");
     } finally {

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -3,7 +3,10 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { findForbiddenChangelogThanks } from "../../scripts/check-changelog-attributions.mjs";
+import {
+  findForbiddenChangelogThanks,
+  isForbiddenChangelogThanksHandle,
+} from "../../scripts/check-changelog-attributions.mjs";
 
 const changelogScriptPath = path.join(process.cwd(), "scripts", "pr-lib", "changelog.sh");
 
@@ -80,6 +83,13 @@ describe("check-changelog-attributions", () => {
     ).toStrictEqual([]);
   });
 
+  it("uses one attribution predicate for scanner and shell checks", () => {
+    expect(isForbiddenChangelogThanksHandle("codex")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("app/clawsweeper")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("openclaw-clawsweeper[bot]")).toBe(true);
+    expect(isForbiddenChangelogThanksHandle("Ziy1-Tan")).toBe(false);
+  });
+
   it("requires explicit human thanks for bot PR changelog entries", () => {
     const repo = initChangelogRepo("- Bot repair (#123).");
     try {
@@ -113,11 +123,10 @@ describe("check-changelog-attributions", () => {
 
     expect(commonLib).toContain("pr_contributor_allows_human_trailers");
     expect(commonLib).toContain("resolve_contributor_coauthor_email");
-    expect(changelogLib).toContain("node scripts/check-changelog-attributions.mjs CHANGELOG.md");
+    expect(changelogLib).toContain("changelog_attribution_script");
+    expect(changelogLib).toContain("--is-forbidden-handle");
     expect(changelogLib).toContain("changelog_thanks_required_for_contributor");
     expect(changelogLib).toContain("Choose the credited original contributor");
-    expect(changelogLib).toContain('"app/"*');
-    expect(changelogLib).toContain("*clawsweeper*");
     expect(gates).toContain("validate_changelog_attribution_policy");
     expect(prepareCore).toContain("resolve_contributor_coauthor_email");
     expect(mergeLib).toContain("pr_contributor_allows_human_trailers");

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -1,6 +1,55 @@
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { findForbiddenChangelogThanks } from "../../scripts/check-changelog-attributions.mjs";
+
+const changelogScriptPath = path.join(process.cwd(), "scripts", "pr-lib", "changelog.sh");
+
+function run(cwd: string, command: string, args: string[], env?: NodeJS.ProcessEnv): string {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: env ? { ...process.env, ...env } : process.env,
+  }).trim();
+}
+
+function initChangelogRepo(entry: string): string {
+  const repo = mkdtempSync(path.join(os.tmpdir(), "openclaw-changelog-credit-"));
+  run(repo, "git", ["init", "-q", "--initial-branch=main"]);
+  run(repo, "git", ["config", "user.email", "test@example.com"]);
+  run(repo, "git", ["config", "user.name", "Test User"]);
+  writeFileSync(repo + "/CHANGELOG.md", "# Changelog\n\n## Unreleased\n\n### Fixes\n\n", "utf8");
+  run(repo, "git", ["add", "CHANGELOG.md"]);
+  run(repo, "git", ["commit", "-qm", "seed"]);
+  const baseSha = run(repo, "git", ["rev-parse", "HEAD"]);
+  run(repo, "git", ["update-ref", "refs/remotes/origin/main", baseSha]);
+  run(repo, "git", ["checkout", "-qb", "feature"]);
+  writeFileSync(
+    repo + "/CHANGELOG.md",
+    `# Changelog\n\n## Unreleased\n\n### Fixes\n\n${entry}\n`,
+    "utf8",
+  );
+  run(repo, "git", ["add", "CHANGELOG.md"]);
+  run(repo, "git", ["commit", "-qm", "add changelog entry"]);
+  return repo;
+}
+
+function validateChangelogEntry(repo: string, contrib: string): string {
+  return run(
+    repo,
+    "bash",
+    [
+      "-lc",
+      'source "$OPENCLAW_PR_CHANGELOG_SH"; validate_changelog_entry_for_pr 123 "$OPENCLAW_TEST_CONTRIB"',
+    ],
+    {
+      OPENCLAW_PR_CHANGELOG_SH: changelogScriptPath,
+      OPENCLAW_TEST_CONTRIB: contrib,
+    },
+  );
+}
 
 describe("check-changelog-attributions", () => {
   it("flags forbidden bot, org, and maintainer thanks attributions", () => {
@@ -9,6 +58,8 @@ describe("check-changelog-attributions", () => {
       "- Org-owned fix. Thanks @openclaw.",
       "- Maintainer-owned fix. Thanks @steipete.",
       "- Mixed credit. Thanks @contributor and @OpenClaw.",
+      "- Bot repair. Thanks @clawsweeper[bot].",
+      "- App repair. Thanks @app/clawsweeper.",
     ].join("\n");
 
     expect(findForbiddenChangelogThanks(content)).toEqual([
@@ -16,6 +67,8 @@ describe("check-changelog-attributions", () => {
       { line: 2, handle: "openclaw", text: "- Org-owned fix. Thanks @openclaw." },
       { line: 3, handle: "steipete", text: "- Maintainer-owned fix. Thanks @steipete." },
       { line: 4, handle: "openclaw", text: "- Mixed credit. Thanks @contributor and @OpenClaw." },
+      { line: 5, handle: "clawsweeper", text: "- Bot repair. Thanks @clawsweeper[bot]." },
+      { line: 6, handle: "app/clawsweeper", text: "- App repair. Thanks @app/clawsweeper." },
     ]);
   });
 
@@ -25,6 +78,62 @@ describe("check-changelog-attributions", () => {
         "- User-facing fix. Fixes #123. Thanks @external-contributor and @other-user.",
       ),
     ).toStrictEqual([]);
+  });
+
+  it("requires explicit human thanks for bot PR changelog entries", () => {
+    const repo = initChangelogRepo("- Bot repair (#123).");
+    try {
+      let output = "";
+      try {
+        validateChangelogEntry(repo, "clawsweeper[bot]");
+      } catch (error) {
+        output = String((error as { stdout?: unknown }).stdout ?? error);
+      }
+      expect(output).toContain("must include an explicit human Thanks @handle");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects bot thanks as explicit human credit for bot PR changelog entries", () => {
+    const repo = initChangelogRepo("- Bot repair (#123). Thanks @clawsweeper[bot].");
+    try {
+      let output = "";
+      try {
+        validateChangelogEntry(repo, "clawsweeper[bot]");
+      } catch (error) {
+        output = String((error as { stdout?: unknown }).stdout ?? error);
+      }
+      expect(output).toContain("must include an explicit human Thanks @handle");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects app bot thanks as explicit human credit for bot PR changelog entries", () => {
+    const repo = initChangelogRepo(
+      "- Session transcripts: redact sensitive message content in the centralized JSONL append path so CLI turns, gateway transcript injection, transcript mirrors, and guarded tool results use the same configured redaction behavior. Fixes #73565. Refs #73563. (#123) Thanks @app/clawsweeper.",
+    );
+    try {
+      let output = "";
+      try {
+        validateChangelogEntry(repo, "clawsweeper[bot]");
+      } catch (error) {
+        output = String((error as { stdout?: unknown }).stdout ?? error);
+      }
+      expect(output).toContain("must include an explicit human Thanks @handle");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts explicit human thanks for bot PR changelog entries", () => {
+    const repo = initChangelogRepo("- Bot repair (#123). Thanks @Ziy1-Tan.");
+    try {
+      expect(validateChangelogEntry(repo, "clawsweeper[bot]")).toContain("explicit human thanks");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 
   it("keeps PR changelog gates on the same attribution policy", () => {
@@ -38,6 +147,8 @@ describe("check-changelog-attributions", () => {
     expect(commonLib).toContain("resolve_contributor_coauthor_email");
     expect(changelogLib).toContain("node scripts/check-changelog-attributions.mjs CHANGELOG.md");
     expect(changelogLib).toContain("changelog_thanks_required_for_contributor");
+    expect(changelogLib).toContain("changelog_entry_has_explicit_human_thanks");
+    expect(changelogLib).toContain("Choose the credited original contributor");
     expect(changelogLib).toContain('"app/"*');
     expect(changelogLib).toContain('"clawsweeper"');
     expect(gates).toContain("validate_changelog_attribution_policy");


### PR DESCRIPTION
## Summary

- Expand forbidden changelog `Thanks` handles to include ClawSweeper bot accounts (`clawsweeper`, `openclaw-clawsweeper`, `clawsweeper[bot]`, `openclaw-clawsweeper[bot]`) and `app/` prefixed handles.
- Unify the attribution check predicate between the JS scanner (`check-changelog-attributions.mjs`) and the shell gate (`scripts/pr-lib/changelog.sh`) so both use `isForbiddenChangelogThanksHandle`.
- Require bot/app-authored PR changelog entries to include an explicit human `Thanks @handle`; reject entries that credit only a bot or omit human credit entirely.
- Add a `--is-forbidden-handle` CLI flag to the attribution script for shell-side reuse.
- Add tests for multi-handle lines, shared predicate correctness, missing human credit, and valid human credit on bot-authored entries.

## Change Type

- [x] Bug fix

## Scope

- [x] CI/CD / infra

## Linked Issue/PR

- Refs #79645

## Regression Test Plan

- [x] Unit test
- Target: `test/scripts/check-changelog-attributions.test.ts`
- Scenarios locked: bot/app handle rejection, multi-handle scanning, shell-side `validate_changelog_entry_for_pr` requiring explicit human Thanks for bot authors.

## User-visible / Behavior Changes

- PRs with bot/app authors must include a credited human `Thanks @handle` in their CHANGELOG entry line, or the changelog gate will fail.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Existing bot-authored PRs with `Thanks @clawsweeper` in changelog will fail the gate.
  - Mitigation: These are already blocked by the expanded forbidden list; contributors should credit the human author instead.