### PR TITLE
fix(telegram): release polling leases at in-process gateway restart boundary

### DIFF
--- a/extensions/telegram/src/polling-lease.test.ts
+++ b/extensions/telegram/src/polling-lease.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runInProcessRestartHooks } from "openclaw/plugin-sdk/lifecycle-restart-hooks";
 import {
   acquireTelegramPollingLease,
+  releaseTelegramPollingLeasesForLifecycleReset,
   resetTelegramPollingLeasesForTests,
 } from "./polling-lease.js";
 
@@ -98,5 +100,92 @@ describe("Telegram polling lease", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // Regression: openclaw/openclaw#81507
+  // The polling lease registry lives on a process-global Symbol, so a stale
+  // entry left by a dropped previous-lifecycle monitor task blocks every new
+  // acquire after an in-process gateway restart. The Telegram extension
+  // registers a lifecycle reset hook that drains the registry at the restart
+  // boundary; after that runs, a fresh acquire for the same token must
+  // succeed even though the old lease was never explicitly released.
+  it("clears stale same-token leases at the in-process restart boundary", async () => {
+    const oldAbort = new AbortController();
+    const stale = await acquireTelegramPollingLease({
+      token: "123:abc",
+      accountId: "old-lifecycle",
+      abortSignal: oldAbort.signal,
+    });
+
+    // Simulate the previous lifecycle dying without ever calling release()
+    // (its `finally` block was interrupted by the in-process restart).
+    await expect(
+      acquireTelegramPollingLease({
+        token: "123:abc",
+        accountId: "new-lifecycle",
+        waitMs: 0,
+      }),
+    ).rejects.toThrow('refusing duplicate poller for account "new-lifecycle"');
+
+    // The gateway run-loop drains plugin-registered subsystem hooks at the
+    // restart boundary. The Telegram extension registers itself on first
+    // module load, so this drain frees the stale lease.
+    const drained = releaseTelegramPollingLeasesForLifecycleReset();
+    expect(drained).toBe(1);
+
+    const fresh = await acquireTelegramPollingLease({
+      token: "123:abc",
+      accountId: "new-lifecycle",
+    });
+    expect(fresh.tokenFingerprint).toBe(stale.tokenFingerprint);
+
+    // A late `release()` from the dropped previous-lifecycle task must NOT
+    // delete the fresh lease (owner-checked release).
+    stale.release();
+    await expect(
+      acquireTelegramPollingLease({
+        token: "123:abc",
+        accountId: "third",
+      }),
+    ).rejects.toThrow('refusing duplicate poller for account "new-lifecycle"');
+
+    fresh.release();
+  });
+
+  // Regression: openclaw/openclaw#81507
+  // The cleanup is lifecycle-owned, not steady-state. Two concurrent live
+  // pollers within the same lifecycle (no restart in between) must still be
+  // rejected by the same-token guard.
+  it("keeps the same-token live duplicate guard outside the restart boundary", async () => {
+    const first = await acquireTelegramPollingLease({
+      token: "123:abc",
+      accountId: "a",
+    });
+    await expect(
+      acquireTelegramPollingLease({
+        token: "123:abc",
+        accountId: "b",
+      }),
+    ).rejects.toThrow('refusing duplicate poller for account "b"');
+    first.release();
+  });
+
+  // The Telegram extension wires its cleanup through the shared
+  // in-process-restart-hooks registry on first module load. Running the
+  // registry must cascade through to the Telegram lease registry without
+  // any callers having to know about the Telegram-specific helper.
+  it("is wired into the shared in-process restart hook registry", async () => {
+    const lease = await acquireTelegramPollingLease({
+      token: "123:abc",
+      accountId: "hook-test",
+    });
+    expect(runInProcessRestartHooks()).toBeGreaterThanOrEqual(1);
+    const fresh = await acquireTelegramPollingLease({
+      token: "123:abc",
+      accountId: "hook-test-2",
+    });
+    fresh.release();
+    // Late stale release from the dropped previous-lifecycle task is safe.
+    lease.release();
   });
 });

--- a/extensions/telegram/src/polling-lease.ts
+++ b/extensions/telegram/src/polling-lease.ts
@@ -1,3 +1,4 @@
+import { registerInProcessRestartHook } from "openclaw/plugin-sdk/lifecycle-restart-hooks";
 import { fingerprintTelegramBotToken } from "./token-fingerprint.js";
 
 const TELEGRAM_POLLING_LEASES_KEY = Symbol.for("openclaw.telegram.pollingLeases");
@@ -186,4 +187,67 @@ export async function acquireTelegramPollingLease(
 
 export function resetTelegramPollingLeasesForTests(): void {
   pollingLeaseRegistry().clear();
+}
+
+/**
+ * Self-register the lifecycle reset hook on first module load. The underlying
+ * registry already de-duplicates by hook identity, but a fresh closure would
+ * be created on every module load, so we guard with a process-symbol flag to
+ * keep the registration idempotent across ESM/CJS interop boundaries.
+ */
+const LIFECYCLE_HOOK_REGISTERED_KEY = Symbol.for(
+  "openclaw.telegram.pollingLeases.lifecycleHookRegistered",
+);
+{
+  const host = process as NodeJS.Process & {
+    [LIFECYCLE_HOOK_REGISTERED_KEY]?: boolean;
+  };
+  if (!host[LIFECYCLE_HOOK_REGISTERED_KEY]) {
+    host[LIFECYCLE_HOOK_REGISTERED_KEY] = true;
+    registerInProcessRestartHook(() => {
+      releaseTelegramPollingLeasesForLifecycleReset();
+    });
+  }
+}
+
+/**
+ * Lifecycle boundary cleanup for in-process gateway restarts.
+ *
+ * The lease registry lives on a process-global symbol so it survives Node-level
+ * restarts that recycle the gateway lifecycle without exiting the process
+ * (SIGUSR1 in-process restart, OPENCLAW_NO_RESPAWN reload, etc.). When the old
+ * lifecycle's monitor task is dropped before its `finally` releases the lease,
+ * the next lifecycle's `acquireTelegramPollingLease()` sees a stale same-token
+ * entry and rejects every Telegram account with the duplicate-poller error.
+ *
+ * The fix is lifecycle-owned: at the restart boundary the gateway clears every
+ * lease this process is holding. We deliberately drop entries even if the
+ * abort signal has not yet observed the abort, because by definition the old
+ * lifecycle is ending and any still-running poller belongs to it. Late
+ * `release()` calls from the dropped tasks are safe — release() is idempotent
+ * and owner-checked, so they will not delete a fresh lease acquired by the new
+ * lifecycle.
+ *
+ * Same-token guard within a single lifecycle is unaffected: this function is
+ * only called from the in-process restart boundary, never from steady-state
+ * acquire/release paths. Two concurrent live pollers within one lifecycle are
+ * still rejected by `acquireTelegramPollingLease()`.
+ *
+ * Issue: openclaw/openclaw#81507
+ */
+export function releaseTelegramPollingLeasesForLifecycleReset(): number {
+  const registry = pollingLeaseRegistry();
+  if (registry.size === 0) {
+    return 0;
+  }
+  const entries = Array.from(registry.values());
+  registry.clear();
+  for (const entry of entries) {
+    try {
+      entry.resolveDone();
+    } catch {
+      // resolveDone is safe to call multiple times; ignore.
+    }
+  }
+  return entries.length;
 }

--- a/package.json
+++ b/package.json
@@ -343,6 +343,10 @@
       "types": "./dist/plugin-sdk/heartbeat-runtime.d.ts",
       "default": "./dist/plugin-sdk/heartbeat-runtime.js"
     },
+    "./plugin-sdk/lifecycle-restart-hooks": {
+      "types": "./dist/plugin-sdk/lifecycle-restart-hooks.d.ts",
+      "default": "./dist/plugin-sdk/lifecycle-restart-hooks.js"
+    },
     "./plugin-sdk/number-runtime": {
       "types": "./dist/plugin-sdk/number-runtime.d.ts",
       "default": "./dist/plugin-sdk/number-runtime.js"

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -29,5 +29,6 @@ export {
   resetAllLanes,
   waitForActiveTasks,
 } from "../../process/command-queue.js";
+export { runInProcessRestartHooks } from "../../infra/in-process-restart-hooks.js";
 export { getInspectableActiveTaskRestartBlockers } from "../../tasks/task-registry.maintenance.js";
 export { reloadTaskRegistryFromStore } from "../../tasks/runtime-internal.js";

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -50,6 +50,7 @@ const markGatewayDraining = vi.fn();
 const waitForActiveTasks = vi.fn(async (_timeoutMs?: number) => ({ drained: true }));
 const resetAllLanes = vi.fn();
 const reloadTaskRegistryFromStore = vi.fn();
+const runInProcessRestartHooks = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
   () => { mode: "spawned" | "supervised" | "disabled" | "failed"; pid?: number; detail?: string }
 >(() => ({ mode: "disabled" }));
@@ -131,6 +132,10 @@ vi.mock("../../process/command-queue.js", () => ({
 
 vi.mock("../../tasks/runtime-internal.js", () => ({
   reloadTaskRegistryFromStore: () => reloadTaskRegistryFromStore(),
+}));
+
+vi.mock("../../infra/in-process-restart-hooks.js", () => ({
+  runInProcessRestartHooks: () => runInProcessRestartHooks(),
 }));
 
 vi.mock("../../tasks/task-registry.maintenance.js", () => ({
@@ -532,6 +537,7 @@ describe("runGatewayLoop", () => {
       expect(resetAllLanes).toHaveBeenCalledTimes(1);
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(1);
       expect(reloadTaskRegistryFromStore).toHaveBeenCalledTimes(1);
+      expect(runInProcessRestartHooks).toHaveBeenCalledTimes(1);
 
       sigusr1();
 
@@ -546,6 +552,7 @@ describe("runGatewayLoop", () => {
       expect(resetAllLanes).toHaveBeenCalledTimes(2);
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(2);
       expect(reloadTaskRegistryFromStore).toHaveBeenCalledTimes(2);
+      expect(runInProcessRestartHooks).toHaveBeenCalledTimes(2);
       expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
 
       sigterm();

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -525,10 +525,15 @@ export async function runGatewayLoop(params: {
         reloadTaskRegistryFromStore,
         resetAllLanes,
         resetGatewayRestartStateForInProcessRestart,
+        runInProcessRestartHooks,
       } = await loadGatewayLifecycleRuntimeModule();
       resetAllLanes();
       resetGatewayRestartStateForInProcessRestart();
       reloadTaskRegistryFromStore();
+      // Drain plugin-registered subsystem cleanup (e.g. Telegram polling
+      // leases) at the same boundary so process-global state seeded by the
+      // previous lifecycle does not leak into the next one. (#81507)
+      runInProcessRestartHooks();
     });
 
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).

--- a/src/infra/in-process-restart-hooks.ts
+++ b/src/infra/in-process-restart-hooks.ts
@@ -1,0 +1,84 @@
+/**
+ * Process-global registry of subsystem cleanup hooks invoked at the gateway
+ * in-process restart boundary (SIGUSR1 / OPENCLAW_NO_RESPAWN reload).
+ *
+ * Most subsystem state is recreated per gateway lifecycle, but a few helpers
+ * (notably the Telegram polling lease registry) live on `process[Symbol.for(...)]`
+ * so they survive across in-process restarts. When the previous lifecycle's
+ * task is dropped before its `finally` releases the resource, the next
+ * lifecycle observes a stale entry and rejects all work for that subsystem
+ * (#81507). The fix is for those subsystems to register a lifecycle reset
+ * hook here; the gateway run-loop drains them at the same boundary that
+ * already resets command lanes and restart-deferral state.
+ *
+ * Hooks must be:
+ *  - synchronous and side-effect-only (no I/O, no awaiting), so the boundary
+ *    stays cheap and predictable;
+ *  - safe to call repeatedly (idempotent), so process-respawn paths and
+ *    test harnesses can invoke them without coordinating ordering;
+ *  - safe to throw \u2014 errors from one hook never block sibling hooks.
+ *
+ * Hooks are stored on a `Symbol.for()`-keyed registry on `process`, matching
+ * the storage style used by the subsystems they clean up. A second module
+ * load (e.g. ESM/CJS interop boundaries) reuses the same Set instead of
+ * creating a duplicate.
+ */
+
+const HOOKS_KEY = Symbol.for("openclaw.inProcessRestartHooks.v1");
+
+type ResetHook = () => void;
+
+type RegistryHost = NodeJS.Process & {
+  [HOOKS_KEY]?: Set<ResetHook>;
+};
+
+function getRegistry(): Set<ResetHook> {
+  const host = process as RegistryHost;
+  host[HOOKS_KEY] ??= new Set<ResetHook>();
+  return host[HOOKS_KEY];
+}
+
+/**
+ * Register a lifecycle reset hook. Returns an unregister function; calling
+ * it more than once is safe.
+ */
+export function registerInProcessRestartHook(hook: ResetHook): () => void {
+  const registry = getRegistry();
+  registry.add(hook);
+  let unregistered = false;
+  return () => {
+    if (unregistered) {
+      return;
+    }
+    unregistered = true;
+    registry.delete(hook);
+  };
+}
+
+/**
+ * Run every registered hook, swallowing per-hook errors so a single failing
+ * subsystem cannot block the rest. Returns the number of hooks invoked.
+ */
+export function runInProcessRestartHooks(): number {
+  const registry = getRegistry();
+  if (registry.size === 0) {
+    return 0;
+  }
+  // Snapshot to allow hooks to safely register/unregister others.
+  const snapshot = Array.from(registry);
+  for (const hook of snapshot) {
+    try {
+      hook();
+    } catch {
+      // Hooks must be best-effort; swallow to keep the restart boundary
+      // moving. Subsystems that need to surface failures should log inside
+      // the hook itself.
+    }
+  }
+  return snapshot.length;
+}
+
+/** Test-only helper: drop every registered hook. */
+export function clearInProcessRestartHooksForTests(): void {
+  getRegistry().clear();
+}

--- a/src/plugin-sdk/lifecycle-restart-hooks.ts
+++ b/src/plugin-sdk/lifecycle-restart-hooks.ts
@@ -1,0 +1,10 @@
+// Lifecycle reset hook registry. Plugins may register a synchronous cleanup
+// callback that the gateway run-loop drains at the in-process restart
+// boundary (SIGUSR1 / OPENCLAW_NO_RESPAWN reload). See `in-process-restart-hooks`
+// docs and openclaw/openclaw#81507 for context.
+
+export {
+  registerInProcessRestartHook,
+  runInProcessRestartHooks,
+  clearInProcessRestartHooksForTests,
+} from "../infra/in-process-restart-hooks.js";


### PR DESCRIPTION
Fixes #81507

## Root cause
Telegram polling leases live on a process-global `Symbol.for("openclaw.telegram.pollingLeases")` Map. The registry survives any gateway restart that recycles the lifecycle without exiting the Node process (SIGUSR1 in-process restart, OPENCLAW_NO_RESPAWN reload, etc.).

When the previous lifecycle's `monitorTelegramProvider` task is dropped before its `finally pollingLease.release()` runs, the entry stays. The next lifecycle then calls `acquireTelegramPollingLease()`, finds a same-token entry whose abort signal hasn't observed an abort yet, and throws the duplicate-poller error indefinitely. This matches the reporter's "855 errors/day" symptom.

## Fix
Lifecycle-owned cleanup at the in-process restart boundary, per Codex review.

1. New `src/infra/in-process-restart-hooks.ts` — small process-global registry of synchronous, idempotent reset hooks. Hooks are best-effort (errors swallowed) and the registry is stored on a `Symbol.for(...)` key so it deduplicates across module reloads.
2. New `openclaw/plugin-sdk/lifecycle-restart-hooks` re-export so plugins can register without importing internal infra.
3. `extensions/telegram/src/polling-lease.ts` — exports `releaseTelegramPollingLeasesForLifecycleReset()` and self-registers it on first module load (process-symbol-guarded so duplicate ESM loads don't double-register).
4. `src/cli/gateway-cli/run-loop.ts` — invokes `runInProcessRestartHooks()` from the existing restart iteration hook, alongside `resetAllLanes()` / `resetGatewayRestartStateForInProcessRestart()` / `reloadTaskRegistryFromStore()`.

The cleanup is **only** invoked at the in-process restart boundary. Steady-state `acquireTelegramPollingLease()` still rejects two live pollers for the same bot token within one lifecycle. Late `release()` calls from dropped previous-lifecycle tasks are safe — `release()` is owner-checked and idempotent, so they won't delete a fresh lease that the new lifecycle just acquired.

## Tests
- `extensions/telegram/src/polling-lease.test.ts` — three new regressions:
  - stale same-token leases get cleared at the restart boundary, fresh acquire succeeds, and a late stale `release()` does NOT delete the fresh lease;
  - two concurrent live pollers within one lifecycle still rejected (same-token guard preserved);
  - the cleanup is wired into the shared in-process restart hook registry (no Telegram-specific knowledge needed at the call site).
- `src/cli/gateway-cli/run-loop.test.ts` — adds `runInProcessRestartHooks` mock + assertion that it's called once per restart iteration alongside the existing lane/registry resets.

## Verification
- `pnpm test extensions/telegram/src/polling-lease.test.ts`
- `pnpm test src/cli/gateway-cli/run-loop.test.ts`

(Local pnpm not available — relying on CI for the full run.)