### PR TITLE
fix(agents): inherit agentRuntime from agent entry and agents.defaults

### DIFF
--- a/src/agents/harness/policy.ts
+++ b/src/agents/harness/policy.ts
@@ -11,7 +11,7 @@ import {
 
 export type AgentHarnessPolicy = {
   runtime: EmbeddedAgentRuntime;
-  runtimeSource?: "model" | "provider" | "implicit";
+  runtimeSource?: "agent" | "defaults" | "model" | "provider" | "implicit";
 };
 
 export function resolveAgentHarnessPolicy(params: {

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -369,7 +369,8 @@ describe("selectAgentHarness", () => {
     );
   });
 
-  it("ignores legacy agentRuntime as a runtime policy source", () => {
+  it("resolves agentRuntime from agents.defaults", () => {
+    registerSuccessfulCodexHarness();
     const config = {
       agents: {
         defaults: {
@@ -384,15 +385,15 @@ describe("selectAgentHarness", () => {
         modelId: "sonnet-4.6",
         config,
       }).id,
-    ).toBe("pi");
+    ).toBe("codex");
   });
 
-  it("ignores legacy agent CLI runtime aliases for OpenAI agent model runs", async () => {
+  it("resolves agentRuntime from agents.defaults for OpenAI agent model runs", async () => {
     registerSuccessfulCodexHarness();
     const config: OpenClawConfig = {
       agents: {
         defaults: {
-          agentRuntime: { id: "claude-cli" },
+          agentRuntime: { id: "codex" },
         },
       },
     };

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -6,7 +6,7 @@ import { normalizeAgentId } from "../routing/session-key.js";
 import { listAgentEntries, resolveSessionAgentIds } from "./agent-scope.js";
 import { normalizeProviderId } from "./provider-id.js";
 
-export type ModelRuntimePolicySource = "model" | "provider";
+export type ModelRuntimePolicySource = "agent" | "defaults" | "model" | "provider";
 
 export type ResolvedModelRuntimePolicy = {
   policy?: AgentRuntimePolicyConfig;
@@ -150,6 +150,24 @@ export function resolveModelRuntimePolicy(params: {
   if (agentModelPolicy.policy) {
     return agentModelPolicy;
   }
+
+  if (params.config) {
+    const { sessionAgentId } = resolveSessionAgentIds({
+      config: params.config,
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+    });
+    const agentEntry = listAgentEntries(params.config).find(
+      (entry) => normalizeAgentId(entry.id) === sessionAgentId,
+    );
+    if (hasRuntimePolicy(agentEntry?.agentRuntime)) {
+      return { policy: agentEntry.agentRuntime, source: "agent" };
+    }
+    if (hasRuntimePolicy(params.config.agents?.defaults?.agentRuntime)) {
+      return { policy: params.config.agents.defaults.agentRuntime, source: "defaults" };
+    }
+  }
+
   const providerConfig = resolveProviderConfig(params.config, params.provider);
   const modelConfig = resolveModelConfig({
     providerConfig,


### PR DESCRIPTION
## Summary

Subagents were ignoring the `agentRuntime` configuration set at `agents.defaults` or per-agent level, falling back to direct HTTP instead of the configured runtime (e.g., `claude-cli`).

This caused subagents to bypass the CLI runtime, hit the Extra Usage quota instead of the Max/Pro subscription, and trigger 24h auth lockout on billing errors.

## Changes

- Added checks for `agents.list[].agentRuntime` and `agents.defaults.agentRuntime` in `resolveModelRuntimePolicy()` before the provider-level fallback
- Updated type `ModelRuntimePolicySource` to include `"agent" | "defaults"` sources
- Updated tests to verify the new behavior instead of verifying legacy ignore behavior

## Resolution Chain

```
model-entry agentRuntime → agent-level agentRuntime → defaults agentRuntime → provider model config → provider config
```

## Testing

All affected tests pass:
- `src/agents/harness/selection.test.ts` — 38/38 ✅
- `src/agents/harness/` — 380/380 ✅
- `src/agents/subagent-spawn.test.ts` — 44/44 ✅

## Fix

Fixes #81395