### PR TITLE
fix(cron): treat attempt dispatch as execution start

### DIFF
--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1606,6 +1606,88 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("clears the pre-execution watchdog when isolated cron reaches attempt dispatch (#81368)", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-05-13T09:56:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "isolated-attempt-dispatch-81368",
+        name: "attempt dispatch regression",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 1_200 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const started = createDeferred<void>();
+      let abortObserved = false;
+      const cleanupTimedOutAgentRun = vi.fn(async () => {});
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        cleanupTimedOutAgentRun,
+        runIsolatedAgentJob: vi.fn(
+          async ({
+            abortSignal,
+            onExecutionStarted,
+            onExecutionPhase,
+          }: {
+            abortSignal?: AbortSignal;
+            onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
+            onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
+          }) => {
+            onExecutionStarted?.({
+              jobId: "isolated-attempt-dispatch-81368",
+              phase: "runner_entered",
+            });
+            onExecutionPhase?.({
+              jobId: "isolated-attempt-dispatch-81368",
+              phase: "attempt_dispatch",
+              backend: "codex-app-server",
+            });
+            started.resolve();
+            abortSignal?.addEventListener(
+              "abort",
+              () => {
+                abortObserved = true;
+              },
+              { once: true },
+            );
+            return await new Promise<never>(() => {});
+          },
+        ),
+      });
+
+      const timerPromise = onTimer(state);
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      expect(abortObserved).toBe(false);
+      expect(cleanupTimedOutAgentRun).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_140_000);
+      now += 1_140_000;
+      await timerPromise;
+
+      const job = requireJob(state, "isolated-attempt-dispatch-81368");
+      expect(abortObserved).toBe(true);
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.lastError).toContain("job execution timed out");
+      expect(job.state.lastError).toContain("attempt-dispatch");
+      expect(cleanupTimedOutAgentRun).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps state updates when cron next-run computation throws after a successful run (#30905)", () => {
     const startedAt = Date.parse("2026-03-02T12:00:00.000Z");
     const endedAt = startedAt + 50;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -309,6 +309,7 @@ function isCronAgentExecutionStarted(info: CronAgentExecutionStarted): boolean {
     return true;
   }
   switch (info.phase) {
+    case "attempt_dispatch":
     case "turn_accepted":
     case "process_spawned":
     case "tool_execution_started":


### PR DESCRIPTION
Fixes #81368

## Summary
- Treat `attempt_dispatch` as an isolated cron execution-start milestone.
- Add a regression test proving the pre-execution watchdog is cleared after `attempt_dispatch`; the run then fails only at the configured job timeout.

## Root cause
`pi-embedded-runner` can report `attempt_dispatch`, but `isCronAgentExecutionStarted` did not classify that phase as execution-started. For isolated cron runs that reach dispatch before the first model call, the 60s pre-execution watchdog could still abort the run as stalled.

## Audits
- Existing helper: reused `isCronAgentExecutionStarted`; no new classifier.
- Shared caller: helper is private to `src/cron/service/timer.ts` and only broadens the set of positive execution milestones.
- Rival scan: no open direct PR for #81368. #80923 is closed/superseded and was a large dirty branch; #80888 is closed but the beta.4 repro in #81368 shows the local hotfix is still needed.

## Tests
- `pnpm format:check src/cron/service/timer.ts src/cron/service/timer.regression.test.ts`
- `node scripts/test-projects.mjs src/cron/service/timer.regression.test.ts`
- `pnpm check:test-types`
- `git diff --check`

## Real behavior proof
- **Behavior or issue addressed:** Isolated cron jobs that reach `attempt_dispatch` were still aborted by the 60s pre-execution watchdog as `cron: isolated agent run stalled before execution start (last phase: attempt-dispatch)`, even though the configured job timeout was longer.
- **Real environment tested:** Reporter live setup from #81368: OpenClaw `2026.5.12-beta.4 (d124625)`, npm global install, Linux, isolated cron job, delivery disabled, model `openai/gpt-5.5`. Local patch in this PR applies the same classifier change on current `main`.
- **Exact steps or command run after this patch:** Reporter created the same no-delivery isolated cron job after applying the one-line `case "attempt_dispatch":` hotfix to the installed `server-cron-*.js` bundle and restarting the gateway:

```bash
openclaw cron add \
  --at "<now+15s ISO>" \
  --delete-after-run \
  --no-deliver \
  --session isolated \
  --agent cron \
  --model openai/gpt-5.5 \
  --timeout-seconds 240 \
  --message 'Run this exact shell command via exec: bash -lc "sleep 75". After it exits, reply exactly: OK_CRON_WATCHDOG_BETA4'
```

- **Evidence after fix:** Copied live runtime output from #81368 after the same one-line classifier hotfix and gateway restart:

```json
{
  "status": "ok",
  "summary": "OK_CRON_WATCHDOG_HOTFIX",
  "durationMs": 128739,
  "model": "gpt-5.5",
  "provider": "openai",
  "deliveryStatus": "not-requested"
}
```

- **Observed result after fix:** The isolated cron run continued past the previous 60s false-stall cutoff and completed successfully at 128739ms with `deliveryStatus: "not-requested"`.
- **What was not tested:** I did not rerun the live OpenAI cron smoke from this workspace; the after-fix live evidence is the reporter runtime log from #81368. I locally verified this source patch with the focused cron regression shard and test typecheck.

## Not changed
- No watchdog duration changes.
- No runner phase emission changes.
- No cron scheduling or retry policy changes.