### PR TITLE
fix(slack): warn on name-keyed channel allowlist routes

### DIFF
--- a/extensions/slack/src/doctor.test.ts
+++ b/extensions/slack/src/doctor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { slackDoctor } from "./doctor.js";
+import { collectSlackIgnoredChannelRouteKeyWarnings, slackDoctor } from "./doctor.js";
 
 function getSlackCompatibilityNormalizer(): NonNullable<
   typeof slackDoctor.normalizeCompatibilityConfig
@@ -12,6 +12,89 @@ function getSlackCompatibilityNormalizer(): NonNullable<
 }
 
 describe("slack doctor", () => {
+  it("warns when allowlisted channel routes are keyed by name", () => {
+    const warnings = collectSlackIgnoredChannelRouteKeyWarnings({
+      cfg: {
+        channels: {
+          slack: {
+            groupPolicy: "allowlist",
+            channels: {
+              "example-channel": { requireMention: false },
+              C0AL2GDUA7J: { requireMention: false },
+              "*": { requireMention: true },
+            },
+            accounts: {
+              work: {
+                channels: {
+                  "ops-room": { requireMention: false },
+                  C0AL2GDUA8K: { requireMention: false },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('channels.slack.channels."example-channel"');
+    expect(warnings[0]).toContain("is keyed by name, not a Slack channel ID");
+    expect(warnings[1]).toContain('channels.slack.accounts.work.channels."ops-room"');
+  });
+
+  it("does not warn about name-keyed routes when dangerous name matching is enabled", () => {
+    expect(
+      collectSlackIgnoredChannelRouteKeyWarnings({
+        cfg: {
+          channels: {
+            slack: {
+              groupPolicy: "allowlist",
+              dangerouslyAllowNameMatching: true,
+              channels: {
+                "example-channel": { requireMention: false },
+              },
+            },
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("honors account-level dangerous name matching overrides", () => {
+    const warnings = collectSlackIgnoredChannelRouteKeyWarnings({
+      cfg: {
+        channels: {
+          slack: {
+            groupPolicy: "allowlist",
+            dangerouslyAllowNameMatching: true,
+            accounts: {
+              inherited: {
+                channels: {
+                  "ops-room": { requireMention: false },
+                },
+              },
+              disabled: {
+                dangerouslyAllowNameMatching: false,
+                channels: {
+                  "alerts-room": { requireMention: false },
+                },
+              },
+              enabled: {
+                dangerouslyAllowNameMatching: true,
+                channels: {
+                  "triage-room": { requireMention: false },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('channels.slack.accounts.disabled.channels."alerts-room"');
+  });
+
   it("warns when mutable allowlist entries rely on disabled name matching", async () => {
     const warnings = await Promise.resolve(
       slackDoctor.collectMutableAllowlistWarnings?.({

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -1,9 +1,14 @@
 import { type ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { createDangerousNameMatchingMutableAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
+import { resolveDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 import {
   legacyConfigRules as SLACK_LEGACY_CONFIG_RULES,
   normalizeCompatibilityConfig as normalizeSlackCompatibilityConfig,
 } from "./doctor-contract.js";
+import {
+  collectIgnoredSlackChannelRouteKeys,
+  formatIgnoredSlackChannelRouteKeyWarning,
+} from "./monitor/channel-config.js";
 import { isSlackMutableAllowEntry } from "./security-doctor.js";
 
 function asObjectRecord(value: unknown): Record<string, unknown> | null {
@@ -47,6 +52,67 @@ const collectSlackMutableAllowlistWarnings =
     },
   });
 
+export function collectSlackIgnoredChannelRouteKeyWarnings(params: {
+  cfg: Record<string, unknown>;
+}): string[] {
+  const slack = asObjectRecord(asObjectRecord(params.cfg.channels)?.slack);
+  if (!slack) {
+    return [];
+  }
+  const warnings: string[] = [];
+  const topGroupPolicy = typeof slack.groupPolicy === "string" ? slack.groupPolicy : undefined;
+  const topAllowNameMatching = slack.dangerouslyAllowNameMatching === true;
+  const topChannels = asObjectRecord(slack.channels);
+  if (topChannels) {
+    for (const key of collectIgnoredSlackChannelRouteKeys({
+      channels: topChannels as never,
+      groupPolicy: topGroupPolicy,
+      allowNameMatching: topAllowNameMatching,
+    })) {
+      warnings.push(
+        formatIgnoredSlackChannelRouteKeyWarning({
+          path: "channels.slack.channels",
+          key,
+        }),
+      );
+    }
+  }
+
+  const accounts = asObjectRecord(slack.accounts);
+  if (!accounts) {
+    return warnings;
+  }
+  for (const [accountId, rawAccount] of Object.entries(accounts)) {
+    const account = asObjectRecord(rawAccount);
+    if (!account) {
+      continue;
+    }
+    const accountChannels = asObjectRecord(account.channels);
+    if (!accountChannels) {
+      continue;
+    }
+    const accountGroupPolicy =
+      typeof account.groupPolicy === "string" ? account.groupPolicy : topGroupPolicy;
+    const accountAllowNameMatching = resolveDangerousNameMatchingEnabled({
+      providerConfig: slack,
+      accountConfig: account,
+    });
+    for (const key of collectIgnoredSlackChannelRouteKeys({
+      channels: accountChannels as never,
+      groupPolicy: accountGroupPolicy,
+      allowNameMatching: accountAllowNameMatching,
+    })) {
+      warnings.push(
+        formatIgnoredSlackChannelRouteKeyWarning({
+          path: `channels.slack.accounts.${accountId}.channels`,
+          key,
+        }),
+      );
+    }
+  }
+  return warnings;
+}
+
 export const slackDoctor: ChannelDoctorAdapter = {
   dmAllowFromMode: "topOnly",
   groupModel: "route",
@@ -54,5 +120,6 @@ export const slackDoctor: ChannelDoctorAdapter = {
   warnOnEmptyGroupSenderAllowlist: false,
   legacyConfigRules: SLACK_LEGACY_CONFIG_RULES,
   normalizeCompatibilityConfig: normalizeSlackCompatibilityConfig,
+  collectPreviewWarnings: ({ cfg }) => collectSlackIgnoredChannelRouteKeyWarnings({ cfg }),
   collectMutableAllowlistWarnings: collectSlackMutableAllowlistWarnings,
 };

--- a/extensions/slack/src/monitor/channel-config.ts
+++ b/extensions/slack/src/monitor/channel-config.ts
@@ -33,6 +33,8 @@ type SlackChannelConfigEntry = {
 
 export type SlackChannelConfigEntries = Record<string, SlackChannelConfigEntry>;
 
+const SLACK_CHANNEL_ROUTE_ID_KEY_RE = /^(?:channel:)?[CGD][A-Z0-9]{8,}$/i;
+
 function firstDefined<T>(...values: Array<T | undefined>) {
   for (const value of values) {
     if (value !== undefined) {
@@ -40,6 +42,31 @@ function firstDefined<T>(...values: Array<T | undefined>) {
     }
   }
   return undefined;
+}
+
+export function isSlackChannelRouteIdKey(raw: string): boolean {
+  return SLACK_CHANNEL_ROUTE_ID_KEY_RE.test(raw.trim());
+}
+
+export function collectIgnoredSlackChannelRouteKeys(params: {
+  channels?: SlackChannelConfigEntries;
+  groupPolicy?: string;
+  allowNameMatching?: boolean;
+  keys?: string[];
+}): string[] {
+  if (params.groupPolicy !== "allowlist" || params.allowNameMatching) {
+    return [];
+  }
+  const entries = params.channels ?? {};
+  const keys = params.keys ?? Object.keys(entries);
+  return keys.filter((key) => key !== "*" && !isSlackChannelRouteIdKey(key));
+}
+
+export function formatIgnoredSlackChannelRouteKeyWarning(params: {
+  path: string;
+  key: string;
+}): string {
+  return `[slack] ${params.path}."${params.key}" is keyed by name, not a Slack channel ID. Entries under groupPolicy: "allowlist" key by ID and this entry will not match. Find the channel's Slack ID in the Slack URL or via conversations.info, then rekey.`;
 }
 
 export function resolveSlackChannelLabel(params: { channelId?: string; channelName?: string }) {

--- a/extensions/slack/src/monitor/provider.allowlist.test.ts
+++ b/extensions/slack/src/monitor/provider.allowlist.test.ts
@@ -1,3 +1,4 @@
+import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   flush,
@@ -49,6 +50,45 @@ describe("slack allowlist log formatting", () => {
 });
 
 describe("slack startup user allowlist resolution", () => {
+  it("warns when allowlisted channel routes are keyed by unresolved names", async () => {
+    resetSlackTestState({
+      channels: {
+        slack: {
+          enabled: true,
+          groupPolicy: "allowlist",
+          channels: {
+            "example-channel": { requireMention: false },
+            C0AL2GDUA7J: { requireMention: false },
+          },
+        },
+      },
+    });
+    const runtime = createNonExitingRuntimeEnv();
+    const controller = new AbortController();
+    const run = monitorSlackProvider({
+      botToken: "bot-token",
+      appToken: "app-token",
+      abortSignal: controller.signal,
+      config: slackTestState.config,
+      runtime,
+    });
+    try {
+      await getSlackHandlerOrThrow("message");
+      await flush();
+      await flush();
+
+      expect(runtime.log).toHaveBeenCalledWith(
+        expect.stringContaining('channels.slack.channels."example-channel" is keyed by name'),
+      );
+      expect(runtime.log).not.toHaveBeenCalledWith(
+        expect.stringContaining('channels.slack.channels."C0AL2GDUA7J"'),
+      );
+    } finally {
+      controller.abort();
+      await run;
+    }
+  });
+
   it("skips user entry resolution when name matching is not enabled", async () => {
     resetSlackTestState({
       messages: {

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -35,6 +35,10 @@ import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
 import { resolveSlackUserAllowlist, type SlackUserResolution } from "../resolve-users.js";
 import { resolveSlackAppToken, resolveSlackBotToken } from "../token.js";
 import { normalizeAllowList } from "./allow-list.js";
+import {
+  collectIgnoredSlackChannelRouteKeys,
+  formatIgnoredSlackChannelRouteKeyWarning,
+} from "./channel-config.js";
 import { resolveSlackSlashCommandConfig } from "./commands.js";
 import {
   getRuntimeConfig,
@@ -422,6 +426,24 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             channelsConfig = nextChannels;
             ctx.channelsConfig = nextChannels;
             summarizeMapping("slack channels", mapping, unresolved, runtime);
+            for (const key of collectIgnoredSlackChannelRouteKeys({
+              channels: channelsConfig,
+              groupPolicy,
+              allowNameMatching,
+              keys: unresolved,
+            })) {
+              runtime.log?.(
+                warn(
+                  formatIgnoredSlackChannelRouteKeyWarning({
+                    path:
+                      account.accountId === "default"
+                        ? "channels.slack.channels"
+                        : `channels.slack.accounts.${account.accountId}.channels`,
+                    key,
+                  }),
+                ),
+              );
+            }
           }
         } catch (err) {
           runtime.log?.(


### PR DESCRIPTION
## Summary
- warn when Slack `channels.slack.channels` allowlist entries are keyed by channel name instead of Slack channel ID
- surface the same diagnostic through `openclaw doctor` preview warnings
- keep Slack ID-first routing semantics unchanged and honor account-level `dangerouslyAllowNameMatching` overrides

Fixes #81665

## Real behavior proof
- Behavior or issue addressed: under Slack `groupPolicy: "allowlist"`, name-keyed channel route entries are accepted by config but do not match Slack channel IDs at runtime, leaving operators without an actionable signal.
- Real environment tested: local OpenClaw checkout on Linux, branch `fix/slack-channel-name-allowlist-warning-81665`, commit `f2cd9372dd5d4086dbd6ff6f091e135c23e21211`.
- Exact steps or command run after this patch:

```bash
HOME=/tmp/openclaw-slack-account-proof-yO9EZm \
OPENCLAW_CONFIG_PATH=/tmp/openclaw-slack-account-proof-yO9EZm/.openclaw/openclaw.json \
node scripts/run-node.mjs doctor
```

- Evidence after fix: copied terminal output from the actual `openclaw doctor` run above:

```text
◇  Doctor warnings

  [slack] channels.slack.accounts.work.channels."ops-room" is keyed by
  name, not a Slack channel ID. Entries under groupPolicy: "allowlist"
  key by ID and this entry will not match. Find the channel's Slack ID
  in the Slack URL or via conversations.info, then rekey.
```

- Observed result after fix: `openclaw doctor` reports the name-keyed account route and tells the operator it will not match under allowlist; the ID-keyed route `C0AL2GDUA8K` is not reported.
- What was not tested: live Slack API resolution, because the fix is local diagnostics and does not change Slack routing or delivery.

## Tests
- `pnpm test extensions/slack/src/doctor.test.ts extensions/slack/src/monitor/provider.allowlist.test.ts`
- `pnpm test extensions/slack/src/monitor/monitor.test.ts extensions/slack/src/monitor/provider.allowlist.test.ts extensions/slack/src/doctor.test.ts`
- `git diff --check`
- `pnpm check:changed`