### PR TITLE
Test package patch guard

### DIFF
--- a/patches/ci-guard-should-fail.patch
+++ b/patches/ci-guard-should-fail.patch
@@ -1,0 +1,5 @@
+diff --git a/package.json b/package.json
+--- a/package.json
++++ b/package.json
+@@
++ci guard fixture


### PR DESCRIPTION
Summary
- Adds a dummy tracked package patch file to verify the package patch guard rejects PRs that try to introduce package patches.
- This PR is expected to fail CI and will be closed after verification.

Verification
- pnpm deps:patches:check

Expected result
- package patch guard fails on patches/ci-guard-should-fail.patch
