### PR TITLE
fix(agents): route channel current-turn metadata through runtime-context envelope

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -548,8 +548,21 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(systemPrompt).toContain("Ask who I am before continuing.");
   });
 
-  it("adds current-turn context to the current model input without exposing internal runtime context", async () => {
-    let seenPrompt: string | undefined;
+  it("routes channel current-turn context out-of-band alongside internal runtime context", async () => {
+    const seen: { prompt?: string; messages?: unknown[]; systemPrompt?: string } = {};
+    const channelMetadata = [
+      "Reply target of current user message (untrusted, for context):",
+      "```json",
+      JSON.stringify(
+        {
+          sender_label: "Mike",
+          body: "WT daily plan - Sat May 2\nSee ./quoted-secret.png and [media attached: media://inbound/quoted.png]",
+        },
+        null,
+        2,
+      ),
+      "```",
+    ].join("\n");
 
     const result = await createContextEngineAttemptRunner({
       contextEngine: createContextEngineBootstrapAndAssemble(),
@@ -565,24 +578,12 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
           "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
         ].join("\n"),
         transcriptPrompt: "what does this mean?",
-        currentTurnContext: {
-          text: [
-            "Reply target of current user message (untrusted, for context):",
-            "```json",
-            JSON.stringify(
-              {
-                sender_label: "Mike",
-                body: "WT daily plan - Sat May 2\nSee ./quoted-secret.png and [media attached: media://inbound/quoted.png]",
-              },
-              null,
-              2,
-            ),
-            "```",
-          ].join("\n"),
-        },
+        currentTurnContext: { text: channelMetadata },
       },
       sessionPrompt: async (session, prompt) => {
-        seenPrompt = prompt;
+        seen.prompt = prompt;
+        seen.messages = [...session.messages];
+        seen.systemPrompt = session.agent.state.systemPrompt;
         session.messages = [
           ...session.messages,
           { role: "assistant", content: "done", timestamp: 2 },
@@ -590,20 +591,41 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
     });
 
-    expect(seenPrompt).toContain("what does this mean?");
-    expect(seenPrompt).toContain("Reply target of current user message (untrusted, for context):");
-    expect(seenPrompt).toContain('"sender_label": "Mike"');
-    expect(seenPrompt).toContain("WT daily plan - Sat May 2");
-    expect(seenPrompt).toContain("./quoted-secret.png");
-    expect(seenPrompt).toContain("media://inbound/quoted.png");
-    expect(seenPrompt).not.toContain("OPENCLAW_INTERNAL_CONTEXT");
-    expect(seenPrompt).not.toContain("secret runtime context");
-    expect(seenPrompt?.trim().startsWith("Reply target of current user message")).toBe(true);
-    expect(result.finalPromptText).toBe(seenPrompt);
+    expect(seen.prompt).toBe("what does this mean?");
+    expect(result.finalPromptText).toBe("what does this mean?");
+    expect(seen.prompt).not.toContain("Reply target of current user message");
+    expect(seen.prompt).not.toContain('"sender_label"');
+    expect(seen.prompt).not.toContain("OPENCLAW_INTERNAL_CONTEXT");
+    expect(seen.prompt).not.toContain("secret runtime context");
+
+    const runtimeContextMessage = findRecord(
+      requireRecords(seen.messages, "seen messages"),
+      (message) => message.customType === "openclaw.runtime-context",
+      "runtime context message",
+    );
+    expectFields(runtimeContextMessage, {
+      role: "custom",
+      customType: "openclaw.runtime-context",
+      display: false,
+    });
+    const customContentValue = (runtimeContextMessage as { content?: unknown }).content;
+    const customContent = typeof customContentValue === "string" ? customContentValue : "";
+    expect(customContent).toContain("Reply target of current user message");
+    expect(customContent).toContain('"sender_label": "Mike"');
+    expect(customContent).toContain("WT daily plan - Sat May 2");
+    expect(customContent).toContain("./quoted-secret.png");
+    expect(customContent).toContain("media://inbound/quoted.png");
+    expect(customContent).toContain("<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>");
+    expect(customContent).toContain("secret runtime context");
+
+    expect(seen.systemPrompt).not.toContain("Reply target of current user message");
+    expect(seen.systemPrompt).not.toContain("secret runtime context");
+
     expect(hoisted.detectAndLoadPromptImagesMock).toHaveBeenCalledTimes(1);
     expect(mockParams(hoisted.detectAndLoadPromptImagesMock, 0, "prompt image params").prompt).toBe(
       "what does this mean?",
     );
+
     const trajectoryEvents = (
       await fs.readFile(path.join(tempPaths[0] ?? "", "session.trajectory.jsonl"), "utf8")
     )
@@ -611,9 +633,64 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       .split("\n")
       .map((line) => JSON.parse(line) as TrajectoryEvent);
     const promptSubmitted = trajectoryEvents.find((event) => event.type === "prompt.submitted");
-    expect(promptSubmitted?.data?.prompt).toBe(seenPrompt);
-    expect(promptSubmitted?.data?.prompt).toContain("WT daily plan - Sat May 2");
-    expect(promptSubmitted?.data?.prompt).not.toContain("secret runtime context");
+    const trajectoryPrompt = promptSubmitted?.data?.prompt;
+    const trajectoryPromptText = typeof trajectoryPrompt === "string" ? trajectoryPrompt : "";
+    expect(trajectoryPromptText).toBe("what does this mean?");
+    expect(trajectoryPromptText).not.toContain("Reply target");
+    expect(trajectoryPromptText).not.toContain("secret runtime context");
+  });
+
+  it("queues current-turn channel metadata as the sole runtime-context custom message", async () => {
+    const seen: { prompt?: string; messages?: unknown[] } = {};
+    const channelMetadata = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify(
+        {
+          chat_id: "telegram:8719706209",
+          sender_id: "8719706209",
+          sender: "Ben Jensen",
+        },
+        null,
+        2,
+      ),
+      "```",
+    ].join("\n");
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        prompt: "sure please do.",
+        transcriptPrompt: "sure please do.",
+        currentTurnContext: { text: channelMetadata },
+      },
+      sessionPrompt: async (session, prompt) => {
+        seen.prompt = prompt;
+        seen.messages = [...session.messages];
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "done", timestamp: 2 },
+        ];
+      },
+    });
+
+    expect(seen.prompt).toBe("sure please do.");
+
+    const runtimeContextMessages = requireRecords(seen.messages, "seen messages").filter(
+      (message) => message.customType === "openclaw.runtime-context",
+    );
+    expect(runtimeContextMessages).toHaveLength(1);
+    expectFields(runtimeContextMessages[0] ?? {}, {
+      role: "custom",
+      customType: "openclaw.runtime-context",
+      display: false,
+    });
+    const onlyContentValue = (runtimeContextMessages[0] as { content?: unknown } | undefined)
+      ?.content;
+    const onlyContent = typeof onlyContentValue === "string" ? onlyContentValue : "";
+    expect(onlyContent).toBe(channelMetadata);
   });
 
   it("marks inter-session transcriptPrompt before submitting the visible prompt", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -360,10 +360,9 @@ import {
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
 import {
-  buildCurrentTurnPrompt,
   buildRuntimeContextSystemContext,
   queueRuntimeContextForNextTurn,
-  resolveRuntimeContextPromptParts,
+  resolveCurrentTurnPromptSubmission,
 } from "./runtime-context-prompt.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
@@ -3117,14 +3116,12 @@ export async function runEmbeddedAttempt(
           }
           prePromptMessageCount = activeSession.messages.length;
 
-          const promptSubmission = resolveRuntimeContextPromptParts({
+          const promptSubmission = resolveCurrentTurnPromptSubmission({
             effectivePrompt,
             transcriptPrompt: effectiveTranscriptPrompt,
+            currentTurnContext: params.currentTurnContext,
           });
-          const promptForModel = buildCurrentTurnPrompt({
-            context: promptSubmission.runtimeOnly ? undefined : params.currentTurnContext,
-            prompt: promptSubmission.prompt,
-          });
+          const promptForModel = promptSubmission.prompt;
           const runtimeSystemContext = promptSubmission.runtimeSystemContext?.trim();
           if (promptSubmission.runtimeOnly && runtimeSystemContext) {
             const runtimeSystemPrompt = composeSystemPromptWithHookContext({

--- a/src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts
@@ -4,6 +4,7 @@ import {
   buildCurrentTurnPromptContextPrefix,
   buildRuntimeContextSystemContext,
   queueRuntimeContextForNextTurn,
+  resolveCurrentTurnPromptSubmission,
   resolveRuntimeContextPromptParts,
 } from "./runtime-context-prompt.js";
 
@@ -139,5 +140,91 @@ describe("runtime context prompt submission", () => {
 
     expect(buildRuntimeEventSystemContext("internal event")).toContain("OpenClaw runtime event.");
     expect(buildRuntimeEventSystemContext("internal event")).toContain("not user-authored");
+  });
+
+  describe("resolveCurrentTurnPromptSubmission", () => {
+    it("passes through when no channel current-turn context is set", () => {
+      expect(
+        resolveCurrentTurnPromptSubmission({
+          effectivePrompt: "visible ask",
+          transcriptPrompt: "visible ask",
+          currentTurnContext: undefined,
+        }),
+      ).toEqual({ prompt: "visible ask" });
+    });
+
+    it("routes channel metadata into hidden runtime context, not the visible prompt", () => {
+      expect(
+        resolveCurrentTurnPromptSubmission({
+          effectivePrompt: "visible ask",
+          transcriptPrompt: "visible ask",
+          currentTurnContext: {
+            text: "Conversation info (untrusted metadata):\n```json\n{}\n```",
+          },
+        }),
+      ).toEqual({
+        prompt: "visible ask",
+        runtimeContext: "Conversation info (untrusted metadata):\n```json\n{}\n```",
+      });
+    });
+
+    it("combines channel metadata with existing hidden runtime context", () => {
+      const effectivePrompt = [
+        "visible ask",
+        "",
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+        "secret runtime context",
+        "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      ].join("\n");
+
+      const parts = resolveCurrentTurnPromptSubmission({
+        effectivePrompt,
+        transcriptPrompt: "visible ask",
+        currentTurnContext: { text: "Conversation info: chat 8719706209" },
+      });
+
+      expect(parts.prompt).toBe("visible ask");
+      expect(parts.runtimeContext).toBe(
+        "Conversation info: chat 8719706209\n\n<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nsecret runtime context\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      );
+      expect(parts.runtimeOnly).toBeUndefined();
+    });
+
+    it("ignores whitespace-only channel context", () => {
+      expect(
+        resolveCurrentTurnPromptSubmission({
+          effectivePrompt: "visible ask",
+          transcriptPrompt: "visible ask",
+          currentTurnContext: { text: "   " },
+        }),
+      ).toEqual({ prompt: "visible ask" });
+    });
+
+    it("preserves runtime-only event semantics without disturbing the system-prompt route", () => {
+      const parts = resolveCurrentTurnPromptSubmission({
+        effectivePrompt: "internal event",
+        transcriptPrompt: "",
+        currentTurnContext: { text: "Conversation info: chat 8719706209" },
+      });
+
+      // Runtime-event turns deliver hidden context via the system prompt (not next-turn custom
+      // messages), so the helper leaves them unchanged. Channel metadata on a runtime-only turn
+      // is an out-of-scope edge case that pre-dates this fix.
+      expect(parts.prompt).toBe("Continue the OpenClaw runtime event.");
+      expect(parts.runtimeOnly).toBe(true);
+      expect(parts.runtimeContext).toBe("internal event");
+      expect(parts.runtimeSystemContext).toContain("OpenClaw runtime event.");
+      expect(parts.runtimeSystemContext).toContain("internal event");
+    });
+
+    it("does not promote channel metadata to system context for normal user turns", () => {
+      const parts = resolveCurrentTurnPromptSubmission({
+        effectivePrompt: "visible ask",
+        transcriptPrompt: "visible ask",
+        currentTurnContext: { text: "Conversation info: chat 8719706209" },
+      });
+
+      expect(parts.runtimeSystemContext).toBeUndefined();
+    });
   });
 });

--- a/src/agents/pi-embedded-runner/run/runtime-context-prompt.ts
+++ b/src/agents/pi-embedded-runner/run/runtime-context-prompt.ts
@@ -88,6 +88,32 @@ export function resolveRuntimeContextPromptParts(params: {
   return runtimeContext ? { prompt, runtimeContext } : { prompt };
 }
 
+// Routes channel-supplied current-turn metadata (e.g. inbound Telegram `Conversation info` and
+// `Sender` blocks) into the hidden runtime-context stream instead of the visible user prompt, so
+// the user message text submitted to the provider stays equal to the user-authored body. The
+// metadata still reaches the model as a hidden next-turn custom message via
+// `queueRuntimeContextForNextTurn`. Mirrors the trust-boundary split introduced for legacy
+// `<<<OPENCLAW_INTERNAL_CONTEXT>>>` prompts (see 11e6928b3edc).
+export function resolveCurrentTurnPromptSubmission(params: {
+  effectivePrompt: string;
+  transcriptPrompt?: string;
+  currentTurnContext: CurrentTurnPromptContext | undefined;
+}): RuntimeContextPromptParts {
+  const base = resolveRuntimeContextPromptParts({
+    effectivePrompt: params.effectivePrompt,
+    transcriptPrompt: params.transcriptPrompt,
+  });
+  const channelText = params.currentTurnContext?.text.trim() ?? "";
+  if (!channelText || base.runtimeOnly) {
+    // Skip the merge for runtime-event turns: their hidden context flows via the system prompt,
+    // not via queueRuntimeContextForNextTurn, so a merge here would silently drop the channel
+    // metadata. Leaving channel context untouched preserves the pre-fix behavior for that path.
+    return base;
+  }
+  const combined = base.runtimeContext ? `${channelText}\n\n${base.runtimeContext}` : channelText;
+  return { ...base, runtimeContext: combined };
+}
+
 function buildRuntimeContextMessageContent(params: {
   runtimeContext: string;
   kind: "next-turn" | "runtime-event";


### PR DESCRIPTION
## Summary

Fixes #81241. Inbound channel messages (Telegram, and any other channel that populates `inboundUserContext`) ended up with the runtime-context envelope - `Conversation info` / `Sender` JSON blocks - concatenated into the user message text submitted to the model, even though the envelope was meant to flow out-of-band as a `custom_message` of `customType: "openclaw.runtime-context"`. The agent saw both copies, which inflated tokens and softened the trust boundary the envelope is meant to establish.

This PR extends the runtime-context separation pattern introduced in 11e6928b (`fix: keep runtime context out of user turns`) to the current-turn channel-metadata variant.

### Approach

- New `resolveCurrentTurnPromptSubmission` helper in `src/agents/pi-embedded-runner/run/runtime-context-prompt.ts` wraps `resolveRuntimeContextPromptParts` and merges `currentTurnContext.text` into the hidden `runtimeContext` field that `queueRuntimeContextForNextTurn` already consumes. The user-authored body stays as the visible prompt.
- In `attempt.ts`, the `buildCurrentTurnPrompt(currentTurnContext, prompt)` call at the prompt-submission site is replaced with the new helper. `promptForModel` becomes the user body only; the metadata still reaches the model via the existing `deliverAs: "nextTurn"` custom-message path (`display: false`).
- Runtime-event turns (`runtimeOnly: true`) are left unchanged. Those deliver hidden context via the system prompt, not via `queueRuntimeContextForNextTurn`, so a merge there would silently drop channel metadata. Pre-fix behavior already suppressed `currentTurnContext` on those turns; the helper preserves that invariant.

### Out of scope (intentional)

- **CLI runner** (`src/agents/cli-runner/prepare.ts:409` calls `buildCurrentTurnPrompt` similarly). CLI backends (claude-cli, codex-cli, google-gemini-cli) have no out-of-band runtime-context channel in their protocols, so the inline form is currently the only way the metadata reaches those models. A separate fix design is needed and was not bundled here.
- **Bare-session reset** (`src/auto-reply/reply/prompt-prelude.ts:104-115`). When `isBareSessionReset` is true, `inboundUserContext` is inlined into `resetModelBody` and no `currentTurnContext` is set. The existing test `src/auto-reply/reply/prompt-prelude.test.ts:6-30` pins this behavior; reset turns are infrequent and the metadata acts as deliberate startup context for the fresh session. Not changed here.
- **PR #75755** (`Sanitize modern runtime context wrappers`). Complementary, not duplicative: that PR makes the inline form compact; this PR moves the content out of the user turn entirely.

## Real behavior proof

- **Behavior or issue addressed:** Issue #81241. Inbound channel metadata (`Conversation info` and `Sender` JSON blocks set by `buildReplyPromptEnvelopeBase`) was being concatenated into the user-turn text submitted by `runEmbeddedAttempt`, duplicating the `openclaw.runtime-context` envelope and weakening the trust boundary established by 11e6928b. After this patch the channel metadata is delivered exclusively as a hidden `custom_message` with `customType: "openclaw.runtime-context"`, `display: false`, `deliverAs: "nextTurn"`.
- **Real environment tested:** Linux x86_64, Node 22.22.2. Branch checked out at HEAD `87e5a8aca37c211219c779f8aa8e3a7c9a2f56c9`, built with `pnpm build`, served by the user-systemd gateway unit `ExecStart=node openclaw/dist/index.js gateway --port 18789`. The proof harness imports from the exact same `dist/runtime-context-prompt-DLCWQ7Do.js` bundle the running gateway loads.
- **Exact steps or command run after this patch:**
  1. `pnpm build` against branch HEAD `87e5a8aca37c`. Confirmed `dist/runtime-context-prompt-DLCWQ7Do.js` exports `resolveCurrentTurnPromptSubmission` via `grep "^export" dist/runtime-context-prompt-DLCWQ7Do.js`.
  2. `systemctl --user restart openclaw-gateway` and confirmed `[gateway] ready` and `[telegram] [default] starting provider (@<bot>)` boot lines in `journalctl --user -u openclaw-gateway --since "30 sec ago"`.
  3. Ran `node /tmp/proof-81521.mjs` - an ESM harness that imports the `resolveCurrentTurnPromptSubmission` and `queueRuntimeContextForNextTurn` symbols from the just-built `dist/` bundle and exercises them against the redacted issue-#81241 Telegram inbound shape. The harness wires a captured fake session so the live `sendCustomMessage` call from `queueRuntimeContextForNextTurn` can be inspected.
- **Evidence after fix:** Terminal capture from `node /tmp/proof-81521.mjs` running against the live built `dist/` bundle - the same module the gateway loads. Channel identifiers redacted. Stdout transcript and a redacted runtime-log JSONL excerpt follow; this is real captured stdout, not unit-test output.

  Stdout transcript:

  ```
  === After-fix transcript (synthetic Telegram inbound from issue #81241 shape) ===

  Submitted user prompt (what the model sees):
  "sure please do."

  Length: 15 (user body only)
  Contains 'Conversation info': false
  Contains 'Sender': false

  Runtime-context custom_message queued (deliverAs=nextTurn, display=false):
    count: 1
    customType: openclaw.runtime-context
    display: false
    details: {"source":"openclaw-runtime-context"}
    deliverAs: nextTurn
    content length: 330
    content contains channel metadata: true
  ```

  Redacted runtime-log JSONL excerpt produced by the live `queueRuntimeContextForNextTurn` call against the same bundle:

  ```jsonl
  {"type":"message","timestamp":"<UTC>","message":{"role":"user","content":[{"type":"text","text":"sure please do."}]}}
  {"type":"custom_message","timestamp":"<UTC>","customType":"openclaw.runtime-context","content":"Conversation info (untrusted metadata):\n```json\n{\n  \"chat_id\": \"telegram:REDACTED\",\n  \"sender\": \"REDACTED\"\n}\n```\n\nSender (untrusted metadata):\n```json\n{\n  \"label\": \"REDACTED (REDACTED)\",\n  \"name\": \"REDACTED\"\n}\n```","display":false,"details":{"source":"openclaw-runtime-context"},"deliverAs":"nextTurn"}
  ```

  Pre-fix shape from the same exercise - single combined `role: user` line - what the model was actually receiving on `origin/main` HEAD `b7d3b74f1c`:

  ```jsonl
  {"type":"message","timestamp":"<UTC>","message":{"role":"user","content":[{"type":"text","text":"Conversation info (untrusted metadata):\n```json\n{...}\n```\n\nSender (untrusted metadata):\n```json\n{...}\n```\n\nsure please do."}]}}
  ```

- **Observed result after fix:** `promptActiveSession` receives `"sure please do."` verbatim (15 characters). The submitted user prompt no longer contains the `"Conversation info"` or `"Sender"` substrings. Exactly one `custom_message` with `customType: "openclaw.runtime-context"`, `display: false`, `deliverAs: "nextTurn"` is queued by `queueRuntimeContextForNextTurn`, carrying the channel metadata content unchanged. The `details` payload is `{"source":"openclaw-runtime-context"}`. The integration test `routes channel current-turn context out-of-band alongside internal runtime context` asserts the same boundary through the full `runEmbeddedAttempt` path - it intercepts the prompt submitted via `sessionPrompt`, the `prompt.submitted.prompt` trajectory event, the `model.completed.finalPromptText` value, and the queued runtime-context custom message.
- **What was not tested:** The bare-session-reset path (`isBareSessionReset: true` in `buildReplyPromptEnvelopeBase`) was not exercised - that branch intentionally inlines `inboundUserContext` into `resetModelBody` per the existing pinning test in `src/auto-reply/reply/prompt-prelude.test.ts:6-30` and is documented as out of scope above. The CLI runner (`src/agents/cli-runner/prepare.ts:409` calls `buildCurrentTurnPrompt` similarly) was not exercised because CLI backends carry no out-of-band runtime-context channel; a separate fix design is needed and is documented in the "Out of scope" section above.

## Verification

Local commands (run on `b7d3b74f1c` plus this branch):

- `pnpm test src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts` -> 16/16 passing (6 new tests for `resolveCurrentTurnPromptSubmission` covering pass-through, channel-only routing, merge with legacy runtime context, whitespace handling, runtime-only invariant, no system-prompt promotion for normal turns).
- `pnpm test src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts` -> 37/37 passing. Flipped one assertion that previously locked the inline behavior; added one new integration test for the channel-only case (no legacy markers, common Telegram path) asserting exactly one `openclaw.runtime-context` `custom_message` is queued with the channel metadata as its content.
- `pnpm test src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply/inbound-meta.test.ts src/auto-reply/reply/strip-inbound-meta.test.ts` -> 57 + 44 + 30 passing.
- `pnpm test src/auto-reply/reply/prompt-prelude.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts` -> green.
- `pnpm tsgo:core` and `pnpm tsgo:test` -> clean.
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json` on the four touched files -> 0 warnings, 0 errors.

### Pre-existing failures observed on `origin/main` and unrelated to this change

- `oxlint`: `src/agents/pi-embedded-runner/run/attempt.ts:701` (`no-underscore-dangle` on `_rewriteFile`, from the `Revert "refactor: move runtime state to SQLite"` in `694ca50e9`); `src/plugins/install-security-scan.runtime.ts:579` (`prefer-includes`). Reproduced after `git stash -u` from clean `b7d3b74f1c`.

## Test plan

- [x] Failing unit + integration tests written first (TDD); confirmed they fail against unmodified source before implementing the helper.
- [x] Helper unit tests (`runtime-context-prompt.test.ts`).
- [x] Integration test flip (`attempt.spawn-workspace.context-engine.test.ts`).
- [x] Channel-only integration regression.
- [x] ClawSweeper-flagged downstream suites (`get-reply-run.media-only`, `inbound-meta`, `strip-inbound-meta`).
- [x] Bare-reset behaviour pinned by existing `prompt-prelude.test.ts` (unchanged).
- [x] `pnpm tsgo:core` + `pnpm tsgo:test` clean.
- [x] `pnpm exec oxlint` clean on touched files.
- [x] Real-runtime stdout + JSONL captured against the built `dist/` bundle (see Real behavior proof above).

Refs: closes #81241; related to (not duplicate of) #75755; extends the pattern from 11e6928b.
