### PR TITLE
fix: restore Codex cron automation compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 - Validate node exec event provenance [AI]. (#81071) Thanks @pgondhi987.
 - Gateway: keep active reply runs visible to stuck-session diagnostics and clear no-active-work recovery state, preventing stale queued lanes after compaction or tool failures. Fixes #80677. (#81302)
 - Codex app-server: rotate incompatible context-engine-managed native threads so Lossless-managed sessions do not resume stale hidden Codex history. (#81223) Thanks @jalehman.
+- Codex cron: execute scheduled command-style automation payloads before workspace bootstrap or memory review, preserving existing isolated cron jobs after Codex harness migration. (#81510) Thanks @jalehman.
 - Gateway/OpenAI HTTP: return OpenAI-compatible 400 errors for invalid sampling params and provider validation failures instead of collapsing them to 500s. (#81275) Thanks @Lellansin.
 - Telegram: publish plugin and skill command description localizations to native command menus while filtering unsupported locale codes and preserving Telegram command limits. (#81351) Thanks @jzakirov.
 - Limit hook CLI tool authority [AI]. (#81065) Thanks @pgondhi987.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2268,6 +2268,50 @@ describe("runCodexAppServerAttempt", () => {
     expect(config?.instructions).toBeUndefined();
   });
 
+  it("keeps lightweight cron Codex turns out of OpenClaw bootstrap context", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const exactCommand =
+      "cd /Users/phaedrus/Projects/openclaw && /Users/phaedrus/clawd/scripts/clawsweeper-related-scan.py";
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "Follow AGENTS guidance.");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "Soul voice goes here.");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.trigger = "cron";
+    params.prompt = exactCommand;
+    params.bootstrapContextMode = "lightweight";
+    params.bootstrapContextRunKind = "cron";
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const threadStart = harness.requests.find((request) => request.method === "thread/start");
+    const threadStartParams = threadStart?.params as {
+      developerInstructions?: string;
+    };
+    expect(threadStartParams.developerInstructions).not.toContain("Soul voice goes here.");
+    expect(threadStartParams.developerInstructions).not.toContain("Follow AGENTS guidance.");
+
+    const turnStart = harness.requests.find((request) => request.method === "turn/start");
+    const turnStartParams = turnStart?.params as {
+      collaborationMode?: {
+        settings?: { developer_instructions?: string | null };
+      };
+      input?: Array<{ text?: string }>;
+    };
+    expect(turnStartParams.input?.[0]?.text).toBe(exactCommand);
+    expect(turnStartParams.collaborationMode?.settings?.developer_instructions).toContain(
+      "This is an OpenClaw cron automation turn",
+    );
+    expect(turnStartParams.collaborationMode?.settings?.developer_instructions).toContain(
+      "run that command before doing any investigation",
+    );
+  });
+
   it("fires llm_input, llm_output, and agent_end hooks for codex turns", async () => {
     const llmInput = vi.fn();
     const llmOutput = vi.fn();
@@ -5614,6 +5658,25 @@ describe("runCodexAppServerAttempt", () => {
 
     params.trigger = "user";
     expect(buildTurnCollaborationMode(params).settings.developer_instructions).toBeNull();
+  });
+
+  it("uses turn-scoped collaboration instructions for cron Codex turns", () => {
+    const params = createParams("/tmp/session.jsonl", "/tmp/workspace");
+    params.trigger = "cron";
+
+    const cronCollaborationMode = buildTurnCollaborationMode(params);
+    expect(cronCollaborationMode.mode).toBe("default");
+    expect(cronCollaborationMode.settings.model).toBe("gpt-5.4-codex");
+    expect(cronCollaborationMode.settings.reasoning_effort).toBe("medium");
+    expect(cronCollaborationMode.settings.developer_instructions).toContain(
+      "This is an OpenClaw cron automation turn",
+    );
+    expect(cronCollaborationMode.settings.developer_instructions).toContain(
+      "If it asks you to run an exact command, run that command before doing any investigation",
+    );
+    expect(cronCollaborationMode.settings.developer_instructions).toContain(
+      "Do not read AGENTS.md, SOUL.md, USER.md, PROJECTS.md, MEMORY.md",
+    );
   });
 
   it("preserves the bound auth profile when resume params omit authProfileId", async () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -517,10 +517,28 @@ export function buildTurnCollaborationMode(
     settings: {
       model: params.modelId,
       reasoning_effort: resolveReasoningEffort(params.thinkLevel, params.modelId),
-      developer_instructions:
-        params.trigger === "heartbeat" ? buildHeartbeatCollaborationInstructions() : null,
+      developer_instructions: buildTurnScopedCollaborationInstructions(params),
     },
   };
+}
+
+function buildTurnScopedCollaborationInstructions(params: EmbeddedRunAttemptParams): string | null {
+  if (params.trigger === "cron") {
+    return buildCronCollaborationInstructions();
+  }
+  if (params.trigger === "heartbeat") {
+    return buildHeartbeatCollaborationInstructions();
+  }
+  return null;
+}
+
+function buildCronCollaborationInstructions(): string {
+  return [
+    "This is an OpenClaw cron automation turn. Apply these instructions only to this scheduled job; ordinary chat turns should stay in Codex Default mode.",
+    "Execute the cron payload directly. If it asks you to run an exact command, run that command before doing any investigation, planning, memory review, or workspace bootstrap.",
+    "Do not read AGENTS.md, SOUL.md, USER.md, PROJECTS.md, MEMORY.md, day logs, entity summaries, or other workspace memory/bootstrap files unless the cron payload explicitly asks you to inspect them or the requested command fails and the file is needed to diagnose that failure.",
+    "Keep output concise and automation-oriented. Prefer the final command result or a short failure summary over status narration.",
+  ].join("\n\n");
 }
 
 function buildHeartbeatCollaborationInstructions(): string {


### PR DESCRIPTION
## Summary

- Problem: existing isolated cron agent turns could time out after migrating to the Codex harness because Codex treated scheduled automation like an ordinary workspace chat turn.
- Why it matters: cron jobs that worked under Pi should keep working under Codex without users manually editing every existing job.
- What changed: cron-triggered Codex turns now receive turn-scoped automation instructions that execute the cron payload first and skip workspace/bootstrap memory reads unless explicitly needed.
- What did NOT change (scope boundary): ordinary chat turns, heartbeat turns, cron permissions, model selection, and sandbox/auth policy are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: an existing isolated cron job that runs an exact command was timing out under the Codex harness after spending most of its timeout budget on workspace/bootstrap inspection.
- Real environment tested: maintainer OpenClaw gateway running this patch, Codex harness runtime, existing scheduled job `Clawsweeper Related PR Watch`.
- Exact steps or command run after this patch: manually triggered the existing cron job through OpenClaw cron run tooling without editing the job.
- Evidence after fix (copied live output, redacted only for local paths):

```text
Manual run id:
manual:60723825-9649-4a0a-9107-34382d2aad68:1778699245289:1

Cron state after completion:
lastRunStatus: ok
lastStatus: ok
lastDurationMs: 40091
lastDeliveryStatus: delivered
consecutiveErrors: 0
consecutiveSkipped: 0
lastDelivered: true

Cron session status:
Model: openai/gpt-5.5
Runtime: OpenAI Codex
Context: 28k/400k (7%)
```

- Observed result after fix: the existing cron completed successfully under Codex, delivered its result, and found a real Clawsweeper related-person PR instead of timing out during pre-command bootstrap.
- What was not tested: broad migration across unrelated user cron shapes; only the previously failing exact-command isolated cron pattern was live-tested.
- Before evidence (optional but encouraged): the same job previously failed with `cron: job execution timed out (last phase: tool-execution-started)` after Codex spent the timeout budget on workspace bootstrap before starting the payload command.

## Root Cause (if applicable)

- Root cause: Codex cron turns were using the normal turn collaboration behavior, so scheduled automation could obey workspace bootstrap instructions before executing a direct cron payload.
- Missing detection / guardrail: there was no Codex app-server regression that asserted cron-triggered lightweight turns avoid AGENTS/SOUL/workspace bootstrap context and receive automation-specific instructions.
- Contributing context (if known): Pi/direct-ish cron behavior did not expose this because those runs did not spend the same timeout budget on Codex workspace bootstrapping.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/run-attempt.test.ts`
- Scenario the test should lock in: cron-triggered Codex turns get turn-scoped cron automation instructions, preserve exact command-style prompts, and keep lightweight cron runs out of OpenClaw bootstrap context.
- Why this is the smallest reliable guardrail: the regression lived at the Codex app-server turn construction boundary, not in the cron script or GitHub auth.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Existing isolated cron agent turns that migrate onto the Codex harness should execute automation payloads directly instead of first reading workspace/bootstrap memory files.

## Diagram (if applicable)

```text
Before:
cron trigger -> Codex normal workspace mode -> bootstrap/memory reads -> payload starts late -> timeout

After:
cron trigger -> Codex cron automation instructions -> payload command first -> result delivered
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (Yes)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: this changes turn guidance for cron-triggered Codex runs so they execute the existing authorized cron payload first. It does not grant new tools or permissions, and the behavior is gated to `params.trigger === "cron"`.

## Repro + Verification

### Environment

- OS: macOS maintainer gateway
- Runtime/container: OpenClaw gateway with Codex app-server harness
- Model/provider: `openai/gpt-5.5` via Codex runtime
- Integration/channel (if any): cron isolated agent turn with announce delivery
- Relevant config (redacted): existing cron job, `sessionTarget: isolated`, `payload.kind: agentTurn`, `payload.lightContext: true`, `timeoutSeconds: 120`

### Steps

1. Run the Codex app-server regression tests added in this PR.
2. Manually trigger the existing `Clawsweeper Related PR Watch` cron job on a gateway running this patch.
3. Inspect the cron state and cron session status after completion.

### Expected

- Codex cron turn receives cron automation instructions.
- Exact command-style prompt is preserved.
- Lightweight cron turn does not include workspace bootstrap file contents.
- Live cron run completes before timeout and delivers output.

### Actual

- Tests assert the turn-scoped cron behavior.
- Live cron completed with `lastRunStatus: ok`, `lastDurationMs: 40091`, `lastDeliveryStatus: delivered`, Runtime `OpenAI Codex`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before failure:
```text
cron: job execution timed out (last phase: tool-execution-started)
```

After live proof:
```text
lastRunStatus: ok
lastDurationMs: 40091
lastDeliveryStatus: delivered
Runtime: OpenAI Codex
Context: 28k/400k (7%)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: manually triggered the previously failing Clawsweeper cron on a gateway running this patch and confirmed successful completion/delivery under Codex.
- Edge cases checked: verified the run stayed on Runtime `OpenAI Codex` rather than falling back to Pi/direct runtime.
- What you did **not** verify: broad migration behavior for every cron payload type or every third-party user configuration.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: cron-specific instructions might over-constrain cron turns that intentionally need repository context first.
  - Mitigation: the instructions still allow reading workspace files when the payload explicitly asks for them or when the requested command fails and context is needed to diagnose that failure.
- Risk: behavior could accidentally affect normal chat turns.
  - Mitigation: the new instructions are emitted only when `params.trigger === "cron"`; normal turns continue to receive no turn-scoped developer instructions from this path.

