### PR TITLE
fix(agents): mark caught tool execution failures with isError:true (#81546)

### DIFF
--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -53,6 +53,10 @@ describe("pi tool definition adapter", () => {
     expect(details?.tool).toBe("boom");
     expect(details?.error).toBe("nope");
     expect(JSON.stringify(result.details)).not.toContain("\n    at ");
+    // Regression for #81546: caught tool failures must carry isError:true so
+    // downstream transports/transcripts surface them as real errors instead of
+    // delivering an apparent-success status:"error" payload.
+    expect((result as { isError?: boolean }).isError).toBe(true);
   });
 
   it("normalizes exec tool aliases in error results", async () => {
@@ -64,6 +68,7 @@ describe("pi tool definition adapter", () => {
     expect(details?.status).toBe("error");
     expect(details?.tool).toBe("exec");
     expect(details?.error).toBe("nope");
+    expect((result as { isError?: boolean }).isError).toBe(true);
   });
 
   it("coerces details-only tool results to include content", async () => {

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -148,11 +148,16 @@ function buildToolExecutionErrorResult(params: {
   toolName: string;
   message: string;
 }): AgentToolResult<unknown> {
-  return jsonResult({
+  // Mark caught tool execution failures with isError:true so downstream
+  // transports (Anthropic is_error, OpenAI tool_result, transcript repair,
+  // mutating-failure tracking) can distinguish them from successful
+  // status:"error" payloads. See issue #81546.
+  const result = jsonResult({
     status: "error",
     tool: params.toolName,
     error: params.message,
   });
+  return { ...result, isError: true } as AgentToolResult<unknown>;
 }
 
 function splitToolExecuteArgs(args: ToolExecuteArgsAny): {


### PR DESCRIPTION
## Summary

Fixes #81546.

When a tool throws inside the pi tool-definition adapter's catch path, the failure was wrapped as a `status:"error"` payload via `jsonResult()` but the resulting `AgentToolResult` had **no** `isError` flag. Downstream consumers that key off the structured flag instead of parsing the JSON `status` field then treated the result as a successful tool delivery containing text that happened to mention an error:

- `anthropic-transport-stream.ts` sends `is_error: undefined` (i.e. not an error) on the resulting `tool_result` block.
- `session-transcript-repair.ts` / runner result classifiers filter on `isError === true`.
- The model only sees a normal-looking tool result and decides not to retry.

In the reporter's session, an ambiguous-`oldText` `edit` failure surfaced as `{status:"error", error:"Found 4 occurrences ..."}` with `isError=false`; the agent read the file, then ended the session normally without ever retrying the write. Codex review confirmed the gap is exactly here in current main: caught tool exceptions become payload errors without an explicit error flag.

## Change

`src/agents/pi-tool-definition-adapter.ts` – `buildToolExecutionErrorResult` now returns `{ ...jsonResult(...), isError: true }` so caught tool exceptions are flagged as real errors on every adapter path (Anthropic `is_error`, OpenAI tool_result, transcript repair, mutating-failure tracking) while preserving the existing `status:"error"` payload shape for backwards compatibility.

The mutating-failure warning / retry-tracking logic in `pi-embedded-subscribe.handlers.tools.ts` is intentionally untouched – per the codex-review guidance we are not adding blind automatic retries of mutating edits, only restoring the model-visible failure marker so the model itself can react.

## Tests

- `src/agents/pi-tool-definition-adapter.test.ts` – the existing "wraps tool errors into a tool result" and exec-alias cases now also assert the wrapped error result has `isError: true` (regression for #81546).

The pre-existing handler tests covering `status:"error"` recognition (`pi-embedded-subscribe.handlers.tools.test.ts`) continue to pass: that path already tolerated either flag, and now it gets the explicit one too.

## Notes

- No prettier/format-only churn; only the targeted lines were edited.
- Verified no existing PR open for #81546 before pushing (`gh pr list -R openclaw/openclaw --search "81546" --state all`).