### PR TITLE
fix(agents): honor OPENCLAW_WORKSPACE_DIR fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: honor `OPENCLAW_WORKSPACE_DIR` when resolving the default agent workspace, preserving explicit config precedence while keeping env-backed deployments out of the system prompt fallback path. Fixes #66786.
 - Doctor/Codex: stop warning that the message tool is unavailable for source-reply paths where OpenClaw grants `message` at runtime, keeping update and doctor output aligned with the OpenAI happy path. Thanks @pashpashpash.
 - Channels/Weixin: bump the external Weixin catalog entry to `@tencent-weixin/openclaw-weixin@2.4.3` with the matching package integrity. (#81730) Thanks @scotthuang.
 - Agents/subagents: apply `agents.defaults.subagents.model` before target agent primary models during `sessions_spawn`, so model-scoped runtimes such as `claude-cli` stay attached to default child runs. Fixes #81395. (#81783) Thanks @joshavant.

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -15,13 +15,17 @@ top-level keys, see [Configuration reference](/gateway/configuration-reference).
 
 ### `agents.defaults.workspace`
 
-Default: `~/.openclaw/workspace`.
+Default: `OPENCLAW_WORKSPACE_DIR` when set, otherwise `~/.openclaw/workspace`.
 
 ```json5
 {
   agents: { defaults: { workspace: "~/.openclaw/workspace" } },
 }
 ```
+
+An explicit `agents.defaults.workspace` value takes precedence over
+`OPENCLAW_WORKSPACE_DIR`. Use the environment variable to point default agents
+at a mounted workspace when you do not want to write that path into config.
 
 ### `agents.defaults.repoRoot`
 

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -615,6 +615,15 @@ describe("resolveAgentConfig", () => {
     expect(workspace).toBe(path.join(path.resolve(home), ".openclaw", "workspace"));
   });
 
+  it("uses OPENCLAW_WORKSPACE_DIR for default agent workspace", () => {
+    const workspaceDir = path.join(path.sep, "srv", "openclaw-workspace");
+    vi.stubEnv("OPENCLAW_WORKSPACE_DIR", workspaceDir);
+    vi.stubEnv("OPENCLAW_HOME", path.join(path.sep, "srv", "openclaw-home"));
+
+    const workspace = resolveAgentWorkspaceDir({} as OpenClawConfig, "main");
+    expect(workspace).toBe(path.resolve(workspaceDir));
+  });
+
   it("uses OPENCLAW_HOME for default agentDir", () => {
     const home = path.join(path.sep, "srv", "openclaw-home");
     vi.stubEnv("OPENCLAW_HOME", home);
@@ -636,7 +645,7 @@ describe("resolveAgentConfig", () => {
 
     const agentDir = resolveDefaultAgentDir(cfg);
 
-    expect(agentDir).toBe(path.join(stateDir, "agents", "ops", "agent"));
+    expect(agentDir).toBe(path.resolve(stateDir, "agents", "ops", "agent"));
   });
 
   it("non-default agent uses agents.defaults.workspace as base (#59789)", () => {
@@ -670,7 +679,7 @@ describe("resolveAgentConfig", () => {
       },
     };
     const workspace = resolveAgentWorkspaceDir(cfg, "main");
-    expect(workspace).toBe(path.join(stateDir, "workspace-main"));
+    expect(workspace).toBe(path.resolve(stateDir, "workspace-main"));
   });
 });
 

--- a/src/agents/workspace-default.ts
+++ b/src/agents/workspace-default.ts
@@ -7,6 +7,10 @@ export function resolveDefaultAgentWorkspaceDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
 ): string {
+  const workspaceDir = env.OPENCLAW_WORKSPACE_DIR?.trim();
+  if (workspaceDir) {
+    return path.resolve(workspaceDir);
+  }
   const home = resolveRequiredHomeDir(env, homedir);
   const profile = env.OPENCLAW_PROFILE?.trim();
   if (profile && normalizeOptionalLowercaseString(profile) !== "default") {

--- a/src/agents/workspace-run.test.ts
+++ b/src/agents/workspace-run.test.ts
@@ -60,16 +60,18 @@ describe("resolveRunWorkspaceDir", () => {
   });
 
   it("falls back to built-in main workspace when config is unavailable", () => {
+    const workspaceDir = path.join(path.sep, "srv", "openclaw-workspace");
     const result = resolveRunWorkspaceDir({
       workspaceDir: null,
       sessionKey: "agent:main:subagent:test",
       config: undefined,
+      env: { ...process.env, OPENCLAW_WORKSPACE_DIR: workspaceDir },
     });
 
     expect(result.usedFallback).toBe(true);
     expect(result.fallbackReason).toBe("missing");
     expect(result.agentId).toBe("main");
-    expect(result.workspaceDir).toBe(path.resolve(resolveDefaultAgentWorkspaceDir(process.env)));
+    expect(result.workspaceDir).toBe(path.resolve(workspaceDir));
   });
 
   it("throws for malformed agent session keys", () => {

--- a/src/agents/workspace.defaults.test.ts
+++ b/src/agents/workspace.defaults.test.ts
@@ -16,4 +16,12 @@ describe("DEFAULT_AGENT_WORKSPACE_DIR", () => {
       path.join(path.resolve(home), ".openclaw", "workspace"),
     );
   });
+
+  it("uses OPENCLAW_WORKSPACE_DIR before OPENCLAW_HOME", () => {
+    const workspaceDir = path.join(path.sep, "srv", "openclaw-workspace");
+    vi.stubEnv("OPENCLAW_WORKSPACE_DIR", workspaceDir);
+    vi.stubEnv("OPENCLAW_HOME", path.join(path.sep, "srv", "openclaw-home"));
+
+    expect(resolveDefaultAgentWorkspaceDir()).toBe(path.resolve(workspaceDir));
+  });
 });

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -31,6 +31,16 @@ describe("resolveDefaultAgentWorkspaceDir", () => {
 
     expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "workspace"));
   });
+
+  it("prefers OPENCLAW_WORKSPACE_DIR for default workspace resolution", () => {
+    const dir = resolveDefaultAgentWorkspaceDir({
+      OPENCLAW_WORKSPACE_DIR: "/srv/openclaw-workspace",
+      OPENCLAW_HOME: "/srv/openclaw-home",
+      HOME: "/home/other",
+    } as NodeJS.ProcessEnv);
+
+    expect(dir).toBe(path.resolve("/srv/openclaw-workspace"));
+  });
 });
 
 const WORKSPACE_STATE_PATH_SEGMENTS = [".openclaw", "workspace-state.json"] as const;


### PR DESCRIPTION
## Summary

Fixes #66786.

Honor `OPENCLAW_WORKSPACE_DIR` in the shared default workspace resolver so default-agent and run-workspace fallback paths use the operator-provided workspace mount before falling back to `OPENCLAW_HOME` / profile-derived paths.

## Behavior

- `resolveDefaultAgentWorkspaceDir()` now prefers a non-empty `OPENCLAW_WORKSPACE_DIR`.
- Explicit per-agent workspace and `agents.defaults.workspace` behavior remains unchanged because those are resolved before the default fallback.
- Docs now call out the environment fallback and precedence.

## Real behavior proof

- **Behavior or issue addressed:** Default agent workspaces ignored `OPENCLAW_WORKSPACE_DIR`, so env-mounted deployments could fall back to a home/profile workspace path instead of the operator-provided workspace.
- **Real environment tested:** Windows checkout at `C:\src\openclaw-pr-66786`, running the real `src/agents/workspace-default.ts` resolver through `pnpm exec tsx` after rebasing on current `main`.
- **Exact steps or command run after this patch:**

```console
PS C:\src\openclaw-pr-66786> $env:OPENCLAW_WORKSPACE_DIR='C:\tmp\openclaw-env-workspace'; pnpm exec tsx -e "import { resolveDefaultAgentWorkspaceDir } from './src/agents/workspace-default.ts'; console.log(resolveDefaultAgentWorkspaceDir(process.env, () => 'C:/Users/example'));"; Remove-Item Env:OPENCLAW_WORKSPACE_DIR
```

- **Evidence after fix:** Copied live terminal output from the real resolver command:

```console
C:\tmp\openclaw-env-workspace
```

- **Observed result after fix:** The resolver returned `C:\tmp\openclaw-env-workspace`, confirming that `OPENCLAW_WORKSPACE_DIR` wins before the home/profile fallback path.
- **What was not tested:** Full interactive agent startup was not rerun in this sweep; existing agent workspace tests cover the integration paths, and this proof targets the shared fallback resolver used by those paths.

## Proof

- `pnpm test src/agents/workspace.test.ts src/agents/workspace.defaults.test.ts src/agents/agent-scope.test.ts src/agents/workspace-run.test.ts src/agents/system-prompt.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/workspace-default.ts src/agents/workspace.test.ts src/agents/workspace.defaults.test.ts src/agents/agent-scope.test.ts src/agents/workspace-run.test.ts src/agents/system-prompt.test.ts CHANGELOG.md docs/gateway/config-agents.md`
- `pnpm check:changed`
- Current rebase sanity: `git diff --check`; `pnpm exec oxfmt --check CHANGELOG.md docs/gateway/config-agents.md src/agents/agent-scope.test.ts src/agents/workspace-default.ts src/agents/workspace-run.test.ts src/agents/workspace.defaults.test.ts src/agents/workspace.test.ts`
