### PR TITLE
fix(codex): handle app-server setup race during onboarding

### DIFF
--- a/extensions/codex/src/migration/apply.ts
+++ b/extensions/codex/src/migration/apply.ts
@@ -39,6 +39,10 @@ import {
 import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
 import type { v2 } from "../app-server/protocol.js";
 import { requestCodexAppServerJson } from "../app-server/request.js";
+import {
+  clearSharedCodexAppServerClientAndWait,
+  getSharedCodexAppServerClient,
+} from "../app-server/shared-client.js";
 import { buildCodexMigrationPlan } from "./plan.js";
 import {
   buildCodexPluginsConfigValue,
@@ -53,6 +57,16 @@ import { resolveCodexMigrationTargets } from "./targets.js";
 const CODEX_PLUGIN_AUTH_REQUIRED_REASON = "auth_required";
 const CODEX_PLUGIN_NOT_SELECTED_REASON = "not selected for migration";
 const CODEX_CONFIG_PATCH_MODE_RETURN = "return";
+const CODEX_PLUGIN_LOAD_WARNING =
+  "Some Codex plugins could not be migrated. Run `openclaw migrate codex` after onboarding.";
+const TARGET_CODEX_MARKETPLACE_DISCOVERY_POLL_MS = 250;
+const TARGET_CODEX_MARKETPLACE_DISCOVERY_TIMEOUT_MS = 30_000;
+const TARGET_CODEX_MARKETPLACE_DISCOVERY_TIMEOUT_ENV =
+  "OPENCLAW_CODEX_MIGRATION_PLUGIN_LIST_TIMEOUT_MS";
+
+export type CodexMigrationTargetAppServerPreparation = {
+  dispose: () => Promise<void>;
+};
 
 class CodexPluginConfigConflictError extends Error {
   constructor(readonly reason: string) {
@@ -63,6 +77,31 @@ class CodexPluginConfigConflictError extends Error {
 
 function shouldReturnCodexPluginConfigPatch(ctx: MigrationProviderContext): boolean {
   return ctx.providerOptions?.configPatchMode === CODEX_CONFIG_PATCH_MODE_RETURN;
+}
+
+export function prepareTargetCodexAppServer(
+  ctx: MigrationProviderContext,
+): CodexMigrationTargetAppServerPreparation {
+  const appServer = resolveTargetCodexAppServer(ctx);
+  const targets = resolveCodexMigrationTargets(ctx);
+  const ready = getSharedCodexAppServerClient({
+    startOptions: appServer.start,
+    timeoutMs: 60_000,
+    agentDir: targets.agentDir,
+    config: ctx.config,
+  }).then(
+    () => undefined,
+    () => undefined,
+  );
+  return {
+    async dispose() {
+      await ready;
+      await clearSharedCodexAppServerClientAndWait({
+        exitTimeoutMs: 2_000,
+        forceKillDelayMs: 250,
+      });
+    },
+  };
 }
 
 export async function applyCodexMigrationPlan(params: {
@@ -102,6 +141,10 @@ export async function applyCodexMigrationPlan(params: {
     backupPath: params.ctx.backupPath,
     reportDir,
   };
+  if (items.some(isCodexPluginLoadWarningItem)) {
+    result.warnings = [...new Set([...(result.warnings ?? []), CODEX_PLUGIN_LOAD_WARNING])];
+    result.nextSteps = [...new Set([CODEX_PLUGIN_LOAD_WARNING, ...(result.nextSteps ?? [])])];
+  }
   await writeMigrationReport(result, { title: "Codex Migration Report" });
   return result;
 }
@@ -124,14 +167,14 @@ async function applyCodexPluginInstallItem(
       identity: policy,
       installEvenIfActive: true,
       request: async (method, requestParams) =>
-        await requestCodexAppServerJson({
+        await requestTargetCodexAppServerJson({
           method,
           requestParams,
           timeoutMs: 60_000,
           startOptions: appServer.start,
           agentDir: resolveCodexMigrationTargets(ctx).agentDir,
           config: ctx.config,
-          isolated: true,
+          isolated: false,
         }),
       appCache: defaultCodexAppInventoryCache,
       appCacheKey,
@@ -163,6 +206,18 @@ async function applyCodexPluginInstallItem(
         },
       };
     }
+    if (result.reason === "plugin_missing" || result.reason === "marketplace_missing") {
+      return {
+        ...item,
+        status: "warning",
+        reason: result.reason,
+        message: `Codex plugin "${policy.pluginName}" could not be migrated automatically`,
+        details: {
+          ...baseDetails,
+          warningReason: CODEX_PLUGIN_LOAD_WARNING,
+        },
+      };
+    }
     return {
       ...item,
       status: "error",
@@ -170,10 +225,24 @@ async function applyCodexPluginInstallItem(
       details: baseDetails,
     };
   } catch (error) {
+    if (isCodexPluginInventoryLoadError(error)) {
+      return {
+        ...item,
+        status: "warning",
+        reason: "plugin_inventory_unavailable",
+        message: `Codex plugin "${policy.pluginName}" could not be migrated automatically`,
+        details: {
+          ...item.details,
+          code: "plugin_inventory_unavailable",
+          warningReason: CODEX_PLUGIN_LOAD_WARNING,
+          diagnostic: formatCodexMigrationError(error),
+        },
+      };
+    }
     return {
       ...item,
       status: "error",
-      reason: error instanceof Error ? error.message : String(error),
+      reason: formatCodexMigrationError(error),
       details: {
         ...item.details,
         code: "plugin_install_failed",
@@ -182,10 +251,97 @@ async function applyCodexPluginInstallItem(
   }
 }
 
+function isCodexPluginInventoryLoadError(error: unknown): boolean {
+  const message = formatCodexMigrationError(error);
+  return message.includes("codex app-server plugin/list timed out");
+}
+
+function formatCodexMigrationError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function resolveTargetCodexAppServer(ctx: MigrationProviderContext) {
   return resolveCodexAppServerRuntimeOptions({
     pluginConfig: readCodexPluginConfig(ctx.config),
   });
+}
+
+async function requestTargetCodexAppServerJson(params: {
+  method: string;
+  requestParams?: unknown;
+  timeoutMs: number;
+  startOptions: ReturnType<typeof resolveTargetCodexAppServer>["start"];
+  agentDir: string;
+  config: MigrationProviderContext["config"];
+  isolated?: boolean;
+}): Promise<unknown> {
+  if (params.method !== "plugin/list") {
+    return await requestCodexAppServerJson(params);
+  }
+
+  const deadline = Date.now() + params.timeoutMs;
+  const discoveryTimeoutMs = targetCodexMarketplaceDiscoveryTimeoutMs();
+  const discoveryDeadline = Math.min(deadline, Date.now() + discoveryTimeoutMs);
+  let lastResponse: unknown;
+  let attempt = 0;
+  do {
+    attempt += 1;
+    const remainingMs = Math.max(1, discoveryDeadline - Date.now());
+    lastResponse = await requestCodexAppServerJson({
+      ...params,
+      timeoutMs: remainingMs,
+    });
+    if (hasOpenAiCuratedMarketplace(lastResponse)) {
+      return lastResponse;
+    }
+    if (Date.now() >= discoveryDeadline) {
+      return lastResponse;
+    }
+    const waitMs = Math.min(
+      TARGET_CODEX_MARKETPLACE_DISCOVERY_POLL_MS,
+      discoveryDeadline - Date.now(),
+    );
+    await sleep(waitMs);
+  } while (Date.now() < discoveryDeadline);
+
+  return lastResponse;
+}
+
+function hasOpenAiCuratedMarketplace(response: unknown): boolean {
+  if (!response || typeof response !== "object" || !("marketplaces" in response)) {
+    return false;
+  }
+  const marketplaces = (response as { marketplaces?: unknown }).marketplaces;
+  return (
+    Array.isArray(marketplaces) &&
+    marketplaces.some(
+      (marketplace) =>
+        marketplace &&
+        typeof marketplace === "object" &&
+        (marketplace as { name?: unknown }).name === CODEX_PLUGINS_MARKETPLACE_NAME,
+    )
+  );
+}
+
+function targetCodexMarketplaceDiscoveryTimeoutMs(): number {
+  const configured = Number(process.env[TARGET_CODEX_MARKETPLACE_DISCOVERY_TIMEOUT_ENV]);
+  if (Number.isFinite(configured) && configured >= 0) {
+    return configured;
+  }
+  return TARGET_CODEX_MARKETPLACE_DISCOVERY_TIMEOUT_MS;
+}
+
+function isCodexPluginLoadWarningItem(item: MigrationItem): boolean {
+  return (
+    item.kind === "plugin" &&
+    item.action === "install" &&
+    item.status === "warning" &&
+    item.details?.warningReason === CODEX_PLUGIN_LOAD_WARNING
+  );
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function buildTargetCodexPluginAppCacheKey(ctx: MigrationProviderContext): Promise<string> {

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -155,6 +155,7 @@ function sourceAppCacheKey(fixture: { codexHome: string }): string {
 }
 
 afterEach(async () => {
+  vi.useRealTimers();
   vi.unstubAllEnvs();
   appServerRequest.mockReset();
   defaultCodexAppInventoryCache.clear();
@@ -885,30 +886,43 @@ describe("buildCodexMigrationProvider", () => {
       },
       agents: { defaults: { workspace: fixture.workspaceDir } },
     } as MigrationProviderContext["config"];
-    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
-      if (method === "plugin/list") {
-        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
-      }
-      if (method === "plugin/read") {
-        return pluginRead("google-calendar");
-      }
-      if (method === "plugin/install") {
-        return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
-      }
-      if (method === "skills/list") {
-        return { data: [] } satisfies v2.SkillsListResponse;
-      }
-      if (method === "hooks/list") {
-        return { data: [] } satisfies v2.HooksListResponse;
-      }
-      if (method === "config/mcpServer/reload") {
-        return {};
-      }
-      if (method === "app/list") {
-        return appsList([]);
-      }
-      throw new Error(`unexpected request ${method}`);
-    });
+    let targetPluginListCalls = 0;
+    let targetPluginListCallsAtInstall = 0;
+    appServerRequest.mockImplementation(
+      async ({ method, agentDir }: { method: string; agentDir?: string }) => {
+        const isTarget = typeof agentDir === "string";
+        if (method === "plugin/list" && !isTarget) {
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/list" && isTarget) {
+          targetPluginListCalls += 1;
+          if (targetPluginListCalls === 1) {
+            return { marketplaces: [], marketplaceLoadErrors: [], featuredPluginIds: [] };
+          }
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read") {
+          return pluginRead("google-calendar");
+        }
+        if (method === "plugin/install") {
+          targetPluginListCallsAtInstall = targetPluginListCalls;
+          return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
+        }
+        if (method === "skills/list") {
+          return { data: [] } satisfies v2.SkillsListResponse;
+        }
+        if (method === "hooks/list") {
+          return { data: [] } satisfies v2.HooksListResponse;
+        }
+        if (method === "config/mcpServer/reload") {
+          return {};
+        }
+        if (method === "app/list") {
+          return appsList([]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    );
     const provider = buildCodexMigrationProvider({
       runtime: createConfigRuntime(configState),
     });
@@ -926,6 +940,7 @@ describe("buildCodexMigrationProvider", () => {
     const installCall = appServerRequest.mock.calls.find(
       ([arg]) => (arg as { method?: string }).method === "plugin/install",
     )?.[0] as Record<string, unknown>;
+    expect(targetPluginListCallsAtInstall).toBe(2);
     expectRecordFields(installCall, {
       method: "plugin/install",
       requestParams: {
@@ -961,6 +976,138 @@ describe("buildCodexMigrationProvider", () => {
       },
     });
     expect(configState.plugins?.entries?.codex?.config?.codexPlugins).not.toHaveProperty("*");
+  });
+
+  it("leaves selected Codex plugins as warnings when target curated plugins never load", async () => {
+    vi.stubEnv("OPENCLAW_CODEX_MIGRATION_PLUGIN_LIST_TIMEOUT_MS", "1");
+    const fixture = await createCodexFixture();
+    const configState: MigrationProviderContext["config"] = {
+      agents: { defaults: { workspace: fixture.workspaceDir } },
+    } as MigrationProviderContext["config"];
+    appServerRequest.mockImplementation(
+      async ({ method, agentDir }: { method: string; agentDir?: string }) => {
+        const isTarget = typeof agentDir === "string";
+        if (method === "plugin/list" && !isTarget) {
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read" && !isTarget) {
+          return pluginRead("google-calendar");
+        }
+        if (method === "plugin/list" && isTarget) {
+          return {
+            marketplaces: [],
+            marketplaceLoadErrors: [],
+            featuredPluginIds: [],
+          } satisfies v2.PluginListResponse;
+        }
+        if (method === "skills/list") {
+          return { data: [] } satisfies v2.SkillsListResponse;
+        }
+        if (method === "hooks/list") {
+          return { data: [] } satisfies v2.HooksListResponse;
+        }
+        if (method === "config/mcpServer/reload") {
+          return {};
+        }
+        if (method === "app/list") {
+          return appsList([]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    );
+    const provider = buildCodexMigrationProvider({
+      runtime: createConfigRuntime(configState),
+    });
+
+    const result = await provider.apply(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+        config: configState,
+      }),
+    );
+
+    expect(
+      appServerRequest.mock.calls.some(
+        ([arg]) => (arg as { method?: string }).method === "plugin/install",
+      ),
+    ).toBe(false);
+    expectRecordFields(findItem(result.items, "plugin:google-calendar"), {
+      kind: "plugin",
+      action: "install",
+      status: "warning",
+      reason: "marketplace_missing",
+    });
+    expect(result.warnings).toContain(
+      "Some Codex plugins could not be migrated. Run `openclaw migrate codex` after onboarding.",
+    );
+    expect(result.nextSteps).toContain(
+      "Some Codex plugins could not be migrated. Run `openclaw migrate codex` after onboarding.",
+    );
+    expect(configState.plugins?.entries?.codex?.config?.codexPlugins).toBeUndefined();
+  });
+
+  it("leaves selected Codex plugins as warnings when target inventory times out", async () => {
+    const fixture = await createCodexFixture();
+    const configState: MigrationProviderContext["config"] = {
+      agents: { defaults: { workspace: fixture.workspaceDir } },
+    } as MigrationProviderContext["config"];
+    appServerRequest.mockImplementation(
+      async ({ method, agentDir }: { method: string; agentDir?: string }) => {
+        const isTarget = typeof agentDir === "string";
+        if (method === "plugin/list" && !isTarget) {
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read" && !isTarget) {
+          return pluginRead("google-calendar");
+        }
+        if (method === "plugin/list" && isTarget) {
+          throw new Error("codex app-server plugin/list timed out");
+        }
+        if (method === "skills/list") {
+          return { data: [] } satisfies v2.SkillsListResponse;
+        }
+        if (method === "hooks/list") {
+          return { data: [] } satisfies v2.HooksListResponse;
+        }
+        if (method === "config/mcpServer/reload") {
+          return {};
+        }
+        if (method === "app/list") {
+          return appsList([]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    );
+    const provider = buildCodexMigrationProvider({
+      runtime: createConfigRuntime(configState),
+    });
+
+    const result = await provider.apply(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+        config: configState,
+      }),
+    );
+
+    expectRecordFields(findItem(result.items, "plugin:google-calendar"), {
+      kind: "plugin",
+      action: "install",
+      status: "warning",
+      reason: "plugin_inventory_unavailable",
+      message: 'Codex plugin "google-calendar" could not be migrated automatically',
+    });
+    expect(result.warnings).toContain(
+      "Some Codex plugins could not be migrated. Run `openclaw migrate codex` after onboarding.",
+    );
+    expect(result.nextSteps).toContain(
+      "Some Codex plugins could not be migrated. Run `openclaw migrate codex` after onboarding.",
+    );
+    expect(result.summary.errors).toBe(0);
+    expect(configState.plugins?.entries?.codex?.config?.codexPlugins).toBeUndefined();
   });
 
   it("plans already configured target Codex plugins as plugin-level conflicts", async () => {

--- a/extensions/codex/src/migration/provider.ts
+++ b/extensions/codex/src/migration/provider.ts
@@ -3,7 +3,7 @@ import type {
   MigrationProviderContext,
   MigrationProviderPlugin,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { applyCodexMigrationPlan } from "./apply.js";
+import { applyCodexMigrationPlan, prepareTargetCodexAppServer } from "./apply.js";
 import { buildCodexMigrationPlan } from "./plan.js";
 import { discoverCodexSource, hasCodexSource } from "./source.js";
 
@@ -31,6 +31,9 @@ export function buildCodexMigrationProvider(
       };
     },
     plan: buildCodexMigrationPlan,
+    prepareApply(ctx) {
+      return prepareTargetCodexAppServer(ctx);
+    },
     async apply(ctx, plan?: MigrationPlan) {
       return await applyCodexMigrationPlan({ ctx, plan, runtime: params.runtime });
     },

--- a/src/commands/migrate/output.test.ts
+++ b/src/commands/migrate/output.test.ts
@@ -80,6 +80,21 @@ describe("formatMigrationPreview", () => {
     expect(output).not.toContain("Config:");
     expect(output).not.toContain("codex-plugins-root");
   });
+
+  it("renders migration warnings with a warning glyph", () => {
+    const output = formatMigrationPreview({
+      ...plan([skillItem(1)]),
+      warnings: [
+        "Some Codex plugins could not be migrated. Run `openclaw migrate codex` after onboarding.",
+      ],
+    })
+      .map(stripAnsi)
+      .join("\n");
+
+    expect(output).toContain(
+      "⚠️  Some Codex plugins could not be migrated. Run `openclaw migrate codex` after onboarding.",
+    );
+  });
 });
 
 describe("formatMigrationResult", () => {
@@ -101,6 +116,43 @@ describe("formatMigrationResult", () => {
 
     expect(output).toContain("❌");
     expect(output).toContain("Plugin not found in the Codex marketplace");
+  });
+
+  it("renders warning plugin items under the plugin section", () => {
+    const output = formatMigrationResult(
+      plan([
+        {
+          ...pluginItem("google-calendar"),
+          status: "warning",
+          reason: "marketplace_missing",
+          message: 'Codex plugin "google-calendar" could not be migrated automatically',
+        },
+      ]),
+    )
+      .map(stripAnsi)
+      .join("\n");
+
+    expect(output).toContain("Plugins:");
+    expect(output).not.toContain("Manual review:");
+    expect(output).toContain("⚠️");
+    expect(output).toContain(
+      'google-calendar (Codex plugin "google-calendar" could not be migrated automatically)',
+    );
+  });
+
+  it("renders warning-backed next steps with a warning glyph", () => {
+    const warning =
+      "Some Codex plugins could not be migrated. Run `openclaw migrate codex` after onboarding.";
+    const output = formatMigrationResult({
+      ...plan([{ ...pluginItem("google-calendar"), status: "warning" }]),
+      warnings: [warning],
+      nextSteps: [warning, "Run openclaw doctor after applying the migration."],
+    })
+      .map(stripAnsi)
+      .join("\n");
+
+    expect(output).toContain(`⚠️  ${warning}`);
+    expect(output).toContain("• Run openclaw doctor after applying the migration.");
   });
 
   it("says (Skipped) for user-deselected skill/plugin items", () => {

--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -90,7 +90,7 @@ function formatPlanWarnings(plan: MigrationPlan): string[] {
   }
   const lines = ["", theme.warn("Warnings:")];
   for (const warning of plan.warnings) {
-    lines.push(`• ${warning}`);
+    lines.push(`⚠️  ${warning}`);
   }
   return lines;
 }
@@ -109,7 +109,8 @@ export function formatMigrationResult(plan: MigrationPlan): string[] {
     lines.push("");
     lines.push(theme.heading("Next:"));
     for (const step of plan.nextSteps) {
-      lines.push(`• ${step}`);
+      const prefix = plan.warnings?.includes(step) ? "⚠️ " : "•";
+      lines.push(`${prefix} ${step}`);
     }
   }
   return lines;
@@ -157,7 +158,12 @@ function humanizeReason(reason: string | undefined): string | undefined {
 
 function formatItemMessage(item: MigrationItem, mode: FormatMode): string | undefined {
   if (mode === "preview") {
-    if (item.status === "conflict" || item.status === "skipped" || item.status === "error") {
+    if (
+      item.status === "conflict" ||
+      item.status === "skipped" ||
+      item.status === "warning" ||
+      item.status === "error"
+    ) {
       return humanizeReason(item.reason) ?? item.message;
     }
     if (item.kind === "skill" && item.action === "copy") {
@@ -178,12 +184,15 @@ function formatItemMessage(item: MigrationItem, mode: FormatMode): string | unde
     if (item.status === "skipped") {
       return "Skipped";
     }
+    if (item.status === "warning") {
+      return item.message ?? humanizeReason(item.reason);
+    }
     if (item.status === "error" || item.status === "conflict") {
       return humanizeReason(item.reason) ?? item.message;
     }
     return undefined;
   }
-  if (item.status === "error" || item.status === "conflict") {
+  if (item.status === "warning" || item.status === "error" || item.status === "conflict") {
     return humanizeReason(item.reason) ?? item.message;
   }
   return item.message ?? humanizeReason(item.reason);
@@ -191,6 +200,7 @@ function formatItemMessage(item: MigrationItem, mode: FormatMode): string | unde
 
 const RESULT_STATUS_GLYPHS: Record<string, string> = {
   migrated: "✅",
+  warning: "⚠️ ",
   error: "❌",
   skipped: "⏭️ ",
   conflict: "⚠️ ",

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2347,7 +2347,13 @@ export type PluginConfigMigration = (config: OpenClawConfig) =>
   | null
   | undefined;
 
-export type MigrationItemStatus = "planned" | "migrated" | "skipped" | "conflict" | "error";
+export type MigrationItemStatus =
+  | "planned"
+  | "migrated"
+  | "skipped"
+  | "warning"
+  | "conflict"
+  | "error";
 export type MigrationItemKind =
   | "config"
   | "secret"
@@ -2415,6 +2421,10 @@ export type MigrationApplyResult = MigrationPlan & {
   reportDir?: string;
 };
 
+export type MigrationProviderPreparation = {
+  dispose?: () => void | Promise<void>;
+};
+
 export type MigrationProviderContext = {
   config: OpenClawConfig;
   runtime?: PluginRuntime;
@@ -2435,6 +2445,9 @@ export type MigrationProviderPlugin = {
   label: string;
   description?: string;
   detect?: (ctx: MigrationProviderContext) => MigrationDetection | Promise<MigrationDetection>;
+  prepareApply?: (
+    ctx: MigrationProviderContext,
+  ) => MigrationProviderPreparation | Promise<MigrationProviderPreparation | undefined> | undefined;
   plan: (ctx: MigrationProviderContext) => MigrationPlan | Promise<MigrationPlan>;
   apply: (
     ctx: MigrationProviderContext,

--- a/src/wizard/setup.post-install-migration.ts
+++ b/src/wizard/setup.post-install-migration.ts
@@ -188,8 +188,22 @@ export async function offerPostInstallMigrations(
       logMigrationHint(params.runtime, candidate);
       continue;
     }
+    let preparation: Awaited<ReturnType<NonNullable<MigrationProviderPlugin["prepareApply"]>>> =
+      undefined;
     try {
-      const { migrateDefaultCommand } = await import("../commands/migrate.js");
+      const [{ migrateDefaultCommand }, { createMigrationLogger }, { resolveStateDir }] =
+        await Promise.all([
+          import("../commands/migrate.js"),
+          import("../commands/migrate/context.js"),
+          import("../config/paths.js"),
+        ]);
+      preparation = await candidate.provider.prepareApply?.({
+        config: nextConfig,
+        stateDir: resolveStateDir(),
+        logger: createMigrationLogger(params.runtime),
+        ...(candidate.source ? { source: candidate.source } : {}),
+        providerOptions: { configPatchMode: "return" },
+      });
       const result = await migrateDefaultCommand(params.runtime, {
         provider: candidate.provider.id,
         configOverride: nextConfig,
@@ -202,6 +216,8 @@ export async function offerPostInstallMigrations(
         `${candidate.provider.label} migration failed: ${formatErrorMessage(error)}. ` +
           `Re-run with ${formatCliCommand(`openclaw migrate ${candidate.provider.id} --dry-run`)} to inspect.`,
       );
+    } finally {
+      await preparation?.dispose?.();
     }
   }
   return { config: nextConfig };


### PR DESCRIPTION
## Summary
- fix an onboarding race where the Codex migration asks a freshly started target Codex app-server for `plugin/list` before its `openai-curated` marketplace has finished loading
- this race caused selected native Codex plugins to fail migration as missing/unavailable even though they are available after the app-server finishes bootstrapping
- prewarm the target Codex app-server as soon as the user accepts the post-install Codex migration prompt, so it can load plugin inventory while the migration plan and confirmation screens run
- retry target Codex `plugin/list` for up to 30 seconds when `openai-curated` is not present yet
- keep selected Codex plugins in the Plugins section as warnings when the marketplace or plugin inventory cannot be loaded in time
- show `⚠️  Some Codex plugins could not be migrated. Run \`openclaw migrate codex\` after onboarding.` in the migration next steps

Success
<img width="2854" height="1924" alt="Screenshot 2026-05-14 at 01 04 38" src="https://github.com/user-attachments/assets/27dbe957-2dd9-40ab-8596-46a960ae4ef4" />

Loading plugins timed out
<img width="2540" height="1900" alt="Screenshot 2026-05-14 at 01 07 48" src="https://github.com/user-attachments/assets/a1b61b2a-0cf2-422f-af9f-3e6903d3f4f5" />


## Verification
- `git diff --check HEAD~1..HEAD`
- Attempted: `pnpm test src/commands/migrate/output.test.ts extensions/codex/src/migration/provider.test.ts -t "warning-backed next steps|inventory times out|target curated plugins never load"` hung before producing Vitest runner output and was stopped.

## Real behavior proof
Behavior addressed: Fresh target Codex homes can answer `plugin/list` before the `openai-curated` marketplace is available, or time out while loading plugin inventory, causing selected native Codex plugins to fail migration during onboarding.
Real environment tested: Local OpenClaw Codex migration repro against an OpenClaw-managed Codex home during onboarding.
Exact steps or command run after this patch: Added provider/output coverage for late marketplace availability, marketplace timeout warning items, plugin inventory timeout warning items, and warning-backed next-step rendering; attempted the focused test command above, but pnpm hung before Vitest output.
Evidence after fix: The target app-server is warmed immediately after the user accepts the Codex post-install migration, target `plugin/list` retries for 30 seconds, and inventory/marketplace load failures are represented as warning plugin items with the retry command in `Next:`.
Observed result after fix: Static diff validation passes; local focused test execution is currently blocked by the pnpm hang noted above.
What was not tested: Full migration provider test suite and a fresh end-to-end onboarding run after the latest message rendering change.
