### PR TITLE
fix: clear Telegram progress drafts before final reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Security/Windows ACL audit: classify Anonymous Logon, Guests, Interactive, Local, and Network SIDs as world-equivalent principals so broadly writable paths stay critical instead of being downgraded to group-writable. Fixes #74350. (#74383) Thanks @dwc1997.
 - Media-understanding: retry transient remote attachment fetch failures before audio or vision processing, so Discord voice notes are not lost after one network/CDN blip. Fixes #74316. Thanks @vyctorbrzezowski and @gabrielexito-stack.
 - Control UI: order timestamped live stream and tool items before untimestamped history fallbacks, keeping chat history in visible time order. Fixes #80759. (#81016) Thanks @akrimm702.
+- Telegram: clear progress-mode tool-progress drafts before final delivery in group/forum chats, matching direct-message cleanup behavior. (#81486) Thanks @keshavbotagent.
 - iMessage: stop sending visible `<media:image>` placeholder text for media-only native image sends while preserving the internal echo key that prevents self-echo duplicate replies. (#81209) Thanks @homer-byte.
 - Agents/sessions: create configured agent main sessions before first `sessions_send` or gateway send, so agent-to-agent messages no longer fail when the target agent has not started yet.
 - gateway: pass Talk session scope to resolver [AI]. (#81379) Thanks @pgondhi987.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1219,7 +1219,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(rotationOrder).toBeLessThan(finalUpdateOrder);
   });
 
-  it("keeps progress updates in a draft and sends the final answer normally", async () => {
+  it("clears the progress draft before final delivery in group topics", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
@@ -1235,19 +1235,100 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
 
     await dispatchWithContext({
-      context: createContext(),
+      context: createContext({
+        chatId: -1001234,
+        isGroup: true,
+        ctxPayload: {
+          SessionKey: "agent:test:telegram:group:-1001234:topic:547",
+          ChatType: "group",
+        } as TelegramMessageContext["ctxPayload"],
+        primaryCtx: {
+          message: { chat: { id: -1001234, type: "supergroup", is_forum: true } },
+        } as TelegramMessageContext["primaryCtx"],
+        msg: {
+          chat: { id: -1001234, type: "supergroup", is_forum: true },
+          message_id: 456,
+          message_thread_id: 547,
+        } as TelegramMessageContext["msg"],
+        threadSpec: { id: 547, scope: "forum" },
+        replyThreadId: 547,
+      }),
       streamMode: "progress",
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expect(answerDraftStream.update).toHaveBeenCalledWith(
-      "Cracking...\n`🛠️ Exec`\n`🛠️ git rev-parse --abbrev-ref HEAD`",
-    );
+    const progressDraftText = answerDraftStream.update.mock.calls.at(-1)?.[0] ?? "";
+    expect(progressDraftText).toContain("`🛠️ Exec`");
+    expect(progressDraftText).toContain("`🛠️ git rev-parse --abbrev-ref HEAD`");
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Branch is up to date");
-    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
     expectDeliveredReply(0, { text: "Branch is up to date" });
     expect(editMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("deletes retained overflow progress previews before group final delivery", async () => {
+    const bot = createBot();
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    let streamParams:
+      | Parameters<NonNullable<TelegramBotDeps["createTelegramDraftStream"]>>[0]
+      | undefined;
+    answerDraftStream.clear.mockImplementation(async () => {
+      streamParams?.onSupersededPreview?.({
+        messageId: 1998,
+        textSnapshot: "late stale progress",
+        retain: true,
+      });
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        streamParams = mockCallArg(createTelegramDraftStream) as Parameters<
+          NonNullable<TelegramBotDeps["createTelegramDraftStream"]>
+        >[0];
+        streamParams.onSupersededPreview?.({
+          messageId: 1999,
+          textSnapshot: "stale progress",
+          retain: true,
+        });
+        expect(bot.api.deleteMessage).not.toHaveBeenCalledWith(-1001234, 1999);
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      bot,
+      context: createContext({
+        chatId: -1001234,
+        isGroup: true,
+        ctxPayload: {
+          SessionKey: "agent:test:telegram:group:-1001234:topic:547",
+          ChatType: "group",
+        } as TelegramMessageContext["ctxPayload"],
+        primaryCtx: {
+          message: { chat: { id: -1001234, type: "supergroup", is_forum: true } },
+        } as TelegramMessageContext["primaryCtx"],
+        msg: {
+          chat: { id: -1001234, type: "supergroup", is_forum: true },
+          message_id: 456,
+          message_thread_id: 547,
+        } as TelegramMessageContext["msg"],
+        threadSpec: { id: 547, scope: "forum" },
+        replyThreadId: 547,
+      }),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    expect(bot.api.deleteMessage).toHaveBeenCalledWith(-1001234, 1999);
+    expect(bot.api.deleteMessage).toHaveBeenCalledWith(-1001234, 1998);
+    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
+    expectDeliveredReply(0, { text: "Done" });
+    const deleteMessageMock = bot.api.deleteMessage as unknown as ReturnType<typeof vi.fn>;
+    const retainedDeleteOrder = deleteMessageMock.mock.invocationCallOrder[0];
+    const finalDeliveryOrder = deliverReplies.mock.invocationCallOrder[0];
+    expect(retainedDeleteOrder).toBeLessThan(finalDeliveryOrder);
   });
 
   it("streams the first long final chunk and sends follow-up chunks", async () => {
@@ -1366,9 +1447,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.update).toHaveBeenCalledWith(
       "Shelling\n`🔎 Web Search: docs lookup`\n• `tests passed`",
     );
-    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    expect(draftStream.materialize).not.toHaveBeenCalled();
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(draftStream.materialize).not.toHaveBeenCalled();
     expectDeliveredReply(0, { text: "Final after tool" });
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -546,6 +546,15 @@ export const dispatchTelegramMessage = async ({
   const draftMinInitialChars = streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS;
   const progressSeed = `${route.accountId}:${chatId}:${threadSpec.id ?? ""}`;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
+  const retainedAnswerToolProgressPreviewIds = new Set<number>();
+  let activeAnswerDraftIsToolProgressOnly = false;
+  const deleteSupersededDraftPreview = (laneName: LaneName, messageId: number) => {
+    void bot.api.deleteMessage(chatId, messageId).catch((err: unknown) => {
+      logVerbose(
+        `telegram: superseded ${laneName} stream cleanup failed (${messageId}): ${String(err)}`,
+      );
+    });
+  };
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
     const stream = enabled
       ? (telegramDeps.createTelegramDraftStream ?? createTelegramDraftStream)({
@@ -558,13 +567,16 @@ export const dispatchTelegramMessage = async ({
           renderText: renderStreamText,
           onSupersededPreview: (superseded) => {
             if (superseded.retain) {
+              if (
+                laneName === "answer" &&
+                streamMode === "progress" &&
+                activeAnswerDraftIsToolProgressOnly
+              ) {
+                retainedAnswerToolProgressPreviewIds.add(superseded.messageId);
+              }
               return;
             }
-            void bot.api.deleteMessage(chatId, superseded.messageId).catch((err: unknown) => {
-              logVerbose(
-                `telegram: superseded ${laneName} stream cleanup failed (${superseded.messageId}): ${String(err)}`,
-              );
-            });
+            deleteSupersededDraftPreview(laneName, superseded.messageId);
           },
           log: logVerbose,
           warn: logVerbose,
@@ -588,10 +600,21 @@ export const dispatchTelegramMessage = async ({
   let streamToolProgressSuppressed = false;
   let streamToolProgressLines: string[] = [];
   let lastAnswerPartialText = "";
-  let activeAnswerDraftIsToolProgressOnly = false;
   function resetAnswerToolProgressDraft() {
     activeAnswerDraftIsToolProgressOnly = false;
   }
+  const clearRetainedAnswerToolProgressPreviews = async () => {
+    const messageIds = [...retainedAnswerToolProgressPreviewIds];
+    retainedAnswerToolProgressPreviewIds.clear();
+    for (const messageId of messageIds) {
+      try {
+        await bot.api.deleteMessage(chatId, messageId);
+        logVerbose(`telegram progress preview deleted (chat=${chatId}, message=${messageId})`);
+      } catch (err) {
+        logVerbose(`telegram progress preview cleanup failed (${messageId}): ${String(err)}`);
+      }
+    }
+  };
   async function prepareAnswerLaneForToolProgress() {
     if (activeAnswerDraftIsToolProgressOnly) {
       return;
@@ -764,8 +787,13 @@ export const dispatchTelegramMessage = async ({
     if (!activeAnswerDraftIsToolProgressOnly) {
       return false;
     }
-    await answerLane.stream?.clear();
-    answerLane.stream?.forceNewMessage();
+    if (streamMode === "progress") {
+      await answerLane.stream?.clear();
+      await clearRetainedAnswerToolProgressPreviews();
+    } else {
+      await answerLane.stream?.clear();
+      answerLane.stream?.forceNewMessage();
+    }
     resetDraftLaneState(answerLane);
     streamToolProgressSuppressed = true;
     streamToolProgressLines = [];


### PR DESCRIPTION
## Summary
- clear Telegram progress-mode tool-progress drafts before final delivery instead of leaving them visible
- track and delete retained overflow progress previews before the normal final reply
- add group-topic regression coverage for active and retained progress-preview cleanup
- add changelog entry

## Review follow-up
- Retained `onSupersededPreview(... retain: true)` previews are tracked only while the answer lane owns a progress-mode tool-progress draft.
- Final delivery clears the active draft and then deletes any retained progress-owned preview ids before sending the final reply.
- The regression test covers retained previews created before final delivery and retained previews surfaced during `clear()`.

## Real behavior proof
- Behavior or issue addressed: Telegram progress-mode tool-progress drafts in group/forum chats stayed visible after the normal final reply; this change makes group/forum cleanup match the direct-message cleanup behavior.
- Real environment tested: Real OpenClaw Telegram bot in a Telegram group/forum topic, using the attached after-fix screen recording.
- Exact steps or command run after this patch: Ran a Telegram group/forum topic turn that produced tool progress, waited for the tool-progress draft, then let the turn complete with a normal final reply.
- Evidence after fix: [telegram-progress-proof.mp4](https://raw.githubusercontent.com/keshavbotagent/openclaw/proof/telegram-progress-video-81486/.proof/81486/telegram-progress-proof.mp4)
- Observed result after fix: The tool-progress draft is visible while work is running, then disappears before/when the final reply remains in the topic; no stale tool-progress message is left behind.
- What was not tested: No additional live scenarios beyond the attached Telegram group/forum recording; retained overflow rollover is covered by the focused regression test.

## Verification
- `HOME=/home/clawuser pnpm test extensions/telegram/src/bot-message-dispatch.test.ts` - 52 tests passed
- `HOME=/home/clawuser pnpm config:channels:gen`
- `git diff --check`
