### PR TITLE
fix(migrate): swap glyphs on manual-review and archive item rows

### DIFF
--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -39,7 +39,7 @@ const ITEM_GROUPS: ItemGroup[] = [
   { kind: "memory", heading: "Memory:" },
   { kind: "secret", heading: "Secrets:" },
   { kind: "archive", heading: "Archive:" },
-  { kind: "manual", heading: "🔍 Manual review:" },
+  { kind: "manual", heading: "Manual review:" },
 ];
 
 const HIDDEN_KINDS = new Set(["config"]);
@@ -178,6 +178,12 @@ const RESULT_STATUS_GLYPHS: Record<string, string> = {
 };
 
 function formatItemPrefix(item: MigrationItem, mode: FormatMode): string {
+  // Manual-review items are technically status:"skipped", but rendering them
+  // with the skip glyph reads like "done, ignored". Use a magnifying glass to
+  // signal "look closer here" instead.
+  if (item.kind === "manual") {
+    return "🔍 ";
+  }
   if (mode === "result") {
     const glyph = RESULT_STATUS_GLYPHS[item.status];
     if (glyph) {

--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -184,6 +184,12 @@ function formatItemPrefix(item: MigrationItem, mode: FormatMode): string {
   if (item.kind === "manual") {
     return "🔍 ";
   }
+  // Archive items get status "migrated" once written to the report directory,
+  // but the ✅ glyph overstates what happened — the file was saved aside, not
+  // imported. A book signals "filed away for later reference".
+  if (item.kind === "archive") {
+    return "📖 ";
+  }
   if (mode === "result") {
     const glyph = RESULT_STATUS_GLYPHS[item.status];
     if (glyph) {

--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -178,15 +178,9 @@ const RESULT_STATUS_GLYPHS: Record<string, string> = {
 };
 
 function formatItemPrefix(item: MigrationItem, mode: FormatMode): string {
-  // Manual-review items are technically status:"skipped", but rendering them
-  // with the skip glyph reads like "done, ignored". Use a magnifying glass to
-  // signal "look closer here" instead.
   if (item.kind === "manual") {
     return "🔍 ";
   }
-  // Archive items get status "migrated" once written to the report directory,
-  // but the ✅ glyph overstates what happened — the file was saved aside, not
-  // imported. A book signals "filed away for later reference".
   if (item.kind === "archive") {
     return "📖 ";
   }

--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -39,7 +39,7 @@ const ITEM_GROUPS: ItemGroup[] = [
   { kind: "memory", heading: "Memory:" },
   { kind: "secret", heading: "Secrets:" },
   { kind: "archive", heading: "Archive:" },
-  { kind: "manual", heading: "Manual review:" },
+  { kind: "manual", heading: "🔍 Manual review:" },
 ];
 
 const HIDDEN_KINDS = new Set(["config"]);


### PR DESCRIPTION
## Summary
Two per-item glyph fixes in the `openclaw migrate` plan/result rendering:

1. **Manual-review items** (`kind: "manual"`) used to render with `⏭️` because they carry `status: "skipped"`. That reads like *done, ignored* — exactly the wrong signal for items that still need user attention. Render with `🔍` instead so the row says *look closer here*.

2. **Archive items** (`kind: "archive"`) used to render with `✅` once written to the report dir, which overstates what happened — the file was saved aside, not imported. Render with `📖` so the row reads *filed away for later reference*.

## Verification
- `pnpm openclaw migrate codex` (preview + apply):
  - Skill/plugin rows continue to render with their status glyphs (✅ ❌ ⏭️ ⚠️) unchanged.
  - Manual-review rows render as `🔍 <name> (<message>)`.
  - Archive rows render as `📖 <name> (<message>)`.
  - JSON output (`--json`) is unaffected — change is in display-prefix only.

## Affected surface
- `src/commands/migrate/output.ts` only — `formatItemPrefix`, kind-specific overrides.