### PR TITLE
fix(config): use plugin channel schemas in dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Config: validate JSON dry-runs against plugin-owned channel schemas, so external channel fields are not rejected by stale bundled schemas. Fixes #77887.
 - ACP: preserve redacted numeric JSON-RPC `RequestError` details in runtime failure text, so backend diagnostics are visible instead of only `Internal error`. Fixes #81126. (#81188) Thanks @vyctorbrzezowski.
 - Security/Windows ACL audit: classify Anonymous Logon, Guests, Interactive, Local, and Network SIDs as world-equivalent principals so broadly writable paths stay critical instead of being downgraded to group-writable. Fixes #74350. (#74383) Thanks @dwc1997.
 - Media-understanding: retry transient remote attachment fetch failures before audio or vision processing, so Discord voice notes are not lost after one network/CDN blip. Fixes #74316. Thanks @vyctorbrzezowski and @gabrielexito-stack.

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -135,7 +135,7 @@ is available, then fall back to `latest`.
 
     This CLI flag applies to plugin install/update flows. Gateway-backed skill dependency installs use the matching `dangerouslyForceUnsafeInstall` request override, while `openclaw skills install` remains a separate ClawHub skill download/install flow.
 
-    If a plugin you published on ClawHub is hidden or blocked by a registry scan, use the publisher steps in [ClawHub](/clawhub/security). `--dangerously-force-unsafe-install` only affects installs on your own machine; it does not ask ClawHub to rescan the plugin or make a blocked release public.
+    If a plugin you published on ClawHub is hidden or blocked by a registry scan, use the publisher steps in [ClawHub publishing](/clawhub/publishing). `--dangerously-force-unsafe-install` only affects installs on your own machine; it does not ask ClawHub to rescan the plugin or make a blocked release public.
 
   </Accordion>
   <Accordion title="Hook packs and npm specs">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1334,7 +1334,6 @@
                 "pages": [
                   "clawhub/api",
                   "clawhub/http-api",
-                  "clawhub/security",
                   "clawhub/acceptable-usage"
                 ]
               }

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -23,7 +23,7 @@ const mockWriteConfigFile = vi.fn<
 >(async () => {});
 const mockResolveSecretRefValue = vi.fn();
 const mockReadBestEffortRuntimeConfigSchema = vi.fn();
-const mockLoadPluginMetadataSnapshot = vi.fn(() => createPluginMetadataSnapshot());
+const mockLoadPluginMetadataSnapshot = vi.fn((_config: unknown) => createPluginMetadataSnapshot());
 
 vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();
@@ -53,7 +53,7 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>();
   return {
     ...actual,
-    loadPluginMetadataSnapshot: (...args: unknown[]) => mockLoadPluginMetadataSnapshot(...args),
+    loadPluginMetadataSnapshot: (config: unknown) => mockLoadPluginMetadataSnapshot(config),
   };
 });
 
@@ -186,7 +186,7 @@ function setExternalFeishuSchema() {
       plugins: [
         createPluginManifestRecord({
           id: "openclaw-lark",
-          origin: "external",
+          origin: "global",
           channels: ["feishu"],
           channelConfigs: {
             feishu: {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
+import type { PluginManifestRecord, PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { createCliRuntimeCapture, mockRuntimeModule } from "./test-runtime-capture.js";
 
 /**
@@ -21,6 +23,7 @@ const mockWriteConfigFile = vi.fn<
 >(async () => {});
 const mockResolveSecretRefValue = vi.fn();
 const mockReadBestEffortRuntimeConfigSchema = vi.fn();
+const mockLoadPluginMetadataSnapshot = vi.fn(() => createPluginMetadataSnapshot());
 
 vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();
@@ -45,6 +48,14 @@ vi.mock("../secrets/resolve.js", () => ({
 vi.mock("../config/runtime-schema.js", () => ({
   readBestEffortRuntimeConfigSchema: () => mockReadBestEffortRuntimeConfigSchema(),
 }));
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>();
+  return {
+    ...actual,
+    loadPluginMetadataSnapshot: (...args: unknown[]) => mockLoadPluginMetadataSnapshot(...args),
+  };
+});
 
 const { defaultRuntime, resetRuntimeCapture } = createCliRuntimeCapture();
 const mockLog = defaultRuntime.log;
@@ -105,6 +116,98 @@ function withRuntimeDefaults(resolved: OpenClawConfig): OpenClawConfig {
       } as never,
     } as never,
   };
+}
+
+function createPluginManifestRecord(
+  overrides: Partial<PluginManifestRecord> & Pick<PluginManifestRecord, "id">,
+): PluginManifestRecord {
+  return {
+    channels: [],
+    cliBackends: [],
+    hooks: [],
+    manifestPath: `/tmp/${overrides.id}/openclaw.plugin.json`,
+    origin: "bundled",
+    providers: [],
+    rootDir: `/tmp/${overrides.id}`,
+    skills: [],
+    source: `/tmp/${overrides.id}/index.js`,
+    ...overrides,
+  };
+}
+
+function createPluginMetadataSnapshot(
+  manifestRegistry: PluginManifestRegistry = { diagnostics: [], plugins: [] },
+): PluginMetadataSnapshot {
+  const plugins = manifestRegistry.plugins;
+  return {
+    policyHash: "test-policy",
+    index: {
+      version: 1,
+      hostContractVersion: "test",
+      compatRegistryVersion: "test",
+      migrationVersion: 1,
+      policyHash: "test-policy",
+      generatedAtMs: 0,
+      installRecords: {},
+      plugins: [],
+      diagnostics: [],
+    },
+    registryDiagnostics: [],
+    manifestRegistry,
+    plugins,
+    diagnostics: manifestRegistry.diagnostics,
+    byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
+    normalizePluginId: (pluginId: string) => pluginId.trim().toLowerCase(),
+    owners: {
+      channels: new Map(),
+      channelConfigs: new Map(),
+      providers: new Map(),
+      modelCatalogProviders: new Map(),
+      cliBackends: new Map(),
+      setupProviders: new Map(),
+      commandAliases: new Map(),
+      contracts: new Map(),
+    },
+    metrics: {
+      registrySnapshotMs: 0,
+      manifestRegistryMs: 0,
+      ownerMapsMs: 0,
+      totalMs: 0,
+      indexPluginCount: 0,
+      manifestPluginCount: plugins.length,
+    },
+  };
+}
+
+function setExternalFeishuSchema() {
+  mockLoadPluginMetadataSnapshot.mockReturnValue(
+    createPluginMetadataSnapshot({
+      diagnostics: [],
+      plugins: [
+        createPluginManifestRecord({
+          id: "openclaw-lark",
+          origin: "external",
+          channels: ["feishu"],
+          channelConfigs: {
+            feishu: {
+              schema: {
+                type: "object",
+                properties: {
+                  appId: { type: "string" },
+                  appSecret: { type: "string" },
+                  replyMode: { type: "string", enum: ["thread", "direct"] },
+                  footer: { type: "string" },
+                },
+                required: ["appId", "appSecret"],
+                additionalProperties: false,
+              },
+              uiHints: {},
+            },
+          },
+        }),
+      ],
+    }),
+  );
 }
 
 function makeInvalidSnapshot(params: {
@@ -233,6 +336,7 @@ describe("config cli", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetRuntimeCapture();
+    mockLoadPluginMetadataSnapshot.mockReturnValue(createPluginMetadataSnapshot());
     mockReadBestEffortRuntimeConfigSchema.mockResolvedValue({
       schema: {
         $schema: "http://json-schema.org/draft-07/schema#",
@@ -1266,6 +1370,35 @@ describe("config cli", () => {
 
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
       expectErrorIncludes("Dry run failed: config schema validation failed.");
+    });
+
+    it("dry-runs config patch channel fields against plugin-owned schemas", async () => {
+      setExternalFeishuSchema();
+      const resolved: OpenClawConfig = {
+        channels: {
+          feishu: {
+            appId: "app-id",
+            appSecret: "secret",
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+      const pathname = writeTempJson5File("openclaw-config-plugin-channel-schema", {
+        channels: {
+          feishu: {
+            appId: "app-id",
+            appSecret: "secret",
+            replyMode: "thread",
+            footer: "OpenClaw",
+          },
+        },
+      });
+
+      await runConfigCommand(["config", "patch", "--file", pathname, "--dry-run"]);
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockError).not.toHaveBeenCalledWith(expect.stringContaining("replyMode"));
+      expect(mockError).not.toHaveBeenCalledWith(expect.stringContaining("footer"));
     });
 
     it("fails dry-run when unsupported mutable paths receive SecretRef objects in value/json mode", async () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -24,7 +24,6 @@ import {
 } from "../config/types.secrets.js";
 import {
   collectUnsupportedSecretRefPolicyIssues,
-  validateConfigObjectRaw,
   validateConfigObjectRawWithPlugins,
 } from "../config/validation.js";
 import { SecretProviderSchema } from "../config/zod-schema.core.js";

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -25,6 +25,7 @@ import {
 import {
   collectUnsupportedSecretRefPolicyIssues,
   validateConfigObjectRaw,
+  validateConfigObjectRawWithPlugins,
 } from "../config/validation.js";
 import { SecretProviderSchema } from "../config/zod-schema.core.js";
 import { danger, info, success } from "../globals.js";
@@ -1579,14 +1580,8 @@ function formatAutoManagedMetaError(paths: readonly PathSegment[][]): string {
   ].join("\n");
 }
 
-function collectDryRunSchemaErrors(params: {
-  config: OpenClawConfig;
-  operations: ReadonlyArray<ConfigSetOperation>;
-}): ConfigSetDryRunError[] {
-  const validated = validateConfigObjectRaw(params.config, {
-    touchedPaths: params.operations.map((operation) => operation.setPath),
-    validateBundledChannels: true,
-  });
+function collectDryRunSchemaErrors(params: { config: OpenClawConfig }): ConfigSetDryRunError[] {
+  const validated = validateConfigObjectRawWithPlugins(params.config);
   if (validated.ok) {
     return [];
   }
@@ -1733,7 +1728,6 @@ async function runConfigOperations(params: {
       errors.push(
         ...collectDryRunSchemaErrors({
           config: nextConfig,
-          operations,
         }),
       );
     }

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -79,7 +79,7 @@ function createExternalFeishuSchemaRegistry(): PluginManifestRegistry {
     plugins: [
       createPluginManifestRecord({
         id: "openclaw-lark",
-        origin: "external",
+        origin: "global",
         channels: ["feishu"],
         channelConfigs: {
           feishu: {

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -73,6 +73,35 @@ function createPluginConfigSchemaRegistry(): PluginManifestRegistry {
   };
 }
 
+function createExternalFeishuSchemaRegistry(): PluginManifestRegistry {
+  return {
+    diagnostics: [],
+    plugins: [
+      createPluginManifestRecord({
+        id: "openclaw-lark",
+        origin: "external",
+        channels: ["feishu"],
+        channelConfigs: {
+          feishu: {
+            schema: {
+              type: "object",
+              properties: {
+                appId: { type: "string" },
+                appSecret: { type: "string" },
+                replyMode: { type: "string", enum: ["thread", "direct"] },
+                footer: { type: "string" },
+              },
+              required: ["appId", "appSecret"],
+              additionalProperties: false,
+            },
+            uiHints: {},
+          },
+        },
+      }),
+    ],
+  };
+}
+
 function createCompatPluginConfigSchemaRegistry(): PluginManifestRegistry {
   return {
     diagnostics: [],
@@ -199,6 +228,23 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
       // This is intentional — see comment above.
       expect(result.config.channels?.telegram?.dmPolicy).toBe("pairing");
     }
+  });
+
+  it("uses external plugin channel schemas for raw validation", () => {
+    mockLoadPluginManifestRegistry.mockReturnValue(createExternalFeishuSchemaRegistry());
+
+    const result = validateConfigObjectRawWithPlugins({
+      channels: {
+        feishu: {
+          appId: "app-id",
+          appSecret: "secret",
+          replyMode: "thread",
+          footer: "OpenClaw",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Make `config set/patch --dry-run` use plugin-aware raw config validation instead of bundled-only channel schema validation.
- Preserve strict channel validation while allowing externally-owned channel schema fields such as `channels.feishu.replyMode` and `channels.feishu.footer` when plugin metadata owns that channel config.
- Add CLI and lower-level validation regression coverage plus a changelog entry.

Fixes #77887.

## Real behavior proof

Behavior or issue addressed:
`openclaw config patch --dry-run` should validate channel config with the active plugin-owned channel schema. When an external Feishu/Lark plugin owns `channelConfigs.feishu.schema`, a dry-run patch containing `channels.feishu.replyMode` and `channels.feishu.footer` should pass instead of failing against the bundled Feishu schema's `additionalProperties: false` rule.

Real environment tested:
Windows 11 local OpenClaw source checkout, branch `fix-config-plugin-channel-schema`, Node/pnpm repo test harness. The proof uses the real config CLI command path with a mocked external plugin metadata snapshot so the CLI sees an external `openclaw-lark` owner for `channels.feishu`.

Exact steps or command run after this patch:
1. Configure the CLI test harness with an external plugin metadata snapshot for `openclaw-lark` that declares `channels: ["feishu"]` and a `channelConfigs.feishu.schema` containing `appId`, `appSecret`, `replyMode`, and `footer`.
2. Create a temporary JSON config patch file containing `channels.feishu.replyMode` and `channels.feishu.footer`.
3. Run `openclaw config patch --file <patch-file> --dry-run` through the real config CLI command registration.
4. Assert the command does not write the config and does not emit schema errors for `replyMode` or `footer`.

Evidence after fix:
Terminal transcript from the local source checkout:

```sh
pnpm test src/cli/config-cli.test.ts -- -t "dry-runs config patch channel fields" --reporter=verbose
```

```text
✓ config cli > config set builders and dry-run > dry-runs config patch channel fields against plugin-owned schemas
Test Files  1 passed (1)
Tests  1 passed | 85 skipped (86)
```

Observed result after fix:
The focused CLI proof passed. The dry-run accepted the plugin-owned Feishu fields and did not call the config writer.

What was not tested:
I did not install the real external `@larksuite/openclaw-lark` package in a live OpenClaw instance for this proof. The test exercises the real CLI dry-run path with plugin metadata shaped like the external plugin manifest so the validation behavior is covered without depending on a network install.

## Validation

```sh
pnpm test src/cli/config-cli.test.ts src/config/validation.channel-metadata.test.ts src/commands/doctor/shared/channel-plugin-blockers.test.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts -- --reporter=dot
pnpm exec oxfmt --check --threads=1 src/cli/config-cli.ts src/cli/config-cli.test.ts src/config/validation.channel-metadata.test.ts CHANGELOG.md
pnpm exec oxlint src/cli/config-cli.ts src/cli/config-cli.test.ts src/config/validation.channel-metadata.test.ts
pnpm check:changed
git diff --check
```

All passed locally on Windows.
