### PR TITLE
fix(line): load accounts.default and default-enable named accounts

### DIFF
--- a/extensions/line/src/accounts.test.ts
+++ b/extensions/line/src/accounts.test.ts
@@ -200,6 +200,161 @@ describe("LINE accounts", () => {
         /LINE credential file.*must not be a symlink/,
       );
     });
+
+    it("resolves default account credentials from accounts.default", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            enabled: true,
+            accounts: {
+              default: {
+                channelAccessToken: "default-token",
+                channelSecret: "default-secret",
+                name: "Default Bot",
+              },
+            },
+          },
+        },
+      };
+
+      const account = resolveLineAccount({ cfg });
+
+      expect(account.accountId).toBe(DEFAULT_ACCOUNT_ID);
+      expect(account.enabled).toBe(true);
+      expect(account.channelAccessToken).toBe("default-token");
+      expect(account.channelSecret).toBe("default-secret");
+      expect(account.name).toBe("Default Bot");
+      expect(account.tokenSource).toBe("config");
+    });
+
+    it("prefers accounts.default credentials over top-level base credentials", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            enabled: true,
+            channelAccessToken: "base-token",
+            channelSecret: "base-secret",
+            accounts: {
+              default: {
+                channelAccessToken: "override-token",
+                channelSecret: "override-secret",
+              },
+            },
+          },
+        },
+      };
+
+      const account = resolveLineAccount({ cfg });
+
+      expect(account.channelAccessToken).toBe("override-token");
+      expect(account.channelSecret).toBe("override-secret");
+    });
+
+    it("treats named accounts without explicit enabled as enabled", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            enabled: true,
+            accounts: {
+              twgreen: {
+                channelAccessToken: "twgreen-token",
+                channelSecret: "twgreen-secret",
+              },
+            },
+          },
+        },
+      };
+
+      const account = resolveLineAccount({ cfg, accountId: "twgreen" });
+
+      expect(account.enabled).toBe(true);
+      expect(account.channelAccessToken).toBe("twgreen-token");
+      expect(account.channelSecret).toBe("twgreen-secret");
+    });
+
+    it("disables a named account when channels.line.enabled is false", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            enabled: false,
+            accounts: {
+              twgreen: {
+                enabled: true,
+                channelAccessToken: "twgreen-token",
+                channelSecret: "twgreen-secret",
+              },
+            },
+          },
+        },
+      };
+
+      const account = resolveLineAccount({ cfg, accountId: "twgreen" });
+
+      expect(account.enabled).toBe(false);
+    });
+
+    it("disables accounts.default when channels.line.enabled is false", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            enabled: false,
+            accounts: {
+              default: {
+                channelAccessToken: "default-token",
+                channelSecret: "default-secret",
+              },
+            },
+          },
+        },
+      };
+
+      const account = resolveLineAccount({ cfg });
+
+      expect(account.enabled).toBe(false);
+    });
+
+    it("respects explicit enabled:false on a named account", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            enabled: true,
+            accounts: {
+              twgreen: {
+                enabled: false,
+                channelAccessToken: "twgreen-token",
+                channelSecret: "twgreen-secret",
+              },
+            },
+          },
+        },
+      };
+
+      const account = resolveLineAccount({ cfg, accountId: "twgreen" });
+
+      expect(account.enabled).toBe(false);
+    });
+
+    it("prefers accounts.default name over top-level channels.line.name", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            enabled: true,
+            name: "Top-level Bot",
+            accounts: {
+              default: {
+                channelAccessToken: "default-token",
+                channelSecret: "default-secret",
+                name: "Default Account Bot",
+              },
+            },
+          },
+        },
+      };
+
+      const account = resolveLineAccount({ cfg });
+
+      expect(account.name).toBe("Default Account Bot");
+    });
   });
 
   describe("resolveDefaultLineAccountId", () => {

--- a/extensions/line/src/accounts.ts
+++ b/extensions/line/src/accounts.ts
@@ -97,8 +97,7 @@ export function resolveLineAccount(params: {
   const accountId = normalizeSharedAccountId(params.accountId ?? resolveDefaultLineAccountId(cfg));
   const lineConfig = cfg.channels?.line as LineConfig | undefined;
   const accounts = lineConfig?.accounts;
-  const accountConfig =
-    accountId !== DEFAULT_ACCOUNT_ID ? resolveAccountEntry(accounts, accountId) : undefined;
+  const accountConfig = resolveAccountEntry(accounts, accountId);
 
   const { token, tokenSource } = resolveToken({
     accountId,
@@ -125,9 +124,9 @@ export function resolveLineAccount(params: {
     ...accountConfig,
   };
 
-  const enabled =
-    accountConfig?.enabled ??
-    (accountId === DEFAULT_ACCOUNT_ID ? (lineConfig?.enabled ?? true) : false);
+  const baseEnabled = lineConfig?.enabled !== false;
+  const accountEnabled = accountConfig?.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
 
   const name =
     accountConfig?.name ?? (accountId === DEFAULT_ACCOUNT_ID ? lineConfig?.name : undefined);


### PR DESCRIPTION
## Summary

Fixes #47264. The LINE multi-account resolver had two bugs that prevented webhook routes from registering when `channels.line.accounts` was used:

1. **`accounts.default` was ignored.** `resolveLineAccount` short-circuited the account lookup when `accountId === DEFAULT_ACCOUNT_ID`, so credentials placed under `channels.line.accounts.default` never reached the gateway. With no top-level credentials, the default account resolved to an empty token and the `/line/webhook` route never registered (HTTP 404).
2. **Named accounts defaulted to disabled.** `enabled` fell through to `false` for named accounts that did not explicitly set `enabled: true`. Gateway start-up returned early for "disabled" accounts, so the named account's webhook never registered either.

Both behaviours diverged from the Telegram plugin (`extensions/telegram/src/accounts.ts:148-153`), which uses `baseEnabled && accountEnabled` with each defaulting to `enabled !== false`. The LINE resolver now matches that idiom.

## Changes

- `extensions/line/src/accounts.ts`: drop the `DEFAULT_ACCOUNT_ID` guard around `resolveAccountEntry`; replace the `??`-chain `enabled` formula with the Telegram-style `baseEnabled && accountEnabled`.
- `extensions/line/src/accounts.test.ts`: seven new regression tests cover `accounts.default` credential lookup, `accounts.default` precedence over top-level base credentials, named accounts default-enabled when their config exists, channel-level `enabled: false` propagating to named accounts and `accounts.default`, explicit `enabled: false` on a named account still winning, and `accounts.default.name` taking precedence over `channels.line.name`.

The `name` resolution path is intentionally unchanged to avoid silently leaking the top-level `channels.line.name` into unnamed named accounts (a concern raised in the review of the earlier closed attempt #47528).

## Real behavior proof

**Behavior or issue addressed:** With a config that uses `channels.line.accounts.default` (no top-level credentials) plus a named second account (no `enabled: true`), both LINE webhook routes return HTTP 404. This blocks all inbound messages from both bots and matches the symptoms in #47264 ("Both webhook endpoints return 404 Not Found — even the default account's webhook breaks").

**Real environment tested:** OpenClaw gateway started locally on Windows 11 (Node 22.16.0) under an isolated `--profile linetest` profile, port 18789. Two real LINE Messaging API channels were provisioned in the LINE Developers Console with real channel access tokens and channel secrets. An ngrok tunnel forwarded the LINE platform's HTTPS traffic to `http://localhost:18789`. Channel A's webhook URL pointed at `/line/webhook`; channel B's webhook URL pointed at `/line-twgreen/webhook`.

**Exact steps or command run after this patch:** Start the gateway with the multi-account config under the isolated profile, then start an ngrok tunnel that forwards to gateway port 18789, paste the resulting `https://...ngrok-free.app/line/webhook` and `https://...ngrok-free.app/line-twgreen/webhook` URLs into the two channels in the LINE Developers Console, click "Verify" on each, then add both bots as friends from the LINE app via their QR codes and send a real text message to each one.

```
node scripts/run-node.mjs --profile linetest gateway --port 18789 --bind loopback --auth none --force
ngrok http 18789
curl http://127.0.0.1:4040/api/requests/http
```

**Evidence after fix:** Gateway console output (timestamps abbreviated):

```
[gateway] http server listening (9 plugins: acpx, browser, canvas, device-pair,
          file-transfer, line, memory-core, phone-control, talk-voice; 9.4s)
[gateway] ready
[line] [default] starting LINE provider
[line] [twgreen] starting LINE provider
```

ngrok inbound request log (real LINE platform traffic, copied from `curl http://127.0.0.1:4040/api/requests/http`):

```
23:52:12  POST /line/webhook          -> 401  ua=curl/8.12.1            (local smoke test, deliberately invalid signature)
23:52:13  POST /line-twgreen/webhook  -> 401  ua=curl/8.12.1            (local smoke test, deliberately invalid signature)
23:53:24  POST /line/webhook          -> 200  ua=LineBotWebhook/2.0     (channel A Verify probe from LINE)
23:54:37  POST /line-twgreen/webhook  -> 200  ua=LineBotWebhook/2.0     (channel B Verify probe from LINE)
23:56:16  POST /line-twgreen/webhook  -> 200  ua=LineBotWebhook/2.0     (real text message sent to bot B from the LINE app)
23:56:30  POST /line/webhook          -> 200  ua=LineBotWebhook/2.0     (real text message sent to bot A from the LINE app)
```

Local fake-token bug-repro curl (post-fix), against `http://127.0.0.1:18789`:

```
POST /line/webhook          -> HTTP 401 {"error":"Invalid signature"}
POST /line-twgreen/webhook  -> HTTP 401 {"error":"Invalid signature"}
GET  /                      -> HTTP 200 (gateway alive)
```

Same curl against the same gateway built from `accounts.ts` with the two-line patch reverted (bug-repro baseline):

```
POST /line/webhook          -> HTTP 404 Not Found
POST /line-twgreen/webhook  -> HTTP 404 Not Found
GET  /                      -> HTTP 200 (gateway alive)
```

The reverted-fix gateway emits no `starting LINE provider` log lines for either account, confirming both accounts are skipped at start-up.

**Observed result after fix:** Both LINE webhook routes register at gateway start-up; the console log shows `[default] starting LINE provider` and `[twgreen] starting LINE provider`. LINE platform's Verify probes from channel A and channel B both return HTTP 200, displayed as Success in the LINE Console. Real user-originated messages sent from the LINE app to each bot arrive at the gateway over the ngrok tunnel and return HTTP 200. The HTTP 200 is the proof that signature validation succeeded — for each request, the resolver retrieved the matching account's `channelSecret` (`accounts.default.channelSecret` for channel A, `accounts.<name>.channelSecret` for channel B) and `validateLineSignature` passed against the live `X-Line-Signature` header. On the same machine with the patch reverted, the identical multi-account config produces HTTP 404 on both webhook paths and no `starting LINE provider` log output, reproducing the original issue 1:1.

**What was not tested:** Outbound replies to the LINE app. The test gateway intentionally had no agent runtime or LLM credentials configured — this patch changes only account resolution and webhook registration, and the inbound HTTP 200 from real LINE platform traffic already exercises the changed resolver path end to end (config lookup, token and secret retrieval, signature validation, bot dispatch).

## Test plan

- `pnpm test extensions/line/src/accounts.test.ts` → 20 passed, 1 skipped (the platform-skipped symlink test). All 7 new tests pass and all 13 pre-existing tests still pass.
- `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test`, `pnpm lint:extensions` — all clean.
- `oxfmt --check` on the two touched files — clean. (`pnpm format:check` over the full repo surfaces unrelated drift on 19 files outside the LINE plugin on current `main`.)
- Resolver before/after revert: reverting only the two `accounts.ts` changes from this commit causes 5 of the 7 new tests to fail with messages that mirror the issue symptoms exactly, e.g. `expected '' to be 'default-token'` and `expected false to be true`. Restoring the fix returns the suite to all green.

Closes #47264.
