### PR TITLE
docs: harden daily memory note guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/agent memory: clarify memory-file write guidance to read before writing and avoid empty placeholders.
 - Control UI/WebChat: add a persisted auto-scroll mode selector so users can keep the current near-bottom behavior, always follow streaming output, or turn automatic streaming scroll off and use the New messages button manually. Fixes #7648 and #81287. Thanks @BunsDev.
 - ACP: add `acp.fallbacks` so ACP turns can try configured backup runtime backends when the primary backend is unavailable before any output is emitted. (#69542) Thanks @kaseonedge.
 

--- a/docs/reference/AGENTS.default.md
+++ b/docs/reference/AGENTS.default.md
@@ -67,6 +67,7 @@ cp docs/reference/AGENTS.default.md ~/.openclaw/workspace/AGENTS.md
 - Long-term memory: `MEMORY.md` for durable facts, preferences, and decisions.
 - Lowercase `memory.md` is legacy repair input only; do not keep both root files on purpose.
 - On session start, read today + yesterday + `MEMORY.md` when present.
+- Before writing memory files, read them first; write only concrete updates, never empty placeholders.
 - Capture: decisions, preferences, constraints, open loops.
 - Avoid secrets unless explicitly requested.
 

--- a/docs/reference/templates/AGENTS.dev.md
+++ b/docs/reference/templates/AGENTS.dev.md
@@ -37,6 +37,7 @@ git commit -m "Add agent workspace"
 
 - Keep a short daily log at memory/YYYY-MM-DD.md (create memory/ if needed).
 - On session start, read today + yesterday if present.
+- Before writing memory files, read them first; write only concrete updates, never empty placeholders.
 - Capture durable facts, preferences, and decisions; avoid secrets.
 
 ## Heartbeats (optional)

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -52,6 +52,7 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 
 - **Memory is limited** — if you want to remember something, WRITE IT TO A FILE
 - "Mental notes" don't survive session restarts. Files do.
+- Before writing memory files, read them first; write only concrete updates, never empty placeholders.
 - When someone says "remember this" → update `memory/YYYY-MM-DD.md` or relevant file
 - When you learn a lesson → update AGENTS.md, TOOLS.md, or the relevant skill
 - When you make a mistake → document it so future-you doesn't repeat it


### PR DESCRIPTION
## Summary

- Default AGENTS memory guidance can be read as permission to write memory files directly.
- In live sessions, that led the model to perform normal file writes to daily notes without first reading the existing file, including replacing prior daily memory content with placeholder content.
- This PR keeps the fix narrow: memory-file write guidance now says to read memory files first and only write concrete updates.

## Community Search

I searched existing issues/PRs before opening this and did not find a direct report for this specific daily-note overwrite pattern.

Queries checked across title/body/comments:

```text
memory overwrite
daily notes memory
daily memory overwrite
memory/YYYY-MM-DD overwrite
Successfully wrote memory
```

The hits were about cron data overwrite, memory capability overwrite, memory wiki, and daily-note auto-load behavior, not normal model-initiated writes replacing `memory/YYYY-MM-DD.md`.

## Real behavior proof

- Behavior or issue addressed: Daily memory notes could be overwritten when the model called the normal file `write` tool on `memory/YYYY-MM-DD.md` without reading the existing note first, including placeholder-only writes.
- Real environment tested: Redacted live OpenClaw agent sessions in a user workspace, with the same memory-file write guidance applied locally after this change.
- Exact steps or command run after this patch: Applied the equivalent daily-note prompt wording in the live setup, then continued normal memory-capture conversations and checked later session trajectories for direct daily-note overwrite entries.
- Before evidence optional:

```text
case 1: capture path rejected, then direct daily-note write

assistant toolCall write
path: memory/2026-05-09.md
content: <redacted daily-note body>

toolResult write
Successfully wrote 193 bytes to memory/2026-05-09.md

case 2: capture path succeeded, then direct daily-note write

assistant text
I will also record today's discussion in the daily notes.

assistant toolCall write
path: memory/2026-05-13.md
content: <redacted daily-note body>

toolResult write
Successfully wrote 152 bytes to memory/2026-05-13.md

case 3: "\new" interpreted as "create today's daily note"

user
\new

assistant text
Check whether the daily note exists; create it if missing.

assistant toolCall write
path: memory/2026-05-14.md
append: false
content: "# 2026-05-14\n\n## Daily Notes\n-\n\n## Task List\n- [ ]\n\n## Progress / Learnings\n-\n\n## Questions / Reflections\n-\n"

toolResult write
Successfully wrote 64 bytes to memory/2026-05-14.md
```

- Evidence after fix:

```text
redacted live observation after applying the prompt hardening:
no later trajectory entry showed the same direct daily-note overwrite pattern
no new "Successfully wrote ... memory/YYYY-MM-DD.md" daily-note replacement was observed
```

- Observed result after fix: The reporter has not observed another daily-note overwrite after applying the equivalent prompt hardening in the live setup.
- What was not tested: No additional gaps.

## Root Cause

The prompt said daily notes are raw logs in `memory/YYYY-MM-DD.md`, and separately asked the agent to capture important context. Some models interpret that as permission to write memory files directly, including initializing today's daily note from a short "new" request. Since the prompt did not say to read memory files before writing or to avoid placeholder-only content, a normal file write could replace the whole daily note.

## Change

- `docs/reference/templates/AGENTS.md`: memory write guidance now says to read memory files before writing and only write concrete updates.
- `docs/reference/AGENTS.default.md`: same clarification for the personal assistant default.
- `docs/reference/templates/AGENTS.dev.md`: same clarification for the dev template.
- `CHANGELOG.md`: notes the prompt hardening.

## Scope

This is prompt/documentation hardening only. It does not change memory storage code, file-write behavior, tools, plugin APIs, or runtime enforcement.

## Verification

```text
git diff --check
pnpm format:docs:check
pnpm docs:check-mdx
```

All passed.

## Risk

Prompt guidance cannot fully prevent a model from ignoring instructions. Runtime file-tool guardrails for `memory/YYYY-MM-DD.md` would be a separate change.
