### PR TITLE
fix: use managed codex binary for source migration

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -361,10 +361,16 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
   </Accordion>
 
   <Accordion title="Reserved bundled-helper subpaths">
-    There are currently no reserved bundled-helper SDK subpaths. Owner-specific
-    helpers live inside the owning plugin package, while reusable host contracts
-    use generic SDK subpaths such as `plugin-sdk/gateway-runtime`,
-    `plugin-sdk/security-runtime`, and `plugin-sdk/plugin-config-runtime`.
+    These private compatibility surfaces are reserved for their owning bundled
+    plugin. New reusable host contracts should use generic SDK subpaths such as
+    `plugin-sdk/gateway-runtime`, `plugin-sdk/security-runtime`, and
+    `plugin-sdk/plugin-config-runtime`.
+
+    | Subpath | Key exports |
+    | --- | --- |
+    | `plugin-sdk/codex-mcp-projection` | Codex-owned user MCP server projection helper for the bundled Codex app-server harness |
+    | `plugin-sdk/codex-native-task-runtime` | Codex-owned detached task runtime helpers for native subagent mirroring |
+
   </Accordion>
 </AccordionGroup>
 

--- a/extensions/codex/src/migration/plan.ts
+++ b/extensions/codex/src/migration/plan.ts
@@ -441,6 +441,9 @@ export async function buildCodexMigrationPlan(
           "Codex app-backed plugins were planned without source app accessibility verification. Re-run with --verify-plugin-apps to force a fresh source app/list check before planning native plugin activation.",
         ]
       : []),
+    ...(source.plugins.some((plugin) => plugin.sourceKind === "cache")
+      ? ["Codex cached plugin bundles remain manual-review only."]
+      : []),
     ...(source.pluginDiscoveryError
       ? [
           `Codex app-server plugin inventory discovery failed: ${source.pluginDiscoveryError}. Cached plugin bundles, if any, are advisory only.`,

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -140,7 +140,7 @@ function sourceAppCacheKey(fixture: { codexHome: string }): string {
       start: {
         transport: "stdio",
         command: "codex",
-        commandSource: "config",
+        commandSource: "managed",
         args: ["app-server", "--listen", "stdio://"],
         headers: {},
         env: {
@@ -241,6 +241,14 @@ describe("buildCodexMigrationProvider", () => {
     expectRecordFields(mockCallArg(appServerRequest), {
       method: "plugin/list",
       requestParams: { cwds: [] },
+    });
+    expectRecordFields((mockCallArg(appServerRequest) as { startOptions?: unknown }).startOptions, {
+      command: "codex",
+      commandSource: "managed",
+      env: {
+        CODEX_HOME: fixture.codexHome,
+        HOME: path.dirname(fixture.codexHome),
+      },
     });
     expect(
       appServerRequest.mock.calls.some(

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -245,7 +245,7 @@ function sourceCodexAppServerStartOptions(codexHome: string): CodexAppServerStar
   return {
     transport: "stdio",
     command: "codex",
-    commandSource: "config",
+    commandSource: "managed",
     args: ["app-server", "--listen", "stdio://"],
     headers: {},
     env: {


### PR DESCRIPTION
## Summary
- use OpenClaw's managed Codex app-server binary when inventorying source Codex plugins during migration
- keep source CODEX_HOME/HOME overrides so inventory still reads the source Codex state
- restore the standalone cached-plugin warning expected by migration dry-runs

## Real behavior proof
- **Behavior or issue addressed:** Source Codex plugin inventory for `openclaw migrate plan codex --json` should not fail when `codex` on PATH points to a broken old global install. The migration should use OpenClaw's managed Codex app-server binary while still reading the source `CODEX_HOME`.
- **Real environment tested:** Local macOS OpenClaw checkout at `/Users/jason/workspace/openclaw-migrate-managed-codex`, source Codex home `/Users/jason/.codex`, temporary OpenClaw state dir `/tmp/openclaw-pr-proof.DsRCiz`, and patched source checkout bundled plugins via `OPENCLAW_BUNDLED_PLUGINS_DIR=/Users/jason/workspace/openclaw-migrate-managed-codex/dist/extensions`.
- **Exact steps or command run after this patch:**

  ```bash
  env OPENCLAW_STATE_DIR=/tmp/openclaw-pr-proof.DsRCiz \
    OPENCLAW_BUNDLED_PLUGINS_DIR=/Users/jason/workspace/openclaw-migrate-managed-codex/dist/extensions \
    pnpm openclaw migrate plan codex --json
  ```

- **Evidence after fix:** Live output excerpt from that command:

  ```json
  {
    "providerId": "codex",
    "source": "/Users/jason/.codex",
    "target": "/Users/jason/.openclaw/workspace",
    "summary": {
      "total": 44,
      "planned": 39,
      "skipped": 5,
      "conflicts": 0,
      "errors": 0
    },
    "warnings": [
      "Codex cached plugin bundles remain manual-review only.",
      "Codex config and hook files are archive-only. They are preserved in the migration report, not loaded into OpenClaw automatically."
    ],
    "metadata": {
      "agentDir": "/tmp/openclaw-pr-proof.DsRCiz/agents/main/agent",
      "codexHome": "/Users/jason/.codex"
    }
  }
  ```

- **Observed result after fix:** The real migration plan completed with 44 detected items, 39 planned items, 0 conflicts, and 0 errors. It did not emit the prior source plugin inventory discovery failure and did not reference the broken old global Codex path `/Users/jason/.nvm/versions/node/v23.11.1/lib/node_modules/@openai/codex/.../codex ENOENT`.
- **What was not tested:** The apply/execute migration path was not run; this PR only changes source inventory planning.

## Tests
- pnpm exec vitest run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/migration/provider.test.ts --maxWorkers=1 --reporter=verbose
- pnpm format:check extensions/codex/src/migration/source.ts extensions/codex/src/migration/plan.ts extensions/codex/src/migration/provider.test.ts
- pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/migration/source.ts extensions/codex/src/migration/plan.ts extensions/codex/src/migration/provider.test.ts
- git diff --check