### PR TITLE
fix(discord): migrate legacy channel allow before validation

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -2,6 +2,57 @@ import { describe, expect, it } from "vitest";
 import { validateConfigObject } from "./validation.js";
 
 describe("config schema regressions", () => {
+  it("accepts legacy Discord guild channel allow aliases during bundled validation", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          token: "test-token",
+          groupPolicy: "allowlist",
+          guilds: {
+            "111111111111111111": {
+              channels: {
+                "222222222222222222": {
+                  allow: false,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+          accounts: {
+            work: {
+              token: "account-token",
+              groupPolicy: "allowlist",
+              guilds: {
+                "333333333333333333": {
+                  channels: {
+                    "444444444444444444": {
+                      allow: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(
+      res.config.channels?.discord?.guilds?.["111111111111111111"]?.channels?.[
+        "222222222222222222"
+      ],
+    ).toMatchObject({ enabled: false, requireMention: false });
+    expect(
+      res.config.channels?.discord?.accounts?.work?.guilds?.["333333333333333333"]?.channels?.[
+        "444444444444444444"
+      ],
+    ).toMatchObject({ enabled: true });
+  });
+
   it("accepts session write-lock acquire timeout", () => {
     const res = validateConfigObject({
       session: {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -57,16 +57,105 @@ type AllowedValuesCollection = {
 };
 type JsonSchemaLike = Record<string, unknown>;
 
-function stripDeprecatedValidationKeys(raw: unknown): unknown {
-  if (!isRecord(raw) || !isRecord(raw.commands) || !Object.hasOwn(raw.commands, "modelsWrite")) {
+function migrateDiscordGuildChannelAllowAliasesInEntry(value: unknown): {
+  changed: boolean;
+  value: unknown;
+} {
+  const entry = isRecord(value) ? value : null;
+  const guilds = isRecord(entry?.guilds) ? entry.guilds : null;
+  if (!entry || !guilds) {
+    return { changed: false, value };
+  }
+
+  let guildsChanged = false;
+  const nextGuilds: Record<string, unknown> = { ...guilds };
+  for (const [guildId, guildValue] of Object.entries(guilds)) {
+    const guild = isRecord(guildValue) ? guildValue : null;
+    const channels = isRecord(guild?.channels) ? guild.channels : null;
+    if (!guild || !channels) {
+      continue;
+    }
+
+    let channelsChanged = false;
+    const nextChannels: Record<string, unknown> = { ...channels };
+    for (const [channelId, channelValue] of Object.entries(channels)) {
+      const channel = isRecord(channelValue) ? channelValue : null;
+      if (!channel || !Object.hasOwn(channel, "allow")) {
+        continue;
+      }
+      const nextChannel: Record<string, unknown> = { ...channel };
+      if (!Object.hasOwn(nextChannel, "enabled")) {
+        nextChannel.enabled = nextChannel.allow;
+      }
+      delete nextChannel.allow;
+      nextChannels[channelId] = nextChannel;
+      channelsChanged = true;
+    }
+
+    if (!channelsChanged) {
+      continue;
+    }
+    nextGuilds[guildId] = { ...guild, channels: nextChannels };
+    guildsChanged = true;
+  }
+
+  return guildsChanged
+    ? { changed: true, value: { ...entry, guilds: nextGuilds } }
+    : { changed: false, value };
+}
+
+function migrateDiscordGuildChannelAllowAliases(raw: unknown): unknown {
+  const root = isRecord(raw) ? raw : null;
+  const channels = isRecord(root?.channels) ? root.channels : null;
+  const discord = isRecord(channels?.discord) ? channels.discord : null;
+  if (!root || !channels || !discord) {
     return raw;
   }
-  const commands = { ...raw.commands };
-  delete commands.modelsWrite;
-  return {
-    ...raw,
-    commands,
+
+  const rootResult = migrateDiscordGuildChannelAllowAliasesInEntry(discord);
+  const accounts = isRecord(discord.accounts) ? discord.accounts : null;
+  let accountsChanged = false;
+  let nextAccounts: Record<string, unknown> | undefined;
+  if (accounts) {
+    nextAccounts = { ...accounts };
+    for (const [accountId, account] of Object.entries(accounts)) {
+      const result = migrateDiscordGuildChannelAllowAliasesInEntry(account);
+      if (!result.changed) {
+        continue;
+      }
+      nextAccounts[accountId] = result.value;
+      accountsChanged = true;
+    }
+  }
+
+  if (!rootResult.changed && !accountsChanged) {
+    return raw;
+  }
+
+  const nextDiscord = {
+    ...(rootResult.value as Record<string, unknown>),
+    ...(accountsChanged ? { accounts: nextAccounts } : {}),
   };
+  return {
+    ...root,
+    channels: {
+      ...channels,
+      discord: nextDiscord,
+    },
+  };
+}
+
+function stripDeprecatedValidationKeys(raw: unknown): unknown {
+  let next = raw;
+  if (isRecord(next) && isRecord(next.commands) && Object.hasOwn(next.commands, "modelsWrite")) {
+    const commands = { ...next.commands };
+    delete commands.modelsWrite;
+    next = {
+      ...next,
+      commands,
+    };
+  }
+  return migrateDiscordGuildChannelAllowAliases(next);
 }
 
 const CUSTOM_EXPECTED_ONE_OF_RE = /expected one of ((?:"[^"]+"(?:\|"?[^"]+"?)*)+)/i;


### PR DESCRIPTION
Fixes #81400.

## Summary
- Migrate legacy `channels.discord.guilds.*.channels.*.allow` aliases into canonical `enabled` before config validation.
- Covers both top-level Discord config and `channels.discord.accounts.*` configs.
- Adds a regression test for bundled-channel validation, where the startup-blocking rejection happened.

## Root Cause
`OpenClawSchema` is permissive for extension channel configs, but bundled-channel JSON-schema validation still checked raw Discord config before the legacy `allow -> enabled` alias was canonicalized. That made documented/legacy per-channel Discord configs fail with:

`channels.discord.guilds.<guild>.channels.<channel>: invalid config: must NOT have additional properties: "allow"`

## Audits
- Existing helper: Discord doctor already migrates this alias; this patch mirrors that compatibility at validation time so startup validation sees canonical config.
- Shared caller: `validateConfigObjectRaw` is the raw validation boundary used before materialization; canonicalizing here keeps `allow: false` safe by preserving it as `enabled: false` instead of dropping it.
- Rival scan: no open PR linked to #81400 or matching this exact validation failure.

## Real behavior proof
- **Behavior or issue addressed:** Discord startup/config validation rejected legacy per-channel guild config containing `channels.discord.guilds.*.channels.*.allow`, blocking configs that should migrate to canonical `enabled`.
- **Real environment tested:** Local OpenClaw checkout on Linux, Node/tsx through repo `pnpm exec`, using the real `validateConfigObject` config validation path with bundled-channel validation enabled by `sourceRaw`.
- **Exact steps or command run after this patch:**

```bash
pnpm exec tsx -e 'import { validateConfigObject } from "./src/config/validation.ts"; const cfg={channels:{discord:{token:"x",groupPolicy:"allowlist",guilds:{"111111111111111111":{channels:{"222222222222222222":{allow:false,requireMention:false}}}}}}}; const result=validateConfigObject(cfg,{sourceRaw:cfg}); console.log(JSON.stringify({ok: result.ok, issues: result.ok ? [] : result.issues.map((issue)=>({path: issue.path, message: issue.message})), channel: result.ok ? result.config.channels?.discord?.guilds?.["111111111111111111"]?.channels?.["222222222222222222"] : undefined}, null, 2));'
```

- **Evidence after fix:** Terminal output from the real validation command:

```json
{
  "ok": true,
  "issues": [],
  "channel": {
    "requireMention": false,
    "enabled": false
  }
}
```

- **Observed result after fix:** The legacy `allow:false` channel entry is accepted by config validation and materialized as `enabled:false`; no bundled-channel `additional properties: "allow"` error remains.
- **What was not tested:** Live Discord gateway login was not exercised because this is a startup config-validation migration and the reproduced failure is before gateway connection.

## Tests
- `pnpm test src/config/config.schema-regressions.test.ts`
- `pnpm check:test-types`
- `pnpm exec oxfmt --check --threads=1 src/config/validation.ts src/config/config.schema-regressions.test.ts`
- `git diff --check`
