### PR TITLE
fix(mcp): parent-PID watchdog to prevent orphan channel-server workers

### DIFF
--- a/src/mcp/channel-server.parent-watchdog.test.ts
+++ b/src/mcp/channel-server.parent-watchdog.test.ts
@@ -1,0 +1,100 @@
+import { spawn } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  MCP_PARENT_GONE_GRACE_MS,
+  MCP_PARENT_WATCHDOG_INTERVAL_MS,
+} from "./channel-server.js";
+
+// Re-export probe under test through a local copy — kept identical to the
+// implementation in channel-server.ts so this test does not require deep
+// internals access (the function is not exported, but its behavior is the
+// canonical contract for the watchdog and is covered here against a spawned
+// real child process to lock in the cross-platform semantics).
+function parentProcessIsAliveProbe(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EPERM") return true;
+    return false;
+  }
+}
+
+describe("MCP channel-server parent watchdog contract", () => {
+  test("constants are tuned for fast orphan reaping without thrash", () => {
+    // If you change these, also update the matching comments in
+    // src/mcp/channel-server.ts so operators reading the source agree with
+    // the runtime behavior.
+    expect(MCP_PARENT_WATCHDOG_INTERVAL_MS).toBeGreaterThan(1_000);
+    expect(MCP_PARENT_WATCHDOG_INTERVAL_MS).toBeLessThanOrEqual(10_000);
+    expect(MCP_PARENT_GONE_GRACE_MS).toBeGreaterThan(0);
+    expect(MCP_PARENT_GONE_GRACE_MS).toBeLessThan(MCP_PARENT_WATCHDOG_INTERVAL_MS);
+  });
+
+  test("liveness probe returns true for the running process", () => {
+    expect(parentProcessIsAliveProbe(process.pid)).toBe(true);
+  });
+
+  test("liveness probe returns false for a pid that has exited", async () => {
+    // Spawn a no-op child that exits immediately, then probe its dead pid.
+    // We do this against a *real* spawned process so the test exercises the
+    // same `process.kill(pid, 0)` path the watchdog uses, on whatever OS
+    // the suite is currently running on.
+    const child = spawn(process.execPath, ["-e", "process.exit(0)"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    const deadPid = child.pid!;
+    await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    // Give the OS a moment to release the pid table entry. Windows can keep
+    // a "zombie" handle around for a short window — `process.kill(pid, 0)`
+    // can still return alive for a tick or two on Windows specifically. Poll
+    // until the OS agrees the pid is gone, up to a 5s budget.
+    const deadline = Date.now() + 5_000;
+    let alive = parentProcessIsAliveProbe(deadPid);
+    while (alive && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      alive = parentProcessIsAliveProbe(deadPid);
+    }
+    expect(alive).toBe(false);
+  });
+
+  test("liveness probe returns false for a clearly invalid pid", () => {
+    // PID 0 is reserved on POSIX and process.kill treats it as a process-group
+    // signal. We special-case ppid > 1 in production code, so this test just
+    // confirms the probe returns false for a non-existent high pid.
+    expect(parentProcessIsAliveProbe(2 ** 30)).toBe(false);
+  });
+});
+
+describe("MCP channel-server parent watchdog scheduling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("a setInterval at MCP_PARENT_WATCHDOG_INTERVAL_MS fires only after the interval", () => {
+    let ticks = 0;
+    const handle = setInterval(() => {
+      ticks++;
+    }, MCP_PARENT_WATCHDOG_INTERVAL_MS);
+    try {
+      vi.advanceTimersByTime(MCP_PARENT_WATCHDOG_INTERVAL_MS - 1);
+      expect(ticks).toBe(0);
+      vi.advanceTimersByTime(2);
+      expect(ticks).toBe(1);
+      vi.advanceTimersByTime(MCP_PARENT_WATCHDOG_INTERVAL_MS);
+      expect(ticks).toBe(2);
+    } finally {
+      clearInterval(handle);
+    }
+  });
+
+  test("force-exit grace window is shorter than the polling interval", () => {
+    expect(MCP_PARENT_GONE_GRACE_MS).toBeLessThan(MCP_PARENT_WATCHDOG_INTERVAL_MS);
+  });
+});

--- a/src/mcp/channel-server.ts
+++ b/src/mcp/channel-server.ts
@@ -70,6 +70,47 @@ export async function createOpenClawChannelMcpServer(opts: OpenClawMcpServeOptio
   };
 }
 
+/**
+ * How often to poll the parent process for liveness while the MCP child is
+ * serving STDIO. Picked so a hung child closes within a few seconds of an
+ * abrupt parent kill (e.g. `taskkill /F` on Windows or `kill -9` on POSIX),
+ * but loose enough that healthy parents do not generate measurable load.
+ *
+ * Exported for tests; not part of the public API.
+ */
+export const MCP_PARENT_WATCHDOG_INTERVAL_MS = 5_000;
+
+/**
+ * How long after detecting that the parent is gone we wait for a clean
+ * `close()` before force-exiting. Force-exit is the failure case for the
+ * MCP orphan-worker class: the parent (gateway) is gone, the child's STDIO
+ * pipe is wedged, and no SIGTERM is coming -- but the child still holds an
+ * MCP protocol handshake in memory and will lose to the freshly-restarted
+ * gateway on the next `openclaw mcp serve` connect.
+ *
+ * Exported for tests; not part of the public API.
+ */
+export const MCP_PARENT_GONE_GRACE_MS = 2_000;
+
+function parentProcessIsAlive(parentPid: number): boolean {
+  // `process.kill(pid, 0)` is a probe: it throws when the target does not
+  // exist (or we lack permission). Cross-platform on Windows + POSIX.
+  // Treat any thrown error other than EPERM as "gone" -- EPERM is the rare
+  // case where a different uid owns a still-live pid; we should not kill
+  // ourselves in that case.
+  try {
+    process.kill(parentPid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EPERM") {
+      // Permission denied but pid exists. Parent still alive from our POV.
+      return true;
+    }
+    return false;
+  }
+}
+
 export async function serveOpenClawChannelMcp(opts: OpenClawMcpServeOptions = {}): Promise<void> {
   const { server, start, close } = await createOpenClawChannelMcpServer(opts);
   const transport = new StdioServerTransport();
@@ -90,8 +131,39 @@ export async function serveOpenClawChannelMcp(opts: OpenClawMcpServeOptions = {}
     process.off("SIGINT", shutdown);
     process.off("SIGTERM", shutdown);
     transport["onclose"] = undefined;
+    if (parentWatchdog !== undefined) {
+      clearInterval(parentWatchdog);
+      parentWatchdog = undefined;
+    }
     close().then(resolveClosed, resolveClosed);
   };
+
+  // Parent-PID watchdog: when the gateway (parent) is killed abruptly --
+  // SIGKILL on POSIX, `taskkill /F` on Windows, OOM-killer, etc. -- our
+  // STDIO pipe is left in a state where no `end`/`close` event ever fires
+  // and the MCP server stays running. Across an `openclaw` npm upgrade that
+  // stale child holds the previous protocol version in memory and the next
+  // gateway boot loses the handshake (the "protocol mismatch after upgrade"
+  // class of bug). Poll the parent PID and exit cleanly when it disappears,
+  // force-exiting after a short grace window if a clean close stalls.
+  const parentPid = typeof process.ppid === "number" && process.ppid > 1 ? process.ppid : 0;
+  let parentWatchdog: ReturnType<typeof setInterval> | undefined;
+  if (parentPid > 0) {
+    parentWatchdog = setInterval(() => {
+      if (shuttingDown) return;
+      if (parentProcessIsAlive(parentPid)) return;
+      // Parent is gone. Begin shutdown immediately; if a clean close stalls
+      // (closing the channel bridge needs network IO that may also be wedged),
+      // force-exit after the grace window so we cannot become an orphan.
+      shutdown();
+      setTimeout(() => {
+        // eslint-disable-next-line no-process-exit -- deliberate force-exit
+        process.exit(0);
+      }, MCP_PARENT_GONE_GRACE_MS).unref();
+    }, MCP_PARENT_WATCHDOG_INTERVAL_MS);
+    // Do not keep the event loop alive solely for this timer.
+    parentWatchdog.unref?.();
+  }
 
   transport["onclose"] = shutdown;
   process.stdin.once("end", shutdown);


### PR DESCRIPTION
## Summary

Adds a parent-PID watchdog inside `serveOpenClawChannelMcp` (`src/mcp/channel-server.ts:73`) so an MCP STDIO child cleanly exits when its gateway parent dies abruptly. Cross-platform (Windows + POSIX) via `process.kill(parentPid, 0)`.

## Why

When the gateway parent dies abruptly (`SIGKILL` on POSIX, `taskkill /F` on Windows, OOM-killer) the STDIO pipe to the `openclaw mcp serve` child is left in a state where neither `end` nor `close` ever fires on `process.stdin` and no `SIGTERM` is delivered. The child stays running in memory, still holding the previous MCP protocol revision.

Across an `openclaw` npm upgrade this is the canonical *"protocol mismatch after upgrade"* failure mode: the stale worker loses the handshake on the next gateway boot, and the operator sees a gateway that refuses to start until the orphan is manually killed.

The current workaround in many operator stacks is a periodic "sweep MCP children whose gateway PID is gone" job — but that runs after the damage is done. The right place to enforce parent liveness is in the child itself.

## How

- Poll `process.kill(ppid, 0)` every `MCP_PARENT_WATCHDOG_INTERVAL_MS` (5s, exported for tests). The probe is cross-platform — Node accepts it on both Windows and POSIX, with `ESRCH`/`EPERM` semantics matching the underlying OS.
- `EPERM` is treated as *still alive* (the rare case where a different uid holds the pid) so we never false-positive into a self-kill.
- When the parent is gone: start the clean shutdown path and arm a `MCP_PARENT_GONE_GRACE_MS` (2s) force-exit timer so a wedged `close()` (e.g. when the channel bridge needs network IO that is also stuck) cannot keep the child alive past the orphan window.
- Interval is `.unref()`'d so it does not by itself extend the event loop.
- Skipped when `process.ppid <= 1` (init / orphan situations / detached child) so we do not policy-kill ourselves in degenerate setups.

## Test plan

- [x] `pnpm test src/mcp/channel-server.parent-watchdog.test.ts` — 6/6 pass (probe semantics against a real spawned-and-exited child PID, plus constant-bounds and timer-scheduling sanity)
- [x] `pnpm test src/mcp/channel-server.test.ts src/mcp/channel-server.shutdown-unhandled-rejection.test.ts` — 11/11 pass (no regression on existing channel-server / shutdown paths)
- [x] `pnpm tsgo` — clean

The probe test deliberately spawns a real Node subprocess and waits for its exit, then polls until the OS releases the PID handle (with a 5s budget) — this catches a Windows-specific quirk where `process.kill(pid, 0)` can briefly still report alive for a few hundred ms after the child exits.

## Notes

- Constants `MCP_PARENT_WATCHDOG_INTERVAL_MS` and `MCP_PARENT_GONE_GRACE_MS` are exported for test access and tuned together: the grace window is intentionally a fraction of the poll interval so a parent flap cannot stack two force-exits.
- This is additive — no callers need to change.