### PR TITLE
fix(codex): hide empty rate-limit buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - Discord: honor `threadName` on `message send` to existing threads by renaming the thread after successful delivery, and warn when the rename cannot be applied. Fixes #81836. (#81933) Thanks @joshavant.
 - Build: keep externalized Slack, OpenShell sandbox, and Anthropic Vertex runtime dependency declarations out of the root dist artifact build.
 - ClawHub: include Amazon Bedrock and Bedrock Mantle provider packages in the published registry metadata so the externalized providers are discoverable from ClawHub as well as npm.
+- Codex account/status: hide empty rate-limit buckets and show server-reported usage-limit blocks without calling them available.
 - Auto-reply/Claude CLI: bridge CLI-runtime assistant text-delta agent events into the chat reasoning preview through `onReasoningStream`, mirroring the existing assistant-text (#76914) and tool-event (#80046) bridges and adding gating so non-CLI runtimes are unaffected. Thanks @anagnorisis2peripeteia and @pashpashpash.
 - Mantis: keep QA evidence in Actions artifacts only and stop publishing evidence files to Git-backed artifact branches.
 - CLI/migrate: handle delayed Codex plugin marketplace responses so warnings, next-steps, and conflict states render with ⚠️ glyphs and post-install migration retries the marketplace fetch instead of silently skipping plugin items. (#81625) Thanks @sjf.

--- a/extensions/codex/src/app-server/rate-limits.test.ts
+++ b/extensions/codex/src/app-server/rate-limits.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   formatCodexUsageLimitErrorMessage,
   resolveCodexUsageLimitResetAtMs,
-  summarizeCodexRateLimits,
   summarizeCodexAccountUsage,
+  summarizeCodexRateLimits,
 } from "./rate-limits.js";
 
 describe("formatCodexUsageLimitErrorMessage", () => {
@@ -94,5 +94,58 @@ describe("summarizeCodexRateLimits", () => {
         nowMs,
       ),
     ).toBe("Codex: primary 74% left ⏱3h · secondary 96% left ⏱7d");
+  });
+
+  it("ignores empty named buckets instead of showing them as available limits", () => {
+    const nowMs = 1_700_000_000_000;
+    const payload = {
+      rateLimitsByLimitId: {
+        premium: {
+          limitId: "premium",
+          limitName: "premium",
+          primary: null,
+          secondary: null,
+          credits: null,
+          planType: "pro",
+          rateLimitReachedType: null,
+        },
+        codex: {
+          limitId: "codex",
+          limitName: "Codex",
+          primary: {
+            usedPercent: 5,
+            windowDurationMins: 300,
+            resetsAt: Math.ceil(nowMs / 1000) + 3600,
+          },
+          secondary: null,
+          credits: null,
+          planType: "pro",
+          rateLimitReachedType: null,
+        },
+      },
+    };
+
+    expect(summarizeCodexRateLimits(payload, nowMs)).toContain("Codex: primary 95% left ⏱1h");
+    expect(summarizeCodexRateLimits(payload, nowMs)).not.toContain("premium");
+    expect(summarizeCodexAccountUsage(payload, nowMs)?.usageLine).toBe("short-term 5%");
+  });
+
+  it("does not render a server-reported usage-limit block as available", () => {
+    const payload = {
+      rateLimits: {
+        limitId: "codex",
+        limitName: "Codex",
+        primary: null,
+        secondary: null,
+        credits: null,
+        rateLimitReachedType: "rate_limit_reached",
+      },
+    };
+
+    expect(summarizeCodexRateLimits(payload, 1_700_000_000_000)).toBe("Codex: rate limit reached");
+    expect(summarizeCodexAccountUsage(payload, 1_700_000_000_000)).toMatchObject({
+      blocked: true,
+      blockingReason: "Codex usage limit is reached",
+    });
   });
 });

--- a/extensions/codex/src/app-server/rate-limits.ts
+++ b/extensions/codex/src/app-server/rate-limits.ts
@@ -71,14 +71,19 @@ export function summarizeCodexRateLimits(
   value: JsonValue | undefined,
   nowMs = Date.now(),
 ): string | undefined {
-  const snapshots = collectCodexRateLimitSnapshots(value);
+  const snapshots = collectCodexRateLimitSnapshots(value).filter(snapshotHasDisplayableData);
   if (snapshots.length === 0) {
     return undefined;
   }
-  return snapshots
+  const summaries = snapshots
     .slice(0, 4)
     .map((snapshot) => summarizeRateLimitSnapshot(snapshot, nowMs))
-    .join("; ");
+    .filter((summary): summary is string => summary !== undefined);
+  return summaries.length > 0 ? summaries.join("; ") : undefined;
+}
+
+export function hasCodexRateLimitSnapshots(value: JsonValue | undefined): boolean {
+  return collectCodexRateLimitSnapshots(value).length > 0;
 }
 
 export function summarizeCodexAccountRateLimits(
@@ -113,7 +118,7 @@ export function summarizeCodexAccountUsage(
   value: JsonValue | undefined,
   nowMs = Date.now(),
 ): CodexAccountUsageSummary | undefined {
-  const snapshots = collectCodexRateLimitSnapshots(value);
+  const snapshots = collectCodexRateLimitSnapshots(value).filter(snapshotHasDisplayableData);
   if (snapshots.length === 0) {
     return undefined;
   }
@@ -192,7 +197,7 @@ function selectBlockingRateLimitReset(
   return blockingSnapshot ? selectSnapshotBlockingReset(blockingSnapshot, nowMs) : undefined;
 }
 
-function summarizeRateLimitSnapshot(snapshot: JsonObject, nowMs: number): string {
+function summarizeRateLimitSnapshot(snapshot: JsonObject, nowMs: number): string | undefined {
   const label = formatLimitLabel(snapshot);
   const windows = LIMIT_WINDOW_KEYS.flatMap((key) => {
     const window = readRateLimitWindow(snapshot, key);
@@ -201,7 +206,13 @@ function summarizeRateLimitSnapshot(snapshot: JsonObject, nowMs: number): string
   const reachedType =
     readString(snapshot, "rateLimitReachedType") ?? readString(snapshot, "rate_limit_reached_type");
   const suffix = reachedType ? ` (${formatReachedType(reachedType)})` : "";
-  return `${label}: ${windows.join(" · ") || "available"}${suffix}`;
+  if (windows.length > 0) {
+    return `${label}: ${windows.join(" · ")}${suffix}`;
+  }
+  if (reachedType) {
+    return `${label}: ${formatReachedType(reachedType)}`;
+  }
+  return undefined;
 }
 
 function collectCodexRateLimitSnapshots(value: JsonValue | undefined): JsonObject[] {
@@ -312,6 +323,18 @@ function readRateLimitWindow(
       "window_minutes",
     ),
   };
+}
+
+function snapshotHasDisplayableData(snapshot: JsonObject): boolean {
+  if (
+    readString(snapshot, "rateLimitReachedType") ??
+    readString(snapshot, "rate_limit_reached_type")
+  ) {
+    return true;
+  }
+  return readWindowEntries(snapshot).some(
+    (entry) => entry.window.usedPercent !== undefined || entry.window.resetsAtMs > 0,
+  );
 }
 
 function readOptionalNumberField(

--- a/extensions/codex/src/command-formatters.ts
+++ b/extensions/codex/src/command-formatters.ts
@@ -2,6 +2,7 @@ import type { CodexComputerUseStatus } from "./app-server/computer-use.js";
 import type { CodexAppServerModelListResult } from "./app-server/models.js";
 import { isJsonObject, type JsonObject, type JsonValue } from "./app-server/protocol.js";
 import {
+  hasCodexRateLimitSnapshots,
   summarizeCodexAccountRateLimits,
   summarizeCodexRateLimits,
 } from "./app-server/rate-limits.js";
@@ -349,13 +350,21 @@ function summarizeArrayLike(value: JsonValue | undefined): string {
 }
 
 function formatCodexRateLimitSummary(value: JsonValue | undefined): string {
-  return formatCodexDisplayText(summarizeCodexRateLimits(value) ?? summarizeRateLimits(value));
+  const summary = summarizeCodexRateLimits(value);
+  if (summary) {
+    return formatCodexDisplayText(summary);
+  }
+  return formatCodexDisplayText(
+    hasCodexRateLimitSnapshots(value) ? "none returned" : summarizeRateLimits(value),
+  );
 }
 
 function formatCodexRateLimitDetails(value: JsonValue | undefined): string {
   const lines = summarizeCodexAccountRateLimits(value);
   if (!lines) {
-    return formatCodexDisplayText(summarizeRateLimits(value));
+    return formatCodexDisplayText(
+      hasCodexRateLimitSnapshots(value) ? "none returned" : summarizeRateLimits(value),
+    );
   }
   return lines.map(formatCodexDisplayText).join("\n");
 }

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -643,6 +643,51 @@ describe("codex command", () => {
     expectResultTextContains(accountResult, "Codex is available.");
   });
 
+  it("does not count empty Codex rate-limit buckets as returned limits", async () => {
+    const limits = {
+      ok: true as const,
+      value: {
+        rateLimitsByLimitId: {
+          premium: {
+            limitId: "premium",
+            limitName: "premium",
+            primary: null,
+            secondary: null,
+            credits: null,
+            planType: "pro",
+            rateLimitReachedType: null,
+          },
+        },
+      },
+    };
+    const deps = createDeps({
+      readCodexStatusProbes: vi.fn(async () => ({
+        models: { ok: false as const, error: "offline" },
+        account: { ok: false as const, error: "offline" },
+        limits,
+        mcps: { ok: true as const, value: { data: [], nextCursor: null } },
+        skills: { ok: true as const, value: { data: [] } },
+      })),
+      safeCodexControlRequest: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true as const,
+          value: { account: { email: "codex@example.com" } },
+        })
+        .mockResolvedValueOnce(limits),
+    });
+
+    const statusResult = await handleCodexCommand(createContext("status"), { deps });
+    expectResultTextContains(statusResult, "Rate limits: none returned");
+    expect(statusResult.text).not.toContain("Rate limits: 1");
+    expect(statusResult.text).not.toContain("premium");
+
+    const accountResult = await handleCodexCommand(createContext("account"), { deps });
+    expectResultTextContains(accountResult, "Rate limits: none returned");
+    expect(accountResult.text).not.toContain("Rate limits: 1");
+    expect(accountResult.text).not.toContain("premium");
+  });
+
   it("rejects extra operands for read-only Codex commands", async () => {
     const readCodexStatusProbes = vi.fn();
     const listCodexAppServerModels = vi.fn();


### PR DESCRIPTION
## Summary

- Hide empty Codex rate-limit buckets from account/status summaries instead of rendering them as available.
- Preserve server-reported Codex usage-limit blocks even when the payload has no usable percentage/reset window.
- Prevent recognized-but-empty Codex rate-limit payloads from falling back to the generic `Rate limits: 1` counter.
- Add focused app-server and command formatter coverage for empty premium buckets, reachedType-only blocks, and the `/codex status` + `/codex account` formatter path.

## Verification

- `node_modules/.bin/oxfmt --check CHANGELOG.md extensions/codex/src/app-server/rate-limits.ts extensions/codex/src/app-server/rate-limits.test.ts extensions/codex/src/command-formatters.ts extensions/codex/src/commands.test.ts`
- `git diff --check origin/main...HEAD`
- `node --import tsx --eval '<Codex rate-limit display smoke>'`
- GitHub CI `25893563666` on `54981d6fe7db6f8745394559ad2f7036f872e425`: passed, including `check`, `check-lint`, `check-prod-types`, `check-test-types`, `checks-fast-bundled`, and `build-artifacts`.
- GitHub CodeQL Critical Quality `25893563673` on `54981d6fe7db6f8745394559ad2f7036f872e425`: passed or skipped all selected shards.
- GitHub Real behavior proof `25893562703`: passed.

## Real behavior proof

Behavior addressed: Codex account/status summaries no longer show empty buckets such as `premium` as available limits or as generic `Rate limits: 1`, while server usage-limit blocks still display as blocked instead of looking healthy.

Real environment tested: GitHub CI on the OpenClaw pull-request branch, plus a local TypeScript smoke import of the Codex app-server rate-limit summarizer.

Exact steps or command run after this patch: `node --import tsx --eval '<Codex rate-limit display smoke>'`, `node_modules/.bin/oxfmt --check CHANGELOG.md extensions/codex/src/app-server/rate-limits.ts extensions/codex/src/app-server/rate-limits.test.ts extensions/codex/src/command-formatters.ts extensions/codex/src/commands.test.ts`, and the GitHub CI workflows listed above on `54981d6fe7db6f8745394559ad2f7036f872e425`.

Evidence after fix: the smoke asserted that empty `premium` buckets are omitted, valid Codex usage windows render as `Codex: primary 95% left ⏱1h`, account usage reports `short-term 5%`, and a server `rate_limit_reached` payload without windows marks account usage as blocked. GitHub CI passed the full selected PR gate on the same head SHA.

Observed result after fix: empty named buckets are omitted from the display summary, recognized-but-empty Codex payloads render as `Rate limits: none returned` in status/account instead of `Rate limits: 1`, valid Codex usage windows still summarize normally, and a server `rate_limit_reached` payload without windows is surfaced as `Codex: rate limit reached` with account usage marked blocked.

What was not tested: no live Codex backend OAuth session was exercised; this patch is limited to OpenClaw’s local rendering/classification of already-received rate-limit payloads. A direct local Vitest wrapper run in this linked Codex worktree was blocked by stale shared dependencies after `@openclaw/proxyline` landed on `main`, so the merge gate relies on GitHub CI for the full test environment.
