### PR TITLE
[AI-assisted] fix(web-search): honor legacy search apiKey in runtime selection

### DIFF
--- a/src/cron/isolated-agent.web-search.test.ts
+++ b/src/cron/isolated-agent.web-search.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "../agents/test-helpers/fast-coding-tools.js";
+import {
+  clearFastTestEnv,
+  loadRunCronIsolatedAgentTurn,
+  resetRunCronIsolatedAgentTurnHarness,
+  restoreFastTestEnv,
+  runEmbeddedPiAgentMock,
+  runWithModelFallbackMock,
+} from "./isolated-agent/run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function makeParams() {
+  const legacySecretRef = {
+    source: "env",
+    provider: "default",
+    id: "LEGACY_WEB_SEARCH_REF",
+  } as const;
+  return {
+    cfg: {
+      tools: {
+        web: {
+          search: {
+            apiKey: legacySecretRef,
+          },
+        },
+      },
+    },
+    deps: {} as never,
+    job: {
+      id: "web-search",
+      name: "Web Search",
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      payload: {
+        kind: "agentTurn",
+        message: "search status",
+        toolsAllow: ["web_search"],
+      },
+      delivery: { mode: "none" },
+    } as never,
+    message: "search status",
+    sessionKey: "cron:web-search",
+    lane: "cron",
+    legacySecretRef,
+  };
+}
+
+function requireEmbeddedPiAgentParams(): {
+  toolsAllow?: string[];
+  config?: {
+    tools?: {
+      web?: {
+        search?: {
+          apiKey?: unknown;
+        };
+      };
+    };
+  };
+} {
+  const call = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+  if (!call || typeof call !== "object" || Array.isArray(call)) {
+    throw new Error("Expected embedded PI agent params for isolated web_search cron");
+  }
+  return call;
+}
+
+describe("runCronIsolatedAgentTurn web_search legacy config (#81538)", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+    runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
+      const result = await run(provider, model);
+      return { result, provider, model, attempts: [] };
+    });
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("forwards web_search toolsAllow with legacy top-level search credential config", async () => {
+    const { legacySecretRef, ...params } = makeParams();
+
+    const result = await runCronIsolatedAgentTurn(params);
+
+    expect(result.status).toBe("ok");
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+
+    const embeddedParams = requireEmbeddedPiAgentParams();
+    expect(embeddedParams.toolsAllow).toEqual(["web_search"]);
+    expect(embeddedParams.config?.tools?.web?.search?.apiKey).toEqual(legacySecretRef);
+  });
+});

--- a/src/secrets/runtime-web-tools.shared.ts
+++ b/src/secrets/runtime-web-tools.shared.ts
@@ -64,6 +64,11 @@ export type RuntimeWebProviderSelectionParams<
     config: OpenClawConfig;
     toolConfig: TToolConfig;
   }) => unknown;
+  readInactiveConfiguredCredential?: (params: {
+    provider: TProvider;
+    config: OpenClawConfig;
+    toolConfig: TToolConfig;
+  }) => unknown;
   readConfiguredCredentialFallback?: (params: {
     provider: TProvider;
     config: OpenClawConfig;
@@ -99,11 +104,13 @@ function pushInactiveProviderCredentialWarnings<
   skipProviderId?: string;
   details: string;
 }): void {
+  const readInactiveConfiguredCredential =
+    params.selection.readInactiveConfiguredCredential ?? params.selection.readConfiguredCredential;
   for (const provider of params.selection.providers) {
     if (provider.id === params.skipProviderId) {
       continue;
     }
-    const value = params.selection.readConfiguredCredential({
+    const value = readInactiveConfiguredCredential({
       provider,
       config: params.selection.sourceConfig,
       toolConfig: params.selection.toolConfig,

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -1095,7 +1095,7 @@ describe("runtime web tools resolution", () => {
   });
 
   it("auto-detects from legacy top-level web search apiKey", async () => {
-    const { metadata, resolvedConfig } = await runRuntimeWebTools({
+    const { metadata, resolvedConfig, context } = await runRuntimeWebTools({
       config: asConfig({
         tools: {
           web: {
@@ -1118,6 +1118,9 @@ describe("runtime web tools resolution", () => {
     expect(resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
     expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).toHaveBeenCalled();
     expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
+    expect(
+      context.warnings.filter((warning) => warning.code === "SECRETS_REF_IGNORED_INACTIVE_SURFACE"),
+    ).toEqual([]);
   });
 
   it("does not resolve web fetch provider SecretRef when web fetch is inactive", async () => {

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -1094,8 +1094,8 @@ describe("runtime web tools resolution", () => {
     expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
   });
 
-  it("does not auto-detect from legacy top-level web search apiKey", async () => {
-    const { metadata } = await runRuntimeWebTools({
+  it("auto-detects from legacy top-level web search apiKey", async () => {
+    const { metadata, resolvedConfig } = await runRuntimeWebTools({
       config: asConfig({
         tools: {
           web: {
@@ -1106,13 +1106,17 @@ describe("runtime web tools resolution", () => {
         },
       }),
       env: {
-        LEGACY_WEB_SEARCH_REF: "legacy-web-search-key",
+        LEGACY_WEB_SEARCH_REF: "legacy-web-search-key", // pragma: allowlist secret
       },
     });
 
-    expect(metadata.search.selectedProvider).toBe("duckduckgo");
+    expect(metadata.search.selectedProvider).toBe("brave");
+    expect(metadata.search.selectedProviderKeySource).toBe("secretRef");
+    expect(metadata.search.providerSource).toBe("auto-detect");
+    expect(readProviderKey(resolvedConfig, "brave")).toBe("legacy-web-search-key");
     expect(resolveManifestContractPluginIdsByCompatibilityRuntimePathMock).not.toHaveBeenCalled();
     expect(resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).toHaveBeenCalled();
     expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
   });
 

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -483,6 +483,13 @@ function readConfiguredProviderCredential(params: {
   return configuredValue ?? params.provider.getCredentialValue(params.search);
 }
 
+function readConfiguredProviderScopedCredential(params: {
+  provider: PluginWebSearchProviderEntry;
+  config: OpenClawConfig;
+}): unknown {
+  return params.provider.getConfiguredCredentialValue?.(params.config);
+}
+
 function readConfiguredProviderCredentialFallback(params: {
   provider: PluginWebSearchProviderEntry;
   config: OpenClawConfig;
@@ -698,6 +705,11 @@ export async function resolveRuntimeWebTools(params: {
           provider,
           config,
           search: toolConfig,
+        }),
+      readInactiveConfiguredCredential: ({ provider, config }) =>
+        readConfiguredProviderScopedCredential({
+          provider,
+          config,
         }),
       readConfiguredCredentialFallback: ({ provider, config, toolConfig }) =>
         readConfiguredProviderCredentialFallback({

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -479,7 +479,8 @@ function readConfiguredProviderCredential(params: {
   config: OpenClawConfig;
   search: Record<string, unknown> | undefined;
 }): unknown {
-  return params.provider.getConfiguredCredentialValue?.(params.config);
+  const configuredValue = params.provider.getConfiguredCredentialValue?.(params.config);
+  return configuredValue ?? params.provider.getCredentialValue(params.search);
 }
 
 function readConfiguredProviderCredentialFallback(params: {

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -232,6 +232,45 @@ describe("web search runtime", () => {
     });
   });
 
+  it("auto-detects a provider from legacy top-level search credentials", async () => {
+    const legacyApiKey = "legacy-config-key"; // pragma: allowlist secret
+    const provider = createWebSearchTestProvider({
+      pluginId: "legacy-search",
+      id: "legacy",
+      credentialPath: "tools.web.search.apiKey",
+      autoDetectOrder: 1,
+      getCredentialValue: (searchConfig) => searchConfig?.apiKey,
+      createTool: ({ searchConfig }) => ({
+        description: "legacy",
+        parameters: {},
+        execute: async (args) => ({
+          ...args,
+          apiKey: searchConfig?.apiKey,
+        }),
+      }),
+    });
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([provider]);
+    resolvePluginWebSearchProvidersMock.mockReturnValue([provider]);
+
+    await expect(
+      runWebSearch({
+        config: {
+          tools: {
+            web: {
+              search: {
+                apiKey: legacyApiKey,
+              },
+            },
+          },
+        },
+        args: { query: "legacy" },
+      }),
+    ).resolves.toEqual({
+      provider: "legacy",
+      result: { query: "legacy", apiKey: legacyApiKey },
+    });
+  });
+
   it("auto-detects a provider from a configured credential fallback", async () => {
     const provider = createCustomSearchProvider({
       getConfiguredCredentialFallback: (config) => {

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -88,8 +88,9 @@ function hasEntryCredential(
     provider,
     config,
     toolConfig: search as Record<string, unknown> | undefined,
-    resolveRawValue: ({ provider: currentProvider, config: currentConfig }) =>
-      currentProvider.getConfiguredCredentialValue?.(currentConfig),
+    resolveRawValue: ({ provider: currentProvider, config: currentConfig, toolConfig }) =>
+      currentProvider.getConfiguredCredentialValue?.(currentConfig) ??
+      currentProvider.getCredentialValue(toolConfig),
     resolveFallbackRawValue: ({ provider: currentProvider, config: currentConfig }) =>
       currentProvider.getConfiguredCredentialFallback?.(currentConfig)?.value,
     resolveEnvValue: ({ provider: currentProvider, configuredEnvVarId }) =>


### PR DESCRIPTION
## Summary

- Problem: runtime web-search provider selection could miss the documented legacy `tools.web.search.apiKey` config path when no provider was explicitly selected.
- Why it matters: isolated cron jobs that allow `web_search` can still report the provider unavailable if the persistent config only has the legacy top-level search credential.
- What changed: web-search credential detection now falls back from plugin-scoped credentials to provider `getCredentialValue(searchConfig)`, matching the actual provider execution path.
- What did NOT change: no cron scheduler rewrite, no tool-policy change, no provider/network change, and no new dependency.

## Change Type

- Bug fix

## Scope

- Skills / tool execution
- Integrations
- API / contracts

## Linked Issue/PR

- Related #81538
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: legacy `tools.web.search.apiKey` is now honored during runtime provider selection instead of only after a provider is already selected.
- Real environment tested: fresh disposable Ubuntu 24.04 OpenClaw checkout with Node 22.16.0 and pnpm 11.1.0; no real API key, no external API call, and no daemon/systemd install.
- Exact steps or command run after this patch:

```text
pnpm install --frozen-lockfile --store-dir <cache>
node scripts/check-changed.mjs
node_modules/.bin/vitest run src/secrets/runtime-web-tools.test.ts src/web-search/runtime.test.ts src/agents/tools/web-tools.enabled-defaults.test.ts src/cron/isolated-agent.web-search.test.ts
node --import tsx 81538-runtime-proof.mjs
```

- Evidence after fix:

```text
Test Files  5 passed (5)
Tests       73 passed (73)

{
  "selectedProvider": "brave",
  "providerSource": "auto-detect",
  "selectedProviderKeySource": "secretRef",
  "resolvedBravePluginKeyPresent": true,
  "runtimeSelectedProviderFromLegacyConfig": "legacy"
}
PASS: legacy tools.web.search.apiKey is honored by runtime resolver and web_search provider selection
```

- Observed result after fix: the fake legacy SecretRef selects `brave` through runtime discovery, populates the plugin credential, and the web-search runtime selection also recognizes a legacy top-level config credential.
- What was not tested: live Brave API request, reporter's Docker/Hostinger cron setup, and a real paid/credentialed provider call.
- Before evidence: source inspection and the regression test show the previous path only checked plugin-scoped configured credentials before falling back to keyless/default behavior.

## Root Cause

- Root cause: the web-search runtime credential selection path only consulted `provider.getConfiguredCredentialValue(config)` for configured credentials, while the provider execution path can also read `provider.getCredentialValue(searchConfig)`.
- Missing detection / guardrail: there was no regression proving legacy `tools.web.search.apiKey` can drive provider auto-detection.
- Contributing context: isolated cron already forwards `toolsAllow`; the gap was in web-search credential/provider selection, not cron scheduling.

## Regression Test Plan

- Coverage level that should have caught this:
  - Unit test
  - Seam / integration test
- Target test or file:
  - `src/secrets/runtime-web-tools.test.ts`
  - `src/web-search/runtime.test.ts`
  - `src/cron/isolated-agent.web-search.test.ts`
  - `src/agents/tools/web-tools.enabled-defaults.test.ts`
- Scenario the test should lock in: legacy top-level web-search credentials participate in runtime discovery, web-search runtime provider selection, and isolated cron forwarding with `toolsAllow: ["web_search"]`.
- Why this is the smallest reliable guardrail: it covers the broken credential-selection contract and the isolated cron handoff without adding a live external provider dependency.
- Existing test that already covers this: `src/agents/tools/web-tools.enabled-defaults.test.ts` keeps the managed web-search tool enabled/defaulted in runtime contexts.

## User-visible / Behavior Changes

Legacy `tools.web.search.apiKey` remains usable for web-search provider auto-detection in runtime paths. No config migration is required.

## Diagram

```text
Before:
legacy tools.web.search.apiKey
  -> runtime provider discovery
  -> only plugin-scoped credential checked
  -> provider may look unavailable

After:
legacy tools.web.search.apiKey
  -> runtime provider discovery
  -> plugin-scoped credential check
  -> legacy searchConfig credential fallback
  -> provider can be selected
```

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: existing web-search credential detection now also checks the existing legacy top-level search config surface. The value is not logged, persisted to a new location, or sent anywhere new; tests use fake SecretRef/config values only.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 disposable checkout
- Runtime/container: Node 22.16.0, pnpm 11.1.0
- Model/provider: N/A
- Integration/channel: runtime web-search config and isolated cron unit coverage
- Relevant config (redacted):

```text
tools.web.search.apiKey = { source: "env", provider: "default", id: "LEGACY_WEB_SEARCH_REF" }
```

### Steps

1. Apply the patch to a fresh checkout.
2. Run `node scripts/check-changed.mjs`.
3. Run the focused Vitest command listed above.
4. Run the runtime proof script with a fake SecretRef value.

### Expected

- Runtime discovery selects the credentialed provider from legacy top-level config.
- Focused tests and changed-file checks pass.

### Actual

- Runtime discovery selected `brave` with `selectedProviderKeySource=secretRef`.
- Web-search runtime selection recognized the legacy top-level config provider.
- `check-changed`, focused Vitest, formatting, lint, and diff checks passed.

## Evidence

- Failing test/log before + passing after
- Trace/log snippets

## Human Verification

- Verified scenarios: runtime credential discovery from legacy `tools.web.search.apiKey`, web-search runtime provider selection from top-level legacy config, and isolated cron forwarding of `toolsAllow: ["web_search"]` with the legacy config still present.
- Edge cases checked: `tools.web.search.enabled=false` still leaves runtime provider selection disabled, even with a legacy top-level credential configured.
- Not verified: live Brave API request, reporter's Docker/Hostinger cron deployment, or a full gateway/daemon run.

## Review Conversations

- No bot or reviewer conversations have been opened on this PR yet.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- Exact upgrade steps: None beyond updating OpenClaw.

## Risks and Mitigations

- Risk: the reporter's Docker environment inheritance problem may be a separate issue from the persistent legacy config fallback.
  - Mitigation: this PR is scoped to the source-level credential-selection gap called out in #81538 and does not claim to fix Docker env inheritance.
