### PR TITLE
fix(codex): backport app-server auth refresh failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex harness: classify native app-server token-refresh logout and relogin failures as authentication refresh errors, so users get re-authentication guidance instead of a raw runtime failure.
 - Codex startup: treat selectable configured OpenAI agent models as Codex runtime requirements during plugin auto-enable, startup planning, and doctor install repair, so Anthropic-primary configs can still switch to OpenAI/Codex cleanly.
 - Agents: preserve source-reply delivery metadata when merging tool-returned media into the final reply, keeping message-tool-only replies deliverable and mirrored. Thanks @pashpashpash and @vincentkoc.
 - WebChat/TUI: route Codex `tools.message` source replies to the active internal UI turn and mirror them to session history, so message-tool-only harness replies, including rich presentation and button-only replies, no longer disappear while WebChat and TUI remain non-targetable outbound channels. (#81586) Thanks @pashpashpash.

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -126,6 +126,42 @@ describe("CodexAppServerClient", () => {
     await expect(request).rejects.toHaveProperty("message", "Method not found");
   });
 
+  it("surfaces relogin details from Codex app-server RPC errors", async () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+
+    const request = harness.client.request("thread/start", {});
+    const outbound = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
+    harness.send({
+      id: outbound.id,
+      error: {
+        code: -32602,
+        message: "failed to load configuration",
+        data: {
+          reason: "cloudRequirements",
+          errorCode: "Auth",
+          action: "relogin",
+          statusCode: 401,
+          detail:
+            "Your authentication session could not be refreshed automatically. Please log out and sign in again.",
+        },
+      },
+    });
+
+    await expect(request).rejects.toHaveProperty(
+      "message",
+      "failed to load configuration: Your authentication session could not be refreshed automatically. Please log out and sign in again.",
+    );
+    await expect(request).rejects.toHaveProperty("data", {
+      reason: "cloudRequirements",
+      errorCode: "Auth",
+      action: "relogin",
+      statusCode: 401,
+      detail:
+        "Your authentication session could not be refreshed automatically. Please log out and sign in again.",
+    });
+  });
+
   it("rejects timed-out requests and ignores late responses", async () => {
     vi.useFakeTimers();
     const harness = createClientHarness();

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -42,11 +42,37 @@ export class CodexAppServerRpcError extends Error {
   readonly data?: JsonValue;
 
   constructor(error: { code?: number; message: string; data?: JsonValue }, method: string) {
-    super(error.message || `${method} failed`);
+    super(formatCodexAppServerRpcErrorMessage(error, method));
     this.name = "CodexAppServerRpcError";
     this.code = error.code;
     this.data = error.data;
   }
+}
+
+function formatCodexAppServerRpcErrorMessage(
+  error: { message: string; data?: JsonValue },
+  method: string,
+): string {
+  const message = error.message || `${method} failed`;
+  const detail = readCodexAppServerRpcReloginDetail(error.data);
+  return detail && !message.includes(detail) ? `${message}: ${detail}` : message;
+}
+
+function readCodexAppServerRpcReloginDetail(data: JsonValue | undefined): string | undefined {
+  const record = isJsonObject(data) ? data : undefined;
+  const nested = isJsonObject(record?.error) ? record.error : record;
+  if (!nested) {
+    return undefined;
+  }
+  const isRelogin =
+    nested.action === "relogin" ||
+    (nested.reason === "cloudRequirements" && nested.errorCode === "Auth");
+  const detail = typeof nested.detail === "string" ? nested.detail.trim() : "";
+  return isRelogin && detail ? detail : undefined;
+}
+
+function isJsonObject(value: unknown): value is { [key: string]: JsonValue } {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 export function isCodexAppServerConnectionClosedError(error: unknown): boolean {

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -12,6 +12,15 @@ export type OAuthRefreshFailureReason =
 const OAUTH_REFRESH_FAILURE_PROVIDER_RE = /OAuth token refresh failed for ([^:]+):/i;
 const SAFE_PROVIDER_ID_RE = /^[a-z0-9][a-z0-9._-]*$/;
 
+function isOAuthRefreshFailureMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("oauth token refresh failed") ||
+    lower.includes("access token could not be refreshed") ||
+    lower.includes("authentication session could not be refreshed automatically")
+  );
+}
+
 function extractOAuthRefreshFailureProvider(message: string): string | null {
   const provider = message.match(OAUTH_REFRESH_FAILURE_PROVIDER_RE)?.[1]?.trim();
   return provider && provider.length > 0 ? provider : null;
@@ -49,7 +58,7 @@ export function classifyOAuthRefreshFailure(message: string): {
   provider: string | null;
   reason: OAuthRefreshFailureReason | null;
 } | null {
-  if (!/oauth token refresh failed/i.test(message)) {
+  if (!isOAuthRefreshFailureMessage(message)) {
     return null;
   }
   return {

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -281,6 +281,15 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("returns an explicit re-authentication message for Codex app-server refresh failures", () => {
+    const msg = makeAssistantError(
+      "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.",
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "Authentication refresh failed. Re-authenticate this provider and try again.",
+    );
+  });
+
   it("returns a contention-specific message for OAuth refresh lock timeouts", () => {
     const msg = makeAssistantError("file lock timeout for /tmp/openclaw-oauth-refresh.lock");
     expect(formatAssistantErrorText(msg)).toBe(

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1447,6 +1447,16 @@ describe("classifyProviderRuntimeFailureKind", () => {
         "OAuth token refresh failed for openai-codex: invalid_grant. Please try again or re-authenticate.",
       ),
     ).toBe("auth_refresh");
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.",
+      ),
+    ).toBe("auth_refresh");
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "Your authentication session could not be refreshed automatically. Please log out and sign in again.",
+      ),
+    ).toBe("auth_refresh");
   });
 
   it("classifies OAuth refresh timeouts and lock contention distinctly", () => {


### PR DESCRIPTION
## Summary
- Backports https://github.com/openclaw/openclaw/pull/81638 to `release/2026.5.12`.
- Classifies Codex native/app-server token-refresh logout and relogin failures as auth-refresh failures.
- Preserves Codex app-server relogin detail in RPC error messages and includes the release changelog entry.

## Verification
- `git diff --check origin/release/2026.5.12...HEAD`
- `node scripts/test-projects.mjs extensions/codex/src/app-server/client.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts -- --reporter=dot`
- Testbox `tbx_01krjagtmhdtaxq2bfpkx6et2r`, https://github.com/openclaw/openclaw/actions/runs/25840979009: `pnpm check:changed --base origin/release/2026.5.12 --head HEAD` passed with exit 0 after fetching the release base ref.

Behavior addressed: Codex native/app-server token-refresh logout and relogin failures on the release branch classify as authentication refresh failures instead of raw runtime errors.
Real environment tested: local release-branch worktree plus Blacksmith Testbox.
Exact steps or command run after this patch: `node scripts/test-projects.mjs extensions/codex/src/app-server/client.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts -- --reporter=dot`; `git diff --check origin/release/2026.5.12...HEAD`; Testbox `pnpm check:changed --base origin/release/2026.5.12 --head HEAD`.
Evidence after fix: targeted tests passed 2 Vitest shards, 228 tests total; release-base diff check passed; Testbox `tbx_01krjagtmhdtaxq2bfpkx6et2r` passed changed lanes with exit 0.
Observed result after fix: exact Codex logout/account-switch text formats as `Authentication refresh failed. Re-authenticate this provider and try again.`, generic app-server relogin detail is preserved in the RPC error message, and both paths classify as `auth_refresh`.
What was not tested: no live mutation of an expired OpenAI account session; regression coverage is based on the current Codex harness source and app-server RPC error shape.
