### PR TITLE
fix(cli): route plugin loader logs to stderr for --json before parseAsync

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -638,8 +638,15 @@ export async function runCli(argv: string[] = process.argv) {
 
     try {
       // Capture all console output into structured logs while keeping stdout/stderr behavior.
-      const { enableConsoleCapture } = await import("../logging.js");
+      const { enableConsoleCapture, routeLogsToStderr } = await import("../logging.js");
       enableConsoleCapture();
+      // The commander preAction hook routes logs to stderr for --json commands, but only
+      // after parseAsync resolves the action. Plugin command registration below loads the
+      // primary command's plugin to populate the command tree, and that plugin-loader
+      // chatter would otherwise land on stdout and corrupt JSON output. Route early.
+      if (hasJsonOutputFlag(normalizedArgv)) {
+        routeLogsToStderr();
+      }
 
       const [
         { buildProgram },


### PR DESCRIPTION
## Summary

- Detect `--json` in argv and call the existing `routeLogsToStderr()` immediately after `enableConsoleCapture()` in `runCli`, so lazy plugin command-registration runs with `loggingState.forceConsoleToStderr = true` and its `[plugins] loading <id> from <path>` / `[plugins] loaded N plugin(s) ...` chatter lands on stderr instead of stdout.
- Keep diagnostic/log output on stderr in `--json` mode (existing policy, preserved) and keep the JSON payload itself on stdout (existing per-command behavior, also preserved).
- No changes to the routed flow (`tryRouteCli` → `prepareRoutedCommand` → `applyCliExecutionStartupPresentation`) — it already does the same thing earlier; this PR brings the non-routed (commander-attached) `--json` flow to parity.

Fixes #81535.

## Root cause (verbatim from the issue)

`runCli` ([`src/cli/run-main.ts`](https://github.com/openclaw/openclaw/blob/main/src/cli/run-main.ts)) calls `enableConsoleCapture()` at line 642, then `registerPluginCliCommandsFromValidatedConfig` at lines 725-732 — which loads the primary's plugin so commander knows about its subcommands. The commander `preAction` hook ([`src/cli/program/preaction.ts:85-94`](https://github.com/openclaw/openclaw/blob/main/src/cli/program/preaction.ts#L85-L94)) is what flips `forceConsoleToStderr` for `--json` via `applyCliExecutionStartupPresentation`, but it doesn't fire until `program.parseAsync()` at run-main.ts:765 — strictly after the registration phase.

The plugin loader's `logger.debug?.(...)` lines at [`src/plugins/loader.ts:2054`](https://github.com/openclaw/openclaw/blob/main/src/plugins/loader.ts#L2054) and [`:2412`](https://github.com/openclaw/openclaw/blob/main/src/plugins/loader.ts#L2412) flow through `createSubsystemLogger` → [`writeConsoleLine`](https://github.com/openclaw/openclaw/blob/main/src/logging/subsystem.ts#L286-L305), which routes `debug`/`info` to raw stdout when `forceConsoleToStderr === false`. Result: every non-routed `--json` command that resolves to a plugin-provided primary gets `[plugins] ...` chatter prepended to its stdout output.

## Change

```ts
// src/cli/run-main.ts (inside runCli's main try-block, after enableConsoleCapture())
const { enableConsoleCapture, routeLogsToStderr } = await import("../logging.js");
enableConsoleCapture();
// The commander preAction hook routes logs to stderr for --json commands, but only
// after parseAsync resolves the action. Plugin command registration below loads the
// primary command's plugin to populate the command tree, and that plugin-loader
// chatter would otherwise land on stdout and corrupt JSON output. Route early.
if (hasJsonOutputFlag(normalizedArgv)) {
  routeLogsToStderr();
}
```

`hasJsonOutputFlag` is the existing helper at [`run-main.ts:136-138`](https://github.com/openclaw/openclaw/blob/main/src/cli/run-main.ts#L136-L138) (matches both `--json` and `--json=…`). `routeLogsToStderr` is already exported from `../logging.js` (re-export from [`src/logging/console.ts:104`](https://github.com/openclaw/openclaw/blob/main/src/logging/console.ts#L104)). Net diff: +8 / −1, one file.

This mirrors:
- What [`prepareRoutedCommand` in `route.ts:24-29`](https://github.com/openclaw/openclaw/blob/main/src/cli/route.ts#L24-L29) already does for routed commands.
- What `applyCliExecutionStartupPresentation` does later via the preaction hook — just shifted earlier so the plugin command-registration phase also inherits the stderr routing.

## Tests

- Existing unit tests in adjacent code paths verified pass after the change: 46 tests across `src/cli/run-main.test.ts`, `src/cli/route.test.ts`, `src/cli/plugin-registry-loader.test.ts` complete in 2.11s. These tests already verify the routed and preaction `forceConsoleToStderr` flows; no test exercised the early-load path in `runCli` itself, so this PR doesn't break any existing assertions.
- A targeted regression test for the new branch in `runCli` would need to mock `enableConsoleCapture`, `routeLogsToStderr`, and `registerPluginCliCommandsFromValidatedConfig` to drive `runCli` past the early-load phase — significant mock surface. Recommend adding such a test in a small follow-up PR rather than blocking this fix; happy to do that as a separate change if a reviewer prefers it bundled.

## Real behavior proof

**Behavior addressed:** `openclaw memory search "<query>" --json` (and every other non-routed `--json` command that uses a plugin-provided primary) writes machine-readable JSON to stdout with no `[plugins] ...` startup chatter prepended, so automation can pipe the output to `jq` or `JSON.parse` without a `tail -n +N` preprocessor.

**Real environment tested:** Raspberry Pi 5 (Ubuntu 24.04 ARM64, 8GB), `OpenClaw 2026.5.10-beta.1 (40b4ffa)` built locally from `local-integration-4-fixes-20260511` (= `upstream/main` for the three files this PR analyzes — `src/cli/run-main.ts`, `src/logging/subsystem.ts`, `src/logging/console.ts` are byte-identical between that base and `upstream/main`, verified via `git diff HEAD upstream/main -- <files>` returning zero lines).

**Exact steps run after this patch:**

```bash
openclaw memory search "BRAIN autonomy" --json > /tmp/out.json 2> /tmp/err.log
jq . /tmp/out.json > /dev/null && echo "OK: stdout is valid JSON"
grep -q '"id":' /tmp/err.log && echo "FAIL" || echo "OK: stderr has no payload"
grep -q '\[plugins\]' /tmp/out.json && echo "FAIL" || echo "OK: stdout is clean"
```

**Evidence after fix:** All three checks pass.

```
exit=0  stdout=21b  stderr=1.4Kb
{
  "results": []
}
OK: stdout is valid JSON
OK: stderr has no payload
OK: stdout is clean
```

stderr correctly captures the previously-leaked early-load lines plus the rest of the loader chatter:

```
[35m[plugins][39m [90mloading memory-core from /home/eric/.npm-global/lib/node_modules/openclaw/dist/extensions/memory-core/index.js[39m
[35m[plugins][39m [90mloaded 1 plugin(s) (1 attempted) in 471.1ms[39m
[35m[plugins][39m [90mloading amazon-bedrock from ...
... (the rest, unchanged from pre-fix)
```

**Regression check — non-`--json` invocation unchanged:**

```bash
openclaw memory search "BRAIN autonomy" > /tmp/text-out.txt 2> /tmp/text-err.log
```

stdout still contains the chatter as it always did (the gate is `hasJsonOutputFlag`, so the non-JSON path is untouched). This is intentional — the existing default for human-facing text output is preserved.

**Regression check — `status --json` (routed command) unchanged:**

```bash
openclaw status --json > /tmp/s.json 2> /tmp/s.err
jq . /tmp/s.json > /dev/null && echo "OK"   # OK
wc -l /tmp/s.err                              # 0
```

Routed `--json` commands take a different bootstrap path (`tryRouteCli` → `prepareRoutedCommand` already calls `routeLogsToStderr()` before any plugins load) — they were unaffected before this PR and remain so after.

**What was not tested:** A full `pnpm test` / `pnpm check:changed` did not run to completion on this Pi 5 because `tsdown` was repeatedly SIGTERM-killed mid-build (memory-pressure flakiness specific to this host, swap was 67% used) — see "Build note for reviewers" below. The 46 adjacent-suite tests cited above did run cleanly. Recommend a reviewer with a less memory-constrained host run the full check suite.

## Cross-references — context for this bug class

This PR addresses the **loader-chatter-on-stdout** half of an existing bug class in the `--json` output discipline. The **JSON-payload-on-stderr** half was just resolved in the same week:

- **Sibling issue #81183** (closed 2026-05-13): `[Bug]: openclaw commitments [list|dismiss] --json produces empty stdout — all JSON output goes to stderr`. Same `forceConsoleToStderr` infrastructure, opposite direction (per-command code used `runtime.log(JSON.stringify(...))`, which the redirect caught, sending the JSON payload to stderr).
- **Sibling PR #81215** (merged 2026-05-13, by @giodl73-repo, merged via squash by @galiniliev): `fix(commitments): write json output to stdout`. Resolved by routing the commitments JSON branches through `writeRuntimeJson(runtime, value)` so the payload bypasses the console patch. PR description articulates the same policy this PR preserves: *"Keep diagnostic/log output separate from machine-readable stdout."*

**Prior maintainer acknowledgment of the exact symptom this PR fixes:**

- Commit [`05ba1335d93`](https://github.com/openclaw/openclaw/commit/05ba1335d93a2b525966f889cbf0080d5e57809c) by @steipete, 2026-04-21, `fix: tolerate qa cli json startup logs`. Added a `parseQaCliJsonOutput` helper in `extensions/qa-lab/src/suite-runtime-agent-process.ts` that strips ANSI, attempts `JSON.parse(whole)`, and on failure scans line-by-line for the first `{`/`[`. Inline comment: `// Some startup repair logs are emitted on stdout before command JSON.` The test fixture at [`suite-runtime-agent-process.test.ts:198`](https://github.com/openclaw/openclaw/blob/main/extensions/qa-lab/src/suite-runtime-agent-process.test.ts#L198) explicitly captures `'\\u001b[35m[plugins]\\u001b[39m \\u001b[36mcodex loaded plugin package metadata\\u001b[39m\\n{"results":...}\\n'` as expected stdout — i.e., the qa-lab harness was made to tolerate the buggy stdout shape rather than the underlying routing being fixed. With this PR, that line-skipping fallback in `parseQaCliJsonOutput` is no longer needed for built-in commands; can be simplified in a separate follow-up.

## Build note for reviewers

The verification install on the Pi 5 used a **compiled-JS-equivalent patch** (same logical change applied to `dist/cli/run-main.js`, taken from the byte-identical sibling worktree's dist) because `pnpm build` succeeded the first time (~10 min) but was killed mid-`tsdown` on every subsequent rebuild. SIGTERM source was external (not the tsdown-build.mjs internal watchdog, which is timeout-disabled by default; presumably OS memory pressure on the constrained host). The source-level commit on this branch is the canonical fix; a reviewer with adequate build headroom should produce an identical-shape install via the standard `pnpm install && pnpm build && pnpm pack && npm install -g ./openclaw-*.tgz` flow.

The verification results above were captured against the install with the equivalent compiled-JS patch applied.