### PR TITLE
[codex] Route Telegram management commands to the control lane

### DIFF
--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -112,6 +112,28 @@ describe("getTelegramSequentialKey", () => {
     ],
     [{ message: mockMessage({ chat: mockChat({ id: 123 }), text: "/export" }) }, "telegram:123"],
     [
+      { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/steer keep going" }) },
+      "telegram:123:control",
+    ],
+    [
+      { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/tell keep going" }) },
+      "telegram:123:control",
+    ],
+    [
+      {
+        me: { username: "openclaw_bot" } as never,
+        message: mockMessage({
+          chat: mockChat({ id: 123 }),
+          text: "/steer@openclaw_bot keep going",
+        }),
+      },
+      "telegram:123:control",
+    ],
+    [
+      { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/queue steer 500ms 3" }) },
+      "telegram:123:control",
+    ],
+    [
       { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/btw what is the time?" }) },
       "telegram:123:btw:1",
     ],

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -49,6 +49,20 @@ function resolveStatusCommandControlLane(params: {
   return command?.category === "status" && command.key !== "export-session";
 }
 
+const IMMEDIATE_COMMAND_CONTROL_LANE_ALIASES = new Set(["/queue", "/steer"]);
+
+function resolveImmediateCommandControlLane(params: {
+  rawText?: string;
+  botUsername?: string;
+}): boolean {
+  const normalizedBody = normalizeCommandBody(
+    params.rawText?.trim() ?? "",
+    params.botUsername ? { botUsername: params.botUsername } : undefined,
+  );
+  const alias = maybeResolveTextAlias(normalizedBody);
+  return alias ? IMMEDIATE_COMMAND_CONTROL_LANE_ALIASES.has(alias) : false;
+}
+
 export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): string {
   const reaction = ctx.update?.message_reaction;
   if (reaction?.chat?.id) {
@@ -74,6 +88,12 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
     return "telegram:control";
   }
   if (resolveStatusCommandControlLane({ rawText, botUsername })) {
+    if (typeof chatId === "number") {
+      return `telegram:${chatId}:control`;
+    }
+    return "telegram:control";
+  }
+  if (resolveImmediateCommandControlLane({ rawText, botUsername })) {
     if (typeof chatId === "number") {
       return `telegram:${chatId}:control`;
     }


### PR DESCRIPTION
## Summary

Routes Telegram `/steer`, `/tell`, and `/queue` text commands onto the existing per-chat control sequentialization lane.

## Why

Telegram updates are sequentialized by chat/thread so normal messages do not race with each other. That is correct for conversational messages, but management commands that are intended to affect an active run should not wait behind the same long-running message they are trying to control.

`/stop` and status commands already bypass the normal chat lane. This gives `/steer`, its `/tell` alias, and `/queue` the same immediate lane behavior.

## Validation

- `vitest run extensions/telegram/src/sequential-key.test.ts`
- `oxfmt --check --threads=1 extensions/telegram/src/sequential-key.ts extensions/telegram/src/sequential-key.test.ts`
