### PR TITLE
[codex] fix plugins doctor runtime config warning attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: finish handling pending debounced inbound messages before closing the socket. (#81246) Thanks @mcaxtr.
 - CLI/commitments: write `--json` output to stdout instead of diagnostic logs so automation can parse commitment list and dismiss results. (#81215) Thanks @giodl73-repo.
 - Update: allow pnpm GitHub-source OpenClaw updates to approve the OpenClaw package build, so source installs complete their prepare/prepack lifecycle. (#81294) Thanks @fuller-stack-dev.
+- Plugins/runtime: attribute deprecated runtime config load/write warnings to the plugin id and source that triggered them so logs and plugin doctor runs are actionable. Fixes #81394.
 
 ### Changes
 

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginRecord } from "./loader-records.js";
+import { createPluginRegistry } from "./registry.js";
+import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
+import type { PluginRuntime } from "./runtime/types.js";
+
+function createTestRegistry(runtime: PluginRuntime) {
+  return createPluginRegistry({
+    logger: {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    runtime,
+    activateGlobalSideEffects: false,
+  });
+}
+
+describe("plugin registry runtime config scope", () => {
+  it("runs deprecated config helpers with the owning plugin scope", async () => {
+    let loadScope = getPluginRuntimeGatewayRequestScope();
+    let writeScope = getPluginRuntimeGatewayRequestScope();
+    const config = {} as OpenClawConfig;
+    const replaceResult = {
+      previousHash: null,
+      nextHash: "next",
+    } as unknown as Awaited<ReturnType<PluginRuntime["config"]["replaceConfigFile"]>>;
+    const configRuntime = {
+      current: vi.fn(() => config),
+      mutateConfigFile: async <T = void>() => ({
+        ...replaceResult,
+        result: undefined as T | undefined,
+      }),
+      replaceConfigFile: async () => replaceResult,
+      loadConfig: vi.fn(() => {
+        loadScope = getPluginRuntimeGatewayRequestScope();
+        return config;
+      }),
+      writeConfigFile: vi.fn(async () => {
+        writeScope = getPluginRuntimeGatewayRequestScope();
+      }),
+    } satisfies PluginRuntime["config"];
+    const pluginRegistry = createTestRegistry({ config: configRuntime } as PluginRuntime);
+    const record = createPluginRecord({
+      id: "legacy-plugin",
+      name: "Legacy Plugin",
+      source: "/plugins/legacy-plugin/index.js",
+      origin: "global",
+      enabled: true,
+    });
+    const api = pluginRegistry.createApi(record, { config });
+
+    expect(api.runtime.config.loadConfig()).toBe(config);
+    await api.runtime.config.writeConfigFile(config);
+
+    expect(loadScope).toMatchObject({
+      pluginId: "legacy-plugin",
+      pluginSource: "/plugins/legacy-plugin/index.js",
+    });
+    expect(writeScope).toMatchObject({
+      pluginId: "legacy-plugin",
+      pluginSource: "/plugins/legacy-plugin/index.js",
+    });
+  });
+});

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -124,7 +124,10 @@ export type {
   PluginSessionExtensionRegistryRegistration,
 } from "./registry-types.js";
 import { getActivePluginRegistry } from "./runtime.js";
-import { withPluginRuntimePluginIdScope } from "./runtime/gateway-request-scope.js";
+import {
+  withPluginRuntimePluginIdScope,
+  withPluginRuntimePluginScope,
+} from "./runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { validateJsonSchemaValue, type JsonSchemaValue } from "./schema-validator.js";
 import { normalizeSessionEntrySlotKey } from "./session-entry-slot-keys.js";
@@ -2367,6 +2370,14 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
     const runtime = new Proxy(registryParams.runtime, {
       get(target, prop, receiver) {
+        const runWithPluginScope = <T>(run: () => T): T => {
+          const record =
+            pluginRuntimeRecordById.get(pluginId) ??
+            registry.plugins.find((entry) => entry.id === pluginId);
+          return record?.source
+            ? withPluginRuntimePluginScope({ pluginId, pluginSource: record.source }, run)
+            : withPluginRuntimePluginScope({ pluginId }, run);
+        };
         if (prop === "state") {
           const baseState = Reflect.get(target, prop, receiver);
           return {
@@ -2383,6 +2394,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
               return createPluginStateKeyedStore<T>(pluginId, options);
             },
           } satisfies PluginRuntime["state"];
+        }
+        if (prop === "config") {
+          const config = Reflect.get(target, prop, receiver) as PluginRuntime["config"];
+          return {
+            ...config,
+            loadConfig: () => runWithPluginScope(() => config.loadConfig()),
+            writeConfigFile: (cfg, options) =>
+              runWithPluginScope(() => config.writeConfigFile(cfg, options)),
+          } satisfies PluginRuntime["config"];
         }
         if (prop === "llm") {
           const llm = Reflect.get(target, prop, receiver);

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -10,6 +10,12 @@ export type PluginRuntimeGatewayRequestScope = {
   client?: GatewayRequestOptions["client"];
   isWebchatConnect: GatewayRequestOptions["isWebchatConnect"];
   pluginId?: string;
+  pluginSource?: string;
+};
+
+export type PluginRuntimePluginScope = {
+  pluginId: string;
+  pluginSource?: string;
 };
 
 const PLUGIN_RUNTIME_GATEWAY_REQUEST_SCOPE_KEY: unique symbol = Symbol.for(
@@ -36,15 +42,27 @@ export function withPluginRuntimeGatewayRequestScope<T>(
 /**
  * Runs work under the current gateway request scope while attaching plugin identity.
  */
-export function withPluginRuntimePluginIdScope<T>(pluginId: string, run: () => T): T {
+export function withPluginRuntimePluginScope<T>(scope: PluginRuntimePluginScope, run: () => T): T {
   const current = pluginRuntimeGatewayRequestScope.getStore();
   const scoped: PluginRuntimeGatewayRequestScope = current
-    ? { ...current, pluginId }
+    ? { ...current, pluginId: scope.pluginId }
     : {
-        pluginId,
+        pluginId: scope.pluginId,
         isWebchatConnect: () => false,
       };
+  if (scope.pluginSource !== undefined) {
+    scoped.pluginSource = scope.pluginSource;
+  } else {
+    delete scoped.pluginSource;
+  }
   return pluginRuntimeGatewayRequestScope.run(scoped, run);
+}
+
+/**
+ * Runs work under the current gateway request scope while attaching plugin identity.
+ */
+export function withPluginRuntimePluginIdScope<T>(pluginId: string, run: () => T): T {
+  return withPluginRuntimePluginScope({ pluginId }, run);
 }
 
 /**

--- a/src/plugins/runtime/runtime-config.test.ts
+++ b/src/plugins/runtime/runtime-config.test.ts
@@ -19,11 +19,14 @@ vi.mock("../../logger.js", () => ({
   logWarn: (...args: unknown[]) => logWarnMock(...args),
 }));
 
-const { createRuntimeConfig } = await import("./runtime-config.js");
+const { withPluginRuntimePluginScope } = await import("./gateway-request-scope.js");
+const { createRuntimeConfig, resetRuntimeConfigDeprecationWarningStateForTest } =
+  await import("./runtime-config.js");
 const deprecatedConfigCode = "runtime-config-load-write";
 
 describe("createRuntimeConfig", () => {
   beforeEach(() => {
+    resetRuntimeConfigDeprecationWarningStateForTest();
     getRuntimeConfigMock.mockReset();
     mutateConfigFileMock.mockReset();
     replaceConfigFileMock.mockReset();
@@ -46,6 +49,40 @@ describe("createRuntimeConfig", () => {
     );
   });
 
+  it("attributes deprecated loadConfig warnings to the active plugin scope", () => {
+    const runtimeConfig = { plugins: { entries: {} } };
+    getRuntimeConfigMock.mockReturnValue(runtimeConfig);
+    const configApi = createRuntimeConfig();
+
+    const loaded = withPluginRuntimePluginScope(
+      { pluginId: "legacy-plugin", pluginSource: "/plugins/legacy-plugin/index.js" },
+      () => configApi.loadConfig(),
+    );
+
+    expect(loaded).toBe(runtimeConfig);
+    expect(logWarnMock).toHaveBeenCalledWith(
+      `plugin "legacy-plugin" runtime config.loadConfig() is deprecated (${deprecatedConfigCode}); use config.current(). Source: /plugins/legacy-plugin/index.js`,
+    );
+  });
+
+  it("keeps deprecated loadConfig warning attribution per plugin", () => {
+    const configApi = createRuntimeConfig();
+
+    withPluginRuntimePluginScope({ pluginId: "first" }, () => configApi.loadConfig());
+    withPluginRuntimePluginScope({ pluginId: "first" }, () => configApi.loadConfig());
+    withPluginRuntimePluginScope({ pluginId: "second" }, () => configApi.loadConfig());
+
+    expect(logWarnMock).toHaveBeenCalledTimes(2);
+    expect(logWarnMock).toHaveBeenNthCalledWith(
+      1,
+      `plugin "first" runtime config.loadConfig() is deprecated (${deprecatedConfigCode}); use config.current().`,
+    );
+    expect(logWarnMock).toHaveBeenNthCalledWith(
+      2,
+      `plugin "second" runtime config.loadConfig() is deprecated (${deprecatedConfigCode}); use config.current().`,
+    );
+  });
+
   it("routes deprecated writeConfigFile through replaceConfigFile with afterWrite", async () => {
     const configApi = createRuntimeConfig();
     const nextConfig = { plugins: { entries: {} } } as OpenClawConfig;
@@ -54,6 +91,25 @@ describe("createRuntimeConfig", () => {
 
     expect(logWarnMock).toHaveBeenCalledWith(
       `plugin runtime config.writeConfigFile() is deprecated (${deprecatedConfigCode}); use config.mutateConfigFile(...) or config.replaceConfigFile(...).`,
+    );
+    expect(replaceConfigFileMock).toHaveBeenCalledWith({
+      nextConfig,
+      afterWrite: { mode: "auto" },
+      writeOptions: undefined,
+    });
+  });
+
+  it("attributes deprecated writeConfigFile warnings to the active plugin scope", async () => {
+    const configApi = createRuntimeConfig();
+    const nextConfig = { plugins: { entries: {} } } as OpenClawConfig;
+
+    await withPluginRuntimePluginScope(
+      { pluginId: "legacy-plugin", pluginSource: "/plugins/legacy-plugin/index.js" },
+      async () => await configApi.writeConfigFile(nextConfig),
+    );
+
+    expect(logWarnMock).toHaveBeenCalledWith(
+      `plugin "legacy-plugin" runtime config.writeConfigFile() is deprecated (${deprecatedConfigCode}); use config.mutateConfigFile(...) or config.replaceConfigFile(...). Source: /plugins/legacy-plugin/index.js`,
     );
     expect(replaceConfigFileMock).toHaveBeenCalledWith({
       nextConfig,

--- a/src/plugins/runtime/runtime-config.ts
+++ b/src/plugins/runtime/runtime-config.ts
@@ -4,23 +4,48 @@ import {
   replaceConfigFile as replaceConfigFileInternal,
 } from "../../config/mutate.js";
 import { logWarn } from "../../logger.js";
+import { getPluginRuntimeGatewayRequestScope } from "./gateway-request-scope.js";
 import type { PluginRuntime } from "./types.js";
 
 const RUNTIME_CONFIG_LOAD_WRITE_COMPAT_CODE = "runtime-config-load-write";
 
 const warnedDeprecatedConfigApis = new Set<string>();
 
+function formatDeprecatedConfigApiSubject(name: "loadConfig" | "writeConfigFile"): string {
+  const scope = getPluginRuntimeGatewayRequestScope();
+  if (!scope?.pluginId) {
+    return `plugin runtime config.${name}()`;
+  }
+  return `plugin "${scope.pluginId}" runtime config.${name}()`;
+}
+
+function formatDeprecatedConfigApiSource(): string {
+  const scope = getPluginRuntimeGatewayRequestScope();
+  return scope?.pluginSource ? ` Source: ${scope.pluginSource}` : "";
+}
+
+function formatDeprecatedConfigApiWarningKey(name: "loadConfig" | "writeConfigFile"): string {
+  const scope = getPluginRuntimeGatewayRequestScope();
+  return `${name}:${scope?.pluginId ?? "anonymous"}`;
+}
+
 function warnDeprecatedConfigApiOnce(
   name: "loadConfig" | "writeConfigFile",
   replacement: string,
 ): void {
-  if (warnedDeprecatedConfigApis.has(name)) {
+  const warningKey = formatDeprecatedConfigApiWarningKey(name);
+  if (warnedDeprecatedConfigApis.has(warningKey)) {
     return;
   }
-  warnedDeprecatedConfigApis.add(name);
+  warnedDeprecatedConfigApis.add(warningKey);
   logWarn(
-    `plugin runtime config.${name}() is deprecated (${RUNTIME_CONFIG_LOAD_WRITE_COMPAT_CODE}); use ${replacement}.`,
+    `${formatDeprecatedConfigApiSubject(name)} is deprecated (${RUNTIME_CONFIG_LOAD_WRITE_COMPAT_CODE}); use ${replacement}.${formatDeprecatedConfigApiSource()}`,
   );
+}
+
+/** @internal Test-only reset for the runtime config compatibility warning cache. */
+export function resetRuntimeConfigDeprecationWarningStateForTest(): void {
+  warnedDeprecatedConfigApis.clear();
 }
 
 export function createRuntimeConfig(): PluginRuntime["config"] {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw plugins doctor` could load a plugin that calls deprecated `api.runtime.config.loadConfig()` / `writeConfigFile(...)`, print an anonymous `runtime-config-load-write` warning, then still report no plugin issues.
- Why it matters: operators could not tell which plugin or path triggered the warning, so the output was noisy instead of actionable.
- What changed: deprecated runtime config warnings now run inside the owning plugin scope and include the plugin id plus source path; warning dedupe is per plugin/API so multiple offending plugins can be identified.
- What did NOT change (scope boundary): no plugin migration, no plugin update fallback-summary work, no restart-health/update-message work, and no change to the deprecated compatibility helpers themselves.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #81394
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: anonymous runtime config deprecation warnings are now attributed to the plugin id/source that triggered them.
- Real environment tested: local OpenClaw worktree in the maintainer Docker dev container on macOS.
- Exact steps or command run after this patch:
  1. `git diff --check`
  2. `pnpm test src/plugins/runtime/runtime-config.test.ts src/plugins/registry.runtime-config.test.ts`
  3. `pnpm test src/cli/plugins-cli.list.test.ts`
  4. `pnpm tsgo`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): targeted tests passed locally, including attribution assertions for `plugin "legacy-plugin" runtime config.loadConfig()` and `plugin "legacy-plugin" runtime config.writeConfigFile()` plus registry-scope assertions.
- Observed result after fix: runtime config deprecation warnings emitted from plugin-scoped runtime helpers include the plugin id and source path.
- What was not tested: a live third-party plugin installed into a real user config and run through `openclaw plugins doctor` end-to-end.
- Before evidence (optional but encouraged): issue #81394 reports the previous output as `plugin runtime config.loadConfig() is deprecated (runtime-config-load-write); use config.current().` followed by `No plugin issues detected.`

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the deprecated runtime config helpers logged through shared runtime code without reading the plugin identity already available in the per-plugin runtime proxy.
- Missing detection / guardrail: tests covered the compatibility warning text, but not plugin-scoped attribution for operator-facing diagnostics.
- Contributing context (if known): the warning cache deduped only by helper name, so even after attribution only the first offending plugin would have been visible without per-plugin dedupe.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/runtime/runtime-config.test.ts`, `src/plugins/registry.runtime-config.test.ts`, `src/cli/plugins-cli.list.test.ts`
- Scenario the test should lock in: deprecated `loadConfig` and `writeConfigFile` warnings include plugin id/source when called under plugin scope, and per-plugin runtime config helpers receive the owning plugin scope from the registry proxy.
- Why this is the smallest reliable guardrail: it exercises the runtime warning formatter and the registry seam that injects plugin-scoped runtime helpers without needing a full external plugin install fixture.
- Existing test that already covers this (if any): `src/cli/plugins-cli.list.test.ts` still covers the clean doctor success path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Deprecated plugin runtime config warnings now include plugin identity and source path when emitted from plugin-scoped runtime helpers.

## Diagram (if applicable)

```text
Before:
[plugin calls deprecated config helper] -> [shared warning without plugin id] -> [operator cannot identify source]

After:
[plugin calls deprecated config helper] -> [plugin-scoped runtime proxy] -> [warning includes plugin id/source]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS host with OpenClaw Docker dev container
- Runtime/container: Node 24 dev container via `openclaw-shell`
- Model/provider: N/A
- Integration/channel (if any): plugins runtime / CLI doctor diagnostics
- Relevant config (redacted): N/A

### Steps

1. Run the runtime config and registry attribution tests.
2. Run the plugins CLI doctor/list tests.
3. Run core `tsgo`.

### Expected

- Deprecated runtime config warnings are attributed to plugin id/source under plugin scope.
- Existing plugins doctor clean-output tests continue to pass.
- Typecheck passes.

### Actual

- `pnpm test src/plugins/runtime/runtime-config.test.ts src/plugins/registry.runtime-config.test.ts`: 2 files passed, 7 tests passed.
- `pnpm test src/cli/plugins-cli.list.test.ts`: 1 file passed, 9 tests passed.
- `pnpm tsgo`: passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Regression tests now assert warning strings like:

```text
plugin "legacy-plugin" runtime config.loadConfig() is deprecated (runtime-config-load-write); use config.current(). Source: /plugins/legacy-plugin/index.js
plugin "legacy-plugin" runtime config.writeConfigFile() is deprecated (runtime-config-load-write); use config.mutateConfigFile(...) or config.replaceConfigFile(...). Source: /plugins/legacy-plugin/index.js
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: attributed warning formatting, per-plugin warning dedupe, registry proxy scoping for deprecated config helpers, existing CLI doctor/list tests.
- Edge cases checked: duplicate calls from the same plugin warn once; calls from a second plugin warn separately; nested plugin scope does not retain stale `pluginSource` when only a new plugin id is supplied.
- What you did **not** verify: a live external plugin installed in a real operator config and run through full `openclaw plugins doctor`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: additional warning lines if multiple plugins use the same deprecated helper.
  - Mitigation: warnings are still deduped per plugin/API, and the added lines are actionable instead of anonymous.
- Risk: plugin scoping accidentally drops request-scope fields.
  - Mitigation: `withPluginRuntimePluginScope` preserves the existing scope via object spread and only updates `pluginId`/`pluginSource`.