### PR TITLE
fix(codex): keep post-tool watchdog armed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,7 +174,7 @@ Docs: https://docs.openclaw.ai
 - Sessions: display `model: "<agentId>-acp"` / `modelProvider: "acpx"` (ACP-runtime sentinel) for ACP control-plane sessions in `openclaw sessions` output, instead of the agent's configured model which was misleading. Catalog finding 20. (#79543)
 - Slack: normalize message read `before` and `after` timestamp bounds before calling Slack history or thread reply APIs. Fixes #80835. (#81338) Thanks @honor2030.
 - Gateway: throttle assistant/thinking agent event fanout during streaming bursts without dropping buffered deltas. (#80335) Thanks @samzong.
-- Codex app-server: keep the short post-tool completion watchdog armed across dynamic tool completion bookkeeping so embedded Codex runs fail fast and release their session lane when Codex goes quiet after a tool result.
+- Codex app-server: keep the short post-tool completion watchdog armed across dynamic tool completion bookkeeping so embedded Codex runs fail fast and release their session lane when Codex goes quiet after a tool result. (#81697) Thanks @mbelinky.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ Docs: https://docs.openclaw.ai
 - Sessions: display `model: "<agentId>-acp"` / `modelProvider: "acpx"` (ACP-runtime sentinel) for ACP control-plane sessions in `openclaw sessions` output, instead of the agent's configured model which was misleading. Catalog finding 20. (#79543)
 - Slack: normalize message read `before` and `after` timestamp bounds before calling Slack history or thread reply APIs. Fixes #80835. (#81338) Thanks @honor2030.
 - Gateway: throttle assistant/thinking agent event fanout during streaming bursts without dropping buffered deltas. (#80335) Thanks @samzong.
+- Codex app-server: keep the short post-tool completion watchdog armed across dynamic tool completion bookkeeping so embedded Codex runs fail fast and release their session lane when Codex goes quiet after a tool result.
 
 ### Changes
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1521,6 +1521,98 @@ describe("runCodexAppServerAttempt", () => {
     expect(warnData?.lastActivityReason).toBe("request:item/tool/call:response");
   });
 
+  it("keeps the post-tool completion watchdog armed across dynamic tool completion bookkeeping", async () => {
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    let handleRequest:
+      | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
+      | undefined;
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+    __testing.setCodexAppServerClientFactoryForTests(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: (
+            handler: (request: {
+              id: string;
+              method: string;
+              params?: unknown;
+            }) => Promise<unknown>,
+          ) => {
+            handleRequest = handler;
+            return () => undefined;
+          },
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 5,
+      turnTerminalIdleTimeoutMs: 200,
+    });
+    await vi.waitFor(() => expect(handleRequest).toBeTypeOf("function"), { interval: 1 });
+
+    const toolResult = (await handleRequest?.({
+      id: "request-tool-1",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: null,
+        tool: "message",
+        arguments: { action: "send", text: "already sent" },
+      },
+    })) as { success?: boolean };
+    expect(toolResult.success).toBe(false);
+    await notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "dynamicToolCall",
+          id: "call-1",
+          tool: "message",
+        },
+      },
+    });
+
+    const result = await run;
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+    expect(
+      warn.mock.calls.some(
+        ([message]) => message === "codex app-server turn idle timed out waiting for completion",
+      ),
+    ).toBe(true);
+    expect(
+      warn.mock.calls.some(
+        ([message]) =>
+          message === "codex app-server turn idle timed out waiting for terminal event",
+      ),
+    ).toBe(false);
+  });
+
   it("keeps waiting when Codex emits a raw assistant item after a dynamic tool response", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     let handleRequest:

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -923,6 +923,7 @@ export async function runCodexAppServerAttempt(
   let turnCompletionLastActivityReason = "startup";
   let turnCompletionLastActivityDetails: Record<string, unknown> | undefined;
   let activeAppServerTurnRequests = 0;
+  const activeOpenClawDynamicToolCallIds = new Set<string>();
   const activeTurnItemIds = new Set<string>();
 
   const clearTurnCompletionIdleTimer = () => {
@@ -1268,12 +1269,16 @@ export async function runCodexAppServerAttempt(
       turnCompletionIdleWatchArmed &&
       !turnCompletionIdleWatchPinnedByTerminalError &&
       notification.method !== "turn/completed" &&
-      isCurrentTurnNotification
+      isCurrentTurnNotification &&
+      !isTrackedOpenClawDynamicToolCompletionNotification(
+        notification,
+        activeOpenClawDynamicToolCallIds,
+      )
     ) {
       // The short completion-idle watchdog only guards the blind gap after
-      // OpenClaw hands a turn-scoped request result back to Codex. Once Codex
-      // sends another current-turn notification, the app-server is alive again;
-      // the longer terminal watchdog remains the stuck-turn backstop.
+      // OpenClaw hands a turn-scoped request result back to Codex. Bookkeeping
+      // that closes the just-served OpenClaw dynamic tool item is still part of
+      // that handoff, so keep the short watchdog armed for that notification.
       disarmTurnCompletionIdleWatch();
     }
     // Determine terminal-turn status before invoking the projector so a throw
@@ -1369,6 +1374,7 @@ export async function runCodexAppServerAttempt(
         return undefined;
       }
       armCompletionWatchOnResponse = true;
+      activeOpenClawDynamicToolCallIds.add(call.callId);
       trajectoryRecorder?.recordEvent("tool.call", {
         threadId: call.threadId,
         turnId: call.turnId,
@@ -2705,6 +2711,22 @@ function readNotificationItemId(notification: CodexServerNotification): string |
     readString(notification.params, "itemId") ??
     readString(notification.params, "id")
   );
+}
+
+function isTrackedOpenClawDynamicToolCompletionNotification(
+  notification: CodexServerNotification,
+  activeOpenClawDynamicToolCallIds: ReadonlySet<string>,
+): boolean {
+  if (notification.method !== "item/completed" || !isJsonObject(notification.params)) {
+    return false;
+  }
+  const itemId = readNotificationItemId(notification);
+  if (!itemId || !activeOpenClawDynamicToolCallIds.has(itemId)) {
+    return false;
+  }
+  const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
+  const itemType = item ? readString(item, "type") : undefined;
+  return itemType === undefined || itemType === "dynamicToolCall";
 }
 
 function readRawAssistantTextPreview(item: JsonObject): string | undefined {


### PR DESCRIPTION
## Summary

- keep the short Codex app-server post-tool completion watchdog armed when Codex only emits dynamic-tool `item/completed` bookkeeping after an OpenClaw tool result
- add a regression test for the stuck-turn case where `turn/completed` never arrives after that bookkeeping notification
- add the Unreleased changelog entry for the lifecycle/session-lane fix

## Real behavior proof

**Behavior or issue addressed:** Embedded Codex app-server runs could leave the OpenClaw session lane stuck running after an OpenClaw dynamic tool returned if Codex then emitted only the matching dynamic-tool `item/completed` bookkeeping notification and never emitted `turn/completed`.

**Real environment tested:** Crabbox remote Linux Testbox with a full OpenClaw checkout and installed workspace dependencies. Repro lease: `tbx_01krhtb4jkr55pkmavt6a7s21c`. Fixed-proof lease: `tbx_01krjhnhq74mq40pz0espe7j15`.

**Exact steps or command run after this patch:**

```sh
CI=1 pnpm install --frozen-lockfile && env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm test extensions/codex/src/app-server/run-attempt.test.ts -t post-tool
```

**Evidence after fix:** Terminal output from Crabbox/Blacksmith Testbox `tbx_01krjhnhq74mq40pz0espe7j15`:

```text
> openclaw@2026.5.6 test /home/runner/_work/openclaw/openclaw
> node scripts/test-projects.mjs extensions/codex/src/app-server/run-attempt.test.ts -t post-tool

[test] starting test/vitest/vitest.extensions.config.ts

 RUN  v4.1.5 /home/runner/_work/openclaw/openclaw

 ✓ extensions extensions/codex/src/app-server/run-attempt.test.ts (76 tests | 75 skipped) 32ms

 Test Files  1 passed (1)
      Tests  1 passed | 75 skipped (76)
   Start at  06:11:09
   Duration  5.41s (transform 3.90s, setup 303ms, import 4.99s, tests 32ms, environment 0ms)

[test] passed 1 Vitest shard in 7.47s
blacksmith run summary sync=delegated command=1m41.674s total=1m44.419s exit=0
{"provider":"blacksmith-testbox","leaseId":"tbx_01krjhnhq74mq40pz0espe7j15","syncDelegated":true,"exitCode":0}
Testbox tbx_01krjhnhq74mq40pz0espe7j15 stopped (completed)
```

**Observed result after fix:** The focused post-tool scenario now reaches the short completion-idle timeout and releases the app-server run instead of waiting for the longer terminal watchdog or leaving the session lane running. Local focused coverage also passed with `4 passed`, covering the dynamic-tool response timeout, the new bookkeeping case, and the adjacent raw assistant item case.

**What was not tested:** The original Can Brull Telegram group publish path was not replayed end to end against production Telegram. AWS Crabbox was attempted after Mariano set AWS as the preferred provider, but validation did not reach the test command reliably: one lease did not become SSH-reachable, a second raw lease had no `pnpm`, and a quick environment probe timed out before command execution.

## Verification

- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=4 pnpm test extensions/codex/src/app-server/run-attempt.test.ts -t "post-tool completion watchdog|dynamic tool response|raw assistant item after a dynamic tool response"`
- `git diff --check -- CHANGELOG.md extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts`

## Notes

- Before the fix, Crabbox reproduced the stuck-turn failure on Blacksmith Testbox `tbx_01krhtb4jkr55pkmavt6a7s21c`: the injected scenario returned an OpenClaw dynamic tool result, then delivered Codex's matching dynamic-tool `item/completed` bookkeeping notification without any later `turn/completed`; current code disarmed the short post-tool watchdog after that bookkeeping event, so the expected completion-idle timeout did not fire.
- Latest active release branch seen during prep: `origin/release/2026.5.12`. This is runtime lifecycle behavior and should be considered for release-line inclusion if that branch is still the active release line.
