### PR TITLE
fix(minimax): parse thinking-first model run responses

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -581,6 +581,79 @@ describe("anthropic transport stream", () => {
     expect(result.usage.output).toBe(9);
   });
 
+  it("extracts MiniMax text after thinking blocks and calculates usage cost", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_minimax", usage: { input_tokens: 48, output_tokens: 0 } },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "thinking",
+            thinking: "Need a direct answer.",
+            signature: "sig_1",
+          },
+        },
+        {
+          type: "content_block_stop",
+          index: 0,
+        },
+        {
+          type: "content_block_start",
+          index: 1,
+          content_block: { type: "text", text: "pong" },
+        },
+        {
+          type: "content_block_stop",
+          index: 1,
+        },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 48, output_tokens: 38 },
+        },
+      ]),
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        {
+          id: "MiniMax-M2.7-highspeed",
+          name: "MiniMax M2.7 Highspeed",
+          api: "anthropic-messages",
+          provider: "minimax-portal",
+          baseUrl: "https://api.minimax.io/anthropic/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 204800,
+          maxTokens: 131072,
+          headers: { Authorization: "Bearer oauth-token" },
+        } satisfies AnthropicMessagesModel,
+        {
+          messages: [{ role: "user", content: "Reply with pong" }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "oauth-token",
+          maxTokens: 1024,
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content[1]).toEqual({ type: "text", text: "pong" });
+    expect(result.usage.input).toBe(48);
+    expect(result.usage.output).toBe(38);
+    expect(result.usage.cost.total).toBeGreaterThan(0);
+    const [url, init] = guardedFetchCall();
+    expect(url).toBe("https://api.minimax.io/anthropic/v1/messages");
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer oauth-token");
+    expect(latestAnthropicRequest().payload.max_tokens).toBe(1024);
+  });
+
   it("recovers orphan text deltas when an Anthropic-compatible provider omits block start", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -6,6 +6,7 @@ const hoisted = vi.hoisted(() => ({
   resolveModelMock: vi.fn(),
   resolveModelAsyncMock: vi.fn(),
   getApiKeyForModelMock: vi.fn(),
+  applyAuthHeaderOverrideMock: vi.fn((model: unknown) => model),
   applyLocalNoAuthHeaderOverrideMock: vi.fn(),
   setRuntimeApiKeyMock: vi.fn(),
   resolveCopilotApiTokenMock: vi.fn(),
@@ -29,6 +30,7 @@ vi.mock("./simple-completion-transport.js", () => ({
 
 vi.mock("./model-auth.js", () => ({
   getApiKeyForModel: hoisted.getApiKeyForModelMock,
+  applyAuthHeaderOverride: hoisted.applyAuthHeaderOverrideMock,
   applyLocalNoAuthHeaderOverride: hoisted.applyLocalNoAuthHeaderOverrideMock,
 }));
 
@@ -53,9 +55,11 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  vi.unstubAllGlobals();
   hoisted.resolveModelMock.mockReset();
   hoisted.resolveModelAsyncMock.mockReset();
   hoisted.getApiKeyForModelMock.mockReset();
+  hoisted.applyAuthHeaderOverrideMock.mockReset();
   hoisted.applyLocalNoAuthHeaderOverrideMock.mockReset();
   hoisted.setRuntimeApiKeyMock.mockReset();
   hoisted.resolveCopilotApiTokenMock.mockReset();
@@ -63,6 +67,7 @@ beforeEach(() => {
   hoisted.prepareModelForSimpleCompletionMock.mockReset();
   hoisted.completeMock.mockReset();
 
+  hoisted.applyAuthHeaderOverrideMock.mockImplementation((model: unknown) => model);
   hoisted.applyLocalNoAuthHeaderOverrideMock.mockImplementation((model: unknown) => model);
   hoisted.prepareModelForSimpleCompletionMock.mockImplementation(
     (params: { model: unknown }) => params.model,

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -12,6 +12,7 @@ import { resolveAgentDir, resolveAgentEffectiveModelPrimary } from "./agent-scop
 import { DEFAULT_PROVIDER } from "./defaults.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import {
+  applyAuthHeaderOverride,
   applyLocalNoAuthHeaderOverride,
   getApiKeyForModel,
   type ResolvedProviderAuth,
@@ -268,7 +269,10 @@ export async function prepareSimpleCompletionModel(params: {
   };
 
   return {
-    model: applyLocalNoAuthHeaderOverride(resolvedModel, resolvedAuth),
+    model: applyLocalNoAuthHeaderOverride(
+      applyAuthHeaderOverride(resolvedModel, resolvedAuth, params.cfg),
+      resolvedAuth,
+    ),
     auth: resolvedAuth,
   };
 }

--- a/src/agents/simple-completion-transport.test.ts
+++ b/src/agents/simple-completion-transport.test.ts
@@ -6,7 +6,9 @@ const createAnthropicVertexStreamFnForModel = vi.fn();
 const ensureCustomApiRegistered = vi.fn();
 const resolveProviderStreamFn = vi.fn();
 const buildTransportAwareSimpleStreamFn = vi.fn();
+const createOpenClawTransportStreamFnForModel = vi.fn();
 const prepareTransportAwareSimpleModel = vi.fn();
+const resolveTransportAwareSimpleApi = vi.fn();
 
 vi.mock("./anthropic-vertex-stream.js", () => ({
   createAnthropicVertexStreamFnForModel,
@@ -18,7 +20,9 @@ vi.mock("./custom-api-registry.js", () => ({
 
 vi.mock("./provider-transport-stream.js", () => ({
   buildTransportAwareSimpleStreamFn,
+  createOpenClawTransportStreamFnForModel,
   prepareTransportAwareSimpleModel,
+  resolveTransportAwareSimpleApi,
 }));
 
 vi.mock("../plugins/provider-runtime.js", async () => {
@@ -47,7 +51,11 @@ describe("prepareModelForSimpleCompletion", () => {
     createAnthropicVertexStreamFnForModel.mockReturnValue("vertex-stream");
     resolveProviderStreamFn.mockReturnValue("ollama-stream");
     buildTransportAwareSimpleStreamFn.mockReturnValue(undefined);
+    createOpenClawTransportStreamFnForModel.mockReset();
+    createOpenClawTransportStreamFnForModel.mockReturnValue("openclaw-transport-stream");
     prepareTransportAwareSimpleModel.mockImplementation((model) => model);
+    resolveTransportAwareSimpleApi.mockReset();
+    resolveTransportAwareSimpleApi.mockReturnValue("openclaw-anthropic-messages-transport");
   });
 
   it("registers the configured Ollama transport and keeps the original api", () => {
@@ -158,6 +166,38 @@ describe("prepareModelForSimpleCompletion", () => {
     expect(result).toEqual({
       ...model,
       api: "openclaw-openai-responses-transport",
+    });
+  });
+
+  it("uses the OpenClaw Anthropic transport for MiniMax simple completions", () => {
+    const model: Model<"anthropic-messages"> = {
+      id: "MiniMax-M2.7-highspeed",
+      name: "MiniMax M2.7 Highspeed",
+      api: "anthropic-messages",
+      provider: "minimax-portal",
+      baseUrl: "https://api.minimax.io/anthropic",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 204800,
+      maxTokens: 131072,
+    };
+
+    resolveProviderStreamFn.mockReturnValueOnce(undefined);
+
+    const result = prepareModelForSimpleCompletion({ model });
+
+    expect(createOpenClawTransportStreamFnForModel).toHaveBeenCalledWith(model, {
+      cfg: undefined,
+    });
+    expect(resolveTransportAwareSimpleApi).toHaveBeenCalledWith("anthropic-messages");
+    expect(ensureCustomApiRegistered).toHaveBeenCalledWith(
+      "openclaw-anthropic-messages-transport",
+      "openclaw-transport-stream",
+    );
+    expect(result).toEqual({
+      ...model,
+      api: "openclaw-anthropic-messages-transport",
     });
   });
 });

--- a/src/agents/simple-completion-transport.ts
+++ b/src/agents/simple-completion-transport.ts
@@ -5,12 +5,21 @@ import { ensureCustomApiRegistered } from "./custom-api-registry.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import {
   buildTransportAwareSimpleStreamFn,
+  createOpenClawTransportStreamFnForModel,
   prepareTransportAwareSimpleModel,
+  resolveTransportAwareSimpleApi,
 } from "./provider-transport-stream.js";
 
 function resolveAnthropicVertexSimpleApi(baseUrl?: string): Api {
   const suffix = baseUrl?.trim() ? encodeURIComponent(baseUrl.trim()) : "default";
   return `openclaw-anthropic-vertex-simple:${suffix}`;
+}
+
+function isMiniMaxAnthropicMessagesModel(model: Model<Api>): boolean {
+  return (
+    model.api === "anthropic-messages" &&
+    (model.provider === "minimax" || model.provider === "minimax-portal")
+  );
 }
 
 export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
@@ -29,6 +38,15 @@ export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
     if (streamFn) {
       ensureCustomApiRegistered(transportAwareModel.api, streamFn);
       return transportAwareModel;
+    }
+  }
+
+  if (isMiniMaxAnthropicMessagesModel(model)) {
+    const api = resolveTransportAwareSimpleApi(model.api);
+    const streamFn = createOpenClawTransportStreamFnForModel(model, { cfg });
+    if (api && streamFn) {
+      ensureCustomApiRegistered(api, streamFn);
+      return { ...model, api };
     }
   }
 


### PR DESCRIPTION
## Summary
- route MiniMax Anthropic-compatible simple model runs through OpenClaw's existing Anthropic transport alias instead of a MiniMax-specific raw fetch path
- preserve provider transport policy, `authHeader` handling, guarded fetch/proxy/TLS behavior, and shared usage cost calculation
- add regression coverage for MiniMax thinking-before-text responses and transport registration

Fixes #81607

## Real behavior proof
- Behavior or issue addressed: `openclaw infer model run` can receive a MiniMax Anthropic-compatible response whose first content block is `thinking` and whose later content block is `text`; the local model.run output must use the later text instead of reporting no text output.
- Real environment tested: local OpenClaw checkout on Linux, Node 22.22.0, branch `fix/minimax-portal-thinking-text-81607`. No external MiniMax credential was available.
- Exact command run after this patch: `pnpm test src/agents/simple-completion-runtime.test.ts src/agents/simple-completion-transport.test.ts src/agents/anthropic-transport-stream.test.ts extensions/minimax/index.test.ts`
- Evidence after fix: the MiniMax Anthropic transport regression replays `content_block_start(type=thinking)` before `content_block_start(type=text, text=pong)`, verifies the final text block is preserved, verifies `max_tokens=1024`, verifies the Authorization bearer header path used by MiniMax OAuth, and verifies nonzero usage cost is calculated from MiniMax model rates.
- Observed result after fix: the OpenClaw simple-completion path keeps the request inside the Anthropic transport stream, returns the later visible text block, and reports token usage through shared cost accounting.
- What was not tested: live MiniMax OAuth/provider call, because this checkout has no MiniMax credential.

## Tests
- `pnpm test src/agents/simple-completion-runtime.test.ts src/agents/simple-completion-transport.test.ts src/agents/anthropic-transport-stream.test.ts extensions/minimax/index.test.ts`
- `git diff --check`
- `pnpm check:changed`