### PR TITLE
[Fix] Carry transcript update sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI: lazy-load model and plugin runtime helpers for command actions so parent/help output renders without importing those runtime paths.
+- Gateway/session history: carry monotonic transcript message sequence through live updates and refresh SSE history when stale sequence input would otherwise append bad incremental state. (#81474) Thanks @samzong.
 - Security/sandbox: include Windows `USERPROFILE` in the sandbox blocked home roots so credential-bearing binds (such as `.codex`, `.openclaw`, or `.ssh` under the Windows user profile) are denied even when `HOME` points at a different shell home. (#63074) Thanks @luoyanglang.
 - Models config/auth: stop inferring provider env-var markers from broad `^[A-Z_][A-Z0-9_]*$` strings, and resolve config-backed provider `apiKey` values only through structured env SecretRefs (`secrets.providers[id]` / `secrets.defaults`), so unrelated env vars cannot accidentally become provider credentials. Thanks @sallyom.
 - Media fetch: skip allocating and buffering the response body for bodyless media responses (HEAD probes and 204-style empty bodies), avoiding wasted heap on streams that carry no payload. Thanks @shakkernerd.

--- a/src/agents/session-tool-result-guard.transcript-events.test.ts
+++ b/src/agents/session-tool-result-guard.transcript-events.test.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   onSessionTranscriptUpdate,
   type SessionTranscriptUpdate,
@@ -49,10 +49,124 @@ describe("guardSessionManager transcript updates", () => {
           timestamp,
         },
         messageId: expect.any(String),
+        messageSeq: 1,
         sessionFile,
         sessionKey: "agent:main:worker",
       },
     ]);
     expect(updates[0]?.messageId).not.toBe("");
+  });
+
+  it("does not resolve transcript sequence when no session file is available", () => {
+    const sm = SessionManager.inMemory();
+    Object.assign(sm, {
+      getSessionFile: () => undefined,
+    });
+    const getBranchSpy = vi.spyOn(sm, "getBranch");
+
+    const guarded = guardSessionManager(sm, {
+      agentId: "main",
+      sessionKey: "agent:main:worker",
+    });
+    const appendMessage = guarded.appendMessage.bind(guarded) as unknown as (
+      message: AgentMessage,
+    ) => void;
+
+    appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: Date.now(),
+    } as AgentMessage);
+
+    expect(getBranchSpy).not.toHaveBeenCalled();
+    getBranchSpy.mockRestore();
+  });
+
+  it("reuses cached transcript sequence for consecutive appended messages", () => {
+    const updates: SessionTranscriptUpdate[] = [];
+    listeners.push(onSessionTranscriptUpdate((update) => updates.push(update)));
+
+    const sm = SessionManager.inMemory();
+    sm.appendMessage({
+      role: "user",
+      content: "existing prompt",
+      timestamp: Date.now(),
+    } as Parameters<typeof sm.appendMessage>[0]);
+    const getBranchSpy = vi.spyOn(sm, "getBranch");
+    const sessionFile = "/tmp/openclaw-session-message-events.jsonl";
+    Object.assign(sm, {
+      getSessionFile: () => sessionFile,
+    });
+
+    const guarded = guardSessionManager(sm, {
+      agentId: "main",
+      sessionKey: "agent:main:worker",
+    });
+    const appendMessage = guarded.appendMessage.bind(guarded) as unknown as (
+      message: AgentMessage,
+    ) => void;
+
+    appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "first" }],
+      timestamp: Date.now(),
+    } as AgentMessage);
+    appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "second" }],
+      timestamp: Date.now(),
+    } as AgentMessage);
+
+    expect(getBranchSpy).toHaveBeenCalledTimes(1);
+    expect(updates.map((update) => update.messageSeq)).toEqual([2, 3]);
+    getBranchSpy.mockRestore();
+  });
+
+  it("caches real tool result sequence before final assistant messages", () => {
+    const updates: SessionTranscriptUpdate[] = [];
+    listeners.push(onSessionTranscriptUpdate((update) => updates.push(update)));
+
+    const sm = SessionManager.inMemory();
+    sm.appendMessage({
+      role: "user",
+      content: "existing prompt",
+      timestamp: Date.now(),
+    } as Parameters<typeof sm.appendMessage>[0]);
+    const getBranchSpy = vi.spyOn(sm, "getBranch");
+    const sessionFile = "/tmp/openclaw-session-message-events.jsonl";
+    Object.assign(sm, {
+      getSessionFile: () => sessionFile,
+    });
+
+    const guarded = guardSessionManager(sm, {
+      agentId: "main",
+      sessionKey: "agent:main:worker",
+    });
+    const appendMessage = guarded.appendMessage.bind(guarded) as unknown as (
+      message: AgentMessage,
+    ) => void;
+
+    appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      timestamp: Date.now(),
+    } as AgentMessage);
+    appendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      content: [{ type: "text", text: "tool output" }],
+      isError: false,
+      timestamp: Date.now(),
+    } as AgentMessage);
+    appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "final answer" }],
+      timestamp: Date.now(),
+    } as AgentMessage);
+
+    expect(getBranchSpy).toHaveBeenCalledTimes(1);
+    expect(updates.map((update) => update.messageSeq)).toEqual([2, 4]);
+    getBranchSpy.mockRestore();
   });
 });

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -55,6 +55,52 @@ function isUserAgentMessage(message: AgentMessage): message is UserAgentMessage 
   return message.role === "user";
 }
 
+type TranscriptSeqByEntryId = Map<string, number>;
+
+function resolveEntryTranscriptSeq(
+  sessionManager: SessionManager,
+  entryId: string | null | undefined,
+  seqByEntryId: TranscriptSeqByEntryId,
+): number | undefined {
+  if (!entryId) {
+    return 0;
+  }
+  const cached = seqByEntryId.get(entryId);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let seq = 0;
+  for (const entry of sessionManager.getBranch(entryId)) {
+    if (entry.type === "message" || entry.type === "compaction") {
+      seq += 1;
+    }
+    seqByEntryId.set(entry.id, seq);
+  }
+  return seqByEntryId.get(entryId);
+}
+
+function resolveAppendedMessageSeq(params: {
+  sessionManager: SessionManager;
+  entryId: unknown;
+  parentEntryId: string | null | undefined;
+  seqByEntryId: TranscriptSeqByEntryId;
+}): number | undefined {
+  if (typeof params.entryId !== "string") {
+    return undefined;
+  }
+  const parentSeq = resolveEntryTranscriptSeq(
+    params.sessionManager,
+    params.parentEntryId,
+    params.seqByEntryId,
+  );
+  if (parentSeq === undefined) {
+    return undefined;
+  }
+  const messageSeq = parentSeq + 1;
+  params.seqByEntryId.set(params.entryId, messageSeq);
+  return messageSeq;
+}
+
 // `details` is runtime/UI metadata, not model-visible tool output. Keep the
 // session JSONL useful for debugging without letting metadata blobs dominate
 // disk, replay repair, transcript broadcasts, or future tooling that reads raw
@@ -536,7 +582,32 @@ export function installSessionToolResultGuard(
   const beforeWrite = opts?.beforeMessageWriteHook;
   const redactionConfig = opts?.redactLoggingConfig;
   const maxToolResultChars = resolveMaxToolResultChars(opts);
+  const transcriptSeqByEntryId: TranscriptSeqByEntryId = new Map();
   let suppressNextUserMessagePersistence = opts?.suppressNextUserMessagePersistence === true;
+
+  const getSessionFile = () =>
+    (sessionManager as { getSessionFile?: () => string | null }).getSessionFile?.();
+
+  const appendMessageAndCacheTranscriptSeq = (
+    message: AgentMessage,
+  ): { entryId: string; messageSeq?: number; sessionFile?: string | null } => {
+    const parentEntryId = sessionManager.getLeafId();
+    const entryId = originalAppend(message as never);
+    const sessionFile = getSessionFile();
+    if (!sessionFile) {
+      return { entryId, sessionFile };
+    }
+    return {
+      entryId,
+      sessionFile,
+      messageSeq: resolveAppendedMessageSeq({
+        sessionManager,
+        entryId,
+        parentEntryId,
+        seqByEntryId: transcriptSeqByEntryId,
+      }),
+    };
+  };
 
   /**
    * Run the before_message_write hook. Returns the (possibly modified) message,
@@ -575,8 +646,8 @@ export function installSessionToolResultGuard(
           }),
         );
         if (flushed) {
-          originalAppend(
-            capToolResultForPersistence(flushed, maxToolResultChars, redactionConfig) as never,
+          appendMessageAndCacheTranscriptSeq(
+            capToolResultForPersistence(flushed, maxToolResultChars, redactionConfig),
           );
         }
       }
@@ -629,9 +700,9 @@ export function installSessionToolResultGuard(
       if (!persisted) {
         return undefined;
       }
-      return originalAppend(
-        capToolResultForPersistence(persisted, maxToolResultChars, redactionConfig) as never,
-      );
+      return appendMessageAndCacheTranscriptSeq(
+        capToolResultForPersistence(persisted, maxToolResultChars, redactionConfig),
+      ).entryId;
     }
 
     // Skip tool call extraction for aborted/errored assistant messages.
@@ -675,17 +746,18 @@ export function installSessionToolResultGuard(
       suppressNextUserMessagePersistence = false;
       return undefined;
     }
-    const result = originalAppend(finalMessage as never);
-
-    const sessionFile = (
-      sessionManager as { getSessionFile?: () => string | null }
-    ).getSessionFile?.();
+    const {
+      entryId: result,
+      messageSeq,
+      sessionFile,
+    } = appendMessageAndCacheTranscriptSeq(finalMessage);
     if (sessionFile) {
       emitSessionTranscriptUpdate({
         sessionFile,
         sessionKey: opts?.sessionKey,
         message: finalMessage,
         messageId: typeof result === "string" ? result : undefined,
+        ...(messageSeq !== undefined ? { messageSeq } : {}),
       });
     }
 

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -1,5 +1,6 @@
 import type { SessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import type { SessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import { asPositiveSafeInteger } from "../shared/number-coercion.js";
 import { projectChatDisplayMessage } from "./chat-display-projection.js";
 import type { GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
 import type {
@@ -17,10 +18,6 @@ import {
 
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
-
-function normalizeMessageSeq(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
-}
 
 function buildGatewaySessionSnapshot(params: {
   sessionRow: GatewaySessionRow | null | undefined;
@@ -122,11 +119,11 @@ async function handleTranscriptUpdateBroadcast(
   if (connIds.size === 0) {
     return;
   }
-  let messageSeq = normalizeMessageSeq(update.messageSeq);
+  let messageSeq = asPositiveSafeInteger(update.messageSeq);
   if (messageSeq === undefined) {
     const { entry, storePath } = loadSessionEntry(sessionKey);
     messageSeq = entry?.sessionId
-      ? normalizeMessageSeq(
+      ? asPositiveSafeInteger(
           await readSessionMessageCountAsync(entry.sessionId, storePath, entry.sessionFile),
         )
       : undefined;

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -18,6 +18,10 @@ import {
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
 
+function normalizeMessageSeq(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
 function buildGatewaySessionSnapshot(params: {
   sessionRow: GatewaySessionRow | null | undefined;
   includeSession?: boolean;
@@ -118,17 +122,22 @@ async function handleTranscriptUpdateBroadcast(
   if (connIds.size === 0) {
     return;
   }
-  const { entry, storePath } = loadSessionEntry(sessionKey);
-  const messageSeq = entry?.sessionId
-    ? await readSessionMessageCountAsync(entry.sessionId, storePath, entry.sessionFile)
-    : undefined;
+  let messageSeq = normalizeMessageSeq(update.messageSeq);
+  if (messageSeq === undefined) {
+    const { entry, storePath } = loadSessionEntry(sessionKey);
+    messageSeq = entry?.sessionId
+      ? normalizeMessageSeq(
+          await readSessionMessageCountAsync(entry.sessionId, storePath, entry.sessionFile),
+        )
+      : undefined;
+  }
   const sessionSnapshot = buildGatewaySessionSnapshot({
     sessionRow: loadGatewaySessionRow(sessionKey, { transcriptUsageMaxBytes: 64 * 1024 }),
     includeSession: true,
   });
   const rawMessage = attachOpenClawTranscriptMeta(update.message, {
     ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
-    ...(typeof messageSeq === "number" ? { seq: messageSeq } : {}),
+    ...(messageSeq !== undefined ? { seq: messageSeq } : {}),
   });
   const message = projectChatDisplayMessage(rawMessage);
   if (message) {
@@ -138,7 +147,7 @@ async function handleTranscriptUpdateBroadcast(
         sessionKey,
         message,
         ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),
-        ...(typeof messageSeq === "number" ? { messageSeq } : {}),
+        ...(messageSeq !== undefined ? { messageSeq } : {}),
         ...sessionSnapshot,
       },
       connIds,
@@ -157,7 +166,7 @@ async function handleTranscriptUpdateBroadcast(
       phase: "message",
       ts: Date.now(),
       ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),
-      ...(typeof messageSeq === "number" ? { messageSeq } : {}),
+      ...(messageSeq !== undefined ? { messageSeq } : {}),
       ...sessionSnapshot,
     },
     sessionEventConnIds,

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -77,6 +77,55 @@ describe("SessionHistorySseState", () => {
     expect(snapshot.rawTranscriptSeq).toBe(2);
   });
 
+  test("uses carried sequence for inline SSE appends", () => {
+    const state = SessionHistorySseState.fromRawSnapshot({
+      target: { sessionId: "sess-main" },
+      rawMessages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "initial" }],
+          __openclaw: { seq: 2 },
+        },
+      ],
+    });
+
+    const appended = state.appendInlineMessage({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "carried" }],
+      },
+      messageSeq: 9,
+    });
+
+    expect(appended?.messageSeq).toBe(9);
+    expect(state.snapshot().messages.at(-1)?.__openclaw?.seq).toBe(9);
+  });
+
+  test("requests refresh for non-monotonic carried inline sequence", () => {
+    const state = SessionHistorySseState.fromRawSnapshot({
+      target: { sessionId: "sess-main" },
+      rawMessages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "current" }],
+          __openclaw: { seq: 5 },
+        },
+      ],
+    });
+
+    const appended = state.appendInlineMessage({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "rewound branch" }],
+      },
+      messageSeq: 3,
+    });
+
+    expect(appended).toEqual({ shouldRefresh: true });
+    expect(state.snapshot().messages).toHaveLength(1);
+    expect(state.snapshot().messages.at(-1)?.__openclaw?.seq).toBe(5);
+  });
+
   test("marks bounded tail snapshots as having older history", () => {
     const snapshot = buildSessionHistorySnapshot({
       rawMessages: [

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -1,3 +1,4 @@
+import { asPositiveSafeInteger } from "../shared/number-coercion.js";
 import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   projectChatDisplayMessages,
@@ -67,10 +68,6 @@ function resolveCursorSeq(cursor: string | undefined): number | undefined {
   return Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
-function resolvePositiveInteger(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
-}
-
 function toSessionHistoryMessages(messages: unknown[]): SessionHistoryMessage[] {
   return messages.filter(
     (message): message is SessionHistoryMessage =>
@@ -92,7 +89,7 @@ function buildPaginatedSessionHistory(params: {
 }
 
 function resolveMessageSeq(message: SessionHistoryMessage | undefined): number | undefined {
-  return resolvePositiveInteger(message?.__openclaw?.seq);
+  return asPositiveSafeInteger(message?.__openclaw?.seq);
 }
 
 function paginateSessionMessages(
@@ -238,7 +235,7 @@ export class SessionHistorySseState {
     if (this.limit !== undefined || this.cursor !== undefined) {
       return null;
     }
-    const carriedSeq = resolvePositiveInteger(update.messageSeq);
+    const carriedSeq = asPositiveSafeInteger(update.messageSeq);
     if (carriedSeq !== undefined) {
       if (carriedSeq <= this.rawTranscriptSeq) {
         return { shouldRefresh: true };

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -28,6 +28,12 @@ type SessionHistorySnapshot = {
   rawTranscriptSeq: number;
 };
 
+type InlineSessionHistoryAppend = {
+  message?: unknown;
+  messageSeq?: number;
+  shouldRefresh?: boolean;
+};
+
 type SessionHistoryTranscriptTarget = {
   sessionId: string;
   storePath?: string;
@@ -61,6 +67,10 @@ function resolveCursorSeq(cursor: string | undefined): number | undefined {
   return Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
+function resolvePositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
 function toSessionHistoryMessages(messages: unknown[]): SessionHistoryMessage[] {
   return messages.filter(
     (message): message is SessionHistoryMessage =>
@@ -82,8 +92,7 @@ function buildPaginatedSessionHistory(params: {
 }
 
 function resolveMessageSeq(message: SessionHistoryMessage | undefined): number | undefined {
-  const seq = message?.__openclaw?.seq;
-  return typeof seq === "number" && Number.isFinite(seq) && seq > 0 ? seq : undefined;
+  return resolvePositiveInteger(message?.__openclaw?.seq);
 }
 
 function paginateSessionMessages(
@@ -224,11 +233,20 @@ export class SessionHistorySseState {
   appendInlineMessage(update: {
     message: unknown;
     messageId?: string;
-  }): { message: unknown; messageSeq?: number } | null {
+    messageSeq?: number;
+  }): InlineSessionHistoryAppend | null {
     if (this.limit !== undefined || this.cursor !== undefined) {
       return null;
     }
-    this.rawTranscriptSeq += 1;
+    const carriedSeq = resolvePositiveInteger(update.messageSeq);
+    if (carriedSeq !== undefined) {
+      if (carriedSeq <= this.rawTranscriptSeq) {
+        return { shouldRefresh: true };
+      }
+      this.rawTranscriptSeq = carriedSeq;
+    } else {
+      this.rawTranscriptSeq += 1;
+    }
     const nextMessage = attachOpenClawTranscriptMeta(update.message, {
       ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
       seq: this.rawTranscriptSeq,

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -99,6 +99,7 @@ async function emitTranscriptUpdateAndCollectEvents(params: {
   sessionFile: string;
   message: Record<string, unknown>;
   messageId: string;
+  messageSeq?: number;
 }) {
   const messageEventPromise = waitForSessionMessageEvent(params.ws, params.sessionKey);
   const changedEventPromise = waitForSessionsChangedMessagePhase(params.ws, params.sessionKey);
@@ -108,6 +109,7 @@ async function emitTranscriptUpdateAndCollectEvents(params: {
     sessionKey: params.sessionKey,
     message: params.message,
     messageId: params.messageId,
+    ...(typeof params.messageSeq === "number" ? { messageSeq: params.messageSeq } : {}),
   });
 
   const [messageEvent, changedEvent] = await Promise.all([
@@ -458,6 +460,49 @@ describe("session.message websocket events", () => {
         modelProvider: "openai",
         model: "gpt-5.4",
       });
+    });
+  });
+
+  test("prefers carried transcript sequence for live session events", async () => {
+    const storePath = await createSessionStoreFile();
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+        },
+      },
+      storePath,
+    });
+
+    await withOperatorSessionSubscriber(async (ws) => {
+      const { messageEvent, changedEvent } = await emitTranscriptUpdateAndCollectEvents({
+        ws,
+        sessionKey: "agent:main:main",
+        sessionFile: path.join(path.dirname(storePath), "missing-transcript.jsonl"),
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "carried sequence" }],
+          timestamp: Date.now(),
+        },
+        messageId: "msg-carried-seq",
+        messageSeq: 7,
+      });
+
+      expectRecordFields(messageEvent.payload, {
+        sessionKey: "agent:main:main",
+        messageId: "msg-carried-seq",
+        messageSeq: 7,
+      });
+      expectRecordFields(changedEvent.payload, {
+        sessionKey: "agent:main:main",
+        phase: "message",
+        messageId: "msg-carried-seq",
+        messageSeq: 7,
+      });
+      const payload = requireRecord(messageEvent.payload, "session.message payload");
+      const message = requireRecord(payload.message, "session.message payload message");
+      expect((message.__openclaw as { seq?: unknown } | undefined)?.seq).toBe(7);
     });
   });
 

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -7,6 +7,7 @@ import {
   appendAssistantMessageToSessionTranscript,
   appendExactAssistantMessageToSessionTranscript,
 } from "../config/sessions/transcript.js";
+import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
   connectReq,
@@ -576,6 +577,59 @@ describe("session history HTTP endpoints", () => {
         seq: 2,
         id: appended.messageId,
       });
+
+      await stream.reader.cancel();
+    });
+  });
+
+  test("refreshes SSE history for non-monotonic carried sequence", async () => {
+    const storePath = await createSessionStoreFile();
+    const transcriptPath = path.join(path.dirname(storePath), "sess-main.jsonl");
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          sessionFile: transcriptPath,
+          updatedAt: Date.now(),
+        },
+      },
+      storePath,
+    });
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({ type: "session", version: 1, id: "sess-main" }),
+        JSON.stringify({
+          id: "msg-first",
+          message: makeTranscriptAssistantMessage({ text: "first message" }),
+        }),
+        JSON.stringify({
+          id: "msg-second",
+          message: makeTranscriptAssistantMessage({ text: "second message" }),
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await withGatewayHarness(async (harness) => {
+      const stream = await openSessionHistorySse(harness.port, "agent:main:main");
+      await expectHistoryEventTexts(stream, ["first message", "second message"]);
+
+      emitSessionTranscriptUpdate({
+        sessionFile: transcriptPath,
+        sessionKey: "agent:main:main",
+        message: makeTranscriptAssistantMessage({ text: "rewound branch message" }),
+        messageId: "msg-rewound",
+        messageSeq: 1,
+      });
+
+      const refreshEvent = await readSseEvent(stream.reader, stream.streamState);
+      expect(refreshEvent.event).toBe("history");
+      expect(
+        (
+          refreshEvent.data as { messages?: Array<{ content?: Array<{ text?: string }> }> }
+        ).messages?.map((message) => message.content?.[0]?.text),
+      ).toEqual(["first message", "second message"]);
 
       await stream.reader.cancel();
     });

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -327,8 +327,20 @@ export async function handleSessionHistoryHttpRequest(
           const nextEvent = sseState.appendInlineMessage({
             message: update.message,
             messageId: update.messageId,
+            messageSeq: update.messageSeq,
           });
           if (!nextEvent) {
+            return;
+          }
+          if (nextEvent.shouldRefresh) {
+            sentHistory = await sseState.refreshAsync();
+            sseWrite(res, "history", {
+              sessionKey: target.canonicalKey,
+              ...sentHistory,
+            });
+            return;
+          }
+          if (nextEvent.message === undefined) {
             return;
           }
           sentHistory = sseState.snapshot();

--- a/src/sessions/transcript-events.test.ts
+++ b/src/sessions/transcript-events.test.ts
@@ -28,13 +28,40 @@ describe("transcript events", () => {
       sessionFile: "  /tmp/session.jsonl  ",
       sessionKey: "  agent:main:main  ",
       message: { role: "assistant", content: "hi" },
+      messageId: "  msg-1  ",
+      messageSeq: 2,
     });
 
     expect(listener).toHaveBeenCalledWith({
       sessionFile: "/tmp/session.jsonl",
       sessionKey: "agent:main:main",
       message: { role: "assistant", content: "hi" },
+      messageId: "msg-1",
+      messageSeq: 2,
     });
+  });
+
+  it("drops invalid message sequence values", () => {
+    const listener = vi.fn();
+    cleanup.push(onSessionTranscriptUpdate(listener));
+
+    emitSessionTranscriptUpdate({
+      sessionFile: "/tmp/session.jsonl",
+      messageSeq: 0,
+    });
+    emitSessionTranscriptUpdate({
+      sessionFile: "/tmp/session.jsonl",
+      messageSeq: 1.5,
+    });
+    emitSessionTranscriptUpdate({
+      sessionFile: "/tmp/session.jsonl",
+      messageSeq: Number.POSITIVE_INFINITY,
+    });
+
+    expect(listener).toHaveBeenCalledTimes(3);
+    expect(listener).toHaveBeenNthCalledWith(1, { sessionFile: "/tmp/session.jsonl" });
+    expect(listener).toHaveBeenNthCalledWith(2, { sessionFile: "/tmp/session.jsonl" });
+    expect(listener).toHaveBeenNthCalledWith(3, { sessionFile: "/tmp/session.jsonl" });
   });
 
   it("continues notifying other listeners when one throws", () => {

--- a/src/sessions/transcript-events.ts
+++ b/src/sessions/transcript-events.ts
@@ -5,11 +5,16 @@ export type SessionTranscriptUpdate = {
   sessionKey?: string;
   message?: unknown;
   messageId?: string;
+  messageSeq?: number;
 };
 
 type SessionTranscriptListener = (update: SessionTranscriptUpdate) => void;
 
 const SESSION_TRANSCRIPT_LISTENERS = new Set<SessionTranscriptListener>();
+
+function normalizeMessageSeq(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
 
 export function onSessionTranscriptUpdate(listener: SessionTranscriptListener): () => void {
   SESSION_TRANSCRIPT_LISTENERS.add(listener);
@@ -27,11 +32,13 @@ export function emitSessionTranscriptUpdate(update: string | SessionTranscriptUp
           sessionKey: update.sessionKey,
           message: update.message,
           messageId: update.messageId,
+          messageSeq: update.messageSeq,
         };
   const trimmed = normalizeOptionalString(normalized.sessionFile);
   if (!trimmed) {
     return;
   }
+  const messageSeq = normalizeMessageSeq(normalized.messageSeq);
   const nextUpdate: SessionTranscriptUpdate = {
     sessionFile: trimmed,
     ...(normalizeOptionalString(normalized.sessionKey)
@@ -41,6 +48,7 @@ export function emitSessionTranscriptUpdate(update: string | SessionTranscriptUp
     ...(normalizeOptionalString(normalized.messageId)
       ? { messageId: normalizeOptionalString(normalized.messageId) }
       : {}),
+    ...(messageSeq !== undefined ? { messageSeq } : {}),
   };
   for (const listener of SESSION_TRANSCRIPT_LISTENERS) {
     try {

--- a/src/sessions/transcript-events.ts
+++ b/src/sessions/transcript-events.ts
@@ -1,3 +1,4 @@
+import { asPositiveSafeInteger } from "../shared/number-coercion.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 
 export type SessionTranscriptUpdate = {
@@ -11,10 +12,6 @@ export type SessionTranscriptUpdate = {
 type SessionTranscriptListener = (update: SessionTranscriptUpdate) => void;
 
 const SESSION_TRANSCRIPT_LISTENERS = new Set<SessionTranscriptListener>();
-
-function normalizeMessageSeq(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
-}
 
 export function onSessionTranscriptUpdate(listener: SessionTranscriptListener): () => void {
   SESSION_TRANSCRIPT_LISTENERS.add(listener);
@@ -38,7 +35,7 @@ export function emitSessionTranscriptUpdate(update: string | SessionTranscriptUp
   if (!trimmed) {
     return;
   }
-  const messageSeq = normalizeMessageSeq(normalized.messageSeq);
+  const messageSeq = asPositiveSafeInteger(normalized.messageSeq);
   const nextUpdate: SessionTranscriptUpdate = {
     sessionFile: trimmed,
     ...(normalizeOptionalString(normalized.sessionKey)

--- a/src/shared/number-coercion.ts
+++ b/src/shared/number-coercion.ts
@@ -1,3 +1,7 @@
 export function asFiniteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
+
+export function asPositiveSafeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: live transcript updates recomputed message sequence state from the transcript file and SSE inline history could accept stale carried sequence values.
- Why it matters: busy sessions could hit avoidable branch/file scans and live history streams could regress to an invalid incremental state after branch rewrites or stale updates.
- What changed: guarded session appends now carry cached `messageSeq`; websocket broadcasts prefer carried sequence; history SSE refreshes instead of appending when carried sequence is non-monotonic.
- What did NOT change (scope boundary): no public protocol schema, plugin, UI, auth, or storage format migration changes.
- AI-assisted: yes, implemented and reviewed with Codex.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: transcript updates carry monotonic sequence without repeated branch scans, and stale SSE sequence input triggers a history refresh instead of corrupting incremental state.
- Real environment tested: local OpenClaw worktree on macOS via `pnpm exec tsx`, using the real `guardSessionManager`, `onSessionTranscriptUpdate`, and `SessionHistorySseState` modules.
- Exact steps or command run after this patch:
  - `pnpm exec tsx` runtime probe that appended assistant/toolResult/final assistant messages through the guarded `SessionManager`, then applied a stale carried sequence to `SessionHistorySseState.appendInlineMessage()`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{"transcriptUpdateSeqs":[2,4],"branchScans":1,"staleAppend":{"shouldRefresh":true},"retainedHistorySeq":5}
```

- Observed result after fix: the final assistant update carried seq `4` after the real tool result, only one branch scan occurred for the sequence cache warmup, and stale seq `3` against current seq `5` requested refresh while preserving seq `5`.
- What was not tested: a full browser/UI live SSE session against a running Gateway; no external channel integration was involved.
- Before evidence (optional but encouraged): not captured in this run; the added regression tests encode the previous missing guard paths.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: transcript update consumers had to rediscover sequence after writes, and history SSE inline state trusted locally incremented or carried sequence without a monotonicity guard.
- Missing detection / guardrail: there was no coverage for carried `messageSeq`, sequence-cache reuse across tool result writes, or stale carried sequence refresh behavior.
- Contributing context (if known): tool result writes are not themselves broadcast as transcript updates, but they still affect the raw transcript sequence used by the next assistant update.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/session-tool-result-guard.transcript-events.test.ts`
  - `src/gateway/session-history-state.test.ts`
  - `src/gateway/session-message-events.test.ts`
  - `src/gateway/sessions-history-http.test.ts`
  - `src/sessions/transcript-events.test.ts`
- Scenario the test should lock in: carried transcript sequence is normalized and propagated; guarded appends reuse cached sequence; real tool results advance sequence before final assistant updates; non-monotonic SSE sequence forces full history refresh.
- Why this is the smallest reliable guardrail: it covers the producer, event normalization, websocket projection, and history SSE state without requiring a full external channel run.
- Existing test that already covers this (if any): N/A before this PR.
- If no new test is added, why not: new tests are included.

## User-visible / Behavior Changes

Gateway live session history and session message events are more consistent: assistant transcript updates can include accurate `messageSeq`, and history SSE clients get a full refresh instead of a bad incremental append when sequence input is stale.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
append message -> transcript update -> consumer recomputes or increments seq -> stale updates can append bad state

After:
append message -> cached seq carried in transcript update -> consumer uses carried seq -> stale seq requests history refresh
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local developer machine
- Runtime/container: local Node/pnpm worktree
- Model/provider: N/A
- Integration/channel (if any): Gateway session history and transcript event path only
- Relevant config (redacted): default local test config

### Steps

1. Run the targeted Vitest command for changed transcript/Gateway surfaces.
2. Run the runtime `pnpm exec tsx` probe shown in the Real behavior proof section.
3. Run the scoped changed gate against `upstream/main`.

### Expected

- Targeted tests pass.
- Runtime probe shows carried sequence `[2,4]`, one branch scan, stale sequence refresh, and retained current sequence.
- Scoped changed gate should only report failures in touched surfaces, or identify unrelated repo noise clearly.

### Actual

- `pnpm test src/agents/session-tool-result-guard.transcript-events.test.ts src/gateway/session-history-state.test.ts src/gateway/session-message-events.test.ts src/gateway/sessions-history-http.test.ts src/sessions/transcript-events.test.ts`: passed, 4 Vitest shards, 43 tests.
- `pnpm exec tsx` runtime probe: passed with `{"transcriptUpdateSeqs":[2,4],"branchScans":1,"staleAppend":{"shouldRefresh":true},"retainedHistorySeq":5}`.
- `pnpm check:changed --base upstream/main --head HEAD`: failed in unrelated `src/plugins/registry.runtime-config.test.ts` type errors at lines 45 and 46; that file is not in this PR diff.
- `git diff HEAD~1..HEAD --check`: passed.
- `command codex review --base upstream/main`: passed before the final rebase; the final rebase replayed the same 10-file patch cleanly onto `upstream/main`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: guarded append sequence propagation, real toolResult sequence advancement, stale SSE sequence refresh, transcript event normalization, websocket carried sequence projection, and HTTP history SSE refresh behavior.
- Edge cases checked: missing session file does not scan branch; invalid message sequence values are dropped; non-monotonic carried sequence does not mutate inline SSE history.
- What you did **not** verify: full external channel delivery and browser UI rendering.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: sequence cache could become stale if another path mutates the session branch without going through guarded appends.
  - Mitigation: cache misses resolve the current branch, and rewrite/compaction paths emit refresh-style transcript updates instead of inline message updates.
