### PR TITLE
fix(acpx): keep oneshot client alive for initial turn

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -236,6 +236,33 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(ensureInput).not.toHaveProperty("thinking");
   });
 
+  it("keeps ACPX clients alive across OpenClaw oneshot ensure-to-turn handoff", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const ensure = vi.spyOn(delegate, "ensureSession").mockResolvedValue({
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "claude",
+    });
+
+    await runtime.ensureSession({
+      sessionKey: "agent:claude:acp:test",
+      agent: "claude",
+      mode: "oneshot",
+      cwd: "/tmp/workspace",
+    });
+
+    expect(readFirstEnsureSessionInput(ensure)).toEqual({
+      sessionKey: "agent:claude:acp:test",
+      agent: "claude",
+      mode: "persistent",
+      cwd: "/tmp/workspace",
+    });
+  });
+
   it("does not normalize model startup for non-Codex ACP agents", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => undefined),

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -54,6 +54,20 @@ type AcpxLaunchLeaseContext = {
   stableCommand?: string;
 };
 
+function delegateEnsureMode(mode: Parameters<AcpRuntime["ensureSession"]>[0]["mode"]):
+  | "persistent"
+  | "oneshot" {
+  // ACPX one-shot records close the adapter process immediately after session/new.
+  // OpenClaw then invokes the first prompt through a separate runTurn call, which
+  // forces ACPX to reconnect/load before any user prompt has been sent. Some ACP
+  // adapters, notably Claude Agent ACP, can create a fresh session and prompt in
+  // one process but fail this create-close-load-prompt sequence with a generic
+  // Internal error. Keep the ACPX client alive across OpenClaw's ensureSession →
+  // runTurn boundary by using ACPX persistent mode underneath; OpenClaw still owns
+  // oneshot lifecycle and closes the handle after the turn.
+  return mode === "oneshot" ? "persistent" : mode;
+}
+
 function readSessionRecordName(record: unknown): string {
   if (typeof record !== "object" || record === null) {
     return "";
@@ -865,17 +879,22 @@ export class AcpxRuntime implements AcpRuntime {
       resumeSessionId: input.resumeSessionId,
     }));
 
+    const delegateInput = {
+      ...input,
+      mode: delegateEnsureMode(input.mode),
+    };
+
     if (!codexModelOverride) {
       return await this.runWithLaunchLease({
         sessionKey: input.sessionKey,
         command: stableLaunchCommand,
         enabled: shouldStartWithLease,
-        run: () => delegate.ensureSession(input),
+        run: () => delegate.ensureSession(delegateInput),
       });
     }
 
     const normalizedInput = {
-      ...input,
+      ...delegateInput,
       ...(codexAcpSessionModelId(codexModelOverride)
         ? { model: codexAcpSessionModelId(codexModelOverride) }
         : {}),

--- a/extensions/matrix/src/test-runtime.ts
+++ b/extensions/matrix/src/test-runtime.ts
@@ -2,10 +2,36 @@ import {
   implicitMentionKindWhen,
   resolveInboundMentionDecision,
 } from "openclaw/plugin-sdk/channel-mention-gating";
-import { createPluginRuntimeMediaMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import { vi } from "vitest";
 import type { PluginRuntime } from "./runtime-api.js";
 import { setMatrixRuntime } from "./runtime.js";
+
+type MatrixPluginRuntimeMediaMock = NonNullable<NonNullable<PluginRuntime["channel"]>["media"]>;
+
+function createMatrixRuntimeMediaMock(
+  overrides: Partial<MatrixPluginRuntimeMediaMock> = {},
+): MatrixPluginRuntimeMediaMock {
+  const readRemoteMediaBuffer =
+    vi.fn() as unknown as MatrixPluginRuntimeMediaMock["readRemoteMediaBuffer"];
+  return {
+    readRemoteMediaBuffer,
+    fetchRemoteMedia:
+      readRemoteMediaBuffer as unknown as MatrixPluginRuntimeMediaMock["fetchRemoteMedia"],
+    saveRemoteMedia: vi.fn().mockResolvedValue({
+      path: "/tmp/test-media.jpg",
+      contentType: "image/jpeg",
+    }) as unknown as MatrixPluginRuntimeMediaMock["saveRemoteMedia"],
+    saveResponseMedia: vi.fn().mockResolvedValue({
+      path: "/tmp/test-media.jpg",
+      contentType: "image/jpeg",
+    }) as unknown as MatrixPluginRuntimeMediaMock["saveResponseMedia"],
+    saveMediaBuffer: vi.fn().mockResolvedValue({
+      path: "/tmp/test-media.jpg",
+      contentType: "image/jpeg",
+    }) as unknown as MatrixPluginRuntimeMediaMock["saveMediaBuffer"],
+    ...overrides,
+  };
+}
 
 type MatrixTestRuntimeOptions = {
   cfg?: Record<string, unknown>;
@@ -76,7 +102,7 @@ export function installMatrixMonitorTestRuntime(
         implicitMentionKindWhen,
         resolveInboundMentionDecision,
       },
-      media: createPluginRuntimeMediaMock({
+      media: createMatrixRuntimeMediaMock({
         saveMediaBuffer: options.saveMediaBuffer ?? vi.fn(),
       }) as unknown as PluginRuntime["channel"]["media"],
     },

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -125,7 +125,7 @@ export async function applySessionsPatchToStore(params: {
         updatedAt: Math.max(existing.updatedAt ?? 0, now),
       }
     : {
-        ...(existing ?? {}),
+        ...existing,
         sessionId: randomUUID(),
         sessionFile: undefined,
         updatedAt: Math.max(existing?.updatedAt ?? 0, now),

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -19,47 +19,64 @@ function createTestRegistry(runtime: PluginRuntime) {
 }
 
 describe("plugin registry runtime config scope", () => {
-  it("runs deprecated config helpers with the owning plugin scope", async () => {
-    let loadScope = getPluginRuntimeGatewayRequestScope();
-    let writeScope = getPluginRuntimeGatewayRequestScope();
+  it("runs config access and writes with the owning plugin scope", async () => {
+    let currentScope = getPluginRuntimeGatewayRequestScope();
+    let mutateScope = getPluginRuntimeGatewayRequestScope();
+    let replaceScope = getPluginRuntimeGatewayRequestScope();
     const config = {} as OpenClawConfig;
     const replaceResult = {
       previousHash: null,
       nextHash: "next",
     } as unknown as Awaited<ReturnType<PluginRuntime["config"]["replaceConfigFile"]>>;
     const configRuntime = {
-      current: vi.fn(() => config),
-      mutateConfigFile: async <T = void>() => ({
-        ...replaceResult,
-        result: undefined as T | undefined,
-      }),
-      replaceConfigFile: async () => replaceResult,
-      loadConfig: vi.fn(() => {
-        loadScope = getPluginRuntimeGatewayRequestScope();
+      current: vi.fn(() => {
+        currentScope = getPluginRuntimeGatewayRequestScope();
         return config;
       }),
-      writeConfigFile: vi.fn(async () => {
-        writeScope = getPluginRuntimeGatewayRequestScope();
+      mutateConfigFile: vi.fn(async () => {
+        mutateScope = getPluginRuntimeGatewayRequestScope();
+        return {
+          ...replaceResult,
+          result: undefined,
+        };
       }),
+      replaceConfigFile: vi.fn(async () => {
+        replaceScope = getPluginRuntimeGatewayRequestScope();
+        return replaceResult;
+      }),
+      loadConfig: vi.fn(() => config),
+      writeConfigFile: vi.fn(async () => {}),
     } satisfies PluginRuntime["config"];
-    const pluginRegistry = createTestRegistry({ config: configRuntime } as PluginRuntime);
+    const pluginRegistry = createTestRegistry({ config: configRuntime } as unknown as PluginRuntime);
     const record = createPluginRecord({
       id: "legacy-plugin",
       name: "Legacy Plugin",
       source: "/plugins/legacy-plugin/index.js",
       origin: "global",
       enabled: true,
+      configSchema: true,
     });
     const api = pluginRegistry.createApi(record, { config });
 
-    expect(api.runtime.config.loadConfig()).toBe(config);
-    await api.runtime.config.writeConfigFile(config);
+    expect(api.runtime.config.current()).toBe(config);
+    await api.runtime.config.mutateConfigFile({
+      mutate: () => config,
+      afterWrite: { mode: "none", reason: "test" },
+    });
+    await api.runtime.config.replaceConfigFile({
+      nextConfig: config,
+      afterWrite: { mode: "none", reason: "test" },
+    });
 
-    expect(loadScope).toMatchObject({
+    expect(currentScope).toMatchObject({
       pluginId: "legacy-plugin",
       pluginSource: "/plugins/legacy-plugin/index.js",
     });
-    expect(writeScope).toMatchObject({
+    expect(mutateScope).toMatchObject({
+      pluginId: "legacy-plugin",
+      pluginSource: "/plugins/legacy-plugin/index.js",
+    });
+    expect(replaceScope).toMatchObject({
       pluginId: "legacy-plugin",
       pluginSource: "/plugins/legacy-plugin/index.js",
     });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2396,12 +2396,14 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
           } satisfies PluginRuntime["state"];
         }
         if (prop === "config") {
-          const config = Reflect.get(target, prop, receiver) as PluginRuntime["config"];
+          const config = Reflect.get(target, prop, receiver);
           return {
             ...config,
-            loadConfig: () => runWithPluginScope(() => config.loadConfig()),
-            writeConfigFile: (cfg, options) =>
-              runWithPluginScope(() => config.writeConfigFile(cfg, options)),
+            current: () => runWithPluginScope(() => config.current()),
+            mutateConfigFile: (params) =>
+              runWithPluginScope(() => config.mutateConfigFile(params)),
+            replaceConfigFile: (params) =>
+              runWithPluginScope(() => config.replaceConfigFile(params)),
           } satisfies PluginRuntime["config"];
         }
         if (prop === "llm") {


### PR DESCRIPTION
## Summary
- keep ACPX adapter clients alive across OpenClaw's ensureSession to runTurn boundary for one-shot sessions
- delegate OpenClaw one-shot session creation to ACPX persistent mode while preserving OpenClaw-owned one-shot lifecycle and close behavior
- add regression coverage for the Claude/native ACP handoff shape
- update adjacent guardrail drift exposed by current CI so the branch stays green on latest main

## Why
Native OpenClaw ACP spawns call ensureSession and then runTurn as separate operations. ACPX one-shot mode closes the adapter immediately after session/new, so runTurn has to reconnect/load before any user prompt has been sent. Claude Agent ACP can handle create plus prompt in one process, but the create-close-load-prompt sequence fails with a generic Internal error before producing output.

## Real behavior proof
Before this patch, a native OpenClaw ACP Claude spawn accepted runtime="acp" and created session state, but the first turn failed before assistant output with AcpRuntimeError: Internal error. A direct ACPX baseline still worked from the same machine with /opt/homebrew/bin/acpx --timeout 60 --format json claude exec 'Reply exactly ACP_JSON_OK', proving the adapter/auth path was available and the failure was in the OpenClaw to ACPX handoff.

After this patch, local runtime regression evidence from a real checkout shows the handoff is preserved instead of closing between ensureSession and runTurn:
- node scripts/test-projects.mjs extensions/acpx/src/runtime.test.ts
- result: extension-acpx runtime.test.ts passed, 36 tests

The added regression asserts that an OpenClaw one-shot ACP ensure for agent:claude:acp:test is delegated to ACPX with mode persistent, keeping the client alive for the initial turn while OpenClaw still owns one-shot cleanup.

## Tests
- node scripts/test-projects.mjs extensions/acpx/src/runtime.test.ts
- pnpm lint --threads=8
- pnpm check:test-types
- OPENCLAW_VITEST_INCLUDE_FILE=/tmp/plugin-contract-include.json pnpm test:contracts:plugins for plugin-sdk-package-contract-guardrails.test.ts and deprecated-internal-config-api.test.ts
## Contributor response to ClawSweeper proof request

Additional live proof from the later integrated local hotfix validation:

The one-shot handoff fix from this PR was included in the local OpenClaw 2026.5.7 installed-runtime hotfix set used for native ACP validation. After applying the equivalent installed-runtime patch, native ACP fresh turns completed instead of failing before first output.

Redacted live smoke output:

```text
Claude ACP fresh:  CLAUDE_ACP_FRESH2_OK  <workspace>
Claude ACP resume: CLAUDE_ACP_RESUME2_OK <workspace>
```

This specifically exercises the failure shape this PR targets: OpenClaw creates/ensures the ACP session, then sends the first turn through the native ACP path. Before the fix, that handoff failed with `AcpRuntimeError: Internal error` before assistant output; after the fix, the fresh Claude ACP turn completed and the resumed turn also completed.

Private local session identifiers and workspace paths are redacted. The source regression remains:

```text
extensions/acpx/src/runtime.test.ts passed, including the one-shot ensure delegated as persistent regression.
```

Note: later ACP adapter/config/auth fixes are covered separately in PR #81541; this proof is included here because the live fresh ACP turn also depends on this one-shot handoff behaviour.
