### PR TITLE
Preserve user HOME for Codex app-server launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram: delete tool-progress-only draft bubbles before rotating to the real answer, preventing orphaned progress messages in streamed replies.
+- Codex app-server: keep per-agent `CODEX_HOME` isolation without rewriting `HOME` by default, so Codex-run subprocesses can still find normal user-home config, tokens, and CLI state unless the launch explicitly overrides `HOME`. Thanks @pashpashpash.
 - ACP: preserve redacted numeric JSON-RPC `RequestError` details in runtime failure text, so backend diagnostics are visible instead of only `Internal error`. Fixes #81126. (#81188) Thanks @vyctorbrzezowski.
 - Agents: cache unchanged PI model discovery stores and model lookups, reducing repeated model-resolution startup latency under large model configs. Fixes #78851.
 - Security/Windows ACL audit: classify Anonymous Logon, Guests, Interactive, Local, and Network SIDs as world-equivalent principals so broadly writable paths stay critical instead of being downgraded to group-writable. Fixes #74350. (#74383) Thanks @dwc1997.

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -123,8 +123,9 @@ inventory a specific Codex home.
 
 Use this provider when moving to the OpenClaw Codex harness and you want to
 promote useful personal Codex CLI assets deliberately. Local Codex app-server
-launches use per-agent `CODEX_HOME` and `HOME` directories, so they do not read
-your personal Codex CLI state by default.
+launches use a per-agent `CODEX_HOME`, so they do not read your personal Codex
+CLI state by default, while subprocesses still inherit the normal process
+`HOME` unless the app-server launch explicitly overrides it.
 
 Running `openclaw migrate codex` in an interactive terminal previews the full
 plan, then opens checkbox selectors before the final apply confirmation. Skill

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -172,7 +172,7 @@ async function writeCodexCliAuthFile(codexHome: string): Promise<void> {
 }
 
 describe("bridgeCodexAppServerStartOptions", () => {
-  it("sets agent-owned CODEX_HOME and HOME for local app-server launches", async () => {
+  it("sets agent-owned CODEX_HOME without overriding HOME for local app-server launches", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const startOptions = createStartOptions();
     try {
@@ -188,12 +188,35 @@ describe("bridgeCodexAppServerStartOptions", () => {
         ...startOptions,
         env: {
           CODEX_HOME: codexHome,
-          HOME: nativeHome,
         },
       });
       await expect(fs.access(codexHome)).resolves.toBeUndefined();
-      await expect(fs.access(nativeHome)).resolves.toBeUndefined();
+      await expectPathMissing(nativeHome);
       expect(startOptions.env).toBeUndefined();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves inherited HOME when clearEnv asks to clear app-server isolation vars", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const startOptions = createStartOptions({
+      clearEnv: ["CODEX_HOME", "HOME", "FOO"],
+    });
+    try {
+      await expect(
+        bridgeCodexAppServerStartOptions({
+          startOptions,
+          agentDir,
+        }),
+      ).resolves.toEqual({
+        ...startOptions,
+        env: {
+          CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
+        },
+        clearEnv: ["FOO"],
+      });
+      expect(startOptions.clearEnv).toEqual(["CODEX_HOME", "HOME", "FOO"]);
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
@@ -260,7 +283,6 @@ describe("bridgeCodexAppServerStartOptions", () => {
         env: {
           EXISTING: "1",
           CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
-          HOME: resolveCodexAppServerNativeHomeDir(agentDir),
         },
         clearEnv: ["FOO", "CODEX_API_KEY", "OPENAI_API_KEY"],
       });
@@ -298,7 +320,6 @@ describe("bridgeCodexAppServerStartOptions", () => {
         ...startOptions,
         env: {
           CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
-          HOME: resolveCodexAppServerNativeHomeDir(agentDir),
         },
         clearEnv: ["FOO", "CODEX_API_KEY", "OPENAI_API_KEY"],
       });
@@ -331,7 +352,6 @@ describe("bridgeCodexAppServerStartOptions", () => {
         ...startOptions,
         env: {
           CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
-          HOME: resolveCodexAppServerNativeHomeDir(agentDir),
         },
         clearEnv: ["FOO", "CODEX_API_KEY", "OPENAI_API_KEY"],
       });
@@ -364,7 +384,6 @@ describe("bridgeCodexAppServerStartOptions", () => {
         ...startOptions,
         env: {
           CODEX_HOME: resolveCodexAppServerHomeDir(agentDir),
-          HOME: resolveCodexAppServerNativeHomeDir(agentDir),
         },
       });
     } finally {

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -35,7 +35,7 @@ const CODEX_APP_SERVER_NATIVE_HOME_DIRNAME = "home";
 const CODEX_API_KEY_ENV_VAR = "CODEX_API_KEY";
 const OPENAI_API_KEY_ENV_VAR = "OPENAI_API_KEY";
 const CODEX_APP_SERVER_API_KEY_ENV_VARS = [CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR];
-const CODEX_APP_SERVER_ISOLATION_ENV_VARS = [CODEX_HOME_ENV_VAR, HOME_ENV_VAR];
+const CODEX_APP_SERVER_HOME_ENV_VARS = [CODEX_HOME_ENV_VAR, HOME_ENV_VAR];
 
 type AuthProfileOrderConfig = Parameters<typeof resolveAuthProfileOrder>[0]["cfg"];
 
@@ -262,18 +262,20 @@ async function withAgentCodexHomeEnvironment(
     : resolveCodexAppServerHomeDir(agentDir);
   const nativeHome = startOptions.env?.[HOME_ENV_VAR]?.trim()
     ? startOptions.env[HOME_ENV_VAR]
-    : path.join(codexHome, CODEX_APP_SERVER_NATIVE_HOME_DIRNAME);
+    : undefined;
   await fs.mkdir(codexHome, { recursive: true });
-  await fs.mkdir(nativeHome, { recursive: true });
+  if (nativeHome) {
+    await fs.mkdir(nativeHome, { recursive: true });
+  }
   const nextStartOptions: CodexAppServerStartOptions = {
     ...startOptions,
     env: {
       ...startOptions.env,
       [CODEX_HOME_ENV_VAR]: codexHome,
-      [HOME_ENV_VAR]: nativeHome,
+      ...(nativeHome ? { [HOME_ENV_VAR]: nativeHome } : {}),
     },
   };
-  const clearEnv = withoutClearedCodexIsolationEnv(startOptions.clearEnv);
+  const clearEnv = withoutClearedCodexHomeEnv(startOptions.clearEnv);
   if (clearEnv) {
     nextStartOptions.clearEnv = clearEnv;
   } else {
@@ -282,11 +284,11 @@ async function withAgentCodexHomeEnvironment(
   return nextStartOptions;
 }
 
-function withoutClearedCodexIsolationEnv(clearEnv: string[] | undefined): string[] | undefined {
+function withoutClearedCodexHomeEnv(clearEnv: string[] | undefined): string[] | undefined {
   if (!clearEnv) {
     return undefined;
   }
-  const reserved = new Set(CODEX_APP_SERVER_ISOLATION_ENV_VARS);
+  const reserved = new Set(CODEX_APP_SERVER_HOME_ENV_VARS);
   const filtered = clearEnv.filter((envVar) => !reserved.has(envVar.trim().toUpperCase()));
   return filtered.length === clearEnv.length ? clearEnv : filtered;
 }


### PR DESCRIPTION
Codex mode needs two different kinds of state separation.

OpenClaw should keep Codex's own runtime state isolated per agent, so each agent gets its own Codex config, auth, plugins, and native thread history under its agent-owned `CODEX_HOME`. That part is still right.

What was too aggressive is that local Codex app-server launches also rewrote `HOME` to a synthetic directory under that Codex home. That made normal subprocesses launched by Codex think the user home had moved. Commands like `openclaw`, `gh`, cloud CLIs, git, and other local tools could then fail to find the config and token files they normally resolve from the real user home.

This PR keeps the per-agent `CODEX_HOME` behavior, stops setting `HOME` by default, and still preserves explicit `HOME` overrides for callers that intentionally want a hermetic launch. It also keeps `HOME` out of `clearEnv` so the process-inherited home survives app-server launches instead of being silently stripped.

The migration docs now describe the narrower isolation boundary: Codex state is per-agent through `CODEX_HOME`, while subprocesses inherit the normal process `HOME` unless the app-server launch explicitly overrides it.

tldr
- CODEX_HOME stays per-agent: Codex config, native Codex auth/account state, plugins, skills, app-server state, and native thread state stay under the OpenClaw agent's isolated Codex home.
- HOME stays normal: subprocesses Codex launches, including shell commands, openclaw, gh, cloud CLIs, git, etc., see the real user home and can find normal config/token files.
- Explicit HOME overrides still work if we ever need a hermetic launch mode.

## Real behavior proof

- Behavior or issue addressed: Codex app-server launches should keep per-agent `CODEX_HOME` isolation without rewriting subprocess `HOME` to the synthetic Codex home.
- Real environment tested: Actual local OpenClaw checkout on macOS, running `openclaw agent --local --model openai/gpt-5.5` through the Codex harness with the real main agent auth/profile.
- Exact steps or command run after this patch: Created a sentinel at `/Users/pash/.openclaw/codex-home-smoke-sentinel`, then ran the same `openclaw agent --local` smoke on current `origin/main` and this PR branch. The prompt asked the agent to use its native shell tool to print `os.homedir()`, `process.env.HOME`, `process.env.CODEX_HOME`, and whether the sentinel was visible from the subprocess home.
- Before evidence: On `origin/main` at `dc7fab4dc5`, the run went through the Codex harness with one `bash` tool call and no fallback, but the subprocess home was the synthetic Codex home.

```json
{
  "agentHarnessId": "codex",
  "provider": "openai",
  "model": "gpt-5.5",
  "fallbackUsed": false,
  "toolSummary": { "calls": 1, "tools": ["bash"], "failures": 0 },
  "payload": {
    "home": "/Users/pash/.openclaw/agents/main/agent/codex-home/home",
    "envHome": "/Users/pash/.openclaw/agents/main/agent/codex-home/home",
    "codexHome": "/Users/pash/.openclaw/agents/main/agent/codex-home",
    "sentinelExists": false,
    "sentinelPath": "/Users/pash/.openclaw/agents/main/agent/codex-home/home/.openclaw/codex-home-smoke-sentinel"
  }
}
```

- Evidence after fix: Copied live output from the after-fix `openclaw agent --local` run on this PR branch. The run still used the Codex harness with one `bash` tool call and no fallback, while the subprocess inherited the real user home and Codex stayed isolated under the agent-owned `CODEX_HOME`.

```json
{
  "agentHarnessId": "codex",
  "provider": "openai",
  "model": "gpt-5.5",
  "fallbackUsed": false,
  "toolSummary": { "calls": 1, "tools": ["bash"], "failures": 0 },
  "payload": {
    "home": "/Users/pash",
    "envHome": "/Users/pash",
    "codexHome": "/Users/pash/.openclaw/agents/main/agent/codex-home",
    "sentinelExists": true,
    "sentinelPath": "/Users/pash/.openclaw/codex-home-smoke-sentinel"
  }
}
```

- Observed result after fix: The OpenAI/Codex agent completed on the primary `openai/gpt-5.5` route with `fallbackUsed: false`; `home` and `envHome` were `/Users/pash`, `codexHome` remained `/Users/pash/.openclaw/agents/main/agent/codex-home`, and the sentinel was visible from the subprocess home.
- What was not tested: None.

The mirrored session files also show the actual Codex `bash` calls and tool results for both runs:

- `/Users/pash/.openclaw/agents/main/sessions/codex-home-smoke-before-20260513-161720.jsonl`
- `/Users/pash/.openclaw/agents/main/sessions/codex-home-smoke-after-20260513-161720.jsonl`
