### PR TITLE
fix: preserve managed plugin peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Feishu/WhatsApp/Line: enforce inbound media size caps while reading download streams, avoiding full buffering of oversized attachments. (#81044, #81050) Thanks @samzong.
 - Config: serialize and retry semantic config mutations centrally, so concurrent commands can rebase safe changes instead of clobbering or hand-rolling command-local retry loops. (#76601)
 - Require approval for setup-code device pairing [AI]. (#81292) Thanks @pgondhi987.
+- Plugins/install: preserve third-party peer dependencies in the managed npm root when later plugin installs or updates recalculate the shared dependency tree. Thanks @shakkernerd.
 - Docker: pin setup-time container paths so stale host `.env` OpenClaw paths cannot leak into Linux containers. Fixes #80381. (#81105) Thanks @brokemac79.
 - Channels/WeCom: refresh the official onboarding install to `@wecom/wecom-openclaw-plugin@2026.5.7` and update existing managed npm installs instead of failing on the package directory. Fixes #79884. (#80390) Thanks @brokemac79.
 - Control UI/WebChat: keep short assistant replies clear of in-bubble copy/open action buttons by applying the existing reserved action spacing in the grouped chat renderer. Fixes #79509. (#81244) Thanks @JARVIS-Glasses.

--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -521,6 +521,7 @@ export async function syncManagedNpmRootPeerDependencies(params: {
   const manifest = await readManagedNpmRootManifest(manifestPath);
   const dependencies = readDependencyRecord(manifest.dependencies);
   const previousManagedPeerDependencies = readManagedPeerDependencyKeys(manifest.openclaw);
+  const previousManagedPeerDependencySet = new Set(previousManagedPeerDependencies);
   const peerPins = await collectManagedNpmRootPeerDependencyPins({ npmRoot: params.npmRoot });
   const nextDependencies = { ...dependencies };
   for (const packageName of previousManagedPeerDependencies) {
@@ -541,7 +542,13 @@ export async function syncManagedNpmRootPeerDependencies(params: {
     delete overrides[key];
   }
   Object.assign(overrides, managedOverrides);
-  const managedPeerDependencyKeys = Object.keys(peerPins).toSorted();
+  const managedPeerDependencyKeys = Object.keys(peerPins)
+    .filter(
+      (packageName) =>
+        previousManagedPeerDependencySet.has(packageName) ||
+        !Object.hasOwn(dependencies, packageName),
+    )
+    .toSorted();
   const openclawMetadata = buildManagedOpenClawMetadata({
     current: manifest.openclaw,
     managedOverrideKeys,
@@ -567,13 +574,6 @@ export async function syncManagedNpmRootPeerDependencies(params: {
     await writeJson(manifestPath, next, { trailingNewline: true });
   }
   return changed;
-}
-
-export async function readManagedNpmRootPeerDependencyNames(params: {
-  npmRoot: string;
-}): Promise<Set<string>> {
-  const manifest = await readManagedNpmRootManifest(path.join(params.npmRoot, "package.json"));
-  return new Set(readManagedPeerDependencyKeys(manifest.openclaw));
 }
 
 export async function repairManagedNpmRootOpenClawPeer(params: {

--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -24,6 +25,7 @@ type HostPackageManifest = {
 
 type ManagedNpmRootOpenClawMetadata = {
   managedOverrides?: string[];
+  managedPeerDependencies?: string[];
   [key: string]: unknown;
 };
 
@@ -86,9 +88,17 @@ function readManagedOverrideKeys(value: unknown): string[] {
   return value.managedOverrides.filter((key): key is string => typeof key === "string");
 }
 
+function readManagedPeerDependencyKeys(value: unknown): string[] {
+  if (!isRecord(value) || !Array.isArray(value.managedPeerDependencies)) {
+    return [];
+  }
+  return value.managedPeerDependencies.filter((key): key is string => typeof key === "string");
+}
+
 function buildManagedOpenClawMetadata(params: {
   current: unknown;
   managedOverrideKeys: string[];
+  managedPeerDependencyKeys?: string[];
 }): ManagedNpmRootOpenClawMetadata | undefined {
   const metadata: ManagedNpmRootOpenClawMetadata = isRecord(params.current)
     ? { ...params.current }
@@ -97,6 +107,12 @@ function buildManagedOpenClawMetadata(params: {
     metadata.managedOverrides = params.managedOverrideKeys;
   } else {
     delete metadata.managedOverrides;
+  }
+  const managedPeerDependencyKeys = params.managedPeerDependencyKeys;
+  if (managedPeerDependencyKeys && managedPeerDependencyKeys.length > 0) {
+    metadata.managedPeerDependencies = managedPeerDependencyKeys;
+  } else if (managedPeerDependencyKeys) {
+    delete metadata.managedPeerDependencies;
   }
   return Object.keys(metadata).length > 0 ? metadata : undefined;
 }
@@ -241,6 +257,174 @@ export async function upsertManagedNpmRootDependency(params: {
     delete next.openclaw;
   }
   await writeJson(manifestPath, next, { trailingNewline: true });
+}
+
+async function readPackageJsonIfExists(
+  packageDir: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(path.join(packageDir, "package.json"), "utf8"));
+    return isRecord(parsed) ? parsed : null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function readPackageVersion(packageDir: string): Promise<string | undefined> {
+  const parsed = await readPackageJsonIfExists(packageDir);
+  return parsed ? readOptionalString(parsed.version) : undefined;
+}
+
+function isOptionalPeerDependency(manifest: Record<string, unknown>, peerName: string): boolean {
+  if (!isRecord(manifest.peerDependenciesMeta)) {
+    return false;
+  }
+  const peerMetadata = manifest.peerDependenciesMeta[peerName];
+  return isRecord(peerMetadata) && peerMetadata.optional === true;
+}
+
+async function listNodeModulesPackageDirs(nodeModulesDir: string): Promise<string[]> {
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(nodeModulesDir, { withFileTypes: true });
+  } catch (err) {
+    if (
+      (err as NodeJS.ErrnoException).code === "ENOENT" ||
+      (err as NodeJS.ErrnoException).code === "ENOTDIR"
+    ) {
+      return [];
+    }
+    throw err;
+  }
+  const packageDirs: string[] = [];
+  for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
+    if (entry.name === ".bin" || entry.name.startsWith(".")) {
+      continue;
+    }
+    const entryPath = path.join(nodeModulesDir, entry.name);
+    if (entry.name.startsWith("@") && entry.isDirectory()) {
+      let scopedEntries: Dirent[];
+      try {
+        scopedEntries = await fs.readdir(entryPath, { withFileTypes: true });
+      } catch (err) {
+        if (
+          (err as NodeJS.ErrnoException).code === "ENOENT" ||
+          (err as NodeJS.ErrnoException).code === "ENOTDIR"
+        ) {
+          continue;
+        }
+        throw err;
+      }
+      for (const scopedEntry of scopedEntries.toSorted((left, right) =>
+        left.name.localeCompare(right.name),
+      )) {
+        if (scopedEntry.isDirectory() || scopedEntry.isSymbolicLink()) {
+          packageDirs.push(path.join(entryPath, scopedEntry.name));
+        }
+      }
+      continue;
+    }
+    if (entry.isDirectory() || entry.isSymbolicLink()) {
+      packageDirs.push(entryPath);
+    }
+  }
+  return packageDirs;
+}
+
+async function collectManagedNpmRootPeerDependencyPins(params: {
+  npmRoot: string;
+}): Promise<Record<string, string>> {
+  const pins = new Map<string, string>();
+  const queue = await listNodeModulesPackageDirs(path.join(params.npmRoot, "node_modules"));
+  for (let index = 0; index < queue.length; index += 1) {
+    const packageDir = queue[index];
+    if (!packageDir) {
+      continue;
+    }
+    const manifest = await readPackageJsonIfExists(packageDir);
+    if (manifest) {
+      if (readOptionalString(manifest.name) === "openclaw") {
+        continue;
+      }
+      const peerDependencies = readDependencyRecord(manifest.peerDependencies);
+      for (const [peerName, peerRange] of Object.entries(peerDependencies)) {
+        if (peerName === "openclaw" || pins.has(peerName)) {
+          continue;
+        }
+        const installedVersion = await readPackageVersion(
+          path.join(params.npmRoot, "node_modules", ...peerName.split("/")),
+        );
+        if (!installedVersion && isOptionalPeerDependency(manifest, peerName)) {
+          continue;
+        }
+        pins.set(peerName, installedVersion ?? peerRange);
+      }
+    }
+    queue.push(...(await listNodeModulesPackageDirs(path.join(packageDir, "node_modules"))));
+  }
+  return Object.fromEntries(
+    [...pins.entries()].toSorted(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+export async function syncManagedNpmRootPeerDependencies(params: {
+  npmRoot: string;
+  managedOverrides?: Record<string, unknown>;
+  omitUnsupportedManagedOverrides?: boolean;
+}): Promise<boolean> {
+  const manifestPath = path.join(params.npmRoot, "package.json");
+  const manifest = await readManagedNpmRootManifest(manifestPath);
+  const dependencies = readDependencyRecord(manifest.dependencies);
+  const previousManagedPeerDependencies = readManagedPeerDependencyKeys(manifest.openclaw);
+  const peerPins = await collectManagedNpmRootPeerDependencyPins({ npmRoot: params.npmRoot });
+  const nextDependencies = { ...dependencies };
+  for (const packageName of previousManagedPeerDependencies) {
+    if (!Object.hasOwn(peerPins, packageName)) {
+      delete nextDependencies[packageName];
+    }
+  }
+  for (const [packageName, dependencySpec] of Object.entries(peerPins)) {
+    nextDependencies[packageName] = dependencies[packageName] ?? dependencySpec;
+  }
+
+  const managedOverrides = params.omitUnsupportedManagedOverrides
+    ? filterUnsupportedManagedNpmRootOverrides(params.managedOverrides)
+    : readOverrideRecord(params.managedOverrides);
+  const managedOverrideKeys = Object.keys(managedOverrides).toSorted();
+  const overrides = readOverrideRecord(manifest.overrides);
+  for (const key of readManagedOverrideKeys(manifest.openclaw)) {
+    delete overrides[key];
+  }
+  Object.assign(overrides, managedOverrides);
+  const managedPeerDependencyKeys = Object.keys(peerPins).toSorted();
+  const openclawMetadata = buildManagedOpenClawMetadata({
+    current: manifest.openclaw,
+    managedOverrideKeys,
+    managedPeerDependencyKeys,
+  });
+  const next: ManagedNpmRootManifest = {
+    ...manifest,
+    private: true,
+    dependencies: nextDependencies,
+  };
+  if (Object.keys(overrides).length > 0) {
+    next.overrides = overrides;
+  } else {
+    delete next.overrides;
+  }
+  if (openclawMetadata) {
+    next.openclaw = openclawMetadata;
+  } else {
+    delete next.openclaw;
+  }
+  const changed = JSON.stringify(next) !== JSON.stringify(manifest);
+  if (changed) {
+    await writeJson(manifestPath, next, { trailingNewline: true });
+  }
+  return changed;
 }
 
 export async function repairManagedNpmRootOpenClawPeer(params: {

--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -427,6 +427,13 @@ export async function syncManagedNpmRootPeerDependencies(params: {
   return changed;
 }
 
+export async function readManagedNpmRootPeerDependencyNames(params: {
+  npmRoot: string;
+}): Promise<Set<string>> {
+  const manifest = await readManagedNpmRootManifest(path.join(params.npmRoot, "package.json"));
+  return new Set(readManagedPeerDependencyKeys(manifest.openclaw));
+}
+
 export async function repairManagedNpmRootOpenClawPeer(params: {
   npmRoot: string;
   timeoutMs?: number;

--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -29,6 +29,11 @@ type ManagedNpmRootOpenClawMetadata = {
   [key: string]: unknown;
 };
 
+export type ManagedNpmRootPeerDependencySnapshot = {
+  dependencies: Record<string, string>;
+  managedPeerDependencies: string[];
+};
+
 export type ManagedNpmRootInstalledDependency = {
   version?: string;
   integrity?: string;
@@ -46,6 +51,16 @@ type ManagedNpmRootLogger = {
 };
 
 type ManagedNpmRootRunCommand = typeof runCommandWithTimeout;
+
+type ManagedNpmPeerTraversalLimits = {
+  maxDepth: number;
+  maxDirectories: number;
+};
+
+const DEFAULT_MANAGED_NPM_PEER_TRAVERSAL_LIMITS: ManagedNpmPeerTraversalLimits = {
+  maxDepth: 64,
+  maxDirectories: 10_000,
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -66,6 +81,47 @@ function readDependencyRecord(value: unknown): Record<string, string> {
     }
   }
   return dependencies;
+}
+
+function readPositiveIntegerEnv(name: string, fallback: number): number {
+  const rawValue = process.env[name];
+  if (!rawValue) {
+    return fallback;
+  }
+  const parsedValue = Number.parseInt(rawValue, 10);
+  return Number.isFinite(parsedValue) && parsedValue >= 1 ? parsedValue : fallback;
+}
+
+function resolveManagedNpmPeerTraversalLimits(): ManagedNpmPeerTraversalLimits {
+  return {
+    maxDepth: readPositiveIntegerEnv(
+      "OPENCLAW_INSTALL_SCAN_MAX_DEPTH",
+      DEFAULT_MANAGED_NPM_PEER_TRAVERSAL_LIMITS.maxDepth,
+    ),
+    maxDirectories: readPositiveIntegerEnv(
+      "OPENCLAW_INSTALL_SCAN_MAX_DIRECTORIES",
+      DEFAULT_MANAGED_NPM_PEER_TRAVERSAL_LIMITS.maxDirectories,
+    ),
+  };
+}
+
+function isSamePathOrInside(parentPath: string, candidatePath: string): boolean {
+  const relative = path.relative(parentPath, candidatePath);
+  return (
+    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function isSafePackageName(name: string): boolean {
+  if (name.startsWith("@")) {
+    const parts = name.split("/");
+    return (
+      parts.length === 2 && parts.every((part) => part.length > 0 && part !== "." && part !== "..")
+    );
+  }
+  return (
+    name.length > 0 && !name.includes("/") && !name.includes("\\") && name !== "." && name !== ".."
+  );
 }
 
 function readOverrideRecord(value: unknown): Record<string, unknown> {
@@ -301,7 +357,7 @@ async function listNodeModulesPackageDirs(nodeModulesDir: string): Promise<strin
   }
   const packageDirs: string[] = [];
   for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
-    if (entry.name === ".bin" || entry.name.startsWith(".")) {
+    if (entry.name === ".bin" || entry.name === "openclaw" || entry.name.startsWith(".")) {
       continue;
     }
     const entryPath = path.join(nodeModulesDir, entry.name);
@@ -338,12 +394,42 @@ async function collectManagedNpmRootPeerDependencyPins(params: {
   npmRoot: string;
 }): Promise<Record<string, string>> {
   const pins = new Map<string, string>();
-  const queue = await listNodeModulesPackageDirs(path.join(params.npmRoot, "node_modules"));
+  const limits = resolveManagedNpmPeerTraversalLimits();
+  const boundaryRealPath = await fs
+    .realpath(params.npmRoot)
+    .catch(() => path.resolve(params.npmRoot));
+  const queue = (await listNodeModulesPackageDirs(path.join(params.npmRoot, "node_modules"))).map(
+    (packageDir) => ({ depth: 0, packageDir }),
+  );
+  const visitedRealPaths = new Set<string>();
   for (let index = 0; index < queue.length; index += 1) {
-    const packageDir = queue[index];
-    if (!packageDir) {
+    const current = queue[index];
+    if (!current) {
       continue;
     }
+    if (current.depth > limits.maxDepth) {
+      throw new Error(
+        `managed npm peer dependency scan exceeded max depth (${limits.maxDepth}) at ${current.packageDir}`,
+      );
+    }
+    const packageDirRealPath = await fs
+      .realpath(current.packageDir)
+      .catch(() => path.resolve(current.packageDir));
+    if (!isSamePathOrInside(boundaryRealPath, packageDirRealPath)) {
+      throw new Error(
+        `managed npm peer dependency scan found package outside managed npm root at ${current.packageDir}`,
+      );
+    }
+    if (visitedRealPaths.has(packageDirRealPath)) {
+      continue;
+    }
+    visitedRealPaths.add(packageDirRealPath);
+    if (visitedRealPaths.size > limits.maxDirectories) {
+      throw new Error(
+        `managed npm peer dependency scan exceeded max packages (${limits.maxDirectories}) under ${params.npmRoot}`,
+      );
+    }
+    const packageDir = current.packageDir;
     const manifest = await readPackageJsonIfExists(packageDir);
     if (manifest) {
       if (readOptionalString(manifest.name) === "openclaw") {
@@ -351,7 +437,7 @@ async function collectManagedNpmRootPeerDependencyPins(params: {
       }
       const peerDependencies = readDependencyRecord(manifest.peerDependencies);
       for (const [peerName, peerRange] of Object.entries(peerDependencies)) {
-        if (peerName === "openclaw" || pins.has(peerName)) {
+        if (peerName === "openclaw" || pins.has(peerName) || !isSafePackageName(peerName)) {
           continue;
         }
         const installedVersion = await readPackageVersion(
@@ -363,11 +449,67 @@ async function collectManagedNpmRootPeerDependencyPins(params: {
         pins.set(peerName, installedVersion ?? peerRange);
       }
     }
-    queue.push(...(await listNodeModulesPackageDirs(path.join(packageDir, "node_modules"))));
+    queue.push(
+      ...(await listNodeModulesPackageDirs(path.join(packageDir, "node_modules"))).map(
+        (nestedPackageDir) => ({
+          depth: current.depth + 1,
+          packageDir: nestedPackageDir,
+        }),
+      ),
+    );
   }
   return Object.fromEntries(
     [...pins.entries()].toSorted(([left], [right]) => left.localeCompare(right)),
   );
+}
+
+export async function readManagedNpmRootPeerDependencySnapshot(params: {
+  npmRoot: string;
+}): Promise<ManagedNpmRootPeerDependencySnapshot> {
+  const manifest = await readManagedNpmRootManifest(path.join(params.npmRoot, "package.json"));
+  const dependencies = readDependencyRecord(manifest.dependencies);
+  const managedPeerDependencies = readManagedPeerDependencyKeys(manifest.openclaw).toSorted();
+  const dependencySnapshot: Record<string, string> = {};
+  for (const packageName of managedPeerDependencies) {
+    const dependencySpec = dependencies[packageName];
+    if (dependencySpec) {
+      dependencySnapshot[packageName] = dependencySpec;
+    }
+  }
+  return {
+    dependencies: dependencySnapshot,
+    managedPeerDependencies,
+  };
+}
+
+export async function restoreManagedNpmRootPeerDependencySnapshot(params: {
+  npmRoot: string;
+  snapshot: ManagedNpmRootPeerDependencySnapshot;
+}): Promise<void> {
+  const manifestPath = path.join(params.npmRoot, "package.json");
+  const manifest = await readManagedNpmRootManifest(manifestPath);
+  const dependencies = readDependencyRecord(manifest.dependencies);
+  for (const packageName of readManagedPeerDependencyKeys(manifest.openclaw)) {
+    delete dependencies[packageName];
+  }
+  Object.assign(dependencies, params.snapshot.dependencies);
+  const managedOverrideKeys = readManagedOverrideKeys(manifest.openclaw).toSorted();
+  const openclawMetadata = buildManagedOpenClawMetadata({
+    current: manifest.openclaw,
+    managedOverrideKeys,
+    managedPeerDependencyKeys: params.snapshot.managedPeerDependencies.toSorted(),
+  });
+  const next: ManagedNpmRootManifest = {
+    ...manifest,
+    private: true,
+    dependencies,
+  };
+  if (openclawMetadata) {
+    next.openclaw = openclawMetadata;
+  } else {
+    delete next.openclaw;
+  }
+  await writeJson(manifestPath, next, { trailingNewline: true });
 }
 
 export async function syncManagedNpmRootPeerDependencies(params: {

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -444,7 +444,7 @@ describe("installPluginFromNpmSpec e2e", () => {
     ).resolves.toBeTruthy();
   });
 
-  it("does not attribute repaired pre-existing peer dependencies to later installs", async () => {
+  it("scans repaired pre-existing peer dependencies during later installs", async () => {
     const rootDir = await makeTempDir("npm-plugin-repaired-peer-scan-e2e");
     const npmRoot = path.join(rootDir, "managed-npm");
     const pluginWithRuntimePeer = `existing-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
@@ -531,13 +531,27 @@ describe("installPluginFromNpmSpec e2e", () => {
       logger: { info: () => {}, warn: () => {} },
       timeoutMs: 120_000,
     });
-    if (!later.ok) {
-      throw new Error(later.error);
+    expect(later.ok).toBe(false);
+    if (later.ok) {
+      throw new Error("expected repaired peer dependency scan to block installation");
     }
+    expect(later.error).toContain("Dynamic code execution detected");
 
     await expect(
+      fs.lstat(path.join(npmRoot, "node_modules", laterPlugin, "package.json")),
+    ).rejects.toHaveProperty("code", "ENOENT");
+    await expect(
       fs.lstat(path.join(npmRoot, "node_modules", runtimePeer, "package.json")),
-    ).resolves.toBeTruthy();
+    ).rejects.toHaveProperty("code", "ENOENT");
+    const rootManifest = JSON.parse(
+      await fs.readFile(path.join(npmRoot, "package.json"), "utf8"),
+    ) as {
+      dependencies?: Record<string, string>;
+      openclaw?: { managedPeerDependencies?: string[] };
+    };
+    expect(rootManifest.dependencies?.[laterPlugin]).toBeUndefined();
+    expect(rootManifest.dependencies?.[runtimePeer]).toBeUndefined();
+    expect(rootManifest.openclaw?.managedPeerDependencies ?? []).not.toContain(runtimePeer);
   });
 
   it("bounds peer dependency discovery across repeated nested package realpaths", async () => {
@@ -672,6 +686,119 @@ describe("installPluginFromNpmSpec e2e", () => {
     expect(rootManifest.dependencies?.[blockedPlugin]).toBeUndefined();
     expect(rootManifest.dependencies?.[runtimePeer]).toBeUndefined();
     expect(rootManifest.openclaw?.managedPeerDependencies ?? []).not.toContain(runtimePeer);
+    await expect(
+      fs.lstat(path.join(npmRoot, "node_modules", blockedPlugin, "package.json")),
+    ).rejects.toHaveProperty("code", "ENOENT");
+    await expect(
+      fs.lstat(path.join(npmRoot, "node_modules", runtimePeer, "package.json")),
+    ).rejects.toHaveProperty("code", "ENOENT");
+  });
+
+  it("does not take ownership of an existing root dependency observed as a peer", async () => {
+    const rootDir = await makeTempDir("npm-plugin-peer-existing-root-e2e");
+    const npmRoot = path.join(rootDir, "managed-npm");
+    const existingRootDependency = `existing-root-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const blockedPlugin = `blocked-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const runtimePeer = `runtime-peer-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const registry = await startStaticRegistry([
+      {
+        packageName: existingRootDependency,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: existingRootDependency,
+            pluginId: existingRootDependency,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: blockedPlugin,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: blockedPlugin,
+            peerDependencies: {
+              [existingRootDependency]: "^1.0.0",
+              [runtimePeer]: "^1.0.0",
+            },
+            peerDependenciesMeta: {},
+            pluginId: blockedPlugin,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: runtimePeer,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            indexJs: "eval('1');\n",
+            packageName: runtimePeer,
+            pluginId: runtimePeer,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+    ]);
+    process.env.NPM_CONFIG_REGISTRY = registry;
+    process.env.npm_config_registry = registry;
+
+    await fs.mkdir(npmRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(npmRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          private: true,
+          dependencies: { [existingRootDependency]: "1.0.0" },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await execFileAsync(
+      "npm",
+      [
+        "install",
+        "--omit=dev",
+        "--omit=peer",
+        "--legacy-peer-deps",
+        "--loglevel=error",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+      ],
+      { cwd: npmRoot },
+    );
+
+    const result = await installPluginFromNpmSpec({
+      spec: `${blockedPlugin}@1.0.0`,
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+      timeoutMs: 120_000,
+    });
+
+    expect(result.ok).toBe(false);
+    const rootManifest = JSON.parse(
+      await fs.readFile(path.join(npmRoot, "package.json"), "utf8"),
+    ) as {
+      dependencies?: Record<string, string>;
+      openclaw?: { managedPeerDependencies?: string[] };
+    };
+    expect(rootManifest.dependencies?.[existingRootDependency]).toBe("1.0.0");
+    expect(rootManifest.dependencies?.[blockedPlugin]).toBeUndefined();
+    expect(rootManifest.dependencies?.[runtimePeer]).toBeUndefined();
+    expect(rootManifest.openclaw?.managedPeerDependencies ?? []).not.toContain(
+      existingRootDependency,
+    );
+    expect(rootManifest.openclaw?.managedPeerDependencies ?? []).not.toContain(runtimePeer);
+    await expect(
+      fs.lstat(path.join(npmRoot, "node_modules", existingRootDependency, "package.json")),
+    ).resolves.toBeTruthy();
     await expect(
       fs.lstat(path.join(npmRoot, "node_modules", blockedPlugin, "package.json")),
     ).rejects.toHaveProperty("code", "ENOENT");

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -362,7 +362,84 @@ describe("installPluginFromNpmSpec e2e", () => {
     ).resolves.toBe(true);
   });
 
-  it("omits peers when installing beside an existing host-peer plugin", async () => {
+  it("keeps third-party peer dependencies across later managed npm installs", async () => {
+    const rootDir = await makeTempDir("npm-plugin-third-party-peer-e2e");
+    const npmRoot = path.join(rootDir, "managed-npm");
+    const pluginWithRuntimePeer = `runtime-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const laterPlugin = `later-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const runtimePeer = `runtime-peer-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const registry = await startStaticRegistry([
+      {
+        packageName: pluginWithRuntimePeer,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: pluginWithRuntimePeer,
+            peerDependencies: { [runtimePeer]: "^1.0.0" },
+            peerDependenciesMeta: {},
+            pluginId: pluginWithRuntimePeer,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: laterPlugin,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: laterPlugin,
+            pluginId: laterPlugin,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: runtimePeer,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: runtimePeer,
+            pluginId: runtimePeer,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+    ]);
+    process.env.NPM_CONFIG_REGISTRY = registry;
+    process.env.npm_config_registry = registry;
+
+    const first = await installPluginFromNpmSpec({
+      spec: `${pluginWithRuntimePeer}@1.0.0`,
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+      timeoutMs: 120_000,
+    });
+    if (!first.ok) {
+      throw new Error(first.error);
+    }
+    await expect(
+      fs.lstat(path.join(npmRoot, "node_modules", runtimePeer, "package.json")),
+    ).resolves.toBeTruthy();
+
+    const second = await installPluginFromNpmSpec({
+      spec: `${laterPlugin}@1.0.0`,
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+      timeoutMs: 120_000,
+    });
+    if (!second.ok) {
+      throw new Error(second.error);
+    }
+
+    await expect(
+      fs.lstat(path.join(npmRoot, "node_modules", runtimePeer, "package.json")),
+    ).resolves.toBeTruthy();
+  });
+
+  it("scrubs host peers when installing beside an existing host-peer plugin", async () => {
     const rootDir = await makeTempDir("npm-plugin-sibling-peer-e2e");
     const npmRoot = path.join(rootDir, "managed-npm");
     const codexName = `codex-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -540,6 +540,146 @@ describe("installPluginFromNpmSpec e2e", () => {
     ).resolves.toBeTruthy();
   });
 
+  it("bounds peer dependency discovery across repeated nested package realpaths", async () => {
+    const rootDir = await makeTempDir("npm-plugin-peer-cycle-e2e");
+    const npmRoot = path.join(rootDir, "managed-npm");
+    const existingPlugin = `existing-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const laterPlugin = `later-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const registry = await startStaticRegistry([
+      {
+        packageName: existingPlugin,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: existingPlugin,
+            pluginId: existingPlugin,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: laterPlugin,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: laterPlugin,
+            pluginId: laterPlugin,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+    ]);
+    process.env.NPM_CONFIG_REGISTRY = registry;
+    process.env.npm_config_registry = registry;
+
+    await fs.mkdir(npmRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(npmRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          private: true,
+          dependencies: { [existingPlugin]: "1.0.0" },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await execFileAsync(
+      "npm",
+      [
+        "install",
+        "--omit=dev",
+        "--omit=peer",
+        "--legacy-peer-deps",
+        "--loglevel=error",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+      ],
+      { cwd: npmRoot },
+    );
+    const existingPluginDir = path.join(npmRoot, "node_modules", existingPlugin);
+    await fs.mkdir(path.join(existingPluginDir, "node_modules"), { recursive: true });
+    await fs.symlink(existingPluginDir, path.join(existingPluginDir, "node_modules", "self"));
+
+    const later = await installPluginFromNpmSpec({
+      spec: `${laterPlugin}@1.0.0`,
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+      timeoutMs: 120_000,
+    });
+
+    expect(later.ok).toBe(true);
+    await expect(
+      fs.lstat(path.join(npmRoot, "node_modules", laterPlugin, "package.json")),
+    ).resolves.toBeTruthy();
+  });
+
+  it("rolls back managed peer dependencies added before a failed install scan", async () => {
+    const rootDir = await makeTempDir("npm-plugin-peer-rollback-e2e");
+    const npmRoot = path.join(rootDir, "managed-npm");
+    const blockedPlugin = `blocked-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const runtimePeer = `runtime-peer-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const registry = await startStaticRegistry([
+      {
+        packageName: blockedPlugin,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: blockedPlugin,
+            peerDependencies: { [runtimePeer]: "^1.0.0" },
+            peerDependenciesMeta: {},
+            pluginId: blockedPlugin,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: runtimePeer,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            indexJs: "eval('1');\n",
+            packageName: runtimePeer,
+            pluginId: runtimePeer,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+    ]);
+    process.env.NPM_CONFIG_REGISTRY = registry;
+    process.env.npm_config_registry = registry;
+
+    const result = await installPluginFromNpmSpec({
+      spec: `${blockedPlugin}@1.0.0`,
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+      timeoutMs: 120_000,
+    });
+
+    expect(result.ok).toBe(false);
+    const rootManifest = JSON.parse(
+      await fs.readFile(path.join(npmRoot, "package.json"), "utf8"),
+    ) as {
+      dependencies?: Record<string, string>;
+      openclaw?: { managedPeerDependencies?: string[] };
+    };
+    expect(rootManifest.dependencies?.[blockedPlugin]).toBeUndefined();
+    expect(rootManifest.dependencies?.[runtimePeer]).toBeUndefined();
+    expect(rootManifest.openclaw?.managedPeerDependencies ?? []).not.toContain(runtimePeer);
+    await expect(
+      fs.lstat(path.join(npmRoot, "node_modules", blockedPlugin, "package.json")),
+    ).rejects.toHaveProperty("code", "ENOENT");
+    await expect(
+      fs.lstat(path.join(npmRoot, "node_modules", runtimePeer, "package.json")),
+    ).rejects.toHaveProperty("code", "ENOENT");
+  });
+
   it("scrubs host peers when installing beside an existing host-peer plugin", async () => {
     const rootDir = await makeTempDir("npm-plugin-sibling-peer-e2e");
     const npmRoot = path.join(rootDir, "managed-npm");

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -52,6 +52,7 @@ async function packPlugin(params: {
   pluginId: string;
   version: string;
   rootDir: string;
+  indexJs?: string;
 }): Promise<PackedVersion> {
   const packageDir = path.join(params.rootDir, `package-${params.packageName}-${params.version}`);
   const peerDependenciesMeta = params.peerDependencies
@@ -94,7 +95,11 @@ async function packPlugin(params: {
     )}\n`,
     "utf8",
   );
-  await fs.writeFile(path.join(packageDir, "dist", "index.js"), "export {};\n", "utf8");
+  await fs.writeFile(
+    path.join(packageDir, "dist", "index.js"),
+    params.indexJs ?? "export {};\n",
+    "utf8",
+  );
 
   const packOutput = execFileSync(
     "npm",
@@ -432,6 +437,102 @@ describe("installPluginFromNpmSpec e2e", () => {
     });
     if (!second.ok) {
       throw new Error(second.error);
+    }
+
+    await expect(
+      fs.lstat(path.join(npmRoot, "node_modules", runtimePeer, "package.json")),
+    ).resolves.toBeTruthy();
+  });
+
+  it("does not attribute repaired pre-existing peer dependencies to later installs", async () => {
+    const rootDir = await makeTempDir("npm-plugin-repaired-peer-scan-e2e");
+    const npmRoot = path.join(rootDir, "managed-npm");
+    const pluginWithRuntimePeer = `existing-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const laterPlugin = `later-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const runtimePeer = `runtime-peer-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const registry = await startStaticRegistry([
+      {
+        packageName: pluginWithRuntimePeer,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: pluginWithRuntimePeer,
+            peerDependencies: { [runtimePeer]: "^1.0.0" },
+            peerDependenciesMeta: {},
+            pluginId: pluginWithRuntimePeer,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: laterPlugin,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: laterPlugin,
+            pluginId: laterPlugin,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: runtimePeer,
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            indexJs: "eval('1');\n",
+            packageName: runtimePeer,
+            pluginId: runtimePeer,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+    ]);
+    process.env.NPM_CONFIG_REGISTRY = registry;
+    process.env.npm_config_registry = registry;
+
+    await fs.mkdir(npmRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(npmRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          private: true,
+          dependencies: { [pluginWithRuntimePeer]: "1.0.0" },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await execFileAsync(
+      "npm",
+      [
+        "install",
+        "--omit=dev",
+        "--omit=peer",
+        "--legacy-peer-deps",
+        "--loglevel=error",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+      ],
+      { cwd: npmRoot },
+    );
+    await expect(
+      fs.lstat(path.join(npmRoot, "node_modules", runtimePeer, "package.json")),
+    ).rejects.toHaveProperty("code", "ENOENT");
+
+    const later = await installPluginFromNpmSpec({
+      spec: `${laterPlugin}@1.0.0`,
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+      timeoutMs: 120_000,
+    });
+    if (!later.ok) {
+      throw new Error(later.error);
     }
 
     await expect(

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -304,6 +304,16 @@ function mockNpmViewAndInstallMany(packages: MockNpmPackage[]) {
         const installedPackages: MockNpmPackage[] = [];
         prunePluginLocalOpenClawPeerLinks(npmRoot);
         for (const packageName of Object.keys(manifest.dependencies ?? {})) {
+          if (packageName === "openclaw") {
+            const openclawRoot = path.join(npmRoot, "node_modules", "openclaw");
+            fs.mkdirSync(openclawRoot, { recursive: true });
+            fs.writeFileSync(
+              path.join(openclawRoot, "package.json"),
+              JSON.stringify({ name: "openclaw", version: "0.0.0-test" }),
+              "utf8",
+            );
+            continue;
+          }
           const pkg = packagesByName.get(packageName);
           if (!pkg) {
             throw new Error(`unexpected managed npm dependency: ${packageName}`);

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -13,7 +13,6 @@ import { resolveNpmIntegrityDriftWithDefaultMessage } from "../infra/npm-integri
 import {
   type ManagedNpmRootPeerDependencySnapshot,
   readManagedNpmRootInstalledDependency,
-  readManagedNpmRootPeerDependencyNames,
   readManagedNpmRootPeerDependencySnapshot,
   readOpenClawManagedNpmRootOverrides,
   repairManagedNpmRootOpenClawPeer,
@@ -380,11 +379,21 @@ async function rollbackManagedNpmPluginInstall(params: {
   }
   if (params.peerDependencySnapshot) {
     try {
+      const preRestorePeerDependencySnapshot = await readManagedNpmRootPeerDependencySnapshot({
+        npmRoot: params.npmRoot,
+      });
+      const restoredPeerDependencyNames = new Set(
+        params.peerDependencySnapshot.managedPeerDependencies,
+      );
+      const addedPeerDependencyNames =
+        preRestorePeerDependencySnapshot.managedPeerDependencies.filter(
+          (packageName) => !restoredPeerDependencyNames.has(packageName),
+        );
       await restoreManagedNpmRootPeerDependencySnapshot({
         npmRoot: params.npmRoot,
         snapshot: params.peerDependencySnapshot,
       });
-      await runCommandWithTimeout(
+      const cleanupResult = await runCommandWithTimeout(
         [
           "npm",
           "install",
@@ -406,6 +415,25 @@ async function rollbackManagedNpmPluginInstall(params: {
           }),
         },
       );
+      if (cleanupResult.code !== 0) {
+        params.logger.warn?.(
+          `npm install cleanup after rollback for ${params.packageName} exited ${cleanupResult.code}: ${cleanupResult.stderr.trim() || cleanupResult.stdout.trim()}`,
+        );
+        await Promise.all(
+          addedPeerDependencyNames.map(async (packageName) => {
+            try {
+              await fs.rm(resolveManagedNpmRootPackageDir(params.npmRoot, packageName), {
+                recursive: true,
+                force: true,
+              });
+            } catch (error) {
+              params.logger.warn?.(
+                `Failed to remove rolled-back managed peer dependency ${packageName}: ${String(error)}`,
+              );
+            }
+          }),
+        );
+      }
     } catch (error) {
       params.logger.warn?.(
         `Failed to restore managed npm peer dependencies after rollback for ${params.packageName}: ${String(error)}`,
@@ -504,16 +532,11 @@ function resolveManagedNpmRootPackageDir(npmRoot: string, packageName: string): 
 
 async function listNewManagedNpmRootPackageDirs(params: {
   beforeInstallPackageNames: Set<string>;
-  excludePackageNames?: Set<string>;
   npmRoot: string;
 }): Promise<string[]> {
   const afterInstallPackageNames = await listManagedNpmRootPackageNames(params.npmRoot);
   return [...afterInstallPackageNames]
-    .filter(
-      (packageName) =>
-        !params.beforeInstallPackageNames.has(packageName) &&
-        !params.excludePackageNames?.has(packageName),
-    )
+    .filter((packageName) => !params.beforeInstallPackageNames.has(packageName))
     .map((packageName) => resolveManagedNpmRootPackageDir(params.npmRoot, packageName))
     .toSorted((left, right) => left.localeCompare(right));
 }
@@ -619,9 +642,6 @@ async function installPluginFromManagedNpmRoot(
     managedOverrides,
   });
   await syncManagedNpmRootPeerDependencies({ npmRoot, managedOverrides });
-  const preExistingManagedPeerDependencyNames = await readManagedNpmRootPeerDependencyNames({
-    npmRoot,
-  });
   const npmInstallArgs = [
     "npm",
     ...createSafeNpmInstallArgs({
@@ -808,7 +828,6 @@ async function installPluginFromManagedNpmRoot(
 
   const newRootPackageDirs = await listNewManagedNpmRootPackageDirs({
     beforeInstallPackageNames: preInstallRootPackageNames,
-    excludePackageNames: preExistingManagedPeerDependencyNames,
     npmRoot,
   });
   const result = await installPluginFromInstalledPackageDir({

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -16,6 +16,7 @@ import {
   repairManagedNpmRootOpenClawPeer,
   removeManagedNpmRootDependency,
   resolveManagedNpmRootDependencySpec,
+  syncManagedNpmRootPeerDependencies,
   upsertManagedNpmRootDependency,
   type ManagedNpmRootInstalledDependency,
 } from "../infra/npm-managed-root.js";
@@ -372,6 +373,19 @@ async function rollbackManagedNpmPluginInstall(params: {
       `Failed to remove managed npm dependency ${params.packageName}: ${String(error)}`,
     );
   }
+  if (params.packageName !== "openclaw") {
+    try {
+      await repairManagedNpmRootOpenClawPeer({
+        npmRoot: params.npmRoot,
+        timeoutMs: params.timeoutMs,
+        logger: params.logger,
+      });
+    } catch (error) {
+      params.logger.warn?.(
+        `Failed to repair managed npm openclaw peer after rollback: ${String(error)}`,
+      );
+    }
+  }
   try {
     await relinkOpenClawPeerDependenciesInManagedNpmRoot({
       npmRoot: params.npmRoot,
@@ -557,6 +571,7 @@ async function installPluginFromManagedNpmRoot(
     dependencySpec: params.dependencySpec,
     managedOverrides,
   });
+  await syncManagedNpmRootPeerDependencies({ npmRoot, managedOverrides });
   const npmInstallArgs = [
     "npm",
     ...createSafeNpmInstallArgs({
@@ -578,10 +593,12 @@ async function installPluginFromManagedNpmRoot(
     }),
   };
   let install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
+  let omitUnsupportedManagedOverrides = false;
   if (install.code !== 0 && isNpmAliasOverrideComparatorError(install)) {
     logger.warn?.(
       "npm rejected managed npm alias overrides; retrying plugin install without alias overrides for this npm version.",
     );
+    omitUnsupportedManagedOverrides = true;
     await upsertManagedNpmRootDependency({
       npmRoot,
       packageName: params.packageName,
@@ -602,6 +619,54 @@ async function installPluginFromManagedNpmRoot(
     return {
       ok: false,
       error: `npm install failed: ${install.stderr.trim() || install.stdout.trim()}`,
+    };
+  }
+  let settledManagedPeerDependencies = false;
+  for (let peerSyncPass = 0; peerSyncPass < 10; peerSyncPass += 1) {
+    const syncedPeerDependencies = await syncManagedNpmRootPeerDependencies({
+      npmRoot,
+      managedOverrides,
+      omitUnsupportedManagedOverrides,
+    });
+    if (!syncedPeerDependencies) {
+      settledManagedPeerDependencies = true;
+      break;
+    }
+    install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
+    if (install.code !== 0) {
+      await rollbackManagedNpmPluginInstall({
+        npmRoot,
+        packageName: params.packageName,
+        targetDir: installRoot,
+        timeoutMs,
+        logger,
+      });
+      return {
+        ok: false,
+        error: `npm install failed after syncing managed peer dependencies: ${install.stderr.trim() || install.stdout.trim()}`,
+      };
+    }
+  }
+  if (!settledManagedPeerDependencies) {
+    const syncedPeerDependencies = await syncManagedNpmRootPeerDependencies({
+      npmRoot,
+      managedOverrides,
+      omitUnsupportedManagedOverrides,
+    });
+    settledManagedPeerDependencies = !syncedPeerDependencies;
+  }
+  if (!settledManagedPeerDependencies) {
+    await rollbackManagedNpmPluginInstall({
+      npmRoot,
+      packageName: params.packageName,
+      targetDir: installRoot,
+      timeoutMs,
+      logger,
+    });
+    return {
+      ok: false,
+      error:
+        "npm install could not settle managed peer dependencies after 10 sync passes; refusing to leave a partially reconciled plugin dependency tree.",
     };
   }
   if (params.packageName !== "openclaw") {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -11,12 +11,15 @@ import {
 } from "../infra/install-source-utils.js";
 import { resolveNpmIntegrityDriftWithDefaultMessage } from "../infra/npm-integrity.js";
 import {
+  type ManagedNpmRootPeerDependencySnapshot,
   readManagedNpmRootInstalledDependency,
   readManagedNpmRootPeerDependencyNames,
+  readManagedNpmRootPeerDependencySnapshot,
   readOpenClawManagedNpmRootOverrides,
   repairManagedNpmRootOpenClawPeer,
   removeManagedNpmRootDependency,
   resolveManagedNpmRootDependencySpec,
+  restoreManagedNpmRootPeerDependencySnapshot,
   syncManagedNpmRootPeerDependencies,
   upsertManagedNpmRootDependency,
   type ManagedNpmRootInstalledDependency,
@@ -329,6 +332,7 @@ async function rollbackManagedNpmPluginInstall(params: {
   targetDir: string;
   timeoutMs: number;
   logger: PluginInstallLogger;
+  peerDependencySnapshot?: ManagedNpmRootPeerDependencySnapshot;
 }): Promise<void> {
   try {
     await runCommandWithTimeout(
@@ -373,6 +377,40 @@ async function rollbackManagedNpmPluginInstall(params: {
     params.logger.warn?.(
       `Failed to remove managed npm dependency ${params.packageName}: ${String(error)}`,
     );
+  }
+  if (params.peerDependencySnapshot) {
+    try {
+      await restoreManagedNpmRootPeerDependencySnapshot({
+        npmRoot: params.npmRoot,
+        snapshot: params.peerDependencySnapshot,
+      });
+      await runCommandWithTimeout(
+        [
+          "npm",
+          "install",
+          "--omit=dev",
+          "--omit=peer",
+          "--loglevel=error",
+          "--legacy-peer-deps",
+          "--ignore-scripts",
+          "--no-audit",
+          "--no-fund",
+        ],
+        {
+          cwd: params.npmRoot,
+          timeoutMs: Math.max(params.timeoutMs, 300_000),
+          env: createSafeNpmInstallEnv(process.env, {
+            legacyPeerDeps: true,
+            packageLock: true,
+            quiet: true,
+          }),
+        },
+      );
+    } catch (error) {
+      params.logger.warn?.(
+        `Failed to restore managed npm peer dependencies after rollback for ${params.packageName}: ${String(error)}`,
+      );
+    }
   }
   if (params.packageName !== "openclaw") {
     try {
@@ -571,6 +609,9 @@ async function installPluginFromManagedNpmRoot(
   }
   const preInstallRootPackageNames = await listManagedNpmRootPackageNames(npmRoot);
   const managedOverrides = await readOpenClawManagedNpmRootOverrides();
+  const rollbackPeerDependencySnapshot = await readManagedNpmRootPeerDependencySnapshot({
+    npmRoot,
+  });
   await upsertManagedNpmRootDependency({
     npmRoot,
     packageName: params.packageName,
@@ -624,6 +665,7 @@ async function installPluginFromManagedNpmRoot(
       targetDir: installRoot,
       timeoutMs,
       logger,
+      peerDependencySnapshot: rollbackPeerDependencySnapshot,
     });
     return {
       ok: false,
@@ -649,6 +691,7 @@ async function installPluginFromManagedNpmRoot(
         targetDir: installRoot,
         timeoutMs,
         logger,
+        peerDependencySnapshot: rollbackPeerDependencySnapshot,
       });
       return {
         ok: false,
@@ -671,6 +714,7 @@ async function installPluginFromManagedNpmRoot(
       targetDir: installRoot,
       timeoutMs,
       logger,
+      peerDependencySnapshot: rollbackPeerDependencySnapshot,
     });
     return {
       ok: false,
@@ -700,6 +744,7 @@ async function installPluginFromManagedNpmRoot(
       targetDir: installRoot,
       timeoutMs,
       logger,
+      peerDependencySnapshot: rollbackPeerDependencySnapshot,
     });
     return {
       ok: false,
@@ -713,6 +758,7 @@ async function installPluginFromManagedNpmRoot(
       targetDir: installRoot,
       timeoutMs,
       logger,
+      peerDependencySnapshot: rollbackPeerDependencySnapshot,
     });
     return {
       ok: false,
@@ -733,6 +779,7 @@ async function installPluginFromManagedNpmRoot(
       targetDir: installRoot,
       timeoutMs,
       logger,
+      peerDependencySnapshot: rollbackPeerDependencySnapshot,
     });
     return {
       ok: false,
@@ -751,6 +798,7 @@ async function installPluginFromManagedNpmRoot(
       targetDir: installRoot,
       timeoutMs,
       logger,
+      peerDependencySnapshot: rollbackPeerDependencySnapshot,
     });
     return {
       ok: false,
@@ -781,6 +829,7 @@ async function installPluginFromManagedNpmRoot(
       targetDir: installRoot,
       timeoutMs,
       logger,
+      peerDependencySnapshot: rollbackPeerDependencySnapshot,
     });
     return result;
   }

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -12,6 +12,7 @@ import {
 import { resolveNpmIntegrityDriftWithDefaultMessage } from "../infra/npm-integrity.js";
 import {
   readManagedNpmRootInstalledDependency,
+  readManagedNpmRootPeerDependencyNames,
   readOpenClawManagedNpmRootOverrides,
   repairManagedNpmRootOpenClawPeer,
   removeManagedNpmRootDependency,
@@ -465,11 +466,16 @@ function resolveManagedNpmRootPackageDir(npmRoot: string, packageName: string): 
 
 async function listNewManagedNpmRootPackageDirs(params: {
   beforeInstallPackageNames: Set<string>;
+  excludePackageNames?: Set<string>;
   npmRoot: string;
 }): Promise<string[]> {
   const afterInstallPackageNames = await listManagedNpmRootPackageNames(params.npmRoot);
   return [...afterInstallPackageNames]
-    .filter((packageName) => !params.beforeInstallPackageNames.has(packageName))
+    .filter(
+      (packageName) =>
+        !params.beforeInstallPackageNames.has(packageName) &&
+        !params.excludePackageNames?.has(packageName),
+    )
     .map((packageName) => resolveManagedNpmRootPackageDir(params.npmRoot, packageName))
     .toSorted((left, right) => left.localeCompare(right));
 }
@@ -572,6 +578,9 @@ async function installPluginFromManagedNpmRoot(
     managedOverrides,
   });
   await syncManagedNpmRootPeerDependencies({ npmRoot, managedOverrides });
+  const preExistingManagedPeerDependencyNames = await readManagedNpmRootPeerDependencyNames({
+    npmRoot,
+  });
   const npmInstallArgs = [
     "npm",
     ...createSafeNpmInstallArgs({
@@ -751,6 +760,7 @@ async function installPluginFromManagedNpmRoot(
 
   const newRootPackageDirs = await listNewManagedNpmRootPackageDirs({
     beforeInstallPackageNames: preInstallRootPackageNames,
+    excludePackageNames: preExistingManagedPeerDependencyNames,
     npmRoot,
   });
   const result = await installPluginFromInstalledPackageDir({


### PR DESCRIPTION
## Summary

Fixes the beta update/plugin install path where `npm install` in the shared OpenClaw npm root could prune peer dependencies used by existing plugins.

The concrete reported failure was a custom plugin depending on `@lancedb/lancedb`; LanceDB declares `apache-arrow` as a peer dependency, and a later beta plugin install/update could remove `apache-arrow`, causing the custom plugin to fail loading.

This change:
- discovers and preserves third-party peer dependencies in the managed npm root
- tracks only peer dependencies OpenClaw actually owns
- avoids marking existing root plugin dependencies as managed peers
- scans repaired/materialized peer packages instead of silently trusting them
- rolls back managed peer dependency mutations on failed installs
- bounds peer discovery traversal to avoid symlink/cycle/unbounded scan issues

## Verification

Post-rebase sanity:

```text
git diff --check origin/main..HEAD
```

Live CLI checks were run against the same four-commit patch stack before the final clean rebase:

- Built and installed a packed CLI from the patch stack: `OpenClaw 2026.5.12-beta.1 (8aeb0b8)`.
- Installed an existing root plugin, then attempted a plugin whose peers included that existing root plugin plus a dangerous peer.
  - install failed with the expected security scan block
  - existing root plugin stayed installed/listed
  - existing root plugin was not marked as a managed peer
  - blocked plugin and dangerous peer were not left in dependencies, on disk, or managed metadata
- Installed a safe plugin with a missing peer.
  - missing peer was materialized
  - peer stayed tracked in `managedPeerDependencies`
- Ran real `plugins update` against a local registry moving latest from `1.0.0` to `1.0.1`.
  - target updated to `1.0.1`
  - managed peer stayed installed/tracked
- Reproduced the reported LanceDB shape live:
  - temp custom plugin depended on real `@lancedb/lancedb@0.27.2`
  - OpenClaw installed/tracked `apache-arrow@18.1.0`
  - installed real `@openclaw/acpx@2026.5.12-beta.4`
  - `@lancedb/lancedb` and `apache-arrow` both remained present
  - custom plugin and acpx both listed cleanly
  - no stale diagnostics from `plugins list --json`
