### PR TITLE
fix(wizard): show migration plan/result on failure during onboarding

### DIFF
--- a/src/wizard/setup.post-install-migration.ts
+++ b/src/wizard/setup.post-install-migration.ts
@@ -150,12 +150,11 @@ export async function offerPostInstallMigrations(
       const { migrateDefaultCommand } = await import("../commands/migrate.js");
       await migrateDefaultCommand(params.runtime, {
         provider: candidate.provider.id,
-        suppressPlanLog: true,
       });
     } catch (error) {
       params.runtime.log(
-        `${candidate.provider.label} migration failed: ${formatErrorMessage(error)}. ` +
-          `Re-run with ${formatCliCommand(`openclaw migrate ${candidate.provider.id} --dry-run`)} to inspect.`,
+        `${candidate.provider.label} migration failed: ${formatErrorMessage(error)}\n` +
+          `Re-run ${formatCliCommand(`openclaw migrate ${candidate.provider.id} --dry-run`)} to inspect the plan.`,
       );
     }
   }


### PR DESCRIPTION
## Problem
When a migration prompted during onboarding hit plan-level conflicts (or apply-level errors), the wizard rendered only the bare error message:

```
Codex migration failed: Migration has 2 conflicts. Re-run with --overwrite after reviewing openclaw migrate plan codex.. Re-run with openclaw migrate codex --dry-run to inspect.
```

No per-item breakdown, no indication of *which* two items conflicted, no link to the migration report directory. The user had to drop out of onboarding and re-run `openclaw migrate codex --dry-run` separately to figure anything out.

## Fix
- Drop `suppressPlanLog: true` from the call into `migrateDefaultCommand` in `src/wizard/setup.post-install-migration.ts:153`. The migrate command already renders the per-item preview (with `⚠️` markers on conflicting items) before `assertConflictFreePlan` throws, and `writeApplyResult` already prints the per-row apply result plus `Backup:` and `Report:` paths before `assertApplySucceeded` throws on apply-level failures. The wizard was just hiding that output.
- Break the wizard's wrapping error log onto two lines so the inner error message (which already ends with `.`) doesn't get a double period glued to the recovery hint.

After the fix the user sees the full preview/result block above the wizard's recovery hint, including which items conflicted/failed and (on apply-level failures) the absolute path to the migration report.

## Verification
- `./run.sh onboard-fast --non-interactive --import-from codex` reproduces a plan with conflicts against a non-empty `~/.openclaw`. With the fix, the per-item rows show before the error and the wizard's recovery line reads cleanly on its own line.
- `gh pr checks` will likely show the same pre-existing red checks observed on #81597 (`checks-fast-contracts-plugins-d` undocumented-plugins drift, `checks-node-agentic-control-plane-agent-chat` gateway sessions-send fixture, `Real behavior proof`). Single-line wizard tweak; touches no plugin/registry surface.