### PR TITLE
[AI-assisted] fix(codex): route legacy auth profiles

### DIFF
--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -49,6 +49,22 @@ describe("OpenAI Codex routing policy", () => {
         authProfileId: "openai-codex:work",
       }),
     ).toBe("openai-codex");
+    expect(
+      resolveOpenAIRuntimeProviderForPi({
+        provider: "openai",
+        harnessRuntime: "pi",
+        authProfileProvider: "codex-cli",
+        authProfileId: "codex-cli:legacy",
+      }),
+    ).toBe("openai-codex");
+    expect(
+      resolveOpenAIRuntimeProviderForPi({
+        provider: "openai",
+        harnessRuntime: "pi",
+        authProfileProvider: "openai-codex-import",
+        authProfileId: "openai-codex-import:legacy",
+      }),
+    ).toBe("openai-codex");
   });
 
   it("ignores session PI pins when validating OpenAI auth profiles", () => {

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -1,7 +1,9 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { normalizeEmbeddedAgentRuntime } from "./pi-embedded-runner/runtime.js";
-import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
+import {
+  resolveProviderIdForAuth,
+  type ProviderAuthAliasLookupParams,
+} from "./provider-auth-aliases.js";
 import { normalizeProviderId } from "./provider-id.js";
 
 export const OPENAI_PROVIDER_ID = "openai";
@@ -71,11 +73,27 @@ export function modelSelectionShouldEnsureCodexPlugin(params: {
   return provider === OPENAI_PROVIDER_ID && !openAIProviderUsesCustomBaseUrl(params.config);
 }
 
-export function hasOpenAICodexAuthProfileOverride(value: unknown): boolean {
-  return (
-    typeof value === "string" &&
-    normalizeOptionalLowercaseString(value)?.startsWith(`${OPENAI_CODEX_PROVIDER_ID}:`) === true
-  );
+function parseAuthProfileProvider(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  const colonIndex = trimmed.indexOf(":");
+  if (colonIndex <= 0) {
+    return undefined;
+  }
+  return normalizeProviderId(trimmed.slice(0, colonIndex));
+}
+
+export function hasOpenAICodexAuthProfileOverride(
+  value: unknown,
+  aliasLookupParams?: ProviderAuthAliasLookupParams,
+): boolean {
+  const provider = parseAuthProfileProvider(value);
+  if (!provider) {
+    return false;
+  }
+  return resolveProviderIdForAuth(provider, aliasLookupParams) === OPENAI_CODEX_PROVIDER_ID;
 }
 
 export function shouldRouteOpenAIPiThroughCodexAuthProvider(params: {
@@ -87,20 +105,20 @@ export function shouldRouteOpenAIPiThroughCodexAuthProvider(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
 }): boolean {
-  if (
-    !isOpenAIProvider(params.provider) ||
-    !hasOpenAICodexAuthProfileOverride(params.authProfileId)
-  ) {
+  const aliasLookupParams = {
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+  };
+  if (!isOpenAIProvider(params.provider)) {
+    return false;
+  }
+  if (!hasOpenAICodexAuthProfileOverride(params.authProfileId, aliasLookupParams)) {
     return false;
   }
   const runtime = normalizeEmbeddedAgentRuntime(params.agentHarnessId ?? params.harnessRuntime);
   if (runtime !== "pi") {
     return false;
   }
-  const aliasLookupParams = {
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-  };
   const authProfileProvider = resolveProviderIdForAuth(
     params.authProfileProvider ?? params.authProfileId?.split(":", 1)[0] ?? "",
     aliasLookupParams,


### PR DESCRIPTION
## Summary

- Problem: explicit `openai` + `pi` runs only recognized `openai-codex:*` auth profile IDs for Codex OAuth routing.
- Why it matters: older stored Codex profile IDs such as `codex-cli:*` or `openai-codex-import:*` could fall back to the plain `openai` transport instead of the Codex-auth transport.
- What changed: Codex auth-profile override detection now resolves the profile ID prefix through the existing provider auth alias map before deciding the PI transport.
- What did NOT change: no auth storage migration, no provider discovery changes, no new auth methods, and no network behavior changes.

## Change Type

- Bug fix

## Scope

- Auth / tokens
- API / contracts

## Linked Issue/PR

- Closes: N/A
- Related: N/A
- Fixes bug/regression: Yes

## Real behavior proof

- Behavior or issue addressed: legacy Codex auth profile ID prefixes should keep explicit `openai` + `pi` runs on the `openai-codex` transport.
- Real environment tested: local OpenClaw checkout on Windows, no external API call and no credentials.
- Exact steps or command run after this patch:

```powershell
node --import tsx -e "const { resolveOpenAIRuntimeProviderForPi } = await import('./src/agents/openai-codex-routing.ts'); const base={provider:'openai',harnessRuntime:'pi',config:{}}; console.log(JSON.stringify({canonical:resolveOpenAIRuntimeProviderForPi({...base,authProfileProvider:'openai-codex',authProfileId:'openai-codex:work'}), legacyBoth:resolveOpenAIRuntimeProviderForPi({...base,authProfileProvider:'codex-cli',authProfileId:'codex-cli:legacy'}), importAlias:resolveOpenAIRuntimeProviderForPi({...base,authProfileProvider:'openai-codex-import',authProfileId:'openai-codex-import:legacy'})}, null, 2));"
```

- Evidence after fix:

```json
{
  "canonical": "openai-codex",
  "legacyBoth": "openai-codex",
  "importAlias": "openai-codex"
}
```

- Observed result after fix: canonical and legacy Codex profile IDs all resolve to the `openai-codex` PI transport.
- What was not tested: live OpenAI/Codex API request, live gateway run, and full repo test suite.
- Before evidence: before the patch, `codex-cli:legacy` and `openai-codex-import:legacy` returned `openai` from the same helper.

## Root Cause

- Root cause: `hasOpenAICodexAuthProfileOverride` checked the raw `authProfileId` string for the canonical `openai-codex:` prefix before the existing provider auth alias resolver could map legacy prefixes.
- Missing detection / guardrail: routing coverage only covered canonical `openai-codex:*` profile IDs.
- Contributing context: the OpenAI plugin still declares `codex-cli` and `openai-codex-import` as deprecated auth choice IDs for `openai-codex`.

## Regression Test Plan

- Coverage level that should have caught this:
  - Unit test
- Target test or file: `src/agents/openai-codex-routing.test.ts`
- Scenario the test should lock in: explicit `openai` + `pi` routing with `codex-cli:*` and `openai-codex-import:*` auth profile IDs resolves to `openai-codex`.
- Why this is the smallest reliable guardrail: the bug is isolated to the routing helper that chooses the PI transport.
- Existing related coverage: canonical `openai-codex:*` routing coverage existed, but not legacy profile prefixes.

## User-visible / Behavior Changes

Explicit OpenAI PI runs with older saved Codex auth profile IDs keep using the Codex-auth transport instead of falling back to plain OpenAI.

## Diagram

```text
Before:
openai + pi + codex-cli:legacy -> openai

After:
openai + pi + codex-cli:legacy -> alias resolver -> openai-codex
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local checkout, Node via repo tooling
- Model/provider: OpenAI / OpenAI Codex routing helper only
- Integration/channel: N/A
- Relevant config: no credentials or external config used

### Steps

1. Run the routing helper with `provider: "openai"` and `harnessRuntime: "pi"`.
2. Compare canonical `openai-codex:*` with legacy `codex-cli:*` and `openai-codex-import:*` profile IDs.
3. Run the targeted routing and nearby runtime/auth tests.

### Expected

- Canonical and legacy Codex auth profile prefixes resolve to `openai-codex`.

### Actual

- After the patch, all tested Codex auth profile prefixes resolve to `openai-codex`.

## Evidence

- Trace/log snippets

## Human Verification

- Verified scenarios:
  - `node --import tsx` proof for canonical and legacy auth profile prefixes.
  - `node scripts/test-projects.mjs src\agents\openai-codex-routing.test.ts` -> pass, 4/4.
  - `node scripts/test-projects.mjs src\agents\runtime-plan\build.test.ts src\agents\auth-profile-runtime-contract.test.ts` -> pass, 28/28.
  - `.\node_modules\.bin\oxfmt.CMD --check src\agents\openai-codex-routing.ts src\agents\openai-codex-routing.test.ts` -> pass.
  - `git diff --check` -> pass.
- Edge cases checked: canonical `openai-codex:*`, legacy `codex-cli:*`, and legacy `openai-codex-import:*` profile IDs.
- What you did **not** verify: live OpenAI/Codex API request, live gateway run, and full repo test suite.

## Review Conversations

- Addressed bot review conversations: N/A
- Unresolved conversations needing reviewer or maintainer judgment: N/A

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- Exact upgrade steps: N/A

## Risks and Mitigations

- Risk: legacy aliases could resolve through plugin metadata unexpectedly if the alias map changes.
  - Mitigation: this uses the existing `resolveProviderIdForAuth` path already used by auth planning, and the added regression test locks the intended OpenAI Codex aliases.
