### PR TITLE
fix(telegram): expose CLI thread remap

### DIFF
--- a/extensions/telegram/src/channel-actions.contract.test.ts
+++ b/extensions/telegram/src/channel-actions.contract.test.ts
@@ -1,6 +1,6 @@
 import { installChannelActionsContractSuite } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { telegramPlugin } from "../api.js";
 
 describe("telegram actions contract", () => {
@@ -20,5 +20,25 @@ describe("telegram actions contract", () => {
         expectedCapabilities: ["delivery-pin", "presentation"],
       },
     ],
+  });
+
+  it("remaps CLI thread-create requests to Telegram topic-create", () => {
+    const request = telegramPlugin.actions?.resolveCliActionRequest?.({
+      action: "thread-create",
+      args: {
+        channel: "telegram",
+        target: "-100123",
+        threadName: "Build Updates",
+      },
+    });
+
+    expect(request).toEqual({
+      action: "topic-create",
+      args: {
+        channel: "telegram",
+        target: "-100123",
+        name: "Build Updates",
+      },
+    });
   });
 });

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -221,6 +221,14 @@ const telegramMessageActions: ChannelMessageActionAdapter = {
     getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.resolveExecutionMode?.(ctx) ??
     telegramMessageActionsImpl.resolveExecutionMode?.(ctx) ??
     "gateway",
+  resolveCliActionRequest: (ctx) =>
+    getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.resolveCliActionRequest?.(
+      ctx,
+    ) ??
+    telegramMessageActionsImpl.resolveCliActionRequest?.(ctx) ?? {
+      action: ctx.action,
+      args: ctx.args,
+    },
   describeMessageTool: (ctx) =>
     getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.describeMessageTool?.(ctx) ??
     telegramMessageActionsImpl.describeMessageTool?.(ctx) ??


### PR DESCRIPTION
## Summary
- forward Telegram's channel-owned `resolveCliActionRequest` through the exported Telegram plugin actions adapter
- preserve the existing default action/args behavior when no runtime or static remap exists
- add a plugin-surface contract test proving CLI `thread-create` remaps to Telegram `topic-create`

Fixes #81581.

## Verification
- pnpm exec oxfmt --check extensions/telegram/src/channel.ts extensions/telegram/src/channel-actions.contract.test.ts
- pnpm vitest run extensions/telegram/src/channel-actions.contract.test.ts src/cli/program/message/register.thread.test.ts
- pnpm check:changed
- git diff --check

## Real behavior proof

Behavior addressed: Before this patch, the static Telegram action implementation contained the `thread-create` -> `topic-create` remap, but the exported `telegramPlugin.actions` wrapper did not expose `resolveCliActionRequest`. The shared CLI asks the exported channel plugin for the remap, so Telegram thread creation could fall through as bare `thread-create` and reach the gateway unsupported.

Real setup tested: Local OpenClaw checkout at `/home/chenglunhu/code/openclaw`, branch `fix/telegram-thread-create-cli-remap-81581`, commit `1a534aa741cf0a7f65358e5d159d357d9e9f1822`, using the real `registerMessageThreadCommands` CLI registration and exported `telegramPlugin` action surface through `pnpm exec tsx`.

Exact steps or command run after the patch: Registered the exported Telegram plugin in a test registry, registered the real `message thread create` command, parsed `thread create --channel telegram -t -1003894873578 --thread-name "Test topic" --json`, and captured the action/options that the CLI would dispatch.

Evidence after fix: Terminal output from the live command:

```text
{
  "action": "topic-create",
  "target": "-1003894873578",
  "name": "Test topic",
  "hasThreadName": false
}
```

Observed result after fix: The CLI dispatch target is `topic-create`, the Telegram forum topic name is mapped to `name`, and the generic `threadName` field is removed before gateway dispatch. This is the action shape the Telegram runtime already supports.

Not tested: I did not call the live Telegram Bot API; the reporter already verified raw `createForumTopic` works and the bug is in OpenClaw's CLI/plugin dispatch boundary.

## Scout audit
- Audit A (existing helper): existing remap helper found in `extensions/telegram/src/channel-actions.ts`; reused by forwarding it through the exported wrapper.
- Audit B (shared callers): no shared helper contract changed; `ChannelMessageActionAdapter.resolveCliActionRequest` contract preserved with default `{ action, args }` fallback.
- Audit C (broader rival): `gh pr list --search "81581 in:body"` found no open rival PR.