### PR TITLE
fix: replace regex in isValidBase64 with Buffer round-trip to prevent stack overflow on large attachments

### DIFF
--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -114,21 +114,43 @@ function shouldIgnoreProvidedImageMime(params: {
   return isGenericContainerMime(params.sniffedMime) && isImageMime(params.providedMime);
 }
 
+function isBase64DataChar(code: number): boolean {
+  return (
+    (code >= 0x41 && code <= 0x5a) || // A-Z
+    (code >= 0x61 && code <= 0x7a) || // a-z
+    (code >= 0x30 && code <= 0x39) || // 0-9
+    code === 0x2b ||                   // +
+    code === 0x2f                      // /
+  );
+}
+
 function isValidBase64(value: string): boolean {
-  // Regex-based validation is unsafe for large payloads in V8 — running
-  // RegExp.test() against a multi-MB base64 string can exhaust the engine's
-  // recursion stack and throw RangeError: Maximum call stack size exceeded.
-  // Use a Buffer round-trip check instead: zero regex, safe at any size.
+  // Regex-based validation is unsafe for large payloads — running RegExp.test()
+  // against a multi-MB base64 string exhausts V8's recursion stack and throws
+  // RangeError: Maximum call stack size exceeded.
   // See: https://github.com/openclaw/openclaw/issues/80679
-  if (value.length === 0) {
+  //
+  // Use a character-loop validator instead: no regex, no Buffer decode, no
+  // memory allocation beyond the loop counter. Size guards remain intact and
+  // run after this check, preserving the estimate-before-decode contract.
+  if (value.length === 0 || value.length % 4 !== 0) {
     return false;
   }
-  try {
-    const normalized = value.replace(/\s/g, "");
-    return Buffer.from(normalized, "base64").toString("base64") === normalized;
-  } catch {
-    return false;
+  let padding = 0;
+  let sawPadding = false;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code === 0x3d) { // '='
+      padding++;
+      if (padding > 2) return false;
+      sawPadding = true;
+      continue;
+    }
+    if (sawPadding || !isBase64DataChar(code)) {
+      return false;
+    }
   }
+  return true;
 }
 
 function verifyDecodedSize(buffer: Buffer, estimatedBytes: number, label: string): void {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -115,10 +115,20 @@ function shouldIgnoreProvidedImageMime(params: {
 }
 
 function isValidBase64(value: string): boolean {
-  if (value.length === 0 || value.length % 4 !== 0) {
+  // Regex-based validation is unsafe for large payloads in V8 — running
+  // RegExp.test() against a multi-MB base64 string can exhaust the engine's
+  // recursion stack and throw RangeError: Maximum call stack size exceeded.
+  // Use a Buffer round-trip check instead: zero regex, safe at any size.
+  // See: https://github.com/openclaw/openclaw/issues/80679
+  if (value.length === 0) {
     return false;
   }
-  return /^[A-Za-z0-9+/]+={0,2}$/.test(value);
+  try {
+    const normalized = value.replace(/\s/g, "");
+    return Buffer.from(normalized, "base64").toString("base64") === normalized;
+  } catch {
+    return false;
+  }
 }
 
 function verifyDecodedSize(buffer: Buffer, estimatedBytes: number, label: string): void {


### PR DESCRIPTION
## Summary

Fixes #80679.

`isValidBase64()` previously validated the full base64 string with a regex. For large payloads (multi-MB iPhone JPEGs encoded to base64), V8’s regex engine can hit its internal recursion limit and throw `RangeError: Maximum call stack size exceeded`, crashing the gateway and disconnecting the WebSocket with code 1006.

## Root cause

`RegExp.test()` on a string in the multi-megabyte range can exhaust V8’s regex recursion stack. This is a known V8 behavior and is not fixable by tweaking the regex pattern.

## Fix (revised per ClawSweeper review)

The first version of this PR used a `Buffer` round-trip which, as ClawSweeper correctly identified, decodes the full payload **before** size guards run — a pre-guard allocation risk that breaks the existing test contract.

This revision uses a **character-loop validator** instead, consistent with the `canonicalizeBase64` pattern already used in `src/media/base64.ts`:

```ts
function isBase64DataChar(code: number): boolean {
  return (
    (code >= 0x41 && code <= 0x5a) || // A-Z
    (code >= 0x61 && code <= 0x7a) || // a-z
    (code >= 0x30 && code <= 0x39) || // 0-9
    code === 0x2b ||                   // +
    code === 0x2f                      // /
  );
}

function isValidBase64(value: string): boolean {
  if (value.length === 0 || value.length % 4 !== 0) {
    return false;
  }
  let padding = 0;
  let sawPadding = false;
  for (let i = 0; i < value.length; i++) {
    const code = value.charCodeAt(i);
    if (code === 0x3d) {
      padding++;
      if (padding > 2) return false;
      sawPadding = true;
      continue;
    }
    if (sawPadding || !isBase64DataChar(code)) {
      return false;
    }
  }
  return true;
}
```

This approach:
- Uses **no regex** on the payload string
- Performs **no Buffer decode** — size guards remain intact and run after validation
- Is safe at any payload size
- Matches the existing `canonicalizeBase64` pattern in `src/media/base64.ts`
- Has zero new dependencies

## Proof

Ran a regression suite on Node v22.22.2 / Linux (same environment as the reported crash):

```
Node: v22.22.2 | Platform: linux

Case                                Expected Old(ms) New(ms) Match
--------------------------------------------------------------------------------
empty string                        false    0ms     0ms     ✅
valid: "hello"                      true     0ms     0ms     ✅
valid: 5MB payload                  true     12ms    37ms    ✅
valid: 7MB payload                  true     12ms    48ms    ✅
invalid char in payload             false    0ms     0ms     ✅
too much padding                    false    0ms     0ms     ✅
char after padding                  false    0ms     0ms     ✅
wrong length (not mod 4)            false    0ms     0ms     ✅

All tests passed: ✅ YES
```

**Note on crash reproducibility:** The `RangeError` stack overflow was not reproduced on Node v22.22.2 in an isolated script context on this platform — V8’s regex behavior on large strings is engine-version and pipeline-context dependent. The crash is confirmed by the gateway logs in #80679 (exact stack trace naming `isValidBase64` at line 43) and is a known V8 pattern. The fix is still correct and warranted: it removes the runtime-dependent regex risk entirely and aligns with the existing codebase pattern.

## Related

- Fixes #80679
- Pattern follows `canonicalizeBase64` in `src/media/base64.ts`
- The secondary `sharp` packaging issue mentioned in #80679 is out of scope and should be tracked separately