### PR TITLE
fix(discord): implement messages.statusReactions timing lifecycle

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -973,7 +973,12 @@ export async function processDiscordMessage(
         }
         if (removeAckAfterReply) {
           void (async () => {
-            await sleep(dispatchError ? DEFAULT_TIMING.errorHoldMs : DEFAULT_TIMING.doneHoldMs);
+            const configuredTiming = cfg.messages?.statusReactions?.timing;
+            await sleep(
+              dispatchError
+                ? configuredTiming?.errorHoldMs ?? DEFAULT_TIMING.errorHoldMs
+                : configuredTiming?.doneHoldMs ?? DEFAULT_TIMING.doneHoldMs,
+            );
             await statusReactions.clear();
           })();
         } else {


### PR DESCRIPTION
Resolves #78431

This PR fixes the issue where Discord status reactions did not properly respect the `doneHoldMs` and `errorHoldMs` lifecycle timings configured in `cfg.messages.statusReactions.timing`. It wires the logic correctly in `message-handler.process.ts` by utilizing the configuration values instead of hardcoding `DEFAULT_TIMING`.