### PR TITLE
fix(migrate): humanize conflict-status messaging across migrate UI

### DIFF
--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -576,7 +576,7 @@ export async function discoverCodexSource(
   const hooksPath = path.join(codexHome, "hooks", "hooks.json");
   const codexSkills = await discoverSkillDirs({
     root: codexSkillsDir,
-    sourceLabel: "Codex CLI skill",
+    sourceLabel: "Codex skill",
     excludeSystem: true,
   });
   const personalAgentSkills = await discoverSkillDirs({

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -103,7 +103,7 @@ function codexSkillPlan(overrides: Partial<MigrationPlan> = {}): MigrationPlan {
       target: "/tmp/openclaw/workspace/skills/alpha",
       details: {
         skillName: "alpha",
-        sourceLabel: "Codex CLI skill",
+        sourceLabel: "Codex skill",
       },
     },
     {
@@ -640,7 +640,7 @@ describe("migrateApplyCommand", () => {
     const optionsByValue = new Map(pluginPrompt.options?.map((option) => [option.value, option]));
     expect(optionsByValue.get("plugin:google-calendar")?.label).toBe("google-calendar");
     expect(String(optionsByValue.get("plugin:google-calendar")?.hint)).toContain(
-      "conflict: plugin exists",
+      "already installed in workspace",
     );
     expect(optionsByValue.get("plugin:gmail")?.label).toBe("gmail");
     const appliedPlan = firstAppliedPlan();

--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -132,15 +132,34 @@ const REASON_CODE_MESSAGES: Record<string, string> = {
   "not selected for migration": "Skipped because it was not selected for migration.",
 };
 
+// Phrase-form conflict reasons, used as-is in selection-prompt hints
+// (`<source label> <phrase>`) and wrapped into sentence form for preview
+// /result rows. Keep one map so the two surfaces never drift.
+export const MIGRATION_CONFLICT_REASON_PHRASES: Record<string, string> = {
+  "target exists": "already installed in workspace",
+  "plugin exists": "already installed in workspace",
+};
+
+function conflictReasonSentence(reason: string): string | undefined {
+  const phrase = MIGRATION_CONFLICT_REASON_PHRASES[reason];
+  if (!phrase) {
+    return undefined;
+  }
+  return `${phrase.charAt(0).toUpperCase()}${phrase.slice(1)}.`;
+}
+
 function humanizeReason(reason: string | undefined): string | undefined {
   if (!reason) {
     return undefined;
   }
-  return REASON_CODE_MESSAGES[reason] ?? reason;
+  return REASON_CODE_MESSAGES[reason] ?? conflictReasonSentence(reason) ?? reason;
 }
 
 function formatItemMessage(item: MigrationItem, mode: FormatMode): string | undefined {
   if (mode === "preview") {
+    if (item.status === "conflict" || item.status === "skipped" || item.status === "error") {
+      return humanizeReason(item.reason) ?? item.message;
+    }
     if (item.kind === "skill" && item.action === "copy") {
       return "Copy Codex skill into OpenClaw";
     }
@@ -177,21 +196,18 @@ const RESULT_STATUS_GLYPHS: Record<string, string> = {
   conflict: "⚠️ ",
 };
 
-function formatItemPrefix(item: MigrationItem, mode: FormatMode): string {
+function formatItemPrefix(item: MigrationItem): string {
   if (item.kind === "manual") {
     return "🔍 ";
   }
   if (item.kind === "archive") {
     return "📖 ";
   }
-  if (mode === "result") {
-    const glyph = RESULT_STATUS_GLYPHS[item.status];
-    if (glyph) {
-      return `${glyph} `;
-    }
-    return "• ";
+  const glyph = RESULT_STATUS_GLYPHS[item.status];
+  if (glyph) {
+    return `${glyph} `;
   }
-  return item.status === "planned" ? "• " : `• ${item.status}: `;
+  return "• ";
 }
 
 function formatMigrationItem(item: MigrationItem, mode: FormatMode): string {
@@ -199,7 +215,7 @@ function formatMigrationItem(item: MigrationItem, mode: FormatMode): string {
   const message = formatItemMessage(item, mode);
   const messageSuffix = message ? ` ${theme.muted(`(${message})`)}` : "";
   const sensitive = item.sensitive ? " [sensitive]" : "";
-  const prefix = formatItemPrefix(item, mode);
+  const prefix = formatItemPrefix(item);
   return `${prefix}${name}${sensitive}${messageSuffix}`;
 }
 

--- a/src/commands/migrate/selection.test.ts
+++ b/src/commands/migrate/selection.test.ts
@@ -36,7 +36,7 @@ function skillItem(params: {
     reason: params.reason,
     details: {
       skillName: params.name,
-      sourceLabel: "Codex CLI skill",
+      sourceLabel: "Codex skill",
     },
   };
 }
@@ -491,7 +491,7 @@ describe("applyMigrationPluginSelection", () => {
       "plugin:gmail",
     ]);
     expect(formatMigrationPluginSelectionHint(items[1])).toBe(
-      "openai-curated; conflict: plugin exists",
+      "openai-curated plugin already installed in workspace",
     );
   });
 

--- a/src/commands/migrate/selection.ts
+++ b/src/commands/migrate/selection.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { markMigrationItemSkipped, summarizeMigrationItems } from "../../plugin-sdk/migration.js";
 import type { MigrationItem, MigrationPlan } from "../../plugins/types.js";
+import { MIGRATION_CONFLICT_REASON_PHRASES } from "./output.js";
 
 export const MIGRATION_SKILL_NOT_SELECTED_REASON = "not selected for migration";
 export const MIGRATION_PLUGIN_NOT_SELECTED_REASON = "not selected for migration";
@@ -253,28 +254,34 @@ export function formatMigrationSkillSelectionLabel(item: MigrationItem): string 
   return readMigrationSkillName(item) ?? item.id.replace(/^skill:/u, "");
 }
 
-export function formatMigrationSkillSelectionHint(item: MigrationItem): string | undefined {
-  const parts = [readMigrationSkillSourceLabel(item)];
-  if (item.status === "conflict") {
-    parts.push(item.reason ? `conflict: ${item.reason}` : "conflict");
+function humanizeMigrationConflictReason(reason: string | undefined): string {
+  if (!reason) {
+    return "conflict";
   }
-  return (
-    parts
-      .filter((value): value is string => typeof value === "string" && value.length > 0)
-      .join("; ") || undefined
-  );
+  return MIGRATION_CONFLICT_REASON_PHRASES[reason] ?? reason;
+}
+
+export function formatMigrationSkillSelectionHint(item: MigrationItem): string | undefined {
+  const sourceLabel = readMigrationSkillSourceLabel(item);
+  if (item.status === "conflict") {
+    const reason = humanizeMigrationConflictReason(item.reason);
+    return sourceLabel ? `${sourceLabel} ${reason}` : reason;
+  }
+  return sourceLabel ?? undefined;
 }
 
 export function formatMigrationPluginSelectionHint(item: MigrationItem): string | undefined {
   const pluginName = readMigrationPluginName(item);
   const configKey = readMigrationPluginConfigKey(item);
+  const marketplace = readMigrationPluginMarketplaceName(item);
+  if (item.status === "conflict") {
+    const reason = humanizeMigrationConflictReason(item.reason);
+    return marketplace ? `${marketplace} plugin ${reason}` : reason;
+  }
   const parts = [
-    readMigrationPluginMarketplaceName(item),
+    marketplace,
     configKey && configKey !== pluginName ? `config: ${configKey}` : undefined,
   ];
-  if (item.status === "conflict") {
-    parts.push(item.reason ? `conflict: ${item.reason}` : "conflict");
-  }
   return (
     parts
       .filter((value): value is string => typeof value === "string" && value.length > 0)


### PR DESCRIPTION
Replace internal `MIGRATION_REASON_*` codes with natural sentences across the migrate UI.

| Surface | Before | After |
| --- | --- | --- |
| Selection prompt (skill) | `(Codex CLI skill; conflict: target exists)` | `(Codex skill already installed in workspace)` |
| Selection prompt (plugin) | `(openai-curated; conflict: plugin exists)` | `(openai-curated plugin already installed in workspace)` |
| Plan/result row (skill conflict) | `• conflict: gh-address-comments (Copy Codex skill into OpenClaw)` | `⚠️ gh-address-comments (Already installed in workspace.)` |
| Plan/result row (plugin conflict) | `• conflict: <name> (Install Codex plugin into OpenClaw)` | `⚠️ <name> (Already installed in workspace.)` |
