### PR TITLE
feat(memory-core): scale default softThresholdTokens with model context window

### DIFF
--- a/extensions/memory-core/src/flush-plan.test.ts
+++ b/extensions/memory-core/src/flush-plan.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
+  DEFAULT_MEMORY_FLUSH_SOFT_TOKENS_MAX,
+  buildMemoryFlushPlan,
+  defaultMemoryFlushSoftThresholdTokens,
+} from "./flush-plan.js";
+
+describe("defaultMemoryFlushSoftThresholdTokens", () => {
+  it("returns the legacy floor when no context window is provided", () => {
+    expect(defaultMemoryFlushSoftThresholdTokens()).toBe(DEFAULT_MEMORY_FLUSH_SOFT_TOKENS);
+    expect(defaultMemoryFlushSoftThresholdTokens(undefined)).toBe(
+      DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
+    );
+  });
+
+  it("returns the legacy floor for invalid or non-positive windows", () => {
+    expect(defaultMemoryFlushSoftThresholdTokens(0)).toBe(DEFAULT_MEMORY_FLUSH_SOFT_TOKENS);
+    expect(defaultMemoryFlushSoftThresholdTokens(-1)).toBe(DEFAULT_MEMORY_FLUSH_SOFT_TOKENS);
+    expect(defaultMemoryFlushSoftThresholdTokens(Number.NaN)).toBe(
+      DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
+    );
+    expect(defaultMemoryFlushSoftThresholdTokens(Number.POSITIVE_INFINITY)).toBe(
+      DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
+    );
+  });
+
+  it("keeps the legacy floor for small windows where 70% would be smaller", () => {
+    // 4000 / 0.7 = 5714.28 → any window <= 5714 stays at the legacy floor.
+    expect(defaultMemoryFlushSoftThresholdTokens(4000)).toBe(DEFAULT_MEMORY_FLUSH_SOFT_TOKENS);
+    expect(defaultMemoryFlushSoftThresholdTokens(5000)).toBe(DEFAULT_MEMORY_FLUSH_SOFT_TOKENS);
+  });
+
+  it("scales with the window once 70% exceeds the legacy floor", () => {
+    expect(defaultMemoryFlushSoftThresholdTokens(10_000)).toBe(7_000);
+    expect(defaultMemoryFlushSoftThresholdTokens(200_000)).toBe(140_000);
+    expect(defaultMemoryFlushSoftThresholdTokens(500_000)).toBe(350_000);
+  });
+
+  it("caps at DEFAULT_MEMORY_FLUSH_SOFT_TOKENS_MAX for very large windows", () => {
+    // 1_000_000 * 0.7 = 700_000, still under the 900_000 cap.
+    expect(defaultMemoryFlushSoftThresholdTokens(1_000_000)).toBe(700_000);
+    // 2_000_000 * 0.7 = 1_400_000, capped.
+    expect(defaultMemoryFlushSoftThresholdTokens(2_000_000)).toBe(
+      DEFAULT_MEMORY_FLUSH_SOFT_TOKENS_MAX,
+    );
+    expect(defaultMemoryFlushSoftThresholdTokens(10_000_000)).toBe(
+      DEFAULT_MEMORY_FLUSH_SOFT_TOKENS_MAX,
+    );
+  });
+});
+
+describe("buildMemoryFlushPlan softThresholdTokens default", () => {
+  it("uses the legacy default when caller does not provide modelContextWindowTokens", () => {
+    const plan = buildMemoryFlushPlan({});
+    expect(plan).not.toBeNull();
+    expect(plan!.softThresholdTokens).toBe(DEFAULT_MEMORY_FLUSH_SOFT_TOKENS);
+  });
+
+  it("scales the default with modelContextWindowTokens when provided", () => {
+    const plan = buildMemoryFlushPlan({ modelContextWindowTokens: 200_000 });
+    expect(plan!.softThresholdTokens).toBe(140_000);
+  });
+
+  it("caps the scaled default at DEFAULT_MEMORY_FLUSH_SOFT_TOKENS_MAX", () => {
+    // 5_000_000 * 0.7 = 3_500_000 → capped at 900_000.
+    const plan = buildMemoryFlushPlan({ modelContextWindowTokens: 5_000_000 });
+    expect(plan!.softThresholdTokens).toBe(DEFAULT_MEMORY_FLUSH_SOFT_TOKENS_MAX);
+  });
+
+  it("still honors an explicit operator-set softThresholdTokens override", () => {
+    const plan = buildMemoryFlushPlan({
+      modelContextWindowTokens: 1_000_000,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: {
+                softThresholdTokens: 12_345,
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(plan!.softThresholdTokens).toBe(12_345);
+  });
+
+  it("returns null when memory flush is explicitly disabled regardless of window", () => {
+    const plan = buildMemoryFlushPlan({
+      modelContextWindowTokens: 1_000_000,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: {
+                enabled: false,
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(plan).toBeNull();
+  });
+});

--- a/extensions/memory-core/src/flush-plan.ts
+++ b/extensions/memory-core/src/flush-plan.ts
@@ -8,7 +8,45 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 
 export const DEFAULT_MEMORY_FLUSH_SOFT_TOKENS = 4000;
+export const DEFAULT_MEMORY_FLUSH_SOFT_TOKENS_MAX = 900_000;
 export const DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Default `softThresholdTokens` headroom buffer used when the operator did
+ * not pick a value in `agents.defaults.compaction.memoryFlush.softThresholdTokens`.
+ *
+ * History: prior to v2026.5.x this was a hard-coded 4000 regardless of model
+ * context window. On 1M-token models that left the flush trigger at ~99.6% of
+ * the window, so a bot with a long-lived session would skip pre-compaction
+ * flushes and arrive at the auto-compaction boundary with nothing persisted —
+ * producing the "bot turns slow over days" symptom (a fully resident, near-full
+ * prompt). Workspace operators had to manually set `softThresholdTokens` to a
+ * very large number (e.g. 900_000) to force eager pre-compaction flushing.
+ *
+ * The window-aware default keeps the legacy 4000 floor for small models and
+ * grows the buffer with the window, capped at 900_000 to stay within the
+ * upper bound operators already use as a manual override.
+ *
+ * Callers that cannot resolve the model context window (e.g. control-plane
+ * tooling building a plan for documentation purposes) should omit the param;
+ * we'll keep the legacy 4000 default in that path.
+ */
+export function defaultMemoryFlushSoftThresholdTokens(
+  modelContextWindowTokens?: number,
+): number {
+  if (
+    typeof modelContextWindowTokens !== "number" ||
+    !Number.isFinite(modelContextWindowTokens) ||
+    modelContextWindowTokens <= 0
+  ) {
+    return DEFAULT_MEMORY_FLUSH_SOFT_TOKENS;
+  }
+  const auto = Math.floor(modelContextWindowTokens * 0.7);
+  if (auto <= DEFAULT_MEMORY_FLUSH_SOFT_TOKENS) {
+    return DEFAULT_MEMORY_FLUSH_SOFT_TOKENS;
+  }
+  return Math.min(auto, DEFAULT_MEMORY_FLUSH_SOFT_TOKENS_MAX);
+}
 
 const MEMORY_FLUSH_TARGET_HINT =
   "Store durable memories only in memory/YYYY-MM-DD.md (create memory/ if needed).";
@@ -96,6 +134,16 @@ export function buildMemoryFlushPlan(
   params: {
     cfg?: OpenClawConfig;
     nowMs?: number;
+    /**
+     * Resolved model context window in tokens for the caller's run. Optional;
+     * when present we scale the default `softThresholdTokens` to keep the flush
+     * trigger at a sensible buffer below the window for large-window models.
+     * See {@link defaultMemoryFlushSoftThresholdTokens}.
+     *
+     * Always honored as an *override hint*: an explicit operator-set
+     * `agents.defaults.compaction.memoryFlush.softThresholdTokens` still wins.
+     */
+    modelContextWindowTokens?: number;
   } = {},
 ): MemoryFlushPlan | null {
   const resolved = params;
@@ -107,7 +155,8 @@ export function buildMemoryFlushPlan(
   }
 
   const softThresholdTokens =
-    normalizeNonNegativeInt(defaults?.softThresholdTokens) ?? DEFAULT_MEMORY_FLUSH_SOFT_TOKENS;
+    normalizeNonNegativeInt(defaults?.softThresholdTokens) ??
+    defaultMemoryFlushSoftThresholdTokens(resolved.modelContextWindowTokens);
   const forceFlushTranscriptBytes =
     parseNonNegativeByteSize(defaults?.forceFlushTranscriptBytes) ??
     DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES;

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -518,7 +518,10 @@ export async function runPreflightCompactionIfNeeded(params: {
     modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
   });
-  const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
+  const memoryFlushPlan = resolveMemoryFlushPlan({
+    cfg: params.cfg,
+    modelContextWindowTokens: contextWindowTokens,
+  });
   const reserveTokensFloor =
     memoryFlushPlan?.reserveTokensFloor ??
     params.cfg.agents?.defaults?.compaction?.reserveTokensFloor ??
@@ -722,7 +725,19 @@ export async function runMemoryFlushIfNeeded(params: {
   replyOperation: ReplyOperation;
   onVisibleErrorPayloads?: (payloads: ReplyPayload[]) => void;
 }): Promise<SessionEntry | undefined> {
-  const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
+  // Resolve the model context window first so we can plumb it into the
+  // memory-flush plan resolver; window-aware defaults (notably
+  // `softThresholdTokens`) need it.
+  const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
+    cfg: params.cfg,
+    provider: params.followupRun.run.provider,
+    modelId: params.followupRun.run.model ?? params.defaultModel,
+    agentCfgContextTokens: params.agentCfgContextTokens,
+  });
+  const memoryFlushPlan = resolveMemoryFlushPlan({
+    cfg: params.cfg,
+    modelContextWindowTokens: contextWindowTokens,
+  });
   if (!memoryFlushPlan) {
     return params.sessionEntry;
   }
@@ -747,12 +762,6 @@ export async function runMemoryFlushIfNeeded(params: {
   let entry =
     params.sessionEntry ??
     (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
-  const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
-    cfg: params.cfg,
-    provider: params.followupRun.run.provider,
-    modelId: params.followupRun.run.model ?? params.defaultModel,
-    agentCfgContextTokens: params.agentCfgContextTokens,
-  });
 
   const promptTokenEstimate = estimatePromptTokensForMemoryFlush(
     params.promptForEstimate ?? params.followupRun.prompt,
@@ -930,6 +939,7 @@ export async function runMemoryFlushIfNeeded(params: {
     resolveMemoryFlushPlan({
       cfg: params.cfg,
       nowMs: memoryFlushNowMs,
+      modelContextWindowTokens: contextWindowTokens,
     }) ?? memoryFlushPlan;
   const memoryFlushWritePath = activeMemoryFlushPlan.relativePath;
   const flushSystemPrompt = [

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -77,6 +77,13 @@ export type MemoryFlushPlan = {
 export type MemoryFlushPlanResolver = (params: {
   cfg?: OpenClawConfig;
   nowMs?: number;
+  /**
+   * Resolved model context window in tokens for the caller's run, when
+   * available. Passed through to plan resolvers so they can scale defaults
+   * (notably `softThresholdTokens`) for large-window models. Optional —
+   * resolvers that do not need it (control-plane / docs) may ignore it.
+   */
+  modelContextWindowTokens?: number;
 }) => MemoryFlushPlan | null;
 
 export type RegisteredMemorySearchManager = MemorySearchManager;
@@ -256,6 +263,7 @@ export function registerMemoryFlushPlanResolverForPlugin(
 export function resolveMemoryFlushPlan(params: {
   cfg?: OpenClawConfig;
   nowMs?: number;
+  modelContextWindowTokens?: number;
 }): MemoryFlushPlan | null {
   return memoryPluginState.capability?.capability.flushPlanResolver?.(params) ?? null;
 }


### PR DESCRIPTION
## Summary

Replaces the hard-coded `DEFAULT_MEMORY_FLUSH_SOFT_TOKENS = 4000` default in `extensions/memory-core/src/flush-plan.ts` with a window-aware helper `defaultMemoryFlushSoftThresholdTokens(window)` that returns `min(floor(window * 0.7), 900_000)`, falling back to the legacy `4000` when the window is unknown or small.

## Why

On 1M-token models the legacy 4000 default left the pre-compaction flush trigger at ~99.6% of the context window, so long-lived sessions skipped the pre-compaction flush entirely and arrived at auto-compaction with nothing persisted -- the *"bot turns slow after a few days"* symptom (a fully resident, near-full prompt). Operators were already manually setting `agents.defaults.compaction.memoryFlush.softThresholdTokens` to `900_000` to work around it; this PR makes that the implicit default for big-window models while leaving small-window operators untouched.

Reference math (using `threshold = contextWindow - reserveTokensFloor - softThresholdTokens` from `src/auto-reply/reply/memory-flush.ts`, with the default 20k reserve floor):

| Context window | Old softThreshold | Old flush trigger | New softThreshold | New flush trigger |
|---|---|---|---|---|
| 8k | 4000 | ~50% | 4000 (legacy floor preserved) | ~50% |
| 200k | 4000 | ~98.8% | 140000 | ~20% |
| 1M | 4000 | ~99.6% | 700000 | ~28% |
| 2M | 4000 | ~99.8% | 900000 (cap) | ~54% |

## Plumbing

- `MemoryFlushPlanResolver` (`src/plugins/memory-state.ts:77`) gains an optional `modelContextWindowTokens` parameter -- additive, backward-compatible. Third-party resolver implementations that ignore the param keep working.
- `agent-runner-memory.ts` already resolves the context-window tokens via `resolveMemoryFlushContextWindowTokens()` in both flush call sites; this PR plumbs that value through to `resolveMemoryFlushPlan({...})` and the follow-up `activeMemoryFlushPlan` re-resolve.
- The `defaultMemoryFlushSoftThresholdTokens()` helper is exported so third-party plugins can match the upstream policy if they replace the resolver.
- Explicit operator-set `agents.defaults.compaction.memoryFlush.softThresholdTokens` values still win unchanged.

## Test plan

- [x] `pnpm test extensions/memory-core/src/flush-plan.test.ts` -- 10/10 pass (new tests cover the helper at boundary conditions plus the resolver wiring)
- [x] `pnpm test src/auto-reply/reply/reply-state.test.ts` -- 37/37 pass (existing memory-flush context-window tests still green)
- [x] `pnpm tsgo` -- clean (resolver signature change typechecks across all callers)

## Notes

- Cap chosen at 900_000 because that is the upper bound house operators were already using as a manual override. Easy to raise later if frontier models ship even larger windows.
- The legacy `DEFAULT_MEMORY_FLUSH_SOFT_TOKENS = 4000` constant is retained as the fallback for callers that cannot resolve a window (control-plane tooling, doc generation, etc.) so the previously documented constant value is preserved.