### PR TITLE
fix(migrate): drop trailing periods from migrate item messages

### DIFF
--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -178,7 +178,7 @@ async function discoverPluginDirs(codexHome: string): Promise<CodexPluginSource[
         sourceKind: "cache",
         migratable: false,
         message:
-          "Cached Codex plugin bundle found. Review manually unless the plugin is also installed in the source Codex app-server inventory.",
+          "Cached Codex plugin bundle found. Review manually unless the plugin is also installed in the source Codex app-server inventory",
       });
       return;
     }
@@ -602,7 +602,7 @@ export async function discoverCodexSource(
       id: "archive:config.toml",
       path: configPath,
       relativePath: "config.toml",
-      message: "Codex config is archived for manual review; it is not activated automatically.",
+      message: "Codex config is archived for manual review; it is not activated automatically",
     });
   }
   if (await exists(hooksPath)) {
@@ -611,7 +611,7 @@ export async function discoverCodexSource(
       path: hooksPath,
       relativePath: "hooks/hooks.json",
       message:
-        "Codex native hooks are archived for manual review because they can execute commands.",
+        "Codex native hooks are archived for manual review because they can execute commands",
     });
   }
   const skills = [...codexSkills, ...personalAgentSkills].toSorted((a, b) =>

--- a/src/commands/migrate/output.test.ts
+++ b/src/commands/migrate/output.test.ts
@@ -100,7 +100,7 @@ describe("formatMigrationResult", () => {
       .join("\n");
 
     expect(output).toContain("❌");
-    expect(output).toContain("Plugin not found in the Codex marketplace.");
+    expect(output).toContain("Plugin not found in the Codex marketplace");
   });
 
   it("says (Skipped) for user-deselected skill/plugin items", () => {

--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -120,16 +120,16 @@ function formatItemDisplayName(item: MigrationItem): string {
 }
 
 const REASON_CODE_MESSAGES: Record<string, string> = {
-  plugin_missing: "Plugin not found in the Codex marketplace.",
-  marketplace_missing: "Codex marketplace is unavailable.",
-  disabled: "Plugin is disabled in Codex.",
-  refresh_failed: "Failed to refresh the Codex plugin marketplace.",
-  auth_required: "Plugin requires additional authentication.",
-  already_active: "Plugin is already active in OpenClaw.",
-  installed: "Plugin is already installed in OpenClaw.",
-  plugin_install_failed: "Plugin installation failed.",
-  codex_subscription_required: "Plugin requires an active Codex subscription.",
-  "not selected for migration": "Skipped because it was not selected for migration.",
+  plugin_missing: "Plugin not found in the Codex marketplace",
+  marketplace_missing: "Codex marketplace is unavailable",
+  disabled: "Plugin is disabled in Codex",
+  refresh_failed: "Failed to refresh the Codex plugin marketplace",
+  auth_required: "Plugin requires additional authentication",
+  already_active: "Plugin is already active in OpenClaw",
+  installed: "Plugin is already installed in OpenClaw",
+  plugin_install_failed: "Plugin installation failed",
+  codex_subscription_required: "Plugin requires an active Codex subscription",
+  "not selected for migration": "Skipped because it was not selected for migration",
 };
 
 // Phrase-form conflict reasons, used as-is in selection-prompt hints
@@ -145,7 +145,7 @@ function conflictReasonSentence(reason: string): string | undefined {
   if (!phrase) {
     return undefined;
   }
-  return `${phrase.charAt(0).toUpperCase()}${phrase.slice(1)}.`;
+  return `${phrase.charAt(0).toUpperCase()}${phrase.slice(1)}`;
 }
 
 function humanizeReason(reason: string | undefined): string | undefined {


### PR DESCRIPTION
## Summary

Migrate-output rows render messages inside parens, where a trailing period reads as cruft. Strip the periods so rows read cleanly.

Before / after:

| Before | After |
| --- | --- |
| `❌ google-calendar (Plugin not found in the Codex marketplace.)` | `❌ google-calendar (Plugin not found in the Codex marketplace)` |
| `📖 config.toml (Codex config is archived for manual review; it is not activated automatically.)` | `📖 config.toml (Codex config is archived for manual review; it is not activated automatically)` |
| `🔍 browser-use (Cached Codex plugin bundle found. Review manually unless the plugin is also installed in the source Codex app-server inventory.)` | `🔍 browser-use (Cached Codex plugin bundle found. Review manually unless the plugin is also installed in the source Codex app-server inventory)` |

Touches:
- `REASON_CODE_MESSAGES` (10 entries) and `conflictReasonSentence` in `src/commands/migrate/output.ts`
- Archive/manual-review messages in `extensions/codex/src/migration/source.ts` (3 entries)
- Matching assertion in `src/commands/migrate/output.test.ts`

## Test plan

- [ ] `pnpm test src/commands/migrate/output.test.ts`
- [ ] `./run.sh migrate` against the `codex_home/` fixture and visually confirm preview/result rows render without trailing periods