### PR TITLE
[codex] Harden Telegram HTML parse fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/WebChat: render `/tts audio` replies as playable audio attachments through the assistant-media ticket path, with structured-audio compatibility for older live payloads. (#81722) Thanks @Conan-Scott.
 - Bind gateway approval access to requester metadata [AI]. (#81380) Thanks @pgondhi987.
 - Telegram: let isolated polling drain independent topics, DMs, and status/control commands concurrently while preserving same-lane order. (#81849) Thanks @VACInc.
+- Telegram: derive readable plain-text retries from HTML fallback sends so parse failures show `label (url)` links instead of raw anchors. (#81764) Thanks @alexph-dev.
 - Ollama/Doctor: copy explicit native Ollama `contextWindow` or `maxTokens` provider/model budgets into `params.num_ctx` during `openclaw doctor --fix`, preserving large-context configs after native Ollama stopped inferring per-request `num_ctx`. Fixes #81878. (#81928) Thanks @joshavant and @ArthurusDent.
 - Discord: honor `threadName` on `message send` to existing threads by renaming the thread after successful delivery, and warn when the rename cannot be applied. Fixes #81836. (#81933) Thanks @joshavant.
 - Build: keep externalized Slack, OpenShell sandbox, and Anthropic Vertex runtime dependency declarations out of the root dist artifact build.

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -4,6 +4,7 @@ import {
   markdownToTelegramHtml,
   renderTelegramHtmlText,
   splitTelegramHtmlChunks,
+  telegramHtmlToPlainTextFallback,
 } from "./format.js";
 
 describe("markdownToTelegramHtml", () => {
@@ -227,6 +228,20 @@ describe("markdownToTelegramHtml", () => {
     const chunks = splitTelegramHtmlChunks(`&${"A".repeat(5000)}`, 4000);
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.every((chunk) => chunk.length <= 4000)).toBe(true);
+  });
+
+  it("derives readable plain text from Telegram HTML fallback markup", () => {
+    const html = [
+      'Created: <a href="https://example.com/a?x=1&amp;y=2">Task &amp; One</a>',
+      "<code>file.md</code>",
+      "<br>",
+      '<a href="https://example.com/same">https://example.com/same</a>',
+      "<b>done</b>",
+    ].join(" ");
+
+    expect(telegramHtmlToPlainTextFallback(html)).toBe(
+      "Created: Task & One (https://example.com/a?x=1&y=2) file.md \n https://example.com/same done",
+    );
   });
 
   it("fails loudly when tag overhead leaves no room for text", () => {

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -244,6 +244,14 @@ describe("markdownToTelegramHtml", () => {
     );
   });
 
+  it("preserves escaped angle-bracket text in Telegram HTML fallback links", () => {
+    expect(
+      telegramHtmlToPlainTextFallback(
+        '<a href="https://example.com/task?id=1&amp;kind=bug">Task &lt;id&gt;</a>',
+      ),
+    ).toBe("Task <id> (https://example.com/task?id=1&kind=bug)");
+  });
+
   it("fails loudly when tag overhead leaves no room for text", () => {
     expect(() => splitTelegramHtmlChunks("<b><i><u>x</u></i></b>", 10)).toThrow(/tag overhead/i);
   });

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -320,6 +320,21 @@ function stripTelegramHtmlForPlainText(html: string): string {
   );
 }
 
+function encodePlainTextForTelegramHtmlStrip(text: string): string {
+  return text.replace(/[&<>]/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      default:
+        return char;
+    }
+  });
+}
+
 export function telegramHtmlToPlainTextFallback(html: string): string {
   TELEGRAM_HTML_ANCHOR_PATTERN.lastIndex = 0;
   const withPlainLinks = html.replace(
@@ -336,9 +351,11 @@ export function telegramHtmlToPlainTextFallback(html: string): string {
       ).trim();
       const label = stripTelegramHtmlForPlainText(labelHtml).trim();
       if (!href) {
-        return label;
+        return encodePlainTextForTelegramHtmlStrip(label);
       }
-      return !label || label === href ? href : `${label} (${href})`;
+      return encodePlainTextForTelegramHtmlStrip(
+        !label || label === href ? href : `${label} (${href})`,
+      );
     },
   );
   return stripTelegramHtmlForPlainText(withPlainLinks);

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -165,6 +165,11 @@ const AUTO_LINKED_ANCHOR_PATTERN = /<a\s+href="https?:\/\/([^"]+)"[^>]*>\1<\/a>/
 const HTML_TAG_PATTERN = /(<\/?)([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*?>/gi;
 const HTML_MODE_TAG_PATTERN = /^<(\/?)([a-zA-Z][a-zA-Z0-9-]*)([^<>]*)>$/;
 const ESCAPED_HTML_TAG_PATTERN = /&lt;(\/?)([a-zA-Z][a-zA-Z0-9-]*)(.*?)&gt;/g;
+const TELEGRAM_HTML_ANCHOR_PATTERN =
+  /<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>([\s\S]*?)<\/a\s*>/gi;
+const TELEGRAM_HTML_BREAK_PATTERN = /<br\s*\/?>/gi;
+const TELEGRAM_HTML_ENTITY_PATTERN = /&(#x[0-9A-Fa-f]+|#\d+|amp|lt|gt|quot|apos);/g;
+const TELEGRAM_HTML_TAG_PATTERN = /<[^>]*>/g;
 const TELEGRAM_SIMPLE_HTML_TAGS = new Set([
   "b",
   "strong",
@@ -272,6 +277,71 @@ function escapeUnsupportedTelegramHtml(text: string): string {
     index += 1;
   }
   return result;
+}
+
+function decodeTelegramHtmlEntity(entity: string, fallback: string): string {
+  if (entity.startsWith("#x") || entity.startsWith("#X")) {
+    const codePoint = Number.parseInt(entity.slice(2), 16);
+    return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+      ? String.fromCodePoint(codePoint)
+      : fallback;
+  }
+  if (entity.startsWith("#")) {
+    const codePoint = Number.parseInt(entity.slice(1), 10);
+    return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+      ? String.fromCodePoint(codePoint)
+      : fallback;
+  }
+  switch (entity) {
+    case "amp":
+      return "&";
+    case "lt":
+      return "<";
+    case "gt":
+      return ">";
+    case "quot":
+      return '"';
+    case "apos":
+      return "'";
+    default:
+      return fallback;
+  }
+}
+
+function decodeTelegramHtmlEntities(text: string): string {
+  return text.replace(TELEGRAM_HTML_ENTITY_PATTERN, (match, entity: string) =>
+    decodeTelegramHtmlEntity(entity, match),
+  );
+}
+
+function stripTelegramHtmlForPlainText(html: string): string {
+  return decodeTelegramHtmlEntities(
+    html.replace(TELEGRAM_HTML_BREAK_PATTERN, "\n").replace(TELEGRAM_HTML_TAG_PATTERN, ""),
+  );
+}
+
+export function telegramHtmlToPlainTextFallback(html: string): string {
+  TELEGRAM_HTML_ANCHOR_PATTERN.lastIndex = 0;
+  const withPlainLinks = html.replace(
+    TELEGRAM_HTML_ANCHOR_PATTERN,
+    (
+      _match: string,
+      doubleQuotedHref: string | undefined,
+      singleQuotedHref: string | undefined,
+      unquotedHref: string | undefined,
+      labelHtml: string,
+    ) => {
+      const href = decodeTelegramHtmlEntities(
+        doubleQuotedHref ?? singleQuotedHref ?? unquotedHref ?? "",
+      ).trim();
+      const label = stripTelegramHtmlForPlainText(labelHtml).trim();
+      if (!href) {
+        return label;
+      }
+      return !label || label === href ? href : `${label} (${href})`;
+    },
+  );
+  return stripTelegramHtmlForPlainText(withPlainLinks);
 }
 
 function promoteEscapedSupportedTelegramTags(text: string, openTags: string[]): string {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2836,6 +2836,28 @@ describe("editMessageTelegram", () => {
     expect(botApi.editMessageText).toHaveBeenCalledTimes(1);
   });
 
+  it("derives readable plain text when Telegram rejects edited HTML", async () => {
+    botApi.editMessageText
+      .mockRejectedValueOnce(new Error("400: Bad Request: can't parse entities"))
+      .mockResolvedValueOnce({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram(
+      "123",
+      1,
+      'Created: <a href="https://example.com/a?x=1&amp;y=2">Task &lt;id&gt;</a>',
+      {
+        token: "tok",
+        cfg: {},
+        textMode: "html",
+      },
+    );
+
+    expect(botApi.editMessageText).toHaveBeenCalledTimes(2);
+    expect(mockCall(botApi.editMessageText, 1, "plain edit fallback")[2]).toBe(
+      "Created: Task <id> (https://example.com/a?x=1&y=2)",
+    );
+  });
+
   it("retries editMessageTelegram on Telegram 5xx errors", async () => {
     botApi.editMessageText
       .mockRejectedValueOnce(Object.assign(new Error("502: Bad Gateway"), { error_code: 502 }))

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -686,6 +686,38 @@ describe("sendMessageTelegram", () => {
     }
   });
 
+  it("derives plain-text fallback from html-mode anchors when Telegram rejects HTML", async () => {
+    const chatId = "123";
+    const htmlText =
+      'Created: <a href="https://example.com/a?x=1&amp;y=2">Task &amp; One</a> <code>file.md</code>';
+    const parseErr = new Error(
+      "400: Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 9",
+    );
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(parseErr)
+      .mockResolvedValueOnce({ message_id: 43, chat: { id: chatId } });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    const res = await sendMessageTelegram(chatId, htmlText, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      textMode: "html",
+    });
+
+    expect(sendMessage).toHaveBeenNthCalledWith(1, chatId, htmlText, { parse_mode: "HTML" });
+    expect(sendMessage).toHaveBeenNthCalledWith(
+      2,
+      chatId,
+      "Created: Task & One (https://example.com/a?x=1&y=2) file.md",
+    );
+    expect(res.chatId).toBe(chatId);
+    expect(res.messageId).toBe("43");
+  });
+
   it("keeps link_preview_options disabled for both html and plain-text fallback", async () => {
     const parseErr = new Error(
       "400: Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 9",

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -18,7 +18,11 @@ import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { asTelegramClientFetch, createTelegramClientFetch } from "./client-fetch.js";
 import { resolveTelegramTransport } from "./fetch.js";
-import { renderTelegramHtmlText, splitTelegramHtmlChunks } from "./format.js";
+import {
+  renderTelegramHtmlText,
+  splitTelegramHtmlChunks,
+  telegramHtmlToPlainTextFallback,
+} from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 import {
   isRecoverableTelegramNetworkError,
@@ -175,77 +179,6 @@ function splitTelegramPlainTextFallback(text: string, chunkCount: number, limit:
     offset += nextChunkLength;
   }
   return chunks;
-}
-
-const TELEGRAM_HTML_ANCHOR_PATTERN =
-  /<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>([\s\S]*?)<\/a\s*>/gi;
-const TELEGRAM_HTML_BREAK_PATTERN = /<br\s*\/?>/gi;
-const TELEGRAM_HTML_ENTITY_PATTERN = /&(#x[0-9A-Fa-f]+|#\d+|amp|lt|gt|quot|apos);/g;
-const TELEGRAM_HTML_TAG_PATTERN = /<[^>]*>/g;
-
-function decodeTelegramHtmlEntity(entity: string, fallback: string): string {
-  if (entity.startsWith("#x") || entity.startsWith("#X")) {
-    const codePoint = Number.parseInt(entity.slice(2), 16);
-    return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
-      ? String.fromCodePoint(codePoint)
-      : fallback;
-  }
-  if (entity.startsWith("#")) {
-    const codePoint = Number.parseInt(entity.slice(1), 10);
-    return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
-      ? String.fromCodePoint(codePoint)
-      : fallback;
-  }
-  switch (entity) {
-    case "amp":
-      return "&";
-    case "lt":
-      return "<";
-    case "gt":
-      return ">";
-    case "quot":
-      return '"';
-    case "apos":
-      return "'";
-    default:
-      return fallback;
-  }
-}
-
-function decodeTelegramHtmlEntities(text: string): string {
-  return text.replace(TELEGRAM_HTML_ENTITY_PATTERN, (match, entity: string) =>
-    decodeTelegramHtmlEntity(entity, match),
-  );
-}
-
-function stripTelegramHtmlForPlainText(html: string): string {
-  return decodeTelegramHtmlEntities(
-    html.replace(TELEGRAM_HTML_BREAK_PATTERN, "\n").replace(TELEGRAM_HTML_TAG_PATTERN, ""),
-  );
-}
-
-function telegramHtmlToPlainTextFallback(html: string): string {
-  TELEGRAM_HTML_ANCHOR_PATTERN.lastIndex = 0;
-  const withPlainLinks = html.replace(
-    TELEGRAM_HTML_ANCHOR_PATTERN,
-    (
-      _match: string,
-      doubleQuotedHref: string | undefined,
-      singleQuotedHref: string | undefined,
-      unquotedHref: string | undefined,
-      labelHtml: string,
-    ) => {
-      const href = decodeTelegramHtmlEntities(
-        doubleQuotedHref ?? singleQuotedHref ?? unquotedHref ?? "",
-      ).trim();
-      const label = stripTelegramHtmlForPlainText(labelHtml).trim();
-      if (!href) {
-        return label;
-      }
-      return !label || label === href ? href : `${label} (${href})`;
-    },
-  );
-  return stripTelegramHtmlForPlainText(withPlainLinks);
 }
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1384,6 +1384,7 @@ export async function editMessageTelegram(
     accountId: account.accountId,
   });
   const htmlText = renderTelegramHtmlText(text, { textMode, tableMode });
+  const plainText = textMode === "html" ? telegramHtmlToPlainTextFallback(htmlText) : text;
 
   // Reply markup semantics:
   // - buttons === undefined → don't send reply_markup (keep existing)
@@ -1424,8 +1425,8 @@ export async function editMessageTelegram(
         requestWithEditShouldLog(
           () =>
             Object.keys(plainParams).length > 0
-              ? api.editMessageText(chatId, messageId, text, plainParams)
-              : api.editMessageText(chatId, messageId, text),
+              ? api.editMessageText(chatId, messageId, plainText, plainParams)
+              : api.editMessageText(chatId, messageId, plainText),
           retryLabel,
           (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
         ),

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -177,6 +177,77 @@ function splitTelegramPlainTextFallback(text: string, chunkCount: number, limit:
   return chunks;
 }
 
+const TELEGRAM_HTML_ANCHOR_PATTERN =
+  /<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>([\s\S]*?)<\/a\s*>/gi;
+const TELEGRAM_HTML_BREAK_PATTERN = /<br\s*\/?>/gi;
+const TELEGRAM_HTML_ENTITY_PATTERN = /&(#x[0-9A-Fa-f]+|#\d+|amp|lt|gt|quot|apos);/g;
+const TELEGRAM_HTML_TAG_PATTERN = /<[^>]*>/g;
+
+function decodeTelegramHtmlEntity(entity: string, fallback: string): string {
+  if (entity.startsWith("#x") || entity.startsWith("#X")) {
+    const codePoint = Number.parseInt(entity.slice(2), 16);
+    return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+      ? String.fromCodePoint(codePoint)
+      : fallback;
+  }
+  if (entity.startsWith("#")) {
+    const codePoint = Number.parseInt(entity.slice(1), 10);
+    return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+      ? String.fromCodePoint(codePoint)
+      : fallback;
+  }
+  switch (entity) {
+    case "amp":
+      return "&";
+    case "lt":
+      return "<";
+    case "gt":
+      return ">";
+    case "quot":
+      return '"';
+    case "apos":
+      return "'";
+    default:
+      return fallback;
+  }
+}
+
+function decodeTelegramHtmlEntities(text: string): string {
+  return text.replace(TELEGRAM_HTML_ENTITY_PATTERN, (match, entity: string) =>
+    decodeTelegramHtmlEntity(entity, match),
+  );
+}
+
+function stripTelegramHtmlForPlainText(html: string): string {
+  return decodeTelegramHtmlEntities(
+    html.replace(TELEGRAM_HTML_BREAK_PATTERN, "\n").replace(TELEGRAM_HTML_TAG_PATTERN, ""),
+  );
+}
+
+function telegramHtmlToPlainTextFallback(html: string): string {
+  TELEGRAM_HTML_ANCHOR_PATTERN.lastIndex = 0;
+  const withPlainLinks = html.replace(
+    TELEGRAM_HTML_ANCHOR_PATTERN,
+    (
+      _match: string,
+      doubleQuotedHref: string | undefined,
+      singleQuotedHref: string | undefined,
+      unquotedHref: string | undefined,
+      labelHtml: string,
+    ) => {
+      const href = decodeTelegramHtmlEntities(
+        doubleQuotedHref ?? singleQuotedHref ?? unquotedHref ?? "",
+      ).trim();
+      const label = stripTelegramHtmlForPlainText(labelHtml).trim();
+      if (!href) {
+        return label;
+      }
+      return !label || label === href ? href : `${label} (${href})`;
+    },
+  );
+  return stripTelegramHtmlForPlainText(withPlainLinks);
+}
+
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const THREAD_NOT_FOUND_RE = /400:\s*Bad Request:\s*message thread not found/i;
 const MESSAGE_NOT_MODIFIED_RE =
@@ -736,7 +807,8 @@ export async function sendMessageTelegram(
 
   const buildChunkedTextPlan = (rawText: string, context: string): TelegramTextChunk[] => {
     const htmlText = renderHtmlText(rawText);
-    const fallbackText = opts.plainText ?? rawText;
+    const fallbackText =
+      opts.plainText ?? (textMode === "html" ? telegramHtmlToPlainTextFallback(htmlText) : rawText);
     let htmlChunks: string[];
     try {
       htmlChunks = splitTelegramHtmlChunks(htmlText, 4000);


### PR DESCRIPTION
AI-assisted: yes (Codex).

## Summary

Fixes #81742. Follow-up after #81758 landed.

- Keep this PR scoped to Telegram send fallback hardening only.
- When Telegram rejects an HTML parse-mode send and no caller-provided `plainText` fallback exists, derive readable plain text from the rendered HTML instead of retrying with literal `<a href=...>` markup.
- Preserve anchor targets in the fallback as `label (url)` and strip/decode supported Telegram HTML tags/entities.
- Add a regression for the HTML parse retry path.

This no longer changes the lazy sender/core cron delivery path; that overlapping fix was handled by #81758.

## Verification

- `pnpm test extensions/telegram/src/send.test.ts`
- `git diff --check`
- `GOMEMLIMIT=2GiB GOGC=30 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`

## Real Behavior Proof

Behavior addressed: If Telegram rejects an HTML parse-mode message, the plain retry should be readable and should not expose raw rendered anchors like `<a href="...">label</a>`.

Real environment tested: Local OpenClaw setup using `~/.openclaw/openclaw.json`, gateway-backed secret resolution, the real Telegram bot API for `@smarty5bot`, and a redacted Alex-private Telegram group target. The source checkout was at `841fc6d1f92c` from this PR branch.

Exact steps or command run after this patch: `OPENCLAW_PROOF_SOURCE_HEAD=$(git rev-parse --short=12 HEAD) node --import tsx /home/clawd/.openclaw/workspace/tmp/openclaw-telegram-real-proof.mjs`

Evidence after fix: Terminal capture from the live OpenClaw/Telegram proof run:

```text
OPENCLAW_REAL_BEHAVIOR_PROOF telegram-html-fallback
source_head=841fc6d1f92c
runtime_config=~/.openclaw/openclaw.json via gateway secret resolution
target=telegram:alex-private-group-redacted
input_html=OpenClaw PR #81764 live fallback proof 2026-05-14T17:36:26Z: <a href="https://example.com/openclaw-proof?x=1&amp;y=2">proof link</a> <b>forced parse error
expected_plain_retry=OpenClaw PR #81764 live fallback proof 2026-05-14T17:36:26Z: proof link (https://example.com/openclaw-proof?x=1&y=2) forced parse error
{
  "liveTelegramApiCall": 1,
  "parseMode": "HTML",
  "delegatedTo": "grammy Bot.api.sendMessage",
  "text": "OpenClaw PR #81764 live fallback proof 2026-05-14T17:36:26Z: <a href=\"https://example.com/openclaw-proof?x=1&amp;y=2\">proof link</a> <b>forced parse error"
}
[telegram] message failed: Call to 'sendMessage' failed! (400: Bad Request: can't parse entities: Can't find end tag corresponding to start tag "b")
{
  "liveTelegramApiCall": 2,
  "parseMode": "plain",
  "delegatedTo": "grammy Bot.api.sendMessage",
  "text": "OpenClaw PR #81764 live fallback proof 2026-05-14T17:36:26Z: proof link (https://example.com/openclaw-proof?x=1&y=2) forced parse error"
}
[telegram] message failed with HTML parse error, retrying as plain text: Call to 'sendMessage' failed! (400: Bad Request: can't parse entities: Can't find end tag corresponding to start tag "b")
{
  "status": "sent",
  "channel": "telegram",
  "target": "alex-private-group-redacted",
  "messageId": "5334",
  "chatId": "redacted",
  "expectedVisibleText": "OpenClaw PR #81764 live fallback proof 2026-05-14T17:36:26Z: proof link (https://example.com/openclaw-proof?x=1&y=2) forced parse error"
}
```

Observed result after fix: The first real Telegram API call used `parse_mode: HTML` and failed with Telegram's 400 HTML parse error. The second real Telegram API call was plain text and sent the readable fallback `proof link (https://example.com/openclaw-proof?x=1&y=2)` instead of raw `<a href=...>` markup. Telegram returned message id `5334`.

What was not tested: A full cron rerun on this PR branch was not run; this proof directly forced the Telegram HTML parse fallback path against the live Telegram Bot API.
