### PR TITLE
Fix Telegram cron HTML announce formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Security/sandbox: include Windows `USERPROFILE` in the sandbox blocked home roots so credential-bearing binds (such as `.codex`, `.openclaw`, or `.ssh` under the Windows user profile) are denied even when `HOME` points at a different shell home. (#63074) Thanks @luoyanglang.
 - Gateway/OpenAI-compatible HTTP: parse shared JSON endpoint paths without trusting malformed Host headers, avoiding 500s before `/v1/chat/completions`, `/v1/responses`, and `/v1/embeddings` request handling.
 - Telegram: keep Bot API polling alive during main event-loop stalls by moving ingress to an isolated worker with a durable local spool. Fixes #81132. (#81746) Thanks @joshavant.
+- Telegram: preserve rendered HTML formatting through lazy cron announce delivery so Markdown links stay clickable instead of falling back to literal anchor tags. Fixes #81742. (#81758)
 - Voice-call webhooks: parse webhook and realtime upgrade paths without trusting malformed Host headers, avoiding 500s before provider signature checks or path rejection.
 - Media store: reject malformed redirect `Location` headers as media-download failures instead of letting URL parsing escape the async response callback.
 - ClickClack: skip malformed realtime websocket frames instead of stopping the channel monitor on a single bad JSON event.

--- a/src/cli/send-runtime/channel-outbound-send.test.ts
+++ b/src/cli/send-runtime/channel-outbound-send.test.ts
@@ -89,6 +89,28 @@ describe("createChannelOutboundRuntimeSend", () => {
     expect(params.accountId).toBe("default");
   });
 
+  it("preserves rendered html formatting through lazy text sends", async () => {
+    const sendText = vi.fn(async () => ({ channel: "telegram", messageId: "tg-1" }));
+    mocks.loadChannelOutboundAdapter.mockResolvedValue({
+      sendText,
+    });
+
+    const { createChannelOutboundRuntimeSend } = await import("./channel-outbound-send.js");
+    const runtimeSend = createChannelOutboundRuntimeSend({
+      channelId: "telegram" as never,
+      unavailableMessage: "unavailable",
+    });
+    const opts = {
+      cfg: {},
+      textMode: "html" as const,
+    };
+
+    await runtimeSend.sendMessage("12345", '<a href="https://example.com">Example</a>', opts);
+
+    const params = expectSingleCallParams(sendText);
+    expect(params.formatting).toEqual({ parseMode: "HTML" });
+  });
+
   it("routes block sends through payload delivery", async () => {
     const sendPayload = vi.fn(async () => ({ channel: "slack", messageId: "slack-blocks" }));
     const sendText = vi.fn();

--- a/src/cli/send-runtime/channel-outbound-send.ts
+++ b/src/cli/send-runtime/channel-outbound-send.ts
@@ -2,6 +2,7 @@ import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { OutboundDeliveryFormattingOptions } from "../../infra/outbound/formatting.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 
@@ -20,8 +21,10 @@ type RuntimeSendOpts = {
   replyToMessageId?: string | number;
   silent?: boolean;
   forceDocument?: boolean;
+  formatting?: OutboundDeliveryFormattingOptions;
   gifPlayback?: boolean;
   gatewayClientScopes?: readonly string[];
+  textMode?: "markdown" | "html";
 };
 
 function resolveRuntimeThreadId(opts: RuntimeSendOpts): string | number | undefined {
@@ -55,6 +58,8 @@ export function createChannelOutboundRuntimeSend(params: {
         replyToId,
         silent: opts.silent,
         forceDocument: opts.forceDocument,
+        formatting:
+          opts.formatting ?? (opts.textMode === "html" ? { parseMode: "HTML" } : undefined),
         gifPlayback: opts.gifPlayback,
         gatewayClientScopes: opts.gatewayClientScopes,
       });


### PR DESCRIPTION
Summary:
- Preserve explicit HTML formatting through the CLI lazy channel sender.
- Add a regression proving rendered Telegram HTML is forwarded as `parseMode: HTML` instead of being reinterpreted as markdown.

Proof:
- Regression failed before the fix: `expected undefined to deeply equal { parseMode: 'HTML' }`.
- `pnpm test src/cli/send-runtime/channel-outbound-send.test.ts -- --reporter=verbose`
- `pnpm check:changed`

Fixes #81742
