### PR TITLE
fix(telegram): keep plugin slash commands on native path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Security/sandbox: include Windows `USERPROFILE` in the sandbox blocked home roots so credential-bearing binds (such as `.codex`, `.openclaw`, or `.ssh` under the Windows user profile) are denied even when `HOME` points at a different shell home. (#63074) Thanks @luoyanglang.
 - Gateway/OpenAI-compatible HTTP: parse shared JSON endpoint paths without trusting malformed Host headers, avoiding 500s before `/v1/chat/completions`, `/v1/responses`, and `/v1/embeddings` request handling.
 - Telegram: keep Bot API polling alive during main event-loop stalls by moving ingress to an isolated worker with a durable local spool. Fixes #81132. (#81746) Thanks @joshavant.
+- Telegram: resolve plugin native commands with the active runtime config so commands like `/codex ...` stay on the native command path.
 - Telegram: preserve rendered HTML formatting through lazy cron announce delivery so Markdown links stay clickable instead of falling back to literal anchor tags. Fixes #81742. (#81758)
 - Voice-call webhooks: parse webhook and realtime upgrade paths without trusting malformed Host headers, avoiding 500s before provider signature checks or path rejection.
 - Media store: reject malformed redirect `Location` headers as media-download failures instead of letting URL parsing escape the async response callback.

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -284,6 +284,23 @@ describe("registerTelegramNativeCommands", () => {
     expect(registeredHandlers).not.toContain("export-session");
   });
 
+  it("resolves plugin commands with the Telegram runtime config", () => {
+    const cfg: OpenClawConfig = {
+      commands: { native: true },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+        },
+      },
+    };
+
+    registerTelegramNativeCommands(createNativeCommandTestParams(cfg));
+
+    expect(pluginCommandMocks.getPluginCommandSpecs).toHaveBeenCalledWith("telegram", {
+      config: cfg,
+    });
+  });
+
   it("registers only Telegram-safe command names across native, custom, and plugin sources", async () => {
     const setMyCommands = vi.fn().mockResolvedValue(undefined);
 

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -732,7 +732,7 @@ export const registerTelegramNativeCommands = ({
   const pluginCommandSpecs =
     (
       telegramDeps.getPluginCommandSpecs ?? defaultTelegramNativeCommandDeps.getPluginCommandSpecs
-    )?.("telegram") ?? [];
+    )?.("telegram", { config: cfg }) ?? [];
   const existingCommands = new Set(
     [
       ...nativeCommands.map((command) => normalizeTelegramCommandName(command.name)),


### PR DESCRIPTION
## Summary

- Pass Telegram runtime config into plugin native-command discovery so plugin slash commands use the same config-aware path as other command surfaces.
- Add a regression test for the Telegram native command registrar.
- Add an Unreleased changelog fix entry.

Follow-up to #81747.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/telegram/src/bot-native-commands.test.ts --testNamePattern 'runtime config|Telegram-safe command names|hyphenated native command names'`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/telegram/src/bot-native-commands.registry.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: Telegram plugin slash commands like `/codex sessions --host ...` should stay on the native command path instead of falling through as ordinary chat text.
Real environment tested: local Telegram bot profile against PR 81747 before this follow-up, with a paired `codex-pr81747-local` node and Codex CLI session listing enabled.
Exact steps or command run after this patch: focused Telegram native-command tests listed above, plus the local live Telegram profile check below from the same investigation.
Evidence after fix: copied redacted terminal output from the live local setup:

```json
{
  "scope": "default",
  "ok": true,
  "count": 54,
  "hasCodex": true,
  "codex": {
    "command": "codex",
    "description": "Inspect and control the Codex app-server harness"
  }
}
{
  "scope": "all_group_chats",
  "ok": true,
  "count": 54,
  "hasCodex": true,
  "codex": {
    "command": "codex",
    "description": "Inspect and control the Codex app-server harness"
  }
}
```

```json
{
  "ok": true,
  "nodeId": "cb8d019b...eaf6c",
  "command": "codex.cli.sessions.list",
  "payload": {
    "sessions": [
      {
        "sessionId": "019e2597-b5a0-7343-a17b-98b0b96b9b56",
        "cwd": "<redacted>/openclaw",
        "messageCount": 6
      }
    ],
    "codexHome": "<redacted>/.codex"
  }
}
```

Observed result after fix: in the local proof run, `/codex sessions --host codex-pr81747-local` listed Codex sessions through `codex.cli.sessions.list` instead of invoking the LLM.
What was not tested: full CI and a fresh post-PR live Telegram run from this exact branch.
