### PR TITLE
fix(browser): request admin scope for CLI control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - CLI/plugins: keep bare plugin and parent-command help on the lightweight path, avoiding plugin registry discovery before rendering help.
 - CLI tables: preserve muted/color styling on wrapped continuation lines after multiline cells, keeping `openclaw plugins list` descriptions readable.
 - Process execution: collapse case-insensitive duplicate child environment keys on Windows so caller-provided overrides such as `PATH` cannot be shadowed by host `Path`.
+- Browser CLI: request the existing `operator.admin` gateway scope explicitly for browser control commands, avoiding unnecessary scope-upgrade approval loops. Fixes #81555. (#81716) Thanks @joshavant.
 - iOS: restore first-use Contacts, Calendar, and Reminders permission prompts and add Privacy & Access status/actions in Settings. Thanks @BunsDev.
 - Canvas: return not found for malformed percent-encoded Canvas/A2UI/document asset paths and keep decoded parent traversal blocked before path normalization.
 - Telegram: allow trusted local Bot API media files whose filenames start with dots instead of falling back to remote download.

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -7,6 +7,10 @@ import type {
   OpenClawPluginToolContext,
   OpenClawPluginToolFactory,
 } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  BROWSER_REQUEST_GATEWAY_METHOD,
+  BROWSER_REQUEST_GATEWAY_SCOPE,
+} from "./src/browser-gateway-contract.js";
 import { BrowserToolSchema } from "./src/browser-tool.schema.js";
 
 const BROWSER_CLI_DESCRIPTOR = {
@@ -107,13 +111,13 @@ export function registerBrowserPlugin(api: OpenClawPluginApi) {
     { commands: ["browser"], descriptors: [BROWSER_CLI_DESCRIPTOR] },
   );
   api.registerGatewayMethod(
-    "browser.request",
+    BROWSER_REQUEST_GATEWAY_METHOD,
     async (opts) => {
       const { handleBrowserGatewayRequest } = await import("./register.runtime.js");
       return await handleBrowserGatewayRequest(opts);
     },
     {
-      scope: "operator.admin",
+      scope: BROWSER_REQUEST_GATEWAY_SCOPE,
     },
   );
   api.registerService(createLazyBrowserPluginService());

--- a/extensions/browser/src/browser-gateway-contract.ts
+++ b/extensions/browser/src/browser-gateway-contract.ts
@@ -1,0 +1,3 @@
+export const BROWSER_REQUEST_GATEWAY_METHOD = "browser.request" as const;
+export const BROWSER_REQUEST_GATEWAY_SCOPE = "operator.admin" as const;
+export const BROWSER_REQUEST_GATEWAY_SCOPES = [BROWSER_REQUEST_GATEWAY_SCOPE] as const;

--- a/extensions/browser/src/cli/browser-cli-shared.test.ts
+++ b/extensions/browser/src/cli/browser-cli-shared.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { callGatewayFromCli } from "./core-api.js";
+
+type CallGatewayFromCliArgs = Parameters<typeof callGatewayFromCli>;
+
+const gatewayMocks = vi.hoisted(() => ({
+  callGatewayFromCli: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("./core-api.js", () => ({
+  callGatewayFromCli: gatewayMocks.callGatewayFromCli,
+}));
+
+const { callBrowserRequest } = await import("./browser-cli-shared.js");
+
+describe("callBrowserRequest", () => {
+  beforeEach(() => {
+    gatewayMocks.callGatewayFromCli.mockClear();
+  });
+
+  it("requests the browser.request admin scope explicitly", async () => {
+    await callBrowserRequest(
+      { json: true },
+      { method: "GET", path: "/status", query: { profile: "openclaw" } },
+      { progress: true },
+    );
+
+    const call = gatewayMocks.callGatewayFromCli.mock.calls[0] as unknown as
+      | CallGatewayFromCliArgs
+      | undefined;
+    const extra = call?.[3];
+    expect(extra).toEqual({ progress: true, scopes: ["operator.admin"] });
+  });
+});

--- a/extensions/browser/src/cli/browser-cli-shared.ts
+++ b/extensions/browser/src/cli/browser-cli-shared.ts
@@ -1,4 +1,8 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  BROWSER_REQUEST_GATEWAY_METHOD,
+  BROWSER_REQUEST_GATEWAY_SCOPES,
+} from "../browser-gateway-contract.js";
 import { callGatewayFromCli, type GatewayRpcOpts } from "./core-api.js";
 
 export type BrowserParentOpts = GatewayRpcOpts & {
@@ -44,7 +48,7 @@ export async function callBrowserRequest<T>(
       : undefined;
   const timeout = typeof resolvedTimeout === "number" ? String(resolvedTimeout) : opts.timeout;
   const payload = await callGatewayFromCli(
-    "browser.request",
+    BROWSER_REQUEST_GATEWAY_METHOD,
     { ...opts, timeout },
     {
       method: params.method,
@@ -53,7 +57,7 @@ export async function callBrowserRequest<T>(
       body: params.body,
       timeoutMs: resolvedTimeout,
     },
-    { progress: extra?.progress },
+    { progress: extra?.progress, scopes: [...BROWSER_REQUEST_GATEWAY_SCOPES] },
   );
   if (payload === undefined) {
     throw new Error("Unexpected browser.request response");


### PR DESCRIPTION
## Summary

Fixes #81555.

Browser CLI commands route through the shared `callBrowserRequest()` wrapper and call the gateway `browser.request` method. That method is registered by the browser plugin with `operator.admin`, but the CLI wrapper did not pass explicit scopes, so standalone CLI calls could fall back to the broad default CLI scope bundle and trigger unnecessary scope-upgrade approval loops for paired devices.

This change adds a side-effect-free browser gateway contract module and uses it from both plugin registration and the browser CLI wrapper so the registered method/scope and the requested CLI scope stay aligned.

## Real behavior proof

Behavior addressed: Browser CLI `browser.request` calls request only the existing `operator.admin` gateway scope instead of the broad default CLI operator scope bundle.

Real environment tested: Blacksmith Testbox via Crabbox, Linux, Node/pnpm hydrated by `.github/workflows/ci-check-testbox.yml`, synced branch `codex/browser-cli-admin-scope-81555` at commit `1179705aac`.

Exact steps or command run after this patch: `node scripts/test-projects.mjs extensions/browser/src/cli/browser-cli-shared.test.ts extensions/browser/src/cli/browser-cli.test.ts extensions/browser/src/cli/browser-cli-manage.test.ts extensions/browser/src/cli/browser-cli-inspect.test.ts extensions/browser/index.test.ts src/gateway/method-scopes.test.ts`, followed by a loopback WebSocket gateway harness importing `extensions/browser/src/cli/browser-cli-shared.ts` and invoking `callBrowserRequest(...)` against `ws://127.0.0.1:<port>`.

Evidence after fix: Testbox `tbx_01krjmvrggkfgwfh7ma8rc2q8f` passed 62 gateway method-scope tests and 26 browser extension tests. The loopback gateway captured the CLI connect frame with `connectScopes: ["operator.admin"]`, then observed the `browser.request` RPC for `/` with `profile=openclaw` and returned a status payload.

Observed result after fix: The browser CLI wrapper connected as `{ "id": "cli", "mode": "cli" }`, requested only `operator.admin`, sent `browser.request`, and received `{ "enabled": true, "running": false, "profile": "openclaw", "transport": "loopback" }`.

What was not tested: The original Hostinger VPS environment and the reporter's existing paired device were not available. This proof covers the actual browser CLI gateway request shape in a real hydrated Linux Testbox.

## Verification

- `git diff --check`
- Crabbox/Testbox `tbx_01krjmvrggkfgwfh7ma8rc2q8f`: `node scripts/test-projects.mjs extensions/browser/src/cli/browser-cli-shared.test.ts extensions/browser/src/cli/browser-cli.test.ts extensions/browser/src/cli/browser-cli-manage.test.ts extensions/browser/src/cli/browser-cli-inspect.test.ts extensions/browser/index.test.ts src/gateway/method-scopes.test.ts`
- Crabbox/Testbox `tbx_01krjmvrggkfgwfh7ma8rc2q8f`: loopback gateway proof captured `connectScopes: ["operator.admin"]`

Local note: local Vitest execution is blocked in this checkout by missing `@openclaw/fs-safe/config`, so dependency-backed proof was run on Testbox.
