### PR TITLE
perf(plugins): memoize metadata snapshots per process

### DIFF
--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
-import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import type { PluginManifestRegistry } from "./manifest-registry.js";
 import {
   clearLoadPluginMetadataSnapshotMemo,
   loadPluginMetadataSnapshot,
@@ -75,41 +75,24 @@ function makeIndex(pluginId = "demo"): InstalledPluginIndex {
 }
 
 function makeManifestRegistry(pluginId = "demo"): PluginManifestRegistry {
-  const plugin: PluginManifestRecord = {
-    id: pluginId,
-    name: pluginId,
-    channels: [],
-    providers: [pluginId],
-    cliBackends: [],
-    skills: [],
-    hooks: [],
-    commandAliases: [{ name: `${pluginId}-command` }],
-    rootDir: `/plugins/${pluginId}`,
-    source: `/plugins/${pluginId}/index.js`,
-    manifestPath: `/plugins/${pluginId}/openclaw.plugin.json`,
-    origin: "global",
+  return {
+    plugins: [
+      {
+        id: pluginId,
+        name: pluginId,
+        channels: [],
+        providers: [pluginId],
+        cliBackends: [],
+        skills: [],
+        hooks: [],
+        rootDir: `/plugins/${pluginId}`,
+        source: `/plugins/${pluginId}/index.js`,
+        manifestPath: `/plugins/${pluginId}/openclaw.plugin.json`,
+        origin: "global",
+      },
+    ],
+    diagnostics: [],
   };
-  return { plugins: [plugin], diagnostics: [] };
-}
-
-function requireFirstPlugin(
-  snapshot: ReturnType<typeof loadPluginMetadataSnapshot>,
-): PluginManifestRecord {
-  const plugin = snapshot.plugins[0];
-  if (!plugin) {
-    throw new Error("expected metadata snapshot to include a plugin");
-  }
-  return plugin;
-}
-
-function requireFirstCommandAlias(
-  plugin: PluginManifestRecord,
-): NonNullable<PluginManifestRecord["commandAliases"]>[number] {
-  const commandAlias = plugin.commandAliases?.[0];
-  if (!commandAlias) {
-    throw new Error("expected metadata snapshot plugin to include a command alias");
-  }
-  return commandAlias;
 }
 
 describe("loadPluginMetadataSnapshot process memo", () => {
@@ -137,19 +120,16 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     });
 
     const first = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
-    const firstPlugin = requireFirstPlugin(first);
-    firstPlugin.providers.push("first-mutated");
-    requireFirstCommandAlias(firstPlugin).name = "first-command-mutated";
+    expect(first.plugins[0]).toBeDefined();
+    first.plugins[0]?.providers.push("first-mutated");
     const second = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
-    const secondPlugin = requireFirstPlugin(second);
-    secondPlugin.providers.push("second-mutated");
-    requireFirstCommandAlias(secondPlugin).name = "second-command-mutated";
+    expect(second.plugins[0]).toBeDefined();
+    second.plugins[0]?.providers.push("second-mutated");
     const third = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
 
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledOnce();
     expect(loadPluginManifestRegistryForInstalledIndex).toHaveBeenCalledOnce();
     expect(third.plugins[0]?.providers).toEqual(["demo"]);
-    expect(third.plugins[0]?.commandAliases?.[0]?.name).toBe("demo-command");
     expect(second.manifestRegistry.plugins[0]).toBe(second.plugins[0]);
     expect(second.byPluginId.get("demo")).toBe(second.plugins[0]);
   });

--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -1,0 +1,178 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import {
+  clearLoadPluginMetadataSnapshotMemo,
+  loadPluginMetadataSnapshot,
+} from "./plugin-metadata-snapshot.js";
+
+const loadPluginRegistrySnapshotWithMetadata = vi.hoisted(() => vi.fn());
+const loadPluginManifestRegistryForInstalledIndex = vi.hoisted(() => vi.fn());
+
+vi.mock("./plugin-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./plugin-registry.js")>();
+  return {
+    ...actual,
+    loadPluginRegistrySnapshotWithMetadata: (params: unknown) =>
+      loadPluginRegistrySnapshotWithMetadata(params),
+  };
+});
+
+vi.mock("./manifest-registry-installed.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./manifest-registry-installed.js")>();
+  return {
+    ...actual,
+    loadPluginManifestRegistryForInstalledIndex: (params: unknown) =>
+      loadPluginManifestRegistryForInstalledIndex(params),
+  };
+});
+
+const tempDirs: string[] = [];
+
+function tempStateDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-metadata-memo-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function touchPersistedIndex(stateDir: string, value = 1): void {
+  const indexPath = path.join(stateDir, "plugins", "installs.json");
+  fs.mkdirSync(path.dirname(indexPath), { recursive: true });
+  fs.writeFileSync(indexPath, JSON.stringify({ value }));
+}
+
+function makeIndex(pluginId = "demo"): InstalledPluginIndex {
+  return {
+    installRecords: {},
+    diagnostics: [],
+    plugins: [
+      {
+        pluginId,
+        manifestPath: `/plugins/${pluginId}/openclaw.plugin.json`,
+        manifestHash: `${pluginId}-manifest`,
+        rootDir: `/plugins/${pluginId}`,
+        origin: "global",
+        enabled: true,
+      },
+    ],
+  } as InstalledPluginIndex;
+}
+
+function makeManifestRegistry(pluginId = "demo"): PluginManifestRegistry {
+  const plugin: PluginManifestRecord = {
+    id: pluginId,
+    name: pluginId,
+    channels: [],
+    providers: [pluginId],
+    cliBackends: [],
+    skills: [],
+    hooks: [],
+    commandAliases: [{ name: `${pluginId}-command` }],
+    rootDir: `/plugins/${pluginId}`,
+    source: `/plugins/${pluginId}/index.js`,
+    manifestPath: `/plugins/${pluginId}/openclaw.plugin.json`,
+    origin: "global",
+  };
+  return { plugins: [plugin], diagnostics: [] };
+}
+
+describe("loadPluginMetadataSnapshot process memo", () => {
+  beforeEach(() => {
+    clearLoadPluginMetadataSnapshotMemo();
+    loadPluginRegistrySnapshotWithMetadata.mockReset();
+    loadPluginManifestRegistryForInstalledIndex.mockReset();
+    loadPluginManifestRegistryForInstalledIndex.mockReturnValue(makeManifestRegistry());
+  });
+
+  afterEach(() => {
+    clearLoadPluginMetadataSnapshotMemo();
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses persisted metadata snapshots for repeated process lookups", () => {
+    const stateDir = tempStateDir();
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "persisted",
+      snapshot: makeIndex(),
+      diagnostics: [],
+    });
+
+    const first = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    first.plugins[0]?.providers.push("first-mutated");
+    first.plugins[0]!.commandAliases![0]!.name = "first-command-mutated";
+    const second = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    second.plugins[0]?.providers.push("second-mutated");
+    second.plugins[0]!.commandAliases![0]!.name = "second-command-mutated";
+    const third = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledOnce();
+    expect(loadPluginManifestRegistryForInstalledIndex).toHaveBeenCalledOnce();
+    expect(third.plugins[0]?.providers).toEqual(["demo"]);
+    expect(third.plugins[0]?.commandAliases?.[0]?.name).toBe("demo-command");
+    expect(second.manifestRegistry.plugins[0]).toBe(second.plugins[0]);
+    expect(second.byPluginId.get("demo")).toBe(second.plugins[0]);
+  });
+
+  it("memoizes policy-stale derived snapshots used by validation callers", () => {
+    const stateDir = tempStateDir();
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex(),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-policy",
+          message: "policy changed",
+        },
+      ],
+    });
+
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["persisted-registry-missing", undefined],
+    ["persisted-registry-stale-source", undefined],
+    ["persisted-registry-disabled", undefined],
+    [undefined, { preferPersisted: false }],
+  ])("does not memoize derived snapshots for %s diagnostics", (code, options) => {
+    const stateDir = tempStateDir();
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex(),
+      diagnostics: code ? [{ level: "warn", code, message: "registry not reusable" }] : [],
+    });
+
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, ...options });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, ...options });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes when the persisted registry file changes", () => {
+    const stateDir = tempStateDir();
+    touchPersistedIndex(stateDir, 1);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "persisted",
+      snapshot: makeIndex(),
+      diagnostics: [],
+    });
+
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    touchPersistedIndex(stateDir, 22);
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -46,6 +46,12 @@ function touchPersistedIndex(stateDir: string, value = 1): void {
 
 function makeIndex(pluginId = "demo"): InstalledPluginIndex {
   return {
+    version: 1,
+    hostContractVersion: "test",
+    compatRegistryVersion: "test",
+    migrationVersion: 1,
+    policyHash: "policy",
+    generatedAtMs: 1,
     installRecords: {},
     diagnostics: [],
     plugins: [
@@ -58,7 +64,7 @@ function makeIndex(pluginId = "demo"): InstalledPluginIndex {
         enabled: true,
       },
     ],
-  } as InstalledPluginIndex;
+  };
 }
 
 function makeManifestRegistry(pluginId = "demo"): PluginManifestRegistry {

--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -62,6 +62,13 @@ function makeIndex(pluginId = "demo"): InstalledPluginIndex {
         rootDir: `/plugins/${pluginId}`,
         origin: "global",
         enabled: true,
+        startup: {
+          sidecar: false,
+          memory: false,
+          deferConfiguredChannelFullLoadUntilAfterListen: false,
+          agentHarnesses: [],
+        },
+        compat: [],
       },
     ],
   };
@@ -83,6 +90,26 @@ function makeManifestRegistry(pluginId = "demo"): PluginManifestRegistry {
     origin: "global",
   };
   return { plugins: [plugin], diagnostics: [] };
+}
+
+function requireFirstPlugin(
+  snapshot: ReturnType<typeof loadPluginMetadataSnapshot>,
+): PluginManifestRecord {
+  const plugin = snapshot.plugins[0];
+  if (!plugin) {
+    throw new Error("expected metadata snapshot to include a plugin");
+  }
+  return plugin;
+}
+
+function requireFirstCommandAlias(
+  plugin: PluginManifestRecord,
+): NonNullable<PluginManifestRecord["commandAliases"]>[number] {
+  const commandAlias = plugin.commandAliases?.[0];
+  if (!commandAlias) {
+    throw new Error("expected metadata snapshot plugin to include a command alias");
+  }
+  return commandAlias;
 }
 
 describe("loadPluginMetadataSnapshot process memo", () => {
@@ -110,11 +137,13 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     });
 
     const first = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
-    first.plugins[0]?.providers.push("first-mutated");
-    first.plugins[0]!.commandAliases![0]!.name = "first-command-mutated";
+    const firstPlugin = requireFirstPlugin(first);
+    firstPlugin.providers.push("first-mutated");
+    requireFirstCommandAlias(firstPlugin).name = "first-command-mutated";
     const second = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
-    second.plugins[0]?.providers.push("second-mutated");
-    second.plugins[0]!.commandAliases![0]!.name = "second-command-mutated";
+    const secondPlugin = requireFirstPlugin(second);
+    secondPlugin.providers.push("second-mutated");
+    requireFirstCommandAlias(secondPlugin).name = "second-command-mutated";
     const third = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
 
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledOnce();

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -1,9 +1,16 @@
+import path from "node:path";
+import { resolveIsNixMode } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   getActiveDiagnosticsTimelineSpan,
   measureDiagnosticsTimelineSpanSync,
 } from "../infra/diagnostics-timeline.js";
+import { resolveUserPath } from "../utils.js";
+import { resolveCompatibilityHostVersion } from "../version.js";
+import { resolveDefaultPluginNpmDir } from "./install-paths.js";
+import { hashJson, safeFileSignature } from "./installed-plugin-index-hash.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
+import { resolveInstalledPluginIndexStorePath } from "./installed-plugin-index-store-path.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
   loadPluginManifestRegistryForInstalledIndex,
@@ -17,7 +24,37 @@ import type {
   PluginMetadataSnapshotOwnerMaps,
 } from "./plugin-metadata-snapshot.types.js";
 import { createPluginRegistryIdNormalizer } from "./plugin-registry-id-normalizer.js";
-import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry.js";
+import {
+  loadPluginRegistrySnapshotWithMetadata,
+  type PluginRegistrySnapshotSource,
+} from "./plugin-registry.js";
+
+type PluginMetadataSnapshotMemo = {
+  key: string;
+  snapshot: PluginMetadataSnapshot;
+};
+
+let pluginMetadataSnapshotMemo: PluginMetadataSnapshotMemo | undefined;
+
+export function clearLoadPluginMetadataSnapshotMemo(): void {
+  pluginMetadataSnapshotMemo = undefined;
+}
+
+const MEMO_RELEVANT_ENV_KEYS = [
+  "APPDATA",
+  "HOME",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_COMPATIBILITY_HOST_VERSION",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+  "OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS",
+  "OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY",
+  "OPENCLAW_HOME",
+  "OPENCLAW_NIX_MODE",
+  "OPENCLAW_STATE_DIR",
+  "USERPROFILE",
+  "XDG_CONFIG_HOME",
+] as const;
 export type {
   LoadPluginMetadataSnapshotParams,
   PluginMetadataManifestView,
@@ -27,6 +64,126 @@ export type {
   PluginMetadataSnapshotOwnerMaps,
   PluginMetadataSnapshotRegistryDiagnostic,
 } from "./plugin-metadata-snapshot.types.js";
+
+function fileFingerprint(filePath: string): unknown {
+  const signature = safeFileSignature(filePath);
+  if (!signature) {
+    return [filePath, "missing"];
+  }
+  return [filePath, signature.size, signature.mtimeMs, signature.ctimeMs];
+}
+
+function pickMemoRelevantEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  return Object.fromEntries(
+    MEMO_RELEVANT_ENV_KEYS.flatMap((key) => {
+      const value = env[key];
+      return value === undefined ? [] : [[key, value]];
+    }),
+  );
+}
+
+function cloneOwnerMaps(owners: PluginMetadataSnapshotOwnerMaps): PluginMetadataSnapshotOwnerMaps {
+  return {
+    channels: new Map(owners.channels),
+    channelConfigs: new Map(owners.channelConfigs),
+    providers: new Map(owners.providers),
+    modelCatalogProviders: new Map(owners.modelCatalogProviders),
+    cliBackends: new Map(owners.cliBackends),
+    setupProviders: new Map(owners.setupProviders),
+    commandAliases: new Map(owners.commandAliases),
+    contracts: new Map(owners.contracts),
+  };
+}
+
+function cloneSnapshotValue<T>(value: T): T {
+  return value && typeof value === "object" ? structuredClone(value) : value;
+}
+
+function clonePluginManifestRecord(plugin: PluginManifestRecord): PluginManifestRecord {
+  return cloneSnapshotValue(plugin);
+}
+
+function clonePluginMetadataSnapshot(snapshot: PluginMetadataSnapshot): PluginMetadataSnapshot {
+  const plugins = snapshot.plugins.map(clonePluginManifestRecord);
+  const pluginsById = new Map(plugins.map((plugin) => [plugin.id, plugin]));
+  const diagnostics = snapshot.diagnostics.map(cloneSnapshotValue);
+  return {
+    ...snapshot,
+    index: {
+      ...snapshot.index,
+      installRecords: cloneSnapshotValue(snapshot.index.installRecords ?? {}),
+      plugins: snapshot.index.plugins.map(cloneSnapshotValue),
+      diagnostics: snapshot.index.diagnostics.map(cloneSnapshotValue),
+    },
+    registryDiagnostics: snapshot.registryDiagnostics.map(cloneSnapshotValue),
+    manifestRegistry: {
+      ...snapshot.manifestRegistry,
+      plugins,
+      diagnostics,
+    },
+    plugins,
+    diagnostics,
+    byPluginId: new Map(
+      [...snapshot.byPluginId.entries()].map(([pluginId, plugin]) => [
+        pluginId,
+        pluginsById.get(plugin.id) ?? clonePluginManifestRecord(plugin),
+      ]),
+    ),
+    owners: cloneOwnerMaps(snapshot.owners),
+    metrics: { ...snapshot.metrics },
+  };
+}
+
+function resolvePersistedRegistryMemoFingerprint(params: {
+  env: NodeJS.ProcessEnv;
+  preferPersisted?: boolean;
+  stateDir?: string;
+}): unknown {
+  const indexPath = resolveInstalledPluginIndexStorePath({
+    env: params.env,
+    ...(params.stateDir ? { stateDir: params.stateDir } : {}),
+  });
+  const npmRoot = params.stateDir
+    ? path.join(params.stateDir, "npm")
+    : resolveDefaultPluginNpmDir(params.env);
+  return {
+    disabled:
+      params.preferPersisted === false || params.env.OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY,
+    index: fileFingerprint(indexPath),
+    npmPackageJson: fileFingerprint(path.join(npmRoot, "package.json")),
+  };
+}
+
+function computePluginMetadataSnapshotMemoKey(params: LoadPluginMetadataSnapshotParams): string {
+  const env = params.env ?? process.env;
+  const indexFingerprint = params.index
+    ? resolveInstalledManifestRegistryIndexFingerprint(params.index)
+    : undefined;
+  return hashJson({
+    controlPlane: resolvePluginControlPlaneFingerprint({
+      config: params.config,
+      env,
+      workspaceDir: params.workspaceDir,
+      policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
+      ...(indexFingerprint ? { inventoryFingerprint: indexFingerprint } : {}),
+    }),
+    cwd: process.cwd(),
+    env: pickMemoRelevantEnv(env),
+    index: indexFingerprint ?? null,
+    pathPolicy: {
+      compatibilityHostVersion: resolveCompatibilityHostVersion(env),
+      nixMode: resolveIsNixMode(env),
+    },
+    preferPersisted: params.preferPersisted ?? null,
+    registry: resolvePersistedRegistryMemoFingerprint({
+      env,
+      ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
+      ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
+    }),
+    stateDir: params.stateDir ? resolveUserPath(params.stateDir, env) : null,
+    workspaceDir: params.workspaceDir ?? null,
+  });
+}
 
 function resolvePluginMetadataControlPlaneFingerprint(
   params: Pick<LoadPluginMetadataSnapshotParams, "config" | "env" | "workspaceDir"> & {
@@ -173,11 +330,34 @@ export function listPluginOriginsFromMetadataSnapshot(
   return new Map(snapshot.plugins.map((record) => [record.id, record.origin]));
 }
 
+// Process-local memoization is keyed by stable registry/config/env inputs. It
+// intentionally does not watch arbitrary direct plugin file edits after a
+// persisted registry has been accepted; registry refreshes and process restarts
+// are the freshness boundaries for that broader edit flow.
 export function loadPluginMetadataSnapshot(
   params: LoadPluginMetadataSnapshotParams,
 ): PluginMetadataSnapshot {
   const activeTimelineSpan = getActiveDiagnosticsTimelineSpan();
-  return measureDiagnosticsTimelineSpanSync(
+  const memoKey = computePluginMetadataSnapshotMemoKey(params);
+  const memo = pluginMetadataSnapshotMemo;
+  if (memo?.key === memoKey) {
+    return measureDiagnosticsTimelineSpanSync(
+      "plugins.metadata.scan",
+      () => clonePluginMetadataSnapshot(memo.snapshot),
+      {
+        phase: activeTimelineSpan?.phase ?? "startup",
+        config: params.config,
+        env: params.env,
+        attributes: {
+          cacheHit: true,
+          hasWorkspaceDir: params.workspaceDir !== undefined,
+          hasInstalledIndex: params.index !== undefined,
+        },
+      },
+    );
+  }
+
+  const result = measureDiagnosticsTimelineSpanSync(
     "plugins.metadata.scan",
     () => loadPluginMetadataSnapshotImpl(params),
     {
@@ -190,11 +370,37 @@ export function loadPluginMetadataSnapshot(
       },
     },
   );
+  if (canMemoizePluginMetadataSnapshotResult(result)) {
+    pluginMetadataSnapshotMemo = {
+      key: memoKey,
+      snapshot: clonePluginMetadataSnapshot(result.snapshot),
+    };
+  }
+  return result.snapshot;
 }
 
-function loadPluginMetadataSnapshotImpl(
-  params: LoadPluginMetadataSnapshotParams,
-): PluginMetadataSnapshot {
+function canMemoizePluginMetadataSnapshotResult(result: {
+  registrySource: PluginRegistrySnapshotSource;
+  snapshot: PluginMetadataSnapshot;
+}): boolean {
+  if (result.snapshot.index.plugins.length === 0) {
+    return false;
+  }
+  if (result.registrySource !== "derived") {
+    return true;
+  }
+  return (
+    result.snapshot.registryDiagnostics.length > 0 &&
+    result.snapshot.registryDiagnostics.every(
+      (diagnostic) => diagnostic.code === "persisted-registry-stale-policy",
+    )
+  );
+}
+
+function loadPluginMetadataSnapshotImpl(params: LoadPluginMetadataSnapshotParams): {
+  snapshot: PluginMetadataSnapshot;
+  registrySource: PluginRegistrySnapshotSource;
+} {
   const totalStartedAt = performance.now();
   const registryStartedAt = performance.now();
   const registryResult = loadPluginRegistrySnapshotWithMetadata({
@@ -237,30 +443,33 @@ function loadPluginMetadataSnapshotImpl(
   const totalMs = performance.now() - totalStartedAt;
 
   return {
-    policyHash: index.policyHash,
-    configFingerprint: resolvePluginMetadataControlPlaneFingerprint({
-      config: params.config,
-      env: params.env,
-      index,
+    registrySource: registryResult.source,
+    snapshot: {
       policyHash: index.policyHash,
-      workspaceDir: params.workspaceDir,
-    }),
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-    index,
-    registryDiagnostics: registryResult.diagnostics,
-    manifestRegistry,
-    plugins: manifestRegistry.plugins,
-    diagnostics: manifestRegistry.diagnostics,
-    byPluginId,
-    normalizePluginId,
-    owners,
-    metrics: {
-      registrySnapshotMs,
-      manifestRegistryMs,
-      ownerMapsMs,
-      totalMs,
-      indexPluginCount: index.plugins.length,
-      manifestPluginCount: manifestRegistry.plugins.length,
+      configFingerprint: resolvePluginMetadataControlPlaneFingerprint({
+        config: params.config,
+        env: params.env,
+        index,
+        policyHash: index.policyHash,
+        workspaceDir: params.workspaceDir,
+      }),
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      index,
+      registryDiagnostics: registryResult.diagnostics,
+      manifestRegistry,
+      plugins: manifestRegistry.plugins,
+      diagnostics: manifestRegistry.diagnostics,
+      byPluginId,
+      normalizePluginId,
+      owners,
+      metrics: {
+        registrySnapshotMs,
+        manifestRegistryMs,
+        ownerMapsMs,
+        totalMs,
+        indexPluginCount: index.plugins.length,
+        manifestPluginCount: manifestRegistry.plugins.length,
+      },
     },
   };
 }

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { resolveIsNixMode } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   getActiveDiagnosticsTimelineSpan,
@@ -172,7 +171,7 @@ function computePluginMetadataSnapshotMemoKey(params: LoadPluginMetadataSnapshot
     index: indexFingerprint ?? null,
     pathPolicy: {
       compatibilityHostVersion: resolveCompatibilityHostVersion(env),
-      nixMode: resolveIsNixMode(env),
+      nixMode: env.OPENCLAW_NIX_MODE ?? null,
     },
     preferPersisted: params.preferPersisted ?? null,
     registry: resolvePersistedRegistryMemoFingerprint({

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -148,6 +148,29 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     expect(whatsappPlugin.origin).toBe("global");
   });
 
+  it("keeps vanished recovered install records on the persisted fast path", () => {
+    const tempRoot = makeTempDir();
+    const stateDir = path.join(tempRoot, "state");
+    const goneDir = path.join(tempRoot, "gone");
+    const env = {
+      ...createHermeticEnv(tempRoot),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    writePersistedInstalledPluginIndexSync(
+      {
+        ...loadInstalledPluginIndex({ config: {}, env, stateDir, installRecords: {} }),
+        installRecords: { gone: { source: "npm", spec: "gone@1.0.0", installPath: goneDir } },
+      },
+      { stateDir },
+    );
+
+    const result = loadPluginRegistrySnapshotWithMetadata({ config: {}, env, stateDir });
+
+    expect(result.source).toBe("persisted");
+    expect(result.diagnostics).toStrictEqual([]);
+  });
+
   it("keeps persisted manifestless Claude bundles on the fast path", () => {
     const tempRoot = makeTempDir();
     const rootDir = path.join(tempRoot, "workspace");

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveUserPath } from "../utils.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { fileSignatureMatches } from "./installed-plugin-index-hash.js";
 import { hasOptionalMissingPluginManifestFile } from "./installed-plugin-index-manifest.js";
@@ -196,12 +197,23 @@ function loadSnapshotInstallRecords(params: LoadPluginRegistryParams, env: NodeJ
 function hasRecoveredInstallRecordsMissingFromPersistedIndex(
   index: InstalledPluginIndex,
   installRecords: ReturnType<typeof loadInstalledPluginIndexInstallRecordsSync>,
+  env: NodeJS.ProcessEnv,
 ): boolean {
   const persistedRecords = extractPluginInstallRecordsFromInstalledPluginIndex(index);
   const persistedPluginIds = new Set(index.plugins.map((plugin) => plugin.pluginId));
-  return Object.keys(installRecords).some(
-    (pluginId) => !persistedRecords[pluginId] || !persistedPluginIds.has(pluginId),
-  );
+  return Object.entries(installRecords).some(([pluginId, record]) => {
+    if (persistedRecords[pluginId] && persistedPluginIds.has(pluginId)) {
+      return false;
+    }
+    const installPaths = [record.installPath, record.sourcePath].filter(
+      (candidate): candidate is string =>
+        typeof candidate === "string" && candidate.trim().length > 0,
+    );
+    if (installPaths.length === 0) {
+      return true;
+    }
+    return installPaths.some((installPath) => fs.existsSync(resolveUserPath(installPath, env)));
+  });
 }
 
 export function loadPluginRegistrySnapshotWithMetadata(
@@ -267,6 +279,7 @@ export function loadPluginRegistrySnapshotWithMetadata(
         hasRecoveredInstallRecordsMissingFromPersistedIndex(
           persistedIndex,
           loadSnapshotInstallRecords(params, env),
+          env,
         )
       ) {
         diagnostics.push({


### PR DESCRIPTION
## Summary
- Add a small process-local memo around `loadPluginMetadataSnapshot` so repeated same-process CLI startup callers reuse metadata snapshot work.
- Keep the memo key intentionally narrow: caller-visible config/control-plane inputs plus persisted registry and managed npm root fingerprints.
- Cache only persisted/provided snapshots and policy-stale derived snapshots; broader discovery freshness hardening remains in #81064 / follow-up.
- Ignore vanished recovered install records when their install/source paths are gone, so stale local install-record residue does not force beta6 back to full derived discovery.

AI-assisted: yes, with Codex.

## Root cause
Beta6 still calls `loadPluginMetadataSnapshot` hundreds of times during CLI startup. The lower-level manifest scan cache helps, but callers still repeatedly rebuild registry snapshot state, manifest registry state, owner maps, id normalizers, and metrics.

The earlier slim branch avoided some broad caching risk, but it skipped policy-stale derived snapshots. On this beta6 install, many validation callers use `config: {}`, which produces `persisted-registry-stale-policy`; skipping those snapshots left the hot path intact.

## Scope notes
This is the release-sized hotfix slice. It intentionally does not attempt the full freshness matrix from #81064. In particular, arbitrary direct plugin file edits in the same process are not exhaustively detected unless the persisted registry / managed npm fingerprint changes or the process restarts. That broader P2 hardening should stay with #81064 or a follow-up.

GitHub file API after the final recut reports 4 files changed, 468 additions, and 31 deletions (`size: M`).

## Real behavior proof
**Behavior or issue addressed:** repeated in-process plugin metadata snapshot construction dominates beta6 CLI startup on installs with many plugins.

**Real environment tested:** local production OpenClaw install on Linux/WSL2, upgraded to `OpenClaw 2026.5.12-beta.6 (c4292e0)`. The local CLI exit-fix patch was not applied for the final proof. The after-fix timing proof used #81570 production head `fb8e1ce931def59793d3218ffef7c0393f8deedd` applied to beta6 commit `c4292e053d7c86361700b3acb59cb51e4a310f2d`, built from a fresh beta6 proof worktree, and temporarily overlaid as a complete `dist/` onto the same install. The current PR head is `9de96674aff0415862d1ef88be3f5722a53e61a0`; commits after the timing proof are limited to a memo-key Nix-mode input simplification and test fixture/size trims. The install was restored to beta6 afterward.

**Exact steps or command run after this patch:** `pnpm -C <slim-pr-worktree> format:check src/plugins/plugin-metadata-snapshot.ts src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/plugin-registry-snapshot.ts src/plugins/plugin-registry-snapshot.test.ts`; `pnpm -C <slim-pr-worktree> test src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/plugin-registry-snapshot.test.ts src/plugins/plugin-registry.test.ts`; `timeout 90s pnpm tsgo:core`; `pnpm -C <beta6-proof-worktree> format:check src/plugins/plugin-metadata-snapshot.ts src/plugins/plugin-registry-snapshot.ts src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/plugin-registry-snapshot.test.ts`; `pnpm -C <beta6-proof-worktree> test src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/plugin-registry-snapshot.test.ts src/plugins/plugin-registry.test.ts`; `timeout 240s pnpm build`; `/usr/bin/time -p timeout 240s openclaw plugins list`; `/usr/bin/time -p timeout 240s openclaw gateway status`; `OPENCLAW_DIAGNOSTICS=timeline OPENCLAW_DIAGNOSTICS_TIMELINE_PATH=/tmp/openclaw-beta6-81570-fb8-timeline.jsonl timeout 120s openclaw plugins list --json`.

**Evidence after fix:** unpatched beta6 baseline in the same install was `openclaw plugins list` `real 80.63` and `openclaw gateway status` `real 64.15`. With #81570 head `fb8e1ce` overlaid, `openclaw plugins list` completed with `Plugins (18/104 enabled)` in `real 14.69`, `user 14.25`, `sys 1.53`; `openclaw gateway status` completed in `real 12.69`, `user 12.28`, `sys 1.69`. The timeline run recorded 906 `plugins.metadata.scan` spans with 896 cache hits, total metadata span time `9411.2ms`, max `291.8ms`, and no stderr.

**Observed result after fix:** beta6 CLI metadata startup work collapses to process-local cache hits after the first few distinct contexts. `plugins list` improves from 80.63s to 14.69s, and `gateway status` improves from 64.15s to 12.69s on the same install.

**What was not tested:** current head `9de96674aff0415862d1ef88be3f5722a53e61a0` was not retimed in the local beta6 install after the post-proof memo-key Nix-mode input simplification and test-only trim commits; hosted non-draft CI is green on that exact head. The comprehensive plugin discovery freshness matrix from #81064 is intentionally out of scope for this release-sized PR; this PR only includes compact coverage for the vanished install-record case needed to keep beta6 on the persisted fast path.

## Verification
- `pnpm -C <slim-pr-worktree> format:check src/plugins/plugin-metadata-snapshot.ts src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/plugin-registry-snapshot.ts src/plugins/plugin-registry-snapshot.test.ts`
- `pnpm -C <slim-pr-worktree> test src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/plugin-registry-snapshot.test.ts src/plugins/plugin-registry.test.ts`
- `timeout 90s pnpm tsgo:core`
- `pnpm -C <beta6-proof-worktree> format:check src/plugins/plugin-metadata-snapshot.ts src/plugins/plugin-registry-snapshot.ts src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/plugin-registry-snapshot.test.ts`
- `pnpm -C <beta6-proof-worktree> test src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/plugin-registry-snapshot.test.ts src/plugins/plugin-registry.test.ts`
- `timeout 240s pnpm build` from the beta6 proof worktree
- `git diff --check`
- Hosted non-draft CI on `9de96674aff0415862d1ef88be3f5722a53e61a0`: `Real behavior proof`, `check-lint`, `check-test-types`, `check-prod-types`, `check`, `build-artifacts`, `build-smoke`, `checks-node-core`, `checks-node-core-fast`, `checks-fast-protocol`, `Critical Quality (plugin-boundary)`, `Critical Quality (network-runtime-boundary)`, selected `Security High` shards, and the remaining required PR checks.
