### PR TITLE
Backport oauthRef runtime auth fix to release 2026.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Codex harness: classify native app-server token-refresh logout and relogin failures as authentication refresh errors, so users get re-authentication guidance instead of a raw runtime failure.
+- Codex auth: accept OAuth profiles backed by `oauthRef` during runtime auth selection, so official Codex OAuth logins are used by app-server agent runs. (#81633)
 - Codex startup: treat selectable configured OpenAI agent models as Codex runtime requirements during plugin auto-enable, startup planning, and doctor install repair, so Anthropic-primary configs can still switch to OpenAI/Codex cleanly.
 - Agents: preserve source-reply delivery metadata when merging tool-returned media into the final reply, keeping message-tool-only replies deliverable and mirrored. Thanks @pashpashpash and @vincentkoc.
 - WebChat/TUI: route Codex `tools.message` source replies to the active internal UI turn and mirror them to session history, so message-tool-only harness replies, including rich presentation and button-only replies, no longer disappear while WebChat and TUI remain non-targetable outbound channels. (#81586) Thanks @pashpashpash.

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -12,6 +12,7 @@ import {
   bridgeCodexAppServerStartOptions,
   refreshCodexAppServerAuthTokens,
   resolveCodexAppServerAuthAccountCacheKey,
+  resolveCodexAppServerAuthProfileId,
   resolveCodexAppServerHomeDir,
   resolveCodexAppServerNativeHomeDir,
 } from "./auth-bridge.js";
@@ -649,6 +650,30 @@ describe("bridgeCodexAppServerStartOptions", () => {
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
+  });
+
+  it("selects an oauthRef-backed Codex profile for app-server login", () => {
+    expect(
+      resolveCodexAppServerAuthProfileId({
+        store: {
+          version: 1,
+          profiles: {
+            "openai-codex:default": {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "",
+              refresh: "",
+              expires: Date.now() + 60_000,
+              oauthRef: {
+                source: "openclaw-credentials",
+                provider: "openai-codex",
+                id: "0123456789abcdef0123456789abcdef",
+              },
+            },
+          },
+        },
+      }),
+    ).toBe("openai-codex:default");
   });
 
   it("applies native Codex CLI OAuth when no OpenClaw auth profile exists", async () => {

--- a/src/agents/auth-profiles/credential-state.test.ts
+++ b/src/agents/auth-profiles/credential-state.test.ts
@@ -103,4 +103,23 @@ describe("evaluateStoredCredentialEligibility", () => {
     });
     expect(result).toEqual({ eligible: false, reasonCode: "invalid_expires" });
   });
+
+  it("marks oauth with oauthRef as eligible", () => {
+    const result = evaluateStoredCredentialEligibility({
+      credential: {
+        type: "oauth",
+        provider: "openai-codex",
+        access: "",
+        refresh: "",
+        expires: now + 60_000,
+        oauthRef: {
+          source: "openclaw-credentials",
+          provider: "openai-codex",
+          id: "0123456789abcdef0123456789abcdef",
+        },
+      },
+      now,
+    });
+    expect(result).toEqual({ eligible: true, reasonCode: "ok" });
+  });
 });

--- a/src/agents/auth-profiles/credential-state.ts
+++ b/src/agents/auth-profiles/credential-state.ts
@@ -1,5 +1,5 @@
 import { coerceSecretRef, normalizeSecretInputString } from "../../config/types.secrets.js";
-import type { AuthProfileCredential, OAuthCredential } from "./types.js";
+import type { AuthProfileCredential, OAuthCredential, OAuthCredentialRef } from "./types.js";
 
 export type AuthCredentialReasonCode =
   | "ok"
@@ -69,6 +69,15 @@ function hasConfiguredSecretString(value: unknown): boolean {
   return normalizeSecretInputString(value) !== undefined;
 }
 
+function hasConfiguredOAuthRef(value: OAuthCredentialRef | undefined): boolean {
+  return (
+    value?.source === "openclaw-credentials" &&
+    value.provider === "openai-codex" &&
+    typeof value.id === "string" &&
+    /^[a-f0-9]{32}$/.test(value.id)
+  );
+}
+
 export function evaluateStoredCredentialEligibility(params: {
   credential: AuthProfileCredential;
   now?: number;
@@ -104,7 +113,8 @@ export function evaluateStoredCredentialEligibility(params: {
 
   if (
     normalizeSecretInputString(credential.access) === undefined &&
-    normalizeSecretInputString(credential.refresh) === undefined
+    normalizeSecretInputString(credential.refresh) === undefined &&
+    !hasConfiguredOAuthRef(credential.oauthRef)
   ) {
     return { eligible: false, reasonCode: "missing_credential" };
   }

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -276,6 +276,33 @@ describe("resolveAuthProfileOrder", () => {
     expect(order).toEqual(["openai-codex:personal", "openai:backup"]);
   });
 
+  it("lets Codex auth discover oauthRef-backed OAuth profiles", async () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai-codex:personal": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "",
+          refresh: "",
+          expires: Date.now() + 60_000,
+          oauthRef: {
+            source: "openclaw-credentials",
+            provider: "openai-codex",
+            id: "0123456789abcdef0123456789abcdef",
+          },
+        },
+      },
+    };
+
+    const order = resolveAuthProfileOrder({
+      store,
+      provider: "openai-codex",
+    });
+
+    expect(order).toEqual(["openai-codex:personal"]);
+  });
+
   it("preserves native Codex profiles before OpenAI alias API-key order", async () => {
     const store: AuthProfileStore = {
       version: 1,


### PR DESCRIPTION
## Summary

Backports #81633 to `release/2026.5.12`.

This keeps the official Codex OAuth storage path working on the 2026.5.12 release branch: OAuth profiles stored with `oauthRef` now count as configured credentials during runtime auth selection, so Codex app-server runs can select the profile and log in instead of reaching Responses with `profile=-` / missing auth.

## Real behavior proof

- Before: an `openai-codex` OAuth profile backed only by `oauthRef` was visible to status, but runtime auth ordering treated it as `missing_credential`.
- After: regression tests prove `evaluateStoredCredentialEligibility` accepts `oauthRef`, `resolveAuthProfileOrder` includes the Codex profile, and Codex app-server auth selection picks it for login.

## Verification

- `pnpm test src/agents/auth-profiles/credential-state.test.ts src/agents/auth-profiles/order.test.ts extensions/codex/src/app-server/auth-bridge.test.ts -- --reporter=verbose`
- `node scripts/test-projects.mjs --changed origin/release/2026.5.12`
- `node scripts/check-changed.mjs --base origin/release/2026.5.12`
