### PR TITLE
fix(skills): skip non-symlink plugin skill entries

### DIFF
--- a/src/agents/skills/plugin-skills.test.ts
+++ b/src/agents/skills/plugin-skills.test.ts
@@ -504,6 +504,21 @@ describe("publishPluginSkills", () => {
     expect(fsSync.existsSync(staleDir)).toBe(false);
   });
 
+  it("leaves existing regular directories in place when publishing matching skill names", async () => {
+    const skillParent = await tempDirs.make("plugin-skills-");
+    const managedDir = await tempDirs.make("managed-skills-");
+
+    const dir = await writeSkillDir(skillParent, "my-skill");
+    const existingDir = path.join(managedDir, "my-skill");
+    await fs.mkdir(existingDir, { recursive: true });
+    const readlinkSpy = vi.spyOn(fsSync, "readlinkSync");
+
+    publishPluginSkills([dir], { pluginSkillsDir: managedDir });
+
+    expect((await fs.lstat(existingDir)).isDirectory()).toBe(true);
+    expect(readlinkSpy).not.toHaveBeenCalledWith(existingDir);
+  });
+
   it("treats Windows directory entries as generated plugin skill entries", () => {
     const directoryEntry = {
       isDirectory: () => true,

--- a/src/agents/skills/plugin-skills.ts
+++ b/src/agents/skills/plugin-skills.ts
@@ -220,11 +220,16 @@ function publishPluginSkills(skillDirs: string[], opts?: { pluginSkillsDir?: str
       // best-effort; symlink will fail below if dir is truly unusable
     }
     try {
-      const existingTarget = fs.readlinkSync(linkPath);
-      if (existingTarget === target) {
+      const existingEntry = fs.lstatSync(linkPath);
+      if (existingEntry.isSymbolicLink()) {
+        const existingTarget = fs.readlinkSync(linkPath);
+        if (existingTarget === target) {
+          continue;
+        }
+        removeGeneratedPluginSkillEntry(linkPath);
+      } else {
         continue;
       }
-      removeGeneratedPluginSkillEntry(linkPath);
     } catch (err) {
       if (!isNotFoundError(err)) {
         log.warn(`failed to inspect plugin skill symlink "${linkPath}": ${String(err)}`);


### PR DESCRIPTION
## Summary
- avoid calling `readlinkSync` on existing regular directories in the managed plugin skills directory
- leave non-symlink entries in place instead of treating them as generated symlinks
- add coverage for the regular-directory collision case

## Verification
- `pnpm test src/agents/skills/plugin-skills.test.ts`
- `pnpm check:changed` *(fails on existing TypeScript errors in `src/plugins/registry.runtime-config.test.ts`, outside this change)*

Fixes #81432
