### PR TITLE
fix(line): canonicalize lowercased LINE chat ids at send boundary (#81628)

### DIFF
--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -409,6 +409,52 @@ describe("LINE send helpers", () => {
     );
   });
 
+  it("restores capital-letter prefix for lowercased LINE chat ids (issue #81628)", async () => {
+    // Simulates the cron / session-key fallback path that lowercases peer ids
+    // before they reach the channel boundary. The LINE push API rejects
+    // lowercased ids with HTTP 400, so the channel-owned send helper must
+    // canonicalize the leading letter back to U/C/R.
+    const lowercasedGroupId = `c${"a".repeat(32)}`;
+    const expectedGroupId = `C${"a".repeat(32)}`;
+
+    await sendModule.sendMessageLine(lowercasedGroupId, "hello", { cfg: LINE_TEST_CFG });
+
+    expect(pushMessageMock).toHaveBeenCalledWith({
+      to: expectedGroupId,
+      messages: [{ type: "text", text: "hello" }],
+    });
+  });
+
+  it("strips line:* prefix and uppercases first char on durable replay (issue #81628)", async () => {
+    // Simulates a queued/durable delivery target that survived as a raw
+    // session-key fragment such as "line:group:c<hex>". The plugin must strip
+    // the prefix and restore canonical casing before calling pushMessage.
+    const lowercasedUserId = `u${"b".repeat(32)}`;
+    const expectedUserId = `U${"b".repeat(32)}`;
+
+    await sendModule.pushMessagesLine(
+      `line:user:${lowercasedUserId}`,
+      [{ type: "text", text: "replay" }],
+      { cfg: LINE_TEST_CFG },
+    );
+
+    expect(pushMessageMock).toHaveBeenCalledWith({
+      to: expectedUserId,
+      messages: [{ type: "text", text: "replay" }],
+    });
+  });
+
+  it("leaves non-LINE-id-shaped recipients untouched", async () => {
+    // Custom test harness ids (not 33-char U/C/R + 32 hex) should pass through
+    // unchanged so existing test fixtures keep working.
+    await sendModule.sendMessageLine("U-quick", "hi", { cfg: LINE_TEST_CFG });
+
+    expect(pushMessageMock).toHaveBeenCalledWith({
+      to: "U-quick",
+      messages: [{ type: "text", text: "hi" }],
+    });
+  });
+
   it("pushes quick-reply text and caps to 13 buttons", async () => {
     await sendModule.pushTextMessageWithQuickReplies(
       "U-quick",

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -52,23 +52,41 @@ interface LineReplyBehavior {
   verboseMessage?: (messageCount: number) => string;
 }
 
+// LINE chat IDs (userId / groupId / roomId) are case-sensitive: per the
+// Messaging API spec they are 33 chars total, starting with a capital U / C / R
+// followed by 32 lowercase hex digits. The LINE push API rejects ids whose
+// first character is lowercased (HTTP 400 "The property, 'to', in the request
+// body is invalid"). Some core paths (e.g. session-key fallback in cron and
+// durable delivery recovery) can resurface a lowercased id, so the
+// channel-owned delivery boundary canonicalizes the leading letter here
+// instead of relying on every caller. See issue #81628.
+const LINE_CHAT_ID_PATTERN = /^[curCUR][0-9a-f]{32}$/;
+
 function normalizeTarget(to: string): string {
   const trimmed = to.trim();
   if (!trimmed) {
     throw new Error("Recipient is required for LINE sends");
   }
 
-  const normalized = trimmed
+  const stripped = trimmed
     .replace(/^line:group:/i, "")
     .replace(/^line:room:/i, "")
     .replace(/^line:user:/i, "")
     .replace(/^line:/i, "");
 
-  if (!normalized) {
+  if (!stripped) {
     throw new Error("Recipient is required for LINE sends");
   }
 
-  return normalized;
+  if (LINE_CHAT_ID_PATTERN.test(stripped)) {
+    const head = stripped.charAt(0);
+    const upperHead = head.toUpperCase();
+    if (head !== upperHead) {
+      return `${upperHead}${stripped.slice(1)}`;
+    }
+  }
+
+  return stripped;
 }
 
 function isLineUserChatId(chatId: string): boolean {


### PR DESCRIPTION
## Summary

Fixes #81628. LINE delivery silently dropped messages because `delivery.to` could reach the LINE plugin lowercased (e.g. `cxxx…` instead of `Cxxx…`); the LINE Messaging API rejects those ids with `HTTP 400 The property, 'to', in the request body is invalid`. Per the codex review on the issue, the fix lives at the channel-owned delivery boundary rather than in core.

## Root cause

LINE chat IDs (`userId` / `groupId` / `roomId`) are case-sensitive (per spec: capital `U` / `C` / `R` followed by 32 lowercase hex chars). Several core paths can surface a lowercased value:

- `src/routing/session-key.ts` lowercases peer ids when building agent session keys (`buildAgentPeerSessionKey` → `normalizeLowercaseStringOrEmpty`).
- `src/agents/tools/cron-tool.ts` `inferDeliveryFromSessionKey()` parses that lowercased fragment and assigns it directly to `delivery.to` when there is no current delivery context — exactly the path used by long-running jobs whose reply token has expired.
- `src/infra/outbound/delivery-queue-recovery.ts` `buildRecoveryDeliverParams` replays the stored `params.to` verbatim, so once a lowercased id is queued every retry hits the same 400 until the entry is moved to `failed/`.

The reply-token-bound path inside the inbound webhook keeps the original casing, which is why fast replies look fine and only post-token-expiry / long task pushes fail — matching the bug report.

## Fix

Extend `normalizeTarget()` in `extensions/line/src/send.ts` (the function every push / reply / loading-animation call already routes through):

1. Strip the existing `line:(group|room|user):` / `line:` prefixes (unchanged).
2. If the result matches the LINE chat-id shape `^[curCUR][0-9a-f]{32}$`, restore the leading letter to its canonical uppercase. Non-id-shaped strings (custom test fixtures, future formats) pass through unchanged.

This is intentionally a single channel-owned guard so we do not have to teach core about LINE casing, and so it also covers durable-recovery replays where the queued `to` is whatever core enqueued.

## Tests

`extensions/line/src/send.test.ts` adds three regression cases:

- Lowercased chat id (simulating the cron / session-key fallback path) is sent with capital first letter.
- Durable replay-style input `line:user:u<hex>` is stripped and uppercased before reaching `client.pushMessage`.
- Non-id-shaped recipients (e.g. `U-quick`) still pass through unchanged so existing fixtures keep working.

## Risk / scope

- Only touches the LINE plugin (`extensions/line/src/send.ts` + its test).
- Behaviour change is gated on the LINE chat-id shape regex, so non-LINE-id inputs are unaffected.
- Does not modify core session-key or delivery-queue logic; their lowercasing stays as-is for routing identity, but the wire-level `to` is now always canonical.

## Verification done locally

- `git diff --stat` confirms only the two files changed.
- pnpm is not installed on this dev box (per `TOOLS.md` constraint), so the relevant suites listed in the codex review (`extensions/line/src/send.test.ts`, `extensions/line/src/channel.sendPayload.test.ts`, `extensions/line/src/bot-message-context.test.ts`, `extensions/line/src/monitor-durable.test.ts`, `extensions/line/src/auto-reply-delivery.test.ts`, `src/agents/tools/cron-tool.test.ts`, `src/infra/outbound/delivery-queue.recovery.test.ts`, `src/infra/outbound/deliver.test.ts`) are validated via CI.

Fixes #81628
