### PR TITLE
[codex] fix browser CLI admin scope

### DIFF
--- a/extensions/browser/src/cli/browser-cli-shared.test.ts
+++ b/extensions/browser/src/cli/browser-cli-shared.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const gatewayMocks = vi.hoisted(() => ({
+  callGatewayFromCli: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("./core-api.js", () => ({
+  callGatewayFromCli: gatewayMocks.callGatewayFromCli,
+}));
+
+const { callBrowserRequest } = await import("./browser-cli-shared.js");
+
+describe("callBrowserRequest", () => {
+  beforeEach(() => {
+    gatewayMocks.callGatewayFromCli.mockClear();
+  });
+
+  it("requests the browser.request admin scope explicitly", async () => {
+    await callBrowserRequest(
+      { json: true },
+      { method: "GET", path: "/status", query: { profile: "openclaw" } },
+      { progress: true },
+    );
+
+    const extra = gatewayMocks.callGatewayFromCli.mock.calls[0]?.[3];
+    expect(extra).toEqual({ progress: true, scopes: ["operator.admin"] });
+  });
+});

--- a/extensions/browser/src/cli/browser-cli-shared.test.ts
+++ b/extensions/browser/src/cli/browser-cli-shared.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { callGatewayFromCli } from "./core-api.js";
+
+type CallGatewayFromCliArgs = Parameters<typeof callGatewayFromCli>;
 
 const gatewayMocks = vi.hoisted(() => ({
   callGatewayFromCli: vi.fn(async () => ({ ok: true })),
@@ -22,7 +25,10 @@ describe("callBrowserRequest", () => {
       { progress: true },
     );
 
-    const extra = gatewayMocks.callGatewayFromCli.mock.calls[0]?.[3];
+    const call = gatewayMocks.callGatewayFromCli.mock.calls[0] as unknown as
+      | CallGatewayFromCliArgs
+      | undefined;
+    const extra = call?.[3];
     expect(extra).toEqual({ progress: true, scopes: ["operator.admin"] });
   });
 });

--- a/extensions/browser/src/cli/browser-cli-shared.ts
+++ b/extensions/browser/src/cli/browser-cli-shared.ts
@@ -13,6 +13,8 @@ type BrowserRequestParams = {
   body?: unknown;
 };
 
+const BROWSER_REQUEST_GATEWAY_SCOPES = ["operator.admin"] as const;
+
 function normalizeQuery(query: BrowserRequestParams["query"]): Record<string, string> | undefined {
   if (!query) {
     return undefined;
@@ -53,7 +55,7 @@ export async function callBrowserRequest<T>(
       body: params.body,
       timeoutMs: resolvedTimeout,
     },
-    { progress: extra?.progress },
+    { progress: extra?.progress, scopes: [...BROWSER_REQUEST_GATEWAY_SCOPES] },
   );
   if (payload === undefined) {
     throw new Error("Unexpected browser.request response");


### PR DESCRIPTION
## Summary

Fixes #81555.

Browser CLI commands call the gateway `browser.request` method, which the browser plugin registers with `operator.admin`. The shared browser CLI wrapper was not passing explicit gateway scopes, so standalone CLI calls could rely on local method-scope inference that is unavailable when plugin registry activation is non-active. That can trigger a scope-upgrade approval loop for paired CLI devices.

This change makes `callBrowserRequest()` request `operator.admin` explicitly for every browser CLI RPC while preserving the existing progress and timeout behavior.

## Real behavior proof

- Behavior or issue addressed: Browser CLI RPCs must request gateway scope `operator.admin` for `browser.request`, so paired CLI devices do not get stuck in a scope-upgrade approval loop.
- Real environment tested: Local OpenClaw source checkout on Windows 11/PowerShell, branch `fix/browser-cli-admin-scope-81555`, commit `93ce05c101`, Node `v24.14.0`, pnpm `11.1.0`. A loopback OpenClaw gateway-protocol endpoint captured the actual gateway frames emitted by `extensions/browser/src/cli/browser-cli-shared.ts`.
- Exact steps or command run after this patch: Ran `node --import tsx --input-type=module` with a local WebSocket gateway listener, then invoked `callBrowserRequest(...)` from the browser CLI wrapper against `ws://127.0.0.1:<local-port>`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the local proof command:

```json
{
  "proof": "browser CLI wrapper live gateway handshake",
  "gatewayUrl": "ws://127.0.0.1:<local-port>",
  "connectMethod": "connect",
  "connectRole": "operator",
  "connectScopes": [
    "operator.admin"
  ],
  "client": {
    "id": "cli",
    "mode": "cli"
  },
  "rpcMethod": "browser.request",
  "requestPath": "/",
  "requestQuery": {
    "profile": "openclaw"
  },
  "observedStatus": {
    "enabled": true,
    "running": false,
    "profile": "openclaw",
    "transport": "local"
  }
}
```

- Observed result after fix: The CLI client connected with `connectScopes: ["operator.admin"]`, identified as `{ "id": "cli", "mode": "cli" }`, then sent the `browser.request` RPC for `/` with `profile=openclaw` and received the status payload.
- What was not tested: A remote hosted browser gateway with the original paired device was unavailable in this local checkout. This proof covers the actual local gateway-protocol request emitted by the browser CLI wrapper.

## Tests

- `pnpm test extensions/browser/src/cli/browser-cli-shared.test.ts extensions/browser/src/cli/browser-cli.test.ts extensions/browser/src/cli/browser-cli-manage.test.ts extensions/browser/src/cli/browser-cli-inspect.test.ts extensions/browser/index.test.ts src/gateway/method-scopes.test.ts`
- `pnpm check:changed`
- `git diff --check`
