### PR TITLE
docs(plugins): document session end shutdown budget

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -134,7 +134,7 @@ observation-only.
 
 **Sessions and compaction**
 
-- `session_start` / `session_end` - track session lifecycle boundaries. The event's `reason` is one of `new`, `reset`, `idle`, `daily`, `compaction`, `deleted`, `shutdown`, `restart`, or `unknown`. The `shutdown` and `restart` values fire from the gateway shutdown finalizer when the process is stopped or restarted while sessions are still active, so downstream plugins (such as memory or transcript stores) can finalize ghost rows that would otherwise be left in an open state across restarts. The finalizer is bounded so a slow plugin cannot block SIGTERM/SIGINT.
+- `session_start` / `session_end` - track session lifecycle boundaries. The event's `reason` is one of `new`, `reset`, `idle`, `daily`, `compaction`, `deleted`, `shutdown`, `restart`, or `unknown`. The `shutdown` and `restart` values fire from the gateway shutdown finalizer when the process is stopped or restarted while sessions are still active, so downstream plugins (such as memory or transcript stores) can finalize ghost rows that would otherwise be left in an open state across restarts. The shutdown finalizer has a 2-second total drain budget for plugin `session_end` work, so plugins should fast-path those reasons with an early return or bounded finalize path. If a plugin needs heavier persistence, make that path crash-consistent and tolerant of partial writes because slow handlers may be truncated when the process exits.
 - `before_compaction` / `after_compaction` - observe or annotate compaction cycles
 - `before_reset` - observe session-reset events (`/reset`, programmatic resets)
 


### PR DESCRIPTION
## Summary
- document the `shutdown` and `restart` `session_end` reasons as shutdown-finalizer events
- call out the 2-second total drain budget for plugin `session_end` work
- advise plugin maintainers to fast-path or make persistence crash-consistent for shutdown/restart handling

Fixes #81310.

## Verification
- `pnpm docs:list`
- `git diff --check docs/plugins/hooks.md`
- `sed -n '132,139p' docs/plugins/hooks.md`

## Real behavior proof
- Behavior addressed: the plugin hooks docs now state that `shutdown` and `restart` `session_end` reasons run during gateway shutdown/restart finalization, with a 2-second total drain budget and bounded/crash-consistent plugin guidance.
- Real environment tested: local OpenClaw docs checkout on macOS, reading the real `docs/plugins/hooks.md` file after the patch and running the repo docs inventory command.
- Exact steps or command run after this patch: `pnpm docs:list`; `git diff --check docs/plugins/hooks.md`; `sed -n '132,139p' docs/plugins/hooks.md`
- Evidence after fix:
```text
$ pnpm docs:list
Listing all markdown files in docs folder:
AGENTS.md - [missing front matter]
...
Reminder: keep docs up to date as behavior changes. When your task matches any "Read when" hint above (React hooks, cache directives, database work, tests, etc.), read that doc before coding, and suggest new coverage when it is missing.

$ git diff --check docs/plugins/hooks.md
(no output; exit code 0)

$ sed -n '132,139p' docs/plugins/hooks.md
- **`before_dispatch`** - inspect or rewrite an outbound dispatch before channel handoff
- **`reply_dispatch`** - participate in the final reply-dispatch pipeline

**Sessions and compaction**

- `session_start` / `session_end` - track session lifecycle boundaries. The event's `reason` is one of `new`, `reset`, `idle`, `daily`, `compaction`, `deleted`, `shutdown`, `restart`, or `unknown`. The `shutdown` and `restart` values fire from the gateway shutdown finalizer when the process is stopped or restarted while sessions are still active, so downstream plugins (such as memory or transcript stores) can finalize ghost rows that would otherwise be left in an open state across restarts. The shutdown finalizer has a 2-second total drain budget for plugin `session_end` work, so plugins should fast-path those reasons with an early return or bounded finalize path. If a plugin needs heavier persistence, make that path crash-consistent and tolerant of partial writes because slow handlers may be truncated when the process exits.
- `before_compaction` / `after_compaction` - observe or annotate compaction cycles
- `before_reset` - observe session-reset events (`/reset`, programmatic resets)
```
- Observed result after fix: the terminal output shows the Sessions and compaction section includes the 2-second total drain budget and tells plugins to fast-path shutdown/restart or use crash-consistent bounded persistence.
- What was not tested: no live gateway shutdown/restart was run because this PR is documentation-only; runtime behavior is covered by the existing implementation/tests referenced in the linked issue and ClawSweeper review.
