### PR TITLE
fix(skills): replace generated plugin skill directories

### DIFF
--- a/src/agents/skills/plugin-skills.test.ts
+++ b/src/agents/skills/plugin-skills.test.ts
@@ -473,6 +473,22 @@ describe("publishPluginSkills", () => {
     expect(fsSync.readlinkSync(path.join(managedDir, "my-skill"))).toBe(dir2);
   });
 
+  it("replaces generated Windows directory entries before publishing a current skill", async () => {
+    const skillParent = await tempDirs.make("plugin-skills-");
+    const managedDir = await tempDirs.make("managed-skills-");
+
+    const dir = await writeSkillDir(skillParent, "my-skill");
+    const existingDir = path.join(managedDir, "my-skill");
+    await fs.mkdir(existingDir, { recursive: true });
+    await fs.writeFile(path.join(existingDir, "stale.txt"), "stale");
+
+    withPlatform("win32", () => {
+      publishPluginSkills([dir], { pluginSkillsDir: managedDir });
+    });
+
+    expect(fsSync.readlinkSync(existingDir)).toBe(dir);
+  });
+
   it("cleans up stale symlinks whose targets still exist", async () => {
     const skillParent = await tempDirs.make("plugin-skills-");
     const managedDir = await tempDirs.make("managed-skills-");

--- a/src/agents/skills/plugin-skills.ts
+++ b/src/agents/skills/plugin-skills.ts
@@ -220,11 +220,19 @@ function publishPluginSkills(skillDirs: string[], opts?: { pluginSkillsDir?: str
       // best-effort; symlink will fail below if dir is truly unusable
     }
     try {
-      const existingTarget = fs.readlinkSync(linkPath);
-      if (existingTarget === target) {
+      const existingEntry = fs.lstatSync(linkPath);
+      if (existingEntry.isSymbolicLink()) {
+        const existingTarget = fs.readlinkSync(linkPath);
+        if (existingTarget === target) {
+          continue;
+        }
+        removeGeneratedPluginSkillEntry(linkPath);
+      } else if (isGeneratedPluginSkillEntry(existingEntry)) {
+        removeGeneratedPluginSkillEntry(linkPath);
+      } else {
+        log.warn(`plugin skill entry is not a generated symlink: ${linkPath}`);
         continue;
       }
-      removeGeneratedPluginSkillEntry(linkPath);
     } catch (err) {
       if (!isNotFoundError(err)) {
         log.warn(`failed to inspect plugin skill symlink "${linkPath}": ${String(err)}`);
@@ -259,7 +267,9 @@ function publishPluginSkills(skillDirs: string[], opts?: { pluginSkillsDir?: str
   }
 }
 
-function isGeneratedPluginSkillEntry(entry: fs.Dirent): boolean {
+function isGeneratedPluginSkillEntry(
+  entry: Pick<fs.Dirent, "isDirectory" | "isSymbolicLink">,
+): boolean {
   return entry.isSymbolicLink() || (process.platform === "win32" && entry.isDirectory());
 }
 


### PR DESCRIPTION
## Summary
- inspect existing managed plugin-skill entries with lstat before readlink
- replace Windows generated directory entries before creating the current skill link
- keep non-generated entries untouched and add focused regression coverage

Fixes #81432.

## Verification
- pnpm vitest run src/agents/skills/plugin-skills.test.ts
- git diff --check

## Real behavior proof

Behavior addressed: Before this patch, `publishPluginSkills()` called `fs.readlinkSync(linkPath)` directly while publishing an active plugin skill. If `linkPath` already existed as a regular directory, Node raised `EINVAL`, the code logged `failed to inspect plugin skill symlink`, skipped the current skill, and left the stale directory in place. After this patch, `publishPluginSkills()` first runs `fs.lstatSync(linkPath)`, removes generated Windows directory entries through the existing cleanup path, and creates the current plugin skill link.

Real setup tested: Local OpenClaw checkout at `/home/chenglunhu/code/openclaw`, branch `fix/plugin-skills-nonsymlink-managed-entry-81432`, commit `6f74f42e6eb1e24a36e00a9cdad361e6bccc76bd`, using the real `src/agents/skills/plugin-skills.ts` implementation through `pnpm exec tsx`.

Exact steps or command run after the patch: Ran a `pnpm exec tsx -e ...` console script that created a temporary plugin skill with `SKILL.md`, created the managed plugin-skill entry with the same basename as a regular directory containing `stale.txt`, simulated Windows platform handling for `publishPluginSkills([skill], { pluginSkillsDir: managed })`, then printed the resulting link target and stale-file state.

Evidence after fix: Terminal output from the live command:

```text
{
  "before": "regular-directory",
  "afterLinkTarget": "/tmp/oc-real-proof-H4C1fW/plugins/my-skill",
  "expected": "/tmp/oc-real-proof-H4C1fW/plugins/my-skill",
  "staleFileExists": false
}
```

Observed result after fix: The managed path that started as a regular directory became a link whose target exactly matched the active plugin skill directory, and the stale file under the old directory no longer existed. This confirms the `EINVAL` skip path is avoided for generated Windows directory entries.

Not tested: I did not run a manual Windows desktop `openclaw skills list` session.

