### PR TITLE
fix(steer): fallback to sibling direct/DM lanes when slash lane has no active run

### DIFF
--- a/src/auto-reply/reply/commands-steer.ts
+++ b/src/auto-reply/reply/commands-steer.ts
@@ -68,6 +68,20 @@ function resolveSteerSessionId(params: {
   const entry = resolveStoredSessionEntry(params.commandParams, params.targetSessionKey);
   const sessionId = normalizeOptionalString(entry?.sessionId);
   if (!sessionId || !isEmbeddedPiRunActive(sessionId)) {
+    // If the steer target is a slash lane but has no active run,
+    // try sibling direct/DM lanes that may have the active run instead.
+    if (params.targetSessionKey.includes(":slash:")) {
+      const siblingKeys = [
+        params.targetSessionKey.replace(":slash:", ":direct:"),
+        params.targetSessionKey.replace(":slash:", ":dm:"),
+      ];
+      for (const siblingKey of siblingKeys) {
+        const siblingId = resolveActiveEmbeddedRunSessionId(siblingKey);
+        if (siblingId) {
+          return siblingId;
+        }
+      }
+    }
     return undefined;
   }
   return sessionId;


### PR DESCRIPTION
## Summary

Fixes #81594

When `/steer` targets a slash-command session lane but no active embedded run exists there, the command reports "no active run" even though the user has an active run on the sibling direct/DM lane for the same peer.

## Root Cause

`resolveSteerSessionId()` in `src/auto-reply/reply/commands-steer.ts` only checks the resolved target session key. When the key resolves to a `:slash:` lane (because the `/steer` text command is dispatched through the slash lane), it finds no active run and gives up immediately, without checking sibling lanes.

## Fix

After the initial active-run lookup fails on the slash lane, check if the session key contains `:slash:` and try the corresponding `:direct:` and `:dm:` sibling keys. Return the first sibling with an active embedded run.

This matches the approach suggested in the issue and mirrors the pattern used by other channel dispatch paths (Telegram, Discord) where the active run lives on the direct/DM lane.

## Testing

- Code reviewed line-by-line against the existing session resolution pattern
- Logic verified: only falls back when the original target is a slash lane AND has no active run
- No side effects: if neither sibling has an active run, existing behavior (return undefined → fallback prompt) is preserved

## AI-assisted

This PR was written with AI assistance. I have reviewed and understand every line of the change.