### PR TITLE
fix(telegram): forward resolveCliActionRequest in action wrapper

### DIFF
--- a/extensions/telegram/src/channel-actions.test.ts
+++ b/extensions/telegram/src/channel-actions.test.ts
@@ -314,4 +314,26 @@ describe("telegramMessageActions", () => {
       }
     }
   });
+
+  it("remaps thread-create to topic-create via resolveCliActionRequest", () => {
+    const result = telegramMessageActions.resolveCliActionRequest?.({
+      action: "thread-create",
+      args: { threadName: "Build Updates", target: "-100123", channel: "telegram" },
+    });
+    expect(result).toBeDefined();
+    expect(result!.action).toBe("topic-create");
+    expect(result!.args.name).toBe("Build Updates");
+    expect(result!.args.target).toBe("-100123");
+    expect(result!.args).not.toHaveProperty("threadName");
+  });
+
+  it("passes non-thread-create actions through resolveCliActionRequest unchanged", () => {
+    const result = telegramMessageActions.resolveCliActionRequest?.({
+      action: "send",
+      args: { message: "hello", target: "-100123" },
+    });
+    expect(result).toBeDefined();
+    expect(result!.action).toBe("send");
+    expect(result!.args.message).toBe("hello");
+  });
 });

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -217,6 +217,8 @@ const telegramMessageAdapter = createChannelMessageAdapterFromOutbound<OpenClawC
 });
 
 const telegramMessageActions: ChannelMessageActionAdapter = {
+  resolveCliActionRequest: (ctx) =>
+    telegramMessageActionsImpl.resolveCliActionRequest?.(ctx) ?? { action: ctx.action, args: ctx.args },
   resolveExecutionMode: (ctx) =>
     getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.resolveExecutionMode?.(ctx) ??
     telegramMessageActionsImpl.resolveExecutionMode?.(ctx) ??


### PR DESCRIPTION
## Summary

The `telegramMessageActions` wrapper in `channel.ts` delegates `resolveExecutionMode`, `describeMessageTool`, `extractToolSend`, and `handleAction` to the implementation in `channel-actions.ts`, but omits `resolveCliActionRequest`. This causes the CLI `thread-create` → `topic-create` remap to silently fail: `getChannelPlugin('telegram').actions.resolveCliActionRequest` is `undefined`, so the bare `thread-create` action reaches the gateway and is rejected as unsupported.

## Related Issue

Closes #81581

## Changes

- **`extensions/telegram/src/channel.ts`**: Add `resolveCliActionRequest` forwarding to the wrapper object, delegating to the existing implementation in `channel-actions.ts`
- **`extensions/telegram/src/channel-actions.test.ts`**: Add tests verifying the `thread-create` → `topic-create` remap and passthrough for other actions

## Testing

```
✓ channel-actions.test.ts (8 tests, all pass)
✓ register.thread.test.ts (2 tests, all pass)
```

## Real behavior proof

I don't have a Telegram bot configured to reproduce end-to-end. However, the root cause is verifiable by code inspection:

1. `register.thread.ts:10` calls `getChannelPlugin(channel)?.actions?.resolveCliActionRequest`
2. `channel.ts:219-244` defines the `telegramMessageActions` wrapper — before this fix, it had no `resolveCliActionRequest` property
3. Therefore, the optional chain always returned `undefined`, and the fallback at line 21 dispatched the bare `thread-create` action
4. `handleAction` in the same wrapper (line 234) calls `resolveTelegramMessageActionName(action)` which has no mapping for `thread-create` (only `topic-create`), throwing `Unsupported Telegram action: thread-create`

The fix adds the missing forwarding — the implementation in `channel-actions.ts:164` already handles the remap correctly and is covered by the new unit tests.

## CI Notes

- `checks-fast-contracts-plugins-d`: Pre-existing failure — `codex-mcp-projection` and `codex-native-task-runtime` are undocumented in the SDK guardrail test. Unrelated to this change.
- `Real behavior proof`: No Telegram bot available for live verification. Requesting `proof: override` if the code-level proof above is sufficient.