### PR TITLE
fix: preserve all-caps provider api keys

### DIFF
--- a/src/agents/models-config.providers.auth-provenance.test.ts
+++ b/src/agents/models-config.providers.auth-provenance.test.ts
@@ -2,6 +2,9 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 
 vi.mock("../plugins/provider-runtime.js", () => ({
+  normalizeProviderConfigWithPlugin: vi.fn(
+    (params: { context?: { providerConfig?: unknown } }) => params.context?.providerConfig,
+  ),
   resolveProviderSyntheticAuthWithPlugin: vi.fn(),
 }));
 
@@ -240,7 +243,7 @@ describe("models-config provider auth provenance", () => {
           providers: {
             vllm: {
               baseUrl: "http://127.0.0.1:8000/v1",
-              apiKey: "MY_VLLM_KEY",
+              apiKey: "${MY_VLLM_KEY}",
               api: "openai-completions",
               models: [],
             },
@@ -252,6 +255,60 @@ describe("models-config provider auth provenance", () => {
     expect(auth("vllm")).toEqual({
       apiKey: undefined,
       discoveryApiKey: undefined,
+    });
+  });
+
+  it("does not send missing known provider env markers as catalog discovery keys", () => {
+    const auth = createProviderApiKeyResolver(
+      {} as NodeJS.ProcessEnv,
+      {
+        version: 1,
+        profiles: {},
+      },
+      {
+        models: {
+          providers: {
+            vllm: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              apiKey: "VLLM_API_KEY",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(auth("vllm")).toEqual({
+      apiKey: undefined,
+      discoveryApiKey: undefined,
+    });
+  });
+
+  it("preserves bare all-caps configured api keys as literal catalog discovery keys", () => {
+    const auth = createProviderApiKeyResolver(
+      {} as NodeJS.ProcessEnv,
+      {
+        version: 1,
+        profiles: {},
+      },
+      {
+        models: {
+          providers: {
+            vllm: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              apiKey: "ALLCAPS_SAMPLE",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(auth("vllm")).toEqual({
+      apiKey: "ALLCAPS_SAMPLE",
+      discoveryApiKey: "ALLCAPS_SAMPLE",
     });
   });
 

--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -1,7 +1,9 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { resolveProviderSyntheticAuthWithPlugin } from "../plugins/provider-runtime.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import {
+  isKnownEnvApiKeyMarker,
   isNonSecretApiKeyMarker,
   resolveNonEnvSecretRefApiKeyMarker,
 } from "./model-auth-markers.js";
@@ -40,8 +42,6 @@ export {
 } from "./models-config.providers.secret-helpers.js";
 
 type AuthProfileStoreInput = AuthProfileStore | (() => AuthProfileStore);
-
-const ENV_VAR_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
 
 function resolveAuthProfileStoreInput(input: AuthProfileStoreInput) {
   return typeof input === "function" ? input() : input;
@@ -208,23 +208,49 @@ function resolveConfigBackedProviderAuth(params: {
   }
 
   const configuredProvider = params.config?.models?.providers?.[authProvider];
-  if (typeof configuredProvider?.apiKey !== "string") {
+  const configuredProviderApiKey = configuredProvider?.apiKey;
+  const configuredApiKeyRef = resolveSecretInputRef({
+    value: configuredProviderApiKey,
+    defaults: params.config?.secrets?.defaults,
+  }).ref;
+  if (configuredApiKeyRef) {
+    if (configuredApiKeyRef.source === "env") {
+      const envVar = configuredApiKeyRef.id.trim();
+      const envValue = params.env?.[envVar]?.trim();
+      return envValue
+        ? {
+            apiKey: envVar,
+            discoveryApiKey: toDiscoveryApiKey(envValue),
+            mode: "api_key",
+            source: "config",
+          }
+        : undefined;
+    }
+    return {
+      apiKey: resolveNonEnvSecretRefApiKeyMarker(configuredApiKeyRef.source),
+      discoveryApiKey: undefined,
+      mode: "api_key",
+      source: "config",
+    };
+  }
+  if (typeof configuredProviderApiKey !== "string") {
     return undefined;
   }
-  const configuredApiKey = normalizeApiKeyConfig(configuredProvider.apiKey);
+  const configuredApiKey = normalizeApiKeyConfig(configuredProviderApiKey);
   if (!configuredApiKey) {
     return undefined;
   }
-  if (ENV_VAR_NAME_RE.test(configuredApiKey)) {
+  if (isKnownEnvApiKeyMarker(configuredApiKey)) {
     const envValue = params.env?.[configuredApiKey]?.trim();
-    return envValue
-      ? {
-          apiKey: configuredApiKey,
-          discoveryApiKey: toDiscoveryApiKey(envValue),
-          mode: "api_key",
-          source: "config",
-        }
-      : undefined;
+    if (envValue) {
+      return {
+        apiKey: configuredApiKey,
+        discoveryApiKey: toDiscoveryApiKey(envValue),
+        mode: "api_key",
+        source: "config",
+      };
+    }
+    return undefined;
   }
   return isNonSecretApiKeyMarker(configuredApiKey)
     ? {


### PR DESCRIPTION
## Summary

- Partial revert of #81230: commit `02b81977` was too broad. It treated any env-shaped all-caps configured provider `apiKey` as an environment variable reference.
- Bare all-caps values such as `ALLCAPS_SAMPLE` now remain literal provider keys when no explicit env ref is configured.
- Explicit env refs such as `${MY_VLLM_KEY}` still resolve through the environment for configured-provider discovery, so #81230 keeps the self-hosted wildcard discovery fix without expanding the persisted provider `apiKey` marker contract.
- Known provider env markers such as `VLLM_API_KEY` keep their existing behavior.

## Real Behavior Proof

Behavior or issue addressed: #81230 commit `02b81977` treated any env-shaped all-caps configured provider `apiKey` as an env var reference. That made a bare configured value such as `ALLCAPS_SAMPLE` disappear when no matching environment variable existed. This PR partially reverts that broad inference while preserving explicit `${MY_VLLM_KEY}` env-ref behavior and known provider env markers.

Real environment tested: local OpenClaw checkout on the same machine, comparing current `origin/main` (`b55d9fa466`) with this PR head (`5db85fbe`) through the configured-provider auth resolver.

Before on `origin/main`:

```json
{
  "rawMissing": {},
  "rawResolved": {
    "apiKey": "MY_VLLM_KEY",
    "discoveryApiKey": "resolved-vllm-key"
  },
  "bareAllCaps": {},
  "knownMarker": {
    "apiKey": "VLLM_API_KEY",
    "discoveryApiKey": "known-vllm-key"
  },
  "knownMissing": {}
}
```

After on this PR:

```json
{
  "rawMissing": {},
  "rawResolved": {
    "apiKey": "MY_VLLM_KEY",
    "discoveryApiKey": "resolved-vllm-key"
  },
  "bareAllCaps": {
    "apiKey": "ALLCAPS_SAMPLE",
    "discoveryApiKey": "ALLCAPS_SAMPLE"
  },
  "knownMarker": {
    "apiKey": "VLLM_API_KEY",
    "discoveryApiKey": "known-vllm-key"
  },
  "knownMissing": {}
}
```

Observed result after fix: a bare all-caps configured provider key remains a literal discovery key, while explicit `${MY_VLLM_KEY}` only resolves when the env var exists. Known `VLLM_API_KEY` marker behavior is unchanged: it resolves when the env var exists and remains unavailable when the env var is absent.

## Verification

- `pnpm test src/agents/models-config.providers.auth-provenance.test.ts src/agents/models-config.providers.normalize-keys.test.ts src/agents/models-config.providers.implicit.discovery-scope.test.ts src/commands/models/list.provider-catalog.test.ts extensions/vllm/provider-discovery.contract.test.ts extensions/lmstudio/src/runtime.test.ts`
- `git diff --check origin/main...HEAD`

Current known gap: `pnpm check:changed` is blocked locally by an unrelated core-test typecheck failure in `src/plugins/registry.runtime-config.test.ts`.

## Notes

This intentionally does not introduce a new persisted `secretref-env:*` provider `apiKey` marker. Provider-specific runtime paths that read `provider.apiKey` directly are left compatible with the existing marker contract.
