### PR TITLE
[Chore] Add gateway startup trace attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Control UI/WebChat: add a persisted auto-scroll mode selector so users can keep the current near-bottom behavior, always follow streaming output, or turn automatic streaming scroll off and use the New messages button manually. Fixes #7648 and #81287. Thanks @BunsDev.
 - ACP: add `acp.fallbacks` so ACP turns can try configured backup runtime backends when the primary backend is unavailable before any output is emitted. (#69542) Thanks @kaseonedge.
+- Gateway/startup: add owner-level startup trace attribution for auth, plugin loading, lookup counts, and plugin sidecar services. (#81738) Thanks @samzong.
 
 ### Fixes
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -661,6 +661,8 @@ export function loadGatewayPlugins(params: {
       ["pluginIdsMs", pluginIdsMs],
       ["loadMs", 0],
       ["pluginIds", "0"],
+      ["pluginCount", 0],
+      ["gatewayHandlerCount", 0],
     ]);
     return {
       pluginRegistry,
@@ -692,6 +694,9 @@ export function loadGatewayPlugins(params: {
     },
     preferSetupRuntimeForChannelPlugins: params.preferSetupRuntimeForChannelPlugins,
     preferBuiltPluginArtifacts: true,
+    ...(params.startupTrace !== undefined && {
+      startupTrace: params.startupTrace,
+    }),
     ...(params.pluginLookUpTable?.manifestRegistry
       ? { manifestRegistry: params.pluginLookUpTable.manifestRegistry }
       : {}),
@@ -706,7 +711,9 @@ export function loadGatewayPlugins(params: {
     ["pluginIdsMs", pluginIdsMs],
     ["loadMs", loadMs],
     ["pluginIds", String(pluginIds.length)],
+    ["pluginCount", pluginIds.length],
     ["gatewayHandlers", String(pluginMethods.length)],
+    ["gatewayHandlerCount", pluginMethods.length],
     ["loaderCallsCount", loaderStatsAfter.calls - loaderStatsBefore.calls],
     ["loaderNativeHitsCount", loaderStatsAfter.nativeHits - loaderStatsBefore.nativeHits],
     ["loaderNativeMissesCount", loaderStatsAfter.nativeMisses - loaderStatsBefore.nativeMisses],

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -86,6 +86,41 @@ describe("gateway startup config secret preflight", () => {
     }
   });
 
+  it("measures startup auth subphases", async () => {
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => preparedSnapshot(config));
+    const measured: string[] = [];
+
+    await prepareGatewayStartupConfig({
+      configSnapshot: buildSnapshot(gatewayTokenConfig({})),
+      activateRuntimeSecrets: createRuntimeSecretsActivator({
+        logSecrets: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        emitStateEvent: vi.fn(),
+        prepareRuntimeSecretsSnapshot,
+        activateRuntimeSecretsSnapshot: vi.fn(),
+      }),
+      measure: async (name, run) => {
+        measured.push(name);
+        return await run();
+      },
+    });
+
+    expect(measured).toEqual([
+      "config.auth.snapshot-validate",
+      "config.auth.runtime-overrides",
+      "config.auth.startup-overrides",
+      "config.auth.secret-surface",
+      "config.auth.secret-preflight",
+      "config.auth.preflight-override",
+      "config.auth.ensure",
+      "config.auth.runtime-startup-overrides",
+      "config.auth.secrets-activate",
+    ]);
+  });
+
   it("wraps startup secret activation failures without emitting reload state events", async () => {
     const error = new Error('Environment variable "OPENAI_API_KEY" is missing or empty.');
     const prepareRuntimeSecretsSnapshot = vi.fn(async () => {

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -234,24 +234,37 @@ export async function prepareGatewayStartupConfig(params: {
   tailscaleOverride?: GatewayTailscaleConfig;
   activateRuntimeSecrets: ActivateRuntimeSecrets;
   persistStartupAuth?: boolean;
+  measure?: GatewayStartupConfigMeasure;
 }): Promise<Awaited<ReturnType<typeof ensureGatewayStartupAuth>>> {
-  assertValidGatewayStartupConfigSnapshot(params.configSnapshot);
+  const measure = params.measure ?? (async (_name, run) => await run());
+  await measure("config.auth.snapshot-validate", () =>
+    assertValidGatewayStartupConfigSnapshot(params.configSnapshot),
+  );
 
-  const runtimeConfig = applyConfigOverrides(params.configSnapshot.config);
-  const startupPreflightConfig = applyGatewayAuthOverridesForStartupPreflight(runtimeConfig, {
-    auth: params.authOverride,
-    tailscale: params.tailscaleOverride,
+  const runtimeConfig = await measure("config.auth.runtime-overrides", () =>
+    applyConfigOverrides(params.configSnapshot.config),
+  );
+  const startupPreflightConfig = await measure("config.auth.startup-overrides", () =>
+    applyGatewayAuthOverridesForStartupPreflight(runtimeConfig, {
+      auth: params.authOverride,
+      tailscale: params.tailscaleOverride,
+    }),
+  );
+  const needsAuthSecretPreflight = await measure("config.auth.secret-surface", () =>
+    hasActiveGatewayAuthSecretRef(startupPreflightConfig),
+  );
+  const preflightConfig = await measure("config.auth.secret-preflight", async () => {
+    if (!needsAuthSecretPreflight) {
+      return startupPreflightConfig;
+    }
+    return (
+      await params.activateRuntimeSecrets(startupPreflightConfig, {
+        reason: "startup",
+        activate: false,
+      })
+    ).config;
   });
-  const needsAuthSecretPreflight = hasActiveGatewayAuthSecretRef(startupPreflightConfig);
-  const preflightConfig = needsAuthSecretPreflight
-    ? (
-        await params.activateRuntimeSecrets(startupPreflightConfig, {
-          reason: "startup",
-          activate: false,
-        })
-      ).config
-    : startupPreflightConfig;
-  const preflightAuthOverride =
+  const preflightAuthOverride = await measure("config.auth.preflight-override", () =>
     typeof preflightConfig.gateway?.auth?.token === "string" ||
     typeof preflightConfig.gateway?.auth?.password === "string"
       ? {
@@ -263,25 +276,32 @@ export async function prepareGatewayStartupConfig(params: {
             ? { password: preflightConfig.gateway.auth.password }
             : {}),
         }
-      : params.authOverride;
+      : params.authOverride,
+  );
 
-  const authBootstrap = await ensureGatewayStartupAuth({
-    cfg: runtimeConfig,
-    env: process.env,
-    authOverride: preflightAuthOverride,
-    tailscaleOverride: params.tailscaleOverride,
-    persist: params.persistStartupAuth ?? false,
-    baseHash: params.configSnapshot.hash,
-  });
-  const runtimeStartupConfig = applyGatewayAuthOverridesForStartupPreflight(authBootstrap.cfg, {
-    auth: params.authOverride,
-    tailscale: params.tailscaleOverride,
-  });
+  const authBootstrap = await measure("config.auth.ensure", () =>
+    ensureGatewayStartupAuth({
+      cfg: runtimeConfig,
+      env: process.env,
+      authOverride: preflightAuthOverride,
+      tailscaleOverride: params.tailscaleOverride,
+      persist: params.persistStartupAuth ?? false,
+      baseHash: params.configSnapshot.hash,
+    }),
+  );
+  const runtimeStartupConfig = await measure("config.auth.runtime-startup-overrides", () =>
+    applyGatewayAuthOverridesForStartupPreflight(authBootstrap.cfg, {
+      auth: params.authOverride,
+      tailscale: params.tailscaleOverride,
+    }),
+  );
   const activatedConfig = (
-    await params.activateRuntimeSecrets(runtimeStartupConfig, {
-      reason: "startup",
-      activate: true,
-    })
+    await measure("config.auth.secrets-activate", () =>
+      params.activateRuntimeSecrets(runtimeStartupConfig, {
+        reason: "startup",
+        activate: true,
+      }),
+    )
   ).config;
   return {
     ...authBootstrap,

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -520,6 +520,7 @@ export async function startGatewaySidecars(params: {
         registry: params.pluginRegistry,
         config: params.cfg,
         workspaceDir: params.defaultWorkspaceDir,
+        startupTrace: params.startupTrace,
       });
     } catch (err) {
       params.log.warn(`plugin services failed to start: ${String(err)}`);

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -583,6 +583,7 @@ export async function startGatewayServer(
       authOverride: opts.auth,
       tailscaleOverride: opts.tailscale,
       activateRuntimeSecrets,
+      measure: (name, run) => startupTrace.measure(name, run),
     }),
   );
   cfgAtStart = authBootstrap.cfg;
@@ -663,9 +664,13 @@ export async function startGatewayServer(
       ["ownerMapsMs", metrics.ownerMapsMs],
       ["totalMs", metrics.totalMs],
       ["indexPlugins", String(metrics.indexPluginCount)],
+      ["indexPluginCount", metrics.indexPluginCount],
       ["manifestPlugins", String(metrics.manifestPluginCount)],
+      ["manifestPluginCount", metrics.manifestPluginCount],
       ["startupPlugins", String(metrics.startupPluginCount)],
+      ["startupPluginCount", metrics.startupPluginCount],
       ["deferredChannelPlugins", String(metrics.deferredChannelPluginCount)],
+      ["deferredChannelPluginCount", metrics.deferredChannelPluginCount],
     ]);
   }
   let { pluginRegistry, baseGatewayMethods } = pluginBootstrap;

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -46,6 +46,7 @@ import {
   __testing,
   clearPluginLoaderCache,
   loadOpenClawPlugins,
+  type PluginLoadOptions,
   PluginLoadReentryError,
   resolveRuntimePluginRegistry,
 } from "./loader.js";
@@ -96,6 +97,10 @@ let cachedBundledTelegramDir = "";
 let cachedBundledMemoryDir = "";
 
 type GlobalHookRunner = NonNullable<ReturnType<typeof getGlobalHookRunner>>;
+type PluginStartupTraceDetail = {
+  name: string;
+  metrics: ReadonlyArray<readonly [string, number | string]>;
+};
 
 function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean): number {
   let count = 0;
@@ -913,6 +918,36 @@ function expectEscapingEntryRejected(params: {
   return registry;
 }
 
+function createStartupTraceRecorder(): {
+  details: PluginStartupTraceDetail[];
+  startupTrace: NonNullable<PluginLoadOptions["startupTrace"]>;
+} {
+  const details: PluginStartupTraceDetail[] = [];
+  return {
+    details,
+    startupTrace: {
+      detail: (name, metrics) => {
+        details.push({ name, metrics });
+      },
+    },
+  };
+}
+
+function collectStartupTraceMetrics(
+  details: readonly PluginStartupTraceDetail[],
+  name: string,
+): Record<string, number | string> {
+  const matched = details.filter((entry) => entry.name === name);
+  expect(matched.length).toBeGreaterThan(0);
+  const metrics: Record<string, number | string> = {};
+  for (const entry of matched) {
+    for (const [key, value] of entry.metrics) {
+      metrics[key] = value;
+    }
+  }
+  return metrics;
+}
+
 afterEach(() => {
   clearRuntimeConfigSnapshot();
   runtimeRegistryLoaderTesting.resetPluginRegistryLoadedForTests();
@@ -926,6 +961,76 @@ afterAll(() => {
 });
 
 describe("loadOpenClawPlugins", () => {
+  it("emits loader startup trace timings for normal plugin load and register", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "trace-plugin",
+      filename: "trace-plugin.cjs",
+      body: `module.exports = { id: "trace-plugin", register() {} };`,
+    });
+    const { details, startupTrace } = createStartupTraceRecorder();
+
+    loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["trace-plugin"],
+      },
+      options: {
+        startupTrace,
+      },
+    });
+
+    const metrics = collectStartupTraceMetrics(details, "plugins.gateway-load.plugin.trace-plugin");
+    expect(metrics.loadMs).toEqual(expect.any(Number));
+    expect(metrics.loadFailedCount).toBe(0);
+    expect(metrics.registerMs).toEqual(expect.any(Number));
+    expect(metrics.registerFailedCount).toBe(0);
+    expect(metrics.loadAndRegisterMs).toEqual(expect.any(Number));
+  });
+
+  it("emits loader startup trace failure counts for load and register failures", () => {
+    useNoBundledPlugins();
+    const loadFailPlugin = writePlugin({
+      id: "trace-load-fail",
+      filename: "trace-load-fail.cjs",
+      body: `throw new Error("load boom");`,
+    });
+    const registerFailPlugin = writePlugin({
+      id: "trace-register-fail",
+      filename: "trace-register-fail.cjs",
+      body: `module.exports = { id: "trace-register-fail", register() { throw new Error("register boom"); } };`,
+    });
+    const { details, startupTrace } = createStartupTraceRecorder();
+
+    loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [loadFailPlugin.file, registerFailPlugin.file] },
+          allow: ["trace-load-fail", "trace-register-fail"],
+        },
+      },
+      startupTrace,
+    });
+
+    const loadFailMetrics = collectStartupTraceMetrics(
+      details,
+      "plugins.gateway-load.plugin.trace-load-fail",
+    );
+    expect(loadFailMetrics.loadMs).toEqual(expect.any(Number));
+    expect(loadFailMetrics.loadFailedCount).toBe(1);
+    expect(loadFailMetrics.registerMs).toBeUndefined();
+
+    const registerFailMetrics = collectStartupTraceMetrics(
+      details,
+      "plugins.gateway-load.plugin.trace-register-fail",
+    );
+    expect(registerFailMetrics.loadFailedCount).toBe(0);
+    expect(registerFailMetrics.registerMs).toEqual(expect.any(Number));
+    expect(registerFailMetrics.registerFailedCount).toBe(1);
+    expect(registerFailMetrics.loadAndRegisterMs).toEqual(expect.any(Number));
+  });
+
   it("can load scoped plugins from a supplied manifest registry without rereading manifests", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -148,6 +148,7 @@ import {
   shouldPreferNativeModuleLoad,
 } from "./sdk-alias.js";
 import { hasKind, kindsEqual } from "./slots.js";
+import { encodeStartupTraceSegment } from "./startup-trace-segment.js";
 import type {
   OpenClawPluginApi,
   OpenClawPluginDefinition,
@@ -172,6 +173,9 @@ export type PluginLoadOptions = {
   coreGatewayMethodNames?: readonly string[];
   hostServices?: PluginRegistryParams["hostServices"];
   runtimeOptions?: CreatePluginRuntimeOptions;
+  startupTrace?: {
+    detail: (name: string, metrics: ReadonlyArray<readonly [string, number | string]>) => void;
+  };
   pluginSdkResolution?: PluginSdkResolutionPreference;
   cache?: boolean;
   mode?: "full" | "validate";
@@ -195,6 +199,17 @@ export type PluginLoadOptions = {
   throwOnLoadError?: boolean;
   manifestRegistry?: PluginManifestRegistry;
 };
+
+function detailPluginStartupTrace(
+  startupTrace: PluginLoadOptions["startupTrace"] | undefined,
+  pluginId: string,
+  metrics: ReadonlyArray<readonly [string, number | string]>,
+): void {
+  startupTrace?.detail(
+    `plugins.gateway-load.plugin.${encodeStartupTraceSegment(pluginId)}`,
+    metrics,
+  );
+}
 
 const CLI_METADATA_ENTRY_BASENAMES = [
   "cli-metadata.ts",
@@ -2060,6 +2075,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       fs.closeSync(opened.fd);
 
       let mod: OpenClawPluginModule | null = null;
+      let moduleLoadMs = 0;
+      let moduleLoadFailed = false;
+      const beforeModuleLoad = performance.now();
       try {
         // Track the plugin as imported once module evaluation begins. Top-level
         // code may have already executed even if evaluation later throws.
@@ -2084,7 +2102,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
           diagnosticMessagePrefix: "failed to load plugin: ",
         });
+        moduleLoadFailed = true;
         continue;
+      } finally {
+        moduleLoadMs = performance.now() - beforeModuleLoad;
+        detailPluginStartupTrace(options.startupTrace, record.id, [
+          ["loadMs", moduleLoadMs],
+          ["loadFailedCount", moduleLoadFailed ? 1 : 0],
+        ]);
       }
 
       if (registrationPlan.loadSetupEntry && manifestRecord.setupSource) {
@@ -2382,6 +2407,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
       const previousMemoryPromptSupplements = listMemoryPromptSupplements();
 
+      const beforeRegister = performance.now();
+      let registerFailed = false;
       try {
         withProfile(
           { pluginId: record.id, source: record.source },
@@ -2426,6 +2453,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
           diagnosticMessagePrefix: "plugin failed during register: ",
         });
+        registerFailed = true;
+      } finally {
+        const registerMs = performance.now() - beforeRegister;
+        detailPluginStartupTrace(options.startupTrace, record.id, [
+          ["registerMs", registerMs],
+          ["loadAndRegisterMs", moduleLoadMs + registerMs],
+          ["registerFailedCount", registerFailed ? 1 : 0],
+        ]);
       }
     }
 

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -90,11 +90,13 @@ async function startTrackingServices(params: {
   services: OpenClawPluginService[];
   config?: Parameters<typeof startPluginServices>[0]["config"];
   workspaceDir?: string;
+  startupTrace?: Parameters<typeof startPluginServices>[0]["startupTrace"];
 }) {
   return startPluginServices({
     registry: createRegistry(params.services),
     config: params.config ?? createServiceConfig(),
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    ...(params.startupTrace ? { startupTrace: params.startupTrace } : {}),
   });
 }
 
@@ -188,6 +190,71 @@ describe("startPluginServices", () => {
     ]);
     expect(stopOk).toHaveBeenCalledOnce();
     expect(stopThrows).toHaveBeenCalledOnce();
+  });
+
+  it("emits per-service startup trace spans and summary", async () => {
+    const measured: string[] = [];
+    const details: Array<{
+      name: string;
+      metrics: ReadonlyArray<readonly [string, number | string]>;
+    }> = [];
+    const startupTrace: NonNullable<Parameters<typeof startPluginServices>[0]["startupTrace"]> = {
+      measure: async (name, run) => {
+        measured.push(name);
+        return await run();
+      },
+      detail: (name, metrics) => {
+        details.push({ name, metrics });
+      },
+    };
+
+    await startTrackingServices({
+      services: [
+        createTrackingService("service-a"),
+        createTrackingService("service-fail", { failOnStart: true }),
+      ],
+      startupTrace,
+    });
+
+    expect(measured).toEqual([
+      "sidecars.plugin-services.plugin~003Atest.service-a",
+      "sidecars.plugin-services.plugin~003Atest.service-fail",
+    ]);
+    expect(details).toEqual([
+      {
+        name: "sidecars.plugin-services.summary",
+        metrics: [
+          ["serviceCount", 2],
+          ["startedCount", 1],
+          ["failedCount", 1],
+        ],
+      },
+    ]);
+  });
+
+  it("keeps distinct service trace ownership keys non-colliding", async () => {
+    const measured: string[] = [];
+    const startupTrace: NonNullable<Parameters<typeof startPluginServices>[0]["startupTrace"]> = {
+      measure: async (name, run) => {
+        measured.push(name);
+        return await run();
+      },
+    };
+
+    await startPluginServices({
+      registry: createRegistry(
+        [createTrackingService("service:a"), createTrackingService("service_a")],
+        "plugin:test",
+      ),
+      config: createServiceConfig(),
+      startupTrace,
+    });
+
+    expect(measured).toEqual([
+      "sidecars.plugin-services.plugin~003Atest.service~003Aa",
+      "sidecars.plugin-services.plugin~003Atest.service_a",
+    ]);
+    expect(new Set(measured).size).toBe(measured.length);
   });
 
   it("grants internal diagnostics only to trusted diagnostics exporter services", async () => {

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -7,6 +7,7 @@ import {
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginServiceRegistration } from "./registry-types.js";
 import type { PluginRegistry } from "./registry.js";
+import { encodeStartupTraceSegment } from "./startup-trace-segment.js";
 import type { OpenClawPluginServiceContext, PluginLogger } from "./types.js";
 
 const log = createSubsystemLogger("plugins");
@@ -52,15 +53,22 @@ export type PluginServicesHandle = {
   stop: () => Promise<void>;
 };
 
+type PluginServiceStartupTrace = {
+  detail?: (name: string, metrics: ReadonlyArray<readonly [string, number | string]>) => void;
+  measure: <T>(name: string, run: () => T | Promise<T>) => Promise<T>;
+};
+
 export async function startPluginServices(params: {
   registry: PluginRegistry;
   config: OpenClawConfig;
   workspaceDir?: string;
+  startupTrace?: PluginServiceStartupTrace;
 }): Promise<PluginServicesHandle> {
   const running: Array<{
     id: string;
     stop?: () => void | Promise<void>;
   }> = [];
+  let failedCount = 0;
   for (const entry of params.registry.services) {
     const service = entry.service;
     const serviceContext = createServiceContext({
@@ -69,18 +77,30 @@ export async function startPluginServices(params: {
       service: entry,
     });
     try {
-      await service.start(serviceContext);
+      const startService = () => service.start(serviceContext);
+      const traceName = `sidecars.plugin-services.${encodeStartupTraceSegment(entry.pluginId)}.${encodeStartupTraceSegment(service.id)}`;
+      if (params.startupTrace) {
+        await params.startupTrace.measure(traceName, startService);
+      } else {
+        await startService();
+      }
       running.push({
         id: service.id,
         stop: service.stop ? () => service.stop?.(serviceContext) : undefined,
       });
     } catch (err) {
+      failedCount += 1;
       const error = err as Error;
       log.error(
         `plugin service failed (${service.id}, plugin=${entry.pluginId}, root=${entry.rootDir ?? "unknown"}): ${error?.message ?? String(err)}`,
       );
     }
   }
+  params.startupTrace?.detail?.("sidecars.plugin-services.summary", [
+    ["serviceCount", params.registry.services.length],
+    ["startedCount", running.length],
+    ["failedCount", failedCount],
+  ]);
 
   return {
     stop: async () => {

--- a/src/plugins/startup-trace-segment.test.ts
+++ b/src/plugins/startup-trace-segment.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { encodeStartupTraceSegment } from "./startup-trace-segment.js";
+
+describe("encodeStartupTraceSegment", () => {
+  it("keeps distinct trace owner ids non-colliding", () => {
+    const encoded = [
+      encodeStartupTraceSegment("plugin:test"),
+      encodeStartupTraceSegment("plugin_test"),
+      encodeStartupTraceSegment("service/a"),
+      encodeStartupTraceSegment("service_a"),
+      encodeStartupTraceSegment(""),
+      encodeStartupTraceSegment("~"),
+    ];
+
+    expect(encoded).toEqual([
+      "plugin~003Atest",
+      "plugin_test",
+      "service~002Fa",
+      "service_a",
+      "~",
+      "~007E",
+    ]);
+    expect(new Set(encoded).size).toBe(encoded.length);
+  });
+});

--- a/src/plugins/startup-trace-segment.ts
+++ b/src/plugins/startup-trace-segment.ts
@@ -1,0 +1,17 @@
+const SAFE_STARTUP_TRACE_SEGMENT_CHAR = /^[A-Za-z0-9_-]$/u;
+
+export function encodeStartupTraceSegment(value: string): string {
+  if (!value) {
+    return "~";
+  }
+  let encoded = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index] ?? "";
+    if (SAFE_STARTUP_TRACE_SEGMENT_CHAR.test(char)) {
+      encoded += char;
+      continue;
+    }
+    encoded += `~${value.charCodeAt(index).toString(16).toUpperCase().padStart(4, "0")}`;
+  }
+  return encoded;
+}


### PR DESCRIPTION
## Summary

- Problem: gateway startup traces grouped large phases together, and plugin/service ownership keys were either missing or previously risked lossy path-segment collisions.
- Why it matters: startup performance work needs stable attribution by auth phase, plugin load/register phase, lookup-table size, and sidecar service owner.
- What changed: added fine-grained startup trace details for auth bootstrap, plugin loader load/register timings and failure counts, plugin lookup/load counts, and plugin sidecar service spans with non-colliding encoded owner segments.
- What did NOT change (scope boundary): no gateway startup behavior, plugin registration behavior, config behavior, or setup-runtime branch contract was changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: default gateway startup now emits ownership-level trace keys for auth subphases, plugin load/register phases, lookup/load counts, and plugin sidecar services.
- Real environment tested: local macOS/Darwin 25.4.0 arm64, Node v24.14.0, pnpm 11.1.0.
- Exact steps or command run after this patch: `node --import tsx scripts/bench-gateway-startup.ts --case default --runs 1 --output .artifacts/gateway-startup-default-observability-runs1-20260514-pr-proof.json`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
[gateway-startup-bench] default run 1/1: healthz=2289.3ms readyz=2594.0ms readyLog=2209.2ms cpu=3050.0ms cpuCore=1.176 rss=659.3MB heap=181.4MB
trace top:
  config.auth.secrets-activate: p50=304.4ms avg=304.4ms min=304.4ms max=304.4ms
  sidecars.plugin-services.acpx.acpx-runtime: p50=237.3ms avg=237.3ms min=237.3ms max=237.3ms
  plugins.gateway-load.loadMs: p50=193.8ms avg=193.8ms min=193.8ms max=193.8ms
```

Additional parsed trace values from the same output JSON:

```json
{
  "sidecarServiceCount": 4,
  "sidecarStartedCount": 4,
  "sidecarFailedCount": 0,
  "pluginCount": 8,
  "lookupStartupPluginCount": 8,
  "acpxLoadMs": 25.4,
  "acpxRegisterMs": 0.2,
  "acpxLoadFailedCount": 0,
  "acpxRegisterFailedCount": 0
}
```

- Observed result after fix: `/healthz` and `/readyz` stayed healthy, and the generated startup trace included the new per-owner and count fields.
- What was not tested: setup-runtime branch-specific extra module load attribution; this is deferred below because default gateway startup does not take that path.
- Before evidence (optional but encouraged): previous default bench output only exposed coarser groups such as `config.auth`, `sidecars.plugin-services`, and aggregate plugin load spans.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `startupTrace` was available at the gateway level but not passed into several lower-level startup owners, and owner ids were not encoded with a stable non-colliding segment format.
- Missing detection / guardrail: loader/service tests did not assert emitted startup trace keys or failure-status metrics.
- Contributing context (if known): performance work needs ownership-level traces before it can safely distinguish real startup cost from aggregate phase noise.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/startup-trace-segment.test.ts`, `src/plugins/services.test.ts`, `src/plugins/loader.test.ts`, `src/gateway/server-startup-config.secrets.test.ts`.
- Scenario the test should lock in: non-colliding trace segment encoding, per-service trace spans and summary counts, loader load/register timing and failure counts, and config auth subphase measurement order.
- Why this is the smallest reliable guardrail: the behavior is internal trace emission, so direct unit/seam assertions catch regressions without requiring a full gateway process for every edge case.
- Existing test that already covers this (if any): N/A; this PR adds the targeted assertions.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Gateway behavior is unchanged. Startup bench and trace consumers can now see additional attribution keys.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[gateway startup] -> [coarse config/plugin/sidecar trace groups]

After:
[gateway startup] -> [auth subphase keys] -> [plugin load/register owner keys] -> [sidecar service owner keys] -> [counts and failure dimensions]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Darwin 25.4.0 arm64
- Runtime/container: Node v24.14.0, pnpm 11.1.0
- Model/provider: N/A
- Integration/channel (if any): gateway startup default bench
- Relevant config (redacted): default startup benchmark config

### Steps

1. Run `node scripts/run-vitest.mjs src/plugins/startup-trace-segment.test.ts src/plugins/services.test.ts src/plugins/loader.test.ts src/gateway/server-startup-config.secrets.test.ts`.
2. Run `pnpm check:changed`.
3. Run `pnpm build`.
4. Run `node --import tsx scripts/bench-gateway-startup.ts --case default --runs 1 --output .artifacts/gateway-startup-default-observability-runs1-20260514-pr-proof.json`.
5. Run `command codex review --base origin/main`.

### Expected

- Tests and changed checks pass.
- Gateway startup bench reaches `/healthz` and `/readyz`.
- Startup trace output contains auth subphase keys, per-plugin load/register keys, plugin/service count keys, sidecar service owner keys, and failure-count dimensions.

### Actual

- `node scripts/run-vitest.mjs src/plugins/startup-trace-segment.test.ts src/plugins/services.test.ts src/plugins/loader.test.ts src/gateway/server-startup-config.secrets.test.ts`: 4 files passed, 145 tests passed.
- `pnpm check:changed`: passed.
- `pnpm build`: passed.
- `command codex review --base origin/main`: no findings; its verification also passed the focused Vitest files and `git diff --check`.
- Startup bench reached `/healthz` 200 and `/readyz` 200 with the trace fields shown above.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused Vitest coverage, changed check, build, real default gateway startup bench, parsed trace keys from generated bench JSON, and local Codex review.
- Edge cases checked: lossy trace-key collision between punctuation and underscore ids, service start failures, plugin load failures, plugin register failures, and auth secret activation phase tracing.
- What you did **not** verify: setup-runtime branch-specific extra module load attribution and cross-OS startup bench behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No existing GitHub bot review conversations exist for this new PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: additional trace keys increase startup trace cardinality.
  - Mitigation: keys are bounded to configured startup plugins/services and use stable encoded owner segments.
- Risk: timing wrappers could accidentally change startup behavior.
  - Mitigation: wrappers return the original callback result and focused tests cover normal, failure, and auth-preflight paths.

## Considered and deferred

- src/plugins/loader.ts:2115 [BOT-SCOPE]: The setup-runtime branch still performs an extra branch-specific runtime load outside this per-plugin load/register timing split; default gateway startup does not take that path, and covering it belongs in a focused follow-up trace contract/test.
