### PR TITLE
fix(exec): fail closed without sandbox runtime

### DIFF
--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -108,6 +108,21 @@ describe("detectCursorKeyMode", () => {
 });
 
 describe("resolveExecTarget", () => {
+  it("defaults omitted host config to sandbox", () => {
+    expectExecTarget(
+      resolveExecTarget({
+        elevatedRequested: false,
+        sandboxAvailable: false,
+      }),
+      {
+        configuredTarget: "sandbox",
+        requestedTarget: null,
+        selectedTarget: "sandbox",
+        effectiveHost: "sandbox",
+      },
+    );
+  });
+
   it("keeps implicit auto on sandbox when a sandbox runtime is available", () => {
     expectExecTarget(
       resolveExecTarget({

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -239,7 +239,7 @@ export function resolveExecTarget(params: {
   elevatedRequested: boolean;
   sandboxAvailable: boolean;
 }) {
-  const configuredTarget = params.configuredTarget ?? "auto";
+  const configuredTarget = params.configuredTarget ?? "sandbox";
   const requestedTarget = params.requestedTarget ?? null;
   if (
     requestedTarget &&

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -310,10 +310,20 @@ describe("exec host env validation", () => {
     }
   });
 
-  it("routes implicit auto host to gateway when sandbox runtime is unavailable", async () => {
+  it("fails closed for the implicit sandbox default when sandbox runtime is unavailable", async () => {
     const tool = createExecTool({ security: "full", ask: "off" });
 
-    const result = await tool.execute("call1", {
+    await expect(
+      tool.execute("call1", {
+        command: "echo ok",
+      }),
+    ).rejects.toThrow(/requires a sandbox runtime/);
+  });
+
+  it("routes explicit auto host to gateway when sandbox runtime is unavailable", async () => {
+    const tool = createExecTool({ host: "auto", security: "full", ask: "off" });
+
+    const result = await tool.execute("call-explicit-auto", {
       command: "echo ok",
       yieldMs: FOREGROUND_TEST_YIELD_MS,
     });

--- a/src/agents/pi-tools-agent-config.exec.test.ts
+++ b/src/agents/pi-tools-agent-config.exec.test.ts
@@ -76,7 +76,7 @@ describe("Agent-specific exec tool defaults", () => {
     expect(resultDetails?.status).toBe("completed");
   });
 
-  it("routes implicit auto exec to gateway without a sandbox runtime", async () => {
+  it("fails closed for the implicit sandbox exec host when sandbox runtime is unavailable", async () => {
     const tools = createOpenClawCodingTools({
       config: {
         tools: {
@@ -92,7 +92,31 @@ describe("Agent-specific exec tool defaults", () => {
     });
     const execTool = requireExecTool(tools);
 
-    const result = await execTool.execute("call-implicit-auto-default", {
+    await expect(
+      execTool.execute("call-implicit-sandbox-default", {
+        command: "echo done",
+      }),
+    ).rejects.toThrow(/requires a sandbox runtime/);
+  });
+
+  it("routes explicit auto exec to gateway without a sandbox runtime", async () => {
+    const tools = createOpenClawCodingTools({
+      config: {
+        tools: {
+          exec: {
+            host: "auto",
+            security: "full",
+            ask: "off",
+          },
+        },
+      },
+      sessionKey: "agent:main:main",
+      workspaceDir: "/tmp/test-main-explicit-auto-gateway",
+      agentDir: "/tmp/agent-main-explicit-auto-gateway",
+    });
+    const execTool = requireExecTool(tools);
+
+    const result = await execTool.execute("call-explicit-auto-default", {
       command: "echo done",
     });
     const resultDetails = result?.details as { status?: string } | undefined;


### PR DESCRIPTION
## Summary
- default omitted exec host config to sandbox instead of auto fallback
- keep explicit host: auto as the opt-in path for gateway/node fallback
- update exec runtime/config tests for the fail-closed default

## Validation
- corepack pnpm exec oxfmt --check src/agents/bash-tools.exec-runtime.ts src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.exec.path.test.ts src/agents/pi-tools-agent-config.exec.test.ts
- corepack pnpm tsgo
- node scripts/test-projects.mjs src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.exec.path.test.ts src/agents/pi-tools-agent-config.exec.test.ts
- git diff --check