### PR TITLE
docs(browser): clarify --load networkidle scope across browser profiles (#80587)

### DIFF
--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -294,6 +294,7 @@ You can wait on more than just time/text:
   - `openclaw browser wait --url "**/dash"`
 - Wait for load state:
   - `openclaw browser wait --load networkidle`
+  - `--load networkidle` is supported on managed and remote-CDP profiles. Existing-session profiles only support `load` and `domcontentloaded` for `--load`.
 - Wait for a JS predicate:
   - `openclaw browser wait --fn "window.ready===true"`
 - Wait for a selector to become visible:

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -646,7 +646,7 @@ Compared to the managed `openclaw` profile, existing-session drivers are more co
 
 - **Screenshots** - page captures and `--ref` element captures work; CSS `--element` selectors do not. `--full-page` cannot combine with `--ref` or `--element`. Playwright is not required for page or ref-based element screenshots.
 - **Actions** - `click`, `type`, `hover`, `scrollIntoView`, `drag`, and `select` require snapshot refs (no CSS selectors). `click-coords` clicks visible viewport coordinates and does not require a snapshot ref. `click` is left-button only. `type` does not support `slowly=true`; use `fill` or `press`. `press` does not support `delayMs`. `type`, `hover`, `scrollIntoView`, `drag`, `select`, `fill`, and `evaluate` do not support per-call timeouts. `select` accepts a single value.
-- **Wait / upload / dialog** - `wait --url` supports exact, substring, and glob patterns; `wait --load networkidle` is not supported. Upload hooks require `ref` or `inputRef`, one file at a time, no CSS `element`. Dialog hooks do not support timeout overrides.
+- **Wait / upload / dialog** - `wait --url` supports exact, substring, and glob patterns; `wait --load networkidle` is not supported on existing-session profiles (it works on managed and remote-CDP profiles). Upload hooks require `ref` or `inputRef`, one file at a time, no CSS `element`. Dialog hooks do not support timeout overrides.
 - **Managed-only features** - batch actions, PDF export, download interception, and `responsebody` still require the managed browser path.
 
 </Accordion>


### PR DESCRIPTION
## Summary

- Problem: `docs/tools/browser.md` and `docs/tools/browser-control.md` give opposite answers about whether `openclaw browser wait --load networkidle` is supported, with no profile qualifier on the no-side. Reported by @esqandil in #80587.
- Why it matters: agents and operators reading the two docs side-by-side get contradictory guidance for the same flag. The behavior is actually profile-scoped (managed and remote-CDP support `networkidle`; existing-session profiles do not), so a flat "is not supported" is misleading.
- What changed: aligned both docs with the actual code paths in `extensions/browser`. `browser.md` now names the profile scope explicitly, and `browser-control.md` adds a one-line companion note next to the `--load networkidle` bullet.
- What did NOT change (scope boundary): no behavior change, no schema/types change, no other docs touched.

## Change Type

- [x] Docs

## Scope

- [x] UI / DX

## Linked Issue/PR

- Closes #80587

## Real behavior proof

- Behavior or issue addressed: docs contradiction on `browser wait --load networkidle` support.
- Real environment tested: local OpenClaw checkout at upstream/main `52370c5998` plus this branch on macOS arm64; rendered docs inspected as raw Markdown on disk.
- Exact steps or command run after this patch:

```text
$ grep -n "networkidle" docs/tools/browser.md docs/tools/browser-control.md
$ git diff 52370c5998..HEAD -- docs/tools/browser.md docs/tools/browser-control.md
```

- Evidence after fix: copied terminal output from the local checkout with the patch applied. Both grep hits in `browser.md` and `browser-control.md` now name the existing-session scope, and the diff against `52370c5998` is exactly two lines:

```text
$ grep -n "networkidle" docs/tools/browser.md docs/tools/browser-control.md
docs/tools/browser.md:649:- **Wait / upload / dialog** - `wait --url` supports exact, substring, and glob patterns; `wait --load networkidle` is not supported on existing-session profiles (it works on managed and remote-CDP profiles). Upload hooks require `ref` or `inputRef`, one file at a time, no CSS `element`. Dialog hooks do not support timeout overrides.
docs/tools/browser-control.md:197:openclaw browser wait "#main" --url "**/dash" --load networkidle --fn "window.ready===true"
docs/tools/browser-control.md:296:  - `openclaw browser wait --load networkidle`
docs/tools/browser-control.md:297:  - `--load networkidle` is supported on managed and remote-CDP profiles. Existing-session profiles only support `load` and `domcontentloaded` for `--load`.
docs/tools/browser-control.md:308:  --load networkidle \

$ git diff 52370c5998..HEAD --stat -- docs/tools/browser.md docs/tools/browser-control.md
 docs/tools/browser-control.md | 1 +
 docs/tools/browser.md         | 2 +-
 2 files changed, 2 insertions(+), 1 deletion(-)
```

- Observed result after fix: the same `grep` console output above shows both docs agree on the profile-scoped behavior; the only remaining `networkidle` mentions in `browser-control.md` are the example invocations (lines 197, 308), which continue to be valid for the managed and remote-CDP profiles where those examples target.
- What was not tested: I did not re-render the docs site (`docs.openclaw.ai`). The edits are plain Markdown bullets in blocks that already exist in the rendered docs, with no Mintlify component changes.
- Before evidence: same grep against `52370c5998` shows the contradiction — `browser.md` line 649 says "is not supported" with no qualifier, and `browser-control.md` line 296 lists `--load networkidle` as a supported example with no qualifier.

## Root Cause

- Root cause: the "is not supported" bullet in `browser.md` was written without an explicit profile qualifier, even though the runtime restriction is scoped to existing-session profiles only.
- Missing detection / guardrail: no docs-linter rule cross-checks parity bullets against `EXISTING_SESSION_LIMITS` keys; not something this PR adds.
- Contributing context: `EXISTING_SESSION_LIMITS.act.waitNetworkIdle` reads "existing-session wait does not support loadState=networkidle yet." — the doc text loses the "existing-session" qualifier on the way over.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
- Existing test that already covers this: `extensions/browser/src/browser/routes/agent.existing-session.test.ts` — "fails closed for existing-session networkidle waits" — locks in the runtime restriction; this PR is a docs alignment to that already-tested behavior, not a behavior change.
- If no new test is added, why not: docs-only PR with no behavior surface.

## User-visible / Behavior Changes

None — docs-only.

## Diagram

N/A — content-only docs change.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: none — docs-only verification via grep and git diff against upstream/main `52370c5998` plus this branch
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: N/A

### Steps

1. Check out upstream/main at `52370c5998` and grep `networkidle` across the two docs files — observe contradiction.
2. Apply this branch.
3. Re-run the same grep and a `git diff` — observe both files name the existing-session scope and the diff is two lines.
4. Cross-check against `extensions/browser/src/browser/routes/agent.act.ts` (lines 320-332) and `extensions/browser/src/browser/routes/existing-session-limits.ts:22` — runtime restriction is existing-session-only; `load` and `domcontentloaded` are handled explicitly at `agent.act.ts:201-204`.

### Expected

Both docs files describe the same profile-scoped behavior.

### Actual

Both docs files describe the same profile-scoped behavior. The remaining `networkidle` mentions are example invocations (still valid for managed/remote-CDP).

## Evidence

- [x] Copied live terminal output (grep + diff) before and after — included inline in the Real behavior proof section above

## Human Verification

- Verified scenarios: re-read both files in full around the touched blocks; confirmed wording reads correctly inside and outside the "Existing-session feature limitations" accordion in `browser.md`; confirmed the new bullet in `browser-control.md` sits naturally next to the existing example and does not break the combined-wait code block immediately below.
- Edge cases checked: managed profile and remote-CDP profile both still continue to work — example invocations are unchanged.
- What I did not verify: rendered Mintlify output; the change is plain Markdown bullets so no component behavior is affected.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None — docs alignment to existing behavior, no surface change.
