### PR TITLE
fix(sessions): preserve pending subagent rows during maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Media-understanding: retry transient remote attachment fetch failures before audio or vision processing, so Discord voice notes are not lost after one network/CDN blip. Fixes #74316. Thanks @vyctorbrzezowski and @gabrielexito-stack.
+- Sessions: preserve active and cleanup-pending subagent session rows during enforced max-entry maintenance, preventing completion handoffs from reporting `(no output)`, `session_id: unknown`, and zero token stats after the child already finished. Fixes #81492. Thanks @bek91.
 - iMessage: stop sending visible `<media:image>` placeholder text for media-only native image sends while preserving the internal echo key that prevents self-echo duplicate replies. (#81209) Thanks @homer-byte.
 - Agents/sessions: create configured agent main sessions before first `sessions_send` or gateway send, so agent-to-agent messages no longer fail when the target agent has not started yet.
 - gateway: pass Talk session scope to resolver [AI]. (#81379) Thanks @pgondhi987.

--- a/extensions/matrix/src/channel.directory.test.ts
+++ b/extensions/matrix/src/channel.directory.test.ts
@@ -4,7 +4,7 @@ import type { RuntimeEnv } from "../runtime-api.js";
 import { matrixPlugin } from "./channel.js";
 import { resolveMatrixAccount } from "./matrix/accounts.js";
 import { resolveMatrixConfigForAccount } from "./matrix/client/config.js";
-import { installMatrixTestRuntime } from "./test-runtime.js";
+import { installMatrixTestRuntime } from "./test-support/test-runtime.js";
 import type { CoreConfig } from "./types.js";
 
 function requireMatrixDirectory() {

--- a/extensions/matrix/src/channel.setup.test.ts
+++ b/extensions/matrix/src/channel.setup.test.ts
@@ -12,7 +12,7 @@ vi.mock("./matrix/actions/verification.js", () => ({
 import { matrixConfigAdapter } from "./config-adapter.js";
 import { runMatrixSetupBootstrapAfterConfigWrite } from "./setup-bootstrap.js";
 import { matrixSetupAdapter } from "./setup-core.js";
-import { installMatrixTestRuntime } from "./test-runtime.js";
+import { installMatrixTestRuntime } from "./test-support/test-runtime.js";
 import type { CoreConfig } from "./types.js";
 
 describe("matrix setup post-write bootstrap", () => {

--- a/extensions/matrix/src/matrix/accounts.readiness.test.ts
+++ b/extensions/matrix/src/matrix/accounts.readiness.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { installMatrixTestRuntime } from "../test-runtime.js";
+import { installMatrixTestRuntime } from "../test-support/test-runtime.js";
 import type { CoreConfig } from "../types.js";
 import { resolveMatrixAccount } from "./accounts.js";
 

--- a/extensions/matrix/src/matrix/client.test.ts
+++ b/extensions/matrix/src/matrix/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { installMatrixTestRuntime } from "../test-runtime.js";
+import { installMatrixTestRuntime } from "../test-support/test-runtime.js";
 import type { CoreConfig } from "../types.js";
 import {
   backfillMatrixAuthDeviceIdAfterStartup,

--- a/extensions/matrix/src/matrix/client/config.test.ts
+++ b/extensions/matrix/src/matrix/client/config.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { LookupFn } from "../../runtime-api.js";
-import { installMatrixTestRuntime } from "../../test-runtime.js";
+import { installMatrixTestRuntime } from "../../test-support/test-runtime.js";
 import type { CoreConfig } from "../../types.js";
 import {
   getMatrixScopedEnvVarNames,

--- a/extensions/matrix/src/matrix/client/storage.test.ts
+++ b/extensions/matrix/src/matrix/client/storage.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveMatrixAccountStorageRoot } from "../../storage-paths.js";
-import { installMatrixTestRuntime } from "../../test-runtime.js";
+import { installMatrixTestRuntime } from "../../test-support/test-runtime.js";
 import {
   claimCurrentTokenStorageState,
   maybeMigrateLegacyStorage,

--- a/extensions/matrix/src/matrix/credentials.test.ts
+++ b/extensions/matrix/src/matrix/credentials.test.ts
@@ -3,7 +3,7 @@ import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { installMatrixTestRuntime } from "../test-runtime.js";
+import { installMatrixTestRuntime } from "../test-support/test-runtime.js";
 import {
   credentialsMatchConfig,
   loadMatrixCredentials,

--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { installMatrixMonitorTestRuntime } from "../../test-runtime.js";
+import { installMatrixMonitorTestRuntime } from "../../test-support/test-runtime.js";
 import type { MatrixClient } from "../sdk.js";
 import {
   createMatrixHandlerTestHarness,

--- a/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { installMatrixMonitorTestRuntime } from "../../test-runtime.js";
+import { installMatrixMonitorTestRuntime } from "../../test-support/test-runtime.js";
 import {
   createMatrixHandlerTestHarness,
   createMatrixRoomMessageEvent,

--- a/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { installMatrixMonitorTestRuntime } from "../../test-runtime.js";
+import { installMatrixMonitorTestRuntime } from "../../test-support/test-runtime.js";
 import { MatrixMediaSizeLimitError } from "../media-errors.js";
 import {
   createMatrixHandlerTestHarness,

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -6,7 +6,7 @@ import {
   registerSessionBindingAdapter,
 } from "openclaw/plugin-sdk/session-binding-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { installMatrixMonitorTestRuntime } from "../../test-runtime.js";
+import { installMatrixMonitorTestRuntime } from "../../test-support/test-runtime.js";
 import { MATRIX_OPENCLAW_FINALIZED_PREVIEW_KEY } from "../send/types.js";
 import { createMatrixRoomMessageHandler, MatrixRetryableInboundError } from "./handler.js";
 import {

--- a/extensions/matrix/src/matrix/monitor/handler.thread-root-media.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.thread-root-media.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { installMatrixMonitorTestRuntime } from "../../test-runtime.js";
+import { installMatrixMonitorTestRuntime } from "../../test-support/test-runtime.js";
 import {
   createMatrixHandlerTestHarness,
   createMatrixRoomMessageEvent,

--- a/extensions/matrix/src/onboarding.resolve.test.ts
+++ b/extensions/matrix/src/onboarding.resolve.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WizardPrompter } from "../runtime-api.js";
-import { installMatrixTestRuntime } from "./test-runtime.js";
+import { installMatrixTestRuntime } from "./test-support/test-runtime.js";
 import type { CoreConfig } from "./types.js";
 
 const resolveMatrixTargetsMock = vi.hoisted(() =>

--- a/extensions/matrix/src/onboarding.test.ts
+++ b/extensions/matrix/src/onboarding.test.ts
@@ -14,7 +14,7 @@ import {
   runMatrixAddAccountAllowlistConfigure,
   runMatrixInteractiveConfigure,
 } from "./onboarding.test-harness.js";
-import { installMatrixTestRuntime } from "./test-runtime.js";
+import { installMatrixTestRuntime } from "./test-support/test-runtime.js";
 import type { CoreConfig } from "./types.js";
 
 vi.mock("./matrix/deps.js", () => ({

--- a/extensions/matrix/src/test-support/test-runtime.ts
+++ b/extensions/matrix/src/test-support/test-runtime.ts
@@ -4,8 +4,8 @@ import {
 } from "openclaw/plugin-sdk/channel-mention-gating";
 import { createPluginRuntimeMediaMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import { vi } from "vitest";
-import type { PluginRuntime } from "./runtime-api.js";
-import { setMatrixRuntime } from "./runtime.js";
+import type { PluginRuntime } from "../runtime-api.js";
+import { setMatrixRuntime } from "../runtime.js";
 
 type MatrixTestRuntimeOptions = {
   cfg?: Record<string, unknown>;

--- a/scripts/e2e/lib/release-user-journey/clickclack-fixture.mjs
+++ b/scripts/e2e/lib/release-user-journey/clickclack-fixture.mjs
@@ -100,7 +100,7 @@ function readBody(req) {
   });
 }
 
-function createMessage({ body, author = humanUser, parentMessageId = undefined }) {
+function createMessage({ body, author = humanUser, parentMessageId }) {
   messageSeq += 1;
   const id = `msg_${messageSeq}`;
   const message = {

--- a/scripts/lib/config-boundary-guard.mjs
+++ b/scripts/lib/config-boundary-guard.mjs
@@ -15,6 +15,8 @@ const COMPAT_CONFIG_API_FILES = new Set([
   "src/plugins/compat/registry.ts",
   "src/plugins/contracts/config-boundary-guard.test.ts",
   "src/plugins/contracts/deprecated-internal-config-api.test.ts",
+  "src/plugins/registry.runtime-config.test.ts",
+  "src/plugins/registry.ts",
   "src/plugins/runtime/runtime-config.test.ts",
   "src/plugins/runtime/runtime-config.ts",
   "src/plugins/runtime/types-core.ts",

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -163,9 +163,13 @@ vi.mock("./subagent-orphan-recovery.js", () => ({
 
 describe("subagent registry seam flow", () => {
   let mod: typeof import("./subagent-registry.js");
+  let collectSessionMaintenancePreserveKeys: typeof import("../config/sessions/store-maintenance-runtime.js").collectSessionMaintenancePreserveKeys;
 
   beforeAll(async () => {
-    mod = await import("./subagent-registry.js");
+    [mod, { collectSessionMaintenancePreserveKeys }] = await Promise.all([
+      import("./subagent-registry.js"),
+      import("../config/sessions/store-maintenance-runtime.js"),
+    ]);
   });
 
   beforeEach(() => {
@@ -217,6 +221,48 @@ describe("subagent registry seam flow", () => {
       resolveContextEngine: mocks.resolveContextEngine,
     });
     mod.resetSubagentRegistryForTests({ persist: false });
+  });
+
+  it("preserves active and cleanup-pending child session keys during session maintenance", () => {
+    const now = Date.now();
+    mod.registerSubagentRun({
+      runId: "run-active-preserve",
+      childSessionKey: "agent:main:subagent:active-preserve",
+      requesterSessionKey: "agent:main:slack:dm:u1",
+      requesterDisplayKey: "slack:u1",
+      task: "active preserve",
+      cleanup: "delete",
+      expectsCompletionMessage: true,
+    });
+    mod.addSubagentRunForTests({
+      runId: "run-ended-preserve",
+      childSessionKey: "agent:main:subagent:ended-preserve",
+      requesterSessionKey: "agent:main:slack:dm:u1",
+      requesterDisplayKey: "slack:u1",
+      task: "ended preserve",
+      cleanup: "delete",
+      createdAt: now - 100,
+      endedAt: now,
+      expectsCompletionMessage: true,
+    });
+    mod.addSubagentRunForTests({
+      runId: "run-cleaned-up",
+      childSessionKey: "agent:main:subagent:cleaned-up",
+      requesterSessionKey: "agent:main:slack:dm:u1",
+      requesterDisplayKey: "slack:u1",
+      task: "cleaned up",
+      cleanup: "delete",
+      createdAt: now - 200,
+      endedAt: now - 100,
+      cleanupCompletedAt: now,
+      expectsCompletionMessage: true,
+    });
+
+    const keys = collectSessionMaintenancePreserveKeys();
+
+    expect(keys).toContain("agent:main:subagent:active-preserve");
+    expect(keys).toContain("agent:main:subagent:ended-preserve");
+    expect(keys).not.toContain("agent:main:subagent:cleaned-up");
   });
 
   afterEach(() => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -6,6 +6,7 @@ import {
   resolveStorePath,
   type SessionEntry,
 } from "../config/sessions.js";
+import { registerSessionMaintenancePreserveKeysProvider } from "../config/sessions/store-maintenance-runtime.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ResolveContextEngineOptions } from "../context-engine/registry.js";
 import type { ContextEngine, SubagentEndReason } from "../context-engine/types.js";
@@ -65,6 +66,7 @@ import {
 } from "./subagent-registry-state.js";
 import { configureSubagentRegistrySteerRuntime } from "./subagent-registry-steer-runtime.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import { hasSubagentRunEnded, isLiveUnendedSubagentRun } from "./subagent-run-liveness.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 
 export type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -137,6 +139,37 @@ const defaultSubagentRegistryDeps: SubagentRegistryDeps = {
 };
 
 let subagentRegistryDeps: SubagentRegistryDeps = defaultSubagentRegistryDeps;
+
+function shouldPreserveSubagentSessionForMaintenance(
+  entry: SubagentRunRecord,
+  now = Date.now(),
+): boolean {
+  if (typeof entry.cleanupCompletedAt === "number") {
+    return false;
+  }
+  if (isLiveUnendedSubagentRun(entry, now)) {
+    return true;
+  }
+  return hasSubagentRunEnded(entry);
+}
+
+export function collectSubagentSessionMaintenancePreserveKeys(): string[] {
+  const now = Date.now();
+  const preserveKeys = new Set<string>();
+  for (const entry of subagentRuns.values()) {
+    if (!shouldPreserveSubagentSessionForMaintenance(entry, now)) {
+      continue;
+    }
+    const childSessionKey = entry.childSessionKey.trim();
+    if (childSessionKey) {
+      preserveKeys.add(childSessionKey);
+    }
+  }
+  return [...preserveKeys];
+}
+
+registerSessionMaintenancePreserveKeysProvider(collectSubagentSessionMaintenancePreserveKeys);
+
 type ContextEngineInitModule = Pick<
   {
     ensureContextEnginesInitialized: () => void;

--- a/src/config/sessions/store-maintenance-runtime.ts
+++ b/src/config/sessions/store-maintenance-runtime.ts
@@ -5,6 +5,10 @@ import {
   type ResolvedSessionMaintenanceConfig,
 } from "./store-maintenance.js";
 
+export type SessionMaintenancePreserveKeysProvider = () => Iterable<string> | undefined;
+
+const preserveKeysProviders = new Set<SessionMaintenancePreserveKeysProvider>();
+
 export function resolveMaintenanceConfig(): ResolvedSessionMaintenanceConfig {
   let maintenance: SessionMaintenanceConfig | undefined;
   try {
@@ -13,4 +17,41 @@ export function resolveMaintenanceConfig(): ResolvedSessionMaintenanceConfig {
     // Config may not be available in narrow test/runtime helpers.
   }
   return resolveMaintenanceConfigFromInput(maintenance);
+}
+
+export function registerSessionMaintenancePreserveKeysProvider(
+  provider: SessionMaintenancePreserveKeysProvider,
+): () => void {
+  preserveKeysProviders.add(provider);
+  return () => {
+    preserveKeysProviders.delete(provider);
+  };
+}
+
+export function collectSessionMaintenancePreserveKeys(
+  seedKeys?: Iterable<string | undefined>,
+): Set<string> | undefined {
+  let preserveKeys: Set<string> | undefined;
+  const addKey = (key: string | undefined) => {
+    const trimmed = key?.trim();
+    if (!trimmed) {
+      return;
+    }
+    preserveKeys ??= new Set<string>();
+    preserveKeys.add(trimmed);
+  };
+
+  for (const key of seedKeys ?? []) {
+    addKey(key);
+  }
+  for (const provider of preserveKeysProviders) {
+    try {
+      for (const key of provider() ?? []) {
+        addKey(key);
+      }
+    } catch {
+      // Preserve providers are lifecycle hints; maintenance must remain best-effort.
+    }
+  }
+  return preserveKeys;
 }

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -17,6 +17,7 @@ vi.mock("../config.js", async () => ({
 
 import { getRuntimeConfig } from "../config.js";
 import { runSessionsCleanup } from "./cleanup-service.js";
+import { registerSessionMaintenancePreserveKeysProvider } from "./store-maintenance-runtime.js";
 import {
   clearSessionStoreCacheForTest,
   loadSessionStore,
@@ -866,6 +867,27 @@ describe("Integration: saveSessionStore with pruning", () => {
       name.startsWith(`${oldestSessionId}.jsonl.deleted.`),
     );
     expect(archivedOldestTranscripts.length).toBeGreaterThan(0);
+  });
+
+  it("keeps provider-preserved entries when maxEntries capping runs", async () => {
+    applyCappedMaintenanceConfig(mockLoadConfig);
+
+    const now = Date.now();
+    const unregister = registerSessionMaintenancePreserveKeysProvider(() => ["oldest", "newest"]);
+    try {
+      const store: Record<string, SessionEntry> = {
+        oldest: { sessionId: "oldest-session", updatedAt: now - DAY_MS },
+        newest: { sessionId: "newest-session", updatedAt: now },
+      };
+
+      await saveSessionStore(storePath, store);
+
+      const loaded = loadSessionStore(storePath, { skipCache: true });
+      expect(loaded).toHaveProperty("oldest");
+      expect(loaded).toHaveProperty("newest");
+    } finally {
+      unregister();
+    }
   });
 
   it("does not archive external transcript paths when capping entries", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -23,7 +23,10 @@ import {
 } from "./store-cache.js";
 import { normalizeStoreSessionKey, resolveSessionStoreEntry } from "./store-entry.js";
 import { loadSessionStore, normalizeSessionStore } from "./store-load.js";
-import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
+import {
+  collectSessionMaintenancePreserveKeys,
+  resolveMaintenanceConfig,
+} from "./store-maintenance-runtime.js";
 import {
   capEntryCount,
   getActiveSessionMaintenanceWarning,
@@ -282,9 +285,9 @@ async function saveSessionStoreUnlocked(
         diskBudget,
       });
     } else {
-      const preserveSessionKeys = opts?.activeSessionKey
-        ? new Set([opts.activeSessionKey])
-        : undefined;
+      const preserveSessionKeys = collectSessionMaintenancePreserveKeys(
+        opts?.activeSessionKey ? [opts.activeSessionKey] : undefined,
+      );
       // Prune stale entries and cap total count before serializing.
       const removedSessionFiles = new Map<string, string | undefined>();
       const pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -263,6 +263,25 @@ describe("node.invoke approval bypass", () => {
     return ws;
   };
 
+  const approveConnectedNodePairing = async (nodeId: string) => {
+    const ws = await connectOperator(["operator.pairing", "operator.admin"]);
+    try {
+      const listed = await rpcReq<{
+        pending?: Array<{ requestId?: string; nodeId?: string }>;
+      }>(ws, "node.pair.list", {});
+      expect(listed.ok).toBe(true);
+      const pending = listed.payload?.pending?.find((entry) => entry.nodeId === nodeId);
+      if (pending?.requestId) {
+        const approved = await rpcReq(ws, "node.pair.approve", {
+          requestId: pending.requestId,
+        });
+        expect(approved.ok).toBe(true);
+      }
+    } finally {
+      ws.close();
+    }
+  };
+
   const connectOperatorWithNewDevice = async (scopes: string[]) => {
     const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
     const publicKeyPem = publicKey.export({ type: "spki", format: "pem" });
@@ -359,6 +378,7 @@ describe("node.invoke approval bypass", () => {
         clearTimeout(timer);
       }
     }
+    await approveConnectedNodePairing(resolvedDeviceIdentity.deviceId);
     return client;
   };
 

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -125,7 +125,7 @@ export async function applySessionsPatchToStore(params: {
         updatedAt: Math.max(existing.updatedAt ?? 0, now),
       }
     : {
-        ...(existing ?? {}),
+        ...existing,
         sessionId: randomUUID(),
         sessionFile: undefined,
         updatedAt: Math.max(existing?.updatedAt ?? 0, now),

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -27,12 +27,13 @@ describe("plugin registry runtime config scope", () => {
       previousHash: null,
       nextHash: "next",
     } as unknown as Awaited<ReturnType<PluginRuntime["config"]["replaceConfigFile"]>>;
+    const mutateConfigFile: PluginRuntime["config"]["mutateConfigFile"] = async () => ({
+      ...replaceResult,
+      result: undefined,
+    });
     const configRuntime = {
       current: vi.fn(() => config),
-      mutateConfigFile: async <T = void>() => ({
-        ...replaceResult,
-        result: undefined as T | undefined,
-      }),
+      mutateConfigFile,
       replaceConfigFile: async () => replaceResult,
       loadConfig: vi.fn(() => {
         loadScope = getPluginRuntimeGatewayRequestScope();
@@ -42,13 +43,16 @@ describe("plugin registry runtime config scope", () => {
         writeScope = getPluginRuntimeGatewayRequestScope();
       }),
     } satisfies PluginRuntime["config"];
-    const pluginRegistry = createTestRegistry({ config: configRuntime } as PluginRuntime);
+    const pluginRegistry = createTestRegistry({
+      config: configRuntime,
+    } as unknown as PluginRuntime);
     const record = createPluginRecord({
       id: "legacy-plugin",
       name: "Legacy Plugin",
       source: "/plugins/legacy-plugin/index.js",
       origin: "global",
       enabled: true,
+      configSchema: false,
     });
     const api = pluginRegistry.createApi(record, { config });
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2396,7 +2396,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
           } satisfies PluginRuntime["state"];
         }
         if (prop === "config") {
-          const config = Reflect.get(target, prop, receiver) as PluginRuntime["config"];
+          const config = Reflect.get(target, prop, receiver);
           return {
             ...config,
             loadConfig: () => runWithPluginScope(() => config.loadConfig()),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: enforced `session.maintenance.maxEntries` could cap a just-finished subagent session row before the announce/result path read its output.
- Why it matters: parent sessions could receive a successful completion handoff with `(no output)`, `session_id: unknown`, and zero token stats even though the child produced a real result.
- What changed: session maintenance now supports lifecycle-owned preserve-key providers, and the subagent registry registers active plus cleanup-pending child session keys until cleanup is complete.
- CI cleanup: also carries small latest-main guard fixes needed for the required lint/type/contract shards: plugin registry config-scope test cleanup, Matrix test helper moved under test-support, and release journey fixture lint cleanup.
- What did NOT change (scope boundary): no archive transcript fallback, delivery retry policy, or session disk-budget policy changes are included here.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #81492
- Supersedes #81496
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: subagent child session rows remain available to announce/result capture while active or cleanup-pending, even when entry-count maintenance is enforcing a saturated cap.
- Real environment tested: local Linux checkout on Node 24 / pnpm 11.1.0.
- Exact steps or command run after this patch: `pnpm test src/config/sessions/store.pruning.integration.test.ts src/agents/subagent-registry.test.ts`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): real production-module terminal proof, no Vitest and no mocks:

```text
$ tmpdir=$(mktemp -d); PROOF_DIR="$tmpdir" OPENCLAW_SESSION_CACHE_TTL_MS=0 pnpm exec tsx -e '<production saveSessionStore proof>'
[sessions/store] capped session entry count
{
  "keys": [
    "agent:main:subagent:pending-proof"
  ],
  "preservedPendingSubagent": true,
  "cappedFreshDm": true
}
```

- Observed result after fix: with enforced `maxEntries: 1`, the lifecycle-preserved pending subagent row remained in the real session store while the unpreserved fresh DM row was capped.
- What was not tested: live Slack/macOS reproduction from the original report was not rerun in this environment.
- Before evidence (optional but encouraged): source-visible root cause matched the issue report: capping previously only preserved the active writer key, not pending subagent child keys.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: enforced session maintenance built its preserve set from only `activeSessionKey`, while subagent announce/result capture later depended on the child session row still existing.
- Missing detection / guardrail: no regression covered max-entry capping while subagent delivery cleanup was still pending.
- Contributing context (if known): subagent keys are synthetic session keys, so generic protected session rules intentionally did not protect them.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/sessions/store.pruning.integration.test.ts`, `src/agents/subagent-registry.test.ts`.
- Scenario the test should lock in: max-entry maintenance honors lifecycle preserve keys, and the subagent registry preserves active plus cleanup-pending child sessions but not cleanup-completed ones.
- Why this is the smallest reliable guardrail: it proves the generic maintenance seam and the subagent-owned lifecycle key provider without needing a live Slack channel.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Subagent completion handoffs are less likely to lose successful child output or token stats under enforced session-entry caps.

## Diagram (if applicable)

```text
Before:
[subagent finishes] -> [maxEntries capping removes child row] -> [announce reads no output]

After:
[subagent active/cleanup-pending] -> [registry preserves child row] -> [announce can read child output]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux local checkout
- Runtime/container: Node 24, pnpm 11.1.0
- Model/provider: N/A
- Integration/channel (if any): subagent/session maintenance seam; no live Slack rerun
- Relevant config (redacted): `session.maintenance.mode = "enforce"`, low `maxEntries` in regression test

### Steps

1. Register/seed lifecycle preserve keys for active and cleanup-pending subagent rows.
2. Run enforced session maintenance with `maxEntries` below the preserved row count.
3. Verify preserved child rows remain available and cleanup-completed rows are not preserved.

### Expected

- Active and cleanup-pending subagent child session rows survive entry-count maintenance.

### Actual

- Active and cleanup-pending subagent child session rows survive entry-count maintenance.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: real production-module session-store cap proof; focused regression tests; targeted formatting; production core typecheck; architecture, lint, plugin contract, and affected Matrix test checks.
- Edge cases checked: cleanup-completed subagent rows are not preserved; provider-preserved rows may exceed the cap when all candidates are protected.
- What you did **not** verify: live Slack/macOS reproduction.

Additional validation notes:

- Real production-module terminal proof above passed.
- `pnpm test src/config/sessions/store.pruning.integration.test.ts src/agents/subagent-registry.test.ts` passed.
- `pnpm tsgo:core` passed.
- `pnpm check:architecture` passed.
- `pnpm check:test-types` passed.
- `pnpm lint --threads=8` passed before the replacement PR branch; `pnpm lint:core` passed after the latest amend.
- `pnpm test src/plugins/registry.runtime-config.test.ts src/config/sessions/store.pruning.integration.test.ts src/agents/subagent-registry.test.ts` passed.
- `pnpm test src/gateway/server.node-invoke-approval-bypass.test.ts src/gateway/server.sessions-send.test.ts` passed after fixing the latest-main node-pairing test helper.
- `pnpm test:contracts:plugins` passed.
- `pnpm test extensions/matrix/src/channel.setup.test.ts extensions/matrix/src/channel.directory.test.ts extensions/matrix/src/onboarding.test.ts extensions/matrix/src/onboarding.resolve.test.ts extensions/matrix/src/matrix/client.test.ts extensions/matrix/src/matrix/accounts.readiness.test.ts extensions/matrix/src/matrix/credentials.test.ts extensions/matrix/src/matrix/client/config.test.ts extensions/matrix/src/matrix/client/storage.test.ts extensions/matrix/src/matrix/monitor/handler.test.ts extensions/matrix/src/matrix/monitor/handler.group-history.test.ts extensions/matrix/src/matrix/monitor/handler.thread-root-media.test.ts extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts` passed.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: preserving lifecycle-critical subagent rows can temporarily exceed `maxEntries`.
  - Mitigation: preservation ends after subagent cleanup completes, and only active or cleanup-pending child keys are contributed by the subagent registry.



