### PR TITLE
fix: pass prompt cache expiry to context engines

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -632,6 +632,36 @@ describe("CodexAppServerEventProjector", () => {
     });
   });
 
+  it("projects Codex prompt-cache metadata into attempt results", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(agentMessageDelta("done"));
+    await projector.handleNotification(
+      forCurrentTurn("thread/tokenUsage/updated", {
+        tokenUsage: {
+          last_token_usage: {
+            total_tokens: 17,
+            input_tokens: 8,
+            cached_input_tokens: 3,
+            output_tokens: 9,
+            prompt_cache: {
+              retention: "24h",
+              expires_at: "2026-05-14T12:00:00.000Z",
+              last_cache_touch_at: 1_800_000_000_000,
+            },
+          },
+        },
+      }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.promptCache?.retention).toBe("24h");
+    expect(result.promptCache?.expiresAt).toBe(Date.parse("2026-05-14T12:00:00.000Z"));
+    expect(result.promptCache?.lastCacheTouchAt).toBe(1_800_000_000_000);
+    expect(result.promptCache?.lastCallUsage?.cacheRead).toBe(3);
+  });
+
   it("keeps intermediate agentMessage items out of the final visible reply", async () => {
     const { onAssistantMessageStart, onPartialReply, projector } =
       await createProjectorWithAssistantHooks();

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -82,6 +82,31 @@ const CURRENT_TOKEN_USAGE_KEYS = [
   "last_token_usage",
 ] as const;
 
+const PROMPT_CACHE_KEYS = ["promptCache", "prompt_cache"] as const;
+const PROMPT_CACHE_EXPIRES_AT_KEYS = [
+  "expiresAt",
+  "expires_at",
+  "cacheExpiresAt",
+  "cache_expires_at",
+  "promptCacheExpiresAt",
+  "prompt_cache_expires_at",
+] as const;
+const PROMPT_CACHE_TOUCH_AT_KEYS = [
+  "lastCacheTouchAt",
+  "last_cache_touch_at",
+  "cacheTouchedAt",
+  "cache_touched_at",
+  "promptCacheTouchedAt",
+  "prompt_cache_touched_at",
+] as const;
+const PROMPT_CACHE_RETENTION_KEYS = [
+  "retention",
+  "cacheRetention",
+  "cache_retention",
+  "promptCacheRetention",
+  "prompt_cache_retention",
+] as const;
+
 const CODEX_PROMPT_TOTAL_INPUT_KEYS = [
   "inputTokens",
   "input_tokens",
@@ -139,6 +164,7 @@ export class CodexAppServerEventProjector {
   private guardianReviewCount = 0;
   private completedCompactionCount = 0;
   private latestRateLimits: JsonValue | undefined;
+  private promptCacheInfo: EmbeddedRunAttemptResult["promptCache"];
   private readonly nativeSubagentTaskMirror: CodexNativeSubagentTaskMirror;
 
   constructor(
@@ -289,6 +315,11 @@ export class CodexAppServerEventProjector {
     if (lastAssistant) {
       messagesSnapshot.push(attachCodexMirrorIdentity(lastAssistant, `${turnId}:assistant`));
     }
+    const promptCache = buildCodexAttemptPromptCacheInfo({
+      runtimePromptCache: this.promptCacheInfo,
+      usage: this.tokenUsage,
+      fallbackLastCacheTouchAt: lastAssistant?.timestamp,
+    });
     const turnFailed = this.completedTurn?.status === "failed";
     const turnInterrupted = this.completedTurn?.status === "interrupted";
     const promptError =
@@ -329,6 +360,7 @@ export class CodexAppServerEventProjector {
       successfulCronAdds: toolTelemetry.successfulCronAdds,
       cloudCodeAssistFormatError: false,
       attemptUsage: this.tokenUsage,
+      ...(promptCache ? { promptCache } : {}),
       replayMetadata: {
         hadPotentialSideEffects: toolTelemetry.didSendViaMessagingTool,
         replaySafe: !toolTelemetry.didSendViaMessagingTool,
@@ -554,6 +586,10 @@ export class CodexAppServerEventProjector {
     const usage = normalizeCodexTokenUsage(current);
     if (usage) {
       this.tokenUsage = usage;
+    }
+    const promptCache = normalizeCodexPromptCacheInfo(params, tokenUsage, current);
+    if (promptCache) {
+      this.promptCacheInfo = promptCache;
     }
   }
 
@@ -1328,6 +1364,91 @@ function readNumberAlias(record: JsonObject, keys: readonly string[]): number | 
     }
   }
   return undefined;
+}
+
+function readTimestampAlias(record: JsonObject, keys: readonly string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const timestamp = Date.parse(value);
+      if (Number.isFinite(timestamp)) {
+        return timestamp;
+      }
+    }
+  }
+  return undefined;
+}
+
+type CodexPromptCacheInfo = NonNullable<EmbeddedRunAttemptResult["promptCache"]>;
+
+function readPromptCacheRetention(record: JsonObject): CodexPromptCacheInfo["retention"] {
+  for (const key of PROMPT_CACHE_RETENTION_KEYS) {
+    const value = readString(record, key);
+    if (
+      value === "none" ||
+      value === "short" ||
+      value === "long" ||
+      value === "in_memory" ||
+      value === "24h"
+    ) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function applyCodexPromptCacheRecord(
+  target: CodexPromptCacheInfo,
+  record: JsonObject | undefined,
+): void {
+  if (!record) {
+    return;
+  }
+  target.retention ??= readPromptCacheRetention(record);
+  target.expiresAt ??= readTimestampAlias(record, PROMPT_CACHE_EXPIRES_AT_KEYS);
+  target.lastCacheTouchAt ??= readTimestampAlias(record, PROMPT_CACHE_TOUCH_AT_KEYS);
+}
+
+function normalizeCodexPromptCacheInfo(
+  params: JsonObject,
+  tokenUsage: JsonObject | undefined,
+  currentUsage: JsonObject,
+): EmbeddedRunAttemptResult["promptCache"] {
+  const promptCache: CodexPromptCacheInfo = {};
+  applyCodexPromptCacheRecord(promptCache, readFirstJsonObject(currentUsage, PROMPT_CACHE_KEYS));
+  applyCodexPromptCacheRecord(promptCache, currentUsage);
+  if (tokenUsage) {
+    applyCodexPromptCacheRecord(promptCache, readFirstJsonObject(tokenUsage, PROMPT_CACHE_KEYS));
+    applyCodexPromptCacheRecord(promptCache, tokenUsage);
+  }
+  applyCodexPromptCacheRecord(promptCache, readFirstJsonObject(params, PROMPT_CACHE_KEYS));
+  applyCodexPromptCacheRecord(promptCache, params);
+  return Object.keys(promptCache).length > 0 ? promptCache : undefined;
+}
+
+function buildCodexAttemptPromptCacheInfo(params: {
+  runtimePromptCache?: EmbeddedRunAttemptResult["promptCache"];
+  usage?: ReturnType<typeof normalizeUsage>;
+  fallbackLastCacheTouchAt?: number;
+}): EmbeddedRunAttemptResult["promptCache"] {
+  const promptCache: CodexPromptCacheInfo = { ...(params.runtimePromptCache ?? {}) };
+  if (params.usage) {
+    promptCache.lastCallUsage = { ...params.usage };
+  }
+  const hasCacheUsage =
+    typeof params.usage?.cacheRead === "number" || typeof params.usage?.cacheWrite === "number";
+  if (
+    hasCacheUsage &&
+    promptCache.lastCacheTouchAt === undefined &&
+    typeof params.fallbackLastCacheTouchAt === "number" &&
+    Number.isFinite(params.fallbackLastCacheTouchAt)
+  ) {
+    promptCache.lastCacheTouchAt = params.fallbackLastCacheTouchAt;
+  }
+  return Object.keys(promptCache).length > 0 ? promptCache : undefined;
 }
 
 function normalizeCodexTokenUsage(record: JsonObject): ReturnType<typeof normalizeUsage> {

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -500,6 +500,49 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(maintain).toHaveBeenCalledTimes(1);
   });
 
+  it("passes Codex prompt-cache telemetry to context-engine afterTurn", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const afterTurn = vi.fn(
+      async (_params: Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]) => undefined,
+    );
+    const contextEngine = createContextEngine({ afterTurn, maintain: undefined });
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextEngine = contextEngine;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        tokenUsage: {
+          last_token_usage: {
+            total_tokens: 17,
+            input_tokens: 8,
+            cached_input_tokens: 3,
+            output_tokens: 9,
+            prompt_cache: {
+              retention: "24h",
+              expires_at: 1_800_000_000_000,
+            },
+          },
+        },
+      },
+    });
+    await harness.completeTurn();
+    await run;
+
+    const afterTurnCall = requireFirstCallArg(afterTurn, "afterTurn") as Parameters<
+      NonNullable<ContextEngine["afterTurn"]>
+    >[0];
+    expect(afterTurnCall.runtimeContext?.promptCache?.retention).toBe("24h");
+    expect(afterTurnCall.runtimeContext?.promptCache?.expiresAt).toBe(1_800_000_000_000);
+    expect(afterTurnCall.runtimeContext?.promptCache?.lastCallUsage?.cacheRead).toBe(3);
+  });
+
   it("reloads mirrored history after bootstrap mutates the session transcript", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/src/agents/pi-embedded-runner/cache-ttl.test.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.test.ts
@@ -25,7 +25,12 @@ vi.mock("../../plugins/provider-runtime.js", async () => {
   };
 });
 
-import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "./cache-ttl.js";
+import {
+  isCacheTtlEligibleProvider,
+  readLastCacheTtlInfo,
+  readLastCacheTtlTimestamp,
+  resolveCacheTtlExpiresAt,
+} from "./cache-ttl.js";
 
 describe("isCacheTtlEligibleProvider", () => {
   it("allows anthropic", () => {
@@ -139,5 +144,74 @@ describe("readLastCacheTtlTimestamp", () => {
         modelId: "claude-sonnet-4-5",
       }),
     ).toBeNull();
+  });
+});
+
+describe("readLastCacheTtlInfo", () => {
+  it("returns stored cache expiry when available", () => {
+    const sessionManager = {
+      getEntries: () => [
+        {
+          type: "custom",
+          customType: "openclaw.cache-ttl",
+          data: {
+            timestamp: 1_700_000_000_000,
+            expiresAt: 1_700_000_300_000,
+            provider: "anthropic",
+            modelId: "claude-sonnet-4-5",
+          },
+        },
+      ],
+    };
+
+    expect(
+      readLastCacheTtlInfo(sessionManager, {
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-5",
+        retention: "long",
+      }),
+    ).toEqual({
+      lastCacheTouchAt: 1_700_000_000_000,
+      expiresAt: 1_700_000_300_000,
+    });
+  });
+
+  it("derives cache expiry for older markers when retention is known", () => {
+    const sessionManager = {
+      getEntries: () => [
+        {
+          type: "custom",
+          customType: "openclaw.cache-ttl",
+          data: {
+            timestamp: 1_700_000_000_000,
+            provider: "anthropic",
+            modelId: "claude-sonnet-4-5",
+          },
+        },
+      ],
+    };
+
+    expect(
+      readLastCacheTtlInfo(sessionManager, {
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-5",
+        retention: "short",
+      }),
+    ).toEqual({
+      lastCacheTouchAt: 1_700_000_000_000,
+      expiresAt: 1_700_000_300_000,
+    });
+  });
+});
+
+describe("resolveCacheTtlExpiresAt", () => {
+  it("maps short and long retention to known provider TTLs", () => {
+    expect(resolveCacheTtlExpiresAt(1_700_000_000_000, "short")).toBe(1_700_000_300_000);
+    expect(resolveCacheTtlExpiresAt(1_700_000_000_000, "long")).toBe(1_700_003_600_000);
+  });
+
+  it("does not synthesize expiry when retention is disabled or unknown", () => {
+    expect(resolveCacheTtlExpiresAt(1_700_000_000_000, "none")).toBeNull();
+    expect(resolveCacheTtlExpiresAt(1_700_000_000_000, undefined)).toBeNull();
   });
 });

--- a/src/agents/pi-embedded-runner/cache-ttl.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.ts
@@ -15,6 +15,7 @@ const CACHE_TTL_CUSTOM_TYPE = "openclaw.cache-ttl";
 
 export type CacheTtlEntryData = {
   timestamp: number;
+  expiresAt?: number;
   provider?: string;
   modelId?: string;
 };
@@ -22,7 +23,16 @@ export type CacheTtlEntryData = {
 type CacheTtlContext = {
   provider?: string;
   modelId?: string;
+  retention?: "none" | "short" | "long";
 };
+
+export type CacheTtlInfo = {
+  lastCacheTouchAt: number;
+  expiresAt?: number;
+};
+
+const SHORT_CACHE_TTL_MS = 5 * 60_000;
+const LONG_CACHE_TTL_MS = 60 * 60_000;
 
 export function isCacheTtlEligibleProvider(
   provider: string,
@@ -75,17 +85,32 @@ function matchesCacheTtlContext(
   return true;
 }
 
-export function readLastCacheTtlTimestamp(
+export function resolveCacheTtlExpiresAt(
+  lastCacheTouchAt: number | null | undefined,
+  retention: CacheTtlContext["retention"],
+): number | null {
+  if (typeof lastCacheTouchAt !== "number" || !Number.isFinite(lastCacheTouchAt)) {
+    return null;
+  }
+  if (retention === "short") {
+    return lastCacheTouchAt + SHORT_CACHE_TTL_MS;
+  }
+  if (retention === "long") {
+    return lastCacheTouchAt + LONG_CACHE_TTL_MS;
+  }
+  return null;
+}
+
+export function readLastCacheTtlInfo(
   sessionManager: unknown,
   context?: CacheTtlContext,
-): number | null {
+): CacheTtlInfo | null {
   const sm = sessionManager as { getEntries?: () => CustomEntryLike[] };
   if (!sm?.getEntries) {
     return null;
   }
   try {
     const entries = sm.getEntries();
-    let last: number | null = null;
     for (let i = entries.length - 1; i >= 0; i--) {
       const entry = entries[i];
       if (entry?.type !== "custom" || entry?.customType !== CACHE_TTL_CUSTOM_TYPE) {
@@ -97,12 +122,26 @@ export function readLastCacheTtlTimestamp(
       }
       const ts = typeof data?.timestamp === "number" ? data.timestamp : null;
       if (ts && Number.isFinite(ts)) {
-        last = ts;
-        break;
+        const storedExpiresAt =
+          typeof data?.expiresAt === "number" && Number.isFinite(data.expiresAt)
+            ? data.expiresAt
+            : null;
+        const expiresAt = storedExpiresAt ?? resolveCacheTtlExpiresAt(ts, context?.retention);
+        return {
+          lastCacheTouchAt: ts,
+          ...(expiresAt ? { expiresAt } : {}),
+        };
       }
     }
-    return last;
+    return null;
   } catch {
     return null;
   }
+}
+
+export function readLastCacheTtlTimestamp(
+  sessionManager: unknown,
+  context?: CacheTtlContext,
+): number | null {
+  return readLastCacheTtlInfo(sessionManager, context)?.lastCacheTouchAt ?? null;
 }

--- a/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
@@ -70,6 +70,7 @@ export function buildContextEnginePromptCacheInfo(params: {
       }
     | undefined;
   lastCacheTouchAt?: number | null;
+  expiresAt?: number | null;
 }): EmbeddedRunAttemptResult["promptCache"] {
   const promptCache: NonNullable<EmbeddedRunAttemptResult["promptCache"]> = {};
   if (params.retention) {
@@ -99,6 +100,9 @@ export function buildContextEnginePromptCacheInfo(params: {
   }
   if (typeof params.lastCacheTouchAt === "number" && Number.isFinite(params.lastCacheTouchAt)) {
     promptCache.lastCacheTouchAt = params.lastCacheTouchAt;
+  }
+  if (typeof params.expiresAt === "number" && Number.isFinite(params.expiresAt)) {
+    promptCache.expiresAt = params.expiresAt;
   }
   return Object.keys(promptCache).length > 0 ? promptCache : undefined;
 }
@@ -150,6 +154,7 @@ export function buildLoopPromptCacheInfo(params: {
   prePromptMessageCount: number;
   retention?: "none" | "short" | "long";
   fallbackLastCacheTouchAt?: number | null;
+  fallbackExpiresAt?: number | null;
 }): EmbeddedRunAttemptResult["promptCache"] {
   const currentAttemptAssistant = findCurrentAttemptAssistantMessage({
     messagesSnapshot: params.messagesSnapshot,
@@ -165,5 +170,6 @@ export function buildLoopPromptCacheInfo(params: {
       assistantTimestamp: currentAttemptAssistant?.timestamp,
       fallbackLastCacheTouchAt: params.fallbackLastCacheTouchAt,
     }),
+    expiresAt: params.fallbackExpiresAt,
   });
 }

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.cache-ttl.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.cache-ttl.test.ts
@@ -25,6 +25,7 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
       provider: "anthropic",
       modelId: "claude-sonnet-4-20250514",
       modelApi: "anthropic-messages",
+      cacheRetention: "short",
       isCacheTtlEligibleProvider: () => true,
       now: 123,
     });
@@ -53,6 +54,7 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
       provider: "anthropic",
       modelId: "claude-sonnet-4-20250514",
       modelApi: "anthropic-messages",
+      cacheRetention: "short",
       isCacheTtlEligibleProvider: () => true,
       now: 123,
     });
@@ -60,6 +62,7 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
     expect(appended).toBe(true);
     expect(sessionManager.appendCustomEntry).toHaveBeenCalledWith(ATTEMPT_CACHE_TTL_CUSTOM_TYPE, {
       timestamp: 123,
+      expiresAt: 300_123,
       provider: "anthropic",
       modelId: "claude-sonnet-4-20250514",
     });

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1136,6 +1136,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
           total: 57,
         },
         lastCacheTouchAt: 123,
+        expiresAt: 456,
       }),
     ).toEqual({
       retention: "short",
@@ -1147,6 +1148,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         total: 57,
       },
       lastCacheTouchAt: 123,
+      expiresAt: 456,
     });
   });
 
@@ -1198,12 +1200,14 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       prePromptMessageCount: 1,
       retention: "short",
       fallbackLastCacheTouchAt: 123,
+      fallbackExpiresAt: 456,
     });
     expect(promptCache?.retention).toBe("short");
     expect(promptCache?.lastCallUsage?.cacheRead).toBe(39036);
     expect(promptCache?.lastCallUsage?.cacheWrite).toBe(59934);
     expect(promptCache?.lastCallUsage?.total).toBe(98973);
     expect(promptCache?.lastCacheTouchAt).toBe(Date.parse("2026-04-16T16:49:59.536Z"));
+    expect(promptCache?.expiresAt).toBe(456);
   });
 
   it("falls back to the persisted cache touch when loop usage has no cache metrics", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -649,17 +649,12 @@ vi.mock("../../transcript-policy.js", () => ({
   }),
 }));
 
-vi.mock("../cache-ttl.js", () => ({
-  appendCacheTtlTimestamp: (
-    sessionManager: { appendCustomEntry?: (customType: string, data: unknown) => void },
-    data: unknown,
-  ) => sessionManager.appendCustomEntry?.("openclaw.cache-ttl", data),
-  isCacheTtlEligibleProvider: (provider?: string) => provider === "anthropic",
-  readLastCacheTtlTimestamp: (
+vi.mock("../cache-ttl.js", () => {
+  const readLastCacheTtlInfo = (
     sessionManager: {
       appendCustomEntry?: { mock?: { calls?: unknown[][] } };
     },
-    context?: { provider?: string; modelId?: string },
+    context?: { provider?: string; modelId?: string; retention?: "none" | "short" | "long" },
   ) => {
     const calls = sessionManager.appendCustomEntry?.mock?.calls ?? [];
     for (let index = calls.length - 1; index >= 0; index -= 1) {
@@ -670,6 +665,7 @@ vi.mock("../cache-ttl.js", () => ({
       const entry = data as
         | {
             timestamp?: unknown;
+            expiresAt?: unknown;
             provider?: string;
             modelId?: string;
           }
@@ -689,11 +685,40 @@ vi.mock("../cache-ttl.js", () => ({
         continue;
       }
       const timestamp = entry?.timestamp;
-      return typeof timestamp === "number" ? timestamp : null;
+      if (typeof timestamp !== "number") {
+        return null;
+      }
+      const expiresAt =
+        typeof entry?.expiresAt === "number"
+          ? entry.expiresAt
+          : context?.retention === "short"
+            ? timestamp + 5 * 60_000
+            : context?.retention === "long"
+              ? timestamp + 60 * 60_000
+              : undefined;
+      return {
+        lastCacheTouchAt: timestamp,
+        ...(expiresAt ? { expiresAt } : {}),
+      };
     }
     return null;
-  },
-}));
+  };
+
+  return {
+    appendCacheTtlTimestamp: (
+      sessionManager: { appendCustomEntry?: (customType: string, data: unknown) => void },
+      data: unknown,
+    ) => sessionManager.appendCustomEntry?.("openclaw.cache-ttl", data),
+    isCacheTtlEligibleProvider: (provider?: string) => provider === "anthropic",
+    readLastCacheTtlInfo,
+    readLastCacheTtlTimestamp: (
+      sessionManager: {
+        appendCustomEntry?: { mock?: { calls?: unknown[][] } };
+      },
+      context?: { provider?: string; modelId?: string; retention?: "none" | "short" | "long" },
+    ) => readLastCacheTtlInfo(sessionManager, context)?.lastCacheTouchAt ?? null,
+  };
+});
 
 vi.mock("../compaction-runtime-context.js", () => ({
   buildEmbeddedCompactionRuntimeContext: () => ({}),

--- a/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts
@@ -65,14 +65,23 @@ export function appendAttemptCacheTtlIfNeeded(params: {
   provider: string;
   modelId: string;
   modelApi?: string;
+  cacheRetention?: "none" | "short" | "long";
   isCacheTtlEligibleProvider: (provider: string, modelId: string, modelApi?: string) => boolean;
   now?: number;
 }): boolean {
   if (!shouldAppendAttemptCacheTtl(params)) {
     return false;
   }
+  const timestamp = params.now ?? Date.now();
+  const expiresAt =
+    params.cacheRetention === "short"
+      ? timestamp + 5 * 60_000
+      : params.cacheRetention === "long"
+        ? timestamp + 60 * 60_000
+        : undefined;
   params.sessionManager.appendCustomEntry?.(ATTEMPT_CACHE_TTL_CUSTOM_TYPE, {
-    timestamp: params.now ?? Date.now(),
+    timestamp,
+    ...(expiresAt ? { expiresAt } : {}),
     provider: params.provider,
     modelId: params.modelId,
   });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -191,7 +191,7 @@ import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
-import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
+import { isCacheTtlEligibleProvider, readLastCacheTtlInfo } from "../cache-ttl.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { runContextEngineMaintenance } from "../context-engine-maintenance.js";
 import { applyFinalEffectiveToolPolicy } from "../effective-tool-policy.js";
@@ -1999,8 +1999,13 @@ export async function runEmbeddedAttempt(
           onAfterTurnCheckpoint: (messageCount) => {
             contextEngineAfterTurnCheckpoint = messageCount;
           },
-          getRuntimeContext: ({ messages, prePromptMessageCount: loopPrePromptMessageCount }) =>
-            buildAfterTurnRuntimeContext({
+          getRuntimeContext: ({ messages, prePromptMessageCount: loopPrePromptMessageCount }) => {
+            const cacheTtlInfo = readLastCacheTtlInfo(sessionManager, {
+              provider: params.provider,
+              modelId: params.modelId,
+              retention: effectivePromptCacheRetention,
+            });
+            return buildAfterTurnRuntimeContext({
               attempt: params,
               workspaceDir: effectiveWorkspace,
               agentDir,
@@ -2011,12 +2016,11 @@ export async function runEmbeddedAttempt(
                   messagesSnapshot: messages,
                   prePromptMessageCount: loopPrePromptMessageCount,
                   retention: effectivePromptCacheRetention,
-                  fallbackLastCacheTouchAt: readLastCacheTtlTimestamp(sessionManager, {
-                    provider: params.provider,
-                    modelId: params.modelId,
-                  }),
+                  fallbackLastCacheTouchAt: cacheTtlInfo?.lastCacheTouchAt,
+                  fallbackExpiresAt: cacheTtlInfo?.expiresAt,
                 }),
-            }),
+            });
+          },
         });
       }
       const removeLoopContextGuard = removeToolResultContextGuard;
@@ -3665,6 +3669,7 @@ export async function runEmbeddedAttempt(
           provider: params.provider,
           modelId: params.modelId,
           modelApi: params.model.api,
+          cacheRetention: effectivePromptCacheRetention,
           isCacheTtlEligibleProvider,
         });
 
@@ -3723,9 +3728,10 @@ export async function runEmbeddedAttempt(
                 changes: cacheBreak?.changes ?? promptCacheChangesForTurn,
               }
             : undefined;
-        const fallbackLastCacheTouchAt = readLastCacheTtlTimestamp(sessionManager, {
+        const cacheTtlInfo = readLastCacheTtlInfo(sessionManager, {
           provider: params.provider,
           modelId: params.modelId,
+          retention: effectivePromptCacheRetention,
         });
         promptCache = buildContextEnginePromptCacheInfo({
           retention: effectivePromptCacheRetention,
@@ -3734,8 +3740,9 @@ export async function runEmbeddedAttempt(
           lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
             lastCallUsage,
             assistantTimestamp: currentAttemptAssistant?.timestamp,
-            fallbackLastCacheTouchAt,
+            fallbackLastCacheTouchAt: cacheTtlInfo?.lastCacheTouchAt,
           }),
+          expiresAt: cacheTtlInfo?.expiresAt,
         });
 
         if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {


### PR DESCRIPTION
## What
Pass prompt-cache expiry and related prompt-cache telemetry through OpenClaw runtime paths into context-engine runtime context.

## Why
Cache-aware context engines need a positive expiry signal to avoid treating a freshly written cache as cold while still knowing when the known cache window has elapsed. The runtime already knew cache touches and Codex usage, but the expiry and Codex prompt-cache metadata were not consistently surfaced.

## Changes
- Add PI cache `expiresAt` markers
- Derive expiry for older markers
- Thread expiry into context engines
- Project Codex prompt-cache metadata
- Cover PI and Codex paths

## Testing
- `pnpm test src/agents/pi-embedded-runner/cache-ttl.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.cache-ttl.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts`
- `pnpm build`
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts src/agents/pi-embedded-runner/cache-ttl.test.ts src/agents/pi-embedded-runner/cache-ttl.ts src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.cache-ttl.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts src/agents/pi-embedded-runner/run/attempt.ts`
- `git diff --check`

Note: full `pnpm format:check` currently reports pre-existing formatting issues in unrelated files outside this branch.
