### PR TITLE
fix(nextcloud-talk): ignore signed non-message webhooks

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -246,31 +246,47 @@ describe("createNextcloudTalkWebhookServer payload validation", () => {
 
   it("acknowledges signed non-message Talk events without invoking the handler", async () => {
     const onMessage = vi.fn(async () => {});
-    const payload = {
-      type: "Create",
-      actor: { type: "Person", id: "alice", name: "Alice" },
-      object: {
-        type: "Document",
-        id: "file-1",
-        name: "report.pdf",
-        mediaType: "application/pdf",
-      },
-      target: { type: "Collection", id: "room-1", name: "Room 1" },
-    };
-    const { body, headers } = createSignedWebhookRequest(payload);
     const harness = await startWebhookServer({
       path: "/nextcloud-non-message-event",
       onMessage,
     });
+    const payloads = [
+      {
+        type: "Create",
+        actor: { type: "Person", id: "alice", name: "Alice" },
+        object: {
+          type: "Document",
+          id: "file-1",
+          name: "report.pdf",
+          mediaType: "application/pdf",
+        },
+        target: { type: "Collection", id: "room-1", name: "Room 1" },
+      },
+      {
+        type: "Add",
+        actor: { type: "Person", id: "alice", name: "Alice" },
+        object: { type: "Like", id: "reaction-1", name: "👍" },
+        target: { type: "Note", id: "msg-1", name: "hello" },
+      },
+      {
+        type: "Create",
+        actor: { type: "Application", id: "openclaw-bot", name: "OpenClaw" },
+        object: { type: "Application", id: "openclaw-bot", name: "OpenClaw" },
+        target: { type: "Collection", id: "room-1", name: "Room 1" },
+      },
+    ];
 
-    const response = await fetch(harness.webhookUrl, {
-      method: "POST",
-      headers,
-      body,
-    });
+    for (const payload of payloads) {
+      const { body, headers } = createSignedWebhookRequest(payload);
+      const response = await fetch(harness.webhookUrl, {
+        method: "POST",
+        headers,
+        body,
+      });
 
-    expect(response.status).toBe(200);
-    expect(await response.text()).toBe("");
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("");
+    }
     expect(onMessage).not.toHaveBeenCalled();
   });
 });

--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -244,6 +244,33 @@ describe("createNextcloudTalkWebhookServer payload validation", () => {
     expect(await response.json()).toEqual({ error: "Invalid payload format" });
   });
 
+  it("rejects partial signed message-shaped payloads", async () => {
+    const payload = {
+      type: "Create",
+      actor: { type: "Person", id: "alice", name: "Alice" },
+      object: {
+        type: "Note",
+        id: "msg-1",
+        content: "hello",
+        mediaType: "text/plain",
+      },
+    };
+    const { body, headers } = createSignedWebhookRequest(payload);
+    const harness = await startWebhookServer({
+      path: "/nextcloud-partial-message-payload",
+      onMessage: vi.fn(),
+    });
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers,
+      body,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid payload format" });
+  });
+
   it("acknowledges signed non-message Talk events without invoking the handler", async () => {
     const onMessage = vi.fn(async () => {});
     const harness = await startWebhookServer({

--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -181,6 +181,23 @@ describe("createNextcloudTalkWebhookServer replay handling", () => {
 });
 
 describe("createNextcloudTalkWebhookServer payload validation", () => {
+  function createSignedWebhookRequest(payload: unknown) {
+    const body = typeof payload === "string" ? payload : JSON.stringify(payload);
+    const { random, signature } = generateNextcloudTalkSignature({
+      body,
+      secret: "nextcloud-secret", // pragma: allowlist secret
+    });
+    return {
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-nextcloud-talk-random": random,
+        "x-nextcloud-talk-signature": signature,
+        "x-nextcloud-talk-backend": "https://nextcloud.example",
+      },
+    };
+  }
+
   it("rejects malformed webhook payloads after signature verification", async () => {
     const payload = {
       type: "Create",
@@ -194,11 +211,7 @@ describe("createNextcloudTalkWebhookServer payload validation", () => {
       },
       target: { type: "Collection", id: "", name: "Room 1" },
     };
-    const body = JSON.stringify(payload);
-    const { random, signature } = generateNextcloudTalkSignature({
-      body,
-      secret: "nextcloud-secret", // pragma: allowlist secret
-    });
+    const { body, headers } = createSignedWebhookRequest(payload);
     const harness = await startWebhookServer({
       path: "/nextcloud-invalid-payload",
       onMessage: vi.fn(),
@@ -206,17 +219,59 @@ describe("createNextcloudTalkWebhookServer payload validation", () => {
 
     const response = await fetch(harness.webhookUrl, {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-nextcloud-talk-random": random,
-        "x-nextcloud-talk-signature": signature,
-        "x-nextcloud-talk-backend": "https://nextcloud.example",
-      },
+      headers,
       body,
     });
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: "Invalid payload format" });
+  });
+
+  it("rejects malformed JSON after signature verification", async () => {
+    const { body, headers } = createSignedWebhookRequest("{");
+    const harness = await startWebhookServer({
+      path: "/nextcloud-malformed-json",
+      onMessage: vi.fn(),
+    });
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers,
+      body,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid payload format" });
+  });
+
+  it("acknowledges signed non-message Talk events without invoking the handler", async () => {
+    const onMessage = vi.fn(async () => {});
+    const payload = {
+      type: "Create",
+      actor: { type: "Person", id: "alice", name: "Alice" },
+      object: {
+        type: "Document",
+        id: "file-1",
+        name: "report.pdf",
+        mediaType: "application/pdf",
+      },
+      target: { type: "Collection", id: "room-1", name: "Room 1" },
+    };
+    const { body, headers } = createSignedWebhookRequest(payload);
+    const harness = await startWebhookServer({
+      path: "/nextcloud-non-message-event",
+      onMessage,
+    });
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers,
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("");
+    expect(onMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -265,7 +265,7 @@ describe("createNextcloudTalkWebhookServer payload validation", () => {
       {
         type: "Add",
         actor: { type: "Person", id: "alice", name: "Alice" },
-        object: { type: "Like", id: "reaction-1", name: "👍" },
+        object: { type: "Like", id: "reaction-1", name: "like" },
         target: { type: "Note", id: "msg-1", name: "hello" },
       },
       {

--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -125,18 +125,23 @@ function isSupportedWebhookMessageShape(value: unknown): boolean {
   if (!isRecord(value)) {
     return false;
   }
+  if (value.type !== "Create" && value.type !== "Update" && value.type !== "Delete") {
+    return false;
+  }
   const actor = value.actor;
   const object = value.object;
   const target = value.target;
-  if (!isRecord(actor) || !isRecord(object) || !isRecord(target)) {
+  const actorType = isRecord(actor) ? actor.type : undefined;
+  const objectType = isRecord(object) ? object.type : undefined;
+  const targetType = isRecord(target) ? target.type : undefined;
+  if (
+    (actorType && actorType !== "Person") ||
+    (objectType && objectType !== "Note") ||
+    (targetType && targetType !== "Collection")
+  ) {
     return false;
   }
-  return (
-    (value.type === "Create" || value.type === "Update" || value.type === "Delete") &&
-    actor.type === "Person" &&
-    object.type === "Note" &&
-    target.type === "Collection"
-  );
+  return actorType === "Person" || objectType === "Note" || targetType === "Collection";
 }
 
 function parseWebhookPayload(value: unknown): NextcloudTalkWebhookPayload | null {

--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -1,5 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { safeParseJsonWithSchema } from "openclaw/plugin-sdk/extension-shared";
+import { safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
 import {
   WEBHOOK_RATE_LIMIT_DEFAULTS,
   createAuthRateLimiter,
@@ -109,8 +109,38 @@ function formatError(err: unknown): string {
   return typeof err === "string" ? err : JSON.stringify(err);
 }
 
-function parseWebhookPayload(body: string): NextcloudTalkWebhookPayload | null {
-  return safeParseJsonWithSchema(NextcloudTalkWebhookPayloadSchema, body);
+function parseWebhookJson(body: string): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: JSON.parse(body) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSupportedWebhookMessageShape(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const actor = value.actor;
+  const object = value.object;
+  const target = value.target;
+  if (!isRecord(actor) || !isRecord(object) || !isRecord(target)) {
+    return false;
+  }
+  return (
+    (value.type === "Create" || value.type === "Update" || value.type === "Delete") &&
+    actor.type === "Person" &&
+    object.type === "Note" &&
+    target.type === "Collection"
+  );
+}
+
+function parseWebhookPayload(value: unknown): NextcloudTalkWebhookPayload | null {
+  return safeParseWithSchema(NextcloudTalkWebhookPayloadSchema, value);
 }
 
 function writeJsonResponse(
@@ -183,10 +213,19 @@ function decodeWebhookCreateMessage(params: {
   | { kind: "message"; message: NextcloudTalkInboundMessage }
   | { kind: "ignore" }
   | { kind: "invalid" } {
-  const payload = parseWebhookPayload(params.body);
-  if (!payload) {
+  const payloadJson = parseWebhookJson(params.body);
+  if (!payloadJson.ok) {
     writeWebhookError(params.res, 400, WEBHOOK_ERRORS.invalidPayloadFormat);
     return { kind: "invalid" };
+  }
+
+  const payload = parseWebhookPayload(payloadJson.value);
+  if (!payload) {
+    if (isSupportedWebhookMessageShape(payloadJson.value)) {
+      writeWebhookError(params.res, 400, WEBHOOK_ERRORS.invalidPayloadFormat);
+      return { kind: "invalid" };
+    }
+    return { kind: "ignore" };
   }
   if (payload.type !== "Create") {
     return { kind: "ignore" };


### PR DESCRIPTION
## Summary
- parse signed webhook JSON before applying the strict chat-message schema
- acknowledge signed non-message Talk Activity Streams events without invoking the message handler
- keep malformed JSON and malformed supported message payloads on the existing 400 Invalid payload format path

Fixes #81566.

## Verification
- pnpm exec oxfmt --check extensions/nextcloud-talk/src/monitor.ts extensions/nextcloud-talk/src/monitor.replay.test.ts
- pnpm vitest run extensions/nextcloud-talk/src/monitor.replay.test.ts
- pnpm check:changed
- git diff --check

## Real behavior proof

Behavior addressed: Before this patch, a signed valid JSON Nextcloud Talk webhook whose Activity Streams object was not a chat-message Note failed the strict message schema and returned HTTP 400 Invalid payload format. After this patch, the webhook handler distinguishes malformed JSON / malformed supported message payloads from signed non-message Talk events, acknowledges the latter, and skips onMessage.

Real setup tested: Local OpenClaw checkout at /home/chenglunhu/code/openclaw, branch fix/nextcloud-talk-ignore-non-message-events-81566, commit 8418995537fc5f419f5aa11aa38e4976ad7b3d61, using the real extensions/nextcloud-talk/src/monitor.ts webhook server through pnpm exec tsx.

Exact steps or command run after the patch: Started createNextcloudTalkWebhookServer on 127.0.0.1:18788 with the real signature verifier and sent two signed requests: a non-message Document event shaped like a Talk file-share event, then malformed JSON.

Evidence after fix: Terminal output from the live command:

```text
{
  "nonMessageStatus": 200,
  "nonMessageBody": "",
  "malformedStatus": 400,
  "malformedBody": "{\"error\":\"Invalid payload format\"}",
  "onMessageCalls": 0
}
```

Observed result after fix: The signed non-message event returned 200 with an empty body and did not invoke the message handler. The signed malformed JSON request still returned 400 Invalid payload format, preserving the useful bad-request signal.

Not tested: I did not run a live Nextcloud 33/Talk instance; this proof exercises the real OpenClaw webhook server locally with signed HTTP requests.