### PR TITLE
fix(agents): suppress aborted assistant output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply: preserve same-key ordering when debounced inbound work falls back to immediate flushes, so follow-up turns cannot overtake an active buffered flush.
 - Telegram/WhatsApp: keep Telegram same-chat replies ordered behind active no-delay turns without blocking WhatsApp follow-up message dispatch.
 - Codex migration: avoid duplicate cached plugin bundle warnings when app-server plugin inventory is available.
+- Agents: suppress aborted embedded assistant partials, reasoning text, reply directives, and stale prior replies before user-facing delivery while preserving clean timeout/error payloads. Fixes #48241. Thanks @BunsDev, @andyliu, and @yassinebkr.
 - iOS/chat: resize PhotosPicker image attachments to capped JPEGs before staging and sending, stripping source metadata and keeping oversized camera photos under the chat upload budget. Fixes #68524. Thanks @BunsDev.
 - Control UI: keep shared form, config, and usage text-entry controls at 16px on touch-primary devices while preserving chat composer input sizing, so iOS Safari no longer auto-zooms focused fields. Fixes #64651; carries forward #64673. Thanks @NianJiuZst and @BunsDev.
 - Codex harness: classify native app-server token-refresh logout and relogin failures as authentication refresh errors, so users get re-authentication guidance instead of a raw runtime failure.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2503,6 +2503,7 @@ export async function runEmbeddedPiAgent(
             sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
             agentId: params.agentId,
             runId: params.runId,
+            runAborted: aborted,
             didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
             heartbeatToolResponse: attempt.heartbeatToolResponse,
           });

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -169,6 +169,69 @@ describe("buildEmbeddedRunPayloads", () => {
     });
   });
 
+  it("suppresses aborted assistant partial text and surfaces a clean timeout error", () => {
+    const payloads = buildPayloads({
+      runAborted: true,
+      assistantTexts: [
+        "Need answer concise mention not fully E2E tested tomorrow.\n[[reply_to_current]] Final draft",
+      ],
+      lastAssistant: makeAssistant({
+        stopReason: "aborted",
+        errorMessage: "request timed out",
+        content: [
+          {
+            type: "text",
+            text: "Need answer concise mention not fully E2E tested tomorrow.\n[[reply_to_current]] Final draft",
+          },
+        ],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request timed out.",
+      isError: true,
+    });
+    expectNoPayloadTextContaining(payloads, "Need answer concise");
+    expectNoPayloadTextContaining(payloads, "[[reply_to_current]]");
+  });
+
+  it("suppresses aborted assistant reasoning text as well as partial answer text", () => {
+    const payloads = buildPayloads({
+      runAborted: true,
+      assistantTexts: ["partial answer that should not leak"],
+      lastAssistant: makeAssistant({
+        stopReason: "aborted",
+        errorMessage: "request timed out",
+        content: [
+          { type: "thinking", thinking: "partial hidden reasoning" },
+          { type: "text", text: "partial answer that should not leak" },
+        ],
+      }),
+      reasoningLevel: "on",
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request timed out.",
+      isError: true,
+    });
+    expectNoPayloadTextContaining(payloads, "partial hidden reasoning");
+    expectNoPayloadTextContaining(payloads, "partial answer that should not leak");
+  });
+
+  it("does not replay a stale previous assistant when an aborted run has no new text", () => {
+    const payloads = buildPayloads({
+      runAborted: true,
+      assistantTexts: [],
+      lastAssistant: makeAssistant({
+        stopReason: "stop",
+        errorMessage: undefined,
+        content: [{ type: "text", text: "Previous completed assistant reply" }],
+      }),
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
   it("includes provider and model context for billing errors", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -199,6 +199,7 @@ export function buildEmbeddedRunPayloads(params: {
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   agentId?: string;
   runId?: string;
+  runAborted?: boolean;
   didSendDeterministicApprovalPrompt?: boolean;
   heartbeatToolResponse?: HeartbeatToolResponse;
 }): ReplyPayload[] {
@@ -263,9 +264,13 @@ export function buildEmbeddedRunPayloads(params: {
   const useMarkdown = params.toolResultFormat === "markdown";
   const suppressAssistantArtifacts =
     params.didSendDeterministicApprovalPrompt === true || hasSourceReplyPayload;
-  const lastAssistantErrored = params.lastAssistant?.stopReason === "error";
+  const lastAssistantStopReason = params.lastAssistant?.stopReason;
+  const lastAssistantErrored = lastAssistantStopReason === "error";
+  const lastAssistantAborted = lastAssistantStopReason === "aborted";
+  const runAborted = params.runAborted === true || lastAssistantAborted;
+  const lastAssistantNeedsErrorSurface = lastAssistantErrored || lastAssistantAborted;
   const errorText =
-    params.lastAssistant && lastAssistantErrored
+    params.lastAssistant && lastAssistantNeedsErrorSurface
       ? suppressAssistantArtifacts
         ? undefined
         : formatAssistantErrorText(params.lastAssistant, {
@@ -275,7 +280,7 @@ export function buildEmbeddedRunPayloads(params: {
             model: params.model,
           })
       : undefined;
-  const rawErrorMessage = lastAssistantErrored
+  const rawErrorMessage = lastAssistantNeedsErrorSurface
     ? normalizeOptionalString(params.lastAssistant?.errorMessage)
     : undefined;
   const rawErrorFingerprint = rawErrorMessage
@@ -325,11 +330,12 @@ export function buildEmbeddedRunPayloads(params: {
     }
   }
 
-  const reasoningText = suppressAssistantArtifacts
-    ? ""
-    : params.lastAssistant && params.reasoningLevel === "on" && params.thinkingLevel !== "off"
-      ? extractAssistantThinking(params.lastAssistant)
-      : "";
+  const reasoningText =
+    suppressAssistantArtifacts || runAborted
+      ? ""
+      : params.lastAssistant && params.reasoningLevel === "on" && params.thinkingLevel !== "off"
+        ? extractAssistantThinking(params.lastAssistant)
+        : "";
   if (reasoningText) {
     replyItems.push({ text: reasoningText, isReasoning: true });
   }
@@ -339,7 +345,7 @@ export function buildEmbeddedRunPayloads(params: {
     : "";
   const fallbackRawAnswerText = resolveRawAssistantAnswerText(params.lastAssistant);
   const shouldSuppressRawErrorText = (text: string) => {
-    if (!lastAssistantErrored) {
+    if (!lastAssistantNeedsErrorSurface) {
       return false;
     }
     const trimmed = text.trim();
@@ -416,18 +422,19 @@ export function buildEmbeddedRunPayloads(params: {
     fallbackAnswerSourceText.length > 0 &&
     normalizedFallbackAnswerSourceText.length > 0;
   const hasAssistantTextPayload = nonEmptyAssistantTexts.length > 0;
-  const answerTexts = suppressAssistantArtifacts
-    ? []
-    : (shouldUseCanonicalFinalAnswer
-        ? [fallbackAnswerSourceText]
-        : shouldPreferRawAnswerText && fallbackRawAnswerText
-          ? [fallbackRawAnswerText]
-          : hasAssistantTextPayload
-            ? nonEmptyAssistantTexts
-            : fallbackAnswerText
-              ? [fallbackAnswerText]
-              : []
-      ).filter((text) => !shouldSuppressRawErrorText(text));
+  const answerTexts =
+    suppressAssistantArtifacts || runAborted
+      ? []
+      : (shouldUseCanonicalFinalAnswer
+          ? [fallbackAnswerSourceText]
+          : shouldPreferRawAnswerText && fallbackRawAnswerText
+            ? [fallbackRawAnswerText]
+            : hasAssistantTextPayload
+              ? nonEmptyAssistantTexts
+              : fallbackAnswerText
+                ? [fallbackAnswerText]
+                : []
+        ).filter((text) => !shouldSuppressRawErrorText(text));
 
   let hasUserFacingAssistantReply = hasSourceReplyPayload;
   const hasUserFacingErrorReply = replyItems.some((item) => item.isError === true);


### PR DESCRIPTION
## Summary

- Add an explicit `runAborted` signal to the embedded PI run payload builder and wire the runner's aborted state into final payload creation.
- Suppress aborted assistant partial text, reasoning text, reply directives, and stale `lastAssistant` fallback text before user-facing delivery.
- Preserve clean timeout/error payload delivery, tool/media payload merging, source-reply suppression behavior, and compaction/retry bookkeeping.
- Add focused regressions for #48241 and credit the carried-forward payload-builder work from #74816/#48283 in the changelog.

Fixes #48241.
Supersedes #48283.
Supersedes #74816.
Related to #50147.

## Verification

- `PATH=/Users/buns/.nvm/versions/node/v22.22.2/bin:$PATH pnpm test src/agents/pi-embedded-runner/run/payloads.errors.test.ts src/agents/pi-embedded-runner/run/payloads.test.ts -- --reporter=verbose` — 2 files, 69 tests passed.
- `PATH=/Users/buns/.nvm/versions/node/v22.22.2/bin:$PATH pnpm test src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/get-reply-run-queue.test.ts src/auto-reply/reply/abort.test.ts -- --reporter=verbose` — 5 files, 156 tests passed across auto-reply and agents shards.
- `PATH=/Users/buns/.nvm/versions/node/v22.22.2/bin:$PATH pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts src/agents/pi-embedded-runner/run/payloads.ts` — passed.
- `git diff --check HEAD~1..HEAD` — passed.
- `PATH=/Users/buns/.nvm/versions/node/v22.22.2/bin:$PATH pnpm check:changed` — passed core/coreTests/docs changed lanes, including tsgo core, tsgo core tests, oxlint core, dependency pin guard, runtime sidecar loader guard, import-cycle guard, and auth/webhook guards.

## Real behavior proof

Behavior addressed: aborted embedded PI runs can finish with nonblank assistant buffers; this patch prevents those buffers from becoming user-facing payload text, reasoning text, reply directives, or stale previous-assistant fallback output while still surfacing clean timeout/error copy when the abort carries an error surface.

Real environment tested: local OpenClaw worktree on macOS, rebased on `origin/main` at `2d231cef27`, using Node `v22.22.2` from NVM because `/opt/homebrew/bin/node` is currently missing `libllhttp.9.3.dylib`.

Exact steps or command run after this patch: ran the payload regression tests, related abort/reply runner tests, focused formatting check, `git diff --check HEAD~1..HEAD`, and `pnpm check:changed` with the exact commands listed above.

Evidence after fix: the new payload tests prove aborted partial text with `[[reply_to_current]]`, aborted reasoning content, and stale prior assistant fallback are not emitted; existing timeout/tool-media runner tests still prove clean timeout payloads and tool media survive the abort path.

Observed result after fix: aborted runs now return no assistant text payload unless there is a clean aborted/error surface to show; timeout/error output remains sanitized as `LLM request timed out.` and existing source-reply/tool-media paths remain covered by unchanged green tests.

What was not tested: no live Telegram/sub2api abort race was reproduced locally; duplicate grouping/tagging was not completed because `prtags search text "aborted assistant partial" -R openclaw/openclaw --types group --limit 10` still returns HTTP 502 even though `prtags auth status` reports `BunsDev` with repo scope.

## Bug/Security Review

- No dependency, lockfile, workflow, permission, credential, network, or external execution surface changed.
- The new flag only gates final outbound payload assembly for aborted embedded runs; it does not alter model execution, tool execution, auth, or channel permissions.
- Gateway/WebChat abort-partial retention is intentionally untouched; this fix is scoped to the embedded user-facing payload path described in #48241.



