### PR TITLE
fix(test): isolate auth profile secrets in test state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: finish handling pending debounced inbound messages before closing the socket. (#81246) Thanks @mcaxtr.
 - CLI/commitments: write `--json` output to stdout instead of diagnostic logs so automation can parse commitment list and dismiss results. (#81215) Thanks @giodl73-repo.
 - Update: allow pnpm GitHub-source OpenClaw updates to approve the OpenClaw package build, so source installs complete their prepare/prepack lifecycle. (#81294) Thanks @fuller-stack-dev.
+- Test state: seed isolated auth-profile secret keys for generated homes, preventing helper-backed proof runs from falling back to host Keychain secrets. (#81393) Thanks @altaywtf.
 
 ### Changes
 

--- a/scripts/lib/openclaw-test-state.mjs
+++ b/scripts/lib/openclaw-test-state.mjs
@@ -254,12 +254,22 @@ function renderExports(env) {
 }
 
 function generateAuthProfileSecretKey() {
-  return randomBytes(32).toString("base64url");
+  return randomBytes(32).toString("hex");
 }
 
 function renderAuthProfileSecretKeyExport() {
   return [
-    `OPENCLAW_AUTH_PROFILE_SECRET_KEY="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("base64url"))')"`,
+    'OPENCLAW_AUTH_PROFILE_SECRET_KEY_FILE="$OPENCLAW_TEST_STATE_HOME/.openclaw-test-auth-profile-secret-key"',
+    'if [ -s "$OPENCLAW_AUTH_PROFILE_SECRET_KEY_FILE" ]; then',
+    '  OPENCLAW_AUTH_PROFILE_SECRET_KEY="$(cat "$OPENCLAW_AUTH_PROFILE_SECRET_KEY_FILE")"',
+    "else",
+    '  OPENCLAW_AUTH_PROFILE_SECRET_KEY="$(od -An -N 32 -tx1 /dev/urandom | tr -d " \\n")"',
+    '  ( umask 077; printf "%s\\n" "$OPENCLAW_AUTH_PROFILE_SECRET_KEY" > "$OPENCLAW_AUTH_PROFILE_SECRET_KEY_FILE" )',
+    "fi",
+    'if [ -z "$OPENCLAW_AUTH_PROFILE_SECRET_KEY" ]; then',
+    '  echo "failed to generate OPENCLAW_AUTH_PROFILE_SECRET_KEY" >&2',
+    "  return 1 2>/dev/null || exit 1",
+    "fi",
     "export OPENCLAW_AUTH_PROFILE_SECRET_KEY",
   ];
 }

--- a/scripts/lib/openclaw-test-state.mjs
+++ b/scripts/lib/openclaw-test-state.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -7,7 +8,6 @@ import { fileURLToPath } from "node:url";
 
 const DEFAULT_LABEL = "state";
 const DEFAULT_SCENARIO = "empty";
-const TEST_AUTH_PROFILE_SECRET_KEY = "openclaw-test-state-auth-profile-secret-key";
 const SCENARIOS = new Set([
   "empty",
   "minimal",
@@ -253,6 +253,17 @@ function renderExports(env) {
     .join("\n");
 }
 
+function generateAuthProfileSecretKey() {
+  return randomBytes(32).toString("base64url");
+}
+
+function renderAuthProfileSecretKeyExport() {
+  return [
+    `OPENCLAW_AUTH_PROFILE_SECRET_KEY="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("base64url"))')"`,
+    "export OPENCLAW_AUTH_PROFILE_SECRET_KEY",
+  ];
+}
+
 function renderConfigWrite(configPathExpression, config) {
   if (config === undefined) {
     return "";
@@ -283,7 +294,7 @@ function buildCreatePlan(options = {}) {
     OPENCLAW_HOME: home,
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_CONFIG_PATH: configPath,
-    OPENCLAW_AUTH_PROFILE_SECRET_KEY: TEST_AUTH_PROFILE_SECRET_KEY,
+    OPENCLAW_AUTH_PROFILE_SECRET_KEY: generateAuthProfileSecretKey(),
     ...scenarioEnv(scenario),
   };
   return {
@@ -332,7 +343,7 @@ export function renderShellSnippet(options = {}) {
     'export OPENCLAW_HOME="$OPENCLAW_TEST_STATE_HOME"',
     'export OPENCLAW_STATE_DIR="$OPENCLAW_TEST_STATE_HOME/.openclaw"',
     'export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"',
-    `export OPENCLAW_AUTH_PROFILE_SECRET_KEY=${shellQuote(TEST_AUTH_PROFILE_SECRET_KEY)}`,
+    ...renderAuthProfileSecretKeyExport(),
     'export OPENCLAW_TEST_WORKSPACE_DIR="$OPENCLAW_TEST_STATE_HOME/workspace"',
     'mkdir -p "$OPENCLAW_STATE_DIR" "$OPENCLAW_TEST_WORKSPACE_DIR"',
   ];
@@ -376,7 +387,7 @@ export function renderShellFunction() {
   export OPENCLAW_HOME="$OPENCLAW_TEST_STATE_HOME"
   export OPENCLAW_STATE_DIR="$OPENCLAW_TEST_STATE_HOME/.openclaw"
   export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
-  export OPENCLAW_AUTH_PROFILE_SECRET_KEY=${shellQuote(TEST_AUTH_PROFILE_SECRET_KEY)}
+  ${renderAuthProfileSecretKeyExport().join("\n  ")}
   export OPENCLAW_TEST_WORKSPACE_DIR="$OPENCLAW_TEST_STATE_HOME/workspace"
   unset OPENCLAW_AGENT_DIR
   unset PI_CODING_AGENT_DIR

--- a/scripts/lib/openclaw-test-state.mjs
+++ b/scripts/lib/openclaw-test-state.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const DEFAULT_LABEL = "state";
 const DEFAULT_SCENARIO = "empty";
+const TEST_AUTH_PROFILE_SECRET_KEY = "openclaw-test-state-auth-profile-secret-key";
 const SCENARIOS = new Set([
   "empty",
   "minimal",
@@ -282,6 +283,7 @@ function buildCreatePlan(options = {}) {
     OPENCLAW_HOME: home,
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_AUTH_PROFILE_SECRET_KEY: TEST_AUTH_PROFILE_SECRET_KEY,
     ...scenarioEnv(scenario),
   };
   return {
@@ -330,6 +332,7 @@ export function renderShellSnippet(options = {}) {
     'export OPENCLAW_HOME="$OPENCLAW_TEST_STATE_HOME"',
     'export OPENCLAW_STATE_DIR="$OPENCLAW_TEST_STATE_HOME/.openclaw"',
     'export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"',
+    `export OPENCLAW_AUTH_PROFILE_SECRET_KEY=${shellQuote(TEST_AUTH_PROFILE_SECRET_KEY)}`,
     'export OPENCLAW_TEST_WORKSPACE_DIR="$OPENCLAW_TEST_STATE_HOME/workspace"',
     'mkdir -p "$OPENCLAW_STATE_DIR" "$OPENCLAW_TEST_WORKSPACE_DIR"',
   ];
@@ -373,6 +376,7 @@ export function renderShellFunction() {
   export OPENCLAW_HOME="$OPENCLAW_TEST_STATE_HOME"
   export OPENCLAW_STATE_DIR="$OPENCLAW_TEST_STATE_HOME/.openclaw"
   export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
+  export OPENCLAW_AUTH_PROFILE_SECRET_KEY=${shellQuote(TEST_AUTH_PROFILE_SECRET_KEY)}
   export OPENCLAW_TEST_WORKSPACE_DIR="$OPENCLAW_TEST_STATE_HOME/workspace"
   unset OPENCLAW_AGENT_DIR
   unset PI_CODING_AGENT_DIR

--- a/test/scripts/openclaw-test-state.test.ts
+++ b/test/scripts/openclaw-test-state.test.ts
@@ -19,11 +19,7 @@ function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
-function expectGeneratedSecretKey(value: string | undefined): void {
-  expect(typeof value).toBe("string");
-  expect(value?.length ?? 0).toBeGreaterThan(20);
-  expect(value).not.toBe("openclaw-test-state-auth-profile-secret-key");
-}
+const secretKeyPattern = /^[a-f0-9]{64}$/u;
 
 describe("scripts/lib/openclaw-test-state", () => {
   it("creates a sourceable env file and JSON description", async () => {
@@ -53,7 +49,7 @@ describe("scripts/lib/openclaw-test-state", () => {
       expect(payload.stateDir).toBe(path.join(payload.home, ".openclaw"));
       expect(payload.configPath).toBe(path.join(payload.stateDir, "openclaw.json"));
       expect(payload.workspaceDir).toBe(path.join(payload.home, "workspace"));
-      expectGeneratedSecretKey(payload.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY);
+      expect(payload.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY).toMatch(secretKeyPattern);
       expect(payload.env).toEqual({
         HOME: payload.home,
         USERPROFILE: payload.home,
@@ -126,7 +122,7 @@ describe("scripts/lib/openclaw-test-state", () => {
       );
       expect(payload.openclawHome).toBe(payload.home);
       expect(payload.workspace).toBe(`${payload.home}/workspace`);
-      expectGeneratedSecretKey(payload.secretKey);
+      expect(payload.secretKey).toMatch(secretKeyPattern);
       expect(payload.channel).toBe("stable");
 
       const customTemp = path.join(tempRoot, "state-tmp");
@@ -141,6 +137,52 @@ describe("scripts/lib/openclaw-test-state", () => {
           `^${escapeRegex(customTemp)}/openclaw-update-channel-switch-update-stable-home\\.`,
         ),
       );
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps shell key generation independent of node", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-state-path-node-"));
+    const fakeBin = path.join(tempRoot, "bin");
+    const snippetFile = path.join(tempRoot, "state.sh");
+    const functionFile = path.join(tempRoot, "state-function.sh");
+    try {
+      await fs.mkdir(fakeBin, { recursive: true });
+      await fs.writeFile(
+        path.join(fakeBin, "node"),
+        "#!/bin/sh\necho 'fake node should not be used for key generation' >&2\nexit 42\n",
+        "utf8",
+      );
+      await fs.chmod(path.join(fakeBin, "node"), 0o755);
+
+      const shell = await execFileAsync(process.execPath, [
+        scriptPath,
+        "shell",
+        "--label",
+        "path-node",
+        "--scenario",
+        "empty",
+      ]);
+      await fs.writeFile(snippetFile, shell.stdout, "utf8");
+
+      const shellProbe = await execFileAsync("bash", [
+        "-lc",
+        `export PATH=${shellQuote(fakeBin)}:$PATH; source ${shellQuote(snippetFile)}; printf '%s' "$OPENCLAW_AUTH_PROFILE_SECRET_KEY"; rm -rf "$HOME"`,
+      ]);
+      expect(shellProbe.stdout).toMatch(secretKeyPattern);
+
+      const renderedFunction = await execFileAsync(process.execPath, [
+        scriptPath,
+        "shell-function",
+      ]);
+      await fs.writeFile(functionFile, renderedFunction.stdout, "utf8");
+
+      const functionProbe = await execFileAsync("bash", [
+        "-lc",
+        `export PATH=${shellQuote(fakeBin)}:$PATH; export OPENCLAW_TEST_STATE_TMPDIR=${shellQuote(path.join(tempRoot, "function-tmp"))}; source ${shellQuote(functionFile)}; openclaw_test_state_create "path node" minimal; printf '%s' "$OPENCLAW_AUTH_PROFILE_SECRET_KEY"; rm -rf "$HOME"`,
+      ]);
+      expect(functionProbe.stdout).toMatch(secretKeyPattern);
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }
@@ -201,17 +243,18 @@ describe("scripts/lib/openclaw-test-state", () => {
       expect(payload.home).toContain("/openclaw-onboard-case-minimal-home.");
       expect(payload.agentDir).toBeNull();
       expect(payload.workspace).toBe(`${payload.home}/workspace`);
-      expectGeneratedSecretKey(payload.secretKey);
+      expect(payload.secretKey).toMatch(secretKeyPattern);
       expect(payload.config).toStrictEqual({});
 
       const existingHome = path.join(tempRoot, "existing-home");
       const existingProbe = await execFileAsync("bash", [
         "-lc",
-        `source ${shellQuote(snippetFile)}; openclaw_test_state_create ${shellQuote(existingHome)} minimal; printf '{"kept":true}\\n' > "$OPENCLAW_CONFIG_PATH"; openclaw_test_state_create ${shellQuote(existingHome)} empty; node -e 'const fs=require("node:fs"); const config=JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH,"utf8")); process.stdout.write(JSON.stringify({home:process.env.HOME,config}));'`,
+        `source ${shellQuote(snippetFile)}; openclaw_test_state_create ${shellQuote(existingHome)} minimal; firstKey="$OPENCLAW_AUTH_PROFILE_SECRET_KEY"; export firstKey; printf '{"kept":true}\\n' > "$OPENCLAW_CONFIG_PATH"; openclaw_test_state_create ${shellQuote(existingHome)} empty; node -e 'const fs=require("node:fs"); const config=JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH,"utf8")); process.stdout.write(JSON.stringify({home:process.env.HOME,secretKey:process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY,firstKey:process.env.firstKey,config}));'`,
       ]);
 
       const existingPayload = JSON.parse(existingProbe.stdout);
       expect(existingPayload.home).toBe(existingHome);
+      expect(existingPayload.secretKey).toBe(existingPayload.firstKey);
       expect(existingPayload.config).toEqual({ kept: true });
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });

--- a/test/scripts/openclaw-test-state.test.ts
+++ b/test/scripts/openclaw-test-state.test.ts
@@ -19,6 +19,12 @@ function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
+function expectGeneratedSecretKey(value: string | undefined): void {
+  expect(typeof value).toBe("string");
+  expect(value?.length ?? 0).toBeGreaterThan(20);
+  expect(value).not.toBe("openclaw-test-state-auth-profile-secret-key");
+}
+
 describe("scripts/lib/openclaw-test-state", () => {
   it("creates a sourceable env file and JSON description", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-state-script-"));
@@ -47,13 +53,14 @@ describe("scripts/lib/openclaw-test-state", () => {
       expect(payload.stateDir).toBe(path.join(payload.home, ".openclaw"));
       expect(payload.configPath).toBe(path.join(payload.stateDir, "openclaw.json"));
       expect(payload.workspaceDir).toBe(path.join(payload.home, "workspace"));
+      expectGeneratedSecretKey(payload.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY);
       expect(payload.env).toEqual({
         HOME: payload.home,
         USERPROFILE: payload.home,
         OPENCLAW_HOME: payload.home,
         OPENCLAW_STATE_DIR: payload.stateDir,
         OPENCLAW_CONFIG_PATH: payload.configPath,
-        OPENCLAW_AUTH_PROFILE_SECRET_KEY: "openclaw-test-state-auth-profile-secret-key",
+        OPENCLAW_AUTH_PROFILE_SECRET_KEY: payload.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY,
       });
       expect(payload.config).toEqual({
         update: {
@@ -76,7 +83,7 @@ describe("scripts/lib/openclaw-test-state", () => {
       expect(JSON.parse(probe.stdout)).toEqual({
         home: payload.home,
         stateDir: payload.stateDir,
-        secretKey: "openclaw-test-state-auth-profile-secret-key",
+        secretKey: payload.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY,
         channel: "stable",
       });
       await fs.rm(payload.root, { recursive: true, force: true });
@@ -119,7 +126,7 @@ describe("scripts/lib/openclaw-test-state", () => {
       );
       expect(payload.openclawHome).toBe(payload.home);
       expect(payload.workspace).toBe(`${payload.home}/workspace`);
-      expect(payload.secretKey).toBe("openclaw-test-state-auth-profile-secret-key");
+      expectGeneratedSecretKey(payload.secretKey);
       expect(payload.channel).toBe("stable");
 
       const customTemp = path.join(tempRoot, "state-tmp");
@@ -194,7 +201,7 @@ describe("scripts/lib/openclaw-test-state", () => {
       expect(payload.home).toContain("/openclaw-onboard-case-minimal-home.");
       expect(payload.agentDir).toBeNull();
       expect(payload.workspace).toBe(`${payload.home}/workspace`);
-      expect(payload.secretKey).toBe("openclaw-test-state-auth-profile-secret-key");
+      expectGeneratedSecretKey(payload.secretKey);
       expect(payload.config).toStrictEqual({});
 
       const existingHome = path.join(tempRoot, "existing-home");

--- a/test/scripts/openclaw-test-state.test.ts
+++ b/test/scripts/openclaw-test-state.test.ts
@@ -53,6 +53,7 @@ describe("scripts/lib/openclaw-test-state", () => {
         OPENCLAW_HOME: payload.home,
         OPENCLAW_STATE_DIR: payload.stateDir,
         OPENCLAW_CONFIG_PATH: payload.configPath,
+        OPENCLAW_AUTH_PROFILE_SECRET_KEY: "openclaw-test-state-auth-profile-secret-key",
       });
       expect(payload.config).toEqual({
         update: {
@@ -66,14 +67,16 @@ describe("scripts/lib/openclaw-test-state", () => {
       expect(envFileText).toContain("export OPENCLAW_HOME=");
       expect(envFileText).toContain("export OPENCLAW_STATE_DIR=");
       expect(envFileText).toContain("export OPENCLAW_CONFIG_PATH=");
+      expect(envFileText).toContain("export OPENCLAW_AUTH_PROFILE_SECRET_KEY=");
 
       const probe = await execFileAsync("bash", [
         "-lc",
-        `source ${shellQuote(envFile)}; node -e 'const fs=require("node:fs"); const config=JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH,"utf8")); process.stdout.write(JSON.stringify({home:process.env.HOME,stateDir:process.env.OPENCLAW_STATE_DIR,channel:config.update.channel}));'`,
+        `source ${shellQuote(envFile)}; node -e 'const fs=require("node:fs"); const config=JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH,"utf8")); process.stdout.write(JSON.stringify({home:process.env.HOME,stateDir:process.env.OPENCLAW_STATE_DIR,secretKey:process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY,channel:config.update.channel}));'`,
       ]);
       expect(JSON.parse(probe.stdout)).toEqual({
         home: payload.home,
         stateDir: payload.stateDir,
+        secretKey: "openclaw-test-state-auth-profile-secret-key",
         channel: "stable",
       });
       await fs.rm(payload.root, { recursive: true, force: true });
@@ -106,7 +109,7 @@ describe("scripts/lib/openclaw-test-state", () => {
 
       const probe = await execFileAsync("bash", [
         "-lc",
-        `source ${shellQuote(snippetFile)}; node -e 'const fs=require("node:fs"); const config=JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH,"utf8")); process.stdout.write(JSON.stringify({home:process.env.HOME,openclawHome:process.env.OPENCLAW_HOME,workspace:process.env.OPENCLAW_TEST_WORKSPACE_DIR,channel:config.update.channel}));'; rm -rf "$HOME"`,
+        `source ${shellQuote(snippetFile)}; node -e 'const fs=require("node:fs"); const config=JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH,"utf8")); process.stdout.write(JSON.stringify({home:process.env.HOME,openclawHome:process.env.OPENCLAW_HOME,workspace:process.env.OPENCLAW_TEST_WORKSPACE_DIR,secretKey:process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY,channel:config.update.channel}));'; rm -rf "$HOME"`,
       ]);
 
       const payload = JSON.parse(probe.stdout);
@@ -116,6 +119,7 @@ describe("scripts/lib/openclaw-test-state", () => {
       );
       expect(payload.openclawHome).toBe(payload.home);
       expect(payload.workspace).toBe(`${payload.home}/workspace`);
+      expect(payload.secretKey).toBe("openclaw-test-state-auth-profile-secret-key");
       expect(payload.channel).toBe("stable");
 
       const customTemp = path.join(tempRoot, "state-tmp");
@@ -182,7 +186,7 @@ describe("scripts/lib/openclaw-test-state", () => {
 
       const probe = await execFileAsync("bash", [
         "-lc",
-        `export OPENCLAW_TEST_STATE_TMPDIR=${shellQuote(path.join(tempRoot, "function-tmp"))}; source ${shellQuote(snippetFile)}; export OPENCLAW_AGENT_DIR=/tmp/outside-agent; openclaw_test_state_create "onboard case" minimal; node -e 'const fs=require("node:fs"); const config=JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH,"utf8")); process.stdout.write(JSON.stringify({home:process.env.HOME,tmpDir:process.env.OPENCLAW_TEST_STATE_TMPDIR,agentDir:process.env.OPENCLAW_AGENT_DIR || null,workspace:process.env.OPENCLAW_TEST_WORKSPACE_DIR,config}));'; rm -rf "$HOME"`,
+        `export OPENCLAW_TEST_STATE_TMPDIR=${shellQuote(path.join(tempRoot, "function-tmp"))}; source ${shellQuote(snippetFile)}; export OPENCLAW_AGENT_DIR=/tmp/outside-agent; openclaw_test_state_create "onboard case" minimal; node -e 'const fs=require("node:fs"); const config=JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH,"utf8")); process.stdout.write(JSON.stringify({home:process.env.HOME,tmpDir:process.env.OPENCLAW_TEST_STATE_TMPDIR,agentDir:process.env.OPENCLAW_AGENT_DIR || null,workspace:process.env.OPENCLAW_TEST_WORKSPACE_DIR,secretKey:process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY,config}));'; rm -rf "$HOME"`,
       ]);
 
       const payload = JSON.parse(probe.stdout);
@@ -190,6 +194,7 @@ describe("scripts/lib/openclaw-test-state", () => {
       expect(payload.home).toContain("/openclaw-onboard-case-minimal-home.");
       expect(payload.agentDir).toBeNull();
       expect(payload.workspace).toBe(`${payload.home}/workspace`);
+      expect(payload.secretKey).toBe("openclaw-test-state-auth-profile-secret-key");
       expect(payload.config).toStrictEqual({});
 
       const existingHome = path.join(tempRoot, "existing-home");


### PR DESCRIPTION
## Summary

Isolates OpenClaw test-state/proof environments from the host macOS Keychain by exporting a deterministic `OPENCLAW_AUTH_PROFILE_SECRET_KEY` from the shared test-state helper.

## Changed

- `scripts/lib/openclaw-test-state.mjs` now includes a test-only auth profile secret key in created env files, shell snippets, and the reusable shell function.
- `test/scripts/openclaw-test-state.test.ts` verifies that all three helper surfaces export the key.

## Risks

Low. This only affects isolated test/proof state helpers and does not change production auth-profile persistence or real login flows.

## Verification

- `pnpm test test/scripts/openclaw-test-state.test.ts -- --reporter=verbose`
- `npx oxfmt --check scripts/lib/openclaw-test-state.mjs test/scripts/openclaw-test-state.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/lib/openclaw-test-state.mjs`
- `git diff --check`

## Complexity

Reduced: shared test-state helpers now provide the secret material directly instead of letting proof-style runs fall through to host credential storage.
