### PR TITLE
fix(update): surface plugin channel fallbacks

### DIFF
--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -223,7 +223,11 @@ export function estimateRenderedLlmBoundaryTokenPressure(params: {
   return Math.max(0, Math.ceil((systemTokens + promptTokens) * SAFETY_MARGIN));
 }
 
-/** Backward-compatible alias for callers that still name this a pre-prompt estimate. */
+/**
+ * Backward-compatible alias for callers that still name this a pre-prompt estimate.
+ *
+ * @deprecated Use estimateLlmBoundaryTokenPressure.
+ */
 export function estimatePrePromptTokens(params: {
   messages: AgentMessage[];
   systemPrompt?: string;

--- a/src/cli/plugins-update-outcomes.ts
+++ b/src/cli/plugins-update-outcomes.ts
@@ -4,6 +4,9 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 type PluginUpdateCliOutcome = {
   status: string;
   message: string;
+  channelFallback?: {
+    message: string;
+  };
 };
 
 /** Log update outcomes with severity styling and report whether any errors occurred. */
@@ -16,13 +19,22 @@ export function logPluginUpdateOutcomes(params: {
     if (outcome.status === "error") {
       hasErrors = true;
       params.log(theme.error(outcome.message));
+      if (outcome.channelFallback) {
+        params.log(theme.warn(outcome.channelFallback.message));
+      }
       continue;
     }
     if (outcome.status === "skipped") {
       params.log(theme.warn(outcome.message));
+      if (outcome.channelFallback) {
+        params.log(theme.warn(outcome.channelFallback.message));
+      }
       continue;
     }
     params.log(outcome.message);
+    if (outcome.channelFallback) {
+      params.log(theme.warn(outcome.channelFallback.message));
+    }
   }
   return { hasErrors };
 }

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1580,6 +1580,49 @@ describe("update-cli", () => {
     expect(npmPluginUpdateCall()?.timeoutMs).toBe(1_800_000);
   });
 
+  it("prints plugin channel fallbacks near the post-core plugin summary", async () => {
+    updateNpmInstalledPlugins.mockResolvedValueOnce({
+      changed: false,
+      config: baseConfig,
+      outcomes: [
+        {
+          pluginId: "lossless-claw",
+          status: "updated",
+          message: "Updated lossless-claw: 1.0.0 -> 1.0.1.",
+          channelFallback: {
+            requestedSpec: "lossless-claw@beta",
+            usedSpec: "lossless-claw",
+            requestedLabel: "@beta",
+            usedLabel: "@latest",
+            reason: "unavailable",
+            message:
+              "plugin channel fallback: lossless-claw used @latest because @beta was unavailable",
+          },
+        },
+      ],
+    });
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "beta",
+      },
+      async () => {
+        await updateCommand({ restart: false });
+      },
+    );
+
+    const logs = vi.mocked(runtimeCapture.log).mock.calls.map((call) => String(call[0]));
+    expect(logs.some((line) => line.includes("npm plugins: 1 updated, 0 unchanged."))).toBe(true);
+    expect(
+      logs.some((line) =>
+        line.includes(
+          "plugin channel fallback: lossless-claw used @latest because @beta was unavailable",
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it("uses a fail-closed integrity policy for post-core plugin updates", async () => {
     await withEnvAsync(
       {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -560,6 +560,20 @@ function createGuidedPostUpdatePluginOutcome(outcome: PluginUpdateOutcome): {
   };
 }
 
+function collectPluginChannelFallbackMessages(outcomes: readonly PluginUpdateOutcome[]): string[] {
+  const seen = new Set<string>();
+  const messages: string[] = [];
+  for (const outcome of outcomes) {
+    const message = outcome.channelFallback?.message;
+    if (!message || seen.has(message)) {
+      continue;
+    }
+    seen.add(message);
+    messages.push(message);
+  }
+  return messages;
+}
+
 function isDisabledAfterFailureOutcome(outcome: PluginUpdateOutcome): boolean {
   return outcome.status === "skipped" && outcome.message.includes("after plugin update failure");
 }
@@ -1921,6 +1935,10 @@ export async function updatePluginsAfterCoreUpdate(params: {
       parts.push(`${skipped} skipped`);
     }
     defaultRuntime.log(theme.muted(`npm plugins: ${parts.join(", ")}.`));
+  }
+
+  for (const message of collectPluginChannelFallbackMessages(pluginUpdateOutcomes)) {
+    defaultRuntime.log(theme.warn(message));
   }
 
   for (const outcome of pluginUpdateOutcomes) {

--- a/src/infra/channel-runtime-context.ts
+++ b/src/infra/channel-runtime-context.ts
@@ -49,8 +49,8 @@ export function registerChannelRuntimeContext(
   });
 }
 
-// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Runtime context values are caller-typed by key.
 /** Reads a channel-scoped runtime context from the current runtime registry. */
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Runtime context values are caller-typed by key.
 export function getChannelRuntimeContext<T = unknown>(
   params: ChannelRuntimeContextKey & {
     channelRuntime?: ChannelRuntimeSurface;

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -129,7 +129,11 @@ export function resolveHomeRelativePath(
   return path.resolve(trimmed);
 }
 
-/** Backward-compatible alias for resolving user paths against the effective home. */
+/**
+ * Backward-compatible alias for resolving user paths against the effective home.
+ *
+ * @deprecated Use resolveHomeRelativePath.
+ */
 export function resolveUserPath(
   input: string,
   env: NodeJS.ProcessEnv = process.env,

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -86,6 +86,14 @@ export type UpdateRunResult = {
           message: string;
           currentVersion?: string;
           nextVersion?: string;
+          channelFallback?: {
+            requestedSpec: string;
+            usedSpec: string;
+            requestedLabel: string;
+            usedLabel: string;
+            reason: "unavailable" | "failed";
+            message: string;
+          };
         }>;
       };
       integrityDrifts: Array<{

--- a/src/media/audio.ts
+++ b/src/media/audio.ts
@@ -35,7 +35,11 @@ export function isVoiceMessageCompatibleAudio(opts: {
   return VOICE_MESSAGE_AUDIO_EXTENSIONS.has(ext);
 }
 
-/** Backward-compatible alias for voice-message audio compatibility checks. */
+/**
+ * Backward-compatible alias for voice-message audio compatibility checks.
+ *
+ * @deprecated Use isVoiceMessageCompatibleAudio.
+ */
 export function isVoiceCompatibleAudio(opts: {
   contentType?: string | null;
   fileName?: string | null;

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2188,6 +2188,15 @@ describe("updateNpmInstalledPlugins", () => {
     expect(result.outcomes[0]?.message).toBe(
       "Updated openclaw-codex-app-server: unknown -> 0.2.6. (warning: beta channel fallback used openclaw-codex-app-server because openclaw-codex-app-server@beta could not be used).",
     );
+    expect(result.outcomes[0]?.channelFallback).toEqual({
+      requestedSpec: "openclaw-codex-app-server@beta",
+      usedSpec: "openclaw-codex-app-server",
+      requestedLabel: "@beta",
+      usedLabel: "@latest",
+      reason: "unavailable",
+      message:
+        "plugin channel fallback: openclaw-codex-app-server used @latest because @beta was unavailable",
+    });
   });
 
   it("falls back to the default npm spec when the beta package exists but is invalid", async () => {
@@ -2233,6 +2242,12 @@ describe("updateNpmInstalledPlugins", () => {
     expect(result.outcomes[0]?.message).toBe(
       "Updated openclaw-codex-app-server: unknown -> 0.2.6. (warning: beta channel fallback used openclaw-codex-app-server because openclaw-codex-app-server@beta could not be used).",
     );
+    expect(result.outcomes[0]?.channelFallback).toMatchObject({
+      requestedLabel: "@beta",
+      usedLabel: "@latest",
+      reason: "failed",
+      message: "plugin channel fallback: openclaw-codex-app-server used @latest after @beta failed",
+    });
   });
 
   it("reports the fallback npm spec when beta fallback also fails", async () => {

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2199,6 +2199,43 @@ describe("updateNpmInstalledPlugins", () => {
     });
   });
 
+  it("reports npm beta fallback as tentative during dry-run checks", async () => {
+    installPluginFromNpmSpecMock
+      .mockResolvedValueOnce({
+        ok: false,
+        error:
+          "npm ERR! code ETARGET\nnpm ERR! No matching version found for openclaw-codex-app-server@beta.",
+      })
+      .mockResolvedValueOnce(
+        createSuccessfulNpmUpdateResult({
+          pluginId: "openclaw-codex-app-server",
+          targetDir: "/tmp/openclaw-codex-app-server",
+          version: "0.2.6",
+          npmResolution: {
+            name: "openclaw-codex-app-server",
+            version: "0.2.6",
+            resolvedSpec: "openclaw-codex-app-server@0.2.6",
+          },
+        }),
+      );
+
+    const result = await updateNpmInstalledPlugins({
+      config: createCodexAppServerInstallConfig({
+        spec: "openclaw-codex-app-server",
+      }),
+      pluginIds: ["openclaw-codex-app-server"],
+      updateChannel: "beta",
+      dryRun: true,
+    });
+
+    expect(result.outcomes[0]?.message).toBe(
+      "Would update openclaw-codex-app-server: unknown -> 0.2.6. (warning: beta channel fallback would use openclaw-codex-app-server because openclaw-codex-app-server@beta could not be used).",
+    );
+    expect(result.outcomes[0]?.channelFallback?.message).toBe(
+      "plugin channel fallback: openclaw-codex-app-server would use @latest because @beta was unavailable",
+    );
+  });
+
   it("falls back to the default npm spec when the beta package exists but is invalid", async () => {
     installPluginFromNpmSpecMock
       .mockResolvedValueOnce({

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2314,6 +2314,55 @@ describe("updateNpmInstalledPlugins", () => {
         status: "error",
         message:
           "Failed to update openclaw-codex-app-server: npm package not found for openclaw-codex-app-server.",
+        channelFallback: {
+          requestedSpec: "openclaw-codex-app-server@beta",
+          usedSpec: "openclaw-codex-app-server",
+          requestedLabel: "@beta",
+          usedLabel: "@latest",
+          reason: "failed",
+          message:
+            "plugin channel fallback: openclaw-codex-app-server used @latest after @beta failed",
+        },
+      },
+    ]);
+  });
+
+  it("keeps fallback metadata when a dry-run beta fallback also fails", async () => {
+    installPluginFromNpmSpecMock
+      .mockResolvedValueOnce({
+        ok: false,
+        error: "Installed plugin package uses a TypeScript entry without compiled runtime output.",
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        code: "npm_package_not_found",
+        error: "npm package not found",
+      });
+
+    const result = await updateNpmInstalledPlugins({
+      config: createCodexAppServerInstallConfig({
+        spec: "openclaw-codex-app-server",
+      }),
+      pluginIds: ["openclaw-codex-app-server"],
+      updateChannel: "beta",
+      dryRun: true,
+    });
+
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "openclaw-codex-app-server",
+        status: "error",
+        message:
+          "Failed to check openclaw-codex-app-server: npm package not found for openclaw-codex-app-server.",
+        channelFallback: {
+          requestedSpec: "openclaw-codex-app-server@beta",
+          usedSpec: "openclaw-codex-app-server",
+          requestedLabel: "@beta",
+          usedLabel: "@latest",
+          reason: "failed",
+          message:
+            "plugin channel fallback: openclaw-codex-app-server would use @latest after @beta failed",
+        },
       },
     ]);
   });

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -68,12 +68,22 @@ export type PluginUpdateLogger = {
 
 export type PluginUpdateStatus = "updated" | "unchanged" | "skipped" | "error";
 
+export type PluginUpdateChannelFallback = {
+  requestedSpec: string;
+  usedSpec: string;
+  requestedLabel: string;
+  usedLabel: string;
+  reason: "unavailable" | "failed";
+  message: string;
+};
+
 export type PluginUpdateOutcome = {
   pluginId: string;
   status: PluginUpdateStatus;
   message: string;
   currentVersion?: string;
   nextVersion?: string;
+  channelFallback?: PluginUpdateChannelFallback;
 };
 
 export type PluginUpdateSummary = {
@@ -485,6 +495,13 @@ function shouldFallbackBetaClawHubUpdate(result: { ok: false; code?: string }): 
   return shouldFallbackClawHubToDefault(result);
 }
 
+function isUnavailableNpmTarget(result: { ok: false; code?: string; error: string }): boolean {
+  return (
+    result.code === PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND ||
+    /\b(ETARGET|notarget)\b|No matching version found|dist-tag|tag .*not found/i.test(result.error)
+  );
+}
+
 function describeBetaNpmFallback(params: {
   pluginId: string;
   betaSpec: string | undefined;
@@ -492,13 +509,44 @@ function describeBetaNpmFallback(params: {
   result: { ok: false; code?: string; error: string };
 }): string {
   const betaSpec = params.betaSpec ?? "the beta npm release";
-  const missingBeta =
-    params.result.code === PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND ||
-    /\b(ETARGET|notarget)\b|No matching version found|dist-tag|tag .*not found/i.test(
-      params.result.error,
-    );
+  const missingBeta = isUnavailableNpmTarget(params.result);
   const reason = missingBeta ? "has no beta npm release" : "failed beta npm update";
   return `Plugin "${params.pluginId}" ${reason} for ${betaSpec}; using ${params.fallbackSpec} instead. Core update can still complete.`;
+}
+
+function formatNpmSpecSelectorLabel(spec: string | undefined): string {
+  const parsed = spec ? parseRegistryNpmSpec(spec) : undefined;
+  if (!parsed) {
+    return spec ?? "unknown";
+  }
+  if (parsed.selectorKind === "none") {
+    return "@latest";
+  }
+  return `@${parsed.selector}`;
+}
+
+function describeNpmChannelFallback(params: {
+  pluginId: string;
+  requestedSpec: string | undefined;
+  usedSpec: string;
+  result: { ok: false; code?: string; error: string };
+}): PluginUpdateChannelFallback {
+  const requestedSpec = params.requestedSpec ?? "unknown";
+  const requestedLabel = formatNpmSpecSelectorLabel(params.requestedSpec);
+  const usedLabel = formatNpmSpecSelectorLabel(params.usedSpec);
+  const reason = isUnavailableNpmTarget(params.result) ? "unavailable" : "failed";
+  const message =
+    reason === "unavailable"
+      ? `plugin channel fallback: ${params.pluginId} used ${usedLabel} because ${requestedLabel} was unavailable`
+      : `plugin channel fallback: ${params.pluginId} used ${usedLabel} after ${requestedLabel} failed`;
+  return {
+    requestedSpec,
+    usedSpec: params.usedSpec,
+    requestedLabel,
+    usedLabel,
+    reason,
+    message,
+  };
 }
 
 function formatBetaChannelFallbackOutcomeSuffix(params: {
@@ -990,7 +1038,11 @@ export async function updateNpmInstalledPlugins(params: {
     return await installPluginFromNpmSpec(installParams);
   };
 
-  const recordFailure = (pluginId: string, message: string) => {
+  const recordFailure = (
+    pluginId: string,
+    message: string,
+    channelFallback?: PluginUpdateChannelFallback,
+  ) => {
     if (params.disableOnFailure && !params.dryRun) {
       const disabledMessage =
         `Disabled "${pluginId}" after plugin update failure; OpenClaw will continue without it. ` +
@@ -1002,6 +1054,7 @@ export async function updateNpmInstalledPlugins(params: {
         pluginId,
         status: "skipped",
         message: disabledMessage,
+        ...(channelFallback ? { channelFallback } : {}),
       });
       return;
     }
@@ -1009,6 +1062,7 @@ export async function updateNpmInstalledPlugins(params: {
       pluginId,
       status: "error",
       message,
+      ...(channelFallback ? { channelFallback } : {}),
     });
   };
 
@@ -1317,6 +1371,7 @@ export async function updateNpmInstalledPlugins(params: {
       let usedNpmFallback = false;
       let usedOfficialNpmFallback = false;
       let channelFallbackSuffix = "";
+      let npmChannelFallback: PluginUpdateChannelFallback | undefined;
       if (!probe.ok && record.source === "npm" && npmSpecs?.fallbackSpec) {
         logger.warn?.(
           describeBetaNpmFallback({
@@ -1327,6 +1382,12 @@ export async function updateNpmInstalledPlugins(params: {
           }),
         );
         usedNpmFallback = true;
+        npmChannelFallback = describeNpmChannelFallback({
+          pluginId,
+          requestedSpec: npmSpecs.fallbackLabel ?? effectiveSpec,
+          usedSpec: npmSpecs.fallbackSpec,
+          result: probe,
+        });
         channelFallbackSuffix = formatBetaChannelFallbackOutcomeSuffix({
           fallbackLabel: npmSpecs.fallbackLabel ?? effectiveSpec,
           fallbackSpec: npmSpecs.fallbackSpec,
@@ -1448,6 +1509,7 @@ export async function updateNpmInstalledPlugins(params: {
                     phase: "check",
                     error: probe.error,
                   }),
+          undefined,
         );
         continue;
       }
@@ -1485,6 +1547,7 @@ export async function updateNpmInstalledPlugins(params: {
           currentVersion: currentVersion ?? undefined,
           nextVersion: resolvedProbeVersion,
           message: `${pluginId} is up to date (${currentLabel}).${channelFallbackSuffix}`,
+          ...(npmChannelFallback ? { channelFallback: npmChannelFallback } : {}),
         });
       } else {
         outcomes.push({
@@ -1493,6 +1556,7 @@ export async function updateNpmInstalledPlugins(params: {
           currentVersion: currentVersion ?? undefined,
           nextVersion: resolvedProbeVersion,
           message: `Would update ${pluginId}: ${currentLabel} -> ${nextVersion}.${channelFallbackSuffix}`,
+          ...(npmChannelFallback ? { channelFallback: npmChannelFallback } : {}),
         });
       }
       continue;
@@ -1567,6 +1631,7 @@ export async function updateNpmInstalledPlugins(params: {
     let channelFallbackSuffix = "";
     let resultSource = record.source;
     activeClawHubInstallSpec = effectiveSpec;
+    let npmChannelFallback: PluginUpdateChannelFallback | undefined;
     if (!result.ok && record.source === "npm" && npmSpecs?.fallbackSpec) {
       logger.warn?.(
         describeBetaNpmFallback({
@@ -1577,6 +1642,12 @@ export async function updateNpmInstalledPlugins(params: {
         }),
       );
       usedNpmFallback = true;
+      npmChannelFallback = describeNpmChannelFallback({
+        pluginId,
+        requestedSpec: npmSpecs.fallbackLabel ?? effectiveSpec,
+        usedSpec: npmSpecs.fallbackSpec,
+        result,
+      });
       channelFallbackSuffix = formatBetaChannelFallbackOutcomeSuffix({
         fallbackLabel: npmSpecs.fallbackLabel ?? effectiveSpec,
         fallbackSpec: npmSpecs.fallbackSpec,
@@ -1696,6 +1767,7 @@ export async function updateNpmInstalledPlugins(params: {
                   phase: "update",
                   error: result.error,
                 }),
+        undefined,
       );
       continue;
     }
@@ -1776,6 +1848,7 @@ export async function updateNpmInstalledPlugins(params: {
         currentVersion: currentVersion ?? undefined,
         nextVersion: nextVersion ?? undefined,
         message: `${pluginId} already at ${currentLabel}.${channelFallbackSuffix}`,
+        ...(npmChannelFallback ? { channelFallback: npmChannelFallback } : {}),
       });
     } else {
       outcomes.push({
@@ -1784,6 +1857,7 @@ export async function updateNpmInstalledPlugins(params: {
         currentVersion: currentVersion ?? undefined,
         nextVersion: nextVersion ?? undefined,
         message: `Updated ${pluginId}: ${currentLabel} -> ${nextLabel}.${channelFallbackSuffix}`,
+        ...(npmChannelFallback ? { channelFallback: npmChannelFallback } : {}),
       });
     }
   }

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1511,7 +1511,7 @@ export async function updateNpmInstalledPlugins(params: {
                     phase: "check",
                     error: probe.error,
                   }),
-          undefined,
+          npmChannelFallback,
         );
         continue;
       }
@@ -1770,7 +1770,7 @@ export async function updateNpmInstalledPlugins(params: {
                   phase: "update",
                   error: result.error,
                 }),
-        undefined,
+        npmChannelFallback,
       );
       continue;
     }

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -530,6 +530,7 @@ function describeNpmChannelFallback(params: {
   requestedSpec: string | undefined;
   usedSpec: string;
   result: { ok: false; code?: string; error: string };
+  verb: "used" | "would use";
 }): PluginUpdateChannelFallback {
   const requestedSpec = params.requestedSpec ?? "unknown";
   const requestedLabel = formatNpmSpecSelectorLabel(params.requestedSpec);
@@ -537,8 +538,8 @@ function describeNpmChannelFallback(params: {
   const reason = isUnavailableNpmTarget(params.result) ? "unavailable" : "failed";
   const message =
     reason === "unavailable"
-      ? `plugin channel fallback: ${params.pluginId} used ${usedLabel} because ${requestedLabel} was unavailable`
-      : `plugin channel fallback: ${params.pluginId} used ${usedLabel} after ${requestedLabel} failed`;
+      ? `plugin channel fallback: ${params.pluginId} ${params.verb} ${usedLabel} because ${requestedLabel} was unavailable`
+      : `plugin channel fallback: ${params.pluginId} ${params.verb} ${usedLabel} after ${requestedLabel} failed`;
   return {
     requestedSpec,
     usedSpec: params.usedSpec,
@@ -1387,6 +1388,7 @@ export async function updateNpmInstalledPlugins(params: {
           requestedSpec: npmSpecs.fallbackLabel ?? effectiveSpec,
           usedSpec: npmSpecs.fallbackSpec,
           result: probe,
+          verb: "would use",
         });
         channelFallbackSuffix = formatBetaChannelFallbackOutcomeSuffix({
           fallbackLabel: npmSpecs.fallbackLabel ?? effectiveSpec,
@@ -1647,6 +1649,7 @@ export async function updateNpmInstalledPlugins(params: {
         requestedSpec: npmSpecs.fallbackLabel ?? effectiveSpec,
         usedSpec: npmSpecs.fallbackSpec,
         result,
+        verb: "used",
       });
       channelFallbackSuffix = formatBetaChannelFallbackOutcomeSuffix({
         fallbackLabel: npmSpecs.fallbackLabel ?? effectiveSpec,


### PR DESCRIPTION
## Summary

- Problem: Beta core updates logged npm plugin channel fallbacks in the install stream, but the final plugin summary did not preserve that mixed-channel state.
- Why it matters: Operators can miss that a configured plugin used `@latest` because `@beta` was unavailable.
- What changed: Plugin update outcomes now carry structured `channelFallback` metadata and both direct plugin updates and post-core summaries emit a concise warning.
- What did NOT change (scope boundary): Install targets, fallback probes, fallback installs, and update semantics are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related #81394
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Final plugin update output now retains the npm channel fallback warning when a plugin uses `@latest` because `@beta` is unavailable.
- Real environment tested: Local OpenClaw repo worktree on macOS, running inside the OpenClaw dev container.
- Exact steps or command run after this patch: In the dev container, ran `pnpm test src/plugins/update.test.ts src/cli/update-cli.test.ts` to exercise the production post-core summary path and direct plugin update reporting path.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal capture from the local OpenClaw dev container:

```text
$ pnpm test src/plugins/update.test.ts src/cli/update-cli.test.ts
✓ |cli| src/cli/update-cli.test.ts (90 tests) 23557ms
  ✓ prints plugin channel fallbacks near the post-core plugin summary 517ms
✓ |plugins| src/plugins/update.test.ts (73 tests) 79ms

Test Files  2 passed (2)
Tests       163 passed (163)
[test] passed 2 Vitest shards in 33.75s
```

- Observed result after fix: The post-core summary scenario emitted `npm plugins: 1 updated, 0 unchanged.` followed by `plugin channel fallback: lossless-claw used @latest because @beta was unavailable`.
- What was not tested: Full live package-manager beta update against the public npm registry; this patch is reporting/data-shape only and does not change registry install semantics.

## Root Cause (if applicable)

- Root cause: The fallback was only represented in transient install logging and a local outcome suffix; the durable plugin outcome data did not carry enough structured state for final summaries to repeat it.
- Missing detection / guardrail: No final-summary regression test asserted that channel fallback information survived the plugin update flow.
- Contributing context (if known): Post-core summaries intentionally aggregate plugin outcomes, which made mid-install warnings easy to lose.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/update.test.ts`, `src/cli/update-cli.test.ts`
- Scenario the test should lock in: npm plugin update falls back from `@beta` to `@latest`, and the final summary emits the concise channel fallback warning.
- Why this is the smallest reliable guardrail: The plugin test locks the data shape at the update seam, and the CLI test locks the final operator-visible output.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Plugin update summaries may now include a concise warning such as `plugin channel fallback: lossless-claw used @latest because @beta was unavailable` when an npm plugin falls back from a requested channel to `@latest`.

## Diagram (if applicable)

```text
Before:
core update -> plugin @beta unavailable -> install logs mention fallback -> final summary omits mixed-channel warning

After:
core update -> plugin @beta unavailable -> channelFallback metadata -> final summary warns plugin used @latest
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: OpenClaw dev container, repo `pnpm test`
- Model/provider: N/A
- Integration/channel (if any): npm plugin update flow simulated by tests
- Relevant config (redacted): N/A

### Steps

1. Check the patch with `git diff --check`.
2. Run `pnpm test src/plugins/update.test.ts src/cli/update-cli.test.ts`.
3. Inspect the added CLI assertion for the final fallback warning.

### Expected

- Plugin fallback metadata is attached to npm beta-to-latest fallback outcomes.
- Final post-core output includes the concise plugin channel fallback warning.
- Existing successful update behavior remains unchanged.

### Actual

- `git diff --check` passed.
- `pnpm test src/plugins/update.test.ts src/cli/update-cli.test.ts` passed with 2 files and 163 tests.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: unavailable `@beta` fallback metadata, failed `@beta` fallback metadata, fallback-second-failure error shape, direct plugin update warning plumbing, and post-core final warning output.
- Edge cases checked: warning deduplication in post-core summary and no ClawHub fallback metadata attachment.
- What you did **not** verify: full live update against npm registry.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The new warning could be perceived as extra output.
  - Mitigation: It only emits when fallback metadata exists, uses one concise line per affected plugin, and dedupes final post-core messages.