### PR TITLE
fix(auth): drop stale Codex OAuth routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: preserve run-mode keep subagent registry entries past the session sweep TTL, so kept subagent runs remain visible after cleanup completes. Fixes #83132. (#83168) Thanks @yetval.
 - Agents/OpenAI streams: yield via `setTimeout(0)` instead of `setImmediate` between bursty Responses chunks so abort timers can fire during the yield, keeping cancel-on-timeout responsive on hot streams. Refs #82462.
 - Agents/Codex: keep legacy `oauthRef`-backed OAuth profiles usable while `openclaw doctor --fix` migrates them back to inline credentials, without creating new sidecar credentials. (#83312) Thanks @joshavant.
+- Agents/Codex: ignore stale auto-selected session auth profiles that are no longer eligible for the current OpenAI/Codex route.
 - CLI/config: send SecretRef diagnostics to stderr so JSON command stdout remains parseable.
 - CLI/doctor: seed Control UI allowed origins when migrating legacy non-loopback gateway bind host aliases like `0.0.0.0`. Fixes #83286. Thanks @giodl73-repo.
 - CLI/plugins: ship the bundled memory CLI as a package entry so package-installed `openclaw memory` commands register correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -660,6 +660,7 @@ Docs: https://docs.openclaw.ai
 - Plugins: keep process-local plugin metadata snapshot memo freshness tied to the cached registry snapshot so policy-stale derived plugin metadata edits invalidate the memo instead of returning stale owners or command aliases. (#81064) Thanks @Kaspre.
 - Plugins: discover provider plugins from `setup.providers[].envVars` credentials during provider discovery while keeping the deprecated `providerAuthEnvVars` fallback. (#81542) Thanks @JARVIS-Glasses.
 - Docs/Codex harness: clarify that per-agent `CODEX_HOME` isolates `~/.codex` while inherited `HOME` intentionally keeps `.agents` discovery and subprocess user-home state available.
+- Codex harness: show plain OpenAI account sign-in guidance for terminal Codex OAuth refresh failures while leaving generic account-state drift non-terminal.
 - CLI/plugins: keep bare plugin and parent-command help on the lightweight path, avoiding plugin registry discovery before rendering help.
 - Auth: reclaim dead-owner stale file locks before retrying locked writes, so crashed OAuth refreshes no longer wedge `auth-profiles.json` until manual cleanup.
 - CLI tables: preserve muted/color styling on wrapped continuation lines after multiline cells, keeping `openclaw plugins list` descriptions readable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI streams: yield via `setTimeout(0)` instead of `setImmediate` between bursty Responses chunks so abort timers can fire during the yield, keeping cancel-on-timeout responsive on hot streams. Refs #82462.
 - Agents/Codex: keep legacy `oauthRef`-backed OAuth profiles usable while `openclaw doctor --fix` migrates them back to inline credentials, without creating new sidecar credentials. (#83312) Thanks @joshavant.
 - Agents/Codex: ignore stale auto-selected session auth profiles that are no longer eligible for the current OpenAI/Codex route.
+- Agents/Codex: keep OpenAI PI runtime selection from switching to `openai-codex` based only on stale `auth.order.openai` entries, and skip Codex harness auth bootstrap when no eligible forwarded profile exists. Fixes #83223. (#83345) Thanks @fuller-stack-dev and @BKF-Gitty.
 - CLI/config: send SecretRef diagnostics to stderr so JSON command stdout remains parseable.
 - CLI/doctor: seed Control UI allowed origins when migrating legacy non-loopback gateway bind host aliases like `0.0.0.0`. Fixes #83286. Thanks @giodl73-repo.
 - CLI/plugins: ship the bundled memory CLI as a package entry so package-installed `openclaw memory` commands register correctly.

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -75,6 +75,17 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
         return null;
       }
       let oauthCredential = credential;
+      if (
+        !oauthCredential.access?.trim() &&
+        oauthCredential.oauthRef?.source === "openclaw-credentials" &&
+        (params.agentDir || process.env.OPENCLAW_STATE_DIR)
+      ) {
+        const runtimeCredential = actual.loadAuthProfileStoreForSecretsRuntime(params.agentDir)
+          .profiles[params.profileId];
+        if (runtimeCredential?.type === "oauth") {
+          oauthCredential = runtimeCredential;
+        }
+      }
       if (params.forceRefresh || (oauthCredential.expires ?? 0) <= Date.now()) {
         const refreshed = await providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin({
           provider: oauthCredential.provider,
@@ -693,6 +704,26 @@ describe("bridgeCodexAppServerStartOptions", () => {
           email: "codex@example.test",
         },
       });
+      const persisted = JSON.parse(
+        await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+      ) as {
+        profiles?: Record<
+          string,
+          {
+            access?: string;
+            refresh?: string;
+            oauthRef?: { source?: string; provider?: string; id?: string };
+          }
+        >;
+      };
+      const persistedCredential = persisted.profiles?.["openai-codex:default"];
+      expect(persistedCredential?.access).toBeUndefined();
+      expect(persistedCredential?.refresh).toBeUndefined();
+      expect(persistedCredential?.oauthRef).toMatchObject({
+        source: "openclaw-credentials",
+        provider: "openai-codex",
+      });
+      clearRuntimeAuthProfileStoreSnapshots();
 
       await expect(refreshCodexAppServerAuthTokens({ agentDir })).resolves.toEqual({
         accessToken: "refreshed-ref-backed-access-token",

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -75,9 +75,12 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
         return null;
       }
       let oauthCredential = credential;
+      const legacyOAuthCredential = oauthCredential as typeof oauthCredential & {
+        oauthRef?: { source?: string };
+      };
       if (
-        !oauthCredential.access?.trim() &&
-        oauthCredential.oauthRef?.source === "openclaw-credentials" &&
+        !legacyOAuthCredential.access?.trim() &&
+        legacyOAuthCredential.oauthRef?.source === "openclaw-credentials" &&
         (params.agentDir || process.env.OPENCLAW_STATE_DIR)
       ) {
         const runtimeCredential = actual.loadAuthProfileStoreForSecretsRuntime(params.agentDir)

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -720,12 +720,9 @@ describe("bridgeCodexAppServerStartOptions", () => {
         >;
       };
       const persistedCredential = persisted.profiles?.["openai-codex:default"];
-      expect(persistedCredential?.access).toBeUndefined();
-      expect(persistedCredential?.refresh).toBeUndefined();
-      expect(persistedCredential?.oauthRef).toMatchObject({
-        source: "openclaw-credentials",
-        provider: "openai-codex",
-      });
+      expect(persistedCredential?.access).toBe("ref-backed-access-token");
+      expect(persistedCredential?.refresh).toBe("ref-backed-refresh-token");
+      expect(persistedCredential?.oauthRef).toBeUndefined();
       clearRuntimeAuthProfileStoreSnapshots();
 
       await expect(refreshCodexAppServerAuthTokens({ agentDir })).resolves.toEqual({

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOAuthRefreshFailureLoginCommand,
+  classifyOAuthRefreshFailure,
+  classifyOAuthRefreshFailureReason,
+  formatOAuthRefreshFailureAccountLabel,
+} from "./oauth-refresh-failure.js";
+
+describe("classifyOAuthRefreshFailureReason", () => {
+  it.each([
+    ["OAuth token refresh failed for openai-codex: refresh_token_reused.", "refresh_token_reused"],
+    [
+      "Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.",
+      "refresh_token_reused",
+    ],
+    [
+      "Your access token could not be refreshed because your refresh token has expired. Please log out and sign in again.",
+      "refresh_token_expired",
+    ],
+    [
+      "OAuth token refresh failed for openai-codex: refresh_token_invalidated.",
+      "refresh_token_invalidated",
+    ],
+    [
+      "Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.",
+      "revoked",
+    ],
+    [
+      "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.",
+      "sign_in_again",
+    ],
+  ] as const)("classifies Codex refresh failure %s", (message, reason) => {
+    expect(classifyOAuthRefreshFailureReason(message)).toBe(reason);
+  });
+
+  it("does not mark generic app-server account drift as terminal re-auth", () => {
+    expect(
+      classifyOAuthRefreshFailure(
+        "Your access token could not be refreshed because the backend account state is temporarily inconsistent.",
+      ),
+    ).toEqual({ provider: null, reason: null });
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(classifyOAuthRefreshFailure("rate limit exceeded; try again later")).toBeNull();
+  });
+});
+
+describe("buildOAuthRefreshFailureLoginCommand", () => {
+  it("sanitizes provider ids in login guidance", () => {
+    expect(buildOAuthRefreshFailureLoginCommand("openai-codex` --bad")).toBe(
+      "openclaw models auth login",
+    );
+  });
+});
+
+describe("formatOAuthRefreshFailureAccountLabel", () => {
+  it("uses everyday account wording for Codex OAuth", () => {
+    expect(formatOAuthRefreshFailureAccountLabel("openai-codex")).toBe(
+      "your OpenAI account for Codex",
+    );
+    expect(formatOAuthRefreshFailureAccountLabel(null)).toBe("your model provider account");
+  });
+});

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -4,6 +4,8 @@ import { normalizeProviderId } from "../provider-id.js";
 
 export type OAuthRefreshFailureReason =
   | "refresh_token_reused"
+  | "refresh_token_expired"
+  | "refresh_token_invalidated"
   | "invalid_grant"
   | "sign_in_again"
   | "invalid_refresh_token"
@@ -36,20 +38,31 @@ export function classifyOAuthRefreshFailureReason(
   message: string,
 ): OAuthRefreshFailureReason | null {
   const lower = message.toLowerCase();
-  if (lower.includes("refresh_token_reused")) {
+  if (
+    lower.includes("refresh_token_reused") ||
+    lower.includes("refresh token was already used") ||
+    lower.includes("refresh token has already been used") ||
+    lower.includes("already been used to generate a new access token")
+  ) {
     return "refresh_token_reused";
+  }
+  if (lower.includes("refresh_token_expired") || lower.includes("refresh token has expired")) {
+    return "refresh_token_expired";
+  }
+  if (lower.includes("refresh_token_invalidated")) {
+    return "refresh_token_invalidated";
   }
   if (lower.includes("invalid_grant")) {
     return "invalid_grant";
-  }
-  if (lower.includes("signing in again") || lower.includes("sign in again")) {
-    return "sign_in_again";
   }
   if (lower.includes("invalid refresh token")) {
     return "invalid_refresh_token";
   }
   if (lower.includes("expired or revoked") || lower.includes("revoked")) {
     return "revoked";
+  }
+  if (lower.includes("signing in again") || lower.includes("sign in again")) {
+    return "sign_in_again";
   }
   return null;
 }
@@ -65,6 +78,20 @@ export function classifyOAuthRefreshFailure(message: string): {
     provider: sanitizeOAuthRefreshFailureProvider(extractOAuthRefreshFailureProvider(message)),
     reason: classifyOAuthRefreshFailureReason(message),
   };
+}
+
+export function formatOAuthRefreshFailureAccountLabel(provider: string | null | undefined): string {
+  const safeProvider = sanitizeOAuthRefreshFailureProvider(provider);
+  switch (safeProvider) {
+    case "openai-codex":
+      return "your OpenAI account for Codex";
+    case "openai":
+      return "your OpenAI account";
+    case null:
+      return "your model provider account";
+    default:
+      return `your ${safeProvider} account`;
+  }
 }
 
 export function buildOAuthRefreshFailureLoginCommand(provider: string | null | undefined): string {

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -1535,6 +1535,88 @@ describe("embedded attempt harness pinning", () => {
     });
   });
 
+  it("replaces stale auto-selected Codex sidecar auth profiles before default Codex harness runs", async () => {
+    const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
+    const sessionEntry: SessionEntry = {
+      sessionId: "stale-codex-auth-session",
+      updatedAt: Date.now(),
+      authProfileOverride: "openai-codex:stale",
+      authProfileOverrideSource: "auto",
+    };
+    await fs.writeFile(
+      path.join(tmpDir, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "openai-codex:stale": {
+            type: "oauth",
+            provider: "openai-codex",
+            oauthRef: {
+              source: "openclaw-credentials",
+              provider: "openai-codex",
+              id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            },
+          },
+          "openai-codex:fresh": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "fresh-access-token",
+            refresh: "fresh-refresh-token",
+            expires: Date.now() + 60_000,
+          },
+        },
+      }),
+    );
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      meta: { durationMs: 1 },
+    } satisfies EmbeddedPiRunResult);
+    clearAgentHarnesses();
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt: vi.fn(),
+    });
+
+    try {
+      await runAgentAttempt({
+        providerOverride: "openai",
+        originalProvider: "openai",
+        modelOverride: "gpt-5.4",
+        cfg: {} as OpenClawConfig,
+        sessionEntry,
+        sessionId: sessionEntry.sessionId,
+        sessionKey: "agent:main:main",
+        sessionAgentId: "main",
+        sessionFile: path.join(tmpDir, "session.jsonl"),
+        workspaceDir: tmpDir,
+        body: "continue",
+        isFallbackRetry: false,
+        resolvedThinkLevel: "medium",
+        timeoutMs: 1_000,
+        runId: "run-codex-replaces-stale-auto-auth-profile",
+        opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
+        runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+        spawnedBy: undefined,
+        messageChannel: undefined,
+        skillsSnapshot: undefined,
+        resolvedVerboseLevel: undefined,
+        agentDir: tmpDir,
+        onAgentEvent: vi.fn(),
+        authProfileProvider: "openai",
+        sessionHasHistory: true,
+      });
+    } finally {
+      clearAgentHarnesses();
+    }
+
+    expectMockArgFields(runEmbeddedPiAgentMock, {
+      agentHarnessId: undefined,
+      authProfileId: "openai-codex:fresh",
+      authProfileIdSource: "auto",
+    });
+  });
+
   it("pins a fresh OpenAI session to the Codex harness by default", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "fresh-session",

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -18,7 +18,7 @@ import { annotateInterSessionPromptText } from "../../sessions/input-provenance.
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { sanitizeForLog } from "../../terminal/ansi.js";
 import { resolveMessageChannel } from "../../utils/message-channel.js";
-import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
+import { resolveAuthProfileEligibility, resolveAuthProfileOrder } from "../auth-profiles/order.js";
 import { ensureAuthProfileStore } from "../auth-profiles/store.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../bootstrap-budget.js";
 import { runCliAgent } from "../cli-runner.js";
@@ -120,20 +120,6 @@ type HarnessAuthProfileSelection = {
   authProfileMode?: string;
 };
 
-function resolveProfileAuthFromStore(params: { agentDir: string; profileId: string | undefined }): {
-  provider?: string;
-  mode?: string;
-} {
-  const profileId = params.profileId?.trim();
-  if (!profileId) {
-    return {};
-  }
-  const credential = ensureAuthProfileStore(params.agentDir, {
-    allowKeychainPrompt: false,
-  }).profiles[profileId];
-  return { provider: credential?.provider, mode: credential?.type };
-}
-
 function resolveHarnessAuthProfileSelection(params: {
   config: OpenClawConfig;
   agentDir: string;
@@ -148,16 +134,46 @@ function resolveHarnessAuthProfileSelection(params: {
 }): HarnessAuthProfileSelection {
   const sessionAuthProfileId = params.sessionAuthProfileId?.trim();
   if (sessionAuthProfileId) {
-    const profileAuth = resolveProfileAuthFromStore({
-      agentDir: params.agentDir,
-      profileId: sessionAuthProfileId,
+    const store = ensureAuthProfileStore(params.agentDir, {
+      allowKeychainPrompt: false,
     });
-    return {
-      authProfileId: sessionAuthProfileId,
-      authProfileIdSource: params.sessionAuthProfileSource,
+    const credential = store.profiles[sessionAuthProfileId];
+    const profileAuth = {
+      provider: credential?.provider,
+      mode: credential?.type,
+    };
+    const sessionAuthPlan = buildAgentRuntimeAuthPlan({
+      provider: params.provider,
       authProfileProvider: profileAuth.provider ?? params.authProfileProvider,
       authProfileMode: profileAuth.mode,
-    };
+      sessionAuthProfileId,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      harnessId: params.harnessId,
+      harnessRuntime: params.harnessRuntime,
+      allowHarnessAuthProfileForwarding: params.allowHarnessAuthProfileForwarding,
+    });
+    const sessionProfileProvider =
+      sessionAuthPlan.harnessAuthProvider ?? sessionAuthPlan.authProfileProviderForAuth;
+    const sessionProfileEligible =
+      credential !== undefined &&
+      resolveAuthProfileEligibility({
+        cfg: params.config,
+        store,
+        provider: sessionProfileProvider,
+        profileId: sessionAuthProfileId,
+      }).eligible;
+    if (
+      params.sessionAuthProfileSource === "user" ||
+      (sessionAuthPlan.forwardedAuthProfileId === sessionAuthProfileId && sessionProfileEligible)
+    ) {
+      return {
+        authProfileId: sessionAuthProfileId,
+        authProfileIdSource: params.sessionAuthProfileSource,
+        authProfileProvider: profileAuth.provider ?? params.authProfileProvider,
+        authProfileMode: profileAuth.mode,
+      };
+    }
   }
 
   const runtimeAuthPlan = buildAgentRuntimeAuthPlan({

--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -74,6 +74,15 @@ describe("OpenAI Codex routing policy", () => {
         harnessRuntime: "pi",
         config,
       }),
+    ).toBe("openai");
+    expect(
+      resolveSelectedOpenAIPiRuntimeProvider({
+        provider: "openai",
+        harnessRuntime: "pi",
+        authProfileProvider: "openai-codex",
+        authProfileId: "openai-codex:work",
+        config,
+      }),
     ).toBe("openai-codex");
     expect(
       resolveOpenAIRuntimeProviderForPi({

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -187,11 +187,7 @@ export function resolveSelectedOpenAIPiRuntimeProvider(params: {
   if (runtime === "codex") {
     return OPENAI_CODEX_PROVIDER_ID;
   }
-  return runtime === "pi" &&
-    !params.authProfileId?.trim() &&
-    configuredOpenAIAuthOrderStartsWithCodexProfile(params.config)
-    ? OPENAI_CODEX_PROVIDER_ID
-    : params.provider;
+  return params.provider;
 }
 
 export function resolveContextConfigProviderForRuntime(params: {

--- a/src/agents/pi-embedded-runner.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.e2e.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import "./test-helpers/fast-coding-tools.js";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "./auth-profiles.js";
 import {
   buildEmbeddedRunnerAssistant,
   cleanupEmbeddedPiRunnerTestWorkspace,
@@ -155,6 +156,8 @@ const installRunEmbeddedMocks = () => {
 
 let runEmbeddedPiAgent: typeof import("./pi-embedded-runner/run.js").runEmbeddedPiAgent;
 let SessionManager: typeof import("@earendil-works/pi-coding-agent").SessionManager;
+let clearRuntimeAuthProfileStoreSnapshots: typeof import("./auth-profiles.js").clearRuntimeAuthProfileStoreSnapshots;
+let replaceRuntimeAuthProfileStoreSnapshots: typeof import("./auth-profiles.js").replaceRuntimeAuthProfileStoreSnapshots;
 let e2eWorkspace: EmbeddedPiRunnerTestWorkspace | undefined;
 let agentDir: string;
 let workspaceDir: string;
@@ -167,17 +170,21 @@ beforeAll(async () => {
   installRunEmbeddedMocks();
   ({ runEmbeddedPiAgent } = await import("./pi-embedded-runner/run.js"));
   ({ SessionManager } = await import("@earendil-works/pi-coding-agent"));
+  ({ clearRuntimeAuthProfileStoreSnapshots, replaceRuntimeAuthProfileStoreSnapshots } =
+    await import("./auth-profiles.js"));
   e2eWorkspace = await createEmbeddedPiRunnerTestWorkspace("openclaw-embedded-agent-");
   ({ agentDir, workspaceDir } = e2eWorkspace);
 }, 180_000);
 
 afterAll(async () => {
+  clearRuntimeAuthProfileStoreSnapshots?.();
   await cleanupEmbeddedPiRunnerTestWorkspace(e2eWorkspace);
   e2eWorkspace = undefined;
 });
 
 beforeEach(() => {
   vi.useRealTimers();
+  clearRuntimeAuthProfileStoreSnapshots();
   runEmbeddedAttemptMock.mockReset();
   disposeSessionMcpRuntimeMock.mockReset();
   resolveSessionKeyForRequestMock.mockReset();
@@ -305,6 +312,100 @@ function firstRunEmbeddedAttemptParams(): { sessionKey?: string } {
   return firstMockCall(runEmbeddedAttemptMock, "embedded attempt")[0] as { sessionKey?: string };
 }
 
+function replaceAuthProfileStoreForTest(store: AuthProfileStore) {
+  replaceRuntimeAuthProfileStoreSnapshots([
+    { store: { version: 1, profiles: {} } },
+    { agentDir, store },
+  ]);
+}
+
+function createOpenAIPiRuntimeConfig(params?: { authOrder?: string[]; providerAuth?: "api-key" }) {
+  const baseConfig = createEmbeddedPiRunnerOpenAiConfig(["mock-1"]);
+  const openAIProvider = baseConfig.models?.providers?.openai;
+  if (!openAIProvider) {
+    throw new Error("expected OpenAI provider test config");
+  }
+  return {
+    ...baseConfig,
+    models: {
+      providers: {
+        openai: {
+          ...openAIProvider,
+          ...(params?.providerAuth ? { auth: params.providerAuth } : {}),
+          baseUrl: "https://api.openai.com/v1",
+        },
+      },
+    },
+    agents: {
+      defaults: {
+        models: {
+          "openai/mock-1": {
+            agentRuntime: { id: "pi" },
+          },
+        },
+      },
+    },
+    ...(params?.authOrder
+      ? {
+          auth: {
+            order: {
+              openai: params.authOrder,
+            },
+          },
+        }
+      : {}),
+  };
+}
+
+async function runOpenAIPiRuntimeTurn(
+  cfg: ReturnType<typeof createOpenAIPiRuntimeConfig>,
+  runId: string,
+) {
+  runEmbeddedAttemptMock.mockResolvedValueOnce(
+    makeEmbeddedRunnerAttempt({
+      assistantTexts: ["ok"],
+      lastAssistant: buildEmbeddedRunnerAssistant({
+        content: [{ type: "text", text: "ok" }],
+      }),
+    }),
+  );
+
+  await runEmbeddedPiAgent({
+    sessionId: runId,
+    sessionFile: nextSessionFile(),
+    workspaceDir,
+    config: cfg,
+    prompt: "hello",
+    provider: "openai",
+    model: "mock-1",
+    timeoutMs: 5_000,
+    agentDir,
+    runId: nextRunId(runId),
+    enqueue: immediateEnqueue,
+  });
+}
+
+function expectModelResolutionProvider(
+  callIndex: number,
+  provider: string,
+  cfg: ReturnType<typeof createOpenAIPiRuntimeConfig>,
+) {
+  expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
+    callIndex,
+    provider,
+    "mock-1",
+    agentDir,
+    cfg,
+    expect.objectContaining({ skipPiDiscovery: true }),
+  );
+}
+
+function expectAttemptModelProvider(provider: string) {
+  expect(
+    (firstRunEmbeddedAttemptParams() as { model?: { provider?: string } }).model?.provider,
+  ).toBe(provider);
+}
+
 describe("runEmbeddedPiAgent", () => {
   it("skips models.json generation when dynamic model resolution succeeds", async () => {
     const sessionFile = nextSessionFile();
@@ -344,79 +445,104 @@ describe("runEmbeddedPiAgent", () => {
   });
 
   it("resolves explicit OpenAI PI runs through Codex when auth order starts with Codex OAuth", async () => {
-    const sessionFile = nextSessionFile();
-    const baseConfig = createEmbeddedPiRunnerOpenAiConfig(["mock-1"]);
-    const openAIProvider = baseConfig.models?.providers?.openai;
-    if (!openAIProvider) {
-      throw new Error("expected OpenAI provider test config");
-    }
-    const cfg = {
-      ...baseConfig,
-      models: {
-        providers: {
-          openai: {
-            ...openAIProvider,
-            baseUrl: "https://api.openai.com/v1",
-          },
+    const cfg = createOpenAIPiRuntimeConfig({
+      authOrder: ["openai-codex:work", "openai:backup"],
+    });
+    replaceAuthProfileStoreForTest({
+      version: 1,
+      profiles: {
+        "openai-codex:work": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
         },
       },
-      agents: {
-        defaults: {
-          models: {
-            "openai/mock-1": {
-              agentRuntime: { id: "pi" },
-            },
-          },
-        },
-      },
-      auth: {
-        order: {
-          openai: ["openai-codex:work", "openai:backup"],
-        },
-      },
-    };
-    runEmbeddedAttemptMock.mockResolvedValueOnce(
-      makeEmbeddedRunnerAttempt({
-        assistantTexts: ["ok"],
-        lastAssistant: buildEmbeddedRunnerAssistant({
-          content: [{ type: "text", text: "ok" }],
-        }),
-      }),
-    );
-
-    await runEmbeddedPiAgent({
-      sessionId: "codex-first-pi",
-      sessionFile,
-      workspaceDir,
-      config: cfg,
-      prompt: "hello",
-      provider: "openai",
-      model: "mock-1",
-      timeoutMs: 5_000,
-      agentDir,
-      runId: nextRunId("codex-first-pi"),
-      enqueue: immediateEnqueue,
     });
 
-    expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
-      1,
-      "openai",
-      "mock-1",
-      agentDir,
-      cfg,
-      expect.objectContaining({ skipPiDiscovery: true }),
-    );
-    expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
-      2,
-      "openai-codex",
-      "mock-1",
-      agentDir,
-      cfg,
-      expect.objectContaining({ skipPiDiscovery: true }),
-    );
-    expect(
-      (firstRunEmbeddedAttemptParams() as { model?: { provider?: string } }).model?.provider,
-    ).toBe("openai-codex");
+    await runOpenAIPiRuntimeTurn(cfg, "codex-first-pi");
+
+    expectModelResolutionProvider(1, "openai", cfg);
+    expectModelResolutionProvider(2, "openai-codex", cfg);
+    expectAttemptModelProvider("openai-codex");
+  });
+
+  it("does not route explicit OpenAI PI runs through stale Codex auth-order entries", async () => {
+    const cfg = createOpenAIPiRuntimeConfig({
+      authOrder: ["openai-codex:legacy-repro"],
+    });
+    replaceAuthProfileStoreForTest({
+      version: 1,
+      profiles: {
+        "openai-codex:legacy-repro": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "",
+          refresh: "",
+          expires: Date.now() + 60_000,
+        },
+      },
+    });
+
+    await runOpenAIPiRuntimeTurn(cfg, "stale-codex-first-pi");
+
+    expect(resolveModelAsyncMock).toHaveBeenCalledTimes(1);
+    expectModelResolutionProvider(1, "openai", cfg);
+    expectAttemptModelProvider("openai");
+  });
+
+  it("routes OpenAI PI runs through later eligible Codex auth-order entries", async () => {
+    const cfg = createOpenAIPiRuntimeConfig({
+      authOrder: ["openai-codex:legacy-repro", "openai-codex:work"],
+    });
+    replaceAuthProfileStoreForTest({
+      version: 1,
+      profiles: {
+        "openai-codex:legacy-repro": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "",
+          refresh: "",
+          expires: Date.now() + 60_000,
+        },
+        "openai-codex:work": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        },
+      },
+    });
+
+    await runOpenAIPiRuntimeTurn(cfg, "later-codex-first-pi");
+
+    expectModelResolutionProvider(1, "openai", cfg);
+    expectModelResolutionProvider(2, "openai-codex", cfg);
+    expectAttemptModelProvider("openai-codex");
+  });
+
+  it("does not route OpenAI PI runs through stored Codex backup profiles", async () => {
+    const cfg = createOpenAIPiRuntimeConfig({ providerAuth: "api-key" });
+    replaceAuthProfileStoreForTest({
+      version: 1,
+      profiles: {
+        "openai-codex:work": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        },
+      },
+    });
+
+    await runOpenAIPiRuntimeTurn(cfg, "stored-codex-backup-pi");
+
+    expect(resolveModelAsyncMock).toHaveBeenCalledTimes(1);
+    expectModelResolutionProvider(1, "openai", cfg);
+    expectAttemptModelProvider("openai");
   });
 
   it("backfills a trimmed session key from sessionId when the embedded run omits it", async () => {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -227,6 +227,9 @@ export const mockedEnsureAuthProfileStoreWithoutExternalProfiles = vi.fn(
 export const mockedResolveAuthProfileOrder = vi.fn<(_params?: unknown) => string[]>(
   (_params?: unknown) => [],
 );
+export const mockedResolveAuthProfileEligibility = vi.fn<
+  (_params?: unknown) => { eligible: boolean }
+>((_params?: unknown) => ({ eligible: true }));
 export const mockedMarkAuthProfileSuccess = vi.fn(async () => {});
 export const mockedShouldPreferExplicitConfigApiKeyAuth = vi.fn(() => false);
 
@@ -412,6 +415,8 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedEnsureAuthProfileStoreWithoutExternalProfiles.mockReturnValue({});
   mockedResolveAuthProfileOrder.mockReset();
   mockedResolveAuthProfileOrder.mockReturnValue([]);
+  mockedResolveAuthProfileEligibility.mockReset();
+  mockedResolveAuthProfileEligibility.mockReturnValue({ eligible: true });
   mockedMarkAuthProfileSuccess.mockReset();
   mockedMarkAuthProfileSuccess.mockResolvedValue(undefined);
   mockedShouldPreferExplicitConfigApiKeyAuth.mockReset();
@@ -463,6 +468,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     isProfileInCooldown: vi.fn(() => false),
     markAuthProfileFailure: vi.fn(async () => {}),
     markAuthProfileSuccess: mockedMarkAuthProfileSuccess,
+    resolveAuthProfileEligibility: mockedResolveAuthProfileEligibility,
     resolveProfilesUnavailableReason: vi.fn(() => undefined),
   }));
 

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -827,6 +827,107 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     });
   });
 
+  it("skips Codex auth bootstrap when configured Codex profiles are not eligible", async () => {
+    const codexAuthStorage = {
+      setRuntimeApiKey: vi.fn(),
+      getApiKey: vi.fn(async () => "stored-test-key"),
+    };
+    const codexAuthStore = {
+      version: 1 as const,
+      profiles: {
+        "openai-codex:legacy-repro": {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          access: "",
+          refresh: "",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    const runtimePlan = makeForwardedRuntimePlan({
+      resolvedRef: {
+        provider: "openai-codex",
+        modelId: "gpt-5.5",
+        harnessId: "codex",
+      },
+      auth: {
+        providerForAuth: "openai-codex",
+        authProfileProviderForAuth: "openai-codex",
+        harnessAuthProvider: "openai-codex",
+      },
+    });
+    mockedEnsureAuthProfileStore.mockReturnValueOnce(codexAuthStore);
+    mockedResolveAuthProfileOrder.mockReturnValueOnce([]);
+    mockedResolveModelAsync
+      .mockResolvedValueOnce({
+        model: {
+          id: "gpt-5.5",
+          provider: "openai",
+          contextWindow: 200000,
+          api: "openai-responses",
+        },
+        error: null,
+        authStorage: { setRuntimeApiKey: vi.fn() },
+        modelRegistry: {},
+      })
+      .mockResolvedValueOnce({
+        model: {
+          id: "gpt-5.5",
+          provider: "openai-codex",
+          contextWindow: 200000,
+          api: "openai-codex-responses",
+        },
+        error: null,
+        authStorage: codexAuthStorage,
+        modelRegistry: {},
+      });
+    mockedBuildAgentRuntimePlan.mockReturnValueOnce(runtimePlan);
+    mockedGetApiKeyForModel.mockImplementation(async () => {
+      throw new Error("generic auth should be skipped");
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      config: {
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex" },
+          },
+        },
+        auth: {
+          order: {
+            openai: ["openai-codex:legacy-repro"],
+          },
+        },
+      },
+      runId: "forced-openai-codex-responses-skips-stale-bootstrap",
+    });
+
+    expect(mockedEnsureAuthProfileStore).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(mockedEnsureAuthProfileStore, 0, 1), {
+      externalCliProviderIds: ["openai-codex"],
+      allowKeychainPrompt: false,
+    });
+    expect(mockedEnsureAuthProfileStoreWithoutExternalProfiles).not.toHaveBeenCalled();
+    expectMockCallFields(mockedResolveAuthProfileOrder, {
+      provider: "openai-codex",
+      store: codexAuthStore,
+    });
+    expect(mockedGetApiKeyForModel).not.toHaveBeenCalled();
+    expect(codexAuthStorage.setRuntimeApiKey).not.toHaveBeenCalled();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    const pluginParams = expectMockCallFields(mockedRunEmbeddedAttempt, {
+      provider: "openai-codex",
+      authProfileId: undefined,
+      resolvedApiKey: undefined,
+    });
+    const authProfileStore = expectRecordFields(pluginParams.authProfileStore, {});
+    expect(authProfileStore.profiles).toEqual({});
+  });
+
   it("refreshes bootstrapped Codex OAuth credentials when rotating profiles", async () => {
     const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
     const subscriptionLimit = new Error(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -64,6 +64,7 @@ import {
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
   OPENAI_CODEX_PROVIDER_ID,
+  hasOpenAICodexAuthProfileOverride,
   listOpenAIAuthProfileProvidersForAgentRuntime,
   resolveContextConfigProviderForRuntime,
   resolveSelectedOpenAIPiRuntimeProvider,
@@ -90,6 +91,7 @@ import {
 } from "../pi-embedded-helpers.js";
 import { resolveProcessToolScopeKey } from "../pi-tools.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
+import { findNormalizedProviderValue } from "../provider-id.js";
 import { runAgentCleanupStep } from "../run-cleanup-timeout.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
@@ -205,6 +207,44 @@ function resolveAttemptDispatchApiKey(params: {
     return undefined;
   }
   return params.apiKeyInfo?.apiKey;
+}
+
+function resolveSelectedRuntimeAuthProfileId(params: {
+  provider: string;
+  harnessRuntime: string;
+  authProfileId?: string;
+  config: RunEmbeddedPiAgentParams["config"];
+  authStore: AuthProfileStore;
+}): string | undefined {
+  const requestedProfileId = params.authProfileId?.trim();
+  if (requestedProfileId) {
+    return requestedProfileId;
+  }
+  if (shouldPreferExplicitConfigApiKeyAuth(params.config, params.provider)) {
+    return undefined;
+  }
+  const firstAuthProvider = listOpenAIAuthProfileProvidersForAgentRuntime({
+    provider: params.provider,
+    harnessRuntime: params.harnessRuntime,
+    agentHarnessId: params.harnessRuntime,
+    config: params.config,
+  })[0];
+  if (firstAuthProvider !== OPENAI_CODEX_PROVIDER_ID) {
+    return undefined;
+  }
+  const configuredOrder = findNormalizedProviderValue(params.config?.auth?.order, params.provider);
+  const configuredProfileId = configuredOrder
+    ?.find((profileId) => typeof profileId === "string" && profileId.trim().length > 0)
+    ?.trim();
+  if (!hasOpenAICodexAuthProfileOverride(configuredProfileId)) {
+    return undefined;
+  }
+  const eligibleProfileIds = resolveAuthProfileOrder({
+    cfg: params.config,
+    store: params.authStore,
+    provider: OPENAI_CODEX_PROVIDER_ID,
+  });
+  return eligibleProfileIds[0]?.trim();
 }
 
 function resolveEmbeddedRunLaneTimeoutMs(timeoutMs: number): number | undefined {
@@ -611,12 +651,27 @@ export async function runEmbeddedPiAgent(
       });
       const pluginHarnessOwnsTransport = agentHarness.id !== "pi";
       const modelConfigProvider = provider;
+      const piRuntimeAuthProfileStore =
+        agentHarness.id === "pi"
+          ? ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+              allowKeychainPrompt: false,
+            })
+          : undefined;
+      const selectedRuntimeAuthProfileId = piRuntimeAuthProfileStore
+        ? resolveSelectedRuntimeAuthProfileId({
+            provider,
+            harnessRuntime: agentHarness.id,
+            authProfileId: params.authProfileId,
+            config: params.config,
+            authStore: piRuntimeAuthProfileStore,
+          })
+        : params.authProfileId;
       const selectedPiRuntimeProvider = resolveSelectedOpenAIPiRuntimeProvider({
         provider,
         harnessRuntime: agentHarness.id,
         agentHarnessId: agentHarness.id,
-        authProfileProvider: params.authProfileId?.split(":", 1)[0],
-        authProfileId: params.authProfileId,
+        authProfileProvider: selectedRuntimeAuthProfileId?.split(":", 1)[0],
+        authProfileId: selectedRuntimeAuthProfileId,
         config: params.config,
         workspaceDir: resolvedWorkspace,
       });
@@ -699,9 +754,10 @@ export async function runEmbeddedPiAgent(
                 externalCliProviderIds: [OPENAI_CODEX_PROVIDER_ID],
                 allowKeychainPrompt: false,
               })
-            : ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+            : (piRuntimeAuthProfileStore ??
+              ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
                 allowKeychainPrompt: false,
-              });
+              }));
       const attemptAuthProfileStore =
         pluginHarnessOwnsTransport && !pluginHarnessNeedsOpenClawAuthBootstrap
           ? ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -742,14 +742,14 @@ export async function runEmbeddedPiAgent(
       startupStages.mark("model-resolution");
       notifyExecutionPhase("model_resolution", { provider, model: modelId });
 
-      const pluginHarnessNeedsOpenClawAuthBootstrap =
+      const pluginHarnessSupportsOpenClawAuthBootstrap =
         pluginHarnessOwnsTransport &&
         provider === OPENAI_CODEX_PROVIDER_ID &&
         effectiveModel.api === "openai-codex-responses";
       const authStore =
-        pluginHarnessOwnsTransport && !pluginHarnessNeedsOpenClawAuthBootstrap
+        pluginHarnessOwnsTransport && !pluginHarnessSupportsOpenClawAuthBootstrap
           ? createEmptyAuthProfileStore()
-          : pluginHarnessNeedsOpenClawAuthBootstrap
+          : pluginHarnessSupportsOpenClawAuthBootstrap
             ? ensureAuthProfileStore(agentDir, {
                 externalCliProviderIds: [OPENAI_CODEX_PROVIDER_ID],
                 allowKeychainPrompt: false,
@@ -759,7 +759,7 @@ export async function runEmbeddedPiAgent(
                 allowKeychainPrompt: false,
               }));
       const attemptAuthProfileStore =
-        pluginHarnessOwnsTransport && !pluginHarnessNeedsOpenClawAuthBootstrap
+        pluginHarnessOwnsTransport && !pluginHarnessSupportsOpenClawAuthBootstrap
           ? ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
               allowKeychainPrompt: false,
             })
@@ -837,6 +837,8 @@ export async function runEmbeddedPiAgent(
       const pluginHarnessProfileOrder = pluginHarnessOwnsTransport
         ? resolvePluginHarnessProfileOrder()
         : [];
+      const pluginHarnessNeedsOpenClawAuthBootstrap =
+        pluginHarnessSupportsOpenClawAuthBootstrap && pluginHarnessProfileOrder.length > 0;
       const resolvePluginHarnessPreferredProfileId = (): string | undefined =>
         pluginHarnessProfileOrder[0];
       const preferredProfileId = pluginHarnessOwnsTransport

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -730,6 +730,16 @@ export async function runEmbeddedPiAgent(
         });
         return runtimeAuthPlan.forwardedAuthProfileId === profileId;
       };
+      const isEligiblePluginHarnessAuthProfile = (profileId: string): boolean => {
+        const credential = attemptAuthProfileStore.profiles?.[profileId];
+        const providerForEligibility = credential?.provider ?? profileId.split(":", 1)[0];
+        return resolveAuthProfileEligibility({
+          cfg: params.config,
+          store: attemptAuthProfileStore,
+          provider: providerForEligibility,
+          profileId,
+        }).eligible;
+      };
       const resolvePluginHarnessProfileOrder = (): string[] => {
         if (requestedProfileId && requestedProfileIsUserLocked) {
           return isForwardablePluginHarnessAuthProfile(requestedProfileId)
@@ -759,7 +769,11 @@ export async function runEmbeddedPiAgent(
         if (resolvedOrder.length > 0) {
           return resolvedOrder;
         }
-        if (requestedProfileId && isForwardablePluginHarnessAuthProfile(requestedProfileId)) {
+        if (
+          requestedProfileId &&
+          isForwardablePluginHarnessAuthProfile(requestedProfileId) &&
+          (requestedProfileIsUserLocked || isEligiblePluginHarnessAuthProfile(requestedProfileId))
+        ) {
           return [requestedProfileId];
         }
         return [];

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -4124,7 +4124,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(
-        "⚠️ Model login expired on the gateway for openai-codex. Re-auth with `openclaw models auth login --provider openai-codex`, then try again.",
+        "⚠️ OpenClaw can't use your OpenAI account for Codex right now. This usually happens when the account sign-in expired, was signed out, or was replaced by another account. Sign in again with `openclaw models auth login --provider openai-codex`, then try again.",
       );
     }
   });
@@ -4242,7 +4242,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(
-        "⚠️ Model login expired on the gateway. Re-auth with `openclaw models auth login`, then try again.",
+        "⚠️ OpenClaw can't use your model provider account right now. This usually happens when the account sign-in expired, was signed out, or was replaced by another account. Sign in again with `openclaw models auth login`, then try again.",
       );
     }
   });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -13,6 +13,7 @@ import {
 import {
   buildOAuthRefreshFailureLoginCommand,
   classifyOAuthRefreshFailure,
+  formatOAuthRefreshFailureAccountLabel,
 } from "../../agents/auth-profiles/oauth-refresh-failure.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { getCliSessionBinding } from "../../agents/cli-session.js";
@@ -584,14 +585,15 @@ function buildExternalRunFailureReply(
   const oauthRefreshFailure = classifyOAuthRefreshFailure(normalizedMessage);
   if (oauthRefreshFailure) {
     const loginCommand = buildOAuthRefreshFailureLoginCommand(oauthRefreshFailure.provider);
+    const accountLabel = formatOAuthRefreshFailureAccountLabel(oauthRefreshFailure.provider);
     if (oauthRefreshFailure.reason) {
       return {
-        text: `⚠️ Model login expired on the gateway${oauthRefreshFailure.provider ? ` for ${oauthRefreshFailure.provider}` : ""}. Re-auth with \`${loginCommand}\`, then try again.`,
+        text: `⚠️ OpenClaw can't use ${accountLabel} right now. This usually happens when the account sign-in expired, was signed out, or was replaced by another account. Sign in again with \`${loginCommand}\`, then try again.`,
         isGenericRunnerFailure: false,
       };
     }
     return {
-      text: `⚠️ Model login failed on the gateway${oauthRefreshFailure.provider ? ` for ${oauthRefreshFailure.provider}` : ""}. Please try again. If this keeps happening, re-auth with \`${loginCommand}\`.`,
+      text: `⚠️ OpenClaw couldn't refresh ${accountLabel}. Please try again. If this keeps happening, sign in again with \`${loginCommand}\`.`,
       isGenericRunnerFailure: false,
     };
   }

--- a/src/commands/doctor-auth.hints.test.ts
+++ b/src/commands/doctor-auth.hints.test.ts
@@ -26,7 +26,7 @@ describe("resolveUnusableProfileHint", () => {
     );
   });
 
-  it("formats permanent OAuth refresh failures as reauth-required", () => {
+  it("formats permanent OAuth refresh failures as account sign-in guidance", () => {
     expect(
       formatOAuthRefreshFailureDoctorLine({
         profileId: "openai-codex:default",
@@ -35,11 +35,11 @@ describe("resolveUnusableProfileHint", () => {
           "OAuth token refresh failed for openai-codex: refresh_token_reused. Please try again or re-authenticate.",
       }),
     ).toBe(
-      "- openai-codex:default: re-auth required [refresh_token_reused] — Run `openclaw models auth login --provider openai-codex`.",
+      "- openai-codex:default: OpenClaw can't use your OpenAI account for Codex right now (refresh_token_reused). Sign in again with `openclaw models auth login --provider openai-codex`.",
     );
   });
 
-  it("formats non-permanent OAuth refresh failures as retry-then-reauth guidance", () => {
+  it("formats non-permanent OAuth refresh failures as retry-then-sign-in guidance", () => {
     expect(
       formatOAuthRefreshFailureDoctorLine({
         profileId: "openai-codex:default",
@@ -48,7 +48,7 @@ describe("resolveUnusableProfileHint", () => {
           "OAuth token refresh failed for openai-codex: temporary upstream issue. Please try again or re-authenticate.",
       }),
     ).toBe(
-      "- openai-codex:default: OAuth refresh failed — Try again; if this persists, run `openclaw models auth login --provider openai-codex`.",
+      "- openai-codex:default: OpenClaw couldn't refresh your OpenAI account for Codex. Try again; if this keeps happening, sign in again with `openclaw models auth login --provider openai-codex`.",
     );
   });
 
@@ -61,7 +61,7 @@ describe("resolveUnusableProfileHint", () => {
           "OAuth token refresh failed for openai-codex`\nrm -rf /: invalid_grant. Please try again or re-authenticate.",
       }),
     ).toBe(
-      "- openai-codex:default: re-auth required [invalid_grant] — Run `openclaw models auth login --provider openai-codex`.",
+      "- openai-codex:default: OpenClaw can't use your OpenAI account for Codex right now (invalid_grant). Sign in again with `openclaw models auth login --provider openai-codex`.",
     );
   });
 });

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -14,6 +14,7 @@ import { formatAuthDoctorHint } from "../agents/auth-profiles/doctor.js";
 import {
   buildOAuthRefreshFailureLoginCommand,
   classifyOAuthRefreshFailure,
+  formatOAuthRefreshFailureAccountLabel,
   type OAuthRefreshFailureReason,
 } from "../agents/auth-profiles/oauth-refresh-failure.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -138,6 +139,10 @@ function formatOAuthRefreshFailureReason(reason: OAuthRefreshFailureReason | nul
   switch (reason) {
     case "refresh_token_reused":
       return "refresh_token_reused";
+    case "refresh_token_expired":
+      return "refresh_token_expired";
+    case "refresh_token_invalidated":
+      return "refresh_token_invalidated";
     case "invalid_grant":
       return "invalid_grant";
     case "sign_in_again":
@@ -162,10 +167,11 @@ export function formatOAuthRefreshFailureDoctorLine(params: {
   }
   const provider = classified.provider ?? params.provider;
   const command = buildOAuthRefreshFailureLoginCommand(provider);
+  const accountLabel = formatOAuthRefreshFailureAccountLabel(provider);
   if (classified.reason) {
-    return `- ${params.profileId}: re-auth required [${formatOAuthRefreshFailureReason(classified.reason)}] — Run \`${command}\`.`;
+    return `- ${params.profileId}: OpenClaw can't use ${accountLabel} right now (${formatOAuthRefreshFailureReason(classified.reason)}). Sign in again with \`${command}\`.`;
   }
-  return `- ${params.profileId}: OAuth refresh failed — Try again; if this persists, run \`${command}\`.`;
+  return `- ${params.profileId}: OpenClaw couldn't refresh ${accountLabel}. Try again; if this keeps happening, sign in again with \`${command}\`.`;
 }
 
 async function resolveAuthIssueHint(

--- a/src/commands/status-all/gateway.test.ts
+++ b/src/commands/status-all/gateway.test.ts
@@ -2,13 +2,15 @@ import { describe, expect, it } from "vitest";
 import { summarizeLogTail } from "./gateway.js";
 
 describe("summarizeLogTail", () => {
-  it("marks permanent OAuth refresh failures as reauth-required", () => {
+  it("marks permanent OAuth refresh failures as sign-in attention", () => {
     const lines = summarizeLogTail([
       "[openai-codex] Token refresh failed: 401 {",
       '"error":{"code":"invalid_grant","message":"Session invalidated due to signing in again"}',
       "}",
     ]);
 
-    expect(lines).toEqual(["[openai-codex] token refresh 401 invalid_grant · re-auth required"]);
+    expect(lines).toEqual([
+      "[openai-codex] token refresh 401 invalid_grant · OpenAI sign-in needs attention",
+    ]);
   });
 });

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -119,7 +119,11 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
         const code = normalizeOptionalString(parsed?.error?.code) ?? null;
         const msg = normalizeOptionalString(parsed?.error?.message) ?? null;
         const refreshReason = classifyOAuthRefreshFailureReason(msg ?? "");
-        const msgShort = msg ? (refreshReason ? "re-auth required" : shorten(msg, 52)) : null;
+        const msgShort = msg
+          ? refreshReason
+            ? "OpenAI sign-in needs attention"
+            : shorten(msg, 52)
+          : null;
         const base = `[${tag}] token refresh ${status}${code ? ` ${code}` : ""}${msgShort ? ` · ${msgShort}` : ""}`;
         addGroup(`token:${tag}:${status}:${code ?? ""}:${msgShort ?? ""}`, base);
         continue;


### PR DESCRIPTION
## Summary

- expand Codex OAuth refresh-failure classification to match current refresh-token reuse, expiry, invalidation, revocation, and account-mismatch messages
- keep stale persisted/session-selected Codex auth profiles and stale `auth.order.openai` entries from switching OpenAI PI runs to `openai-codex`
- preserve explicit eligible Codex OAuth routing when a valid forwarded Codex harness profile exists
- skip Codex harness auth bootstrap when there is no eligible forwarded plugin harness profile
- fold the stale-routing fix from #83345 into this OAuth-only PR

Keychain compatibility/recovery was split out to #83451 so this PR stays focused on the OpenAI/Codex OAuth routing issue.

Fixes #83223.
Supersedes #83345.
Related: #83451

## Verification

- `git diff --check`: passed
- `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-refresh-failure.test.ts extensions/codex/src/app-server/auth-bridge.test.ts src/commands/doctor-auth.hints.test.ts src/commands/status-all/gateway.test.ts src/agents/command/attempt-execution.cli.test.ts src/agents/openai-codex-routing.test.ts src/agents/pi-embedded-runner.e2e.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`: passed, 9 files / 181 tests
- Testbox-through-Crabbox `check:changed`: passed on `tbx_01krws8xgjb8931mj9jgzamzww`, Actions run `https://github.com/openclaw/openclaw/actions/runs/26015522296`

## Real behavior proof

Behavior addressed: Codex app-server OAuth refresh failures now classify current Codex terminal refresh-token states precisely while user-facing messages explain that OpenClaw cannot use the user's OpenAI account for Codex until they sign in again. Stale Codex profile references from prior config/session state no longer force OpenAI PI runs onto the `openai-codex` provider when the requested route is `openai/gpt-5.5`. Valid eligible Codex OAuth profiles remain covered and still route through the Codex harness path.

Real environment tested: Blacksmith Testbox via Crabbox wrapper using the OpenClaw CI check workflow.

Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-workflow ci-check-testbox.yml --blacksmith-job check --keep-on-failure --shell -- "git fetch origin +refs/heads/main:refs/remotes/origin/main +refs/heads/fix-codex-oauth-refresh-parity:refs/remotes/origin/fix-codex-oauth-refresh-parity && git checkout --force refs/remotes/origin/fix-codex-oauth-refresh-parity && git reset --hard HEAD && git status --short && git diff --name-only origin/main...HEAD | wc -l && pnpm --config.verify-deps-before-run=false check:changed"`.

Evidence after fix: the Testbox run checked out #81700 head `8d2630a5dea`, confirmed an 18-file branch diff, and completed `check:changed` successfully.

Observed result after fix: OAuth copy/classifier, stale profile boundary, Codex app-server auth bridge, doctor/status messaging, stale OpenAI PI routing, and harness bootstrap regression coverage all pass; the remote changed gate passes typecheck, lint, import-cycle, and changed-surface checks.

What was not tested: a live Docker session with a real revoked/expired OpenAI refresh token was not reproduced; coverage is source-level parity with current Codex messages plus mocked OAuth refresh paths and focused stale-routing regression tests.
