### PR TITLE
fix(agents): prevent premature subagent completion from causing message loss and session-state drift [AI-assisted]

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -964,7 +964,6 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
     state.runAgentAttemptMock.mockResolvedValue(makePendingToolCallResult("openai", "gpt-5.4"));
 
-    const agentCommand = await getAgentCommand();
     await agentCommand({
       message: "hello",
       to: "+1234567890",

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -656,6 +656,25 @@ function makeEmptyResult(provider: string, model: string) {
   };
 }
 
+function makePendingToolCallResult(provider: string, model: string) {
+  return {
+    payloads: undefined,
+    meta: {
+      durationMs: 100,
+      aborted: false,
+      stopReason: "tool_calls",
+      pendingToolCalls: [
+        {
+          id: "call-read-1",
+          name: "read",
+          arguments: "{}",
+        },
+      ],
+      agentMeta: { provider, model },
+    },
+  };
+}
+
 function setupModelSwitchRetry(switchOptions: ModelSwitchOptions) {
   let invocation = 0;
   state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
@@ -719,7 +738,6 @@ function expectFallbackOverrideCalls(first: boolean, second: boolean) {
     hasSessionModelOverride: second,
   });
 }
-
 describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -932,6 +950,41 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       id: "gpt-5.4",
       compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
     });
+  });
+
+  it("emits lifecycle error instead of success when a run exits with unresolved pending tool calls", async () => {
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      };
+    });
+    state.runAgentAttemptMock.mockResolvedValue(makePendingToolCallResult("openai", "gpt-5.4"));
+
+    const agentCommand = await getAgentCommand();
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      senderIsOwner: true,
+    });
+
+    const lifecycleEndCalls = state.emitAgentEventMock.mock.calls.filter((call: unknown[]) => {
+      const arg = call[0] as { stream?: string; data?: { phase?: string } };
+      return arg?.stream === "lifecycle" && arg?.data?.phase === "end";
+    });
+    const lifecycleErrorCalls = state.emitAgentEventMock.mock.calls.filter((call: unknown[]) => {
+      const arg = call[0] as { stream?: string; data?: { phase?: string; error?: string } };
+      return arg?.stream === "lifecycle" && arg?.data?.phase === "error";
+    });
+
+    expect(lifecycleEndCalls).toHaveLength(0);
+    expect(lifecycleErrorCalls).toHaveLength(1);
+    expect((lifecycleErrorCalls[0]?.[0] as { data?: { error?: string } })?.data?.error).toContain(
+      "pending tool call",
+    );
   });
 
   it("records fallback steps to the session trajectory runtime", async () => {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -675,6 +675,26 @@ function makePendingToolCallResult(provider: string, model: string) {
   };
 }
 
+function makePendingClientToolCallResult(provider: string, model: string) {
+  return {
+    payloads: undefined,
+    meta: {
+      durationMs: 100,
+      aborted: false,
+      stopReason: "tool_calls",
+      pendingToolCalls: [
+        {
+          id: "call-hosted-tool-1",
+          name: "hosted_tool",
+          arguments: "{}",
+        },
+      ],
+      clientToolCallsPending: true,
+      agentMeta: { provider, model },
+    },
+  };
+}
+
 function setupModelSwitchRetry(switchOptions: ModelSwitchOptions) {
   let invocation = 0;
   state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
@@ -984,6 +1004,42 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect((lifecycleErrorCalls[0]?.[0] as { data?: { error?: string } })?.data?.error).toContain(
       "pending tool call",
     );
+  });
+
+  it("keeps hosted client tool handoff as lifecycle end instead of error", async () => {
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      };
+    });
+    state.runAgentAttemptMock.mockResolvedValue(
+      makePendingClientToolCallResult("openai", "gpt-5.4"),
+    );
+
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      senderIsOwner: true,
+    });
+
+    const lifecycleEndCalls = state.emitAgentEventMock.mock.calls.filter((call: unknown[]) => {
+      const arg = call[0] as { stream?: string; data?: { phase?: string; stopReason?: string } };
+      return arg?.stream === "lifecycle" && arg?.data?.phase === "end";
+    });
+    const lifecycleErrorCalls = state.emitAgentEventMock.mock.calls.filter((call: unknown[]) => {
+      const arg = call[0] as { stream?: string; data?: { phase?: string } };
+      return arg?.stream === "lifecycle" && arg?.data?.phase === "error";
+    });
+
+    expect(lifecycleErrorCalls).toHaveLength(0);
+    expect(lifecycleEndCalls).toHaveLength(1);
+    expect(
+      (lifecycleEndCalls[0]?.[0] as { data?: { stopReason?: string } })?.data?.stopReason,
+    ).toBe("tool_calls");
   });
 
   it("records fallback steps to the session trajectory runtime", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1284,11 +1284,13 @@ async function agentCommandInternal(
           const pendingToolCalls = Array.isArray(result.meta.pendingToolCalls)
             ? result.meta.pendingToolCalls
             : [];
+          const clientToolCallsPending = result.meta.clientToolCallsPending === true;
           const endedWithUnresolvedToolBoundary =
-            pendingToolCalls.length > 0 ||
-            stopReason === "tool_calls" ||
-            stopReason === "toolUse" ||
-            stopReason === "tool_use";
+            !clientToolCallsPending &&
+            (pendingToolCalls.length > 0 ||
+              stopReason === "tool_calls" ||
+              stopReason === "toolUse" ||
+              stopReason === "tool_use");
           if (endedWithUnresolvedToolBoundary) {
             const error =
               pendingToolCalls.length > 0

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1281,20 +1281,46 @@ async function agentCommandInternal(
         }
         if (!lifecycleEnded) {
           const stopReason = result.meta.stopReason;
-          if (stopReason && stopReason !== "end_turn") {
-            console.error(`[agent] run ${runId} ended with stopReason=${stopReason}`);
+          const pendingToolCalls = Array.isArray(result.meta.pendingToolCalls)
+            ? result.meta.pendingToolCalls
+            : [];
+          const endedWithUnresolvedToolBoundary =
+            pendingToolCalls.length > 0 ||
+            stopReason === "tool_calls" ||
+            stopReason === "toolUse" ||
+            stopReason === "tool_use";
+          if (endedWithUnresolvedToolBoundary) {
+            const error =
+              pendingToolCalls.length > 0
+                ? `Agent run ended before ${pendingToolCalls.length} pending tool call(s) were resolved.`
+                : `Agent run ended at unresolved tool boundary (${stopReason ?? "unknown"}).`;
+            console.error(`[agent] run ${runId} ${error}`);
+            emitAgentEvent({
+              runId,
+              stream: "lifecycle",
+              data: {
+                phase: "error",
+                startedAt,
+                endedAt: Date.now(),
+                error,
+              },
+            });
+          } else {
+            if (stopReason && stopReason !== "end_turn") {
+              console.error(`[agent] run ${runId} ended with stopReason=${stopReason}`);
+            }
+            emitAgentEvent({
+              runId,
+              stream: "lifecycle",
+              data: {
+                phase: "end",
+                startedAt,
+                endedAt: Date.now(),
+                aborted: result.meta.aborted ?? false,
+                stopReason,
+              },
+            });
           }
-          emitAgentEvent({
-            runId,
-            stream: "lifecycle",
-            data: {
-              phase: "end",
-              startedAt,
-              endedAt: Date.now(),
-              aborted: result.meta.aborted ?? false,
-              stopReason,
-            },
-          });
         }
         break;
       } catch (err) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -3138,6 +3138,7 @@ export async function runEmbeddedPiAgent(
             livenessState,
             stopReason,
             yielded: attempt.yieldDetected === true,
+            clientToolCallsPending: attempt.clientToolCalls ? true : undefined,
           });
           return {
             payloads: terminalPayloads?.length ? terminalPayloads : undefined,
@@ -3168,6 +3169,7 @@ export async function runEmbeddedPiAgent(
                 name: call.name,
                 arguments: JSON.stringify(call.params),
               })),
+              ...(attempt.clientToolCalls ? { clientToolCallsPending: true } : {}),
               executionTrace: {
                 winnerProvider: reportedModelRef.provider,
                 winnerModel: reportedModelRef.model,

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -150,5 +150,6 @@ export type EmbeddedRunAttemptResult = {
     livenessState?: EmbeddedRunLivenessState;
     stopReason?: string;
     yielded?: boolean;
+    clientToolCallsPending?: boolean;
   }) => void;
 };

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -156,6 +156,8 @@ export type EmbeddedPiRunMeta = {
     name: string;
     arguments: string;
   }>;
+  /** True when pendingToolCalls came from hosted/client tools awaiting external resolution. */
+  clientToolCallsPending?: boolean;
   executionTrace?: ExecutionTrace;
   requestShaping?: RequestShapingTrace;
   promptSegments?: PromptSegmentTrace[];

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -37,6 +37,7 @@ function createContext(
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
       terminalStopReason: undefined,
       yielded: false,
+      clientToolCallsPending: false,
       blockState: {
         thinking: true,
         final: true,
@@ -346,6 +347,25 @@ describe("handleAgentEnd", () => {
       data: {
         phase: "error",
         error: "Agent run ended at unresolved tool boundary (tool_calls).",
+        stopReason: "tool_calls",
+        livenessState: "working",
+      },
+    });
+  });
+
+  it("keeps hosted client tool handoff as lifecycle end for terminal tool-call stop reasons", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(undefined, { onAgentEvent });
+    ctx.state.terminalStopReason = "tool_calls";
+    ctx.state.clientToolCallsPending = true;
+    ctx.state.livenessState = "working";
+
+    await handleAgentEnd(ctx);
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "end",
         stopReason: "tool_calls",
         livenessState: "working",
       },

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -35,6 +35,8 @@ function createContext(
       pendingToolMediaUrls: [],
       pendingToolAudioAsVoice: false,
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
+      terminalStopReason: undefined,
+      yielded: false,
       blockState: {
         thinking: true,
         final: true,
@@ -327,6 +329,25 @@ describe("handleAgentEnd", () => {
         phase: "end",
         livenessState: "abandoned",
         replayInvalid: true,
+      },
+    });
+  });
+
+  it("emits lifecycle error for terminal tool-call stop reasons", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(undefined, { onAgentEvent });
+    ctx.state.terminalStopReason = "tool_calls";
+    ctx.state.livenessState = "working";
+
+    await handleAgentEnd(ctx);
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        error: "Agent run ended at unresolved tool boundary (tool_calls).",
+        stopReason: "tool_calls",
+        livenessState: "working",
       },
     });
   });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -21,6 +21,10 @@ export {
   handleCompactionStart,
 } from "./pi-embedded-subscribe.handlers.compaction.js";
 
+function isUnresolvedToolBoundaryStopReason(stopReason: string | undefined): boolean {
+  return stopReason === "tool_calls" || stopReason === "toolUse" || stopReason === "tool_use";
+}
+
 export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
   emitAgentEvent({
@@ -54,6 +58,10 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
   });
   const replayInvalid =
     ctx.state.replayState.replayInvalid || incompleteTerminalAssistant ? true : undefined;
+  const unresolvedToolBoundary = isUnresolvedToolBoundaryStopReason(ctx.state.terminalStopReason);
+  const unresolvedToolBoundaryError = unresolvedToolBoundary
+    ? `Agent run ended at unresolved tool boundary (${ctx.state.terminalStopReason ?? "unknown"}).`
+    : undefined;
   // Tool-use terminal guard: when the last assistant message ended with a
   // tool-call stop reason, the turn is incomplete even when pre-tool text
   // exists — mark as abandoned so lifecycle consumers do not see a working
@@ -121,13 +129,13 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
       ...(ctx.state.terminalStopReason ? { stopReason: ctx.state.terminalStopReason } : {}),
       ...(ctx.state.yielded === true ? { yielded: true } : {}),
     };
-    if (isError) {
+    if (isError || unresolvedToolBoundary) {
       emitAgentEvent({
         runId: ctx.params.runId,
         stream: "lifecycle",
         data: {
           phase: "error",
-          error: lifecycleErrorText ?? "LLM request failed.",
+          error: lifecycleErrorText ?? unresolvedToolBoundaryError ?? "LLM request failed.",
           ...terminalMeta,
           ...(livenessState ? { livenessState } : {}),
           ...(replayInvalid ? { replayInvalid } : {}),
@@ -138,7 +146,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
         stream: "lifecycle",
         data: {
           phase: "error",
-          error: lifecycleErrorText ?? "LLM request failed.",
+          error: lifecycleErrorText ?? unresolvedToolBoundaryError ?? "LLM request failed.",
           ...terminalMeta,
           ...(livenessState ? { livenessState } : {}),
           ...(replayInvalid ? { replayInvalid } : {}),

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -62,6 +62,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
   const unresolvedToolBoundaryError = unresolvedToolBoundary
     ? `Agent run ended at unresolved tool boundary (${ctx.state.terminalStopReason ?? "unknown"}).`
     : undefined;
+  const clientToolCallsPending = ctx.state.clientToolCallsPending === true;
   // Tool-use terminal guard: when the last assistant message ended with a
   // tool-call stop reason, the turn is incomplete even when pre-tool text
   // exists — mark as abandoned so lifecycle consumers do not see a working
@@ -129,7 +130,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
       ...(ctx.state.terminalStopReason ? { stopReason: ctx.state.terminalStopReason } : {}),
       ...(ctx.state.yielded === true ? { yielded: true } : {}),
     };
-    if (isError || unresolvedToolBoundary) {
+    if (isError || (unresolvedToolBoundary && !clientToolCallsPending)) {
       emitAgentEvent({
         runId: ctx.params.runId,
         stream: "lifecycle",

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -91,6 +91,7 @@ export type EmbeddedPiSubscribeState = {
   livenessState?: EmbeddedRunLivenessState;
   terminalStopReason?: string;
   yielded?: boolean;
+  clientToolCallsPending?: boolean;
   hadDeterministicSideEffect?: boolean;
 
   messagingToolSentTexts: string[];

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -1090,6 +1090,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       livenessState?: EmbeddedRunLivenessState;
       stopReason?: string;
       yielded?: boolean;
+      clientToolCallsPending?: boolean;
     }) => {
       if (typeof meta.replayInvalid === "boolean") {
         state.replayState = { ...state.replayState, replayInvalid: meta.replayInvalid };
@@ -1102,6 +1103,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       }
       if (typeof meta.yielded === "boolean") {
         state.yielded = meta.yielded;
+      }
+      if (typeof meta.clientToolCallsPending === "boolean") {
+        state.clientToolCallsPending = meta.clientToolCallsPending;
       }
     },
     isCompacting: () => state.compactionInFlight || state.pendingCompactionRetry > 0,

--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -5,15 +5,17 @@ import {
   readSubagentOutput,
 } from "./subagent-announce-output.js";
 
-type CallGateway = typeof import("../gateway/call.js").callGateway;
-type ReadLatestAssistantReply = typeof import("./tools/agent-step.js").readLatestAssistantReply;
+type InstallOutputDepsParams = {
+  messages: Array<unknown>;
+  latestAssistantReply?: string;
+};
 
-function installOutputDeps(params: { messages: Array<unknown>; latestAssistantReply?: string }) {
+function installOutputDeps(params: InstallOutputDepsParams) {
   const callGateway = vi.fn(async () => ({ messages: params.messages }));
   const readLatestAssistantReply = vi.fn(async () => params.latestAssistantReply);
   __testing.setDepsForTest({
-    callGateway: callGateway as unknown as CallGateway,
-    readLatestAssistantReply: readLatestAssistantReply as unknown as ReadLatestAssistantReply,
+    callGateway: callGateway as never,
+    readLatestAssistantReply: readLatestAssistantReply as never,
   });
   return { callGateway, readLatestAssistantReply };
 }
@@ -102,6 +104,52 @@ describe("readSubagentOutput", () => {
 
     await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBe(
       "Mapped the code path.",
+    );
+  });
+
+  it("does not fall back to raw tool output when the latest turn is still awaiting tool continuation", async () => {
+    const deps = installOutputDeps({
+      messages: [
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "const staleFileSlice = 'app/app.js';" }],
+        },
+        {
+          role: "assistant",
+          stopReason: "toolUse",
+          content: [{ type: "toolCall", id: "call-read", name: "read", arguments: {} }],
+        },
+      ],
+      latestAssistantReply: "stale assistant reply",
+    });
+
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
+    expect(deps.readLatestAssistantReply).not.toHaveBeenCalled();
+  });
+
+  it("returns final assistant output after a tool turn is followed by a real completion", async () => {
+    installOutputDeps({
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "toolUse",
+          content: [{ type: "toolCall", id: "call-read", name: "read", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "file contents" }],
+        },
+        {
+          role: "assistant",
+          stopReason: "stop",
+          content: [{ type: "text", text: "Patched successfully." }],
+        },
+      ],
+      latestAssistantReply: "stale assistant reply",
+    });
+
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBe(
+      "Patched successfully.",
     );
   });
 });

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -303,6 +303,9 @@ function selectSubagentOutputText(
   outcome?: SubagentRunOutcome,
 ): string | undefined {
   if (snapshot.waitingForContinuation) {
+    if (snapshot.latestAssistantText) {
+      return snapshot.latestAssistantText;
+    }
     return undefined;
   }
   if (snapshot.latestSilentText) {

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -212,7 +212,11 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
     }
     const role = (message as { role?: unknown }).role;
     if (role === "assistant") {
-      snapshot.toolCallCount += countAssistantToolCalls((message as { content?: unknown }).content);
+      const assistantToolCallCount = countAssistantToolCalls(
+        (message as { content?: unknown }).content,
+      );
+      snapshot.toolCallCount += assistantToolCallCount;
+      const hasToolCalls = assistantToolCallCount > 0;
       if (assistantCallsSessionsYield(message)) {
         snapshot.latestAssistantText = undefined;
         snapshot.latestRawText = undefined;
@@ -222,8 +226,17 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
         previousAssistantCalledYield = true;
         continue;
       }
+      if (hasToolCalls) {
+        snapshot.waitingForContinuation = true;
+      }
       const text = extractSubagentOutputText(message).trim();
       if (!text) {
+        if (hasToolCalls) {
+          snapshot.latestAssistantText = undefined;
+          snapshot.latestRawText = undefined;
+          snapshot.latestSilentText = undefined;
+          snapshot.assistantFragments = [];
+        }
         previousAssistantCalledYield = false;
         continue;
       }
@@ -237,8 +250,10 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
       }
       snapshot.latestSilentText = undefined;
       snapshot.latestAssistantText = text;
-      snapshot.assistantFragments.push(text);
-      snapshot.waitingForContinuation = false;
+      if (!hasToolCalls) {
+        snapshot.assistantFragments.push(text);
+        snapshot.waitingForContinuation = false;
+      }
       previousAssistantCalledYield = false;
       continue;
     }
@@ -254,7 +269,6 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
     const text = extractSubagentOutputText(message).trim();
     if (text) {
       snapshot.latestRawText = text;
-      snapshot.waitingForContinuation = false;
     }
     previousAssistantCalledYield = false;
   }

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -589,7 +589,7 @@ describe("subagent announce formatting", () => {
 
     const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
     const msg = call?.params?.message as string;
-    expect(msg).toContain("completed successfully");
+    expect(msg).toContain("completed; ready for parent review");
     expect(msg).toContain("(no output)");
     expect(msg).not.toContain("const staleFileSlice = 'app/app.js';");
     expect(msg).not.toContain("stale assistant reply should never surface");

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -540,6 +540,61 @@ describe("subagent announce formatting", () => {
     expect(msg).toContain("completed; ready for parent review");
   });
 
+  it("does not surface raw tool-result text as terminal completion when the child is still awaiting continuation", async () => {
+    callGatewaySpy.mockImplementation(async (req: unknown) => {
+      const typed = req as { method?: string; params?: { sessionKey?: string } };
+      if (typed.method === "agent") {
+        return await agentSpy(typed);
+      }
+      if (typed.method === "send") {
+        return await sendSpy(typed);
+      }
+      if (typed.method === "agent.wait") {
+        return { status: "ok", startedAt: 10, endedAt: 20 };
+      }
+      if (typed.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "toolResult",
+              content: [{ type: "text", text: "const staleFileSlice = 'app/app.js';" }],
+            },
+            {
+              role: "assistant",
+              stopReason: "toolUse",
+              content: [{ type: "toolCall", id: "call-read", name: "read", arguments: {} }],
+            },
+          ],
+        };
+      }
+      if (typed.method === "sessions.patch" || typed.method === "sessions.delete") {
+        return {};
+      }
+      return {};
+    });
+    readLatestAssistantReplyMock.mockResolvedValue("stale assistant reply should never surface");
+
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-tool-boundary-no-final",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 50,
+      cleanup: "keep",
+      waitForCompletion: true,
+      startedAt: 10,
+      endedAt: 20,
+    });
+
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
+    const msg = call?.params?.message as string;
+    expect(msg).toContain("completed successfully");
+    expect(msg).toContain("(no output)");
+    expect(msg).not.toContain("const staleFileSlice = 'app/app.js';");
+    expect(msg).not.toContain("stale assistant reply should never surface");
+  });
+
   it("rechecks timed-out waits before announcing timeout when the run finishes immediately after", async () => {
     const waitStatuses = [
       { status: "timeout", startedAt: 10, endedAt: 20 },
@@ -755,6 +810,9 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.sessionKey).toBe("agent:main:main");
     expectInputProvenance(call?.params, "agent:main:subagent:test");
     expect(msg).toContain("final answer: 2");
+    expect(msg).toContain(
+      `Reply ONLY: ${SILENT_REPLY_TOKEN} if this exact result was already delivered to the user in this same turn.`,
+    );
     expect(msg).not.toContain("✅ Subagent");
   });
 
@@ -2026,7 +2084,7 @@ describe("subagent announce formatting", () => {
     expect(msg).toContain("tool output only");
   });
 
-  it("ignores user text when deriving fallback completion output", async () => {
+  it("defers completion delivery instead of announcing empty successful output", async () => {
     chatHistoryMock.mockResolvedValueOnce({
       messages: [
         {
@@ -2047,13 +2105,9 @@ describe("subagent announce formatting", () => {
       ...defaultOutcomeAnnounce,
     });
 
-    expect(didAnnounce).toBe(true);
+    expect(didAnnounce).toBe(false);
     expect(sendSpy).not.toHaveBeenCalled();
-    expect(agentSpy).toHaveBeenCalledTimes(1);
-    const call = getAgentCall() as { params?: { message?: string } };
-    const msg = call?.params?.message as string;
-    expect(msg).toContain("(no output)");
-    expect(msg).not.toContain("user prompt should not be announced");
+    expect(agentSpy).not.toHaveBeenCalled();
   });
 
   it("keeps announce delivery inside requester subagent session", async () => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -508,7 +508,6 @@ export async function runSubagentAnnounceFlow(params: {
     const replyInstruction = buildAnnounceReplyInstruction({
       requesterIsSubagent,
       announceType,
-      expectsCompletionMessage,
     });
     const statsLine = await buildCompactAnnounceStatsLine({
       sessionKey: params.childSessionKey,

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -403,6 +403,11 @@ export async function runSubagentAnnounceFlow(params: {
         reply = fallbackReply;
       }
 
+      if (expectsCompletionMessage && outcome?.status === "ok" && !reply?.trim()) {
+        shouldDeleteChildSession = false;
+        return false;
+      }
+
       // A worker can finish just after the first wait request timed out.
       // If we already have real completion content, do one cached recheck so
       // the final completion event prefers the authoritative terminal state.


### PR DESCRIPTION
## Summary
- treat unresolved tool-boundary endings as lifecycle errors instead of successful subagent completion
- ignore `sessions_yield` wait turns and stale raw tool output when selecting frozen child completion text
- add regression coverage for unresolved pending tool calls, yield-wait turns, and announce formatting around tool-boundary completions

## Why
This fix targets the same bug family as:
- #80879 — blocked terminals reported as `completed successfully` with no output
- #80498 — completion announcements can be premature or duplicated after tool-use turns
- #79285 — subagents can report `completed successfully` when work did not actually finish

It also complements related work in this area without duplicating it:
- #81184
- #81360
- #81498

The scope here is intentionally narrow: when a child run ends at an unresolved tool boundary, or is explicitly still waiting for continuation, the parent should not freeze or announce that state as a successful completed result.

## What changed
- `agent-command` now classifies unresolved pending tool calls / unresolved tool-boundary endings as lifecycle **error** instead of successful lifecycle completion.
- `pi-embedded-subscribe.handlers.lifecycle` now emits lifecycle **error** instead of lifecycle **end** when embedded terminal metadata still reports an unresolved tool boundary (`tool_calls` / `toolUse` / `tool_use`).
- `subagent-announce-output` now tracks `waitingForContinuation` across tool-use and `sessions_yield` turns so announce selection does not fall back to stale raw tool/file text or premature completion text.
- regression coverage now includes:
  - unresolved pending tool calls
  - embedded lifecycle terminal tool-boundary stop reasons
  - `sessions_yield` wait turns
  - final assistant output arriving after a wait/tool boundary
  - announce formatting around these cases

## Real behavior proof
- Behavior or issue addressed: In a real Telegram-topic subagent flow, completion could previously degrade into one or more of: a bogus successful completion at a tool boundary, stale raw tool/file text, duplicate completion signaling, or `(no output)` instead of the child’s real final reply.
- Real environment tested: Live local OpenClaw install on WSL2/Linux, exercised through a real Telegram forum topic and a real spawned subagent session. This was a real parent/child Telegram run on the installed system, not a mocked transport.
- Exact steps or command run after this patch:
  1. From a separate Telegram topic, asked the parent session to spawn a review-only subagent for a complex real task.
  2. Let the child run to completion while it performed real tool work across GitHub + local files.
  3. Inspected the resulting parent topic transcript and child transcript after completion.
- Evidence after fix: The real Telegram run completed as follows:

```text
Parent topic session: topic 8175
Child subagent session: c193950f-5672-4a9e-9e54-18482e047017-topic-8175.jsonl

Observed child workload:
- 23 exec tool calls
- 13 read tool calls
- 1 write tool call
- 1 memory_search call
- final child assistant summary present in the child transcript

Observed parent delivery behavior:
- exactly 1 internal completion event for the child task
- exactly 1 user-facing final assistant summary delivered back to the parent topic
- no stale raw tool/file text delivered as the final readback
- no `(no output)` completion
- no duplicate final completion announcement
```
- Observed result after fix: On a real Telegram topic with a long-running, tool-heavy spawned child, the parent received one clean human-facing completion summary instead of degrading into the earlier false-success / stale-output / duplicate-announcement failure modes. That is the exact user-visible behavior this PR is hardening.
- What was not tested: This real proof was against the live locally patched installation path, not a freshly rebuilt latest-main binary/package install from scratch. I still have not run a totally clean latest-main reinstall lane on this WSL host.

## Supplemental validation
- `pnpm vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/subagent-announce-output.test.ts`
- `pnpm vitest run --config test/vitest/vitest.e2e.config.ts src/agents/subagent-announce.format.e2e.test.ts`
- `pnpm check:changed`

## Screenshots
- Not applicable — non-UI behavior fix

## AI assistance
AI-assisted. Human-directed, human-validated, and limited to the focused subagent completion fix surface.