### PR TITLE
[codex] Tolerate unsupported ACP timeout config hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACP: treat rejected timeout config options as best-effort hints so ACP turns continue with adapters that do not support `session/set_config_option` timeout keys. Fixes #81250. (#81603) Thanks @qkal.
 - Cron/Codex: default exact-command scheduled agent turns to lightweight bootstrap context so automation runs the command before loading workspace identity or memory context.
 - Codex plugin/Gateway: strip unpaired UTF-16 surrogates from Codex app-server JSON-RPC payloads and let stale reply-work recovery abort stalled reply runs, preventing malformed media turns from wedging gateway lanes.
 - Codex app server: force OAuth refresh requests to perform a real token refresh instead of reusing unchanged inherited auth-profile tokens after refresh failures. (#80738) Thanks @simplyclever914.

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -269,6 +269,8 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/acp-runtime` | ACP runtime/session and reply-dispatch helpers |
     | `plugin-sdk/acp-runtime-backend` | Lightweight ACP backend registration and reply-dispatch helpers for startup-loaded plugins |
     | `plugin-sdk/acp-binding-resolve-runtime` | Read-only ACP binding resolution without lifecycle startup imports |
+    | `plugin-sdk/codex-mcp-projection` | Reserved bundled Codex helper for projecting user MCP server config into Codex app-server thread config; not for third-party plugins |
+    | `plugin-sdk/codex-native-task-runtime` | Reserved bundled Codex helper for mirroring native Codex tasks into OpenClaw task registry; not for third-party plugins |
     | `plugin-sdk/agent-config-primitives` | Narrow agent runtime config-schema primitives |
     | `plugin-sdk/boolean-param` | Loose boolean param reader |
     | `plugin-sdk/dangerous-name-runtime` | Dangerous-name matching resolution helpers |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -269,8 +269,6 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/acp-runtime` | ACP runtime/session and reply-dispatch helpers |
     | `plugin-sdk/acp-runtime-backend` | Lightweight ACP backend registration and reply-dispatch helpers for startup-loaded plugins |
     | `plugin-sdk/acp-binding-resolve-runtime` | Read-only ACP binding resolution without lifecycle startup imports |
-    | `plugin-sdk/codex-mcp-projection` | Reserved bundled Codex helper for projecting user MCP server config into Codex app-server thread config; not for third-party plugins |
-    | `plugin-sdk/codex-native-task-runtime` | Reserved bundled Codex helper for mirroring native Codex tasks into OpenClaw task registry; not for third-party plugins |
     | `plugin-sdk/agent-config-primitives` | Narrow agent runtime config-schema primitives |
     | `plugin-sdk/boolean-param` | Loose boolean param reader |
     | `plugin-sdk/dangerous-name-runtime` | Dangerous-name matching resolution helpers |

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -16,6 +16,8 @@ import {
   resolveRuntimeOptionsFromMeta,
 } from "./runtime-options.js";
 
+const OPTIONAL_TIMEOUT_CONFIG_KEYS = new Set(["timeout", "timeout_seconds"]);
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -43,6 +45,10 @@ function extractRuntimeStatusConfigOptionKeys(status: AcpRuntimeStatus | undefin
     ...extractConfigOptionKeys(details?.configOptions),
     ...extractConfigOptionKeys(details?.config_options),
   ];
+}
+
+function isOptionalTimeoutConfigKey(key: string): boolean {
+  return OPTIONAL_TIMEOUT_CONFIG_KEYS.has(normalizeLowercaseStringOrEmpty(key));
 }
 
 export async function resolveManagerRuntimeCapabilities(params: {
@@ -159,11 +165,18 @@ export async function applyManagerRuntimeControls(params: {
               `ACP backend "${backend}" does not accept config key "${key}".`,
             );
           }
-          await params.runtime.setConfigOption({
-            handle: params.handle,
-            key,
-            value,
-          });
+          try {
+            await params.runtime.setConfigOption({
+              handle: params.handle,
+              key,
+              value,
+            });
+          } catch (error) {
+            if (isOptionalTimeoutConfigKey(key)) {
+              continue;
+            }
+            throw error;
+          }
         }
       }
     },

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -51,6 +51,27 @@ function isOptionalTimeoutConfigKey(key: string): boolean {
   return OPTIONAL_TIMEOUT_CONFIG_KEYS.has(normalizeLowercaseStringOrEmpty(key));
 }
 
+function isUnsupportedOptionalTimeoutConfigRejection(key: string, error: unknown): boolean {
+  if (!isOptionalTimeoutConfigKey(key)) {
+    return false;
+  }
+  const errorCode = error && typeof error === "object" ? (error as { code?: unknown }).code : null;
+  if (errorCode === "ACP_BACKEND_UNSUPPORTED_CONTROL") {
+    return true;
+  }
+  const message =
+    error instanceof Error ? error.message : typeof error === "string" ? error : String(error);
+  const normalized = normalizeLowercaseStringOrEmpty(message);
+  return (
+    normalized.includes("session/set_config_option") &&
+    (normalized.includes("-32602") ||
+      normalized.includes("invalid params") ||
+      normalized.includes("unsupported") ||
+      normalized.includes("not supported") ||
+      normalized.includes("not implement"))
+  );
+}
+
 export async function resolveManagerRuntimeCapabilities(params: {
   runtime: AcpRuntime;
   handle: AcpRuntimeHandle;
@@ -172,7 +193,7 @@ export async function applyManagerRuntimeControls(params: {
               value,
             });
           } catch (error) {
-            if (isOptionalTimeoutConfigKey(key)) {
+            if (isUnsupportedOptionalTimeoutConfigRejection(key, error)) {
               continue;
             }
             throw error;

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -3310,6 +3310,89 @@ describe("AcpSessionManager", () => {
     });
   });
 
+  it("continues turns when adapters reject optional timeout config", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.setConfigOption.mockImplementation(async (input: { key: string }) => {
+      if (input.key === "timeout") {
+        throw new AcpRuntimeError(
+          "ACP_TURN_FAILED",
+          'Agent rejected session/set_config_option for "timeout": ACP -32602 Invalid params',
+        );
+      }
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:opencode:acp:session-1",
+      storeSessionKey: "agent:opencode:acp:session-1",
+      acp: {
+        ...readySessionMeta({ agent: "opencode" }),
+        runtimeOptions: {
+          timeoutSeconds: 120,
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:opencode:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-opencode",
+    });
+
+    expectMockCallFields(runtimeState.setConfigOption, {
+      key: "timeout",
+      value: "120",
+    });
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails turns when adapters reject required runtime config", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.setConfigOption.mockImplementation(async (input: { key: string }) => {
+      if (input.key === "model") {
+        throw new AcpRuntimeError(
+          "ACP_TURN_FAILED",
+          'Agent rejected session/set_config_option for "model": ACP -32602 Invalid params',
+        );
+      }
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:opencode:acp:session-1",
+      storeSessionKey: "agent:opencode:acp:session-1",
+      acp: {
+        ...readySessionMeta({ agent: "opencode" }),
+        runtimeOptions: {
+          model: "opencode/gpt-5.4",
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await expectRejectedRecord(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:opencode:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-opencode",
+      }),
+      {
+        code: "ACP_TURN_FAILED",
+      },
+    );
+
+    expect(runtimeState.runTurn).not.toHaveBeenCalled();
+  });
+
   it("maps persisted thinking runtime options to advertised effort config keys before running turns", async () => {
     const runtimeState = createRuntime();
     runtimeState.getCapabilities.mockResolvedValue({

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -3351,6 +3351,49 @@ describe("AcpSessionManager", () => {
     expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
   });
 
+  it("fails turns when optional timeout config writes hit runtime failures", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.setConfigOption.mockImplementation(async (input: { key: string }) => {
+      if (input.key === "timeout") {
+        throw new AcpRuntimeError("ACP_BACKEND_UNAVAILABLE", "ACP backend unavailable");
+      }
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:opencode:acp:session-1",
+      storeSessionKey: "agent:opencode:acp:session-1",
+      acp: {
+        ...readySessionMeta({ agent: "opencode" }),
+        runtimeOptions: {
+          timeoutSeconds: 120,
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await expectRejectedRecord(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:opencode:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-opencode",
+      }),
+      {
+        code: "ACP_BACKEND_UNAVAILABLE",
+      },
+    );
+
+    expectMockCallFields(runtimeState.setConfigOption, {
+      key: "timeout",
+      value: "120",
+    });
+    expect(runtimeState.runTurn).not.toHaveBeenCalled();
+  });
+
   it("fails turns when adapters reject required runtime config", async () => {
     const runtimeState = createRuntime();
     runtimeState.setConfigOption.mockImplementation(async (input: { key: string }) => {


### PR DESCRIPTION
## Summary

- Treat ACP timeout config options as best-effort pre-turn hints when an adapter rejects them.
- Keep required runtime config options strict so model/thinking/permission failures still stop the turn.
- Add regression coverage for OpenCode-style timeout rejection and required config rejection.
- Document reserved Codex helper SDK subpaths so plugin contract shard D stays green.

Fixes #81250.

## Verification

- `pnpm test src/acp/control-plane/manager.test.ts -- --reporter=verbose -t "adapters reject"`
- `pnpm test extensions/acpx/src/runtime.test.ts -- --reporter=verbose -t "timeout config controls"`
- `pnpm test src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts -- --reporter=verbose -t "keeps plugin-owned SDK subpaths explicitly classified and documented"`
- `OPENCLAW_VITEST_INCLUDE_FILE=<temp shard-d include json> pnpm test:contracts:plugins`
- `pnpm check:changed`
- `git diff --check`

## Real behavior proof

Behavior addressed: ACP child sessions with adapters such as OpenCode no longer fail before conversation starts when the adapter rejects `session/set_config_option` for the optional `timeout` key.
Real environment tested: Local Windows checkout using commit `9235690c5f`; OpenCode CLI `1.14.48`; real OpenCode ACP server launched as `opencode --pure acp`; real upstream model `opencode-go/kimi-k2.6`; OpenClaw manager created a persistent `opencode` ACP session with `runtimeOptions.timeoutSeconds = 45`. The live proof harness delegated `ensureSession`, `setConfigOption`, and `runTurn` to the real OpenCode ACP runtime while withholding status-derived strict config keys so the manager exercised the OpenCode-style unknown-key contract that triggered this bug.
Exact steps or command run after this patch: Ran a `pnpm exec tsx -` proof script that instantiated `AcpxRuntime` with `createAgentRegistry({ overrides: { opencode: "opencode --pure acp" } })`, set `OPENCODE_CONFIG_CONTENT={"model":"opencode-go/kimi-k2.6"}`, called `AcpSessionManager.initializeSession(...)`, forced the manager to send `timeout=45`, logged the real OpenCode ACP rejection from `setConfigOption`, then called `AcpSessionManager.runTurn(...)` with prompt `Reply exactly: ACP_TIMEOUT_REJECTION_PROOF_OK`; then ran `pnpm test src/acp/control-plane/manager.test.ts -- --reporter=verbose -t "fails turns when adapters reject required runtime config|continues turns when adapters reject optional timeout config"`.
Evidence after fix: Terminal console output from the live OpenCode ACP rejection proof and focused manager regression rerun:

```text
$ @'<live proof script>'@ | pnpm exec tsx -
initialized: backend=acpx runtimeSession=acpx:v2:<redacted-session-handle>
set_config_attempt: key=timeout value=45
set_config_result: rejected key=timeout message=Agent rejected session/set_config_option for "timeout"="45": Invalid params (ACP -32602). The adapter may not implement session/set_config_option, or the requested value is not supported.
The user wants me to reply exactly with the string "ACP_TIMEOUT_REJECTION_PROOF_OK". This is a straightforward request that doesn't require any tools or file operations. I should just output that exact string.ACP_TIMEOUT_REJECTION_PROOF_OK
done_event: yes
observed_token: yes
events_seen: 50

$ pnpm test src/acp/control-plane/manager.test.ts -- --reporter=verbose -t "fails turns when adapters reject required runtime config|continues turns when adapters reject optional timeout config"
✓ |unit-fast| src/acp/control-plane/manager.test.ts > AcpSessionManager > continues turns when adapters reject optional timeout config 5ms
✓ |unit-fast| src/acp/control-plane/manager.test.ts > AcpSessionManager > fails turns when adapters reject required runtime config 6ms

Test Files  1 passed (1)
Tests  2 passed | 70 skipped (72)
[test] passed 1 Vitest shard in 5.56s
```

Observed result after fix: The real OpenCode ACP runtime rejected the optional `timeout` config with `ACP -32602`, the manager continued into a live OpenCode conversation, the turn emitted a terminal `done` event, and the assistant output included `ACP_TIMEOUT_REJECTION_PROOF_OK`. The focused negative regression still confirms required non-timeout runtime config failures stop before the turn.
What was not tested: The broader Docker gateway `/acp bind` lane was not run locally because this environment lacks the parent OpenAI auth used by that lane, and Crabbox/Testbox is not runnable from this checkout (`crabbox` absent from PATH and `pnpm crabbox:run` failed wrapper sanity checks). The direct live OpenCode ACP manager proof above covers the issue path.
