### PR TITLE
fix(agents): make trajectory cleanup timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 - iOS/chat: resize PhotosPicker image attachments to capped JPEGs before staging and sending, stripping source metadata and keeping oversized camera photos under the chat upload budget. Fixes #68524. Thanks @BunsDev.
 - Codex harness: classify native app-server token-refresh logout and relogin failures as authentication refresh errors, so users get re-authentication guidance instead of a raw runtime failure.
+- Agents/trajectory: make the trajectory flush cleanup timeout configurable with `OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS`, preserving the 10s default while slower stores drain. Refs #75839. Thanks @BunsDev.
 - Codex startup: treat selectable configured OpenAI agent models as Codex runtime requirements during plugin auto-enable, startup planning, and doctor install repair, so Anthropic-primary configs can still switch to OpenAI/Codex cleanly.
 - Agents: preserve source-reply delivery metadata when merging tool-returned media into the final reply, keeping message-tool-only replies deliverable and mirrored. Thanks @pashpashpash and @vincentkoc.
 - macOS/companion: require system TLS trust before pinning a first-use direct `wss://` gateway certificate and honor `gateway.remote.tlsFingerprint` as the explicit pin for remote node-mode sessions, so fresh endpoints fail closed when macOS cannot trust the certificate unless configured out of band. Fixes #50642. Thanks @BunsDev.

--- a/docs/tools/trajectory.md
+++ b/docs/tools/trajectory.md
@@ -168,6 +168,20 @@ This disables runtime trajectory capture. `/export-trajectory` can still export
 the transcript branch, but runtime-only files such as compiled context,
 provider artifacts, and prompt metadata may be missing.
 
+## Tune flush timeout
+
+OpenClaw flushes runtime trajectory sidecars during agent cleanup. The default
+cleanup timeout is 10,000 ms. On slow disks or large stores, set
+`OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS` before starting OpenClaw:
+
+```bash
+export OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS=30000
+```
+
+This controls when OpenClaw logs a `pi-trajectory-flush` timeout and continues.
+It does not change the trajectory size caps. To tune all agent cleanup steps
+that do not pass an explicit timeout, set `OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS`.
+
 ## Privacy and limits
 
 Trajectory bundles are designed for support and debugging, not public posting.

--- a/src/agents/run-cleanup-timeout.test.ts
+++ b/src/agents/run-cleanup-timeout.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AGENT_CLEANUP_STEP_TIMEOUT_MS, runAgentCleanupStep } from "./run-cleanup-timeout.js";
+import {
+  AGENT_CLEANUP_STEP_TIMEOUT_MS,
+  resolveAgentCleanupStepTimeoutMs,
+  runAgentCleanupStep,
+} from "./run-cleanup-timeout.js";
 
 describe("agent cleanup timeout", () => {
   const log = {
@@ -33,6 +37,91 @@ describe("agent cleanup timeout", () => {
     expect(log.warn).toHaveBeenCalledWith(
       "agent cleanup timed out: runId=run-1 sessionId=session-1 step=bundle-mcp-retire timeoutMs=10000",
     );
+  });
+
+  it("uses the trajectory flush timeout environment override for trajectory cleanup", async () => {
+    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
+
+    const result = runAgentCleanupStep({
+      runId: "run-trajectory",
+      sessionId: "session-trajectory",
+      step: "pi-trajectory-flush",
+      cleanup,
+      log,
+      env: {
+        OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "25000",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(24_999);
+    expect(log.warn).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(result).resolves.toBeUndefined();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      "agent cleanup timed out: runId=run-trajectory sessionId=session-trajectory step=pi-trajectory-flush timeoutMs=25000",
+    );
+  });
+
+  it("uses the general cleanup timeout environment override for other cleanup steps", async () => {
+    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
+
+    const result = runAgentCleanupStep({
+      runId: "run-general",
+      sessionId: "session-general",
+      step: "bundle-mcp-retire",
+      cleanup,
+      log,
+      env: {
+        OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "1500",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(1_500);
+    await expect(result).resolves.toBeUndefined();
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "agent cleanup timed out: runId=run-general sessionId=session-general step=bundle-mcp-retire timeoutMs=1500",
+    );
+  });
+
+  it("prefers explicit cleanup timeout values over environment overrides", () => {
+    expect(
+      resolveAgentCleanupStepTimeoutMs({
+        step: "pi-trajectory-flush",
+        timeoutMs: 2_000,
+        env: {
+          OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "25000",
+          OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "15000",
+        },
+      }),
+    ).toBe(2_000);
+  });
+
+  it("keeps explicit zero cleanup timeouts as a one millisecond timeout", () => {
+    expect(
+      resolveAgentCleanupStepTimeoutMs({
+        step: "pi-trajectory-flush",
+        timeoutMs: 0,
+        env: {
+          OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "25000",
+        },
+      }),
+    ).toBe(1);
+  });
+
+  it("ignores invalid cleanup timeout environment values", () => {
+    expect(
+      resolveAgentCleanupStepTimeoutMs({
+        step: "pi-trajectory-flush",
+        env: {
+          OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "0",
+          OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "not-a-number",
+        },
+      }),
+    ).toBe(AGENT_CLEANUP_STEP_TIMEOUT_MS);
   });
 
   it("logs cleanup rejection without throwing", async () => {

--- a/src/agents/run-cleanup-timeout.ts
+++ b/src/agents/run-cleanup-timeout.ts
@@ -1,10 +1,53 @@
 import { formatErrorMessage } from "../infra/errors.js";
 
 export const AGENT_CLEANUP_STEP_TIMEOUT_MS = 10_000;
+export const AGENT_CLEANUP_STEP_TIMEOUT_ENV = "OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS";
+export const TRAJECTORY_FLUSH_TIMEOUT_ENV = "OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS";
 
 type AgentCleanupLogger = {
   warn: (message: string) => void;
 };
+
+function normalizeExplicitTimeoutMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function parseTimeoutEnvValue(value: string | undefined): number | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const timeoutMs = Number(trimmed);
+  if (!Number.isFinite(timeoutMs)) {
+    return undefined;
+  }
+  const normalized = Math.floor(timeoutMs);
+  return normalized > 0 ? normalized : undefined;
+}
+
+export function resolveAgentCleanupStepTimeoutMs(params: {
+  step: string;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+}): number {
+  const explicitTimeoutMs = normalizeExplicitTimeoutMs(params.timeoutMs);
+  if (explicitTimeoutMs !== undefined) {
+    return explicitTimeoutMs;
+  }
+
+  const env = params.env ?? process.env;
+  if (params.step === "pi-trajectory-flush") {
+    const trajectoryTimeoutMs = parseTimeoutEnvValue(env[TRAJECTORY_FLUSH_TIMEOUT_ENV]);
+    if (trajectoryTimeoutMs !== undefined) {
+      return trajectoryTimeoutMs;
+    }
+  }
+
+  return parseTimeoutEnvValue(env[AGENT_CLEANUP_STEP_TIMEOUT_ENV]) ?? AGENT_CLEANUP_STEP_TIMEOUT_MS;
+}
 
 export async function runAgentCleanupStep(params: {
   runId: string;
@@ -12,9 +55,14 @@ export async function runAgentCleanupStep(params: {
   step: string;
   cleanup: () => Promise<void>;
   log: AgentCleanupLogger;
+  env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
 }): Promise<void> {
-  const timeoutMs = Math.max(1, Math.floor(params.timeoutMs ?? AGENT_CLEANUP_STEP_TIMEOUT_MS));
+  const timeoutMs = resolveAgentCleanupStepTimeoutMs({
+    step: params.step,
+    timeoutMs: params.timeoutMs,
+    env: params.env,
+  });
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
   const cleanupPromise = Promise.resolve().then(params.cleanup);


### PR DESCRIPTION
## Summary

- Problem: #75839 still reports `pi-trajectory-flush` cleanup warnings at exactly 10000 ms under slow or large session stores, and `origin/main` still hard-codes the generic cleanup default when no per-call timeout is passed.
- Why it matters: operators can already relocate or disable trajectory capture, but they cannot tune the cleanup warning threshold for slower disks or larger trajectory queues without patching source.
- What changed: `runAgentCleanupStep` now resolves timeouts from explicit params first, then `OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS` for `pi-trajectory-flush`, then the general `OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS`, then the existing 10s default.
- What did NOT change (scope boundary): this does not close the broader `sessions.list` half of #75839, does not change trajectory size caps, does not add config-schema surface, and does not alter queued writer flushing semantics already present on `origin/main`.

## Duplicate and related work triage

- #75839 remains open and is not fully resolved: current `origin/main` has several `sessions.list` mitigations plus trajectory writer yielding, but the cleanup timeout remains fixed at 10s by default.
- #77133 is the closest open trajectory PR, but it still proposes a constant bump and cap change; current `origin/main` already has the writer-yield/docs-cap pieces, while this PR implements the missing configurable timeout as a narrower replacement for that part.
- #78126 was closed as duplicate of #75839 after ClawSweeper confirmed the same `OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS` ask.
- #78133 was closed as superseded/duplicate and targeted periodic trajectory runtime flushing, not the `pi-trajectory-flush` cleanup timeout path.
- #77187 remains the closest open sessions-list resolver-cache PR and should stay separate from this cleanup-timeout fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Refs #75839
- Related #77133
- Related #78126
- Related #78133
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: `pi-trajectory-flush` cleanup no longer has an unconfigurable fixed 10000 ms timeout; operators can set `OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS` while the default remains 10000 ms.
- Real environment tested: local OpenClaw checkout, Node v24.13.0 for the direct `tsx` runtime proof, pnpm 10.33.2, no secrets or live channel credentials involved.
- Exact steps or command run after this patch:
  1. Ran a direct `tsx` invocation of `runAgentCleanupStep` with `step: "pi-trajectory-flush"`, a non-resolving cleanup promise, and `env: { OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "25" }`.
  2. Ran the focused Vitest file for cleanup timeout resolution.
  3. Ran format, docs, changed-lane, type/lint/import-cycle, and diff checks listed below.
- Evidence after fix:

```text
$ pnpm exec tsx -e '<invoke runAgentCleanupStep with OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS=25>'
{
  "elapsedMs": 27,
  "logs": [
    "agent cleanup timed out: runId=proof-run sessionId=proof-session step=pi-trajectory-flush timeoutMs=25"
  ]
}
```

```text
$ pnpm test src/agents/run-cleanup-timeout.test.ts
Test Files  1 passed (1)
Tests  7 passed (7)
[test] passed 1 Vitest shard in 2.75s
```

- Observed result after fix: the runtime helper uses the trajectory-specific environment value for the `pi-trajectory-flush` timeout, while focused tests cover trajectory-specific env, general cleanup env, explicit timeout precedence, explicit zero normalization, invalid env fallback, default timeout, and rejection logging.
- What was not tested: full Raspberry Pi, Windows, or long-running production gateway soak. This PR is scoped to the cleanup timeout resolver; the broader `sessions.list` latency remains tracked separately by #75839 and related sessions-list PRs.
- Before evidence (optional but encouraged): `origin/main` still has `AGENT_CLEANUP_STEP_TIMEOUT_MS = 10_000` and `runAgentCleanupStep` previously used `params.timeoutMs ?? AGENT_CLEANUP_STEP_TIMEOUT_MS`, so the `pi-trajectory-flush` call had no env/config-derived override.

## Root Cause (if applicable)

- Root cause: `runAgentCleanupStep` only accepted an explicit `timeoutMs` or fell back to the 10s constant, and the `pi-trajectory-flush` call site does not pass an override.
- Missing detection / guardrail: existing coverage only asserted the hard-coded default timeout and cleanup rejection behavior; it did not cover operator-configurable cleanup timeouts.
- Contributing context (if known): current `origin/main` already added trajectory writer event-loop yielding and 10 MiB live capture bounds, so the remaining source-reproducible timeout issue is the cleanup helper defaulting path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/run-cleanup-timeout.test.ts`
- Scenario the test should lock in: timeout resolution honors trajectory-specific env, falls back to general cleanup env, preserves explicit caller values, and ignores invalid env values.
- Why this is the smallest reliable guardrail: the bug lives in the cleanup timeout resolver, not in gateway startup, channel transport, or trajectory serialization.
- Existing test that already covers this (if any): the pre-existing test covered the default timeout warning only.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Operators can set `OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS` to tune the `pi-trajectory-flush` cleanup timeout warning threshold. Operators can set `OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS` as a fallback for cleanup steps that do not pass an explicit timeout. Existing default behavior remains 10 seconds.

## Diagram (if applicable)

```text
Before:
pi-trajectory-flush -> runAgentCleanupStep -> fixed 10000 ms default

After:
pi-trajectory-flush -> explicit timeout? -> trajectory env? -> general cleanup env? -> 10000 ms default
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A. The new environment values are numeric timeout controls only; invalid values are ignored, and logs include only the resolved numeric timeout.

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: local Node/pnpm workspace; direct runtime proof used Node v24.13.0, repo supports Node 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS=25` for direct runtime proof

### Steps

1. Confirm current main has no trajectory cleanup timeout env override.
2. Apply this patch.
3. Run the direct cleanup helper proof with the trajectory env override.
4. Run focused tests and changed-surface gates.

### Expected

- `pi-trajectory-flush` uses the trajectory-specific env timeout when set.
- Invalid or missing env values preserve the 10s default.
- Explicit `timeoutMs` remains highest precedence.

### Actual

- Direct runtime proof logged `timeoutMs=25` for `pi-trajectory-flush`.
- Focused tests and changed checks passed.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run after this patch:

```text
pnpm install
pnpm docs:list
pnpm test src/agents/run-cleanup-timeout.test.ts
pnpm exec oxfmt --check --threads=1 src/agents/run-cleanup-timeout.ts src/agents/run-cleanup-timeout.test.ts
git diff --check
pnpm changed:lanes --json
pnpm check:changed
pnpm format:docs:check docs/tools/trajectory.md
```

Results:

```text
pnpm changed:lanes --json -> lanes=core, coreTests, docs; all=false
pnpm check:changed -> lanes=core, coreTests, docs; passed
pnpm format:docs:check docs/tools/trajectory.md -> Docs formatting clean
```

## Human Verification (required)

- Verified scenarios: direct runtime proof of the env override, focused fake-timer coverage for timeout precedence/fallbacks, docs updated for the new operator knobs.
- Edge cases checked: explicit timeout beats env, explicit zero still normalizes to 1 ms for backward compatibility, invalid env values fall back to default, general cleanup env applies to non-trajectory cleanup steps.
- What you did **not** verify: live production deployment under the reported Raspberry Pi/Windows stores; this PR avoids claiming the broader `sessions.list` half is fixed.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations exist on this PR yet.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: Optional only. Set `OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS=<milliseconds>` before starting OpenClaw to tune trajectory flush cleanup warnings; otherwise no action required.

## Risks and Mitigations

- Risk: operators can set an excessively high timeout and delay timeout warnings for stuck cleanup work.
  - Mitigation: default remains 10000 ms; the knob is opt-in and explicit per-call timeouts still win.
- Risk: invalid environment values could accidentally change cleanup behavior.
  - Mitigation: invalid, empty, zero, negative, or non-finite env values are ignored and fall back to the existing default.
