### PR TITLE
Rename Telegram quick settings label to Telegram Bot

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -480,7 +480,7 @@ function buildAssistantAvatarRoute(basePathValue: string | null | undefined, age
 // ── Quick Settings data extraction helpers ──
 
 const KNOWN_CHANNEL_IDS = [
-  { id: "telegram", label: "Telegram" },
+  { id: "telegram", label: "Telegram Bot" },
   { id: "discord", label: "Discord" },
   { id: "slack", label: "Slack" },
   { id: "whatsapp", label: "WhatsApp" },


### PR DESCRIPTION
## Summary\n- Rename the Quick Settings channel label from Telegram to Telegram Bot so BYO bot token setup is clearer.\n\n## Test\n- Verified the Quick Settings source entry now uses `Telegram Bot` and the old exact `Telegram` entry is absent.\n\nGenerated by Devik.