### PR TITLE
[codex] Guard Codex abort marker attribution

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -48,6 +48,7 @@ import {
   buildTurnStartParams,
   startOrResumeThread,
 } from "./thread-lifecycle.js";
+import { registerCodexAppServerActiveTurn } from "./turn-attribution.js";
 
 let tempDir: string;
 
@@ -190,6 +191,16 @@ function mockCall(mock: unknown, label: string, index = 0): unknown[] {
     throw new Error(`Expected ${label} call ${index + 1}`);
   }
   return call;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 function createAppServerHarness(
@@ -3881,6 +3892,551 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
     expect(result.promptError).toBeNull();
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+  });
+
+  it("releases completion when Codex raw-events an unscoped interrupted turn marker", async () => {
+    const harness = createStartedThreadHarness();
+    const run = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+    let resolved = false;
+    void run.then(() => {
+      resolved = true;
+    });
+
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "rawResponseItem/completed",
+      params: {
+        item: {
+          id: "abort-marker-1",
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: "<turn_aborted>\nThe user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.\n</turn_aborted>",
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await run;
+    expect(resolved).toBe(true);
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+  });
+
+  it("replays an unscoped interrupted marker emitted during turn start", async () => {
+    const handlers = new Set<(notification: CodexServerNotification) => Promise<void> | void>();
+    const notifyAll = async (notification: CodexServerNotification) => {
+      await Promise.all([...handlers].map(async (handler) => await handler(notification)));
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        queueMicrotask(() => {
+          queueMicrotask(() => {
+            void notifyAll({
+              method: "rawResponseItem/completed",
+              params: {
+                item: {
+                  id: "abort-marker-1",
+                  type: "message",
+                  role: "user",
+                  content: [
+                    {
+                      type: "input_text",
+                      text: "<turn_aborted>\nThe user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.\n</turn_aborted>",
+                    },
+                  ],
+                },
+              },
+            });
+          });
+        });
+        return turnStartResult("turn-1");
+      }
+      return {};
+    });
+    __testing.setCodexAppServerClientFactoryForTests(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: (notification: CodexServerNotification) => void) => {
+            handlers.add(handler);
+            return () => {
+              handlers.delete(handler);
+            };
+          },
+          addRequestHandler: () => () => undefined,
+        }) as never,
+    );
+    const result = await runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+  });
+
+  it("does not attribute an unscoped interrupted marker when an active turn overlaps a starting turn", async () => {
+    const handlers = new Set<(notification: CodexServerNotification) => Promise<void> | void>();
+    const notifyAll = async (notification: CodexServerNotification) => {
+      await Promise.all([...handlers].map(async (handler) => await handler(notification)));
+    };
+    let threadIndex = 0;
+    let turnIndex = 0;
+    const secondTurnStart = createDeferred<unknown>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        threadIndex += 1;
+        return threadStartResult(`thread-${threadIndex}`);
+      }
+      if (method === "turn/start") {
+        turnIndex += 1;
+        const turnId = `turn-${turnIndex}`;
+        if (turnIndex === 2) {
+          queueMicrotask(() => {
+            queueMicrotask(() => {
+              void notifyAll({
+                method: "rawResponseItem/completed",
+                params: {
+                  item: {
+                    id: "abort-marker-1",
+                    type: "message",
+                    role: "user",
+                    content: [
+                      {
+                        type: "input_text",
+                        text: "<turn_aborted>\nThe user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.\n</turn_aborted>",
+                      },
+                    ],
+                  },
+                },
+              });
+            });
+          });
+        }
+        return turnIndex === 2 ? await secondTurnStart.promise : turnStartResult(turnId);
+      }
+      return {};
+    });
+    const sharedClient = {
+      request,
+      addNotificationHandler: (handler: (notification: CodexServerNotification) => void) => {
+        handlers.add(handler);
+        return () => {
+          handlers.delete(handler);
+        };
+      },
+      addRequestHandler: () => () => undefined,
+    } as never;
+    __testing.setCodexAppServerClientFactoryForTests(async () => sharedClient);
+
+    const runA = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session-a.jsonl"), path.join(tempDir, "workspace-a")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+    let resolvedA = false;
+    void runA.then(() => {
+      resolvedA = true;
+    });
+    await vi.waitFor(
+      () =>
+        expect(request.mock.calls.filter(([method]) => method === "turn/start")).toHaveLength(1),
+      { interval: 1 },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const runB = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session-b.jsonl"), path.join(tempDir, "workspace-b")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+    let resolvedB = false;
+    void runB.then(() => {
+      resolvedB = true;
+    });
+    await vi.waitFor(
+      () =>
+        expect(request.mock.calls.filter(([method]) => method === "turn/start")).toHaveLength(2),
+      { interval: 1 },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(resolvedB).toBe(false);
+    expect(resolvedA).toBe(false);
+
+    secondTurnStart.resolve(turnStartResult("turn-2"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(resolvedB).toBe(false);
+
+    await notifyAll({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-2",
+        turnId: "turn-2",
+        turn: { id: "turn-2", status: "completed" },
+      },
+    });
+    const resultB = await runB;
+    expect(resultB.aborted).toBe(false);
+
+    await notifyAll({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+    const resultA = await runA;
+    expect(resultA.aborted).toBe(false);
+  });
+
+  it("does not release concurrent shared-client turns on an unscoped interrupted marker", async () => {
+    const handlers = new Set<(notification: CodexServerNotification) => Promise<void> | void>();
+    let threadIndex = 0;
+    let turnIndex = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        threadIndex += 1;
+        return threadStartResult(`thread-${threadIndex}`);
+      }
+      if (method === "turn/start") {
+        turnIndex += 1;
+        return turnStartResult("turn-1");
+      }
+      return {};
+    });
+    const sharedClient = {
+      request,
+      addNotificationHandler: (handler: (notification: CodexServerNotification) => void) => {
+        handlers.add(handler);
+        return () => {
+          handlers.delete(handler);
+        };
+      },
+      addRequestHandler: () => () => undefined,
+    } as never;
+    __testing.setCodexAppServerClientFactoryForTests(async () => sharedClient);
+    const notifyAll = async (notification: CodexServerNotification) => {
+      await Promise.all([...handlers].map(async (handler) => await handler(notification)));
+    };
+
+    const runA = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session-a.jsonl"), path.join(tempDir, "workspace-a")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+    const runB = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session-b.jsonl"), path.join(tempDir, "workspace-b")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+    let resolvedA = false;
+    let resolvedB = false;
+    void runA.then(() => {
+      resolvedA = true;
+    });
+    void runB.then(() => {
+      resolvedB = true;
+    });
+
+    await vi.waitFor(
+      () =>
+        expect(request.mock.calls.filter(([method]) => method === "turn/start")).toHaveLength(2),
+      { interval: 1 },
+    );
+    await notifyAll({
+      method: "rawResponseItem/completed",
+      params: {
+        item: {
+          id: "abort-marker-1",
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: "<turn_aborted>\nThe user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.\n</turn_aborted>",
+            },
+          ],
+        },
+      },
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(resolvedA).toBe(false);
+    expect(resolvedB).toBe(false);
+
+    await notifyAll({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+    await notifyAll({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-2",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+
+    const [resultA, resultB] = await Promise.all([runA, runB]);
+    expect(resultA.aborted).toBe(false);
+    expect(resultB.aborted).toBe(false);
+  });
+
+  it("does not treat a harness turn as only active while a bound Codex turn is registered", async () => {
+    const handlers = new Set<(notification: CodexServerNotification) => Promise<void> | void>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1");
+      }
+      return {};
+    });
+    const sharedClient = {
+      request,
+      addNotificationHandler: (handler: (notification: CodexServerNotification) => void) => {
+        handlers.add(handler);
+        return () => {
+          handlers.delete(handler);
+        };
+      },
+      addRequestHandler: () => () => undefined,
+    } as never;
+    const boundTurn = registerCodexAppServerActiveTurn(sharedClient);
+    __testing.setCodexAppServerClientFactoryForTests(async () => sharedClient);
+    const notifyAll = async (notification: CodexServerNotification) => {
+      await Promise.all([...handlers].map(async (handler) => await handler(notification)));
+    };
+    try {
+      const run = runCodexAppServerAttempt(
+        createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+        { turnTerminalIdleTimeoutMs: 60_000 },
+      );
+      let resolved = false;
+      void run.then(() => {
+        resolved = true;
+      });
+
+      await vi.waitFor(
+        () =>
+          expect(request.mock.calls.filter(([method]) => method === "turn/start")).toHaveLength(1),
+        { interval: 1 },
+      );
+      await notifyAll({
+        method: "rawResponseItem/completed",
+        params: {
+          item: {
+            id: "abort-marker-1",
+            type: "message",
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "<turn_aborted>\nThe user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.\n</turn_aborted>",
+              },
+            ],
+          },
+        },
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(resolved).toBe(false);
+
+      await notifyAll({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "completed" },
+        },
+      });
+      const result = await run;
+      expect(result.aborted).toBe(false);
+    } finally {
+      boundTurn.cleanup();
+    }
+  });
+
+  it("replays an unscoped interrupted marker received while the only turn start is pending", async () => {
+    const handlers = new Set<(notification: CodexServerNotification) => Promise<void> | void>();
+    const notifyAll = async (notification: CodexServerNotification) => {
+      await Promise.all([...handlers].map(async (handler) => await handler(notification)));
+    };
+    const turnStart = createDeferred<unknown>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        queueMicrotask(() => {
+          void notifyAll({
+            method: "rawResponseItem/completed",
+            params: {
+              item: {
+                id: "abort-marker-1",
+                type: "message",
+                role: "user",
+                content: [
+                  {
+                    type: "input_text",
+                    text: "<turn_aborted>\nThe user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.\n</turn_aborted>",
+                  },
+                ],
+              },
+            },
+          });
+        });
+        return await turnStart.promise;
+      }
+      return {};
+    });
+    const sharedClient = {
+      request,
+      addNotificationHandler: (handler: (notification: CodexServerNotification) => void) => {
+        handlers.add(handler);
+        return () => {
+          handlers.delete(handler);
+        };
+      },
+      addRequestHandler: () => () => undefined,
+    } as never;
+    __testing.setCodexAppServerClientFactoryForTests(async () => sharedClient);
+
+    const run = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+    let resolved = false;
+    void run.then(() => {
+      resolved = true;
+    });
+
+    await vi.waitFor(
+      () =>
+        expect(request.mock.calls.filter(([method]) => method === "turn/start")).toHaveLength(1),
+      { interval: 1 },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(resolved).toBe(false);
+
+    turnStart.resolve(turnStartResult("turn-1"));
+    const result = await run;
+    expect(result.aborted).toBe(true);
+  });
+
+  it("does not replay stale unscoped interrupted markers queued before turn start", async () => {
+    const handlers = new Set<(notification: CodexServerNotification) => Promise<void> | void>();
+    let threadIndex = 0;
+    let turnIndex = 0;
+    const secondThreadStart = createDeferred<unknown>();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        threadIndex += 1;
+        if (threadIndex === 2) {
+          return await secondThreadStart.promise;
+        }
+        return threadStartResult(`thread-${threadIndex}`);
+      }
+      if (method === "turn/start") {
+        turnIndex += 1;
+        return turnStartResult(`turn-${turnIndex}`);
+      }
+      return {};
+    });
+    const sharedClient = {
+      request,
+      addNotificationHandler: (handler: (notification: CodexServerNotification) => void) => {
+        handlers.add(handler);
+        return () => {
+          handlers.delete(handler);
+        };
+      },
+      addRequestHandler: () => () => undefined,
+    } as never;
+    __testing.setCodexAppServerClientFactoryForTests(async () => sharedClient);
+    const notifyAll = async (notification: CodexServerNotification) => {
+      await Promise.all([...handlers].map(async (handler) => await handler(notification)));
+    };
+
+    const runA = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session-a.jsonl"), path.join(tempDir, "workspace-a")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+
+    await vi.waitFor(
+      () =>
+        expect(request.mock.calls.filter(([method]) => method === "turn/start")).toHaveLength(1),
+      { interval: 1 },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const runB = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session-b.jsonl"), path.join(tempDir, "workspace-b")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+    let resolvedB = false;
+    void runB.then(() => {
+      resolvedB = true;
+    });
+
+    await vi.waitFor(
+      () =>
+        expect(request.mock.calls.filter(([method]) => method === "thread/start")).toHaveLength(2),
+      { interval: 1 },
+    );
+    await notifyAll({
+      method: "rawResponseItem/completed",
+      params: {
+        item: {
+          id: "abort-marker-1",
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: "<turn_aborted>\nThe user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.\n</turn_aborted>",
+            },
+          ],
+        },
+      },
+    });
+
+    const resultA = await runA;
+    expect(resultA.aborted).toBe(true);
+    expect(resolvedB).toBe(false);
+
+    secondThreadStart.resolve(threadStartResult("thread-2"));
+    await vi.waitFor(
+      () =>
+        expect(request.mock.calls.filter(([method]) => method === "turn/start")).toHaveLength(2),
+      { interval: 1 },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(resolvedB).toBe(false);
+    await notifyAll({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-2",
+        turnId: "turn-2",
+        turn: { id: "turn-2", status: "completed" },
+      },
+    });
+
+    const resultB = await runB;
+    expect(resultB.aborted).toBe(false);
   });
 
   it("does not treat a user prompt containing the interrupted marker as terminal", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -141,6 +141,12 @@ import {
   recordCodexTrajectoryContext,
 } from "./trajectory.js";
 import { mirrorCodexAppServerTranscript } from "./transcript-mirror.js";
+import {
+  hasCodexAppServerActiveTurns,
+  isOnlyCodexAppServerActiveTurn,
+  registerCodexAppServerActiveTurn,
+  type CodexAppServerActiveTurnRegistration,
+} from "./turn-attribution.js";
 import { createCodexUserInputBridge } from "./user-input-bridge.js";
 import { filterToolsForVisionInputs } from "./vision-tools.js";
 
@@ -426,6 +432,59 @@ function restrictCodexAppServerSandboxForOpenClawSandbox(
     ...appServer,
     sandbox: "workspace-write",
   };
+}
+
+type CodexAppServerStartingTurn = object;
+const startingCodexAppServerTurnsByClient = new WeakMap<
+  CodexAppServerClient,
+  Set<CodexAppServerStartingTurn>
+>();
+
+function registerStartingCodexAppServerTurn(client: CodexAppServerClient): {
+  cleanup: () => void;
+  registration: CodexAppServerStartingTurn;
+} {
+  let startingTurns = startingCodexAppServerTurnsByClient.get(client);
+  if (!startingTurns) {
+    startingTurns = new Set<CodexAppServerStartingTurn>();
+    startingCodexAppServerTurnsByClient.set(client, startingTurns);
+  }
+  const startingTurn: CodexAppServerStartingTurn = {};
+  startingTurns.add(startingTurn);
+  let cleanedUp = false;
+  return {
+    cleanup: () => {
+      if (cleanedUp) {
+        return;
+      }
+      cleanedUp = true;
+      startingTurns.delete(startingTurn);
+      if (startingTurns.size === 0) {
+        startingCodexAppServerTurnsByClient.delete(client);
+      }
+    },
+    registration: startingTurn,
+  };
+}
+
+function isOnlyActiveCodexAppServerTurn(
+  client: CodexAppServerClient,
+  activeTurn: CodexAppServerActiveTurnRegistration,
+): boolean {
+  const startingTurns = startingCodexAppServerTurnsByClient.get(client);
+  return (startingTurns?.size ?? 0) === 0 && isOnlyCodexAppServerActiveTurn(client, activeTurn);
+}
+
+function isOnlyStartingCodexAppServerTurn(
+  client: CodexAppServerClient,
+  startingTurn: CodexAppServerStartingTurn,
+): boolean {
+  const startingTurns = startingCodexAppServerTurnsByClient.get(client);
+  return (
+    !hasCodexAppServerActiveTurns(client) &&
+    startingTurns?.size === 1 &&
+    startingTurns.has(startingTurn)
+  );
 }
 
 export async function runCodexAppServerAttempt(
@@ -887,9 +946,18 @@ export async function runCodexAppServerAttempt(
 
   let projector: CodexAppServerEventProjector | undefined;
   let turnId: string | undefined;
-  const pendingNotifications: CodexServerNotification[] = [];
+  type QueuedCodexServerNotification = {
+    notification: CodexServerNotification;
+    startingTurnAtEnqueue?: CodexAppServerStartingTurn;
+    activeTurnAtEnqueue?: CodexAppServerActiveTurnRegistration;
+  };
+  const pendingNotifications: QueuedCodexServerNotification[] = [];
   let userInputBridge: ReturnType<typeof createCodexUserInputBridge> | undefined;
   let steeringQueue: ReturnType<typeof createCodexSteeringQueue> | undefined;
+  let startingTurnRegistration: CodexAppServerStartingTurn | undefined;
+  let activeTurnStartedFromRegistration: CodexAppServerStartingTurn | undefined;
+  let activeTurnRegistration: CodexAppServerActiveTurnRegistration | undefined;
+  let cleanupActiveTurnRegistration: (() => void) | undefined;
   let completed = false;
   let timedOut = false;
   let turnCompletionIdleTimedOut = false;
@@ -1220,10 +1288,26 @@ export async function runCodexAppServerAttempt(
     });
   };
 
-  const handleNotification = async (notification: CodexServerNotification) => {
+  const handleNotification = async (queued: QueuedCodexServerNotification) => {
+    const { notification } = queued;
     userInputBridge?.handleNotification(notification);
     if (!projector || !turnId) {
-      pendingNotifications.push(notification);
+      if (
+        !hasCodexNotificationTurnScope(notification.params) &&
+        isCodexTurnAbortMarkerNotification(notification, { currentPromptText: promptBuild.prompt })
+      ) {
+        if (
+          (queued.startingTurnAtEnqueue &&
+            (queued.startingTurnAtEnqueue === startingTurnRegistration ||
+              queued.startingTurnAtEnqueue === activeTurnStartedFromRegistration)) ||
+          (queued.activeTurnAtEnqueue !== undefined &&
+            queued.activeTurnAtEnqueue === activeTurnRegistration)
+        ) {
+          pendingNotifications.push(queued);
+        }
+        return;
+      }
+      pendingNotifications.push(queued);
       return;
     }
     const isCurrentTurnNotification = isTurnNotification(
@@ -1231,8 +1315,17 @@ export async function runCodexAppServerAttempt(
       thread.threadId,
       turnId,
     );
+    const isUnscopedTurnAbortMarker =
+      !isCurrentTurnNotification &&
+      !hasCodexNotificationTurnScope(notification.params) &&
+      ((queued.activeTurnAtEnqueue !== undefined &&
+        queued.activeTurnAtEnqueue === activeTurnRegistration) ||
+        (queued.startingTurnAtEnqueue !== undefined &&
+          queued.startingTurnAtEnqueue === activeTurnStartedFromRegistration)) &&
+      isCodexTurnAbortMarkerNotification(notification, { currentPromptText: promptBuild.prompt });
+    const isActiveTurnNotification = isCurrentTurnNotification || isUnscopedTurnAbortMarker;
     const isTurnCompletion = notification.method === "turn/completed" && isCurrentTurnNotification;
-    if (isCurrentTurnNotification) {
+    if (isActiveTurnNotification) {
       touchTurnCompletionActivity(`notification:${notification.method}`, {
         details: describeNotificationActivity(notification),
       });
@@ -1285,7 +1378,7 @@ export async function runCodexAppServerAttempt(
     // inside projector.handleNotification still releases the session lane.
     // See openclaw/openclaw#67996.
     const isTurnAbortMarker =
-      isCurrentTurnNotification &&
+      isActiveTurnNotification &&
       isCodexTurnAbortMarkerNotification(notification, { currentPromptText: promptBuild.prompt });
     const isTurnTerminal = isTurnCompletion || isTurnAbortMarker;
     try {
@@ -1300,6 +1393,7 @@ export async function runCodexAppServerAttempt(
         if (isTurnAbortMarker) {
           projector.markAborted();
         }
+        cleanupActiveTurnRegistration?.();
         if (!timedOut && !runAbortController.signal.aborted) {
           await steeringQueue?.flushPending();
         }
@@ -1311,12 +1405,33 @@ export async function runCodexAppServerAttempt(
       }
     }
   };
-  const enqueueNotification = (notification: CodexServerNotification): Promise<void> => {
+  const enqueueQueuedNotification = (queued: QueuedCodexServerNotification): Promise<void> => {
     notificationQueue = notificationQueue.then(
-      () => handleNotification(notification),
-      () => handleNotification(notification),
+      () => handleNotification(queued),
+      () => handleNotification(queued),
     );
     return notificationQueue;
+  };
+  const enqueueNotification = (notification: CodexServerNotification): Promise<void> => {
+    const isUnscopedTurnAbortMarker =
+      !hasCodexNotificationTurnScope(notification.params) &&
+      isCodexTurnAbortMarkerNotification(notification, { currentPromptText: promptBuild.prompt });
+    return enqueueQueuedNotification({
+      notification,
+      startingTurnAtEnqueue:
+        isUnscopedTurnAbortMarker &&
+        (!projector || !turnId) &&
+        startingTurnRegistration !== undefined &&
+        isOnlyStartingCodexAppServerTurn(client, startingTurnRegistration)
+          ? startingTurnRegistration
+          : undefined,
+      activeTurnAtEnqueue:
+        isUnscopedTurnAbortMarker && activeTurnRegistration
+          ? isOnlyActiveCodexAppServerTurn(client, activeTurnRegistration)
+            ? activeTurnRegistration
+            : undefined
+          : undefined,
+    });
   };
 
   const notificationCleanup = client.addNotificationHandler(enqueueNotification);
@@ -1478,19 +1593,33 @@ export async function runCodexAppServerAttempt(
   ];
 
   let turn: CodexTurnStartResponse | undefined;
-  const startCodexTurn = async (): Promise<CodexTurnStartResponse> =>
-    assertCodexTurnStartResponse(
-      await client.request(
-        "turn/start",
-        buildTurnStartParams(params, {
-          threadId: thread.threadId,
-          cwd: effectiveWorkspace,
-          appServer: pluginAppServer,
-          promptText: promptBuild.prompt,
-        }),
-        { timeoutMs: params.timeoutMs, signal: runAbortController.signal },
-      ),
-    );
+  let cleanupStartedTurnRegistration: (() => void) | undefined;
+  const startCodexTurn = async (): Promise<CodexTurnStartResponse> => {
+    const startingTurn = registerStartingCodexAppServerTurn(client);
+    startingTurnRegistration = startingTurn.registration;
+    try {
+      const response = assertCodexTurnStartResponse(
+        await client.request(
+          "turn/start",
+          buildTurnStartParams(params, {
+            threadId: thread.threadId,
+            cwd: effectiveWorkspace,
+            appServer: pluginAppServer,
+            promptText: promptBuild.prompt,
+          }),
+          { timeoutMs: params.timeoutMs, signal: runAbortController.signal },
+        ),
+      );
+      cleanupStartedTurnRegistration = startingTurn.cleanup;
+      return response;
+    } catch (error) {
+      startingTurn.cleanup();
+      if (startingTurnRegistration === startingTurn.registration) {
+        startingTurnRegistration = undefined;
+      }
+      throw error;
+    }
+  };
   try {
     runAgentHarnessLlmInputHook({
       event: llmInputEvent,
@@ -1534,7 +1663,7 @@ export async function runCodexAppServerAttempt(
       const usageLimitError = await formatCodexTurnStartUsageLimitError({
         client,
         error: turnStartError,
-        pendingNotifications,
+        pendingNotifications: pendingNotifications.map(({ notification }) => notification),
         timeoutMs: appServer.requestTimeoutMs,
         signal: runAbortController.signal,
       });
@@ -1609,6 +1738,22 @@ export async function runCodexAppServerAttempt(
   }
   turnId = turn.turn.id;
   const activeTurnId = turn.turn.id;
+  const activeTurnHandle = registerCodexAppServerActiveTurn(client);
+  activeTurnRegistration = activeTurnHandle.registration;
+  let activeTurnRegistrationCleanedUp = false;
+  cleanupActiveTurnRegistration = () => {
+    if (activeTurnRegistrationCleanedUp) {
+      return;
+    }
+    activeTurnRegistrationCleanedUp = true;
+    activeTurnHandle.cleanup();
+    activeTurnRegistration = undefined;
+    activeTurnStartedFromRegistration = undefined;
+  };
+  activeTurnStartedFromRegistration = startingTurnRegistration;
+  cleanupStartedTurnRegistration?.();
+  cleanupStartedTurnRegistration = undefined;
+  startingTurnRegistration = undefined;
   emitExecutionPhaseOnce("turn_accepted", { phase: "turn_accepted" });
   userInputBridge = createCodexUserInputBridge({
     paramsForRun: params,
@@ -1628,8 +1773,8 @@ export async function runCodexAppServerAttempt(
   });
   emitLifecycleStart();
   const activeProjector = projector;
-  for (const notification of pendingNotifications.splice(0)) {
-    await enqueueNotification(notification);
+  for (const queued of pendingNotifications.splice(0)) {
+    await enqueueQueuedNotification(queued);
   }
   if (!completed && isTerminalTurnStatus(turn.turn.status)) {
     await enqueueNotification({
@@ -1863,6 +2008,12 @@ export async function runCodexAppServerAttempt(
     runAbortController.signal.removeEventListener("abort", abortListener);
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);
     steeringQueue?.cancel();
+    cleanupStartedTurnRegistration?.();
+    cleanupStartedTurnRegistration = undefined;
+    startingTurnRegistration = undefined;
+    activeTurnStartedFromRegistration = undefined;
+    cleanupActiveTurnRegistration?.();
+    cleanupActiveTurnRegistration = undefined;
     clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
   }
 }
@@ -2758,6 +2909,13 @@ function isTurnNotification(
     return false;
   }
   return readString(value, "threadId") === threadId && readNotificationTurnId(value) === turnId;
+}
+
+function hasCodexNotificationTurnScope(value: JsonValue | undefined): boolean {
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  return readString(value, "threadId") !== undefined || readNotificationTurnId(value) !== undefined;
 }
 
 function isRetryableErrorNotification(value: JsonValue | undefined): boolean {

--- a/extensions/codex/src/app-server/turn-attribution.ts
+++ b/extensions/codex/src/app-server/turn-attribution.ts
@@ -1,0 +1,47 @@
+import type { CodexAppServerClient } from "./client.js";
+
+export type CodexAppServerActiveTurnRegistration = object;
+
+const activeCodexAppServerTurnsByClient = new WeakMap<
+  CodexAppServerClient,
+  Set<CodexAppServerActiveTurnRegistration>
+>();
+
+export function registerCodexAppServerActiveTurn(client: CodexAppServerClient): {
+  cleanup: () => void;
+  registration: CodexAppServerActiveTurnRegistration;
+} {
+  let activeTurns = activeCodexAppServerTurnsByClient.get(client);
+  if (!activeTurns) {
+    activeTurns = new Set<CodexAppServerActiveTurnRegistration>();
+    activeCodexAppServerTurnsByClient.set(client, activeTurns);
+  }
+  const registration: CodexAppServerActiveTurnRegistration = {};
+  activeTurns.add(registration);
+  let cleanedUp = false;
+  return {
+    cleanup: () => {
+      if (cleanedUp) {
+        return;
+      }
+      cleanedUp = true;
+      activeTurns.delete(registration);
+      if (activeTurns.size === 0) {
+        activeCodexAppServerTurnsByClient.delete(client);
+      }
+    },
+    registration,
+  };
+}
+
+export function hasCodexAppServerActiveTurns(client: CodexAppServerClient): boolean {
+  return (activeCodexAppServerTurnsByClient.get(client)?.size ?? 0) > 0;
+}
+
+export function isOnlyCodexAppServerActiveTurn(
+  client: CodexAppServerClient,
+  activeTurn: CodexAppServerActiveTurnRegistration,
+): boolean {
+  const activeTurns = activeCodexAppServerTurnsByClient.get(client);
+  return activeTurns?.size === 1 && activeTurns.has(activeTurn);
+}

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -29,6 +29,7 @@ import {
   type CodexAppServerAuthProfileLookup,
 } from "./app-server/session-binding.js";
 import { getSharedCodexAppServerClient } from "./app-server/shared-client.js";
+import { registerCodexAppServerActiveTurn } from "./app-server/turn-attribution.js";
 import { formatCodexDisplayText } from "./command-formatters.js";
 import {
   createCodexConversationBindingData,
@@ -377,6 +378,8 @@ async function runBoundTurn(params: {
       return undefined;
     },
   );
+  const activeTurnHandle = registerCodexAppServerActiveTurn(client);
+  let cleanupConversationActiveTurn: (() => void) | undefined;
   try {
     const response: CodexTurnStartResponse = await client.request(
       "turn/start",
@@ -401,17 +404,15 @@ async function runBoundTurn(params: {
       { timeoutMs: runtime.requestTimeoutMs },
     );
     const turnId = response.turn.id;
-    const activeCleanup = trackCodexConversationActiveTurn({
+    cleanupConversationActiveTurn = trackCodexConversationActiveTurn({
       sessionFile: params.data.sessionFile,
       threadId,
       turnId,
     });
     collector.setTurnId(turnId);
-    const completion = await collector
-      .wait({
-        timeoutMs: params.timeoutMs ?? DEFAULT_BOUND_TURN_TIMEOUT_MS,
-      })
-      .finally(activeCleanup);
+    const completion = await collector.wait({
+      timeoutMs: params.timeoutMs ?? DEFAULT_BOUND_TURN_TIMEOUT_MS,
+    });
     const replyText = completion.replyText.trim();
     return {
       reply: {
@@ -419,6 +420,8 @@ async function runBoundTurn(params: {
       },
     };
   } finally {
+    cleanupConversationActiveTurn?.();
+    activeTurnHandle.cleanup();
     notificationCleanup();
     requestCleanup();
   }


### PR DESCRIPTION
## Summary
- Guard unscoped Codex `<turn_aborted>` raw response markers so they only terminate a run when the shared app-server client has exactly one attributable turn owner.
- Preserve abort markers emitted during the `turn/start` await gap and replay them only for the same starting turn token.
- Track bound Codex conversation turns as shared-client owners so harness runs do not claim their unscoped abort markers.
- Add regression coverage for startup races, stale marker replay, concurrent shared-client runs, and bound-turn ambiguity.

## Verification
- `pnpm test extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/conversation-binding.test.ts`
- `git diff --check`
- `codex exec --cd /Users/steipete/clawdbot --sandbox read-only --ephemeral review --uncommitted`

## Real behavior proof
Behavior addressed: Codex app-server sessions can stall when an unscoped `<turn_aborted>` raw marker arrives without `turn/completed`, and shared-client runs can incorrectly attribute that marker to another active turn.
Real environment tested: local OpenClaw checkout on macOS with the Codex app-server harness tests.
Exact steps or command run after this patch: `pnpm test extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/conversation-binding.test.ts`
Evidence after fix: focused Vitest shard passed 2 files and 130 tests after rebasing onto latest `origin/main`.
Observed result after fix: startup-gap abort markers complete the intended run, ambiguous shared-client markers are ignored, and scoped completions still complete normally.
What was not tested: a live external Codex app-server process emitting malformed unscoped raw markers in production.
