### PR TITLE
[codex] Link heartbeat commitment questions to replies

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
@@ -22,9 +22,14 @@ const hostHookStateMocks = vi.hoisted(() => ({
   drainPluginNextTurnInjectionContext: vi.fn(),
 }));
 
+const pendingQuestionContextMocks = vi.hoisted(() => ({
+  drainHeartbeatPendingQuestionContext: vi.fn(),
+}));
+
 vi.mock("../../music-generation-task-status.js", () => musicGenerationTaskStatusMocks);
 vi.mock("../../video-generation-task-status.js", () => videoGenerationTaskStatusMocks);
 vi.mock("../../../plugins/host-hook-state.js", () => hostHookStateMocks);
+vi.mock("../../../config/sessions/pending-question-context.js", () => pendingQuestionContextMocks);
 
 import {
   forgetPromptBuildDrainCacheForRun,
@@ -147,6 +152,10 @@ describe("resolvePromptSubmissionSkipReason", () => {
 describe("resolvePromptBuildHookResult drain cache", () => {
   it("drains plugin next-turn injections at most once per runId across retry attempts", async () => {
     hostHookStateMocks.drainPluginNextTurnInjectionContext.mockReset();
+    pendingQuestionContextMocks.drainHeartbeatPendingQuestionContext.mockReset();
+    pendingQuestionContextMocks.drainHeartbeatPendingQuestionContext.mockResolvedValue(
+      "pending heartbeat question",
+    );
     hostHookStateMocks.drainPluginNextTurnInjectionContext.mockResolvedValue({
       queuedInjections: [
         {
@@ -161,7 +170,7 @@ describe("resolvePromptBuildHookResult drain cache", () => {
     });
     forgetPromptBuildDrainCacheForRun("run-cache-test");
 
-    const hookCtx = { runId: "run-cache-test", sessionKey: "agent:main:main" };
+    const hookCtx = { runId: "run-cache-test", sessionKey: "agent:main:main", trigger: "user" };
 
     const first = await resolvePromptBuildHookResult({
       config: {},
@@ -177,14 +186,19 @@ describe("resolvePromptBuildHookResult drain cache", () => {
     });
 
     expect(hostHookStateMocks.drainPluginNextTurnInjectionContext).toHaveBeenCalledTimes(1);
-    expect(first.prependContext).toBe("first attempt context");
-    expect(second.prependContext).toBe("first attempt context");
+    expect(pendingQuestionContextMocks.drainHeartbeatPendingQuestionContext).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(first.prependContext).toBe("pending heartbeat question\n\nfirst attempt context");
+    expect(second.prependContext).toBe("pending heartbeat question\n\nfirst attempt context");
 
     forgetPromptBuildDrainCacheForRun("run-cache-test");
   });
 
   it("re-drains after the run-scoped cache is forgotten", async () => {
     hostHookStateMocks.drainPluginNextTurnInjectionContext.mockReset();
+    pendingQuestionContextMocks.drainHeartbeatPendingQuestionContext.mockReset();
+    pendingQuestionContextMocks.drainHeartbeatPendingQuestionContext.mockResolvedValue(undefined);
     hostHookStateMocks.drainPluginNextTurnInjectionContext.mockResolvedValueOnce({
       queuedInjections: [],
       prependContext: undefined,
@@ -207,6 +221,8 @@ describe("resolvePromptBuildHookResult drain cache", () => {
 
   it("drains every call when no runId is provided (no caching key)", async () => {
     hostHookStateMocks.drainPluginNextTurnInjectionContext.mockReset();
+    pendingQuestionContextMocks.drainHeartbeatPendingQuestionContext.mockReset();
+    pendingQuestionContextMocks.drainHeartbeatPendingQuestionContext.mockResolvedValue(undefined);
     hostHookStateMocks.drainPluginNextTurnInjectionContext.mockResolvedValue({
       queuedInjections: [],
       prependContext: undefined,
@@ -226,5 +242,42 @@ describe("resolvePromptBuildHookResult drain cache", () => {
     });
 
     expect(hostHookStateMocks.drainPluginNextTurnInjectionContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("only drains heartbeat pending questions for user-triggered turns", async () => {
+    hostHookStateMocks.drainPluginNextTurnInjectionContext.mockReset();
+    hostHookStateMocks.drainPluginNextTurnInjectionContext.mockResolvedValue({
+      queuedInjections: [],
+      prependContext: undefined,
+    });
+    pendingQuestionContextMocks.drainHeartbeatPendingQuestionContext.mockReset();
+    pendingQuestionContextMocks.drainHeartbeatPendingQuestionContext.mockResolvedValue(
+      "pending heartbeat question",
+    );
+
+    const heartbeat = await resolvePromptBuildHookResult({
+      config: {},
+      prompt: "hi",
+      messages: [],
+      hookCtx: {
+        runId: "heartbeat-drain-test",
+        sessionKey: "agent:main:main",
+        trigger: "heartbeat",
+      },
+    });
+    forgetPromptBuildDrainCacheForRun("heartbeat-drain-test");
+    const user = await resolvePromptBuildHookResult({
+      config: {},
+      prompt: "hi",
+      messages: [],
+      hookCtx: { runId: "user-drain-test", sessionKey: "agent:main:main", trigger: "user" },
+    });
+
+    expect(heartbeat.prependContext).toBeUndefined();
+    expect(user.prependContext).toBe("pending heartbeat question");
+    expect(pendingQuestionContextMocks.drainHeartbeatPendingQuestionContext).toHaveBeenCalledTimes(
+      1,
+    );
+    forgetPromptBuildDrainCacheForRun("user-drain-test");
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -1,3 +1,4 @@
+import { drainHeartbeatPendingQuestionContext } from "../../../config/sessions/pending-question-context.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type {
   ContextEnginePromptCacheInfo,
@@ -64,12 +65,13 @@ export type PromptBuildHookRunner = {
 // retry, dropping injection context). The cache is bounded to keep memory flat
 // across long-lived processes; entries are evicted FIFO once the cap is hit.
 const PROMPT_BUILD_DRAIN_CACHE_MAX = 256;
-const promptBuildDrainCache = new Map<string, PluginNextTurnInjectionRecord[]>();
+type PromptBuildDrainCacheEntry = {
+  queuedInjections: PluginNextTurnInjectionRecord[];
+  heartbeatPendingQuestionContext?: string;
+};
+const promptBuildDrainCache = new Map<string, PromptBuildDrainCacheEntry>();
 
-function rememberDrainedInjections(
-  runId: string,
-  injections: PluginNextTurnInjectionRecord[],
-): void {
+function rememberDrainedInjections(runId: string, entry: PromptBuildDrainCacheEntry): void {
   if (promptBuildDrainCache.has(runId)) {
     promptBuildDrainCache.delete(runId);
   } else if (promptBuildDrainCache.size >= PROMPT_BUILD_DRAIN_CACHE_MAX) {
@@ -78,7 +80,7 @@ function rememberDrainedInjections(
       promptBuildDrainCache.delete(oldest);
     }
   }
-  promptBuildDrainCache.set(runId, injections);
+  promptBuildDrainCache.set(runId, entry);
 }
 
 /**
@@ -100,18 +102,29 @@ export async function resolvePromptBuildHookResult(params: {
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
 }): Promise<PluginHookBeforePromptBuildResult> {
   const runId = params.hookCtx.runId;
-  const cachedInjections = runId ? promptBuildDrainCache.get(runId) : undefined;
-  const queuedContext = cachedInjections
+  const cachedDrain = runId ? promptBuildDrainCache.get(runId) : undefined;
+  const drainedPluginContext = cachedDrain
     ? {
-        queuedInjections: cachedInjections,
-        ...buildPluginAgentTurnPrepareContext({ queuedInjections: cachedInjections }),
+        queuedInjections: cachedDrain.queuedInjections,
+        ...buildPluginAgentTurnPrepareContext({ queuedInjections: cachedDrain.queuedInjections }),
       }
     : await drainPluginNextTurnInjectionContext({
         cfg: params.config,
         sessionKey: params.hookCtx.sessionKey,
       });
-  if (runId && !cachedInjections) {
-    rememberDrainedInjections(runId, queuedContext.queuedInjections);
+  const heartbeatPendingQuestionContext =
+    cachedDrain?.heartbeatPendingQuestionContext ??
+    (params.hookCtx.trigger === "user"
+      ? await drainHeartbeatPendingQuestionContext({
+          cfg: params.config,
+          sessionKey: params.hookCtx.sessionKey,
+        })
+      : undefined);
+  if (runId && !cachedDrain) {
+    rememberDrainedInjections(runId, {
+      queuedInjections: drainedPluginContext.queuedInjections,
+      ...(heartbeatPendingQuestionContext ? { heartbeatPendingQuestionContext } : {}),
+    });
   }
   const turnPrepareResult =
     params.hookRunner?.runAgentTurnPrepare && params.hookRunner.hasHooks("agent_turn_prepare")
@@ -120,7 +133,7 @@ export async function resolvePromptBuildHookResult(params: {
             {
               prompt: params.prompt,
               messages: params.messages,
-              queuedInjections: queuedContext.queuedInjections,
+              queuedInjections: drainedPluginContext.queuedInjections,
             },
             params.hookCtx,
           )
@@ -182,14 +195,15 @@ export async function resolvePromptBuildHookResult(params: {
   return {
     systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
     prependContext: joinPresentTextSegments([
-      queuedContext.prependContext,
+      heartbeatPendingQuestionContext,
+      drainedPluginContext.prependContext,
       turnPrepareResult?.prependContext,
       heartbeatContribution?.prependContext,
       promptBuildResult?.prependContext,
       legacyResult?.prependContext,
     ]),
     appendContext: joinPresentTextSegments([
-      queuedContext.appendContext,
+      drainedPluginContext.appendContext,
       turnPrepareResult?.appendContext,
       heartbeatContribution?.appendContext,
       promptBuildResult?.appendContext,

--- a/src/commitments/extraction.test.ts
+++ b/src/commitments/extraction.test.ts
@@ -8,6 +8,7 @@ import {
   parseCommitmentExtractionOutput,
   persistCommitmentExtractionResult,
   validateCommitmentCandidates,
+  validateCommitmentResolutions,
 } from "./extraction.js";
 import { loadCommitmentStore } from "./store.js";
 import type { CommitmentCandidate, CommitmentExtractionItem } from "./types.js";
@@ -89,6 +90,31 @@ describe("commitment extraction", () => {
     expect(parsed.candidates[0]?.suggestedText).toBe("How did the interview go?");
   });
 
+  it("parses valid resolved pending commitments from JSON output", () => {
+    const parsed = parseCommitmentExtractionOutput(
+      JSON.stringify({
+        candidates: [],
+        resolved: [
+          {
+            itemId: "turn-1",
+            dedupeKey: "gmail-reauth:sprichert",
+            reason: "The assistant reported the Gmail reauth was completed and verified.",
+            confidence: 0.95,
+          },
+        ],
+      }),
+    );
+
+    expect(parsed.resolved).toEqual([
+      {
+        itemId: "turn-1",
+        dedupeKey: "gmail-reauth:sprichert",
+        reason: "The assistant reported the Gmail reauth was completed and verified.",
+        confidence: 0.95,
+      },
+    ]);
+  });
+
   it("omits routing scope identifiers from extractor prompts", () => {
     const prompt = buildCommitmentExtractionPrompt({
       items: [
@@ -113,6 +139,29 @@ describe("commitment extraction", () => {
     expect(prompt).not.toContain("thread-secret");
   });
 
+  it("asks the extractor to resolve pending commitments closed by later verified turns", () => {
+    const prompt = buildCommitmentExtractionPrompt({
+      items: [
+        item({
+          assistantText: "The Gmail reauth completed and I verified the account is working.",
+          existingPending: [
+            {
+              kind: "open_loop",
+              reason: "User requested a Gmail reauth link.",
+              dedupeKey: "gmail-reauth:sprichert",
+              earliestMs: Date.parse("2026-04-30T17:00:00.000Z"),
+              latestMs: Date.parse("2026-04-30T23:00:00.000Z"),
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(prompt).toContain('"resolved"');
+    expect(prompt).toContain("tool-verified completion");
+    expect(prompt).toContain("gmail-reauth:sprichert");
+  });
+
   it("rejects disabled, low-confidence, and non-future candidates", () => {
     const cfg: OpenClawConfig = { commitments: { enabled: true } };
     const valid = validateCommitmentCandidates({
@@ -131,6 +180,50 @@ describe("commitment extraction", () => {
     });
 
     expect(valid.map((entry) => entry.candidate.dedupeKey)).toEqual(["interview:2026-04-30"]);
+  });
+
+  it("validates only high-confidence resolutions for existing pending commitments", () => {
+    const valid = validateCommitmentResolutions({
+      cfg: { commitments: { enabled: true } },
+      items: [
+        item({
+          existingPending: [
+            {
+              kind: "open_loop",
+              reason: "User requested a Gmail reauth link.",
+              dedupeKey: "gmail-reauth:sprichert",
+              earliestMs: Date.parse("2026-04-30T17:00:00.000Z"),
+              latestMs: Date.parse("2026-04-30T23:00:00.000Z"),
+            },
+          ],
+        }),
+      ],
+      result: {
+        candidates: [],
+        resolved: [
+          {
+            itemId: "turn-1",
+            dedupeKey: "gmail-reauth:sprichert",
+            reason: "The assistant verified reauth completed.",
+            confidence: 0.91,
+          },
+          {
+            itemId: "turn-1",
+            dedupeKey: "gmail-reauth:other",
+            reason: "Not in existing pending list.",
+            confidence: 0.99,
+          },
+          {
+            itemId: "turn-1",
+            dedupeKey: "gmail-reauth:sprichert",
+            reason: "Too uncertain.",
+            confidence: 0.5,
+          },
+        ],
+      },
+    });
+
+    expect(valid.map((entry) => entry.resolution.dedupeKey)).toEqual(["gmail-reauth:sprichert"]);
   });
 
   it("clamps inferred due time to at least one heartbeat interval after write time", () => {
@@ -193,5 +286,62 @@ describe("commitment extraction", () => {
     expect(store.commitments[0]?.reason).toBe("Updated reason");
     expect(store.commitments[0]?.confidence).toBe(0.97);
     expect(store.commitments[0]?.status).toBe("pending");
+  });
+
+  it("dismisses existing pending commitments resolved by later extraction", async () => {
+    const cfg = await createConfig();
+    await persistCommitmentExtractionResult({
+      cfg,
+      items: [item()],
+      result: {
+        candidates: [
+          candidate({
+            dedupeKey: "gmail-reauth:sprichert",
+            reason: "User requested a Gmail reauth link.",
+            suggestedText: "Did the gog Gmail reauth go through for sprichert@gmail.com?",
+          }),
+        ],
+      },
+      nowMs,
+    });
+    await persistCommitmentExtractionResult({
+      cfg,
+      items: [
+        item({
+          nowMs: nowMs + 60_000,
+          userText: "It went through.",
+          assistantText: "Confirmed: the Gmail reauth completed and the account is working.",
+          existingPending: [
+            {
+              kind: "open_loop",
+              reason: "User requested a Gmail reauth link.",
+              dedupeKey: "gmail-reauth:sprichert",
+              earliestMs: Date.parse("2026-04-30T17:00:00.000Z"),
+              latestMs: Date.parse("2026-04-30T23:00:00.000Z"),
+            },
+          ],
+        }),
+      ],
+      result: {
+        candidates: [],
+        resolved: [
+          {
+            itemId: "turn-1",
+            dedupeKey: "gmail-reauth:sprichert",
+            reason: "The assistant confirmed the reauth completed and was verified.",
+            confidence: 0.96,
+          },
+        ],
+      },
+      nowMs: nowMs + 60_000,
+    });
+
+    const store = await loadCommitmentStore();
+    expect(store.commitments).toHaveLength(1);
+    expect(store.commitments[0]).toMatchObject({
+      dedupeKey: "gmail-reauth:sprichert",
+      status: "dismissed",
+      dismissedAtMs: nowMs + 60_000,
+    });
   });
 });

--- a/src/commitments/extraction.ts
+++ b/src/commitments/extraction.ts
@@ -3,12 +3,17 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveHeartbeatIntervalMs } from "../infra/heartbeat-summary.js";
 import { isRecord } from "../utils.js";
 import { resolveCommitmentsConfig } from "./config.js";
-import { listPendingCommitmentsForScope, upsertInferredCommitments } from "./store.js";
+import {
+  dismissPendingCommitmentsForScope,
+  listPendingCommitmentsForScope,
+  upsertInferredCommitments,
+} from "./store.js";
 import type {
   CommitmentCandidate,
   CommitmentExtractionBatchResult,
   CommitmentExtractionItem,
   CommitmentKind,
+  CommitmentResolutionCandidate,
   CommitmentSensitivity,
   CommitmentSource,
 } from "./types.js";
@@ -79,6 +84,25 @@ function parseCandidate(raw: unknown): CommitmentCandidate | undefined {
   };
 }
 
+function parseResolutionCandidate(raw: unknown): CommitmentResolutionCandidate | undefined {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const itemId = asString(raw.itemId);
+  const dedupeKey = asString(raw.dedupeKey);
+  const reason = asString(raw.reason);
+  const confidence = asNumber(raw.confidence);
+  if (!itemId || !dedupeKey || !reason || confidence === undefined) {
+    return undefined;
+  }
+  return {
+    itemId,
+    dedupeKey,
+    reason,
+    confidence,
+  };
+}
+
 function extractJsonObjectCandidates(raw: string): string[] {
   const out: string[] = [];
   let depth = 0;
@@ -124,6 +148,7 @@ function extractJsonObjectCandidates(raw: string): string[] {
 
 export function parseCommitmentExtractionOutput(raw: string): CommitmentExtractionBatchResult {
   const candidates: CommitmentCandidate[] = [];
+  const resolved: CommitmentResolutionCandidate[] = [];
   const trimmed = raw.trim();
   if (!trimmed) {
     return { candidates };
@@ -154,8 +179,15 @@ export function parseCommitmentExtractionOutput(raw: string): CommitmentExtracti
         candidates.push(parsed);
       }
     }
+    const rawResolved = Array.isArray(record.resolved) ? record.resolved : [];
+    for (const resolution of rawResolved) {
+      const parsed = parseResolutionCandidate(resolution);
+      if (parsed) {
+        resolved.push(parsed);
+      }
+    }
   }
-  return { candidates };
+  return resolved.length > 0 ? { candidates, resolved } : { candidates };
 }
 
 export async function hydrateCommitmentExtractionItem(params: {
@@ -209,10 +241,12 @@ Create inferred follow-up commitments only. Exact user requests such as "remind 
 Use these categories: event_check_in, deadline_check, care_check_in, open_loop.
 
 Create a candidate only when the latest exchange creates a useful future check-in opportunity that the user did not explicitly schedule. Prefer no candidate over weak candidates.
+Also resolve existing pending commitments when the latest exchange clearly closes that loop, especially when the assistant reports tool-verified completion or confirms the requested action succeeded.
 
 Rules:
-- Output JSON only, with top-level {"candidates":[...]}.
+- Output JSON only, with top-level {"candidates":[...],"resolved":[...]}.
 - Each candidate must include itemId, kind, sensitivity, source, dueWindow, reason, suggestedText, confidence, and dedupeKey.
+- Each resolved item must include itemId, dedupeKey, reason, and confidence.
 - kind is one of event_check_in, deadline_check, care_check_in, open_loop.
 - sensitivity is routine, personal, or care.
 - source is inferred_user_context or agent_promise.
@@ -220,6 +254,8 @@ Rules:
 - Skip explicit reminders/scheduling requests; those are cron-owned.
 - Skip if the assistant already clearly says a cron reminder was scheduled.
 - Skip if the topic is already resolved in the assistant response.
+- Resolve an existing pending commitment instead of repeating it when the latest exchange says the underlying task is complete, verified, no longer needed, or superseded.
+- Do not resolve on vague acknowledgements, partial progress, or if the user still appears to be waiting for completion.
 - Care check-ins must be gentle, rare, and high confidence. Avoid interrogating language.
 - Suggested text should be short, natural, and suitable to send in the same channel.
 - Dedupe keys should be stable within a session, like "interview:2026-04-29" or "sleep:2026-04-29".
@@ -311,6 +347,37 @@ export function validateCommitmentCandidates(params: {
   return validated;
 }
 
+export function validateCommitmentResolutions(params: {
+  cfg?: OpenClawConfig;
+  items: CommitmentExtractionItem[];
+  result: CommitmentExtractionBatchResult;
+}): Array<{
+  item: CommitmentExtractionItem;
+  resolution: CommitmentResolutionCandidate;
+}> {
+  const resolved = resolveCommitmentsConfig(params.cfg);
+  const itemsById = new Map(params.items.map((item) => [item.itemId, item]));
+  const validated: Array<{
+    item: CommitmentExtractionItem;
+    resolution: CommitmentResolutionCandidate;
+  }> = [];
+  for (const resolution of params.result.resolved ?? []) {
+    const item = itemsById.get(resolution.itemId);
+    if (!item || resolution.confidence < resolved.extraction.confidenceThreshold) {
+      continue;
+    }
+    if (
+      !item.existingPending.some(
+        (commitment) => commitment.dedupeKey === resolution.dedupeKey.trim(),
+      )
+    ) {
+      continue;
+    }
+    validated.push({ item, resolution });
+  }
+  return validated;
+}
+
 export async function persistCommitmentExtractionResult(params: {
   cfg?: OpenClawConfig;
   items: CommitmentExtractionItem[];
@@ -318,8 +385,30 @@ export async function persistCommitmentExtractionResult(params: {
   nowMs?: number;
 }) {
   const valid = validateCommitmentCandidates(params);
+  const resolutions = validateCommitmentResolutions(params);
+  const resolvedDedupeKeysByItemId = new Map<string, Set<string>>();
+  for (const entry of resolutions) {
+    const existing = resolvedDedupeKeysByItemId.get(entry.item.itemId) ?? new Set<string>();
+    existing.add(entry.resolution.dedupeKey.trim());
+    resolvedDedupeKeysByItemId.set(entry.item.itemId, existing);
+  }
+  for (const [itemId, dedupeKeys] of resolvedDedupeKeysByItemId.entries()) {
+    const item = params.items.find((candidate) => candidate.itemId === itemId);
+    if (!item) {
+      continue;
+    }
+    await dismissPendingCommitmentsForScope({
+      cfg: params.cfg,
+      scope: item,
+      dedupeKeys: [...dedupeKeys],
+      nowMs: params.nowMs,
+    });
+  }
   const byItem = new Map<string, typeof valid>();
   for (const entry of valid) {
+    if (resolvedDedupeKeysByItemId.get(entry.item.itemId)?.has(entry.candidate.dedupeKey.trim())) {
+      continue;
+    }
     const existing = byItem.get(entry.item.itemId) ?? [];
     existing.push(entry);
     byItem.set(entry.item.itemId, existing);

--- a/src/commitments/store.ts
+++ b/src/commitments/store.ts
@@ -332,6 +332,48 @@ export async function upsertInferredCommitments(params: {
   return created;
 }
 
+export async function dismissPendingCommitmentsForScope(params: {
+  cfg?: OpenClawConfig;
+  scope: CommitmentScope;
+  dedupeKeys: string[];
+  nowMs?: number;
+}): Promise<CommitmentRecord[]> {
+  const dedupeKeys = [
+    ...new Set(params.dedupeKeys.map((key) => key.trim()).filter((key) => key.length > 0)),
+  ];
+  if (dedupeKeys.length === 0) {
+    return [];
+  }
+  const nowMs = params.nowMs ?? Date.now();
+  const store = await loadCommitmentStoreWithExpiredMarked(nowMs);
+  const scopeKey = buildCommitmentScopeKey(params.scope);
+  const dedupeKeySet = new Set(dedupeKeys);
+  const dismissed: CommitmentRecord[] = [];
+  let changed = false;
+  store.commitments = store.commitments.map((commitment) => {
+    if (
+      buildCommitmentScopeKey(commitment) !== scopeKey ||
+      !dedupeKeySet.has(commitment.dedupeKey) ||
+      !isActiveStatus(commitment.status)
+    ) {
+      return commitment;
+    }
+    changed = true;
+    const next = {
+      ...commitment,
+      status: "dismissed" as const,
+      dismissedAtMs: nowMs,
+      updatedAtMs: nowMs,
+    };
+    dismissed.push(next);
+    return next;
+  });
+  if (changed) {
+    await saveCommitmentStore(undefined, store);
+  }
+  return dismissed;
+}
+
 function countSentCommitmentsForSession(params: {
   store: CommitmentStoreFile;
   agentId: string;

--- a/src/commitments/types.ts
+++ b/src/commitments/types.ts
@@ -70,6 +70,13 @@ export type CommitmentCandidate = {
   };
 };
 
+export type CommitmentResolutionCandidate = {
+  itemId: string;
+  dedupeKey: string;
+  reason: string;
+  confidence: number;
+};
+
 export type CommitmentExtractionItem = CommitmentScope & {
   itemId: string;
   nowMs: number;
@@ -89,4 +96,5 @@ export type CommitmentExtractionItem = CommitmentScope & {
 
 export type CommitmentExtractionBatchResult = {
   candidates: CommitmentCandidate[];
+  resolved?: CommitmentResolutionCandidate[];
 };

--- a/src/config/sessions/pending-question-context.ts
+++ b/src/config/sessions/pending-question-context.ts
@@ -1,0 +1,161 @@
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import { resolveStorePath } from "./paths.js";
+import { loadSessionStore } from "./store-load.js";
+import { normalizeStoreSessionKey, updateSessionStore } from "./store.js";
+import type { SessionHeartbeatPendingQuestion } from "./types.js";
+
+const DEFAULT_PENDING_QUESTION_TTL_MS = 72 * 60 * 60 * 1000;
+const MAX_PENDING_QUESTIONS_PER_SESSION = 8;
+const MAX_PENDING_QUESTION_TEXT_CHARS = 2_000;
+
+function resolveStorePathForSession(params: { cfg: OpenClawConfig; sessionKey: string }): string {
+  const agentId =
+    params.cfg.session?.scope === "global"
+      ? resolveDefaultAgentId(params.cfg)
+      : resolveAgentIdFromSessionKey(params.sessionKey);
+  return resolveStorePath(params.cfg.session?.store, { agentId });
+}
+
+function normalizeStringList(values: string[] | undefined): string[] | undefined {
+  const normalized = [
+    ...new Set(
+      (values ?? [])
+        .map(normalizeOptionalString)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ];
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizePendingQuestion(
+  question: SessionHeartbeatPendingQuestion,
+): SessionHeartbeatPendingQuestion | undefined {
+  const id = normalizeOptionalString(question.id);
+  const text = normalizeOptionalString(question.text);
+  if (!id || !text) {
+    return undefined;
+  }
+  const commitmentIds = normalizeStringList(question.commitmentIds);
+  const sourceRunIds = normalizeStringList(question.sourceRunIds);
+  const sourceMessageIds = normalizeStringList(question.sourceMessageIds);
+  return {
+    id,
+    text: text.slice(0, MAX_PENDING_QUESTION_TEXT_CHARS),
+    ...(commitmentIds ? { commitmentIds } : {}),
+    ...(sourceRunIds ? { sourceRunIds } : {}),
+    ...(sourceMessageIds ? { sourceMessageIds } : {}),
+    createdAt: Number.isFinite(question.createdAt) ? question.createdAt : Date.now(),
+    ...(question.ttlMs !== undefined && Number.isFinite(question.ttlMs) && question.ttlMs >= 0
+      ? { ttlMs: question.ttlMs }
+      : {}),
+  };
+}
+
+function isPendingQuestionLive(question: SessionHeartbeatPendingQuestion, now: number): boolean {
+  const ttlMs = question.ttlMs ?? DEFAULT_PENDING_QUESTION_TTL_MS;
+  return question.createdAt + ttlMs >= now;
+}
+
+export async function enqueueHeartbeatPendingQuestion(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  question: SessionHeartbeatPendingQuestion;
+  nowMs?: number;
+}): Promise<boolean> {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return false;
+  }
+  const normalizedQuestion = normalizePendingQuestion(params.question);
+  if (!normalizedQuestion) {
+    return false;
+  }
+  const storePath = resolveStorePathForSession({ cfg: params.cfg, sessionKey });
+  const normalizedKey = normalizeStoreSessionKey(sessionKey);
+  const now = params.nowMs ?? Date.now();
+  let enqueued = false;
+  await updateSessionStore(storePath, (store) => {
+    const storeKey = store[normalizedKey] ? normalizedKey : sessionKey;
+    const entry = store[storeKey];
+    if (!entry) {
+      return;
+    }
+    const existing = (
+      Array.isArray(entry.heartbeatPendingQuestions) ? entry.heartbeatPendingQuestions : []
+    )
+      .map(normalizePendingQuestion)
+      .filter((candidate): candidate is SessionHeartbeatPendingQuestion =>
+        Boolean(
+          candidate &&
+          isPendingQuestionLive(candidate, now) &&
+          candidate.id !== normalizedQuestion.id,
+        ),
+      );
+    entry.heartbeatPendingQuestions = [...existing, normalizedQuestion].slice(
+      -MAX_PENDING_QUESTIONS_PER_SESSION,
+    );
+    entry.updatedAt = now;
+    enqueued = true;
+  });
+  return enqueued;
+}
+
+export function buildHeartbeatPendingQuestionContext(
+  questions: SessionHeartbeatPendingQuestion[],
+): string | undefined {
+  const liveQuestions = questions
+    .map(normalizePendingQuestion)
+    .filter((question): question is SessionHeartbeatPendingQuestion => Boolean(question));
+  if (liveQuestions.length === 0) {
+    return undefined;
+  }
+  const rendered = liveQuestions
+    .map((question, index) => {
+      const label = liveQuestions.length === 1 ? "Question" : `Question ${index + 1}`;
+      return `${label}: ${question.text}`;
+    })
+    .join("\n");
+  return `A proactive heartbeat check-in was delivered to the user before this turn, but that assistant message may be transcript-only and absent from replay history. If the latest user message appears to answer it, interpret the user message in this context and continue naturally. Do not mention heartbeat, commitments, pending-question state, or internal delivery machinery.
+
+${rendered}`;
+}
+
+export async function drainHeartbeatPendingQuestionContext(params: {
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+  nowMs?: number;
+}): Promise<string | undefined> {
+  const sessionKey = params.sessionKey?.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const storePath = resolveStorePathForSession({ cfg: params.cfg, sessionKey });
+  const normalizedKey = normalizeStoreSessionKey(sessionKey);
+  const loaded = loadSessionStore(storePath, { skipCache: true });
+  const loadedEntry = loaded[normalizedKey] ?? loaded[sessionKey];
+  if (!loadedEntry?.heartbeatPendingQuestions?.length) {
+    return undefined;
+  }
+  const now = params.nowMs ?? Date.now();
+  const drained = await updateSessionStore(storePath, (store) => {
+    const storeKey = store[normalizedKey] ? normalizedKey : sessionKey;
+    const entry = store[storeKey];
+    if (!entry?.heartbeatPendingQuestions?.length) {
+      return [] as SessionHeartbeatPendingQuestion[];
+    }
+    const active = entry.heartbeatPendingQuestions
+      .map(normalizePendingQuestion)
+      .filter((candidate): candidate is SessionHeartbeatPendingQuestion =>
+        Boolean(candidate && isPendingQuestionLive(candidate, now)),
+      );
+    delete entry.heartbeatPendingQuestions;
+    if (active.length > 0) {
+      entry.updatedAt = now;
+    }
+    return active;
+  });
+  return buildHeartbeatPendingQuestionContext(drained);
+}

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -134,6 +134,16 @@ export type SessionPluginNextTurnInjection = {
   metadata?: SessionPluginJsonValue;
 };
 
+export type SessionHeartbeatPendingQuestion = {
+  id: string;
+  text: string;
+  commitmentIds?: string[];
+  sourceRunIds?: string[];
+  sourceMessageIds?: string[];
+  createdAt: number;
+  ttlMs?: number;
+};
+
 export type SubagentRecoveryState = {
   /** Consecutive accepted automatic orphan-recovery resumes in the rapid re-wedge window. */
   automaticAttempts?: number;
@@ -193,6 +203,8 @@ export type SessionEntry = {
   pluginExtensionSlotKeys?: Record<string, Record<string, string>>;
   /** Durable one-shot prompt additions drained before the next agent turn. */
   pluginNextTurnInjections?: Record<string, SessionPluginNextTurnInjection[]>;
+  /** Core heartbeat questions awaiting the next user turn for conversational linkage. */
+  heartbeatPendingQuestions?: SessionHeartbeatPendingQuestion[];
   sessionId: string;
   updatedAt: number;
   sessionFile?: string;

--- a/src/infra/heartbeat-runner.commitments.test.ts
+++ b/src/infra/heartbeat-runner.commitments.test.ts
@@ -32,6 +32,8 @@ describe("runHeartbeatOnce commitments", () => {
     to: string;
     sourceUserText?: string;
     sourceAssistantText?: string;
+    sourceMessageId?: string;
+    sourceRunId?: string;
   }): CommitmentRecord {
     return {
       id: params.id,
@@ -58,6 +60,8 @@ describe("runHeartbeatOnce commitments", () => {
       createdAtMs: nowMs - 24 * 60 * 60_000,
       updatedAtMs: nowMs - 24 * 60 * 60_000,
       attempts: 0,
+      sourceMessageId: params.sourceMessageId ?? "14517",
+      sourceRunId: params.sourceRunId ?? "e3f41c01-062c-4c5d-967d-500998f34f30",
     };
   }
 
@@ -160,10 +164,19 @@ describe("runHeartbeatOnce commitments", () => {
           nowMs: () => nowMs,
         },
       });
+      const sessionStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        { sessionFile?: string; heartbeatPendingQuestions?: Array<Record<string, unknown>> }
+      >;
+      const transcript = sessionStore[sessionKey]?.sessionFile
+        ? await fs.readFile(sessionStore[sessionKey].sessionFile, "utf-8").catch(() => "")
+        : "";
 
       return {
         result,
         sendTelegram,
+        transcript,
+        sessionEntry: sessionStore[sessionKey],
         store: await loadCommitmentStore(),
       };
     });
@@ -384,6 +397,32 @@ describe("runHeartbeatOnce commitments", () => {
     expect(result.status).toBe("ran");
     expect(sendTelegram).toHaveBeenCalled();
     expectCommitmentFields(store.commitments[0], {
+      id: "cm_interview",
+      status: "sent",
+      attempts: 1,
+      sentAtMs: nowMs,
+    });
+  });
+
+  it("queues delivered commitment questions as pending next-turn context", async () => {
+    const { sessionEntry } = await setupCommitmentCase();
+
+    expect(sessionEntry?.heartbeatPendingQuestions).toEqual([
+      expect.objectContaining({
+        id: "heartbeat:commitments:agent:main:telegram:user-155462274:cm_interview",
+        text: "How did the interview go?",
+        commitmentIds: ["cm_interview"],
+        sourceMessageIds: ["14517"],
+        sourceRunIds: ["e3f41c01-062c-4c5d-967d-500998f34f30"],
+        createdAt: nowMs,
+      }),
+    ]);
+  });
+
+  it("marks delivered commitments as sent after queuing pending question context", async () => {
+    const { store } = await setupCommitmentCase();
+
+    expect(store.commitments[0]).toMatchObject({
       id: "cm_interview",
       status: "sent",
       attempts: 1,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -58,6 +58,7 @@ import {
   resolveAgentMainSessionKey,
 } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
+import { enqueueHeartbeatPendingQuestion } from "../config/sessions/pending-question-context.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
 import { archiveRemovedSessionTranscripts, updateSessionStore } from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -1954,6 +1955,26 @@ export async function runHeartbeatOnce(opts: {
       }
     }
 
+    const visibleMainPayload =
+      shouldSkipMain || (!normalized.text.trim() && mediaUrls.length === 0)
+        ? undefined
+        : {
+            text: normalized.text,
+            mediaUrls,
+          };
+    const heartbeatMirror = visibleMainPayload
+      ? {
+          agentId,
+          sessionKey,
+          text: visibleMainPayload.text,
+          mediaUrls: visibleMainPayload.mediaUrls,
+          storePath,
+          idempotencyKey: dueCommitmentIds.length
+            ? `heartbeat:commitments:${sessionKey}:${dueCommitmentIds.join(",")}`
+            : `heartbeat:${sessionKey}:${startedAt}`,
+        }
+      : undefined;
+
     const send = await sendDurableMessageBatch({
       cfg,
       channel: delivery.channel,
@@ -1961,21 +1982,31 @@ export async function runHeartbeatOnce(opts: {
       accountId: deliveryAccountId,
       session: outboundSession,
       threadId: delivery.threadId,
-      payloads: [
-        ...reasoningPayloads,
-        ...(shouldSkipMain
-          ? []
-          : [
-              {
-                text: normalized.text,
-                mediaUrls,
-              },
-            ]),
-      ],
+      payloads: [...reasoningPayloads, ...(visibleMainPayload ? [visibleMainPayload] : [])],
+      mirror: heartbeatMirror,
       deps: opts.deps,
     });
     if (send.status === "failed" || send.status === "partial_failed") {
       throw send.error;
+    }
+    if (send.status === "sent" && hasDueCommitments && visibleMainPayload) {
+      await enqueueHeartbeatPendingQuestion({
+        cfg,
+        sessionKey,
+        nowMs: startedAt,
+        question: {
+          id: `heartbeat:commitments:${sessionKey}:${dueCommitmentIds.join(",")}`,
+          text: visibleMainPayload.text,
+          commitmentIds: dueCommitmentIds,
+          sourceRunIds: preflight.dueCommitments
+            .map((commitment) => commitment.sourceRunId)
+            .filter((value): value is string => Boolean(value?.trim())),
+          sourceMessageIds: preflight.dueCommitments
+            .map((commitment) => commitment.sourceMessageId)
+            .filter((value): value is string => Boolean(value?.trim())),
+          createdAt: startedAt,
+        },
+      });
     }
     await markCommitmentsStatus({
       cfg,

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -8,6 +8,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "lastHeartbeatSentAt",
   "heartbeatIsolatedBaseSessionKey",
   "heartbeatTaskState",
+  "heartbeatPendingQuestions",
   "pluginExtensions",
   "pluginExtensionSlotKeys",
   "pluginNextTurnInjections",


### PR DESCRIPTION
## Summary

This PR fixes the architectural gap where inferred commitment heartbeats can ask open-ended questions from a proactive heartbeat session, while the user's later answer lands in the target conversation without durable context tying it back to that question.

It now covers both failure modes from the reports:

- Delivered heartbeat questions are mirrored into durable pending-question context on the target session, then drained into the next user-triggered prompt exactly once.
- Inferred commitments get a resolution pass before persistence/delivery, so later same-session completion evidence, including tool-verified completion, can dismiss stale pending follow-ups instead of sending them.

## Root Cause

Heartbeat commitment delivery can happen in an isolated heartbeat run. The visible proactive question is transcript-only delivery state, and replay intentionally filters `openclaw/delivery-mirror` assistant messages before model calls. That means a later user response can be replayed without the assistant question that prompted it unless the transport provides reply metadata.

A second gap existed upstream: extraction could infer an open-loop follow-up before later turns completed and verified the work, but there was no pre-delivery resolution pass against existing pending commitments.

## Approach

- Add `SessionHeartbeatPendingQuestion` / `heartbeatPendingQuestions` to session state.
- Queue a pending question only after a due commitment heartbeat is actually sent successfully.
- Drain pending heartbeat questions only for `trigger: "user"` prompt builds.
- Cache the drained pending-question context alongside plugin next-turn injections for retry stability.
- Teach the extractor to emit top-level `resolved` entries for existing pending commitments closed by the latest exchange.
- Validate resolutions against the current item's `existingPending` dedupe keys and confidence threshold.
- Dismiss matching active commitments before upserting new candidates, and skip creating a candidate resolved in the same extraction item.
- Reserve the new session-entry key so plugin slot projection cannot claim it.

## ClawSweeper / Review Notes

This is intentionally architectural, not wording-only. It avoids depending on Telegram reply context, gives the next ordinary user turn a durable resolution path, and prevents stale inferred commitments from reaching heartbeat delivery when later verified completion has already closed the loop.

The PR branch was fast-forwarded with the resolution-pass commit on top of the existing pending-question fix.

Current PR head: `b329e57e77fbed0b103cefe726a973797dd8d6cc`.

## Real behavior proof

Behavior or issue addressed: Durable pending-question linkage for proactive commitment questions. A delivered heartbeat question is persisted on the target session with source metadata, then drained into the next user-turn prompt context exactly once.

Real environment tested: Local OpenClaw source checkout `/Users/jeeves/openclaw`, branch `codex/commitment-pending-question-context`, head `b329e57e77`, Node v26.0.0 with `tsx`, disposable temp session store under `/tmp/openclaw-pending-question-proof-REDACTED/sessions.json`. No Telegram/network send and no live user session data were used for this proof.

Exact steps or command run after this patch:
1. Set `OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-missing-config.json` to avoid reading the live installed config.
2. Seeded a disposable `sessions.json` entry for `agent:main:telegram:user-155462274`.
3. Imported the real source functions from `src/config/sessions/pending-question-context.ts` via `node --import tsx`.
4. Called `enqueueHeartbeatPendingQuestion(...)` with redacted May 9-style commitment/source metadata.
5. Read the session store to verify the queued question and source message id were persisted.
6. Called `drainHeartbeatPendingQuestionContext(...)` for the same session and read the store again.

Evidence after fix:
```json
{
  "enqueued": true,
  "queuedText": "Want me to check your Mega Millions ticket from last night?",
  "queuedCommitmentIds": ["cm_demo"],
  "queuedSourceMessageIds": ["14517"],
  "contextIncludesQuestion": true,
  "contextMentionsInternalSuppression": true,
  "queueAfterDrain": null,
  "tempSessionStore": "/tmp/openclaw-pending-question-proof-REDACTED/sessions.json"
}
```

Observed result after fix: The enqueue path returned `true`, the pending question persisted with the source message id, the drained context included the original proactive question plus the instruction to hide internal heartbeat/commitment machinery, and the subsequent store read showed `queueAfterDrain: null`, proving one-shot drainage for the next user turn.

What was not tested: This proof did not send a real Telegram message or inspect a real lottery ticket image. Physical transport delivery remains covered by the existing heartbeat outbound path; this PR targets the missing durable reply-linkage layer after successful delivery.

Behavior or issue addressed: Inferred commitments are resolved before delivery when later same-session evidence shows the loop is already complete, matching the Gmail reauth false-positive pattern.

Real environment tested: Local OpenClaw source checkout `/Users/jeeves/openclaw`, branch `codex/commitment-pending-question-context`, head `b329e57e77`, Node v26.0.0 with `tsx`, disposable commitment store under `OPENCLAW_STATE_DIR=$(mktemp -d)`. No live installed commitment store and no Gmail account credentials were read.

Exact steps or command run after this patch:
1. Set `OPENCLAW_STATE_DIR` to a disposable temp directory.
2. Seeded the real commitment store API with a pending inferred Gmail reauth follow-up using id `cm_mp4j2jsy_9a9a2f424e` and dedupe key `gmail-reauth:sprichert@gmail.com`.
3. Imported `persistCommitmentExtractionResult(...)` from `src/commitments/extraction.ts` via `node --import tsx`.
4. Persisted an extraction result whose latest assistant turn reported tool-verified Gmail reauth completion and emitted both a repeated candidate and a high-confidence `resolved` entry for the same dedupe key.
5. Reloaded the commitment store through the real store API.

Evidence after fix:
```json
{
  "proof": "resolved pending inferred Gmail reauth commitment before delivery",
  "createdCount": 0,
  "finalCommitments": [
    {
      "id": "cm_mp4j2jsy_9a9a2f424e",
      "dedupeKey": "gmail-reauth:sprichert@gmail.com",
      "status": "dismissed",
      "dismissedAtMs": 1778752800000,
      "suggestedText": "Did the gog Gmail reauth go through for sprichert@gmail.com?"
    }
  ]
}
```

Observed result after fix: The pending inferred follow-up was dismissed before delivery, and `createdCount: 0` proves the repeated same-key candidate was not recreated in the same extraction pass.

What was not tested: This proof did not run a live Gmail OAuth flow. It exercises the OpenClaw commitment extraction/persistence path that decides whether an already-completed inferred follow-up remains eligible for heartbeat delivery.

## Validation

- `CI=true pnpm test src/commitments/extraction.test.ts src/commitments/runtime.test.ts src/infra/heartbeat-runner.commitments.test.ts src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts`
- `CI=true pnpm check:changed`

