### PR TITLE
fix(cli): route [secrets] diagnostics to stderr so --json stdout stays parseable (#81055)

### DIFF
--- a/src/cli/command-config-resolution.test.ts
+++ b/src/cli/command-config-resolution.test.ts
@@ -20,14 +20,17 @@ describe("resolveCommandConfigWithSecrets", () => {
     vi.clearAllMocks();
   });
 
-  it("logs diagnostics and preserves resolved config when auto-enable is off", async () => {
+  it("routes diagnostics to stderr (not stdout) so --json consumers can parse stdout cleanly (#81055)", async () => {
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as const;
     const config = { channels: {} };
     const resolvedConfig = { channels: { telegram: {} } };
     const targetIds = new Set(["channels.telegram.token"]);
     mocks.resolveCommandSecretRefsViaGateway.mockResolvedValue({
       resolvedConfig,
-      diagnostics: ["resolved channels.telegram.token"],
+      diagnostics: [
+        "status --json: failed to resolve channels.discord.token locally (env unset).",
+        "status --json: gateway secrets.resolve unavailable (protocol mismatch).",
+      ],
     });
 
     const result = await resolveCommandConfigWithSecrets({
@@ -44,12 +47,22 @@ describe("resolveCommandConfigWithSecrets", () => {
       targetIds,
       mode: "read_only_status",
     });
-    expect(runtime.log).toHaveBeenCalledWith("[secrets] resolved channels.telegram.token");
+    expect(runtime.error).toHaveBeenCalledWith(
+      "[secrets] status --json: failed to resolve channels.discord.token locally (env unset).",
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      "[secrets] status --json: gateway secrets.resolve unavailable (protocol mismatch).",
+    );
+    expect(runtime.error).toHaveBeenCalledTimes(2);
+    expect(runtime.log).not.toHaveBeenCalled();
     expect(mocks.applyPluginAutoEnable).not.toHaveBeenCalled();
     expect(result).toEqual({
       resolvedConfig,
       effectiveConfig: resolvedConfig,
-      diagnostics: ["resolved channels.telegram.token"],
+      diagnostics: [
+        "status --json: failed to resolve channels.discord.token locally (env unset).",
+        "status --json: gateway secrets.resolve unavailable (protocol mismatch).",
+      ],
     });
   });
 

--- a/src/cli/command-config-resolution.ts
+++ b/src/cli/command-config-resolution.ts
@@ -28,8 +28,12 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
     ...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
   });
   if (params.runtime) {
+    // Route diagnostics to stderr (not stdout) so `--json` consumers can pipe
+    // stdout through `jq` / `JSON.parse` without these informational lines
+    // corrupting the JSON document on the wire. Same defect class as the
+    // already-closed `models status --json` leak (#72962); fixes #81055.
     for (const entry of diagnostics) {
-      params.runtime.log(`[secrets] ${entry}`);
+      params.runtime.error(`[secrets] ${entry}`);
     }
   }
   const effectiveConfig = params.autoEnable

--- a/src/commands/models/load-config.test.ts
+++ b/src/commands/models/load-config.test.ts
@@ -69,8 +69,11 @@ describe("models load-config", () => {
       targetIds,
     });
     expect(mocks.setRuntimeConfigSnapshot).toHaveBeenCalledWith(resolvedConfig, sourceConfig);
-    expect(runtime.log).toHaveBeenNthCalledWith(1, "[secrets] diag-one");
-    expect(runtime.log).toHaveBeenNthCalledWith(2, "[secrets] diag-two");
+    // Routed to stderr (not stdout) so `models … --json` consumers can parse
+    // stdout cleanly; see #81055.
+    expect(runtime.error).toHaveBeenNthCalledWith(1, "[secrets] diag-one");
+    expect(runtime.error).toHaveBeenNthCalledWith(2, "[secrets] diag-two");
+    expect(runtime.log).not.toHaveBeenCalled();
     expect(result).toEqual({
       sourceConfig,
       resolvedConfig,


### PR DESCRIPTION
## Summary

`resolveCommandConfigWithSecrets` in `src/cli/command-config-resolution.ts` forwards every secret-resolution diagnostic through `params.runtime.log(`[secrets] ${entry}`)`. `runtime.log` writes to **stdout**, so any command that prints structured output to stdout (notably `openclaw status --json` and `openclaw models … --json`) ends up emitting `[secrets] …` lines before the JSON document. `jq` / `JSON.parse` then fail at byte 1.

This is the same defect class as already-closed `#72962` (`models status --json` emitting `[agents/auth-profiles]` log before JSON); the route-first `status --json` path uses a different emit site that the prior fix did not cover.

Fixes #81055.

## Fix

Switch the diagnostics emit from `params.runtime.log` to `params.runtime.error`. `RuntimeEnv.error` writes via `console.error` → stderr (`src/runtime.ts:77-80`), so `[secrets] …` lines stay visible to operators reading the terminal but are no longer on the stdout stream that `--json` consumers parse.

Single-call-site change. The diagnostics array returned from the function is unchanged, so any caller that wants to format them differently (or wire them into a structured `diagnostics: []` field on the JSON document) still has access to them.

## Test changes

- `src/cli/command-config-resolution.test.ts` — pre-existing assertion that `runtime.log` received the `[secrets] …` line is replaced with a #81055 regression test asserting `runtime.error` is called for every diagnostic and `runtime.log` is **not** called. Covers the two real-world diagnostic lines from the issue body (`failed to resolve channels.discord.token locally`, `gateway secrets.resolve unavailable (protocol mismatch)`).
- `src/commands/models/load-config.test.ts` — the downstream `loadModelsConfigWithSource` test asserted `runtime.log` for the same lines; flipped to assert `runtime.error` and added a `runtime.log` not-called guard. This closes the `models … --json` half of the original `#72962` defect class for real (it was previously enforced only at the emit-helper layer in that PR).

## Real behavior proof

- Behavior addressed: `[secrets] …` diagnostics emitted on stdout corrupt `openclaw status --json` and `openclaw models … --json` output, causing `jq` / `JSON.parse` consumers to fail at byte 1 whenever secret resolution falls back to local or the gateway is unreachable (issue #81055, reproduced verbatim diagnostic strings).
- Real environment tested: not run against a live OpenClaw CLI process by this contributor; the patched function is exercised by the regression test against the real `resolveCommandConfigWithSecrets` implementation (the gateway resolver is the only mocked seam).
- Exact steps or command run after this patch:
  ```
  OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs \
      src/cli/command-config-resolution.test.ts \
      src/commands/models/load-config.test.ts
  ```
- Evidence after fix:
  ```
  Test Files  1 passed (1)
       Tests  2 passed (2)
  …
  Test Files  1 passed (1)
       Tests  3 passed (3)
  [test] passed 2 Vitest shards in 7.27s
  ```
  The new regression test asserts (a) `runtime.error` is called for each `[secrets] …` line emitted by `resolveCommandConfigWithSecrets`, (b) `runtime.log` is **not** called for any diagnostic, and (c) the downstream `loadModelsConfigWithSource` path also routes diagnostics to `runtime.error` (closing the `models … --json` half of the original `#72962` defect class).
- Observed result after fix: stdout from the patched code path no longer carries `[secrets] …` lines; they appear only on the stream wired to `runtime.error` (stderr in the production CLI runtime). The `diagnostics: string[]` array returned from the function is unchanged, so any caller that wants to surface diagnostics structurally still has access to them.
- What was not tested: a live `openclaw status --json | jq .` pipeline against a real gateway in this contributor's local environment. Two other test files keep their own private mocks of `resolveCommandConfigWithSecrets` that route to `runtime.log` and are intentionally not updated (see Notes); they pass against their own stub output, not against the production wrapper.

## Notes

Other test files that maintain their own private mock of `resolveCommandConfigWithSecrets` (`src/commands/message.test.ts`, `src/commands/channels.status.command-flow.test.ts`) are intentionally left untouched — they replace the function entirely with their own stubs that route to `runtime.log`, so the stubs do not reflect the new production behavior. Updating them would require reshaping the assertions they own (`logs.some(...)` array checks) which is out of scope for this fix. They keep passing because they test against their own stub output, not against the production wrapper.
