### PR TITLE
[AI-assisted] fix(plugins): discover setup provider env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins: discover provider plugins from `setup.providers[].envVars` credentials during provider discovery while keeping the deprecated `providerAuthEnvVars` fallback. (#81542) Thanks @JARVIS-Glasses.
 - Docs/Codex harness: clarify that per-agent `CODEX_HOME` isolates `~/.codex` while inherited `HOME` intentionally keeps `.agents` discovery and subprocess user-home state available.
 - CLI tables: preserve muted/color styling on wrapped continuation lines after multiline cells, keeping `openclaw plugins list` descriptions readable.
 - iOS: restore first-use Contacts, Calendar, and Reminders permission prompts and add Privacy & Access status/actions in Settings. Thanks @BunsDev.

--- a/src/plugins/provider-discovery.runtime.test.ts
+++ b/src/plugins/provider-discovery.runtime.test.ts
@@ -51,12 +51,14 @@ function createManifestPlugin(id: string): PluginManifestRecord {
 function createManifestPluginWithoutDiscovery(params: {
   id: string;
   providerAuthEnvVars?: Record<string, string[]>;
+  setupProviders?: NonNullable<PluginManifestRecord["setup"]>["providers"];
 }): PluginManifestRecord {
   const { providerDiscoverySource: _providerDiscoverySource, ...plugin } = createManifestPlugin(
     params.id,
   );
   return {
     ...plugin,
+    ...(params.setupProviders ? { setup: { providers: params.setupProviders } } : {}),
     ...(params.providerAuthEnvVars ? { providerAuthEnvVars: params.providerAuthEnvVars } : {}),
   };
 }
@@ -182,6 +184,36 @@ describe("resolvePluginDiscoveryProvidersRuntime", () => {
     expect(mocks.resolvePluginProviders).toHaveBeenCalledTimes(1);
     const params = requireResolvePluginProvidersParams();
     expect(params.onlyPluginIds).toEqual(["deepseek", "kilocode"]);
+  });
+
+  it("falls back to full provider plugins when setup provider env vars are configured", () => {
+    const codexEntryProvider = createProvider({ id: "codex", mode: "catalog" });
+    const fullProviders = [createProvider({ id: "kilocode", mode: "catalog" })];
+    mocks.resolveDiscoveredProviderPluginIds.mockReturnValue(["codex", "kilocode"]);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      index: { plugins: [] },
+      manifestRegistry: {
+        plugins: [
+          createManifestPlugin("codex"),
+          createManifestPluginWithoutDiscovery({
+            id: "kilocode",
+            setupProviders: [{ id: "kilocode", envVars: ["KILOCODE_API_KEY"] }],
+          }),
+        ],
+        diagnostics: [],
+      },
+    });
+    mocks.loadSource.mockReturnValue(codexEntryProvider);
+    mocks.resolvePluginProviders.mockReturnValue(fullProviders);
+
+    expect(
+      resolvePluginDiscoveryProvidersRuntime({
+        env: { KILOCODE_API_KEY: "sk-test" } as NodeJS.ProcessEnv,
+      }),
+    ).toEqual([{ ...codexEntryProvider, pluginId: "codex" }, ...fullProviders]);
+    expect(mocks.resolvePluginProviders).toHaveBeenCalledTimes(1);
+    const params = requireResolvePluginProvidersParams();
+    expect(params.onlyPluginIds).toEqual(["kilocode"]);
   });
 
   it("shares one metadata snapshot between provider id discovery and entry loading", () => {

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -56,12 +56,14 @@ function hasProviderAuthEnvCredential(
   plugin: PluginManifestRecord,
   env: NodeJS.ProcessEnv,
 ): boolean {
-  return Object.values(plugin.providerAuthEnvVars ?? {}).some((envVars) =>
-    envVars.some((name) => {
-      const value = env[name]?.trim();
-      return value !== undefined && value !== "";
-    }),
-  );
+  const envVars = [
+    ...(plugin.setup?.providers ?? []).flatMap((provider) => provider.envVars ?? []),
+    ...Object.values(plugin.providerAuthEnvVars ?? {}).flat(),
+  ];
+  return envVars.some((name) => {
+    const value = env[name]?.trim();
+    return value !== undefined && value !== "";
+  });
 }
 
 function dedupeSorted(values: Iterable<string>): string[] {


### PR DESCRIPTION
## Summary

- Problem: runtime provider discovery only checked legacy `providerAuthEnvVars` when deciding whether a provider plugin without a discovery entry needed full plugin loading.
- Why it matters: plugins that have moved their env metadata to `setup.providers[].envVars` can be skipped by the fast discovery path even when their env key is present.
- What changed: the selective full-load credential check now reads `setup.providers[].envVars` and keeps the legacy `providerAuthEnvVars` fallback.
- What did NOT change: no provider config schema, provider API calls, plugin loading policy, or env value handling changed.

## Change Type

- Bug fix

## Scope

- Integrations
- API / contracts

## Linked Issue/PR

- Closes: N/A
- Related: N/A
- Fixes bug/regression: Yes

## Real behavior proof

- Behavior or issue addressed: provider runtime discovery includes setup-only provider env metadata when deciding which missing discovery-entry plugins need full loading.
- Real environment tested: local OpenClaw checkout on Windows, no real API credentials.
- Exact steps or command run after this patch:

```powershell
node --import tsx -e "const { resolvePluginDiscoveryProvidersRuntime } = await import('./src/plugins/provider-discovery.runtime.ts'); const providers = resolvePluginDiscoveryProvidersRuntime({ env: { ...process.env, DEEPINFRA_API_KEY: 'test-key' } }); const ids = providers.map((provider) => provider.id).filter((id) => ['deepinfra','codex','anthropic','deepseek'].includes(id)).sort(); console.log(JSON.stringify({ includesDeepinfra: ids.includes('deepinfra'), selectedIds: ids }, null, 2));"
```

- Evidence after fix:

```json
{
  "includesDeepinfra": true,
  "selectedIds": [
    "anthropic",
    "codex",
    "deepinfra",
    "deepseek"
  ]
}
```

- Observed result after fix: `deepinfra` is included through the runtime discovery path when only its setup provider env var is present.
- What was not tested: live provider API call, live gateway run, and full repo CI.
- Before evidence: source inspection showed the previous credential check read only `plugin.providerAuthEnvVars`, while setup-only provider env metadata lives under `plugin.setup.providers[].envVars`.

## Root Cause

- Root cause: the selective full-plugin fallback was still tied to deprecated `providerAuthEnvVars` metadata.
- Missing detection / guardrail: runtime discovery coverage did not include a provider plugin with `setup.providers[].envVars` and no discovery entry.
- Contributing context: provider env metadata has been moving toward `setup.providers[].envVars`, while the runtime fallback still had one legacy-only check.

## Regression Test Plan

- Coverage level that should have caught this:
  - Unit test
- Target test or file: `src/plugins/provider-discovery.runtime.test.ts`
- Scenario the test should lock in: a plugin without a discovery entry but with `setup.providers[].envVars` gets selected for full provider loading when that env var is set.
- Why this is the smallest reliable guardrail: the bug is in the runtime provider discovery selection logic, so a focused runtime test catches it without loading a real provider or doing network I/O.
- Existing related coverage: existing legacy `providerAuthEnvVars` coverage remained in place; this PR adds setup-provider env coverage.

## User-visible / Behavior Changes

Provider plugins that declare env metadata only through `setup.providers[].envVars` are more reliably discovered when the env key is present. No user config migration is needed.

## Diagram

```text
Before:
[setup.providers env key present] -> [fast discovery path] -> [plugin without discovery entry not selected for full load]

After:
[setup.providers env key present] -> [credential check sees setup env var] -> [plugin selected for full load]
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node.js/OpenClaw checkout, no container
- Model/provider: DeepInfra env-marker path with dummy value; no provider API request
- Integration/channel: N/A
- Relevant config: `DEEPINFRA_API_KEY=test-key` in the one command environment only

### Steps

1. Run the runtime discovery proof command above with a dummy `DEEPINFRA_API_KEY`.
2. Run the focused provider discovery runtime test.
3. Run the src test typecheck.

### Expected

- Runtime discovery includes a setup-only provider env plugin in the full-load selection when its env key is present.

### Actual

- Runtime proof reported `"includesDeepinfra": true`.
- Focused tests and src test typecheck passed.

## Evidence

- Trace/log snippets

Focused test output:

```text
Test Files  1 passed (1)
Tests       7 passed (7)
```

Typecheck:

```text
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo
passed
```

## Human Verification

- Verified scenarios: local runtime discovery proof with dummy setup provider env; focused runtime regression test; src test typecheck.
- Edge cases checked: legacy `providerAuthEnvVars` fallback still passes through existing coverage; new setup-provider env-only fallback is covered.
- What you did **not** verify: live provider API request, live gateway run, full repository test suite, and hosted CI.

## Review Conversations

- Addressed bot review conversations: N/A
- Unresolved conversations needing reviewer or maintainer judgment: N/A

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- Exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a plugin with a matching non-empty setup env var may now be fully loaded where it was previously skipped by the fast discovery path.
  - Mitigation: this matches the existing legacy env behavior, is scoped to plugins without discovery entries, and only checks env var presence without reading or logging secret values.
