### PR TITLE
fix(infra): fall back when session lock hardlinks fail

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -244,6 +244,63 @@ describe("session cost usage", () => {
     });
   });
 
+  it("falls back to exclusive create when usage cache lock hardlinks are unsupported", async () => {
+    const root = await makeSessionCostRoot("cost-cache-lock-no-hardlink");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-cache-lock-no-hardlink.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      transcriptText("sess-cache-lock-no-hardlink", {
+        type: "message",
+        timestamp: "2026-02-05T12:00:00.000Z",
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.4",
+          usage: {
+            input: 10,
+            output: 20,
+            totalTokens: 30,
+            cost: { total: 0.03 },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const unsupportedLink = Object.assign(new Error("hard links are not supported"), {
+      code: "ENOTSUP",
+    });
+    const linkSpy = vi.spyOn(nodeFs.promises, "link").mockRejectedValueOnce(unsupportedLink);
+
+    try {
+      await withStateDir(root, async () => {
+        const result = await refreshCostUsageCache();
+        expect(result).toBe("refreshed");
+
+        const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
+        const summary = await loadCostUsageSummaryFromCache({
+          startMs: Date.UTC(2026, 1, 5),
+          endMs: Date.UTC(2026, 1, 5) + 24 * 60 * 60 * 1000 - 1,
+          requestRefresh: false,
+        });
+        const lockPath = `${cachePath}.lock`;
+        const remainingTempLocks = (await fs.readdir(sessionsDir)).filter(
+          (entry) => entry.startsWith(".usage-cost-cache.json.lock.") && entry.endsWith(".tmp"),
+        );
+
+        expect(linkSpy).toHaveBeenCalledTimes(1);
+        await expect(fs.access(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+        expect(remainingTempLocks).toEqual([]);
+        expect(summary.totals.totalTokens).toBe(30);
+        expect(summary.cacheStatus?.status).toBe("fresh");
+      });
+    } finally {
+      linkSpy.mockRestore();
+    }
+  });
+
   it("refreshes append-only durable aggregate cache by scanning only appended bytes", async () => {
     const root = await makeSessionCostRoot("cost-cache-append");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -226,14 +226,44 @@ function isMalformedUsageCostCacheLockRecent(mtimeMs: number): boolean {
   return Date.now() - mtimeMs < USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS;
 }
 
+function isUnsupportedHardLinkError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException).code;
+  return code === "ENOTSUP" || code === "EOPNOTSUPP" || code === "EXDEV";
+}
+
+async function writeUsageCostCacheLockWithExclusiveCreate(
+  lockPath: string,
+  content: string,
+): Promise<void> {
+  const handle = await fs.promises.open(lockPath, "wx");
+  let wrote = false;
+  try {
+    await handle.writeFile(content);
+    wrote = true;
+  } finally {
+    await handle.close().catch(() => undefined);
+    if (!wrote) {
+      await fs.promises.rm(lockPath, { force: true }).catch(() => undefined);
+    }
+  }
+}
+
 async function writeUsageCostCacheLockAtomically(
   lockPath: string,
   lock: UsageCostCacheLock,
 ): Promise<void> {
   const tempPath = `${lockPath}.${process.pid}.${process.hrtime.bigint()}.tmp`;
-  await fs.promises.writeFile(tempPath, `${JSON.stringify(lock)}\n`, { flag: "wx" });
+  const content = `${JSON.stringify(lock)}\n`;
+  await fs.promises.writeFile(tempPath, content, { flag: "wx" });
   try {
-    await fs.promises.link(tempPath, lockPath);
+    try {
+      await fs.promises.link(tempPath, lockPath);
+    } catch (err) {
+      if (!isUnsupportedHardLinkError(err)) {
+        throw err;
+      }
+      await writeUsageCostCacheLockWithExclusiveCreate(lockPath, content);
+    }
   } finally {
     await fs.promises.rm(tempPath, { force: true }).catch(() => undefined);
   }


### PR DESCRIPTION
Summary
- Keep the existing hard-link based session usage cache lock fast path.
- Fall back to exclusive `wx` lock-file creation when hard links fail with unsupported-filesystem errors such as `ENOTSUP`, `EOPNOTSUPP`, or `EXDEV`.
- Add a regression test that simulates `fs.promises.link()` returning `ENOTSUP` and verifies the cache refresh succeeds, the lock is released, and temp lock files are cleaned up.

Verification
- `pnpm test src/infra/session-cost-usage.test.ts -t "falls back to exclusive create"`
- `pnpm test src/infra/session-cost-usage.test.ts`
- `git diff --check`
- `pnpm check:changed`

Real behavior proof
Behavior addressed: session usage-cost cache lock acquisition no longer fails outright when `fs.promises.link()` reports hard links are unsupported.
Real environment tested: local OpenClaw worktree on macOS with Node/pnpm; filesystem unsupported-hardlink behavior simulated at the Node `fs.promises.link()` boundary.
Exact steps or command run after this patch: `pnpm test src/infra/session-cost-usage.test.ts -t "falls back to exclusive create"`.
Evidence after fix: the regression test forces `fs.promises.link()` to reject with `code: "ENOTSUP"`, then `refreshCostUsageCache()` returns `"refreshed"` and `loadCostUsageSummaryFromCache()` reports a fresh cache with the expected token total.
Observed result after fix: lock fallback completed, the `.usage-cost-cache.json.lock` file was released, and no `.usage-cost-cache.json.lock.*.tmp` files remained.
What was not tested: a live SMB/NFS/virtiofs mount; the unsupported-filesystem condition was simulated in-process.

Fixes #81089
