### PR TITLE
[AI-assisted] fix(update): clear stale plugin refs after failed updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Docs: https://docs.openclaw.ai
 - Update: allow pnpm GitHub-source OpenClaw updates to approve the OpenClaw package build, so source installs complete their prepare/prepack lifecycle. (#81294) Thanks @fuller-stack-dev.
 - Test state: seed isolated auth-profile secret keys for generated homes, preventing helper-backed proof runs from falling back to host Keychain secrets. (#81393) Thanks @altaywtf.
 - Plugins/runtime: attribute deprecated runtime config load/write warnings to the plugin id and source that triggered them so logs and plugin doctor runs are actionable. Refs #81394. (#81425) Thanks @BKF-Gitty.
+- Plugins/update: clear stale allow/deny entries and selected plugin slots when disabling a plugin after update failure, keeping failed external plugin updates from leaving half-disabled config. (#81512) Thanks @JARVIS-Glasses.
 - Memory/LanceDB: make auto-capture recognize short CJK memory phrases and configurable literal triggers, so Chinese, Japanese, and Korean users can capture memories without regex or LLM intent detection. Fixes #75680. Thanks @vyctorbrzezowski and @guokewuming.
 - Plugins doctor: report stale plugin config warnings and avoid claiming full plugin health when config warnings remain. (#81515) Thanks @BKF-Gitty.
 - Sessions: display `model: "<agentId>-acp"` / `modelProvider: "acpx"` (ACP-runtime sentinel) for ACP control-plane sessions in `openclaw sessions` output, instead of the agent's configured model which was misleading. Catalog finding 20. (#79543)

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1729,6 +1729,64 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
+  it("clears stale plugin policy and slot references when disabling failed updates", async () => {
+    const warn = vi.fn();
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: false,
+      error: "security scan blocked install",
+    });
+    const config = {
+      plugins: {
+        allow: ["demo", "keep"],
+        deny: ["demo", "blocked"],
+        slots: {
+          memory: "demo",
+          contextEngine: "demo",
+        },
+        entries: {
+          demo: {
+            enabled: true,
+          },
+        },
+        installs: {
+          demo: {
+            source: "npm" as const,
+            spec: "@acme/demo",
+            installPath: "/tmp/demo",
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await updateNpmInstalledPlugins({
+      config,
+      disableOnFailure: true,
+      logger: { warn },
+    });
+
+    const message =
+      'Disabled "demo" after plugin update failure; OpenClaw will continue without it. Failed to update demo: security scan blocked install';
+    expect(warn).toHaveBeenCalledWith(message);
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.entries?.demo).toEqual({
+      enabled: false,
+    });
+    expect(result.config.plugins?.installs?.demo).toEqual(config.plugins.installs.demo);
+    expect(result.config.plugins?.allow).toEqual(["keep"]);
+    expect(result.config.plugins?.deny).toEqual(["blocked"]);
+    expect(result.config.plugins?.slots).toEqual({
+      memory: "memory-core",
+      contextEngine: "legacy",
+    });
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "demo",
+        status: "skipped",
+        message,
+      },
+    ]);
+  });
+
   it("aborts exact pinned npm plugin updates on integrity drift by default", async () => {
     const warn = vi.fn();
     installPluginFromNpmSpecMock.mockImplementation(

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -48,6 +48,7 @@ import {
   resolveOfficialExternalPluginInstall,
 } from "./official-external-plugin-catalog.js";
 import { linkOpenClawPeerDependencies } from "./plugin-peer-link.js";
+import { defaultSlotIdForKey } from "./slots.js";
 
 export type PluginUpdateLogger = {
   info?: (message: string) => void;
@@ -760,14 +761,52 @@ function createPluginUpdateIntegrityDriftHandler(params: {
   };
 }
 
+function removeDisabledPluginIdFromList(
+  list: string[] | undefined,
+  pluginId: string,
+): string[] | undefined {
+  if (!Array.isArray(list) || !list.includes(pluginId)) {
+    return list;
+  }
+  const next = list.filter((id) => id !== pluginId);
+  return next.length > 0 ? next : undefined;
+}
+
+function resetDisabledPluginSlots(
+  slots: NonNullable<OpenClawConfig["plugins"]>["slots"] | undefined,
+  pluginId: string,
+): NonNullable<OpenClawConfig["plugins"]>["slots"] | undefined {
+  if (!slots) {
+    return slots;
+  }
+  let next = slots;
+  if (next.memory === pluginId) {
+    next = {
+      ...next,
+      memory: defaultSlotIdForKey("memory"),
+    };
+  }
+  if (next.contextEngine === pluginId) {
+    next = {
+      ...next,
+      contextEngine: defaultSlotIdForKey("contextEngine"),
+    };
+  }
+  return next;
+}
+
 function disablePluginConfigEntry(config: OpenClawConfig, pluginId: string): OpenClawConfig {
-  const existingEntry = config.plugins?.entries?.[pluginId];
+  const pluginsConfig = config.plugins ?? {};
+  const existingEntry = pluginsConfig.entries?.[pluginId];
   return {
     ...config,
     plugins: {
-      ...config.plugins,
+      ...pluginsConfig,
+      allow: removeDisabledPluginIdFromList(pluginsConfig.allow, pluginId),
+      deny: removeDisabledPluginIdFromList(pluginsConfig.deny, pluginId),
+      slots: resetDisabledPluginSlots(pluginsConfig.slots, pluginId),
       entries: {
-        ...config.plugins?.entries,
+        ...pluginsConfig.entries,
         [pluginId]: {
           ...existingEntry,
           enabled: false,


### PR DESCRIPTION
## Summary

- Problem: plugin update failures with `disableOnFailure` only disabled `plugins.entries.<id>` and could leave stale `plugins.allow`, `plugins.deny`, and selected plugin slots pointing at the disabled plugin.
- Why it matters: after a failed external plugin update, operators could see a half-disabled config where the context-engine slot still referenced a plugin that OpenClaw had just disabled.
- What changed: failed-update disable now also removes the disabled plugin from allow/deny lists and resets selected `memory` / `contextEngine` slots to their defaults while preserving the install record for later repair.
- What did NOT change: no plugin install, package scanning, fallback-channel selection, or uninstall behavior changed.

## Change Type

- Bug fix

## Scope

- API / contracts
- UI / DX

## Linked Issue/PR

- Closes: N/A
- Related: #81499
- Fixes bug/regression: Yes

## Real behavior proof

- Behavior or issue addressed: failed plugin updates that disable a plugin now leave config policy and selected slots consistent with the disabled entry.
- Real environment tested: local OpenClaw repo checkout on Windows, Node 24.14, using the real `updateNpmInstalledPlugins` production helper with a synthetic local config and no external credentials.
- Exact steps or command run after this patch:

```powershell
node_modules\.bin\tsx.cmd -e "import { updateNpmInstalledPlugins } from './src/plugins/update.ts'; void (async () => { const result = await updateNpmInstalledPlugins({ config: { plugins: { allow: ['demo', 'keep'], deny: ['demo', 'blocked'], slots: { memory: 'demo', contextEngine: 'demo' }, entries: { demo: { enabled: true } }, installs: { demo: { source: 'npm', spec: 'not a valid spec?', installPath: '/tmp/demo' } } } }, pluginIds: ['demo'], disableOnFailure: true, logger: { warn: () => undefined } }); console.log(JSON.stringify({ changed: result.changed, entry: result.config.plugins?.entries?.demo, allow: result.config.plugins?.allow, deny: result.config.plugins?.deny, slots: result.config.plugins?.slots, installPreserved: Boolean(result.config.plugins?.installs?.demo), outcome: result.outcomes[0]?.status }, null, 2)); })();"
```

- Evidence after fix:

```json
{
  "changed": true,
  "entry": {
    "enabled": false
  },
  "allow": [
    "keep"
  ],
  "deny": [
    "blocked"
  ],
  "slots": {
    "memory": "memory-core",
    "contextEngine": "legacy"
  },
  "installPreserved": true,
  "outcome": "skipped"
}
```

- Observed result after fix: the failed-update disable path disables the plugin entry, removes stale allow/deny references, resets both selected slots to defaults, preserves the install record, and records the update as skipped.
- What was not tested: a live beta update against the public npm registry and the specific third-party `lossless-claw` package from #81499.
- Before evidence: source inspection on current main showed `disablePluginConfigEntry()` only set `entries.<id>.enabled = false` and did not touch allow/deny or slots.

## Root Cause

- Root cause: the failed-update disable helper only updated the plugin entry, unlike explicit uninstall config cleanup which already removes policy references and resets selected slots.
- Missing detection / guardrail: no regression test covered `disableOnFailure` with a plugin selected in policy lists and plugin slots.
- Contributing context: plugin update failure handling preserves install records so repair/reinstall remains possible, but dependent runtime config still needs to stop selecting the disabled plugin.

## Regression Test Plan

- Coverage level that should have caught this:
  - Unit test
- Target test or file: `src/plugins/update.test.ts`
- Scenario the test should lock in: an npm plugin update failure with `disableOnFailure` clears stale allow/deny references and resets selected memory/context-engine slots while preserving the install record.
- Why this is the smallest reliable guardrail: the bug is pure config mutation in the update failure path, so a focused plugin update test covers the contract without registry access.
- Existing related coverage: existing disable coverage checked the entry and install record only, not policy lists or slots.

## User-visible / Behavior Changes

After an external plugin update failure disables a plugin, plugin policy and selected plugin slots are kept consistent with that disabled state. A context-engine plugin disabled during update now leaves the slot reset to `legacy` instead of continuing to point at the disabled plugin.

## Diagram

```text
Before:
plugin update failure -> entries.demo.enabled=false -> allow/deny/slots may still point at demo

After:
plugin update failure -> entries.demo.enabled=false -> allow/deny remove demo -> slots reset to defaults
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local OpenClaw checkout, Node 24.14
- Model/provider: N/A
- Integration/channel: plugin update config path
- Relevant config: synthetic plugin config with `demo` selected in `allow`, `deny`, `slots.memory`, and `slots.contextEngine`

### Steps

1. Run the local after-fix `tsx` proof above.
2. Run the focused regression test for stale policy/slot cleanup.
3. Run the adjacent existing disable regression test.
4. Run formatting and diff checks.

### Expected

- Failed-update disable marks the plugin entry disabled.
- Stale allow/deny references are removed.
- Selected memory/context-engine slots reset to defaults.
- The install record remains available for later repair.

### Actual

- Local proof produced `entry.enabled=false`, `allow=["keep"]`, `deny=["blocked"]`, `slots.memory="memory-core"`, `slots.contextEngine="legacy"`, `installPreserved=true`, and `outcome="skipped"`.
- Focused stale policy/slot regression test passed.
- Existing disable regression test passed.
- `git diff --check` and `oxfmt` passed.

## Evidence

- Trace/log snippets

## Human Verification

- Verified scenarios: failed-update disable cleans policy lists and resets `memory` / `contextEngine` slots while preserving the install record.
- Edge cases checked: existing entry config is still preserved by the adjacent disable test.
- What you did **not** verify: live third-party package update or public npm registry fallback behavior.

## Review Conversations

- Addressed bot review conversations: N/A
- Unresolved conversations needing reviewer or maintainer judgment: N/A

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- Exact upgrade steps: N/A

## Risks and Mitigations

- Risk: resetting a selected slot during failed-update disable changes the active fallback sooner than before.
  - Mitigation: this only happens after OpenClaw has already disabled the plugin due to an update failure; resetting to the existing default prevents a stale selection from pointing at the disabled plugin.
