### PR TITLE
fix(xiaomi): MiMo reasoning models fail multi-turn tool calls (#81419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - Control UI/WebChat: focus the composer when users click the visible input chrome and restore larger, labeled desktop composer controls while preserving compact mobile taps. Fixes #45656. Thanks @BunsDev.
 - System events: keep owner downgrades in structured metadata while rendering queued prompt text as plain `System:` lines, preserving least-privilege wakeups without prompt-visible trust labels. (#82067)
+- Providers/Xiaomi: preserve MiMo `reasoning_content` on multi-turn tool-call replay, including custom Xiaomi-compatible proxy routes, so follow-up turns no longer fail with `400 Param Incorrect`. Fixes #81419. (#81589) Thanks @lovelefeng-glitch and @jimdawdy-hub.
 - Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
 
 ## 2026.5.14

--- a/extensions/xiaomi/index.test.ts
+++ b/extensions/xiaomi/index.test.ts
@@ -197,12 +197,10 @@ describe("xiaomi provider plugin", () => {
     const modelIds = catalogProvider.models?.map((m) => m.id);
     expect(modelIds).toContain("mimo-v2-pro");
     expect(modelIds).toContain("mimo-v2-omni");
-    expect(modelIds).toContain("mimo-v2.5");
-    expect(modelIds).toContain("mimo-v2.5-pro");
     expect(modelIds).toContain("mimo-v2-flash");
 
     expect(catalogProvider.models?.find((m) => m.id === "mimo-v2-pro")?.reasoning).toBe(true);
-    expect(catalogProvider.models?.find((m) => m.id === "mimo-v2.5-pro")?.reasoning).toBe(true);
+    expect(catalogProvider.models?.find((m) => m.id === "mimo-v2-omni")?.reasoning).toBe(true);
     expect(catalogProvider.models?.find((m) => m.id === "mimo-v2-flash")?.reasoning).toBeFalsy();
   });
 

--- a/extensions/xiaomi/index.test.ts
+++ b/extensions/xiaomi/index.test.ts
@@ -1,0 +1,317 @@
+import type { Context, Model } from "@earendil-works/pi-ai";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import {
+  registerSingleProviderPlugin,
+  resolveProviderPluginChoice,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
+import { describe, expect, it } from "vitest";
+import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
+import xiaomiPlugin from "./index.js";
+import { createMiMoThinkingWrapper } from "./stream.js";
+
+type OpenAICompletionsModel = Model<"openai-completions">;
+
+type PayloadCapture = {
+  payload?: Record<string, unknown>;
+};
+
+type ThinkingPayload = {
+  type?: unknown;
+};
+
+type ReplayToolCall = {
+  id?: unknown;
+  type?: unknown;
+  function?: {
+    name?: unknown;
+    arguments?: unknown;
+  };
+};
+
+type RegisteredProvider = Awaited<ReturnType<typeof registerSingleProviderPlugin>>;
+
+const emptyUsage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function requireThinkingProfileResolver(
+  provider: RegisteredProvider,
+): NonNullable<RegisteredProvider["resolveThinkingProfile"]> {
+  if (!provider.resolveThinkingProfile) {
+    throw new Error("Xiaomi provider did not register a thinking profile resolver");
+  }
+  return provider.resolveThinkingProfile;
+}
+
+const readToolCall = { type: "toolCall", id: "call_1", name: "read", arguments: {} };
+const readToolResult = {
+  role: "toolResult",
+  toolCallId: "call_1",
+  toolName: "read",
+  content: [{ type: "text", text: "ok" }],
+  isError: false,
+  timestamp: 3,
+};
+const readTool = {
+  name: "read",
+  description: "Read data",
+  parameters: { type: "object", properties: {}, required: [], additionalProperties: false },
+};
+
+function mimoReasoningModel(
+  id: "mimo-v2-pro" | "mimo-v2-omni" | "mimo-v2.5" | "mimo-v2.5-pro",
+): OpenAICompletionsModel {
+  return {
+    provider: "xiaomi",
+    id,
+    name: id,
+    api: "openai-completions",
+    baseUrl: "https://api.xiaomimimo.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_048_576,
+    maxTokens: 32_000,
+    compat: {},
+  } as OpenAICompletionsModel;
+}
+
+function replayAssistantMessage(params: {
+  provider: string;
+  model: string;
+  content: Array<Record<string, unknown>>;
+  stopReason: "stop" | "toolUse";
+}) {
+  return {
+    role: "assistant",
+    api: "openai-completions",
+    provider: params.provider,
+    model: params.model,
+    content: params.content,
+    usage: emptyUsage,
+    stopReason: params.stopReason,
+    timestamp: 2,
+  };
+}
+
+function readToolReplayContext(assistantMessage: ReturnType<typeof replayAssistantMessage>) {
+  return {
+    messages: [{ role: "user", content: "hi", timestamp: 1 }, assistantMessage, readToolResult],
+    tools: [readTool],
+  } as Context;
+}
+
+function mimoReasoningToolReplayContext() {
+  return readToolReplayContext(
+    replayAssistantMessage({
+      provider: "xiaomi",
+      model: "mimo-v2.5-pro",
+      content: [
+        {
+          type: "thinking",
+          thinking: "call reasoning",
+          thinkingSignature: "reasoning_content",
+        },
+        readToolCall,
+      ],
+      stopReason: "toolUse",
+    }),
+  );
+}
+
+function createPayloadCapturingStream(capture: PayloadCapture, model: OpenAICompletionsModel) {
+  return (
+    _streamModel: OpenAICompletionsModel,
+    streamContext: Context,
+    options?: { onPayload?: (payload: unknown, m: unknown) => unknown },
+  ) => {
+    capture.payload = buildOpenAICompletionsParams(model, streamContext, {
+      reasoning: "high",
+    } as never);
+    options?.onPayload?.(capture.payload, model);
+    const stream = createAssistantMessageEventStream();
+    queueMicrotask(() => stream.end());
+    return stream;
+  };
+}
+
+function requireThinkingWrapper(
+  wrapper: ReturnType<typeof createMiMoThinkingWrapper>,
+  label: string,
+): NonNullable<ReturnType<typeof createMiMoThinkingWrapper>> {
+  if (!wrapper) {
+    throw new Error(`expected MiMo thinking wrapper for ${label}`);
+  }
+  return wrapper;
+}
+
+function readThinking(payload: Record<string, unknown> | undefined): ThinkingPayload | undefined {
+  return payload?.thinking as ThinkingPayload | undefined;
+}
+
+function readPayloadMessage(
+  capture: PayloadCapture,
+  index: number,
+): Record<string, unknown> | undefined {
+  return (capture.payload?.messages as Array<Record<string, unknown>> | undefined)?.[index];
+}
+
+function readFirstToolCall(
+  message: Record<string, unknown> | undefined,
+): ReplayToolCall | undefined {
+  return (message?.tool_calls as ReplayToolCall[] | undefined)?.[0];
+}
+
+describe("xiaomi provider plugin", () => {
+  it("registers Xiaomi with api-key auth metadata", async () => {
+    const provider = await registerSingleProviderPlugin(xiaomiPlugin);
+    const resolved = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "xiaomi-api-key",
+    });
+
+    expect(provider.id).toBe("xiaomi");
+    expect(provider.label).toBe("Xiaomi");
+    expect(provider.envVars).toEqual(["XIAOMI_API_KEY"]);
+    expect(provider.auth).toHaveLength(1);
+    if (!resolved) {
+      throw new Error("expected Xiaomi api-key auth choice");
+    }
+    expect(resolved.provider.id).toBe("xiaomi");
+    expect(resolved.method.id).toBe("api-key");
+  });
+
+  it("builds the static Xiaomi model catalog with reasoning flags", async () => {
+    const provider = await registerSingleProviderPlugin(xiaomiPlugin);
+    const catalogProvider = await runSingleProviderCatalog(provider);
+
+    expect(catalogProvider.api).toBe("openai-completions");
+    expect(catalogProvider.baseUrl).toBe("https://api.xiaomimimo.com/v1");
+
+    const modelIds = catalogProvider.models?.map((m) => m.id);
+    expect(modelIds).toContain("mimo-v2-pro");
+    expect(modelIds).toContain("mimo-v2-omni");
+    expect(modelIds).toContain("mimo-v2.5");
+    expect(modelIds).toContain("mimo-v2.5-pro");
+    expect(modelIds).toContain("mimo-v2-flash");
+
+    expect(catalogProvider.models?.find((m) => m.id === "mimo-v2-pro")?.reasoning).toBe(true);
+    expect(catalogProvider.models?.find((m) => m.id === "mimo-v2.5-pro")?.reasoning).toBe(true);
+    expect(catalogProvider.models?.find((m) => m.id === "mimo-v2-flash")?.reasoning).toBeFalsy();
+  });
+
+  it("owns OpenAI-compatible replay policy", async () => {
+    const provider = await registerSingleProviderPlugin(xiaomiPlugin);
+
+    const replayPolicy = provider.buildReplayPolicy?.({ modelApi: "openai-completions" } as never);
+    expect(replayPolicy?.sanitizeToolCallIds).toBe(true);
+    expect(replayPolicy?.toolCallIdMode).toBe("strict");
+    expect(replayPolicy?.validateGeminiTurns).toBe(true);
+    expect(replayPolicy?.validateAnthropicTurns).toBe(true);
+  });
+
+  it("advertises thinking profiles for MiMo reasoning models only", async () => {
+    const provider = await registerSingleProviderPlugin(xiaomiPlugin);
+    const resolveThinkingProfile = requireThinkingProfileResolver(provider);
+    const expectedLevels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+    for (const modelId of ["mimo-v2-pro", "mimo-v2-omni", "mimo-v2.5", "mimo-v2.5-pro"]) {
+      const profile = resolveThinkingProfile({ provider: "xiaomi", modelId } as never);
+      expect(profile?.levels.map((l) => l.id)).toEqual(expectedLevels);
+      expect(profile?.defaultLevel).toBe("high");
+    }
+
+    expect(resolveThinkingProfile({ provider: "xiaomi", modelId: "mimo-v2-flash" } as never)).toBe(
+      undefined,
+    );
+  });
+
+  it("isModernModelRef returns true only for MiMo reasoning models", async () => {
+    const provider = await registerSingleProviderPlugin(xiaomiPlugin);
+
+    expect(
+      provider.isModernModelRef?.({ provider: "xiaomi", modelId: "mimo-v2.5-pro" } as never),
+    ).toBe(true);
+    expect(
+      provider.isModernModelRef?.({ provider: "xiaomi", modelId: "mimo-v2-pro" } as never),
+    ).toBe(true);
+    expect(
+      provider.isModernModelRef?.({ provider: "xiaomi", modelId: "mimo-v2-flash" } as never),
+    ).toBe(false);
+  });
+
+  it("adds blank reasoning_content for replayed tool calls from non-xiaomi turns", async () => {
+    const capture: PayloadCapture = {};
+    const model = mimoReasoningModel("mimo-v2.5-pro");
+    const context = readToolReplayContext(
+      replayAssistantMessage({
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [readToolCall],
+        stopReason: "toolUse",
+      }),
+    );
+    const baseStreamFn = createPayloadCapturingStream(capture, model);
+
+    const wrapThinkingHigh = requireThinkingWrapper(
+      createMiMoThinkingWrapper(baseStreamFn as never, "high"),
+      "high",
+    );
+    await wrapThinkingHigh(model, context, {});
+
+    const assistantMessage = readPayloadMessage(capture, 1);
+    expect(assistantMessage?.role).toBe("assistant");
+    expect(assistantMessage?.reasoning_content).toBe("");
+    const toolCall = readFirstToolCall(assistantMessage);
+    expect(toolCall?.id).toBe("call_1");
+    expect(toolCall?.type).toBe("function");
+    expect(toolCall?.function?.name).toBe("read");
+    expect(toolCall?.function?.arguments).toBe("{}");
+  });
+
+  it("preserves replayed reasoning_content when MiMo thinking is enabled", async () => {
+    const capture: PayloadCapture = {};
+    const model = mimoReasoningModel("mimo-v2.5-pro");
+    const context = mimoReasoningToolReplayContext();
+    const baseStreamFn = createPayloadCapturingStream(capture, model);
+
+    const wrapThinkingHigh = requireThinkingWrapper(
+      createMiMoThinkingWrapper(baseStreamFn as never, "high"),
+      "high",
+    );
+    await wrapThinkingHigh(model, context, {});
+
+    expect(readThinking(capture.payload)?.type).toBe("enabled");
+    const assistantMessage = readPayloadMessage(capture, 1);
+    expect(assistantMessage?.role).toBe("assistant");
+    expect(assistantMessage?.reasoning_content).toBe("call reasoning");
+    const toolCall = readFirstToolCall(assistantMessage);
+    expect(toolCall?.id).toBe("call_1");
+    expect(toolCall?.type).toBe("function");
+    expect(toolCall?.function?.name).toBe("read");
+  });
+
+  it("strips reasoning_content when MiMo thinking is disabled", async () => {
+    const capture: PayloadCapture = {};
+    const model = mimoReasoningModel("mimo-v2-pro");
+    const context = mimoReasoningToolReplayContext();
+    const baseStreamFn = createPayloadCapturingStream(capture, model);
+
+    const wrapThinkingNone = requireThinkingWrapper(
+      createMiMoThinkingWrapper(baseStreamFn as never, "none" as never),
+      "none",
+    );
+    await wrapThinkingNone(model, context, {});
+
+    expect(readThinking(capture.payload)?.type).toBe("disabled");
+    expect((capture.payload?.messages as Array<Record<string, unknown>>)[1]).not.toHaveProperty(
+      "reasoning_content",
+    );
+  });
+});

--- a/extensions/xiaomi/index.ts
+++ b/extensions/xiaomi/index.ts
@@ -1,8 +1,11 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
 import { PROVIDER_LABELS } from "openclaw/plugin-sdk/provider-usage";
 import { applyXiaomiConfig, XIAOMI_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildXiaomiProvider } from "./provider-catalog.js";
 import { buildXiaomiSpeechProvider } from "./speech-provider.js";
+import { createMiMoThinkingWrapper } from "./stream.js";
+import { resolveMiMoThinkingProfile } from "./thinking.js";
 
 const PROVIDER_ID = "xiaomi";
 
@@ -29,6 +32,13 @@ export default defineSingleProviderPluginEntry({
     catalog: {
       buildProvider: buildXiaomiProvider,
     },
+    ...buildProviderReplayFamilyHooks({
+      family: "openai-compatible",
+      dropReasoningFromHistory: false,
+    }),
+    wrapStreamFn: (ctx) => createMiMoThinkingWrapper(ctx.streamFn, ctx.thinkingLevel),
+    resolveThinkingProfile: ({ modelId }) => resolveMiMoThinkingProfile(modelId),
+    isModernModelRef: ({ modelId }) => Boolean(resolveMiMoThinkingProfile(modelId)),
     resolveUsageAuth: async (ctx) => {
       const apiKey = ctx.resolveApiKeyFromConfigAndStore({
         envDirect: [ctx.env.XIAOMI_API_KEY],

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -51,47 +51,6 @@
               "cacheRead": 0,
               "cacheWrite": 0
             }
-          },
-          {
-            "id": "mimo-v2.5-flash",
-            "name": "Xiaomi MiMo V2.5 Flash",
-            "input": ["text"],
-            "contextWindow": 262144,
-            "maxTokens": 8192,
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "mimo-v2.5",
-            "name": "Xiaomi MiMo V2.5",
-            "input": ["text"],
-            "reasoning": true,
-            "contextWindow": 1048576,
-            "maxTokens": 32000,
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
-          },
-          {
-            "id": "mimo-v2.5-pro",
-            "name": "Xiaomi MiMo V2.5 Pro",
-            "input": ["text"],
-            "reasoning": true,
-            "contextWindow": 1048576,
-            "maxTokens": 32000,
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            }
           }
         ]
       }

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -51,6 +51,47 @@
               "cacheRead": 0,
               "cacheWrite": 0
             }
+          },
+          {
+            "id": "mimo-v2.5-flash",
+            "name": "Xiaomi MiMo V2.5 Flash",
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "mimo-v2.5",
+            "name": "Xiaomi MiMo V2.5",
+            "input": ["text"],
+            "reasoning": true,
+            "contextWindow": 1048576,
+            "maxTokens": 32000,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "mimo-v2.5-pro",
+            "name": "Xiaomi MiMo V2.5 Pro",
+            "input": ["text"],
+            "reasoning": true,
+            "contextWindow": 1048576,
+            "maxTokens": 32000,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
           }
         ]
       }
@@ -59,6 +100,17 @@
       "xiaomi": "static"
     }
   },
+  "providerEndpoints": [
+    {
+      "endpointClass": "xiaomi-native",
+      "hosts": [
+        "api.xiaomimimo.com",
+        "token-plan-ams.xiaomimimo.com",
+        "token-plan-cn.xiaomimimo.com",
+        "token-plan-sgp.xiaomimimo.com"
+      ]
+    }
+  ],
   "contracts": {
     "speechProviders": ["xiaomi"]
   },

--- a/extensions/xiaomi/stream.ts
+++ b/extensions/xiaomi/stream.ts
@@ -1,0 +1,14 @@
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { createDeepSeekV4OpenAICompatibleThinkingWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+import { isMiMoReasoningModelRef } from "./thinking.js";
+
+export function createMiMoThinkingWrapper(
+  baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
+  thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
+): ProviderWrapStreamFnContext["streamFn"] {
+  return createDeepSeekV4OpenAICompatibleThinkingWrapper({
+    baseStreamFn,
+    thinkingLevel,
+    shouldPatchModel: isMiMoReasoningModelRef,
+  });
+}

--- a/extensions/xiaomi/thinking.ts
+++ b/extensions/xiaomi/thinking.ts
@@ -1,0 +1,37 @@
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
+
+const MIMO_REASONING_MODEL_IDS = new Set([
+  "mimo-v2-pro",
+  "mimo-v2-omni",
+  "mimo-v2.5",
+  "mimo-v2.5-pro",
+]);
+
+export function isMiMoReasoningModelId(modelId: string): boolean {
+  return MIMO_REASONING_MODEL_IDS.has(modelId.toLowerCase());
+}
+
+export function isMiMoReasoningModelRef(model: { provider?: string; id?: unknown }): boolean {
+  return (
+    model.provider === "xiaomi" && typeof model.id === "string" && isMiMoReasoningModelId(model.id)
+  );
+}
+
+const MIMO_THINKING_LEVEL_IDS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+
+const MIMO_THINKING_PROFILE = {
+  levels: MIMO_THINKING_LEVEL_IDS.map((id) => ({ id })),
+  defaultLevel: "high",
+} satisfies ProviderThinkingProfile;
+
+export function resolveMiMoThinkingProfile(modelId: string): ProviderThinkingProfile | undefined {
+  return isMiMoReasoningModelId(modelId) ? MIMO_THINKING_PROFILE : undefined;
+}

--- a/src/agents/openai-completions-compat.test.ts
+++ b/src/agents/openai-completions-compat.test.ts
@@ -73,3 +73,55 @@ describe("detectOpenAICompletionsCompat", () => {
     expect(detected.defaults.supportsUsageInStreaming).toBe(true);
   });
 });
+
+describe("xiaomi compat detection", () => {
+  it("sets thinkingFormat to deepseek for xiaomi-native endpoint", () => {
+    expect(
+      resolveOpenAICompletionsCompatDefaults({
+        provider: "xiaomi",
+        endpointClass: "xiaomi-native",
+        knownProviderFamily: "xiaomi",
+      }).thinkingFormat,
+    ).toBe("deepseek");
+  });
+
+  it("sets requiresReasoningContentOnAssistantMessages for xiaomi-native endpoint", () => {
+    expect(
+      resolveOpenAICompletionsCompatDefaults({
+        provider: "xiaomi",
+        endpointClass: "xiaomi-native",
+        knownProviderFamily: "xiaomi",
+      }).requiresReasoningContentOnAssistantMessages,
+    ).toBe(true);
+  });
+
+  it("sets thinkingFormat to deepseek for default-route xiaomi provider", () => {
+    expect(
+      resolveOpenAICompletionsCompatDefaults({
+        provider: "xiaomi",
+        endpointClass: "default",
+        knownProviderFamily: "xiaomi",
+      }).thinkingFormat,
+    ).toBe("deepseek");
+  });
+
+  it("sets requiresReasoningContentOnAssistantMessages for default-route xiaomi provider", () => {
+    expect(
+      resolveOpenAICompletionsCompatDefaults({
+        provider: "xiaomi",
+        endpointClass: "default",
+        knownProviderFamily: "xiaomi",
+      }).requiresReasoningContentOnAssistantMessages,
+    ).toBe(true);
+  });
+
+  it("does not set requiresReasoningContentOnAssistantMessages for unrelated custom provider", () => {
+    expect(
+      resolveOpenAICompletionsCompatDefaults({
+        provider: "other-provider",
+        endpointClass: "custom",
+        knownProviderFamily: "other-provider",
+      }).requiresReasoningContentOnAssistantMessages,
+    ).toBe(false);
+  });
+});

--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -67,6 +67,7 @@ export function resolveOpenAICompletionsCompatDefaults(
     endpointClass === "mistral-public" ||
     endpointClass === "opencode-native" ||
     endpointClass === "xai-native" ||
+    isXiaomi ||
     isZai ||
     (isDefaultRoute &&
       isDefaultRouteProvider(input.provider, "cerebras", "chutes", "deepseek", "opencode", "xai"));

--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -20,6 +20,7 @@ type OpenAICompletionsCompatDefaults = {
   thinkingFormat: "openai" | "openrouter" | "deepseek" | "zai";
   visibleReasoningDetailTypes: string[];
   supportsStrictMode: boolean;
+  requiresReasoningContentOnAssistantMessages: boolean;
 };
 
 type DetectedOpenAICompletionsCompat = {
@@ -56,6 +57,9 @@ export function resolveOpenAICompletionsCompatDefaults(
   const isDeepSeek =
     endpointClass === "deepseek-native" ||
     (isDefaultRoute && isDefaultRouteProvider(input.provider, "deepseek"));
+  const isXiaomi =
+    endpointClass === "xiaomi-native" ||
+    (isDefaultRoute && isDefaultRouteProvider(input.provider, "xiaomi"));
   const isNonStandard =
     endpointClass === "cerebras-native" ||
     endpointClass === "chutes-native" ||
@@ -85,15 +89,17 @@ export function resolveOpenAICompletionsCompatDefaults(
       supportsOpenAICompletionsStreamingUsageCompat ||
       (!isNonStandard && (!usesConfiguredNonOpenAIEndpoint || supportsNativeStreamingUsageCompat)),
     maxTokensField: usesMaxTokens ? "max_tokens" : "max_completion_tokens",
-    thinkingFormat: isDeepSeek
-      ? "deepseek"
-      : isZai
-        ? "zai"
-        : isOpenRouterLike
-          ? "openrouter"
-          : "openai",
+    thinkingFormat:
+      isDeepSeek || isXiaomi
+        ? "deepseek"
+        : isZai
+          ? "zai"
+          : isOpenRouterLike
+            ? "openrouter"
+            : "openai",
     visibleReasoningDetailTypes: isOpenRouterLike ? ["response.output_text", "response.text"] : [],
     supportsStrictMode: !isZai && !usesConfiguredNonOpenAIEndpoint,
+    requiresReasoningContentOnAssistantMessages: isDeepSeek || isXiaomi,
   };
 }
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5441,6 +5441,25 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
     maxTokens: 8192,
   } satisfies Model<"openai-completions">;
 
+  const xiaomiModel = {
+    id: "mimo-v2.5-pro",
+    name: "MiMo V2.5 Pro",
+    api: "openai-completions",
+    provider: "xiaomi",
+    baseUrl: "https://api.xiaomimimo.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_048_576,
+    maxTokens: 32_000,
+  } satisfies Model<"openai-completions">;
+
+  const customMiMoProxyModel = {
+    ...xiaomiModel,
+    provider: "xiaomi-orbit",
+    baseUrl: "https://proxy.example.com/v1",
+  } satisfies Model<"openai-completions">;
+
   function getAssistantMessage(params: { messages: unknown }) {
     expect(Array.isArray(params.messages)).toBe(true);
     const list = params.messages as Array<Record<string, unknown>>;
@@ -5513,6 +5532,40 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
 
     expect(assistant).not.toHaveProperty("reasoning_text");
     expect(assistant.reasoning).toBe("Need to answer politely.");
+  });
+
+  it("preserves DeepSeek-style reasoning_content replay for Xiaomi MiMo", () => {
+    const assistant = getAssistantMessage(buildReplayParams(xiaomiModel, "reasoning_content"));
+
+    expect(assistant.reasoning_content).toBe("Need to answer politely.");
+    expect(assistant).not.toHaveProperty("reasoning_details");
+    expect(assistant).not.toHaveProperty("reasoning");
+    expect(assistant).not.toHaveProperty("reasoning_text");
+  });
+
+  it("preserves reasoning_content replay for custom MiMo proxy routes", () => {
+    const assistant = getAssistantMessage(
+      buildReplayParams(customMiMoProxyModel, "reasoning_content"),
+    );
+
+    expect(assistant.reasoning_content).toBe("Need to answer politely.");
+    expect(assistant).not.toHaveProperty("reasoning_details");
+    expect(assistant).not.toHaveProperty("reasoning");
+    expect(assistant).not.toHaveProperty("reasoning_text");
+  });
+
+  it("preserves reasoning_content replay for suffixed reasoning model ids", () => {
+    const assistant = getAssistantMessage(
+      buildReplayParams(
+        {
+          ...customMiMoProxyModel,
+          id: "xiaomi/mimo-v2.5-pro:cloud",
+        },
+        "reasoning_content",
+      ),
+    );
+
+    expect(assistant.reasoning_content).toBe("Need to answer politely.");
   });
 
   it("preserves OpenRouter array reasoning_details from tool-call signatures", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2469,13 +2469,56 @@ function sanitizeOpenRouterReasoningReplayFields(record: Record<string, unknown>
   }
 }
 
+function sanitizeReasoningContentReplayFields(record: Record<string, unknown>): void {
+  if ("reasoning_content" in record && typeof record.reasoning_content !== "string") {
+    delete record.reasoning_content;
+  }
+  delete record.reasoning_details;
+  delete record.reasoning;
+  delete record.reasoning_text;
+}
+
+const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
+  "deepseek-v4-flash",
+  "deepseek-v4-pro",
+  "mimo-v2-pro",
+  "mimo-v2-omni",
+  "mimo-v2.5",
+  "mimo-v2.5-pro",
+]);
+
+function normalizeReasoningContentReplayModelId(modelId: unknown): string | undefined {
+  if (typeof modelId !== "string") {
+    return undefined;
+  }
+  const normalized = modelId.trim().toLowerCase().split(":", 1)[0];
+  if (!normalized) {
+    return undefined;
+  }
+  const parts = normalized.split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? normalized;
+}
+
+function shouldPreserveReasoningContentReplay(
+  model: OpenAIModeModel,
+  compat: { requiresReasoningContentOnAssistantMessages: boolean },
+): boolean {
+  if (compat.requiresReasoningContentOnAssistantMessages) {
+    return true;
+  }
+  const normalizedModelId = normalizeReasoningContentReplayModelId(model.id);
+  return (
+    normalizedModelId !== undefined && REASONING_CONTENT_REPLAY_MODEL_IDS.has(normalizedModelId)
+  );
+}
+
 // OpenAI Chat Completions assistant-message input does not define reasoning
-// replay fields, while OpenRouter documents a compatible pass-back contract.
-// Keep OpenRouter's valid shapes, but normalize leaked string reasoning_details
-// from pi-ai thinking signatures before a follow-up request hits the wire.
+// replay fields, while OpenRouter and DeepSeek-style providers document
+// compatible pass-back contracts. Keep valid provider-owned replay fields, but
+// strip them for stock OpenAI before a follow-up request hits the wire.
 function sanitizeCompletionsReasoningReplayFields(
   messages: unknown,
-  options: { preserveOpenRouterReasoning: boolean },
+  options: { preserveOpenRouterReasoning: boolean; preserveReasoningContent: boolean },
 ): void {
   if (!Array.isArray(messages)) {
     return;
@@ -2490,6 +2533,8 @@ function sanitizeCompletionsReasoningReplayFields(
     }
     if (options.preserveOpenRouterReasoning) {
       sanitizeOpenRouterReasoningReplayFields(record);
+    } else if (options.preserveReasoningContent) {
+      sanitizeReasoningContentReplayFields(record);
     } else {
       stripCompletionsReasoningReplayFields(record);
     }
@@ -2513,6 +2558,7 @@ export function buildOpenAICompletionsParams(
   injectToolCallThoughtSignatures(messages as unknown[], context, model);
   sanitizeCompletionsReasoningReplayFields(messages, {
     preserveOpenRouterReasoning: compat.thinkingFormat === "openrouter",
+    preserveReasoningContent: shouldPreserveReasoningContentReplay(model, compat),
   });
   if (compat.strictMessageKeys) {
     messages = stripCompletionMessagesToRoleContent(messages) as typeof messages;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2163,6 +2163,8 @@ function detectCompat(model: OpenAIModeModel) {
     openRouterRouting: {},
     vercelGatewayRouting: {},
     supportsStrictMode: compatDefaults.supportsStrictMode,
+    requiresReasoningContentOnAssistantMessages:
+      compatDefaults.requiresReasoningContentOnAssistantMessages,
   };
 }
 
@@ -2184,6 +2186,7 @@ function getCompat(model: OpenAIModeModel): {
   requiresStringContent: boolean;
   strictMessageKeys: boolean;
   visibleReasoningDetailTypes: string[];
+  requiresReasoningContentOnAssistantMessages: boolean;
 } {
   const detected = detectCompat(model);
   const compat = model.compat ?? {};
@@ -2215,6 +2218,9 @@ function getCompat(model: OpenAIModeModel): {
     strictMessageKeys: compat.strictMessageKeys === true,
     visibleReasoningDetailTypes:
       compat.visibleReasoningDetailTypes ?? detected.visibleReasoningDetailTypes,
+    requiresReasoningContentOnAssistantMessages:
+      compat.requiresReasoningContentOnAssistantMessages ??
+      detected.requiresReasoningContentOnAssistantMessages,
   };
 }
 

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2219,7 +2219,6 @@ function getCompat(model: OpenAIModeModel): {
     visibleReasoningDetailTypes:
       compat.visibleReasoningDetailTypes ?? detected.visibleReasoningDetailTypes,
     requiresReasoningContentOnAssistantMessages:
-      compat.requiresReasoningContentOnAssistantMessages ??
       detected.requiresReasoningContentOnAssistantMessages,
   };
 }

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -752,6 +752,17 @@ function applyPostPluginStreamWrappers(
       shouldPatchModel: isDeepSeekV4OpenAICompatibleModel,
     });
 
+    // MiMo reasoning models use the same DeepSeek-style reasoning_content wire
+    // format. When MiMo is reached through an unowned proxy/custom provider
+    // (e.g. `xiaomi-orbit` pointed at token-plan-*.xiaomimimo.com), the bundled
+    // xiaomi plugin's wrapStreamFn does not fire, so apply the shared wrapper
+    // here as a fallback so multi-turn tool calls succeed.
+    ctx.agent.streamFn = createDeepSeekV4OpenAICompatibleThinkingWrapper({
+      baseStreamFn: ctx.agent.streamFn,
+      thinkingLevel: ctx.thinkingLevel,
+      shouldPatchModel: isMiMoReasoningOpenAICompatibleModel,
+    });
+
     // Guard Google-family payloads against invalid negative thinking budgets
     // emitted by upstream model-ID heuristics for Gemini 3.1 variants.
     ctx.agent.streamFn = createGoogleThinkingPayloadWrapper(ctx.agent.streamFn, ctx.thinkingLevel);
@@ -828,6 +839,22 @@ function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): bool
   return (
     model.api === "openai-completions" &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
+  );
+}
+
+const MIMO_REASONING_OPENAI_COMPATIBLE_MODEL_IDS = new Set([
+  "mimo-v2-pro",
+  "mimo-v2-omni",
+  "mimo-v2.5",
+  "mimo-v2.5-pro",
+]);
+
+function isMiMoReasoningOpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
+  const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
+  return (
+    model.api === "openai-completions" &&
+    normalizedModelId !== undefined &&
+    MIMO_REASONING_OPENAI_COMPATIBLE_MODEL_IDS.has(normalizedModelId)
   );
 }
 

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -355,6 +355,22 @@ describe("provider attribution", () => {
       endpointClass: "opencode-native",
       hostname: "opencode.ai",
     });
+    expectRecordFields(resolveProviderEndpoint("https://api.xiaomimimo.com/v1"), {
+      endpointClass: "xiaomi-native",
+      hostname: "api.xiaomimimo.com",
+    });
+    expectRecordFields(resolveProviderEndpoint("https://token-plan-ams.xiaomimimo.com/v1"), {
+      endpointClass: "xiaomi-native",
+      hostname: "token-plan-ams.xiaomimimo.com",
+    });
+    expectRecordFields(resolveProviderEndpoint("https://token-plan-cn.xiaomimimo.com/v1"), {
+      endpointClass: "xiaomi-native",
+      hostname: "token-plan-cn.xiaomimimo.com",
+    });
+    expectRecordFields(resolveProviderEndpoint("https://token-plan-sgp.xiaomimimo.com/v1"), {
+      endpointClass: "xiaomi-native",
+      hostname: "token-plan-sgp.xiaomimimo.com",
+    });
   });
 
   it("treats OpenRouter-hosted Responses routes as explicit proxy-like endpoints", () => {

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -54,6 +54,7 @@ export type ProviderEndpointClass =
   | "azure-openai"
   | "openrouter"
   | "xai-native"
+  | "xiaomi-native"
   | "zai-native"
   | "google-generative-ai"
   | "google-vertex"
@@ -149,6 +150,7 @@ const MANIFEST_PROVIDER_ENDPOINT_CLASSES = new Set<ProviderEndpointClass>([
   "azure-openai",
   "openrouter",
   "xai-native",
+  "xiaomi-native",
   "zai-native",
   "google-generative-ai",
   "google-vertex",

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -682,6 +682,7 @@ export function resolveProviderRequestCapabilities(
     endpointClass === "azure-openai" ||
     endpointClass === "openrouter" ||
     endpointClass === "xai-native" ||
+    endpointClass === "xiaomi-native" ||
     endpointClass === "zai-native" ||
     endpointClass === "google-generative-ai" ||
     endpointClass === "google-vertex";


### PR DESCRIPTION
# Fix: Xiaomi MiMo reasoning models fail on multi-turn tool calls

Closes #81419

## Summary

Xiaomi MiMo reasoning models (mimo-v2-pro, mimo-v2-omni, mimo-v2.5, mimo-v2.5-pro) return `400 Param Incorrect` ("provider rejected the request schema or tool payload") on any turn that replays a prior assistant message — for example the second turn of a tool-call conversation. MiMo uses the same OpenAI-compatible reasoning wire format as DeepSeek V4 and requires `reasoning_content` on every assistant message in the request payload. OpenClaw was never adding that field for MiMo.

The fix mirrors the existing DeepSeek V4 plumbing:

1. **`xiaomi-native` is now a first-class endpoint class** (`src/agents/provider-attribution.ts`) and recognized in `isKnownNativeEndpoint`. Manifest-driven host resolution maps the bundled host plus the three regional `token-plan-*.xiaomimimo.com` hosts (used by self-hosted/custom MiMo proxies) to that class.
2. **OpenAI-completions compat detection** (`src/agents/openai-completions-compat.ts`) now sets `thinkingFormat: "deepseek"` and `requiresReasoningContentOnAssistantMessages: true` for xiaomi-native endpoints, alongside the existing DeepSeek path.
3. **The bundled `xiaomi` plugin** (`extensions/xiaomi/`) registers `wrapStreamFn`, `resolveThinkingProfile`, `isModernModelRef`, and `buildProviderReplayFamilyHooks({ family: "openai-compatible", dropReasoningFromHistory: false })` — same shape as the DeepSeek plugin. Two new local helpers (`thinking.ts`, `stream.ts`) reuse the shared `createDeepSeekV4OpenAICompatibleThinkingWrapper` SDK helper rather than copying its logic.
4. **Core fallback wrapper for "unowned" proxies** (`src/agents/pi-embedded-runner/extra-params.ts`). When MiMo reasoning models are reached through a custom/proxy provider (e.g. a user-configured `xiaomi-orbit` provider pointing at `token-plan-ams.xiaomimimo.com`), the bundled `xiaomi` plugin's `wrapStreamFn` does not match. Core already has the same fallback pattern for DeepSeek V4 in this file; this PR adds the parallel MiMo matcher so the shared wrapper fires there too.

## What we found

### Original bug

User reported `FailoverError: LLM request failed: provider rejected the request schema or tool payload.` (`400 Param Incorrect`) when running mimo-v2.5-pro on a custom `xiaomi-orbit` provider pointed at `https://token-plan-ams.xiaomimimo.com/v1`. The failure consistently fired on the second model turn — i.e., the one that includes a replayed assistant message + tool result.

Root cause: pi-ai's openai-completions message converter does not inject `reasoning_content: ""` on assistant messages for MiMo because OpenClaw never marked MiMo as a DeepSeek-style reasoning provider. The DeepSeek bundled plugin handles this via a `wrapStreamFn` that calls `ensureDeepSeekV4AssistantReasoningContent` on every outgoing payload. MiMo had no equivalent.

### Code review findings (addressed in this PR)

A pre-PR self-review surfaced four issues, all fixed before this PR was opened:

- **Speculative model entries removed.** An earlier draft added `mimo-v2.5-flash`, `mimo-v2.5`, and `mimo-v2.5-pro` to the bundled catalog without confirming those IDs exist on Xiaomi's official `api.xiaomimimo.com`. The bundled manifest in this PR only ships the existing officially-documented models (`mimo-v2-flash`, `mimo-v2-pro`, `mimo-v2-omni`). The reasoning detection set in `extensions/xiaomi/thinking.ts` still recognizes the v2.5 IDs, so users who configure those via a custom provider (the bug-report case) still get correct reasoning treatment.
- **`xiaomi-native` added to `isKnownNativeEndpoint`** in `src/agents/provider-attribution.ts`. Matches the DeepSeek/xAI/zAI pattern.
- **`xiaomi-native` added to `isNonStandard`** in `src/agents/openai-completions-compat.ts`. Functionally consistent with the DeepSeek precedent.
- **Host-resolution coverage test** added in `src/agents/provider-attribution.test.ts` to lock in the `*.xiaomimimo.com` → `xiaomi-native` mapping.

### Live verification

After the first round of fixes (commits 1-7) the live test still failed: pi-ai does not actually read `requiresReasoningContentOnAssistantMessages` (the field appears only in pi-ai's static `models.generated.js`, not in any logic), and the bundled plugin's `wrapStreamFn` only fires when `model.provider === "xiaomi"` — not for the user's `xiaomi-orbit` custom provider. The core fallback in `applyPostPluginStreamWrappers` only matched DeepSeek V4 model IDs.

Commit 10 (`64df7f12dd`) added the MiMo matcher to the core fallback so the shared DeepSeek-style wrapper fires for MiMo reasoning IDs on any provider, including custom proxy providers. Live test then passed.

## Tests

- 13/13 pass in `src/agents/openai-completions-compat.test.ts` (5 new xiaomi cases)
- 8/8 pass in new `extensions/xiaomi/index.test.ts` (auth, catalog, replay policy, thinking profile, `isModernModelRef`, `reasoning_content` injection across thinking-on / thinking-off / cross-provider replay)
- New host-resolution assertions in `src/agents/provider-attribution.test.ts`
- `pnpm build` clean
- `pnpm check:changed` clean (lint, typecheck, import cycles)

---

## Real Behavior Proof

Behavior addressed: Xiaomi MiMo reasoning models (mimo-v2.5-pro on a `xiaomi-orbit` custom provider pointed at `https://token-plan-ams.xiaomimimo.com/v1`) returning `400 Param Incorrect` on any multi-turn / tool-call conversation. Reproduced before the fix; verified fixed after the fix.

Real environment tested: Linux desktop, OpenClaw gateway built from this branch (`fix/mimo-reasoning-content`), run via `pnpm dev gateway --force` on the same port (`18789`) the user normally uses, exercised through the live Telegram channel against a real MiMo backend with a real API key.

Exact steps or command run after this patch: Stopped the systemd-installed openclaw gateway, then started a dev gateway from this branch on the same port the user normally uses. Then, through the user's normal Telegram chat client, sent a message that selects `xiaomi-orbit / mimo-v2.5-pro` (reasoning enabled), prompts a `web_search` tool call, and requires a follow-up model turn after the tool result. Exact commands:

```
systemctl --user stop openclaw-gateway
OPENCLAW_GATEWAY_PORT=18789 OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1 pnpm dev gateway --force
```

Evidence after fix (relevant log lines, gateway log `/tmp/openclaw/openclaw-2026-05-13.log`):

```
2026-05-13T20:04:02.327-05:00 [gateway] log file: /tmp/openclaw/openclaw-2026-05-13.log
2026-05-13T20:04:02.560-05:00 [gateway] ready
2026-05-13T20:04:25.330-05:00 [ws] webchat connected
2026-05-13T20:04:56.414-05:00 [diagnostic] phase=channels.telegram.start-account
  work=[active=agent:main:main(processing/model_call,q=1,age=12s last=model_call:started) ...]
2026-05-13T20:05:15.546-05:00 [tools] web_search failed: Ollama web search authentication failed.
  raw_params={"query":"Esperanto language overview history","count":5,"freshness":"year"}
2026-05-13T20:05:52.507-05:00 [tools] web_search failed: Ollama web search authentication failed.
  raw_params={"query":"Esperanto language history overview facts","count":5,"language":"en"}
```

Pre-fix evidence (same gateway, same user, same provider, before the wrapper was wired):

```
2026-05-13T19:55:04.005-05:00 embedded_run_agent_end isError=true
  error="LLM request failed: provider rejected the request schema or tool payload."
  failoverReason=format model=mimo-v2.5-pro provider=xiaomi-orbit
  rawErrorPreview="400 Param Incorrect" providerRuntimeFailureKind=schema
2026-05-13T19:55:04.090-05:00 model_fallback_decision decision=candidate_failed
  requestedProvider=xiaomi-orbit requestedModel=mimo-v2.5-pro
  attempt=1 reason=format status=400 errorPreview="400 Param Incorrect"
```

Observed result after fix: The MiMo agent received the prompt, emitted a tool call (`web_search` for "Esperanto language overview history"), received the tool result, **then continued the conversation and emitted a second tool call** (`web_search` for "Esperanto language history overview facts"). That second tool call requires the model to receive the prior assistant message + tool result and reason about a new request — exactly the multi-turn scenario the bug regressed. No `FailoverError`, no `400 Param Incorrect`, no `provider rejected the request schema` in the log after the fix went live.

The `web_search failed: Ollama web search authentication failed` messages are an unrelated user-side configuration issue (Ollama needs `ollama signin`) — they show that the model did successfully emit valid tool-use payloads to the gateway and the gateway invoked the tool plugin.

What was not tested:

- Bundled `xiaomi` provider against `api.xiaomimimo.com` directly. The user only currently has a `xiaomi-orbit` custom provider configured. The bundled-provider path is exercised by the new unit tests in `extensions/xiaomi/index.test.ts` (auth, catalog, thinking profile, reasoning_content injection), but no live API hit. The core fallback wrapper test (`pi-embedded-runner-extraparams.test.ts` style) is logically covered by the existing DeepSeek "unowned proxy" precedent.
- TTS path unchanged and not re-verified live (the bundled `xiaomi.live.test.ts` for TTS is unmodified by this PR).
- DeepSeek behavior: not retested live in this session; protected by existing tests and unchanged code paths.

---

## AI assistance

This PR was developed with **Claude Sonnet 4.6** acting as a coding agent over a single working session, driving edits, builds, and tests through Claude Code. After the initial implementation, a self-review pass (also via Claude Sonnet 4.6) identified the four issues listed under "Code review findings" above; all four were fixed before this PR was opened. The live verification step caught a remaining gap (the compat-flag plumbing alone does not fix the bug because pi-ai does not consume that field) which was then resolved by adding the core fallback wrapper.

The human author (Jim Dawdy) reviewed the plan and the final diffs, supplied live API credentials and gateway access for real-environment proof, ran the Telegram chat that produced the post-fix evidence above, and is the named contributor for this change.  All blame falls on human shoulders.
