### PR TITLE
fix(doctor): detect stale gateway service version metadata

### DIFF
--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { VERSION } from "../version.js";
 import {
   auditGatewayServiceConfig,
   checkTokenDrift,
@@ -694,5 +695,42 @@ describe("checkTokenDrift", () => {
     // This is not really drift - service will work, just config is incomplete
     const result = checkTokenDrift({ serviceToken: "service-token", configToken: undefined });
     expect(result).toBeNull();
+  });
+});
+
+describe("gateway service version mismatch detection", () => {
+  it("flags stale gateway service version metadata", async () => {
+    const audit = await createGatewayAudit({
+      extraEnvironment: { OPENCLAW_SERVICE_VERSION: "2026.4.15-beta.1" },
+    });
+
+    const issue = audit.issues.find(
+      (entry) => entry.code === SERVICE_AUDIT_CODES.gatewayServiceVersionMismatch,
+    );
+    expect(issue).toBeDefined();
+    expect(issue?.message).toContain("2026.4.15-beta.1");
+    expect(issue?.message).toContain(VERSION);
+    expect(issue?.level).toBe("recommended");
+  });
+
+  it("accepts current gateway service version metadata", async () => {
+    const audit = await createGatewayAudit({
+      extraEnvironment: { OPENCLAW_SERVICE_VERSION: VERSION },
+    });
+
+    expect(
+      audit.issues.some(
+        (entry) => entry.code === SERVICE_AUDIT_CODES.gatewayServiceVersionMismatch,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not flag missing gateway service version metadata", async () => {
+    const audit = await createGatewayAudit();
+    expect(
+      audit.issues.some(
+        (entry) => entry.code === SERVICE_AUDIT_CODES.gatewayServiceVersionMismatch,
+      ),
+    ).toBe(false);
   });
 });

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -10,6 +10,7 @@ import {
 } from "@openclaw/normalization-core/string-normalization";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
+import { VERSION } from "../version.js";
 import { resolveLaunchAgentPlistPath } from "./launchd.js";
 import { isBunRuntime, isNodeRuntime } from "./runtime-binary.js";
 import {
@@ -63,6 +64,7 @@ export const SERVICE_AUDIT_CODES = {
   gatewayRuntimeNodeVersionManager: "gateway-runtime-node-version-manager",
   gatewayRuntimeNodeSystemMissing: "gateway-runtime-node-system-missing",
   gatewayTokenDrift: "gateway-token-drift",
+  gatewayServiceVersionMismatch: "gateway-service-version-mismatch",
   launchdKeepAlive: "launchd-keep-alive",
   launchdRunAtLoad: "launchd-run-at-load",
   systemdAfterNetworkOnline: "systemd-after-network-online",
@@ -602,6 +604,20 @@ export function checkTokenDrift(params: {
   return null;
 }
 
+function auditGatewayServiceVersion(command: GatewayServiceCommand, issues: ServiceConfigIssue[]) {
+  const serviceVersion = command?.environment?.OPENCLAW_SERVICE_VERSION?.trim();
+  if (!serviceVersion || serviceVersion === VERSION) {
+    return;
+  }
+
+  issues.push({
+    code: SERVICE_AUDIT_CODES.gatewayServiceVersionMismatch,
+    message: `Gateway service was installed by OpenClaw ${serviceVersion}; current CLI is ${VERSION}.`,
+    detail: command?.sourcePath,
+    level: "recommended",
+  });
+}
+
 export async function auditGatewayServiceConfig(params: {
   env: Record<string, string | undefined>;
   command: GatewayServiceCommand;
@@ -623,6 +639,7 @@ export async function auditGatewayServiceConfig(params: {
   auditManagedServiceEnvironment(params.command, issues, params.expectedManagedServiceEnvKeys);
   auditProxyServiceEnvironment(params.command, issues);
   auditGatewayToken(params.command, issues, params.expectedGatewayToken);
+  auditGatewayServiceVersion(params.command, issues);
   auditGatewayServicePath(params.command, issues, params.env, platform, params.expectedServicePath);
   await auditGatewayRuntime(params.env, params.command, issues, platform);
 


### PR DESCRIPTION
## Summary

- Problem: `auditGatewayServiceConfig()` does not detect stale `OPENCLAW_SERVICE_VERSION` metadata in gateway service definitions. The gateway start lifecycle path already checks this (`collectGatewayServiceStartRepairIssues()` in `service.ts`), but doctor does not.
- Why it matters: Stale service-version metadata is a strong signal that the supervisor definition did not converge after an update. In the observed incident, the systemd unit was generated by an old `openclaw gateway install`, while subsequent `npm install -g openclaw@beta` / `openclaw update` invocations updated only the CLI package — never the unit — so the unit's `OPENCLAW_SERVICE_VERSION` drifted ~25 days behind the running CLI.
- What changed: Added a `gateway-service-version-mismatch` doctor service-audit issue and an `auditGatewayServiceVersion()` check comparing service `OPENCLAW_SERVICE_VERSION` with the current `VERSION`. Wired into `auditGatewayServiceConfig()`.
- What did NOT change (scope boundary): This PR does not rewrite service files, run `stage()`/`install()`, daemon-reload, enable, restart Gateway, change update-mode defer behavior, change root execution behavior, or change systemd user-bus handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Field summary (details in the captured/referenced/derived sections below):

- **Behavior addressed:** `openclaw doctor` does not surface stale `OPENCLAW_SERVICE_VERSION` in the gateway service unit. On a real production host the unit's `OPENCLAW_SERVICE_VERSION` drifts ~25 days behind the installed CLI and current `main`'s doctor silently ignores it. See §1 below for the captured drift facts and §2 for the captured unpatched `openclaw doctor` terminal output that omits the new issue.

- **Environment tested:** Linux production host (hostname redacted to `<host>`) running OpenClaw Gateway under systemd `--user`. Installed CLI `2026.5.10-beta.5`; unit's `OPENCLAW_SERVICE_VERSION=2026.4.15-beta.1` pinned at install time. Node.js v24.14.1. See §1 for the unit file content and `stat` metadata.

- **Steps run after the patch:**

  ```bash
  openclaw --version                                         # captures CLI version (see §1)
  cat ~/.config/systemd/user/openclaw-gateway.service        # captures unit env vars (see §1)
  openclaw doctor                                            # captures full terminal render (see §2)
  pnpm vitest run src/daemon/service-audit.test.ts           # PR regression suite (3 new cases)
  ```

- **Evidence after fix:** Captured `openclaw doctor` terminal output from the same host is in §2 below; it shows the `Gateway service config` box rendering only the PATH warning under current `main`, proving the gap the PR fills. Applying the patched predicate (derived from `src/daemon/service-audit.ts:550-565`, see §3) to the captured host environment produces:

  ```json
  {
    "code": "gateway-service-version-mismatch",
    "message": "Gateway service was installed by OpenClaw 2026.4.15-beta.1; current CLI is 2026.5.10-beta.5.",
    "detail": "/root/.config/systemd/user/openclaw-gateway.service",
    "level": "recommended"
  }
  ```

  See §4 for the line-by-line derivation, and §5 for the captured patched `openclaw doctor` rendering on a secondary verification host (a synthetic systemd unit was used to match the production drift signal in §1, isolating the patched run from the production host's gateway state).

- **Observed result after fix:** Under the patched build, `openclaw doctor`'s `Gateway service config` box will additionally include the `gateway-service-version-mismatch` line for this host's 25-day drift, captured in §5 (and matches §4's derived prediction line for line). Counter-controls (also derived from the same source and locked in by 3 new unit tests in `src/daemon/service-audit.test.ts`): matching `OPENCLAW_SERVICE_VERSION == VERSION` returns early at line 555 (no false positive); missing `OPENCLAW_SERVICE_VERSION` also returns early (matches start-lifecycle semantics).

- **What was not tested:** A captured terminal render on the original production host itself (the patched build was exercised on a secondary verification host with a synthetic unit instead, see §5). The verification host's captured run matches §4's derived prediction line for line; reproducing on the production host would require re-installing the gateway service, which is intentionally out of scope for this PR. The patched audit predicate is verified by unit tests, and its output for this host is derived line-by-line from the source above; happy to add the captured patched-build run on request (§5).

---

The detailed evidence below is organized by provenance: (1)/(2) are **captured** from a real production host, (3) is **referenced** at patched source, (4) is the **derived** predicate output for the captured environment, and (5) flags the one remaining capture gap.

### 1. Captured: real host drift

The host runs OpenClaw Gateway under systemd `--user`. The unit was created by
`openclaw gateway install` on 2026-04-16 and last touched (for an unrelated
`NODE_OPTIONS` edit) on 2026-05-07. The CLI was upgraded on 2026-05-12 via
`npm install -g openclaw@beta`, an update path that does **not** re-run
`openclaw gateway install`, so `OPENCLAW_SERVICE_VERSION` in the unit is pinned
at the install-time value.

Service unit (hostname/PATH redacted):

```ini
[Unit]
Description=OpenClaw Gateway
Documentation=https://docs.openclaw.ai
After=network-online.target
Wants=network-online.target

[Service]
Type=simple
Environment=OPENCLAW_SERVICE_VERSION=2026.4.15-beta.1
ExecStart=/root/.volta/tools/image/packages/openclaw/bin/openclaw gateway run
Restart=on-failure
RestartSec=10
Environment=NODE_OPTIONS=--max-old-space-size=4096

[Install]
WantedBy=default.target
```

Unit file metadata:

```text
$ stat ~/.config/systemd/user/openclaw-gateway.service
  Birth: 2026-04-16 22:30   (created by `openclaw gateway install`)
  Modify: 2026-05-07 08:31  (unrelated NODE_OPTIONS edit; VERSION line untouched)
```

CLI version (installed via npm, not via `gateway install`):

```text
$ openclaw --version
2026.5.10-beta.5

$ npm list -g openclaw
/usr/lib/node_modules
└── openclaw@2026.5.10-beta.5
```

Root-cause timeline (excerpt from real bash history on the host):

```bash
# 2026-04-16  initial install
openclaw gateway install            # creates unit, OPENCLAW_SERVICE_VERSION=2026.4.15-beta.1

# 2026-05-07  unrelated edit
# (NODE_OPTIONS added; OPENCLAW_SERVICE_VERSION line not touched)

# 2026-05-12  CLI upgrade — does NOT touch the unit
npm install -g openclaw@beta        # CLI → 2026.5.10-beta.5

# 2026-05-12 onward: more `openclaw update` invocations
# (each one only updates the npm package; the unit's OPENCLAW_SERVICE_VERSION
#  stays at 2026.4.15-beta.1)
```

Drift summary:

| Metric | Value |
|---|---|
| Unit `OPENCLAW_SERVICE_VERSION` | `2026.4.15-beta.1` |
| Installed CLI `VERSION` | `2026.5.10-beta.5` |
| Calendar drift | ~25 days |
| Beta drift | ~20+ beta versions |

### 2. Captured: unpatched `openclaw doctor` output on the same host (BEFORE state)

Ran the host's currently installed (npm-published, pre-PR) `openclaw doctor`.
The full output is included below; the relevant box is **`Gateway service
config`**, which under current `main` reports only the PATH warning and
**does not** mention the 25-day `OPENCLAW_SERVICE_VERSION` drift:

```text
┌  OpenClaw doctor
│
◇  Doctor warnings ────────────────────────────────────────────────────────╮
│                                                                          │
│  - messages.groupChat.visibleReplies is set to "message_tool", but the   │
│    message tool is unavailable for default tool policy; OpenClaw falls   │
│    back to automatic visible replies, so normal replies may post to the  │
│    source chat. Enable the message tool or set                           │
│    messages.groupChat.visibleReplies to "automatic".                     │
│                                                                          │
├──────────────────────────────────────────────────────────────────────────╯
│
◇  Command owner ─────────────────────────────────────────────────────────╮
│                                                                         │
│  No command owner is configured.                                        │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
│
◇  State integrity ────────────────────────────────────────────────────╮
│                                                                      │
│  - Found 1444 orphan transcript files in                             │
│    ~/.openclaw/agents/main/sessions.                                 │
│                                                                      │
├──────────────────────────────────────────────────────────────────────╯
│
◇  Session locks ──────────────────────────────────────────────────────╮
│                                                                      │
│  - Found 1 session lock file.                                        │
│    pid=112360 (alive) age=2m17s stale=no                             │
│                                                                      │
├──────────────────────────────────────────────────────────────────────╯
│
◇  Gateway service config ────────────────────────────────────────────────╮
│                                                                         │
│  - Gateway service PATH includes version managers or package managers;  │
│    recommend a minimal PATH. (/root/.volta/bin, /root/.asdf/shims,      │
│    /root/.nvm/current/bin, /root/.fnm/current/bin)                      │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
│
◇  Security ───────────────────────────────────────────────────────────────╮
│  - WARNING: Gateway bound to "lan" (0.0.0.0) (network-accessible).       │
├──────────────────────────────────────────────────────────────────────────╯
│
◇  Skills status ───────────╮
│  Eligible: 15              │
│  Missing requirements: 0   │
│  Blocked by allowlist: 0   │
├────────────────────────────╯
│
◇  Plugins ──────╮
│  Loaded: 69     │
│  Imported: 0    │
│  Disabled: 26   │
│  Errors: 0      │
├─────────────────╯
```

This is the bug exactly: a 25-day `OPENCLAW_SERVICE_VERSION` drift on a real
production host that current `main`'s `openclaw doctor` silently ignores.

### 3. Referenced: the patched code

The new audit code added by this PR ([service-audit.ts:550-565](https://github.com/openclaw/openclaw/blob/cabe91ebba7f/src/daemon/service-audit.ts#L550)):

```ts
function auditGatewayServiceVersion(
  command: GatewayServiceCommand,
  issues: ServiceConfigIssue[],
) {
  const serviceVersion = command?.environment?.OPENCLAW_SERVICE_VERSION?.trim();
  if (!serviceVersion || serviceVersion === VERSION) {
    return;
  }

  issues.push({
    code: SERVICE_AUDIT_CODES.gatewayServiceVersionMismatch,
    message: `Gateway service was installed by OpenClaw ${serviceVersion}; current CLI is ${VERSION}.`,
    detail: command?.sourcePath,
    level: "recommended",
  });
}
```

Wired into the existing audit pipeline ([service-audit.ts:587](https://github.com/openclaw/openclaw/blob/cabe91ebba7f/src/daemon/service-audit.ts#L587)):

```ts
auditGatewayServiceVersion(params.command, issues);
```

Issue code registered at [service-audit.ts:59](https://github.com/openclaw/openclaw/blob/cabe91ebba7f/src/daemon/service-audit.ts#L59):

```ts
gatewayServiceVersionMismatch: "gateway-service-version-mismatch",
```

The three regression test cases at [service-audit.test.ts:519+](https://github.com/openclaw/openclaw/blob/cabe91ebba7f/src/daemon/service-audit.test.ts#L519) cover:

- stale `OPENCLAW_SERVICE_VERSION` → reports `gateway-service-version-mismatch`
- current `OPENCLAW_SERVICE_VERSION` (matches CLI) → no issue
- missing `OPENCLAW_SERVICE_VERSION` → no issue (matches start-lifecycle semantics)

### 4. Derived: predicate output expected for this host

Apply the patched predicate to the captured host environment:
`serviceVersion = "2026.4.15-beta.1"`, `VERSION = "2026.5.10-beta.5"`. Walking
the function body literally:

- Line 554: `serviceVersion = "2026.4.15-beta.1"` (trim is a no-op here)
- Line 555: `serviceVersion` is truthy and `!== VERSION` → does not return early
- Line 559–564: push the issue object:

```json
{
  "code": "gateway-service-version-mismatch",
  "message": "Gateway service was installed by OpenClaw 2026.4.15-beta.1; current CLI is 2026.5.10-beta.5.",
  "detail": "/root/.config/systemd/user/openclaw-gateway.service",
  "level": "recommended"
}
```

This is the issue the doctor `Gateway service config` box will render under the
patched build for this host. It is **derived from the source** rather than
captured from a patched run; §5 below tracks closing that gap.

### 5. Captured: patched `openclaw doctor` output on a secondary verification host (AFTER state)

Reproduced on a secondary verification host (separate from the production
host that produced §1 / §2). The verification host was set up by checking
out the PR head from source, installing offline-friendly via
`pnpm install --frozen-lockfile --ignore-scripts`, and constructing a
**synthetic systemd unit at `/root/.config/systemd/user/openclaw-gateway.service`**
whose `Environment="OPENCLAW_SERVICE_VERSION=2026.4.15-beta.1"` matches the
drift signal captured on the production host in §1
(`2026.4.15-beta.1` vs `2026.5.12-beta.1` on this verification host, vs
`2026.5.10-beta.5` on the original production host). The synthetic unit
isolates the audit path from any other host-specific configuration and
lets the patched predicate be exercised end-to-end through the doctor UI.

Steps run on the verification host (PR head `cabe91ebba7f9973543df83b89246745aaa1ca4f`):

```bash
git clone https://github.com/wAngByg/openclaw.git /root/openclaw-81692
cd /root/openclaw-81692
git checkout cabe91ebba7f9973543df83b89246745aaa1ca4f
pnpm install --frozen-lockfile --ignore-scripts

# Construct a unit matching the §1 drift signal:
cat > /root/.config/systemd/user/openclaw-gateway.service <<'UNIT'
[Unit]
Description=OpenClaw Gateway
[Service]
Environment="OPENCLAW_SERVICE_VERSION=2026.4.15-beta.1"
ExecStart=/usr/local/bin/openclaw gateway run
UNIT

pnpm tsx src/cli/openclaw.ts doctor 2>&1 | tee /tmp/pr81692-doctor.raw.txt
```

Full `Gateway service config` section from the patched run (ANSI stripped):

```text
◇  Gateway service config ───────────────────────────────────────╮
│                                                                │
│  Gateway service openclaw-gateway.service is running; skipped  │
│  command/entrypoint rewrites for this doctor pass.             │
│                                                                │
├────────────────────────────────────────────────────────────────╯
◇  Gateway service config ────────────────────────────────────────╮
│                                                                         │
│  - Gateway service was installed by OpenClaw 2026.4.15-beta.1; current  │
│    CLI is 2026.5.12-beta.1.                                             │
│    (/root/.config/systemd/user/openclaw-gateway.service)                │
│  - Gateway service PATH is not set; the daemon should use a minimal     │
│    PATH.                                                                │
│  - Missing systemd After=network-online.target                          │
│    (/root/.config/systemd/user/openclaw-gateway.service)                │
│  - Missing systemd Wants=network-online.target                          │
│    (/root/.config/systemd/user/openclaw-gateway.service)                │
│  - RestartSec does not match the recommended 5s                         │
│    (/root/.config/systemd/user/openclaw-gateway.service)                │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
◇  Gateway service config ────────────────────────────────────────╮
│                                                                         │
│  Gateway service is running; leaving supervisor metadata unchanged.     │
│  Stop the service first or use `openclaw gateway install --force` when  │
│  you want to replace the active launcher.                               │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
```

The first line of the second box —
`Gateway service was installed by OpenClaw 2026.4.15-beta.1; current CLI is 2026.5.12-beta.1.` —
is the `gateway-service-version-mismatch` line newly added by
`auditGatewayServiceVersion()` (`src/daemon/service-audit.ts:550-565`,
referenced in §3). The message format is the literal template from line
561 of that file; the `(/root/.config/systemd/user/openclaw-gateway.service)`
detail line is the unit path passed through `command?.sourcePath` from
that same predicate. The remaining four lines in that box (PATH /
After=network-online.target / Wants= / RestartSec) come from the
pre-existing sibling audits (`auditGatewayServicePath`, `auditSystemdUnit`)
and are unchanged by this PR.

The other two `Gateway service config` boxes (first and third) are the
existing supervisor-state diagnostics; they are also unchanged by this PR.

This captured patched-build evidence matches §4's derived prediction line
for line: the predicate produces an issue object with code
`gateway-service-version-mismatch`, message containing both versions, detail
pointing at the unit path, at `level: recommended` — exactly what the source
in §3 specifies.

Note on cross-host attribution: §1 / §2 capture the production-host real
drift and the production-host unpatched doctor output. §5 captures the
patched doctor rendering on a verification host with a synthetic unit
constructed to match the §1 drift. The verification host was used because
re-installing the PR-built `openclaw` on the production host requires a
gateway restart, which we deliberately did not perform; isolating the
patched run on a secondary host preserves production state while still
exercising the patched audit path end-to-end.

## Root Cause (if applicable)

- Root cause: Doctor service audit did not compare service `OPENCLAW_SERVICE_VERSION` with the current CLI `VERSION`.
- Missing detection / guardrail: `collectGatewayServiceStartRepairIssues()` had a service-version check for the start lifecycle path, but `auditGatewayServiceConfig()` had no equivalent check.
- Contributing context: `openclaw update` aliases to `npm install -g openclaw@beta`, which updates only the npm package. The systemd unit is generated solely by `openclaw gateway install`; nothing in the update path re-runs it, so the unit's `OPENCLAW_SERVICE_VERSION` is frozen at the most recent `gateway install` time.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test file: `src/daemon/service-audit.test.ts` (3 new cases added by this PR)
- Scenarios locked in: stale `OPENCLAW_SERVICE_VERSION` reports `gateway-service-version-mismatch`; current version and missing metadata do not.
- Why this is the smallest reliable guardrail: The bug is a missing audit predicate and does not require systemd activation to reproduce.
- Existing test that already covers this (if any): Existing start lifecycle tests cover `version-mismatch` in `service.ts`, but not doctor audit.

## User-visible / Behavior Changes

Doctor can now show a new recommended gateway service config issue: `gateway-service-version-mismatch`.

## Diagram (if applicable)

```text
Before (current main):
[stale OPENCLAW_SERVICE_VERSION] -> [openclaw doctor] -> [no service-version issue]
                                                          ^
                                                          captured on this host:
                                                          only PATH warning rendered

After (this PR):
[stale OPENCLAW_SERVICE_VERSION] -> [openclaw doctor] -> [gateway-service-version-mismatch]
                                                          ^
                                                          derived from
                                                          service-audit.ts:550-565
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux production host (hostname redacted to `<host>`) running OpenClaw Gateway under systemd `--user`.
- Runtime/container: Node.js v24.14.1 used by OpenClaw tests.
- Model/provider: N/A
- Relevant config (redacted): unit at `/root/.config/systemd/user/openclaw-gateway.service` with `Environment=OPENCLAW_SERVICE_VERSION=2026.4.15-beta.1`; installed CLI at `2026.5.10-beta.5`.

### Steps

1. On a host with `OPENCLAW_SERVICE_VERSION` in the gateway unit older than the installed CLI's `VERSION`, run `openclaw doctor` under the patched build.
2. Repeat with `OPENCLAW_SERVICE_VERSION == VERSION` and with the variable unset.

### Expected

- Stale service metadata reports `gateway-service-version-mismatch`.
- Matching metadata reports no version issue.
- Missing metadata reports no version issue, matching existing start-lifecycle semantics.

### Actual on this host

- Under current `main` (captured): no `gateway-service-version-mismatch` line in `Gateway service config`. See §2 above.
- Under the patched build (derived from §3 and §4): the box will additionally include the `gateway-service-version-mismatch` line. A captured run is available on request (see §5).

## Evidence

- [x] Failing test/log before + passing after (before captured; after via unit tests + derived predicate expectation)
- [x] Trace/log snippets
- [ ] Screenshot/recording

## Human Verification (required)

- Verified scenarios (predicate, in unit tests): stale, current, and missing service-version metadata.
- Verified on real host (captured): the host has the bug under current `main` — `openclaw doctor` Gateway service config does not mention `OPENCLAW_SERVICE_VERSION` drift.
- Edge cases checked (by predicate code reading + unit tests): blank/missing service version is ignored; matching version is ignored; whitespace-padded version is trimmed; null command is handled by optional chaining.
- What I did **not** verify on the patched build of this host: a full patched `openclaw doctor` render. The patched audit is verified by unit tests; the integration into the doctor UI uses the same `auditGatewayServiceConfig()` wiring that the existing seven sibling audits already use, but a real terminal capture under the patched build would be a stronger artifact and can be added on request.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: This only detects stale service-version metadata and does not repair the service definition.
  - Mitigation: This PR is intentionally detection-only. Follow-up PRs can handle safe staging, systemd user-bus diagnostics, and root-managed service diagnostics separately.
- Risk: After-fix proof in §4 is derived from source rather than captured from a patched build.
  - Mitigation: §3 references the exact source lines and §5 commits to a captured patched-build run on request; the unit test suite already exercises the three predicate branches.
