### PR TITLE
Guard subagent spawns from direct OpenAI overrides

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -25,6 +25,14 @@ function expectOkPlan(plan: SubagentModelPlan): OkSubagentModelPlan {
   return plan;
 }
 
+function expectForbiddenPlan(plan: SubagentModelPlan): Extract<SubagentModelPlan, { status: "forbidden" }> {
+  expect(plan.status).toBe("forbidden");
+  if (plan.status !== "forbidden") {
+    throw new Error(`Expected forbidden plan, received ${plan.status}`);
+  }
+  return plan;
+}
+
 describe("subagent spawn model + thinking plan", () => {
   it("includes explicit model overrides in the initial patch", () => {
     const plan = expectOkPlan(
@@ -82,6 +90,60 @@ describe("subagent spawn model + thinking plan", () => {
     );
     expect(plan.resolvedModel).toBe("minimax/MiniMax-M2.7");
     expect(plan.initialSessionPatch.model).toBe("minimax/MiniMax-M2.7");
+    expect(plan.initialSessionPatch.modelOverrideSource).toBe("auto");
+  });
+
+  it("rejects bare gpt overrides when the subagent default is openai-codex", () => {
+    const plan = expectForbiddenPlan(
+      resolveSubagentModelAndThinkingPlan({
+        cfg: createConfig({
+          agents: { defaults: { subagents: { model: "openai-codex/gpt-5.5" } } },
+        }),
+        targetAgentId: "research",
+        modelOverride: "gpt",
+      }),
+    );
+    expect(plan.error).toMatch(/Omit the model parameter/i);
+    expect(plan.error).toContain('model="openai-codex/gpt-5.5"');
+  });
+
+  it("rejects explicit direct OpenAI overrides when the subagent default is openai-codex", () => {
+    const plan = expectForbiddenPlan(
+      resolveSubagentModelAndThinkingPlan({
+        cfg: createConfig({
+          agents: { defaults: { subagents: { model: "openai-codex/gpt-5.5" } } },
+        }),
+        targetAgentId: "research",
+        modelOverride: "openai/gpt-5.4",
+      }),
+    );
+    expect(plan.error).toMatch(/direct OpenAI API route/i);
+  });
+
+  it("allows explicit openai-codex overrides when the subagent default is openai-codex", () => {
+    const plan = expectOkPlan(
+      resolveSubagentModelAndThinkingPlan({
+        cfg: createConfig({
+          agents: { defaults: { subagents: { model: "openai-codex/gpt-5.5" } } },
+        }),
+        targetAgentId: "research",
+        modelOverride: "openai-codex/gpt-5.5",
+      }),
+    );
+    expect(plan.resolvedModel).toBe("openai-codex/gpt-5.5");
+    expect(plan.initialSessionPatch.modelOverrideSource).toBe("user");
+  });
+
+  it("allows omitted model overrides to use the configured openai-codex default", () => {
+    const plan = expectOkPlan(
+      resolveSubagentModelAndThinkingPlan({
+        cfg: createConfig({
+          agents: { defaults: { subagents: { model: "openai-codex/gpt-5.5" } } },
+        }),
+        targetAgentId: "research",
+      }),
+    );
+    expect(plan.resolvedModel).toBe("openai-codex/gpt-5.5");
     expect(plan.initialSessionPatch.modelOverrideSource).toBe("auto");
   });
 

--- a/src/agents/subagent-spawn-plan.ts
+++ b/src/agents/subagent-spawn-plan.ts
@@ -25,6 +25,46 @@ export function splitModelRef(ref?: string) {
   return { provider: undefined, model: trimmed };
 }
 
+// When a subagent's configured default is a subscription-backed CLI provider
+// (currently openai-codex), an explicit `model` override that resolves to the
+// raw direct API route (`openai/*` or the bare `gpt` alias) would silently
+// bypass the configured subscription and hit the direct API instead.  Reject
+// these calls early so the caller sees a clear actionable error rather than a
+// downstream auth/quota failure.
+export function detectAmbiguousSubagentModelOverride(params: {
+  modelOverride?: string;
+  configuredDefault?: string;
+  resolvedOverride?: string;
+}): { status: "ok" } | { status: "forbidden"; error: string } {
+  const explicit = params.modelOverride?.trim();
+  if (!explicit) {
+    return { status: "ok" };
+  }
+  const { provider: defaultProvider, model: defaultModel } = splitModelRef(
+    params.configuredDefault,
+  );
+  if (defaultProvider?.toLowerCase() !== "openai-codex") {
+    return { status: "ok" };
+  }
+  const resolved = params.resolvedOverride?.trim() || explicit;
+  const { provider: resolvedProvider, model: resolvedModel } = splitModelRef(resolved);
+  const isDirectOpenaiProvider = resolvedProvider?.toLowerCase() === "openai";
+  const isBareAmbiguousGpt =
+    !resolvedProvider && (resolvedModel ?? "").toLowerCase() === "gpt";
+  if (!isDirectOpenaiProvider && !isBareAmbiguousGpt) {
+    return { status: "ok" };
+  }
+  const recommendedModel = defaultModel ?? "gpt-5.5";
+  const recommended = `openai-codex/${recommendedModel}`;
+  return {
+    status: "forbidden",
+    error:
+      `Refusing to spawn subagent with model "${explicit}": that override resolves to a direct OpenAI API route, ` +
+      `but the configured subagent default is subscription-backed (${params.configuredDefault ?? recommended}). ` +
+      `Omit the model parameter to use the configured default, or pass model="${recommended}" explicitly.`,
+  };
+}
+
 export function resolveConfiguredSubagentRunTimeoutSeconds(params: {
   cfg: OpenClawConfig;
   runTimeoutSeconds?: number;
@@ -51,6 +91,27 @@ export function resolveSubagentModelAndThinkingPlan(params: {
     agentId: params.targetAgentId,
     modelOverride: params.modelOverride,
   });
+
+  const trimmedOverride = params.modelOverride?.trim();
+  if (trimmedOverride) {
+    const configuredDefault = resolveSubagentSpawnModelSelection({
+      cfg: params.cfg,
+      agentId: params.targetAgentId,
+      modelOverride: undefined,
+    });
+    const guardrail = detectAmbiguousSubagentModelOverride({
+      modelOverride: trimmedOverride,
+      configuredDefault,
+      resolvedOverride: resolvedModel,
+    });
+    if (guardrail.status === "forbidden") {
+      return {
+        status: "forbidden" as const,
+        resolvedModel,
+        error: guardrail.error,
+      };
+    }
+  }
 
   const thinkingPlan = resolveSubagentThinkingOverride({
     cfg: params.cfg,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -886,6 +886,12 @@ export async function spawnSubagentDirect(
       error: plan.error,
     };
   }
+  if (plan.status === "forbidden") {
+    return {
+      status: "forbidden",
+      error: plan.error,
+    };
+  }
   const { resolvedModel, thinkingOverride } = plan;
   const patchChildSession = async (patch: Record<string, unknown>): Promise<string | undefined> => {
     try {


### PR DESCRIPTION
## Summary
- Reject native subagent spawns that explicitly override an `openai-codex/*` default with ambiguous/direct OpenAI routes such as `gpt` or `openai/gpt-*`.
- Keep omitted model defaults and explicit `openai-codex/gpt-5.5` overrides working.
- Add regression coverage for risky and safe model override paths.

## Tests
- `node scripts/test-projects.mjs src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts` — passed, 15/15.

## Real behavior proof
- **Behavior or issue addressed:** Native subagent model planning could accept `gpt`/`openai/*` overrides even when the configured subagent default was subscription-backed `openai-codex/*`, causing the worker to bypass the intended route.
- **Real environment tested:** Local OpenClaw source worktree on macOS/Darwin arm64 using Node 22.22.1, with the patched subagent model planner loaded via `tsx`.
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx - <<'NODE'
  import { resolveSubagentModelAndThinkingPlan } from './src/agents/subagent-spawn-plan.ts';
  const cfg = { session: { mainKey: 'main', scope: 'per-sender' }, agents: { defaults: { subagents: { model: 'openai-codex/gpt-5.5' } } } };
  for (const modelOverride of ['gpt', 'openai/gpt-5.4', 'openai-codex/gpt-5.5', undefined]) {
    const plan = resolveSubagentModelAndThinkingPlan({ cfg, targetAgentId: 'openclaw', modelOverride });
    console.log(JSON.stringify({ modelOverride: modelOverride ?? '(omitted)', status: plan.status, resolvedModel: plan.resolvedModel, error: plan.error?.slice(0, 90) }, null, 2));
  }
  NODE
  ```
- **Evidence after fix:** Terminal output from the patched worktree:
  ```json
  { "modelOverride": "gpt", "status": "forbidden", "resolvedModel": "gpt", "error": "Refusing to spawn subagent with model \"gpt\": that override resolves to a direct OpenAI API" }
  { "modelOverride": "openai/gpt-5.4", "status": "forbidden", "resolvedModel": "openai/gpt-5.4", "error": "Refusing to spawn subagent with model \"openai/gpt-5.4\": that override resolves to a direct" }
  { "modelOverride": "openai-codex/gpt-5.5", "status": "ok", "resolvedModel": "openai-codex/gpt-5.5" }
  { "modelOverride": "(omitted)", "status": "ok", "resolvedModel": "openai-codex/gpt-5.5" }
  ```
- **Observed result after fix:** Risky direct OpenAI overrides are rejected before subagent launch; safe subscription-backed explicit and omitted-model paths still resolve successfully.
- **What was not tested:** Full installed gateway runtime was not patched or restarted; this PR is source-level only.

## Notes
- This is a source-level guardrail, not an installed-runtime hotfix.
- Full local test typecheck was blocked by existing missing dependency/type errors unrelated to this patch, including `@earendil-works/pi-ai`.
