### PR TITLE
[codex] fix update restart self-staleness messaging

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../../test-utils/env.js";
 import { VERSION } from "../../version.js";
 import {
   defaultRuntime,
@@ -111,6 +112,30 @@ describe("runServiceRestart config pre-flight (#35862)", () => {
     setConfigSnapshot({ exists: true, valid: true, lastTouchedVersion: "9999.1.1" });
 
     await expect(runServiceRestart(createServiceRunArgs())).rejects.toThrow("__exit__:1");
+
+    expect(service.restart).not.toHaveBeenCalled();
+    expectLatestRuntimeJson({
+      action: "restart",
+      ok: false,
+      error: `Gateway restart blocked: Refusing to restart the gateway service because this OpenClaw binary (${VERSION}) is older than the config last written by OpenClaw 9999.1.1.`,
+      hints: newerConfigHints,
+      hintItems: newerConfigHintItems,
+      warnings: undefined,
+    });
+  });
+
+  it("keeps blocking manual restart with update self-staleness env flags", async () => {
+    setConfigSnapshot({ exists: true, valid: true, lastTouchedVersion: "9999.1.1" });
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
+      },
+      async () => {
+        await expect(runServiceRestart(createServiceRunArgs())).rejects.toThrow("__exit__:1");
+      },
+    );
 
     expect(service.restart).not.toHaveBeenCalled();
     expectLatestRuntimeJson({

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -3232,6 +3232,70 @@ describe("update-cli", () => {
     ).toContain("- telegram: failed to load plugin dependency: ENOSPC");
   });
 
+  it.each(["npm", "pnpm", "bun"] as const)(
+    "marks %s restart health checks as update self-staleness",
+    async (mode) => {
+      const updatedRoot = createCaseDir("openclaw-updated-root");
+      const updatedEntrypoint = path.join(updatedRoot, "dist", "entry.js");
+      const futureConfigWarning =
+        "Your OpenClaw config was written by version 2026.5.12-beta.4, but this command is running 2026.5.12-beta.3.";
+      setupUpdatedRootRefresh({
+        entrypoints: [updatedEntrypoint],
+        gatewayUpdateImpl: async () =>
+          makeOkUpdateResult({
+            mode,
+            root: updatedRoot,
+            before: { version: "2026.5.12-beta.3" },
+            after: { version: "2026.5.12-beta.4" },
+          }),
+      });
+      serviceLoaded.mockResolvedValue(true);
+      probeGateway.mockImplementation(async (opts: { env?: NodeJS.ProcessEnv } = {}) => {
+        if (
+          opts.env?.OPENCLAW_UPDATE_IN_PROGRESS !== "1" ||
+          opts.env?.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE !== "1"
+        ) {
+          defaultRuntime.log(futureConfigWarning);
+        }
+        return {
+          ok: true,
+          close: null,
+          server: {
+            version: "2026.5.12-beta.4",
+            connId: "updated-gateway",
+          },
+          auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
+          health: null,
+          status: null,
+          presence: null,
+          configSnapshot: null,
+          connectLatencyMs: 1,
+          error: null,
+          url: "ws://127.0.0.1:18789",
+        };
+      });
+
+      await updateCommand({ yes: true });
+
+      expect(probeGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: expect.objectContaining({
+            OPENCLAW_UPDATE_IN_PROGRESS: "1",
+            OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
+          }),
+        }),
+      );
+      const output = [
+        ...vi.mocked(defaultRuntime.log).mock.calls,
+        ...vi.mocked(defaultRuntime.error).mock.calls,
+      ]
+        .map((call) => String(call[0]))
+        .join("\n");
+      expect(output).not.toContain(futureConfigWarning);
+      expect(output).not.toContain("older than the config last written by");
+    },
+  );
+
   it.each([
     {
       name: "updateCommand refreshes service env from updated install root when available",

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -734,6 +734,18 @@ function disableUpdatedPackageCompileCacheEnv(env: NodeJS.ProcessEnv): NodeJS.Pr
   };
 }
 
+function resolvePackageUpdateRestartHealthEnv(
+  env: NodeJS.ProcessEnv | undefined,
+): NodeJS.ProcessEnv {
+  return {
+    ...(env ?? process.env),
+    // Restart-health probes pass this env through gateway auth/config and service runtime reads.
+    // Mark only those checks as package-swap self-staleness; the actual restart command stays unmarked.
+    OPENCLAW_UPDATE_IN_PROGRESS: "1",
+    [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
+  };
+}
+
 function stripGatewayServiceMarkerEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const resolvedEnv = { ...env };
   delete resolvedEnv.OPENCLAW_SERVICE_MARKER;
@@ -1490,6 +1502,10 @@ async function maybeRestartService(params: {
   invocationCwd?: string;
 }): Promise<boolean> {
   const verifyRestartedGateway = async (expectedGatewayVersion: string | undefined) => {
+    const restartHealthEnv =
+      isPackageManagerUpdateMode(params.result.mode) && expectedGatewayVersion
+        ? resolvePackageUpdateRestartHealthEnv(params.serviceEnv)
+        : params.serviceEnv;
     const restartAfterStaleCleanup = async () => {
       if (params.refreshServiceEnv && isPackageManagerUpdateMode(params.result.mode)) {
         await runUpdatedInstallGatewayRestart({
@@ -1509,7 +1525,7 @@ async function maybeRestartService(params: {
       service,
       port: params.gatewayPort,
       expectedVersion: expectedGatewayVersion,
-      env: params.serviceEnv,
+      env: restartHealthEnv,
     });
     if (!health.healthy && health.staleGatewayPids.length > 0) {
       if (!params.opts.json) {
@@ -1525,7 +1541,7 @@ async function maybeRestartService(params: {
         service,
         port: params.gatewayPort,
         expectedVersion: expectedGatewayVersion,
-        env: params.serviceEnv,
+        env: restartHealthEnv,
       });
     }
 
@@ -1534,7 +1550,7 @@ async function maybeRestartService(params: {
       service,
       port: params.gatewayPort,
       expectedVersion: expectedGatewayVersion,
-      env: params.serviceEnv,
+      env: restartHealthEnv,
     });
     health = recoveryVerification.health;
     const launchAgentRecovery = recoveryVerification.launchAgentRecovery;
@@ -1627,7 +1643,7 @@ async function maybeRestartService(params: {
             service: resolveGatewayService(),
             port: params.gatewayPort,
             expectedVersion: expectedGatewayVersion,
-            env: params.serviceEnv,
+            env: resolvePackageUpdateRestartHealthEnv(params.serviceEnv),
             attempts: POST_REFRESH_ALREADY_HEALTHY_ATTEMPTS,
             delayMs: POST_REFRESH_ALREADY_HEALTHY_DELAY_MS,
           });


### PR DESCRIPTION
## Summary

- Problem: Package updates can succeed and restart onto the new gateway version while the still-running updater process reports a scary future-config warning from the old binary.
- Why it matters: Users can read the warning as a failed PATH or service mismatch even when the package swap and gateway health check are expected and healthy.
- What changed: Package-manager restart health probes now mark their config/auth/service-runtime reads as update self-staleness, including the post-refresh already-healthy probe and retry/recovery probes.
- What did NOT change (scope boundary): Manual gateway service operations from an actually old binary still hit the future-config guard; the actual restart command is not marked with the self-staleness env.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #81394
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Package-update restart messaging no longer emits the future-config warning during known updater self-staleness health checks.
- Real environment tested: Local OpenClaw PR container mounted to the isolated worktree on macOS.
- Exact steps or command run after this patch: `env OPENCLAW_REPO_DIR="/Users/bandaral-saud/Documents/New project/openclaw-update-restart-message" "/Users/bandaral-saud/Documents/New project/openclaw-dev-env/bin/openclaw-shell" env COREPACK_HOME=/home/node/.cache/corepack CI=true pnpm test src/cli/update-cli.test.ts src/cli/daemon-cli/lifecycle-core.config-guard.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `Test Files 2 passed (2)`, `Tests 102 passed (102)`, `[test] passed 1 Vitest shard in 26.85s`.
- Observed result after fix: Targeted restart-health tests pass, including npm/pnpm/bun package-update health probes with no future-config warning in captured output.
- What was not tested: A live beta package swap on a real installed gateway service was not rerun from this PR branch.
- Before evidence (optional but encouraged): The strengthened test failed before the final code adjustment because the post-refresh already-healthy probe still logged `Your OpenClaw config was written by version 2026.5.12-beta.4, but this command is running 2026.5.12-beta.3.`

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: During package updates, the parent updater can continue running the previous binary after the package swap while health probes read config/auth/service runtime state written by the updated install.
- Missing detection / guardrail: Restart-health verification did not consistently label those package-update probe reads as update self-staleness, especially the post-refresh already-healthy probe.
- Contributing context (if known): The existing future-config guard is correct for manual destructive service operations and needed to remain intact.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/update-cli.test.ts`, `src/cli/daemon-cli/lifecycle-core.config-guard.test.ts`
- Scenario the test should lock in: npm/pnpm/bun package-update restart health probes carry update self-staleness markers and captured output omits the future-config warning.
- Why this is the smallest reliable guardrail: The update CLI seam covers the parent updater restart path without requiring an actual global package swap.
- Existing test that already covers this (if any): Existing future-config guard tests covered manual restart blocking; this PR adds the missing update-path coverage.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Package-update restart output is less alarming in the known self-staleness path. Manual service operations from old binaries still show the blocking future-config guard.

## Diagram (if applicable)

```text
Before:
[package update] -> [new config written] -> [old parent health probe] -> [future-config warning]

After:
[package update] -> [new config written] -> [marked health probe] -> [clear restart output]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: OpenClaw PR container, Node 24 image, pnpm 11.1.0 via Corepack
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run the targeted update CLI and daemon lifecycle guard tests in the PR container.
2. Verify package-manager update restart-health probes carry update self-staleness env markers.
3. Verify manual gateway restart remains blocked by the future-config guard even with those update env flags set.

### Expected

- Targeted tests pass.
- Package-update restart health output omits the future-config warning in the known self-staleness path.
- Manual old-binary service restart remains blocked.

### Actual

- Targeted tests passed: 2 files, 102 tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `git diff --check`; targeted `pnpm test src/cli/update-cli.test.ts src/cli/daemon-cli/lifecycle-core.config-guard.test.ts` in the isolated worktree container.
- Edge cases checked: package-manager modes `npm`, `pnpm`, and `bun`; manual restart future-config guard with update self-staleness env flags.
- What you did **not** verify: A live installed-gateway package update run from this PR branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No public config/env changes; this uses existing internal update env markers for restart health probes.
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The self-staleness marker could accidentally hide a real manual old-binary service operation.
  - Mitigation: The marker is scoped to package-manager update health probes with an expected gateway version, and a daemon lifecycle guard test asserts manual restart remains blocked even when the env flags are set.
