### PR TITLE
fix(cron): make recovered tool errors order agnostic

### DIFF
--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -65,7 +65,7 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.summary).toBe("Write completed successfully.");
   });
 
-  it("treats recovered tool errors as non-fatal regardless of payload order", () => {
+  it("treats recovered exec errors as non-fatal when final assistant text confirms recovery", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [
         { text: "Fallback log written successfully." },
@@ -79,6 +79,21 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.embeddedRunError).toBeUndefined();
     expect(result.outputText).toBe("Fallback log written successfully.");
     expect(result.deliveryPayloads).toEqual([{ text: "Fallback log written successfully." }]);
+  });
+
+  it("keeps trailing exec errors fatal without final assistant recovery text", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "Fallback log written successfully." },
+        { text: "⚠️ 🛠️ Exec failed: Discord channel unavailable", isError: true },
+      ],
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.embeddedRunError).toBe("⚠️ 🛠️ Exec failed: Discord channel unavailable");
+    expect(result.deliveryPayloads).toEqual([
+      { text: "⚠️ 🛠️ Exec failed: Discord channel unavailable", isError: true },
+    ]);
   });
 
   it("treats trailing message delivery warnings as non-fatal when final assistant text exists", () => {
@@ -96,15 +111,15 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.deliveryPayloads).toEqual([{ text: "Final cron report" }]);
   });
 
-  it("treats trailing canvas warnings as non-fatal when earlier assistant output exists", () => {
+  it("keeps trailing canvas warnings fatal when earlier assistant output exists", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [{ text: "Saved report to disk." }, { text: "⚠️ 🖼️ Canvas failed", isError: true }],
     });
 
-    expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.hasFatalErrorPayload).toBe(true);
     expect(result.pendingPresentationWarningError).toBeUndefined();
-    expect(result.embeddedRunError).toBeUndefined();
-    expect(result.deliveryPayloads).toEqual([{ text: "Saved report to disk." }]);
+    expect(result.embeddedRunError).toBe("⚠️ 🖼️ Canvas failed");
+    expect(result.deliveryPayloads).toEqual([{ text: "⚠️ 🖼️ Canvas failed", isError: true }]);
   });
 
   it("keeps standalone presentation warnings fatal when there is no cron output", () => {
@@ -117,17 +132,19 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.deliveryPayloads).toEqual([{ text: "⚠️ ✉️ Message failed", isError: true }]);
   });
 
-  it("treats trailing errors as non-fatal when earlier assistant output exists", () => {
+  it("keeps trailing errors fatal when earlier assistant output exists", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [{ text: "Partial result" }, { text: "model provider unreachable", isError: true }],
       finalAssistantVisibleText: "Partial result",
       preferFinalAssistantVisibleText: true,
     });
 
-    expect(result.hasFatalErrorPayload).toBe(false);
-    expect(result.embeddedRunError).toBeUndefined();
-    expect(result.outputText).toBe("Partial result");
-    expect(result.deliveryPayloads).toEqual([{ text: "Partial result" }]);
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.embeddedRunError).toBe("model provider unreachable");
+    expect(result.outputText).toBe("model provider unreachable");
+    expect(result.deliveryPayloads).toEqual([
+      { text: "model provider unreachable", isError: true },
+    ]);
   });
 
   it("keeps error payloads fatal when the run also reported a run-level error", () => {

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -65,6 +65,22 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.summary).toBe("Write completed successfully.");
   });
 
+  it("treats recovered tool errors as non-fatal regardless of payload order", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "Fallback log written successfully." },
+        { text: "⚠️ 🛠️ Exec failed: Discord channel unavailable", isError: true },
+      ],
+      finalAssistantVisibleText: "Fallback log written successfully.",
+      preferFinalAssistantVisibleText: true,
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.embeddedRunError).toBeUndefined();
+    expect(result.outputText).toBe("Fallback log written successfully.");
+    expect(result.deliveryPayloads).toEqual([{ text: "Fallback log written successfully." }]);
+  });
+
   it("treats trailing message delivery warnings as non-fatal when final assistant text exists", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [{ text: "Draft output" }, { text: "⚠️ ✉️ Message failed", isError: true }],
@@ -80,15 +96,15 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.deliveryPayloads).toEqual([{ text: "Final cron report" }]);
   });
 
-  it("keeps trailing canvas warnings fatal even when earlier assistant output exists", () => {
+  it("treats trailing canvas warnings as non-fatal when earlier assistant output exists", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [{ text: "Saved report to disk." }, { text: "⚠️ 🖼️ Canvas failed", isError: true }],
     });
 
-    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.hasFatalErrorPayload).toBe(false);
     expect(result.pendingPresentationWarningError).toBeUndefined();
-    expect(result.embeddedRunError).toBe("⚠️ 🖼️ Canvas failed");
-    expect(result.deliveryPayloads).toEqual([{ text: "⚠️ 🖼️ Canvas failed", isError: true }]);
+    expect(result.embeddedRunError).toBeUndefined();
+    expect(result.deliveryPayloads).toEqual([{ text: "Saved report to disk." }]);
   });
 
   it("keeps standalone presentation warnings fatal when there is no cron output", () => {
@@ -101,19 +117,17 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.deliveryPayloads).toEqual([{ text: "⚠️ ✉️ Message failed", isError: true }]);
   });
 
-  it("keeps real trailing errors fatal even when earlier assistant output exists", () => {
+  it("treats trailing errors as non-fatal when earlier assistant output exists", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [{ text: "Partial result" }, { text: "model provider unreachable", isError: true }],
       finalAssistantVisibleText: "Partial result",
       preferFinalAssistantVisibleText: true,
     });
 
-    expect(result.hasFatalErrorPayload).toBe(true);
-    expect(result.embeddedRunError).toBe("model provider unreachable");
-    expect(result.outputText).toBe("model provider unreachable");
-    expect(result.deliveryPayloads).toEqual([
-      { text: "model provider unreachable", isError: true },
-    ]);
+    expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.embeddedRunError).toBeUndefined();
+    expect(result.outputText).toBe("Partial result");
+    expect(result.deliveryPayloads).toEqual([{ text: "Partial result" }]);
   });
 
   it("keeps error payloads fatal when the run also reported a run-level error", () => {

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -250,6 +250,10 @@ function isCronMessagePresentationWarning(text: string | undefined): boolean {
   );
 }
 
+function isCronRecoveredExecWarning(text: string | undefined): boolean {
+  return normalizeOptionalString(text)?.startsWith("⚠️ 🛠️ Exec failed") === true;
+}
+
 export function resolveCronPayloadOutcome(params: {
   payloads: DeliveryPayload[];
   runLevelError?: unknown;
@@ -275,9 +279,12 @@ export function resolveCronPayloadOutcome(params: {
   const normalizedFinalAssistantVisibleText = normalizeOptionalString(
     params.finalAssistantVisibleText,
   );
-  const hasAnySuccessfulPayload =
+  const hasSuccessfulPayloadAfterLastError =
     !params.runLevelError &&
-    params.payloads.some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
+    lastErrorPayloadIndex >= 0 &&
+    params.payloads
+      .slice(lastErrorPayloadIndex + 1)
+      .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
   const hasSuccessfulPayloadBeforeLastError =
     !params.runLevelError &&
     lastErrorPayloadIndex > 0 &&
@@ -290,8 +297,17 @@ export function resolveCronPayloadOutcome(params: {
     lastErrorPayloadIndex >= 0 &&
     isCronMessagePresentationWarning(lastErrorPayloadText) &&
     (normalizedFinalAssistantVisibleText !== undefined || hasSuccessfulPayloadBeforeLastError);
+  const hasRecoveredExecWarning =
+    !params.runLevelError &&
+    params.failureSignal?.fatalForCron !== true &&
+    normalizedFinalAssistantVisibleText !== undefined &&
+    hasSuccessfulPayloadBeforeLastError &&
+    isCronRecoveredExecWarning(lastErrorPayloadText);
   const hasFatalStructuredErrorPayload =
-    hasErrorPayload && !hasAnySuccessfulPayload && !hasPendingPresentationWarning;
+    hasErrorPayload &&
+    !hasSuccessfulPayloadAfterLastError &&
+    !hasPendingPresentationWarning &&
+    !hasRecoveredExecWarning;
   const hasStructuredDeliveryPayloads = selectedDeliveryPayloads.some((payload) =>
     payloadHasStructuredDeliveryContent(payload),
   );

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -275,12 +275,9 @@ export function resolveCronPayloadOutcome(params: {
   const normalizedFinalAssistantVisibleText = normalizeOptionalString(
     params.finalAssistantVisibleText,
   );
-  const hasSuccessfulPayloadAfterLastError =
+  const hasAnySuccessfulPayload =
     !params.runLevelError &&
-    lastErrorPayloadIndex >= 0 &&
-    params.payloads
-      .slice(lastErrorPayloadIndex + 1)
-      .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
+    params.payloads.some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
   const hasSuccessfulPayloadBeforeLastError =
     !params.runLevelError &&
     lastErrorPayloadIndex > 0 &&
@@ -294,7 +291,7 @@ export function resolveCronPayloadOutcome(params: {
     isCronMessagePresentationWarning(lastErrorPayloadText) &&
     (normalizedFinalAssistantVisibleText !== undefined || hasSuccessfulPayloadBeforeLastError);
   const hasFatalStructuredErrorPayload =
-    hasErrorPayload && !hasSuccessfulPayloadAfterLastError && !hasPendingPresentationWarning;
+    hasErrorPayload && !hasAnySuccessfulPayload && !hasPendingPresentationWarning;
   const hasStructuredDeliveryPayloads = selectedDeliveryPayloads.some((payload) =>
     payloadHasStructuredDeliveryContent(payload),
   );


### PR DESCRIPTION
## Summary
- Narrow recovered isolated-cron tool-error handling to exec warnings with final assistant-visible recovery text.
- Keep trailing exec warnings without recovery text, canvas warnings, and provider errors fatal.
- Add regression coverage for recovered exec ordering and fatal trailing-error boundaries.

Fixes #81514.

## Verification
- `pnpm test src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts`
- `git diff --check`
- `pnpm check:changed`

## Real behavior proof
- Behavior addressed: isolated cron outcome classification for recovered exec tool failures after a fallback success, without making unresolved trailing exec, canvas, or provider errors non-fatal.
- Real environment tested: local OpenClaw checkout on macOS with Node 22, running the real `src/cron/isolated-agent/helpers.ts` implementation through Node/tsx.
- Exact steps or command run after this patch: `node --import tsx --input-type=module -e 'import { resolveCronPayloadOutcome } from "./src/cron/isolated-agent/helpers.ts"; ...'`
- Evidence after fix:
```json
{
  "recoveredExec": {
    "hasFatalErrorPayload": false,
    "outputText": "Fallback log written successfully."
  },
  "trailingExecNoRecoveryText": {
    "hasFatalErrorPayload": true,
    "embeddedRunError": "⚠️ 🛠️ Exec failed: Discord channel unavailable",
    "outputText": "⚠️ 🛠️ Exec failed: Discord channel unavailable"
  },
  "trailingCanvas": {
    "hasFatalErrorPayload": true,
    "embeddedRunError": "⚠️ 🖼️ Canvas failed",
    "outputText": "⚠️ 🖼️ Canvas failed"
  },
  "trailingProvider": {
    "hasFatalErrorPayload": true,
    "embeddedRunError": "model provider unreachable",
    "outputText": "model provider unreachable"
  }
}
```
- Observed result after fix: terminal output showed `recoveredExec.hasFatalErrorPayload` is `false`; `trailingExecNoRecoveryText`, `trailingCanvas`, and `trailingProvider` all returned `hasFatalErrorPayload: true` with the expected embedded error text.
- What was not tested: a live scheduled isolated cron job against a real Discord channel was not run because this workspace does not have the user's model and channel credentials; the focused tests and direct Node/tsx runtime check covered the classifier behavior.
