### PR TITLE
feat(nvidia): tag NIM requests with app origin

### DIFF
--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -5,6 +5,13 @@
   },
   "enabledByDefault": true,
   "providers": ["nvidia"],
+  "providerEndpoints": [
+    {
+      "endpointClass": "nvidia-native",
+      "hosts": ["integrate.api.nvidia.com"],
+      "baseUrls": ["https://integrate.api.nvidia.com/v1"]
+    }
+  ],
   "modelIdNormalization": {
     "providers": {
       "nvidia": {

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -55,6 +55,11 @@ const providerEndpointPlugins = vi.hoisted(() => [
         endpointClass: "xai-native",
         hosts: ["api.x.ai", "api.grok.x.ai"],
       },
+      {
+        endpointClass: "nvidia-native",
+        hosts: ["integrate.api.nvidia.com"],
+        baseUrls: ["https://integrate.api.nvidia.com/v1"],
+      },
     ],
     providerRequest: {
       providers: {
@@ -68,6 +73,7 @@ const providerEndpointPlugins = vi.hoisted(() => [
         kimi: { family: "moonshot", compatibilityFamily: "moonshot" },
         mistral: { family: "mistral" },
         moonshot: { family: "moonshot", compatibilityFamily: "moonshot" },
+        nvidia: { family: "nvidia" },
         openrouter: { family: "openrouter" },
         qwen: { family: "modelstudio" },
         together: { family: "together" },
@@ -129,6 +135,29 @@ describe("provider attribution", () => {
         "X-OpenRouter-Categories":
           "cli-agent,cloud-agent,programming-app,creative-writing,writing-assistant,general-chat,personal-agent",
       },
+    });
+  });
+
+  it("returns a documented NVIDIA attribution policy", () => {
+    const policy = resolveProviderAttributionPolicy("nvidia", {
+      OPENCLAW_VERSION: "2026.3.22",
+    });
+
+    expect(policy).toEqual({
+      provider: "nvidia",
+      enabledByDefault: true,
+      verification: "vendor-documented",
+      hook: "request-headers",
+      reviewNote:
+        "NVIDIA NIM billing invoke-origin attribution header. Applied only on verified NVIDIA routes.",
+      product: "OpenClaw",
+      version: "2026.3.22",
+      headers: {
+        "X-BILLING-INVOKE-ORIGIN": "OpenClaw",
+      },
+    });
+    expect(resolveProviderAttributionHeaders("NVIDIA", { OPENCLAW_VERSION: "2026.3.22" })).toEqual({
+      "X-BILLING-INVOKE-ORIGIN": "OpenClaw",
     });
   });
 
@@ -198,6 +227,7 @@ describe("provider attribution", () => {
       ]),
     ).toEqual([
       ["openrouter", true, "vendor-documented", "request-headers"],
+      ["nvidia", true, "vendor-documented", "request-headers"],
       ["openai", true, "vendor-hidden-api-spec", "request-headers"],
       ["openai-codex", true, "vendor-hidden-api-spec", "request-headers"],
       ["anthropic", false, "vendor-sdk-hook-only", "default-headers"],
@@ -351,6 +381,10 @@ describe("provider attribution", () => {
       endpointClass: "cerebras-native",
       hostname: "api.cerebras.ai",
     });
+    expectRecordFields(resolveProviderEndpoint("https://integrate.api.nvidia.com/v1"), {
+      endpointClass: "nvidia-native",
+      hostname: "integrate.api.nvidia.com",
+    });
     expectRecordFields(resolveProviderEndpoint("https://opencode.ai/api"), {
       endpointClass: "opencode-native",
       hostname: "opencode.ai",
@@ -393,6 +427,46 @@ describe("provider attribution", () => {
     expect(
       resolveProviderRequestAttributionHeaders({
         provider: "openrouter",
+        baseUrl: "https://proxy.example.com/v1",
+        transport: "stream",
+        capability: "llm",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("gates documented NVIDIA attribution to official NVIDIA NIM endpoints", () => {
+    expectRecordFields(
+      resolveProviderRequestPolicy({
+        provider: "nvidia",
+        api: "openai-completions",
+        baseUrl: "https://integrate.api.nvidia.com/v1",
+        transport: "stream",
+        capability: "llm",
+      }),
+      {
+        endpointClass: "nvidia-native",
+        knownProviderFamily: "nvidia",
+        attributionProvider: "nvidia",
+        allowsHiddenAttribution: false,
+      },
+    );
+
+    expect(
+      resolveProviderRequestAttributionHeaders({
+        provider: "custom-nim",
+        api: "openai-completions",
+        baseUrl: "https://integrate.api.nvidia.com/v1",
+        transport: "stream",
+        capability: "llm",
+      }),
+    ).toEqual({
+      "X-BILLING-INVOKE-ORIGIN": "OpenClaw",
+    });
+
+    expect(
+      resolveProviderRequestAttributionHeaders({
+        provider: "nvidia",
+        api: "openai-completions",
         baseUrl: "https://proxy.example.com/v1",
         transport: "stream",
         capability: "llm",
@@ -469,6 +543,18 @@ describe("provider attribution", () => {
         capability: "llm",
       }),
     ).toBe("provider=groq api=openai-completions endpoint=groq-native route=native policy=none");
+
+    expect(
+      describeProviderRequestRoutingSummary({
+        provider: "nvidia",
+        api: "openai-completions",
+        baseUrl: "https://integrate.api.nvidia.com/v1",
+        transport: "stream",
+        capability: "llm",
+      }),
+    ).toBe(
+      "provider=nvidia api=openai-completions endpoint=nvidia-native route=native policy=documented",
+    );
   });
 
   it("models other provider families without enabling hidden attribution", () => {

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -48,6 +48,7 @@ export type ProviderEndpointClass =
   | "mistral-public"
   | "moonshot-native"
   | "modelstudio-native"
+  | "nvidia-native"
   | "openai-public"
   | "openai-codex"
   | "opencode-native"
@@ -143,6 +144,7 @@ const MANIFEST_PROVIDER_ENDPOINT_CLASSES = new Set<ProviderEndpointClass>([
   "mistral-public",
   "moonshot-native",
   "modelstudio-native",
+  "nvidia-native",
   "openai-public",
   "openai-codex",
   "opencode-native",
@@ -480,6 +482,23 @@ function buildOpenRouterAttributionPolicy(
   };
 }
 
+function buildNvidiaAttributionPolicy(
+  env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
+): ProviderAttributionPolicy {
+  return {
+    provider: "nvidia",
+    enabledByDefault: true,
+    verification: "vendor-documented",
+    hook: "request-headers",
+    reviewNote:
+      "NVIDIA NIM billing invoke-origin attribution header. Applied only on verified NVIDIA routes.",
+    ...resolveProviderAttributionIdentity(env),
+    headers: {
+      "X-BILLING-INVOKE-ORIGIN": OPENCLAW_ATTRIBUTION_PRODUCT,
+    },
+  };
+}
+
 function buildOpenAIAttributionPolicy(
   env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
 ): ProviderAttributionPolicy {
@@ -541,6 +560,7 @@ export function listProviderAttributionPolicies(
 ): ProviderAttributionPolicy[] {
   return [
     buildOpenRouterAttributionPolicy(env),
+    buildNvidiaAttributionPolicy(env),
     buildOpenAIAttributionPolicy(env),
     buildOpenAICodexAttributionPolicy(env),
     buildSdkHookOnlyPolicy(
@@ -626,21 +646,28 @@ export function resolveProviderRequestPolicy(
       attributionProvider = "openrouter";
     }
   }
+  if (!attributionProvider && endpointClass === "nvidia-native") {
+    attributionProvider = "nvidia";
+  }
 
-  const attributionHeaders = attributionProvider
-    ? resolveProviderAttributionHeaders(attributionProvider, env)
+  const attributionPolicy = attributionProvider
+    ? resolveProviderAttributionPolicy(attributionProvider, env)
+    : undefined;
+  const attributionHeaders = attributionPolicy?.enabledByDefault
+    ? attributionPolicy.headers
     : undefined;
 
   return {
     provider: provider || undefined,
-    policy,
+    policy: attributionPolicy ?? policy,
     endpointClass,
     usesConfiguredBaseUrl,
     knownProviderFamily: resolveKnownProviderFamily(provider || undefined),
     attributionProvider,
     attributionHeaders,
     allowsHiddenAttribution:
-      attributionProvider !== undefined && policy?.verification === "vendor-hidden-api-spec",
+      attributionProvider !== undefined &&
+      attributionPolicy?.verification === "vendor-hidden-api-spec",
     usesKnownNativeOpenAIEndpoint,
     usesKnownNativeOpenAIRoute:
       endpointClass === "default" ? provider === "openai" : usesKnownNativeOpenAIEndpoint,
@@ -674,6 +701,7 @@ export function resolveProviderRequestCapabilities(
     endpointClass === "mistral-public" ||
     endpointClass === "moonshot-native" ||
     endpointClass === "modelstudio-native" ||
+    endpointClass === "nvidia-native" ||
     endpointClass === "openai-public" ||
     endpointClass === "openai-codex" ||
     endpointClass === "opencode-native" ||

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -461,6 +461,44 @@ describe("provider request config", () => {
     });
   });
 
+  it("protects NVIDIA billing invoke origin on official NIM routes", () => {
+    const resolved = resolveProviderRequestHeaders({
+      provider: "custom-nim",
+      api: "openai-completions",
+      baseUrl: "https://integrate.api.nvidia.com/v1",
+      capability: "llm",
+      transport: "stream",
+      callerHeaders: {
+        "X-BILLING-INVOKE-ORIGIN": "spoofed",
+        "X-Custom": "1",
+      },
+      precedence: "caller-wins",
+    });
+
+    expect(resolved).toEqual({
+      "X-BILLING-INVOKE-ORIGIN": "OpenClaw",
+      "X-Custom": "1",
+    });
+  });
+
+  it("does not attach NVIDIA billing invoke origin to custom proxy routes", () => {
+    const resolved = resolveProviderRequestHeaders({
+      provider: "nvidia",
+      api: "openai-completions",
+      baseUrl: "https://proxy.example.com/v1",
+      capability: "llm",
+      transport: "stream",
+      callerHeaders: {
+        "X-BILLING-INVOKE-ORIGIN": "operator-value",
+      },
+      precedence: "caller-wins",
+    });
+
+    expect(resolved).toEqual({
+      "X-BILLING-INVOKE-ORIGIN": "operator-value",
+    });
+  });
+
   it("merges header names case-insensitively", () => {
     const resolved = resolveProviderRequestHeaders({
       provider: "openai",


### PR DESCRIPTION
## Summary

- Problem: NVIDIA NIM cannot reliably identify that OpenClaw originated requests unless OpenClaw sends the billing invoke-origin header.
- Why it matters: NVIDIA can use the app-origin signal to track which apps requests are originating from.
- What changed: verified NVIDIA NIM routes now attach `X-BILLING-INVOKE-ORIGIN: OpenClaw` through the shared provider attribution policy path, with endpoint metadata for `https://integrate.api.nvidia.com/v1` and coverage for official-route and custom-proxy behavior.
- What did NOT change (scope boundary): custom proxy hosts do not receive this header automatically, and non-NVIDIA providers are unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: NVIDIA NIM requests from OpenClaw should include `X-BILLING-INVOKE-ORIGIN: OpenClaw` only on verified NVIDIA NIM routes.
- Real environment tested: local OpenClaw checkout on macOS with Node/pnpm test lanes.
- Exact steps or command run after this patch: `pnpm test src/gateway/sessions-patch.test.ts src/plugins/registry.runtime-config.test.ts src/agents/provider-attribution.test.ts src/agents/provider-request-config.test.ts extensions/nvidia/index.test.ts extensions/nvidia/provider-catalog.test.ts extensions/nvidia/plugin-registration.contract.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): targeted tests passed 5 Vitest shards in 58.26s; `OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed` exited 0 after typecheck, lint, guard, and selected changed-lane checks.
- Observed result after fix: official NVIDIA NIM route header resolution returns `X-BILLING-INVOKE-ORIGIN: OpenClaw`; custom proxy routes preserve operator-provided headers and do not get automatic NVIDIA attribution.
- What was not tested: no live NVIDIA API request was sent from this checkout.
- Before evidence (optional but encouraged): prior NVIDIA provider metadata had no route-scoped attribution policy for the billing invoke-origin header.

## Root Cause (if applicable)

- Root cause: N/A.
- Missing detection / guardrail: provider attribution tests did not cover NVIDIA NIM billing-origin tracking because no NVIDIA attribution policy existed.
- Contributing context (if known): OpenRouter already used the shared attribution policy path; NVIDIA NIM needed equivalent route-gated metadata and header handling.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/provider-attribution.test.ts`; `src/agents/provider-request-config.test.ts`
- Scenario the test should lock in: official NVIDIA NIM endpoints attach `X-BILLING-INVOKE-ORIGIN: OpenClaw`, custom proxy hosts do not, and spoofed caller header values cannot override route-owned attribution.
- Why this is the smallest reliable guardrail: the shared provider attribution and request-header merge seams are where OpenRouter-style tracking is resolved before provider requests are made.
- Existing test that already covers this (if any): OpenRouter attribution tests covered the analogous policy shape, but not NVIDIA NIM.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

NVIDIA NIM requests sent to verified NVIDIA routes now include `X-BILLING-INVOKE-ORIGIN: OpenClaw`. Custom NVIDIA-compatible proxy hosts are unchanged.

## Diagram (if applicable)

```text
Before:
[OpenClaw NVIDIA request] -> [integrate.api.nvidia.com/v1] -> [no OpenClaw app-origin header]

After:
[OpenClaw NVIDIA request] -> [verified NVIDIA NIM route] -> [X-BILLING-INVOKE-ORIGIN: OpenClaw]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A. This changes request metadata on existing NVIDIA NIM calls by adding a non-secret app-origin header on verified NVIDIA routes only.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm checkout
- Model/provider: NVIDIA provider request-policy seam
- Integration/channel (if any): N/A
- Relevant config (redacted): verified NVIDIA NIM base URL `https://integrate.api.nvidia.com/v1`

### Steps

1. Resolve provider attribution headers for provider `nvidia` and official NVIDIA NIM base URL.
2. Resolve request headers for a custom provider id pointing at the official NVIDIA NIM base URL with a spoofed caller value.
3. Resolve request headers for provider `nvidia` pointed at a custom proxy host.

### Expected

- Official NVIDIA NIM routes include `X-BILLING-INVOKE-ORIGIN: OpenClaw`.
- Caller-provided spoofed values cannot override the route-owned NVIDIA attribution header.
- Custom proxy hosts do not receive automatic NVIDIA attribution.

### Actual

- Matches expected in `src/agents/provider-attribution.test.ts` and `src/agents/provider-request-config.test.ts`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: official NVIDIA NIM endpoint classification; NVIDIA attribution policy shape; automatic header injection on verified NVIDIA routes; spoofing protection; no automatic header on custom proxy hosts; NVIDIA plugin endpoint metadata.
- Edge cases checked: provider id alias casing; custom provider id using the official NVIDIA route; caller-wins precedence with both route-owned and operator-owned header behavior.
- What you did **not** verify: live NVIDIA API traffic. Testbox validation was attempted but blocked by sandbox approval policy because it would sync the private checkout externally; the local changed gate was used instead.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: custom proxy deployments could unexpectedly receive OpenClaw attribution if treated as NVIDIA routes.
  - Mitigation: attribution is gated by verified NVIDIA endpoint metadata; custom proxy hosts are covered by tests as not receiving the header automatically.
