### PR TITLE
Fix/weixin catalog update 2.4.3

### DIFF
--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -116,7 +116,7 @@
         "install": {
           "npmSpec": "@tencent-weixin/openclaw-weixin@2.4.3",
           "defaultChoice": "npm",
-          "expectedIntegrity": "sha512-FZnUVMQRpKGTKezeplr/DYal+5RSif2tXE51pljIFrO8rn7bVnnvpbj81/i9UMrYbuGiom1sl8OeSDzWRDKGhQ==",
+          "expectedIntegrity": "sha512-dPQbidUNWigC6V10vGW4i+GLH09x+6zUhafZRjuxkJ9GDu8o62WBsnUTojp4KqUH756hz+t2v9khiCRSi0dBDw==",
           "minHostVersion": ">=2026.3.22"
         }
       }

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -114,7 +114,7 @@
           }
         },
         "install": {
-          "npmSpec": "@tencent-weixin/openclaw-weixin@2.4.1",
+          "npmSpec": "@tencent-weixin/openclaw-weixin@2.4.3",
           "defaultChoice": "npm",
           "expectedIntegrity": "sha512-FZnUVMQRpKGTKezeplr/DYal+5RSif2tXE51pljIFrO8rn7bVnnvpbj81/i9UMrYbuGiom1sl8OeSDzWRDKGhQ==",
           "minHostVersion": ">=2026.3.22"


### PR DESCRIPTION
## Summary

- **Problem**: `2.4.1` has a fatal type issue causing Weixin plugin startup failures under certain timing conditions.
- **Why it matters**: 
  - `openclaw plugins update` cannot upgrade to `2.4.3` because the catalog pins `2.4.1`.
  - Worse, running `openclaw update` will **downgrade** users who manually installed `2.4.3` back to `2.4.1`.
- **What changed**: Update `official-external-channel-catalog.json` npmSpec from `@tencent-weixin/openclaw-weixin@2.4.1` to `@tencent-weixin/openclaw-weixin@2.4.3` (integrity hash updated).
- **What did NOT change**: No code changes; only catalog version bump.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause**: `2.4.1` uses a global singleton `pluginRuntime` with async polling (`waitForWeixinRuntime()`), which fails when gateway injection timing is off — throwing "Weixin runtime initialization timeout".
- **Missing detection / guardrail**: `2.4.2+` replaced the singleton pattern with direct `ctx.channelRuntime` injection from gateway context, eliminating the timing issue.
- **Contributing context**: `2.4.3` (May 8) is stable and includes all fixes from `2.4.2`.

## Regression Test Plan (if applicable)

- **Coverage level**:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file**: `test/official-channel-catalog.test.ts`
- **If no new test is added, why not**: This PR only bumps the catalog version; code fixes are in `2.4.2`/`2.4.3`.

## User-visible / Behavior Changes

Official Weixin plugin update target changes from `2.4.1` to `2.4.3`; no runtime code changes in OpenClaw.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Steps

1. Before this PR: `openclaw plugins update` upgrades to `2.4.1` (buggy)
2. After this PR: `openclaw plugins update` upgrades to `2.4.3` (stable)
3. Manual verification: installed `2.4.3` via `openclaw plugins install @tencent-weixin/openclaw-weixin@2.4.3 --force`, works correctly

### Expected

- `openclaw plugins update openclaw-weixin` → `2.4.3`

### Actual

- Before: `openclaw plugins update` → `2.4.1` (with type issues)

## Evidence

- [x] Trace/log snippets

NPM versions: `2.4.1` → `2.4.2` → `2.4.3` (latest, May 8)

NPM proof: `npm view @tencent-weixin/openclaw-weixin version dist-tags dist.integrity --json`

## Human Verification (required)

- **Verified scenarios**: Manually installed `2.4.3`, plugin loads normally after gateway restart.
- **What you did NOT verify**: Detailed diff between `2.4.2` and `2.4.3`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- **Risk**: New version may introduce unexpected behavior.
  - **Mitigation**: `2.4.3` is a stable release on NPM, manually verified.
