### PR TITLE
Bootstrap agent sessions before send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/sessions: create configured agent main sessions before first `sessions_send` or gateway send, so agent-to-agent messages no longer fail when the target agent has not started yet.
 - gateway: pass Talk session scope to resolver [AI]. (#81379) Thanks @pgondhi987.
 - Gateway protocol: require v4 clients and stream explicit chat `deltaText`/`replace` frames so SDK clients can consume assistant updates without local diffing. (#80725) Thanks @samzong.
 - OpenAI plugin: clarify remote Codex OAuth login copy so tunneled users know sign-in may finish automatically before they paste the redirect URL. (#81301) Thanks @rubencu.

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -5,7 +5,8 @@ export const SESSIONS_LIST_TOOL_DISPLAY_SUMMARY =
   "List visible sessions with mailbox filters and optional previews.";
 export const SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY =
   "Read sanitized message history for a visible session.";
-export const SESSIONS_SEND_TOOL_DISPLAY_SUMMARY = "Send a message to another visible session.";
+export const SESSIONS_SEND_TOOL_DISPLAY_SUMMARY =
+  "Send a message to another visible session or configured agent.";
 export const SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY = "Spawn sub-agent or ACP sessions.";
 export const SESSIONS_SPAWN_SUBAGENT_TOOL_DISPLAY_SUMMARY = "Spawn sub-agent sessions.";
 export const SESSION_STATUS_TOOL_DISPLAY_SUMMARY = "Show session status, usage, and model state.";
@@ -27,9 +28,9 @@ export function describeSessionsHistoryTool(): string {
 
 export function describeSessionsSendTool(): string {
   return [
-    "Send a message into another visible session by sessionKey or label.",
+    "Send a message into another visible session by sessionKey or label, or to a configured agent by agentId.",
     "Thread-scoped chat sessions are rejected; target the parent channel session for inter-agent coordination.",
-    "Use this to delegate follow-up work to an existing session; waits for the target run and returns the updated assistant reply when available.",
+    "Missing configured agent main sessions are created before send; waits for the target run and returns the updated assistant reply when available.",
   ].join(" ");
 }
 

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -10,6 +10,7 @@ import {
   isSubagentSessionKey,
   normalizeAgentId,
   resolveAgentIdFromSessionKey,
+  toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
 import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
@@ -18,6 +19,7 @@ import {
   type GatewayMessageChannel,
   INTERNAL_MESSAGE_CHANNEL,
 } from "../../utils/message-channel.js";
+import { listAgentIds } from "../agent-scope.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
 import {
   type AgentWaitResult,
@@ -52,6 +54,78 @@ const SessionsSendToolSchema = Type.Object({
 
 type GatewayCaller = typeof callGateway;
 const SESSIONS_SEND_REPLY_HISTORY_LIMIT = 50;
+
+function resolveConfiguredAgentMainSessionKey(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  mainKey: string;
+}): string | undefined {
+  const agentId = normalizeAgentId(params.agentId);
+  if (!listAgentIds(params.cfg).includes(agentId)) {
+    return undefined;
+  }
+  return toAgentStoreSessionKey({
+    agentId,
+    requestKey: "main",
+    mainKey: params.mainKey,
+  });
+}
+
+function isConfiguredAgentMainSessionKey(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  mainKey: string;
+}): boolean {
+  const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+  return (
+    params.sessionKey ===
+    resolveConfiguredAgentMainSessionKey({
+      cfg: params.cfg,
+      agentId,
+      mainKey: params.mainKey,
+    })
+  );
+}
+
+async function ensureConfiguredAgentMainSession(params: {
+  cfg: OpenClawConfig;
+  callGateway: GatewayCaller;
+  sessionKey: string;
+  mainKey: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (
+    !isConfiguredAgentMainSessionKey({
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+      mainKey: params.mainKey,
+    })
+  ) {
+    return { ok: true };
+  }
+
+  try {
+    await params.callGateway({
+      method: "sessions.resolve",
+      params: { key: params.sessionKey },
+      timeoutMs: 10_000,
+    });
+    return { ok: true };
+  } catch {
+    try {
+      await params.callGateway({
+        method: "sessions.create",
+        params: {
+          key: params.sessionKey,
+          agentId: resolveAgentIdFromSessionKey(params.sessionKey),
+        },
+        timeoutMs: 10_000,
+      });
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: formatErrorMessage(err) };
+    }
+  }
+}
 
 type SessionsSendRouteEntry = Pick<SessionEntry, "acp" | "parentSessionKey" | "spawnedBy">;
 
@@ -145,6 +219,21 @@ export function createSessionsSendTool(opts?: {
       }
 
       let sessionKey = sessionKeyParam;
+      if (!sessionKey && !labelParam && labelAgentIdParam) {
+        const agentMainKey = resolveConfiguredAgentMainSessionKey({
+          cfg,
+          agentId: labelAgentIdParam,
+          mainKey,
+        });
+        if (!agentMainKey) {
+          return jsonResult({
+            runId: crypto.randomUUID(),
+            status: "error",
+            error: `agent not found: ${labelAgentIdParam}`,
+          });
+        }
+        sessionKey = agentMainKey;
+      }
       if (!sessionKey && labelParam) {
         const requesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);
         const requestedAgentId = labelAgentIdParam
@@ -290,6 +379,21 @@ export function createSessionsSendTool(opts?: {
           runId: crypto.randomUUID(),
           status: access.status,
           error: access.error,
+          sessionKey: displayKey,
+        });
+      }
+
+      const ensuredSession = await ensureConfiguredAgentMainSession({
+        cfg,
+        callGateway: gatewayCall,
+        sessionKey: resolvedKey,
+        mainKey,
+      });
+      if (!ensuredSession.ok) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: ensuredSession.error,
           sessionKey: displayKey,
         });
       }

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -398,6 +398,87 @@ function cloneCheckpointSessionEntry(params: {
   };
 }
 
+function isAgentMainSessionKey(cfg: OpenClawConfig, sessionKey: string): boolean {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return false;
+  }
+  return sessionKey === resolveAgentMainSessionKey({ cfg, agentId: parsed.agentId });
+}
+
+async function createAgentMainSessionForSend(params: {
+  req: GatewayRequestHandlerOptions["req"];
+  canonicalKey: string;
+  context: GatewayRequestContext;
+  client: GatewayClient | null;
+  isWebchatConnect: GatewayRequestHandlerOptions["isWebchatConnect"];
+}): Promise<
+  | {
+      ok: true;
+      entry: SessionEntry;
+      canonicalKey: string;
+      storePath: string;
+    }
+  | { ok: false; error: ReturnType<typeof errorShape> }
+> {
+  const agentId = parseAgentSessionKey(params.canonicalKey)?.agentId;
+  if (!agentId) {
+    return {
+      ok: false,
+      error: errorShape(ErrorCodes.INVALID_REQUEST, `session not found: ${params.canonicalKey}`),
+    };
+  }
+
+  let createResult:
+    | { ok: boolean; payload?: { key?: string }; error?: ReturnType<typeof errorShape> }
+    | undefined;
+  await sessionsHandlers["sessions.create"]({
+    req: params.req,
+    params: {
+      key: params.canonicalKey,
+      agentId,
+    },
+    respond: (ok, payload, error) => {
+      createResult = {
+        ok,
+        payload: payload && typeof payload === "object" ? (payload as { key?: string }) : undefined,
+        error,
+      };
+    },
+    context: params.context,
+    client: params.client,
+    isWebchatConnect: params.isWebchatConnect,
+  });
+
+  if (!createResult) {
+    return {
+      ok: false,
+      error: errorShape(ErrorCodes.UNAVAILABLE, "sessions.create did not respond"),
+    };
+  }
+  if (!createResult.ok) {
+    return {
+      ok: false,
+      error: createResult.error ?? errorShape(ErrorCodes.UNAVAILABLE, "failed to create session"),
+    };
+  }
+
+  const createdKey = normalizeOptionalString(createResult.payload?.key) ?? params.canonicalKey;
+  const loaded = loadSessionEntry(createdKey);
+  if (!loaded.entry?.sessionId) {
+    return {
+      ok: false,
+      error: errorShape(ErrorCodes.UNAVAILABLE, `session not created: ${createdKey}`),
+    };
+  }
+  return {
+    ok: true,
+    entry: loaded.entry,
+    canonicalKey: loaded.canonicalKey,
+    storePath: loaded.storePath,
+  };
+}
+
 function ensureSessionTranscriptFile(params: {
   sessionId: string;
   storePath: string;
@@ -581,7 +662,9 @@ async function handleSessionSend(params: {
   if (!key) {
     return;
   }
-  const { cfg, entry, canonicalKey, storePath } = loadSessionEntry(key);
+  const loaded = loadSessionEntry(key);
+  const { cfg } = loaded;
+  let { entry, canonicalKey, storePath } = loaded;
   // Reject sends/steers targeting sessions whose owning agent was deleted (#65524).
   const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, canonicalKey);
   if (deletedAgentId !== null) {
@@ -594,6 +677,22 @@ async function handleSessionSend(params: {
       ),
     );
     return;
+  }
+  if (!entry?.sessionId && !params.interruptIfActive && isAgentMainSessionKey(cfg, canonicalKey)) {
+    const created = await createAgentMainSessionForSend({
+      req: params.req,
+      canonicalKey,
+      context: params.context,
+      client: params.client,
+      isWebchatConnect: params.isWebchatConnect,
+    });
+    if (!created.ok) {
+      params.respond(false, undefined, created.error);
+      return;
+    }
+    entry = created.entry;
+    canonicalKey = created.canonicalKey;
+    storePath = created.storePath;
   }
   if (!entry?.sessionId) {
     params.respond(

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -248,6 +248,37 @@ describe("gateway server chat", () => {
     }
   });
 
+  test("sessions.send creates a configured agent main session before sending", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-send-agent-"));
+    testState.sessionStorePath = path.join(dir, "sessions.json");
+    testState.agentsConfig = {
+      list: [{ id: "main", default: true }, { id: "orion" }],
+    };
+    try {
+      await writeSessionStore({ entries: {} });
+
+      const res = await rpcReq(ws, "sessions.send", {
+        key: "agent:orion:main",
+        message: "hello orion",
+        idempotencyKey: "idem-sessions-send-orion",
+      });
+      expect(res.ok).toBe(true);
+      expect(res.payload?.runId).toBe("idem-sessions-send-orion");
+
+      const rawStore = JSON.parse(await fs.readFile(testState.sessionStorePath, "utf-8")) as Record<
+        string,
+        {
+          sessionId?: string;
+        }
+      >;
+      expect(rawStore["agent:orion:main"]?.sessionId).toBeTypeOf("string");
+    } finally {
+      testState.agentsConfig = undefined;
+      testState.sessionStorePath = undefined;
+      await removeTempDir(dir);
+    }
+  });
+
   test("sessions.steer accepts dashboard follow-up messages for existing sessions", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-steer-"));
     testState.sessionStorePath = path.join(dir, "sessions.json");

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, type Mock } from "vitest";
 import { resolveSessionTranscriptPath } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { captureEnv } from "../test-utils/env.js";
 import {
@@ -10,6 +12,7 @@ import {
   installGatewayTestHooks,
   startGatewayServer,
   testState,
+  writeSessionStore,
 } from "./test-helpers.js";
 
 const { createOpenClawTools } = await import("../agents/openclaw-tools.js");
@@ -45,12 +48,26 @@ async function emitLifecycleAssistantReply(params: {
 }) {
   const commandParams = params.opts as {
     sessionId?: string;
+    sessionKey?: string;
     runId?: string;
     extraSystemPrompt?: string;
   };
   const sessionId = commandParams.sessionId ?? params.defaultSessionId;
   const runId = commandParams.runId ?? sessionId;
-  const sessionFile = resolveSessionTranscriptPath(sessionId);
+  let sessionFile = resolveSessionTranscriptPath(sessionId);
+  if (testState.sessionStorePath && commandParams.sessionKey) {
+    const rawStore = JSON.parse(await fs.readFile(testState.sessionStorePath, "utf-8")) as Record<
+      string,
+      {
+        sessionId?: string;
+        sessionFile?: string;
+      }
+    >;
+    const entry = rawStore[commandParams.sessionKey];
+    if (entry?.sessionId === sessionId && entry.sessionFile) {
+      sessionFile = entry.sessionFile;
+    }
+  }
   await fs.mkdir(path.dirname(sessionFile), { recursive: true });
 
   const startedAt = Date.now();
@@ -217,6 +234,100 @@ describe("sessions_send label lookup", () => {
       expect(details.status).toBe("ok");
       expect(details.reply).toBe("labeled response");
       expect(details.sessionKey).toBe("agent:main:test-labeled-session");
+    },
+  );
+});
+
+describe("sessions_send agent targeting", () => {
+  it(
+    "starts configured agent main session by agentId before sending",
+    { timeout: SESSION_SEND_E2E_TIMEOUT_MS },
+    async () => {
+      const configPath = process.env.OPENCLAW_CONFIG_PATH;
+      if (!configPath) {
+        throw new Error("OPENCLAW_CONFIG_PATH missing in gateway test environment");
+      }
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-send-agent-"));
+      const config: OpenClawConfig = {
+        tools: {
+          sessions: {
+            visibility: "all",
+          },
+          agentToAgent: {
+            enabled: true,
+          },
+        },
+        agents: {
+          list: [{ id: "main", default: true }, { id: "orion" }],
+        },
+      };
+
+      testState.sessionStorePath = path.join(dir, "sessions.json");
+      testState.agentsConfig = config.agents;
+      try {
+        await fs.mkdir(path.dirname(configPath), { recursive: true });
+        await fs.writeFile(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+        await writeSessionStore({
+          entries: {
+            main: {
+              sessionId: "sess-main",
+              updatedAt: Date.now(),
+            },
+          },
+        });
+
+        const spy = agentCommand as unknown as Mock<(opts: unknown) => Promise<void>>;
+        spy.mockImplementation(async (opts: unknown) =>
+          emitLifecycleAssistantReply({
+            opts,
+            defaultSessionId: "orion-created",
+            resolveText: () => "orion response",
+          }),
+        );
+        spy.mockClear();
+
+        const tool = createOpenClawTools({
+          agentSessionKey: "agent:main:main",
+          config,
+        }).find((candidate) => candidate.name === "sessions_send");
+        if (!tool) {
+          throw new Error("missing sessions_send tool");
+        }
+
+        const result = await tool.execute("call-agent-id", {
+          agentId: "orion",
+          message: "hello orion",
+          timeoutSeconds: 5,
+        });
+        const details = result.details as {
+          status?: string;
+          reply?: string;
+          sessionKey?: string;
+        };
+        expect(details.status).toBe("ok");
+        expect(details.reply).toBe("orion response");
+        expect(details.sessionKey).toBe("agent:orion:main");
+
+        const firstCall = spy.mock.calls.at(0)?.[0] as
+          | { sessionId?: string; sessionKey?: string }
+          | undefined;
+        expect(firstCall?.sessionKey).toBe("agent:orion:main");
+        expect(firstCall?.sessionId).toBeTypeOf("string");
+
+        const rawStore = JSON.parse(
+          await fs.readFile(testState.sessionStorePath, "utf-8"),
+        ) as Record<
+          string,
+          {
+            sessionId?: string;
+          }
+        >;
+        expect(rawStore["agent:orion:main"]?.sessionId).toBe(firstCall?.sessionId);
+      } finally {
+        testState.agentsConfig = undefined;
+        testState.sessionStorePath = undefined;
+        await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+      }
     },
   );
 });

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -135,6 +135,55 @@ test("sessions.create scopes the main alias to the requested agent", async () =>
   expect(rawStore["agent:main:main"]).toBeUndefined();
 });
 
+test("sessions.create replaces a dead main entry with a fresh session id", async () => {
+  const { storePath } = await createSessionStoreDir();
+  testState.agentsConfig = { list: [{ id: "ops", default: true }] };
+  try {
+    await writeSessionStore({
+      agentId: "ops",
+      entries: {
+        main: {
+          updatedAt: 1,
+          label: "Ops Main",
+          sessionFile: "stale.jsonl",
+        },
+      },
+    });
+
+    const created = await directSessionReq<{
+      key?: string;
+      sessionId?: string;
+      entry?: {
+        label?: string;
+        sessionFile?: string;
+      };
+    }>("sessions.create", {
+      key: "main",
+      agentId: "ops",
+    });
+
+    expect(created.ok).toBe(true);
+    expect(created.payload?.key).toBe("agent:ops:main");
+    expect(created.payload?.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(created.payload?.entry?.label).toBe("Ops Main");
+    expect(created.payload?.entry?.sessionFile).not.toBe("stale.jsonl");
+
+    const rawStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      {
+        sessionId?: string;
+        sessionFile?: string;
+      }
+    >;
+    expect(rawStore["agent:ops:main"]?.sessionId).toBe(created.payload?.sessionId);
+    expect(rawStore["agent:ops:main"]?.sessionFile).not.toBe("stale.jsonl");
+  } finally {
+    testState.agentsConfig = undefined;
+  }
+});
+
 test("sessions.create preserves global and unknown sentinel keys", async () => {
   const { storePath } = await createSessionStoreDir();
 

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -119,12 +119,17 @@ export async function applySessionsPatchToStore(params: {
   };
 
   const existing = store[storeKey];
-  const next: SessionEntry = existing
+  const next: SessionEntry = existing?.sessionId
     ? {
         ...existing,
         updatedAt: Math.max(existing.updatedAt ?? 0, now),
       }
-    : { sessionId: randomUUID(), updatedAt: now };
+    : {
+        ...(existing ?? {}),
+        sessionId: randomUUID(),
+        sessionFile: undefined,
+        updatedAt: Math.max(existing?.updatedAt ?? 0, now),
+      };
 
   if ("spawnedBy" in patch) {
     const raw = patch.spawnedBy;


### PR DESCRIPTION
Summary:
- Create configured agent main sessions through the existing sessions.create path before first send.
- Let sessions_send target a configured agent by agentId, then continue through the normal send/wait flow.
- Add regression coverage for dead session rows, gateway sessions.send, and sessions_send agentId targeting.

Verification:
- OPENCLAW_LOCAL_CHECK_MODE=throttled bunx pnpm test src/gateway/server.sessions.create.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server.sessions-send.test.ts
- OPENCLAW_LOCAL_CHECK_MODE=throttled bunx pnpm check:changed (current-base core typecheck passed; core test typecheck stopped on unrelated src/plugins/registry.runtime-config.test.ts fixture typing)

## Real behavior proof

- Behavior or issue addressed: First-contact agent-to-agent sends to a configured agent failed when the target agent's main session did not exist yet.
- Real environment tested: Local OpenClaw gateway from this PR checkout with the real Telegram bot-to-bot E2E group and mock OpenAI server.
- Exact steps or command run after this patch: `node ~/.codex/skills/custom/telegram-e2e-bot-to-bot/scripts/run-mock-sut-e2e.mjs --text '@{sut} Please answer with OPENCLAW_E2E_OK only.' --expect OPENCLAW_E2E_OK`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live output: driver message 7849 sent `@foremanclawbot Please answer with OPENCLAW_E2E_OK only.`, SUT reply message 7850 from `foremanclawbot` replied to 7849 with `OPENCLAW_E2E_OK`; mockRequests=1; rttMs=4985.
- Observed result after fix: The SUT replied in the real Telegram group, threaded to the driver message, and the turn reached the model path once.
- What was not tested: Full production OpenAI billing path; mock OpenAI was used intentionally for deterministic model output.
