### PR TITLE
fix(codex): preserve MCP servers in app-server harness

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -723,18 +723,18 @@ describe("runCodexAppServerAttempt", () => {
     expect(binding.mcpServersFingerprint).toBe("mcp-v2");
   });
 
-  it("preserves an MCP-backed Codex thread when MCP config is not evaluated", async () => {
+  it("starts a no-MCP Codex thread when MCP config is evaluated empty", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     await writeCodexAppServerBinding(sessionFile, {
-      threadId: "existing-thread",
+      threadId: "old-thread",
       cwd: workspaceDir,
       dynamicToolsFingerprint: JSON.stringify([]),
       mcpServersFingerprint: "mcp-v1",
     });
     const request = vi.fn(async (method: string, _params: unknown) => {
-      if (method === "thread/resume") {
-        return threadStartResult("existing-thread");
+      if (method === "thread/start") {
+        return threadStartResult("new-thread");
       }
       throw new Error(`unexpected method: ${method}`);
     });
@@ -745,13 +745,13 @@ describe("runCodexAppServerAttempt", () => {
       cwd: workspaceDir,
       dynamicTools: [],
       appServer: createThreadLifecycleAppServerOptions(),
-      mcpServersFingerprintEvaluated: false,
+      mcpServersFingerprintEvaluated: true,
     });
 
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
-    expect(binding.threadId).toBe("existing-thread");
-    expect(binding.mcpServersFingerprint).toBe("mcp-v1");
-    expect((await readCodexAppServerBinding(sessionFile))?.mcpServersFingerprint).toBe("mcp-v1");
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start"]);
+    expect(binding.threadId).toBe("new-thread");
+    expect(binding.mcpServersFingerprint).toBeUndefined();
+    expect((await readCodexAppServerBinding(sessionFile))?.mcpServersFingerprint).toBeUndefined();
   });
 
   it("does not expose OpenClaw Tool Search controls through Codex dynamic tools", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -675,6 +675,7 @@ describe("runCodexAppServerAttempt", () => {
         },
       },
       mcpServersFingerprint: "mcp-v1",
+      mcpServersFingerprintEvaluated: true,
     });
 
     const startRequest = request.mock.calls.find(([method]) => method === "thread/start");
@@ -714,11 +715,43 @@ describe("runCodexAppServerAttempt", () => {
       dynamicTools: [],
       appServer: createThreadLifecycleAppServerOptions(),
       mcpServersFingerprint: "mcp-v2",
+      mcpServersFingerprintEvaluated: true,
     });
 
     expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start"]);
     expect(binding.threadId).toBe("new-thread");
     expect(binding.mcpServersFingerprint).toBe("mcp-v2");
+  });
+
+  it("preserves an MCP-backed Codex thread when MCP config is not evaluated", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "existing-thread",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: JSON.stringify([]),
+      mcpServersFingerprint: "mcp-v1",
+    });
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/resume") {
+        return threadStartResult("existing-thread");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const binding = await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+      mcpServersFingerprintEvaluated: false,
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+    expect(binding.threadId).toBe("existing-thread");
+    expect(binding.mcpServersFingerprint).toBe("mcp-v1");
+    expect((await readCodexAppServerBinding(sessionFile))?.mcpServersFingerprint).toBe("mcp-v1");
   });
 
   it("does not expose OpenClaw Tool Search controls through Codex dynamic tools", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -651,6 +651,76 @@ describe("runCodexAppServerAttempt", () => {
     }
   });
 
+  it("passes MCP server config through to Codex thread/start", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+      config: {
+        mcp_servers: {
+          search: {
+            url: "https://mcp.example.com/mcp",
+          },
+        },
+      },
+      mcpServersFingerprint: "mcp-v1",
+    });
+
+    const startRequest = request.mock.calls.find(([method]) => method === "thread/start");
+    expect((startRequest?.[1] as { config?: unknown } | undefined)?.config).toMatchObject({
+      mcp_servers: {
+        search: {
+          url: "https://mcp.example.com/mcp",
+        },
+      },
+      "features.code_mode": true,
+      "features.code_mode_only": true,
+    });
+    const binding = await readCodexAppServerBinding(sessionFile);
+    expect(binding?.mcpServersFingerprint).toBe("mcp-v1");
+  });
+
+  it("starts a new Codex thread when the MCP server fingerprint changes", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "old-thread",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: JSON.stringify([]),
+      mcpServersFingerprint: "mcp-v1",
+    });
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult("new-thread");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const binding = await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+      mcpServersFingerprint: "mcp-v2",
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start"]);
+    expect(binding.threadId).toBe("new-thread");
+    expect(binding.mcpServersFingerprint).toBe("mcp-v2");
+  });
+
   it("does not expose OpenClaw Tool Search controls through Codex dynamic tools", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -428,10 +428,6 @@ function restrictCodexAppServerSandboxForOpenClawSandbox(
   };
 }
 
-function shouldLoadCodexBundleMcpThreadConfig(params: EmbeddedRunAttemptParams): boolean {
-  return !params.disableTools && supportsModelTools(params.model);
-}
-
 export async function runCodexAppServerAttempt(
   params: EmbeddedRunAttemptParams,
   options: {
@@ -523,13 +519,14 @@ export async function runCodexAppServerAttempt(
     : resolveCodexAppServerEnvApiKeyCacheKey({
         startOptions: appServer.start,
       });
-  const bundleMcpThreadConfig = shouldLoadCodexBundleMcpThreadConfig(params)
-    ? await loadCodexBundleMcpThreadConfig({
-        workspaceDir: effectiveWorkspace,
-        cfg: params.config,
-      })
-    : undefined;
-  for (const diagnostic of bundleMcpThreadConfig?.diagnostics ?? []) {
+  const bundleMcpThreadConfig = await loadCodexBundleMcpThreadConfig({
+    workspaceDir: effectiveWorkspace,
+    cfg: params.config,
+    toolsEnabled: supportsModelTools(params.model),
+    disableTools: params.disableTools,
+    toolsAllow: params.toolsAllow,
+  });
+  for (const diagnostic of bundleMcpThreadConfig.diagnostics) {
     embeddedAgentLog.warn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);
   }
   const activeContextEngine = isActiveHarnessContextEngine(params.contextEngine)
@@ -790,7 +787,8 @@ export async function runCodexAppServerAttempt(
             appServer: pluginAppServer,
             developerInstructions: promptBuild.developerInstructions,
             config: threadConfig,
-            mcpServersFingerprint: bundleMcpThreadConfig?.fingerprint,
+            mcpServersFingerprint: bundleMcpThreadConfig.fingerprint,
+            mcpServersFingerprintEvaluated: bundleMcpThreadConfig.evaluated,
             pluginThreadConfig: pluginThreadConfigEnabled
               ? {
                   enabled: true,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -15,6 +15,7 @@ import {
   formatErrorMessage,
   isActiveHarnessContextEngine,
   isSubagentSessionKey,
+  loadCodexBundleMcpThreadConfig,
   normalizeAgentRuntimeTools,
   resolveAttemptSpawnWorkspaceDir,
   resolveAgentHarnessBeforePromptBuildResult,
@@ -87,6 +88,7 @@ import { buildCodexPluginAppCacheKey } from "./plugin-app-cache-key.js";
 import {
   buildCodexPluginThreadConfig,
   buildCodexPluginThreadConfigInputFingerprint,
+  mergeCodexThreadConfigs,
   shouldBuildCodexPluginThreadConfig,
 } from "./plugin-thread-config.js";
 import {
@@ -426,6 +428,10 @@ function restrictCodexAppServerSandboxForOpenClawSandbox(
   };
 }
 
+function shouldLoadCodexBundleMcpThreadConfig(params: EmbeddedRunAttemptParams): boolean {
+  return !params.disableTools && supportsModelTools(params.model);
+}
+
 export async function runCodexAppServerAttempt(
   params: EmbeddedRunAttemptParams,
   options: {
@@ -517,6 +523,15 @@ export async function runCodexAppServerAttempt(
     : resolveCodexAppServerEnvApiKeyCacheKey({
         startOptions: appServer.start,
       });
+  const bundleMcpThreadConfig = shouldLoadCodexBundleMcpThreadConfig(params)
+    ? await loadCodexBundleMcpThreadConfig({
+        workspaceDir: effectiveWorkspace,
+        cfg: params.config,
+      })
+    : undefined;
+  for (const diagnostic of bundleMcpThreadConfig?.diagnostics ?? []) {
+    embeddedAgentLog.warn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);
+  }
   const activeContextEngine = isActiveHarnessContextEngine(params.contextEngine)
     ? params.contextEngine
     : undefined;
@@ -713,7 +728,10 @@ export async function runCodexAppServerAttempt(
       : options.nativeHookRelay?.enabled === false
         ? buildCodexNativeHookRelayDisabledConfig()
         : undefined;
-    const threadConfig = nativeHookRelayConfig;
+    const threadConfig = mergeCodexThreadConfigs(
+      nativeHookRelayConfig,
+      bundleMcpThreadConfig?.configPatch as JsonObject | undefined,
+    );
     const pluginThreadConfigEnabled = shouldBuildCodexPluginThreadConfig(pluginConfig);
     const pluginAppCacheKey = buildCodexPluginAppCacheKey({
       appServer,
@@ -772,6 +790,7 @@ export async function runCodexAppServerAttempt(
             appServer: pluginAppServer,
             developerInstructions: promptBuild.developerInstructions,
             config: threadConfig,
+            mcpServersFingerprint: bundleMcpThreadConfig?.fingerprint,
             pluginThreadConfig: pluginThreadConfigEnabled
               ? {
                   enabled: true,

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -41,6 +41,7 @@ export type CodexAppServerThreadBinding = {
   serviceTier?: CodexServiceTier;
   dynamicToolsFingerprint?: string;
   userMcpServersFingerprint?: string;
+  mcpServersFingerprint?: string;
   pluginAppsFingerprint?: string;
   pluginAppsInputFingerprint?: string;
   pluginAppPolicyContext?: PluginAppPolicyContext;
@@ -104,6 +105,8 @@ export async function readCodexAppServerBinding(
         typeof parsed.userMcpServersFingerprint === "string"
           ? parsed.userMcpServersFingerprint
           : undefined,
+      mcpServersFingerprint:
+        typeof parsed.mcpServersFingerprint === "string" ? parsed.mcpServersFingerprint : undefined,
       pluginAppsFingerprint:
         typeof parsed.pluginAppsFingerprint === "string" ? parsed.pluginAppsFingerprint : undefined,
       pluginAppsInputFingerprint:
@@ -149,6 +152,7 @@ export async function writeCodexAppServerBinding(
     serviceTier: binding.serviceTier,
     dynamicToolsFingerprint: binding.dynamicToolsFingerprint,
     userMcpServersFingerprint: binding.userMcpServersFingerprint,
+    mcpServersFingerprint: binding.mcpServersFingerprint,
     pluginAppsFingerprint: binding.pluginAppsFingerprint,
     pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
     pluginAppPolicyContext: binding.pluginAppPolicyContext,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -74,6 +74,7 @@ export async function startOrResumeThread(params: {
   developerInstructions?: string;
   config?: JsonObject;
   mcpServersFingerprint?: string;
+  mcpServersFingerprintEvaluated?: boolean;
   pluginThreadConfig?: CodexPluginThreadConfigProvider;
 }): Promise<CodexAppServerThreadLifecycleBinding> {
   const dynamicToolsFingerprint = fingerprintDynamicTools(params.dynamicTools);
@@ -113,7 +114,11 @@ export async function startOrResumeThread(params: {
     await clearCodexAppServerBinding(params.params.sessionFile);
     binding = undefined;
   }
-  if (binding?.threadId && binding.mcpServersFingerprint !== params.mcpServersFingerprint) {
+  if (
+    binding?.threadId &&
+    params.mcpServersFingerprintEvaluated === true &&
+    binding.mcpServersFingerprint !== params.mcpServersFingerprint
+  ) {
     embeddedAgentLog.debug("codex app-server MCP config changed; starting a new thread", {
       threadId: binding.threadId,
     });
@@ -154,7 +159,11 @@ export async function startOrResumeThread(params: {
       binding = undefined;
     }
   }
-  if (binding?.threadId && binding.mcpServersFingerprint !== params.mcpServersFingerprint) {
+  if (
+    binding?.threadId &&
+    params.mcpServersFingerprintEvaluated === true &&
+    binding.mcpServersFingerprint !== params.mcpServersFingerprint
+  ) {
     embeddedAgentLog.debug("codex app-server MCP config changed; starting a new thread", {
       threadId: binding.threadId,
     });
@@ -214,6 +223,10 @@ export async function startOrResumeThread(params: {
           agentDir: params.params.agentDir,
           config: params.params.config,
         });
+        const nextMcpServersFingerprint =
+          params.mcpServersFingerprintEvaluated === true
+            ? params.mcpServersFingerprint
+            : binding.mcpServersFingerprint;
         await writeCodexAppServerBinding(
           params.params.sessionFile,
           {
@@ -224,7 +237,7 @@ export async function startOrResumeThread(params: {
             modelProvider: response.modelProvider ?? fallbackModelProvider,
             dynamicToolsFingerprint,
             userMcpServersFingerprint,
-            mcpServersFingerprint: params.mcpServersFingerprint,
+            mcpServersFingerprint: nextMcpServersFingerprint,
             pluginAppsFingerprint: binding.pluginAppsFingerprint,
             pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
             pluginAppPolicyContext: binding.pluginAppPolicyContext,
@@ -246,7 +259,7 @@ export async function startOrResumeThread(params: {
           modelProvider: response.modelProvider ?? fallbackModelProvider,
           dynamicToolsFingerprint,
           userMcpServersFingerprint,
-          mcpServersFingerprint: params.mcpServersFingerprint,
+          mcpServersFingerprint: nextMcpServersFingerprint,
           pluginAppsFingerprint: binding.pluginAppsFingerprint,
           pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
           pluginAppPolicyContext: binding.pluginAppPolicyContext,
@@ -293,6 +306,8 @@ export async function startOrResumeThread(params: {
     config: params.params.config,
   });
   const createdAt = new Date().toISOString();
+  const nextMcpServersFingerprint =
+    params.mcpServersFingerprintEvaluated === true ? params.mcpServersFingerprint : undefined;
   if (!preserveExistingBinding) {
     await writeCodexAppServerBinding(
       params.params.sessionFile,
@@ -304,7 +319,7 @@ export async function startOrResumeThread(params: {
         modelProvider: response.modelProvider ?? modelProvider,
         dynamicToolsFingerprint,
         userMcpServersFingerprint,
-        mcpServersFingerprint: params.mcpServersFingerprint,
+        mcpServersFingerprint: nextMcpServersFingerprint,
         pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
         pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
         pluginAppPolicyContext: pluginThreadConfig?.policyContext,
@@ -328,7 +343,7 @@ export async function startOrResumeThread(params: {
     modelProvider: response.modelProvider ?? modelProvider,
     dynamicToolsFingerprint,
     userMcpServersFingerprint,
-    mcpServersFingerprint: params.mcpServersFingerprint,
+    mcpServersFingerprint: nextMcpServersFingerprint,
     pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
     pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
     pluginAppPolicyContext: pluginThreadConfig?.policyContext,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -203,6 +203,7 @@ export async function startOrResumeThread(params: {
     } else {
       try {
         const authProfileId = params.params.authProfileId ?? binding.authProfileId;
+        const resumeConfig = mergeCodexThreadConfigs(params.config, userMcpServersConfigPatch);
         const response = assertCodexThreadResumeResponse(
           await params.client.request(
             "thread/resume",
@@ -211,7 +212,7 @@ export async function startOrResumeThread(params: {
               authProfileId,
               appServer: params.appServer,
               developerInstructions: params.developerInstructions,
-              config: params.config,
+              config: resumeConfig,
             }),
           ),
         );

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -73,6 +73,7 @@ export async function startOrResumeThread(params: {
   appServer: CodexAppServerRuntimeOptions;
   developerInstructions?: string;
   config?: JsonObject;
+  mcpServersFingerprint?: string;
   pluginThreadConfig?: CodexPluginThreadConfigProvider;
 }): Promise<CodexAppServerThreadLifecycleBinding> {
   const dynamicToolsFingerprint = fingerprintDynamicTools(params.dynamicTools);
@@ -112,6 +113,13 @@ export async function startOrResumeThread(params: {
     await clearCodexAppServerBinding(params.params.sessionFile);
     binding = undefined;
   }
+  if (binding?.threadId && binding.mcpServersFingerprint !== params.mcpServersFingerprint) {
+    embeddedAgentLog.debug("codex app-server MCP config changed; starting a new thread", {
+      threadId: binding.threadId,
+    });
+    await clearCodexAppServerBinding(params.params.sessionFile);
+    binding = undefined;
+  }
   if (binding?.threadId) {
     let pluginBindingStale = isCodexPluginThreadBindingStale({
       codexPluginsEnabled: params.pluginThreadConfig?.enabled ?? false,
@@ -145,6 +153,13 @@ export async function startOrResumeThread(params: {
       await clearCodexAppServerBinding(params.params.sessionFile);
       binding = undefined;
     }
+  }
+  if (binding?.threadId && binding.mcpServersFingerprint !== params.mcpServersFingerprint) {
+    embeddedAgentLog.debug("codex app-server MCP config changed; starting a new thread", {
+      threadId: binding.threadId,
+    });
+    await clearCodexAppServerBinding(params.params.sessionFile);
+    binding = undefined;
   }
   if (binding?.threadId) {
     // `/codex resume <thread>` writes a binding before the next turn can know
@@ -209,6 +224,7 @@ export async function startOrResumeThread(params: {
             modelProvider: response.modelProvider ?? fallbackModelProvider,
             dynamicToolsFingerprint,
             userMcpServersFingerprint,
+            mcpServersFingerprint: params.mcpServersFingerprint,
             pluginAppsFingerprint: binding.pluginAppsFingerprint,
             pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
             pluginAppPolicyContext: binding.pluginAppPolicyContext,
@@ -230,6 +246,7 @@ export async function startOrResumeThread(params: {
           modelProvider: response.modelProvider ?? fallbackModelProvider,
           dynamicToolsFingerprint,
           userMcpServersFingerprint,
+          mcpServersFingerprint: params.mcpServersFingerprint,
           pluginAppsFingerprint: binding.pluginAppsFingerprint,
           pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
           pluginAppPolicyContext: binding.pluginAppPolicyContext,
@@ -287,6 +304,7 @@ export async function startOrResumeThread(params: {
         modelProvider: response.modelProvider ?? modelProvider,
         dynamicToolsFingerprint,
         userMcpServersFingerprint,
+        mcpServersFingerprint: params.mcpServersFingerprint,
         pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
         pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
         pluginAppPolicyContext: pluginThreadConfig?.policyContext,
@@ -310,6 +328,7 @@ export async function startOrResumeThread(params: {
     modelProvider: response.modelProvider ?? modelProvider,
     dynamicToolsFingerprint,
     userMcpServersFingerprint,
+    mcpServersFingerprint: params.mcpServersFingerprint,
     pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
     pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
     pluginAppPolicyContext: pluginThreadConfig?.policyContext,

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -205,7 +205,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     });
   });
 
-  it("resumes a thread with the matching user MCP fingerprint without resending ignored MCP config", async () => {
+  it("resends user MCP config when resuming a thread with the matching fingerprint", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const config = {
@@ -252,6 +252,8 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
       config?: { mcp_servers?: Record<string, unknown> };
     };
     expect(resumeCall).toBeDefined();
-    expect(resumeParams?.config?.mcp_servers).toBeUndefined();
+    expect(resumeParams?.config?.mcp_servers).toMatchObject({
+      notes: { command: "node", args: ["/opt/notes-mcp/dist/index.js"] },
+    });
   });
 });

--- a/src/agents/cli-runner/bundle-mcp-codex.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.ts
@@ -7,6 +7,7 @@ import {
   decodeHeaderEnvPlaceholder,
   normalizeStringRecord,
 } from "./bundle-mcp-adapter-shared.js";
+import { buildCodexMcpServersConfig } from "../codex-mcp-config.js";
 import { serializeTomlInlineValue } from "./toml-inline.js";
 
 // Mutable JSON shape structurally compatible with the bundled Codex
@@ -70,14 +71,7 @@ export function injectCodexMcpConfigArgs(
   args: string[] | undefined,
   config: BundleMcpConfig,
 ): string[] {
-  const overrides = serializeTomlInlineValue(
-    Object.fromEntries(
-      Object.entries(config.mcpServers).map(([name, server]) => [
-        name,
-        normalizeCodexServerConfig(name, server),
-      ]),
-    ),
-  );
+  const overrides = serializeTomlInlineValue(buildCodexMcpServersConfig(config));
   return [...(args ?? []), "-c", `mcp_servers=${overrides}`];
 }
 

--- a/src/agents/codex-mcp-config.test.ts
+++ b/src/agents/codex-mcp-config.test.ts
@@ -72,7 +72,7 @@ describe("loadCodexBundleMcpThreadConfig", () => {
     expect(loaded.fingerprint).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  it("skips MCP config when Pi would not create a bundle MCP runtime", () => {
+  it("returns an evaluated empty MCP config when Pi would not create a bundle MCP runtime", () => {
     const cfg = {
       mcp: {
         servers: {
@@ -98,7 +98,7 @@ describe("loadCodexBundleMcpThreadConfig", () => {
 
       expect(loaded.configPatch).toBeUndefined();
       expect(loaded.fingerprint).toBeUndefined();
-      expect(loaded.evaluated).toBe(false);
+      expect(loaded.evaluated).toBe(true);
     }
   });
 

--- a/src/agents/codex-mcp-config.test.ts
+++ b/src/agents/codex-mcp-config.test.ts
@@ -72,13 +72,45 @@ describe("loadCodexBundleMcpThreadConfig", () => {
     expect(loaded.fingerprint).toMatch(/^[a-f0-9]{64}$/);
   });
 
+  it("skips MCP config when Pi would not create a bundle MCP runtime", () => {
+    const cfg = {
+      mcp: {
+        servers: {
+          search: {
+            transport: "streamable-http",
+            url: "https://mcp.example.com/mcp",
+          },
+        },
+      },
+    } as const;
+
+    for (const params of [
+      { toolsEnabled: false },
+      { toolsEnabled: true, disableTools: true },
+      { toolsEnabled: true, toolsAllow: [] },
+      { toolsEnabled: true, toolsAllow: ["memory_search"] },
+    ]) {
+      const loaded = loadCodexBundleMcpThreadConfig({
+        workspaceDir: "/workspace",
+        cfg,
+        ...params,
+      });
+
+      expect(loaded.configPatch).toBeUndefined();
+      expect(loaded.fingerprint).toBeUndefined();
+      expect(loaded.evaluated).toBe(false);
+    }
+  });
+
   it("omits the config patch when no MCP servers are configured", () => {
     const loaded = loadCodexBundleMcpThreadConfig({
       workspaceDir: "/workspace",
       cfg: {},
+      toolsEnabled: true,
     });
 
     expect(loaded.configPatch).toBeUndefined();
     expect(loaded.fingerprint).toBeUndefined();
+    expect(loaded.evaluated).toBe(true);
   });
 });

--- a/src/agents/codex-mcp-config.test.ts
+++ b/src/agents/codex-mcp-config.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildCodexMcpServersConfig, loadCodexBundleMcpThreadConfig } from "./codex-mcp-config.js";
+
+const mocks = vi.hoisted(() => ({
+  bundleMcp: {
+    config: {
+      mcpServers: {},
+    },
+    diagnostics: [],
+  },
+}));
+
+vi.mock("../plugins/bundle-mcp.js", () => ({
+  loadEnabledBundleMcpConfig: () => mocks.bundleMcp,
+}));
+
+describe("buildCodexMcpServersConfig", () => {
+  it("normalizes OpenClaw MCP servers into Codex app-server mcp_servers shape", () => {
+    expect(
+      buildCodexMcpServersConfig({
+        mcpServers: {
+          openclaw: {
+            type: "http",
+            url: "http://127.0.0.1:23119/mcp",
+            headers: {
+              Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
+              "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
+              "x-static": "static-value",
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      openclaw: {
+        url: "http://127.0.0.1:23119/mcp",
+        default_tools_approval_mode: "approve",
+        bearer_token_env_var: "OPENCLAW_MCP_TOKEN",
+        http_headers: {
+          "x-static": "static-value",
+        },
+        env_http_headers: {
+          "x-session-key": "OPENCLAW_MCP_SESSION_KEY",
+        },
+      },
+    });
+  });
+});
+
+describe("loadCodexBundleMcpThreadConfig", () => {
+  it("loads configured OpenClaw MCP servers as a Codex thread config patch", () => {
+    const loaded = loadCodexBundleMcpThreadConfig({
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            search: {
+              transport: "streamable-http",
+              url: "https://mcp.example.com/mcp",
+            },
+          },
+        },
+      },
+    });
+
+    expect(loaded.configPatch).toEqual({
+      mcp_servers: {
+        search: {
+          url: "https://mcp.example.com/mcp",
+        },
+      },
+    });
+    expect(loaded.fingerprint).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("omits the config patch when no MCP servers are configured", () => {
+    const loaded = loadCodexBundleMcpThreadConfig({
+      workspaceDir: "/workspace",
+      cfg: {},
+    });
+
+    expect(loaded.configPatch).toBeUndefined();
+    expect(loaded.fingerprint).toBeUndefined();
+  });
+});

--- a/src/agents/codex-mcp-config.test.ts
+++ b/src/agents/codex-mcp-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildCodexMcpServersConfig, loadCodexBundleMcpThreadConfig } from "./codex-mcp-config.js";
 
 const mocks = vi.hoisted(() => ({
@@ -13,6 +13,15 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../plugins/bundle-mcp.js", () => ({
   loadEnabledBundleMcpConfig: () => mocks.bundleMcp,
 }));
+
+beforeEach(() => {
+  mocks.bundleMcp = {
+    config: {
+      mcpServers: {},
+    },
+    diagnostics: [],
+  };
+});
 
 describe("buildCodexMcpServersConfig", () => {
   it("normalizes OpenClaw MCP servers into Codex app-server mcp_servers shape", () => {
@@ -47,16 +56,25 @@ describe("buildCodexMcpServersConfig", () => {
 });
 
 describe("loadCodexBundleMcpThreadConfig", () => {
-  it("loads configured OpenClaw MCP servers as a Codex thread config patch", () => {
+  it("loads enabled bundled MCP servers as a Codex thread config patch", () => {
+    mocks.bundleMcp = {
+      config: {
+        mcpServers: {
+          search: {
+            type: "http",
+            url: "https://mcp.example.com/mcp",
+          },
+        },
+      },
+      diagnostics: [],
+    };
+
     const loaded = loadCodexBundleMcpThreadConfig({
       workspaceDir: "/workspace",
       cfg: {
-        mcp: {
-          servers: {
-            search: {
-              transport: "streamable-http",
-              url: "https://mcp.example.com/mcp",
-            },
+        plugins: {
+          entries: {
+            "bundle-probe": { enabled: true },
           },
         },
       },
@@ -70,6 +88,27 @@ describe("loadCodexBundleMcpThreadConfig", () => {
       },
     });
     expect(loaded.fingerprint).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("leaves user mcp.servers to the Codex user MCP projection path", () => {
+    const loaded = loadCodexBundleMcpThreadConfig({
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            search: {
+              transport: "streamable-http",
+              url: "https://mcp.example.com/mcp",
+            },
+          },
+        },
+      },
+      toolsEnabled: true,
+    });
+
+    expect(loaded.configPatch).toBeUndefined();
+    expect(loaded.fingerprint).toBeUndefined();
+    expect(loaded.evaluated).toBe(true);
   });
 
   it("returns an evaluated empty MCP config when Pi would not create a bundle MCP runtime", () => {

--- a/src/agents/codex-mcp-config.ts
+++ b/src/agents/codex-mcp-config.ts
@@ -12,6 +12,7 @@ import type {
   CodexMcpServersConfig,
   LoadCodexBundleMcpThreadConfigParams,
 } from "./codex-mcp-config.types.js";
+import { shouldCreateBundleMcpRuntimeForAttempt } from "./pi-embedded-runner/run/attempt-tool-construction-plan.js";
 
 export type {
   CodexBundleMcpThreadConfig,
@@ -95,6 +96,17 @@ function fingerprintCodexMcpServersConfig(config: CodexMcpServersConfig): string
 export function loadCodexBundleMcpThreadConfig(
   params: LoadCodexBundleMcpThreadConfigParams,
 ): CodexBundleMcpThreadConfig {
+  const evaluated = shouldCreateBundleMcpRuntimeForAttempt({
+    toolsEnabled: params.toolsEnabled ?? true,
+    disableTools: params.disableTools,
+    toolsAllow: params.toolsAllow,
+  });
+  if (!evaluated) {
+    return {
+      diagnostics: [],
+      evaluated: false,
+    };
+  }
   const merged = loadMergedBundleMcpConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
@@ -104,6 +116,7 @@ export function loadCodexBundleMcpThreadConfig(
   if (Object.keys(mcpServers).length === 0) {
     return {
       diagnostics: merged.diagnostics,
+      evaluated: true,
     };
   }
   return {
@@ -111,6 +124,7 @@ export function loadCodexBundleMcpThreadConfig(
       mcp_servers: mcpServers,
     },
     diagnostics: merged.diagnostics,
+    evaluated: true,
     fingerprint: fingerprintCodexMcpServersConfig(mcpServers),
   };
 }

--- a/src/agents/codex-mcp-config.ts
+++ b/src/agents/codex-mcp-config.ts
@@ -96,15 +96,15 @@ function fingerprintCodexMcpServersConfig(config: CodexMcpServersConfig): string
 export function loadCodexBundleMcpThreadConfig(
   params: LoadCodexBundleMcpThreadConfigParams,
 ): CodexBundleMcpThreadConfig {
-  const evaluated = shouldCreateBundleMcpRuntimeForAttempt({
+  const shouldCreateRuntime = shouldCreateBundleMcpRuntimeForAttempt({
     toolsEnabled: params.toolsEnabled ?? true,
     disableTools: params.disableTools,
     toolsAllow: params.toolsAllow,
   });
-  if (!evaluated) {
+  if (!shouldCreateRuntime) {
     return {
       diagnostics: [],
-      evaluated: false,
+      evaluated: true,
     };
   }
   const merged = loadMergedBundleMcpConfig({

--- a/src/agents/codex-mcp-config.ts
+++ b/src/agents/codex-mcp-config.ts
@@ -1,0 +1,116 @@
+import crypto from "node:crypto";
+import type { BundleMcpConfig, BundleMcpServerConfig } from "../plugins/bundle-mcp.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import { loadMergedBundleMcpConfig, toCliBundleMcpServerConfig } from "./bundle-mcp-config.js";
+import {
+  applyCommonServerConfig,
+  decodeHeaderEnvPlaceholder,
+  normalizeStringRecord,
+} from "./cli-runner/bundle-mcp-adapter-shared.js";
+import type {
+  CodexBundleMcpThreadConfig,
+  CodexMcpServersConfig,
+  LoadCodexBundleMcpThreadConfigParams,
+} from "./codex-mcp-config.types.js";
+
+export type {
+  CodexBundleMcpThreadConfig,
+  CodexMcpServersConfig,
+  LoadCodexBundleMcpThreadConfigParams,
+} from "./codex-mcp-config.types.js";
+
+function isOpenClawLoopbackMcpServer(name: string, server: BundleMcpServerConfig): boolean {
+  return (
+    name === "openclaw" &&
+    typeof server.url === "string" &&
+    /^https?:\/\/(?:127\.0\.0\.1|localhost):\d+\/mcp(?:[?#].*)?$/.test(server.url)
+  );
+}
+
+export function normalizeCodexMcpServerConfig(
+  name: string,
+  server: BundleMcpServerConfig,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = {};
+  applyCommonServerConfig(next, server);
+  if (isOpenClawLoopbackMcpServer(name, server)) {
+    next.default_tools_approval_mode = "approve";
+  }
+  const httpHeaders = normalizeStringRecord(server.headers);
+  if (httpHeaders) {
+    const staticHeaders: Record<string, string> = {};
+    const envHeaders: Record<string, string> = {};
+    for (const [name, value] of Object.entries(httpHeaders)) {
+      const decoded = decodeHeaderEnvPlaceholder(value);
+      if (!decoded) {
+        staticHeaders[name] = value;
+        continue;
+      }
+      if (decoded.bearer && normalizeOptionalLowercaseString(name) === "authorization") {
+        next.bearer_token_env_var = decoded.envVar;
+        continue;
+      }
+      envHeaders[name] = decoded.envVar;
+    }
+    if (Object.keys(staticHeaders).length > 0) {
+      next.http_headers = staticHeaders;
+    }
+    if (Object.keys(envHeaders).length > 0) {
+      next.env_http_headers = envHeaders;
+    }
+  }
+  return next;
+}
+
+export function buildCodexMcpServersConfig(config: BundleMcpConfig): CodexMcpServersConfig {
+  return Object.fromEntries(
+    Object.entries(config.mcpServers).map(([name, server]) => [
+      name,
+      normalizeCodexMcpServerConfig(name, server),
+    ]),
+  );
+}
+
+function stableJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableJsonValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => [key, stableJsonValue(child)]),
+  );
+}
+
+function fingerprintCodexMcpServersConfig(config: CodexMcpServersConfig): string {
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(stableJsonValue(config)))
+    .digest("hex");
+}
+
+export function loadCodexBundleMcpThreadConfig(
+  params: LoadCodexBundleMcpThreadConfigParams,
+): CodexBundleMcpThreadConfig {
+  const merged = loadMergedBundleMcpConfig({
+    workspaceDir: params.workspaceDir,
+    cfg: params.cfg,
+    mapConfiguredServer: toCliBundleMcpServerConfig,
+  });
+  const mcpServers = buildCodexMcpServersConfig(merged.config);
+  if (Object.keys(mcpServers).length === 0) {
+    return {
+      diagnostics: merged.diagnostics,
+    };
+  }
+  return {
+    configPatch: {
+      mcp_servers: mcpServers,
+    },
+    diagnostics: merged.diagnostics,
+    fingerprint: fingerprintCodexMcpServersConfig(mcpServers),
+  };
+}

--- a/src/agents/codex-mcp-config.ts
+++ b/src/agents/codex-mcp-config.ts
@@ -1,7 +1,10 @@
 import crypto from "node:crypto";
-import type { BundleMcpConfig, BundleMcpServerConfig } from "../plugins/bundle-mcp.js";
+import {
+  loadEnabledBundleMcpConfig,
+  type BundleMcpConfig,
+  type BundleMcpServerConfig,
+} from "../plugins/bundle-mcp.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
-import { loadMergedBundleMcpConfig, toCliBundleMcpServerConfig } from "./bundle-mcp-config.js";
 import {
   applyCommonServerConfig,
   decodeHeaderEnvPlaceholder,
@@ -107,15 +110,14 @@ export function loadCodexBundleMcpThreadConfig(
       evaluated: true,
     };
   }
-  const merged = loadMergedBundleMcpConfig({
+  const bundleMcp = loadEnabledBundleMcpConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
-    mapConfiguredServer: toCliBundleMcpServerConfig,
   });
-  const mcpServers = buildCodexMcpServersConfig(merged.config);
+  const mcpServers = buildCodexMcpServersConfig(bundleMcp.config);
   if (Object.keys(mcpServers).length === 0) {
     return {
-      diagnostics: merged.diagnostics,
+      diagnostics: bundleMcp.diagnostics,
       evaluated: true,
     };
   }
@@ -123,7 +125,7 @@ export function loadCodexBundleMcpThreadConfig(
     configPatch: {
       mcp_servers: mcpServers,
     },
-    diagnostics: merged.diagnostics,
+    diagnostics: bundleMcp.diagnostics,
     evaluated: true,
     fingerprint: fingerprintCodexMcpServersConfig(mcpServers),
   };

--- a/src/agents/codex-mcp-config.types.ts
+++ b/src/agents/codex-mcp-config.types.ts
@@ -8,10 +8,14 @@ export type CodexBundleMcpThreadConfig = {
     mcp_servers: CodexMcpServersConfig;
   };
   diagnostics: BundleMcpDiagnostic[];
+  evaluated: boolean;
   fingerprint?: string;
 };
 
 export type LoadCodexBundleMcpThreadConfigParams = {
   workspaceDir: string;
   cfg?: OpenClawConfig;
+  toolsEnabled?: boolean;
+  disableTools?: boolean;
+  toolsAllow?: string[];
 };

--- a/src/agents/codex-mcp-config.types.ts
+++ b/src/agents/codex-mcp-config.types.ts
@@ -1,0 +1,17 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { BundleMcpDiagnostic } from "../plugins/bundle-mcp.js";
+
+export type CodexMcpServersConfig = Record<string, Record<string, unknown>>;
+
+export type CodexBundleMcpThreadConfig = {
+  configPatch?: {
+    mcp_servers: CodexMcpServersConfig;
+  };
+  diagnostics: BundleMcpDiagnostic[];
+  fingerprint?: string;
+};
+
+export type LoadCodexBundleMcpThreadConfigParams = {
+  workspaceDir: string;
+  cfg?: OpenClawConfig;
+};

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -2,6 +2,10 @@
 // Keep heavyweight tool construction out of this module so harness imports can
 // register quickly inside gateway startup and Docker e2e runs.
 
+import type {
+  CodexBundleMcpThreadConfig,
+  LoadCodexBundleMcpThreadConfigParams,
+} from "../agents/codex-mcp-config.types.js";
 import type { EmbeddedRunAttemptResult } from "../agents/pi-embedded-runner/run/types.js";
 import {
   abortEmbeddedPiRun,
@@ -134,7 +138,18 @@ export {
   logAgentRuntimeToolDiagnostics,
   normalizeAgentRuntimeTools,
 } from "../agents/runtime-plan/tools.js";
+export type {
+  CodexBundleMcpThreadConfig,
+  LoadCodexBundleMcpThreadConfigParams,
+} from "../agents/codex-mcp-config.types.js";
 export { normalizeProviderToolSchemas } from "../agents/pi-embedded-runner/tool-schema-runtime.js";
+
+export async function loadCodexBundleMcpThreadConfig(
+  params: LoadCodexBundleMcpThreadConfigParams,
+): Promise<CodexBundleMcpThreadConfig> {
+  const { loadCodexBundleMcpThreadConfig: load } = await import("../agents/codex-mcp-config.js");
+  return load(params);
+}
 export { resolveSandboxContext } from "../agents/sandbox.js";
 export { resolveBootstrapContextForRun } from "../agents/bootstrap-files.js";
 export type { EmbeddedContextFile } from "../agents/pi-embedded-helpers/types.js";


### PR DESCRIPTION
## Summary

- Problem: Codex app-server harness sessions did not reliably receive the same MCP tools as the Pi/CLI paths: plugin-bundled MCP was missing on thread start, and user-configured MCP could disappear after app-server restart because resume did not re-send `mcp_servers`.
- Already handled upstream: direct user OpenClaw config from `mcp.servers` in `~/.openclaw/openclaw.json` is projected on thread start by upstream commit `8a406528b40e2de274bda8b71b3a55136a45622d`; this PR preserves that support across `thread/resume`.
- What changed: enabled plugin-bundled MCP server config is normalized into Codex native `mcp_servers`, user-configured MCP is re-sent on Codex `thread/resume`, Codex app-server bindings track a bundled-MCP fingerprint, and tests cover bundled projection plus MCP resume/rotation behavior.
- What did NOT change: this does not wrap MCP tools as OpenClaw dynamic tools, does not replace Pi MCP materialization, and does not duplicate the upstream user `mcp.servers` thread-start projection path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: Codex app-server thread startup receives enabled plugin-bundled MCP server config through native Codex `mcp_servers`, and Codex thread resume re-sends user-configured `mcp_servers` so tools survive app-server/gateway restart.

Real environment tested: local macOS OpenClaw gateway/Codex app-server session on this branch. Earlier live proof showed native Codex MCP wiring and successful read-only MCP calls. The user MCP resume failure mode was verified against the live gateway status, config, logs, and Codex app-server binding state before the resume fix.

Exact steps or command run after this patch:
1. Confirmed upstream commit `8a406528b40e2de274bda8b71b3a55136a45622d` owns direct user `mcp.servers` projection on thread start.
2. Verified the live gateway was running built code containing that commit and found existing Codex bindings with matching user MCP fingerprints but no saved `mcp_servers` config.
3. Updated resume to re-send the user MCP thread-config patch.
4. Trimmed bundled MCP loading to enabled plugin-bundled servers via `loadEnabledBundleMcpConfig`.
5. Ran targeted regression tests, full build, and whitespace check.

Evidence after fix:

```text
CI=true pnpm test extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts -- --reporter=verbose
[test] passed 1 Vitest shard; 4 tests passed, including "resends user MCP config when resuming a thread with the matching fingerprint"

CI=true pnpm test src/agents/codex-mcp-config.test.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts -- --reporter=verbose
[test] passed 3 Vitest shards; 116 tests passed

CI=true pnpm build
[build-all] write-cli-compat

Live gateway evidence before fix:
gateway command: node /Users/phaedrus/Projects/clawdbot/dist/index.js gateway --port 18789
configured user MCP servers: hetzner, supabase, maniple
Codex binding for topic 24403 had userMcpServersFingerprint including those servers, but hasMcpServersInBindingConfig=false
```

Observed result after fix: the regression test now proves a Codex `thread/resume` request includes `config.mcp_servers.notes` when the user MCP fingerprint still matches, so a resumed thread receives user-configured MCP servers instead of relying on stale app-server process state.

What was not tested: a live installed plugin-bundled MCP execution after the final commit. The bundled-MCP path is covered by focused unit/seam tests; the user MCP resume failure mode was verified from live gateway state and locked by regression coverage rather than a second live external MCP call.

## Root Cause (if applicable)

- Root cause: Codex app-server thread startup did not project enabled plugin-bundled MCP server config into Codex native `mcp_servers` thread config. Separately, user-configured MCP servers projected on `thread/start` were not re-sent on `thread/resume`, so a restarted app-server could resume a bound thread without restoring those native MCP tools.
- Missing detection / guardrail: existing Codex coverage did not assert that bundled MCP servers are included in `thread/start`, that bundled-MCP fingerprints rotate Codex thread bindings when effective bundled MCP state changes or becomes empty, or that user MCP config is re-sent during `thread/resume`.
- Contributing context: direct user `mcp.servers` support was added independently upstream for thread start; this PR keeps that projection intact and adds the missing resume-side preservation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/codex-mcp-config.test.ts`
  - `src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts`
  - `extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts`
  - `extensions/codex/src/app-server/run-attempt.test.ts`
- Scenario the test should lock in: enabled plugin-bundled MCP servers serialize to Codex native `mcp_servers`; direct user `mcp.servers` is projected by the upstream user-MCP path and re-sent on resume; disabled/excluded bundled MCP is treated as an evaluated empty state that rotates stale MCP-backed Codex threads.
- Why this is the smallest reliable guardrail: it tests the config projection and invalidation boundaries directly without needing a live external MCP server in CI.

## User-visible / Behavior Changes

Codex app-server harness sessions can now expose plugin-bundled MCP server tools, matching the intended behavior already available through Pi/CLI bundle-MCP paths. Direct user `mcp.servers` support from upstream commit `8a406528b40e2de274bda8b71b3a55136a45622d` now also survives Codex `thread/resume` after app-server/gateway restart.

## Diagram (if applicable)

```text
Before:
plugin bundled MCP config -> Pi/CLI only
Codex app-server thread/start -> dynamic tools + hook config + user mcp.servers -> no bundled MCP tools
Codex app-server thread/resume after restart -> no re-sent user mcp.servers -> missing user MCP tools

After:
plugin bundled MCP config -> Codex bundle MCP normalizer -> Codex app-server thread/start config.mcp_servers -> native Codex MCP tools
user ~/.openclaw/openclaw.json mcp.servers -> upstream user-MCP projection path -> Codex thread/start and thread/resume config.mcp_servers
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: Codex sessions can now use MCP servers provided by enabled plugin bundles. The implementation reuses the existing Codex MCP serialization behavior, keeps header secret values behind environment references instead of inlining them, scopes the new loader to bundled MCP servers only, and treats disabled or allowlist-excluded bundled MCP as an evaluated empty state so stale MCP-backed native Codex threads are rotated away.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw gateway/Codex app-server for earlier native MCP proof; local test/build for final scoped patch
- Model/provider: Codex harness
- Integration/channel: Codex app-server harness
- Relevant config: enabled plugin-bundled MCP server config in tests; direct user `mcp.servers` covered on the resume path

### Steps

1. Confirm upstream direct user `mcp.servers` projection remains separate.
2. Run targeted MCP/Codex regression tests.
3. Run full build.
4. Run whitespace check.

### Expected

- Bundled MCP servers are projected into Codex `thread/start` config.
- User `mcp.servers` is not re-processed by the bundle-MCP loader, but is re-sent on Codex `thread/resume` through the user-MCP projection path.
- Existing MCP-backed Codex threads rotate when bundled MCP is disabled or excluded.
- Targeted tests, build, and whitespace check pass.

### Actual

- Targeted tests passed.
- `pnpm build` passed.
- `git diff --check` passed.

## Evidence

Targeted local verification:

```sh
CI=true pnpm test src/agents/codex-mcp-config.test.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts -- --reporter=verbose
CI=true pnpm build
git diff --check
```

Result:

```text
[test] passed 3 Vitest shards
pnpm build: passed
git diff --check: no output
```

## Human Verification (required)

- Verified scenarios: scoped bundled-MCP projection behavior; user `mcp.servers` re-sent on resume; stale MCP thread rotation when effective bundled MCP is empty; targeted regression tests; full build.
- Edge cases checked: disabled tools, empty tools allowlist, non-MCP allowlist, no bundled MCP servers, user `mcp.servers` present without bundled MCP.
- What was not verified live after the final scoped patch: live installed plugin-bundled MCP execution.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: Existing Codex sessions could reuse stale bundled-MCP thread config after bundled MCP availability changes.
  - Mitigation: Codex app-server bindings include a bundled-MCP fingerprint and start a fresh thread when it changes or becomes empty.
- Risk: Existing Codex sessions could resume after app-server/gateway restart without user-configured MCP tools.
  - Mitigation: Codex `thread/resume` now re-sends the user MCP `mcp_servers` patch when the binding fingerprint still matches.
- Risk: The PR could duplicate upstream user MCP projection.
  - Mitigation: the bundle-MCP loader now calls `loadEnabledBundleMcpConfig` directly and has a regression test proving user `mcp.servers` is left to the upstream projection path.
- Risk: Secrets could be accidentally inlined into Codex thread config.
  - Mitigation: shared Codex MCP serialization keeps sensitive header placeholders mapped through environment references and has regression coverage.



