### PR TITLE
feat(feishu): add old version document read support

### DIFF
--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -21,6 +21,7 @@ import {
   mergeTableCells,
 } from "./docx-table-ops.js";
 import type { FeishuDocxBlock, FeishuDocxBlockChild } from "./docx-types.js";
+import { fetchOldDocMeta, readOldDoc } from "./old-doc.js";
 import { getFeishuRuntime } from "./runtime.js";
 import {
   createFeishuToolClient,
@@ -845,10 +846,31 @@ async function uploadFileBlock(
 const STRUCTURED_BLOCK_TYPES = new Set([14, 18, 21, 23, 27, 30, 31, 32]);
 
 async function readDoc(client: Lark.Client, docToken: string) {
+  // Version detection: check if this is an old-version document.
+  // Only the meta call is wrapped in try/catch; downstream read errors propagate.
+  let oldDocMeta: Awaited<ReturnType<typeof fetchOldDocMeta>> | undefined;
+  try {
+    const meta = await fetchOldDocMeta(client, docToken);
+    if (!meta.is_upgraded) {
+      // Old version — read via legacy doc v2 API (meta passed to avoid redundant call)
+      return await readOldDoc(client, docToken, meta);
+    }
+    // Document has been upgraded — use the upgraded token with the docx API path below.
+    // No recursion: we read the upgraded docx token directly in the parallel fetch below.
+    if (meta.upgraded_token) {
+      oldDocMeta = meta;
+    }
+  } catch {
+    // Meta API unavailable (permissions, not an old doc, etc.) — proceed with docx API
+  }
+
+  // Use upgraded token if available, otherwise use the original token
+  const resolvedToken = oldDocMeta?.upgraded_token ?? docToken;
+
   const [contentRes, infoRes, blocksRes] = await Promise.all([
-    client.docx.document.rawContent({ path: { document_id: docToken } }),
-    client.docx.document.get({ path: { document_id: docToken } }),
-    client.docx.documentBlock.list({ path: { document_id: docToken } }),
+    client.docx.document.rawContent({ path: { document_id: resolvedToken } }),
+    client.docx.document.get({ path: { document_id: resolvedToken } }),
+    client.docx.documentBlock.list({ path: { document_id: resolvedToken } }),
   ]);
 
   if (contentRes.code !== 0) {

--- a/extensions/feishu/src/old-doc-types.ts
+++ b/extensions/feishu/src/old-doc-types.ts
@@ -1,0 +1,137 @@
+/**
+ * Type definitions for Feishu old version (doc v2) document structures.
+ *
+ * Old version documents use URL format `/docs/:docs_token` and type field `doc`.
+ * They are distinct from upgraded documents (`/docx/:docx_token`, type `docx`).
+ *
+ * Reference: https://open.feishu.cn/document/server-docs/docs/docs/docs-doc-overview
+ */
+
+// ============ Element types ============
+
+export type OldDocTextRun = {
+  content?: string;
+  link?: string;
+  text_element_style?: {
+    bold?: boolean;
+    italic?: boolean;
+    strikethrough?: boolean;
+    underline?: boolean;
+    inline_code?: boolean;
+    link?: { url?: string };
+  };
+};
+
+export type OldDocElement = {
+  type?: string;
+  text_run?: OldDocTextRun;
+  mention?: { tenant_key?: string; user_id?: string; open_id?: string };
+  equation?: { content?: string };
+};
+
+// ============ Block types ============
+
+export type OldDocParagraph = {
+  elements?: OldDocElement[];
+  style?: {
+    align?: string;
+    heading_level?: number;
+    list?: { type?: string };
+  };
+};
+
+export type OldDocTableCell = {
+  content?: { blocks?: OldDocBlock[] };
+  cell_style?: Record<string, unknown>;
+};
+
+export type OldDocTableRow = {
+  cells?: OldDocTableCell[];
+};
+
+export type OldDocTable = {
+  row_size?: number;
+  column_size?: number;
+  rows?: OldDocTableRow[];
+  style?: Record<string, unknown>;
+};
+
+export type OldDocCode = {
+  language?: string;
+  elements?: OldDocElement[];
+  style?: Record<string, unknown>;
+};
+
+export type OldDocGallery = {
+  images?: Array<{
+    file_token?: string;
+    width?: number;
+    height?: number;
+  }>;
+};
+
+export type OldDocFile = {
+  file_token?: string;
+  name?: string;
+  type?: string;
+  size?: number;
+};
+
+export type OldDocBlock = {
+  type: string;
+  paragraph?: OldDocParagraph;
+  table?: OldDocTable;
+  code?: OldDocCode;
+  gallery?: OldDocGallery;
+  file?: OldDocFile;
+  callout?: OldDocParagraph;
+  horizontalLine?: Record<string, unknown>;
+  embeddedPage?: { url?: string };
+  sheet?: Record<string, unknown>;
+  bitable?: Record<string, unknown>;
+};
+
+// ============ Document content ============
+
+export type OldDocContent = {
+  title?: OldDocParagraph;
+  body?: {
+    blocks?: OldDocBlock[];
+  };
+};
+
+// ============ API response types ============
+
+export type OldDocMetaResponse = {
+  code: number;
+  msg?: string;
+  data?: {
+    title?: string;
+    create_time?: number;
+    edit_time?: number;
+    creator?: string;
+    owner?: string;
+    delete_flag?: number;
+    is_upgraded?: boolean;
+    upgraded_token?: string;
+    obj_type?: string;
+    url?: string;
+  };
+};
+
+export type OldDocContentResponse = {
+  code: number;
+  msg?: string;
+  data?: {
+    content?: string; // JSON-encoded OldDocContent
+    revision?: number;
+  };
+};
+
+export type OldDocRawContentResponse = {
+  code: number;
+  msg?: string;
+  data?: {
+    content?: string;
+  };
+};

--- a/extensions/feishu/src/old-doc.ts
+++ b/extensions/feishu/src/old-doc.ts
@@ -1,0 +1,192 @@
+/**
+ * Old version (doc v2) Feishu document support.
+ *
+ * Provides read access to legacy Feishu documents (type `doc`, URL `/docs/:token`)
+ * that are not supported by the `@larksuiteoapi/node-sdk` docx API surface.
+ *
+ * Uses `client.request()` to call old version REST endpoints directly,
+ * reusing the SDK's authentication layer (tenant_access_token management).
+ */
+
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type {
+  OldDocBlock,
+  OldDocContent,
+  OldDocContentResponse,
+  OldDocMetaResponse,
+  OldDocRawContentResponse,
+} from "./old-doc-types.js";
+
+// ============ Internal client type ============
+
+type OldDocInternalClient = Lark.Client & {
+  request(params: {
+    method: "GET" | "POST";
+    url: string;
+    params?: Record<string, string | undefined>;
+    data?: unknown;
+    timeout?: number;
+  }): Promise<unknown>;
+};
+
+const OLD_DOC_REQUEST_TIMEOUT_MS = 30_000;
+
+function getOldDocInternalClient(client: Lark.Client): OldDocInternalClient {
+  return client as OldDocInternalClient;
+}
+
+// ============ API request helpers ============
+
+async function requestOldDocApi<T>(params: {
+  client: Lark.Client;
+  method: "GET" | "POST";
+  url: string;
+  query?: Record<string, string | undefined>;
+  data?: unknown;
+}): Promise<T> {
+  const internal = getOldDocInternalClient(params.client);
+  return (await internal.request({
+    method: params.method,
+    url: params.url,
+    params: params.query ?? {},
+    data: params.data ?? {},
+    timeout: OLD_DOC_REQUEST_TIMEOUT_MS,
+  })) as T;
+}
+
+// ============ API calls ============
+
+/** Fetch document metadata including version info (is_upgraded, upgraded_token). */
+export async function fetchOldDocMeta(client: Lark.Client, docToken: string) {
+  const res = await requestOldDocApi<OldDocMetaResponse>({
+    client,
+    method: "GET",
+    url: `/open-apis/doc/v2/meta/${encodeURIComponent(docToken)}`,
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg ?? `Old doc meta API failed (code: ${res.code})`);
+  }
+  return {
+    is_upgraded: res.data?.is_upgraded ?? false,
+    upgraded_token: res.data?.upgraded_token,
+    title: res.data?.title,
+  };
+}
+
+/** Fetch document rich content (JSON body structure). */
+async function fetchOldDocContent(client: Lark.Client, docToken: string) {
+  const res = await requestOldDocApi<OldDocContentResponse>({
+    client,
+    method: "GET",
+    url: `/open-apis/doc/v2/${encodeURIComponent(docToken)}/content`,
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg ?? `Old doc content API failed (code: ${res.code})`);
+  }
+  return res;
+}
+
+/** Fetch document plain text content. */
+async function fetchOldDocRawContent(client: Lark.Client, docToken: string) {
+  const res = await requestOldDocApi<OldDocRawContentResponse>({
+    client,
+    method: "GET",
+    url: `/open-apis/doc/v2/${encodeURIComponent(docToken)}/raw_content`,
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg ?? `Old doc raw content API failed (code: ${res.code})`);
+  }
+  return res;
+}
+
+// ============ Content parsing ============
+
+/** Extract text from an old doc paragraph's elements. */
+function extractTextFromParagraph(
+  paragraph: { elements?: Array<{ text_run?: { content?: string } }> } | undefined,
+): string {
+  if (!paragraph?.elements) {
+    return "";
+  }
+  return paragraph.elements.map((el) => el.text_run?.content ?? "").join("");
+}
+
+/** Block types that are structured and may not be fully visible in plain text. */
+const STRUCTURED_OLD_BLOCK_TYPES = new Set([
+  "table",
+  "gallery",
+  "file",
+  "code",
+  "sheet",
+  "bitable",
+  "embeddedPage",
+]);
+
+/** Parse old doc blocks into block type counts. */
+function countOldBlockTypes(blocks: OldDocBlock[]): {
+  blockCounts: Record<string, number>;
+  structuredTypes: string[];
+} {
+  const blockCounts: Record<string, number> = {};
+  const structuredTypes: string[] = [];
+
+  for (const block of blocks) {
+    const type = block.type || "unknown";
+    blockCounts[type] = (blockCounts[type] || 0) + 1;
+    if (STRUCTURED_OLD_BLOCK_TYPES.has(type) && !structuredTypes.includes(type)) {
+      structuredTypes.push(type);
+    }
+  }
+
+  return { blockCounts, structuredTypes };
+}
+
+// ============ Main read function ============
+
+/** Pre-fetched meta result passed from readDoc to avoid redundant API calls. */
+export type OldDocMetaResult = {
+  is_upgraded: boolean;
+  upgraded_token?: string;
+  title?: string;
+};
+
+/** Read an old version Feishu document, returning a unified result shape. */
+export async function readOldDoc(client: Lark.Client, docToken: string, meta: OldDocMetaResult) {
+  const [rawContentRes, contentRes] = await Promise.all([
+    fetchOldDocRawContent(client, docToken),
+    fetchOldDocContent(client, docToken),
+  ]);
+
+  // Parse the rich content JSON string
+  let parsedContent: OldDocContent | undefined;
+  try {
+    const contentStr = contentRes.data?.content;
+    if (contentStr) {
+      parsedContent = JSON.parse(contentStr) as OldDocContent;
+    }
+  } catch {
+    // If parsing fails, we still have raw content
+  }
+
+  const blocks = parsedContent?.body?.blocks ?? [];
+  const { blockCounts, structuredTypes } = countOldBlockTypes(blocks);
+
+  // Extract title from content if meta didn't provide one
+  const title = meta.title || (parsedContent ? extractTextFromParagraph(parsedContent.title) : "");
+
+  let hint: string | undefined;
+  if (structuredTypes.length > 0) {
+    hint = `This is an old-version Feishu document containing ${structuredTypes.join(", ")} which may not be fully visible in plain text. Consider upgrading the document for full block-level access.`;
+  }
+
+  return {
+    title,
+    content: rawContentRes.data?.content ?? "",
+    document_version: "old" as const,
+    is_upgraded: meta.is_upgraded,
+    upgraded_token: meta.upgraded_token,
+    block_count: blocks.length,
+    block_types: blockCounts,
+    ...(hint && { hint }),
+  };
+}


### PR DESCRIPTION
## Summary

- Add transparent read support for legacy Feishu documents (type `doc`, URL format `/docs/:token`) that are not covered by the `@larksuiteoapi/node-sdk` docx API surface
- The `readDoc` function auto-detects document version via the old doc meta API (`GET /open-apis/doc/v2/meta/:token`) and routes accordingly:
  - **Old version** (`is_upgraded=false`): fetches content via doc v2 REST endpoints using `client.request()`, with pre-fetched meta passed to avoid redundant API call
  - **Upgraded** (`is_upgraded=true` + `upgraded_token`): uses upgraded token directly with docx API (no recursion, no extra failed request)
  - **Meta API failure**: falls back to existing docx API unchanged
- No schema changes — version detection is fully transparent to callers
- try/catch scoped to meta detection only; downstream read errors propagate normally

### New files
- `extensions/feishu/src/old-doc-types.ts` — TypeScript types for old version document structures
- `extensions/feishu/src/old-doc.ts` — API call helpers, content parsing, and `readOldDoc` orchestration

### Modified files
- `extensions/feishu/src/docx.ts` — adds version detection to `readDoc()` (+~15 lines)

## Test plan

- [x] `oxlint` passes on all files (0 errors, 0 warnings)
- [x] TypeScript parse check passes
- [ ] CI checks pass
- [ ] Manual test: pass an old-version doc token to `feishu_doc` action `read`, verify output includes `document_version: "old"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)