### PR TITLE
Fix Android JVM tests on Linux ARM64

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -152,4 +152,7 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
   useJUnitPlatform()
+  // Robolectric's bundled Conscrypt 2.5.2 does not ship a Linux aarch64 native library.
+  // Keep JVM unit tests portable on ARM64 builders such as Raspberry Pi hosts.
+  systemProperty("robolectric.conscryptMode", "OFF")
 }


### PR DESCRIPTION
Restores the intended Android JVM test fix only.

This PR contains the portable Robolectric/Conscrypt unit-test fix and intentionally excludes later private Android app pairing/system-tab work.

## Real behavior proof

- **Behavior or issue addressed:** Android JVM unit tests on Linux ARM64/Raspberry Pi failed in the real OpenClaw Android Gradle setup because Robolectric attempted to use Conscrypt in a way that is not portable on this host. The patch disables Robolectric Conscrypt for these portable JVM tests.
- **Real environment tested:** Real OpenClaw Raspberry Pi host, Linux arm64, worktree `/tmp/openclaw-pr81392-proof`, PR head commit `2f4bae88ccd48ea61a057e15a6df0cee552437ad`, Android SDK `/mnt/extern/openclaw-data/home-redirects/android-sdk`, ARM64 compatibility env `QEMU_LD_PREFIX=/usr/x86_64-linux-gnu`.
- **Exact steps or command run after this patch:**

```bash
cd /tmp/openclaw-pr81392-proof/apps/android
ANDROID_HOME=/mnt/extern/openclaw-data/home-redirects/android-sdk \
QEMU_LD_PREFIX=/usr/x86_64-linux-gnu \
./gradlew :app:testDebugUnitTest --rerun-tasks --no-build-cache
```

- **Evidence after fix:** Terminal output copied from the real Raspberry Pi run, not CI-only and not a mock/snapshot:

```text
> Task :app:testDebugUnitTest

BUILD SUCCESSFUL in 2m 1s
30 actionable tasks: 30 executed
```

- **Observed result after fix:** The Android JVM unit test task completed successfully on the Linux ARM64 OpenClaw Pi environment at PR head `2f4bae88ccd48ea61a057e15a6df0cee552437ad`; the PR diff against upstream `origin/main` contains only `2f4bae88cc Disable Robolectric Conscrypt for portable Android unit tests`.
- **What was not tested:** No UI/device APK behavior is claimed by this PR; this PR is limited to the portable Android JVM/Robolectric test fix.
