### PR TITLE
fix: sanitize heartbeat protocol scaffolding

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1131,6 +1131,171 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it.each(
+    typedCases<{
+      name: string;
+      replyText: string;
+      expectedText: string | null;
+    }>([
+      {
+        name: "repeated tool call tags only",
+        replyText: ["<tool_calls>", "<tool_calls>", "<tool_calls>"].join("\n"),
+        expectedText: null,
+      },
+      {
+        name: "file contents block only",
+        replyText: [
+          "<file_contents path='/redacted/workspace/HEARTBEAT.md' isStale=false isFullFile=true>",
+          " 1|# HEARTBEAT.md",
+          " 2|",
+          " 3|# internal scaffold",
+          "</file_contents>",
+        ].join("\n"),
+        expectedText: null,
+      },
+      {
+        name: "mixed visible text and protocol scaffolding",
+        replyText: [
+          "Visible alert",
+          "<tool_calls>",
+          "<file_contents path='/redacted/workspace/HEARTBEAT.md' isStale=false isFullFile=true>",
+          " 1|# HEARTBEAT.md",
+          "</file_contents>",
+          "Done",
+        ].join("\n"),
+        expectedText: "Visible alert\n\nDone",
+      },
+      {
+        name: "heartbeat ok still suppresses delivery",
+        replyText: "HEARTBEAT_OK",
+        expectedText: null,
+      },
+    ]),
+  )(
+    "sanitizes protocol scaffolding before heartbeat delivery: $name",
+    async ({ replyText, expectedText }) => {
+      const tmpDir = await createCaseDir("hb-protocol-sanitize");
+      const storePath = path.join(tmpDir, "sessions.json");
+      const replySpy = vi.fn();
+      try {
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: { every: "5m", target: "whatsapp" },
+            },
+          },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+          session: { store: storePath },
+        };
+        const sessionKey = resolveMainSessionKey(cfg);
+
+        await fs.writeFile(
+          storePath,
+          JSON.stringify({
+            [sessionKey]: {
+              sessionId: "sid",
+              updatedAt: Date.now(),
+              lastChannel: "whatsapp",
+              lastTo: "120363401234567890@g.us",
+            },
+          }),
+        );
+
+        replySpy.mockResolvedValue([{ text: replyText }]);
+        const sendWhatsApp = vi
+          .fn<
+            (
+              to: string,
+              text: string,
+              opts?: unknown,
+            ) => Promise<{ messageId: string; toJid: string }>
+          >()
+          .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+        await runHeartbeatOnce({
+          cfg,
+          deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+        });
+
+        if (expectedText === null) {
+          expect(sendWhatsApp).toHaveBeenCalledTimes(0);
+        } else {
+          expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+          expectWhatsAppSendCall(sendWhatsApp, 0, {
+            to: "120363401234567890@g.us",
+            text: expectedText,
+          });
+        }
+      } finally {
+        replySpy.mockReset();
+      }
+    },
+  );
+
+  it("preserves heartbeat media when protocol scaffolding text sanitizes to empty", async () => {
+    const tmpDir = await createCaseDir("hb-protocol-sanitize-media");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.fn();
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([
+        {
+          text: "<file_contents path='/redacted/workspace/HEARTBEAT.md'>hidden</file_contents>",
+          mediaUrls: ["https://example.com/chart.png"],
+        },
+      ]);
+      const sendWhatsApp = vi
+        .fn<
+          (
+            to: string,
+            text: string,
+            opts?: unknown,
+          ) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+      expectWhatsAppSendCall(sendWhatsApp, 0, {
+        to: "120363401234567890@g.us",
+        text: "",
+      });
+      expect(
+        requireRecord(sendWhatsApp.mock.calls[0]?.[2], "WhatsApp media options").mediaUrl,
+      ).toBe("https://example.com/chart.png");
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
   it("suppresses duplicate heartbeat payloads within 24h", async () => {
     const tmpDir = await createCaseDir("hb-dup-suppress");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1172,7 +1172,7 @@ describe("runHeartbeatOnce", () => {
       },
     ]),
   )(
-    "sanitizes protocol scaffolding before heartbeat delivery: $name",
+    "sanitizes legacy reply protocol scaffolding before heartbeat delivery: $name",
     async ({ replyText, expectedText }) => {
       const tmpDir = await createCaseDir("hb-protocol-sanitize");
       const storePath = path.join(tmpDir, "sessions.json");
@@ -1233,7 +1233,7 @@ describe("runHeartbeatOnce", () => {
     },
   );
 
-  it("preserves heartbeat media when protocol scaffolding text sanitizes to empty", async () => {
+  it("preserves legacy heartbeat media when protocol scaffolding text sanitizes to empty", async () => {
     const tmpDir = await createCaseDir("hb-protocol-sanitize-media");
     const storePath = path.join(tmpDir, "sessions.json");
     const replySpy = vi.fn();

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -186,6 +186,48 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     });
   });
 
+  it.each([
+    {
+      name: "text",
+      reply: { text: "Visible alert from a non-tool response" },
+    },
+    {
+      name: "media",
+      reply: {
+        text: "Chart attached from a non-tool response",
+        mediaUrls: ["https://example.com/chart.png"],
+      },
+    },
+  ])("ignores ordinary $name payloads in heartbeat tool mode", async ({ reply }) => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+        agentHarnessId: "codex",
+      });
+      replySpy.mockResolvedValue(reply);
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      const calledOpts = replySpy.mock.calls[0]?.[1] as {
+        enableHeartbeatTool?: boolean;
+        forceHeartbeatTool?: boolean;
+        sourceReplyDeliveryMode?: string;
+      };
+      expect(result.status).toBe("ran");
+      expect(calledOpts.enableHeartbeatTool).toBe(true);
+      expect(calledOpts.forceHeartbeatTool).toBe(true);
+      expect(calledOpts.sourceReplyDeliveryMode).toBe("message_tool_only");
+      expect(sendTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("uses the heartbeat response tool prompt in message-tool mode", async () => {
     const result = await runPromptScenario({
       config: { visibleReplies: "message_tool" },

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -86,6 +86,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
+import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import { escapeRegExp } from "../utils.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS, resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { loadOrCreateDeviceIdentity } from "./device-identity.js";
@@ -740,7 +741,8 @@ function normalizeHeartbeatReply(
   ackMaxChars: number,
 ) {
   const rawText = typeof payload.text === "string" ? payload.text : "";
-  const textForStrip = stripLeadingHeartbeatResponsePrefix(rawText, responsePrefix);
+  const sanitizedText = sanitizeAssistantVisibleText(rawText);
+  const textForStrip = stripLeadingHeartbeatResponsePrefix(sanitizedText, responsePrefix);
   const stripped = stripHeartbeatToken(textForStrip, {
     mode: "heartbeat",
     maxAckChars: ackMaxChars,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -34,6 +34,7 @@ import {
   stripHeartbeatToken,
   type HeartbeatTask,
 } from "../auto-reply/heartbeat.js";
+import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import { resolveDefaultModel } from "../auto-reply/reply/directive-handling.defaults.js";
 import { resolveResponsePrefixTemplate } from "../auto-reply/reply/response-prefix-template.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
@@ -771,6 +772,12 @@ function normalizeHeartbeatToolNotification(
     finalText = `${responsePrefix} ${finalText}`;
   }
   return { shouldSkip: false, text: finalText, hasMedia: false };
+}
+
+function isInternalHeartbeatNoticePayload(payload: ReplyPayload | undefined): boolean {
+  return payload
+    ? getReplyPayloadMetadata(payload)?.deliverDespiteSourceReplySuppression === true
+    : false;
 }
 
 type HeartbeatWakePayloadFlags = {
@@ -1682,6 +1689,8 @@ export async function runHeartbeatOnce(opts: {
       : [];
     const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
     const responsePrefix = resolveHeartbeatResponsePrefix();
+    const canUseReplyPayload =
+      !usesHeartbeatResponseTool || isInternalHeartbeatNoticePayload(replyPayload);
 
     if (heartbeatToolResponse && !heartbeatToolResponse.notify) {
       await restoreHeartbeatUpdatedAt({
@@ -1712,7 +1721,10 @@ export async function runHeartbeatOnce(opts: {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    if (!heartbeatToolResponse && (!replyPayload || !hasOutboundReplyContent(replyPayload))) {
+    if (
+      !heartbeatToolResponse &&
+      (!canUseReplyPayload || !replyPayload || !hasOutboundReplyContent(replyPayload))
+    ) {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,
@@ -1742,15 +1754,15 @@ export async function runHeartbeatOnce(opts: {
 
     const normalized = heartbeatToolResponse
       ? normalizeHeartbeatToolNotification(heartbeatToolResponse, responsePrefix)
-      : replyPayload
+      : canUseReplyPayload && replyPayload
         ? normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars)
         : { shouldSkip: true, text: "", hasMedia: false };
-    // For exec completion events, don't skip even if the response looks like HEARTBEAT_OK.
-    // The model should be responding with exec results, not ack tokens.
-    // Also, if normalized.text is empty due to token stripping but we have exec completion,
-    // fall back to the original reply text.
+    // Legacy exec completion events may relay the original response text when
+    // ack-token stripping leaves the normalized text empty. Heartbeat response
+    // tool mode must not treat ordinary reply text as a delivery path.
     const execFallbackText =
       !heartbeatToolResponse &&
+      !usesHeartbeatResponseTool &&
       hasRelayableExecCompletion &&
       !normalized.text.trim() &&
       replyPayload?.text?.trim()
@@ -1791,7 +1803,7 @@ export async function runHeartbeatOnce(opts: {
     }
 
     const mediaUrls =
-      heartbeatToolResponse || !replyPayload
+      heartbeatToolResponse || !canUseReplyPayload || !replyPayload
         ? []
         : resolveSendableOutboundReplyParts(replyPayload).mediaUrls;
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -625,6 +625,35 @@ describe("sanitizeAssistantVisibleText", () => {
       "Visible prefix",
     );
   });
+
+  it("strips heartbeat protocol scaffolding while preserving visible text", () => {
+    const input = [
+      "Visible alert",
+      "<tool_calls>",
+      "<file_contents path='/redacted/workspace/HEARTBEAT.md' isStale=false isFullFile=true>",
+      " 1|# HEARTBEAT.md",
+      "</file_contents>",
+      "Done",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible alert\n\nDone");
+  });
+
+  it("strips repeated bare tool_calls protocol tags", () => {
+    expect(sanitizeAssistantVisibleText(["<tool_calls>", "<tool_calls>"].join("\n"))).toBe("");
+  });
+
+  it("does not unwrap singular protocol block bodies as visible text", () => {
+    expect(
+      sanitizeAssistantVisibleText(["<tool_result>", "secret", "</tool_result>"].join("\n")),
+    ).toBe("<tool_result>\nsecret\n</tool_result>");
+    expect(sanitizeAssistantVisibleText(["<tool_call>", "secret", "</tool_call>"].join("\n"))).toBe(
+      "<tool_call>\nsecret\n</tool_call>",
+    );
+    expect(
+      sanitizeAssistantVisibleText(["<function_call>", "secret", "</function_call>"].join("\n")),
+    ).toBe("<function_call>\nsecret\n</function_call>");
+  });
 });
 
 describe("sanitizeAssistantVisibleTextWithProfile", () => {

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -10,6 +10,8 @@ import {
 
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
+const FILE_CONTENTS_TAG_RE = /<\s*file_contents\b[^>]*>[\s\S]*?(?:<\s*\/\s*file_contents\s*>|$)/gi;
+const FILE_CONTENTS_TAG_QUICK_RE = /<\s*file_contents\b/i;
 const LEGACY_BRACKET_TOOL_BLOCK_QUICK_RE = /\[\s*\/?\s*TOOL_(?:CALL|RESULT)\s*\]/i;
 
 /**
@@ -623,6 +625,51 @@ function stripRelevantMemoriesTags(text: string): string {
   return result;
 }
 
+function stripFileContentsTags(text: string): string {
+  if (!text || !FILE_CONTENTS_TAG_QUICK_RE.test(text)) {
+    return text;
+  }
+
+  const codeRegions = findCodeRegions(text);
+  let result = "";
+  let cursor = 0;
+  for (const match of text.matchAll(FILE_CONTENTS_TAG_RE)) {
+    const start = match.index ?? 0;
+    if (isInsideCode(start, codeRegions)) {
+      continue;
+    }
+    result += text.slice(cursor, start);
+    cursor = start + match[0].length;
+  }
+  result += text.slice(cursor);
+  return result;
+}
+
+const STANDALONE_TOOL_CALL_TAG_LINE_RE =
+  /^[\t ]*<\s*\/?\s*(?:tool_calls|function_calls)\b[^<>]*>[\t ]*(?:\r?\n|$)/gim;
+const STANDALONE_TOOL_CALL_TAG_LINE_QUICK_RE = /^\s*<\s*\/?\s*(?:tool_calls|function_calls)\b/im;
+
+function stripStandaloneToolCallTagLines(text: string): string {
+  if (!text || !STANDALONE_TOOL_CALL_TAG_LINE_QUICK_RE.test(text)) {
+    return text;
+  }
+
+  const codeRegions = findCodeRegions(text);
+  let result = "";
+  let cursor = 0;
+  STANDALONE_TOOL_CALL_TAG_LINE_RE.lastIndex = 0;
+  for (const match of text.matchAll(STANDALONE_TOOL_CALL_TAG_LINE_RE)) {
+    const start = match.index ?? 0;
+    if (isInsideCode(start, codeRegions)) {
+      continue;
+    }
+    result += text.slice(cursor, start);
+    cursor = start + match[0].length;
+  }
+  result += text.slice(cursor);
+  return result;
+}
+
 export type AssistantVisibleTextSanitizerProfile = "delivery" | "history" | "internal-scaffolding";
 
 type AssistantVisibleTextPipelineOptions = {
@@ -690,9 +737,11 @@ function applyAssistantVisibleTextStagePipeline(
     }
     cleaned = stripModelSpecialTokens(cleaned);
     cleaned = stripRelevantMemoriesTags(cleaned);
+    cleaned = stripFileContentsTags(cleaned);
     cleaned = stripToolCallXmlTags(cleaned, {
       stripFunctionCallsXmlPayloads: options.stripFunctionCallsXmlPayloads,
     });
+    cleaned = stripStandaloneToolCallTagLines(cleaned);
     cleaned = stripLegacyBracketToolCallBlocks(cleaned);
     cleaned = stripPlainTextToolCallBlocks(cleaned);
     if (!options.preserveDowngradedToolText) {


### PR DESCRIPTION
## Summary

- sanitize legacy heartbeat delivery text with the canonical assistant-visible text sanitizer
- strip raw `<file_contents ...>` blocks and standalone tool-call tag lines from assistant-visible text
- require the structured `heartbeat_respond` tool in heartbeat-tool mode; ordinary assistant text/media is ignored when the tool is not called
- preserve internal runtime failure notices that are explicitly marked deliverable despite message-tool source suppression
- add regression coverage for repeated `<tool_calls>`, file contents wrappers, mixed visible text + scaffolding, `HEARTBEAT_OK`, legacy media-bearing payloads, and heartbeat-tool-mode non-tool text/media

Fixes #81369.

## Tests

- `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs run --config test/vitest/vitest.config.ts --project=infra --project=shared-core src/infra/heartbeat-runner.returns-default-unset.test.ts src/infra/heartbeat-runner.tool-response.test.ts src/shared/text/assistant-visible-text.test.ts`
  - Result: 2 files passed, 52 tests passed
- `CI=1 NODE_OPTIONS=--max-old-space-size=4096 node node_modules/vitest/vitest.mjs run src/shared/text/assistant-visible-text.test.ts --environment node --pool forks --passWithNoTests=false`
  - Result: 1 file passed, 79 tests passed
- `git diff --check`
- `git diff --exit-code`

## Real behavior proof

- **Behavior or issue addressed:** heartbeat delivery no longer posts raw Codex protocol scaffolding such as repeated `<tool_calls>` tags or `<file_contents ...>` blocks to visible chat. In heartbeat-tool mode there is no ordinary reply fallback: the agent either calls `heartbeat_respond`, or no heartbeat notification is delivered.
- **Real environment tested:** local OpenClaw checkout on macOS, Node 26, using redacted heartbeat leak payloads and the production assistant-visible sanitizer.
- **Exact steps or command run after this patch:** ran this command from the patched OpenClaw checkout:

  ```sh
  node --import tsx - <<'EOF'
  import { sanitizeAssistantVisibleText } from './src/shared/text/assistant-visible-text.ts';
  const samples = {
    toolOnly: ['<tool_calls>', '<tool_calls>'].join('\\n'),
    fileOnly: ["<file_contents path='/redacted/HEARTBEAT.md' isStale=false isFullFile=true>", ' 1|# HEARTBEAT.md', '</file_contents>'].join('\\n'),
    mixed: ['Visible alert', '<tool_calls>', "<file_contents path='/redacted/HEARTBEAT.md' isStale=false isFullFile=true>", ' 1|# HEARTBEAT.md', '</file_contents>', 'Done'].join('\\n'),
  };
  for (const [name, input] of Object.entries(samples)) {
    console.log(`${name}: ${JSON.stringify(sanitizeAssistantVisibleText(input))}`);
  }
  EOF
  ```

- **Evidence after fix:** terminal output from the patched checkout:

  ```text
  toolOnly: ""
  fileOnly: ""
  mixed: "Visible alert\n\nDone"
  ```

- **Observed result after fix:** protocol-only legacy payloads sanitize to an empty string and suppress delivery when there is no media; mixed legacy payloads preserve only user-visible text; heartbeat-tool mode ignores ordinary text/media if `heartbeat_respond` is not called.
- **What was not tested:** live Discord delivery was not re-run for this PR update; channel-provider end-to-end behavior is covered by the heartbeat runner harness and the real proof above exercises the production sanitizer on leak-shaped payloads.

Scope note: this PR intentionally does not touch dependency manifests, lockfiles, generated inventory files, or unrelated CI/deadcode cleanups.