### PR TITLE
fix(github-copilot): strip thinking blocks from latest assistant turn (#81520)

### DIFF
--- a/extensions/github-copilot/replay-policy.ts
+++ b/extensions/github-copilot/replay-policy.ts
@@ -1,9 +1,15 @@
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 export function buildGithubCopilotReplayPolicy(modelId?: string) {
+  // Copilot's Claude proxy rejects any persisted `thinking` / `redacted_thinking`
+  // content blocks on follow-up turns (HTTP 400), regardless of whether they
+  // belong to a prior or the latest assistant message. Unlike the direct
+  // Anthropic Messages API, Copilot exposes no signed-thinking replay protocol,
+  // so we must strip those blocks from every assistant turn before replay.
+  // See: https://github.com/openclaw/openclaw/issues/81520
   return normalizeLowercaseStringOrEmpty(modelId).includes("claude")
     ? {
-        dropThinkingBlocks: true,
+        dropAllThinkingBlocks: true,
       }
     : {};
 }

--- a/src/agents/pi-embedded-runner.anthropic-tool-replay.live.test.ts
+++ b/src/agents/pi-embedded-runner.anthropic-tool-replay.live.test.ts
@@ -181,6 +181,7 @@ describeLive("pi embedded anthropic replay sanitization (live)", () => {
         validateAnthropicTurns: true,
         preserveSignatures: false,
         dropThinkingBlocks: false,
+        dropAllThinkingBlocks: false,
       });
 
       await Promise.resolve(wrapped(model as never, { messages } as never, {} as never));

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -55,7 +55,7 @@ vi.mock("../plugins/provider-hook-runtime.js", async () => ({
             }
             if (provider === "github-copilot" && modelId.includes("claude")) {
               return {
-                dropThinkingBlocks: true,
+                dropAllThinkingBlocks: true,
               };
             }
             return undefined;
@@ -1298,24 +1298,20 @@ describe("sanitizeSessionHistory", () => {
     ]);
   });
 
-  it("preserves latest assistant thinking blocks for github-copilot models", async () => {
+  it("strips thinking blocks from latest assistant turn for github-copilot Claude (#81520)", async () => {
     setNonGoogleModelApi();
 
     const messages = makeThinkingAndTextAssistantMessages("reasoning_text");
 
     const result = await sanitizeGithubCopilotHistory({ messages });
     const assistant = getAssistantMessage(result);
-    expect(assistant.content).toEqual([
-      {
-        type: "thinking",
-        thinking: "internal",
-        thinkingSignature: "reasoning_text",
-      },
-      { type: "text", text: "hi" },
-    ]);
+    // Copilot's Claude proxy rejects persisted thinking blocks on follow-up
+    // turns (HTTP 400) regardless of position, and exposes no signed-thinking
+    // replay protocol — so the latest assistant turn must be sanitized too.
+    expect(assistant.content).toEqual([{ type: "text", text: "hi" }]);
   });
 
-  it("preserves latest assistant turn when all content is thinking blocks (github-copilot)", async () => {
+  it("replaces thinking-only latest assistant turn with a placeholder (github-copilot)", async () => {
     setNonGoogleModelApi();
 
     const messages: AgentMessage[] = [
@@ -1334,16 +1330,18 @@ describe("sanitizeSessionHistory", () => {
 
     expect(result).toHaveLength(3);
     const assistant = getAssistantMessage(result);
-    expect(assistant.content).toEqual([
-      {
-        type: "thinking",
-        thinking: "some reasoning",
-        thinkingSignature: "reasoning_text",
-      },
-    ]);
+    // Thinking-only turns become a neutral text placeholder so the assistant
+    // turn survives provider-side filters that drop empty content arrays.
+    expect(
+      assistant.content.every(
+        (block: { type: string }) =>
+          block.type !== "thinking" && block.type !== "redacted_thinking",
+      ),
+    ).toBe(true);
+    expect(assistant.content.length).toBeGreaterThan(0);
   });
 
-  it("preserves thinking blocks alongside tool_use blocks in latest assistant message (github-copilot)", async () => {
+  it("drops thinking blocks alongside tool_use blocks in latest assistant message (github-copilot)", async () => {
     setNonGoogleModelApi();
 
     const messages: AgentMessage[] = [
@@ -1361,7 +1359,7 @@ describe("sanitizeSessionHistory", () => {
 
     const result = await sanitizeGithubCopilotHistory({ messages });
     const types = getAssistantContentTypes(result);
-    expect(types).toContain("thinking");
+    expect(types).not.toContain("thinking");
     expect(types).toContain("toolCall");
     expect(types).toContain("text");
   });
@@ -1569,6 +1567,7 @@ describe("sanitizeSessionHistory", () => {
         sanitizeThoughtSignatures: undefined,
         sanitizeThinkingSignatures: false,
         dropThinkingBlocks: false,
+        dropAllThinkingBlocks: false,
         applyGoogleTurnOrdering: false,
         validateGeminiTurns: false,
         validateAnthropicTurns: true,
@@ -1724,7 +1723,7 @@ describe("sanitizeSessionHistory", () => {
     ]);
   });
 
-  it("keeps mutable thinking turns outside exact anthropic replay", async () => {
+  it("strips thinking blocks but normalizes tool name on github-copilot Claude replay", async () => {
     setNonGoogleModelApi();
 
     const messages = castAgentMessages([
@@ -1741,12 +1740,9 @@ describe("sanitizeSessionHistory", () => {
 
     const result = await sanitizeGithubCopilotHistory({ messages });
     const assistant = getAssistantMessage(result);
+    // Copilot Claude replay strips thinking from every assistant turn
+    // (issue #81520) while still normalizing tool names.
     expect(assistant.content).toEqual([
-      {
-        type: "thinking",
-        thinking: "I should use the read tool",
-        thinkingSignature: "reasoning_text",
-      },
       { type: "toolCall", id: "tool_123", name: "read", arguments: { path: "/tmp/test" } },
     ]);
   });
@@ -1851,6 +1847,7 @@ describe("sanitizeSessionHistory", () => {
       sanitizeThoughtSignatures: undefined,
       sanitizeThinkingSignatures: false,
       dropThinkingBlocks: true,
+      dropAllThinkingBlocks: false,
       applyGoogleTurnOrdering: false,
       validateGeminiTurns: false,
       validateAnthropicTurns: true,

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -129,6 +129,7 @@ function createCompactHooksRuntimePlan(params: BuildAgentRuntimePlanParams): Age
     preserveSignatures: false,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks: false,
+    dropAllThinkingBlocks: false,
     applyGoogleTurnOrdering: false,
     validateGeminiTurns: false,
     validateAnthropicTurns: false,

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -128,7 +128,7 @@ function buildContextPruningFactory(params: {
     settings,
     contextWindowTokens: resolveContextWindowTokens(params),
     isToolPrunable: makeToolPrunablePredicate(settings.tools),
-    dropThinkingBlocks: transcriptPolicy.dropThinkingBlocks,
+    dropThinkingBlocks: transcriptPolicy.dropThinkingBlocks || transcriptPolicy.dropAllThinkingBlocks,
     lastCacheTouchAt: readLastCacheTtlTimestamp(params.sessionManager, {
       provider: params.provider,
       modelId: params.modelId,

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -128,7 +128,8 @@ function buildContextPruningFactory(params: {
     settings,
     contextWindowTokens: resolveContextWindowTokens(params),
     isToolPrunable: makeToolPrunablePredicate(settings.tools),
-    dropThinkingBlocks: transcriptPolicy.dropThinkingBlocks || transcriptPolicy.dropAllThinkingBlocks,
+    dropThinkingBlocks: transcriptPolicy.dropThinkingBlocks === true,
+    dropAllThinkingBlocks: transcriptPolicy.dropAllThinkingBlocks === true,
     lastCacheTouchAt: readLastCacheTtlTimestamp(params.sessionManager, {
       provider: params.provider,
       modelId: params.modelId,

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -46,6 +46,7 @@ import {
 } from "../usage.js";
 import { isZeroUsageEmptyStopAssistantTurn } from "./empty-assistant-turn.js";
 import {
+  dropAllThinkingBlocks,
   dropReasoningFromHistory,
   dropThinkingBlocks,
   stripInvalidThinkingSignatures,
@@ -728,9 +729,11 @@ export async function sanitizeSessionHistory(params: {
   const droppedReasoning = policy.dropReasoningFromHistory
     ? dropReasoningFromHistory(validatedThinkingSignatures)
     : validatedThinkingSignatures;
-  const droppedThinking = policy.dropThinkingBlocks
-    ? dropThinkingBlocks(droppedReasoning)
-    : droppedReasoning;
+  const droppedThinking = policy.dropAllThinkingBlocks
+    ? dropAllThinkingBlocks(droppedReasoning)
+    : policy.dropThinkingBlocks
+      ? dropThinkingBlocks(droppedReasoning)
+      : droppedReasoning;
   const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
     allowedToolNames: params.allowedToolNames,
     allowProviderOwnedThinkingReplay,

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -81,6 +81,7 @@ function makeForwardedRuntimePlan(overrides: RuntimePlanOverrides = {}): AgentRu
     preserveSignatures: false,
     sanitizeThinkingSignatures: true,
     dropThinkingBlocks: false,
+    dropAllThinkingBlocks: false,
     applyGoogleTurnOrdering: false,
     validateGeminiTurns: false,
     validateAnthropicTurns: false,

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -752,6 +752,7 @@ vi.mock("../sandbox-info.js", () => ({
 vi.mock("../thinking.js", () => ({
   dropReasoningFromHistory: <T>(messages: T) => messages,
   dropThinkingBlocks: <T>(messages: T) => messages,
+  dropAllThinkingBlocks: <T>(messages: T) => messages,
 }));
 
 vi.mock("../tool-name-allowlist.js", async (importOriginal) => {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -2069,6 +2069,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateAnthropicTurns: true,
       preserveSignatures: true,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     } as never);
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
@@ -2101,6 +2102,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateAnthropicTurns: true,
       preserveSignatures: true,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     } as never);
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
@@ -2131,6 +2133,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateAnthropicTurns: true,
       preserveSignatures: true,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     } as never);
     const stream = wrapped(
       { api: "anthropic-messages" } as never,
@@ -2169,6 +2172,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateGeminiTurns: true,
       preserveSignatures: true,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     } as never);
     const stream = wrapped(
       { api: "google-generative-ai" } as never,
@@ -2210,6 +2214,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateAnthropicTurns: true,
       preserveSignatures: true,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     } as never);
     const stream = wrapped(
       { api: "anthropic-messages" } as never,
@@ -2250,6 +2255,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateAnthropicTurns: true,
       preserveSignatures: true,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     } as never);
     const stream = wrapped(
       { api: "bedrock-converse-stream" } as never,
@@ -2291,6 +2297,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateAnthropicTurns: true,
       preserveSignatures: true,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     } as never);
     const stream = wrapped(
       { api: "anthropic-messages" } as never,
@@ -2343,6 +2350,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
         validateAnthropicTurns: true,
         preserveSignatures: true,
         dropThinkingBlocks: false,
+        dropAllThinkingBlocks: false,
       } as never,
     );
     const stream = wrapped(
@@ -2402,6 +2410,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
         validateAnthropicTurns: true,
         preserveSignatures: true,
         dropThinkingBlocks: false,
+        dropAllThinkingBlocks: false,
       } as never,
     );
     const stream = wrapped(
@@ -2920,6 +2929,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateAnthropicTurns: true,
       preserveSignatures: false,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     });
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
@@ -2967,6 +2977,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateAnthropicTurns: true,
       preserveSignatures: false,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     });
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
@@ -3019,6 +3030,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateAnthropicTurns: true,
       preserveSignatures: true,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     });
     const stream = wrapped(
       { api: "anthropic-messages" } as never,
@@ -3070,6 +3082,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateAnthropicTurns: true,
       preserveSignatures: true,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     });
     const stream = wrapped(
       { api: "anthropic-messages" } as never,
@@ -3114,6 +3127,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
         validateAnthropicTurns: true,
         preserveSignatures: false,
         dropThinkingBlocks: false,
+        dropAllThinkingBlocks: false,
       });
       const stream = wrapped({} as never, { messages } as never, {} as never) as
         | FakeWrappedStream
@@ -3156,6 +3170,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       validateAnthropicTurns: true,
       preserveSignatures: false,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
     });
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -903,7 +903,7 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
   allowedToolNames?: Set<string>,
   transcriptPolicy?: Pick<
     TranscriptPolicy,
-    "validateGeminiTurns" | "validateAnthropicTurns" | "preserveSignatures" | "dropThinkingBlocks"
+    "validateGeminiTurns" | "validateAnthropicTurns" | "preserveSignatures" | "dropThinkingBlocks" | "dropAllThinkingBlocks"
   >,
 ): StreamFn {
   return (model, context, options) => {
@@ -918,6 +918,7 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
         validateAnthropicTurns: transcriptPolicy?.validateAnthropicTurns === true,
         preserveSignatures: transcriptPolicy?.preserveSignatures === true,
         dropThinkingBlocks: transcriptPolicy?.dropThinkingBlocks === true,
+        dropAllThinkingBlocks: transcriptPolicy?.dropAllThinkingBlocks === true,
       },
     });
     const sanitized = sanitizeReplayToolCallInputs(

--- a/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
@@ -25,6 +25,7 @@ describe("resolveAttemptTranscriptPolicy", () => {
       preserveSignatures: true,
       sanitizeThinkingSignatures: false,
       dropThinkingBlocks: true,
+      dropAllThinkingBlocks: false,
       applyGoogleTurnOrdering: false,
       validateGeminiTurns: false,
       validateAnthropicTurns: true,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -254,7 +254,7 @@ import {
   resolveEmbeddedAgentStreamFn,
 } from "../stream-resolution.js";
 import { applySystemPromptOverrideToSession } from "../system-prompt.js";
-import { dropReasoningFromHistory, dropThinkingBlocks } from "../thinking.js";
+import { dropAllThinkingBlocks, dropReasoningFromHistory, dropThinkingBlocks } from "../thinking.js";
 import {
   collectAllowedToolNames,
   collectCoreBuiltinToolNames,
@@ -2743,7 +2743,11 @@ export async function runEmbeddedAttempt(
       // (e.g. thinkingSignature:"reasoning_text") on any follow-up provider
       // call, including tool continuations. Wrap the stream function so every
       // outbound request sees sanitized messages.
-      if (transcriptPolicy.dropThinkingBlocks || transcriptPolicy.dropReasoningFromHistory) {
+      if (
+        transcriptPolicy.dropThinkingBlocks ||
+        transcriptPolicy.dropAllThinkingBlocks ||
+        transcriptPolicy.dropReasoningFromHistory
+      ) {
         const inner = activeSession.agent.streamFn;
         activeSession.agent.streamFn = (model, context, options) => {
           const ctx = context as unknown as { messages?: unknown };
@@ -2754,9 +2758,11 @@ export async function runEmbeddedAttempt(
           const reasoningSanitized = transcriptPolicy.dropReasoningFromHistory
             ? dropReasoningFromHistory(messages as unknown as AgentMessage[])
             : (messages as unknown as AgentMessage[]);
-          const sanitized = transcriptPolicy.dropThinkingBlocks
-            ? (dropThinkingBlocks(reasoningSanitized) as unknown)
-            : (reasoningSanitized as unknown);
+          const sanitized = transcriptPolicy.dropAllThinkingBlocks
+            ? (dropAllThinkingBlocks(reasoningSanitized) as unknown)
+            : transcriptPolicy.dropThinkingBlocks
+              ? (dropThinkingBlocks(reasoningSanitized) as unknown)
+              : (reasoningSanitized as unknown);
           if (sanitized === messages) {
             return inner(model, context, options);
           }

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -5,6 +5,7 @@ import { castAgentMessage, castAgentMessages } from "../test-helpers/agent-messa
 import {
   OMITTED_ASSISTANT_REASONING_TEXT,
   assessLastAssistantMessage,
+  dropAllThinkingBlocks,
   dropReasoningFromHistory,
   dropThinkingBlocks,
   isAssistantMessageWithContent,
@@ -34,6 +35,7 @@ function dropSingleAssistantContent(content: Array<Record<string, unknown>>) {
 const noThinkingReferenceCases = [
   { name: "dropThinkingBlocks", drop: dropThinkingBlocks },
   { name: "dropReasoningFromHistory", drop: dropReasoningFromHistory },
+  { name: "dropAllThinkingBlocks", drop: dropAllThinkingBlocks },
 ];
 
 function createNoThinkingMessages(): AgentMessage[] {
@@ -258,6 +260,76 @@ describe("dropReasoningFromHistory", () => {
     expect(assistant.content).toEqual([
       { type: "toolCall", id: "call123456", name: "lookup", arguments: {} },
     ]);
+  });
+});
+
+describe("dropAllThinkingBlocks", () => {
+  it("strips thinking blocks from the latest assistant turn (issue #81520)", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "hello" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "private reasoning", thinkingSignature: "sig" },
+          { type: "text", text: "hi" },
+        ],
+      }),
+      castAgentMessage({ role: "user", content: "follow up" }),
+    ];
+
+    const result = dropAllThinkingBlocks(messages);
+    const assistant = result[1] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([{ type: "text", text: "hi" }]);
+  });
+
+  it("replaces thinking-only assistant turn with a placeholder text block", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "hi" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "only thoughts", thinkingSignature: "sig" },
+        ],
+      }),
+    ];
+
+    const result = dropAllThinkingBlocks(messages);
+    const assistant = result[1] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([
+      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
+    ]);
+  });
+
+  it("strips redacted_thinking blocks across every assistant turn", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "a" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", data: "opaque" },
+          { type: "text", text: "first" },
+        ],
+      }),
+      castAgentMessage({ role: "user", content: "b" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "more", thinkingSignature: "sig" },
+          { type: "text", text: "second" },
+        ],
+      }),
+    ];
+
+    const result = dropAllThinkingBlocks(messages);
+    const first = result[1] as Extract<AgentMessage, { role: "assistant" }>;
+    const second = result[3] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(first.content).toEqual([{ type: "text", text: "first" }]);
+    expect(second.content).toEqual([{ type: "text", text: "second" }]);
+  });
+
+  it("returns the original reference when no thinking blocks are present", () => {
+    const messages = createNoThinkingMessages();
+    expect(dropAllThinkingBlocks(messages)).toBe(messages);
   });
 });
 

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -235,6 +235,22 @@ function shouldPreserveCurrentToolTurnReasoning(
   return false;
 }
 
+/**
+ * Strip every `thinking` / `redacted_thinking` content block from every
+ * assistant turn, including the latest assistant turn.
+ *
+ * Use this for transports that reject persisted thinking blocks on follow-up
+ * requests regardless of position (e.g. GitHub Copilot's Claude proxy, which
+ * exposes no signed-thinking replay protocol — see issue #81520). For
+ * Anthropic-direct/Bedrock paths that require signed thinking on the latest
+ * turn, prefer `dropThinkingBlocks` instead.
+ *
+ * Returns the original array reference when nothing was changed.
+ */
+export function dropAllThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
+  return stripAllThinkingBlocks(messages);
+}
+
 function stripAllThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
   let touched = false;
   const out: AgentMessage[] = [];

--- a/src/agents/pi-hooks/context-pruning.test.ts
+++ b/src/agents/pi-hooks/context-pruning.test.ts
@@ -318,6 +318,7 @@ describe("context-pruning", () => {
       contextWindowTokens: 1000,
       isToolPrunable: () => true,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
       lastCacheTouchAt: Date.now() - DEFAULT_CONTEXT_PRUNING_SETTINGS.ttlMs - 1000,
     });
 
@@ -341,6 +342,7 @@ describe("context-pruning", () => {
       contextWindowTokens: 1000,
       isToolPrunable: () => true,
       dropThinkingBlocks: false,
+      dropAllThinkingBlocks: false,
       lastCacheTouchAt: lastTouch,
     });
 

--- a/src/agents/pi-hooks/context-pruning/extension.ts
+++ b/src/agents/pi-hooks/context-pruning/extension.ts
@@ -27,6 +27,7 @@ export default function contextPruningExtension(api: ExtensionAPI): void {
       isToolPrunable: runtime.isToolPrunable,
       contextWindowTokensOverride: runtime.contextWindowTokens ?? undefined,
       dropThinkingBlocksForEstimate: runtime.dropThinkingBlocks,
+      dropAllThinkingBlocksForEstimate: runtime.dropAllThinkingBlocks,
     });
 
     if (next === event.messages) {

--- a/src/agents/pi-hooks/context-pruning/pruner.test.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.test.ts
@@ -64,6 +64,7 @@ function makeToolResult(
 function pruneWithOversizedAssistantThinking(params: {
   assistantBlock: AssistantContentBlock;
   dropThinkingBlocksForEstimate?: boolean;
+  dropAllThinkingBlocksForEstimate?: boolean;
 }) {
   return pruneContextMessages({
     messages: [
@@ -77,6 +78,9 @@ function pruneWithOversizedAssistantThinking(params: {
     ctx: CONTEXT_WINDOW_5K,
     isToolPrunable: () => true,
     ...(params.dropThinkingBlocksForEstimate ? { dropThinkingBlocksForEstimate: true } : {}),
+    ...(params.dropAllThinkingBlocksForEstimate
+      ? { dropAllThinkingBlocksForEstimate: true }
+      : {}),
   });
 }
 
@@ -354,6 +358,23 @@ describe("pruneContextMessages", () => {
     });
 
     expect(result).toBe(messages);
+  });
+
+  it("ignores latest-turn thinking signatures when dropAllThinkingBlocksForEstimate is true", () => {
+    const result = pruneWithOversizedAssistantThinking({
+      assistantBlock: {
+        type: "thinking",
+        thinking: "internal",
+        thinkingSignature: "S".repeat(40_000),
+      } as unknown as AssistantContentBlock,
+      dropAllThinkingBlocksForEstimate: true,
+    });
+    const toolResult = result.find((m) => m.role === "toolResult") as Extract<
+      AgentMessage,
+      { role: "toolResult" }
+    >;
+    const textBlock = toolResult.content[0] as { type: "text"; text: string };
+    expect(textBlock.text).toBe("X".repeat(2_000));
   });
 
   it("soft-trims image-containing tool results by replacing image blocks with placeholders", () => {

--- a/src/agents/pi-hooks/context-pruning/pruner.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.ts
@@ -2,7 +2,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ImageContent, TextContent, ToolResultMessage } from "@earendil-works/pi-ai";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { CHARS_PER_TOKEN_ESTIMATE, estimateStringChars } from "../../../utils/cjk-chars.js";
-import { dropThinkingBlocks } from "../../pi-embedded-runner/thinking.js";
+import { dropAllThinkingBlocks, dropThinkingBlocks } from "../../pi-embedded-runner/thinking.js";
 import type { EffectiveContextPruningSettings } from "./settings.js";
 import { makeToolPrunablePredicate } from "./tools.js";
 
@@ -291,6 +291,7 @@ export function pruneContextMessages(params: {
   isToolPrunable?: (toolName: string) => boolean;
   contextWindowTokensOverride?: number;
   dropThinkingBlocksForEstimate?: boolean;
+  dropAllThinkingBlocksForEstimate?: boolean;
 }): AgentMessage[] {
   const { messages, settings, ctx } = params;
   const contextWindowTokens =
@@ -320,9 +321,11 @@ export function pruneContextMessages(params: {
   const pruneStartIndex = firstUserIndex === null ? messages.length : firstUserIndex;
 
   const isToolPrunable = params.isToolPrunable ?? makeToolPrunablePredicate(settings.tools);
-  const estimatedMessages = params.dropThinkingBlocksForEstimate
-    ? dropThinkingBlocks(messages)
-    : messages;
+  const estimatedMessages = params.dropAllThinkingBlocksForEstimate
+    ? dropAllThinkingBlocks(messages)
+    : params.dropThinkingBlocksForEstimate
+      ? dropThinkingBlocks(messages)
+      : messages;
 
   const totalCharsBefore = estimateContextChars(estimatedMessages);
   let totalChars = totalCharsBefore;

--- a/src/agents/pi-hooks/context-pruning/runtime.ts
+++ b/src/agents/pi-hooks/context-pruning/runtime.ts
@@ -6,6 +6,7 @@ export type ContextPruningRuntimeValue = {
   contextWindowTokens?: number | null;
   isToolPrunable: (toolName: string) => boolean;
   dropThinkingBlocks: boolean;
+  dropAllThinkingBlocks: boolean;
   lastCacheTouchAt?: number | null;
 };
 

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -266,6 +266,7 @@ export type AgentRuntimeTranscriptPolicy = {
   };
   sanitizeThinkingSignatures: boolean;
   dropThinkingBlocks: boolean;
+  dropAllThinkingBlocks: boolean;
   dropReasoningFromHistory?: boolean;
   applyGoogleTurnOrdering: boolean;
   validateGeminiTurns: boolean;

--- a/src/agents/test-helpers/pi-embedded-runner-e2e-mocks.ts
+++ b/src/agents/test-helpers/pi-embedded-runner-e2e-mocks.ts
@@ -102,6 +102,7 @@ export function installEmbeddedRunnerFastRunE2eMocks(
             preserveSignatures: false,
             sanitizeThinkingSignatures: true,
             dropThinkingBlocks: false,
+            dropAllThinkingBlocks: false,
             applyGoogleTurnOrdering: false,
             validateGeminiTurns: false,
             validateAnthropicTurns: false,

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -124,6 +124,7 @@ vi.mock("../plugins/provider-hook-runtime.js", async () => {
               return modelId.includes("claude")
                 ? {
                     dropThinkingBlocks: true,
+                    dropAllThinkingBlocks: false,
                   }
                 : {};
             case "mistral":

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -25,6 +25,13 @@ export type TranscriptPolicy = {
   };
   sanitizeThinkingSignatures: boolean;
   dropThinkingBlocks: boolean;
+  /**
+   * Strip thinking blocks from every assistant turn (including the latest)
+   * before each outbound request. Set by providers whose transports reject
+   * persisted thinking blocks regardless of position (e.g. GitHub Copilot's
+   * Claude proxy — see issue #81520).
+   */
+  dropAllThinkingBlocks: boolean;
   dropReasoningFromHistory?: boolean;
   applyGoogleTurnOrdering: boolean;
   validateGeminiTurns: boolean;
@@ -36,14 +43,15 @@ export function shouldAllowProviderOwnedThinkingReplay(params: {
   modelApi?: string | null;
   policy: Pick<
     TranscriptPolicy,
-    "validateAnthropicTurns" | "preserveSignatures" | "dropThinkingBlocks"
+    "validateAnthropicTurns" | "preserveSignatures" | "dropThinkingBlocks" | "dropAllThinkingBlocks"
   >;
 }): boolean {
   return (
     isAnthropicApi(params.modelApi) &&
     params.policy.validateAnthropicTurns &&
     params.policy.preserveSignatures &&
-    !params.policy.dropThinkingBlocks
+    !params.policy.dropThinkingBlocks &&
+    !params.policy.dropAllThinkingBlocks
   );
 }
 
@@ -57,6 +65,7 @@ const DEFAULT_TRANSCRIPT_POLICY: TranscriptPolicy = {
   sanitizeThoughtSignatures: undefined,
   sanitizeThinkingSignatures: false,
   dropThinkingBlocks: false,
+  dropAllThinkingBlocks: false,
   dropReasoningFromHistory: false,
   applyGoogleTurnOrdering: false,
   validateGeminiTurns: false,
@@ -214,6 +223,9 @@ function mergeTranscriptPolicy(
       : {}),
     ...(typeof policy.dropThinkingBlocks === "boolean"
       ? { dropThinkingBlocks: policy.dropThinkingBlocks }
+      : {}),
+    ...(typeof policy.dropAllThinkingBlocks === "boolean"
+      ? { dropAllThinkingBlocks: policy.dropAllThinkingBlocks }
       : {}),
     ...(typeof policy.dropReasoningFromHistory === "boolean"
       ? { dropReasoningFromHistory: policy.dropReasoningFromHistory }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -779,6 +779,14 @@ export type ProviderReplayPolicy = {
     includeCamelCase?: boolean;
   };
   dropThinkingBlocks?: boolean;
+  /**
+   * Strip `thinking` and `redacted_thinking` content blocks from every
+   * assistant turn, including the latest one. Required for transports that
+   * reject persisted thinking blocks on follow-up turns regardless of position
+   * (for example GitHub Copilot's Claude proxy, which has no signed-thinking
+   * replay protocol). Implies `dropThinkingBlocks` semantics for prior turns.
+   */
+  dropAllThinkingBlocks?: boolean;
   dropReasoningFromHistory?: boolean;
   repairToolUseResultPairing?: boolean;
   applyAssistantFirstOrderingFix?: boolean;


### PR DESCRIPTION
## Summary
GitHub Copilot's Claude proxy returns HTTP 400 on every multi-turn conversation with a reasoning model (`claude-sonnet-4.6`, `claude-opus-4`, …) because the assistant message from the prior turn still contains `{ type: "thinking", … }` content blocks when the next request goes out. Unlike the direct Anthropic Messages API, the Copilot transport exposes no signed-thinking replay protocol, so any persisted `thinking` / `redacted_thinking` block is rejected — regardless of whether it sits on the latest or a prior assistant turn.

The Copilot replay policy was reusing the shared `dropThinkingBlocks` helper, which intentionally **preserves** thinking blocks on the latest assistant turn so direct Anthropic / Bedrock can replay the signed payload. That preservation rule is wrong for Copilot.

Fixes #81520.

## Approach
Per the codex review on the issue, the fix is provider-scoped instead of changing global `dropThinkingBlocks` semantics:

- New `ProviderReplayPolicy.dropAllThinkingBlocks` flag.
- New `dropAllThinkingBlocks(messages)` sanitizer that strips `thinking` / `redacted_thinking` from **every** assistant turn (latest included). Thinking-only assistant turns become a single neutral-text placeholder so provider adapters that filter blank content arrays still see a valid turn.
- Threaded through `TranscriptPolicy`, the replay-history pipeline (`sanitizeSessionHistory`), the per-request stream wrapper in `run/attempt.ts`, and the context-pruning token-estimate input.
- `buildGithubCopilotReplayPolicy` now sets `dropAllThinkingBlocks: true` for Claude models (instead of `dropThinkingBlocks: true`). Direct Anthropic / Bedrock / OpenAI paths are untouched and keep their signed-thinking replay semantics.

## Test changes
- **New** unit tests for `dropAllThinkingBlocks` in `src/agents/pi-embedded-runner/thinking.test.ts`: latest-turn stripping, placeholder-on-empty, `redacted_thinking` coverage, original-reference contract.
- **Flipped** the existing Copilot Claude cases in `src/agents/pi-embedded-runner.sanitize-session-history.test.ts` so they now assert the bug-free behaviour described in the issue (thinking dropped from the latest assistant turn for `github-copilot` Claude, including thinking + tool_use + text combinations).
- **Updated** every TranscriptPolicy fixture / mock to include the new `dropAllThinkingBlocks` field so types/tests stay consistent.

## Acceptance (per codex review)
- `pnpm test src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/pi-embedded-runner/thinking.test.ts extensions/github-copilot/provider-runtime.contract.test.ts extensions/github-copilot/stream.test.ts`
- `pnpm check:changed`

(Local pnpm not available in this environment per workspace constraints; tests will run in CI.)

## Risk / scope
- Behavior change is gated on the new `dropAllThinkingBlocks` flag and is only set for `github-copilot` + Claude models.
- No change to direct Anthropic / Bedrock / OpenAI replay paths, which still rely on `dropThinkingBlocks` (preserve latest) or signed-thinking replay.