### PR TITLE
fix(plugin-sdk): export codex runtime helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Docs: https://docs.openclaw.ai
 - Restrict chat sender allowlist matching [AI]. (#80898) Thanks @pgondhi987.
 - Update: suppress the false newer-config warning during restart health probing after an update handoff, while keeping future-version mutation guards intact. (#78652)
 - Sessions: redact persisted tool result detail metadata before writing transcripts so diagnostic secrets do not survive tool output redaction. (#80444) Thanks @nimbleenigma.
-- Codex runtime: allow the official installed `@openclaw/codex` package to use its private task-runtime SDK helper, fixing `MODULE_NOT_FOUND` during migrated OpenAI/Codex beta runs.
+- Codex runtime: allow the official installed `@openclaw/codex` package to use its private task-runtime and MCP projection SDK helpers, fixing `MODULE_NOT_FOUND` during migrated OpenAI/Codex beta runs.
 - Codex migration: make Enter activate the highlighted checkbox row before continuing, so `Skip for now` and bulk-selection rows work even when planned items start preselected.
 - Link understanding: fetch page content through the SSRF guard before running configured CLI summarizers, preventing curl/wget-style link fetchers from reaching private redirect or DNS-rebound targets.
 - fix: harden safe-bin argument validation [AI]. (#80999) Thanks @pgondhi987.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-3468877af0d3fe749812abc6d4852194b07f3468533fd0fee2772dd26c4e62fe  plugin-sdk-api-baseline.json
-2b880b2509bd9a02566b003a4cded1c556245f3625aa13fb3013fa16114ab75a  plugin-sdk-api-baseline.jsonl
+e8c15cff96a0a869cfe3de29679d4296603a16bfa4676940845a484c23db8e56  plugin-sdk-api-baseline.json
+a6cbb8dc21b3ed16e0abd23c60a817ddedd65f336427c9fa565a43ca5dcc9a85  plugin-sdk-api-baseline.jsonl

--- a/package.json
+++ b/package.json
@@ -487,6 +487,14 @@
       "types": "./dist/plugin-sdk/cli-backend.d.ts",
       "default": "./dist/plugin-sdk/cli-backend.js"
     },
+    "./plugin-sdk/codex-mcp-projection": {
+      "types": "./dist/plugin-sdk/codex-mcp-projection.d.ts",
+      "default": "./dist/plugin-sdk/codex-mcp-projection.js"
+    },
+    "./plugin-sdk/codex-native-task-runtime": {
+      "types": "./dist/plugin-sdk/codex-native-task-runtime.d.ts",
+      "default": "./dist/plugin-sdk/codex-native-task-runtime.js"
+    },
     "./plugin-sdk/agent-harness": {
       "types": "./dist/plugin-sdk/agent-harness.d.ts",
       "default": "./dist/plugin-sdk/agent-harness.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -98,6 +98,8 @@
   "gateway-runtime",
   "cli-runtime",
   "cli-backend",
+  "codex-mcp-projection",
+  "codex-native-task-runtime",
   "agent-harness",
   "agent-harness-runtime",
   "hook-runtime",

--- a/scripts/lib/plugin-sdk-private-local-only-subpaths.json
+++ b/scripts/lib/plugin-sdk-private-local-only-subpaths.json
@@ -1,6 +1,4 @@
 [
-  "codex-mcp-projection",
-  "codex-native-task-runtime",
   "qa-channel",
   "qa-channel-protocol",
   "qa-lab",

--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -545,7 +545,7 @@ async function completeSimpleWithTimeout<TApi extends Api>(
   }
 }
 
-function requireToolChoicePayload(payload: unknown): unknown | undefined {
+function requireToolChoicePayload(payload: unknown): unknown {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return undefined;
   }

--- a/src/plugin-sdk/entrypoints.ts
+++ b/src/plugin-sdk/entrypoints.ts
@@ -35,7 +35,10 @@ export const deprecatedBarrelPluginSdkEntrypoints = pluginSdkSubpaths.filter((en
 
 // Transitional compatibility/helper surfaces owned by their matching bundled plugin.
 // Cross-owner extension imports are blocked by the package contract guardrails.
-export const reservedBundledPluginSdkEntrypoints = [] as const;
+export const reservedBundledPluginSdkEntrypoints = [
+  "codex-mcp-projection",
+  "codex-native-task-runtime",
+] as const;
 
 // Supported SDK facades backed by bundled plugins. These are intentionally public
 // until they move to generic, plugin-neutral contracts.


### PR DESCRIPTION
## Summary

- Export the bundled Codex `codex-mcp-projection` and `codex-native-task-runtime` plugin SDK subpaths from the package surface.
- Track those two subpaths as reserved bundled-plugin SDK entrypoints so cross-owner use stays visible.
- Fix the current `origin/main` oxlint failure in `models.profiles.live.test.ts` that the all-lane changed gate now hits.

## Real behavior proof

- Behavior addressed: Crabpot beta reports the official Codex bundle importing `openclaw/plugin-sdk/codex-mcp-projection` and `openclaw/plugin-sdk/codex-native-task-runtime`, while the target package exports omit those subpaths.
- Evidence: https://github.com/openclaw/crabpot/blob/28bc58ae049933afdf6eed8466d1e6db0778f3e8/reports/crabpot-issues.md#L56-L61
- Real environment: refreshed Crabpot beta report for `openclaw@beta` / `2026.5.12-beta.6` at OpenClaw `c4292e053d7c86361700b3acb59cb51e4a310f2d`, Crabpot workflow https://github.com/openclaw/crabpot/actions/runs/25831620309.
- Observed after the patch: package exports sync includes both Codex subpaths, `check-plugin-sdk-subpath-exports` no longer treats the Codex imports as missing, and the Codex boundary summary reports `reserved=2`, `reservedImports=2`, `crossOwnerReservedImports=0`, `unusedReserved=0`.
- Not tested: a new Crabpot beta report against this OpenClaw branch. This should clear the Codex `sdk-export-missing` P1 after the fix lands into the beta/package artifact that Crabpot scans.

## Verification

- `node scripts/sync-plugin-sdk-exports.mjs --check`
- `node scripts/check-plugin-sdk-subpath-exports.mjs`
- `node --import tsx scripts/plugin-boundary-report.ts --summary --owner codex`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.contracts-plugin.config.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/vitest-scoped-config.test.ts`
- `node_modules/.bin/oxlint src/agents/models.profiles.live.test.ts`
- `crabbox run --provider blacksmith-testbox ... pnpm check:changed` passed on `tbx_01krhz23w38q4gd9sv4qhph6w7`: https://github.com/openclaw/openclaw/actions/runs/25834858228
