### PR TITLE
fix(sessions): preserve pending subagent rows during maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions: preserve active and cleanup-pending subagent session rows during enforced max-entry maintenance, preventing completion handoffs from reporting `(no output)`, `session_id: unknown`, and zero token stats after the child already finished. Fixes #81492. Thanks @bek91.
 - iMessage: stop sending visible `<media:image>` placeholder text for media-only native image sends while preserving the internal echo key that prevents self-echo duplicate replies. (#81209) Thanks @homer-byte.
 - Agents/sessions: create configured agent main sessions before first `sessions_send` or gateway send, so agent-to-agent messages no longer fail when the target agent has not started yet.
 - gateway: pass Talk session scope to resolver [AI]. (#81379) Thanks @pgondhi987.

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -163,9 +163,13 @@ vi.mock("./subagent-orphan-recovery.js", () => ({
 
 describe("subagent registry seam flow", () => {
   let mod: typeof import("./subagent-registry.js");
+  let collectSessionMaintenancePreserveKeys: typeof import("../config/sessions/store-maintenance-runtime.js").collectSessionMaintenancePreserveKeys;
 
   beforeAll(async () => {
-    mod = await import("./subagent-registry.js");
+    [mod, { collectSessionMaintenancePreserveKeys }] = await Promise.all([
+      import("./subagent-registry.js"),
+      import("../config/sessions/store-maintenance-runtime.js"),
+    ]);
   });
 
   beforeEach(() => {
@@ -217,6 +221,48 @@ describe("subagent registry seam flow", () => {
       resolveContextEngine: mocks.resolveContextEngine,
     });
     mod.resetSubagentRegistryForTests({ persist: false });
+  });
+
+  it("preserves active and cleanup-pending child session keys during session maintenance", () => {
+    const now = Date.now();
+    mod.registerSubagentRun({
+      runId: "run-active-preserve",
+      childSessionKey: "agent:main:subagent:active-preserve",
+      requesterSessionKey: "agent:main:slack:dm:u1",
+      requesterDisplayKey: "slack:u1",
+      task: "active preserve",
+      cleanup: "delete",
+      expectsCompletionMessage: true,
+    });
+    mod.addSubagentRunForTests({
+      runId: "run-ended-preserve",
+      childSessionKey: "agent:main:subagent:ended-preserve",
+      requesterSessionKey: "agent:main:slack:dm:u1",
+      requesterDisplayKey: "slack:u1",
+      task: "ended preserve",
+      cleanup: "delete",
+      createdAt: now - 100,
+      endedAt: now,
+      expectsCompletionMessage: true,
+    });
+    mod.addSubagentRunForTests({
+      runId: "run-cleaned-up",
+      childSessionKey: "agent:main:subagent:cleaned-up",
+      requesterSessionKey: "agent:main:slack:dm:u1",
+      requesterDisplayKey: "slack:u1",
+      task: "cleaned up",
+      cleanup: "delete",
+      createdAt: now - 200,
+      endedAt: now - 100,
+      cleanupCompletedAt: now,
+      expectsCompletionMessage: true,
+    });
+
+    const keys = collectSessionMaintenancePreserveKeys();
+
+    expect(keys).toContain("agent:main:subagent:active-preserve");
+    expect(keys).toContain("agent:main:subagent:ended-preserve");
+    expect(keys).not.toContain("agent:main:subagent:cleaned-up");
   });
 
   afterEach(() => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -6,6 +6,7 @@ import {
   resolveStorePath,
   type SessionEntry,
 } from "../config/sessions.js";
+import { registerSessionMaintenancePreserveKeysProvider } from "../config/sessions/store-maintenance-runtime.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ResolveContextEngineOptions } from "../context-engine/registry.js";
 import type { ContextEngine, SubagentEndReason } from "../context-engine/types.js";
@@ -65,6 +66,7 @@ import {
 } from "./subagent-registry-state.js";
 import { configureSubagentRegistrySteerRuntime } from "./subagent-registry-steer-runtime.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import { hasSubagentRunEnded, isLiveUnendedSubagentRun } from "./subagent-run-liveness.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 
 export type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -137,6 +139,37 @@ const defaultSubagentRegistryDeps: SubagentRegistryDeps = {
 };
 
 let subagentRegistryDeps: SubagentRegistryDeps = defaultSubagentRegistryDeps;
+
+function shouldPreserveSubagentSessionForMaintenance(
+  entry: SubagentRunRecord,
+  now = Date.now(),
+): boolean {
+  if (typeof entry.cleanupCompletedAt === "number") {
+    return false;
+  }
+  if (isLiveUnendedSubagentRun(entry, now)) {
+    return true;
+  }
+  return hasSubagentRunEnded(entry);
+}
+
+export function collectSubagentSessionMaintenancePreserveKeys(): string[] {
+  const now = Date.now();
+  const preserveKeys = new Set<string>();
+  for (const entry of subagentRuns.values()) {
+    if (!shouldPreserveSubagentSessionForMaintenance(entry, now)) {
+      continue;
+    }
+    const childSessionKey = entry.childSessionKey.trim();
+    if (childSessionKey) {
+      preserveKeys.add(childSessionKey);
+    }
+  }
+  return [...preserveKeys];
+}
+
+registerSessionMaintenancePreserveKeysProvider(collectSubagentSessionMaintenancePreserveKeys);
+
 type ContextEngineInitModule = Pick<
   {
     ensureContextEnginesInitialized: () => void;

--- a/src/config/sessions/store-maintenance-runtime.ts
+++ b/src/config/sessions/store-maintenance-runtime.ts
@@ -5,6 +5,10 @@ import {
   type ResolvedSessionMaintenanceConfig,
 } from "./store-maintenance.js";
 
+export type SessionMaintenancePreserveKeysProvider = () => Iterable<string> | undefined;
+
+const preserveKeysProviders = new Set<SessionMaintenancePreserveKeysProvider>();
+
 export function resolveMaintenanceConfig(): ResolvedSessionMaintenanceConfig {
   let maintenance: SessionMaintenanceConfig | undefined;
   try {
@@ -13,4 +17,41 @@ export function resolveMaintenanceConfig(): ResolvedSessionMaintenanceConfig {
     // Config may not be available in narrow test/runtime helpers.
   }
   return resolveMaintenanceConfigFromInput(maintenance);
+}
+
+export function registerSessionMaintenancePreserveKeysProvider(
+  provider: SessionMaintenancePreserveKeysProvider,
+): () => void {
+  preserveKeysProviders.add(provider);
+  return () => {
+    preserveKeysProviders.delete(provider);
+  };
+}
+
+export function collectSessionMaintenancePreserveKeys(
+  seedKeys?: Iterable<string | undefined>,
+): Set<string> | undefined {
+  let preserveKeys: Set<string> | undefined;
+  const addKey = (key: string | undefined) => {
+    const trimmed = key?.trim();
+    if (!trimmed) {
+      return;
+    }
+    preserveKeys ??= new Set<string>();
+    preserveKeys.add(trimmed);
+  };
+
+  for (const key of seedKeys ?? []) {
+    addKey(key);
+  }
+  for (const provider of preserveKeysProviders) {
+    try {
+      for (const key of provider() ?? []) {
+        addKey(key);
+      }
+    } catch {
+      // Preserve providers are lifecycle hints; maintenance must remain best-effort.
+    }
+  }
+  return preserveKeys;
 }

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -17,6 +17,7 @@ vi.mock("../config.js", async () => ({
 
 import { getRuntimeConfig } from "../config.js";
 import { runSessionsCleanup } from "./cleanup-service.js";
+import { registerSessionMaintenancePreserveKeysProvider } from "./store-maintenance-runtime.js";
 import {
   clearSessionStoreCacheForTest,
   loadSessionStore,
@@ -866,6 +867,27 @@ describe("Integration: saveSessionStore with pruning", () => {
       name.startsWith(`${oldestSessionId}.jsonl.deleted.`),
     );
     expect(archivedOldestTranscripts.length).toBeGreaterThan(0);
+  });
+
+  it("keeps provider-preserved entries when maxEntries capping runs", async () => {
+    applyCappedMaintenanceConfig(mockLoadConfig);
+
+    const now = Date.now();
+    const unregister = registerSessionMaintenancePreserveKeysProvider(() => ["oldest", "newest"]);
+    try {
+      const store: Record<string, SessionEntry> = {
+        oldest: { sessionId: "oldest-session", updatedAt: now - DAY_MS },
+        newest: { sessionId: "newest-session", updatedAt: now },
+      };
+
+      await saveSessionStore(storePath, store);
+
+      const loaded = loadSessionStore(storePath, { skipCache: true });
+      expect(loaded).toHaveProperty("oldest");
+      expect(loaded).toHaveProperty("newest");
+    } finally {
+      unregister();
+    }
   });
 
   it("does not archive external transcript paths when capping entries", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -23,7 +23,10 @@ import {
 } from "./store-cache.js";
 import { normalizeStoreSessionKey, resolveSessionStoreEntry } from "./store-entry.js";
 import { loadSessionStore, normalizeSessionStore } from "./store-load.js";
-import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
+import {
+  collectSessionMaintenancePreserveKeys,
+  resolveMaintenanceConfig,
+} from "./store-maintenance-runtime.js";
 import {
   capEntryCount,
   getActiveSessionMaintenanceWarning,
@@ -282,9 +285,9 @@ async function saveSessionStoreUnlocked(
         diskBudget,
       });
     } else {
-      const preserveSessionKeys = opts?.activeSessionKey
-        ? new Set([opts.activeSessionKey])
-        : undefined;
+      const preserveSessionKeys = collectSessionMaintenancePreserveKeys(
+        opts?.activeSessionKey ? [opts.activeSessionKey] : undefined,
+      );
       // Prune stale entries and cap total count before serializing.
       const removedSessionFiles = new Map<string, string | undefined>();
       const pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: enforced `session.maintenance.maxEntries` could cap a just-finished subagent session row before the announce/result path read its output.
- Why it matters: parent sessions could receive a successful completion handoff with `(no output)`, `session_id: unknown`, and zero token stats even though the child produced a real result.
- What changed: session maintenance now supports lifecycle-owned preserve-key providers, and the subagent registry registers active plus cleanup-pending child session keys until cleanup is complete.
- What did NOT change (scope boundary): no archive transcript fallback, delivery retry policy, or session disk-budget policy changes are included here.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #81492
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: subagent child session rows remain available to announce/result capture while active or cleanup-pending, even when entry-count maintenance is enforcing a saturated cap.
- Real environment tested: local Linux checkout on Node 24 / pnpm 11.1.0.
- Exact steps or command run after this patch: `pnpm test src/config/sessions/store.pruning.integration.test.ts src/agents/subagent-registry.test.ts`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): real production-module terminal proof, no Vitest and no mocks:

```text
$ tmpdir=$(mktemp -d); PROOF_DIR="$tmpdir" OPENCLAW_SESSION_CACHE_TTL_MS=0 pnpm exec tsx -e '<production saveSessionStore proof>'
[sessions/store] capped session entry count
{
  "keys": [
    "agent:main:subagent:pending-proof"
  ],
  "preservedPendingSubagent": true,
  "cappedFreshDm": true
}
```

- Observed result after fix: with enforced `maxEntries: 1`, the lifecycle-preserved pending subagent row remained in the real session store while the unpreserved fresh DM row was capped.
- What was not tested: live Slack/macOS reproduction from the original report was not rerun in this environment.
- Before evidence (optional but encouraged): source-visible root cause matched the issue report: capping previously only preserved the active writer key, not pending subagent child keys.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: enforced session maintenance built its preserve set from only `activeSessionKey`, while subagent announce/result capture later depended on the child session row still existing.
- Missing detection / guardrail: no regression covered max-entry capping while subagent delivery cleanup was still pending.
- Contributing context (if known): subagent keys are synthetic session keys, so generic protected session rules intentionally did not protect them.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/sessions/store.pruning.integration.test.ts`, `src/agents/subagent-registry.test.ts`.
- Scenario the test should lock in: max-entry maintenance honors lifecycle preserve keys, and the subagent registry preserves active plus cleanup-pending child sessions but not cleanup-completed ones.
- Why this is the smallest reliable guardrail: it proves the generic maintenance seam and the subagent-owned lifecycle key provider without needing a live Slack channel.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Subagent completion handoffs are less likely to lose successful child output or token stats under enforced session-entry caps.

## Diagram (if applicable)

```text
Before:
[subagent finishes] -> [maxEntries capping removes child row] -> [announce reads no output]

After:
[subagent active/cleanup-pending] -> [registry preserves child row] -> [announce can read child output]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux local checkout
- Runtime/container: Node 24, pnpm 11.1.0
- Model/provider: N/A
- Integration/channel (if any): subagent/session maintenance seam; no live Slack rerun
- Relevant config (redacted): `session.maintenance.mode = "enforce"`, low `maxEntries` in regression test

### Steps

1. Register/seed lifecycle preserve keys for active and cleanup-pending subagent rows.
2. Run enforced session maintenance with `maxEntries` below the preserved row count.
3. Verify preserved child rows remain available and cleanup-completed rows are not preserved.

### Expected

- Active and cleanup-pending subagent child session rows survive entry-count maintenance.

### Actual

- Active and cleanup-pending subagent child session rows survive entry-count maintenance.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: real production-module session-store cap proof; focused regression tests; targeted formatting; production core typecheck.
- Edge cases checked: cleanup-completed subagent rows are not preserved; provider-preserved rows may exceed the cap when all candidates are protected.
- What you did **not** verify: live Slack/macOS reproduction.

Additional validation notes:

- `pnpm exec oxfmt --check --threads=1 src/config/sessions/store-maintenance-runtime.ts src/config/sessions/store.ts src/agents/subagent-registry.ts src/config/sessions/store.pruning.integration.test.ts src/agents/subagent-registry.test.ts` passed.
- Real production-module terminal proof above passed.
- `pnpm test src/config/sessions/store.pruning.integration.test.ts src/agents/subagent-registry.test.ts` passed after rebasing onto latest `upstream/main`.
- `pnpm tsgo:core` passed before the rebase.
- `pnpm lint:core` is currently blocked by unrelated existing lint errors in `src/gateway/sessions-patch.ts`, `src/plugins/registry.ts`, and `src/plugins/registry.runtime-config.test.ts`.
- `pnpm tsgo:core:test` is currently blocked by unrelated existing type errors in `src/plugins/registry.runtime-config.test.ts`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: preserving lifecycle-critical subagent rows can temporarily exceed `maxEntries`.
  - Mitigation: preservation ends after subagent cleanup completes, and only active or cleanup-pending child keys are contributed by the subagent registry.

