### PR TITLE
fix: require heartbeat response tool delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/install: limit install-time code safety scans to plugin-owned runtime entrypoints while keeping dependency manifest denylist checks, so trusted packages with large dependency trees no longer get blocked or warned on third-party runtime internals.
 - Config: serialize and retry semantic config mutations centrally, so concurrent commands can rebase safe changes instead of clobbering or hand-rolling command-local retry loops. (#76601)
 - Installer: honor `--no-git-update` for existing git checkouts before resolving release refs, preventing pinned source installs from moving during reinstall.
+- Plugins/install: refresh OpenClaw-managed peer dependency pins when installed plugin peer ranges change, while preserving user-owned dependency pins.
 - Require approval for setup-code device pairing [AI]. (#81292) Thanks @pgondhi987.
 - Plugins/install: preserve third-party peer dependencies in the managed npm root when later plugin installs or updates recalculate the shared dependency tree. Thanks @shakkernerd.
 - Plugins/memory: prefer the npm-installed memory-lancedb plugin over the bundled fallback during duplicate resolution, keeping Active Memory's `memory_recall` tool visible after managed installs. Fixes #81193. Thanks @julio-arcila.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Feishu/WhatsApp/Line: enforce inbound media size caps while reading download streams, avoiding full buffering of oversized attachments. (#81044, #81050) Thanks @samzong.
 - Plugins/install: limit install-time code safety scans to plugin-owned runtime entrypoints while keeping dependency manifest denylist checks, so trusted packages with large dependency trees no longer get blocked or warned on third-party runtime internals.
 - Config: serialize and retry semantic config mutations centrally, so concurrent commands can rebase safe changes instead of clobbering or hand-rolling command-local retry loops. (#76601)
+- Installer: honor `--no-git-update` for existing git checkouts before resolving release refs, preventing pinned source installs from moving during reinstall.
 - Require approval for setup-code device pairing [AI]. (#81292) Thanks @pgondhi987.
 - Plugins/install: preserve third-party peer dependencies in the managed npm root when later plugin installs or updates recalculate the shared dependency tree. Thanks @shakkernerd.
 - Plugins/memory: prefer the npm-installed memory-lancedb plugin over the bundled fallback during duplicate resolution, keeping Active Memory's `memory_recall` tool visible after managed installs. Fixes #81193. Thanks @julio-arcila.

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -698,25 +698,32 @@ install_openclaw_from_git() {
   ensure_pnpm
   ensure_pnpm_binary_for_scripts
 
+  local cloned_repo=0
   if [[ -d "$repo_dir/.git" ]]; then
     :
   elif [[ -d "$repo_dir" ]]; then
     if [[ -z "$(ls -A "$repo_dir" 2>/dev/null || true)" ]]; then
       git clone "$repo_url" "$repo_dir"
+      cloned_repo=1
     else
       fail "Git install dir exists but is not a git repo: ${repo_dir}"
     fi
   else
     git clone "$repo_url" "$repo_dir"
+    cloned_repo=1
   fi
 
-  local git_ref
-  git_ref="$(resolve_git_openclaw_ref)"
-  if [[ -z "$(git -C "$repo_dir" status --porcelain 2>/dev/null || true)" ]]; then
-    log "Using git ref: ${git_ref}"
-    checkout_git_openclaw_ref "$repo_dir" "$git_ref"
+  if [[ "$cloned_repo" == "1" || "$GIT_UPDATE" == "1" ]]; then
+    local git_ref
+    git_ref="$(resolve_git_openclaw_ref)"
+    if [[ -z "$(git -C "$repo_dir" status --porcelain 2>/dev/null || true)" ]]; then
+      log "Using git ref: ${git_ref}"
+      checkout_git_openclaw_ref "$repo_dir" "$git_ref"
+    else
+      log "Repo is dirty; skipping git checkout/update"
+    fi
   else
-    log "Repo is dirty; skipping git checkout/update"
+    log "Git update disabled; leaving existing checkout unchanged"
   fi
 
   cleanup_legacy_submodules "$repo_dir"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2352,17 +2352,31 @@ install_openclaw_from_git() {
     ensure_pnpm
     ensure_pnpm_binary_for_scripts
 
-    if [[ ! -d "$repo_dir" ]]; then
+    local cloned_repo=0
+    if [[ -d "$repo_dir/.git" ]]; then
+        :
+    elif [[ ! -d "$repo_dir" ]]; then
         run_quiet_step "Cloning OpenClaw" git clone "$repo_url" "$repo_dir"
+        cloned_repo=1
+    elif [[ -z "$(ls -A "$repo_dir" 2>/dev/null || true)" ]]; then
+        run_quiet_step "Cloning OpenClaw" git clone "$repo_url" "$repo_dir"
+        cloned_repo=1
+    else
+        ui_error "Git install dir exists but is not a git repo: ${repo_dir}"
+        exit 1
     fi
 
-    local git_ref
-    git_ref="$(resolve_git_openclaw_ref)"
-    if [[ -z "$(git -C "$repo_dir" status --porcelain 2>/dev/null || true)" ]]; then
-        ui_info "Using git ref: ${git_ref}"
-        checkout_git_openclaw_ref "$repo_dir" "$git_ref"
+    if [[ "$cloned_repo" == "1" || "$GIT_UPDATE" == "1" ]]; then
+        local git_ref
+        git_ref="$(resolve_git_openclaw_ref)"
+        if [[ -z "$(git -C "$repo_dir" status --porcelain 2>/dev/null || true)" ]]; then
+            ui_info "Using git ref: ${git_ref}"
+            checkout_git_openclaw_ref "$repo_dir" "$git_ref"
+        else
+            ui_info "Repo has local changes; skipping git checkout/update"
+        fi
     else
-        ui_info "Repo has local changes; skipping git checkout/update"
+        ui_info "Git update disabled; leaving existing checkout unchanged"
     fi
 
     cleanup_legacy_submodules "$repo_dir"

--- a/src/agents/models-config.providers.auth-provenance.test.ts
+++ b/src/agents/models-config.providers.auth-provenance.test.ts
@@ -228,6 +228,100 @@ describe("models-config provider auth provenance", () => {
     });
   });
 
+  it("resolves configured env SecretRef api keys for catalog discovery", () => {
+    const auth = createProviderApiKeyResolver(
+      {
+        MY_VLLM_KEY: "resolved-vllm-key",
+      } as NodeJS.ProcessEnv,
+      {
+        version: 1,
+        profiles: {},
+      },
+      {
+        models: {
+          providers: {
+            vllm: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              apiKey: { source: "env", provider: "default", id: "MY_VLLM_KEY" },
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(auth("vllm")).toEqual({
+      apiKey: "MY_VLLM_KEY",
+      discoveryApiKey: "resolved-vllm-key",
+    });
+  });
+
+  it("does not resolve configured env SecretRef api keys outside provider allowlists", () => {
+    const auth = createProviderApiKeyResolver(
+      {
+        AWS_SECRET_ACCESS_KEY: "not-allowed",
+      } as NodeJS.ProcessEnv,
+      {
+        version: 1,
+        profiles: {},
+      },
+      {
+        secrets: {
+          providers: {
+            default: { source: "env", allowlist: ["MY_VLLM_KEY"] },
+          },
+        },
+        models: {
+          providers: {
+            vllm: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              apiKey: { source: "env", provider: "default", id: "AWS_SECRET_ACCESS_KEY" },
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(auth("vllm")).toEqual({
+      apiKey: undefined,
+      discoveryApiKey: undefined,
+    });
+  });
+
+  it("uses configured env SecretRef api keys in config-backed auth summaries", () => {
+    const auth = createProviderAuthResolver(
+      {
+        MY_VLLM_KEY: "resolved-vllm-key",
+      } as NodeJS.ProcessEnv,
+      {
+        version: 1,
+        profiles: {},
+      },
+      {
+        models: {
+          providers: {
+            vllm: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              apiKey: { source: "env", provider: "default", id: "MY_VLLM_KEY" },
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(auth("vllm")).toEqual({
+      apiKey: "MY_VLLM_KEY",
+      discoveryApiKey: "resolved-vllm-key",
+      mode: "api_key",
+      source: "none",
+    });
+  });
+
   it("does not send missing custom env markers as catalog discovery keys", () => {
     const auth = createProviderApiKeyResolver(
       {} as NodeJS.ProcessEnv,

--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -1,5 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { resolveProviderSyntheticAuthWithPlugin } from "../plugins/provider-runtime.js";
+import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import {
   isNonSecretApiKeyMarker,
@@ -42,6 +44,23 @@ export {
 type AuthProfileStoreInput = AuthProfileStore | (() => AuthProfileStore);
 
 const ENV_VAR_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+
+function canResolveEnvSecretRefInConfigAuth(params: {
+  config: OpenClawConfig | undefined;
+  provider: string;
+  id: string;
+}): boolean {
+  const providerName = params.provider.trim();
+  const providerConfig = params.config?.secrets?.providers?.[providerName];
+  if (!providerConfig) {
+    return providerName === resolveDefaultSecretProviderAlias(params.config ?? {}, "env");
+  }
+  if (providerConfig.source !== "env") {
+    return false;
+  }
+  const allowlist = providerConfig.allowlist;
+  return !allowlist || allowlist.includes(params.id);
+}
 
 function resolveAuthProfileStoreInput(input: AuthProfileStoreInput) {
   return typeof input === "function" ? input() : input;
@@ -208,6 +227,38 @@ function resolveConfigBackedProviderAuth(params: {
   }
 
   const configuredProvider = params.config?.models?.providers?.[authProvider];
+  const configuredApiKeyRef = resolveSecretInputRef({
+    value: configuredProvider?.apiKey,
+    defaults: params.config?.secrets?.defaults,
+  }).ref;
+  if (configuredApiKeyRef?.id.trim()) {
+    if (configuredApiKeyRef.source === "env") {
+      const envVar = configuredApiKeyRef.id.trim();
+      if (
+        !canResolveEnvSecretRefInConfigAuth({
+          config: params.config,
+          provider: configuredApiKeyRef.provider,
+          id: envVar,
+        })
+      ) {
+        return undefined;
+      }
+      const envValue = params.env?.[envVar]?.trim();
+      return envValue
+        ? {
+            apiKey: envVar,
+            discoveryApiKey: toDiscoveryApiKey(envValue),
+            mode: "api_key",
+            source: "config",
+          }
+        : undefined;
+    }
+    return {
+      apiKey: resolveNonEnvSecretRefApiKeyMarker(configuredApiKeyRef.source),
+      mode: "api_key",
+      source: "config",
+    };
+  }
   if (typeof configuredProvider?.apiKey !== "string") {
     return undefined;
   }

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -186,6 +186,55 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     });
   });
 
+  it.each([
+    {
+      name: "text",
+      reply: {
+        text: [
+          "<tool_calls>",
+          "<file_contents path='/redacted/workspace/HEARTBEAT.md' isStale=false isFullFile=true>",
+          " 1|# HEARTBEAT.md",
+          "</file_contents>",
+        ].join("\n"),
+      },
+    },
+    {
+      name: "media",
+      reply: {
+        text: "Chart attached from a non-tool response",
+        mediaUrls: ["https://example.com/chart.png"],
+      },
+    },
+  ])("ignores ordinary $name payloads in heartbeat tool mode", async ({ reply }) => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+        agentHarnessId: "codex",
+      });
+      replySpy.mockResolvedValue(reply);
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      const calledOpts = replySpy.mock.calls[0]?.[1] as {
+        enableHeartbeatTool?: boolean;
+        forceHeartbeatTool?: boolean;
+        sourceReplyDeliveryMode?: string;
+      };
+      expect(result.status).toBe("ran");
+      expect(calledOpts.enableHeartbeatTool).toBe(true);
+      expect(calledOpts.forceHeartbeatTool).toBe(true);
+      expect(calledOpts.sourceReplyDeliveryMode).toBe("message_tool_only");
+      expect(sendTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("uses the heartbeat response tool prompt in message-tool mode", async () => {
     const result = await runPromptScenario({
       config: { visibleReplies: "message_tool" },

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -34,6 +34,7 @@ import {
   stripHeartbeatToken,
   type HeartbeatTask,
 } from "../auto-reply/heartbeat.js";
+import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import { resolveDefaultModel } from "../auto-reply/reply/directive-handling.defaults.js";
 import { resolveResponsePrefixTemplate } from "../auto-reply/reply/response-prefix-template.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
@@ -86,6 +87,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
+import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import { escapeRegExp } from "../utils.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS, resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { loadOrCreateDeviceIdentity } from "./device-identity.js";
@@ -740,7 +742,8 @@ function normalizeHeartbeatReply(
   ackMaxChars: number,
 ) {
   const rawText = typeof payload.text === "string" ? payload.text : "";
-  const textForStrip = stripLeadingHeartbeatResponsePrefix(rawText, responsePrefix);
+  const sanitizedText = sanitizeAssistantVisibleText(rawText);
+  const textForStrip = stripLeadingHeartbeatResponsePrefix(sanitizedText, responsePrefix);
   const stripped = stripHeartbeatToken(textForStrip, {
     mode: "heartbeat",
     maxAckChars: ackMaxChars,
@@ -769,6 +772,12 @@ function normalizeHeartbeatToolNotification(
     finalText = `${responsePrefix} ${finalText}`;
   }
   return { shouldSkip: false, text: finalText, hasMedia: false };
+}
+
+function isInternalHeartbeatNoticePayload(payload: ReplyPayload | undefined): boolean {
+  return payload
+    ? getReplyPayloadMetadata(payload)?.deliverDespiteSourceReplySuppression === true
+    : false;
 }
 
 type HeartbeatWakePayloadFlags = {
@@ -1680,6 +1689,8 @@ export async function runHeartbeatOnce(opts: {
       : [];
     const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
     const responsePrefix = resolveHeartbeatResponsePrefix();
+    const canUseReplyPayload =
+      !usesHeartbeatResponseTool || isInternalHeartbeatNoticePayload(replyPayload);
 
     if (heartbeatToolResponse && !heartbeatToolResponse.notify) {
       await restoreHeartbeatUpdatedAt({
@@ -1710,7 +1721,10 @@ export async function runHeartbeatOnce(opts: {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    if (!heartbeatToolResponse && (!replyPayload || !hasOutboundReplyContent(replyPayload))) {
+    if (
+      !heartbeatToolResponse &&
+      (!canUseReplyPayload || !replyPayload || !hasOutboundReplyContent(replyPayload))
+    ) {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,
@@ -1740,15 +1754,15 @@ export async function runHeartbeatOnce(opts: {
 
     const normalized = heartbeatToolResponse
       ? normalizeHeartbeatToolNotification(heartbeatToolResponse, responsePrefix)
-      : replyPayload
+      : canUseReplyPayload && replyPayload
         ? normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars)
         : { shouldSkip: true, text: "", hasMedia: false };
-    // For exec completion events, don't skip even if the response looks like HEARTBEAT_OK.
-    // The model should be responding with exec results, not ack tokens.
-    // Also, if normalized.text is empty due to token stripping but we have exec completion,
-    // fall back to the original reply text.
+    // Legacy exec completion events may relay the original response text when
+    // ack-token stripping leaves the normalized text empty. Heartbeat response
+    // tool mode must not treat ordinary reply text as a delivery path.
     const execFallbackText =
       !heartbeatToolResponse &&
+      !usesHeartbeatResponseTool &&
       hasRelayableExecCompletion &&
       !normalized.text.trim() &&
       replyPayload?.text?.trim()
@@ -1789,7 +1803,7 @@ export async function runHeartbeatOnce(opts: {
     }
 
     const mediaUrls =
-      heartbeatToolResponse || !replyPayload
+      heartbeatToolResponse || !canUseReplyPayload || !replyPayload
         ? []
         : resolveSendableOutboundReplyParts(replyPayload).mediaUrls;
 

--- a/src/infra/npm-managed-root.test.ts
+++ b/src/infra/npm-managed-root.test.ts
@@ -9,6 +9,7 @@ import {
   readManagedNpmRootInstalledDependency,
   readOpenClawManagedNpmRootOverrides,
   resolveManagedNpmRootDependencySpec,
+  syncManagedNpmRootPeerDependencies,
   upsertManagedNpmRootDependency,
 } from "./npm-managed-root.js";
 
@@ -191,6 +192,166 @@ describe("managed npm root", () => {
       },
       openclaw: {
         managedOverrides: ["axios", "nested"],
+      },
+    });
+  });
+
+  it("updates stale managed peer dependency pins from current plugin peers", async () => {
+    const npmRoot = await makeTempRoot();
+    await fs.writeFile(
+      path.join(npmRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          private: true,
+          dependencies: {
+            "fixture-runtime": "1.0.0",
+          },
+          openclaw: {
+            managedPeerDependencies: ["fixture-runtime"],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await fs.mkdir(path.join(npmRoot, "node_modules", "fixture-plugin"), { recursive: true });
+    await fs.mkdir(path.join(npmRoot, "node_modules", "fixture-runtime"), { recursive: true });
+    await fs.writeFile(
+      path.join(npmRoot, "node_modules", "fixture-plugin", "package.json"),
+      `${JSON.stringify({
+        name: "fixture-plugin",
+        version: "1.0.0",
+        peerDependencies: {
+          "fixture-runtime": "^2.0.0",
+        },
+        peerDependenciesMeta: {},
+      })}\n`,
+    );
+    await fs.writeFile(
+      path.join(npmRoot, "node_modules", "fixture-runtime", "package.json"),
+      `${JSON.stringify({
+        name: "fixture-runtime",
+        version: "1.0.0",
+      })}\n`,
+    );
+
+    await expect(
+      syncManagedNpmRootPeerDependencies({
+        npmRoot,
+        preferredPackageName: "fixture-plugin",
+      }),
+    ).resolves.toBe(true);
+
+    await expect(
+      fs.readFile(path.join(npmRoot, "package.json"), "utf8").then((raw) => JSON.parse(raw)),
+    ).resolves.toEqual({
+      private: true,
+      dependencies: {
+        "fixture-runtime": "^2.0.0",
+      },
+      openclaw: {
+        managedPeerDependencies: ["fixture-runtime"],
+      },
+    });
+  });
+
+  it("keeps existing managed peer dependency pins during unrelated plugin installs", async () => {
+    const npmRoot = await makeTempRoot();
+    await fs.writeFile(
+      path.join(npmRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          private: true,
+          dependencies: {
+            "fixture-runtime": "^2.0.0",
+          },
+          openclaw: {
+            managedPeerDependencies: ["fixture-runtime"],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await fs.mkdir(path.join(npmRoot, "node_modules", "fixture-alpha"), { recursive: true });
+    await fs.mkdir(path.join(npmRoot, "node_modules", "fixture-beta"), { recursive: true });
+    await fs.writeFile(
+      path.join(npmRoot, "node_modules", "fixture-alpha", "package.json"),
+      `${JSON.stringify({
+        name: "fixture-alpha",
+        version: "1.0.0",
+        peerDependencies: {
+          "fixture-runtime": "^1.0.0",
+        },
+      })}\n`,
+    );
+    await fs.writeFile(
+      path.join(npmRoot, "node_modules", "fixture-beta", "package.json"),
+      `${JSON.stringify({
+        name: "fixture-beta",
+        version: "1.0.0",
+        peerDependencies: {
+          "fixture-runtime": "^2.0.0",
+        },
+      })}\n`,
+    );
+
+    await expect(
+      syncManagedNpmRootPeerDependencies({
+        npmRoot,
+        preferredPackageName: "fixture-unrelated",
+      }),
+    ).resolves.toBe(false);
+
+    await expect(
+      fs.readFile(path.join(npmRoot, "package.json"), "utf8").then((raw) => JSON.parse(raw)),
+    ).resolves.toEqual({
+      private: true,
+      dependencies: {
+        "fixture-runtime": "^2.0.0",
+      },
+      openclaw: {
+        managedPeerDependencies: ["fixture-runtime"],
+      },
+    });
+  });
+
+  it("preserves user-owned peer dependency pins while scanning plugin peers", async () => {
+    const npmRoot = await makeTempRoot();
+    await fs.writeFile(
+      path.join(npmRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          private: true,
+          dependencies: {
+            "fixture-runtime": "1.0.0",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await fs.mkdir(path.join(npmRoot, "node_modules", "fixture-plugin"), { recursive: true });
+    await fs.writeFile(
+      path.join(npmRoot, "node_modules", "fixture-plugin", "package.json"),
+      `${JSON.stringify({
+        name: "fixture-plugin",
+        version: "1.0.0",
+        peerDependencies: {
+          "fixture-runtime": "^2.0.0",
+        },
+        peerDependenciesMeta: {},
+      })}\n`,
+    );
+
+    await expect(syncManagedNpmRootPeerDependencies({ npmRoot })).resolves.toBe(false);
+
+    await expect(
+      fs.readFile(path.join(npmRoot, "package.json"), "utf8").then((raw) => JSON.parse(raw)),
+    ).resolves.toEqual({
+      private: true,
+      dependencies: {
+        "fixture-runtime": "1.0.0",
       },
     });
   });

--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -392,6 +392,9 @@ async function listNodeModulesPackageDirs(nodeModulesDir: string): Promise<strin
 
 async function collectManagedNpmRootPeerDependencyPins(params: {
   npmRoot: string;
+  preferredPackageName?: string;
+  previousManagedPeerDependencySet?: ReadonlySet<string>;
+  previousManagedPeerDependencySpecs?: ReadonlyMap<string, string>;
 }): Promise<Record<string, string>> {
   const pins = new Map<string, string>();
   const limits = resolveManagedNpmPeerTraversalLimits();
@@ -432,12 +435,18 @@ async function collectManagedNpmRootPeerDependencyPins(params: {
     const packageDir = current.packageDir;
     const manifest = await readPackageJsonIfExists(packageDir);
     if (manifest) {
-      if (readOptionalString(manifest.name) === "openclaw") {
+      const packageName = readOptionalString(manifest.name);
+      if (packageName === "openclaw") {
         continue;
       }
+      const isPreferredPackage = packageName === params.preferredPackageName;
       const peerDependencies = readDependencyRecord(manifest.peerDependencies);
       for (const [peerName, peerRange] of Object.entries(peerDependencies)) {
-        if (peerName === "openclaw" || pins.has(peerName) || !isSafePackageName(peerName)) {
+        if (
+          peerName === "openclaw" ||
+          (pins.has(peerName) && !isPreferredPackage) ||
+          !isSafePackageName(peerName)
+        ) {
           continue;
         }
         const installedVersion = await readPackageVersion(
@@ -446,7 +455,11 @@ async function collectManagedNpmRootPeerDependencyPins(params: {
         if (!installedVersion && isOptionalPeerDependency(manifest, peerName)) {
           continue;
         }
-        pins.set(peerName, installedVersion ?? peerRange);
+        const previousManagedSpec = params.previousManagedPeerDependencySpecs?.get(peerName);
+        pins.set(
+          peerName,
+          isPreferredPackage ? peerRange : (previousManagedSpec ?? installedVersion ?? peerRange),
+        );
       }
     }
     queue.push(
@@ -516,13 +529,25 @@ export async function syncManagedNpmRootPeerDependencies(params: {
   npmRoot: string;
   managedOverrides?: Record<string, unknown>;
   omitUnsupportedManagedOverrides?: boolean;
+  preferredPackageName?: string;
 }): Promise<boolean> {
   const manifestPath = path.join(params.npmRoot, "package.json");
   const manifest = await readManagedNpmRootManifest(manifestPath);
   const dependencies = readDependencyRecord(manifest.dependencies);
   const previousManagedPeerDependencies = readManagedPeerDependencyKeys(manifest.openclaw);
   const previousManagedPeerDependencySet = new Set(previousManagedPeerDependencies);
-  const peerPins = await collectManagedNpmRootPeerDependencyPins({ npmRoot: params.npmRoot });
+  const previousManagedPeerDependencySpecs = new Map(
+    previousManagedPeerDependencies.flatMap((packageName) => {
+      const dependencySpec = dependencies[packageName];
+      return dependencySpec ? [[packageName, dependencySpec] as const] : [];
+    }),
+  );
+  const peerPins = await collectManagedNpmRootPeerDependencyPins({
+    npmRoot: params.npmRoot,
+    preferredPackageName: params.preferredPackageName,
+    previousManagedPeerDependencySet,
+    previousManagedPeerDependencySpecs,
+  });
   const nextDependencies = { ...dependencies };
   for (const packageName of previousManagedPeerDependencies) {
     if (!Object.hasOwn(peerPins, packageName)) {
@@ -530,7 +555,12 @@ export async function syncManagedNpmRootPeerDependencies(params: {
     }
   }
   for (const [packageName, dependencySpec] of Object.entries(peerPins)) {
-    nextDependencies[packageName] = dependencies[packageName] ?? dependencySpec;
+    if (
+      previousManagedPeerDependencySet.has(packageName) ||
+      !Object.hasOwn(dependencies, packageName)
+    ) {
+      nextDependencies[packageName] = dependencySpec;
+    }
   }
 
   const managedOverrides = params.omitUnsupportedManagedOverrides

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -641,7 +641,11 @@ async function installPluginFromManagedNpmRoot(
     dependencySpec: params.dependencySpec,
     managedOverrides,
   });
-  await syncManagedNpmRootPeerDependencies({ npmRoot, managedOverrides });
+  await syncManagedNpmRootPeerDependencies({
+    npmRoot,
+    managedOverrides,
+    preferredPackageName: params.packageName,
+  });
   const npmInstallArgs = [
     "npm",
     ...createSafeNpmInstallArgs({
@@ -698,6 +702,7 @@ async function installPluginFromManagedNpmRoot(
       npmRoot,
       managedOverrides,
       omitUnsupportedManagedOverrides,
+      preferredPackageName: params.packageName,
     });
     if (!syncedPeerDependencies) {
       settledManagedPeerDependencies = true;
@@ -724,6 +729,7 @@ async function installPluginFromManagedNpmRoot(
       npmRoot,
       managedOverrides,
       omitUnsupportedManagedOverrides,
+      preferredPackageName: params.packageName,
     });
     settledManagedPeerDependencies = !syncedPeerDependencies;
   }

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const SCRIPT_PATH = "scripts/install-cli.sh";
@@ -45,6 +47,72 @@ describe("install-cli.sh", () => {
     expect(result.stdout).toContain("semver=v2026.5.12-beta.3");
     expect(result.stdout).toContain("beta=v2026.5.12-beta.3");
     expect(result.stdout).toContain("main=main");
+  });
+
+  it("leaves an existing git checkout on its current ref when git updates are disabled", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-no-git-update-"));
+    const repo = join(tmp, "repo");
+    const prefix = join(tmp, "prefix");
+    try {
+      expect(spawnSync("git", ["init", repo], { encoding: "utf8" }).status).toBe(0);
+      writeFileSync(join(repo, "README.md"), "fixture\n");
+      expect(spawnSync("git", ["-C", repo, "add", "README.md"], { encoding: "utf8" }).status).toBe(
+        0,
+      );
+      expect(
+        spawnSync(
+          "git",
+          [
+            "-C",
+            repo,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "init",
+          ],
+          {
+            encoding: "utf8",
+          },
+        ).status,
+      ).toBe(0);
+      mkdirSync(join(prefix, "tools", "node", "bin"), { recursive: true });
+      const nodeShim = join(prefix, "tools", "node", "bin", "node");
+      writeFileSync(nodeShim, "#!/bin/sh\nexit 0\n");
+      chmodSync(nodeShim, 0o755);
+
+      const result = runInstallCliShell(
+        `
+          set -euo pipefail
+          source "${SCRIPT_PATH}"
+          PREFIX=${JSON.stringify(prefix)}
+          GIT_UPDATE=0
+          ensure_git() { :; }
+          ensure_pnpm() { :; }
+          ensure_pnpm_binary_for_scripts() { :; }
+          cleanup_legacy_submodules() { :; }
+          ensure_pnpm_git_prepare_allowlist() { :; }
+          activate_repo_pnpm_version() { :; }
+          resolve_git_openclaw_ref() { echo SHOULD_NOT_RESOLVE; }
+          checkout_git_openclaw_ref() { echo CHECKOUT_CALLED; return 0; }
+          run_pnpm() { :; }
+          log() { printf 'log:%s\\n' "$*"; }
+          emit_json() { :; }
+          install_openclaw_from_git ${JSON.stringify(repo)}
+        `,
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Git update disabled; leaving existing checkout unchanged");
+      expect(result.stdout).not.toContain("SHOULD_NOT_RESOLVE");
+      expect(result.stdout).not.toContain("CHECKOUT_CALLED");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it("uses frozen lockfile installs for git installs", () => {

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -381,6 +381,107 @@ describe("install.sh", () => {
     expect(result.stdout).toContain("main=main");
   });
 
+  it("leaves an existing git checkout on its current ref when git updates are disabled", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-no-git-update-"));
+    const repo = join(tmp, "repo");
+    const home = join(tmp, "home");
+    mkdirSync(home, { recursive: true });
+    try {
+      expect(spawnSync("git", ["init", repo], { encoding: "utf8" }).status).toBe(0);
+      writeFileSync(join(repo, "README.md"), "fixture\n");
+      expect(spawnSync("git", ["-C", repo, "add", "README.md"], { encoding: "utf8" }).status).toBe(
+        0,
+      );
+      expect(
+        spawnSync(
+          "git",
+          [
+            "-C",
+            repo,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "init",
+          ],
+          {
+            encoding: "utf8",
+          },
+        ).status,
+      ).toBe(0);
+
+      const result = runInstallShell(
+        `
+          set -euo pipefail
+          source "${SCRIPT_PATH}"
+          GIT_UPDATE=0
+          check_git() { return 0; }
+          ensure_pnpm() { :; }
+          ensure_pnpm_binary_for_scripts() { :; }
+          cleanup_legacy_submodules() { :; }
+          activate_repo_pnpm_version() { :; }
+          ensure_user_local_bin_on_path() { mkdir -p "$HOME/.local/bin"; }
+          resolve_git_openclaw_ref() { echo SHOULD_NOT_RESOLVE; }
+          checkout_git_openclaw_ref() { echo CHECKOUT_CALLED; return 0; }
+          run_pnpm() { :; }
+          ui_info() { printf 'info:%s\\n' "$*"; }
+          ui_warn() { printf 'warn:%s\\n' "$*"; }
+          ui_success() { printf 'success:%s\\n' "$*"; }
+          install_openclaw_from_git ${JSON.stringify(repo)}
+        `,
+        {
+          HOME: home,
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Git update disabled; leaving existing checkout unchanged");
+      expect(result.stdout).not.toContain("SHOULD_NOT_RESOLVE");
+      expect(result.stdout).not.toContain("CHECKOUT_CALLED");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects existing non-git dirs even when git updates are disabled", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-no-git-update-non-git-"));
+    const repo = join(tmp, "repo");
+    const home = join(tmp, "home");
+    mkdirSync(repo, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(repo, "README.md"), "fixture\n");
+    try {
+      const result = runInstallShell(
+        `
+          set -euo pipefail
+          source "${SCRIPT_PATH}"
+          GIT_UPDATE=0
+          check_git() { return 0; }
+          ensure_pnpm() { :; }
+          ensure_pnpm_binary_for_scripts() { :; }
+          resolve_git_openclaw_ref() { echo SHOULD_NOT_RESOLVE; }
+          checkout_git_openclaw_ref() { echo CHECKOUT_CALLED; return 0; }
+          ui_error() { printf 'error:%s\\n' "$*"; }
+          install_openclaw_from_git ${JSON.stringify(repo)}
+        `,
+        {
+          HOME: home,
+        },
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(result.stdout).toContain("Git install dir exists but is not a git repo");
+      expect(result.stdout).not.toContain("SHOULD_NOT_RESOLVE");
+      expect(result.stdout).not.toContain("CHECKOUT_CALLED");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("uses frozen lockfile installs for git installs", () => {
     expect(script).toContain(
       'run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install --frozen-lockfile',


### PR DESCRIPTION
Summary
- Requires the structured `heartbeat_respond` tool result for heartbeat-tool mode delivery.
- Ignores ordinary assistant text/media payloads in heartbeat-tool mode, including Codex scaffold-looking text.
- Keeps legacy heartbeat text on the existing sanitizer path without adding new protocol-dialect stripping rules.
- Resolves env-backed `SecretRef` objects from `models.providers.<id>.apiKey` for dynamic provider catalog auth, while honoring env secret provider allowlists.
- Honors `--no-git-update` / `OPENCLAW_GIT_UPDATE=0` for existing git installs before resolving release refs, and rejects existing non-git install dirs instead of building in them.
- Refreshes OpenClaw-managed peer dependency pins when installed plugin peer ranges change, preserves existing managed pins during unrelated plugin installs, and leaves user-owned pins alone.

Commits
- `fix: require heartbeat tool replies`
- `fix: resolve SecretRef catalog auth`
- `fix: honor git no-update installs`
- `fix: reconcile managed plugin peers`

Verification
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.tool-response.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts src/shared/text/assistant-visible-text.test.ts src/agents/models-config.providers.auth-provenance.test.ts src/infra/npm-managed-root.test.ts test/scripts/install-sh.test.ts test/scripts/install-cli.test.ts` passed before the final installer guard follow-up: 8 files / 185 tests.
- `node scripts/run-vitest.mjs test/scripts/install-sh.test.ts test/scripts/install-cli.test.ts` passed after the final installer guard follow-up: 2 files / 25 tests.
- `git diff --check`

Refs
- Replaces #81441
- Fixes #81369

Behavior addressed: heartbeat-tool mode could still fall back to ordinary assistant output and post Codex protocol scaffolding into chat; dynamic provider catalog auth skipped valid env-backed SecretRef provider API keys; git reinstall with no-update could move a clean checkout or continue in a non-git directory; managed plugin peer sync could keep stale OpenClaw-owned peer pins or downgrade existing managed pins during unrelated plugin installs.
Real environment tested: focused local Vitest regression coverage for heartbeat-tool delivery, existing sanitizer behavior, config-backed provider SecretRef catalog auth including allowlist denial, git no-update installer behavior, and managed peer reconciliation.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/infra/heartbeat-runner.tool-response.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts src/shared/text/assistant-visible-text.test.ts src/agents/models-config.providers.auth-provenance.test.ts src/infra/npm-managed-root.test.ts test/scripts/install-sh.test.ts test/scripts/install-cli.test.ts`; `node scripts/run-vitest.mjs test/scripts/install-sh.test.ts test/scripts/install-cli.test.ts`; `git diff --check`
Evidence after fix: focused combined lane passed 8 files / 185 tests before the final installer guard; installer lane passed 2 files / 25 tests after the final guard; diff whitespace check passed.
Observed result after fix: heartbeat-tool mode ignores ordinary non-tool text/media payloads; env SecretRef provider API keys resolve for catalog auth only when the configured env secret provider permits that id; git no-update leaves existing checkouts unchanged without resolving release refs and rejects non-git dirs; managed peer pins update to current plugin peer requirements when OpenClaw owns the pin, preserve existing managed specs on unrelated installs, and keep user-owned pins intact.
What was not tested: full local repo gate and live channel/model discovery delivery were not run locally in this turn.
