### PR TITLE
fix(config): add dry-run for unset

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1083,7 +1083,9 @@ describe("config cli", () => {
 
       const configCommand = program.commands.find((command) => command.name() === "config");
       const setCommand = configCommand?.commands.find((command) => command.name() === "set");
+      const unsetCommand = configCommand?.commands.find((command) => command.name() === "unset");
       const helpText = setCommand?.helpInformation() ?? "";
+      const unsetHelpText = unsetCommand?.helpInformation() ?? "";
       const configHelpText = configCommand?.helpInformation() ?? "";
 
       expect(configHelpText).toContain("get/set/patch/unset/file/schema/validate");
@@ -1106,6 +1108,8 @@ describe("config cli", () => {
       expect(helpText).toContain(
         "openclaw config set --batch-file ./config-set.batch.json --dry-run",
       );
+      expect(unsetHelpText).toContain("--dry-run");
+      expect(unsetHelpText).toContain("Validate the removal without writing openclaw.json");
     });
   });
 
@@ -2523,6 +2527,37 @@ describe("config cli", () => {
       expect(firstWriteConfigOptions()).toEqual({
         unsetPaths: [["channels", "discord", "guilds", "123"]],
       });
+    });
+
+    it("dry-runs config unset without writing (#80721)", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+        tools: {
+          profile: "coding",
+          alsoAllow: ["agents_list"],
+        },
+      };
+      setSnapshot(resolved, resolved);
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "unset", "tools.alsoAllow", "--dry-run"]);
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectLogIncludes("Dry run successful: 1 removal(s) validated against /tmp/openclaw.json.");
+    });
+
+    it("keeps config unset dry-run path-not-found behavior write-free", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand(["config", "unset", "tools.alsoAllow", "--dry-run"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("Config path not found: tools.alsoAllow");
     });
   });
 

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1795,9 +1795,12 @@ async function runConfigOperations(params: {
           ),
         );
       }
+      const noun = operations.every((operation) => operation.mutation === "delete")
+        ? "removal"
+        : "update";
       runtime.log(
         info(
-          `Dry run successful: ${operations.length} update(s) validated against ${shortenHomePath(snapshot.path)}.`,
+          `Dry run successful: ${operations.length} ${noun}(s) validated against ${shortenHomePath(snapshot.path)}.`,
         ),
       );
     }
@@ -1977,7 +1980,11 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
   }
 }
 
-export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv }) {
+export async function runConfigUnset(opts: {
+  path: string;
+  dryRun?: boolean | undefined;
+  runtime?: RuntimeEnv;
+}) {
   const runtime = opts.runtime ?? defaultRuntime;
   try {
     const parsedPath = parseRequiredPath(opts.path);
@@ -1998,6 +2005,15 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
         ),
       );
       runtime.exit(1);
+      return;
+    }
+    if (opts.dryRun) {
+      await runConfigOperations({
+        runtime,
+        operations: [buildDeleteOperation(parsedPath)],
+        options: { dryRun: true },
+        successMode: "set",
+      });
       return;
     }
     await replaceConfigFile({
@@ -2249,8 +2265,9 @@ export function registerConfigCli(program: Command) {
     .command("unset")
     .description("Remove a config value by dot path")
     .argument("<path>", "Config path (dot or bracket notation)")
-    .action(async (path: string) => {
-      await runConfigUnset({ path });
+    .option("--dry-run", "Validate the removal without writing openclaw.json", false)
+    .action(async (path: string, opts: { dryRun?: boolean | undefined }) => {
+      await runConfigUnset({ path, dryRun: opts.dryRun });
     });
 
   cmd


### PR DESCRIPTION
## Summary

Adds `--dry-run` support to `openclaw config unset` so unset operations have the same preflight path as `config set` and `config patch`.

Fixes #80721.

## Behavior

- `openclaw config unset <path> --dry-run` now validates the removal without writing `openclaw.json`.
- Missing paths still fail without writing.
- Existing write behavior is unchanged for real unsets, including array-element removal and unset-path write options.
- Dry-run validation reuses the existing config mutation dry-run machinery instead of adding a second validation path.

## Proof

```text
pnpm test src/cli/config-cli.test.ts -- --reporter=dot
# 87 passed

pnpm exec oxfmt --check --threads=1 src/cli/config-cli.ts src/cli/config-cli.test.ts
# All matched files use the correct format.

pnpm exec oxlint src/cli/config-cli.ts src/cli/config-cli.test.ts
# Found 0 warnings and 0 errors.

git diff --check
# clean
```

## Note

I kept this PR scoped to the config unset parity issue. A full-repo `pnpm check:test-types` on this current upstream base still reports unrelated plugin registry test typing issues that are already fixed on #81454.