### PR TITLE
docs(plugins): correct wrapStreamFn example signature

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -395,16 +395,21 @@ API key auth, and dynamic model resolution.
         For providers that need custom request headers or body modifications:
 
         ```typescript
-        // wrapStreamFn returns a StreamFn derived from ctx.streamFn
+        // wrapStreamFn returns a StreamFn derived from ctx.streamFn.
+        // The wrapped function receives (model, context, options) and must
+        // forward all three to inner. Inject custom headers by merging into
+        // options.headers rather than mutating the model.
         wrapStreamFn: (ctx) => {
           if (!ctx.streamFn) return undefined;
           const inner = ctx.streamFn;
-          return async (params) => {
-            params.headers = {
-              ...params.headers,
-              "X-Acme-Version": "2",
-            };
-            return inner(params);
+          return (model, context, options) => {
+            return inner(model, context, {
+              ...options,
+              headers: {
+                ...options?.headers,
+                "X-Acme-Version": "2",
+              },
+            });
           };
         },
         ```


### PR DESCRIPTION
## Problem

The `Custom headers` example in `docs/plugins/sdk-provider-plugins.md` shows `wrapStreamFn` returning a 1-arg `(params) => ...` function that mutates `params.headers`, `params.body`, etc. That signature doesn't exist anywhere in the codebase or in the published types.

The real `StreamFn` is 3-arg `(model, context, options?)`:

- `@earendil-works/pi-agent-core@0.74.0/dist/types.d.ts` — `type StreamFn = (...args: Parameters<typeof streamSimple>) => ...`
- `@earendil-works/pi-ai@0.74.0/dist/stream.d.ts` — `streamSimple<TApi>(model: Model<TApi>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream`

OpenClaw consistently invokes wrapped StreamFns as 3-arg:

- `src/agents/pi-embedded-runner/extra-params.ts:418` — `const wrappedStreamFn: StreamFn = (callModel, context, options) => ...`
- `src/agents/pi-embedded-runner/openai-stream-wrappers.ts:567` — `return (model, context, options) => streamFn(model, context, { ...options, headers: ... })`
- `src/plugin-sdk/provider-stream-shared.test.ts:78` — `const baseStreamFn: StreamFn = (_model, _context, options) => ...`
- `extensions/openrouter/stream.ts:144` — `return (model, context, options) => ...`
- `extensions/cloudflare-ai-gateway/stream-wrappers.ts` — imports `StreamFn` from `@earendil-works/pi-agent-core`, returns `StreamFn` from `wrapCloudflareAiGatewayProviderStream`

## Why this is hard to catch

The wrong example is *type-system valid* because of function parameter contravariance — a 1-arg function can be assigned to a 3-arg slot. But at **runtime**, JavaScript binds `params = model`, dropping `context` and `options`. The wrap itself doesn't throw; instead, the inner StreamFn (`streamSimple`) is called with `context` and `options` undefined, and the crash surfaces deep inside `@earendil-works/pi-ai` with `Cannot read properties of undefined (reading 'messages')`.

This is exactly the failure mode reported in #78843 — a plugin author's `wrapStreamFn` body reads `model.headers?.['cf-aig-authorization']`, confirming the first arg is `model`, not `params`. The example as written teaches plugin authors to mutate fields on the model that may or may not exist, when the canonical pattern (used by every internal wrapper) is to merge into `options.headers`.

## Fix

Replace the example with the canonical 3-arg shape, mirroring how internal wrappers like `createOpenAIAttributionHeadersWrapper` inject headers — `(model, context, options) => inner(model, context, { ...options, headers: { ...options?.headers, ... } })`.

## Verified against

- `@earendil-works/pi-agent-core@0.74.0` (npm)
- `@earendil-works/pi-ai@0.74.0` (npm)
- `openclaw/openclaw@main` (this PR's base)

## Out of scope

This PR only corrects the example. It does not introduce a typecheck for docs code blocks (separate concern) and does not change any runtime behavior.