### PR TITLE
fix: inherit agents.defaults.agentRuntime in subagent runtime resolution [AI-assisted]

### DIFF
--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveModelRuntimePolicy } from "./model-runtime-policy.js";
+
+function minimalConfig(overrides: Partial<OpenClawConfig> = {}): OpenClawConfig {
+  return { ...overrides } as OpenClawConfig;
+}
+
+describe("resolveModelRuntimePolicy", () => {
+  it("returns empty when no runtime policy is configured anywhere", () => {
+    const result = resolveModelRuntimePolicy({
+      config: minimalConfig(),
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    });
+    expect(result.policy).toBeUndefined();
+  });
+
+  it("returns agents.defaults.agentRuntime as fallback when no model or provider runtime is set", () => {
+    const config = minimalConfig({
+      agents: {
+        defaults: {
+          agentRuntime: { id: "claude-cli" },
+        },
+      },
+    });
+    const result = resolveModelRuntimePolicy({
+      config,
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    });
+    expect(result.policy).toEqual({ id: "claude-cli" });
+  });
+
+  it("prefers provider-level agentRuntime over agents.defaults.agentRuntime", () => {
+    const config = minimalConfig({
+      agents: {
+        defaults: {
+          agentRuntime: { id: "claude-cli" },
+        },
+      },
+      models: {
+        providers: {
+          anthropic: {
+            agentRuntime: { id: "embedded" },
+            models: [],
+          },
+        },
+      },
+    });
+    const result = resolveModelRuntimePolicy({
+      config,
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    });
+    expect(result.policy).toEqual({ id: "embedded" });
+    expect(result.source).toBe("provider");
+  });
+
+  it("prefers model-level agentRuntime over agents.defaults.agentRuntime", () => {
+    const config = minimalConfig({
+      agents: {
+        defaults: {
+          agentRuntime: { id: "claude-cli" },
+          models: {
+            "anthropic/claude-sonnet-4-6": {
+              agentRuntime: { id: "model-specific" },
+            },
+          },
+        },
+      },
+    });
+    const result = resolveModelRuntimePolicy({
+      config,
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    });
+    expect(result.policy).toEqual({ id: "model-specific" });
+    expect(result.source).toBe("model");
+  });
+});

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -162,5 +162,9 @@ export function resolveModelRuntimePolicy(params: {
   if (hasRuntimePolicy(providerConfig?.agentRuntime)) {
     return { policy: providerConfig?.agentRuntime, source: "provider" };
   }
+  const defaultsRuntime = params.config?.agents?.defaults?.agentRuntime;
+  if (hasRuntimePolicy(defaultsRuntime)) {
+    return { policy: defaultsRuntime, source: "provider" };
+  }
   return {};
 }


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: `resolveModelRuntimePolicy` never falls back to `agents.defaults.agentRuntime`, so subagents silently bypass the configured runtime (e.g. `claude-cli`) and use the embedded HTTP runner instead — routing API calls to the wrong billing bucket (Extra Usage instead of Max/Pro subscription). One billing failure sets a 24h lockout in `auth-state.json` that blocks all providers.
- Why it matters: Any Claude Max/Pro user with subagents loses all agent functionality for up to 24 hours with no warning and no auto-recovery.
- What changed: Added `agents.defaults.agentRuntime` as the final fallback in `resolveModelRuntimePolicy()`, after per-model and per-provider checks. Added unit tests covering the inheritance chain.
- What did NOT change (scope boundary): No changes to the embedded HTTP runner, provider auth, billing lockout logic, or startup warnings. The fix is limited to the runtime resolution fallback chain.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Agents

## Linked Issue/PR
- Closes #81395
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `resolveModelRuntimePolicy` resolution chain checked agent model entries, provider config, and model config for `agentRuntime`, but never consulted `agents.defaults.agentRuntime` as a final fallback. The defaults-level runtime was only used for per-model entries under `agents.defaults.models.*`, not as a standalone cascade target.
- Missing detection / guardrail: No unit test validated the full inheritance chain for `agentRuntime` resolution. No startup warning when `agents.defaults.agentRuntime` is set but `subagents` would not inherit it.
- Contributing context (if known): The model-runtime-policy module was likely written before `agents.defaults.agentRuntime` became the primary configuration surface, and the fallback was never added.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/model-runtime-policy.test.ts`
- Scenario the test should lock in: When `agents.defaults.agentRuntime.id` is set and no per-model or per-provider runtime is configured, `resolveModelRuntimePolicy` returns the defaults-level policy as fallback.
- Why this is the smallest reliable guardrail: The resolution function is pure (config in, policy out) — a unit test directly validates the cascade without needing gateway or subprocess infrastructure.
- Existing test that already covers this (if any): N/A — no prior test file existed for this module.
- If no new test is added, why not: N/A — new test added.

## User-visible / Behavior Changes
Subagents now correctly inherit `agents.defaults.agentRuntime` when no per-model or per-provider override is set. Users who set `agents.defaults.agentRuntime.id = "claude-cli"` no longer need to redundantly configure subagent runtime separately.

## Security Impact (required)
- New permissions/capabilities? No
- This fix corrects runtime routing so that subagents use the intended authentication path (CLI OAuth) rather than falling back to direct API access. No new permissions or capabilities are introduced; the fix narrows behavior to match the user's configured intent.
