### PR TITLE
fix(gateway): use resolved runtime config for message actions

### DIFF
--- a/src/agents/model-auth-markers.test.ts
+++ b/src/agents/model-auth-markers.test.ts
@@ -82,6 +82,24 @@ describe("model auth markers", () => {
     expect(markers.has("ollama-local")).toBe(true);
   });
 
+  it("keeps package-stable non-secret markers when excluded plugin manifests are absent", async () => {
+    await withEnvAsync(
+      {
+        ...cleanPluginManifestEnv(),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      },
+      loadMarkerModules,
+    );
+
+    const markers = new Set(listKnownNonSecretApiKeyMarkers());
+    expect(markers.has("codex-app-server")).toBe(true);
+    expect(markers.has("gcp-vertex-credentials")).toBe(true);
+    expect(isNonSecretApiKeyMarker("codex-app-server")).toBe(true);
+    expect(isNonSecretApiKeyMarker(GCP_VERTEX_CREDENTIALS_MARKER)).toBe(true);
+
+    await withEnvAsync(cleanPluginManifestEnv(), loadMarkerModules);
+  });
+
   it("does not treat removed provider markers as active auth markers", () => {
     expect(isNonSecretApiKeyMarker("qwen-oauth")).toBe(false);
   });

--- a/src/agents/model-auth-markers.ts
+++ b/src/agents/model-auth-markers.ts
@@ -9,6 +9,7 @@ export const OLLAMA_LOCAL_AUTH_MARKER = "ollama-local";
 /** @deprecated Bundled local-provider marker; do not use from third-party plugins. */
 export const CUSTOM_LOCAL_AUTH_MARKER = "custom-local";
 export const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
+export const CODEX_APP_SERVER_AUTH_MARKER = "codex-app-server";
 export const NON_ENV_SECRETREF_MARKER = "secretref-managed"; // pragma: allowlist secret
 export const SECRETREF_ENV_HEADER_MARKER_PREFIX = "secretref-env:"; // pragma: allowlist secret
 
@@ -20,6 +21,8 @@ const AWS_SDK_ENV_MARKERS = new Set([
 const CORE_NON_SECRET_API_KEY_MARKERS = [
   CUSTOM_LOCAL_AUTH_MARKER,
   OLLAMA_LOCAL_AUTH_MARKER,
+  GCP_VERTEX_CREDENTIALS_MARKER,
+  CODEX_APP_SERVER_AUTH_MARKER,
   NON_ENV_SECRETREF_MARKER,
 ] as const;
 let knownEnvApiKeyMarkersCache: Set<string> | undefined;

--- a/src/channels/message/send.test.ts
+++ b/src/channels/message/send.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { OutboundDeliveryError } from "../../infra/outbound/deliver-types.js";
 import type { OutboundPayloadDeliveryOutcome } from "../../infra/outbound/deliver-types.js";
@@ -25,6 +26,7 @@ type DeliveryIntentCallbackParams = {
 
 type DeliveryRequest = DeliveryIntentCallbackParams & {
   abortSignal?: AbortSignal;
+  cfg?: OpenClawConfig;
   payloads?: unknown;
   queuePolicy?: string;
   replyToId?: string;
@@ -32,6 +34,10 @@ type DeliveryRequest = DeliveryIntentCallbackParams & {
 };
 
 const cfg = {} as OpenClawConfig;
+
+afterEach(() => {
+  clearRuntimeConfigSnapshot();
+});
 
 function requireMockCall(
   mock: { mock: { calls: unknown[][] } },
@@ -64,6 +70,43 @@ function expectBatchStatus<TStatus extends DurableMessageBatchSendResult["status
 }
 
 describe("withDurableMessageSendContext", () => {
+  it("preserves explicit configs when a runtime snapshot has no source snapshot", async () => {
+    const explicitCfg = { channels: { telegram: { enabled: true } } };
+    const runtimeCfg = { channels: { telegram: { enabled: false } } };
+    setRuntimeConfigSnapshot(runtimeCfg as OpenClawConfig);
+    deliverOutboundPayloads.mockResolvedValueOnce([{ channel: "telegram", messageId: "msg-1" }]);
+
+    const result = await sendDurableMessageBatch({
+      cfg: explicitCfg as OpenClawConfig,
+      channel: "telegram",
+      to: "chat-1",
+      payloads: [{ text: "hello" }],
+    });
+
+    expectBatchStatus(result, "sent");
+    expect(latestDeliveryRequest().cfg).toBe(explicitCfg);
+  });
+
+  it("upgrades source-shaped configs to the active runtime snapshot", async () => {
+    const resolvedCredential = "resolved-runtime-credential";
+    const sourceCfg = {
+      channels: { telegram: { token: { source: "env", provider: "default", id: "TG_TOKEN" } } },
+    };
+    const runtimeCfg = { channels: { telegram: { token: resolvedCredential } } };
+    setRuntimeConfigSnapshot(runtimeCfg as OpenClawConfig, sourceCfg as unknown as OpenClawConfig);
+    deliverOutboundPayloads.mockResolvedValueOnce([{ channel: "telegram", messageId: "msg-1" }]);
+
+    const result = await sendDurableMessageBatch({
+      cfg: sourceCfg as unknown as OpenClawConfig,
+      channel: "telegram",
+      to: "chat-1",
+      payloads: [{ text: "hello" }],
+    });
+
+    expectBatchStatus(result, "sent");
+    expect(latestDeliveryRequest().cfg).toBe(runtimeCfg);
+  });
+
   it("renders and sends through a durable send context", async () => {
     deliverOutboundPayloads.mockImplementationOnce(async (params: DeliveryIntentCallbackParams) => {
       params.onDeliveryIntent?.({

--- a/src/channels/message/send.ts
+++ b/src/channels/message/send.ts
@@ -1,4 +1,10 @@
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+} from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { OutboundDeliveryResult } from "../../infra/outbound/deliver-types.js";
 import {
@@ -105,6 +111,27 @@ export type DurableMessageDeliveryOutcome = DurableMessageBatchSendResult;
 
 const neverAbortedSignal = new AbortController().signal;
 
+function selectDurableDeliveryRuntimeConfig(
+  inputConfig?: OpenClawConfig,
+): OpenClawConfig | undefined {
+  const runtimeConfig = getRuntimeConfigSnapshot() ?? undefined;
+  if (!runtimeConfig) {
+    return inputConfig;
+  }
+  if (!inputConfig || inputConfig === runtimeConfig) {
+    return runtimeConfig;
+  }
+  const runtimeSourceConfig = getRuntimeConfigSourceSnapshot() ?? undefined;
+  if (!runtimeSourceConfig) {
+    return inputConfig;
+  }
+  return selectApplicableRuntimeConfig({
+    inputConfig,
+    runtimeConfig,
+    runtimeSourceConfig,
+  });
+}
+
 function toDurableMessageIntent(
   intent: OutboundDeliveryIntent,
   renderedBatch: RenderedMessageBatch<ReplyPayload>,
@@ -200,8 +227,10 @@ export async function withDurableMessageSendContext<T>(
       const durablePayloadOutcomes = (): DurableMessagePayloadDeliveryOutcome[] =>
         toDurablePayloadOutcomes(payloadOutcomes);
       try {
+        const selectedCfg = selectDurableDeliveryRuntimeConfig(deliveryParams.cfg);
         const results = await deliverOutboundPayloadsInternal({
           ...deliveryParams,
+          ...(selectedCfg ? { cfg: selectedCfg } : {}),
           payloads: rendered.payloads,
           renderedBatchPlan: rendered.plan,
           queuePolicy,

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -28,7 +28,7 @@ const mocks = vi.hoisted(() => ({
   getChannelPlugin: vi.fn(),
   loadOpenClawPlugins: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
-  activeSecretsSnapshot: null as { config: Record<string, unknown> } | null,
+  runtimeConfigSnapshot: null as Record<string, unknown> | null,
 }));
 
 vi.mock("../../config/config.js", async () => {
@@ -37,12 +37,9 @@ vi.mock("../../config/config.js", async () => {
   return {
     ...actual,
     getRuntimeConfig: () => ({}),
+    getRuntimeConfigSnapshot: () => mocks.runtimeConfigSnapshot,
   };
 });
-
-vi.mock("../../secrets/runtime.js", () => ({
-  getActiveSecretsRuntimeSnapshot: () => mocks.activeSecretsSnapshot,
-}));
 
 vi.mock("../../channels/plugins/index.js", () => ({
   getLoadedChannelPlugin: mocks.getChannelPlugin,
@@ -278,7 +275,7 @@ describe("gateway send mirroring", () => {
       changes: [],
       autoEnabledReasons: {},
     }));
-    mocks.activeSecretsSnapshot = null;
+    mocks.runtimeConfigSnapshot = null;
     mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "resolved" });
     mocks.resolveOutboundSessionRoute.mockImplementation(
       async ({ agentId, channel }: { agentId?: string; channel?: string }) => ({
@@ -360,7 +357,7 @@ describe("gateway send mirroring", () => {
     expect(secondCall?.[3]?.cached).toBe(true);
   });
 
-  it("dispatches message actions with the active secrets runtime snapshot config", async () => {
+  it("dispatches message actions with the active runtime config snapshot", async () => {
     const rawSecretRef = { source: "exec", provider: "default", id: "discord-bot-token" };
     const resolvedConfig = {
       channels: {
@@ -369,7 +366,7 @@ describe("gateway send mirroring", () => {
         },
       },
     };
-    mocks.activeSecretsSnapshot = { config: resolvedConfig };
+    mocks.runtimeConfigSnapshot = resolvedConfig;
     mocks.getChannelPlugin.mockReturnValue({
       actions: { handleAction: true },
     });
@@ -380,7 +377,7 @@ describe("gateway send mirroring", () => {
         channel: "discord",
         action: "send",
         params: { channelId: "C1", message: "hello" },
-        idempotencyKey: "idem-message-action-active-secrets",
+        idempotencyKey: "idem-message-action-runtime-snapshot",
       } as never,
       respond,
       context: {

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   getChannelPlugin: vi.fn(),
   loadOpenClawPlugins: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
+  activeSecretsSnapshot: null as { config: Record<string, unknown> } | null,
 }));
 
 vi.mock("../../config/config.js", async () => {
@@ -38,6 +39,10 @@ vi.mock("../../config/config.js", async () => {
     getRuntimeConfig: () => ({}),
   };
 });
+
+vi.mock("../../secrets/runtime.js", () => ({
+  getActiveSecretsRuntimeSnapshot: () => mocks.activeSecretsSnapshot,
+}));
 
 vi.mock("../../channels/plugins/index.js", () => ({
   getLoadedChannelPlugin: mocks.getChannelPlugin,
@@ -273,6 +278,7 @@ describe("gateway send mirroring", () => {
       changes: [],
       autoEnabledReasons: {},
     }));
+    mocks.activeSecretsSnapshot = null;
     mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "resolved" });
     mocks.resolveOutboundSessionRoute.mockImplementation(
       async ({ agentId, channel }: { agentId?: string; channel?: string }) => ({
@@ -352,6 +358,47 @@ describe("gateway send mirroring", () => {
     expect(secondCall?.[2]).toBeUndefined();
     expect(secondCall?.[3]?.channel).toBe("slack");
     expect(secondCall?.[3]?.cached).toBe(true);
+  });
+
+  it("dispatches message actions with the active secrets runtime snapshot config", async () => {
+    const rawSecretRef = { source: "exec", provider: "default", id: "discord-bot-token" };
+    const resolvedConfig = {
+      channels: {
+        discord: {
+          token: "resolved-discord-token",
+        },
+      },
+    };
+    mocks.activeSecretsSnapshot = { config: resolvedConfig };
+    mocks.getChannelPlugin.mockReturnValue({
+      actions: { handleAction: true },
+    });
+
+    const respond = vi.fn();
+    await sendHandlers["message.action"]({
+      params: {
+        channel: "discord",
+        action: "send",
+        params: { channelId: "C1", message: "hello" },
+        idempotencyKey: "idem-message-action-active-secrets",
+      } as never,
+      respond,
+      context: {
+        ...makeContext(),
+        getRuntimeConfig: () => ({ channels: { discord: { token: rawSecretRef } } }),
+      } as never,
+      req: { type: "req", id: "1", method: "message.action" },
+      client: null as never,
+      isWebchatConnect: () => false,
+    });
+
+    expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith(
+      expect.objectContaining({ config: resolvedConfig }),
+    );
+    expect(lastDispatchChannelMessageActionCall()?.cfg).toBe(resolvedConfig);
+    expect(respond).toHaveBeenCalledWith(true, { action: "handled" }, undefined, {
+      channel: "discord",
+    });
   });
 
   it("dedupes concurrent send requests while inflight", async () => {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -3,6 +3,7 @@ import { sendDurableMessageBatch } from "../../channels/message/runtime.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import { createOutboundSendDeps } from "../../cli/deps.js";
+import { getRuntimeConfigSnapshot } from "../../config/config.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveOutboundChannelPlugin } from "../../infra/outbound/channel-resolution.js";
@@ -22,7 +23,6 @@ import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
 import { extractToolPayload } from "../../infra/outbound/tool-payload.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { normalizePollInput } from "../../polls.js";
-import { getActiveSecretsRuntimeSnapshot } from "../../secrets/runtime.js";
 import { parseThreadSessionSuffix } from "../../sessions/session-key-utils.js";
 import {
   normalizeOptionalLowercaseString,
@@ -132,9 +132,9 @@ async function resolveRequestedChannel(params: {
       error: errorShape(ErrorCodes.INVALID_REQUEST, params.unsupportedMessage(channelInput)),
     };
   }
-  const activeSecretsRuntimeConfig = getActiveSecretsRuntimeSnapshot()?.config;
+  const activeRuntimeConfig = getRuntimeConfigSnapshot();
   const cfg = applyPluginAutoEnable({
-    config: activeSecretsRuntimeConfig ?? params.context.getRuntimeConfig(),
+    config: activeRuntimeConfig ?? params.context.getRuntimeConfig(),
     env: process.env,
   }).config;
   let channel = normalizedChannel;

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -22,6 +22,7 @@ import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
 import { extractToolPayload } from "../../infra/outbound/tool-payload.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { normalizePollInput } from "../../polls.js";
+import { getActiveSecretsRuntimeSnapshot } from "../../secrets/runtime.js";
 import { parseThreadSessionSuffix } from "../../sessions/session-key-utils.js";
 import {
   normalizeOptionalLowercaseString,
@@ -131,8 +132,9 @@ async function resolveRequestedChannel(params: {
       error: errorShape(ErrorCodes.INVALID_REQUEST, params.unsupportedMessage(channelInput)),
     };
   }
+  const activeSecretsRuntimeConfig = getActiveSecretsRuntimeSnapshot()?.config;
   const cfg = applyPluginAutoEnable({
-    config: params.context.getRuntimeConfig(),
+    config: activeSecretsRuntimeConfig ?? params.context.getRuntimeConfig(),
     env: process.env,
   }).config;
   let channel = normalizedChannel;

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 const mocks = vi.hoisted(() => ({
   getChannelPlugin: vi.fn(),
@@ -63,6 +64,7 @@ vi.mock("../../utils/message-channel.js", async () => {
   };
 });
 
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 
@@ -134,6 +136,7 @@ describe("sendMessage", () => {
   });
 
   beforeEach(() => {
+    clearRuntimeConfigSnapshot();
     setActivePluginRegistry(createTestRegistry([]));
     resetOutboundChannelResolutionStateForTest();
     mocks.getChannelPlugin.mockClear();
@@ -161,6 +164,39 @@ describe("sendMessage", () => {
 
     const deliveryParams = expectDeliveryCallFields({ channel: "forum", to: "123456" });
     expectRecordFields(deliveryParams.session, { agentId: "work" }, "outbound session");
+  });
+
+  it("preserves explicit configs when a runtime snapshot has no source snapshot", async () => {
+    const explicitCfg = { channels: { forum: { enabled: true } } };
+    const runtimeCfg = { channels: { forum: { enabled: false } } };
+    setRuntimeConfigSnapshot(runtimeCfg as OpenClawConfig);
+
+    await sendMessage({
+      cfg: explicitCfg as OpenClawConfig,
+      channel: "forum",
+      to: "123456",
+      content: "hi",
+    });
+
+    expect(expectDeliveryCallFields({}).cfg).toBe(explicitCfg);
+  });
+
+  it("upgrades source-shaped configs to the active runtime snapshot", async () => {
+    const resolvedCredential = "resolved-runtime-credential";
+    const sourceCfg = {
+      channels: { forum: { token: { source: "env", provider: "default", id: "FORUM_TOKEN" } } },
+    };
+    const runtimeCfg = { channels: { forum: { token: resolvedCredential } } };
+    setRuntimeConfigSnapshot(runtimeCfg as OpenClawConfig, sourceCfg as unknown as OpenClawConfig);
+
+    await sendMessage({
+      cfg: sourceCfg as unknown as OpenClawConfig,
+      channel: "forum",
+      to: "123456",
+      content: "hi",
+    });
+
+    expect(expectDeliveryCallFields({}).cfg).toBe(runtimeCfg);
   });
 
   it("forwards requesterSenderId into the outbound delivery session", async () => {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -1,6 +1,11 @@
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { deriveDurableFinalDeliveryRequirements } from "../../channels/message/capabilities.js";
 import { sendDurableMessageBatch } from "../../channels/message/runtime.js";
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+} from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import type { PollInput } from "../../polls.js";
@@ -305,6 +310,24 @@ async function resolveMessageConfig(cfg?: OpenClawConfig): Promise<OpenClawConfi
   return getRuntimeConfig();
 }
 
+function selectMessageDeliveryRuntimeConfig(inputConfig: OpenClawConfig): OpenClawConfig {
+  const runtimeConfig = getRuntimeConfigSnapshot() ?? undefined;
+  if (!runtimeConfig || inputConfig === runtimeConfig) {
+    return inputConfig;
+  }
+  const runtimeSourceConfig = getRuntimeConfigSourceSnapshot() ?? undefined;
+  if (!runtimeSourceConfig) {
+    return inputConfig;
+  }
+  return (
+    selectApplicableRuntimeConfig({
+      inputConfig,
+      runtimeConfig,
+      runtimeSourceConfig,
+    }) ?? inputConfig
+  );
+}
+
 async function resolveGatewayIdempotencyKey(idempotencyKey?: string): Promise<string> {
   if (idempotencyKey) {
     return idempotencyKey;
@@ -314,7 +337,8 @@ async function resolveGatewayIdempotencyKey(idempotencyKey?: string): Promise<st
 }
 
 export async function sendMessage(params: MessageSendParams): Promise<MessageSendResult> {
-  const cfg = await resolveMessageConfig(params.cfg);
+  let cfg = await resolveMessageConfig(params.cfg);
+  cfg = selectMessageDeliveryRuntimeConfig(cfg);
   const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
   const plugin = resolveRequiredPlugin(channel, cfg);
   const deliveryMode = plugin.outbound?.deliveryMode ?? "direct";
@@ -457,7 +481,8 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
 }
 
 export async function sendPoll(params: MessagePollParams): Promise<MessagePollResult> {
-  const cfg = await resolveMessageConfig(params.cfg);
+  let cfg = await resolveMessageConfig(params.cfg);
+  cfg = selectMessageDeliveryRuntimeConfig(cfg);
   const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
 
   const pollInput: PollInput = {


### PR DESCRIPTION
## Summary
- use the active runtime config snapshot for gateway `message.action` send resolution instead of the legacy secrets-runtime wrapper
- propagate matching resolved runtime configs into durable and direct outbound message sends while preserving explicit per-call configs when no source snapshot exists
- keep package-stable non-secret auth markers for Codex app-server and GCP Vertex credentials when bundled plugin manifests are absent

## Validation
- `pnpm exec oxfmt --check --threads=1 src/agents/model-auth-markers.ts src/agents/model-auth-markers.test.ts src/gateway/server-methods/send.ts src/gateway/server-methods/send.test.ts src/channels/message/send.ts src/channels/message/send.test.ts src/infra/outbound/message.ts src/infra/outbound/message.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/model-auth-markers.test.ts src/gateway/server-methods/send.test.ts src/infra/outbound/message.test.ts src/channels/message/send.test.ts -- --run`
- `pnpm build`
- added-line static scan for hardcoded secret assignments and shell/eval patterns: no findings

## Runtime contract
Source-shaped SecretRef config stays on control-plane paths. Matching source configs upgrade to the resolved runtime snapshot on actual send paths. Explicit per-call configs remain explicit when runtime source snapshot data is unavailable, matching the existing plugin-tool runtime selection contract.
