### PR TITLE
fix(skills): check isSymbolicLink before readlinkSync to avoid EINVAL

### DIFF
--- a/src/agents/skills/plugin-skills.ts
+++ b/src/agents/skills/plugin-skills.ts
@@ -220,16 +220,25 @@ function publishPluginSkills(skillDirs: string[], opts?: { pluginSkillsDir?: str
       // best-effort; symlink will fail below if dir is truly unusable
     }
     try {
-      const existingTarget = fs.readlinkSync(linkPath);
-      if (existingTarget === target) {
-        continue;
+      const stat = fs.lstatSync(linkPath);
+      if (stat.isSymbolicLink()) {
+        const existingTarget = fs.readlinkSync(linkPath);
+        if (existingTarget === target) {
+          continue;
+        }
+        removeGeneratedPluginSkillEntry(linkPath);
+      } else {
+        // Path exists but is not a symlink (e.g. a real directory on Windows
+        // where symlinks were replaced by junctions/copy). Remove so we can
+        // recreate the entry as a proper symlink.
+        removeGeneratedPluginSkillEntry(linkPath);
       }
-      removeGeneratedPluginSkillEntry(linkPath);
     } catch (err) {
       if (!isNotFoundError(err)) {
         log.warn(`failed to inspect plugin skill symlink "${linkPath}": ${String(err)}`);
         continue;
       }
+      // ENOENT: path does not exist — fall through to create symlink below
     }
     try {
       fs.symlinkSync(target, linkPath, resolvePluginSkillLinkType());


### PR DESCRIPTION
## Summary

Fixes #81432

On Windows (and other environments where symlinks may be replaced by real directories or junctions), `publishPluginSkills` calls `fs.readlinkSync()` without first checking if the path is a symbolic link. When the path is a regular directory, this throws `EINVAL`.

## Root Cause

In `src/agents/skills/plugin-skills.ts` line 223, `fs.readlinkSync(linkPath)` is called unconditionally. On Windows, plugin skills directories may be real directories instead of symlinks (due to permissions or junction handling), causing EINVAL.

## Fix

Use `fs.lstatSync()` to check if the path is a symbolic link before calling `readlinkSync()`:
- If it **is** a symlink → existing behavior (compare target, remove if stale)
- If it **is not** a symlink (real directory) → remove so it can be recreated as a proper symlink
- If path **does not exist** → fall through to symlink creation

This matches the approach suggested in the issue.

## Testing

- Code change reviewed line by line
- Logic verified: symlink case preserves existing behavior, non-symlink case gracefully removes and recreates
- Cannot reproduce on macOS (symlinks work normally), but the fix is logically sound for Windows environments
- The existing test suite should continue to pass as the symlink behavior is unchanged

## AI-assisted

This PR was written with AI assistance. I have reviewed and understand every line of the change.