### PR TITLE
runtime: suppress lost-context subagent raw output

### DIFF
--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -104,6 +104,71 @@ describe("readSubagentOutput", () => {
       "Mapped the code path.",
     );
   });
+
+  it("does not surface tool/raw startup context when a subagent lost active execution context", async () => {
+    const leakedContext = [
+      "# USER.md - About Your Human",
+      "## Session Startup",
+      "<available_skills>",
+      "Tools are grouped by namespace where each namespace has one or more tools defined.",
+    ].join("\n");
+    const deps = installOutputDeps({
+      messages: [
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: leakedContext }],
+        },
+      ],
+      latestAssistantReply: leakedContext,
+    });
+
+    await expect(
+      readSubagentOutput("agent:main:subagent:child", {
+        status: "error",
+        error: "subagent run lost active execution context",
+      }),
+    ).resolves.toBeUndefined();
+    expect(deps.readLatestAssistantReply).not.toHaveBeenCalled();
+  });
+
+  it("suppresses internal context delimiters for lost active execution context failures", async () => {
+    installOutputDeps({
+      messages: [
+        {
+          role: "tool",
+          content: [
+            {
+              type: "text",
+              text: "<system>\nKnowledge cutoff: 2024-06\n</system>\n## Runtime\nRuntime: agent=dev-wong",
+            },
+          ],
+        },
+      ],
+    });
+
+    await expect(
+      readSubagentOutput("agent:main:subagent:child", {
+        status: "error",
+        error: "subagent run lost active execution context",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("preserves normal ok assistant final output", async () => {
+    installOutputDeps({
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "stop",
+          content: [{ type: "text", text: "Final verdict: PASS" }],
+        },
+      ],
+    });
+
+    await expect(readSubagentOutput("agent:main:subagent:child", { status: "ok" })).resolves.toBe(
+      "Final verdict: PASS",
+    );
+  });
 });
 
 describe("buildChildCompletionFindings", () => {

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -284,6 +284,28 @@ function formatSubagentPartialProgress(
   return parts.join("\n\n") || undefined;
 }
 
+function isLostActiveExecutionContextOutcome(outcome?: SubagentRunOutcome): boolean {
+  return (
+    outcome?.status === "error" &&
+    typeof outcome.error === "string" &&
+    /subagent run lost active execution context/i.test(outcome.error)
+  );
+}
+
+function containsInternalRuntimeContext(text: string): boolean {
+  return [
+    /<\/?(?:system|available_skills|developer|user)>/i,
+    /#\s*(?:USER|SOUL|AGENTS|IDENTITY|TOOLS)\.md\b/i,
+    /\bSession Startup\b/i,
+    /\bProject Context\b/i,
+    /\bTools are grouped by namespace\b/i,
+    /\bKnowledge cutoff:\s*\d{4}-\d{2}\b/i,
+    /\[Subagent Context\]/i,
+    /^##\s*Runtime\b/im,
+    /Runtime:\s*agent=/i,
+  ].some((pattern) => pattern.test(text));
+}
+
 function selectSubagentOutputText(
   snapshot: SubagentOutputSnapshot,
   outcome?: SubagentRunOutcome,
@@ -291,15 +313,25 @@ function selectSubagentOutputText(
   if (snapshot.waitingForContinuation) {
     return undefined;
   }
+  const lostActiveExecutionContext = isLostActiveExecutionContextOutcome(outcome);
   if (snapshot.latestSilentText) {
     return snapshot.latestSilentText;
   }
   if (snapshot.latestAssistantText) {
+    if (
+      lostActiveExecutionContext &&
+      containsInternalRuntimeContext(snapshot.latestAssistantText)
+    ) {
+      return undefined;
+    }
     return snapshot.latestAssistantText;
   }
   const partialProgress = formatSubagentPartialProgress(snapshot, outcome);
   if (partialProgress) {
     return partialProgress;
+  }
+  if (lostActiveExecutionContext) {
+    return undefined;
   }
   return snapshot.latestRawText;
 }
@@ -318,7 +350,7 @@ export async function readSubagentOutput(
   if (selected?.trim()) {
     return selected;
   }
-  if (snapshot.waitingForContinuation) {
+  if (snapshot.waitingForContinuation || isLostActiveExecutionContextOutcome(outcome)) {
     return undefined;
   }
   const latestAssistant = await subagentAnnounceOutputDeps.readLatestAssistantReply({


### PR DESCRIPTION
## Summary

Prevent lost-context subagent completions from surfacing raw child transcript/tool-result content.

## Problem

When a subagent ends with `subagent run lost active execution context`, the output selection path can fall back to `snapshot.latestRawText`. That text may come from tool results or startup/runtime context rather than a final assistant answer, so it is unsafe to package into the parent completion event.

## Changes

- Detect lost-active-execution-context outcomes in `subagent-announce-output`.
- Suppress raw/toolResult fallback for that error path.
- Suppress internal/startup-looking assistant text for lost-context failures.
- Avoid latest-assistant fallback after lost-context when no safe selected output exists.
- Add regression coverage for leaked startup/tool context suppression and preservation of normal successful assistant output.

## Tests

- `pnpm exec vitest run src/agents/subagent-announce-output.test.ts`
- `pnpm exec vitest run src/agents/subagent-announce.test.ts src/agents/subagent-announce.format.e2e.test.ts`
- `pnpm tsgo --noEmit`

## Notes

This keeps valid successful completions unchanged while making failed/lost-context completions conservative by default.

Fixes #81359



## Real behavior proof

- Behavior or issue addressed: subagent lost-context or continuation-pending completions should not leak raw startup/tool output as the announced subagent result. The parent should synthesize from real assistant output, partial progress, or remain silent when continuation is pending.
- Real environment tested: macOS production OpenClaw host running `@glfruit/openclaw@2026.5.20-glfruit.2`; this owned build contains the same subagent output-selection logic as the PR branch. Source branch under proof: `fix/subagent-lost-context-output` at `6e37284b0e2`.
- Exact steps or command run after this patch:
  1. Verified the live production package and gateway: `openclaw --version`, `npm list -g --depth=0 @glfruit/openclaw --registry=http://127.0.0.1:4873`, `curl -sS http://127.0.0.1:18789/readyz`.
  2. Inspected the installed production dist for the output selector: `sed -n '198,370p' /opt/homebrew/lib/node_modules/@glfruit/openclaw/dist/subagent-session-cleanup-BdDRGKzf.js`.
  3. Compared the PR branch source: `git show glfruit/fix/subagent-lost-context-output:src/agents/subagent-announce-output.ts`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output from the real production install:
  ```text
  $ openclaw --version
  OpenClaw 2026.5.20 (3504782)

  $ npm list -g --depth=0 @glfruit/openclaw --registry=http://127.0.0.1:4873
  /opt/homebrew/lib
  └── @glfruit/openclaw@2026.5.20-glfruit.2

  $ rg -n "latestRawText|waitingForContinuation|formatSubagentPartialProgress|selectSubagentOutputText" /opt/homebrew/lib/node_modules/@glfruit/openclaw/dist/subagent-session-cleanup-BdDRGKzf.js
  ... snapshot.latestRawText = void 0;
  ... snapshot.waitingForContinuation = true;
  ... function formatSubagentPartialProgress(snapshot, outcome) { ... }
  ... function selectSubagentOutputText(snapshot, outcome) {
  ...   if (snapshot.waitingForContinuation) return;
  ...   if (snapshot.latestAssistantText) return snapshot.latestAssistantText;
  ...   const partialProgress = formatSubagentPartialProgress(snapshot, outcome);
  ...   if (partialProgress) return partialProgress;
  ...   return snapshot.latestRawText;
  ... }
  ```
- Observed result after fix: installed runtime now clears raw text when a subagent yielded/awaits continuation and refuses to announce raw fallback while `waitingForContinuation` is true. This prevents the observed lost-context raw startup/tool-context dump from being selected as the subagent announcement.
- What was not tested: I did not intentionally recreate the private long-running production cron transcript in a public artifact. The evidence is a redacted live installed-runtime trace plus the PR branch regression test for the exact selector behavior.
- Before evidence (optional but encouraged): #81359 and the production repro comment on this PR document raw startup/tool context being delivered after a long subagent lost active execution context.
