### PR TITLE
fix(plugins): raise default install scan file limit to 25k

### DIFF
--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -344,7 +344,7 @@ const DEFAULT_PACKAGE_MANIFEST_TRAVERSAL_LIMITS: PackageManifestTraversalLimits 
   maxDirectories: 10_000,
   maxManifests: 10_000,
 };
-const DEFAULT_INSTALLED_PACKAGE_CODE_SCAN_MAX_FILES = 10_000;
+const DEFAULT_INSTALLED_PACKAGE_CODE_SCAN_MAX_FILES = 25_000;
 
 function readPositiveIntegerEnv(name: string, fallback: number): number {
   const rawValue = process.env[name];


### PR DESCRIPTION
The codex plugin install fans out to ~18k files via `@earendil-works/pi-coding-agent` + `@openai/codex`, which trips the 10k scan budget in `scanInstalledPackageDependencyTreeRuntime` and blocks `openclaw onboard`. Bumps the default to 25,000 so the bundled codex install completes; users can still override via `OPENCLAW_INSTALL_SCAN_MAX_CODE_FILES`.

## Test plan
- [x] Local `bash run.sh onboard-fast --non-interactive` against a clean `~/.openclaw` — codex plugin installs without scan error