### PR TITLE
fix(agents): preserve Pi tool result error flags (#81546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,6 +333,7 @@ Docs: https://docs.openclaw.ai
 - Config: return the canonical persisted config from `config.set`, `config.apply`, and `config.patch` responses after write-time shaping. Fixes #77455.
 - Codex auth: accept OAuth profiles backed by `oauthRef` during runtime auth selection, so official Codex OAuth logins are used by app-server agent runs. (#81633) Thanks @obviyus.
 - Telegram: release stopped polling leases after the gateway stop grace so in-process restarts can reuse the same bot token without weakening active duplicate-poller protection. Fixes #81507. (#81890) Thanks @joshavant.
+- Agents: mark adapter-caught tool execution failures as error tool results in embedded Pi sessions, so models can retry recoverable edit failures instead of seeing a successful tool result. Fixes #81546. Thanks @najef1979-code.
 - ACP: preserve redacted numeric JSON-RPC `RequestError` details in runtime failure text, so backend diagnostics are visible instead of only `Internal error`. Fixes #81126. (#81188) Thanks @vyctorbrzezowski.
 - Agents: cache unchanged PI model discovery stores and model lookups, reducing repeated model-resolution startup latency under large model configs. Fixes #78851.
 - Onboarding: carry returned Codex plugin migration config through the OpenAI model wizard so accepted plugin migrations are saved with the final config write.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Cron/agents: honor configured subagent model fallbacks for isolated scheduled runs and forward that fallback policy into embedded agent timeout failover. Fixes #74985. Thanks @chrisgwynne.
 - Codex app-server/MCP: scope user MCP servers to specific OpenClaw agent ids through an optional `mcp.servers.<name>.codex.agents` list and accept `codex.defaultToolsApprovalMode` (`auto`/`prompt`/`approve`) for native Codex approval defaults; OpenClaw strips the `codex` block before handing `mcp_servers` config to Codex. (#82180) Thanks @sercada.
 - Agents/OpenAI Responses: clamp `input_tokens - cached_tokens` at zero and reconstruct `totalTokens` from input + output + cached components so Responses-API streams report consistent usage when providers under-report `input_tokens` relative to `cached_tokens`.
+- Agents: mark adapter-caught tool execution failures as error tool results in embedded Pi sessions, so models can retry recoverable edit failures instead of seeing a successful tool result. Fixes #81546. (#81564) Thanks @najef1979-code and @MonkeyLeeT.
 - Plugins: reject malformed `package.json` `openclaw.extensions` metadata during install, discovery, and post-update payload smoke instead of silently dropping invalid entries.
 - Plugins: reject package metadata records whose `package.json` resolves outside the plugin root instead of trusting persisted or reconstructed registry snapshots.
 - Plugins: ignore malformed persisted package channel/install metadata instead of crashing catalog reconstruction or leaking invalid install hints.
@@ -333,7 +334,6 @@ Docs: https://docs.openclaw.ai
 - Config: return the canonical persisted config from `config.set`, `config.apply`, and `config.patch` responses after write-time shaping. Fixes #77455.
 - Codex auth: accept OAuth profiles backed by `oauthRef` during runtime auth selection, so official Codex OAuth logins are used by app-server agent runs. (#81633) Thanks @obviyus.
 - Telegram: release stopped polling leases after the gateway stop grace so in-process restarts can reuse the same bot token without weakening active duplicate-poller protection. Fixes #81507. (#81890) Thanks @joshavant.
-- Agents: mark adapter-caught tool execution failures as error tool results in embedded Pi sessions, so models can retry recoverable edit failures instead of seeing a successful tool result. Fixes #81546. Thanks @najef1979-code.
 - ACP: preserve redacted numeric JSON-RPC `RequestError` details in runtime failure text, so backend diagnostics are visible instead of only `Internal error`. Fixes #81126. (#81188) Thanks @vyctorbrzezowski.
 - Agents: cache unchanged PI model discovery stores and model lookups, reducing repeated model-resolution startup latency under large model configs. Fixes #78851.
 - Onboarding: carry returned Codex plugin migration config through the OpenAI model wizard so accepted plugin migrations are saved with the final config write.

--- a/src/agents/pi-embedded-runner.extensions.test.ts
+++ b/src/agents/pi-embedded-runner.extensions.test.ts
@@ -69,4 +69,97 @@ describe("buildEmbeddedExtensionFactories", () => {
     expect(seenToolCallIds[1]).toMatch(/^pi-/);
     expect(seenToolCallIds[0]).not.toBe(seenToolCallIds[1]);
   });
+
+  it("marks status-error tool results as model-visible failures", async () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+    });
+
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+    const handler = handlers.get("tool_result");
+    const content = [{ type: "text", text: "oldText must be unique" }];
+    const details = {
+      status: "error",
+      tool: "edit",
+      error: "oldText must be unique",
+    };
+
+    const result = await handler?.(
+      {
+        toolName: "edit",
+        toolCallId: "call-edit",
+        content,
+        details,
+        isError: false,
+      },
+      { cwd: "/tmp" },
+    );
+
+    expect(result).toEqual({
+      content,
+      details,
+      isError: true,
+    });
+  });
+
+  it("preserves model-visible failures when middleware rewrites details", async () => {
+    const registry = createEmptyPluginRegistry();
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "redactor",
+      pluginName: "redactor",
+      rawHandler: () => undefined,
+      handler: (event) => {
+        event.result.content = [{ type: "text", text: "redacted error" }];
+        event.result.details = { redacted: true };
+        return undefined;
+      },
+      runtimes: ["pi"],
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+    });
+
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+    const handler = handlers.get("tool_result");
+
+    const result = await handler?.(
+      {
+        toolName: "edit",
+        toolCallId: "call-edit",
+        content: [{ type: "text", text: "oldText must be unique" }],
+        details: { status: "error", tool: "edit", error: "oldText must be unique" },
+        isError: false,
+      },
+      { cwd: "/tmp" },
+    );
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "redacted error" }],
+      details: { redacted: true },
+      isError: true,
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner.extensions.test.ts
+++ b/src/agents/pi-embedded-runner.extensions.test.ts
@@ -162,4 +162,93 @@ describe("buildEmbeddedExtensionFactories", () => {
       isError: true,
     });
   });
+
+  it("marks status-timeout tool results as model-visible failures", async () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+    });
+
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+    const handler = handlers.get("tool_result");
+
+    const result = await handler?.(
+      {
+        toolName: "exec",
+        toolCallId: "call-exec",
+        content: [{ type: "text", text: "Timed out" }],
+        details: { status: "timeout", tool: "exec", error: "Timed out" },
+        isError: false,
+      },
+      { cwd: "/tmp" },
+    );
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Timed out" }],
+      details: { status: "timeout", tool: "exec", error: "Timed out" },
+      isError: true,
+    });
+  });
+
+  it("does not mark results as errors when status is absent or non-error", async () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+    });
+
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+    const handler = handlers.get("tool_result");
+
+    // Empty details — no status field
+    const noStatusResult = await handler?.(
+      {
+        toolName: "read",
+        toolCallId: "call-read",
+        content: [{ type: "text", text: "file contents" }],
+        details: {},
+        isError: false,
+      },
+      { cwd: "/tmp" },
+    );
+    expect(noStatusResult).toEqual({
+      content: [{ type: "text", text: "file contents" }],
+      details: {},
+    });
+
+    // Explicit ok status
+    const okResult = await handler?.(
+      {
+        toolName: "read",
+        toolCallId: "call-read-2",
+        content: [{ type: "text", text: "ok" }],
+        details: { status: "ok" },
+        isError: false,
+      },
+      { cwd: "/tmp" },
+    );
+    expect(okResult).toEqual({
+      content: [{ type: "text", text: "ok" }],
+      details: { status: "ok" },
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -3,6 +3,7 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionFactory, SessionManager } from "@earendil-works/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { createAgentToolResultMiddlewareRunner } from "../harness/tool-result-middleware.js";
@@ -33,6 +34,12 @@ function recordFromUnknown(value: unknown): Record<string, unknown> {
     : {};
 }
 
+function hasErrorToolResultStatus(result: AgentToolResult<unknown>): boolean {
+  const details = recordFromUnknown(result.details);
+  const status = normalizeOptionalLowercaseString(details.status);
+  return status === "error" || status === "timeout";
+}
+
 function buildAgentToolResultMiddlewareFactory(): ExtensionFactory {
   const runner = createAgentToolResultMiddlewareRunner({ runtime: "pi" });
   return (pi) => {
@@ -50,6 +57,7 @@ function buildAgentToolResultMiddlewareFactory(): ExtensionFactory {
         content,
         details: event.details,
       } satisfies AgentToolResult<unknown>;
+      const inputHadErrorStatus = hasErrorToolResultStatus(current);
       const result = await runner.applyToolResultMiddleware({
         threadId: event.threadId,
         turnId: event.turnId,
@@ -60,9 +68,12 @@ function buildAgentToolResultMiddlewareFactory(): ExtensionFactory {
         isError: event.isError,
         result: current,
       });
+      const isError =
+        event.isError === true || inputHadErrorStatus || hasErrorToolResultStatus(result);
       return {
         content: result.content,
         details: result.details,
+        ...(isError ? { isError: true } : {}),
       };
     });
   };

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -34,6 +34,10 @@ function recordFromUnknown(value: unknown): Record<string, unknown> {
     : {};
 }
 
+// Only checks "error" and "timeout" — the status values emitted by the
+// adapter's buildToolExecutionErrorResult. The subscribe-side classifier
+// (isErrorLikeStatus) uses a broader regex because it handles arbitrary
+// external tool results; this bridge only elevates adapter-produced statuses.
 function hasErrorToolResultStatus(result: AgentToolResult<unknown>): boolean {
   const details = recordFromUnknown(result.details);
   const status = normalizeOptionalLowercaseString(details.status);


### PR DESCRIPTION
## Summary

Fixes #81546.

This marks Pi tool results with `details.status` of `error` or `timeout` as real model-visible failures in the embedded Pi `tool_result` bridge. That bridge is the seam pi-agent-core uses through `afterToolCall` to override the final `toolResult.isError` value written to transcript/model messages.

## Root Cause

OpenClaw's tool-definition adapter catches tool exceptions and wraps them as a returned `AgentToolResult` with `details.status: "error"`. In pi-agent-core, returned tool results are still finalized with `isError: false`; the core runtime only flips the final flag when the tool actually throws or when `afterToolCall` returns an `isError` override.

That means an ambiguous edit failure could be delivered to the model as a normal successful tool result whose JSON text happened to contain `status: "error"`. The model then had no reliable failure signal to drive a retry.

This intentionally fixes the Pi finalization bridge instead of adding blind retry logic. It also preserves the failure flag when tool-result middleware mutates, rewrites, or redacts the result details.

Related: #81557 marks the adapter return object with `isError: true`, but pi-agent-core does not use returned result fields to set the finalized `isError` flag for successful returns. This PR fixes the path that controls the final transcript/model-visible flag.

## Real Behavior Proof

Reported pre-fix symptom from #81546:

```text
Line 194 | role=toolResult | isError=False
  text: {
    "status": "error",
    "tool": "edit",
    "error": "Found 4 occurrences ... Each oldText must be unique."
  }

Line 197 | role=assistant | stopReason=stop
  NO WRITE TOOL CALL — agent pivoted away from the task
```

After-fix focused harness proof at `3929f9e97121f4eb22aea7535246f69e82b39933`:

- `src/agents/pi-embedded-runner.extensions.test.ts` now exercises the embedded Pi `tool_result` bridge with an `edit` result whose `details.status` is `error` and asserts the bridge returns `isError: true`.
- The same test mutates `event.result` in place through tool-result middleware and verifies the original pre-middleware error status still produces final `isError: true`.

Relevant local output:

```text
$ pnpm_config_verify_deps_before_run=false pnpm test src/agents/pi-embedded-runner.extensions.test.ts src/agents/pi-embedded-subscribe.tools.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/pi-tool-definition-adapter.test.ts
[test] starting test/vitest/vitest.unit-fast.config.ts
Test Files  1 passed (1)
Tests  18 passed (18)

[test] starting test/vitest/vitest.agents.config.ts
Test Files  3 passed (3)
Tests  53 passed (53)

[test] passed 2 Vitest shards in 7.78s
```

## Verification

- `pnpm_config_verify_deps_before_run=false pnpm test src/agents/pi-embedded-runner.extensions.test.ts src/agents/pi-embedded-subscribe.tools.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/pi-tool-definition-adapter.test.ts`
- `pnpm_config_verify_deps_before_run=false pnpm check:changed`
- `git diff --check`

`pnpm check:changed` completed successfully locally, including core typecheck, core test typecheck, core lint, import-cycle check, and changed-surface guard scripts. A plain `pnpm test ...` attempt got stuck in pnpm's dependency preflight after printing install completion, so the successful verification commands set `pnpm_config_verify_deps_before_run=false` to bypass that preflight.
