### PR TITLE
fix: validate configured agent runtime ids

### DIFF
--- a/src/config/config.agent-runtime-validation.test.ts
+++ b/src/config/config.agent-runtime-validation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { validateConfigObjectWithPlugins } from "./validation.js";
+
+function createPluginRecord(
+  partial: Pick<PluginManifestRecord, "id"> & Partial<PluginManifestRecord>,
+): PluginManifestRecord {
+  return {
+    channels: [],
+    providers: [],
+    cliBackends: [],
+    skills: [],
+    hooks: [],
+    origin: "bundled",
+    rootDir: `/fake/${partial.id}`,
+    source: `/fake/${partial.id}/index.js`,
+    manifestPath: `/fake/${partial.id}/openclaw.plugin.json`,
+    ...partial,
+  };
+}
+
+function createRegistry(plugins: PluginManifestRecord[]): PluginManifestRegistry {
+  return { plugins, diagnostics: [] };
+}
+
+describe("agent runtime config validation", () => {
+  it("rejects provider ids used as provider-scoped agent runtime ids", () => {
+    const result = validateConfigObjectWithPlugins(
+      {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com/v1",
+              agentRuntime: { id: "anthropic" },
+              models: [],
+            },
+          },
+        },
+      },
+      {
+        pluginMetadataSnapshot: {
+          manifestRegistry: createRegistry([
+            createPluginRecord({
+              id: "anthropic",
+              providers: ["anthropic"],
+              cliBackends: ["claude-cli"],
+            }),
+          ]),
+        },
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual({
+        path: "models.providers.anthropic.agentRuntime.id",
+        message:
+          'unknown agent runtime "anthropic"; "anthropic" is a provider id, not an agent runtime. Use "claude-cli" for this plugin CLI runtime, or remove agentRuntime to use the provider through the default PI runtime.',
+      });
+    }
+  });
+
+  it("rejects unknown model-scoped agent runtime ids", () => {
+    const result = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-sonnet-4-6": {
+                agentRuntime: { id: "missing-runtime" },
+              },
+            },
+          },
+        },
+      },
+      {
+        pluginMetadataSnapshot: {
+          manifestRegistry: createRegistry([
+            createPluginRecord({
+              id: "anthropic",
+              providers: ["anthropic"],
+              cliBackends: ["claude-cli"],
+            }),
+          ]),
+        },
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual({
+        path: "agents.defaults.models.anthropic/claude-sonnet-4-6.agentRuntime.id",
+        message:
+          'unknown agent runtime "missing-runtime". Use a registered agent runtime id such as pi, or remove agentRuntime for automatic selection.',
+      });
+    }
+  });
+});

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -41,6 +41,7 @@ import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-con
 import { collectChannelSchemaMetadata } from "./channel-config-metadata.js";
 import { materializeRuntimeConfig } from "./materialize.js";
 import { collectConfiguredModelRefs } from "./model-refs.js";
+import type { AgentRuntimePolicyConfig } from "./types.agents-shared.js";
 import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { coerceSecretRef } from "./types.secrets.js";
 import { OpenClawSchema } from "./zod-schema.js";
@@ -555,6 +556,118 @@ function isWorkspaceAvatarPath(value: string, workspaceDir: string): boolean {
   const workspaceRoot = path.resolve(workspaceDir);
   const resolved = path.resolve(workspaceRoot, value);
   return isPathWithinRoot(workspaceRoot, resolved);
+}
+
+type AgentRuntimePolicyEntry = {
+  path: string;
+  policy?: AgentRuntimePolicyConfig;
+};
+
+function collectAgentRuntimePolicyEntries(config: OpenClawConfig): AgentRuntimePolicyEntry[] {
+  const entries: AgentRuntimePolicyEntry[] = [];
+  for (const [providerId, providerConfig] of Object.entries(config.models?.providers ?? {})) {
+    entries.push({
+      path: `models.providers.${providerId}.agentRuntime.id`,
+      policy: providerConfig?.agentRuntime,
+    });
+    for (const [index, modelConfig] of (providerConfig?.models ?? []).entries()) {
+      entries.push({
+        path: `models.providers.${providerId}.models.${index}.agentRuntime.id`,
+        policy: modelConfig?.agentRuntime,
+      });
+    }
+  }
+  const pushModelMapEntries = (models: unknown, pathPrefix: string): void => {
+    if (!isRecord(models)) {
+      return;
+    }
+    for (const [modelRef, entry] of Object.entries(models)) {
+      if (!isRecord(entry)) {
+        continue;
+      }
+      entries.push({
+        path: `${pathPrefix}.${modelRef}.agentRuntime.id`,
+        policy: isRecord(entry.agentRuntime)
+          ? (entry.agentRuntime as AgentRuntimePolicyConfig)
+          : undefined,
+      });
+    }
+  };
+  pushModelMapEntries(config.agents?.defaults?.models, "agents.defaults.models");
+  if (Array.isArray(config.agents?.list)) {
+    for (const [index, agent] of config.agents.list.entries()) {
+      pushModelMapEntries(agent?.models, `agents.list.${index}.models`);
+    }
+  }
+  return entries;
+}
+
+function collectAgentRuntimeValidationIssues(params: {
+  config: OpenClawConfig;
+  registry: PluginManifestRegistry;
+}): ConfigValidationIssue[] {
+  const runtimeOwners = new Map<string, Set<string>>();
+  const providerOwners = new Map<string, Set<string>>();
+  const appendOwner = (map: Map<string, Set<string>>, key: string, pluginId: string): void => {
+    const normalized = normalizeLowercaseStringOrEmpty(key);
+    if (!normalized) {
+      return;
+    }
+    const owners = map.get(normalized) ?? new Set<string>();
+    owners.add(pluginId);
+    map.set(normalized, owners);
+  };
+
+  for (const plugin of params.registry.plugins) {
+    for (const runtime of [...(plugin.activation?.onAgentHarnesses ?? []), ...plugin.cliBackends]) {
+      appendOwner(runtimeOwners, runtime, plugin.id);
+    }
+    for (const providerId of plugin.providers) {
+      appendOwner(providerOwners, providerId, plugin.id);
+    }
+  }
+
+  const knownRuntimes = new Set(["auto", "default", "pi"]);
+  for (const runtime of runtimeOwners.keys()) {
+    knownRuntimes.add(runtime);
+  }
+
+  const issues: ConfigValidationIssue[] = [];
+  for (const entry of collectAgentRuntimePolicyEntries(params.config)) {
+    const rawRuntime = entry.policy?.id;
+    if (typeof rawRuntime !== "string") {
+      continue;
+    }
+    const runtime = normalizeLowercaseStringOrEmpty(rawRuntime);
+    if (!runtime || knownRuntimes.has(runtime)) {
+      continue;
+    }
+    const providerPluginIds = providerOwners.get(runtime);
+    const suggestedRuntimes =
+      providerPluginIds && providerPluginIds.size > 0
+        ? [...runtimeOwners.entries()]
+            .filter(([, pluginIds]) =>
+              [...providerPluginIds].some((pluginId) => pluginIds.has(pluginId)),
+            )
+            .map(([candidate]) => candidate)
+            .toSorted((left, right) => left.localeCompare(right))
+        : [];
+    const suggestion =
+      suggestedRuntimes.length === 1
+        ? ` Use "${suggestedRuntimes[0]}" for this plugin CLI runtime, or remove agentRuntime to use the provider through the default PI runtime.`
+        : suggestedRuntimes.length > 1
+          ? ` Use one of ${suggestedRuntimes.map((value) => `"${value}"`).join(", ")}, or remove agentRuntime to use the provider through the default PI runtime.`
+          : " Use a registered agent runtime id such as pi, or remove agentRuntime for automatic selection.";
+    const providerHint = providerPluginIds
+      ? `; "${runtime}" is a provider id, not an agent runtime`
+      : "";
+    issues.push({
+      path: entry.path,
+      message: `unknown agent runtime "${rawRuntime}"${providerHint}.${suggestion}`,
+    });
+  }
+
+  return issues;
 }
 
 function validateIdentityAvatar(config: OpenClawConfig): ConfigValidationIssue[] {
@@ -1337,6 +1450,15 @@ function validateConfigObjectWithPluginsBase(
 
   validateWebSearchProvider();
   validateConfiguredModelRefs();
+
+  if (registryInfo) {
+    issues.push(
+      ...collectAgentRuntimeValidationIssues({
+        config,
+        registry: registryInfo.registry,
+      }),
+    );
+  }
 
   if (!hasExplicitPluginsConfig) {
     if (issues.length > 0) {


### PR DESCRIPTION
## Summary

- Problem: provider/model-scoped `agentRuntime.id` accepted arbitrary strings, so configs that used a provider id such as `anthropic` passed validation and failed later at message time with `Requested agent harness "anthropic" is not registered`.
- Why it matters: this made the Anthropic API-key path look like a plugin load failure instead of a config-layer provider/runtime mixup.
- What changed: plugin-aware config validation now checks provider/model-scoped agent runtime ids against registered plugin harness ids and CLI backend ids, with a specific hint when a provider id is used as a runtime id.
- What did NOT change: `anthropic` is still a provider id, not an agent harness; legacy whole-agent runtime keys remain ignored by runtime selection.

## Change Type

- [x] Bug fix

## Scope

- [x] API / contracts
- [x] UI / DX

## Linked Issue/PR

- Closes #81649
- [x] This PR fixes a bug or regression

## Real behavior proof

Behavior addressed: `openclaw config validate`/plugin-aware config validation now rejects provider/model-scoped `agentRuntime.id: "anthropic"` with actionable guidance before the gateway reaches agent harness selection.
Real environment tested: macOS source checkout, Node 22.22.2, pnpm 11.1.0, local OpenClaw repo.
Exact steps or command run after this patch: `pnpm test src/config/config.agent-runtime-validation.test.ts src/agents/harness/selection.test.ts src/agents/harness-runtimes.test.ts`; `pnpm check:changed`; `git diff --check HEAD`.
Evidence after fix: targeted Vitest run passed 3 shards with 26 tests; `pnpm check:changed` passed core typecheck, core lint, and runtime guards; `git diff --check HEAD` exited 0.
Observed result after fix: invalid provider/model-scoped runtime ids are validation issues, and `anthropic` specifically reports that it is a provider id and suggests `claude-cli` or removing `agentRuntime` for PI/default routing.
What was not tested: a full packaged gateway run with a real Anthropic API key; no network/model call was needed because the bug is in config validation before provider execution.
Before evidence: temporarily removing the new validation call made `pnpm test src/config/config.agent-runtime-validation.test.ts` fail both regression tests because validation returned ok.

## Root Cause

- Root cause: config schema allowed arbitrary `agentRuntime.id` strings, while runtime selection later fails closed for unknown non-PI runtimes.
- Missing detection / guardrail: plugin-aware validation did not verify provider/model-scoped runtime ids against plugin runtime ownership metadata.
- Contributing context: Anthropic declares provider `anthropic` and CLI backend `claude-cli`; using `anthropic` as the runtime id mixes provider and runtime layers.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `src/config/config.agent-runtime-validation.test.ts`
- Scenario the test should lock in: provider ids such as `anthropic` are rejected when used as provider/model-scoped `agentRuntime.id`, and unknown runtime ids are rejected before message-time harness selection.
- Why this is the smallest reliable guardrail: plugin-aware config validation is the first layer with access to plugin provider/runtime declarations.
- Existing test that already covers this: `src/agents/harness/selection.test.ts` covers the later fail-closed selection path but not config validation.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw config validate` can now fail earlier for invalid provider/model-scoped `agentRuntime.id` values such as `anthropic`, with guidance to use a real runtime id or remove the runtime override.

## Diagram

```text
Before:
config validate -> ok -> send message -> unknown harness error

After:
config validate -> unknown agent runtime issue -> fix config before gateway run
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.22.2, pnpm 11.1.0
- Model/provider: Anthropic config shape, no live model call
- Integration/channel: N/A
- Relevant config (redacted): provider/model-scoped `agentRuntime.id: "anthropic"`

### Steps

1. Configure a provider/model-scoped agent runtime id as `anthropic`.
2. Run plugin-aware config validation.
3. Observe validation result.

### Expected

- Validation rejects `anthropic` as an agent runtime and suggests the plugin-owned runtime, `claude-cli`, or removing the override.

### Actual

- Before this patch, validation passed and the error appeared later as `Requested agent harness "anthropic" is not registered`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

## Human Verification

- Verified scenarios: new regression tests fail without the validation call and pass with it; adjacent harness selection/runtime tests still pass; changed core check gate passes.
- Edge cases checked: provider id used as runtime; unknown model-scoped runtime; legacy whole-agent runtime semantics left untouched by using only provider/model-scoped entries.
- What you did **not** verify: live gateway message with real Anthropic credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes
- Migration needed? No
- If yes, exact upgrade steps: configs with invalid provider/model-scoped runtime ids now need to remove `agentRuntime` or use a registered runtime id such as `claude-cli` or `pi`.

## Risks and Mitigations

- Risk: a previously accepted but invalid config now fails validation earlier.
  - Mitigation: the error points to the exact config path and suggests the plugin-owned runtime when the value is a provider id.
