### PR TITLE
fix(cli): report stale plugin doctor config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Docs: https://docs.openclaw.ai
 - Test state: seed isolated auth-profile secret keys for generated homes, preventing helper-backed proof runs from falling back to host Keychain secrets. (#81393) Thanks @altaywtf.
 - Plugins/runtime: attribute deprecated runtime config load/write warnings to the plugin id and source that triggered them so logs and plugin doctor runs are actionable. Refs #81394. (#81425) Thanks @BKF-Gitty.
 - Memory/LanceDB: make auto-capture recognize short CJK memory phrases and configurable literal triggers, so Chinese, Japanese, and Korean users can capture memories without regex or LLM intent detection. Fixes #75680. Thanks @vyctorbrzezowski and @guokewuming.
+- Plugins doctor: report stale plugin config warnings and avoid claiming full plugin health when config warnings remain. (#81515) Thanks @BKF-Gitty.
 
 ### Changes
 

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -386,7 +386,7 @@ The `--json` flag outputs a machine-readable report suitable for scripting and a
 openclaw plugins doctor
 ```
 
-`doctor` reports plugin load errors, manifest/discovery diagnostics, and compatibility notices. When everything is clean it prints `No plugin issues detected.`
+`doctor` reports plugin load errors, manifest/discovery diagnostics, compatibility notices, and stale plugin config references such as missing plugin slots. When the install tree and plugin config are clean it prints `No plugin issues detected.` If stale config remains but the install tree is otherwise healthy, the summary says so instead of implying full plugin health.
 
 If a configured plugin is present on disk but blocked by the loader's path-safety checks, config validation keeps the plugin entry and reports it as `present but blocked`. Fix the preceding blocked-plugin diagnostic, such as path ownership or world-writable permissions, instead of removing the `plugins.entries.<id>` or `plugins.allow` config.
 

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -6,6 +6,8 @@ import {
   buildPluginRegistrySnapshotReport,
   buildPluginSnapshotReport,
   inspectPluginRegistry,
+  loadConfig,
+  readConfigFileSnapshot,
   resetPluginsCliTestState,
   refreshPluginRegistry,
   runPluginsCommand,
@@ -79,8 +81,61 @@ describe("plugins cli list", () => {
 
     await runPluginsCommand(["plugins", "doctor"]);
 
-    expect(buildPluginDiagnosticsReport).toHaveBeenCalledWith({ effectiveOnly: true });
+    expect(buildPluginDiagnosticsReport).toHaveBeenCalledWith({ config: {}, effectiveOnly: true });
     expect(runtimeLogs).toContain("No plugin issues detected.");
+  });
+
+  it("reports stale plugin config in doctor output without claiming full plugin health", async () => {
+    const sourceConfig = {
+      plugins: {
+        allow: ["lossless-claw"],
+        entries: {
+          "lossless-claw": { enabled: true },
+        },
+        slots: {
+          contextEngine: "lossless-claw",
+        },
+      },
+    };
+    loadConfig.mockReturnValue({});
+    readConfigFileSnapshot.mockResolvedValueOnce({
+      path: "/tmp/openclaw-config.json5",
+      exists: true,
+      raw: "{}",
+      parsed: sourceConfig,
+      resolved: sourceConfig,
+      sourceConfig,
+      runtimeConfig: {},
+      config: {},
+      valid: true,
+      hash: "mock",
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    });
+    buildPluginDiagnosticsReport.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
+
+    await runPluginsCommand(["plugins", "doctor"]);
+
+    const output = runtimeLogs.join("\n");
+    expect(output).toContain("Plugin configuration:");
+    expect(output).toContain('plugins.allow: stale plugin reference "lossless-claw" was found.');
+    expect(output).toContain(
+      'plugins.entries.lossless-claw: stale plugin reference "lossless-claw" was found.',
+    );
+    expect(output).toContain(
+      'plugins.slots.contextEngine: slot references missing plugin "lossless-claw".',
+    );
+    expect(output).toContain(
+      'Run "openclaw doctor --fix" to remove stale plugin ids and dangling channel references.',
+    );
+    expect(output).toContain(
+      "No plugin install-tree issues detected; configuration warnings remain.",
+    );
+    expect(output).not.toContain("No plugin issues detected.");
   });
 
   it("reports config-selected plugin source shadowing in doctor output", async () => {

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -365,20 +365,33 @@ export function registerPluginsCli(program: Command) {
         buildPluginDiagnosticsReport,
         formatPluginCompatibilityNotice,
       } = await import("../plugins/status.js");
-      const report = buildPluginDiagnosticsReport({ effectiveOnly: true });
+      const {
+        collectStalePluginConfigWarnings,
+        isStalePluginAutoRepairBlocked,
+        scanStalePluginConfig,
+      } = await import("../commands/doctor/shared/stale-plugin-config.js");
+      const cfg = getRuntimeConfig();
+      const configSnapshot = await readConfigFileSnapshot().catch(() => null);
+      const sourceCfg = (configSnapshot?.sourceConfig ?? configSnapshot?.config ?? cfg) as
+        | OpenClawConfig
+        | undefined;
+      const report = buildPluginDiagnosticsReport({ config: cfg, effectiveOnly: true });
       const errors = report.plugins.filter((p) => p.status === "error");
       const diags = report.diagnostics.filter((d) => d.level === "error");
       const shadowed = report.diagnostics.filter((entry) =>
         isErroredConfigSelectedShadowDiagnostic({ entry, plugins: report.plugins }),
       );
       const compatibility = buildPluginCompatibilityNotices({ report });
+      const stalePluginConfigHits = scanStalePluginConfig(sourceCfg ?? cfg, process.env);
+      const stalePluginConfigWarnings = collectStalePluginConfigWarnings({
+        hits: stalePluginConfigHits,
+        doctorFixCommand: "openclaw doctor --fix",
+        autoRepairBlocked: isStalePluginAutoRepairBlocked(sourceCfg ?? cfg, process.env),
+      });
+      const hasInstallTreeIssues =
+        errors.length > 0 || diags.length > 0 || shadowed.length > 0 || compatibility.length > 0;
 
-      if (
-        errors.length === 0 &&
-        diags.length === 0 &&
-        shadowed.length === 0 &&
-        compatibility.length === 0
-      ) {
+      if (!hasInstallTreeIssues && stalePluginConfigWarnings.length === 0) {
         defaultRuntime.log("No plugin issues detected.");
         return;
       }
@@ -435,6 +448,19 @@ export function registerPluginsCli(program: Command) {
           const marker = notice.severity === "warn" ? theme.warn("warn") : theme.muted("info");
           lines.push(`- ${formatPluginCompatibilityNotice(notice)} [${marker}]`);
         }
+      }
+      if (stalePluginConfigWarnings.length > 0) {
+        if (lines.length > 0) {
+          lines.push("");
+        }
+        lines.push(theme.warn("Plugin configuration:"));
+        lines.push(...stalePluginConfigWarnings);
+      }
+      if (!hasInstallTreeIssues && stalePluginConfigWarnings.length > 0) {
+        if (lines.length > 0) {
+          lines.push("");
+        }
+        lines.push("No plugin install-tree issues detected; configuration warnings remain.");
       }
       const docs = formatDocsLink("/plugin", "docs.openclaw.ai/plugin");
       lines.push("");


### PR DESCRIPTION
## Summary

- Problem: `openclaw plugins doctor` could print stale plugin config warnings and still end with `No plugin issues detected.`
- Why it matters: operators could read that final line as proof that plugin config was healthy, even when `plugins.allow`, `plugins.entries`, or `plugins.slots.*` still referenced a missing plugin.
- What changed: `plugins doctor` now reuses the shared stale-plugin-config scanner, reports those findings under `Plugin configuration:`, and prints `No plugin install-tree issues detected; configuration warnings remain.` when only config findings exist.
- What did NOT change (scope boundary): no plugin rollback, install/security scanner, cleanup, config mutation, JSON, or exit-code behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #81499
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: stale plugin config no longer ends with the plain success line from `openclaw plugins doctor`.
- Real environment tested: OpenClaw source checkout in the local OpenClaw PR container.
- Exact steps or command run after this patch:

```bash
OPENCLAW_CONFIG_PATH=/workspace/openclaw/.tmp/openclaw-81499-proof/openclaw.json \
OPENCLAW_STATE_DIR=/workspace/openclaw/.tmp/openclaw-81499-proof/state \
pnpm openclaw plugins doctor
```

- Evidence after fix:

```text
Plugin configuration:
- plugins.allow: stale plugin reference "lossless-claw" was found.
- plugins.entries.lossless-claw: stale plugin reference "lossless-claw" was found.
- plugins.slots.contextEngine: slot references missing plugin "lossless-claw".
- Run "openclaw doctor --fix" to remove stale plugin ids and dangling channel references.

No plugin install-tree issues detected; configuration warnings remain.
```

- Observed result after fix: the command reports actionable stale-config findings and does not print `No plugin issues detected.` when warnings remain.
- What was not tested: plugin rollback, plugin install/update/uninstall paths, scanner policy changes, JSON output because `plugins doctor` has no JSON mode.
- Before evidence (optional but encouraged): the same command path previously printed config warnings followed by `No plugin issues detected.`

## Root Cause (if applicable)

- Root cause: `plugins doctor` only counted runtime plugin load errors, manifest/discovery errors, source shadowing, and compatibility notices when deciding its final verdict.
- Missing detection / guardrail: stale plugin config warnings already existed in the shared doctor scanner, but `plugins doctor` did not include them.
- Contributing context (if known): the full CLI can warn from source config while runtime config has already normalized or ignored stale plugin references, so the scanner must inspect the config file source snapshot.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/plugins-cli.list.test.ts`
- Scenario the test should lock in: `plugins.allow`, `plugins.entries.lossless-claw`, and `plugins.slots.contextEngine` reference an unavailable `lossless-claw` plugin while runtime diagnostics are otherwise clean.
- Why this is the smallest reliable guardrail: it exercises the `plugins doctor` command path and the real shared stale-config scanner without touching plugin install or cleanup behavior.
- Existing test that already covers this (if any): `src/commands/doctor/shared/stale-plugin-config.test.ts` covers the scanner helper, but not the `plugins doctor` verdict.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw plugins doctor` now reports stale plugin config references and distinguishes a healthy install tree from remaining config warnings.

## Diagram (if applicable)

```text
Before:
plugins doctor -> config warnings -> No plugin issues detected.

After:
plugins doctor -> plugin configuration findings -> install-tree-only summary
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS host with OpenClaw PR container
- Runtime/container: OpenClaw PR container via `openclaw-shell`
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted):

```json
{
  "plugins": {
    "allow": ["lossless-claw"],
    "entries": {
      "lossless-claw": {
        "enabled": true
      }
    },
    "slots": {
      "contextEngine": "lossless-claw"
    }
  }
}
```

### Steps

1. Create the isolated config above.
2. Run `pnpm openclaw plugins doctor` with `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` pointed at the isolated temp paths.
3. Inspect the final doctor output.

### Expected

- Stale plugin config is reported as plugin doctor findings.
- The command does not end with plain `No plugin issues detected.` while config warnings remain.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused Vitest coverage for `plugins doctor`; real `pnpm openclaw plugins doctor` output with a stale `lossless-claw` config.
- Edge cases checked: healthy command output remains `No plugin issues detected.`; source-config scanner catches stale refs even when runtime config is sanitized.
- What you did **not** verify: plugin rollback, install/update/uninstall, security scanner behavior, config cleanup mutation, exit-code changes.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: `plugins doctor` now does one additional config snapshot read and stale-config scan.
  - Mitigation: reuses existing doctor scanner and keeps behavior read-only.

## Validation

- `pnpm run docs:list`: pass
- `pnpm test src/cli/plugins-cli.list.test.ts src/commands/doctor/shared/stale-plugin-config.test.ts`: pass
- `pnpm exec oxfmt --check src/cli/plugins-cli.ts src/cli/plugins-cli.list.test.ts docs/cli/plugins.md`: pass
- `pnpm exec oxlint src/cli/plugins-cli.ts src/cli/plugins-cli.list.test.ts`: pass
- `pnpm tsgo`: pass
- `git diff --check`: pass
- `pnpm check:changed`: fails in unrelated all-project typecheck on `src/plugins/registry.runtime-config.test.ts:45` and `:46`; those files are outside this PR diff.