### PR TITLE
fix(skills): guard publishPluginSkills against EINVAL on non-symlink entries

### DIFF
--- a/src/agents/skills/plugin-skills.test.ts
+++ b/src/agents/skills/plugin-skills.test.ts
@@ -536,6 +536,50 @@ describe("publishPluginSkills", () => {
     expect(fsSync.existsSync(path.join(managedDir, "broken-skill"))).toBe(false);
   });
 
+  it("replaces a non-symlink directory entry without emitting an EINVAL warning (regression #81432)", async () => {
+    const skillParent = await tempDirs.make("plugin-skills-");
+    const managedDir = await tempDirs.make("managed-skills-");
+
+    const dir = await writeSkillDir(skillParent, "my-skill");
+
+    // Simulate an existing real directory at the publish path (e.g. a
+    // Windows junction that was replaced with a regular directory, or a
+    // stale dir left over from a manual edit). Previously the publish
+    // path called fs.readlinkSync directly which threw EINVAL on real
+    // directories and triggered a noisy warning + skipped replacement.
+    const linkPath = path.join(managedDir, "my-skill");
+    await fs.mkdir(linkPath, { recursive: true });
+    // Add a sentinel file so we can prove the directory was actually
+    // removed and replaced rather than left in place.
+    const sentinel = path.join(linkPath, "STALE_SENTINEL");
+    await fs.writeFile(sentinel, "stale");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      publishPluginSkills([dir], { pluginSkillsDir: managedDir });
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    // The stale directory must have been removed and replaced with a
+    // proper plugin-skill entry that points at the target.
+    expect(fsSync.existsSync(sentinel)).toBe(false);
+    const replacedStat = fsSync.lstatSync(linkPath);
+    if (process.platform === "win32") {
+      // On Windows publishPluginSkills uses junctions, which appear as
+      // directories rather than symbolic links.
+      expect(replacedStat.isDirectory()).toBe(true);
+    } else {
+      expect(replacedStat.isSymbolicLink()).toBe(true);
+      expect(fsSync.readlinkSync(linkPath)).toBe(dir);
+    }
+    // No EINVAL-shaped warning should have been emitted.
+    const einvalWarnings = warnSpy.mock.calls
+      .map((args) => args.join(" "))
+      .filter((line) => /EINVAL/i.test(line));
+    expect(einvalWarnings).toEqual([]);
+  });
+
   it.runIf(process.platform !== "win32")(
     "skips child skill directories whose SKILL.md symlinks outside the declared root",
     async () => {

--- a/src/agents/skills/plugin-skills.ts
+++ b/src/agents/skills/plugin-skills.ts
@@ -220,9 +220,17 @@ function publishPluginSkills(skillDirs: string[], opts?: { pluginSkillsDir?: str
       // best-effort; symlink will fail below if dir is truly unusable
     }
     try {
-      const existingTarget = fs.readlinkSync(linkPath);
-      if (existingTarget === target) {
-        continue;
+      // Inspect the existing entry without calling readlinkSync on a
+      // non-symlink: readlinkSync throws EINVAL on regular directories
+      // (e.g. when a junction has been replaced with a real directory on
+      // Windows), which used to surface as a noisy warning and skip the
+      // replacement entirely. Use lstat to branch on the entry kind.
+      const existingStat = fs.lstatSync(linkPath);
+      if (existingStat.isSymbolicLink()) {
+        const existingTarget = fs.readlinkSync(linkPath);
+        if (existingTarget === target) {
+          continue;
+        }
       }
       removeGeneratedPluginSkillEntry(linkPath);
     } catch (err) {


### PR DESCRIPTION
Fixes #81432

## Problem

`publishPluginSkills` in `src/agents/skills/plugin-skills.ts` calls `fs.readlinkSync(linkPath)` directly on every existing entry in `~/.openclaw/plugin-skills/` to compare against the desired target. When the entry is a real directory rather than a symlink — for example on Windows after a junction was replaced with a regular directory, or after a manual edit — `readlinkSync` throws `EINVAL`.

The existing catch path only treats `ENOENT`/`ENOTDIR` as benign, so `EINVAL` falls into the `log.warn("failed to inspect plugin skill symlink …")` branch and then `continue`s, which means:

1. A noisy warning is logged on every `openclaw skills list` / startup.
2. The stale directory is never replaced with a proper symlink/junction.

## Fix

Use `fs.lstatSync` first and only call `readlinkSync` when the entry is actually a symbolic link. Real directories fall through to `removeGeneratedPluginSkillEntry`, which is already `fs.rmSync({ recursive: true, force: true })` and handles both symlinks and dirs. Behavior for symlinks is unchanged.

## Test

Added a regression test in `src/agents/skills/plugin-skills.test.ts` that:

- Pre-creates a real directory (with a sentinel file inside) at the publish path.
- Invokes `publishPluginSkills` and asserts the sentinel is gone, the entry is now a symlink pointing at the target (or a directory on Windows since junctions appear as directories), and no `EINVAL` warning was emitted.

Verified the test fails on `main` and passes with this change:

```
$ node scripts/run-vitest.mjs run \
    --config test/vitest/vitest.agents-support.config.ts \
    src/agents/skills/plugin-skills.test.ts
 ✓ agents-support  src/agents/skills/plugin-skills.test.ts (24 tests) 35ms
 Test Files  1 passed (1)
      Tests  24 passed (24)
```