### PR TITLE
fix(channels): sync status reaction DEFAULT_EMOJIS with documented defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/status reactions: sync `DEFAULT_EMOJIS` with the documented self-explanatory defaults (🧠 thinking, 🛠️ tool, 💻 coding, 🌐 web, ⏳ stallSoft, ⚠️ stallHard, ✅ done, ❌ error) so stall and lifecycle reactions read as status indicators instead of emotional commentary. Fixes #59077. Thanks @OolonColoophid.
 - Infra/retry: keep jittered retry delays at or above server-supplied Retry-After lower bounds when the hint can be honored. Fixes #68541. (#68543) Thanks @Feelw00.
 - Redact persisted secret-shaped payloads [AI]. (#79006) Thanks @pgondhi987.
 - Agents: label `.openclaw/sandboxes` exec workdirs as sandbox runs in compact tool summaries instead of showing the full path.

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -58,14 +58,14 @@ export type StatusReactionController = {
 
 export const DEFAULT_EMOJIS: Required<StatusReactionEmojis> = {
   queued: "👀",
-  thinking: "🤔",
-  tool: "🔥",
-  coding: "👨‍💻",
-  web: "⚡",
-  done: "👍",
-  error: "😱",
-  stallSoft: "🥱",
-  stallHard: "😨",
+  thinking: "🧠",
+  tool: "🛠️",
+  coding: "💻",
+  web: "🌐",
+  done: "✅",
+  error: "❌",
+  stallSoft: "⏳",
+  stallHard: "⚠️",
   compacting: "✍",
 };
 


### PR DESCRIPTION
## Summary

Fixes #59077.

The status reaction defaults in `src/channels/status-reactions.ts` already
*document* a clearer, self-explanatory emoji set in the `StatusReactionEmojis`
type comments — and the rest of the codebase was already updated for it:

- `extensions/slack/src/monitor/message-handler/dispatch.ts` already maps
  `🧠 🛠️ 💻 🌐 ⏳ ⚠️ ✅ ❌` to Slack shortcodes.
- `extensions/telegram/src/status.test.ts` already exercises `🛠️` as a
  requested emoji.

But the actual `DEFAULT_EMOJIS` constant was never flipped — it still held the
old emotional-commentary set (`🥱` yawn / `😨` fear / `🤔` / `🔥` / `👍` / `😱`).
That is exactly the UX confusion reported in #59077: `🥱 → 😨` reads as mood,
not "slow → stuck".

This change syncs the constant to the documented values:

| State | Old | New |
|-------|-----|-----|
| thinking | 🤔 | 🧠 |
| tool | 🔥 | 🛠️ |
| coding | 👨‍💻 | 💻 |
| web | ⚡ | 🌐 |
| done | 👍 | ✅ |
| error | 😱 | ❌ |
| stallSoft | 🥱 | ⏳ |
| stallHard | 😨 | ⚠️ |

`compacting` (✍) and `queued` (👀) are unchanged.

## Cross-platform check

- **Slack** — `UNICODE_TO_SLACK` in `dispatch.ts` already has shortcodes for
  every new emoji (`brain`, `hammer_and_wrench`, `computer`,
  `globe_with_meridians`, `hourglass_flowing_sand`, `warning`,
  `white_check_mark`, `x`).
- **Telegram** — Telegram only allows a fixed reaction set, and none of the new
  emoji are in it. The existing `TELEGRAM_STATUS_REACTION_VARIANTS` fallback
  lists handle this: `resolveTelegramReactionVariant` walks the per-state
  variant list and picks the first Telegram-supported emoji, so Telegram keeps
  rendering its supported equivalents (🤔/🔥/👨‍💻/...). Graceful degradation,
  no behavior change on Telegram.
- **Discord / WhatsApp / others** — use raw unicode reactions; the new emoji
  are all standard and valid as reactions.

Power users can still override any of these via
`messages.statusReactions.emojis` in config.

## Verification

- `pnpm test src/channels/status-reactions.test.ts src/channels/status-reactions.slack-lifecycle.test.ts` — 2 files, 51 tests passed
- `pnpm test extensions/telegram/src/status.test.ts` — 1 file, 27 tests passed
- Tests reference `DEFAULT_EMOJIS.*` symbolically, so no assertions are pinned to the old literals.