### PR TITLE
fix(web): resolve explicit global search providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI tables: preserve muted/color styling on wrapped continuation lines after multiline cells, keeping `openclaw plugins list` descriptions readable.
+- Web: honor explicitly configured global `web_search` providers during provider ownership resolution while keeping sandboxed `web_fetch` limited to bundled providers.
 - iOS: restore first-use Contacts, Calendar, and Reminders permission prompts and add Privacy & Access status/actions in Settings. Thanks @BunsDev.
 - Canvas: return not found for malformed percent-encoded Canvas/A2UI/document asset paths and keep decoded parent traversal blocked before path normalization.
 - Telegram: allow trusted local Bot API media files whose filenames start with dots instead of falling back to remote download.

--- a/src/agents/tools/web-tool-runtime-context.test.ts
+++ b/src/agents/tools/web-tool-runtime-context.test.ts
@@ -77,7 +77,7 @@ describe("web tool runtime context", () => {
     const ownerLookup = latestOwnerLookupParams();
     expect(ownerLookup.contract).toBe("webSearchProviders");
     expect(ownerLookup.value).toBe("perplexity");
-    expect(ownerLookup.origin).toBe("bundled");
+    expect(ownerLookup).not.toHaveProperty("origin");
     expect(ownerLookup.config).toBe(runtimeConfig);
   });
 
@@ -103,7 +103,7 @@ describe("web tool runtime context", () => {
     const ownerLookup = latestOwnerLookupParams();
     expect(ownerLookup.contract).toBe("webSearchProviders");
     expect(ownerLookup.value).toBe("brave");
-    expect(ownerLookup.origin).toBe("bundled");
+    expect(ownerLookup).not.toHaveProperty("origin");
     expect(ownerLookup.config).toBe(capturedConfig);
   });
 
@@ -115,10 +115,24 @@ describe("web tool runtime context", () => {
     const ownerLookup = latestOwnerLookupParams();
     expect(ownerLookup.contract).toBe("webSearchProviders");
     expect(ownerLookup.value).toBe("brave");
-    expect(ownerLookup.origin).toBe("bundled");
+    expect(ownerLookup).not.toHaveProperty("origin");
     expect(ownerLookup.config).toEqual({
       tools: { web: { search: { provider: "Brave" } } },
     });
+  });
+
+  it("treats resolved global provider owners as explicit selections", async () => {
+    mocks.resolveManifestContractOwnerPluginId.mockReturnValue("brave");
+    const { resolveWebSearchToolRuntimeContext } = await import("./web-tool-runtime-context.js");
+
+    const resolved = resolveWebSearchToolRuntimeContext({
+      config: { tools: { web: { search: { provider: "brave" } } } },
+    });
+
+    expect(resolved.preferRuntimeProviders).toBe(false);
+    expect(mocks.resolveManifestContractOwnerPluginId.mock.calls.at(-1)?.[0]).not.toHaveProperty(
+      "origin",
+    );
   });
 
   it("keeps runtime providers disabled for bundled fetch owners", async () => {
@@ -132,7 +146,7 @@ describe("web tool runtime context", () => {
     const ownerLookup = latestOwnerLookupParams();
     expect(ownerLookup.contract).toBe("webFetchProviders");
     expect(ownerLookup.value).toBe("firecrawl");
-    expect(ownerLookup.origin).toBe("bundled");
+    expect(ownerLookup).not.toHaveProperty("origin");
     expect(ownerLookup.config).toEqual({
       tools: { web: { fetch: { provider: "firecrawl" } } },
     });

--- a/src/agents/tools/web-tool-runtime-context.ts
+++ b/src/agents/tools/web-tool-runtime-context.ts
@@ -46,7 +46,6 @@ function shouldPreferRuntimeProviders(params: {
   return !resolveManifestContractOwnerPluginId({
     contract: resolveWebProviderContract(params.kind),
     value: params.providerSelectionId,
-    origin: "bundled",
     config: params.config,
   });
 }

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -595,8 +595,8 @@ describe("web search runtime", () => {
 
     const ownerCall = mockCallParam(resolveManifestContractOwnerPluginIdMock);
     expect(ownerCall.contract).toBe("webSearchProviders");
-    expect(ownerCall.origin).toBe("bundled");
     expect(ownerCall.value).toBe("duckduckgo");
+    expect(ownerCall).not.toHaveProperty("origin");
     expect(mockCallParam(resolveRuntimeWebSearchProvidersMock).onlyPluginIds).toEqual([
       "duckduckgo",
     ]);
@@ -626,6 +626,38 @@ describe("web search runtime", () => {
     expect(result.provider).toBe("gemini");
 
     expect(mockCallParam(resolveRuntimeWebSearchProvidersMock).onlyPluginIds).toEqual(["google"]);
+  });
+
+  it("scopes configured global web_search providers when runtime providers are not preferred", async () => {
+    resolveManifestContractOwnerPluginIdMock.mockImplementation(({ value }) =>
+      value === "custom" ? "custom-search" : undefined,
+    );
+    resolvePluginWebSearchProvidersMock.mockReturnValue([createCustomSearchProvider()]);
+
+    await expect(
+      runWebSearch({
+        config: {
+          tools: {
+            web: {
+              search: {
+                provider: "custom",
+              },
+            },
+          },
+          ...createCustomSearchConfig("custom-key"),
+        },
+        preferRuntimeProviders: false,
+        args: { query: "configured-custom" },
+      }),
+    ).resolves.toMatchObject({
+      provider: "custom",
+    });
+
+    expect(resolvePluginWebSearchProvidersMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["custom-search"],
+      }),
+    );
   });
 
   it("keeps runtime provider loading unscoped when configured provider ownership is unknown", async () => {

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -147,7 +147,6 @@ export function resolveWebSearchProviderId(params: {
       resolvePluginWebSearchProviders({
         config,
         bundledAllowlistCompat: true,
-        origin: "bundled",
       }),
   );
   const raw =
@@ -231,7 +230,6 @@ function resolveExplicitWebSearchProviderPluginIds(params: {
     config: params.config,
     contract: "webSearchProviders",
     value: providerId,
-    origin: "bundled",
   });
   return ownerPluginId ? [ownerPluginId] : undefined;
 }
@@ -270,7 +268,6 @@ export function resolveWebSearchDefinition(
       : resolvePluginWebSearchProviders({
           config,
           bundledAllowlistCompat: true,
-          origin: "bundled",
           ...loadScope,
         }),
   );
@@ -334,7 +331,6 @@ function resolveWebSearchCandidates(
       : resolvePluginWebSearchProviders({
           config,
           bundledAllowlistCompat: true,
-          origin: "bundled",
           ...loadScope,
         }),
   ).filter(Boolean);


### PR DESCRIPTION
## Summary

- Extracts the focused global `web_search` provider-owner fix from #79576 without the unrelated `oc-path` / Codex churn.
- Lets explicit `tools.web.search.provider` ownership resolve across installed/global plugin manifests instead of filtering owners to bundled plugins only.
- Keeps sandboxed `web_fetch` provider loading on its existing bundled-only path.
- Adds focused regressions for global provider ownership and runtime-provider fallback behavior.

Refs #79632. Focused follow-up to #79576. Thanks @jeffla for the original fix and live Brave proof.

## Verification

- `node_modules/.bin/oxfmt --check CHANGELOG.md src/agents/tools/web-tool-runtime-context.ts src/agents/tools/web-tool-runtime-context.test.ts src/web-search/runtime.ts src/web-search/runtime.test.ts src/web-fetch/runtime.ts src/web-fetch/runtime.test.ts`
- `git diff --check origin/main...HEAD`
- Testbox `tbx_01krjfz2w71d5b6f8da7274g3h`, https://github.com/openclaw/openclaw/actions/runs/25843927787:
  - `node scripts/run-vitest.mjs run src/agents/tools/web-tool-runtime-context.test.ts src/web-search/runtime.test.ts src/web-fetch/runtime.test.ts --maxWorkers=1`
  - `pnpm check:changed`

## Real behavior proof

Behavior addressed: Explicitly configured global `web_search` providers, such as Brave, were filtered out during provider ownership resolution because lookup required `origin: "bundled"`.

Real environment tested: Blacksmith Testbox Linux runner using the OpenClaw checkout for this PR branch, plus the original live Brave proof from #79576 by @jeffla.

Exact steps or command run after this patch: Ran focused web runtime tests for runtime context, web search, and web fetch, then ran `pnpm check:changed` on Testbox `tbx_01krjfz2w71d5b6f8da7274g3h`.

Evidence after fix: Targeted Testbox proof passed 4 test files and 43 tests; changed gate completed with exit 0. The diff removes the bundled-origin owner filter from explicit `web_search` resolution and keeps the remaining `origin: "bundled"` check in `src/web-fetch/runtime.ts`.

Observed result after fix: Configured/global `web_search` owners can scope provider loading by plugin id, while sandboxed `web_fetch` keeps its bundled provider boundary.

What was not tested: A fresh live Brave API call from my environment. This PR relies on #79576's live Brave before/after output for that exact provider and adds maintained source/regression proof here.
