### PR TITLE
fix(cron): persist due job outcomes incrementally

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -458,7 +458,12 @@ export function recordScheduleComputeError(params: {
   return true;
 }
 
-function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; nowMs: number }): {
+function normalizeJobTickState(params: {
+  state: CronServiceState;
+  job: CronJob;
+  nowMs: number;
+  preserveRunningJobIds?: ReadonlySet<string>;
+}): {
   changed: boolean;
   skip: boolean;
 } {
@@ -503,6 +508,9 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
 
   const runningAt = job.state.runningAtMs;
   if (typeof runningAt === "number" && nowMs - runningAt > STUCK_RUN_MS) {
+    if (params.preserveRunningJobIds?.has(job.id)) {
+      return { changed, skip: false };
+    }
     state.deps.log.warn(
       { jobId: job.id, runningAtMs: runningAt },
       "cron: clearing stuck running marker",
@@ -523,13 +531,19 @@ function walkSchedulableJobs(
   state: CronServiceState,
   fn: (params: { job: CronJob; nowMs: number }) => boolean,
   nowMs = state.deps.nowMs(),
+  opts?: { preserveRunningJobIds?: ReadonlySet<string> },
 ): boolean {
   if (!state.store) {
     return false;
   }
   let changed = false;
   for (const job of state.store.jobs) {
-    const tick = normalizeJobTickState({ state, job, nowMs });
+    const tick = normalizeJobTickState({
+      state,
+      job,
+      nowMs,
+      preserveRunningJobIds: opts?.preserveRunningJobIds,
+    });
     if (tick.changed) {
       changed = true;
     }
@@ -610,7 +624,12 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
  */
 export function recomputeNextRunsForMaintenance(
   state: CronServiceState,
-  opts?: { recomputeExpired?: boolean; nowMs?: number; repairFutureCronNextRunAtMs?: boolean },
+  opts?: {
+    recomputeExpired?: boolean;
+    nowMs?: number;
+    repairFutureCronNextRunAtMs?: boolean;
+    preserveRunningJobIds?: ReadonlySet<string>;
+  },
 ): boolean {
   const recomputeExpired = opts?.recomputeExpired ?? false;
   const repairFutureCronNextRunAtMs = opts?.repairFutureCronNextRunAtMs ?? true;
@@ -647,6 +666,7 @@ export function recomputeNextRunsForMaintenance(
       return changed;
     },
     opts?.nowMs,
+    { preserveRunningJobIds: opts?.preserveRunningJobIds },
   );
 }
 

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -127,6 +127,59 @@ describe("cron service timer regressions", () => {
     timeoutSpy.mockRestore();
   });
 
+  it("persists a completed due-job outcome before later batch jobs finish", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const now = Date.parse("2026-02-06T10:05:00.000Z");
+    const finishedJob = createDueIsolatedJob({
+      id: "finished",
+      nowMs: now,
+      nextRunAtMs: now - 2,
+      deleteAfterRun: true,
+    });
+    const blockingJob = createDueIsolatedJob({
+      id: "blocking",
+      nowMs: now,
+      nextRunAtMs: now - 1,
+      deleteAfterRun: true,
+    });
+    await writeCronJobs(store.storePath, [finishedJob, blockingJob]);
+
+    const blockingStarted = createDeferred<void>();
+    const releaseBlocking = createDeferred<void>();
+    const runIsolatedAgentJob = vi.fn(async ({ job }) => {
+      if (job.id === "finished") {
+        return { status: "ok" as const, summary: "finished" };
+      }
+      blockingStarted.resolve();
+      await releaseBlocking.promise;
+      return { status: "ok" as const, summary: "blocking finished" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      cronConfig: { maxConcurrentRuns: 1 },
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    const timerRun = onTimer(state);
+    await blockingStarted.promise;
+
+    try {
+      const persisted = JSON.parse(await fs.readFile(store.storePath, "utf8")) as {
+        jobs: CronJob[];
+      };
+      expect(persisted.jobs.find((job) => job.id === "finished")).toBeUndefined();
+      expect(persisted.jobs.find((job) => job.id === "blocking")).toBeDefined();
+    } finally {
+      releaseBlocking.resolve();
+      await timerRun;
+    }
+  });
+
   it("#24355: one-shot job retries then succeeds", async () => {
     const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
 

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -180,6 +180,60 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("preserves queued due-job running markers during incremental batch persistence", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const batchStart = Date.parse("2026-02-06T10:05:00.000Z");
+    const stuckThresholdMs = 2 * 60 * 60 * 1000;
+    const first = createDueIsolatedJob({
+      id: "long-first",
+      nowMs: batchStart,
+      nextRunAtMs: batchStart - 2,
+    });
+    const second = createDueIsolatedJob({
+      id: "reserved-second",
+      nowMs: batchStart,
+      nextRunAtMs: batchStart - 1,
+    });
+    await writeCronJobs(store.storePath, [first, second]);
+
+    let now = batchStart;
+    const secondStarted = createDeferred<void>();
+    const releaseSecond = createDeferred<void>();
+    const runIsolatedAgentJob = vi.fn(async ({ job }) => {
+      if (job.id === "long-first") {
+        now = batchStart + stuckThresholdMs + 1;
+        return { status: "ok" as const, summary: "first finished after stuck threshold" };
+      }
+      secondStarted.resolve();
+      await releaseSecond.promise;
+      return { status: "ok" as const, summary: "second finished" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      cronConfig: { maxConcurrentRuns: 1 },
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    const timerRun = onTimer(state);
+    await secondStarted.promise;
+
+    try {
+      const statePath = store.storePath.replace(/\.json$/u, "-state.json");
+      const persistedState = JSON.parse(await fs.readFile(statePath, "utf8")) as {
+        jobs: Record<string, { state?: { runningAtMs?: number } }>;
+      };
+      expect(persistedState.jobs[second.id]?.state?.runningAtMs).toBe(batchStart);
+    } finally {
+      releaseSecond.resolve();
+      await timerRun;
+    }
+  });
+
   it("#24355: one-shot job retries then succeeds", async () => {
     const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1072,6 +1072,7 @@ export async function onTimer(state: CronServiceState) {
       }
     };
 
+    const unappliedDueJobIds = new Set(dueJobs.map((due) => due.id));
     const applyCompletedResult = async (result: TimedCronRunOutcome) => {
       await locked(state, async () => {
         await ensureLoaded(state, { forceReload: true, skipRecompute: true });
@@ -1082,9 +1083,13 @@ export async function onTimer(state: CronServiceState) {
         // locked block.  The full recomputeNextRuns would silently skip
         // those jobs (advancing nextRunAtMs without execution), causing
         // daily cron schedules to jump 48 h instead of 24 h (#17852).
-        recomputeNextRunsForMaintenance(state);
+        // Jobs from the current due batch keep their running markers until
+        // their own outcomes are applied; otherwise a long batch can cross the
+        // stuck-run threshold and make queued/running jobs look idle on disk.
+        recomputeNextRunsForMaintenance(state, { preserveRunningJobIds: unappliedDueJobIds });
         await persist(state);
       });
+      unappliedDueJobIds.delete(result.jobId);
     };
 
     const concurrency = Math.min(resolveRunConcurrency(state), Math.max(1, dueJobs.length));

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1072,8 +1072,22 @@ export async function onTimer(state: CronServiceState) {
       }
     };
 
+    const applyCompletedResult = async (result: TimedCronRunOutcome) => {
+      await locked(state, async () => {
+        await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+        applyOutcomeToStoredJob(state, result);
+
+        // Use maintenance-only recompute to avoid advancing past-due
+        // nextRunAtMs values that became due between findDueJobs and this
+        // locked block.  The full recomputeNextRuns would silently skip
+        // those jobs (advancing nextRunAtMs without execution), causing
+        // daily cron schedules to jump 48 h instead of 24 h (#17852).
+        recomputeNextRunsForMaintenance(state);
+        await persist(state);
+      });
+    };
+
     const concurrency = Math.min(resolveRunConcurrency(state), Math.max(1, dueJobs.length));
-    const results: (TimedCronRunOutcome | undefined)[] = Array.from({ length: dueJobs.length });
     let cursor = 0;
     const workers = Array.from({ length: concurrency }, async () => {
       for (;;) {
@@ -1085,31 +1099,10 @@ export async function onTimer(state: CronServiceState) {
         if (!due) {
           return;
         }
-        results[index] = await runDueJob(due);
+        await applyCompletedResult(await runDueJob(due));
       }
     });
     await Promise.all(workers);
-
-    const completedResults: TimedCronRunOutcome[] = results.filter(
-      (entry): entry is TimedCronRunOutcome => entry !== undefined,
-    );
-
-    if (completedResults.length > 0) {
-      await locked(state, async () => {
-        await ensureLoaded(state, { forceReload: true, skipRecompute: true });
-        for (const result of completedResults) {
-          applyOutcomeToStoredJob(state, result);
-        }
-
-        // Use maintenance-only recompute to avoid advancing past-due
-        // nextRunAtMs values that became due between findDueJobs and this
-        // locked block.  The full recomputeNextRuns would silently skip
-        // those jobs (advancing nextRunAtMs without execution), causing
-        // daily cron schedules to jump 48 h instead of 24 h (#17852).
-        recomputeNextRunsForMaintenance(state);
-        await persist(state);
-      });
-    }
   } finally {
     // Piggyback session reaper on timer tick (self-throttled to every 5 min).
     // Placed in `finally` so the reaper runs even when a long-running job keeps

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, type Mock } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { resolveSessionTranscriptPath } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
@@ -191,13 +191,18 @@ describe("sessions_send label lookup", () => {
       );
 
       const spy = agentCommand as unknown as Mock<(opts: unknown) => Promise<void>>;
-      spy.mockImplementation(async (opts: unknown) =>
-        emitLifecycleAssistantReply({
+      let announceStepCompleted = false;
+      spy.mockImplementation(async (opts: unknown) => {
+        await emitLifecycleAssistantReply({
           opts,
           defaultSessionId: "test-labeled",
           resolveText: () => "labeled response",
-        }),
-      );
+        });
+        const extraSystemPrompt = (opts as { extraSystemPrompt?: string }).extraSystemPrompt;
+        if (extraSystemPrompt?.includes("Agent-to-agent announce step")) {
+          announceStepCompleted = true;
+        }
+      });
 
       // First, create a session with a label via sessions.patch
       const { callGateway } = await import("./call.js");
@@ -234,6 +239,7 @@ describe("sessions_send label lookup", () => {
       expect(details.status).toBe("ok");
       expect(details.reply).toBe("labeled response");
       expect(details.sessionKey).toBe("agent:main:test-labeled-session");
+      await vi.waitFor(() => expect(announceStepCompleted).toBe(true), { timeout: 5_000 });
     },
   );
 });

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -314,11 +314,11 @@ describe("sessions_send agent targeting", () => {
         expect(details.reply).toBe("orion response");
         expect(details.sessionKey).toBe("agent:orion:main");
 
-        const orionCall = spy.mock.calls
-          .map(([opts]) => opts as { sessionId?: string; sessionKey?: string })
-          .find((call) => call.sessionKey === "agent:orion:main");
-        expect(orionCall).toBeDefined();
-        expect(orionCall?.sessionId).toBeTypeOf("string");
+        const targetCall = spy.mock.calls
+          .map((call) => call[0] as { sessionId?: string; sessionKey?: string } | undefined)
+          .find((call) => call?.sessionKey === "agent:orion:main");
+        expect(targetCall?.sessionKey).toBe("agent:orion:main");
+        expect(targetCall?.sessionId).toBeTypeOf("string");
 
         const rawStore = JSON.parse(
           await fs.readFile(testState.sessionStorePath, "utf-8"),
@@ -328,7 +328,7 @@ describe("sessions_send agent targeting", () => {
             sessionId?: string;
           }
         >;
-        expect(rawStore["agent:orion:main"]?.sessionId).toBe(orionCall?.sessionId);
+        expect(rawStore["agent:orion:main"]?.sessionId).toBe(targetCall?.sessionId);
       } finally {
         testState.agentsConfig = undefined;
         testState.sessionStorePath = undefined;


### PR DESCRIPTION
## Summary

- Problem: one-shot cron jobs that completed successfully could remain visible as `running` with null completion fields while later jobs from the same due batch were still executing or stuck.
- Why it matters: operators and integrations saw completed cron-triggered sessions as still active, and those stale `runningAtMs` entries could suppress logical re-enqueue/dedupe decisions.
- What changed: cron timer workers now persist each completed due-job outcome immediately under the cron store lock instead of buffering outcomes until the whole due-job batch drains.
- What did NOT change (scope boundary): this does not change cron scheduling semantics, job selection, delivery behavior, task classification, or retry policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: completed due cron jobs should be finalized in the cron store and task ledger as soon as that job completes, even when later jobs from the same due batch are still running.
- Real environment tested: live OpenClaw gateway in a Docker container using a patched global OpenClaw install (`OpenClaw 2026.5.12-beta.1`) with cron concurrency set to 1 and a private CodeClaw integration. Private repository names, enterprise host names, and PR URLs are redacted below.
- Exact steps or command run after this patch:
  1. Installed the patched OpenClaw package into the live container and restarted the gateway.
  2. Verified the deployed server cron bundle contained the incremental outcome flush helper (`applyCompletedResult`).
  3. Paused the external CodeClaw system poller, snapshotted state, cleared OpenClaw cron/task stores for a clean live proof run, and marked three private CodeClaw source-state ledger entries dirty so the next tick would enqueue three due jobs.
  4. Resumed the system poller for one tick. It enqueued three CodeClaw cron jobs: one external-review job followed by two own-PR jobs.
  5. Watched `openclaw cron list --json` and `openclaw tasks list --json --runtime cron` while the first job completed and later due jobs were still active.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  ```text
  # Deployed runtime verification
  VERSION=OpenClaw 2026.5.12-beta.1 (b5c3379)
  FIX_GREP
  /usr/local/lib/node_modules/openclaw/dist/server-cron-CP73-T42.js:984: const applyCompletedResult = async (result) => {
  /usr/local/lib/node_modules/openclaw/dist/server-cron-CP73-T42.js:1003: await applyCompletedResult(await runDueJob(due));
  ```

  ```text
  # Poller proof run, redacted private repo/host details
  Plan @ 2026-05-14T00:00:07.352Z
    follow-up (3):
      - private external PR review #A: __force_reprocess__... -> current signature
      - private own PR self-review #B: __force_reprocess__... -> current signature
      - private own PR feedback #B: __force_reprocess__... -> current signature
  ```

  ```text
  # Before first job finished: first due job running; later same-batch jobs idle
  2026-05-14T00:00:47Z
  cron_total=4 codeclaw=3 statuses={'idle': 3, 'running': 1}
  cron codeclaw-topic-2859-external-pr-review status=running id=33a62cf4-a5b7-465f-a972-262d99d22830 runningAt=1778716826339 last=None lastRunAt=None
  cron codeclaw-topic-3071-own-pr-self-review status=idle id=313a5f63-3c97-4daa-894c-e3cc2f452b6c runningAt=None last=None lastRunAt=None
  cron codeclaw-topic-3071-own-pr-comment-response status=idle id=07031b50-b75e-472e-b437-809e93210c8a runningAt=None last=None lastRunAt=None
  cron_tasks_total=1 running=1 succeeded=0 failed=0
  tasks codeclaw-topic-2859-external-pr-review count=1 ['running:62915a4f-df49-464e-83df-d471f07ed650:33a62cf4-a5b7-465f-a972-262d99d22830:None']
  audit findings=0 errors=0 stale=0
  ```

  ```text
  # After first job finished: first deleteAfterRun job is gone and task is terminal while later jobs are still active
  2026-05-14T00:04:48Z
  cron_total=3 codeclaw=2 statuses={'idle': 1, 'running': 2}
  cron codeclaw-topic-2859-external-pr-review absent
  cron codeclaw-topic-3071-own-pr-self-review status=running id=313a5f63-3c97-4daa-894c-e3cc2f452b6c runningAt=1778717067776 last=None lastRunAt=None
  cron codeclaw-topic-3071-own-pr-comment-response status=running id=07031b50-b75e-472e-b437-809e93210c8a runningAt=1778717067669 last=None lastRunAt=None
  cron_tasks_total=2 running=1 succeeded=1 failed=0
  tasks codeclaw-topic-2859-external-pr-review count=1 ['succeeded:62915a4f-df49-464e-83df-d471f07ed650:33a62cf4-a5b7-465f-a972-262d99d22830:1778717065540']
  tasks codeclaw-topic-3071-own-pr-self-review count=1 ['running:24713e99-7412-4cb6-a03a-86b54ac5df23:313a5f63-3c97-4daa-894c-e3cc2f452b6c:None']
  audit findings=0 errors=0 stale=0
  ```

- Observed result after fix: the completed one-shot cron job was deleted from the cron queue and its cron task became `succeeded` while later due jobs from the same batch were still running/claimed. This is the expected immediate completion accounting behavior.
- What was not tested: a production release package built through the full prepack path was not tested in the live container; the emergency live patch was installed from a locally packed artifact after validation. Windows behavior was not tested. This live proof used a private integration with redacted repository/PR details.
- Before evidence (optional but encouraged): in the same live integration before the patch, a cron-triggered review session completed and posted its final approval, but the cron job stayed `running` with `runningAtMs` set and `lastRunAtMs`, `lastRunStatus`, `lastError`, and `lastDurationMs` null; the matching cron task stayed `running` with `endedAt` null. Source tracing showed this could happen because due-job outcomes were buffered until every worker in the due batch finished.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `onTimer` collected due-job outcomes in memory and applied them to the cron store only after `Promise.all(workers)` returned. If an earlier due job completed while a later same-batch job continued running or wedged, the earlier job's `runningAtMs` and task-ledger status could remain active until the entire batch drained.
- Missing detection / guardrail: there was no regression test asserting that a completed due job is persisted/finalized before later jobs from the same due batch finish.
- Contributing context (if known): one-shot `deleteAfterRun` jobs are marked running before worker execution; an active `runningAtMs` excludes a job from future runnable collection and makes the cron list look active even when the underlying session already completed.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/service/timer.regression.test.ts`
- Scenario the test should lock in: with `maxConcurrentRuns=1` and two due one-shot jobs in a batch, the first completed `deleteAfterRun` job is removed from the persisted cron store before the second blocking job finishes.
- Why this is the smallest reliable guardrail: it exercises the cron timer's due-batch outcome persistence behavior directly without requiring model, channel, or Telegram integration.
- Existing test that already covers this (if any): none found before this change.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Completed cron jobs should disappear or show terminal state sooner. Operators should see fewer misleading long-running cron jobs/tasks when later due jobs are still processing.

## Diagram (if applicable)

```text
Before:
[due batch] -> [job A finishes] -> [job B still running] -> [job A outcome buffered, cron/task can still look running]

After:
[due batch] -> [job A finishes] -> [apply + persist job A outcome immediately] -> [job B continues independently]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux container environment for live proof; Node 24 Docker image for local validation.
- Runtime/container: live OpenClaw gateway container patched to `OpenClaw 2026.5.12-beta.1`; local validation in `node:24-bookworm`.
- Model/provider: live integration used the configured private provider; not relevant to the cron timer unit regression.
- Integration/channel (if any): live proof used a Telegram-backed CodeClaw/OpenClaw cron integration; private endpoint and repository details redacted.
- Relevant config (redacted): cron `maxConcurrentRuns=1` for live proof; subagent concurrency was explicitly configured but not relevant to the timer persistence fix.

### Steps

1. Reproduce or simulate a due cron batch with more than one due job.
2. Let the first `deleteAfterRun` one-shot job complete while a later due job remains running.
3. Inspect cron store/list and cron task ledger before the later job finishes.

### Expected

- The completed one-shot job is finalized/deleted promptly.
- Its cron task ledger record is terminal.
- Later due jobs may remain running/claimed independently.

### Actual

- Before this patch, the completed job outcome could remain buffered until all due-job workers completed.
- After this patch, the completed job is finalized immediately, as shown in the live proof above.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run locally with Node 24:

```text
CI=true node scripts/test-projects.mjs src/cron/service/timer.regression.test.ts
# RED before fix: new regression failed because the finished deleteAfterRun job remained persisted until the blocking job finished.
# GREEN after fix: 1 test file, 36 tests passed.

CI=true node scripts/test-projects.mjs src/cron/service/timer.test.ts src/cron/service/timer.regression.test.ts src/cron/service/ops.test.ts src/cron/service/ops.regression.test.ts
# 4 test files, 56 tests passed.

CI=true corepack pnpm build
# passed

git diff --check
# passed
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Regression test fails before the fix and passes after the fix.
  - Cron service timer/ops tests pass after the fix.
  - Build passes under Node 24.
  - A live patched gateway finalizes a completed one-shot job while later jobs remain active.
- Edge cases checked:
  - `deleteAfterRun` one-shot removal with a later blocking due job.
  - Existing cron timer and ops regression coverage.
- What you did **not** verify:
  - Full release/prepack packaging path in the live container.
  - Windows behavior.
  - A public/non-private integration; live proof used a redacted private integration.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: applying outcomes incrementally increases the number of cron store lock/persist operations for large due batches.
  - Mitigation: each operation uses the existing cron store lock, force-reload, outcome application, next-run recompute, and persist paths; regression and cron service tests cover the touched behavior.