### PR TITLE
fix: separate bootstrap warning dedupe state from systemPromptReport

### DIFF
--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -148,6 +148,19 @@ describe("bootstrap prompt warnings", () => {
   it("resolves seen signatures from report history or legacy single signature", () => {
     expect(
       resolveBootstrapWarningSignaturesSeen({
+        bootstrapPromptWarningState: {
+          warningSignaturesSeen: ["sig-state-a", " ", "sig-state-b", "sig-state-a"],
+        },
+        systemPromptReport: {
+          bootstrapTruncation: {
+            warningSignaturesSeen: ["legacy-report-signature"],
+          },
+        },
+      }),
+    ).toEqual(["sig-state-a", "sig-state-b"]);
+
+    expect(
+      resolveBootstrapWarningSignaturesSeen({
         bootstrapTruncation: {
           warningSignaturesSeen: ["sig-a", " ", "sig-b", "sig-a"],
           promptWarningSignature: "legacy-ignored",
@@ -457,7 +470,7 @@ describe("bootstrap prompt warnings", () => {
     expect(meta.truncatedFiles).toBe(1);
     expect(meta.nearLimitFiles).toBe(1);
     expect(meta.promptWarningSignature).toBe(warning.signature);
-    expect(meta.warningSignaturesSeen).toEqual([warning.signature]);
+    expect(meta).not.toHaveProperty("warningSignaturesSeen");
   });
 
   it("improves cache-relevant system prompt stability versus legacy warning injection", () => {

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -51,7 +51,6 @@ type BootstrapTruncationReportMeta = {
   warningMode: BootstrapPromptWarningMode;
   warningShown: boolean;
   promptWarningSignature?: string;
-  warningSignaturesSeen?: string[];
   truncatedFiles: number;
   nearLimitFiles: number;
   totalNearLimit: boolean;
@@ -99,14 +98,28 @@ function appendSeenSignature(signatures: string[], signature: string): string[] 
   return next.slice(-DEFAULT_BOOTSTRAP_PROMPT_WARNING_SIGNATURE_HISTORY_MAX);
 }
 
-export function resolveBootstrapWarningSignaturesSeen(report?: {
+export function resolveBootstrapWarningSignaturesSeen(source?: {
+  bootstrapPromptWarningState?: {
+    warningSignaturesSeen?: string[];
+  };
+  systemPromptReport?: {
+    bootstrapTruncation?: {
+      warningMode?: BootstrapPromptWarningMode;
+      warningSignaturesSeen?: string[];
+      promptWarningSignature?: string;
+    };
+  };
   bootstrapTruncation?: {
     warningMode?: BootstrapPromptWarningMode;
     warningSignaturesSeen?: string[];
     promptWarningSignature?: string;
   };
 }): string[] {
-  const truncation = report?.bootstrapTruncation;
+  if (Object.hasOwn(source ?? {}, "bootstrapPromptWarningState")) {
+    return normalizeSeenSignatures(source?.bootstrapPromptWarningState?.warningSignaturesSeen);
+  }
+
+  const truncation = source?.systemPromptReport?.bootstrapTruncation ?? source?.bootstrapTruncation;
   const seenFromReport = normalizeSeenSignatures(truncation?.warningSignaturesSeen);
   if (seenFromReport.length > 0) {
     return seenFromReport;
@@ -375,9 +388,6 @@ export function buildBootstrapTruncationReportMeta(params: {
     warningMode: params.warningMode,
     warningShown: params.warning.warningShown,
     promptWarningSignature: params.warning.signature,
-    ...(params.warning.warningSignaturesSeen.length > 0
-      ? { warningSignaturesSeen: params.warning.warningSignaturesSeen }
-      : {}),
     truncatedFiles: params.analysis.truncatedFiles.length,
     nearLimitFiles: params.analysis.nearLimitFiles.length,
     totalNearLimit: params.analysis.totalNearLimit,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -405,7 +405,7 @@ export function runAgentAttempt(params: {
     ? resolvedPrompt
     : annotateInterSessionPromptText(resolvedPrompt, params.opts.inputProvenance);
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-    params.sessionEntry?.systemPromptReport,
+    params.sessionEntry,
   );
   const bootstrapPromptWarningSignature =
     bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -447,7 +447,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
-  it("persists latest systemPromptReport for downstream warning dedupe", async () => {
+  it("persists bootstrap warning dedupe state separately from systemPromptReport", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const sessionKey = "agent:codex:report:test-system-prompt-report";
       const sessionId = "test-system-prompt-report-session";
@@ -465,7 +465,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
         generatedAt: Date.now(),
         bootstrapTruncation: {
           warningMode: "once" as const,
-          warningSignaturesSeen: ["sig-a", "sig-b"],
         },
         systemPrompt: {
           chars: 1,
@@ -493,16 +492,20 @@ describe("updateSessionStoreAfterAgentRun", () => {
               provider: "openai",
               model: "gpt-5.4",
             },
+            bootstrapPromptWarningSignaturesSeen: ["sig-a", "sig-b"],
             systemPromptReport: report,
           },
         } as never,
       });
 
       const persisted = loadSessionStore(storePath, { skipCache: true })[sessionKey];
-      expect(persisted?.systemPromptReport?.bootstrapTruncation?.warningSignaturesSeen).toEqual([
+      expect(persisted?.bootstrapPromptWarningState?.warningSignaturesSeen).toEqual([
         "sig-a",
         "sig-b",
       ]);
+      expect(
+        persisted?.systemPromptReport?.bootstrapTruncation?.warningSignaturesSeen,
+      ).toBeUndefined();
       expect(sessionStore[sessionKey]?.systemPromptReport?.bootstrapTruncation?.warningMode).toBe(
         "once",
       );

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -7,6 +7,7 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import { resolveBootstrapWarningSignaturesSeen } from "../bootstrap-budget.js";
 import { clearCliSession, setCliSessionBinding, setCliSessionId } from "../cli-session.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { isCliProvider } from "../model-selection.js";
@@ -173,6 +174,18 @@ export async function updateSessionStoreAfterAgentRun(params: {
   next.abortedLastRun = result.meta.aborted ?? false;
   if (result.meta.systemPromptReport) {
     next.systemPromptReport = result.meta.systemPromptReport;
+  }
+  const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen({
+    bootstrapPromptWarningState: {
+      warningSignaturesSeen: result.meta.bootstrapPromptWarningSignaturesSeen,
+    },
+  });
+  if (bootstrapPromptWarningSignaturesSeen.length > 0) {
+    next.bootstrapPromptWarningState = {
+      warningSignaturesSeen: bootstrapPromptWarningSignaturesSeen,
+    };
+  } else {
+    next.bootstrapPromptWarningState = undefined;
   }
   if (hasNonzeroUsage(usage)) {
     const { estimateUsageCost, resolveModelCostConfig } = await getUsageFormatModule();

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1217,7 +1217,7 @@ export async function runAgentTurnWithFallback(params: {
   let didRetryTransientHttpError = false;
   let liveModelSwitchRetries = 0;
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-    params.getActiveSessionEntry()?.systemPromptReport,
+    params.getActiveSessionEntry(),
   );
   let pendingFallbackCandidateRollback:
     | {
@@ -1590,9 +1590,12 @@ export async function runAgentTurnWithFallback(params: {
                   abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
                   replyOperation: params.replyOperation,
                 });
-                bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-                  result.meta?.systemPromptReport,
-                );
+                bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen({
+                  bootstrapPromptWarningState: {
+                    warningSignaturesSeen: result.meta?.bootstrapPromptWarningSignaturesSeen,
+                  },
+                  systemPromptReport: result.meta?.systemPromptReport,
+                });
 
                 unsubscribeAssistantBridge();
                 await drainAssistantBridgeDelivery();
@@ -1985,9 +1988,12 @@ export async function runAgentTurnWithFallback(params: {
                     })()
                   : undefined,
               });
-              bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-                result.meta?.systemPromptReport,
-              );
+              bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen({
+                bootstrapPromptWarningState: {
+                  warningSignaturesSeen: result.meta?.bootstrapPromptWarningSignaturesSeen,
+                },
+                systemPromptReport: result.meta?.systemPromptReport,
+              });
               lifecycleBackstop.emit("end", result);
               const resultCompactionCount = Math.max(
                 0,

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1129,6 +1129,9 @@ describe("runMemoryFlushIfNeeded", () => {
       updatedAt: Date.now(),
       totalTokens: 80_000,
       compactionCount: 1,
+      bootstrapPromptWarningState: {
+        warningSignaturesSeen: ["sig-a", "sig-b"],
+      },
       systemPromptReport: {
         source: "run",
         generatedAt: Date.now(),
@@ -1140,7 +1143,6 @@ describe("runMemoryFlushIfNeeded", () => {
           warningMode: "once",
           warningShown: true,
           promptWarningSignature: "sig-b",
-          warningSignaturesSeen: ["sig-a", "sig-b"],
           truncatedFiles: 1,
           nearLimitFiles: 0,
           totalNearLimit: false,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -914,8 +914,7 @@ export async function runMemoryFlushIfNeeded(params: {
   let activeSessionEntry = entry ?? params.sessionEntry;
   const activeSessionStore = params.sessionStore;
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-    activeSessionEntry?.systemPromptReport ??
-      (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.systemPromptReport : undefined),
+    activeSessionEntry ?? (params.sessionKey ? activeSessionStore?.[params.sessionKey] : undefined),
   );
   const flushRunId = memoryDeps.randomUUID();
   if (params.sessionKey) {
@@ -996,9 +995,12 @@ export async function runMemoryFlushIfNeeded(params: {
         if (result.meta?.agentMeta?.sessionFile) {
           postCompactionSessionFile = result.meta.agentMeta.sessionFile;
         }
-        bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-          result.meta?.systemPromptReport,
-        );
+        bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen({
+          bootstrapPromptWarningState: {
+            warningSignaturesSeen: result.meta?.bootstrapPromptWarningSignaturesSeen,
+          },
+          systemPromptReport: result.meta?.systemPromptReport,
+        });
         return result;
       },
     });

--- a/src/auto-reply/reply/agent-runner-session-reset.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.ts
@@ -79,6 +79,7 @@ export async function resetReplyRunSession(params: {
     cacheRead: undefined,
     cacheWrite: undefined,
     contextTokens: undefined,
+    bootstrapPromptWarningState: undefined,
     systemPromptReport: undefined,
     fallbackNoticeSelectedModel: undefined,
     fallbackNoticeActiveModel: undefined,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1599,6 +1599,7 @@ export async function runReplyAgent(params: {
       providerUsed,
       contextTokensUsed,
       systemPromptReport: runResult.meta?.systemPromptReport,
+      bootstrapPromptWarningSignaturesSeen: runResult.meta?.bootstrapPromptWarningSignaturesSeen,
       cliSessionId,
       cliSessionBinding,
     });

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1064,6 +1064,9 @@ describe("createFollowupRunner bootstrap warning dedupe", () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
+      bootstrapPromptWarningState: {
+        warningSignaturesSeen: ["sig-a", "sig-b"],
+      },
       systemPromptReport: {
         source: "run",
         generatedAt: Date.now(),
@@ -1086,7 +1089,6 @@ describe("createFollowupRunner bootstrap warning dedupe", () => {
           warningMode: "once",
           warningShown: true,
           promptWarningSignature: "sig-b",
-          warningSignaturesSeen: ["sig-a", "sig-b"],
           truncatedFiles: 1,
           nearLimitFiles: 0,
           totalNearLimit: false,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -251,9 +251,8 @@ export function createFollowupRunner(params: {
         isHeartbeat: opts?.isHeartbeat === true,
         replyOperation,
       });
-      let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-        activeSessionEntry?.systemPromptReport,
-      );
+      let bootstrapPromptWarningSignaturesSeen =
+        resolveBootstrapWarningSignaturesSeen(activeSessionEntry);
       replyOperation.setPhase("running");
       try {
         const outcomePlan = buildAgentRuntimeOutcomePlan();
@@ -338,9 +337,12 @@ export function createFollowupRunner(params: {
                   }
                 },
               });
-              bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-                result.meta?.systemPromptReport,
-              );
+              bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen({
+                bootstrapPromptWarningState: {
+                  warningSignaturesSeen: result.meta?.bootstrapPromptWarningSignaturesSeen,
+                },
+                systemPromptReport: result.meta?.systemPromptReport,
+              });
               const resultCompactionCount = Math.max(
                 0,
                 result.meta?.agentMeta?.compactionCount ?? 0,
@@ -389,6 +391,8 @@ export function createFollowupRunner(params: {
           providerUsed,
           contextTokensUsed,
           systemPromptReport: runResult.meta?.systemPromptReport,
+          bootstrapPromptWarningSignaturesSeen:
+            runResult.meta?.bootstrapPromptWarningSignaturesSeen,
           cliSessionBinding: runResult.meta?.agentMeta?.cliSessionBinding,
           logLabel: "followup",
         });

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -1,3 +1,4 @@
+import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { setCliSessionBinding, setCliSessionId } from "../../agents/cli-session.js";
 import {
   deriveSessionTotalTokens,
@@ -86,6 +87,7 @@ export async function persistSessionUsageUpdate(params: {
   promptTokens?: number;
   usageIsContextSnapshot?: boolean;
   systemPromptReport?: SessionSystemPromptReport;
+  bootstrapPromptWarningSignaturesSeen?: string[];
   cliSessionId?: string;
   cliSessionBinding?: import("../../config/sessions.js").CliSessionBinding;
   logLabel?: string;
@@ -111,6 +113,11 @@ export async function persistSessionUsageUpdate(params: {
         storePath,
         sessionKey,
         update: async (entry) => {
+          const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen({
+            bootstrapPromptWarningState: {
+              warningSignaturesSeen: params.bootstrapPromptWarningSignaturesSeen,
+            },
+          });
           const resolvedContextTokens = params.contextTokensUsed ?? entry.contextTokens;
           // Use last-call usage for totalTokens when available. The accumulated
           // `usage.input` sums input tokens from every API call in the run
@@ -137,6 +144,12 @@ export async function persistSessionUsageUpdate(params: {
             model: params.modelUsed ?? entry.model,
             contextTokens: resolvedContextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
+            bootstrapPromptWarningState:
+              bootstrapPromptWarningSignaturesSeen.length > 0
+                ? {
+                    warningSignaturesSeen: bootstrapPromptWarningSignaturesSeen,
+                  }
+                : undefined,
             updatedAt: Date.now(),
           };
           if (hasUsage) {
@@ -173,11 +186,22 @@ export async function persistSessionUsageUpdate(params: {
         storePath,
         sessionKey,
         update: async (entry) => {
+          const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen({
+            bootstrapPromptWarningState: {
+              warningSignaturesSeen: params.bootstrapPromptWarningSignaturesSeen,
+            },
+          });
           const patch: Partial<SessionEntry> = {
             modelProvider: params.providerUsed ?? entry.modelProvider,
             model: params.modelUsed ?? entry.model,
             contextTokens: params.contextTokensUsed ?? entry.contextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
+            bootstrapPromptWarningState:
+              bootstrapPromptWarningSignaturesSeen.length > 0
+                ? {
+                    warningSignaturesSeen: bootstrapPromptWarningSignaturesSeen,
+                  }
+                : undefined,
             updatedAt: Date.now(),
           };
           return applyCliSessionIdToSessionPatch(params, entry, patch);

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -356,6 +356,7 @@ export type SessionEntry = {
   lastAccountId?: string;
   lastThreadId?: string | number;
   skillsSnapshot?: SessionSkillSnapshot;
+  bootstrapPromptWarningState?: SessionBootstrapPromptWarningState;
   systemPromptReport?: SessionSystemPromptReport;
   /**
    * Generic plugin-owned runtime debug entries shown in verbose status surfaces.
@@ -586,6 +587,14 @@ export type SessionSkillSnapshot = {
   version?: number;
 };
 
+export type SessionBootstrapPromptWarningState = {
+  /**
+   * Internal once-mode dedupe history. This is session runtime state, not a
+   * current-run prompt report metric.
+   */
+  warningSignaturesSeen?: string[];
+};
+
 export type SessionSystemPromptReport = {
   source: "run" | "estimate";
   generatedAt: number;
@@ -600,7 +609,6 @@ export type SessionSystemPromptReport = {
     warningMode?: "off" | "once" | "always";
     warningShown?: boolean;
     promptWarningSignature?: string;
-    warningSignaturesSeen?: string[];
     truncatedFiles?: number;
     nearLimitFiles?: number;
     totalNearLimit?: boolean;

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -124,7 +124,7 @@ export function createCronPromptExecutor(params: {
   let fallbackModel = params.liveSelection.model;
   let runEndedAt = Date.now();
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-    params.cronSession.sessionEntry.systemPromptReport,
+    params.cronSession.sessionEntry,
   );
 
   const runPrompt = async (promptText: string) => {
@@ -180,9 +180,12 @@ export function createCronPromptExecutor(params: {
             bootstrapPromptWarningSignature,
             senderIsOwner: params.senderIsOwner,
           });
-          bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-            result.meta?.systemPromptReport,
-          );
+          bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen({
+            bootstrapPromptWarningState: {
+              warningSignaturesSeen: result.meta?.bootstrapPromptWarningSignaturesSeen,
+            },
+            systemPromptReport: result.meta?.systemPromptReport,
+          });
           return result;
         }
         const { resolveFastModeState, runEmbeddedPiAgent } = await loadCronEmbeddedRuntime();
@@ -251,9 +254,12 @@ export function createCronPromptExecutor(params: {
           bootstrapPromptWarningSignaturesSeen,
           bootstrapPromptWarningSignature,
         });
-        bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-          result.meta?.systemPromptReport,
-        );
+        bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen({
+          bootstrapPromptWarningState: {
+            warningSignaturesSeen: result.meta?.bootstrapPromptWarningSignaturesSeen,
+          },
+          systemPromptReport: result.meta?.systemPromptReport,
+        });
         return result;
       },
     });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -817,6 +817,12 @@ async function finalizeCronRun(params: {
   if (finalRunResult.meta?.systemPromptReport) {
     prepared.cronSession.sessionEntry.systemPromptReport = finalRunResult.meta.systemPromptReport;
   }
+  const bootstrapPromptWarningSignaturesSeen =
+    finalRunResult.meta?.bootstrapPromptWarningSignaturesSeen;
+  prepared.cronSession.sessionEntry.bootstrapPromptWarningState =
+    bootstrapPromptWarningSignaturesSeen && bootstrapPromptWarningSignaturesSeen.length > 0
+      ? { warningSignaturesSeen: bootstrapPromptWarningSignaturesSeen }
+      : undefined;
   const usage = finalRunResult.meta?.agentMeta?.usage;
   const promptTokens = finalRunResult.meta?.agentMeta?.promptTokens;
   const modelUsed =

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -67,6 +67,7 @@ function stripRuntimeModelState(entry?: SessionEntry): SessionEntry | undefined 
     model: undefined,
     modelProvider: undefined,
     contextTokens: undefined,
+    bootstrapPromptWarningState: undefined,
     systemPromptReport: undefined,
   };
 }


### PR DESCRIPTION
## Why

`systemPromptReport.bootstrapTruncation.warningSignaturesSeen` currently mixes historical once-mode dedupe state into a field that otherwise looks like current-run prompt diagnostics.

That makes reports misleading: a clean current run can still show a stale historical truncation signature even when `truncatedFiles` is `0` and `injectedWorkspaceFiles[*].truncated` is `false`.

Bead: OC-tg1mt

## What changed

- add session-internal `bootstrapPromptWarningState.warningSignaturesSeen`
- stop serializing `warningSignaturesSeen` inside `systemPromptReport.bootstrapTruncation`
- seed once-mode dedupe from `SessionEntry.bootstrapPromptWarningState`
- keep legacy fallback reads from old `systemPromptReport.bootstrapTruncation.warningSignaturesSeen` / `promptWarningSignature` so existing persisted sessions still dedupe correctly
- clear the new state on session reset paths
- update affected tests for the new separation

## How I tested

- direct TSX harness verified:
  - `buildBootstrapTruncationReportMeta()` no longer includes `warningSignaturesSeen`
  - `resolveBootstrapWarningSignaturesSeen()` prefers session state over legacy report metadata
  - `updateSessionStoreAfterAgentRun()` persists `bootstrapPromptWarningState` separately while leaving `systemPromptReport` free of `warningSignaturesSeen`
- `pnpm build:plugin-sdk:dts`
- `git diff --check`

## Real behavior proof

After-fix runtime verification against the patched OpenClaw code on this host:

Command:

```bash
source ~/.nvm/nvm.sh && nvm use 25.5.0 >/dev/null && cd /home/claw/.openclaw/worktrees/openclaw/fix-bootstrap-warning-report-state && pnpm exec tsx /tmp/bootstrap-warning-state-check.ts 2>/tmp/bootstrap-proof.stderr | tail -n 1
```

Live output:

```text
bootstrap-warning-state-check:ok
```

That harness exercises the real `bootstrap-budget` and `session-store` codepaths and confirms the persisted session entry stores dedupe history in `bootstrapPromptWarningState` while `systemPromptReport.bootstrapTruncation` no longer carries stale historical signatures.

## Notes

I also tried focused `vitest` runs in this fresh worktree, but vitest startup here appeared unusually slow / hang-prone and did not produce a timely pass/fail summary, so I used the smallest meaningful targeted runtime verification instead.
