### PR TITLE
fix: honour tool error suppression for mutating tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: bound plugin-owned CLI transcript compaction with the host safety timeout so a hung context engine can no longer stall post-turn cleanup. (#84083) Thanks @100yenadmin.
 - Control UI/usage: truncate long context skill, tool, and file names in the usage panel while keeping the full name available on hover. (#42197) Thanks @Rain120.
 - Codex: respect explicit `models auth order set` and `config.auth.order` precedence over stale `lastGood` in `/codex account`, and show `no working credential` when every explicit-order profile is ineligible instead of marking a lower-ranked profile as active. Fixes #84386. (#84412) Thanks @openperf.
+- Agents: honor `messages.suppressToolErrors` for mutating tool failures so configured chat surfaces do not receive separate warning payloads. (#81561) Thanks @moeedahmed.
 
 ## 2026.5.19
 

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -417,13 +417,14 @@ describe("buildEmbeddedRunPayloads", () => {
 
   it.each([
     {
-      name: "still shows mutating tool errors when messages.suppressToolErrors is enabled",
+      name: "suppresses mutating tool errors when messages.suppressToolErrors is enabled",
       payload: {
         lastToolError: { toolName: "write", error: "connection timeout" },
         config: { messages: { suppressToolErrors: true } },
       },
       title: "Write",
       absentDetail: "connection timeout",
+      suppressed: true,
     },
     {
       name: "shows recoverable tool errors for mutating tools",
@@ -441,8 +442,12 @@ describe("buildEmbeddedRunPayloads", () => {
       title: "Browser",
       absentDetail: "connection timeout",
     },
-  ])("$name", ({ payload, title, absentDetail }) => {
+  ])("$name", ({ payload, title, absentDetail, suppressed }) => {
     const payloads = buildPayloads(payload);
+    if (suppressed) {
+      expect(payloads).toEqual([]);
+      return;
+    }
     expectSingleToolErrorPayload(payloads, { title, absentDetail });
   });
 

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -162,6 +162,9 @@ function resolveToolErrorWarningPolicy(params: {
   if (normalizedToolName === "sessions_send") {
     return { showWarning: false, includeDetails };
   }
+  if (params.suppressToolErrors) {
+    return { showWarning: false, includeDetails };
+  }
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {
@@ -171,9 +174,6 @@ function resolveToolErrorWarningPolicy(params: {
     };
   }
   if (isExecLikeToolName(params.lastToolError.toolName) && !includeDetails) {
-    return { showWarning: false, includeDetails };
-  }
-  if (params.suppressToolErrors) {
     return { showWarning: false, includeDetails };
   }
   return {


### PR DESCRIPTION
## Summary
- honour messages.suppressToolErrors before mutating-tool warning generation
- keep sessions_send suppression behaviour unchanged
- update regression coverage so mutating tool errors are suppressed when configured

## Test
- corepack pnpm exec vitest run src/agents/pi-embedded-runner/run/payloads.errors.test.ts --root .

## Context
Without this, internal mutating tool failures such as apply_patch can still emit user-facing warning payloads even when messages.suppressToolErrors is enabled.

## Real behavior proof

Ran the payload builder directly against this branch with a mutating tool error and `messages.suppressToolErrors=true`:

```bash
corepack pnpm exec tsx -e 'import { buildEmbeddedRunPayloads } from "./src/agents/pi-embedded-runner/run/payloads.ts"; const payloads = buildEmbeddedRunPayloads({ assistantTexts: [], toolMetas: [], lastAssistant: undefined, isCronTrigger: false, sessionKey: "session:telegram", inlineToolResultsAllowed: false, verboseLevel: "off", reasoningLevel: "off", toolResultFormat: "plain", lastToolError: { toolName: "write", error: "connection timeout" }, config: { messages: { suppressToolErrors: true } } }); console.log(JSON.stringify({scenario:"mutating write tool error with messages.suppressToolErrors=true", payloadCount: payloads.length, payloadTexts: payloads.map(p=>p.text)}, null, 2));'
```

Output:

```json
{
  "scenario": "mutating write tool error with messages.suppressToolErrors=true",
  "payloadCount": 0,
  "payloadTexts": []
}
```

This directly exercises the changed warning behavior: a mutating `write` tool failure with `messages.suppressToolErrors=true` produces no user-facing payload.

Regression test output:

```text
✓ unit-fast ../../src/agents/pi-embedded-runner/run/payloads.errors.test.ts (40 tests) 18ms
Test Files 1 passed (1)
Tests 40 passed (40)
```
