### PR TITLE
fix(session-cost-usage): fall back to O_EXCL write when fs.link is unsupported (#81089)

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -2983,4 +2983,31 @@ example
 
     expect(logs?.map((log) => log.content)).toEqual(["third", "fourth"]);
   });
+  it("acquires the refresh lock on filesystems where fs.link rejects with ENOTSUP (#81089)", async () => {
+    const root = await makeSessionCostRoot("lock-enotsup");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const lockPath = path.join(sessionsDir, ".usage-cost-cache.json.lock");
+
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async () => {
+      const err = new Error(
+        "ENOTSUP: operation not supported on socket, link",
+      ) as NodeJS.ErrnoException;
+      err.code = "ENOTSUP";
+      throw err;
+    });
+
+    try {
+      await withStateDir(root, async () => {
+        const result = await refreshCostUsageCache({ agentId: "main" });
+        expect(result).toBeDefined();
+        expect(result).not.toBe("busy");
+      });
+
+      expect(linkSpy).toHaveBeenCalled();
+      await expect(fs.access(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      linkSpy.mockRestore();
+    }
+  });
 });

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -221,14 +221,31 @@ function isMalformedUsageCostCacheLockRecent(mtimeMs: number): boolean {
   return Date.now() - mtimeMs < USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS;
 }
 
+// Filesystems without hard-link support (SMB/CIFS, certain NFS configs,
+// virtiofs/9p shared folders, some FUSE stacks) reject link(2) with these
+// codes; in that case, fall back to writing the lock directly with O_EXCL,
+// which provides the same EEXIST contention semantics for a single-step
+// write of a fully-formed payload.
+const HARD_LINK_UNSUPPORTED_CODES = new Set(["ENOTSUP", "EPERM", "EXDEV", "EOPNOTSUPP"]);
+
 async function writeUsageCostCacheLockAtomically(
   lockPath: string,
   lock: UsageCostCacheLock,
 ): Promise<void> {
+  const payload = `${JSON.stringify(lock)}\n`;
   const tempPath = `${lockPath}.${process.pid}.${process.hrtime.bigint()}.tmp`;
-  await fs.promises.writeFile(tempPath, `${JSON.stringify(lock)}\n`, { flag: "wx" });
+  await fs.promises.writeFile(tempPath, payload, { flag: "wx" });
   try {
-    await fs.promises.link(tempPath, lockPath);
+    try {
+      await fs.promises.link(tempPath, lockPath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code && HARD_LINK_UNSUPPORTED_CODES.has(code)) {
+        await fs.promises.writeFile(lockPath, payload, { flag: "wx" });
+        return;
+      }
+      throw err;
+    }
   } finally {
     await fs.promises.rm(tempPath, { force: true }).catch(() => undefined);
   }


### PR DESCRIPTION
## Summary

`writeUsageCostCacheLockAtomically` in `src/infra/session-cost-usage.ts` publishes the usage-cost cache refresh lock by `fs.promises.link`'ing a fully-formed temp file to `<cache>.lock`. On filesystems without hard-link support — SMB/CIFS, some NFS setups, virtiofs/9p shared folders, certain FUSE stacks — `link(2)` rejects with `ENOTSUP` (often surfaced as "ENOTSUP: operation not supported on socket"). The catch in `acquireUsageCostCacheRefreshLock` only handles `EEXIST`, so this `ENOTSUP` propagates as an unhandled crash and the refresh path dies.

Fixes #81089.

## Fix

Catch the small known-set of "hard-link unavailable" `errno`s (`ENOTSUP`, `EPERM`, `EXDEV`, `EOPNOTSUPP`) on `fs.promises.link`, and fall back to writing the lock payload directly with `flag: "wx"` (O_EXCL create-only). This preserves the same `EEXIST` contention semantics — concurrent writers on the same filesystem still race for atomic exclusive creation — while making lock acquisition portable across the failing mount types listed in the issue.

`EEXIST` continues to propagate to the existing `acquireUsageCostCacheRefreshLock` catch (busy-or-stale handling unchanged). Cross-filesystem race semantics between hard-link and O_EXCL are identical for this use case because the lock payload is a single fully-formed JSON object written in one step.

## Real behavior proof

- Behavior addressed: `refreshCostUsageCache({ agentId: "main" })` crashes with `ENOTSUP: operation not supported on socket, link …` on filesystems where `link(2)` rejects (SMB/CIFS, some NFS setups, virtiofs/9p shared folders, certain FUSE stacks — see issue #81089 for the reporter's mount). The unhandled rejection kills the refresh path, leaving usage-cost stale.
- Real environment tested: local dev shell on darwin/arm64 against the real Node 22.21.1 `node:fs` runtime, with `fs.promises.link` monkey-patched at module level to reject with the issue's verbatim errno (`code: "ENOTSUP"`, message prefix `ENOTSUP: operation not supported on socket, link`) so the fallback path under `writeUsageCostCacheLockAtomically` is exercised against actual on-disk reads/writes, not against a Vitest spy.
- Exact steps or command run after this patch:
  ```
  node /tmp/proof-81388.mjs
  ```
  where `proof-81388.mjs` mkdir's a real temp `<cache>/agents/main/sessions/` tree under `os.tmpdir()`, monkey-patches `fs.promises.link` to reject with the issue's exact `ENOTSUP` errno, runs the patched `writeUsageCostCacheLockAtomically` body inline (byte-for-byte from `src/infra/session-cost-usage.ts:236-256`), stats the resulting lock file, then re-runs the same write to confirm the second attempt rejects with `EEXIST` (same O_EXCL contention semantics as the original link-based publish).
- Evidence after fix:
  ```
  $ node /tmp/proof-81388.mjs
  tmp: /var/folders/xb/m960rmw13v7g9qmb3ssqzhyh0000gq/T/openclaw-81388-proof-0FDEkA
  lock written ok via fallback (link rejected ENOTSUP)
  lock file mode: 0644
  lock file bytes: 61
  lock file payload: {"pid":11489,"startedAt":1778759440802,"token":"11489:demo"}
  second writer code: EEXIST
  ```
- Observed result after fix: with `node` exercising the patched body against the real darwin/arm64 filesystem, the fallback branch (a) catches the `ENOTSUP` from `fs.promises.link`, (b) re-publishes the lock payload via `fs.promises.writeFile(lockPath, payload, { flag: "wx" })` so the on-disk lock file lands with the same bytes a successful `link` would have produced (61-byte JSON-line payload, mode 0644), and (c) a second concurrent writer hits `EEXIST` from O_EXCL — proving the contention semantics that `acquireUsageCostCacheRefreshLock`'s existing `EEXIST` catch already handles are preserved end-to-end across the fallback. Before this patch, the equivalent driver crashes with the un-handled `ENOTSUP` from `link` and never reaches the lock-file-on-disk state.
- What was not tested: an actual remote SMB/CIFS, NFS, virtiofs, or 9p mount in this contributor's local environment; the four eligible errno codes (`ENOTSUP`, `EPERM`, `EXDEV`, `EOPNOTSUPP`) were collapsed to one path in this driver since the fallback branch is identical across all of them.

## Notes

Scope is intentionally narrow: only the `writeUsageCostCacheLockAtomically` call site. No other `fs.promises.link` usage was touched. The set of fallback-eligible errno codes is named with a single `Set` so it can be expanded if additional `link`-rejection surfaces are observed in the wild without re-shaping the rest of the function.

Tested against `node:fs` semantics on Node 22.21.1 / darwin arm64; no Node version gating needed (`writeFile` `flag: "wx"` is supported across all Node ≥12).
