### PR TITLE
fix(codex): bridge gateway auth into isolated app-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - iMessage: stop sending visible `<media:image>` placeholder text for media-only native image sends while preserving the internal echo key that prevents self-echo duplicate replies. (#81209) Thanks @homer-byte.
 - Agents/sessions: create configured agent main sessions before first `sessions_send` or gateway send, so agent-to-agent messages no longer fail when the target agent has not started yet.
+- Codex harness: pass resolved local Gateway auth into isolated app-server subprocess environments, so Cron jobs and shell-outs can authenticate when `gateway.auth.*` uses SecretRef storage.
 - gateway: pass Talk session scope to resolver [AI]. (#81379) Thanks @pgondhi987.
 - Gateway protocol: require v4 clients and stream explicit chat `deltaText`/`replace` frames so SDK clients can consume assistant updates without local diffing. (#80725) Thanks @samzong.
 - OpenAI plugin: clarify remote Codex OAuth login copy so tunneled users know sign-in may finish automatically before they paste the redirect URL. (#81301) Thanks @rubencu.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-54198a37be7bbd7949aef79fb7b1b95550967e5a947cd34fc659f3cb648ffa0a  plugin-sdk-api-baseline.json
-345e1f0786b83a3454de82b4434bf4aacaf755db9550366f445fa9a6ac98bf15  plugin-sdk-api-baseline.jsonl
+3468877af0d3fe749812abc6d4852194b07f3468533fd0fee2772dd26c4e62fe  plugin-sdk-api-baseline.json
+2b880b2509bd9a02566b003a4cded1c556245f3625aa13fb3013fa16114ab75a  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -224,7 +224,7 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/lazy-runtime` | Lazy runtime import/binding helpers such as `createLazyRuntimeModule`, `createLazyRuntimeMethod`, and `createLazyRuntimeSurface` |
     | `plugin-sdk/process-runtime` | Process exec helpers |
     | `plugin-sdk/cli-runtime` | CLI formatting, wait, version, argument-invocation, and lazy command-group helpers |
-    | `plugin-sdk/gateway-runtime` | Gateway client, event-loop-ready client start helper, gateway CLI RPC, gateway protocol errors, and channel-status patch helpers |
+    | `plugin-sdk/gateway-runtime` | Gateway client, connection-auth resolution, event-loop-ready client start helper, gateway CLI RPC, gateway protocol errors, and channel-status patch helpers |
     | `plugin-sdk/config-contracts` | Focused type-only config surface for plugin config shapes such as `OpenClawConfig` and channel/provider config types |
     | `plugin-sdk/plugin-config-runtime` | Runtime plugin-config lookup helpers such as `requireRuntimeConfig`, `resolvePluginConfigObject`, and `resolveLivePluginConfigObject` |
     | `plugin-sdk/config-mutation` | Transactional config mutation helpers such as `mutateConfigFile`, `replaceConfigFile`, and `logConfigUpdated` |

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   loadAuthProfileStoreForSecretsRuntime,
@@ -147,6 +148,7 @@ async function expectPathMissing(filePath: string): Promise<void> {
 
 type AuthProfileStore = ReturnType<typeof loadAuthProfileStoreForSecretsRuntime>;
 type AuthProfileCredential = AuthProfileStore["profiles"][string];
+type BridgeConfig = NonNullable<Parameters<typeof bridgeCodexAppServerStartOptions>[0]["config"]>;
 
 function expectOAuthProfile(
   profile: AuthProfileCredential | undefined,
@@ -169,6 +171,61 @@ async function writeCodexCliAuthFile(codexHome: string): Promise<void> {
       },
     })}\n`,
   );
+}
+
+async function writeSecureTextFile(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}-${Math.random()
+    .toString(16)
+    .slice(2)}`;
+  try {
+    await fs.writeFile(tempPath, content, "utf8");
+    await fs.chmod(tempPath, 0o600);
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+function createFileBackedGatewayTokenConfig(tokenPath: string): BridgeConfig {
+  return {
+    gateway: {
+      auth: {
+        mode: "token",
+        token: { source: "file", provider: "gateway-token-file", id: "value" },
+      },
+    },
+    secrets: {
+      providers: {
+        "gateway-token-file": {
+          source: "file",
+          path: tokenPath,
+          mode: "singleValue",
+        },
+      },
+    },
+  } as BridgeConfig;
+}
+
+function createFileBackedGatewayPasswordConfig(passwordPath: string): BridgeConfig {
+  return {
+    gateway: {
+      auth: {
+        mode: "password",
+        password: { source: "file", provider: "gateway-password-file", id: "value" },
+      },
+    },
+    secrets: {
+      providers: {
+        "gateway-password-file": {
+          source: "file",
+          path: passwordPath,
+          mode: "singleValue",
+        },
+      },
+    },
+  } as BridgeConfig;
 }
 
 describe("bridgeCodexAppServerStartOptions", () => {
@@ -227,6 +284,165 @@ describe("bridgeCodexAppServerStartOptions", () => {
       expect(startOptions.clearEnv).toEqual(["CODEX_HOME", "HOME", "FOO"]);
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not inject Gateway auth env vars without runtime config", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    try {
+      await expect(
+        bridgeCodexAppServerStartOptions({
+          startOptions: createStartOptions(),
+          agentDir,
+          env: {
+            OPENCLAW_GATEWAY_TOKEN: "parent-token",
+            OPENCLAW_GATEWAY_PASSWORD: "parent-password",
+          } as NodeJS.ProcessEnv,
+        }),
+      ).resolves.toEqual({
+        transport: "stdio",
+        command: "codex",
+        args: ["app-server"],
+        headers: { authorization: "Bearer dev-token" },
+        env: {
+          CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
+          HOME: resolveCodexAppServerNativeHomeDir(agentDir),
+        },
+      });
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("injects resolved local Gateway token into isolated stdio app-server env", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const agentDir = path.join(root, "agent");
+    const isolatedHome = path.join(root, "isolated-home");
+    const tokenPath = path.join(root, "gateway-token.txt");
+    const startOptions = createStartOptions({
+      env: {
+        HOME: isolatedHome,
+        EXISTING: "1",
+      },
+    });
+    try {
+      await writeSecureTextFile(tokenPath, "resolved-gateway-token\n");
+
+      await expect(
+        bridgeCodexAppServerStartOptions({
+          startOptions,
+          agentDir,
+          authProfileId: null,
+          config: createFileBackedGatewayTokenConfig(tokenPath),
+          env: { OPENCLAW_GATEWAY_TOKEN: "stale-env-token" } as NodeJS.ProcessEnv,
+        }),
+      ).resolves.toEqual({
+        ...startOptions,
+        env: {
+          EXISTING: "1",
+          HOME: isolatedHome,
+          CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
+          OPENCLAW_GATEWAY_TOKEN: "resolved-gateway-token",
+        },
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("injects resolved local Gateway password into isolated stdio app-server env", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const agentDir = path.join(root, "agent");
+    const passwordPath = path.join(root, "gateway-password.txt");
+    try {
+      await writeSecureTextFile(passwordPath, "resolved-gateway-password\n");
+
+      await expect(
+        bridgeCodexAppServerStartOptions({
+          startOptions: createStartOptions(),
+          agentDir,
+          authProfileId: null,
+          config: createFileBackedGatewayPasswordConfig(passwordPath),
+          env: { OPENCLAW_GATEWAY_PASSWORD: "stale-env-password" } as NodeJS.ProcessEnv,
+        }),
+      ).resolves.toEqual({
+        transport: "stdio",
+        command: "codex",
+        args: ["app-server"],
+        headers: { authorization: "Bearer dev-token" },
+        env: {
+          CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
+          HOME: resolveCodexAppServerNativeHomeDir(agentDir),
+          OPENCLAW_GATEWAY_PASSWORD: "resolved-gateway-password",
+        },
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves an explicit app-server Gateway token override", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const agentDir = path.join(root, "agent");
+    const tokenPath = path.join(root, "gateway-token.txt");
+    const startOptions = createStartOptions({
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "explicit-child-token",
+      },
+    });
+    try {
+      await writeSecureTextFile(tokenPath, "resolved-gateway-token\n");
+
+      await expect(
+        bridgeCodexAppServerStartOptions({
+          startOptions,
+          agentDir,
+          config: createFileBackedGatewayTokenConfig(tokenPath),
+        }),
+      ).resolves.toEqual({
+        ...startOptions,
+        env: {
+          OPENCLAW_GATEWAY_TOKEN: "explicit-child-token",
+          CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
+          HOME: resolveCodexAppServerNativeHomeDir(agentDir),
+        },
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("continues without injected Gateway auth when a configured SecretRef is unavailable", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const agentDir = path.join(root, "agent");
+    const missingTokenPath = path.join(root, "missing-gateway-token.txt");
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    try {
+      await expect(
+        bridgeCodexAppServerStartOptions({
+          startOptions: createStartOptions(),
+          agentDir,
+          authProfileId: null,
+          config: createFileBackedGatewayTokenConfig(missingTokenPath),
+          env: { OPENCLAW_GATEWAY_TOKEN: "stale-env-token" } as NodeJS.ProcessEnv,
+        }),
+      ).resolves.toEqual({
+        transport: "stdio",
+        command: "codex",
+        args: ["app-server"],
+        headers: { authorization: "Bearer dev-token" },
+        env: {
+          CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
+          HOME: resolveCodexAppServerNativeHomeDir(agentDir),
+        },
+      });
+      expect(warn).toHaveBeenCalledWith(
+        "codex app-server Gateway auth SecretRef unavailable; continuing without injected Gateway auth",
+        { path: "gateway.auth.token" },
+      );
+    } finally {
+      warn.mockRestore();
+      await fs.rm(root, { recursive: true, force: true });
     }
   });
 

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles,
@@ -16,6 +17,10 @@ import {
   type AuthProfileStore,
   type OAuthCredential,
 } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  isGatewaySecretRefUnavailableError,
+  resolveGatewayConnectionAuth,
+} from "openclaw/plugin-sdk/gateway-runtime";
 import type { CodexAppServerClient } from "./client.js";
 import type { CodexAppServerStartOptions } from "./config.js";
 import type {
@@ -36,14 +41,19 @@ const CODEX_API_KEY_ENV_VAR = "CODEX_API_KEY";
 const OPENAI_API_KEY_ENV_VAR = "OPENAI_API_KEY";
 const CODEX_APP_SERVER_API_KEY_ENV_VARS = [CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR];
 const CODEX_APP_SERVER_ISOLATION_ENV_VARS = [CODEX_HOME_ENV_VAR, HOME_ENV_VAR];
+const OPENCLAW_GATEWAY_TOKEN_ENV_VAR = "OPENCLAW_GATEWAY_TOKEN";
+const OPENCLAW_GATEWAY_PASSWORD_ENV_VAR = "OPENCLAW_GATEWAY_PASSWORD";
 
 type AuthProfileOrderConfig = Parameters<typeof resolveAuthProfileOrder>[0]["cfg"];
+type GatewayAuthResolutionConfig = NonNullable<AuthProfileOrderConfig>;
 
 export async function bridgeCodexAppServerStartOptions(params: {
   startOptions: CodexAppServerStartOptions;
   agentDir: string;
   authProfileId?: string | null;
   config?: AuthProfileOrderConfig;
+  // Injectable parent environment; production callers normally read process.env.
+  env?: NodeJS.ProcessEnv;
 }): Promise<CodexAppServerStartOptions> {
   if (params.startOptions.transport !== "stdio") {
     return params.startOptions;
@@ -52,8 +62,13 @@ export async function bridgeCodexAppServerStartOptions(params: {
     params.startOptions,
     params.agentDir,
   );
+  const startOptionsWithGatewayAuth = await withOpenClawGatewayAuthEnvironment({
+    startOptions: isolatedStartOptions,
+    config: params.config,
+    env: params.env,
+  });
   if (params.authProfileId === null) {
-    return isolatedStartOptions;
+    return startOptionsWithGatewayAuth;
   }
   const store = ensureCodexAppServerAuthProfileStore({
     agentDir: params.agentDir,
@@ -71,8 +86,11 @@ export async function bridgeCodexAppServerStartOptions(params: {
     config: params.config,
   });
   return shouldClearInheritedOpenAiApiKey
-    ? withClearedEnvironmentVariables(isolatedStartOptions, CODEX_APP_SERVER_API_KEY_ENV_VARS)
-    : isolatedStartOptions;
+    ? withClearedEnvironmentVariables(
+        startOptionsWithGatewayAuth,
+        CODEX_APP_SERVER_API_KEY_ENV_VARS,
+      )
+    : startOptionsWithGatewayAuth;
 }
 
 export function resolveCodexAppServerAuthProfileId(params: {
@@ -289,6 +307,70 @@ function withoutClearedCodexIsolationEnv(clearEnv: string[] | undefined): string
   const reserved = new Set(CODEX_APP_SERVER_ISOLATION_ENV_VARS);
   const filtered = clearEnv.filter((envVar) => !reserved.has(envVar.trim().toUpperCase()));
   return filtered.length === clearEnv.length ? clearEnv : filtered;
+}
+
+async function withOpenClawGatewayAuthEnvironment(params: {
+  startOptions: CodexAppServerStartOptions;
+  config?: AuthProfileOrderConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<CodexAppServerStartOptions> {
+  if (!params.config) {
+    return params.startOptions;
+  }
+  const auth = await resolveGatewayAuthForCodexAppServer({
+    config: params.config,
+    env: params.env,
+  });
+  if (!auth) {
+    return params.startOptions;
+  }
+  const env: Record<string, string> = {};
+  if (
+    auth.token &&
+    !readNonEmptyString(params.startOptions.env?.[OPENCLAW_GATEWAY_TOKEN_ENV_VAR])
+  ) {
+    env[OPENCLAW_GATEWAY_TOKEN_ENV_VAR] = auth.token;
+  }
+  if (
+    auth.password &&
+    !readNonEmptyString(params.startOptions.env?.[OPENCLAW_GATEWAY_PASSWORD_ENV_VAR])
+  ) {
+    env[OPENCLAW_GATEWAY_PASSWORD_ENV_VAR] = auth.password;
+  }
+  if (Object.keys(env).length === 0) {
+    return params.startOptions;
+  }
+  return {
+    ...params.startOptions,
+    env: {
+      ...params.startOptions.env,
+      ...env,
+    },
+  };
+}
+
+async function resolveGatewayAuthForCodexAppServer(params: {
+  config: GatewayAuthResolutionConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ token?: string; password?: string } | undefined> {
+  try {
+    return await resolveGatewayConnectionAuth({
+      config: params.config,
+      env: params.env ?? process.env,
+      modeOverride: "local",
+      localTokenPrecedence: "config-first",
+      localPasswordPrecedence: "config-first",
+    });
+  } catch (error) {
+    if (!isGatewaySecretRefUnavailableError(error)) {
+      throw error;
+    }
+    embeddedAgentLog.warn(
+      "codex app-server Gateway auth SecretRef unavailable; continuing without injected Gateway auth",
+      { path: error.path },
+    );
+    return undefined;
+  }
 }
 
 export async function applyCodexAppServerAuthProfile(params: {
@@ -584,6 +666,10 @@ function readFirstNonEmptyEnvEntry(
     }
   }
   return undefined;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function buildChatgptAuthTokensParams(

--- a/extensions/codex/src/app-server/transport-stdio.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.test.ts
@@ -134,6 +134,25 @@ describe("resolveCodexAppServerSpawnEnv", () => {
     });
   });
 
+  it("preserves OpenClaw Gateway auth env vars unless explicitly cleared", () => {
+    expect({
+      ...resolveCodexAppServerSpawnEnv(
+        {
+          env: {
+            OPENCLAW_GATEWAY_TOKEN: "configured-token",
+          },
+        },
+        {
+          OPENCLAW_GATEWAY_TOKEN: "parent-token",
+          OPENCLAW_GATEWAY_PASSWORD: "parent-password",
+        },
+      ),
+    }).toEqual({
+      OPENCLAW_GATEWAY_TOKEN: "configured-token",
+      OPENCLAW_GATEWAY_PASSWORD: "parent-password",
+    });
+  });
+
   it("uses a null-prototype env map and ignores prototype-polluting keys", () => {
     const overrides = Object.create(null) as Record<string, string | undefined>;
     Object.defineProperty(overrides, "__proto__", {

--- a/src/plugin-sdk/gateway-runtime.ts
+++ b/src/plugin-sdk/gateway-runtime.ts
@@ -31,6 +31,9 @@ export {
 export type { GatewayRequestHandlers } from "../gateway/server-methods/types.js";
 export { ensureGatewayStartupAuth } from "../gateway/startup-auth.js";
 export { resolveGatewayAuth } from "../gateway/auth.js";
+export { isGatewaySecretRefUnavailableError } from "../gateway/credentials.js";
+export { resolveGatewayConnectionAuth } from "../gateway/connection-auth.js";
+export type { GatewayConnectionAuthOptions } from "../gateway/connection-auth.js";
 export { rawDataToString } from "../infra/ws.js";
 export { GatewayClient } from "../gateway/client.js";
 export { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-readiness.js";


### PR DESCRIPTION
## Summary

- Problem: Codex app-server stdio launches isolate `HOME`, so OpenClaw CLI subprocesses inside Codex could not resolve `gateway.auth.*` when the parent config used SecretRef-backed local Gateway auth.
- Why it matters: Cron jobs and other Codex tool shell-outs that call `openclaw` could fail with missing Gateway auth even though the parent Gateway/runtime config was valid.
- What changed: The Codex auth bridge now resolves local Gateway auth from the parent config/env and injects `OPENCLAW_GATEWAY_TOKEN` / `OPENCLAW_GATEWAY_PASSWORD` into the stdio app-server environment unless explicitly overridden. Broken Gateway SecretRefs warn and skip injection instead of aborting Codex startup.
- What did NOT change (scope boundary): Websocket app-server transports are unchanged; OpenClaw CLI credential precedence is unchanged; no SecretRef files are copied or symlinked into isolated homes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex isolated app-server subprocesses can inherit resolved Gateway auth env instead of trying to re-resolve parent SecretRefs from the isolated `HOME`.
- Real environment tested: Local OpenClaw PR container on macOS host, running the production Codex app-server bridge and production Gateway auth resolver from this branch against a temp file-backed SecretRef and isolated `HOME`.
- Exact steps or command run after this patch: Ran a one-off live proof command in the OpenClaw PR container: `node --import tsx .artifacts/ci-proof/codex-gateway-auth-proof.ts`. The script created a temp file-backed `gateway.auth.token` SecretRef outside the isolated home, bridged stdio Codex start options, then spawned a child process under the bridged env to resolve Gateway auth through the production resolver.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
OpenClaw Codex Gateway auth bridge live proof
bridge.transport=stdio
bridge.codexHomeCreated=true
bridge.homeIsolated=true
bridge.tokenInjected=true
bridge.tokenMatchesSecret=true
bridge.staleParentEnvOverridden=true
child.resolveGatewayConnectionAuth.tokenFromEnv=true
child.homeIsIsolated=true
```

- Observed result after fix: The bridge created the Codex isolated home, injected `OPENCLAW_GATEWAY_TOKEN` from the parent-resolved file SecretRef, overrode a stale parent env token via config-first precedence, and a subprocess running under the isolated home resolved Gateway auth from the injected env token.
- What was not tested: A live scheduled Cron job invoking `openclaw cron list` against a running user Gateway was not executed.
- Before evidence (optional but encouraged): The previous bridge tests had no Gateway auth injection coverage; the reviewed failure mode was structural and reproduced by code path inspection.

## Root Cause (if applicable)

- Root cause: Codex app-server isolation rewrites `HOME` to an agent-owned directory. Gateway auth SecretRefs stored under the parent OpenClaw home remained resolvable by the parent runtime, but child OpenClaw CLI subprocesses had neither access to that home nor inherited `OPENCLAW_GATEWAY_*` credentials.
- Missing detection / guardrail: No test asserted that stdio app-server launch env bridges resolved local Gateway auth across Codex home isolation.
- Contributing context (if known): CLI credential resolution already supports env-first fallback for Gateway calls; the missing piece was carrying the parent-resolved secret into the spawned Codex environment.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/auth-bridge.test.ts`, `extensions/codex/src/app-server/transport-stdio.test.ts`
- Scenario the test should lock in: File-backed `gateway.auth.token` and `gateway.auth.password` SecretRefs resolve from parent config/env and become `OPENCLAW_GATEWAY_TOKEN` / `OPENCLAW_GATEWAY_PASSWORD` in the isolated stdio app-server env; explicit child env overrides are preserved; unavailable SecretRefs warn and skip injection.
- Why this is the smallest reliable guardrail: The bug is at the app-server spawn option bridge, so testing the bridge catches the failure without needing a live scheduler or Gateway daemon.
- Existing test that already covers this (if any): None before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Codex-based Cron jobs and other Codex app-server subprocesses can authenticate to the local Gateway when Gateway auth is SecretRef-backed in the parent OpenClaw config. If that SecretRef is unavailable, Codex startup continues and logs a warning instead of failing while preparing the spawn environment.

## Diagram (if applicable)

```text
Before:
parent config SecretRef -> Codex isolated HOME -> child openclaw CLI cannot read parent secret -> missing Gateway auth

After:
parent config SecretRef -> resolve once in bridge -> OPENCLAW_GATEWAY_* in app-server env -> child openclaw CLI authenticates via env
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: The resolved local Gateway token/password can now be present in the Codex stdio app-server environment. This is limited to OpenClaw-managed local Codex app-server launches, preserves explicit child env overrides, avoids writing/symlinking secret files into isolated homes, and uses existing Gateway credential precedence and SecretRef resolution helpers.

## Repro + Verification

### Environment

- OS: macOS host, OpenClaw PR container for package/test commands
- Runtime/container: OpenClaw PR container, Node 24, pnpm 11.1.0
- Model/provider: N/A
- Integration/channel (if any): Codex app-server harness / Cron subprocess auth path
- Relevant config (redacted): `gateway.auth.mode = "token"` or `"password"` with file-backed SecretRef

### Steps

1. Configure local Gateway auth with a file-backed SecretRef under the parent OpenClaw environment.
2. Launch Codex app-server through the OpenClaw-managed stdio path with isolated `HOME`.
3. Run an OpenClaw CLI subprocess from inside that environment, such as `openclaw cron list`.

### Expected

- Child subprocess authenticates through inherited `OPENCLAW_GATEWAY_TOKEN` or `OPENCLAW_GATEWAY_PASSWORD`.

### Actual

- Before this patch, the child subprocess could not resolve the parent SecretRef from isolated `HOME` and saw missing Gateway auth.
- After this patch, bridge tests and the live proof above verify the resolved value is injected into the child env and read by the Gateway resolver under isolated `HOME`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Live proof run after the patch:

```text
OpenClaw Codex Gateway auth bridge live proof
bridge.transport=stdio
bridge.codexHomeCreated=true
bridge.homeIsolated=true
bridge.tokenInjected=true
bridge.tokenMatchesSecret=true
bridge.staleParentEnvOverridden=true
child.resolveGatewayConnectionAuth.tokenFromEnv=true
child.homeIsIsolated=true
```

Targeted verification run after the patch:

```text
pnpm test extensions/codex/src/app-server/auth-bridge.test.ts extensions/codex/src/app-server/transport-stdio.test.ts
Test Files 2 passed (2)
Tests 46 passed (46)
```

Additional checks run:

```text
pnpm plugin-sdk:api:check
pnpm tsgo:core
pnpm tsgo:extensions
pnpm tsgo:extensions:test
focused oxfmt --check
focused core/extension oxlint
git diff --check
```

Known unrelated blocker:

```text
pnpm check:changed --base upstream/main
fails in src/plugins/registry.runtime-config.test.ts:45-46 with pre-existing core-test type errors unrelated to this diff.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Production bridge live proof for token SecretRef injection into isolated stdio child env, child Gateway resolver pickup from injected env under isolated `HOME`, token SecretRef injection, password SecretRef injection, explicit child env override preservation, no-config no-op, unavailable SecretRef warning/skip behavior, and app-server spawn env preservation for `OPENCLAW_GATEWAY_*`.
- Edge cases checked: Stale parent env loses to config-first SecretRef resolution; websocket transports remain untouched by stdio-only gating; broken SecretRefs do not abort Codex startup.
- What you did **not** verify: Live Gateway cron execution in a real user setup.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Resolved Gateway auth is present in the Codex app-server process environment.
  - Mitigation: Keep this stdio-only, avoid writing secret files into isolated homes, preserve explicit caller-provided env overrides, and rely on existing credential resolution helpers.
- Risk: A broken configured SecretRef could have made Codex startup fail during env preparation.
  - Mitigation: Catch `GatewaySecretRefUnavailableError`, warn, and continue without injected Gateway auth.
