### PR TITLE
fix: suppress silent final after message tool delivery

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1610,6 +1610,65 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses exact NO_REPLY final text after message tool delivery evidence", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const hasRepliedRef = { value: false };
+    const replyResolver = vi.fn(async () => {
+      hasRepliedRef.value = true;
+      return { text: "NO_REPLY" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "direct",
+        Provider: "telegram",
+        Surface: "telegram",
+        SessionKey: "agent:main:telegram:direct:U1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { hasRepliedRef },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(hasRepliedRef.value).toBe(true);
+    expect(result.queuedFinal).toBe(false);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+  });
+
+  it("keeps non-NO_REPLY final text after message tool delivery evidence", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const hasRepliedRef = { value: false };
+    const replyResolver = vi.fn(async () => {
+      hasRepliedRef.value = true;
+      return { text: "Visible follow-up" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "direct",
+        Provider: "telegram",
+        Surface: "telegram",
+        SessionKey: "agent:main:telegram:direct:U1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { hasRepliedRef },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(hasRepliedRef.value).toBe(true);
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Visible follow-up" });
+  });
+
   it("renders plain-text plan updates and concise approval progress when verbose is enabled", async () => {
     setNoAbort();
     const cfg = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -79,6 +79,7 @@ import type { BlockReplyContext } from "../get-reply-options.types.js";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import { normalizeVerboseLevel } from "../thinking.js";
+import { isSilentReplyPayloadText } from "../tokens.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
 import {
   createInternalHookEvent,
@@ -1025,6 +1026,16 @@ export async function dispatchReplyFromConfig(
       };
     };
 
+    const shouldSuppressMessageToolSilentFinal = (reply: ReplyPayload): boolean => {
+      if (params.replyOptions?.hasRepliedRef?.value !== true) {
+        return false;
+      }
+      if (!isSilentReplyPayloadText(reply.text)) {
+        return false;
+      }
+      return !resolveSendableOutboundReplyParts({ ...reply, text: undefined }).hasContent;
+    };
+
     // Run before_dispatch hook — let plugins inspect or handle before model dispatch.
     if (hookRunner?.hasHooks("before_dispatch")) {
       const beforeDispatchResult = await traceReplyPhase("reply.before_dispatch_hooks", () =>
@@ -1567,6 +1578,9 @@ export async function dispatchReplyFromConfig(
       // Suppress reasoning payloads from channel delivery — channels using this
       // generic dispatch path do not have a dedicated reasoning lane.
       if (reply.isReasoning === true) {
+        continue;
+      }
+      if (shouldSuppressMessageToolSilentFinal(reply)) {
         continue;
       }
       if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply)) {


### PR DESCRIPTION
## Summary
- suppress exact silent final replies after message-tool delivery evidence has already marked the source conversation as replied
- preserve normal final delivery for non-silent text and payloads with other sendable content
- add regression coverage for the Telegram button/message-tool duplicate path

## Real behavior proof
- **Behavior or issue addressed:** Telegram button/message-tool sends could be followed by an assistant final `NO_REPLY`, creating a duplicate visible reply path instead of leaving the button message as the sole visible output.
- **Real environment tested:** Moeed's Mac mini, local OpenClaw source checkout from upstream `main` on branch `fix/message-tool-silent-final-dedupe`, Node/pnpm project environment.
- **Exact steps or command run after this patch:**
  ```bash
  pnpm exec vitest run src/auto-reply/reply/dispatch-from-config.test.ts
  ```
- **Evidence after fix:** Terminal output from the patched OpenClaw source checkout:
  ```text
  RUN  v4.1.6 /Users/moeedahmed/.openclaw/workspace/openclaw-pr-noreply-button

  ✓ auto-reply ../../src/auto-reply/reply/dispatch-from-config.test.ts (108 tests) 5754ms

  Test Files  1 passed (1)
  Tests       108 passed (108)
  ```
- **Observed result after fix:** The regression case `suppresses exact NO_REPLY final text after message tool delivery evidence` verifies that when `hasRepliedRef.value` is already true and the final payload is exactly `NO_REPLY`, no source final reply is queued (`queuedFinal === false`) and `sendFinalReply`, `sendBlockReply`, and `sendToolResult` are not called. The paired guard case `keeps non-NO_REPLY final text after message tool delivery evidence` verifies ordinary visible final text still sends.
- **What was not tested:** Not applied to Moeed's installed runtime and not smoke-tested against live Telegram in this PR branch; this PR is source-level only.

## Verification
- `pnpm exec oxfmt --check src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts`
- `pnpm exec vitest run src/auto-reply/reply/dispatch-from-config.test.ts`
