### PR TITLE
Guard successful subagent completions from raw tool output

### DIFF
--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -86,6 +86,45 @@ describe("readSubagentOutput", () => {
     );
   });
 
+
+  it("does not promote raw tool output to a successful subagent completion", async () => {
+    const deps = installOutputDeps({
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "toolUse",
+          content: [{ type: "toolCall", id: "call-read", name: "read", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-read",
+          toolName: "read",
+          content: "{\n  \"plugins\": [\"telegram\"],\n  \"config\": true\n}",
+        },
+      ],
+    });
+
+    await expect(
+      readSubagentOutput("agent:main:subagent:child", { status: "ok" }),
+    ).resolves.toBeUndefined();
+    expect(deps.readLatestAssistantReply).toHaveBeenCalled();
+  });
+
+  it("keeps raw tool output as diagnostic evidence for failed subagent runs", async () => {
+    installOutputDeps({
+      messages: [
+        {
+          role: "toolResult",
+          content: "tool failed after reading config",
+        },
+      ],
+    });
+
+    await expect(
+      readSubagentOutput("agent:main:subagent:child", { status: "error", error: "boom" }),
+    ).resolves.toBe("tool failed after reading config");
+  });
+
   it("keeps normal tool-use assistant output when the tool is not sessions_yield", async () => {
     installOutputDeps({
       messages: [

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -301,6 +301,15 @@ function selectSubagentOutputText(
   if (partialProgress) {
     return partialProgress;
   }
+  // A successful subagent completion must come from an assistant reply, not a raw
+  // tool result. Falling back to the latest tool result made workers look "done"
+  // when they had only dumped intermediate read/config/plugin output and never
+  // answered the requested task. Keep raw fallback for timeout/error/unknown
+  // cases where it is useful diagnostic evidence, but do not promote it to a
+  // successful child result.
+  if (outcome?.status === "ok") {
+    return undefined;
+  }
   return snapshot.latestRawText;
 }
 


### PR DESCRIPTION
## Summary
- Stop treating raw tool-result text as successful subagent completion output when the run outcome is `ok`.
- Preserve raw tool output for failed/timeout/unknown runs as diagnostic evidence.
- Add regression coverage for the observed failure class: a worker runs tools and dumps config/plugin output without giving a final assistant answer.

## Tests
- `node scripts/test-projects.mjs src/agents/subagent-announce-output.test.ts` — passed, 8/8.

## Real behavior proof
- **Behavior or issue addressed:** Subagents could be marked complete with intermediate tool output instead of a final answer, which made a bad worker result look successful.
- **Real environment tested:** Local OpenClaw source worktree on macOS/Darwin arm64 using Node 22.22.1.
- **Exact steps or command run after this patch:**
  ```bash
  node scripts/test-projects.mjs src/agents/subagent-announce-output.test.ts
  ```
- **Evidence after fix:** Terminal output from the patched worktree:
  ```text
  ✓ agents src/agents/subagent-announce-output.test.ts (8 tests) 11ms
  Test Files 1 passed (1)
  Tests 8 passed (8)
  ```
- **Observed result after fix:** A successful (`ok`) child run with only tool-result/config output now returns no completion text, so the orchestrator cannot mistake intermediate tool output for a valid final answer. Failed runs still retain raw output for debugging.
- **What was not tested:** Full installed gateway runtime was not patched or restarted; this PR is source-level only.
