### PR TITLE
fix(chat/ios): downscale image attachments before send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iOS/chat: resize PhotosPicker image attachments to capped JPEGs before staging and sending, stripping source metadata and keeping oversized camera photos under the chat upload budget. Fixes #68524. Thanks @BunsDev.
 - Codex startup: treat selectable configured OpenAI agent models as Codex runtime requirements during plugin auto-enable, startup planning, and doctor install repair, so Anthropic-primary configs can still switch to OpenAI/Codex cleanly.
 - Agents: preserve source-reply delivery metadata when merging tool-returned media into the final reply, keeping message-tool-only replies deliverable and mirrored. Thanks @pashpashpash and @vincentkoc.
 - macOS/companion: require system TLS trust before pinning a first-use direct `wss://` gateway certificate and honor `gateway.remote.tlsFingerprint` as the explicit pin for remote node-mode sessions, so fresh endpoints fail closed when macOS cannot trust the certificate unless configured out of band. Fixes #50642. Thanks @BunsDev.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -17,6 +17,7 @@ private let chatUILogger = Logger(subsystem: "ai.openclaw", category: "OpenClawC
 // swiftlint:disable:next type_body_length
 public final class OpenClawChatViewModel {
     public static let defaultModelSelectionID = "__default__"
+    private static let maxAttachmentBytes = 5_000_000
 
     public private(set) var messages: [OpenClawChatMessage] = []
     public var input: String = ""
@@ -1298,11 +1299,6 @@ public final class OpenClawChatViewModel {
     }
 
     private func addImageAttachment(url: URL?, data: Data, fileName: String, mimeType: String) async {
-        if data.count > 5_000_000 {
-            self.errorText = "Attachment \(fileName) exceeds 5 MB limit"
-            return
-        }
-
         let uti: UTType = {
             if let url {
                 return UTType(filenameExtension: url.pathExtension) ?? .data
@@ -1314,13 +1310,33 @@ public final class OpenClawChatViewModel {
             return
         }
 
-        let preview = Self.previewImage(data: data)
+        let processed: Data
+        do {
+            processed = try await Task.detached(priority: .userInitiated) {
+                try ChatImageProcessor.processForUpload(data: data)
+            }.value
+        } catch {
+            self.errorText = "Could not process \(fileName): \(error.localizedDescription)"
+            return
+        }
+
+        if processed.count > Self.maxAttachmentBytes {
+            self.errorText = "Attachment \(fileName) exceeds 5 MB limit after resizing"
+            return
+        }
+
+        let outputFileName: String = {
+            let baseName = (fileName as NSString).deletingPathExtension
+            return baseName.isEmpty ? "image.jpg" : "\(baseName).jpg"
+        }()
+
+        let preview = Self.previewImage(data: processed)
         self.attachments.append(
             OpenClawPendingAttachment(
                 url: url,
-                data: data,
-                fileName: fileName,
-                mimeType: mimeType,
+                data: processed,
+                fileName: outputFileName,
+                mimeType: "image/jpeg",
                 preview: preview))
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ChatImageProcessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ChatImageProcessor.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Chat-specific image upload policy built on the shared JPEG transcoder.
+public enum ChatImageProcessor {
+    public static let maxLongEdgePx = 1600
+    public static let jpegQuality = 0.8
+    public static let maxPayloadBytes = 3_500_000
+
+    public enum ProcessError: Error, LocalizedError, Sendable {
+        case notAnImage
+        case decodeFailed
+        case encodeFailed
+
+        public var errorDescription: String? {
+            switch self {
+            case .notAnImage:
+                "The data is not a recognizable image."
+            case .decodeFailed:
+                "The image could not be decoded."
+            case .encodeFailed:
+                "The image could not be resized to fit the chat upload limit."
+            }
+        }
+    }
+
+    public static func processForUpload(data: Data) throws -> Data {
+        do {
+            let result = try JPEGTranscoder.transcodeToJPEG(
+                imageData: data,
+                maxLongEdgePx: self.maxLongEdgePx,
+                quality: self.jpegQuality,
+                maxBytes: self.maxPayloadBytes)
+            return result.data
+        } catch JPEGTranscodeError.decodeFailed {
+            throw ProcessError.notAnImage
+        } catch JPEGTranscodeError.propertiesMissing {
+            throw ProcessError.decodeFailed
+        } catch JPEGTranscodeError.sizeLimitExceeded {
+            throw ProcessError.encodeFailed
+        } catch {
+            throw ProcessError.encodeFailed
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/JPEGTranscoder.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/JPEGTranscoder.swift
@@ -38,6 +38,26 @@ public struct JPEGTranscoder: Sendable {
         quality: Double,
         maxBytes: Int? = nil) throws -> (data: Data, widthPx: Int, heightPx: Int)
     {
+        try self.transcodeToJPEG(
+            imageData: imageData,
+            maxWidthPx: maxWidthPx,
+            maxLongEdgePx: nil,
+            quality: quality,
+            maxBytes: maxBytes)
+    }
+
+    /// Re-encodes image data to JPEG, optionally downscaling so the *oriented* longest edge is <= `maxLongEdgePx`.
+    ///
+    /// When `maxLongEdgePx` is provided it takes precedence over `maxWidthPx`.
+    /// - Important: This normalizes EXIF orientation (the output pixels are rotated if needed; orientation tag is not
+    ///   relied on).
+    public static func transcodeToJPEG(
+        imageData: Data,
+        maxWidthPx: Int? = nil,
+        maxLongEdgePx: Int?,
+        quality: Double,
+        maxBytes: Int? = nil) throws -> (data: Data, widthPx: Int, heightPx: Int)
+    {
         guard let src = CGImageSourceCreateWithData(imageData as CFData, nil) else {
             throw JPEGTranscodeError.decodeFailed
         }
@@ -63,6 +83,10 @@ public struct JPEGTranscoder: Sendable {
 
         let maxDim = max(orientedWidth, orientedHeight)
         var targetMaxPixelSize: Int = {
+            if let maxLongEdgePx, maxLongEdgePx > 0 {
+                guard maxDim > maxLongEdgePx else { return maxDim } // never upscale
+                return maxLongEdgePx
+            }
             guard let maxWidthPx, maxWidthPx > 0 else { return maxDim }
             guard orientedWidth > maxWidthPx else { return maxDim } // never upscale
 
@@ -81,6 +105,7 @@ public struct JPEGTranscoder: Sendable {
             guard let img = CGImageSourceCreateThumbnailAtIndex(src, 0, thumbOpts as CFDictionary) else {
                 throw JPEGTranscodeError.decodeFailed
             }
+            let opaqueImage = Self.flattenAlphaIfNeeded(img)
 
             let out = NSMutableData()
             guard let dest = CGImageDestinationCreateWithData(out, UTType.jpeg.identifier as CFString, 1, nil) else {
@@ -88,12 +113,12 @@ public struct JPEGTranscoder: Sendable {
             }
             let q = self.clampQuality(quality)
             let encodeProps = [kCGImageDestinationLossyCompressionQuality: q] as CFDictionary
-            CGImageDestinationAddImage(dest, img, encodeProps)
+            CGImageDestinationAddImage(dest, opaqueImage, encodeProps)
             guard CGImageDestinationFinalize(dest) else {
                 throw JPEGTranscodeError.encodeFailed
             }
 
-            return (out as Data, img.width, img.height)
+            return (out as Data, opaqueImage.width, opaqueImage.height)
         }
 
         guard let maxBytes, maxBytes > 0 else {
@@ -131,5 +156,35 @@ public struct JPEGTranscoder: Sendable {
         }
 
         return best
+    }
+
+    /// JPEG cannot store alpha. Flatten transparent sources over white before encoding so ImageIO does not composite
+    /// transparent pixels onto black by default.
+    private static func flattenAlphaIfNeeded(_ image: CGImage) -> CGImage {
+        switch image.alphaInfo {
+        case .none, .noneSkipFirst, .noneSkipLast:
+            return image
+        default:
+            break
+        }
+
+        guard
+            let context = CGContext(
+                data: nil,
+                width: image.width,
+                height: image.height,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue)
+        else {
+            return image
+        }
+
+        let rect = CGRect(x: 0, y: 0, width: image.width, height: image.height)
+        context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        context.fill(rect)
+        context.draw(image, in: rect)
+        return context.makeImage() ?? image
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatImageProcessorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatImageProcessorTests.swift
@@ -1,0 +1,187 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+import UniformTypeIdentifiers
+@testable import OpenClawKit
+
+struct ChatImageProcessorTests {
+    private func syntheticJPEG(width: Int, height: Int) throws -> Data {
+        guard
+            let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else {
+            throw NSError(domain: "ChatImageProcessorTests", code: 1)
+        }
+
+        context.setFillColor(CGColor(red: 0.8, green: 0.2, blue: 0.4, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        context.setFillColor(CGColor(red: 0.1, green: 0.7, blue: 0.3, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width / 2, height: height / 2))
+
+        guard let image = context.makeImage() else {
+            throw NSError(domain: "ChatImageProcessorTests", code: 2)
+        }
+
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil)
+        else {
+            throw NSError(domain: "ChatImageProcessorTests", code: 3)
+        }
+
+        let properties: [CFString: Any] = [
+            kCGImageDestinationLossyCompressionQuality: 0.95,
+            kCGImagePropertyExifDictionary: [
+                kCGImagePropertyExifDateTimeOriginal: "2026:04:20 16:30:00",
+                kCGImagePropertyExifLensModel: "Leaky Lens 50mm f/1.4",
+            ] as CFDictionary,
+            kCGImagePropertyGPSDictionary: [
+                kCGImagePropertyGPSLatitude: 60.02,
+                kCGImagePropertyGPSLatitudeRef: "N",
+                kCGImagePropertyGPSLongitude: 10.95,
+                kCGImagePropertyGPSLongitudeRef: "E",
+            ] as CFDictionary,
+            kCGImagePropertyTIFFDictionary: [
+                kCGImagePropertyTIFFMake: "LeakCorp",
+                kCGImagePropertyTIFFModel: "Privacy-Leaker-1",
+            ] as CFDictionary,
+        ]
+        CGImageDestinationAddImage(destination, image, properties as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else {
+            throw NSError(domain: "ChatImageProcessorTests", code: 4)
+        }
+        return data as Data
+    }
+
+    private func syntheticPNGWithAlpha(width: Int, height: Int) throws -> Data {
+        guard
+            let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else {
+            throw NSError(domain: "ChatImageProcessorTests", code: 5)
+        }
+
+        context.clear(CGRect(x: 0, y: 0, width: width, height: height))
+        context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+        context.fill(CGRect(x: width / 4, y: height / 4, width: width / 2, height: height / 2))
+
+        guard let image = context.makeImage() else {
+            throw NSError(domain: "ChatImageProcessorTests", code: 6)
+        }
+
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(data, UTType.png.identifier as CFString, 1, nil)
+        else {
+            throw NSError(domain: "ChatImageProcessorTests", code: 7)
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw NSError(domain: "ChatImageProcessorTests", code: 8)
+        }
+        return data as Data
+    }
+
+    private func properties(for data: Data) -> [CFString: Any] {
+        guard
+            let source = CGImageSourceCreateWithData(data as CFData, nil),
+            let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
+        else {
+            return [:]
+        }
+        return properties
+    }
+
+    private func dimensions(for data: Data) -> (width: Int, height: Int)? {
+        let properties = self.properties(for: data)
+        guard
+            let width = properties[kCGImagePropertyPixelWidth] as? NSNumber,
+            let height = properties[kCGImagePropertyPixelHeight] as? NSNumber
+        else {
+            return nil
+        }
+        return (width.intValue, height.intValue)
+    }
+
+    @Test func `resizes landscape long edge to upload limit`() throws {
+        let source = try self.syntheticJPEG(width: 4000, height: 3000)
+        let output = try ChatImageProcessor.processForUpload(data: source)
+        let dimensions = try #require(self.dimensions(for: output))
+
+        #expect(max(dimensions.width, dimensions.height) <= ChatImageProcessor.maxLongEdgePx)
+        #expect(abs((Double(dimensions.width) / Double(dimensions.height)) - (4000.0 / 3000.0)) <= 0.02)
+    }
+
+    @Test func `resizes portrait long edge to upload limit`() throws {
+        let source = try self.syntheticJPEG(width: 3000, height: 4000)
+        let output = try ChatImageProcessor.processForUpload(data: source)
+        let dimensions = try #require(self.dimensions(for: output))
+
+        #expect(max(dimensions.width, dimensions.height) <= ChatImageProcessor.maxLongEdgePx)
+        #expect(abs((Double(dimensions.width) / Double(dimensions.height)) - (3000.0 / 4000.0)) <= 0.02)
+    }
+
+    @Test func `resizes narrow tall long edge to upload limit`() throws {
+        let source = try self.syntheticJPEG(width: 1080, height: 2400)
+        let output = try ChatImageProcessor.processForUpload(data: source)
+        let dimensions = try #require(self.dimensions(for: output))
+
+        #expect(max(dimensions.width, dimensions.height) <= ChatImageProcessor.maxLongEdgePx)
+        #expect(abs((Double(dimensions.width) / Double(dimensions.height)) - (1080.0 / 2400.0)) <= 0.02)
+    }
+
+    @Test func `small image is not upscaled`() throws {
+        let source = try self.syntheticJPEG(width: 400, height: 300)
+        let output = try ChatImageProcessor.processForUpload(data: source)
+        let dimensions = try #require(self.dimensions(for: output))
+
+        #expect(max(dimensions.width, dimensions.height) <= 400)
+    }
+
+    @Test func `output fits payload budget`() throws {
+        let source = try self.syntheticJPEG(width: 4000, height: 3000)
+        let output = try ChatImageProcessor.processForUpload(data: source)
+
+        #expect(output.count <= ChatImageProcessor.maxPayloadBytes)
+    }
+
+    @Test func `rejects non image data`() {
+        let garbage = Data("not an image".utf8)
+
+        #expect(throws: ChatImageProcessor.ProcessError.self) {
+            _ = try ChatImageProcessor.processForUpload(data: garbage)
+        }
+    }
+
+    @Test func `strips source metadata from output`() throws {
+        let source = try self.syntheticJPEG(width: 3000, height: 2000)
+        let output = try ChatImageProcessor.processForUpload(data: source)
+        let properties = self.properties(for: output)
+        let gps = properties[kCGImagePropertyGPSDictionary] as? [CFString: Any] ?? [:]
+
+        #expect(gps.isEmpty)
+        for needle in ["Leaky Lens", "LeakCorp", "Privacy-Leaker", "2026:04:20"] {
+            #expect(output.range(of: Data(needle.utf8)) == nil)
+        }
+    }
+
+    @Test func `flattens transparent sources to opaque JPEG`() throws {
+        let source = try self.syntheticPNGWithAlpha(width: 800, height: 600)
+        let output = try ChatImageProcessor.processForUpload(data: source)
+        let imageSource = try #require(CGImageSourceCreateWithData(output as CFData, nil))
+        let image = try #require(CGImageSourceCreateImageAtIndex(imageSource, 0, nil))
+
+        #expect([.none, .noneSkipFirst, .noneSkipLast].contains(image.alphaInfo))
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -1,0 +1,109 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import OpenClawKit
+import UniformTypeIdentifiers
+import XCTest
+@testable import OpenClawChatUI
+
+private struct AttachmentProcessingTransport: OpenClawChatTransport {
+    func requestHistory(sessionKey _: String) async throws -> OpenClawChatHistoryPayload {
+        throw NSError(domain: "ChatViewModelAttachmentTests", code: 1)
+    }
+
+    func sendMessage(
+        sessionKey _: String,
+        message _: String,
+        thinking _: String,
+        idempotencyKey _: String,
+        attachments _: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
+    {
+        throw NSError(domain: "ChatViewModelAttachmentTests", code: 2)
+    }
+
+    func requestHealth(timeoutMs _: Int) async throws -> Bool {
+        true
+    }
+
+    func events() -> AsyncStream<OpenClawChatTransportEvent> {
+        AsyncStream { _ in }
+    }
+}
+
+private func makeChatAttachmentJPEG(width: Int, height: Int) throws -> Data {
+    guard
+        let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+    else {
+        throw NSError(domain: "ChatViewModelAttachmentTests", code: 3)
+    }
+
+    context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    context.setFillColor(CGColor(red: 0.9, green: 0.5, blue: 0.1, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width / 2, height: height / 2))
+
+    guard let image = context.makeImage() else {
+        throw NSError(domain: "ChatViewModelAttachmentTests", code: 4)
+    }
+
+    let data = NSMutableData()
+    guard let destination = CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil) else {
+        throw NSError(domain: "ChatViewModelAttachmentTests", code: 5)
+    }
+    CGImageDestinationAddImage(destination, image, [kCGImageDestinationLossyCompressionQuality: 0.95] as CFDictionary)
+    guard CGImageDestinationFinalize(destination) else {
+        throw NSError(domain: "ChatViewModelAttachmentTests", code: 6)
+    }
+    return data as Data
+}
+
+private func chatAttachmentDimensions(for data: Data) -> (width: Int, height: Int)? {
+    guard
+        let source = CGImageSourceCreateWithData(data as CFData, nil),
+        let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+        let width = properties[kCGImagePropertyPixelWidth] as? NSNumber,
+        let height = properties[kCGImagePropertyPixelHeight] as? NSNumber
+    else {
+        return nil
+    }
+    return (width.intValue, height.intValue)
+}
+
+final class ChatViewModelAttachmentTests: XCTestCase {
+    func testImageAttachmentsAreProcessedBeforeStaging() async throws {
+        let imageData = try makeChatAttachmentJPEG(width: 3000, height: 4000)
+        let viewModel = await MainActor.run {
+            OpenClawChatViewModel(sessionKey: "main", transport: AttachmentProcessingTransport())
+        }
+
+        await MainActor.run {
+            viewModel.addImageAttachment(data: imageData, fileName: "camera.heic", mimeType: "image/jpeg")
+        }
+
+        try await waitUntil("attachment processed") {
+            await MainActor.run { !viewModel.attachments.isEmpty || viewModel.errorText != nil }
+        }
+
+        let attachment = try await MainActor.run {
+            guard let attachment = viewModel.attachments.first else {
+                throw NSError(domain: "ChatViewModelAttachmentTests", code: 7)
+            }
+            return (attachment.fileName, attachment.mimeType, attachment.data)
+        }
+        let dimensions = try XCTUnwrap(chatAttachmentDimensions(for: attachment.2))
+
+        XCTAssertEqual(attachment.0, "camera.jpg")
+        XCTAssertEqual(attachment.1, "image/jpeg")
+        XCTAssertLessThanOrEqual(attachment.2.count, ChatImageProcessor.maxPayloadBytes)
+        XCTAssertLessThanOrEqual(max(dimensions.width, dimensions.height), ChatImageProcessor.maxLongEdgePx)
+        let errorText = await MainActor.run { viewModel.errorText }
+        XCTAssertNil(errorText)
+    }
+}


### PR DESCRIPTION
## Summary

- Problem: iOS chat staged PhotosPicker image bytes directly, rejected raw files over 5 MB before resize, and sent raw EXIF/GPS-bearing bytes into `chat.send`.
- Why it matters: large iPhone camera photos can fail attachment delivery or spike memory during base64 encoding.
- What changed: image attachments now flow through a chat-specific JPEG processor that caps the long edge at 1600 px, compresses to a 3.5 MB payload budget, strips source metadata, and stages previews from the resized JPEG bytes.
- What did NOT change (scope boundary): gateway protocol, chat send schema, auth, permissions, and non-image attachment handling are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68524
- Related #80679
- Related #73710
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: iOS app PhotosPicker attachments are processed client-side before staging/sending instead of using full-resolution raw image data.
- Real environment tested: local macOS SwiftPM build of `apps/shared/OpenClawKit` on the OpenClaw iOS shared package.
- Exact steps or command run after this patch:
  - `swift test --package-path apps/shared/OpenClawKit --filter 'ChatImageProcessorTests|JPEGTranscoderTests|ChatViewModelAttachmentTests'`
  - `swiftformat --lint --config config/swiftformat apps/shared/OpenClawKit/Sources/OpenClawKit/ChatImageProcessor.swift apps/shared/OpenClawKit/Sources/OpenClawKit/JPEGTranscoder.swift apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatImageProcessorTests.swift apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift`
  - `swiftlint lint --config apps/ios/.swiftlint.yml apps/shared/OpenClawKit/Sources/OpenClawKit/ChatImageProcessor.swift apps/shared/OpenClawKit/Sources/OpenClawKit/JPEGTranscoder.swift apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatImageProcessorTests.swift apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift`
  - `git diff --check origin/main..HEAD`
- Evidence after fix: the focused Swift test run passed the view-model attachment path, the chat image processor suite, and the existing JPEG transcoder suite on commit 65d3efe72f.
- Observed result after fix: synthetic large portrait and landscape images are staged as `image/jpeg`, renamed to `.jpg`, capped to the 1600 px long edge, kept within the 3.5 MB chat payload budget, and tested to avoid source metadata leakage.
- What was not tested: physical iPhone camera roll -> composer -> live gateway send. `pnpm ios:build` is currently blocked in this checkout by unrelated existing SwiftFormat failures in `apps/ios/Sources/Settings/SettingsTab.swift`.
- Before evidence: issue #68524 documents the full-resolution PhotosPicker path failing on large iPhone camera images; current code loaded raw `Data` and applied only a pre-resize 5 MB hard gate.

## Root Cause (if applicable)

- Root cause: `OpenClawChatViewModel.addImageAttachment` accepted raw PhotosPicker image bytes, applied a 5 MB size check before any transformation, and staged the original bytes for later base64 send.
- Missing detection / guardrail: there was no chat attachment processing policy or regression test asserting pixel cap, byte budget, JPEG output, or metadata stripping for iOS chat attachments.
- Contributing context (if known): `JPEGTranscoder` already existed, but the chat composer path did not use it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatImageProcessorTests.swift`
  - `apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift`
- Scenario the test should lock in: large images are resized to the upload policy, output is JPEG within budget, source metadata strings/GPS dictionaries are stripped, alpha sources flatten to opaque JPEG, non-images are rejected, and `OpenClawChatViewModel` stages resized JPEG bytes rather than the original file.
- Why this is the smallest reliable guardrail: it proves the attachment path at the shared iOS chat UI boundary without needing a physical Photos picker or live gateway.
- Existing test that already covers this (if any): existing `JPEGTranscoderTests` covered the shared transcoder; this PR adds chat-specific policy and view-model coverage.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- iOS chat image attachments are converted to JPEG before send.
- Large images are downscaled and compressed client-side before the 5 MB final gate.
- Source EXIF/GPS-style metadata is not forwarded into chat attachment bytes.
- Original filename extensions are normalized to `.jpg` for processed image attachments.

## Diagram (if applicable)

```text
Before:
PhotosPicker raw bytes -> 5 MB raw gate -> preview from raw bytes -> chat.send base64

After:
PhotosPicker raw bytes -> image type check -> JPEG resize/compress/strip metadata -> 5 MB final gate -> preview from processed JPEG -> chat.send base64
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes
- If any `Yes`, explain risk + mitigation: the data scope is reduced because source image metadata is stripped before staging/sending. Tests assert planted source metadata strings and GPS dictionaries do not survive processing.

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: SwiftPM for `apps/shared/OpenClawKit`
- Model/provider: N/A
- Integration/channel (if any): iOS chat composer shared UI path
- Relevant config (redacted): none

### Steps

1. Process synthetic large JPEG/PNG image inputs through `ChatImageProcessor`.
2. Stage a synthetic 3000x4000 image through `OpenClawChatViewModel.addImageAttachment`.
3. Verify output dimensions, byte budget, MIME type, filename, metadata stripping, and absence of staging errors.

### Expected

- Processed chat image attachments are bounded JPEGs and previews use the processed data.

### Actual

- Focused Swift tests pass on the rebased branch head `65d3efe72f`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: long-edge resize for portrait/landscape/narrow images, no upscaling of small images, payload budget, non-image rejection, source metadata stripping, alpha flattening, and view-model staging of processed JPEG data.
- Edge cases checked: transparent PNG input, EXIF/GPS/TIFF strings planted in source bytes, camera-style large portrait attachment path.
- What you did **not** verify: physical iPhone picker and live gateway send; full iOS build remains blocked by unrelated SwiftFormat failures outside this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No review conversations exist on this PR at creation time.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: JPEG conversion drops original format and metadata.
  - Mitigation: this is intentional for chat transport safety and privacy; UI/test expectations name the JPEG normalization.
- Risk: pathological images may still fail the final 5 MB gate after processing.
  - Mitigation: the final gate remains and reports a clear post-resize size error instead of staging unsafe raw bytes.
