### PR TITLE
feat(xai): add grok-imagine-image-quality image model, deprecate grok-imagine-image-pro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - CLI/config: add `--dry-run` support to `openclaw config unset`, with `--json` output and allow-exec validation parity with `config set`/`config patch` dry-run handling. (#81895) Thanks @giodl73-repo.
 - Memory-core: retry disabled dreaming cron cleanup until cron is available after startup, so persisted managed dreaming jobs are removed after restart. Fixes #82383. (#82389) Thanks @neeravmakwana.
 - Providers/xAI: keep retired Grok 3, Grok 4 Fast, Grok 4.1 Fast, and Grok Code slugs out of model pickers while preserving compatibility resolution for existing configs.
+- Providers/xAI: replace the retired `grok-imagine-image-pro` image model with `grok-imagine-image-quality` in the bundled image-generation provider and docs. (#81399) Thanks @KateWilkins.
 - Providers/OAuth: let browser-hosted identity provider pages read successful localhost callback responses, preventing xAI Grok OAuth from showing a false connection failure after OpenClaw completes login.
 - Gateway/diagnostics: redact credential-bearing gateway target URLs and client diagnostics while preserving raw connection URLs for programmatic use, so connect-failure logs no longer surface embedded tokens.
 - Gateway/auth: honor `OPENCLAW_GATEWAY_TOKEN` as the remote interactive fallback when no remote token is configured, keeping remote TUI setup aligned with documented auth precedence.

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -181,7 +181,6 @@ Legacy aliases still normalize to the canonical bundled ids:
 
     - Default image model: `xai/grok-imagine-image`
     - Additional model: `xai/grok-imagine-image-quality`
-    - Deprecated: `xai/grok-imagine-image-pro` (scheduled for removal)
     - Modes: text-to-image and reference-image edit
     - Reference inputs: one `image` or up to five `images`
     - Aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `2:3`, `3:2`

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -180,7 +180,8 @@ Legacy aliases still normalize to the canonical bundled ids:
     `image_generate` tool.
 
     - Default image model: `xai/grok-imagine-image`
-    - Additional model: `xai/grok-imagine-image-pro`
+    - Additional model: `xai/grok-imagine-image-quality`
+    - Deprecated: `xai/grok-imagine-image-pro` (scheduled for removal)
     - Modes: text-to-image and reference-image edit
     - Reference inputs: one `image` or up to five `images`
     - Aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `2:3`, `3:2`

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -345,7 +345,7 @@ ComfyUI support 1.
     The bundled xAI provider uses `/v1/images/generations` for prompt-only
     requests and `/v1/images/edits` when `image` or `images` is present.
 
-    - Models: `xai/grok-imagine-image`, `xai/grok-imagine-image-pro`
+    - Models: `xai/grok-imagine-image`, `xai/grok-imagine-image-quality`
     - Count: up to 4
     - References: one `image` or up to five `images`
     - Aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `2:3`, `3:2`

--- a/extensions/xai/image-generation-provider.test.ts
+++ b/extensions/xai/image-generation-provider.test.ts
@@ -93,7 +93,12 @@ describe("xai image generation provider", () => {
     expect(provider.id).toBe("xai");
     expect(provider.label).toBe("xAI");
     expect(provider.defaultModel).toBe("grok-imagine-image");
-    expect(provider.models).toEqual(["grok-imagine-image", "grok-imagine-image-pro"]);
+    expect(provider.models).toEqual([
+      "grok-imagine-image",
+      // deprecated; scheduled for removal
+      "grok-imagine-image-pro",
+      "grok-imagine-image-quality",
+    ]);
     expect(provider.capabilities.generate.maxCount).toBe(4);
     expect(provider.capabilities.generate.supportsAspectRatio).toBe(true);
     expect(provider.capabilities.geometry?.aspectRatios).toEqual([

--- a/extensions/xai/image-generation-provider.test.ts
+++ b/extensions/xai/image-generation-provider.test.ts
@@ -93,12 +93,7 @@ describe("xai image generation provider", () => {
     expect(provider.id).toBe("xai");
     expect(provider.label).toBe("xAI");
     expect(provider.defaultModel).toBe("grok-imagine-image");
-    expect(provider.models).toEqual([
-      "grok-imagine-image",
-      // deprecated; scheduled for removal
-      "grok-imagine-image-pro",
-      "grok-imagine-image-quality",
-    ]);
+    expect(provider.models).toEqual(["grok-imagine-image", "grok-imagine-image-quality"]);
     expect(provider.capabilities.generate.maxCount).toBe(4);
     expect(provider.capabilities.generate.supportsAspectRatio).toBe(true);
     expect(provider.capabilities.geometry?.aspectRatios).toEqual([
@@ -194,7 +189,7 @@ describe("xai image generation provider", () => {
     const buffer = Buffer.from("fakeimage");
     await provider.generateImage({
       provider: "xai",
-      model: "grok-imagine-image-pro",
+      model: "grok-imagine-image-quality",
       prompt: "Render this as a pencil sketch with detailed shading",
       inputImages: [
         {
@@ -207,7 +202,7 @@ describe("xai image generation provider", () => {
 
     const request = requirePostJsonCall();
     expect(request.url).toContain("/images/edits");
-    expect(request.body?.model).toBe("grok-imagine-image-pro");
+    expect(request.body?.model).toBe("grok-imagine-image-quality");
     expect(request.body?.prompt).toBe("Render this as a pencil sketch with detailed shading");
     const image = request.body?.image as { url?: string; type?: string } | undefined;
     expect(image?.url).toContain("data:image/png;base64,");

--- a/extensions/xai/model-definitions.ts
+++ b/extensions/xai/model-definitions.ts
@@ -3,12 +3,7 @@ import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coe
 
 export const XAI_BASE_URL = "https://api.x.ai/v1";
 export const XAI_DEFAULT_IMAGE_MODEL = "grok-imagine-image";
-export const XAI_IMAGE_MODELS = [
-  "grok-imagine-image",
-  // deprecated; scheduled for removal
-  "grok-imagine-image-pro",
-  "grok-imagine-image-quality",
-] as const;
+export const XAI_IMAGE_MODELS = ["grok-imagine-image", "grok-imagine-image-quality"] as const;
 export const XAI_DEFAULT_CONTEXT_WINDOW = 1_000_000;
 const XAI_LARGE_CONTEXT_WINDOW = 2_000_000;
 const XAI_GROK_4_CONTEXT_WINDOW = 256_000;

--- a/extensions/xai/model-definitions.ts
+++ b/extensions/xai/model-definitions.ts
@@ -3,7 +3,12 @@ import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coe
 
 export const XAI_BASE_URL = "https://api.x.ai/v1";
 export const XAI_DEFAULT_IMAGE_MODEL = "grok-imagine-image";
-export const XAI_IMAGE_MODELS = ["grok-imagine-image", "grok-imagine-image-pro"] as const;
+export const XAI_IMAGE_MODELS = [
+  "grok-imagine-image",
+  // deprecated; scheduled for removal
+  "grok-imagine-image-pro",
+  "grok-imagine-image-quality",
+] as const;
 export const XAI_DEFAULT_CONTEXT_WINDOW = 1_000_000;
 const XAI_LARGE_CONTEXT_WINDOW = 2_000_000;
 const XAI_GROK_4_CONTEXT_WINDOW = 256_000;


### PR DESCRIPTION
## Summary

  - Problem: xAI released new grok-imagine-image-quality model; existing grok-imagine-image-pro model deprecated and scheduled for removal soon.
  - Why it matters: Agents using pro model will break on removal; users need access to quality model.
  - What changed: Added grok-imagine-image-quality to XAI_IMAGE_MODELS, marked pro deprecated in code + docs, updated test expectation.
  - What did NOT change: Default model (grok-imagine-image) unchanged, image generation logic unchanged, no new capabilities.

## Change Type (select all)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor required for the fix
- [X] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [X] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

## Real behaviour proof (required for external PRs)

```
lyra@LyraHostServer openclaw % npm start -- infer image generate --prompt "A simple red circle on transparent background" --model grok-imagine-image-quality --json

> openclaw@2026.5.12-beta.1 start
> node scripts/run-node.mjs infer image generate --prompt A simple red circle on transparent background --model grok-imagine-image-quality --json

{
  "ok": true,
  "capability": "image.generate",
  "transport": "local",
  "provider": "xai",
  "model": "grok-imagine-image-quality",
  "attempts": [],
  "outputs": [
    {
      "path": "/Users/lyra/.openclaw/media/generated/image-1---6146a1fc-88e7-45ab-9dea-3c64a45c95f2.jpg",
      "mimeType": "image/jpeg",
      "size": 112914,
      "width": 1024,
      "height": 1024
    }
  ],
  "ignoredOverrides": []
}
```
## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- User is now able to use new grok-imagine-image-quality model

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: xAI image provider
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

  1. pnpm test extensions/xai/image-generation-provider.test.ts
  2. pnpm check:changed -- extensions/xai/
 
### Expected

- Test passes, model list includes quality + deprecated pro

### Actual

- Test passes, model list includes quality + deprecated pro

## Evidence

```
lyra@LyraHostServer openclaw % pnpm test extensions/xai/image-generation-provider.test.ts  
$ node scripts/test-projects.mjs extensions/xai/image-generation-provider.test.ts
[test] starting test/vitest/vitest.extension-providers.config.ts

 RUN  v4.1.6 /Users/lyra/projects/openclaw

 ✓  extension-providers  extensions/xai/image-generation-provider.test.ts (4 tests) 22ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  20:04:55
   Duration  147ms (transform 54ms, setup 63ms, import 7ms, tests 22ms, environment 0ms)

[test] passed 1 Vitest shard in 2.36s
```

## Human Verification (required)

- Ran test cases, generated test image, see evidence below.

## Review Conversations

- [X] I replied to or resolved every bot review conversation I addressed in this PR.
- [X] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Risks and Mitigations

None

## Maintainer real behavior proof

Behavior addressed: xAI image generation now exposes `grok-imagine-image-quality` and stops advertising the retired `grok-imagine-image-pro` model.

Real environment tested: Contributor verified live xAI image generation on macOS with Node 22; maintainer verified the focused image provider test locally on the rebased PR branch.

Exact steps or command run after this patch: `npm start -- infer image generate --prompt "A simple red circle on transparent background" --model grok-imagine-image-quality --json`; maintainer also ran `fnm exec --using 22.22.2 pnpm test extensions/xai/image-generation-provider.test.ts -- --reporter=verbose`.

Evidence after fix: Contributor command returned `ok: true` with a generated JPEG output; maintainer test passed 1 Vitest shard, 4 tests.

Observed result after fix: `grok-imagine-image-quality` is accepted by the xAI image provider, the model list test expects it, and docs list it instead of the retired pro model.

What was not tested: Maintainer did not rerun the live xAI image generation call because it requires live provider credentials; maintainer relied on contributor live proof plus the focused local unit test.


## Real behavior proof

Behavior addressed: xAI image generation now exposes `grok-imagine-image-quality` and stops advertising the retired `grok-imagine-image-pro` model.

Real environment tested: Contributor verified live xAI image generation on macOS with Node 22; maintainer verified the focused image provider test locally on the rebased PR branch.

Exact steps or command run after this patch: `npm start -- infer image generate --prompt "A simple red circle on transparent background" --model grok-imagine-image-quality --json`; maintainer also ran `fnm exec --using 22.22.2 pnpm test extensions/xai/image-generation-provider.test.ts -- --reporter=verbose`.

Evidence after fix: Live output:

```json
{
  "ok": true,
  "capability": "image.generate",
  "provider": "xai",
  "model": "grok-imagine-image-quality",
  "outputs": [
    {
      "mimeType": "image/jpeg",
      "size": 112914,
      "width": 1024,
      "height": 1024
    }
  ]
}
```

Observed result after fix: `grok-imagine-image-quality` is accepted by the xAI image provider, the model list test expects it, and docs list it instead of the retired pro model.

What was not tested: Maintainer did not rerun the live xAI image generation call because it requires live provider credentials; maintainer relied on contributor live proof plus the focused local unit test.
