### PR TITLE
fix(cli): prevent [plugins] loader chatter from leaking to stdout in --json mode

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -722,6 +722,17 @@ export async function runCli(argv: string[] = process.argv) {
         hasBuiltinPrimary,
       });
       if (!shouldSkipPluginRegistration) {
+        // For --json mode, route all console output to stderr *before* plugin
+        // registration so that [plugins] loader chatter does not pollute stdout.
+        // Without this, the lazy plugin-command-registration phase loads the
+        // primary command's plugin before commander's preAction hook calls
+        // routeLogsToStderr(), leaking [plugins] lines onto stdout and breaking
+        // downstream `jq` / `JSON.parse` consumers.
+        // See: https://github.com/openclaw/openclaw/issues/81535
+        if (hasJsonOutputFlag(parseArgv)) {
+          const { routeLogsToStderr } = await import("../logging/console.js");
+          routeLogsToStderr();
+        }
         const config = await startupTrace.measure("register-plugin-commands", async () => {
           const { registerPluginCliCommandsFromValidatedConfig } =
             await import("../plugins/cli.js");


### PR DESCRIPTION
## Summary

Fixes #81535

When running non-routed CLI commands with `--json` (e.g. `openclaw memory search --json`), the lazy plugin-command-registration phase loads the primary command's plugin **before** commander's preAction hook calls `routeLogsToStderr()`. This causes `[plugins] loading...` and `[plugins] loaded N plugin(s)...` lines to be emitted on stdout, corrupting the JSON payload and breaking downstream `jq`/`JSON.parse` consumers.

## Root Cause

In `run-main.ts`, the `registerPluginCliCommandsFromValidatedConfig` call (line ~726) triggers plugin loading, which uses `createSubsystemLogger("plugins")` to emit log lines. For non-routed commands, `routeLogsToStderr()` is only called later in the commander preAction hook, so the plugin loader chatter leaks to stdout.

## Fix

Before calling `registerPluginCliCommandsFromValidatedConfig`, check for `--json` flag and call `routeLogsToStderr()` early if present. This ensures all `console.*` output (including plugin loader logs) is redirected to stderr before any plugin loading occurs.

## Testing

Verified the fix logic:
- `hasJsonOutputFlag(parseArgv)` correctly detects `--json` flag
- `routeLogsToStderr()` sets `loggingState.forceConsoleToStderr = true`, which is respected by the subsystem logger used during plugin loading
- The fix is scoped to only affect `--json` mode — normal CLI output is unchanged

```bash
# Before fix (expected): stdout contains [plugins] chatter + JSON → jq fails
# After fix (expected): stdout contains only JSON → jq succeeds
openclaw memory search "test" --json | jq .
```

**Note:** I was unable to build the full project locally (disk space constraint), so I have not run the full test suite. The change is minimal and well-scoped to the code path described in the issue.

## AI-assisted

This PR was written with AI assistance. I have reviewed and understand every line of the change.