### PR TITLE
fix: avoid raw background task completion notices

### DIFF
--- a/src/tasks/task-executor-policy.test.ts
+++ b/src/tasks/task-executor-policy.test.ts
@@ -52,10 +52,10 @@ describe("task-executor-policy", () => {
     };
 
     expect(formatTaskTerminalMessage(blockedTask)).toBe(
-      "Background task blocked: ACP import (run run-1234). Needs login.",
+      "Background work needs follow-up: ACP import. Needs login.",
     );
     expect(formatTaskBlockedFollowupMessage(blockedTask)).toBe(
-      "Task needs follow-up: ACP import (run run-1234). Needs login.",
+      "Follow-up needed for background work: ACP import. Needs login.",
     );
     expect(formatTaskStateChangeMessage(blockedTask, progressEvent)).toBe(
       "Background task update: ACP import. No output for 60s.",
@@ -91,13 +91,13 @@ describe("task-executor-policy", () => {
     };
 
     expect(formatTaskTerminalMessage(blockedTask)).toBe(
-      "Background task blocked: Background task (run run-1234).",
+      "Background work needs follow-up: Background task.",
     );
     expect(formatTaskBlockedFollowupMessage(blockedTask)).toBe(
-      "Task needs follow-up: Background task (run run-1234). Task is blocked and needs follow-up.",
+      "Follow-up needed for background work: Background task. Task is blocked and needs follow-up.",
     );
     expect(formatTaskTerminalMessage(failedTask)).toBe(
-      "Background task failed: Background task (run run-2234). Needs manual approval.",
+      "Background work failed: Background task. Needs manual approval.",
     );
     expect(formatTaskStateChangeMessage(blockedTask, progressEvent)).toBeNull();
   });
@@ -112,11 +112,37 @@ describe("task-executor-policy", () => {
     });
 
     expect(formatTaskTerminalMessage(blockedTask)).toBe(
-      "Background task blocked: ACP import (run run-1234). Command did not run: approval timed out.",
+      "Background work needs follow-up: ACP import. Command did not run: approval timed out.",
     );
     expect(formatTaskBlockedFollowupMessage(blockedTask)).toBe(
-      "Task needs follow-up: ACP import (run run-1234). Command did not run: approval timed out.",
+      "Follow-up needed for background work: ACP import. Command did not run: approval timed out.",
     );
+  });
+
+  it("does not emit raw task completion boilerplate or run metadata", () => {
+    const messages = [
+      formatTaskTerminalMessage(
+        createTask({
+          status: "succeeded",
+          runId: "run-1234567890",
+          task: "ACP smoke test",
+        }),
+      ),
+      formatTaskTerminalMessage(
+        createTask({
+          status: "failed",
+          runId: "run-2234567890",
+          error: "Worker failed.",
+          task: "ACP smoke test",
+        }),
+      ),
+    ];
+
+    for (const message of messages) {
+      expect(message).not.toContain("Background task done:");
+      expect(message).not.toMatch(/\(run [^)]+\)/);
+      expect(message).not.toContain("ACP background task");
+    }
   });
 
   it("keeps delivery policy decisions explicit", () => {

--- a/src/tasks/task-executor-policy.ts
+++ b/src/tasks/task-executor-policy.ts
@@ -14,52 +14,43 @@ export function isTerminalTaskStatus(status: TaskStatus): boolean {
 function resolveTaskDisplayTitle(task: TaskRecord): string {
   return formatTaskStatusTitleText(
     task.label?.trim() ||
-      (task.runtime === "acp"
-        ? "ACP background task"
-        : task.runtime === "subagent"
-          ? "Subagent task"
-          : task.task.trim() || "Background task"),
+      (task.runtime === "subagent" ? "Subagent task" : task.task.trim() || "Background task"),
   );
-}
-
-function resolveTaskRunLabel(task: TaskRecord): string {
-  return task.runId ? ` (run ${task.runId.slice(0, 8)})` : "";
 }
 
 export function formatTaskTerminalMessage(task: TaskRecord): string {
   const title = resolveTaskDisplayTitle(task);
-  const runLabel = resolveTaskRunLabel(task);
   const summary = sanitizeTaskStatusText(task.terminalSummary, {
     errorContext: task.status !== "succeeded" || task.terminalOutcome === "blocked",
   });
   if (task.status === "succeeded") {
     if (task.terminalOutcome === "blocked") {
       return summary
-        ? `Background task blocked: ${title}${runLabel}. ${summary}`
-        : `Background task blocked: ${title}${runLabel}.`;
+        ? `Background work needs follow-up: ${title}. ${summary}`
+        : `Background work needs follow-up: ${title}.`;
     }
     return summary
-      ? `Background task done: ${title}${runLabel}. ${summary}`
-      : `Background task done: ${title}${runLabel}.`;
+      ? `Background work finished: ${title}. ${summary}`
+      : `Background work finished: ${title}. Please send Moeed a concise user-facing summary in your normal voice.`;
   }
   if (task.status === "timed_out") {
-    return `Background task timed out: ${title}${runLabel}.`;
+    return `Background work timed out: ${title}. Please send Moeed a concise update in your normal voice.`;
   }
   if (task.status === "lost") {
     const error = sanitizeTaskStatusText(task.error, { errorContext: true });
     const fallbackSummary = sanitizeTaskStatusText(task.terminalSummary, { errorContext: true });
-    return `Background task lost: ${title}${runLabel}. ${error || fallbackSummary || "Backing session disappeared."}`;
+    return `Background work was interrupted: ${title}. ${error || fallbackSummary || "Backing session disappeared."}`;
   }
   if (task.status === "cancelled") {
-    return `Background task cancelled: ${title}${runLabel}.`;
+    return `Background work was cancelled: ${title}.`;
   }
   const error = sanitizeTaskStatusText(task.error, { errorContext: true });
   const fallbackSummary = sanitizeTaskStatusText(task.terminalSummary, { errorContext: true });
   return error
-    ? `Background task failed: ${title}${runLabel}. ${error}`
+    ? `Background work failed: ${title}. ${error}`
     : fallbackSummary
-      ? `Background task failed: ${title}${runLabel}. ${fallbackSummary}`
-      : `Background task failed: ${title}${runLabel}.`;
+      ? `Background work failed: ${title}. ${fallbackSummary}`
+      : `Background work failed: ${title}. Please send Moeed a concise update in your normal voice.`;
 }
 
 export function formatTaskBlockedFollowupMessage(task: TaskRecord): string | null {
@@ -67,11 +58,10 @@ export function formatTaskBlockedFollowupMessage(task: TaskRecord): string | nul
     return null;
   }
   const title = resolveTaskDisplayTitle(task);
-  const runLabel = resolveTaskRunLabel(task);
   const summary =
     sanitizeTaskStatusText(task.terminalSummary, { errorContext: true }) ||
     "Task is blocked and needs follow-up.";
-  return `Task needs follow-up: ${title}${runLabel}. ${summary}`;
+  return `Follow-up needed for background work: ${title}. ${summary}`;
 }
 
 export function formatTaskStateChangeMessage(

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -914,7 +914,7 @@ describe("task-registry", () => {
         to: "notifychat:123",
         threadId: "321",
       });
-      expect(String(message.content)).toContain("Background task done: ACP background task");
+      expect(String(message.content)).toContain("Background work finished: Investigate issue");
       expectRecordFields(message.mirror, {
         sessionKey: "agent:main:main",
       });
@@ -999,7 +999,7 @@ describe("task-registry", () => {
       });
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
       expect(peekSystemEvents(ownerKey)).toEqual([
-        "Background task done: ACP background task (run run-grou).",
+        "Background work finished: Investigate issue. Please send Moeed a concise user-facing summary in your normal voice.",
       ]);
       expect(hasPendingHeartbeatWake()).toBe(true);
     });
@@ -1047,7 +1047,7 @@ describe("task-registry", () => {
       await waitForAssertion(() => {
         const events = peekSystemEvents("agent:main:main");
         expect(events).toHaveLength(1);
-        expect(events[0]).toContain("Background task failed: ACP background task");
+        expect(events[0]).toContain("Background work failed: Investigate issue");
       });
     });
   });
@@ -1083,8 +1083,8 @@ describe("task-registry", () => {
         }),
       );
       expect(peekSystemEvents("agent:main:main")).toEqual([
-        "Background task blocked: ACP background task (run run-deli). Writable session or apply_patch authorization required.",
-        "Task needs follow-up: ACP background task (run run-deli). Writable session or apply_patch authorization required.",
+        "Background work needs follow-up: Port the repo changes. Writable session or apply_patch authorization required.",
+        "Follow-up needed for background work: Port the repo changes. Writable session or apply_patch authorization required.",
       ]);
       expect(hasPendingHeartbeatWake()).toBe(true);
     });
@@ -1124,7 +1124,7 @@ describe("task-registry", () => {
       );
       const events = peekSystemEvents("agent:main:main");
       expect(events).toHaveLength(1);
-      expect(events[0]).toContain("Background task done: ACP background task");
+      expect(events[0]).toContain("Background work finished: Investigate issue");
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
     });
   });
@@ -1154,8 +1154,8 @@ describe("task-registry", () => {
         }),
       );
       expect(peekSystemEvents("agent:main:main")).toEqual([
-        "Background task blocked: ACP background task (run run-sess). Writable session or apply_patch authorization required.",
-        "Task needs follow-up: ACP background task (run run-sess). Writable session or apply_patch authorization required.",
+        "Background work needs follow-up: Port the repo changes. Writable session or apply_patch authorization required.",
+        "Follow-up needed for background work: Port the repo changes. Writable session or apply_patch authorization required.",
       ]);
       expect(hasPendingHeartbeatWake()).toBe(true);
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
@@ -1206,7 +1206,8 @@ describe("task-registry", () => {
 
       await waitForAssertion(() =>
         expectRecordFields(sentMessageCall(), {
-          content: "Background task done: ACP background task (run run-deta).",
+          content:
+            "Background work finished: Create the file and verify it. Please send Moeed a concise user-facing summary in your normal voice.",
         }),
       );
     });
@@ -1242,11 +1243,11 @@ describe("task-registry", () => {
       await waitForAssertion(() =>
         expectRecordFields(sentMessageCall(), {
           content:
-            "Background task blocked: ACP background task (run run-bloc). Writable session or apply_patch authorization required.",
+            "Background work needs follow-up: Port the repo changes. Writable session or apply_patch authorization required.",
         }),
       );
       expect(peekSystemEvents("agent:main:main")).toEqual([
-        "Task needs follow-up: ACP background task (run run-bloc). Writable session or apply_patch authorization required.",
+        "Follow-up needed for background work: Port the repo changes. Writable session or apply_patch authorization required.",
       ]);
       expect(hasPendingHeartbeatWake()).toBe(true);
     });
@@ -1282,7 +1283,7 @@ describe("task-registry", () => {
       await waitForAssertion(() =>
         expectRecordFields(sentMessageCall(), {
           content:
-            "Background task done: ACP background task (run run-succ). Created /tmp/file.txt and verified contents.",
+            "Background work finished: Create the file and verify it. Created /tmp/file.txt and verified contents.",
         }),
       );
       expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);
@@ -2692,7 +2693,7 @@ describe("task-registry", () => {
       await waitForAssertion(() =>
         expectRecordFields(sentMessageCall(), {
           content:
-            "Background task update: ACP background task. No output for 60s. It may be waiting for input.",
+            "Background task update: Investigate issue. No output for 60s. It may be waiting for input.",
         }),
       );
       expectRecordFields(requireTaskByRunId("run-state-change"), {
@@ -2767,7 +2768,8 @@ describe("task-registry", () => {
       expectRecordFields(sentMessageCall(), {
         channel: "guildchat",
         to: "guildchat:123",
-        content: "Background task done: ACP background task (run run-quie).",
+        content:
+          "Background work finished: Create the file. Please send Moeed a concise user-facing summary in your normal voice.",
       });
       expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);
       relay.dispose();
@@ -2817,8 +2819,7 @@ describe("task-registry", () => {
       expectRecordFields(sentMessageCall(), {
         channel: "guildchat",
         to: "guildchat:123",
-        content:
-          "Background task failed: ACP background task (run run-fail). Permission denied by ACP runtime",
+        content: "Background work failed: Write the file. Permission denied by ACP runtime",
       });
       expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);
     });
@@ -2866,7 +2867,7 @@ describe("task-registry", () => {
       relay.notifyStarted();
       await flushAsyncWork();
       expectRecordFields(sentMessageCall(), {
-        content: "Background task update: ACP background task. Started.",
+        content: "Background task update: Create the file. Started.",
       });
 
       hoisted.sendMessageMock.mockClear();
@@ -2874,7 +2875,7 @@ describe("task-registry", () => {
       await flushAsyncWork();
       expectRecordFields(sentMessageCall(), {
         content:
-          "Background task update: ACP background task. No output for 1s. It may be waiting for input.",
+          "Background task update: Create the file. No output for 1s. It may be waiting for input.",
       });
 
       expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);
@@ -2927,7 +2928,7 @@ describe("task-registry", () => {
         expectRecordFields(sentMessageCall(), {
           channel: "notifychat",
           to: "notifychat:123",
-          content: "Background task cancelled: ACP background task (run run-canc).",
+          content: "Background work was cancelled: Investigate issue.",
         }),
       );
     });
@@ -2979,7 +2980,7 @@ describe("task-registry", () => {
         expectRecordFields(sentMessageCall(), {
           channel: "notifychat",
           to: "notifychat:123",
-          content: "Background task cancelled: Subagent task (run run-canc).",
+          content: "Background work was cancelled: Subagent task.",
         }),
       );
     });
@@ -3026,7 +3027,7 @@ describe("task-registry", () => {
         expectRecordFields(sentMessageCall(), {
           channel: "notifychat",
           to: "notifychat:123",
-          content: "Background task cancelled: Investigate issue (run run-canc).",
+          content: "Background work was cancelled: Investigate issue.",
         }),
       );
     });


### PR DESCRIPTION
## Summary
- Replace raw background task terminal notices with user-facing background work copy.
- Remove run-id snippets and the generic ACP background task fallback from terminal delivery text.
- Add regression coverage so terminal task messages do not expose raw task boilerplate or run metadata.

## Testing
- corepack pnpm exec vitest run src/tasks/task-executor-policy.test.ts src/tasks/task-registry.test.ts --environment node --pool forks
- Result: 2 test files passed, 71 tests passed.
