### PR TITLE
macOS: skip CLI gateway repair when app owns launchd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- macOS/Gateway: skip CLI doctor service install/start/restart repairs when OpenClaw.app owns the default local LaunchAgent, while preserving named profile services such as `OPENCLAW_PROFILE=mac`. Fixes #67631. Thanks @BunsDev.
 - Security/sandbox: include Windows `USERPROFILE` in the sandbox blocked home roots so credential-bearing binds (such as `.codex`, `.openclaw`, or `.ssh` under the Windows user profile) are denied even when `HOME` points at a different shell home. (#63074) Thanks @luoyanglang.
 - Models config/auth: stop inferring provider env-var markers from broad `^[A-Z_][A-Z0-9_]*$` strings, and resolve config-backed provider `apiKey` values only through structured env SecretRefs (`secrets.providers[id]` / `secrets.defaults`), so unrelated env vars cannot accidentally become provider credentials. Thanks @sallyom.
 - Media fetch: skip allocating and buffering the response body for bodyless media responses (HEAD probes and 204-style empty bodies), avoiding wasted heap on streams that carry no payload. Thanks @shakkernerd.

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -39,6 +39,10 @@ Manager:
 
 - The macOS app owns LaunchAgent install/update in Local mode.
 - The CLI can also install it: `openclaw gateway install`.
+- When OpenClaw.app's login LaunchAgent (`ai.openclaw.mac`) is installed and
+  points at `OpenClaw.app/Contents/MacOS/OpenClaw`, terminal
+  `openclaw doctor --fix` treats the app as the owner and does not install a
+  second default Gateway LaunchAgent.
 
 Behavior:
 

--- a/docs/platforms/mac/child-process.md
+++ b/docs/platforms/mac/child-process.md
@@ -20,6 +20,9 @@ If you need tighter coupling to the UI, run the Gateway manually in a terminal.
   (or `ai.openclaw.<profile>` when using `--profile`/`OPENCLAW_PROFILE`; legacy `com.openclaw.*` is supported).
 - When Local mode is enabled, the app ensures the LaunchAgent is loaded and
   starts the Gateway if needed.
+- Terminal `openclaw doctor --fix` does not install or repair the default
+  Gateway LaunchAgent when it detects OpenClaw.app owns local mode through the
+  `ai.openclaw.mac` app LaunchAgent.
 - Logs are written to the launchd gateway log path (visible in Debug Settings).
 
 Common commands:

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatCliCommand } from "../cli/command-format.js";
-import type { ExtraGatewayService } from "../daemon/inspect.js";
+import type { ExtraGatewayService, MacAppLaunchAgentOwnership } from "../daemon/inspect.js";
 import * as launchd from "../daemon/launchd.js";
 import type { GatewayRestartHandoff } from "../infra/restart-handoff.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -31,6 +31,14 @@ const readGatewayRestartHandoffSync = vi.hoisted(() =>
 const findSystemGatewayServices = vi.hoisted(() =>
   vi.fn<() => Promise<ExtraGatewayService[]>>(async () => []),
 );
+const findMacAppLaunchAgentOwnership = vi.hoisted(() =>
+  vi.fn<() => Promise<MacAppLaunchAgentOwnership | null>>(async () => null),
+);
+const resolveGatewayLaunchAgentLabel = vi.hoisted(() =>
+  vi.fn((profile?: string) =>
+    profile?.trim() ? `ai.openclaw.${profile.trim()}` : "ai.openclaw.gateway",
+  ),
+);
 
 vi.mock("../config/config.js", async () => {
   const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
@@ -41,7 +49,7 @@ vi.mock("../config/config.js", async () => {
 });
 
 vi.mock("../daemon/constants.js", () => ({
-  resolveGatewayLaunchAgentLabel: vi.fn(() => "ai.openclaw.gateway"),
+  resolveGatewayLaunchAgentLabel,
   resolveNodeLaunchAgentLabel: vi.fn(() => "ai.openclaw.node"),
 }));
 
@@ -62,6 +70,7 @@ vi.mock("../daemon/launchd.js", async () => {
 });
 
 vi.mock("../daemon/inspect.js", () => ({
+  findMacAppLaunchAgentOwnership,
   findSystemGatewayServices,
 }));
 
@@ -157,6 +166,10 @@ describe("maybeRepairGatewayDaemon", () => {
     service.readCommand.mockResolvedValue(null);
     service.restart.mockResolvedValue({ outcome: "completed" });
     readGatewayRestartHandoffSync.mockReturnValue(null);
+    findMacAppLaunchAgentOwnership.mockResolvedValue(null);
+    resolveGatewayLaunchAgentLabel.mockImplementation((profile?: string) =>
+      profile?.trim() ? `ai.openclaw.${profile.trim()}` : "ai.openclaw.gateway",
+    );
     findSystemGatewayServices.mockResolvedValue([]);
     inspectPortUsage.mockResolvedValue({
       port: 18789,
@@ -440,6 +453,36 @@ describe("maybeRepairGatewayDaemon", () => {
       ].join("\n"),
       "Gateway",
     );
+  });
+
+  it("skips default gateway install when OpenClaw.app owns launchd", async () => {
+    setPlatform("darwin");
+    service.isLoaded.mockResolvedValue(false);
+    findMacAppLaunchAgentOwnership.mockResolvedValue({
+      label: "ai.openclaw.mac",
+      plistPath: "/Users/test/Library/LaunchAgents/ai.openclaw.mac.plist",
+      programPath: "/Applications/OpenClaw.app/Contents/MacOS/OpenClaw",
+    });
+
+    await runAutoRepair();
+
+    expect(service.install).not.toHaveBeenCalled();
+    expect(service.restart).not.toHaveBeenCalled();
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("OpenClaw.app owns the local Gateway LaunchAgent"),
+      "Gateway",
+    );
+  });
+
+  it("does not treat OPENCLAW_PROFILE=mac as app-owned launchd", async () => {
+    setPlatform("darwin");
+    service.isLoaded.mockResolvedValue(false);
+
+    await withEnvAsync({ OPENCLAW_PROFILE: "mac" }, async () => {
+      await runAutoRepair();
+    });
+
+    expect(findMacAppLaunchAgentOwnership).not.toHaveBeenCalled();
   });
 
   it("skips gateway service start when service repair policy is external", async () => {

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -6,7 +6,11 @@ import {
   resolveNodeLaunchAgentLabel,
 } from "../daemon/constants.js";
 import { readLastGatewayErrorLine } from "../daemon/diagnostics.js";
-import { findSystemGatewayServices, type ExtraGatewayService } from "../daemon/inspect.js";
+import {
+  findMacAppLaunchAgentOwnership,
+  findSystemGatewayServices,
+  type ExtraGatewayService,
+} from "../daemon/inspect.js";
 import {
   isLaunchAgentLoaded,
   launchAgentPlistExists,
@@ -40,6 +44,7 @@ import {
   confirmDoctorServiceRepair,
   EXTERNAL_SERVICE_REPAIR_NOTE,
   isServiceRepairExternallyManaged,
+  renderMacAppLaunchAgentRepairSkip,
   resolveServiceRepairPolicy,
   SERVICE_REPAIR_POLICY_ENV,
 } from "./doctor-service-repair-policy.js";
@@ -125,6 +130,13 @@ export async function maybeRepairGatewayDaemon(params: {
 
   const serviceRepairPolicy = resolveServiceRepairPolicy();
   const serviceRepairExternal = isServiceRepairExternallyManaged(serviceRepairPolicy);
+  const macAppOwnership =
+    process.platform === "darwin" &&
+    params.cfg.gateway?.mode !== "remote" &&
+    resolveGatewayLaunchAgentLabel(process.env.OPENCLAW_PROFILE) ===
+      resolveGatewayLaunchAgentLabel()
+      ? await findMacAppLaunchAgentOwnership(process.env)
+      : null;
   const service = resolveGatewayService();
   // systemd can throw in containers/WSL; treat as "not loaded" and fall back to hints.
   let loaded = false;
@@ -220,6 +232,10 @@ export async function maybeRepairGatewayDaemon(params: {
         note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
         return;
       }
+      if (macAppOwnership) {
+        note(renderMacAppLaunchAgentRepairSkip(macAppOwnership), "Gateway");
+        return;
+      }
       const install = await confirmDoctorServiceRepair(
         params.prompter,
         {
@@ -308,6 +324,10 @@ export async function maybeRepairGatewayDaemon(params: {
       note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
       return;
     }
+    if (macAppOwnership) {
+      note(renderMacAppLaunchAgentRepairSkip(macAppOwnership), "Gateway");
+      return;
+    }
     const start = await confirmDoctorServiceRepair(
       params.prompter,
       {
@@ -341,6 +361,10 @@ export async function maybeRepairGatewayDaemon(params: {
   if (serviceRuntime?.status === "running") {
     if (serviceRepairExternal) {
       note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
+      return;
+    }
+    if (macAppOwnership) {
+      note(renderMacAppLaunchAgentRepairSkip(macAppOwnership), "Gateway");
       return;
     }
     const restart = await confirmDoctorServiceRepair(

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -36,6 +36,10 @@ const mocks = vi.hoisted(() => ({
   resolveGatewayAuthTokenForService: vi.fn(),
   resolveGatewayPort: vi.fn(() => 18789),
   resolveIsNixMode: vi.fn(() => false),
+  resolveGatewayLaunchAgentLabel: vi.fn((profile?: string) =>
+    profile?.trim() ? `ai.openclaw.${profile.trim()}` : "ai.openclaw.gateway",
+  ),
+  findMacAppLaunchAgentOwnership: vi.fn().mockResolvedValue(null),
   findExtraGatewayServices: vi.fn().mockResolvedValue([]),
   renderGatewayServiceCleanupHints: vi.fn().mockReturnValue([]),
   needsNodeRuntimeMigration: vi.fn(() => false),
@@ -60,8 +64,13 @@ vi.mock("../config/config.js", async () => {
 });
 
 vi.mock("../daemon/inspect.js", () => ({
+  findMacAppLaunchAgentOwnership: mocks.findMacAppLaunchAgentOwnership,
   findExtraGatewayServices: mocks.findExtraGatewayServices,
   renderGatewayServiceCleanupHints: mocks.renderGatewayServiceCleanupHints,
+}));
+
+vi.mock("../daemon/constants.js", () => ({
+  resolveGatewayLaunchAgentLabel: mocks.resolveGatewayLaunchAgentLabel,
 }));
 
 vi.mock("../daemon/runtime-paths.js", () => ({
@@ -322,6 +331,10 @@ describe("maybeRepairGatewayServiceConfig", () => {
     vi.clearAllMocks();
     fsMocks.realpath.mockImplementation(async (value: string) => value);
     mocks.resolveGatewayPort.mockReturnValue(18789);
+    mocks.resolveGatewayLaunchAgentLabel.mockImplementation((profile?: string) =>
+      profile?.trim() ? `ai.openclaw.${profile.trim()}` : "ai.openclaw.gateway",
+    );
+    mocks.findMacAppLaunchAgentOwnership.mockResolvedValue(null);
     mocks.needsNodeRuntimeMigration.mockReturnValue(false);
     mocks.renderSystemNodeWarning.mockReturnValue(undefined);
     mocks.resolveSystemNodeInfo.mockResolvedValue(null);
@@ -365,6 +378,37 @@ describe("maybeRepairGatewayServiceConfig", () => {
     expectCallConfigGatewayAuthToken(mocks.buildGatewayInstallPlan, "config-token");
     expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
     expect(mocks.stage).not.toHaveBeenCalled();
+    expect(mocks.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips default gateway service rewrite when OpenClaw.app owns launchd", async () => {
+    mockProcessPlatform("darwin");
+    setupGatewayTokenRepairScenario();
+    mocks.findMacAppLaunchAgentOwnership.mockResolvedValue({
+      label: "ai.openclaw.mac",
+      plistPath: "/Users/test/Library/LaunchAgents/ai.openclaw.mac.plist",
+      programPath: "/Applications/OpenClaw.app/Contents/MacOS/OpenClaw",
+    });
+
+    await runRepair({ gateway: {} });
+
+    expect(mocks.install).not.toHaveBeenCalled();
+    expect(mocks.stage).not.toHaveBeenCalled();
+    expectNoteContaining(
+      "OpenClaw.app owns the local Gateway LaunchAgent",
+      "Gateway service config",
+    );
+  });
+
+  it("does not skip profile service rewrites for OPENCLAW_PROFILE=mac", async () => {
+    mockProcessPlatform("darwin");
+    setupGatewayTokenRepairScenario();
+
+    await withEnvAsync({ OPENCLAW_PROFILE: "mac" }, async () => {
+      await runRepair({ gateway: {} });
+    });
+
+    expect(mocks.findMacAppLaunchAgentOwnership).not.toHaveBeenCalled();
     expect(mocks.install).toHaveBeenCalledTimes(1);
   });
 

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -6,7 +6,9 @@ import { promisify } from "node:util";
 import { replaceConfigFile, type OpenClawConfig } from "../config/config.js";
 import { resolveGatewayPort, resolveIsNixMode } from "../config/paths.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { resolveGatewayLaunchAgentLabel } from "../daemon/constants.js";
 import {
+  findMacAppLaunchAgentOwnership,
   findExtraGatewayServices,
   renderGatewayServiceCleanupHints,
   type ExtraGatewayService,
@@ -42,6 +44,7 @@ import {
   confirmDoctorServiceRepair,
   EXTERNAL_SERVICE_REPAIR_NOTE,
   isServiceRepairExternallyManaged,
+  renderMacAppLaunchAgentRepairSkip,
   resolveServiceRepairPolicy,
 } from "./doctor-service-repair-policy.js";
 
@@ -494,6 +497,13 @@ export async function maybeRepairGatewayServiceConfig(
 
   const serviceRepairPolicy = resolveServiceRepairPolicy();
   const serviceRepairExternal = isServiceRepairExternallyManaged(serviceRepairPolicy);
+  const macAppOwnership =
+    process.platform === "darwin" &&
+    cfg.gateway?.mode !== "remote" &&
+    resolveGatewayLaunchAgentLabel(process.env.OPENCLAW_PROFILE) ===
+      resolveGatewayLaunchAgentLabel()
+      ? await findMacAppLaunchAgentOwnership(process.env)
+      : null;
 
   const consolidatedLines: string[] = [];
   let emittedSourceCheckoutWarning = false;
@@ -521,6 +531,11 @@ export async function maybeRepairGatewayServiceConfig(
 
   if (serviceRepairExternal) {
     note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway service config");
+    return;
+  }
+
+  if (macAppOwnership) {
+    note(renderMacAppLaunchAgentRepairSkip(macAppOwnership), "Gateway service config");
     return;
   }
 

--- a/src/commands/doctor-service-repair-policy.ts
+++ b/src/commands/doctor-service-repair-policy.ts
@@ -1,3 +1,4 @@
+import type { MacAppLaunchAgentOwnership } from "../daemon/inspect.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
 type ServiceRepairPolicy = "auto" | "external";
@@ -6,6 +7,15 @@ export const SERVICE_REPAIR_POLICY_ENV = "OPENCLAW_SERVICE_REPAIR_POLICY";
 
 export const EXTERNAL_SERVICE_REPAIR_NOTE =
   "Gateway service is managed externally; skipped service install/start repair. Start or repair the gateway through your supervisor.";
+
+export function renderMacAppLaunchAgentRepairSkip(ownership: MacAppLaunchAgentOwnership): string {
+  return [
+    "OpenClaw.app owns the local Gateway LaunchAgent; skipped CLI service install/start/restart repair.",
+    `App LaunchAgent: ${ownership.label}`,
+    `App binary: ${ownership.programPath}`,
+    "Use OpenClaw.app local mode or launch the app with --attach-only/--no-launchd if the CLI should own the Gateway instead.",
+  ].join("\n");
+}
 
 export function resolveServiceRepairPolicy(
   env: NodeJS.ProcessEnv = process.env,

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -2,6 +2,7 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
 // Default service labels (canonical + legacy compatibility)
 export const GATEWAY_LAUNCH_AGENT_LABEL = "ai.openclaw.gateway";
+export const MAC_APP_LAUNCH_AGENT_LABEL = "ai.openclaw.mac";
 export const GATEWAY_SYSTEMD_SERVICE_NAME = "openclaw-gateway";
 export const GATEWAY_WINDOWS_TASK_NAME = "OpenClaw Gateway";
 export const GATEWAY_SERVICE_MARKER = "openclaw";

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { detectMarkerLineWithGateway, findExtraGatewayServices } from "./inspect.js";
+import {
+  detectMarkerLineWithGateway,
+  findExtraGatewayServices,
+  findMacAppLaunchAgentOwnership,
+  findMacAppProgramPathInLaunchAgentPlist,
+} from "./inspect.js";
 
 const { execSchtasksMock } = vi.hoisted(() => ({
   execSchtasksMock: vi.fn(),
@@ -295,6 +300,41 @@ describe("findExtraGatewayServices (darwin / scanLaunchdDir) — real filesystem
     } finally {
       await fs.rm(tmpHome, { recursive: true, force: true });
     }
+  });
+
+  it("detects OpenClaw.app ownership only from the app LaunchAgent binary", async () => {
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    const launchdDir = path.join(tmpHome, "Library", "LaunchAgents");
+    const plistPath = path.join(launchdDir, "ai.openclaw.mac.plist");
+    try {
+      await fs.mkdir(launchdDir, { recursive: true });
+      await fs.writeFile(
+        plistPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>Label</key><string>ai.openclaw.mac</string>
+<key>ProgramArguments</key><array><string>/Applications/OpenClaw.app/Contents/MacOS/OpenClaw</string></array>
+</dict></plist>`,
+      );
+
+      await expect(findMacAppLaunchAgentOwnership({ HOME: tmpHome })).resolves.toEqual({
+        label: "ai.openclaw.mac",
+        plistPath,
+        programPath: "/Applications/OpenClaw.app/Contents/MacOS/OpenClaw",
+      });
+    } finally {
+      await fs.rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat a CLI profile named mac as OpenClaw.app ownership", () => {
+    expect(
+      findMacAppProgramPathInLaunchAgentPlist(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>Label</key><string>ai.openclaw.mac</string>
+<key>ProgramArguments</key><array><string>/usr/local/bin/openclaw</string><string>gateway</string></array>
+</dict></plist>`),
+    ).toBeNull();
   });
 });
 

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -4,6 +4,7 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
   GATEWAY_SERVICE_KIND,
   GATEWAY_SERVICE_MARKER,
+  MAC_APP_LAUNCH_AGENT_LABEL,
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
@@ -23,6 +24,12 @@ export type ExtraGatewayService = {
 
 export type FindExtraGatewayServicesOptions = {
   deep?: boolean;
+};
+
+export type MacAppLaunchAgentOwnership = {
+  label: typeof MAC_APP_LAUNCH_AGENT_LABEL;
+  plistPath: string;
+  programPath: string;
 };
 
 const EXTRA_MARKERS = ["openclaw", "clawdbot"] as const;
@@ -219,6 +226,51 @@ function tryExtractPlistLabel(contents: string): string | null {
     return null;
   }
   return match[1]?.trim() || null;
+}
+
+function isOpenClawAppProgramPath(value: string): boolean {
+  const normalized = value.trim();
+  return (
+    path.basename(normalized) === "OpenClaw" &&
+    normalized.endsWith("/OpenClaw.app/Contents/MacOS/OpenClaw")
+  );
+}
+
+export function findMacAppProgramPathInLaunchAgentPlist(contents: string): string | null {
+  const label = tryExtractPlistLabel(contents);
+  if (label !== MAC_APP_LAUNCH_AGENT_LABEL) {
+    return null;
+  }
+  const program = extractPlistStringValues(contents, "Program", "string");
+  const programArguments = extractPlistStringValues(contents, "ProgramArguments", "array");
+  return [...program, ...programArguments].find(isOpenClawAppProgramPath) ?? null;
+}
+
+export async function findMacAppLaunchAgentOwnership(
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): Promise<MacAppLaunchAgentOwnership | null> {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+  const plistPath = path.join(
+    resolveHomeDir(env),
+    "Library",
+    "LaunchAgents",
+    `${MAC_APP_LAUNCH_AGENT_LABEL}.plist`,
+  );
+  const contents = await readUtf8File(plistPath);
+  if (contents === null) {
+    return null;
+  }
+  const programPath = findMacAppProgramPathInLaunchAgentPlist(contents);
+  if (!programPath) {
+    return null;
+  }
+  return {
+    label: MAC_APP_LAUNCH_AGENT_LABEL,
+    plistPath,
+    programPath,
+  };
 }
 
 function isIgnoredLaunchdLabel(label: string): boolean {


### PR DESCRIPTION
## Summary
- Detect OpenClaw.app LaunchAgent ownership only when `ai.openclaw.mac.plist` launches `OpenClaw.app/Contents/MacOS/OpenClaw`.
- Skip CLI doctor install/start/restart/service-config repair for the default Gateway LaunchAgent when the app owns local mode.
- Preserve named profile services, including `OPENCLAW_PROFILE=mac`, and document the app-owned behavior.

Fixes #67631.

## Verification
Behavior addressed: terminal `openclaw doctor --fix` no longer installs or repairs a second default Gateway LaunchAgent when OpenClaw.app owns local mode.
Real environment tested: local Codex worktree on macOS with targeted unit/docs proof; no live launchd smoke yet.
Exact steps or command run after this patch: `PATH=/Users/buns/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/commands/doctor-gateway-daemon-flow.test.ts src/commands/doctor-gateway-services.test.ts src/daemon/inspect.test.ts`; `PATH=/Users/buns/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec oxfmt --check --threads=1 src/commands/doctor-gateway-daemon-flow.ts src/commands/doctor-gateway-daemon-flow.test.ts src/commands/doctor-gateway-services.ts src/commands/doctor-gateway-services.test.ts src/commands/doctor-service-repair-policy.ts src/daemon/constants.ts src/daemon/inspect.ts src/daemon/inspect.test.ts`; `PATH=/Users/buns/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm docs:list`; `git diff --check`.
Evidence after fix: targeted Vitest passed 3 files, 60 tests passed and 5 skipped; oxfmt check passed; docs:list completed; git diff whitespace check passed.
Observed result after fix: default app-owned launchd repair paths emit an app ownership skip note and do not call service install/restart; profile `mac` does not trigger app ownership detection by label alone.
What was not tested: live macOS LaunchAgent app/CLI smoke and broad Testbox `pnpm check:changed` are still pending for the full four-slice queue.
