### PR TITLE
fix: sanitize heartbeat Codex scaffolding

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -280,6 +280,24 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("Before\n\nAfter");
   });
 
+  it("strips Codex file contents scaffolding before user-facing delivery", () => {
+    const input = [
+      "Before",
+      '<file_contents path="/tmp/HEARTBEAT.md" isStale=false isFullFile=true>',
+      " 1|# HEARTBEAT.md",
+      "</file_contents>",
+      "After",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Before\n\nAfter");
+  });
+
+  it("strips bare tool_calls scaffolding marker lines before user-facing delivery", () => {
+    const input = ["<tool_calls>", "<tool_calls>", "<tool_calls>"].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("");
+  });
+
   it("preserves literal tool-call tag examples in user-facing prose", () => {
     const input = "Use `<tool_call>` to describe the XML tag in docs.";
     expect(sanitizeUserFacingText(input)).toBe(input);

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -15,6 +15,7 @@ import {
 } from "../../shared/string-coerce.js";
 import {
   stripLegacyBracketToolCallBlocks,
+  stripAssistantXmlScaffolding,
   stripMinimaxToolCallXml,
   stripToolCallXmlTags,
 } from "../../shared/text/assistant-visible-text.js";
@@ -406,7 +407,8 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   }
   const errorContext = opts?.errorContext ?? false;
   const stripped = stripInboundMetadata(stripInternalRuntimeContext(stripFinalTagsFromText(raw)));
-  const withoutToolCallXml = stripToolCallXmlTags(stripMinimaxToolCallXml(stripped), {
+  const withoutAssistantXml = stripAssistantXmlScaffolding(stripped);
+  const withoutToolCallXml = stripToolCallXmlTags(stripMinimaxToolCallXml(withoutAssistantXml), {
     stripFunctionCallsXmlPayloads: true,
   });
   // Replay repair may synthesize this placeholder to keep provider transcripts valid.

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -65,6 +65,38 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads[0]?.text).toBe("Before\n\n\nAfter");
   });
 
+  it("strips Codex XML scaffolding from heartbeat replies", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      isHeartbeat: true,
+      payloads: [
+        {
+          text: [
+            "Before",
+            "<tool_calls>",
+            '<file_contents path="/tmp/HEARTBEAT.md" isStale=false isFullFile=true>',
+            " 1|# HEARTBEAT.md",
+            "</file_contents>",
+            "After",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("Before\n\nAfter");
+  });
+
+  it("drops heartbeat replies that contain only internal scaffolding", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      isHeartbeat: true,
+      payloads: [{ text: ["<tool_calls>", "<tool_calls>", "<tool_calls>"].join("\n") }],
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
   it("preserves internal delivery metadata through final payload normalization", async () => {
     const payload = markReplyPayloadForSourceSuppressionDelivery({
       text: "⚠️ API rate limit reached.\n[[reply_to_current]]",

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -3,7 +3,7 @@ import type { MessagingToolSend } from "../../agents/pi-embedded-messaging.types
 import type { ReplyToMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
-import { stripLegacyBracketToolCallBlocks } from "../../shared/text/assistant-visible-text.js";
+import { sanitizeAssistantVisibleText } from "../../shared/text/assistant-visible-text.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import { copyReplyPayloadMetadata } from "../reply-payload.js";
 import type { OriginatingChannelType } from "../templating.js";
@@ -102,12 +102,12 @@ function sanitizeHeartbeatPayload(payload: ReplyPayload): ReplyPayload {
   if (!text) {
     return payload;
   }
-  const cleaned = stripLegacyBracketToolCallBlocks(text);
+  const cleaned = sanitizeAssistantVisibleText(text);
   if (cleaned === text) {
     return payload;
   }
-  logVerbose("Stripped legacy tool-call block from heartbeat reply");
-  return copyReplyPayloadMetadata(payload, { ...payload, text: cleaned });
+  logVerbose("Stripped internal scaffolding from heartbeat reply");
+  return copyReplyPayloadMetadata(payload, { ...payload, text: cleaned || undefined });
 }
 
 export async function buildReplyPayloads(params: {

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -784,6 +784,134 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("strips Codex XML scaffolding before heartbeat delivery", async () => {
+    const tmpDir = await createCaseDir("hb-strip-codex-scaffolding");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.fn();
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue({
+        text: [
+          "Visible intro",
+          "<tool_calls>",
+          '<file_contents path="/tmp/HEARTBEAT.md" isStale=false isFullFile=true>',
+          " 1|# HEARTBEAT.md",
+          "</file_contents>",
+          "Visible outro",
+        ].join("\n"),
+      });
+      const sendWhatsApp = vi
+        .fn<
+          (
+            to: string,
+            text: string,
+            opts?: unknown,
+          ) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({
+          messageId: "m1",
+          toJid: "jid",
+        });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+      expectWhatsAppSendCall(sendWhatsApp, 0, {
+        to: "120363401234567890@g.us",
+        text: "Visible intro\n\nVisible outro",
+      });
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
+  it("suppresses short heartbeat acknowledgements after removing Codex XML scaffolding", async () => {
+    const tmpDir = await createCaseDir("hb-strip-codex-scaffolding-ack");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.fn();
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue({
+        text: [
+          "All clear HEARTBEAT_OK",
+          '<file_contents path="/tmp/HEARTBEAT.md" isStale=false isFullFile=true>',
+          ` 1|${"x".repeat(350)}`,
+          "</file_contents>",
+        ].join("\n"),
+      });
+      const sendWhatsApp = vi
+        .fn<
+          (
+            to: string,
+            text: string,
+            opts?: unknown,
+          ) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({
+          messageId: "m1",
+          toJid: "jid",
+        });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+
+      expect(sendWhatsApp).toHaveBeenCalledTimes(0);
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
   it("uses per-agent heartbeat overrides and session keys", async () => {
     const tmpDir = await createCaseDir("hb-agent-overrides");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -230,6 +230,30 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     expectHeartbeatToolPrompt(result);
   });
 
+  it("does not fall back to assistant text when the heartbeat response tool is required", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+        agentHarnessId: "codex",
+      });
+      replySpy.mockResolvedValue({ text: "This should have used heartbeat_respond." });
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      const calledOpts = replyOptions(replySpy);
+      expect(result.status).toBe("ran");
+      expect(calledOpts.sourceReplyDeliveryMode).toBe("message_tool_only");
+      expect(sendTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("delivers Codex runtime failure notices during Codex heartbeat message-tool mode", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -33,6 +33,7 @@ import {
   stripHeartbeatToken,
   type HeartbeatTask,
 } from "../auto-reply/heartbeat.js";
+import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import { resolveDefaultModel } from "../auto-reply/reply/directive-handling.defaults.js";
 import { resolveResponsePrefixTemplate } from "../auto-reply/reply/response-prefix-template.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
@@ -810,6 +811,16 @@ function normalizeHeartbeatToolNotification(
     finalText = `${responsePrefix} ${finalText}`;
   }
   return { shouldSkip: false, text: finalText, hasMedia: false };
+}
+
+function canDeliverHeartbeatPayloadWithoutTool(payload: ReplyPayload | undefined): boolean {
+  if (!payload) {
+    return false;
+  }
+  return (
+    payload.isError === true ||
+    getReplyPayloadMetadata(payload)?.deliverDespiteSourceReplySuppression === true
+  );
 }
 
 type HeartbeatWakePayloadFlags = {
@@ -1741,6 +1752,8 @@ export async function runHeartbeatOnce(opts: {
       : [];
     const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
     const responsePrefix = resolveHeartbeatResponsePrefix();
+    const canDeliverReplyPayload =
+      !usesHeartbeatResponseTool || canDeliverHeartbeatPayloadWithoutTool(replyPayload);
 
     if (heartbeatToolResponse && !heartbeatToolResponse.notify) {
       await restoreHeartbeatUpdatedAt({
@@ -1771,7 +1784,10 @@ export async function runHeartbeatOnce(opts: {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    if (!heartbeatToolResponse && (!replyPayload || !hasOutboundReplyContent(replyPayload))) {
+    if (
+      !heartbeatToolResponse &&
+      (!canDeliverReplyPayload || !replyPayload || !hasOutboundReplyContent(replyPayload))
+    ) {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,
@@ -1801,7 +1817,7 @@ export async function runHeartbeatOnce(opts: {
 
     const normalized = heartbeatToolResponse
       ? normalizeHeartbeatToolNotification(heartbeatToolResponse, responsePrefix)
-      : replyPayload
+      : canDeliverReplyPayload && replyPayload
         ? normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars)
         : { shouldSkip: true, text: "", hasMedia: false };
     // For exec completion events, don't skip even if the response looks like HEARTBEAT_OK.
@@ -1810,6 +1826,7 @@ export async function runHeartbeatOnce(opts: {
     // fall back to the original reply text.
     const execFallbackText =
       !heartbeatToolResponse &&
+      canDeliverReplyPayload &&
       hasRelayableExecCompletion &&
       !normalized.text.trim() &&
       replyPayload?.text?.trim()

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -85,6 +85,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
+import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import { escapeRegExp } from "../utils.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS, resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { loadOrCreateDeviceIdentity } from "./device-identity.js";
@@ -771,7 +772,9 @@ function normalizeHeartbeatReply(
   ackMaxChars: number,
 ) {
   const rawText = typeof payload.text === "string" ? payload.text : "";
-  const textForStrip = stripLeadingHeartbeatResponsePrefix(rawText, responsePrefix);
+  const textForStrip = sanitizeAssistantVisibleText(
+    stripLeadingHeartbeatResponsePrefix(rawText, responsePrefix),
+  );
   const stripped = stripHeartbeatToken(textForStrip, {
     mode: "heartbeat",
     maxAckChars: ackMaxChars,
@@ -784,7 +787,14 @@ function normalizeHeartbeatReply(
       hasMedia,
     };
   }
-  let finalText = stripped.text;
+  let finalText = sanitizeAssistantVisibleText(stripped.text);
+  if (!finalText && !hasMedia) {
+    return {
+      shouldSkip: true,
+      text: "",
+      hasMedia,
+    };
+  }
   if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
     finalText = `${responsePrefix} ${finalText}`;
   }

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -608,6 +608,37 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
   });
 
+  it("strips Codex file contents scaffolding on the canonical user-visible path", () => {
+    const input = [
+      "Visible intro",
+      '<file_contents path="/tmp/HEARTBEAT.md" isStale=false isFullFile=true>',
+      " 1|# HEARTBEAT.md",
+      "</file_contents>",
+      "Visible outro",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible intro\n\nVisible outro");
+  });
+
+  it("strips bare tool_calls scaffolding marker lines", () => {
+    const input = ["<tool_calls>", "<tool_calls>", "<tool_calls>"].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("");
+  });
+
+  it("keeps file contents examples inside fenced code", () => {
+    const input = [
+      "```xml",
+      '<file_contents path="/tmp/example.md">',
+      "example",
+      "</file_contents>",
+      "```",
+      "Visible answer",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
   it("drops malformed reasoning before orphan close tags when final text follows", () => {
     expect(sanitizeAssistantVisibleText("private chain of thought </think> Visible answer")).toBe(
       "Visible answer",

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -11,6 +11,11 @@ import {
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
 const LEGACY_BRACKET_TOOL_BLOCK_QUICK_RE = /\[\s*\/?\s*TOOL_(?:CALL|RESULT)\s*\]/i;
+const FILE_CONTENTS_TAG_RE = /<\s*(\/?)\s*file_contents\b[^<>]*>/gi;
+const FILE_CONTENTS_TAG_QUICK_RE = /<\s*\/?\s*file_contents\b/i;
+const TOOL_CALL_SCAFFOLDING_MARKER_LINE_RE =
+  /^[ \t]*<\s*\/?\s*(?:tool_calls|function_calls)\b[^<>]*>[ \t]*(?:\r?\n|$)/gim;
+const TOOL_CALL_SCAFFOLDING_MARKER_QUICK_RE = /<\s*\/?\s*(?:tool_calls|function_calls)\b/i;
 
 /**
  * Strip XML-style tool call tags that models sometimes emit as plain text.
@@ -623,6 +628,68 @@ function stripRelevantMemoriesTags(text: string): string {
   return result;
 }
 
+function stripFileContentsTags(text: string): string {
+  if (!text || !FILE_CONTENTS_TAG_QUICK_RE.test(text)) {
+    return text;
+  }
+  FILE_CONTENTS_TAG_RE.lastIndex = 0;
+
+  const codeRegions = findCodeRegions(text);
+  let result = "";
+  let lastIndex = 0;
+  let inFileContentsBlock = false;
+
+  for (const match of text.matchAll(FILE_CONTENTS_TAG_RE)) {
+    const idx = match.index ?? 0;
+    if (isInsideCode(idx, codeRegions)) {
+      continue;
+    }
+
+    const isClose = match[1] === "/";
+    if (!inFileContentsBlock) {
+      result += text.slice(lastIndex, idx);
+      if (!isClose) {
+        inFileContentsBlock = true;
+      }
+    } else if (isClose) {
+      inFileContentsBlock = false;
+    }
+
+    lastIndex = idx + match[0].length;
+  }
+
+  if (!inFileContentsBlock) {
+    result += text.slice(lastIndex);
+  }
+
+  return result;
+}
+
+function stripToolCallScaffoldingMarkerLines(text: string): string {
+  if (!text || !TOOL_CALL_SCAFFOLDING_MARKER_QUICK_RE.test(text)) {
+    return text;
+  }
+  TOOL_CALL_SCAFFOLDING_MARKER_LINE_RE.lastIndex = 0;
+
+  const codeRegions = findCodeRegions(text);
+  let result = "";
+  let cursor = 0;
+  for (const match of text.matchAll(TOOL_CALL_SCAFFOLDING_MARKER_LINE_RE)) {
+    const idx = match.index ?? 0;
+    if (isInsideCode(idx, codeRegions)) {
+      continue;
+    }
+    result += text.slice(cursor, idx);
+    cursor = idx + match[0].length;
+  }
+  result += text.slice(cursor);
+  return result;
+}
+
+export function stripAssistantXmlScaffolding(text: string): string {
+  return stripToolCallScaffoldingMarkerLines(stripFileContentsTags(text));
+}
+
 export type AssistantVisibleTextSanitizerProfile = "delivery" | "history" | "internal-scaffolding";
 
 type AssistantVisibleTextPipelineOptions = {
@@ -690,6 +757,7 @@ function applyAssistantVisibleTextStagePipeline(
     }
     cleaned = stripModelSpecialTokens(cleaned);
     cleaned = stripRelevantMemoriesTags(cleaned);
+    cleaned = stripAssistantXmlScaffolding(cleaned);
     cleaned = stripToolCallXmlTags(cleaned, {
       stripFunctionCallsXmlPayloads: options.stripFunctionCallsXmlPayloads,
     });


### PR DESCRIPTION
## Summary

- strip Codex XML scaffolding such as `<file_contents ...>` blocks and standalone `<tool_calls>` / `<function_calls>` marker lines from the canonical assistant-visible sanitizer
- apply the canonical sanitizer on heartbeat payload and heartbeat runner delivery paths so protocol-only heartbeat replies are suppressed instead of delivered
- add regression coverage for mixed visible text, protocol-only scaffolding, fenced-code preservation, and heartbeat acknowledgements with trailing scaffolding

Fixes #81369.

Note: #81373 attempted a similar fix but was closed unmerged; this PR is scoped to heartbeat/user-visible sanitization only and avoids unrelated dependency or lockfile changes.

## Real behavior proof

- Behavior or issue addressed: Heartbeat delivery could leak raw Codex protocol scaffolding such as repeated `<tool_calls>` marker lines or `<file_contents ...>` blocks into user-visible chat.
- Real environment tested: Local OpenClaw checkout at commit `d076a884` on Linux, Node `v24.14.1`, pnpm `11.1.0`.
- Exact steps or command run after this patch: Ran `node --import tsx` from the OpenClaw checkout and invoked the production `sanitizeAssistantVisibleText` function against redacted heartbeat-shaped payloads containing repeated tool markers, file contents wrappers, mixed visible text, and a fenced XML example.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the local checkout:

```text
$ git rev-parse --short HEAD && node --version && pnpm --version
d076a884
v24.14.1
11.1.0

$ node --import tsx - <<'NODE_PROOF'
import { sanitizeAssistantVisibleText } from './src/shared/text/assistant-visible-text.ts';

const samples = {
  protocolOnly: ['<tool_calls>', '<tool_calls>', '<tool_calls>'].join('\n'),
  fileOnly: [
    '<file_contents path="/redacted/workspace/HEARTBEAT.md" isStale=false isFullFile=true>',
    ' 1|# HEARTBEAT.md',
    ' 2|internal heartbeat notes',
    '</file_contents>',
  ].join('\n'),
  mixedVisible: [
    'Visible intro',
    '<tool_calls>',
    '<file_contents path="/redacted/workspace/HEARTBEAT.md" isStale=false isFullFile=true>',
    ' 1|# HEARTBEAT.md',
    '</file_contents>',
    'Visible outro',
  ].join('\n'),
  fencedExample: [
    '```xml',
    '<file_contents path="/tmp/example.md">',
    'example',
    '</file_contents>',
    '```',
    'Visible answer',
  ].join('\n'),
};

for (const [name, input] of Object.entries(samples)) {
  console.log(`${name}: ${JSON.stringify(sanitizeAssistantVisibleText(input))}`);
}
NODE_PROOF
protocolOnly: ""
fileOnly: ""
mixedVisible: "Visible intro\n\nVisible outro"
fencedExample: "```xml\n<file_contents path=\"/tmp/example.md\">\nexample\n</file_contents>\n```\nVisible answer"
```

- Observed result after fix: Protocol-only heartbeat-shaped payloads sanitize to an empty string, so delivery paths can suppress them; mixed payloads preserve only visible user-facing text; fenced documentation examples are preserved.
- What was not tested: No live Discord or WhatsApp post was sent from this machine; the proof exercises the production sanitizer directly, and the heartbeat delivery path is covered by the added runner regression case.
- Before evidence (optional but encouraged): The linked issue includes the original reported heartbeat leak context and redacted environment details.

## Tests

- `pnpm vitest run src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
  - 4 files passed, 253 tests passed
- `./node_modules/.bin/oxfmt --check --threads=1 src/infra/heartbeat-runner.returns-default-unset.test.ts src/infra/heartbeat-runner.ts src/shared/text/assistant-visible-text.ts src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/auto-reply/reply/agent-runner-payloads.ts src/auto-reply/reply/agent-runner-payloads.test.ts`
- `git diff --check`
- `pnpm check:changed`

## Known upstream test failures

- `pnpm test:changed` currently fails in the agents shard on files unrelated to this PR:
  - `src/agents/pi-auth-json.test.ts`: mocked `./auth-profiles/external-auth.js` is missing the newer `syncPersistedExternalCliAuthProfiles` export
  - `src/agents/tools/web-fetch.provider-fallback.test.ts`: `SsrFBlockedError: Blocked: resolves to private/internal/special-use IP address`
- To verify these are not caused by this branch, I stashed this PR's changes and reran `pnpm vitest run src/agents/pi-auth-json.test.ts src/agents/tools/web-fetch.provider-fallback.test.ts` on clean `origin/main`; the same failures reproduced there.
