### PR TITLE
fix(webchat): include TTS audio in broadcastChatFinal when media already appended

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2579,11 +2579,9 @@ export const chatHandlers: GatewayRequestHandlers = {
                     sessionKey,
                   });
                 } else {
-                  const rawFinalPayloads = appendedWebchatAgentMedia
-                    ? []
-                    : deliveredReplies
-                        .filter((entry) => entry.kind === "final")
-                        .map((entry) => entry.payload);
+                  const rawFinalPayloads = deliveredReplies
+                      .filter((entry) => entry.kind === "final")
+                      .map((entry) => entry.payload);
                   const finalPayloads = await normalizeWebchatReplyMediaPathsForDisplay({
                     cfg,
                     sessionKey,
@@ -2685,6 +2683,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                       sessionFile: latestEntry?.sessionFile,
                       agentId,
                       createIfMissing: true,
+                      idempotencyKey: `${clientRunId}:assistant-media`,
                       cfg,
                     });
                     if (appended.ok) {


### PR DESCRIPTION
## Problem

When `appendWebchatAgentMediaTranscriptIfNeeded` has already appended TTS audio to the session transcript, the broadcast phase clears `rawFinalPayloads` to an empty array:

```js
const rawFinalPayloads = appendedWebchatAgentMedia ? [] : deliveredReplies.filter(...)
```

This causes both `buildAssistantDisplayContentFromReplyPayloads([])` and `buildWebchatAssistantMediaMessage([])` to return `undefined`, so the broadcast WebSocket message contains no audio (or text) content — even though the audio file is correctly generated on disk.

## Fix

1. **Always include delivered payloads** — removes the `appendedWebchatAgentMedia ? [] :` check so `rawFinalPayloads` always has the reply payloads
2. **Deduplicate transcript entries** — adds `idempotencyKey: \`\${clientRunId}:assistant-media\`` to the broadcast's `appendAssistantTranscriptMessage` call, preventing duplicate transcript entries since `appendWebchatAgentMediaTranscriptIfNeeded` already appended the audio content earlier in the pipeline

The `appendAssistantTranscriptMessage` function already supports `idempotencyKey` for deduplication (see line 1385 of chat.ts).

## Testing

- TTS audio files confirmed generated and valid (`media/outbound/voice-*.mp3`)
- The `assistant-media` endpoint can serve audio via tickets
- Issue originally filed at #81468