### PR TITLE
fix(acpx): tolerate adapter config gaps

### DIFF
--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -35,12 +35,14 @@ function restoreEnv(name: keyof typeof previousEnv): void {
 }
 
 function generatedCodexPaths(stateDir: string): {
+  authPath: string;
   configPath: string;
   wrapperPath: string;
 } {
   const baseDir = path.join(stateDir, "acpx");
   const codexHome = path.join(baseDir, "codex-home");
   return {
+    authPath: path.join(codexHome, "auth.json"),
     configPath: path.join(codexHome, "config.toml"),
     wrapperPath: path.join(baseDir, "codex-acp-wrapper.mjs"),
   };
@@ -344,7 +346,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
     expect(launched.codexHome).toBeNull();
   });
 
-  it("does not copy source Codex auth", async () => {
+  it("symlinks source Codex auth into the isolated Codex home", async () => {
     const root = await makeTempDir();
     const sourceCodexHome = path.join(root, "source-codex");
     const agentDir = path.join(root, "agent");
@@ -382,6 +384,10 @@ describe("prepareAcpxCodexAuthConfig", () => {
     const wrapper = await fs.readFile(generated.wrapperPath, "utf8");
     expect(wrapper).toContain("CODEX_HOME: codexHome");
     expect(wrapper).not.toContain(sourceCodexHome);
+    const isolatedAuthLink = await fs.readlink(generated.authPath);
+    expect(path.resolve(path.dirname(generated.authPath), isolatedAuthLink)).toBe(
+      path.join(sourceCodexHome, "auth.json"),
+    );
     await expectPathMissing(path.join(agentDir, "acp-auth", "codex-source", "auth.json"));
     await expectPathMissing(path.join(agentDir, "acp-auth", "codex", "auth.json"));
   });

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -340,6 +340,39 @@ async function readSourceCodexConfig(codexHome: string): Promise<string | undefi
   }
 }
 
+async function bridgeCodexAuthIntoIsolatedHome(params: {
+  sourceCodexHome: string;
+  isolatedCodexHome: string;
+}): Promise<void> {
+  const sourceAuthPath = path.join(params.sourceCodexHome, "auth.json");
+  const isolatedAuthPath = path.join(params.isolatedCodexHome, "auth.json");
+  try {
+    await fs.access(sourceAuthPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  try {
+    const existing = await fs.lstat(isolatedAuthPath);
+    if (existing.isSymbolicLink()) {
+      const linkTarget = await fs.readlink(isolatedAuthPath);
+      if (path.resolve(params.isolatedCodexHome, linkTarget) === sourceAuthPath) {
+        return;
+      }
+    }
+    await fs.unlink(isolatedAuthPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  await fs.symlink(sourceAuthPath, isolatedAuthPath);
+}
+
 async function prepareIsolatedCodexHome(params: {
   baseDir: string;
   workspaceDir: string;
@@ -357,6 +390,10 @@ async function prepareIsolatedCodexHome(params: {
     renderIsolatedCodexProjectTrustConfig(trustedProjectPaths),
     "utf8",
   );
+  await bridgeCodexAuthIntoIsolatedHome({
+    sourceCodexHome,
+    isolatedCodexHome: codexHome,
+  });
   return codexHome;
 }
 

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -506,7 +506,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(setConfigOption).not.toHaveBeenCalled();
   });
 
-  it("still forwards non-timeout config controls for claude-agent-acp", async () => {
+  it("normalizes supported claude-agent-acp config controls and drops unsupported ones", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
         acpxRecordId: "agent:claude:acp:test",
@@ -528,13 +528,54 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       key: "model",
       value: "claude-sonnet-4.6",
     });
+    await runtime.setConfigOption({
+      handle,
+      key: "thinking",
+      value: "high",
+    });
+    await runtime.setConfigOption({
+      handle,
+      key: "approval_policy",
+      value: "never",
+    });
 
-    expect(setConfigOption).toHaveBeenCalledOnce();
-    expect(setConfigOption).toHaveBeenCalledWith({
+    expect(setConfigOption).toHaveBeenCalledTimes(2);
+    expect(setConfigOption).toHaveBeenNthCalledWith(1, {
       handle,
       key: "model",
       value: "claude-sonnet-4.6",
     });
+    expect(setConfigOption).toHaveBeenNthCalledWith(2, {
+      handle,
+      key: "effort",
+      value: "high",
+    });
+  });
+
+  it("drops config controls for unknown ACP adapters instead of forwarding unsupported calls", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:gemini:acp:test",
+        agentCommand: "gemini acp",
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
+    const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
+      sessionKey: "agent:gemini:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:gemini:acp:test",
+      acpxRecordId: "agent:gemini:acp:test",
+    };
+
+    await runtime.setConfigOption({
+      handle,
+      key: "timeout",
+      value: "60",
+    });
+
+    expect(setConfigOption).not.toHaveBeenCalled();
   });
 
   it("recognizes claude-agent-acp commands", () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -431,6 +431,13 @@ function failUnsupportedCodexAcpModel(rawModel: string, detail?: string): never 
 // See openclaw/openclaw#73071.
 const SUPPORTED_RUNTIME_SESSION_MODES = new Set(["persistent", "oneshot"] as const);
 const WIRE_TIMEOUT_CONFIG_KEYS = new Set(["timeout", "timeout_seconds"]);
+const CLAUDE_ACP_SUPPORTED_CONFIG_KEYS = new Set(["model", "mode", "effort"]);
+const CLAUDE_ACP_THINKING_CONFIG_KEYS = new Set([
+  "thinking",
+  "thought_level",
+  "reasoning_effort",
+  "effort",
+]);
 
 function assertSupportedRuntimeSessionMode(
   mode: unknown,
@@ -918,7 +925,8 @@ export class AcpxRuntime implements AcpRuntime {
     const command = await this.resolveCommandForHandle(input.handle);
     const key = input.key.trim().toLowerCase();
     const isCodexAcp = isCodexAcpCommand(command);
-    if (WIRE_TIMEOUT_CONFIG_KEYS.has(key) && (isCodexAcp || isClaudeAcpCommand(command))) {
+    const isClaudeAcp = isClaudeAcpCommand(command);
+    if (WIRE_TIMEOUT_CONFIG_KEYS.has(key) && (isCodexAcp || isClaudeAcp)) {
       return;
     }
     if (isCodexAcp) {
@@ -953,8 +961,25 @@ export class AcpxRuntime implements AcpRuntime {
           return;
         }
       }
+      await delegate.setConfigOption(input);
+      return;
     }
-    await delegate.setConfigOption(input);
+    if (isClaudeAcp) {
+      if (CLAUDE_ACP_SUPPORTED_CONFIG_KEYS.has(key)) {
+        await delegate.setConfigOption(input);
+        return;
+      }
+      if (CLAUDE_ACP_THINKING_CONFIG_KEYS.has(key)) {
+        await delegate.setConfigOption({
+          ...input,
+          key: "effort",
+        });
+      }
+      return;
+    }
+    if (isOpenClawBridgeCommand(command)) {
+      await delegate.setConfigOption(input);
+    }
   }
 
   async cancel(input: Parameters<AcpRuntime["cancel"]>[0]): Promise<void> {

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -491,6 +491,59 @@ describe("session store writer queue", () => {
     expect(store[key]?.model).toBe("gpt-5.4");
   });
 
+  it("preserves ACP metadata written to disk after a stale cache snapshot", async () => {
+    const key = "agent:codex:acp:binding:telegram:default:cafebabe";
+    const { storePath } = await makeTmpStore({
+      [key]: {
+        sessionId: "sess-acp-race",
+        updatedAt: 100,
+      },
+    });
+
+    // Populate the object cache with an entry that predates ACP initialization.
+    loadSessionStore(storePath);
+
+    const acp = {
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "codex-telegram",
+      mode: "oneshot" as const,
+      state: "idle" as const,
+      lastActivityAt: 200,
+    };
+    await fsPromises.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [key]: {
+            sessionId: "sess-acp-race",
+            updatedAt: 200,
+            acp,
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        store[key] = {
+          sessionId: "sess-acp-race",
+          updatedAt: 300,
+          status: "done",
+        } as SessionEntry;
+      },
+      { skipMaintenance: true },
+    );
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[key]?.acp).toEqual(acp);
+    expect(store[key]?.status).toBe("done");
+  });
+
   it("allows explicit ACP metadata removal through the ACP session helper", async () => {
     const key = "agent:codex:acp:binding:discord:default:deadbeef";
     const { storePath } = await makeTmpStore({

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -442,6 +442,17 @@ export async function updateSessionStore<T>(
   return await runExclusiveSessionStoreWrite(storePath, async () => {
     const store = loadMutableSessionStoreForWriter(storePath);
     const previousAcpByKey = collectAcpMetadataSnapshot(store);
+    try {
+      const diskStore = loadSessionStore(storePath, { skipCache: true, clone: false });
+      for (const [sessionKey, acp] of collectAcpMetadataSnapshot(diskStore)) {
+        if (!previousAcpByKey.has(sessionKey)) {
+          previousAcpByKey.set(sessionKey, acp);
+        }
+      }
+    } catch {
+      // Preserve best-effort write behaviour if the on-disk store is temporarily unavailable.
+      // The in-memory snapshot still protects metadata visible to this writer.
+    }
     const result = await mutator(store);
     preserveExistingAcpMetadata({
       previousAcpByKey,


### PR DESCRIPTION
## Summary

Fix native ACP session failures across adapter-specific runtime gaps:

- gate `session/set_config_option` calls by ACP harness so unsupported adapter controls are dropped instead of hard-failing
- map Claude thinking controls to Claude ACP's supported `effort` option and drop unsupported keys like `timeout` / `approval_policy`
- preserve Codex ACP auth by symlinking `auth.json` into the isolated `CODEX_HOME` used by the bundled wrapper
- preserve ACP session metadata when session-store writers start from a stale cached snapshot and later save a whole-entry update

## Why

Native ACP sessions could start but then fail in different adapter-specific ways:

- Claude ACP surfaced generic internal errors when OpenClaw forwarded unsupported config keys
- Gemini-like/unknown ACP adapters could fail on unsupported `session/set_config_option`
- Codex ACP could report authentication required even when direct Codex CLI auth existed
- successful ACP spawns could later become unresumable if a subsequent session-store write dropped the persisted `acp` metadata block

## Tests

- `pnpm test:extension acpx`
- `pnpm vitest run src/config/sessions/sessions.test.ts src/agents/acp-spawn.test.ts`

## Local smoke verification

On OpenClaw 2026.5.7 with the equivalent live hotfix applied:

- Claude ACP: fresh ✅, resume ✅
- Codex ACP: fresh ✅, resume ✅
- Gemini ACP: fresh ✅, resume ✅
## Live behaviour proof

I also validated the same patch locally against OpenClaw 2026.5.7 with the equivalent installed-runtime hotfix applied, because the original failures only appeared during live ACP turns rather than unit tests alone.

Before the fix, the observed failures were:

- Claude ACP: `Internal error` after OpenClaw forwarded unsupported config keys such as `timeout` / `approval_policy`.
- Gemini-like ACP adapter: `Method not found: session/set_config_option`.
- Codex ACP: `Authentication required` despite direct Codex CLI auth being available.
- Post-spawn resume: `ACP metadata is missing...` after a later session-store write dropped the persisted ACP metadata block.

After the fix, live smoke results were:

```text
Claude ACP fresh:  CLAUDE_ACP_FRESH2_OK  <workspace>
Claude ACP resume: CLAUDE_ACP_RESUME2_OK <workspace>
Codex ACP fresh:   CODEX_ACP_FRESH2_OK   <workspace>
Codex ACP resume:  CODEX_ACP_RESUME2_OK  <workspace>
Gemini ACP fresh:  GEMINI_ACP_FRESH2_OK  <workspace>
Gemini ACP resume: GEMINI_ACP_RESUME2_OK <workspace>
```

The workspace path and local session identifiers are redacted here, but the fresh and resume checks were separate native ACP turns for each adapter.

Local test verification:

```text
pnpm test:extension acpx
# 11 files passed, 107 tests passed

pnpm vitest run src/config/sessions/sessions.test.ts src/agents/acp-spawn.test.ts
# 3 files passed, 139 tests passed
```

The second smoke run specifically covered the previous post-spawn metadata failure: all three resume turns completed after the session-store metadata preservation fix.
