### PR TITLE
fix(skills): tolerate BOM-prefixed frontmatter

### DIFF
--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -370,10 +370,18 @@ describe("loadWorkspaceSkillEntries", () => {
       description: "Hidden prompt entry",
       frontmatterExtra: "disable-model-invocation: true",
     });
+    const bomSkillDir = path.join(workspaceDir, "skills", "bom-skill");
+    await fs.mkdir(bomSkillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(bomSkillDir, "SKILL.md"),
+      "\uFEFF---\nname: bom-skill\ndescription: BOM-prefixed skill\n---\n\n# BOM skill\n",
+      "utf8",
+    );
 
     const entries = loadTestWorkspaceSkillEntries(workspaceDir);
 
     expect(entries.map((entry) => entry.skill.name)).toContain("fallback-name");
+    expect(entries.map((entry) => entry.skill.name)).toContain("bom-skill");
     const hiddenEntry = entries.find((entry) => entry.skill.name === "hidden-skill");
 
     expect(hiddenEntry?.invocation?.disableModelInvocation).toBe(true);

--- a/src/markdown/frontmatter.test.ts
+++ b/src/markdown/frontmatter.test.ts
@@ -101,4 +101,12 @@ metadata:
     const content = "# No frontmatter";
     expect(parseFrontmatterBlock(content)).toStrictEqual({});
   });
+
+  it("parses frontmatter after a leading UTF-8 BOM", () => {
+    const content = "\uFEFF---\nname: windows-skill\ndescription: Written by PowerShell\n---\n";
+    const result = parseFrontmatterBlock(content);
+
+    expect(result.name).toBe("windows-skill");
+    expect(result.description).toBe("Written by PowerShell");
+  });
 });

--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -181,7 +181,10 @@ function shouldPreferInlineLineValue(params: {
 }
 
 function extractFrontmatterBlock(content: string): string | undefined {
-  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const normalized = content
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
   if (!normalized.startsWith("---")) {
     return undefined;
   }


### PR DESCRIPTION
Fixes #66479

## Summary
- strip one leading UTF-8 BOM before shared markdown frontmatter delimiter detection
- add parser coverage for BOM-prefixed frontmatter
- add workspace skill discovery coverage proving a BOM-prefixed `SKILL.md` is still listed

## Real behavior proof
Behavior or issue addressed: Workspace skills whose `SKILL.md` starts with a UTF-8 BOM before `---` should still have frontmatter parsed and appear in `openclaw skills list`.

Real environment tested: Local OpenClaw CLI from this PR branch (`node scripts/run-node.mjs`, commit `38460b2`) on macOS with an isolated `OPENCLAW_HOME` containing a real workspace skill file written with leading BOM bytes (`EF BB BF`).

Exact steps or command run after this patch:

```sh
tmp=$(mktemp -d "${TMPDIR:-/tmp}/openclaw-bom-proof.XXXXXX")
mkdir -p "$tmp/.openclaw/workspace/skills/bom-skill"
printf '\357\273\277---\nname: bom-skill\ndescription: BOM-prefixed workspace skill\n---\n\n# BOM skill\n' > "$tmp/.openclaw/workspace/skills/bom-skill/SKILL.md"
OPENCLAW_HOME="$tmp" HOME="$tmp" node scripts/run-node.mjs skills list --json | jq '{workspaceDir, bomSkill: (.skills[] | select(.name == "bom-skill") | {name, description, eligible, source, commandVisible})}'
```

Evidence after fix: Terminal output from the command above:

```json
{
  "workspaceDir": "/var/folders/qg/ftvdj43s1b79kv3g92r9yzsm0000gn/T/openclaw-bom-proof.9iUyec/.openclaw/workspace",
  "bomSkill": {
    "name": "bom-skill",
    "description": "BOM-prefixed workspace skill",
    "eligible": true,
    "source": "openclaw-workspace",
    "commandVisible": true
  }
}
```

Observed result after fix: The BOM-prefixed `SKILL.md` is discovered as `bom-skill`, its description is parsed from frontmatter, and it is visible as an eligible workspace skill.

What was not tested: I did not run the command on Windows or through PowerShell `WriteAllText`; the runtime proof uses the same BOM byte prefix and the shared parser/CLI skill discovery path on macOS.

## Verification
- `node scripts/run-vitest.mjs src/markdown/frontmatter.test.ts src/agents/skills.loadworkspaceskillentries.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/markdown/frontmatter.ts src/markdown/frontmatter.test.ts src/agents/skills.loadworkspaceskillentries.test.ts`
- `git diff --check origin/main...HEAD`
- `CI=1 pnpm check:changed`
