### PR TITLE
fix(ui): preserve leading whitespace in WebChat code blocks

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -185,7 +185,7 @@ function enqueueChatMessage(
   refreshSessions?: boolean,
   localCommand?: { args: string; name: string },
 ) {
-  const trimmed = text.trim();
+  const trimmed = text.trimEnd(); // Preserve leading whitespace for code blocks / ASCII diagrams
   const hasAttachments = Boolean(attachments && attachments.length > 0);
   if (!trimmed && !hasAttachments) {
     return;
@@ -210,7 +210,7 @@ function enqueuePendingRunMessage(
   pendingRunId: string,
   attachments?: ChatAttachment[],
 ) {
-  const trimmed = text.trim();
+  const trimmed = text.trimEnd(); // Preserve leading whitespace for code blocks / ASCII diagrams
   const hasAttachments = Boolean(attachments && attachments.length > 0);
   if (!trimmed && !hasAttachments) {
     return;
@@ -521,7 +521,7 @@ export async function handleSendChat(
     return;
   }
   const previousDraft = host.chatMessage;
-  const message = (messageOverride ?? host.chatMessage).trim();
+  const message = (messageOverride ?? host.chatMessage).trimEnd(); // Preserve leading whitespace for code blocks / ASCII diagrams
   const submittedSessionKey = host.sessionKey;
   const attachments = host.chatAttachments ?? [];
   const attachmentsToSend = messageOverride == null ? snapshotChatAttachments(attachments) : [];


### PR DESCRIPTION
## Summary

WebChat UI was trimming **both leading and trailing whitespace** from user messages before submission, breaking ASCII diagram alignment in code blocks.

## Changes

Changed `trim()` to `trimEnd()` in three locations in `ui/src/ui/app-chat.ts`:

1. `enqueueChatMessage()` - preserves leading whitespace when queuing messages
2. `enqueuePendingRunMessage()` - preserves leading whitespace for steered messages
3. `handleSendChat()` - preserves leading whitespace when submitting

This preserves **leading whitespace** (critical for code block alignment) while still removing **trailing whitespace**.

## Test Plan

Manually tested:
1. Paste code block with leading spaces for box-drawing alignment
2. Send message in WebChat
3. Verify leading spaces are preserved

Before fix:
```
+5V ──┬── R68
│               ├── R122 10K   ← leading spaces stripped
```

After fix:
```
+5V ──┬── R68
      │               ├── R122 10K   ← leading spaces preserved
```

## Security Considerations

- **Does not introduce new secrets handling**: No
- **Changes authentication or authorization**: No
- **Exposes new network endpoints**: No
- **Changes exec behavior**: No

## Human Verification

- Tested: Manual verification in local WebChat
- Not tested: Automated tests (existing test coverage)

Fixes #81339