### PR TITLE
fix(telegram): honor chat reaction allowlist for ack

### DIFF
--- a/extensions/telegram/src/bot-message-context.reactions.test.ts
+++ b/extensions/telegram/src/bot-message-context.reactions.test.ts
@@ -107,6 +107,120 @@ describe("buildTelegramMessageContext reactions", () => {
     expect(setMessageReaction).not.toHaveBeenCalled();
   });
 
+  it("uses an allowed Telegram fallback emoji for plain ack reactions", async () => {
+    const setMessageReaction = vi.fn(async () => undefined);
+    inboundBodyMock.mockResolvedValueOnce({
+      bodyText: "@bot hello",
+      rawBody: "@bot hello",
+      historyKey: undefined,
+      commandAuthorized: false,
+      effectiveWasMentioned: true,
+      canDetectMention: true,
+      shouldBypassMention: false,
+      stickerCacheHit: false,
+      locationData: undefined,
+    });
+
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 56,
+        chat: {
+          id: -1001234567890,
+          type: "group",
+          title: "Ops",
+          available_reactions: [{ type: "emoji", emoji: "👍" }],
+        },
+        date: 1_700_000_000,
+        text: "@bot hello",
+        from: { id: 42, first_name: "Alice" },
+      },
+      cfg: {
+        agents: {
+          defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" },
+        },
+        channels: {
+          telegram: {
+            groupPolicy: "open",
+            groups: { "*": { requireMention: true } },
+          },
+        },
+        messages: {
+          ackReaction: "👀",
+          groupChat: { mentionPatterns: [] },
+        },
+      },
+      ackReactionScope: "group-all",
+      botApi: { setMessageReaction },
+      resolveGroupActivation: () => false,
+      resolveGroupRequireMention: () => true,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: true },
+        topicConfig: undefined,
+      }),
+    });
+
+    await expect(ctx?.ackReactionPromise).resolves.toBe(true);
+    expect(setMessageReaction).toHaveBeenCalledWith(-1001234567890, 56, [
+      { type: "emoji", emoji: "👍" },
+    ]);
+  });
+
+  it("skips plain ack reactions when Telegram exposes no allowed emoji variant", async () => {
+    const setMessageReaction = vi.fn(async () => undefined);
+    inboundBodyMock.mockResolvedValueOnce({
+      bodyText: "@bot hello",
+      rawBody: "@bot hello",
+      historyKey: undefined,
+      commandAuthorized: false,
+      effectiveWasMentioned: true,
+      canDetectMention: true,
+      shouldBypassMention: false,
+      stickerCacheHit: false,
+      locationData: undefined,
+    });
+
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 57,
+        chat: {
+          id: -1001234567890,
+          type: "group",
+          title: "Ops",
+          available_reactions: [],
+        },
+        date: 1_700_000_000,
+        text: "@bot hello",
+        from: { id: 42, first_name: "Alice" },
+      },
+      cfg: {
+        agents: {
+          defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" },
+        },
+        channels: {
+          telegram: {
+            groupPolicy: "open",
+            groups: { "*": { requireMention: true } },
+          },
+        },
+        messages: {
+          ackReaction: "👀",
+          groupChat: { mentionPatterns: [] },
+        },
+      },
+      ackReactionScope: "group-all",
+      botApi: { setMessageReaction },
+      resolveGroupActivation: () => false,
+      resolveGroupRequireMention: () => true,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: true },
+        topicConfig: undefined,
+      }),
+    });
+
+    await expect(ctx?.ackReactionPromise).resolves.toBe(false);
+    expect(setMessageReaction).not.toHaveBeenCalled();
+  });
+
   it("keeps Telegram status reaction variants available for configured emoji fallbacks", async () => {
     const setMessageReaction = vi.fn(async () => undefined);
     const { controller, createStatusReactionController } = createStatusReactionControllerStub();

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -507,7 +507,20 @@ export const buildTelegramMessageContext = async ({
   const statusReactionVariantsByEmoji = resolvedStatusReactionEmojis
     ? buildTelegramStatusReactionVariants(resolvedStatusReactionEmojis)
     : new Map<string, string[]>();
-  let allowedStatusReactionEmojisPromise: Promise<Set<TelegramReactionEmoji> | null> | null = null;
+  let allowedReactionEmojisPromise: Promise<Set<TelegramReactionEmoji> | null> | null = null;
+  const resolveAllowedReactionEmojis = () => {
+    allowedReactionEmojisPromise ??= resolveTelegramAllowedEmojiReactions({
+      chat: msg.chat,
+      chatId,
+      getChat: getChatApi ?? undefined,
+    }).catch((err) => {
+      logVerbose(
+        `telegram reaction available_reactions lookup failed for chat ${chatId}: ${String(err)}`,
+      );
+      return null;
+    });
+    return allowedReactionEmojisPromise;
+  };
   const createStatusReactionController =
     statusReactionsEnabled && resolvedStatusReactionEmojis && msg.message_id
       ? (runtime?.createStatusReactionController ??
@@ -520,19 +533,7 @@ export const buildTelegramMessageContext = async ({
           adapter: {
             setReaction: async (emoji: string) => {
               if (reactionApi) {
-                if (!allowedStatusReactionEmojisPromise) {
-                  allowedStatusReactionEmojisPromise = resolveTelegramAllowedEmojiReactions({
-                    chat: msg.chat,
-                    chatId,
-                    getChat: getChatApi ?? undefined,
-                  }).catch((err) => {
-                    logVerbose(
-                      `telegram status-reaction available_reactions lookup failed for chat ${chatId}: ${String(err)}`,
-                    );
-                    return null;
-                  });
-                }
-                const allowedStatusReactionEmojis = await allowedStatusReactionEmojisPromise;
+                const allowedStatusReactionEmojis = await resolveAllowedReactionEmojis();
                 const resolvedEmoji = resolveTelegramReactionVariant({
                   requestedEmoji: emoji,
                   variantsByRequestedEmoji: statusReactionVariantsByEmoji,
@@ -566,10 +567,21 @@ export const buildTelegramMessageContext = async ({
     : shouldSendAckReaction && msg.message_id && reactionApi && ackReactionEmoji
       ? withTelegramApiErrorLogging({
           operation: "setMessageReaction",
-          fn: () =>
-            reactionApi(chatId, msg.message_id, [{ type: "emoji", emoji: ackReactionEmoji }]),
+          fn: async () => {
+            const allowedReactionEmojis = await resolveAllowedReactionEmojis();
+            const resolvedEmoji = resolveTelegramReactionVariant({
+              requestedEmoji: ackReactionEmoji,
+              variantsByRequestedEmoji: new Map(),
+              allowedEmojiReactions: allowedReactionEmojis,
+            });
+            if (!resolvedEmoji) {
+              return false;
+            }
+            await reactionApi(chatId, msg.message_id, [{ type: "emoji", emoji: resolvedEmoji }]);
+            return true;
+          },
         }).then(
-          () => true,
+          (didAck) => didAck,
           (err) => {
             logVerbose(`telegram react failed for chat ${chatId}: ${String(err)}`);
             return false;


### PR DESCRIPTION
## Summary
- reuse Telegram available_reactions resolution for plain ack reactions
- fall back from the configured ack emoji to an allowed Telegram reaction variant before calling setMessageReaction
- skip the ack cleanly when a chat exposes no allowed emoji variant, avoiding REACTION_INVALID before reply delivery continues

Fixes #81765.

## Tests
- pnpm vitest run extensions/telegram/src/bot-message-context.reactions.test.ts
- node scripts/check-changed.mjs

## Real behavior proof
**Behavior addressed:** Telegram group ack reactions now respect the chat available_reactions allowlist before calling setMessageReaction. If the configured ack emoji is not allowed, OpenClaw uses an allowed fallback emoji; if no supported variant is allowed, it skips the ack instead of making a Telegram API call that can return REACTION_INVALID.

**Real environment tested:** Local OpenClaw source checkout on commit a243e27411, Node/pnpm test runtime, Telegram message-context execution path. No live Telegram bot token or real group chat was available.

**Exact steps or command run after the patch:**
1. Run `pnpm vitest run extensions/telegram/src/bot-message-context.reactions.test.ts`.
2. Run `node scripts/check-changed.mjs`.
3. Inspect the regression assertions for the limited `available_reactions` group and empty `available_reactions` group.

**Evidence after fix:**
```text
$ pnpm vitest run extensions/telegram/src/bot-message-context.reactions.test.ts
Test Files  1 passed (1)
Tests  4 passed (4)

$ node scripts/check-changed.mjs
[check:changed] lanes=extensions, extensionTests
[check:changed] extensions/telegram/src/bot-message-context.reactions.test.ts: extension test
[check:changed] extensions/telegram/src/bot-message-context.ts: extension production
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).
```

**Observed result after fix:** The limited group path calls setMessageReaction with 👍 instead of the configured but disallowed 👀. The empty allowlist group resolves ackReactionPromise to false and does not call setMessageReaction, avoiding the reported REACTION_INVALID source path before reply delivery continues.

**What was not tested:** Live Telegram group delivery with a real bot token was not tested; no production Telegram credentials or live MiniMax/OpenClaw runtime were available in this environment.
