### PR TITLE
fix(agents): keep current-turn metadata out of user prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: deliver current-turn channel metadata through hidden runtime context instead of prepending it to submitted user prompt text, so Telegram reply context no longer leaks into persisted user messages. Fixes #81241. Thanks @bgjens00.
 - iMessage: stop sending visible `<media:image>` placeholder text for media-only native image sends while preserving the internal echo key that prevents self-echo duplicate replies. (#81209) Thanks @homer-byte.
 - Agents/sessions: create configured agent main sessions before first `sessions_send` or gateway send, so agent-to-agent messages no longer fail when the target agent has not started yet.
 - gateway: pass Talk session scope to resolver [AI]. (#81379) Thanks @pgondhi987.

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -548,8 +548,8 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(systemPrompt).toContain("Ask who I am before continuing.");
   });
 
-  it("adds current-turn context to the current model input without exposing internal runtime context", async () => {
-    let seenPrompt: string | undefined;
+  it("queues current-turn context as hidden runtime context without changing user prompt text", async () => {
+    const seen: { prompt?: string; messages?: unknown[] } = {};
 
     const result = await createContextEngineAttemptRunner({
       contextEngine: createContextEngineBootstrapAndAssemble(),
@@ -582,7 +582,8 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         },
       },
       sessionPrompt: async (session, prompt) => {
-        seenPrompt = prompt;
+        seen.prompt = prompt;
+        seen.messages = [...session.messages];
         session.messages = [
           ...session.messages,
           { role: "assistant", content: "done", timestamp: 2 },
@@ -590,16 +591,23 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
     });
 
-    expect(seenPrompt).toContain("what does this mean?");
-    expect(seenPrompt).toContain("Reply target of current user message (untrusted, for context):");
-    expect(seenPrompt).toContain('"sender_label": "Mike"');
-    expect(seenPrompt).toContain("WT daily plan - Sat May 2");
-    expect(seenPrompt).toContain("./quoted-secret.png");
-    expect(seenPrompt).toContain("media://inbound/quoted.png");
-    expect(seenPrompt).not.toContain("OPENCLAW_INTERNAL_CONTEXT");
-    expect(seenPrompt).not.toContain("secret runtime context");
-    expect(seenPrompt?.trim().startsWith("Reply target of current user message")).toBe(true);
-    expect(result.finalPromptText).toBe(seenPrompt);
+    expect(seen.prompt).toBe("what does this mean?");
+    expect(result.finalPromptText).toBe("what does this mean?");
+    const runtimeContextMessage = findRecord(
+      requireRecords(seen.messages, "seen messages"),
+      (message) => message.customType === "openclaw.runtime-context",
+      "current-turn runtime context message",
+    );
+    const runtimeContextContent = String(runtimeContextMessage.content);
+    expect(runtimeContextContent).toContain("OPENCLAW_INTERNAL_CONTEXT");
+    expect(runtimeContextContent).toContain("secret runtime context");
+    expect(runtimeContextContent).toContain(
+      "Reply target of current user message (untrusted, for context):",
+    );
+    expect(runtimeContextContent).toContain('"sender_label": "Mike"');
+    expect(runtimeContextContent).toContain("WT daily plan - Sat May 2");
+    expect(runtimeContextContent).toContain("./quoted-secret.png");
+    expect(runtimeContextContent).toContain("media://inbound/quoted.png");
     expect(hoisted.detectAndLoadPromptImagesMock).toHaveBeenCalledTimes(1);
     expect(mockParams(hoisted.detectAndLoadPromptImagesMock, 0, "prompt image params").prompt).toBe(
       "what does this mean?",
@@ -611,9 +619,10 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       .split("\n")
       .map((line) => JSON.parse(line) as TrajectoryEvent);
     const promptSubmitted = trajectoryEvents.find((event) => event.type === "prompt.submitted");
-    expect(promptSubmitted?.data?.prompt).toBe(seenPrompt);
-    expect(promptSubmitted?.data?.prompt).toContain("WT daily plan - Sat May 2");
+    expect(promptSubmitted?.data?.prompt).toBe("what does this mean?");
+    expect(promptSubmitted?.data?.prompt).not.toContain("WT daily plan - Sat May 2");
     expect(promptSubmitted?.data?.prompt).not.toContain("secret runtime context");
+    expect(promptSubmitted?.data?.systemPrompt).toContain("WT daily plan - Sat May 2");
   });
 
   it("marks inter-session transcriptPrompt before submitting the visible prompt", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -360,8 +360,9 @@ import {
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
 import {
-  buildCurrentTurnPrompt,
+  buildCurrentTurnPromptContextPrefix,
   buildRuntimeContextSystemContext,
+  combineRuntimeContexts,
   queueRuntimeContextForNextTurn,
   resolveRuntimeContextPromptParts,
 } from "./runtime-context-prompt.js";
@@ -3121,10 +3122,7 @@ export async function runEmbeddedAttempt(
             effectivePrompt,
             transcriptPrompt: effectiveTranscriptPrompt,
           });
-          const promptForModel = buildCurrentTurnPrompt({
-            context: promptSubmission.runtimeOnly ? undefined : params.currentTurnContext,
-            prompt: promptSubmission.prompt,
-          });
+          const promptForModel = promptSubmission.prompt;
           const runtimeSystemContext = promptSubmission.runtimeSystemContext?.trim();
           if (promptSubmission.runtimeOnly && runtimeSystemContext) {
             const runtimeSystemPrompt = composeSystemPromptWithHookContext({
@@ -3136,9 +3134,12 @@ export async function runEmbeddedAttempt(
               systemPromptText = runtimeSystemPrompt;
             }
           }
+          const currentTurnRuntimeContext = promptSubmission.runtimeOnly
+            ? undefined
+            : buildCurrentTurnPromptContextPrefix(params.currentTurnContext);
           const runtimeContextForHook = promptSubmission.runtimeOnly
             ? undefined
-            : promptSubmission.runtimeContext?.trim();
+            : combineRuntimeContexts(promptSubmission.runtimeContext, currentTurnRuntimeContext);
           const runtimeSystemPromptForHook = runtimeContextForHook
             ? composeSystemPromptWithHookContext({
                 baseSystemPrompt: systemPromptText,

--- a/src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts
@@ -3,6 +3,7 @@ import {
   buildCurrentTurnPrompt,
   buildCurrentTurnPromptContextPrefix,
   buildRuntimeContextSystemContext,
+  combineRuntimeContexts,
   queueRuntimeContextForNextTurn,
   resolveRuntimeContextPromptParts,
 } from "./runtime-context-prompt.js";
@@ -96,6 +97,14 @@ describe("runtime context prompt submission", () => {
         prompt: "visible ask",
       }),
     ).toBe("Conversation context:\n\nvisible ask");
+  });
+
+  it("combines prompt-derived and current-turn runtime context blocks", () => {
+    expect(combineRuntimeContexts("secret runtime context", "Sender metadata")).toBe(
+      "secret runtime context\n\nSender metadata",
+    );
+    expect(combineRuntimeContexts(undefined, "  Sender metadata  ")).toBe("Sender metadata");
+    expect(combineRuntimeContexts("   ", undefined)).toBeUndefined();
   });
 
   it("queues runtime context as a hidden next-turn custom message", async () => {

--- a/src/agents/pi-embedded-runner/run/runtime-context-prompt.ts
+++ b/src/agents/pi-embedded-runner/run/runtime-context-prompt.ts
@@ -34,6 +34,8 @@ export function buildCurrentTurnPromptContextPrefix(
   return context?.text.trim() ?? "";
 }
 
+// CLI fallback for backends without hidden runtime-context delivery. Embedded
+// sessions should queue current-turn context via openclaw.runtime-context.
 export function buildCurrentTurnPrompt(params: {
   context: CurrentTurnPromptContext | undefined;
   prompt: string;
@@ -46,6 +48,14 @@ export function buildCurrentTurnPrompt(params: {
     return prefix;
   }
   return [prefix, params.prompt].join(params.context?.promptJoiner ?? "\n\n");
+}
+
+export function combineRuntimeContexts(...contexts: Array<string | undefined>): string | undefined {
+  const combined = contexts
+    .map((context) => context?.trim() ?? "")
+    .filter(Boolean)
+    .join("\n\n");
+  return combined || undefined;
 }
 
 function removeLastPromptOccurrence(text: string, prompt: string): string | null {


### PR DESCRIPTION
## Summary

Fixes #81241.

- Keep embedded runner prompt submission equal to the user/transcript prompt instead of prepending current-turn channel metadata.
- Merge prompt-derived runtime context with current-turn context and deliver it through the hidden `openclaw.runtime-context` next-turn message path.
- Add regression coverage for the embedded runner so Telegram reply metadata remains model-visible without becoming submitted user prompt text.
- Add an Unreleased changelog entry.

## Root Cause

Telegram/auto-reply already split the visible transcript prompt from `currentTurnContext`, but the embedded runner rebuilt the provider prompt with `buildCurrentTurnPrompt(...)`, which prepended that metadata to the submitted session prompt. That made runtime metadata eligible to persist as user-authored prompt text.

## Verification

- `pnpm test src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts -- --run`
- `pnpm test src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts -- --run`
- `pnpm test src/auto-reply/reply/get-reply-run.media-only.test.ts -t "threads inbound context as current-turn context without changing transcript text" -- --run`
- `pnpm test:changed`
- `pnpm format:check -- CHANGELOG.md src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/runtime-context-prompt.ts src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/runtime-context-prompt.ts src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`

Known unrelated local gate issue:

- `pnpm check:changed` passes guard checks and core typecheck, then fails in pre-existing `src/plugins/registry.runtime-config.test.ts` core-test typings (`PluginRuntime` shape / missing `configSchema`).