### PR TITLE
docs(browser): add Notte cloud browser to direct WebSocket CDP providers [AI]

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -482,6 +482,42 @@ Notes:
 - See the [Browserbase docs](https://docs.browserbase.com) for full API
   reference, SDK guides, and integration examples.
 
+### Notte
+
+[Notte](https://www.notte.cc) is a cloud platform for running headless
+browsers with built-in stealth, residential proxies, and a CDP-native
+WebSocket gateway.
+
+```json5
+{
+  browser: {
+    enabled: true,
+    defaultProfile: "notte",
+    remoteCdpTimeoutMs: 3000,
+    remoteCdpHandshakeTimeoutMs: 5000,
+    profiles: {
+      notte: {
+        cdpUrl: "wss://us-prod.notte.cc/sessions/connect?token=<NOTTE_API_KEY>",
+        color: "#7C3AED",
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- [Sign up](https://console.notte.cc) and copy your **API Key** from the
+  console settings page.
+- Replace `<NOTTE_API_KEY>` with your real Notte API key.
+- Notte auto-creates a browser session on WebSocket connect, so no manual
+  session creation step is needed. The session is destroyed when the
+  WebSocket disconnects.
+- The free tier allows five concurrent sessions and 100 lifetime browser
+  hours. See [pricing](https://www.notte.cc/#pricing) for paid plan limits.
+- See the [Notte docs](https://docs.notte.cc) for full API reference, SDK
+  guides, and integration examples.
+
 ## Security
 
 Key ideas:


### PR DESCRIPTION
## Summary

- **Problem:** [Notte](https://www.notte.cc) is a CDP-compatible cloud browser provider in the same category as Browserbase and Browserless, but isn't listed under [`docs/tools/browser.md` → Direct WebSocket CDP providers](https://docs.openclaw.ai/tools/browser#direct-websocket-cdp-providers). Users have to figure out the config shape themselves.
- **Why it matters:** That section was generically framed in #31085 as *"any WSS-based provider works"*, but until a provider is listed, new users default to the documented options. A short config-snippet documenting Notte unblocks discovery without any code change.
- **What changed:** Adds one `### Notte` subsection right after `### Browserbase` in `docs/tools/browser.md` — single-sentence blurb, JSON5 config snippet, and a Notes bullet list. Mirrors the Browserbase subsection structure exactly.
- **What did NOT change (scope boundary):** No source code touched. No tests touched. No new CDP URL shape. Uses the bare-`wss://` root fallback path already supported since #31085 (verified end-to-end against `wss://us-prod.notte.cc/sessions/connect`).

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #31085 — `feat(browser): support direct WebSocket CDP URLs` (introduced the WSS-root fallback path this PR documents a new use of)
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Notte's WSS CDP endpoint is now documented as a supported provider, mirroring the existing Browserbase listing.
- **Real environment tested:** macOS 25.2.0 + OpenClaw `2026.5.7 (eeef486)` from Homebrew, talking to `wss://us-prod.notte.cc/sessions/connect?token=<NOTTE_API_KEY>`. No local code changes — the documented config dropped straight into `~/.openclaw/openclaw.json`.
- **Exact steps or command run after this patch:**

  ```
  $ openclaw browser --browser-profile notte open https://example.com
  $ openclaw browser --browser-profile notte screenshot
  ```

- **Evidence after fix:**

  Reproduced today against the live `wss://us-prod.notte.cc/sessions/connect` endpoint:

  ```
  $ openclaw browser --browser-profile notte open https://example.com
  opened: https://example.com/
  tab: t4
  id: 7FE04AC44931A6E1C799DE4ABF0DC807
  ```

  A screenshot captured via `openclaw browser --browser-profile notte screenshot` against the same session yesterday is a 1254×1111 PNG of the actual rendered `example.com` page (will paste image inline when posting upstream). The local `sharp` optional dep is needed for OpenClaw's screenshot post-processing path, otherwise the documented config drives the live tab end-to-end.

  Playwright `connectOverCDP` flow against the same URL (today, `DEBUG=pw:protocol`):

  | Step | Time |
  |---|---|
  | `connectOverCDP` | 695ms |
  | `context.newCDPSession(page)` | 169ms |
  | `session.send("Target.getTargetInfo")` → targetId | 87ms |
  | `page.goto("https://example.com")` | 631ms |
  | **Total** | **1.8s** |

- **Observed result after fix:** OpenClaw drives a real chromium tab through Notte's CDP gateway. `open` returns a real `targetId`. `screenshot` returns a real PNG. Playwright `newCDPSession` completes in <500ms.
- **What was not tested:** Long-running sessions (>10 min), tab-limit enforcement under heavy concurrent open/close, the `attachOnly` mode of OpenClaw's remote-CDP profile. None of these are gated by this docs change.

## Root Cause (if applicable)

N/A — this PR is not a bug fix.

## Regression Test Plan (if applicable)

N/A — this PR is docs-only, and the underlying feature (WSS-root CDP support) is already covered by the tests added in #31085. No new test surface is required.

## User-visible / Behavior Changes

None. Users who don't read the new subsection are unaffected. Users who do can now configure a `notte` profile by copy-pasting the snippet, replacing `<NOTTE_API_KEY>` with their API key.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No** — the documented config uses the existing `cdpUrl` field with the existing `?token=` query convention (same shape as Browserbase's `?apiKey=`).
- New/changed network calls? **No** — uses the existing WSS CDP transport path.
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS 25.2.0
- Runtime/container: OpenClaw `2026.5.7 (eeef486)` from Homebrew, Node `22.16.0`
- Model/provider: N/A (no LLM involved in the docs change)
- Integration/channel: browser plugin (`extensions/browser`)
- Relevant config (redacted):

  ```json
  {
    "browser": {
      "enabled": true,
      "defaultProfile": "notte",
      "remoteCdpTimeoutMs": 3000,
      "remoteCdpHandshakeTimeoutMs": 5000,
      "profiles": {
        "notte": {
          "cdpUrl": "wss://us-prod.notte.cc/sessions/connect?token=<redacted>",
          "color": "#7C3AED"
        }
      }
    }
  }
  ```

### Steps

1. Drop the documented config block into `~/.openclaw/openclaw.json` (with a real `NOTTE_API_KEY` from `console.notte.cc`).
2. `openclaw browser --browser-profile notte start`
3. `openclaw browser --browser-profile notte open https://example.com`
4. `openclaw browser --browser-profile notte screenshot`

### Expected

- `start` → `🦞 browser [notte] running: true`
- `open` → exits 0 with a non-empty `id` (CDP `targetId`)
- `screenshot` → emits a `MEDIA:` line pointing at a non-empty PNG

### Actual

Matches expected. See "Evidence after fix" above.

## Evidence

- [x] Failing test/log before + passing after (N/A — docs-only, no test was failing)
- [x] Trace/log snippets (included in Real Behavior Proof)
- [x] Screenshot/recording (PNG path captured; will paste image when posting upstream)
- [ ] Perf numbers (N/A)

## Human Verification (required)

- **Verified scenarios:** I personally ran each of `openclaw browser --browser-profile notte {start, status, open, screenshot}` against `wss://us-prod.notte.cc/sessions/connect` and confirmed the documented config works as written. I also independently drove the same endpoint via Playwright's `connectOverCDP` (`context.newCDPSession`, `goto`, `Target.getTargetInfo`) and via raw CDP (`Target.attachToBrowserTarget`, `Target.attachToTarget`, `Browser.getVersion`) to confirm the protocol-level behaviour matches what's documented.
- **Edge cases checked:** Re-runs at +250ms and across multiple fresh sessions returned consistent results; no flake observed in the documented happy path.
- **What I did not verify:** Tab discovery polling under heavy load, the `attachOnly` profile mode, behavior past the Notte free-tier quota.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No** — no schema change, no new required key.
- Migration needed? **No**

## AI-Assisted Disclosure 🤖

This PR was authored with Claude (Opus 4.7). Per CONTRIBUTING.md §AI/Vibe-Coded PRs:

- [x] Marked as AI-assisted in the title (`[AI]` suffix) and description
- [x] Human-run real behavior proof included (see "Real behavior proof" + "Human Verification" above — I personally ran every `openclaw` command against the live `us-prod.notte.cc` endpoint and verified each output)
- [x] Confirmed I understand what the change does (it adds a docs subsection mirroring the existing Browserbase subsection; no source code is touched; no new CDP shape is introduced; the underlying feature was added in #31085)
- [x] `codex review --base origin/main` run locally (Codex CLI `v0.130.0`, model `gpt-5.3-codex`): *"The diff only adds a new documentation section for configuring Notte in `docs/tools/browser.md` and does not introduce code-path changes. I did not identify any actionable correctness issues in the added content."*
- [x] Will resolve / reply to bot review conversations after addressing them

Session prompts / logs available on request.

## Risks and Mitigations

- **Risk:** Notte's documented URL or auth convention changes; users following the snippet hit broken config.
  - **Mitigation:** I'll watch for upstream issue reports on the Notte side and submit a follow-up docs PR if anything moves. The snippet uses the stable `wss://us-prod.notte.cc/sessions/connect?token=…` endpoint that's already used in production.
- **Risk:** Notte service availability outside the documented window.
  - **Mitigation:** Out of scope for OpenClaw — same caveat applies to Browserbase / Browserless.
