### PR TITLE
feat(catalog): add DingTalk to official external channel catalog

### DIFF
--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -122,6 +122,43 @@
       }
     },
     {
+      "name": "@dingtalk-real-ai/dingtalk-connector",
+      "description": "Official OpenClaw DingTalk channel plugin by the DingTalk team.",
+      "source": "external",
+      "kind": "channel",
+      "openclaw": {
+        "plugin": {
+          "id": "dingtalk-connector",
+          "label": "DingTalk"
+        },
+        "channel": {
+          "id": "dingtalk-connector",
+          "label": "DingTalk",
+          "selectionLabel": "DingTalk (钉钉)",
+          "detailLabel": "DingTalk",
+          "docsPath": "/plugins/community#dingtalk",
+          "docsLabel": "dingtalk-connector",
+          "blurb": "Enterprise DingTalk bot via Stream mode with AI Card streaming.",
+          "aliases": ["dd", "ding", "dingtalk"],
+          "order": 36
+        },
+        "channelConfigs": {
+          "dingtalk-connector": {
+            "label": "DingTalk",
+            "description": "DingTalk enterprise bot conversation channel.",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "install": {
+          "npmSpec": "@dingtalk-real-ai/dingtalk-connector",
+          "defaultChoice": "npm"
+        }
+      }
+    },
+    {
       "name": "@openclaw/discord",
       "description": "OpenClaw Discord channel plugin",
       "source": "official",

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -137,7 +137,7 @@
           "selectionLabel": "DingTalk (钉钉)",
           "detailLabel": "DingTalk",
           "docsPath": "/plugins/community#dingtalk",
-          "docsLabel": "dingtalk-connector",
+          "docsLabel": "dingtalk",
           "blurb": "Enterprise DingTalk bot via Stream mode with AI Card streaming.",
           "aliases": ["dd", "ding", "dingtalk"],
           "order": 36
@@ -153,8 +153,9 @@
           }
         },
         "install": {
-          "npmSpec": "@dingtalk-real-ai/dingtalk-connector",
-          "defaultChoice": "npm"
+          "npmSpec": "@dingtalk-real-ai/dingtalk-connector@0.8.20",
+          "defaultChoice": "npm",
+          "expectedIntegrity": "sha512-VyOouiNA4HHuO24P3gDNl5YIQmUbdkNw5sWH74IJo3gnfEdciw7pCufCqYeXojIvSj/iZxwk6Rl9dzT7AmHbiQ=="
         }
       }
     },


### PR DESCRIPTION
## Summary

- Add DingTalk (钉钉) as an external channel entry in `official-external-channel-catalog.json`, so it appears in the `openclaw configure` channel selection wizard with install-on-demand support.
- Follows the same pattern used by WeCom, Yuanbao, and Weixin — all third-party maintained external plugins.
- **No core code changes**: only a single JSON catalog entry addition.

## Context

The DingTalk OpenClaw connector ([`@dingtalk-real-ai/dingtalk-connector`](https://www.npmjs.com/package/@dingtalk-real-ai/dingtalk-connector)) is an external channel plugin maintained by the official DingTalk team. It supports:
- DingTalk enterprise bot via Stream mode
- AI Card streaming responses
- QR code onboarding setup wizard

As suggested in #81708 review comments, this plugin is published as an external npm package rather than bundled in `extensions/`. Adding it to the catalog enables seamless discovery via `openclaw configure` without any core code changes.

## ClawSweeper Review Fixes (v2)

All technical issues from the initial ClawSweeper review have been addressed:

| Issue | Before | After |
|-------|--------|-------|
| Floating npm version | `@dingtalk-real-ai/dingtalk-connector` (bare) | `@dingtalk-real-ai/dingtalk-connector@0.8.20` (pinned) |
| Missing integrity | Not present | `sha512-VyOouiNA4HHuO24P3gDNl5YIQmUbdkNw5sWH74IJo3gnfEdciw7pCufCqYeXojIvSj/iZxwk6Rl9dzT7AmHbiQ==` |
| docsLabel mismatch | `dingtalk-connector` | `dingtalk` (matches community docs anchor) |

The entry now follows the exact same `exact-with-integrity` policy as WeCom (`@wecom/wecom-openclaw-plugin@2026.5.7` + integrity) and other third-party external entries.

## Real Behavior Proof

- **npm registry**: `npm view @dingtalk-real-ai/dingtalk-connector@0.8.20 dist.integrity` returns the exact `sha512` hash used in this entry.
- **Plugin functionality**: The plugin is actively maintained at [DingTalk-Real-AI/dingtalk-openclaw-connector](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector) with 2.1k+ stars, and the maintainer is also a core contributor to the DingTalk channel support in OpenClaw Hermes.
- **Catalog format**: Entry mirrors the existing WeCom, Yuanbao, and Weixin external entries — same `source: "external"`, same `docsPath` convention (`/plugins/community#dingtalk`), same schema shape.

## Verification

- [x] JSON validates successfully
- [x] Entry follows existing external plugin format (WeCom / Yuanbao / Weixin)
- [x] npmSpec pinned to exact version `@0.8.20`
- [x] `expectedIntegrity` hash matches npm registry dist integrity
- [x] `docsLabel` follows naming convention
- [x] Single file change: `scripts/lib/official-external-channel-catalog.json`