### PR TITLE
fix(gateway): suppress startup liveness warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - Hooks: load workspace-relative legacy hook modules from dot-dot-prefixed directories without treating the filename prefix as parent traversal.
 - Plugins: preserve installed package metadata and persisted registry freshness checks for plugin package paths under dot-dot-prefixed directories.
 - Agents: allow dot-dot-prefixed filenames such as `..note.txt` through sandbox FS bridge, remote sandbox reads, and apply_patch summaries without mistaking the name for parent traversal.
+- Gateway/diagnostics: suppress cold-start liveness warnings during the startup grace window while still sampling liveness metrics. Fixes #79915. (#81699) Thanks @joshavant.
 - CLI/migrate: hide per-item source/plugin hints on non-conflicting Codex skill and plugin selection prompts, keeping the hint text reserved for rows that actually need attention. Thanks @sjf.
 - Codex harness: treat high-confidence app-server OAuth refresh invalidation as a terminal auth-profile failure, stopping repeated raw token-refresh errors without turning entitlement or usage-limit payloads into re-auth prompts.
 - CLI/migrate: humanize Codex conflict-status messaging across the migrate UI so selection prompts and plan/result rows say "Codex skill already installed in workspace" instead of surfacing internal `MIGRATION_REASON_*` codes. Thanks @sjf.

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -593,7 +593,10 @@ export async function startGatewayServer(
   const diagnosticsEnabled = isDiagnosticsEnabled(cfgAtStart);
   setDiagnosticsEnabledForProcess(diagnosticsEnabled);
   if (diagnosticsEnabled) {
-    startDiagnosticHeartbeat(undefined, { getConfig: getRuntimeConfig });
+    startDiagnosticHeartbeat(undefined, {
+      getConfig: getRuntimeConfig,
+      startupGraceMs: 60_000,
+    });
   }
   setGatewaySigusr1RestartPolicy({ allowExternal: isRestartEnabled(cfgAtStart) });
   let getActiveTaskCount = () => 0;

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1055,6 +1055,48 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("suppresses liveness warnings during startupGraceMs while still sampling", () => {
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+    const events: string[] = [];
+    const sampleLiveness = vi.fn(() => ({
+      reasons: ["event_loop_delay" as const],
+      intervalMs: 30_000,
+      eventLoopDelayP99Ms: 1_500,
+      eventLoopDelayMaxMs: 2_000,
+    }));
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event.type));
+
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+          },
+        },
+        {
+          emitMemorySample: createEmitMemorySampleMock(),
+          sampleLiveness,
+          startupGraceMs: 60_000,
+        },
+      );
+
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      vi.advanceTimersByTime(30_000);
+
+      expect(sampleLiveness).toHaveBeenCalledTimes(1);
+      expectNoLoggerMessageContaining(warnSpy, "liveness warning:");
+      expect(events).not.toContain("diagnostic.liveness.warning");
+
+      vi.advanceTimersByTime(30_000);
+
+      expect(sampleLiveness).toHaveBeenCalledTimes(2);
+      expectLoggerMessageContaining(warnSpy, "liveness warning:");
+      expect(events).toContain("diagnostic.liveness.warning");
+    } finally {
+      unsubscribe();
+    }
+  });
+
   it("warns for liveness samples when diagnostic work is open", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -123,6 +123,7 @@ type StartDiagnosticHeartbeatOptions = {
   emitMemorySample?: EmitDiagnosticMemorySample;
   sampleLiveness?: SampleDiagnosticLiveness;
   recoverStuckSession?: RecoverStuckSession;
+  startupGraceMs?: number;
 };
 
 let diagnosticLivenessMonitor: EventLoopDelayMonitor | null = null;
@@ -939,6 +940,8 @@ export function startDiagnosticHeartbeat(
     return;
   }
   startDiagnosticLivenessSampler();
+  const livenessGraceUntil =
+    opts?.startupGraceMs != null && opts.startupGraceMs > 0 ? Date.now() + opts.startupGraceMs : 0;
   heartbeatInterval = setInterval(() => {
     let heartbeatConfig = config;
     if (!heartbeatConfig) {
@@ -953,7 +956,10 @@ export function startDiagnosticHeartbeat(
     const now = Date.now();
     pruneDiagnosticSessionStates(now, true);
     const work = getDiagnosticWorkSnapshot(now);
-    const livenessSample = (opts?.sampleLiveness ?? sampleDiagnosticLiveness)(now, work);
+    const inStartupGrace = livenessGraceUntil > 0 && now < livenessGraceUntil;
+    const rawLivenessSample = (opts?.sampleLiveness ?? sampleDiagnosticLiveness)(now, work);
+    // Keep sampling during grace so event-loop delay baselines reset, but suppress startup-only reports.
+    const livenessSample = inStartupGrace ? null : rawLivenessSample;
     const shouldEmitLivenessEvent =
       livenessSample !== null && shouldEmitDiagnosticLivenessEvent(now);
     const shouldEmitLivenessWarning =


### PR DESCRIPTION
## Summary

- Add a `startupGraceMs` window to the diagnostic heartbeat.
- Keep the liveness sampler running during startup grace while suppressing liveness event/warning emission.
- Pass a 60s startup grace from gateway startup and cover the behavior with a focused diagnostics regression test.

Fixes #79915.

## Verification

- `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts --testNamePattern 'startupGraceMs|liveness'`
- `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/logging/diagnostic.ts src/logging/diagnostic.test.ts src/gateway/server.impl.ts CHANGELOG.md`
- `git diff --check`
- Crabbox `tbx_01krjjc31psmpqer3qr5f5kqf8`: `pnpm check:changed`
- Crabbox `tbx_01krjjkx15xnrz4ykdka57ky4w`: `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts --testNamePattern 'startupGraceMs|liveness'`

Behavior addressed: Diagnostic liveness warnings could fire during gateway cold start because the heartbeat had no startup-grace window.
Real environment tested: Blacksmith Testbox Linux via Crabbox, plus local focused Vitest and formatting checks.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts --testNamePattern 'startupGraceMs|liveness'` on Crabbox Testbox `tbx_01krjjkx15xnrz4ykdka57ky4w`, and `pnpm check:changed` on `tbx_01krjjc31psmpqer3qr5f5kqf8`.
Evidence after fix: Focused diagnostics run passed with 6 tests passing, and changed gate exited 0.
Observed result after fix: Liveness sampling continues during the 60s startup grace, but `diagnostic.liveness.warning` is not emitted until the grace window expires.
What was not tested: A live Windows cold-start with multiple real providers/plugins; the fix path is covered through the diagnostic heartbeat unit behavior and remote changed gate.
