### PR TITLE
feat(feishu): add filter, sort, field_names, view_id to feishu_bitable_list_records

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -195,12 +195,56 @@ async function listRecords(
   tableId: string,
   pageSize?: number,
   pageToken?: string,
+  filter?: string,
+  sort?: string[],
+  fieldNames?: string[],
+  viewId?: string,
 ) {
+  const useSearch = !!(filter || sort);
+
+  if (useSearch) {
+    const sortParsed = sort
+      ? sort.map((s) => {
+          const [fieldName, dir] = s.split(":");
+          return { field_name: fieldName, desc: dir === "desc" };
+        })
+      : undefined;
+
+    // The Lark Node SDK types define `filter` as a structured object, but the
+    // underlying HTTP API also accepts the string-based filter expression that
+    // users provide (e.g. 'CurrentValue.[Status]="Open"').  Cast `data` to
+    // satisfy the compiler while passing through the user-supplied string.
+    const searchData: Record<string, unknown> = {
+      ...(filter && { filter }),
+      ...(sortParsed && { sort: sortParsed }),
+      ...(fieldNames && { field_names: fieldNames }),
+      ...(viewId && { view_id: viewId }),
+    };
+    const res = await client.bitable.appTableRecord.search({
+      path: { app_token: appToken, table_id: tableId },
+      params: {
+        page_size: pageSize ?? 100,
+        ...(pageToken && { page_token: pageToken }),
+      },
+      data: searchData as any,
+    });
+    ensureLarkSuccess(res, "bitable.appTableRecord.search", { appToken, tableId, pageSize });
+
+    return {
+      records: res.data?.items ?? [],
+      has_more: res.data?.has_more ?? false,
+      page_token: res.data?.page_token,
+      total: res.data?.total,
+    };
+  }
+
   const res = await client.bitable.appTableRecord.list({
     path: { app_token: appToken, table_id: tableId },
     params: {
       page_size: pageSize ?? 100,
       ...(pageToken && { page_token: pageToken }),
+      ...(fieldNames && { field_names: JSON.stringify(fieldNames) }),
+      ...(viewId && { view_id: viewId }),
     },
   });
   ensureLarkSuccess(res, "bitable.appTableRecord.list", { appToken, tableId, pageSize });
@@ -515,6 +559,23 @@ const ListRecordsSchema = Type.Object({
   page_token: Type.Optional(
     Type.String({ description: "Pagination token from previous response" }),
   ),
+  filter: Type.Optional(
+    Type.String({
+      description:
+        'Filter expression in Feishu syntax, e.g. AND(CurrentValue.[Status]="Open", CurrentValue.[Score]>7)',
+    }),
+  ),
+  sort: Type.Optional(
+    Type.Array(Type.String(), {
+      description: 'Sort fields, e.g. ["field_name:desc", "field_name:asc"]',
+    }),
+  ),
+  field_names: Type.Optional(
+    Type.Array(Type.String(), { description: "Only return these field names" }),
+  ),
+  view_id: Type.Optional(
+    Type.String({ description: "View ID to scope the query" }),
+  ),
 });
 
 const GetRecordSchema = Type.Object({
@@ -663,6 +724,10 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     table_id: string;
     page_size?: number;
     page_token?: string;
+    filter?: string;
+    sort?: string[];
+    field_names?: string[];
+    view_id?: string;
     accountId?: string;
   }>({
     name: "feishu_bitable_list_records",
@@ -676,6 +741,10 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
         params.table_id,
         readBitableListRecordsPageSize(params as Record<string, unknown>),
         params.page_token,
+        params.filter,
+        params.sort,
+        params.field_names,
+        params.view_id,
       );
     },
   });


### PR DESCRIPTION
## What

Add optional `filter`, `sort`, `field_names`, and `view_id` parameters to the `feishu_bitable_list_records` tool.

## How

When `filter` or `sort` is provided, the tool uses the Feishu POST `/search` API endpoint which supports server-side filtering and sorting. For simple queries without filter/sort, it falls back to the existing GET `/list` endpoint (unchanged behavior).

The GET path also gains `field_names` and `view_id` support via query params.

## New Parameters (all optional, backward-compatible)

| Parameter | Type | Description |
|-----------|------|-------------|
| `filter` | string | Feishu filter expression, e.g. `AND(CurrentValue.[Status]="Open")` |
| `sort` | string[] | Sort fields, e.g. `["field_name:desc"]` |
| `field_names` | string[] | Only return these field names |
| `view_id` | string | Scope query to a specific view |

## Testing

- Without new params: identical behavior to before (GET list)
- With filter/sort: routes to POST search endpoint
- With field_names/view_id only: passes to GET list as query params

---
*Rebased against current main (June 2026).*