### PR TITLE
fix(agents): repair persisted tool result pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - Control UI/WebChat: focus the composer when users click the visible input chrome and restore larger, labeled desktop composer controls while preserving compact mobile taps. Fixes #45656. Thanks @BunsDev.
 - Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
+- Agents/session-file repair: move displaced persisted tool results back next to their assistant tool calls and drop orphaned or duplicate tool results before loading JSONL session transcripts, preventing restart-persistent transcript corruption after interrupted tool runs. Fixes #58608. Thanks @funkylazer.
 
 ## 2026.5.14
 

--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -7,7 +7,7 @@ read_when:
 title: "Transcript hygiene"
 ---
 
-OpenClaw applies **provider-specific fixes** to transcripts before a run (building model context). Most of these are **in-memory** adjustments used to satisfy strict provider requirements. A separate session-file repair pass may also rewrite stored JSONL before the session is loaded, but only for malformed lines or persisted turns that are invalid durable records. Delivered assistant replies are preserved on disk; provider-specific assistant-prefill stripping happens only while constructing outbound payloads. When a repair occurs, the original file is backed up alongside the session file.
+OpenClaw applies **provider-specific fixes** to transcripts before a run (building model context). Most of these are **in-memory** adjustments used to satisfy strict provider requirements. A separate session-file repair pass may also rewrite stored JSONL before the session is loaded, but only for malformed lines or persisted turns that are invalid durable records. The disk pass also repairs invalid persisted tool-result pairing by moving displaced matching tool results next to their assistant tool call and dropping duplicate or orphan tool results; generic missing-result synthesis stays replay-only except for the existing Codex session-file repair. Delivered assistant replies are preserved on disk; provider-specific assistant-prefill stripping happens only while constructing outbound payloads. When a repair occurs, the original file is backed up alongside the session file.
 
 Scope includes:
 

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -482,6 +482,182 @@ describe("repairSessionFileIfNeeded", () => {
     expect(after).toBe(original);
   });
 
+  it("moves displaced persisted tool results next to their owning assistant tool call", async () => {
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const toolCallAssistant = {
+      type: "message",
+      id: "msg-asst-tc",
+      parentId: "msg-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", input: { path: "a.txt" } }],
+        stopReason: "toolUse",
+      },
+    };
+    const customSummary = {
+      type: "summary",
+      id: "summary-1",
+      timestamp: new Date().toISOString(),
+      summary: "opaque summary blob",
+    };
+    const userFollowUp = {
+      type: "message",
+      id: "msg-user-2",
+      parentId: "msg-asst-tc",
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: "follow up" },
+    };
+    const displacedToolResult = {
+      type: "message",
+      id: "msg-tool-result",
+      parentId: "custom-parent-to-preserve",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "file contents" }],
+        isError: false,
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(toolCallAssistant)}\n${JSON.stringify(customSummary)}\n${JSON.stringify(userFollowUp)}\n${JSON.stringify(displacedToolResult)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const debug = vi.fn();
+    const result = await repairSessionFileIfNeeded({ sessionFile: file, debug });
+
+    expect(result.repaired).toBe(true);
+    expect(result.movedToolResults).toBe(1);
+    await expect(fs.readFile(requireBackupPath(result), "utf-8")).resolves.toBe(original);
+    expect(requireFirstLogMessage(debug)).toContain("moved 1 tool result(s)");
+
+    const repairedLines = (await fs.readFile(file, "utf-8"))
+      .trimEnd()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(repairedLines).toEqual([
+      header,
+      message,
+      toolCallAssistant,
+      displacedToolResult,
+      customSummary,
+      userFollowUp,
+    ]);
+  });
+
+  it("drops duplicate persisted tool results after preserving the first matching result", async () => {
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const toolCallAssistant = {
+      type: "message",
+      id: "msg-asst-tc",
+      parentId: "msg-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+        stopReason: "toolUse",
+      },
+    };
+    const firstToolResult = {
+      type: "message",
+      id: "msg-tool-result-1",
+      parentId: "msg-asst-tc",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "first" }],
+        isError: false,
+      },
+    };
+    const duplicateToolResult = {
+      type: "message",
+      id: "msg-tool-result-2",
+      parentId: "msg-asst-tc",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "duplicate" }],
+        isError: false,
+      },
+    };
+    const userFollowUp = {
+      type: "message",
+      id: "msg-user-2",
+      parentId: "msg-tool-result-1",
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: "next" },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(toolCallAssistant)}\n${JSON.stringify(firstToolResult)}\n${JSON.stringify(userFollowUp)}\n${JSON.stringify(duplicateToolResult)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(true);
+    expect(result.droppedDuplicateToolResults).toBe(1);
+    expect(result.movedToolResults ?? 0).toBe(0);
+
+    const repairedLines = (await fs.readFile(file, "utf-8"))
+      .trimEnd()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(repairedLines).toEqual([
+      header,
+      message,
+      toolCallAssistant,
+      firstToolResult,
+      userFollowUp,
+    ]);
+  });
+
+  it("drops orphan persisted tool results that have no matching assistant tool call", async () => {
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const orphanToolResult = {
+      type: "message",
+      id: "msg-tool-result-orphan",
+      parentId: "missing-assistant",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: "call_missing",
+        toolName: "read",
+        content: [{ type: "text", text: "orphan" }],
+        isError: false,
+      },
+    };
+    const plainAssistant = {
+      type: "message",
+      id: "msg-asst-plain",
+      parentId: "msg-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }],
+        stopReason: "stop",
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(orphanToolResult)}\n${JSON.stringify(plainAssistant)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(true);
+    expect(result.droppedOrphanToolResults).toBe(1);
+
+    const repairedLines = (await fs.readFile(file, "utf-8"))
+      .trimEnd()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(repairedLines).toEqual([header, message, plainAssistant]);
+  });
+
   it("inserts missing code-mode tool results before replay repair has to synthesize them", async () => {
     const { file } = await createTempSessionPath();
     const { header, message } = buildSessionHeaderAndMessage();

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -17,6 +17,9 @@ type RepairReport = {
   rewrittenAssistantMessages?: number;
   droppedBlankUserMessages?: number;
   rewrittenUserMessages?: number;
+  movedToolResults?: number;
+  droppedDuplicateToolResults?: number;
+  droppedOrphanToolResults?: number;
   insertedToolResults?: number;
   backupPath?: string;
   reason?: string;
@@ -31,12 +34,46 @@ type SessionMessageEntry = {
   message: { role: string; content?: unknown } & Record<string, unknown>;
 } & Record<string, unknown>;
 
+type PersistedToolResultEntry = {
+  entry: SessionMessageEntry;
+  id: string;
+  originalIndex: number;
+};
+
+type PersistedToolResultRepair = {
+  entries: unknown[];
+  movedToolResults: number;
+  droppedDuplicateToolResults: number;
+  droppedOrphanToolResults: number;
+};
+
 function isSessionHeader(entry: unknown): entry is { type: string; id: string } {
   if (!entry || typeof entry !== "object") {
     return false;
   }
   const record = entry as { type?: unknown; id?: unknown };
   return record.type === "session" && typeof record.id === "string" && record.id.length > 0;
+}
+
+function isSessionMessageEntry(entry: unknown): entry is SessionMessageEntry {
+  if (!entry || typeof entry !== "object") {
+    return false;
+  }
+  const record = entry as { type?: unknown; message?: unknown };
+  if (record.type !== "message" || !record.message || typeof record.message !== "object") {
+    return false;
+  }
+  const role = (record.message as { role?: unknown }).role;
+  return typeof role === "string" && role.trim().length > 0;
+}
+
+function extractAssistantToolCalls(entry: SessionMessageEntry) {
+  if (entry.message.role !== "assistant") {
+    return [];
+  }
+  return extractToolCallsFromAssistant(
+    entry.message as unknown as Extract<AgentMessage, { role: "assistant" }>,
+  );
 }
 
 /**
@@ -171,6 +208,9 @@ function buildRepairSummaryParts(params: {
   rewrittenAssistantMessages: number;
   droppedBlankUserMessages: number;
   rewrittenUserMessages: number;
+  movedToolResults: number;
+  droppedDuplicateToolResults: number;
+  droppedOrphanToolResults: number;
   insertedToolResults: number;
 }): string {
   const parts: string[] = [];
@@ -186,10 +226,118 @@ function buildRepairSummaryParts(params: {
   if (params.rewrittenUserMessages > 0) {
     parts.push(`rewrote ${params.rewrittenUserMessages} user message(s)`);
   }
+  if (params.movedToolResults > 0) {
+    parts.push(`moved ${params.movedToolResults} tool result(s)`);
+  }
+  if (params.droppedDuplicateToolResults > 0) {
+    parts.push(`dropped ${params.droppedDuplicateToolResults} duplicate tool result(s)`);
+  }
+  if (params.droppedOrphanToolResults > 0) {
+    parts.push(`dropped ${params.droppedOrphanToolResults} orphan tool result(s)`);
+  }
   if (params.insertedToolResults > 0) {
     parts.push(`inserted ${params.insertedToolResults} missing tool result(s)`);
   }
   return parts.length > 0 ? parts.join(", ") : "no changes";
+}
+
+function repairPersistedToolResultPairing(entries: unknown[]): PersistedToolResultRepair {
+  const out: unknown[] = [];
+  const seenToolResultIds = new Set<string>();
+  let movedToolResults = 0;
+  let droppedDuplicateToolResults = 0;
+  let droppedOrphanToolResults = 0;
+  let changed = false;
+
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
+    if (!isSessionMessageEntry(entry)) {
+      out.push(entry);
+      continue;
+    }
+
+    const role = entry.message.role;
+    if (role !== "assistant") {
+      if (role === "toolResult") {
+        droppedOrphanToolResults += 1;
+        changed = true;
+        continue;
+      }
+      out.push(entry);
+      continue;
+    }
+
+    const toolCalls = extractAssistantToolCalls(entry);
+    if (toolCalls.length === 0) {
+      out.push(entry);
+      continue;
+    }
+
+    const toolCallIds = new Set(toolCalls.map((toolCall) => toolCall.id));
+    const spanResultsById = new Map<string, PersistedToolResultEntry>();
+    const remainder: unknown[] = [];
+
+    let j = i + 1;
+    for (; j < entries.length; j += 1) {
+      const next = entries[j];
+      if (!isSessionMessageEntry(next)) {
+        remainder.push(next);
+        continue;
+      }
+
+      const nextRole = next.message.role;
+      if (nextRole === "assistant" && extractAssistantToolCalls(next).length > 0) {
+        break;
+      }
+
+      if (nextRole === "toolResult") {
+        const id = extractToolResultId(
+          next.message as unknown as Extract<AgentMessage, { role: "toolResult" }>,
+        );
+        if (id && toolCallIds.has(id)) {
+          if (seenToolResultIds.has(id) || spanResultsById.has(id)) {
+            droppedDuplicateToolResults += 1;
+            changed = true;
+            continue;
+          }
+          spanResultsById.set(id, { entry: next, id, originalIndex: j });
+          continue;
+        }
+        droppedOrphanToolResults += 1;
+        changed = true;
+        continue;
+      }
+
+      remainder.push(next);
+    }
+
+    out.push(entry);
+    let expectedIndex = i + 1;
+    for (const toolCall of toolCalls) {
+      const result = spanResultsById.get(toolCall.id);
+      if (!result) {
+        continue;
+      }
+      if (result.originalIndex !== expectedIndex) {
+        movedToolResults += 1;
+        changed = true;
+      }
+      seenToolResultIds.add(result.id);
+      out.push(result.entry);
+      expectedIndex += 1;
+    }
+    for (const rem of remainder) {
+      out.push(rem);
+    }
+    i = j - 1;
+  }
+
+  return {
+    entries: changed ? out : entries,
+    movedToolResults,
+    droppedDuplicateToolResults,
+    droppedOrphanToolResults,
+  };
 }
 
 function isCodeModeToolCallRepairCandidate(entry: unknown): entry is SessionMessageEntry {
@@ -320,6 +468,9 @@ export async function repairSessionFileIfNeeded(params: {
   let rewrittenAssistantMessages = 0;
   let droppedBlankUserMessages = 0;
   let rewrittenUserMessages = 0;
+  let movedToolResults = 0;
+  let droppedDuplicateToolResults = 0;
+  let droppedOrphanToolResults = 0;
   let insertedToolResults = 0;
 
   for (const line of lines) {
@@ -377,24 +528,31 @@ export async function repairSessionFileIfNeeded(params: {
     return { repaired: false, droppedLines, reason: "invalid session header" };
   }
 
+  const repairedPairing = repairPersistedToolResultPairing(entries);
+  movedToolResults = repairedPairing.movedToolResults;
+  droppedDuplicateToolResults = repairedPairing.droppedDuplicateToolResults;
+  droppedOrphanToolResults = repairedPairing.droppedOrphanToolResults;
+  if (movedToolResults > 0 || droppedDuplicateToolResults > 0 || droppedOrphanToolResults > 0) {
+    entries.splice(0, entries.length, ...repairedPairing.entries);
+  }
+
+  const repairedToolResults = insertMissingCodeModeToolResults(entries);
+  insertedToolResults = repairedToolResults.insertedToolResults;
+  if (insertedToolResults > 0) {
+    entries.splice(0, entries.length, ...repairedToolResults.entries);
+  }
+
   if (
     droppedLines === 0 &&
     rewrittenAssistantMessages === 0 &&
     droppedBlankUserMessages === 0 &&
-    rewrittenUserMessages === 0
+    rewrittenUserMessages === 0 &&
+    movedToolResults === 0 &&
+    droppedDuplicateToolResults === 0 &&
+    droppedOrphanToolResults === 0 &&
+    insertedToolResults === 0
   ) {
-    const repairedToolResults = insertMissingCodeModeToolResults(entries);
-    insertedToolResults = repairedToolResults.insertedToolResults;
-    if (insertedToolResults === 0) {
-      return { repaired: false, droppedLines: 0 };
-    }
-    entries.splice(0, entries.length, ...repairedToolResults.entries);
-  } else {
-    const repairedToolResults = insertMissingCodeModeToolResults(entries);
-    insertedToolResults = repairedToolResults.insertedToolResults;
-    if (insertedToolResults > 0) {
-      entries.splice(0, entries.length, ...repairedToolResults.entries);
-    }
+    return { repaired: false, droppedLines: 0 };
   }
 
   const cleaned = `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
@@ -418,6 +576,9 @@ export async function repairSessionFileIfNeeded(params: {
       rewrittenAssistantMessages,
       droppedBlankUserMessages,
       rewrittenUserMessages,
+      movedToolResults,
+      droppedDuplicateToolResults,
+      droppedOrphanToolResults,
       reason: `repair failed: ${err instanceof Error ? err.message : "unknown error"}`,
     };
   }
@@ -428,6 +589,9 @@ export async function repairSessionFileIfNeeded(params: {
       rewrittenAssistantMessages,
       droppedBlankUserMessages,
       rewrittenUserMessages,
+      movedToolResults,
+      droppedDuplicateToolResults,
+      droppedOrphanToolResults,
       insertedToolResults,
     })} (${path.basename(sessionFile)})`,
   );
@@ -437,6 +601,9 @@ export async function repairSessionFileIfNeeded(params: {
     rewrittenAssistantMessages,
     droppedBlankUserMessages,
     rewrittenUserMessages,
+    movedToolResults,
+    droppedDuplicateToolResults,
+    droppedOrphanToolResults,
     insertedToolResults,
     backupPath,
   };


### PR DESCRIPTION
## Summary

- Problem: interrupted or killed tool runs can leave persisted session JSONL with `toolResult` entries separated from their assistant tool-call entry, duplicated, or orphaned.
- Why it matters: session-file repair runs before OpenClaw loads a transcript. If the durable JSONL keeps invalid tool-result ordering, the same session can keep failing on later turns after restart.
- What changed: the session-file repair pass now moves matching persisted tool results next to their assistant tool call and drops duplicate or orphan persisted tool results before loading the transcript.
- What did NOT change: runtime/provider replay can still synthesize missing generic tool results when a provider policy needs it. The durable disk repair does not invent missing generic outputs; it only preserves and reorders real persisted entries or removes invalid persisted entries. The existing Codex-specific session-file repair for `aborted` tool outputs remains unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Agents / runtime
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #58608
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: persisted session JSONL with a displaced matching `toolResult`, a duplicate `toolResult`, and an orphan `toolResult`.
- Real environment tested: local macOS OpenClaw checkout, current `main` JSONL session-file repair path, real temp session file, and production `repairSessionFileIfNeeded`.
- Exact steps or command run after this patch: ran a local `node --import tsx --input-type=module` command that wrote a corrupted `session.jsonl`, invoked `repairSessionFileIfNeeded`, then read the durable JSONL back from disk.
- Evidence after fix: console output from that command:

```text
OpenClaw console output: repair result {
  "repaired": true,
  "movedToolResults": 1,
  "droppedDuplicateToolResults": 1,
  "droppedOrphanToolResults": 1,
  "hasBackup": true
}
OpenClaw console output: repaired role order session > user > assistant > toolResult > user
OpenClaw console output: repaired ids proof-session > msg-user > msg-assistant > msg-tool-result > msg-user-followup
OpenClaw console output: preserved moved result parent preserved-parent
```

- Observed result after fix: the durable JSONL transcript is rewritten so the real matching tool result sits immediately after the assistant tool call, the duplicate and orphan tool results are removed, the moved entry metadata is preserved, and the original session file is backed up.
- What was not tested: a live provider call after killing an active tool run, because this patch is isolated to deterministic durable transcript repair.

## Root Cause

- Root cause: transcript replay already knew how to repair invalid tool-call/tool-result order in memory, but session-file repair did not repair persisted tool-result pairing before loading JSONL transcript entries.
- Missing detection / guardrail: existing disk repair covered malformed JSONL, malformed messages, blank user text, empty assistant error turns, and Codex missing outputs, but did not cover `toolResult` entries that were displaced, duplicated, or orphaned in the persisted transcript.
- Contributing context: interruption paths can persist partial tool-call sequences. Once persisted, the invalid entries survive restart and can poison later context rebuilds for the session.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/session-file-repair.test.ts`
- Scenario the test should lock in: session-file repair moves a real matching late tool result next to its assistant tool call, drops duplicate persisted tool results, and drops orphan persisted tool results without synthesizing missing generic results.
- Why this is the smallest reliable guardrail: it exercises the actual durable JSONL repair boundary and atomic rewrite/backup behavior without requiring provider scheduling or process-kill timing.
- Existing test that already covers this: in-memory replay repair coverage exists in `src/agents/session-transcript-repair.test.ts`, but durable session-file repair did not have persisted-entry coverage for this corruption shape.

## User-visible / Behavior Changes

Sessions with persisted tool-call/tool-result pairing corruption can recover on restart instead of repeatedly failing during later context rebuilds.

## Diagram

```text
Before:
session.jsonl:
assistant(toolCall call_1) -> user follow-up -> toolResult(call_1) -> duplicate/orphan result
load/replay later -> invalid durable transcript can fail again

After:
session-file repair:
assistant(toolCall call_1) -> toolResult(call_1) -> user follow-up
duplicate/orphan persisted results removed
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 repo test wrapper and JSONL session-file repair
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: temp session JSONL file

### Steps

1. Write a session JSONL file with an assistant `toolCall` entry.
2. Persist a user follow-up before the matching `toolResult`.
3. Persist a duplicate matching `toolResult` and an unrelated orphan `toolResult`.
4. Run `repairSessionFileIfNeeded`.
5. Read the repaired session JSONL back from disk.

### Expected

- The matching `toolResult` is moved next to the assistant tool call.
- Duplicate and orphan persisted `toolResult` entries are removed.
- Missing generic tool results are not synthesized into durable state.
- The original session file is backed up.

### Actual

- Before this patch, session-file repair left the invalid tool-result entries in place.
- After this patch, the persisted JSONL entries are repaired deterministically.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: moved displaced matching tool result, duplicate persisted tool result dropped, orphan persisted tool result dropped, moved entry metadata preserved, backup file written.
- Edge cases checked: malformed-line repair still works, empty assistant error-turn repair still works, blank user repair still works, delivered trailing assistant messages remain untouched, Codex-specific missing-output repair remains intact, in-memory replay repair coverage still passes.
- What you did not verify: live provider call after killing an active tool run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: durable repair could accidentally rewrite valid transcript shape.
  - Mitigation: the repair only touches `toolResult` entries whose ids match a visible assistant tool call span, duplicate ids, or tool results with no matching assistant tool call. Regression tests assert delivered assistant turns and unrelated non-message entries are preserved.
- Risk: durable repair could invent fake generic tool output.
  - Mitigation: this pass intentionally does not synthesize missing generic tool results; synthetic missing-output repair remains runtime/provider-specific. The existing Codex session-file `aborted` repair is left as-is.

## Validation

- `pnpm docs:list`
- `pnpm test src/agents/session-file-repair.test.ts src/agents/session-transcript-repair.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/reference/transcript-hygiene.md src/agents/session-file-repair.ts src/agents/session-file-repair.test.ts`
- `git diff --check`
- `pnpm changed:lanes --base upstream/main --json`
- `pnpm check:changed --base upstream/main`
