### PR TITLE
[codex] Mark Codex compaction events completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/sessions: preserve fresh post-compaction token snapshots across stale usage updates, preventing repeated auto-compaction after every message. Fixes #82576. (#82578) Thanks @njuboy11.
 - Gateway/sessions: discard stale metadata when recreating dead main session rows, so replacement sessions do not inherit old labels or transcript paths.
+- Codex app-server: mark native context compaction completion events as successful, preventing false "Compaction incomplete" notices after successful Codex-managed compaction. Fixes #82470. (#81593) Thanks @Kyzcreig.
 - Gateway/WebChat: route image attachments through a configured vision-capable `imageModel` plan before inlining images, and carry that image-model fallback chain through runtime retries. (#82524) Thanks @frankekn.
 - WebChat: show progress while manual `/compact` is running by streaming a session operation event to subscribed Control UI clients. Fixes #82407. Thanks @Conan-Scott.
 - Codex app-server: limit canonical OpenAI Codex app-server attribution rewrites to local transcript and trajectory records, leaving runtime/tool routing on the selected OpenAI model metadata so OpenAI API-key backup profiles keep their billing path.

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1096,6 +1096,12 @@ describe("CodexAppServerEventProjector", () => {
     expect(findAgentEvent(onAgentEvent, { stream: "compaction", phase: "start" }).data.itemId).toBe(
       "compact-1",
     );
+    expect(findAgentEvent(onAgentEvent, { stream: "compaction", phase: "end" }).data).toMatchObject(
+      {
+        itemId: "compact-1",
+        completed: true,
+      },
+    );
     expect(result.toolMetas).toEqual([{ toolName: "sessions_send" }]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
       "user",

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -528,6 +528,7 @@ export class CodexAppServerEventProjector {
         data: {
           phase: "end",
           backend: "codex-app-server",
+          completed: true,
           threadId: this.threadId,
           turnId: this.turnId,
           itemId,

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadResumeResponse.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadResumeResponse.json
@@ -74,6 +74,14 @@
         }
       ]
     },
+    "runtimeWorkspaceRoots": {
+      "description": "Thread-scoped runtime workspace roots used to materialize `:workspace_roots`.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AbsolutePathBuf"
+      }
+    },
     "sandbox": {
       "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `permissionProfile` when they need exact runtime permissions.",
       "allOf": [
@@ -114,41 +122,8 @@
         "id": {
           "description": "Identifier from `default_permissions` or the implicit built-in default, such as `:workspace` or a user-defined `[permissions.<id>]` profile.",
           "type": "string"
-        },
-        "modifications": {
-          "description": "Bounded user-requested modifications applied on top of the named profile, if any.",
-          "default": [],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ActivePermissionProfileModification"
-          }
         }
       }
-    },
-    "ActivePermissionProfileModification": {
-      "oneOf": [
-        {
-          "description": "Additional concrete directory that should be writable.",
-          "type": "object",
-          "required": [
-            "path",
-            "type"
-          ],
-          "properties": {
-            "path": {
-              "$ref": "#/definitions/AbsolutePathBuf"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "additionalWritableRoot"
-              ],
-              "title": "AdditionalWritableRootActivePermissionProfileModificationType"
-            }
-          },
-          "title": "AdditionalWritableRootActivePermissionProfileModification"
-        }
-      ]
     },
     "AgentPath": {
       "type": "string"

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadStartResponse.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadStartResponse.json
@@ -74,6 +74,14 @@
         }
       ]
     },
+    "runtimeWorkspaceRoots": {
+      "description": "Thread-scoped runtime workspace roots used to materialize `:workspace_roots`.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AbsolutePathBuf"
+      }
+    },
     "sandbox": {
       "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `permissionProfile` when they need exact runtime permissions.",
       "allOf": [
@@ -114,41 +122,8 @@
         "id": {
           "description": "Identifier from `default_permissions` or the implicit built-in default, such as `:workspace` or a user-defined `[permissions.<id>]` profile.",
           "type": "string"
-        },
-        "modifications": {
-          "description": "Bounded user-requested modifications applied on top of the named profile, if any.",
-          "default": [],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ActivePermissionProfileModification"
-          }
         }
       }
-    },
-    "ActivePermissionProfileModification": {
-      "oneOf": [
-        {
-          "description": "Additional concrete directory that should be writable.",
-          "type": "object",
-          "required": [
-            "path",
-            "type"
-          ],
-          "properties": {
-            "path": {
-              "$ref": "#/definitions/AbsolutePathBuf"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "additionalWritableRoot"
-              ],
-              "title": "AdditionalWritableRootActivePermissionProfileModificationType"
-            }
-          },
-          "title": "AdditionalWritableRootActivePermissionProfileModification"
-        }
-      ]
     },
     "AgentPath": {
       "type": "string"

--- a/scripts/check-codex-app-server-protocol.ts
+++ b/scripts/check-codex-app-server-protocol.ts
@@ -44,7 +44,7 @@ const checks: Array<{ file: string; snippets: string[] }> = [
   {
     file: "v2/ThreadStartParams.ts",
     snippets: [
-      "permissions?: PermissionProfileSelectionParams | null",
+      "permissions?: string | null",
       "dynamicTools?: Array<DynamicToolSpec> | null",
       "experimentalRawEvents: boolean",
       "persistExtendedHistory: boolean",
@@ -52,10 +52,7 @@ const checks: Array<{ file: string; snippets: string[] }> = [
   },
   {
     file: "v2/TurnStartParams.ts",
-    snippets: [
-      "permissions?: PermissionProfileSelectionParams | null",
-      "serviceTier?: string | null",
-    ],
+    snippets: ["permissions?: string | null", "serviceTier?: string | null"],
   },
   {
     file: "ReviewDecision.ts",


### PR DESCRIPTION
## Summary

Marks Codex app-server compaction end events as completed.

Also syncs the checked Codex app-server protocol mirror with the current upstream schema so the protocol drift check passes again.

## Why

The run-level compaction bookkeeping treats a compaction end event as successful only when `evt.data.completed === true`. The Codex app-server event projector increments its local completed-compaction count when a `contextCompaction` item completes, but the emitted `compaction` end event did not carry the completion flag.

Adding the flag keeps the emitted event contract aligned with the runner's completion check.

## Real behavior proof

Behavior addressed: Codex app-server contextCompaction item completion now emits a compaction end event with completed=true, preventing false incomplete-compaction bookkeeping and notices.

Real environment tested: Local OpenClaw checkout against ../codex protocol schema, plus focused OpenClaw test lanes. Upstream Codex checkout observed at 7fa0007ea8.

Exact steps or command run after this patch: pnpm codex-app-server:protocol:check; pnpm test extensions/codex/src/app-server/event-projector.test.ts; pnpm test src/auto-reply/reply/agent-runner-execution.test.ts -- -t compaction; pnpm oxfmt --check --threads=1 CHANGELOG.md scripts/check-codex-app-server-protocol.ts extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts; git diff --check; /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode branch.

Evidence after fix: protocol check reported the generated protocol matches OpenClaw bridge assumptions; event-projector test file passed 43 tests; agent-runner compaction-filtered test passed 7 tests; oxfmt and git diff checks passed; Codex review reported no accepted/actionable findings.

Observed result after fix: the projected compaction end event includes completed=true while preserving the existing contextCompaction item lifecycle and hook behavior.

What was not tested: Full release/build suite locally; PR CI is the broad proof gate on the pushed head.

## Verification

- pnpm codex-app-server:protocol:check
- pnpm test extensions/codex/src/app-server/event-projector.test.ts
- pnpm test src/auto-reply/reply/agent-runner-execution.test.ts -- -t compaction
- pnpm oxfmt --check --threads=1 CHANGELOG.md scripts/check-codex-app-server-protocol.ts extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts
- git diff --check
- /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode branch
