### PR TITLE
fix: start Codex for selectable OpenAI models

### DIFF
--- a/src/agents/harness-runtimes.test.ts
+++ b/src/agents/harness-runtimes.test.ts
@@ -3,6 +3,71 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { collectConfiguredAgentHarnessRuntimes } from "./harness-runtimes.js";
 
 describe("collectConfiguredAgentHarnessRuntimes", () => {
+  it("includes Codex for selectable OpenAI default models when primary is not OpenAI", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4-6",
+          },
+          models: {
+            "anthropic/claude-sonnet-4-6": {},
+            "openai/gpt-5.5": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(collectConfiguredAgentHarnessRuntimes(config, {}, { includeEnvRuntime: false })).toEqual(
+      ["codex"],
+    );
+  });
+
+  it("does not include Codex for selectable OpenAI models pinned to PI", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4-6",
+          },
+          models: {
+            "openai/gpt-5.5": {
+              agentRuntime: { id: "pi" },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(collectConfiguredAgentHarnessRuntimes(config, {}, { includeEnvRuntime: false })).toEqual(
+      [],
+    );
+  });
+
+  it("includes Codex for selectable per-agent OpenAI models", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4-6",
+          },
+        },
+        list: [
+          {
+            id: "ops",
+            models: {
+              "openai/gpt-5.5": {},
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(collectConfiguredAgentHarnessRuntimes(config, {}, { includeEnvRuntime: false })).toEqual(
+      ["codex"],
+    );
+  });
+
   it("ignores malformed agents.list while scanning best-effort config", () => {
     const config = {
       agents: {

--- a/src/agents/harness-runtimes.ts
+++ b/src/agents/harness-runtimes.ts
@@ -72,6 +72,13 @@ function hasOpenAIModelRef(config: OpenClawConfig, value: unknown, agentId?: str
   });
 }
 
+function hasOpenAIModelMapRef(config: OpenClawConfig, models: unknown, agentId?: string): boolean {
+  if (!isRecord(models)) {
+    return false;
+  }
+  return Object.keys(models).some((ref) => hasOpenAIModelRef(config, ref, agentId));
+}
+
 function pushConfiguredModelRuntimeIds(config: OpenClawConfig, runtimes: Set<string>): void {
   for (const providerConfig of Object.values(config.models?.providers ?? {})) {
     const providerRuntime = normalizeRuntimeId(providerConfig?.agentRuntime?.id);
@@ -141,6 +148,11 @@ export function collectConfiguredAgentHarnessRuntimes(
       runtimes.add("codex");
     }
   };
+  const pushCodexForOpenAIModelMap = (models: unknown, agentId?: string) => {
+    if (hasOpenAIModelMapRef(config, models, agentId)) {
+      runtimes.add("codex");
+    }
+  };
 
   if (includeEnvRuntime) {
     const envRuntime = normalizeRuntimeId(env.OPENCLAW_AGENT_RUNTIME);
@@ -154,6 +166,7 @@ export function collectConfiguredAgentHarnessRuntimes(
   }
   const defaultsModel = config.agents?.defaults?.model;
   pushCodexForOpenAIModel(defaultsModel);
+  pushCodexForOpenAIModelMap(config.agents?.defaults?.models);
   if (Array.isArray(config.agents?.list)) {
     for (const agent of config.agents.list) {
       if (!isRecord(agent)) {
@@ -163,6 +176,7 @@ export function collectConfiguredAgentHarnessRuntimes(
         agent.model ?? defaultsModel,
         typeof agent.id === "string" ? agent.id : undefined,
       );
+      pushCodexForOpenAIModelMap(agent.models, typeof agent.id === "string" ? agent.id : undefined);
     }
   }
 

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -675,6 +675,41 @@ describe("applyPluginAutoEnable core", () => {
     ]);
   });
 
+  it("auto-enables Codex when OpenAI is configured as a selectable model", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-sonnet-4-6",
+            },
+            models: {
+              "anthropic/claude-sonnet-4-6": {},
+              "openai/gpt-5.5": {},
+            },
+          },
+        },
+      },
+      env,
+      manifestRegistry: makeRegistry([
+        { id: "openai", channels: [], providers: ["openai", "openai-codex"] },
+        {
+          id: "codex",
+          channels: [],
+          providers: ["codex"],
+          activation: { onAgentHarnesses: ["codex"] },
+        },
+      ]),
+    });
+
+    expect(result.config.plugins?.entries?.openai?.enabled).toBe(true);
+    expect(result.config.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(result.changes).toEqual([
+      "openai/gpt-5.5 model configured, enabled automatically.",
+      "codex agent runtime configured, enabled automatically.",
+    ]);
+  });
+
   it("auto-enables an opt-in plugin when a provider runtime is configured", () => {
     const result = applyPluginAutoEnable({
       config: {

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -1445,6 +1445,28 @@ describe("resolveGatewayStartupPluginIds", () => {
     });
   });
 
+  it("includes Codex when OpenAI is configured as a selectable model", () => {
+    expectStartupPluginIdsCase({
+      config: {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-sonnet-4-6" },
+            models: {
+              "anthropic/claude-sonnet-4-6": {},
+              "openai/gpt-5.5": {},
+            },
+          },
+        },
+        plugins: {
+          entries: {
+            codex: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      expected: ["demo-channel", "browser", "codex", "memory-core"],
+    });
+  });
+
   it("does not include Codex when an OpenAI model is manually pinned to PI", () => {
     expectStartupPluginIdsCase({
       config: {


### PR DESCRIPTION
## Summary
- include selectable `agents.defaults.models` and per-agent `models` entries when deciding required agent harness runtimes
- preserve the PI opt-out behavior for selectable OpenAI models pinned to `agentRuntime: { id: "pi" }`
- cover auto-enable and gateway startup plugin selection so Codex starts before switching to selectable OpenAI models

## Investigation
`plugins.entries.codex.enabled: true` is not treated as a blanket non-bundled startup trigger today. Startup still requires a concrete activation reason, such as an agent harness runtime requirement. That looks intentional: `enabled` means the plugin may be activated, not that every enabled non-bundled plugin should be eagerly loaded.

The bug was that selectable OpenAI model-map keys were not counted as an agent harness runtime requirement unless the current primary/fallback model was OpenAI or the model entry had an explicit runtime. That made an Anthropic-primary config with selectable `openai/gpt-5.5` skip Codex at startup, then fail later when switching models.

## Verification
- `node scripts/test-projects.mjs src/agents/harness-runtimes.test.ts src/config/plugin-auto-enable.core.test.ts src/plugins/channel-plugin-ids.test.ts` with `OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_MAX_WORKERS=1`
- `git diff --check`

## Known gap
- `node scripts/check-changed.mjs` is blocked in this Codex worktree because the first pnpm-backed lane attempts `pnpm install` and hits `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
- Testbox delegation was attempted with `tbx_01krhtxnj5zt3js79s766e13ha`, but Blacksmith status/stop requests timed out, so the broad gate did not complete.