### PR TITLE
fix(daemon): recognize shell-wrapped gateway commands in service audit

### DIFF
--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -460,6 +460,54 @@ describe("auditGatewayServiceConfig", () => {
 
     expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayProxyEnvEmbedded)).toBe(true);
   });
+
+  it("does not flag gateway-command-missing for shell-wrapped LaunchAgent using zsh -lc", async () => {
+    // Reproduces the pattern reported in #81751:
+    // LaunchAgent ProgramArguments = ["/bin/zsh", "-lc",
+    //   "set -a; [ -f $HOME/.config/api-keys.env ] && . ...; exec .../openclaw/dist/index.js gateway --port 18890"]
+    const shellCmd =
+      "set -a; [ -f \"$HOME/.config/api-keys.env\" ] && . \"$HOME/.config/api-keys.env\"; " +
+      "set +a; unset OPENCLAW_GATEWAY_TOKEN; " +
+      "exec /opt/homebrew/opt/node/bin/node /Users/antonio/.npm-global/lib/node_modules/openclaw/dist/index.js gateway --port 18890";
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "darwin",
+      expectedPort: 18890,
+      command: {
+        programArguments: ["/bin/zsh", "-lc", shellCmd],
+        environment: {},
+      },
+    });
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayCommandMissing)).toBe(false);
+  });
+
+  it("does not flag gateway-command-missing for shell-wrapped LaunchAgent using /bin/sh -c", async () => {
+    const shellCmd =
+      ". /tmp/openclaw-env.sh && exec /usr/local/bin/node /opt/openclaw/dist/index.js gateway --port 18889";
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "darwin",
+      expectedPort: 18889,
+      command: {
+        programArguments: ["/bin/sh", "-c", shellCmd],
+        environment: {},
+      },
+    });
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayCommandMissing)).toBe(false);
+  });
+
+  it("still flags gateway-command-missing when the shell inline command does not contain gateway", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "darwin",
+      expectedPort: 18888,
+      command: {
+        programArguments: ["/bin/sh", "-c", "exec /usr/local/bin/node /opt/openclaw/dist/index.js start"],
+        environment: {},
+      },
+    });
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayCommandMissing)).toBe(true);
+  });
 });
 
 describe("checkTokenDrift", () => {

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -70,8 +70,53 @@ export function needsNodeRuntimeMigration(issues: ServiceConfigIssue[]): boolean
   );
 }
 
+/**
+ * Returns true if the service command includes the `gateway` subcommand.
+ *
+ * Two layouts are recognised:
+ * 1. Direct invocation: `[..., "gateway", ...]` — any element equals `"gateway"`.
+ * 2. Shell-wrapped invocation: `["/bin/zsh", "-lc", "... gateway ..."]` — a
+ *    POSIX shell binary (`/bin/sh`, `/bin/bash`, `/bin/zsh`, `sh`, `bash`,
+ *    `zsh`) is invoked with `-c` or `-lc` flags and the inline shell command
+ *    string contains `gateway` as a word boundary match.
+ */
 function hasGatewaySubcommand(programArguments?: string[]): boolean {
-  return Boolean(programArguments?.some((arg) => arg === "gateway"));
+  if (!programArguments || programArguments.length === 0) {
+    return false;
+  }
+  // Fast path: any element is exactly "gateway"
+  if (programArguments.some((arg) => arg === "gateway")) {
+    return true;
+  }
+  // Shell-wrapped path: detect `/bin/sh -lc "... gateway ..."` style LaunchAgent
+  // wrappers. Match common POSIX shell binaries (bare names or full paths).
+  const SHELL_BASENAMES = new Set(["sh", "bash", "zsh", "dash", "fish"]);
+  const firstArg = programArguments[0];
+  if (!firstArg) {
+    return false;
+  }
+  const basename = firstArg.split("/").pop() ?? firstArg;
+  if (!SHELL_BASENAMES.has(basename)) {
+    return false;
+  }
+  // Look for a `-c` or shell option that precedes an inline command string.
+  // Common patterns: `-c`, `-lc`, `-login -c`, etc.
+  for (let i = 1; i < programArguments.length; i += 1) {
+    const arg = programArguments[i];
+    // If this element looks like a flag, keep scanning; if it looks like the
+    // inline command string (no leading dash), test it for the gateway word.
+    if (arg.startsWith("-")) {
+      // Accept -c, -lc, and other variants that include 'c' (inline command)
+      if (/c/.test(arg)) {
+        // The next element is the inline command string
+        const inlineCmd = programArguments[i + 1];
+        if (inlineCmd && /\bgateway\b/.test(inlineCmd)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }
 
 function parseSystemdUnit(content: string): {


### PR DESCRIPTION
## Problem

When a LaunchAgent's `ProgramArguments` uses a shell wrapper like:
```
["/bin/zsh", "-lc", "set -a; ...; exec .../openclaw/dist/index.js gateway --port 18890"]
```

`gateway status` reports:
```
Service config issue: Service command does not include the gateway subcommand
```

...even though the gateway is reachable and running correctly.

## Root Cause

`hasGatewaySubcommand()` checked if any element in `programArguments` **exactly equals** `"gateway"`. When the gateway binary is invoked inside a shell inline command (the third array element), `"gateway"` is embedded in a larger string — never a standalone token.

## Fix

Extended `hasGatewaySubcommand` with a secondary check: when `programArguments[0]` is a recognized POSIX shell (`sh`, `bash`, `zsh`, `dash`, `fish`), scan subsequent arguments for a `-c`/`-lc`/etc. flag, then test the following inline command string for `/\bgateway\b/`.

## Tests Added

Three new cases in `service-audit.test.ts`:
1. ✅ `/bin/zsh -lc` wrapper with gateway in the inline command → no false positive
2. ✅ `/bin/sh -c` wrapper with gateway in the inline command → no false positive  
3. ✅ `/bin/sh -c` wrapper **without** gateway → correctly flags `gateway-command-missing`

Fixes #81751