### PR TITLE
fix(auto-reply): bridge claude-cli text-delta into reasoning preview

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -863,12 +863,60 @@ describe("runAgentTurnWithFallback", () => {
     expect(onReasoningStream).not.toHaveBeenCalled();
   });
 
+  it("does not bridge non-Claude CLI assistant events to onReasoningStream", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("codex-cli", "gpt-5.5"),
+      provider: "codex-cli",
+      model: "gpt-5.5",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "final answer", delta: "final answer" },
+      });
+      return { payloads: [{ text: "final answer" }], meta: {} };
+    });
+
+    const onReasoningStream = vi.fn<NonNullable<GetReplyOptions["onReasoningStream"]>>(
+      async (_payload) => undefined,
+    );
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "codex-cli";
+    followupRun.run.model = "gpt-5.5";
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      opts: { onReasoningStream },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onReasoningStream).not.toHaveBeenCalled();
+  });
+
   it("does not double-fire onReasoningStream from the bridge when the API/native runtime path is active", async () => {
-    // API/native runtimes get reasoning content from real thinking_delta events
-    // already wired through the embedded harness. The CLI text_delta → reasoning
-    // bridge must be isCliProvider-gated so non-CLI runs don't see assistant
-    // text_delta forwarded as reasoning content (which would duplicate or
-    // pollute the reasoning lane).
     state.isCliProviderMock.mockReturnValue(false);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
       result: await params.run("anthropic", "claude-sonnet-4-7"),
@@ -877,9 +925,6 @@ describe("runAgentTurnWithFallback", () => {
       attempts: [],
     }));
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
-      // Embedded harness emits assistant agent-events (the same bus the CLI
-      // bridge listens to). On the API path, those must NOT be re-emitted as
-      // reasoning content.
       const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
         "../../infra/agent-events.js",
       );
@@ -925,8 +970,6 @@ describe("runAgentTurnWithFallback", () => {
     });
     await new Promise((resolve) => setImmediate(resolve));
 
-    // The bridge only runs in the CLI gate; the embedded API path does not
-    // call onReasoningStream from assistant text_delta.
     expect(onReasoningStream).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -743,6 +743,193 @@ describe("runAgentTurnWithFallback", () => {
     expect(onPartialReply).not.toHaveBeenCalled();
   });
 
+  it("bridges CLI assistant agent events into onReasoningStream for live reasoning preview (opus-4-7 text_delta path)", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-7"),
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "Thinking", delta: "Thinking" },
+      });
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "Thinking about it", delta: " about it" },
+      });
+      return { payloads: [{ text: "Thinking about it" }], meta: {} };
+    });
+
+    const onReasoningStream = vi.fn<NonNullable<GetReplyOptions["onReasoningStream"]>>(
+      async (_payload) => undefined,
+    );
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-7";
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: { onReasoningStream },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    const reasoningTexts = onReasoningStream.mock.calls.map((call) => call[0].text);
+    expect(reasoningTexts).toEqual(["Thinking", "Thinking about it"]);
+  });
+
+  it("does not bridge CLI assistant events to onReasoningStream when silentExpected is set", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-7"),
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "heartbeat scratch text", delta: "heartbeat scratch text" },
+      });
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "NO_REPLY do not preview reasoning", delta: " do not preview reasoning" },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const onReasoningStream = vi.fn<NonNullable<GetReplyOptions["onReasoningStream"]>>(
+      async (_payload) => undefined,
+    );
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-7";
+    followupRun.run.silentExpected = true;
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      opts: { onReasoningStream },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onReasoningStream).not.toHaveBeenCalled();
+  });
+
+  it("does not double-fire onReasoningStream from the bridge when the API/native runtime path is active", async () => {
+    // API/native runtimes get reasoning content from real thinking_delta events
+    // already wired through the embedded harness. The CLI text_delta → reasoning
+    // bridge must be isCliProvider-gated so non-CLI runs don't see assistant
+    // text_delta forwarded as reasoning content (which would duplicate or
+    // pollute the reasoning lane).
+    state.isCliProviderMock.mockReturnValue(false);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("anthropic", "claude-sonnet-4-7"),
+      provider: "anthropic",
+      model: "claude-sonnet-4-7",
+      attempts: [],
+    }));
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      // Embedded harness emits assistant agent-events (the same bus the CLI
+      // bridge listens to). On the API path, those must NOT be re-emitted as
+      // reasoning content.
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      realAgentEvents.emitAgentEvent({
+        runId: "api-run",
+        stream: "assistant",
+        data: { text: "assistant text from API run", delta: "assistant text from API run" },
+      });
+      await params.onAgentEvent?.({
+        stream: "assistant",
+        data: { text: "assistant text from API run", delta: "assistant text from API run" },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const onReasoningStream = vi.fn<NonNullable<GetReplyOptions["onReasoningStream"]>>(
+      async (_payload) => undefined,
+    );
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "anthropic";
+    followupRun.run.model = "claude-sonnet-4-7";
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      opts: { onReasoningStream },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // The bridge only runs in the CLI gate; the embedded API path does not
+    // call onReasoningStream from assistant text_delta.
+    expect(onReasoningStream).not.toHaveBeenCalled();
+  });
+
   it("resolves CLI messageProvider from the live session surface when no origin channel is set", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -95,6 +95,10 @@ const GPT_CHAT_BREVITY_ACK_MAX_SENTENCES = 3;
 const GPT_CHAT_BREVITY_SOFT_MAX_CHARS = 900;
 const GPT_CHAT_BREVITY_SOFT_MAX_SENTENCES = 6;
 
+function shouldBridgeCliAssistantTextToReasoning(provider: string): boolean {
+  return normalizeLowercaseStringOrEmpty(provider) === "claude-cli";
+}
+
 function readApprovalScopeValue(value: unknown): "turn" | "session" | undefined {
   return value === "turn" || value === "session" ? value : undefined;
 }
@@ -1508,92 +1512,53 @@ export async function runAgentTurnWithFallback(params: {
             });
             return (async () => {
               let lifecycleTerminalEmitted = false;
-              let lastBridgedAssistantText: string | undefined;
-              let assistantBridgeUnsubscribed = false;
-              let assistantBridgeDelivery: Promise<void> = Promise.resolve();
-              const deliverBridgedAssistantText = async (text: string): Promise<void> => {
+              const createAssistantTextBridge = (deliver: (text: string) => Promise<void>) => {
+                let lastText: string | undefined;
+                let unsubscribed = false;
+                let delivery = Promise.resolve();
+                const rawUnsubscribe = onAgentEvent((evt) => {
+                  if (evt.runId !== runId || evt.stream !== "assistant") {
+                    return;
+                  }
+                  if (params.followupRun.run.silentExpected) {
+                    return;
+                  }
+                  const text = typeof evt.data.text === "string" ? evt.data.text : undefined;
+                  if (text === undefined || text === lastText) {
+                    return;
+                  }
+                  lastText = text;
+                  delivery = delivery.then(() => deliver(text)).catch(() => undefined);
+                });
+                return {
+                  unsubscribe() {
+                    if (unsubscribed) {
+                      return;
+                    }
+                    unsubscribed = true;
+                    rawUnsubscribe();
+                  },
+                  async drain(): Promise<void> {
+                    await delivery;
+                  },
+                };
+              };
+              const noopBridge = {
+                unsubscribe: () => undefined,
+                drain: async (): Promise<void> => undefined,
+              };
+              const assistantBridge = createAssistantTextBridge(async (text) => {
                 const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
                 if (textForTyping === undefined || !params.opts?.onPartialReply) {
                   return;
                 }
                 await params.opts.onPartialReply({ text: textForTyping });
-              };
-              const queueBridgedAssistantText = (text: string) => {
-                assistantBridgeDelivery = assistantBridgeDelivery
-                  .then(() => deliverBridgedAssistantText(text))
-                  .catch(() => undefined);
-              };
-              const drainAssistantBridgeDelivery = async (): Promise<void> => {
-                await assistantBridgeDelivery;
-              };
-              const rawUnsubscribeAssistantBridge = onAgentEvent((evt) => {
-                if (evt.runId !== runId || evt.stream !== "assistant") {
-                  return;
-                }
-                if (params.followupRun.run.silentExpected) {
-                  return;
-                }
-                const text = typeof evt.data.text === "string" ? evt.data.text : undefined;
-                if (text === undefined || text === lastBridgedAssistantText) {
-                  return;
-                }
-                lastBridgedAssistantText = text;
-                queueBridgedAssistantText(text);
               });
-              const unsubscribeAssistantBridge = () => {
-                if (assistantBridgeUnsubscribed) {
-                  return;
-                }
-                assistantBridgeUnsubscribed = true;
-                rawUnsubscribeAssistantBridge();
-              };
-              let lastBridgedReasoningText: string | undefined;
-              let reasoningBridgeUnsubscribed = false;
-              let reasoningBridgeDelivery: Promise<void> = Promise.resolve();
-              const deliverBridgedReasoningText = async (text: string): Promise<void> => {
-                if (typeof params.opts?.onReasoningStream !== "function") {
-                  return;
-                }
-                await params.opts.onReasoningStream({ text });
-              };
-              const queueBridgedReasoningText = (text: string) => {
-                reasoningBridgeDelivery = reasoningBridgeDelivery
-                  .then(() => deliverBridgedReasoningText(text))
-                  .catch(() => undefined);
-              };
-              const drainReasoningBridgeDelivery = async (): Promise<void> => {
-                await reasoningBridgeDelivery;
-              };
-              // CLI-runtime-only bridge: claude-opus-4-7 over `claude --output-format
-              // stream-json` suppresses readable `thinking_delta` events on the wire,
-              // so the reasoning preview lane stays silent during streaming. Bridge
-              // `stream: "assistant"` agent-events to `onReasoningStream` so the
-              // reasoning lane reflects the model's live text output. The reply lane
-              // is unaffected: `onPartialReply` is still settled by the assistant-text
-              // bridge above (PR #76914). API/native runtimes get reasoning content
-              // from real thinking_delta events and must NOT double-receive
-              // text_delta as reasoning — this bridge is gated on `isCliProvider`.
-              const rawUnsubscribeReasoningBridge = onAgentEvent((evt) => {
-                if (evt.runId !== runId || evt.stream !== "assistant") {
-                  return;
-                }
-                if (params.followupRun.run.silentExpected) {
-                  return;
-                }
-                const text = typeof evt.data.text === "string" ? evt.data.text : undefined;
-                if (text === undefined || text === lastBridgedReasoningText) {
-                  return;
-                }
-                lastBridgedReasoningText = text;
-                queueBridgedReasoningText(text);
-              });
-              const unsubscribeReasoningBridge = () => {
-                if (reasoningBridgeUnsubscribed) {
-                  return;
-                }
-                reasoningBridgeUnsubscribed = true;
-                rawUnsubscribeReasoningBridge();
-              };
+              const reasoningBridge = shouldBridgeCliAssistantTextToReasoning(cliExecutionProvider)
+                ? createAssistantTextBridge(async (text) => {
+                    await params.opts?.onReasoningStream?.({ text });
+                  })
+                : noopBridge;
               try {
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
@@ -1641,10 +1606,10 @@ export async function runAgentTurnWithFallback(params: {
                   result.meta?.systemPromptReport,
                 );
 
-                unsubscribeAssistantBridge();
-                unsubscribeReasoningBridge();
-                await drainAssistantBridgeDelivery();
-                await drainReasoningBridgeDelivery();
+                assistantBridge.unsubscribe();
+                reasoningBridge.unsubscribe();
+                await assistantBridge.drain();
+                await reasoningBridge.drain();
 
                 // CLI backends don't emit streaming assistant events, so we need to
                 // emit one with the final text so server-chat can populate its buffer
@@ -1671,10 +1636,10 @@ export async function runAgentTurnWithFallback(params: {
 
                 return result;
               } catch (err) {
-                unsubscribeAssistantBridge();
-                unsubscribeReasoningBridge();
-                await drainAssistantBridgeDelivery();
-                await drainReasoningBridgeDelivery();
+                assistantBridge.unsubscribe();
+                reasoningBridge.unsubscribe();
+                await assistantBridge.drain();
+                await reasoningBridge.drain();
                 if (rollbackFallbackCandidateSelection) {
                   try {
                     await rollbackFallbackCandidateSelection();
@@ -1698,8 +1663,8 @@ export async function runAgentTurnWithFallback(params: {
                 lifecycleTerminalEmitted = true;
                 throw err;
               } finally {
-                unsubscribeAssistantBridge();
-                unsubscribeReasoningBridge();
+                assistantBridge.unsubscribe();
+                reasoningBridge.unsubscribe();
                 // Defensive backstop: never let a CLI run complete without a terminal
                 // lifecycle event, otherwise downstream consumers can hang.
                 if (!lifecycleTerminalEmitted) {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1547,6 +1547,53 @@ export async function runAgentTurnWithFallback(params: {
                 assistantBridgeUnsubscribed = true;
                 rawUnsubscribeAssistantBridge();
               };
+              let lastBridgedReasoningText: string | undefined;
+              let reasoningBridgeUnsubscribed = false;
+              let reasoningBridgeDelivery: Promise<void> = Promise.resolve();
+              const deliverBridgedReasoningText = async (text: string): Promise<void> => {
+                if (typeof params.opts?.onReasoningStream !== "function") {
+                  return;
+                }
+                await params.opts.onReasoningStream({ text });
+              };
+              const queueBridgedReasoningText = (text: string) => {
+                reasoningBridgeDelivery = reasoningBridgeDelivery
+                  .then(() => deliverBridgedReasoningText(text))
+                  .catch(() => undefined);
+              };
+              const drainReasoningBridgeDelivery = async (): Promise<void> => {
+                await reasoningBridgeDelivery;
+              };
+              // CLI-runtime-only bridge: claude-opus-4-7 over `claude --output-format
+              // stream-json` suppresses readable `thinking_delta` events on the wire,
+              // so the reasoning preview lane stays silent during streaming. Bridge
+              // `stream: "assistant"` agent-events to `onReasoningStream` so the
+              // reasoning lane reflects the model's live text output. The reply lane
+              // is unaffected: `onPartialReply` is still settled by the assistant-text
+              // bridge above (PR #76914). API/native runtimes get reasoning content
+              // from real thinking_delta events and must NOT double-receive
+              // text_delta as reasoning — this bridge is gated on `isCliProvider`.
+              const rawUnsubscribeReasoningBridge = onAgentEvent((evt) => {
+                if (evt.runId !== runId || evt.stream !== "assistant") {
+                  return;
+                }
+                if (params.followupRun.run.silentExpected) {
+                  return;
+                }
+                const text = typeof evt.data.text === "string" ? evt.data.text : undefined;
+                if (text === undefined || text === lastBridgedReasoningText) {
+                  return;
+                }
+                lastBridgedReasoningText = text;
+                queueBridgedReasoningText(text);
+              });
+              const unsubscribeReasoningBridge = () => {
+                if (reasoningBridgeUnsubscribed) {
+                  return;
+                }
+                reasoningBridgeUnsubscribed = true;
+                rawUnsubscribeReasoningBridge();
+              };
               try {
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
@@ -1595,7 +1642,9 @@ export async function runAgentTurnWithFallback(params: {
                 );
 
                 unsubscribeAssistantBridge();
+                unsubscribeReasoningBridge();
                 await drainAssistantBridgeDelivery();
+                await drainReasoningBridgeDelivery();
 
                 // CLI backends don't emit streaming assistant events, so we need to
                 // emit one with the final text so server-chat can populate its buffer
@@ -1623,7 +1672,9 @@ export async function runAgentTurnWithFallback(params: {
                 return result;
               } catch (err) {
                 unsubscribeAssistantBridge();
+                unsubscribeReasoningBridge();
                 await drainAssistantBridgeDelivery();
+                await drainReasoningBridgeDelivery();
                 if (rollbackFallbackCandidateSelection) {
                   try {
                     await rollbackFallbackCandidateSelection();
@@ -1648,6 +1699,7 @@ export async function runAgentTurnWithFallback(params: {
                 throw err;
               } finally {
                 unsubscribeAssistantBridge();
+                unsubscribeReasoningBridge();
                 // Defensive backstop: never let a CLI run complete without a terminal
                 // lifecycle event, otherwise downstream consumers can hang.
                 if (!lifecycleTerminalEmitted) {


### PR DESCRIPTION
## Summary

Adds a CLI-runtime-gated bridge in `src/auto-reply/reply/agent-runner-execution.ts` that forwards `stream: "assistant"` agent-events to `params.opts.onReasoningStream` for the duration of a CLI run. The reasoning preview lane lights up live as the model streams; the reply lane is unchanged (still settled via `onPartialReply` at end-of-turn).

Same shape as PR #76914 (merged) and #80046 (open) — `rawUnsubscribeReasoningBridge = onAgentEvent(...)` inside the same `isCliProvider(...)` gate, filtered by `runId`, respects `silentExpected`, mirrors the Promise-chain serialization + drain pattern, mirrors unsubscribe at success/catch/finally.

Why this is needed for `claude-cli`: the parser at `src/agents/cli-output.ts` already routes `text_delta` events to `onAssistantDelta` (PR #76914) which feeds the reply lane via `stream: "assistant"`. The reasoning lane has no parallel source on the CLI path — `thinking_delta` events are not emitted over the wire for `claude-opus-4-7` (verified empirically: `claude -p --output-format stream-json --include-partial-messages --verbose --effort max --model claude-opus-4-7` emits a `thinking` content_block + `signature_delta` only, no `thinking_delta` deltas). Re-emitting `stream: "assistant"` events as `stream: "reasoning"` is the only available source for live reasoning-preview content on opus-4-7.

API/native runtime path is unaffected — the bridge is `isCliProvider(...)`-gated. Models that emit `thinking_delta` over the API path continue to feed `onReasoningStream` via the existing channel; no double-fire.

## Change Type

- [x] Bug fix

## Scope

- [x] Agents / runtime
- [x] Auto-reply commands

## User-visible / Behaviour Changes

- Telegram, Discord, Slack, WhatsApp, Mattermost, Feishu reasoning preview lanes light up live during Claude CLI runs (previously silent).
- Reply lane unchanged.
- API/native runtime unchanged.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No** — routes existing assistant text events to an existing callback through an existing bus.

## Verification

- `pnpm vitest run src/auto-reply/reply/agent-runner-execution.test.ts` — 75/75 pass (72 pre-existing + 3 new).
- New tests: bridge forwards `stream: "assistant"` events to `onReasoningStream`; respects `silentExpected`; does not double-fire on API/native runtime path.

## Real behavior proof

**Behavior addressed**: Claude CLI runs (`claude-opus-4-7`, `claude-sonnet-4-6`, etc.) silently produce nothing in the Telegram reasoning preview lane during streaming. Users see the typing indicator and the final reply, but no in-progress narrative — opus-4-7 emits no readable `thinking_delta` content over the wire so the existing thinking pipeline never fires for that model.

**Real environment tested**: Windows 11 Pro 26200, Node v22, OpenClaw 2026.5.12-beta.1 with this PR's bridge applied to `node_modules/openclaw/dist/agent-runner.runtime-*.js` as a dist patch. Channel: Telegram, phone client to local gateway. Auth: Claude CLI OAuth.

**Exact steps or command run after this patch**: (1) Restart OpenClaw gateway (auto-restarts via scheduled task on kill). (2) Send a Claude CLI turn from Telegram that involves the model narrating its work — e.g. ask it to investigate something and report back. (3) Observe both lanes streaming in real time.

**Evidence after fix**:

![reasoning lane and reply lane streaming live for a Claude CLI turn](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets/pr-reasoning-bridge/.proof/telegram-reasoning-and-reply.jpg)

Pre-tool narration ("Got it — no auto-notification in this setup. The scan finished in the background...Let me check now since you're here:"), the tool indicator (`🛠️ Bash ⏳`), and the post-tool answer text all appear in the reasoning preview lane as they stream. The reply lane (lower message) contains only the final answer segment ("Scan still running (1 python proc). Output file empty — buffered, only writes at the end. I'll check again when you prompt next.") settled at end-of-turn via the existing `onPartialReply` path.

**Observed result after fix**: Reasoning preview lane shows the chronological narrative + tool markers; reply lane shows the final answer segment. Two complementary views, neither empty. Tested on `claude-opus-4-7` via `--effort max`.

**What was not tested**: Discord / Slack / WhatsApp / Mattermost / Feishu reasoning-preview rendering (the bridge is channel-agnostic at the bus layer; channel-plugin rendering of `onReasoningStream` callbacks is the same path the API/native runtime already exercises, so behaviour should be equivalent — not run end-to-end on those channels).

## Compatibility / Migration

- Backward compatible? **Yes** — additive bridge; no existing path changed.
- Config/env changes? **No**
- Migration needed? **No**
