### PR TITLE
fix(memory): preserve qmd lexical search for hyphenated queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Feishu: detect SecretRef top-level credentials as a configured default account instead of treating object-backed app secrets as missing.
 - CLI/completion: resolve concrete PowerShell profile paths and reload commands during setup and doctor completion installation. Fixes #44296. (#83059) Thanks @yu-xin-c.
 - Providers/Google: preserve and recover Gemini 3 tool-call thought signatures during native replay so function-calling turns no longer fail with missing `thought_signature` 400s. Fixes #72879. (#80358) Thanks @abnershang.
+- Memory/QMD: keep lexical search on raw hyphenated queries while normalizing semantic QMD sub-searches, avoiding fallback to the builtin index for dashed identifiers and dates. Fixes #81328.
 - Memory-core: distinguish sqlite-vec load failures from missing semantic vector embeddings in degraded `memory index` warnings, so vector recall diagnostics point at unresolved dimensions instead of blaming sqlite-vec when the store is ready. Fixes #75624. (#83056) Thanks @xuruiray and @Noah3521.
 - Agents/subagents: preserve sandbox-peer controller ownership while routing completion announcements back to the originating run session, keeping subagent control and completion delivery scoped correctly. Fixes #80201. (#80242) Thanks @Jerry-Xin.
 - Gateway: continue restarting remaining channels when one hot-reload channel restart fails, while still reporting aggregate reload failure and rolling back plugin pre-replace stops. Fixes #83054. Thanks @zqchris.

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -2698,6 +2698,80 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("keeps hyphenated tokens in lexical QMD searches while normalizing semantic searches", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        expect(args[1]).toBe("qmd.query");
+        const callArgs = JSON.parse(args[args.indexOf("--args") + 1]);
+        expect(callArgs.searches).toEqual([
+          { type: "lex", query: "sqlite-vec-qmd backend health 2026-05-04 multi-agent" },
+          { type: "vec", query: "sqlite vec qmd backend health 2026 05 04 multi agent" },
+          { type: "hyde", query: "sqlite vec qmd backend health 2026 05 04 multi agent" },
+        ]);
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("sqlite-vec-qmd backend health 2026-05-04 multi-agent", {
+      sessionKey: "agent:main:slack:dm:u123",
+    });
+    await manager.close();
+  });
+
+  it("normalizes hyphenated tokens for vector-only QMD searches", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "vsearch",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        expect(args[1]).toBe("qmd.query");
+        const callArgs = JSON.parse(args[args.indexOf("--args") + 1]);
+        expect(callArgs.searches).toEqual([{ type: "vec", query: "sqlite vec backend health" }]);
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await manager.search("sqlite-vec backend health", {
+      sessionKey: "agent:main:slack:dm:u123",
+    });
+    await manager.close();
+  });
+
   it("falls back to QMD <1.1 tool names when query tool is not found", async () => {
     // qmdMcpToolVersion is an instance field — each createManager() starts fresh.
 

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1952,21 +1952,22 @@ export class QmdMemoryManager implements MemorySearchManager {
     query: string,
     searchCommand?: string,
   ): Array<{ type: string; query: string }> {
+    const semanticQuery = normalizeQmdSemanticQuery(query);
     switch (searchCommand) {
       case "search":
         // BM25 keyword search only
         return [{ type: "lex", query }];
       case "vsearch":
         // Vector search only
-        return [{ type: "vec", query }];
+        return [{ type: "vec", query: semanticQuery }];
       case "query":
       case undefined:
       default:
         // Full hybrid: lex + vec + hyde (query expansion)
         return [
           { type: "lex", query },
-          { type: "vec", query },
-          { type: "hyde", query },
+          { type: "vec", query: semanticQuery },
+          { type: "hyde", query: semanticQuery },
         ];
     }
   }
@@ -3148,4 +3149,8 @@ function resolveQmdManagerRuntimeConfig(
     syncSettings: resolveMemorySearchSyncConfig(cfg, agentId),
     contextLimits: resolveAgentContextLimits(cfg, agentId),
   };
+}
+
+function normalizeQmdSemanticQuery(query: string): string {
+  return query.replace(/(\w)-(?=\w)/g, "$1 ");
 }


### PR DESCRIPTION
## Summary

- Preserve the raw user query for QMD lexical (`lex`) searches so dashed identifiers, dates, and version strings can still match exactly.
- Normalize only QMD semantic sub-searches (`vec` / `hyde`) by replacing word-internal hyphens with spaces before sending the v2 `qmd.query` searches array.
- Add focused coverage for hybrid and vector-only QMD MCP payloads.

Fixes #81328.

## Tests

- `node scripts/test-projects.mjs extensions/memory-core/src/memory/qmd-manager.test.ts --reporter=verbose -t "hyphenated tokens|vector-only QMD"`
- `node scripts/test-projects.mjs extensions/memory-core/src/memory/search-manager.test.ts --reporter=verbose -t "falls back to builtin search when qmd fails with sqlite busy|keeps original qmd error when fallback manager initialization fails"`
- `pnpm check:changed`
- `git diff --check`

Full `qmd-manager.test.ts` run on Windows reached 104/105 passing; the remaining failure was the existing symlink-permission case (`EPERM` creating a symlink), unrelated to this change.

## Real behavior proof

- Behavior or issue addressed: `memory_search` should not lose QMD lexical recall just because a query contains hyphenated tokens such as `sqlite-vec`, `2026-05-04`, or `multi-agent`, while semantic QMD searches should avoid word-internal hyphens that QMD v2.0.1 treats as NOT-operator syntax.
- Real environment tested: WSL Ubuntu-24.04 source worktrees created from `upstream/main` and PR head `0f7460c4d99d028e07a629bfd178afc105a6c308`.
- Exact steps or command run after this patch: created clean detached worktrees for `upstream/main` and `fork/fix-qmd-hyphenated-memory-search`; in each worktree ran `node --import ./node_modules/tsx/dist/loader.mjs ./probe-qmd-hyphenated-search.mjs`. The probe imported the real `QmdMemoryManager` and called the real `buildV2Searches()` payload-construction seam for hybrid `query` and vector-only `vsearch` payloads.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

![PR #81423 QMD hyphenated search before/after proof](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-81423-fresh/pr-81423/pr-81423-qmd-hyphenated-search-before-after-proof.png)

```text
Fresh proof artifact: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-81423-fresh/pr-81423/pr-81423-qmd-hyphenated-search-before-after-proof.png
Proof summary: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-81423-fresh/pr-81423/summary.txt

BEFORE upstream/main:
status=0
lexPreserved=true
semanticNormalized=false
vectorOnlyNormalized=false
lexQuery=sqlite-vec backend health 2026-05-04 multi-agent
vecQuery=sqlite-vec backend health 2026-05-04 multi-agent
hydeQuery=sqlite-vec backend health 2026-05-04 multi-agent
vectorOnlyQuery=sqlite-vec backend health
ok=false

AFTER PR #81423 head:
status=0
lexPreserved=true
semanticNormalized=true
vectorOnlyNormalized=true
lexQuery=sqlite-vec backend health 2026-05-04 multi-agent
vecQuery=sqlite vec backend health 2026 05 04 multi agent
hydeQuery=sqlite vec backend health 2026 05 04 multi agent
vectorOnlyQuery=sqlite vec backend health
ok=true
```

- Observed result after fix: `upstream/main` preserves the lexical query but sends hyphenated text to semantic `vec`, `hyde`, and vector-only payloads. PR head preserves the raw lexical branch while normalizing only semantic payloads, so exact lexical recall remains available and QMD semantic validation no longer sees word-internal hyphens.
- What was not tested: no live QMD 2.0.1 daemon or full `memory_search` command against an installed QMD index was run in this environment. The proof verifies the runtime payload-construction seam that feeds QMD MCP calls.