### PR TITLE
[codex] support session-isolated app-server clients

### DIFF
--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -55,9 +55,23 @@ export function createCodexAppServerAgentHarness(options?: {
       return maybeCompactCodexAppServerSession(params, { pluginConfig: options?.pluginConfig });
     },
     reset: async (params) => {
+      const { resolveCodexAppServerRuntimeOptions } = await import("./src/app-server/config.js");
+      const appServer = resolveCodexAppServerRuntimeOptions({
+        pluginConfig: options?.pluginConfig,
+      });
+      const isolationKey =
+        appServer.clientIsolation === "session"
+          ? params.sandboxSessionKey?.trim() || params.sessionKey?.trim() || params.sessionId
+          : undefined;
       if (params.sessionFile) {
-        const { clearCodexAppServerBinding } = await import("./src/app-server/session-binding.js");
-        await clearCodexAppServerBinding(params.sessionFile);
+        const { clearAllCodexAppServerBindings } =
+          await import("./src/app-server/session-binding.js");
+        await clearAllCodexAppServerBindings(params.sessionFile);
+      }
+      if (isolationKey) {
+        const { clearSharedCodexAppServerClientForIsolationKey } =
+          await import("./src/app-server/shared-client.js");
+        clearSharedCodexAppServerClientForIsolationKey(isolationKey);
       }
     },
     dispose: async () => {

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -175,6 +175,16 @@
             "minimum": 1,
             "default": 60000
           },
+          "turnTerminalIdleTimeoutMs": {
+            "type": "number",
+            "minimum": 1,
+            "default": 1800000
+          },
+          "clientIsolation": {
+            "type": "string",
+            "enum": ["agent", "session"],
+            "default": "agent"
+          },
           "approvalPolicy": {
             "type": "string",
             "enum": ["never", "on-request", "on-failure", "untrusted"]
@@ -343,6 +353,16 @@
     "appServer.turnCompletionIdleTimeoutMs": {
       "label": "Turn Completion Idle Timeout",
       "help": "Maximum quiet time after Codex accepts a turn or after a turn-scoped app-server request before OpenClaw interrupts the turn while waiting for turn/completed.",
+      "advanced": true
+    },
+    "appServer.turnTerminalIdleTimeoutMs": {
+      "label": "Turn Terminal Idle Timeout",
+      "help": "Maximum quiet time during an accepted Codex app-server turn before OpenClaw interrupts the turn while waiting for a terminal event.",
+      "advanced": true
+    },
+    "appServer.clientIsolation": {
+      "label": "Client Isolation",
+      "help": "Controls whether Codex app-server clients are shared per agent or isolated per OpenClaw session/topic.",
       "advanced": true
     },
     "appServer.approvalPolicy": {

--- a/extensions/codex/src/app-server/client-factory.ts
+++ b/extensions/codex/src/app-server/client-factory.ts
@@ -11,6 +11,7 @@ export type CodexAppServerClientFactory = (
   authProfileId?: string,
   agentDir?: string,
   config?: AuthProfileOrderConfig,
+  isolationKey?: string,
 ) => Promise<CodexAppServerClient>;
 
 export const defaultCodexAppServerClientFactory: CodexAppServerClientFactory = (
@@ -18,7 +19,8 @@ export const defaultCodexAppServerClientFactory: CodexAppServerClientFactory = (
   authProfileId,
   agentDir,
   config,
+  isolationKey,
 ) =>
   import("./shared-client.js").then(({ getSharedCodexAppServerClient }) =>
-    getSharedCodexAppServerClient({ startOptions, authProfileId, agentDir, config }),
+    getSharedCodexAppServerClient({ startOptions, authProfileId, agentDir, config, isolationKey }),
   );

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -311,7 +311,14 @@ async function compactCodexNativeThread(
   options: { pluginConfig?: unknown; clientFactory?: CodexAppServerClientFactory } = {},
 ): Promise<EmbeddedPiCompactResult | undefined> {
   const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig: options.pluginConfig });
-  const binding = await readCodexAppServerBinding(params.sessionFile, { config: params.config });
+  const appServerClientIsolationKey =
+    appServer.clientIsolation === "session"
+      ? resolveCodexAppServerCompactionIsolationKey(params)
+      : undefined;
+  const binding = await readCodexAppServerBinding(params.sessionFile, {
+    config: params.config,
+    isolationKey: appServerClientIsolationKey,
+  });
   if (!binding?.threadId) {
     return { ok: false, compacted: false, reason: "no codex app-server thread binding" };
   }
@@ -330,6 +337,7 @@ async function compactCodexNativeThread(
     requestedAuthProfileId ?? binding.authProfileId,
     params.agentDir,
     params.config,
+    appServerClientIsolationKey,
   );
   const waiter = createCodexNativeCompactionWaiter(client, binding.threadId);
   let completion: CodexNativeCompactionCompletion;
@@ -374,6 +382,16 @@ async function compactCodexNativeThread(
       },
     },
   };
+}
+
+function resolveCodexAppServerCompactionIsolationKey(
+  params: CompactEmbeddedPiSessionParams,
+): string {
+  return (
+    params.sandboxSessionKey?.trim() ||
+    params.sessionKey?.trim() ||
+    params.sessionId
+  ).replace(/:run:[^:]+$/, "");
 }
 
 function createCodexNativeCompactionWaiter(

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -69,6 +69,8 @@ describe("Codex app-server config", () => {
           serviceTier: "flex",
           codeModeOnly: true,
           turnCompletionIdleTimeoutMs: 120_000,
+          turnTerminalIdleTimeoutMs: 180_000,
+          clientIsolation: "session",
         },
       },
       env: {
@@ -84,6 +86,8 @@ describe("Codex app-server config", () => {
       serviceTier: "flex",
       codeModeOnly: true,
       turnCompletionIdleTimeoutMs: 120_000,
+      turnTerminalIdleTimeoutMs: 180_000,
+      clientIsolation: "session",
     });
     expectFields(runtime.start, "runtime start", {
       transport: "websocket",
@@ -120,6 +124,12 @@ describe("Codex app-server config", () => {
     expectFields(runtime.start, "runtime start", {
       clearEnv: ["OPENAI_API_KEY"],
     });
+  });
+
+  it("keeps the terminal idle watchdog default aligned with the existing 30 minute runtime timeout", () => {
+    const runtime = resolveRuntimeForTest();
+
+    expect(runtime.turnTerminalIdleTimeoutMs).toBe(30 * 60_000);
   });
 
   it("normalizes legacy service tiers without discarding the rest of the config", () => {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -32,6 +32,7 @@ export type CodexAppServerEffectiveApprovalPolicy =
 export type CodexAppServerSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
 type CodexAppServerApprovalsReviewer = "user" | "auto_review" | "guardian_subagent";
 type CodexAppServerCommandSource = "managed" | "resolved-managed" | "config" | "env";
+export type CodexAppServerClientIsolation = "agent" | "session";
 export type CodexDynamicToolsLoading = "searchable" | "direct";
 export type CodexPluginDestructivePolicy = boolean;
 
@@ -104,6 +105,8 @@ export type CodexAppServerRuntimeOptions = {
   codeModeOnly: boolean;
   requestTimeoutMs: number;
   turnCompletionIdleTimeoutMs: number;
+  turnTerminalIdleTimeoutMs: number;
+  clientIsolation: CodexAppServerClientIsolation;
   approvalPolicy: CodexAppServerEffectiveApprovalPolicy;
   sandbox: CodexAppServerSandboxMode;
   approvalsReviewer: CodexAppServerApprovalsReviewer;
@@ -131,6 +134,8 @@ export type CodexPluginConfig = {
     codeModeOnly?: boolean;
     requestTimeoutMs?: number;
     turnCompletionIdleTimeoutMs?: number;
+    turnTerminalIdleTimeoutMs?: number;
+    clientIsolation?: CodexAppServerClientIsolation;
     approvalPolicy?: CodexAppServerApprovalPolicy;
     sandbox?: CodexAppServerSandboxMode;
     approvalsReviewer?: CodexAppServerApprovalsReviewer;
@@ -151,6 +156,8 @@ export const CODEX_APP_SERVER_CONFIG_KEYS = [
   "codeModeOnly",
   "requestTimeoutMs",
   "turnCompletionIdleTimeoutMs",
+  "turnTerminalIdleTimeoutMs",
+  "clientIsolation",
   "approvalPolicy",
   "sandbox",
   "approvalsReviewer",
@@ -196,6 +203,7 @@ const codexAppServerApprovalPolicySchema = z.enum([
 ]);
 const codexAppServerSandboxSchema = z.enum(["read-only", "workspace-write", "danger-full-access"]);
 const codexAppServerApprovalsReviewerSchema = z.enum(["user", "auto_review", "guardian_subagent"]);
+const codexAppServerClientIsolationSchema = z.enum(["agent", "session"]);
 const codexDynamicToolsLoadingSchema = z.enum(["searchable", "direct"]);
 const codexAppServerServiceTierSchema = z
   .preprocess(
@@ -259,6 +267,8 @@ const codexPluginConfigSchema = z
         codeModeOnly: z.boolean().optional(),
         requestTimeoutMs: z.number().positive().optional(),
         turnCompletionIdleTimeoutMs: z.number().positive().optional(),
+        turnTerminalIdleTimeoutMs: z.number().positive().optional(),
+        clientIsolation: codexAppServerClientIsolationSchema.optional(),
         approvalPolicy: codexAppServerApprovalPolicySchema.optional(),
         sandbox: codexAppServerSandboxSchema.optional(),
         approvalsReviewer: codexAppServerApprovalsReviewerSchema.optional(),
@@ -377,6 +387,11 @@ export function resolveCodexAppServerRuntimeOptions(
       config.turnCompletionIdleTimeoutMs,
       60_000,
     ),
+    turnTerminalIdleTimeoutMs: normalizePositiveNumber(
+      config.turnTerminalIdleTimeoutMs,
+      30 * 60_000,
+    ),
+    clientIsolation: config.clientIsolation ?? "agent",
     approvalPolicy:
       resolveApprovalPolicy(config.approvalPolicy) ??
       resolveApprovalPolicy(env.OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY) ??

--- a/extensions/codex/src/app-server/request.ts
+++ b/extensions/codex/src/app-server/request.ts
@@ -21,6 +21,7 @@ export async function requestCodexAppServerJson<M extends CodexAppServerRequestM
   agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
   isolated?: boolean;
+  isolationKey?: string;
 }): Promise<CodexAppServerRequestResult<M>>;
 export async function requestCodexAppServerJson<T = JsonValue | undefined>(params: {
   method: string;
@@ -31,6 +32,7 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
   agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
   isolated?: boolean;
+  isolationKey?: string;
 }): Promise<T>;
 export async function requestCodexAppServerJson<T = JsonValue | undefined>(params: {
   method: string;
@@ -41,19 +43,27 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
   agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
   isolated?: boolean;
+  isolationKey?: string;
 }): Promise<T> {
   const timeoutMs = params.timeoutMs ?? 60_000;
   return await withTimeout(
     (async () => {
-      const client = await (
-        params.isolated ? createIsolatedCodexAppServerClient : getSharedCodexAppServerClient
-      )({
-        startOptions: params.startOptions,
-        timeoutMs,
-        authProfileId: params.authProfileId,
-        agentDir: params.agentDir,
-        config: params.config,
-      });
+      const client = await (params.isolated
+        ? createIsolatedCodexAppServerClient({
+            startOptions: params.startOptions,
+            timeoutMs,
+            authProfileId: params.authProfileId,
+            agentDir: params.agentDir,
+            config: params.config,
+          })
+        : getSharedCodexAppServerClient({
+            startOptions: params.startOptions,
+            timeoutMs,
+            authProfileId: params.authProfileId,
+            agentDir: params.agentDir,
+            config: params.config,
+            isolationKey: params.isolationKey,
+          }));
       try {
         return await client.request<T>(params.method, params.requestParams, { timeoutMs });
       } finally {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -234,7 +234,11 @@ function mockCall(mock: unknown, label: string, index = 0): unknown[] {
 function createAppServerHarness(
   requestImpl: (method: string, params: unknown) => Promise<unknown>,
   options: {
-    onStart?: (authProfileId: string | undefined, agentDir: string | undefined) => void;
+    onStart?: (
+      authProfileId: string | undefined,
+      agentDir: string | undefined,
+      isolationKey: string | undefined,
+    ) => void;
   } = {},
 ) {
   const requests: Array<{ method: string; params: unknown }> = [];
@@ -246,24 +250,26 @@ function createAppServerHarness(
     return requestImpl(method, params);
   });
 
-  setCodexAppServerClientFactoryForTest(async (_startOptions, authProfileId, agentDir) => {
-    options.onStart?.(authProfileId, agentDir);
-    return {
-      request,
-      addNotificationHandler: (handler: typeof notify) => {
-        notify = handler;
-        return () => undefined;
-      },
-      addRequestHandler: (handler: AppServerRequestHandler) => {
-        handleServerRequest = handler;
-        return () => undefined;
-      },
-      addCloseHandler: (handler: () => void) => {
-        closeHandlers.add(handler);
-        return () => closeHandlers.delete(handler);
-      },
-    } as never;
-  });
+  setCodexAppServerClientFactoryForTest(
+    async (_startOptions, authProfileId, agentDir, _config, isolationKey) => {
+      options.onStart?.(authProfileId, agentDir, isolationKey);
+      return {
+        request,
+        addNotificationHandler: (handler: typeof notify) => {
+          notify = handler;
+          return () => undefined;
+        },
+        addRequestHandler: (handler: AppServerRequestHandler) => {
+          handleServerRequest = handler;
+          return () => undefined;
+        },
+        addCloseHandler: (handler: () => void) => {
+          closeHandlers.add(handler);
+          return () => closeHandlers.delete(handler);
+        },
+      } as never;
+    },
+  );
 
   const waitForServerRequestHandler = async () => {
     await vi.waitFor(() => expect(handleServerRequest).toBeTypeOf("function"), {
@@ -320,7 +326,11 @@ function createAppServerHarness(
 function createStartedThreadHarness(
   requestImpl: (method: string, params: unknown) => Promise<unknown> = async () => undefined,
   options: {
-    onStart?: (authProfileId: string | undefined, agentDir: string | undefined) => void;
+    onStart?: (
+      authProfileId: string | undefined,
+      agentDir: string | undefined,
+      isolationKey: string | undefined,
+    ) => void;
   } = {},
 ) {
   return createAppServerHarness(async (method, params) => {
@@ -390,6 +400,8 @@ function createThreadLifecycleAppServerOptions(): Parameters<
     },
     requestTimeoutMs: 60_000,
     turnCompletionIdleTimeoutMs: 60_000,
+    turnTerminalIdleTimeoutMs: 30 * 60_000,
+    clientIsolation: "agent",
     approvalPolicy: "never",
     approvalsReviewer: "user",
     sandbox: "workspace-write",
@@ -723,6 +735,37 @@ describe("runCodexAppServerAttempt", () => {
     ]) {
       expect(dynamicToolNames).not.toContain(toolName);
     }
+  });
+
+  it("uses a stable session isolation key for cron run-scoped sessions", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    let seenIsolationKey: string | undefined;
+    const harness = createStartedThreadHarness(undefined, {
+      onStart: (_authProfileId, _agentDir, isolationKey) => {
+        seenIsolationKey = isolationKey;
+      },
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.trigger = "cron";
+    params.sessionKey = "agent:main:cron:job-a:run:run-1";
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { clientIsolation: "session" } },
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await expect(run).resolves.toMatchObject({ aborted: false, timedOut: false });
+
+    expect(seenIsolationKey).toBe("agent:main:cron:job-a");
+    await expect(
+      readCodexAppServerBinding(sessionFile, { isolationKey: "agent:main:cron:job-a" }),
+    ).resolves.toMatchObject({ threadId: "thread-1" });
+    await expect(
+      readCodexAppServerBinding(sessionFile, {
+        isolationKey: "agent:main:cron:job-a:run:run-1",
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it("passes MCP server config through to Codex thread/start", async () => {
@@ -8350,6 +8393,8 @@ describe("runCodexAppServerAttempt", () => {
       codeModeOnly: false,
       requestTimeoutMs: 60_000,
       turnCompletionIdleTimeoutMs: 60_000,
+      turnTerminalIdleTimeoutMs: 60_000,
+      clientIsolation: "agent" as const,
       approvalPolicy: "on-request" as const,
       approvalsReviewer: "guardian_subagent" as const,
       sandbox: "danger-full-access" as const,
@@ -8467,6 +8512,8 @@ describe("runCodexAppServerAttempt", () => {
         codeModeOnly: false,
         requestTimeoutMs: 60_000,
         turnCompletionIdleTimeoutMs: 60_000,
+        turnTerminalIdleTimeoutMs: 60_000,
+        clientIsolation: "agent",
         approvalPolicy: "never",
         approvalsReviewer: "user",
         sandbox: "workspace-write",

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -679,6 +679,7 @@ function maxFiniteNumber(values: Array<number | undefined>): number | undefined 
 async function rotateOversizedCodexAppServerStartupBinding(params: {
   binding: CodexAppServerThreadBinding | undefined;
   sessionFile: string;
+  isolationKey?: string;
   agentDir: string;
   codexHome?: string;
   config: EmbeddedRunAttemptParams["config"] | undefined;
@@ -710,7 +711,7 @@ async function rotateOversizedCodexAppServerStartupBinding(params: {
           files: oversizedFiles.map((file) => ({ path: file.path, bytes: file.bytes })),
         },
       );
-      await clearCodexAppServerBinding(params.sessionFile);
+      await clearCodexAppServerBinding(params.sessionFile, { isolationKey: params.isolationKey });
       return undefined;
     }
   }
@@ -737,10 +738,20 @@ async function rotateOversizedCodexAppServerStartupBinding(params: {
         nativeTokens,
       },
     );
-    await clearCodexAppServerBinding(params.sessionFile);
+    await clearCodexAppServerBinding(params.sessionFile, { isolationKey: params.isolationKey });
     return undefined;
   }
   return binding;
+}
+
+function resolveCodexAppServerRunIsolationKey(
+  params: EmbeddedRunAttemptParams,
+  sandboxSessionKey: string,
+): string {
+  if (params.trigger !== "cron") {
+    return sandboxSessionKey;
+  }
+  return sandboxSessionKey.replace(/:run:[^:]+$/, "");
 }
 
 export async function runCodexAppServerAttempt(
@@ -794,6 +805,10 @@ export async function runCodexAppServerAttempt(
       configuredAppServer.start.transport !== "stdio" ||
       isCodexAppServerApprovalPolicyAllowedByRequirements("untrusted"),
   });
+  const appServerClientIsolationKey =
+    appServer.clientIsolation === "session"
+      ? resolveCodexAppServerRunIsolationKey(params, sandboxSessionKey)
+      : undefined;
   let pluginAppServer: CodexAppServerRuntimeOptions = appServer;
   const nativeHookRelayEvents = resolveCodexNativeHookRelayEvents({
     configuredEvents: options.nativeHookRelay?.events,
@@ -816,11 +831,14 @@ export async function runCodexAppServerAttempt(
     agentId: params.agentId,
   });
   const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, sessionAgentId);
-  let startupBinding = await readCodexAppServerBinding(params.sessionFile);
+  let startupBinding = await readCodexAppServerBinding(params.sessionFile, {
+    isolationKey: appServerClientIsolationKey,
+  });
   const startupBindingAuthProfileId = startupBinding?.authProfileId;
   startupBinding = await rotateOversizedCodexAppServerStartupBinding({
     binding: startupBinding,
     sessionFile: params.sessionFile,
+    isolationKey: appServerClientIsolationKey,
     agentDir,
     codexHome: appServer.start.env?.CODEX_HOME,
     config: params.config,
@@ -1210,6 +1228,7 @@ export async function runCodexAppServerAttempt(
             startupAuthProfileId,
             agentDir,
             params.config,
+            appServerClientIsolationKey,
           );
           attemptedClient = startupClient;
           startupClientForCleanup = startupClient;
@@ -1358,7 +1377,7 @@ export async function runCodexAppServerAttempt(
     options.turnAssistantCompletionIdleTimeoutMs,
   );
   const turnTerminalIdleTimeoutMs = resolveCodexTurnTerminalIdleTimeoutMs(
-    options.turnTerminalIdleTimeoutMs,
+    options.turnTerminalIdleTimeoutMs ?? appServer.turnTerminalIdleTimeoutMs,
   );
   let turnCompletionIdleTimer: ReturnType<typeof setTimeout> | undefined;
   let turnCompletionIdleWatchArmed = false;
@@ -2257,9 +2276,13 @@ export async function runCodexAppServerAttempt(
       );
       const preRetrySessionFile = activeSessionFile;
       const compactedForRetry = await forceContextEngineCompactionForCodexOverflow(turnStartError);
-      await clearCodexAppServerBinding(preRetrySessionFile);
+      await clearCodexAppServerBinding(preRetrySessionFile, {
+        isolationKey: appServerClientIsolationKey,
+      });
       if (activeSessionFile !== preRetrySessionFile) {
-        await clearCodexAppServerBinding(activeSessionFile);
+        await clearCodexAppServerBinding(activeSessionFile, {
+          isolationKey: appServerClientIsolationKey,
+        });
       }
       if (compactedForRetry) {
         await rebuildPromptAfterContextEngineCompaction();
@@ -2285,11 +2308,15 @@ export async function runCodexAppServerAttempt(
       });
       const turnStartErrorMessage = usageLimitError?.message ?? formatErrorMessage(turnStartError);
       if (isInvalidCodexImagePayloadError(turnStartErrorMessage)) {
-        await clearCodexBindingAfterInvalidImagePayload(activeSessionFile, {
-          phase: "turn_start",
-          threadId: thread.threadId,
-          error: turnStartErrorMessage,
-        });
+        await clearCodexBindingAfterInvalidImagePayload(
+          activeSessionFile,
+          {
+            phase: "turn_start",
+            threadId: thread.threadId,
+            error: turnStartErrorMessage,
+          },
+          appServerClientIsolationKey,
+        );
       }
       emitCodexAppServerEvent(params, {
         stream: "codex_app_server.lifecycle",
@@ -2495,12 +2522,16 @@ export async function runCodexAppServerAttempt(
           ? formatErrorMessage(finalPromptError)
           : undefined;
     if (isInvalidCodexImagePayloadError(finalPromptErrorMessage)) {
-      await clearCodexBindingAfterInvalidImagePayload(activeSessionFile, {
-        phase: "turn_completed",
-        threadId: thread.threadId,
-        turnId: activeTurnId,
-        error: finalPromptErrorMessage,
-      });
+      await clearCodexBindingAfterInvalidImagePayload(
+        activeSessionFile,
+        {
+          phase: "turn_completed",
+          threadId: thread.threadId,
+          turnId: activeTurnId,
+          error: finalPromptErrorMessage,
+        },
+        appServerClientIsolationKey,
+      );
     }
     if (shouldRefreshCodexRateLimitsForUsageLimitMessage(finalPromptErrorMessage)) {
       finalPromptError = await refreshCodexUsageLimitErrorMessage({
@@ -3579,8 +3610,9 @@ function isInvalidCodexImagePayloadError(message: unknown): boolean {
 async function clearCodexBindingAfterInvalidImagePayload(
   sessionFile: string,
   fields: { phase: string; threadId?: string; turnId?: string; error?: string },
+  isolationKey?: string,
 ): Promise<void> {
-  const currentBinding = await readCodexAppServerBinding(sessionFile);
+  const currentBinding = await readCodexAppServerBinding(sessionFile, { isolationKey });
   if (fields.threadId && currentBinding && currentBinding.threadId !== fields.threadId) {
     embeddedAgentLog.warn(
       "codex app-server image payload error detected for unbound thread; preserving thread binding",
@@ -3592,7 +3624,7 @@ async function clearCodexBindingAfterInvalidImagePayload(
     "codex app-server image payload error detected; clearing thread binding",
     fields,
   );
-  await clearCodexAppServerBinding(sessionFile);
+  await clearCodexAppServerBinding(sessionFile, { isolationKey });
 }
 
 function describeNotificationActivity(

--- a/extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts
@@ -45,6 +45,8 @@ function createAppServerOptions(): Parameters<typeof startOrResumeThread>[0]["ap
     codeModeOnly: false,
     requestTimeoutMs: 60_000,
     turnCompletionIdleTimeoutMs: 60_000,
+    turnTerminalIdleTimeoutMs: 180_000,
+    clientIsolation: "agent",
     approvalPolicy: "never",
     approvalsReviewer: "user",
     sandbox: "workspace-write",

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  clearAllCodexAppServerBindings,
   clearCodexAppServerBinding,
   readCodexAppServerBinding,
   resolveCodexAppServerBindingPath,
@@ -74,6 +75,69 @@ describe("codex app-server session binding", () => {
     expect(binding?.userMcpServersFingerprint).toBe("user-mcp-v1");
     const bindingStat = await fs.stat(resolveCodexAppServerBindingPath(sessionFile));
     expect(bindingStat.isFile()).toBe(true);
+  });
+
+  it("stores session-isolated thread bindings beside the same transcript separately", async () => {
+    const sessionFile = path.join(tempDir, "session.json");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-default",
+      cwd: tempDir,
+    });
+    await writeCodexAppServerBinding(
+      sessionFile,
+      {
+        threadId: "thread-topic-a",
+        cwd: tempDir,
+      },
+      { isolationKey: "agent:main:topic-a" },
+    );
+
+    expect(resolveCodexAppServerBindingPath(sessionFile)).not.toBe(
+      resolveCodexAppServerBindingPath(sessionFile, { isolationKey: "agent:main:topic-a" }),
+    );
+    expect((await readCodexAppServerBinding(sessionFile))?.threadId).toBe("thread-default");
+    const isolated = await readCodexAppServerBinding(sessionFile, {
+      isolationKey: "agent:main:topic-a",
+    });
+    expect(isolated?.threadId).toBe("thread-topic-a");
+    expect(isolated?.isolationKey).toBe("agent:main:topic-a");
+    await expect(
+      readCodexAppServerBinding(sessionFile, { isolationKey: "agent:main:topic-b" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("clears every isolated binding beside a session file", async () => {
+    const sessionFile = path.join(tempDir, "session.json");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-default",
+      cwd: tempDir,
+    });
+    await writeCodexAppServerBinding(
+      sessionFile,
+      {
+        threadId: "thread-topic-a",
+        cwd: tempDir,
+      },
+      { isolationKey: "agent:main:topic-a" },
+    );
+    await writeCodexAppServerBinding(
+      sessionFile,
+      {
+        threadId: "thread-topic-b",
+        cwd: tempDir,
+      },
+      { isolationKey: "agent:main:topic-b" },
+    );
+
+    await clearAllCodexAppServerBindings(sessionFile);
+
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toBeUndefined();
+    await expect(
+      readCodexAppServerBinding(sessionFile, { isolationKey: "agent:main:topic-a" }),
+    ).resolves.toBeUndefined();
+    await expect(
+      readCodexAppServerBinding(sessionFile, { isolationKey: "agent:main:topic-b" }),
+    ).resolves.toBeUndefined();
   });
 
   it("round-trips plugin app policy context with app ids as record keys", async () => {

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -1,4 +1,6 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   ensureAuthProfileStore,
@@ -26,12 +28,14 @@ export type CodexAppServerAuthProfileLookup = {
   authProfileStore?: AuthProfileStore;
   agentDir?: string;
   config?: ProviderAuthAliasConfig;
+  isolationKey?: string;
 };
 
 export type CodexAppServerThreadBinding = {
   schemaVersion: 1;
   threadId: string;
   sessionFile: string;
+  isolationKey?: string;
   cwd: string;
   authProfileId?: string;
   model?: string;
@@ -64,15 +68,24 @@ export type CodexAppServerContextEngineProjectionBinding = {
   fingerprint?: string;
 };
 
-export function resolveCodexAppServerBindingPath(sessionFile: string): string {
-  return `${sessionFile}.codex-app-server.json`;
+export function resolveCodexAppServerBindingPath(
+  sessionFile: string,
+  options: { isolationKey?: string } = {},
+): string {
+  const isolationKey = normalizeCodexAppServerBindingIsolationKey(options.isolationKey);
+  if (!isolationKey) {
+    return `${sessionFile}.codex-app-server.json`;
+  }
+  const digest = crypto.createHash("sha256").update(isolationKey).digest("hex").slice(0, 16);
+  return `${sessionFile}.codex-app-server.${digest}.json`;
 }
 
 export async function readCodexAppServerBinding(
   sessionFile: string,
   lookup: Omit<CodexAppServerAuthProfileLookup, "authProfileId"> = {},
 ): Promise<CodexAppServerThreadBinding | undefined> {
-  const path = resolveCodexAppServerBindingPath(sessionFile);
+  const isolationKey = normalizeCodexAppServerBindingIsolationKey(lookup.isolationKey);
+  const path = resolveCodexAppServerBindingPath(sessionFile, { isolationKey });
   let raw: string;
   try {
     raw = await fs.readFile(path, "utf8");
@@ -90,10 +103,15 @@ export async function readCodexAppServerBinding(
     }
     const authProfileId =
       typeof parsed.authProfileId === "string" ? parsed.authProfileId : undefined;
+    const parsedIsolationKey = normalizeCodexAppServerBindingIsolationKey(parsed.isolationKey);
+    if (parsedIsolationKey !== isolationKey) {
+      return undefined;
+    }
     return {
       schemaVersion: 1,
       threadId: parsed.threadId,
       sessionFile,
+      isolationKey: parsedIsolationKey,
       cwd: typeof parsed.cwd === "string" ? parsed.cwd : "",
       authProfileId,
       model: typeof parsed.model === "string" ? parsed.model : undefined,
@@ -146,6 +164,7 @@ export async function writeCodexAppServerBinding(
   const payload: CodexAppServerThreadBinding = {
     schemaVersion: 1,
     sessionFile,
+    isolationKey: normalizeCodexAppServerBindingIsolationKey(lookup.isolationKey),
     threadId: binding.threadId,
     cwd: binding.cwd,
     authProfileId: binding.authProfileId,
@@ -169,7 +188,7 @@ export async function writeCodexAppServerBinding(
     updatedAt: now,
   };
   await fs.writeFile(
-    resolveCodexAppServerBindingPath(sessionFile),
+    resolveCodexAppServerBindingPath(sessionFile, { isolationKey: payload.isolationKey }),
     `${JSON.stringify(payload, null, 2)}\n`,
   );
 }
@@ -274,14 +293,70 @@ function readPluginAppPolicyContext(value: unknown): PluginAppPolicyContext | un
   };
 }
 
-export async function clearCodexAppServerBinding(sessionFile: string): Promise<void> {
+export async function clearCodexAppServerBinding(
+  sessionFile: string,
+  options: { isolationKey?: string } = {},
+): Promise<void> {
   try {
-    await fs.unlink(resolveCodexAppServerBindingPath(sessionFile));
+    await fs.unlink(resolveCodexAppServerBindingPath(sessionFile, options));
   } catch (error) {
     if (!isNotFound(error)) {
       embeddedAgentLog.warn("failed to clear codex app-server binding", { sessionFile, error });
     }
   }
+}
+
+export async function clearAllCodexAppServerBindings(sessionFile: string): Promise<void> {
+  const dir = path.dirname(sessionFile);
+  const base = path.basename(sessionFile);
+  const legacyPath = resolveCodexAppServerBindingPath(sessionFile);
+  const prefix = `${base}.codex-app-server.`;
+  const suffix = ".json";
+  try {
+    const entries = await fs.readdir(dir);
+    await Promise.all(
+      entries
+        .filter(
+          (entry) =>
+            entry === `${base}.codex-app-server.json` ||
+            (entry.startsWith(prefix) && entry.endsWith(suffix)),
+        )
+        .map(async (entry) => {
+          const bindingPath = path.join(dir, entry);
+          try {
+            await fs.unlink(bindingPath);
+          } catch (error) {
+            if (!isNotFound(error)) {
+              embeddedAgentLog.warn("failed to clear codex app-server binding", {
+                sessionFile,
+                path: bindingPath,
+                error,
+              });
+            }
+          }
+        }),
+    );
+  } catch (error) {
+    if (isNotFound(error)) {
+      try {
+        await fs.unlink(legacyPath);
+      } catch (unlinkError) {
+        if (!isNotFound(unlinkError)) {
+          embeddedAgentLog.warn("failed to clear codex app-server binding", {
+            sessionFile,
+            path: legacyPath,
+            error: unlinkError,
+          });
+        }
+      }
+      return;
+    }
+    embeddedAgentLog.warn("failed to list codex app-server bindings", { sessionFile, error });
+  }
+}
+
+function normalizeCodexAppServerBindingIsolationKey(isolationKey: unknown): string | undefined {
+  return typeof isolationKey === "string" && isolationKey.trim() ? isolationKey.trim() : undefined;
 }
 
 function isNotFound(error: unknown): boolean {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -76,6 +76,7 @@ export async function getSharedCodexAppServerClient(options?: {
   authProfileId?: string | null;
   agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
+  isolationKey?: string;
 }): Promise<CodexAppServerClient> {
   const agentDir = options?.agentDir ?? resolveDefaultAgentDir(options?.config ?? {});
   const usesNativeAuth = options?.authProfileId === null;
@@ -97,10 +98,13 @@ export async function getSharedCodexAppServerClient(options?: {
     authProfileId: usesNativeAuth ? null : authProfileId,
     config: options?.config,
   });
-  const key = codexAppServerStartOptionsKey(startOptions, {
-    authProfileId,
-    agentDir: usesNativeAuth ? undefined : agentDir,
-  });
+  const key = sharedClientKeyForIsolation(
+    options?.isolationKey,
+    codexAppServerStartOptionsKey(startOptions, {
+      authProfileId,
+      agentDir: usesNativeAuth ? undefined : agentDir,
+    }),
+  );
   const state = getSharedCodexAppServerClientState();
   const entry = getOrCreateSharedClientEntry(state, key);
   const sharedPromise =
@@ -218,6 +222,24 @@ export function clearSharedCodexAppServerClientIfCurrent(
   return false;
 }
 
+export function clearSharedCodexAppServerClientForIsolationKey(
+  isolationKey: string | undefined,
+): boolean {
+  const resolvedIsolationKey = resolveSharedCodexAppServerClientIsolationKey(isolationKey);
+  if (resolvedIsolationKey === DEFAULT_SHARED_CODEX_APP_SERVER_CLIENT_ISOLATION_KEY) {
+    return false;
+  }
+  const state = getSharedCodexAppServerClientState();
+  let cleared = false;
+  for (const [key, entry] of state.clients) {
+    if (readIsolationKeyFromSharedClientKey(key) === resolvedIsolationKey) {
+      clearSharedClientEntry(key, entry);
+      cleared = true;
+    }
+  }
+  return cleared;
+}
+
 export async function clearSharedCodexAppServerClientIfCurrentAndWait(
   client: CodexAppServerClient | undefined,
   options?: {
@@ -247,6 +269,23 @@ export async function clearSharedCodexAppServerClientAndWait(options?: {
   const clients = collectSharedClients(state);
   state.clients.clear();
   await Promise.all(clients.map((client) => client.closeAndWait(options)));
+}
+
+const DEFAULT_SHARED_CODEX_APP_SERVER_CLIENT_ISOLATION_KEY = "agent";
+
+function resolveSharedCodexAppServerClientIsolationKey(isolationKey: string | undefined): string {
+  return isolationKey?.trim() || DEFAULT_SHARED_CODEX_APP_SERVER_CLIENT_ISOLATION_KEY;
+}
+
+function sharedClientKeyForIsolation(isolationKey: string | undefined, key: string): string {
+  return `${resolveSharedCodexAppServerClientIsolationKey(isolationKey)}\0${key}`;
+}
+
+function readIsolationKeyFromSharedClientKey(key: string): string {
+  const separator = key.indexOf("\0");
+  return separator >= 0
+    ? key.slice(0, separator)
+    : DEFAULT_SHARED_CODEX_APP_SERVER_CLIENT_ISOLATION_KEY;
 }
 
 function getOrCreateSharedClientEntry(

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -106,9 +106,16 @@ export async function runCodexAppServerSideQuestion(
     };
   } = {},
 ): Promise<AgentHarnessSideQuestionResult> {
+  const pluginConfig = readCodexPluginConfig(options.pluginConfig);
+  const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig });
+  const appServerClientIsolationKey =
+    appServer.clientIsolation === "session"
+      ? params.sandboxSessionKey?.trim() || params.sessionKey?.trim() || params.sessionId
+      : undefined;
   const binding = await readCodexAppServerBinding(params.sessionFile, {
     agentDir: params.agentDir,
     config: params.cfg,
+    isolationKey: appServerClientIsolationKey,
   });
   if (!binding?.threadId) {
     throw new Error(
@@ -116,8 +123,6 @@ export async function runCodexAppServerSideQuestion(
     );
   }
 
-  const pluginConfig = readCodexPluginConfig(options.pluginConfig);
-  const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig });
   const authProfileId = params.authProfileId ?? binding.authProfileId;
   const client = await getSharedCodexAppServerClient({
     startOptions: appServer.start,
@@ -125,6 +130,7 @@ export async function runCodexAppServerSideQuestion(
     authProfileId,
     agentDir: params.agentDir,
     config: params.cfg,
+    isolationKey: appServerClientIsolationKey,
   });
   const collector = new CodexSideQuestionCollector(params);
   const removeNotificationHandler = client.addNotificationHandler((notification) =>
@@ -476,7 +482,10 @@ async function createCodexSideToolBridge(input: {
     const createOpenClawCodingTools = (await import("openclaw/plugin-sdk/agent-harness"))
       .createOpenClawCodingTools;
     const sandboxSessionKey =
-      input.params.sessionKey?.trim() || input.params.sessionId || input.sessionAgentId;
+      input.params.sandboxSessionKey?.trim() ||
+      input.params.sessionKey?.trim() ||
+      input.params.sessionId ||
+      input.sessionAgentId;
     const sandbox = await resolveSandboxContext({
       config: input.params.cfg,
       sessionKey: sandboxSessionKey,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -104,6 +104,10 @@ export async function startOrResumeThread(params: {
     params.params,
     params.contextEngineProjection,
   );
+  const bindingIsolationKey = resolveCodexAppServerThreadBindingIsolationKey(
+    params.appServer,
+    params.params,
+  );
   const userMcpServersConfigPatch =
     params.userMcpServersEnabled === false
       ? undefined
@@ -115,6 +119,7 @@ export async function startOrResumeThread(params: {
     authProfileStore: params.params.authProfileStore,
     agentDir: params.params.agentDir,
     config: params.params.config,
+    isolationKey: bindingIsolationKey,
   });
   let preserveExistingBinding = false;
   let rotatedContextEngineBinding = false;
@@ -148,7 +153,9 @@ export async function startOrResumeThread(params: {
           previousPolicyFingerprint: binding.contextEngine?.policyFingerprint,
         },
       );
-      await clearCodexAppServerBinding(params.params.sessionFile);
+      await clearCodexAppServerBinding(params.params.sessionFile, {
+        isolationKey: bindingIsolationKey,
+      });
       binding = undefined;
       rotatedContextEngineBinding = true;
     }
@@ -157,7 +164,9 @@ export async function startOrResumeThread(params: {
     embeddedAgentLog.debug("codex app-server user MCP config changed; starting a new thread", {
       threadId: binding.threadId,
     });
-    await clearCodexAppServerBinding(params.params.sessionFile);
+    await clearCodexAppServerBinding(params.params.sessionFile, {
+      isolationKey: bindingIsolationKey,
+    });
     binding = undefined;
   }
   if (
@@ -168,7 +177,9 @@ export async function startOrResumeThread(params: {
     embeddedAgentLog.debug("codex app-server MCP config changed; starting a new thread", {
       threadId: binding.threadId,
     });
-    await clearCodexAppServerBinding(params.params.sessionFile);
+    await clearCodexAppServerBinding(params.params.sessionFile, {
+      isolationKey: bindingIsolationKey,
+    });
     binding = undefined;
   }
   if (binding?.threadId) {
@@ -201,7 +212,9 @@ export async function startOrResumeThread(params: {
       embeddedAgentLog.debug("codex app-server plugin app config changed; starting a new thread", {
         threadId: binding.threadId,
       });
-      await clearCodexAppServerBinding(params.params.sessionFile);
+      await clearCodexAppServerBinding(params.params.sessionFile, {
+        isolationKey: bindingIsolationKey,
+      });
       binding = undefined;
     }
   }
@@ -213,7 +226,9 @@ export async function startOrResumeThread(params: {
     embeddedAgentLog.debug("codex app-server MCP config changed; starting a new thread", {
       threadId: binding.threadId,
     });
-    await clearCodexAppServerBinding(params.params.sessionFile);
+    await clearCodexAppServerBinding(params.params.sessionFile, {
+      isolationKey: bindingIsolationKey,
+    });
     binding = undefined;
   }
   if (binding?.threadId) {
@@ -244,7 +259,9 @@ export async function startOrResumeThread(params: {
             threadId: binding.threadId,
           },
         );
-        await clearCodexAppServerBinding(params.params.sessionFile);
+        await clearCodexAppServerBinding(params.params.sessionFile, {
+          isolationKey: bindingIsolationKey,
+        });
       }
     } else {
       try {
@@ -301,6 +318,7 @@ export async function startOrResumeThread(params: {
             authProfileStore: params.params.authProfileStore,
             agentDir: params.params.agentDir,
             config: params.params.config,
+            isolationKey: bindingIsolationKey,
           },
         );
         if (contextEngineBinding) {
@@ -337,7 +355,9 @@ export async function startOrResumeThread(params: {
         embeddedAgentLog.warn("codex app-server thread resume failed; starting a new thread", {
           error,
         });
-        await clearCodexAppServerBinding(params.params.sessionFile);
+        await clearCodexAppServerBinding(params.params.sessionFile, {
+          isolationKey: bindingIsolationKey,
+        });
       }
     }
   }
@@ -380,6 +400,7 @@ export async function startOrResumeThread(params: {
       params.params.sessionFile,
       {
         threadId: response.thread.id,
+        isolationKey: bindingIsolationKey,
         cwd: params.cwd,
         authProfileId: params.params.authProfileId,
         model: response.model ?? params.params.modelId,
@@ -397,6 +418,7 @@ export async function startOrResumeThread(params: {
         authProfileStore: params.params.authProfileStore,
         agentDir: params.params.agentDir,
         config: params.params.config,
+        isolationKey: bindingIsolationKey,
       },
     );
     if (contextEngineBinding) {
@@ -415,6 +437,7 @@ export async function startOrResumeThread(params: {
     schemaVersion: 1,
     threadId: response.thread.id,
     sessionFile: params.params.sessionFile,
+    isolationKey: bindingIsolationKey,
     cwd: params.cwd,
     authProfileId: params.params.authProfileId,
     model: response.model ?? params.params.modelId,
@@ -477,6 +500,20 @@ function buildContextEngineProjectionBinding(
     epoch: projection.epoch,
     fingerprint: projection.fingerprint,
   };
+}
+
+function resolveCodexAppServerThreadBindingIsolationKey(
+  appServer: CodexAppServerRuntimeOptions,
+  params: EmbeddedRunAttemptParams,
+): string | undefined {
+  if (appServer.clientIsolation !== "session") {
+    return undefined;
+  }
+  const sessionKey = params.sessionKey?.trim() || params.sessionId;
+  if (params.trigger !== "cron") {
+    return sessionKey;
+  }
+  return sessionKey.replace(/:run:[^:]+$/, "");
 }
 
 export function isContextEngineBindingCompatible(

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -7,7 +7,11 @@ import {
   readCodexComputerUseStatus,
   type CodexComputerUseSetupParams,
 } from "./app-server/computer-use.js";
-import { isCodexFastServiceTier, type CodexComputerUseConfig } from "./app-server/config.js";
+import {
+  isCodexFastServiceTier,
+  resolveCodexAppServerRuntimeOptions,
+  type CodexComputerUseConfig,
+} from "./app-server/config.js";
 import { listAllCodexAppServerModels } from "./app-server/models.js";
 import { isJsonObject, type JsonValue } from "./app-server/protocol.js";
 import { rememberCodexRateLimits } from "./app-server/rate-limit-cache.js";
@@ -169,7 +173,9 @@ type ParsedDiagnosticsArgs =
 type CodexDiagnosticsTarget = {
   threadId: string;
   sessionFile: string;
+  isolationKey?: string;
   sessionKey?: string;
+  runtimePolicySessionKey?: string;
   sessionId?: string;
   channel?: string;
   channelId?: string;
@@ -218,6 +224,83 @@ export function resetCodexDiagnosticsFeedbackStateForTests(): void {
   pendingCodexDiagnosticsConfirmationTokensByScope.clear();
 }
 
+function resolveCommandBindingIsolationKey(
+  pluginConfig: unknown,
+  ctx: PluginCommandContext,
+): string | undefined {
+  const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig });
+  if (appServer.clientIsolation !== "session") {
+    return undefined;
+  }
+  return ctx.runtimePolicySessionKey?.trim() || ctx.sessionKey?.trim() || ctx.sessionId;
+}
+
+function resolveCommandBindingLookup(pluginConfig: unknown, ctx: PluginCommandContext) {
+  const scope = resolveCodexConversationControlScope(ctx);
+  return {
+    agentDir: scope.agentDir,
+    config: ctx.config,
+    isolationKey: resolveCommandBindingIsolationKey(pluginConfig, ctx),
+  };
+}
+
+type CodexControlTarget = {
+  sessionFile?: string;
+  bindingLookup: ReturnType<typeof resolveCommandBindingLookup>;
+};
+
+async function resolveControlTarget(
+  pluginConfig: unknown,
+  ctx: PluginCommandContext,
+): Promise<CodexControlTarget> {
+  const binding = await ctx.getCurrentConversationBinding();
+  const data = readCodexConversationBindingData(binding);
+  if (data?.kind === "codex-app-server-session") {
+    return {
+      sessionFile: data.sessionFile,
+      bindingLookup: {
+        agentDir: data.agentDir ?? resolveCodexConversationControlScope(ctx).agentDir,
+        config: ctx.config,
+        isolationKey: data.isolationKey,
+      },
+    };
+  }
+  return {
+    sessionFile: ctx.sessionFile,
+    bindingLookup: resolveCommandBindingLookup(pluginConfig, ctx),
+  };
+}
+
+async function resolveControlSessionFile(
+  pluginConfig: unknown,
+  ctx: PluginCommandContext,
+): Promise<string | undefined> {
+  return (await resolveControlTarget(pluginConfig, ctx)).sessionFile;
+}
+
+function commandControlRequestOptions(
+  _ctx: PluginCommandContext,
+  bindingLookup: ReturnType<typeof resolveCommandBindingLookup>,
+): CodexControlRequestOptions | undefined {
+  return bindingLookup.agentDir || bindingLookup.isolationKey || bindingLookup.config
+    ? {
+        agentDir: bindingLookup.agentDir,
+        isolationKey: bindingLookup.isolationKey,
+        config: bindingLookup.config,
+      }
+    : undefined;
+}
+
+async function runCodexControlRequest(
+  deps: CodexCommandDeps,
+  pluginConfig: unknown,
+  method: CodexControlMethod,
+  requestParams: JsonValue | undefined,
+  options?: CodexControlRequestOptions,
+): Promise<JsonValue | undefined> {
+  return await deps.codexControlRequest(pluginConfig, method, requestParams, options);
+}
+
 export async function handleCodexSubcommand(
   ctx: PluginCommandContext,
   options: { pluginConfig?: unknown; deps?: Partial<CodexCommandDeps> },
@@ -264,7 +347,7 @@ export async function handleCodexSubcommand(
     if (rest.length > 0) {
       return { text: "Usage: /codex detach" };
     }
-    return { text: await detachConversation(deps, ctx) };
+    return { text: await detachConversation(deps, ctx, options.pluginConfig) };
   }
   if (normalized === "binding") {
     if (rest.length > 0) {
@@ -426,19 +509,17 @@ async function bindConversation(
       text: "Cannot bind Codex because this command did not include an OpenClaw session file.",
     };
   }
-  const scope = resolveCodexConversationControlScope(ctx);
   const workspaceDir = parsed.cwd ?? deps.resolveCodexDefaultWorkspaceDir(pluginConfig);
-  const existingBinding = await deps.readCodexAppServerBinding(ctx.sessionFile, {
-    agentDir: scope.agentDir,
-    config: ctx.config,
-  });
+  const bindingLookup = resolveCommandBindingLookup(pluginConfig, ctx);
+  const existingBinding = await deps.readCodexAppServerBinding(ctx.sessionFile, bindingLookup);
   const authProfileId = existingBinding?.authProfileId;
   const startParams: Parameters<CodexCommandDeps["startCodexConversationThread"]>[0] = {
     pluginConfig,
     config: ctx.config,
     sessionFile: ctx.sessionFile,
+    agentDir: bindingLookup.agentDir,
+    isolationKey: bindingLookup.isolationKey,
     workspaceDir,
-    agentDir: scope.agentDir,
     threadId: parsed.threadId,
     model: parsed.model,
     modelProvider: parsed.provider,
@@ -447,10 +528,7 @@ async function bindConversation(
     startParams.authProfileId = authProfileId;
   }
   const data = await deps.startCodexConversationThread(startParams);
-  const binding = await deps.readCodexAppServerBinding(ctx.sessionFile, {
-    agentDir: scope.agentDir,
-    config: ctx.config,
-  });
+  const binding = await deps.readCodexAppServerBinding(ctx.sessionFile, bindingLookup);
   const threadId = binding?.threadId ?? parsed.threadId ?? "new thread";
   const summary = `Codex app-server thread ${formatCodexDisplayText(threadId)} in ${formatCodexDisplayText(workspaceDir)}`;
   let request: Awaited<ReturnType<PluginCommandContext["requestConversationBinding"]>>;
@@ -461,7 +539,7 @@ async function bindConversation(
       data,
     });
   } catch (error) {
-    await deps.clearCodexAppServerBinding(ctx.sessionFile);
+    await deps.clearCodexAppServerBinding(ctx.sessionFile, bindingLookup);
     throw error;
   }
   if (request.status === "bound") {
@@ -474,21 +552,25 @@ async function bindConversation(
   if (request.status === "pending") {
     return request.reply;
   }
-  await deps.clearCodexAppServerBinding(ctx.sessionFile);
+  await deps.clearCodexAppServerBinding(ctx.sessionFile, bindingLookup);
   return { text: formatCodexDisplayText(request.message) };
 }
 
 async function detachConversation(
   deps: CodexCommandDeps,
   ctx: PluginCommandContext,
+  pluginConfig: unknown,
 ): Promise<string> {
   const current = await ctx.getCurrentConversationBinding();
   const data = readCodexConversationBindingData(current);
   const detached = await ctx.detachConversationBinding();
   if (data?.kind === "codex-app-server-session") {
-    await deps.clearCodexAppServerBinding(data.sessionFile);
+    await deps.clearCodexAppServerBinding(data.sessionFile, { isolationKey: data.isolationKey });
   } else if (ctx.sessionFile) {
-    await deps.clearCodexAppServerBinding(ctx.sessionFile);
+    await deps.clearCodexAppServerBinding(
+      ctx.sessionFile,
+      resolveCommandBindingLookup(pluginConfig, ctx),
+    );
   }
   return detached.removed
     ? "Detached this conversation from Codex."
@@ -514,11 +596,13 @@ async function describeConversationBinding(
       "- Active run: not tracked",
     ].join("\n");
   }
-  const threadBinding = await deps.readCodexAppServerBinding(data.sessionFile, {
-    agentDir: data.agentDir,
+  const bindingLookup = {
+    agentDir: data.agentDir ?? resolveCodexConversationControlScope(ctx).agentDir,
     config: ctx.config,
-  });
-  const active = deps.readCodexConversationActiveTurn(data.sessionFile);
+    isolationKey: data.isolationKey,
+  };
+  const threadBinding = await deps.readCodexAppServerBinding(data.sessionFile, bindingLookup);
+  const active = deps.readCodexConversationActiveTurn(data.sessionFile, bindingLookup.isolationKey);
   return [
     "Codex conversation binding:",
     `- Thread: ${formatCodexDisplayText(threadBinding?.threadId ?? "unknown")}`,
@@ -579,22 +663,29 @@ async function resumeThread(
   if (!ctx.sessionFile) {
     return "Cannot attach a Codex thread because this command did not include an OpenClaw session file.";
   }
-  const response = await deps.codexControlRequest(
+  const bindingLookup = resolveCommandBindingLookup(pluginConfig, ctx);
+  const response = await runCodexControlRequest(
+    deps,
     pluginConfig,
     CODEX_CONTROL_METHODS.resumeThread,
     {
       threadId: normalizedThreadId,
       persistExtendedHistory: true,
     },
+    commandControlRequestOptions(ctx, bindingLookup),
   );
   const thread = isJsonObject(response) && isJsonObject(response.thread) ? response.thread : {};
   const effectiveThreadId = readString(thread, "id") ?? normalizedThreadId;
-  await deps.writeCodexAppServerBinding(ctx.sessionFile, {
-    threadId: effectiveThreadId,
-    cwd: readString(thread, "cwd") ?? "",
-    model: isJsonObject(response) ? readString(response, "model") : undefined,
-    modelProvider: isJsonObject(response) ? readString(response, "modelProvider") : undefined,
-  });
+  await deps.writeCodexAppServerBinding(
+    ctx.sessionFile,
+    {
+      threadId: effectiveThreadId,
+      cwd: readString(thread, "cwd") ?? "",
+      model: isJsonObject(response) ? readString(response, "model") : undefined,
+      modelProvider: isJsonObject(response) ? readString(response, "modelProvider") : undefined,
+    },
+    bindingLookup,
+  );
   return `Attached this OpenClaw session to Codex thread ${formatCodexDisplayText(
     effectiveThreadId,
   )}.`;
@@ -646,16 +737,17 @@ async function stopConversationTurn(
   ctx: PluginCommandContext,
   pluginConfig: unknown,
 ): Promise<string> {
-  const target = await resolveControlTarget(ctx);
-  if (!target) {
+  const target = await resolveControlTarget(pluginConfig, ctx);
+  if (!target.sessionFile) {
     return "Cannot stop Codex because this command did not include an OpenClaw session file.";
   }
   return (
     await deps.stopCodexConversationTurn({
       sessionFile: target.sessionFile,
       pluginConfig,
-      agentDir: target.agentDir,
-      config: ctx.config,
+      agentDir: target.bindingLookup.agentDir,
+      isolationKey: target.bindingLookup.isolationKey,
+      config: target.bindingLookup.config,
     })
   ).message;
 }
@@ -666,8 +758,8 @@ async function steerConversationTurn(
   pluginConfig: unknown,
   message: string,
 ): Promise<string> {
-  const target = await resolveControlTarget(ctx);
-  if (!target) {
+  const target = await resolveControlTarget(pluginConfig, ctx);
+  if (!target.sessionFile) {
     return "Cannot steer Codex because this command did not include an OpenClaw session file.";
   }
   return (
@@ -675,8 +767,9 @@ async function steerConversationTurn(
       sessionFile: target.sessionFile,
       pluginConfig,
       message,
-      agentDir: target.agentDir,
-      config: ctx.config,
+      agentDir: target.bindingLookup.agentDir,
+      isolationKey: target.bindingLookup.isolationKey,
+      config: target.bindingLookup.config,
     })
   ).message;
 }
@@ -690,17 +783,14 @@ async function setConversationModel(
   if (args.length > 1) {
     return "Usage: /codex model <model>";
   }
-  const target = await resolveControlTarget(ctx);
-  if (!target) {
+  const target = await resolveControlTarget(pluginConfig, ctx);
+  if (!target.sessionFile) {
     return "Cannot set Codex model because this command did not include an OpenClaw session file.";
   }
   const [model = ""] = args;
   const normalized = model.trim();
   if (!normalized) {
-    const binding = await deps.readCodexAppServerBinding(target.sessionFile, {
-      agentDir: target.agentDir,
-      config: ctx.config,
-    });
+    const binding = await deps.readCodexAppServerBinding(target.sessionFile, target.bindingLookup);
     return binding?.model
       ? `Codex model: ${formatCodexDisplayText(binding.model)}`
       : "Usage: /codex model <model>";
@@ -709,8 +799,9 @@ async function setConversationModel(
     sessionFile: target.sessionFile,
     pluginConfig,
     model: normalized,
-    agentDir: target.agentDir,
-    config: ctx.config,
+    agentDir: target.bindingLookup.agentDir,
+    isolationKey: target.bindingLookup.isolationKey,
+    config: target.bindingLookup.config,
   });
 }
 
@@ -723,8 +814,8 @@ async function setConversationFastMode(
   if (args.length > 1) {
     return "Usage: /codex fast [on|off|status]";
   }
-  const target = await resolveControlTarget(ctx);
-  if (!target) {
+  const target = await resolveControlTarget(pluginConfig, ctx);
+  if (!target.sessionFile) {
     return "Cannot set Codex fast mode because this command did not include an OpenClaw session file.";
   }
   const value = args[0];
@@ -736,8 +827,9 @@ async function setConversationFastMode(
     sessionFile: target.sessionFile,
     pluginConfig,
     enabled: parsed,
-    agentDir: target.agentDir,
-    config: ctx.config,
+    agentDir: target.bindingLookup.agentDir,
+    isolationKey: target.bindingLookup.isolationKey,
+    config: target.bindingLookup.config,
   });
 }
 
@@ -750,8 +842,8 @@ async function setConversationPermissions(
   if (args.length > 1) {
     return "Usage: /codex permissions [default|yolo|status]";
   }
-  const target = await resolveControlTarget(ctx);
-  if (!target) {
+  const target = await resolveControlTarget(pluginConfig, ctx);
+  if (!target.sessionFile) {
     return "Cannot set Codex permissions because this command did not include an OpenClaw session file.";
   }
   const value = args[0];
@@ -763,33 +855,10 @@ async function setConversationPermissions(
     sessionFile: target.sessionFile,
     pluginConfig,
     mode: parsed,
-    agentDir: target.agentDir,
-    config: ctx.config,
+    agentDir: target.bindingLookup.agentDir,
+    isolationKey: target.bindingLookup.isolationKey,
+    config: target.bindingLookup.config,
   });
-}
-
-type CodexConversationControlTarget = {
-  sessionFile: string;
-  agentDir: string;
-};
-
-async function resolveControlTarget(
-  ctx: PluginCommandContext,
-): Promise<CodexConversationControlTarget | undefined> {
-  const binding = await ctx.getCurrentConversationBinding();
-  const data = readCodexConversationBindingData(binding);
-  const scope = resolveCodexConversationControlScope(ctx);
-  if (data?.kind === "codex-app-server-session") {
-    return {
-      sessionFile: data.sessionFile,
-      agentDir: data.agentDir ?? scope.agentDir,
-    };
-  }
-  return ctx.sessionFile ? { sessionFile: ctx.sessionFile, agentDir: scope.agentDir } : undefined;
-}
-
-async function resolveControlSessionFile(ctx: PluginCommandContext): Promise<string | undefined> {
-  return (await resolveControlTarget(ctx))?.sessionFile;
 }
 
 function resolveCodexConversationControlScope(ctx: PluginCommandContext): { agentDir: string } {
@@ -831,24 +900,31 @@ async function handleCodexDiagnosticsFeedback(
   }
   if (ctx.diagnosticsPreviewOnly === true) {
     return {
-      text: await previewCodexDiagnosticsFeedbackApproval(deps, ctx, parsed.note),
+      text: await previewCodexDiagnosticsFeedbackApproval(deps, ctx, pluginConfig, parsed.note),
     };
   }
-  return await requestCodexDiagnosticsFeedbackApproval(deps, ctx, parsed.note, commandPrefix);
+  return await requestCodexDiagnosticsFeedbackApproval(
+    deps,
+    ctx,
+    pluginConfig,
+    parsed.note,
+    commandPrefix,
+  );
 }
 
 async function requestCodexDiagnosticsFeedbackApproval(
   deps: CodexCommandDeps,
   ctx: PluginCommandContext,
+  pluginConfig: unknown,
   note: string,
   commandPrefix: string,
 ): Promise<PluginCommandResult> {
-  if (!(await hasAnyCodexDiagnosticsSessionFile(ctx))) {
+  if (!(await hasAnyCodexDiagnosticsSessionFile(ctx, pluginConfig))) {
     return {
       text: "Cannot send Codex diagnostics because this command did not include an OpenClaw session file.",
     };
   }
-  const targets = await resolveCodexDiagnosticsTargets(deps, ctx);
+  const targets = await resolveCodexDiagnosticsTargets(deps, ctx, pluginConfig);
   if (targets.length === 0) {
     return {
       text: [
@@ -911,12 +987,13 @@ async function requestCodexDiagnosticsFeedbackApproval(
 async function previewCodexDiagnosticsFeedbackApproval(
   deps: CodexCommandDeps,
   ctx: PluginCommandContext,
+  pluginConfig: unknown,
   note: string,
 ): Promise<string> {
-  if (!(await hasAnyCodexDiagnosticsSessionFile(ctx))) {
+  if (!(await hasAnyCodexDiagnosticsSessionFile(ctx, pluginConfig))) {
     return "Cannot send Codex diagnostics because this command did not include an OpenClaw session file.";
   }
-  const targets = await resolveCodexDiagnosticsTargets(deps, ctx);
+  const targets = await resolveCodexDiagnosticsTargets(deps, ctx, pluginConfig);
   if (targets.length === 0) {
     return [
       "No Codex thread is attached to this OpenClaw session yet.",
@@ -964,12 +1041,12 @@ async function confirmCodexDiagnosticsFeedback(
     return scopeMismatch.confirmMessage;
   }
   deletePendingCodexDiagnosticsConfirmation(token);
-  if (!pending.privateRouted && !(await hasAnyCodexDiagnosticsSessionFile(ctx))) {
+  if (!pending.privateRouted && !(await hasAnyCodexDiagnosticsSessionFile(ctx, pluginConfig))) {
     return "Cannot send Codex diagnostics because this command did not include an OpenClaw session file.";
   }
   const currentTargets = pending.privateRouted
     ? await resolvePendingCodexDiagnosticsTargets(deps, pending.targets)
-    : await resolveCodexDiagnosticsTargets(deps, ctx);
+    : await resolveCodexDiagnosticsTargets(deps, ctx, pluginConfig);
   if (!codexDiagnosticsTargetsMatch(pending.targets, currentTargets)) {
     return "The Codex diagnostics sessions changed before confirmation. Run /diagnostics again for the current threads.";
   }
@@ -1014,10 +1091,10 @@ async function sendCodexDiagnosticsFeedbackForContext(
   pluginConfig: unknown,
   note: string,
 ): Promise<string> {
-  if (!(await hasAnyCodexDiagnosticsSessionFile(ctx))) {
+  if (!(await hasAnyCodexDiagnosticsSessionFile(ctx, pluginConfig))) {
     return "Cannot send Codex diagnostics because this command did not include an OpenClaw session file.";
   }
-  const targets = await resolveCodexDiagnosticsTargets(deps, ctx);
+  const targets = await resolveCodexDiagnosticsTargets(deps, ctx, pluginConfig);
   if (targets.length === 0) {
     return [
       "No Codex thread is attached to this OpenClaw session yet.",
@@ -1073,8 +1150,11 @@ async function sendCodexDiagnosticsFeedbackForTargets(
   return formatCodexDiagnosticsUploadResult(sent, failed);
 }
 
-async function hasAnyCodexDiagnosticsSessionFile(ctx: PluginCommandContext): Promise<boolean> {
-  if (await resolveControlSessionFile(ctx)) {
+async function hasAnyCodexDiagnosticsSessionFile(
+  ctx: PluginCommandContext,
+  pluginConfig: unknown,
+): Promise<boolean> {
+  if (await resolveControlSessionFile(pluginConfig, ctx)) {
     return true;
   }
   return (ctx.diagnosticsSessions ?? []).some((session) => Boolean(session.sessionFile));
@@ -1083,14 +1163,18 @@ async function hasAnyCodexDiagnosticsSessionFile(ctx: PluginCommandContext): Pro
 async function resolveCodexDiagnosticsTargets(
   deps: CodexCommandDeps,
   ctx: PluginCommandContext,
+  pluginConfig: unknown,
 ): Promise<CodexDiagnosticsTarget[]> {
-  const activeSessionFile = await resolveControlSessionFile(ctx);
+  const activeSessionFile = await resolveControlSessionFile(pluginConfig, ctx);
+  const activeBindingLookup = resolveCommandBindingLookup(pluginConfig, ctx);
   const candidates: CodexDiagnosticsTarget[] = [];
   if (activeSessionFile) {
     candidates.push({
       threadId: "",
       sessionFile: activeSessionFile,
+      isolationKey: activeBindingLookup.isolationKey,
       sessionKey: ctx.sessionKey,
+      runtimePolicySessionKey: ctx.runtimePolicySessionKey,
       sessionId: ctx.sessionId,
       channel: ctx.channel,
       channelId: ctx.channelId,
@@ -1106,7 +1190,9 @@ async function resolveCodexDiagnosticsTargets(
     candidates.push({
       threadId: "",
       sessionFile: session.sessionFile,
+      isolationKey: resolveDiagnosticsSessionBindingIsolationKey(pluginConfig, session),
       sessionKey: session.sessionKey,
+      runtimePolicySessionKey: session.runtimePolicySessionKey,
       sessionId: session.sessionId,
       channel: session.channel,
       channelId: session.channelId,
@@ -1123,7 +1209,9 @@ async function resolveCodexDiagnosticsTargets(
       continue;
     }
     seenSessionFiles.add(candidate.sessionFile);
-    const binding = await deps.readCodexAppServerBinding(candidate.sessionFile);
+    const binding = await deps.readCodexAppServerBinding(candidate.sessionFile, {
+      isolationKey: candidate.isolationKey,
+    });
     if (!binding?.threadId || seenThreadIds.has(binding.threadId)) {
       continue;
     }
@@ -1133,13 +1221,31 @@ async function resolveCodexDiagnosticsTargets(
   return targets;
 }
 
+function resolveDiagnosticsSessionBindingIsolationKey(
+  pluginConfig: unknown,
+  session: NonNullable<PluginCommandContext["diagnosticsSessions"]>[number],
+): string | undefined {
+  const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig });
+  if (appServer.clientIsolation !== "session") {
+    return undefined;
+  }
+  return (
+    session.runtimePolicySessionKey?.trim() ||
+    session.sessionKey?.trim() ||
+    session.sessionId?.trim() ||
+    undefined
+  );
+}
+
 async function resolvePendingCodexDiagnosticsTargets(
   deps: CodexCommandDeps,
   targets: readonly CodexDiagnosticsTarget[],
 ): Promise<CodexDiagnosticsTarget[]> {
   const resolved: CodexDiagnosticsTarget[] = [];
   for (const target of targets) {
-    const binding = await deps.readCodexAppServerBinding(target.sessionFile);
+    const binding = await deps.readCodexAppServerBinding(target.sessionFile, {
+      isolationKey: target.isolationKey,
+    });
     if (!binding?.threadId) {
       continue;
     }
@@ -1661,19 +1767,17 @@ async function startThreadAction(
   if (args.length > 0) {
     return `Usage: /codex ${label === "compaction" ? "compact" : label}`;
   }
-  const target = await resolveControlTarget(ctx);
-  if (!target) {
+  const target = await resolveControlTarget(pluginConfig, ctx);
+  if (!target.sessionFile) {
     return `Cannot start Codex ${label} because this command did not include an OpenClaw session file.`;
   }
-  const binding = await deps.readCodexAppServerBinding(target.sessionFile, {
-    agentDir: target.agentDir,
-    config: ctx.config,
-  });
+  const binding = await deps.readCodexAppServerBinding(target.sessionFile, target.bindingLookup);
   if (!binding?.threadId) {
     return `No Codex thread is attached to this OpenClaw session yet.`;
   }
   if (method === CODEX_CONTROL_METHODS.review) {
-    await deps.codexControlRequest(
+    await runCodexControlRequest(
+      deps,
       pluginConfig,
       method,
       {
@@ -1681,20 +1785,19 @@ async function startThreadAction(
         target: { type: "uncommittedChanges" },
       },
       {
-        agentDir: target.agentDir,
+        ...commandControlRequestOptions(ctx, target.bindingLookup),
         authProfileId: binding.authProfileId,
-        config: ctx.config,
       },
     );
   } else {
-    await deps.codexControlRequest(
+    await runCodexControlRequest(
+      deps,
       pluginConfig,
       method,
       { threadId: binding.threadId },
       {
-        agentDir: target.agentDir,
+        ...commandControlRequestOptions(ctx, target.bindingLookup),
         authProfileId: binding.authProfileId,
-        config: ctx.config,
       },
     );
   }

--- a/extensions/codex/src/command-rpc.ts
+++ b/extensions/codex/src/command-rpc.ts
@@ -25,6 +25,7 @@ export type CodexControlRequestOptions = {
   authProfileId?: string;
   agentDir?: string;
   isolated?: boolean;
+  isolationKey?: string;
 };
 
 export function requestOptions(
@@ -71,6 +72,7 @@ export async function codexControlRequest(
     authProfileId: options.authProfileId,
     agentDir: options.agentDir,
     isolated: options.isolated,
+    isolationKey: options.isolationKey,
   });
 }
 

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -16,6 +16,10 @@ import {
   readRecentCodexRateLimits,
   resetCodexRateLimitCacheForTests,
 } from "./app-server/rate-limit-cache.js";
+import {
+  readCodexAppServerBinding,
+  writeCodexAppServerBinding,
+} from "./app-server/session-binding.js";
 import { resetSharedCodexAppServerClientForTests } from "./app-server/shared-client.js";
 import {
   resetCodexDiagnosticsFeedbackStateForTests,
@@ -246,6 +250,51 @@ describe("codex command", () => {
     ]);
     await expect(fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8")).resolves.toContain(
       '"threadId": "thread-123"',
+    );
+  });
+
+  it("attaches resumed Codex threads to the runtime-policy binding when session isolation is enabled", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const codexControlRequest = vi.fn(async () => ({
+      thread: { id: "thread-isolated", cwd: "/repo" },
+      model: "gpt-5.4",
+      modelProvider: "openai",
+    }));
+    const deps = createDeps({
+      codexControlRequest,
+    });
+
+    await expect(
+      handleCodexCommand(
+        createContext("resume thread-isolated", sessionFile, {
+          sessionKey: "agent:main:main",
+          runtimePolicySessionKey: "agent:main:telegram:default:direct:12345",
+        }),
+        {
+          pluginConfig: { appServer: { clientIsolation: "session" } },
+          deps,
+        },
+      ),
+    ).resolves.toEqual({
+      text: "Attached this OpenClaw session to Codex thread thread-isolated.",
+    });
+
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toBeUndefined();
+    await expect(
+      readCodexAppServerBinding(sessionFile, {
+        isolationKey: "agent:main:telegram:default:direct:12345",
+      }),
+    ).resolves.toMatchObject({ threadId: "thread-isolated" });
+    expect(codexControlRequest).toHaveBeenCalledWith(
+      { appServer: { clientIsolation: "session" } },
+      CODEX_CONTROL_METHODS.resumeThread,
+      {
+        threadId: "thread-isolated",
+        persistExtendedHistory: true,
+      },
+      expect.objectContaining({
+        isolationKey: "agent:main:telegram:default:direct:12345",
+      }),
     );
   });
 
@@ -1328,6 +1377,44 @@ describe("codex command", () => {
     );
   });
 
+  it("starts compaction from the runtime-policy binding when session isolation is enabled", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await writeCodexAppServerBinding(
+      sessionFile,
+      {
+        threadId: "thread-isolated",
+        cwd: "/repo",
+      },
+      { isolationKey: "agent:main:telegram:default:direct:12345" },
+    );
+    const codexControlRequest = vi.fn(async () => ({}));
+
+    await expect(
+      handleCodexCommand(
+        createContext("compact", sessionFile, {
+          sessionKey: "agent:main:main",
+          runtimePolicySessionKey: "agent:main:telegram:default:direct:12345",
+        }),
+        {
+          pluginConfig: { appServer: { clientIsolation: "session" } },
+          deps: createDeps({ codexControlRequest }),
+        },
+      ),
+    ).resolves.toEqual({
+      text: "Started Codex compaction for thread thread-isolated.",
+    });
+    expect(codexControlRequest).toHaveBeenCalledWith(
+      { appServer: { clientIsolation: "session" } },
+      CODEX_CONTROL_METHODS.compact,
+      {
+        threadId: "thread-isolated",
+      },
+      expect.objectContaining({
+        isolationKey: "agent:main:telegram:default:direct:12345",
+      }),
+    );
+  });
+
   it("starts review with the generated app-server target shape", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     await fs.writeFile(
@@ -1620,6 +1707,128 @@ describe("codex command", () => {
     );
   });
 
+  it("sends diagnostics through the runtime-policy binding when session isolation is enabled", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await writeCodexAppServerBinding(
+      sessionFile,
+      { threadId: "thread-isolated", cwd: "/repo" },
+      { isolationKey: "agent:main:telegram:default:direct:12345" },
+    );
+    const safeCodexControlRequest = vi.fn(async () => ({
+      ok: true as const,
+      value: { threadId: "thread-isolated" },
+    }));
+    const deps = createDeps({ safeCodexControlRequest });
+    const pluginConfig = { appServer: { clientIsolation: "session" } };
+
+    const request = await handleCodexCommand(
+      createContext("diagnostics isolated repro", sessionFile, {
+        senderId: "user-1",
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        runtimePolicySessionKey: "agent:main:telegram:default:direct:12345",
+      }),
+      { deps, pluginConfig },
+    );
+
+    const token = readDiagnosticsConfirmationToken(request);
+    expect(request.text).toContain("thread-isolated");
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toBeUndefined();
+
+    await expect(
+      handleCodexCommand(
+        createContext(`diagnostics confirm ${token}`, sessionFile, {
+          senderId: "user-1",
+          sessionId: "session-1",
+          sessionKey: "agent:main:main",
+          runtimePolicySessionKey: "agent:main:telegram:default:direct:12345",
+        }),
+        { deps, pluginConfig },
+      ),
+    ).resolves.toMatchObject({
+      text: expect.stringContaining("Codex diagnostics sent to OpenAI servers:"),
+    });
+    expect(safeCodexControlRequest).toHaveBeenCalledWith(
+      pluginConfig,
+      CODEX_CONTROL_METHODS.feedback,
+      expect.objectContaining({
+        classification: "bug",
+        reason: "isolated repro",
+        threadId: "thread-isolated",
+      }),
+      expect.objectContaining({
+        isolationKey: "agent:main:telegram:default:direct:12345",
+      }),
+    );
+  });
+
+  it("sends bound diagnostics through the stored Codex isolation key", async () => {
+    const hostSessionFile = path.join(tempDir, "host-session.jsonl");
+    await writeCodexAppServerBinding(
+      hostSessionFile,
+      { threadId: "thread-bound", cwd: "/repo" },
+      { isolationKey: "agent:main:slack:default:direct:u123" },
+    );
+    const safeCodexControlRequest = vi.fn(async () => ({
+      ok: true as const,
+      value: { threadId: "thread-bound" },
+    }));
+    const deps = createDeps({ safeCodexControlRequest });
+    const pluginConfig = { appServer: { clientIsolation: "session" } };
+    const bindingContext = {
+      senderId: "user-1",
+      sessionId: "plugin-session",
+      sessionKey: "plugin-binding:codex:bound",
+      runtimePolicySessionKey: "agent:main:slack:default:direct:u999",
+      getCurrentConversationBinding: async () => ({
+        bindingId: "binding-1",
+        pluginId: "codex",
+        pluginRoot: "/plugin",
+        channel: "slack",
+        accountId: "default",
+        conversationId: "user:U123",
+        boundAt: 1,
+        data: {
+          kind: "codex-app-server-session",
+          version: 1,
+          sessionFile: hostSessionFile,
+          workspaceDir: tempDir,
+          isolationKey: "agent:main:slack:default:direct:u123",
+        },
+      }),
+    } satisfies Partial<PluginCommandContext>;
+
+    const request = await handleCodexCommand(
+      createContext("diagnostics bound repro", undefined, bindingContext),
+      { deps, pluginConfig },
+    );
+
+    const token = readDiagnosticsConfirmationToken(request);
+    expect(request.text).toContain("thread-bound");
+    await expect(readCodexAppServerBinding(hostSessionFile)).resolves.toBeUndefined();
+
+    await expect(
+      handleCodexCommand(createContext(`diagnostics confirm ${token}`, undefined, bindingContext), {
+        deps,
+        pluginConfig,
+      }),
+    ).resolves.toMatchObject({
+      text: expect.stringContaining("Codex diagnostics sent to OpenAI servers:"),
+    });
+    expect(safeCodexControlRequest).toHaveBeenCalledWith(
+      pluginConfig,
+      CODEX_CONTROL_METHODS.feedback,
+      expect.objectContaining({
+        classification: "bug",
+        reason: "bound repro",
+        threadId: "thread-bound",
+      }),
+      expect.objectContaining({
+        isolationKey: "agent:main:slack:default:direct:u123",
+      }),
+    );
+  });
+
   it("rejects malformed diagnostics confirmation commands without consuming the token", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     await fs.writeFile(
@@ -1855,6 +2064,47 @@ describe("codex command", () => {
     const secondFeedbackParams = requestParams(safeCodexControlRequest, 1);
     expect(secondFeedbackParams.threadId).toBe("thread-222");
     expect(secondFeedbackParams.includeLogs).toBe(true);
+  });
+
+  it("looks up diagnostics sessions with session-isolated Codex bindings", async () => {
+    const sessionFile = path.join(tempDir, "session-one.jsonl");
+    await writeCodexAppServerBinding(
+      sessionFile,
+      {
+        threadId: "thread-isolated",
+        cwd: "/repo",
+      },
+      { isolationKey: "agent:main:telegram:default:direct:user-1" },
+    );
+    const diagnosticsSessions = [
+      {
+        sessionKey: "agent:main:telegram:default:direct:user-1",
+        runtimePolicySessionKey: "agent:main:telegram:default:direct:user-1",
+        sessionId: "session-one",
+        sessionFile,
+        channel: "telegram",
+      },
+    ];
+
+    const request = await handleCodexCommand(
+      createContext("diagnostics multi-session repro", sessionFile, {
+        senderId: "user-1",
+        channel: "telegram",
+        sessionKey: "agent:main",
+        sessionId: "session-main",
+        diagnosticsSessions,
+      }),
+      {
+        deps: createDeps(),
+        pluginConfig: { appServer: { clientIsolation: "session" } },
+      },
+    );
+
+    expect(request.text).toContain("Codex runtime thread detected.");
+    expect(request.text).toContain(
+      "OpenClaw session key: `agent:main:telegram:default:direct:user-1`",
+    );
+    expect(request.text).toContain("Codex thread id: `thread-isolated`");
   });
 
   it("requires an owner for Codex diagnostics feedback uploads", async () => {
@@ -2702,6 +2952,57 @@ describe("codex command", () => {
     });
   });
 
+  it("binds conversations through the runtime-policy binding when session isolation is enabled", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const startCodexConversationThread = vi.fn(async () => ({
+      kind: "codex-app-server-session" as const,
+      version: 1 as const,
+      sessionFile,
+      workspaceDir: "/repo",
+      isolationKey: "agent:main:telegram:default:direct:12345",
+    }));
+    const requestConversationBinding = vi.fn(async () => ({
+      status: "bound" as const,
+      binding: {
+        bindingId: "binding-1",
+        pluginId: "codex",
+        pluginRoot: "/plugin",
+        channel: "test",
+        accountId: "default",
+        conversationId: "conversation",
+        boundAt: 1,
+      },
+    }));
+
+    await handleCodexCommand(
+      createContext("bind thread-123 --cwd /repo", sessionFile, {
+        sessionKey: "agent:main:main",
+        runtimePolicySessionKey: "agent:main:telegram:default:direct:12345",
+        requestConversationBinding,
+      }),
+      {
+        pluginConfig: { appServer: { clientIsolation: "session" } },
+        deps: createDeps({
+          startCodexConversationThread,
+          resolveCodexDefaultWorkspaceDir: vi.fn(() => "/default"),
+        }),
+      },
+    );
+
+    expect(startCodexConversationThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isolationKey: "agent:main:telegram:default:direct:12345",
+      }),
+    );
+    expect(requestConversationBinding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          isolationKey: "agent:main:telegram:default:direct:12345",
+        }),
+      }),
+    );
+  });
+
   it("binds quoted workspace paths that contain spaces", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const startCodexConversationThread = vi.fn(async () => ({
@@ -2920,7 +3221,9 @@ describe("codex command", () => {
     ).resolves.toEqual({
       text: "binding unsupported &lt;\uff20U123&gt; \uff3btrusted\uff3d\uff08https://evil\uff09",
     });
-    expect(clearCodexAppServerBinding).toHaveBeenCalledWith(sessionFile);
+    expect(clearCodexAppServerBinding).toHaveBeenCalledWith(sessionFile, {
+      isolationKey: undefined,
+    });
   });
 
   it("detaches the current conversation and clears the Codex app-server thread binding", async () => {
@@ -2931,6 +3234,8 @@ describe("codex command", () => {
     await expect(
       handleCodexCommand(
         createContext("detach", sessionFile, {
+          sessionKey: "agent:main:main",
+          runtimePolicySessionKey: "agent:main:telegram:default:direct:12345",
           detachConversationBinding,
           getCurrentConversationBinding: async () => ({
             bindingId: "binding-1",
@@ -2948,13 +3253,59 @@ describe("codex command", () => {
             },
           }),
         }),
-        { deps: createDeps({ clearCodexAppServerBinding }) },
+        {
+          deps: createDeps({ clearCodexAppServerBinding }),
+          pluginConfig: { appServer: { clientIsolation: "session" } },
+        },
       ),
     ).resolves.toEqual({
       text: "Detached this conversation from Codex.",
     });
     expect(detachConversationBinding).toHaveBeenCalled();
-    expect(clearCodexAppServerBinding).toHaveBeenCalledWith(sessionFile);
+    expect(clearCodexAppServerBinding).toHaveBeenCalledWith(sessionFile, {
+      isolationKey: undefined,
+    });
+  });
+
+  it("detaches using the stored Codex isolation key", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const clearCodexAppServerBinding = vi.fn(async () => {});
+    const detachConversationBinding = vi.fn(async () => ({ removed: true }));
+
+    await expect(
+      handleCodexCommand(
+        createContext("detach", sessionFile, {
+          sessionKey: "agent:main:main",
+          detachConversationBinding,
+          getCurrentConversationBinding: async () => ({
+            bindingId: "binding-1",
+            pluginId: "codex",
+            pluginRoot: "/plugin",
+            channel: "test",
+            accountId: "default",
+            conversationId: "conversation",
+            boundAt: 1,
+            data: {
+              kind: "codex-app-server-session",
+              version: 1,
+              sessionFile,
+              workspaceDir: "/repo",
+              isolationKey: "agent:main:telegram:default:direct:12345",
+            },
+          }),
+        }),
+        {
+          deps: createDeps({ clearCodexAppServerBinding }),
+          pluginConfig: { appServer: { clientIsolation: "session" } },
+        },
+      ),
+    ).resolves.toEqual({
+      text: "Detached this conversation from Codex.",
+    });
+    expect(detachConversationBinding).toHaveBeenCalled();
+    expect(clearCodexAppServerBinding).toHaveBeenCalledWith(sessionFile, {
+      isolationKey: "agent:main:telegram:default:direct:12345",
+    });
   });
 
   it("rejects malformed detach commands before clearing bindings", async () => {
@@ -3159,10 +3510,13 @@ describe("codex command", () => {
     const hostSessionFile = path.join(tempDir, "host-session.jsonl");
     const pluginSessionFile = path.join(tempDir, "plugin-session.jsonl");
     const setCodexConversationFastMode = vi.fn(async () => "Codex fast mode enabled.");
+    const pluginConfig = { appServer: { clientIsolation: "session" } };
 
     await expect(
       handleCodexCommand(
         createContext("fast on", pluginSessionFile, {
+          sessionKey: "plugin-binding:codex:bound",
+          runtimePolicySessionKey: "agent:main:slack:default:direct:u999",
           getCurrentConversationBinding: async () => ({
             bindingId: "binding-1",
             pluginId: "codex",
@@ -3183,13 +3537,60 @@ describe("codex command", () => {
           deps: createDeps({
             setCodexConversationFastMode,
           }),
+          pluginConfig,
         },
       ),
     ).resolves.toEqual({ text: "Codex fast mode enabled." });
 
     expect(setCodexConversationFastMode).toHaveBeenCalledWith({
       sessionFile: hostSessionFile,
-      pluginConfig: undefined,
+      pluginConfig,
+      isolationKey: undefined,
+      enabled: true,
+    });
+  });
+
+  it("uses stored plugin binding isolation for follow-up control commands", async () => {
+    const hostSessionFile = path.join(tempDir, "host-session.jsonl");
+    const pluginSessionFile = path.join(tempDir, "plugin-session.jsonl");
+    const setCodexConversationFastMode = vi.fn(async () => "Codex fast mode enabled.");
+    const pluginConfig = { appServer: { clientIsolation: "session" } };
+
+    await expect(
+      handleCodexCommand(
+        createContext("fast on", pluginSessionFile, {
+          sessionKey: "plugin-binding:codex:bound",
+          runtimePolicySessionKey: "agent:main:slack:default:direct:u999",
+          getCurrentConversationBinding: async () => ({
+            bindingId: "binding-1",
+            pluginId: "codex",
+            pluginRoot: "/plugin",
+            channel: "slack",
+            accountId: "default",
+            conversationId: "user:U123",
+            boundAt: 1,
+            data: {
+              kind: "codex-app-server-session",
+              version: 1,
+              sessionFile: hostSessionFile,
+              workspaceDir: tempDir,
+              isolationKey: "agent:main:slack:default:direct:u123",
+            },
+          }),
+        }),
+        {
+          deps: createDeps({
+            setCodexConversationFastMode,
+          }),
+          pluginConfig,
+        },
+      ),
+    ).resolves.toEqual({ text: "Codex fast mode enabled." });
+
+    expect(setCodexConversationFastMode).toHaveBeenCalledWith({
+      sessionFile: hostSessionFile,
+      pluginConfig,
+      isolationKey: "agent:main:slack:default:direct:u123",
       enabled: true,
       agentDir: path.join(tempDir, "agents", "main", "agent"),
       config: {},
@@ -3214,6 +3615,8 @@ describe("codex command", () => {
     await expect(
       handleCodexCommand(
         createContext("binding", sessionFile, {
+          sessionKey: "agent:main:main",
+          runtimePolicySessionKey: "agent:main:telegram:default:direct:12345",
           getCurrentConversationBinding: async () => ({
             bindingId: "binding-1",
             pluginId: "codex",
@@ -3231,6 +3634,7 @@ describe("codex command", () => {
           }),
         }),
         {
+          pluginConfig: { appServer: { clientIsolation: "session" } },
           deps: createDeps({
             readCodexConversationActiveTurn: vi.fn(() => ({
               sessionFile,

--- a/extensions/codex/src/conversation-binding-data.ts
+++ b/extensions/codex/src/conversation-binding-data.ts
@@ -9,6 +9,7 @@ export type CodexAppServerConversationBindingData = {
   sessionFile: string;
   workspaceDir: string;
   agentDir?: string;
+  isolationKey?: string;
 };
 
 export type CodexCliNodeConversationBindingData = {
@@ -27,14 +28,17 @@ export function createCodexConversationBindingData(params: {
   sessionFile: string;
   workspaceDir: string;
   agentDir?: string;
+  isolationKey?: string;
 }): CodexAppServerConversationBindingData {
   const agentDir = params.agentDir?.trim();
+  const isolationKey = params.isolationKey?.trim() || undefined;
   return {
     kind: "codex-app-server-session",
     version: BINDING_DATA_VERSION,
     sessionFile: params.sessionFile,
     workspaceDir: params.workspaceDir,
     ...(agentDir ? { agentDir } : {}),
+    ...(isolationKey ? { isolationKey } : {}),
   };
 }
 
@@ -98,6 +102,10 @@ export function readCodexConversationBindingDataRecord(
     kind: "codex-app-server-session",
     version: BINDING_DATA_VERSION,
     sessionFile: data.sessionFile,
+    isolationKey:
+      typeof data.isolationKey === "string" && data.isolationKey.trim()
+        ? data.isolationKey.trim()
+        : undefined,
     workspaceDir:
       typeof data.workspaceDir === "string" && data.workspaceDir.trim()
         ? data.workspaceDir

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -66,6 +66,7 @@ type CodexConversationStartParams = {
   sessionFile: string;
   workspaceDir?: string;
   agentDir?: string;
+  isolationKey?: string;
   threadId?: string;
   model?: string;
   modelProvider?: string;
@@ -99,10 +100,12 @@ export async function startCodexConversationThread(
   const workspaceDir =
     params.workspaceDir?.trim() || resolveCodexDefaultWorkspaceDir(params.pluginConfig);
   const agentDir = params.agentDir?.trim();
-  const agentLookup = buildAgentLookup({ agentDir, config: params.config });
-  const existingBinding = await readCodexAppServerBinding(params.sessionFile, {
-    ...agentLookup,
+  const agentLookup = buildAgentLookup({
+    agentDir,
+    config: params.config,
+    isolationKey: params.isolationKey,
   });
+  const existingBinding = await readCodexAppServerBinding(params.sessionFile, agentLookup);
   const authProfileId = resolveCodexAppServerAuthProfileIdForAgent({
     authProfileId: params.authProfileId ?? existingBinding?.authProfileId,
     ...agentLookup,
@@ -114,6 +117,7 @@ export async function startCodexConversationThread(
       threadId: params.threadId.trim(),
       workspaceDir,
       ...(agentDir ? { agentDir } : {}),
+      isolationKey: params.isolationKey,
       model: params.model,
       modelProvider: params.modelProvider,
       authProfileId,
@@ -128,6 +132,7 @@ export async function startCodexConversationThread(
       sessionFile: params.sessionFile,
       workspaceDir,
       ...(agentDir ? { agentDir } : {}),
+      isolationKey: params.isolationKey,
       model: params.model,
       modelProvider: params.modelProvider,
       authProfileId,
@@ -141,6 +146,7 @@ export async function startCodexConversationThread(
     sessionFile: params.sessionFile,
     workspaceDir,
     ...(agentDir ? { agentDir } : {}),
+    isolationKey: params.isolationKey,
   });
 }
 
@@ -222,7 +228,9 @@ export async function handleCodexConversationBindingResolved(
   if (!data || data.kind !== "codex-app-server-session") {
     return;
   }
-  await clearCodexAppServerBinding(data.sessionFile);
+  await clearCodexAppServerBinding(data.sessionFile, {
+    isolationKey: data.isolationKey,
+  });
 }
 
 async function attachExistingThread(params: {
@@ -231,6 +239,7 @@ async function attachExistingThread(params: {
   threadId: string;
   workspaceDir: string;
   agentDir?: string;
+  isolationKey?: string;
   model?: string;
   modelProvider?: string;
   authProfileId?: string;
@@ -242,7 +251,11 @@ async function attachExistingThread(params: {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
   });
-  const agentLookup = buildAgentLookup({ agentDir: params.agentDir, config: params.config });
+  const agentLookup = buildAgentLookup({
+    agentDir: params.agentDir,
+    config: params.config,
+    isolationKey: params.isolationKey,
+  });
   const modelProvider = resolveThreadRequestModelProvider({
     authProfileId: params.authProfileId,
     modelProvider: params.modelProvider,
@@ -300,6 +313,7 @@ async function createThread(params: {
   sessionFile: string;
   workspaceDir: string;
   agentDir?: string;
+  isolationKey?: string;
   model?: string;
   modelProvider?: string;
   authProfileId?: string;
@@ -311,7 +325,11 @@ async function createThread(params: {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
   });
-  const agentLookup = buildAgentLookup({ agentDir: params.agentDir, config: params.config });
+  const agentLookup = buildAgentLookup({
+    agentDir: params.agentDir,
+    config: params.config,
+    isolationKey: params.isolationKey,
+  });
   const modelProvider = resolveThreadRequestModelProvider({
     authProfileId: params.authProfileId,
     modelProvider: params.modelProvider,
@@ -376,7 +394,10 @@ async function runBoundTurn(params: {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
   });
-  const agentLookup = buildAgentLookup({ agentDir: params.data.agentDir });
+  const agentLookup = buildAgentLookup({
+    agentDir: params.data.agentDir,
+    isolationKey: params.data.isolationKey,
+  });
   const binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
   const threadId = binding?.threadId;
   if (!threadId) {
@@ -457,6 +478,7 @@ async function runBoundTurn(params: {
       sessionFile: params.data.sessionFile,
       threadId,
       turnId,
+      isolationKey: params.data.isolationKey,
     });
     collector.setTurnId(turnId);
     const completion = await collector
@@ -489,13 +511,17 @@ async function runBoundTurnWithMissingThreadRecovery(params: {
     if (!isCodexThreadNotFoundError(error)) {
       throw error;
     }
-    const agentLookup = buildAgentLookup({ agentDir: params.data.agentDir });
+    const agentLookup = buildAgentLookup({
+      agentDir: params.data.agentDir,
+      isolationKey: params.data.isolationKey,
+    });
     const binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
     await startCodexConversationThread({
       pluginConfig: params.pluginConfig,
       sessionFile: params.data.sessionFile,
       workspaceDir: binding?.cwd || params.data.workspaceDir,
       ...agentLookup,
+      isolationKey: params.data.isolationKey,
       model: binding?.model,
       modelProvider: binding?.modelProvider,
       authProfileId: binding?.authProfileId,
@@ -551,11 +577,14 @@ function resolveThreadRequestModelProvider(params: {
 
 function buildAgentLookup(params: {
   agentDir?: string;
+  isolationKey?: string;
   config?: CodexAppServerAuthProfileLookup["config"];
-}): Pick<CodexAppServerAuthProfileLookup, "agentDir" | "config"> {
+}): Pick<CodexAppServerAuthProfileLookup, "agentDir" | "config" | "isolationKey"> {
   const agentDir = params.agentDir?.trim();
+  const isolationKey = params.isolationKey?.trim();
   return {
     ...(agentDir ? { agentDir } : {}),
+    ...(isolationKey ? { isolationKey } : {}),
     ...(params.config ? { config: params.config } : {}),
   };
 }

--- a/extensions/codex/src/conversation-control.test.ts
+++ b/extensions/codex/src/conversation-control.test.ts
@@ -9,9 +9,11 @@ import {
   writeCodexAppServerBinding,
 } from "./app-server/session-binding.js";
 import {
+  stopCodexConversationTurn,
   setCodexConversationFastMode,
   setCodexConversationModel,
   setCodexConversationPermissions,
+  trackCodexConversationActiveTurn,
 } from "./conversation-control.js";
 
 let tempDir: string;
@@ -122,5 +124,54 @@ describe("codex conversation controls", () => {
     await expect(setCodexConversationModel({ sessionFile, model: "gpt-5.5" })).resolves.toBe(
       "Codex model set to gpt-5.5 &lt;\uff20U123&gt; \uff3btrusted\uff3d\uff08https://evil\uff09.",
     );
+  });
+
+  it("stops only the active turn for the requested isolation key", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await writeCodexAppServerBinding(
+      sessionFile,
+      { threadId: "thread-a", cwd: tempDir },
+      { isolationKey: "topic-a" },
+    );
+    await writeCodexAppServerBinding(
+      sessionFile,
+      { threadId: "thread-b", cwd: tempDir },
+      { isolationKey: "topic-b" },
+    );
+    const request = vi.fn(async () => ({}));
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({ request });
+    const cleanupA = trackCodexConversationActiveTurn({
+      sessionFile,
+      threadId: "thread-a",
+      turnId: "turn-a",
+      isolationKey: "topic-a",
+    });
+    const cleanupB = trackCodexConversationActiveTurn({
+      sessionFile,
+      threadId: "thread-b",
+      turnId: "turn-b",
+      isolationKey: "topic-b",
+    });
+
+    try {
+      await expect(
+        stopCodexConversationTurn({
+          sessionFile,
+          isolationKey: "topic-a",
+        }),
+      ).resolves.toEqual({ stopped: true, message: "Codex stop requested." });
+
+      expect(request).toHaveBeenCalledWith(
+        "turn/interrupt",
+        {
+          threadId: "thread-a",
+          turnId: "turn-a",
+        },
+        expect.any(Object),
+      );
+    } finally {
+      cleanupA();
+      cleanupB();
+    }
   });
 });

--- a/extensions/codex/src/conversation-control.ts
+++ b/extensions/codex/src/conversation-control.ts
@@ -17,6 +17,7 @@ type ActiveTurn = {
   sessionFile: string;
   threadId: string;
   turnId: string;
+  isolationKey?: string;
 };
 
 type CodexAppServerBindingLookup = NonNullable<Parameters<typeof readCodexAppServerBinding>[1]>;
@@ -35,26 +36,31 @@ function getActiveTurns(): Map<string, ActiveTurn> {
 
 export function trackCodexConversationActiveTurn(active: ActiveTurn): () => void {
   const activeTurns = getActiveTurns();
-  activeTurns.set(active.sessionFile, active);
+  const key = activeTurnKey(active.sessionFile, active.isolationKey);
+  activeTurns.set(key, active);
   return () => {
-    const current = activeTurns.get(active.sessionFile);
+    const current = activeTurns.get(key);
     if (current?.turnId === active.turnId) {
-      activeTurns.delete(active.sessionFile);
+      activeTurns.delete(key);
     }
   };
 }
 
-export function readCodexConversationActiveTurn(sessionFile: string): ActiveTurn | undefined {
-  return getActiveTurns().get(sessionFile);
+export function readCodexConversationActiveTurn(
+  sessionFile: string,
+  isolationKey?: string,
+): ActiveTurn | undefined {
+  return getActiveTurns().get(activeTurnKey(sessionFile, isolationKey));
 }
 
 export async function stopCodexConversationTurn(params: {
   sessionFile: string;
   pluginConfig?: unknown;
   agentDir?: string;
+  isolationKey?: string;
   config?: CodexAppServerBindingLookup["config"];
 }): Promise<{ stopped: boolean; message: string }> {
-  const active = readCodexConversationActiveTurn(params.sessionFile);
+  const active = readCodexConversationActiveTurn(params.sessionFile, params.isolationKey);
   if (!active) {
     return { stopped: false, message: "No active Codex run to stop." };
   }
@@ -83,9 +89,10 @@ export async function steerCodexConversationTurn(params: {
   message: string;
   pluginConfig?: unknown;
   agentDir?: string;
+  isolationKey?: string;
   config?: CodexAppServerBindingLookup["config"];
 }): Promise<{ steered: boolean; message: string }> {
-  const active = readCodexConversationActiveTurn(params.sessionFile);
+  const active = readCodexConversationActiveTurn(params.sessionFile, params.isolationKey);
   const text = params.message.trim();
   if (!text) {
     return { steered: false, message: "Usage: /codex steer <message>" };
@@ -114,11 +121,16 @@ export async function steerCodexConversationTurn(params: {
   return { steered: true, message: "Sent steer message to Codex." };
 }
 
+function activeTurnKey(sessionFile: string, isolationKey?: string): string {
+  return isolationKey ? `${sessionFile}\0${isolationKey}` : sessionFile;
+}
+
 export async function setCodexConversationModel(params: {
   sessionFile: string;
   model: string;
   pluginConfig?: unknown;
   agentDir?: string;
+  isolationKey?: string;
   config?: CodexAppServerBindingLookup["config"];
 }): Promise<string> {
   const model = params.model.trim();
@@ -156,6 +168,7 @@ export async function setCodexConversationFastMode(params: {
   enabled?: boolean;
   pluginConfig?: unknown;
   agentDir?: string;
+  isolationKey?: string;
   config?: CodexAppServerBindingLookup["config"];
 }): Promise<string> {
   const lookup = buildBindingLookup(params);
@@ -182,6 +195,7 @@ export async function setCodexConversationPermissions(params: {
   mode?: PermissionsMode;
   pluginConfig?: unknown;
   agentDir?: string;
+  isolationKey?: string;
   config?: CodexAppServerBindingLookup["config"];
 }): Promise<string> {
   const lookup = buildBindingLookup(params);
@@ -254,6 +268,7 @@ async function resumeThreadWithOverrides(params: {
   threadId: string;
   authProfileId?: string;
   agentDir?: string;
+  isolationKey?: string;
   config?: CodexAppServerBindingLookup["config"];
   model?: string;
   approvalPolicy?: CodexAppServerApprovalPolicy;
@@ -284,11 +299,14 @@ async function resumeThreadWithOverrides(params: {
 
 function buildBindingLookup(params: {
   agentDir?: string;
+  isolationKey?: string;
   config?: CodexAppServerBindingLookup["config"];
 }): CodexAppServerBindingLookup {
   const agentDir = params.agentDir?.trim();
+  const isolationKey = params.isolationKey?.trim();
   return {
     ...(agentDir ? { agentDir } : {}),
+    ...(isolationKey ? { isolationKey } : {}),
     ...(params.config ? { config: params.config } : {}),
   };
 }

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -281,6 +281,7 @@ type RunBtwSideQuestionParams = {
   sessionEntry: StoredSessionEntry;
   sessionStore?: Record<string, StoredSessionEntry>;
   sessionKey?: string;
+  sandboxSessionKey?: string;
   storePath?: string;
   resolvedThinkLevel?: ThinkLevel;
   resolvedReasoningLevel: ReasoningLevel;

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -22,6 +22,7 @@ export type AgentHarnessSideQuestionParams = {
   sessionEntry: import("../../config/sessions.js").SessionEntry;
   sessionStore?: Record<string, import("../../config/sessions.js").SessionEntry>;
   sessionKey?: string;
+  sandboxSessionKey?: string;
   storePath?: string;
   resolvedThinkLevel?: import("../../auto-reply/thinking.js").ThinkLevel;
   resolvedReasoningLevel: import("../../auto-reply/thinking.js").ReasoningLevel;
@@ -49,6 +50,7 @@ export type AgentHarnessCompactResult =
 export type AgentHarnessResetParams = {
   sessionId?: string;
   sessionKey?: string;
+  sandboxSessionKey?: string;
   sessionFile?: string;
   reason?: "new" | "reset" | "idle" | "daily" | "compaction" | "deleted" | "unknown";
 };

--- a/src/auto-reply/reply/commands-btw.test.ts
+++ b/src/auto-reply/reply/commands-btw.test.ts
@@ -102,6 +102,7 @@ describe("handleBtwCommand", () => {
   it("still delegates while the session is actively running", async () => {
     const params = buildParams("/btw what changed?");
     params.agentDir = "/tmp/agent";
+    params.runtimePolicySessionKey = "agent:main:telegram:default:direct:12345";
     params.sessionEntry = {
       sessionId: "session-1",
       updatedAt: Date.now(),
@@ -113,6 +114,7 @@ describe("handleBtwCommand", () => {
     expectObjectFields(mockFirstObjectArg(runBtwSideQuestionMock), {
       question: "what changed?",
       sessionEntry: params.sessionEntry,
+      sandboxSessionKey: "agent:main:telegram:default:direct:12345",
       resolvedThinkLevel: "off",
       resolvedReasoningLevel: "off",
     });

--- a/src/auto-reply/reply/commands-btw.ts
+++ b/src/auto-reply/reply/commands-btw.ts
@@ -3,6 +3,7 @@ import { runBtwSideQuestion } from "../../agents/btw.js";
 import { extractBtwQuestion } from "./btw-command.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
+import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 
 const BTW_USAGE = "Usage: /btw [side question]";
 
@@ -63,6 +64,13 @@ export const handleBtwCommand: CommandHandler = async (params, allowTextCommands
       sessionEntry: targetSessionEntry,
       sessionStore: params.sessionStore,
       sessionKey: params.sessionKey,
+      sandboxSessionKey:
+        params.runtimePolicySessionKey ??
+        resolveRuntimePolicySessionKey({
+          cfg: params.cfg,
+          ctx: params.ctx,
+          sessionKey: params.sessionKey,
+        }),
       storePath: params.storePath,
       // BTW is intentionally a quick side question, so do not inherit slower
       // session-level think/reasoning settings from the main run.

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -157,6 +157,7 @@ describe("handleCompactCommand", () => {
           SenderE164: "+15551234567",
         },
         agentDir: "/tmp/openclaw-agent-compact",
+        runtimePolicySessionKey: "agent:main:whatsapp:default:direct:15550001",
         sessionEntry: {
           sessionId: "session-1",
           updatedAt: Date.now(),
@@ -175,6 +176,7 @@ describe("handleCompactCommand", () => {
     const call = requireCompactEmbeddedPiSessionCall();
     expect(call.sessionId).toBe("session-1");
     expect(call.sessionKey).toBe("agent:main:main");
+    expect(call.sandboxSessionKey).toBe("agent:main:whatsapp:default:direct:15550001");
     expect(call.allowGatewaySubagentBinding).toBe(true);
     expect(call.trigger).toBe("manual");
     expect(call.customInstructions).toBe("focus on decisions");

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -229,6 +229,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   const result = await runtime.compactEmbeddedPiSession({
     sessionId,
     sessionKey: params.sessionKey,
+    sandboxSessionKey: params.runtimePolicySessionKey,
     allowGatewaySubagentBinding: true,
     messageChannel: params.command.channel,
     groupId: targetSessionEntry.groupId,

--- a/src/auto-reply/reply/commands-diagnostics.test.ts
+++ b/src/auto-reply/reply/commands-diagnostics.test.ts
@@ -37,6 +37,7 @@ type DiagnosticsSession = {
   accountId?: string;
   agentHarnessId?: string;
   channel?: string;
+  runtimePolicySessionKey?: string;
   sessionFile?: string;
   sessionId?: string;
   sessionKey?: string;
@@ -401,6 +402,9 @@ describe("diagnostics command", () => {
     expect(diagnosticsSessions[0]?.agentHarnessId).toBe("codex");
     expect(diagnosticsSessions[0]?.sessionId).toBe("session-1");
     expect(diagnosticsSessions[0]?.sessionFile).toBe("/tmp/session.jsonl");
+    expect(diagnosticsSessions[0]?.runtimePolicySessionKey).toBe(
+      "agent:main:whatsapp:direct:user-1",
+    );
     expect(diagnosticsSessions[0]?.channel).toBe("whatsapp");
     expect(diagnosticsSessions[0]?.accountId).toBe("account-1");
     const { defaults } = requireExecCall(execCalls);
@@ -453,15 +457,46 @@ describe("diagnostics command", () => {
     const diagnosticsSessions = requireDiagnosticsSessions(calls[0]);
     expect(diagnosticsSessions).toHaveLength(2);
     expect(diagnosticsSessions[0]?.sessionKey).toBe("agent:main:telegram:direct:user-1");
+    expect(diagnosticsSessions[0]?.runtimePolicySessionKey).toBe(
+      "agent:main:telegram:direct:user-1",
+    );
     expect(diagnosticsSessions[0]?.sessionId).toBe("telegram-session");
     expect(diagnosticsSessions[0]?.sessionFile).toBe("/tmp/telegram.jsonl");
     expect(diagnosticsSessions[0]?.channel).toBe("whatsapp");
     expect(diagnosticsSessions[1]?.sessionKey).toBe("agent:main:discord:channel:123");
+    expect(diagnosticsSessions[1]?.runtimePolicySessionKey).toBe("agent:main:discord:channel:123");
     expect(diagnosticsSessions[1]?.sessionId).toBe("discord-session");
     expect(diagnosticsSessions[1]?.sessionFile).toBe("/tmp/discord.jsonl");
     expect(diagnosticsSessions[1]?.channel).toBe("discord");
     expect(requireExecCall(execCalls).defaults.approvalWarningText).toContain(
       "OpenAI Codex harness:",
+    );
+  });
+
+  it("rebuilds diagnostics runtime-policy keys from stored origin from ids", async () => {
+    const { calls } = registerCodexDiagnosticsCommandForTest(async () => null);
+    const { handleDiagnosticsCommand } = createDiagnosticsHandlerForTest();
+    await handleDiagnosticsCommand(
+      buildDiagnosticsParams("/diagnostics", {
+        sessionKey: "agent:main:main",
+        sessionEntry: {
+          sessionId: "main-session",
+          sessionFile: "/tmp/main.jsonl",
+          updatedAt: 1,
+          origin: {
+            provider: "telegram",
+            chatType: "direct",
+            from: "user-1",
+            accountId: "default",
+          },
+        },
+      }),
+      true,
+    );
+
+    const diagnosticsSessions = requireDiagnosticsSessions(calls[0]);
+    expect(diagnosticsSessions[0]?.runtimePolicySessionKey).toBe(
+      "agent:main:telegram:default:direct:user-1",
     );
   });
 

--- a/src/auto-reply/reply/commands-diagnostics.ts
+++ b/src/auto-reply/reply/commands-diagnostics.ts
@@ -20,6 +20,7 @@ import {
   type PrivateCommandRouteTarget,
 } from "./commands-private-route.js";
 import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
+import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 
 const DIAGNOSTICS_COMMAND = "/diagnostics";
 const CODEX_DIAGNOSTICS_COMMAND = "/codex diagnostics";
@@ -457,6 +458,7 @@ async function executeCodexDiagnosticsAddon(
     senderIsOwner: params.command.senderIsOwner,
     gatewayClientScopes: params.ctx.GatewayClientScopes,
     sessionKey: params.sessionKey,
+    runtimePolicySessionKey: params.runtimePolicySessionKey,
     sessionId: targetSessionEntry?.sessionId,
     sessionFile: targetSessionEntry?.sessionFile,
     commandBody,
@@ -500,6 +502,11 @@ function buildCodexDiagnosticsSessions(
     .filter(([, entry]) => Boolean(entry.sessionFile))
     .map(([sessionKey, entry]) => ({
       sessionKey,
+      runtimePolicySessionKey: resolveDiagnosticsSessionRuntimePolicySessionKey(
+        params,
+        sessionKey,
+        entry,
+      ),
       sessionId: entry.sessionId,
       sessionFile: entry.sessionFile,
       agentHarnessId: entry.agentHarnessId,
@@ -524,6 +531,49 @@ function buildCodexDiagnosticsSessions(
           ? normalizeOptionalString(params.ctx.ThreadParentId)
           : undefined,
     }));
+}
+
+function resolveDiagnosticsSessionRuntimePolicySessionKey(
+  params: HandleCommandsParams,
+  sessionKey: string,
+  entry: SessionEntry,
+): string | undefined {
+  if (sessionKey === params.sessionKey && params.runtimePolicySessionKey) {
+    return params.runtimePolicySessionKey;
+  }
+  const accountId =
+    normalizeOptionalString(entry.deliveryContext?.accountId) ??
+    normalizeOptionalString(entry.origin?.accountId) ??
+    normalizeOptionalString(entry.lastAccountId) ??
+    (sessionKey === params.sessionKey ? (params.ctx.AccountId ?? undefined) : undefined);
+  const channel =
+    normalizeOptionalString(entry.deliveryContext?.channel) ??
+    normalizeOptionalString(entry.origin?.provider) ??
+    normalizeOptionalString(entry.channel) ??
+    normalizeOptionalString(entry.lastChannel);
+  const to =
+    normalizeOptionalString(entry.deliveryContext?.to) ??
+    normalizeOptionalString(entry.origin?.to) ??
+    normalizeOptionalString(entry.lastTo);
+  return resolveRuntimePolicySessionKey({
+    cfg: params.cfg,
+    sessionKey,
+    ctx: {
+      AccountId: accountId,
+      ChatType: entry.origin?.chatType ?? entry.chatType,
+      From:
+        normalizeOptionalString(entry.origin?.from) ??
+        (sessionKey === params.sessionKey ? params.command.from : undefined),
+      NativeDirectUserId: entry.origin?.nativeDirectUserId,
+      OriginatingChannel: channel,
+      OriginatingTo: to,
+      Provider: normalizeOptionalString(entry.origin?.provider) ?? channel,
+      SenderId: entry.origin?.senderId,
+      SessionKey: sessionKey,
+      Surface: entry.origin?.surface,
+      To: to,
+    },
+  });
 }
 
 function resolveDiagnosticsSessionChannel(

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -42,6 +42,7 @@ export const handlePluginCommand: CommandHandler = async (
     senderIsOwner: command.senderIsOwner,
     gatewayClientScopes: params.ctx.GatewayClientScopes,
     sessionKey: params.sessionKey,
+    runtimePolicySessionKey: params.runtimePolicySessionKey,
     sessionId: targetSessionEntry?.sessionId,
     sessionFile: targetSessionEntry?.sessionFile,
     commandBody: command.commandBodyNormalized,

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -47,6 +47,7 @@ export type HandleCommandsParams = {
   previousSessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey: string;
+  runtimePolicySessionKey?: string;
   storePath?: string;
   sessionScope?: SessionScope;
   workspaceDir: string;

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1063,6 +1063,38 @@ describe("createFollowupRunner runtime config", () => {
     });
   });
 
+  it("passes queued runtime-policy keys into preflight compaction and embedded runs", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+    const runtimePolicySessionKey = "agent:main:telegram:default:direct:12345";
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "openai/gpt-5.4",
+      sessionKey: "agent:main:main",
+    });
+
+    await runner(
+      createQueuedRun({
+        run: {
+          sessionKey: "agent:main:main",
+          runtimePolicySessionKey,
+          provider: "openai",
+          model: "gpt-5.4",
+        },
+      }),
+    );
+
+    expect(requireMockCallArg(runPreflightCompactionIfNeededMock, 0).runtimePolicySessionKey).toBe(
+      runtimePolicySessionKey,
+    );
+    expect(requireMockCallArg(runEmbeddedPiAgentMock, 0).sandboxSessionKey).toBe(
+      runtimePolicySessionKey,
+    );
+  });
+
   it("passes queued images into queued embedded followup runs", async () => {
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [],

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -31,6 +31,7 @@ import type { InlineDirectives } from "./directive-handling.parse.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import type { createModelSelectionState } from "./model-selection.js";
 import { extractInlineSimpleCommand } from "./reply-inline.js";
+import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import type { TypingController } from "./typing.js";
 
 type SkillCommandsRuntime = typeof import("../skill-commands.runtime.js");
@@ -168,6 +169,7 @@ export async function handleInlineActions(params: {
   previousSessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey: string;
+  runtimePolicySessionKey?: string;
   storePath?: string;
   sessionScope: Parameters<typeof buildStatusReply>[0]["sessionScope"];
   workspaceDir: string;
@@ -210,6 +212,7 @@ export async function handleInlineActions(params: {
     previousSessionEntry,
     sessionStore,
     sessionKey,
+    runtimePolicySessionKey,
     storePath,
     sessionScope,
     workspaceDir,
@@ -456,6 +459,9 @@ export async function handleInlineActions(params: {
       previousSessionEntry,
       sessionStore,
       sessionKey,
+      runtimePolicySessionKey:
+        runtimePolicySessionKey ??
+        resolveRuntimePolicySessionKey({ cfg, ctx: sessionCtx, sessionKey }),
       storePath,
       sessionScope,
       workspaceDir,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -17,6 +17,7 @@ import { resolveReplyDirectives } from "./get-reply-directives.js";
 import { initFastReplySessionState } from "./get-reply-fast-path.js";
 import { handleInlineActions } from "./get-reply-inline-actions.js";
 import { stripStructuralPrefixes } from "./mentions.js";
+import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import type { createTypingController } from "./typing.js";
 
 type AgentDefaults = NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
@@ -100,6 +101,11 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     triggerBodyNormalized: sessionState.triggerBodyNormalized,
     commandAuthorized: params.commandAuthorized,
   });
+  const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
+    cfg: params.cfg,
+    ctx: sessionState.sessionCtx,
+    sessionKey: sessionState.sessionKey,
+  });
   if (command.commandBodyNormalized === "/status") {
     const targetSessionEntry =
       sessionState.sessionStore[sessionState.sessionKey] ?? sessionState.sessionEntry;
@@ -158,6 +164,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     previousSessionEntry: sessionState.previousSessionEntry,
     sessionStore: sessionState.sessionStore,
     sessionKey: sessionState.sessionKey,
+    runtimePolicySessionKey,
     storePath: sessionState.storePath,
     sessionScope: sessionState.sessionScope,
     workspaceDir: params.workspaceDir,
@@ -223,6 +230,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     previousSessionEntry: sessionState.previousSessionEntry,
     sessionStore: sessionState.sessionStore,
     sessionKey: sessionState.sessionKey,
+    runtimePolicySessionKey,
     storePath: sessionState.storePath,
     sessionScope: sessionState.sessionScope,
     workspaceDir: params.workspaceDir,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -47,6 +47,7 @@ import { hasInboundMedia } from "./inbound-media.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
 import { createFastTestModelSelectionState, createModelSelectionState } from "./model-selection.js";
 import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
+import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import { initSessionState } from "./session.js";
 import {
   isStaleHeartbeatAutoFallbackOverride,
@@ -786,6 +787,7 @@ export async function getReplyFromConfig(
       previousSessionEntry,
       sessionStore,
       sessionKey,
+      runtimePolicySessionKey: resolveRuntimePolicySessionKey({ cfg, ctx: sessionCtx, sessionKey }),
       storePath,
       sessionScope,
       workspaceDir,

--- a/src/auto-reply/reply/runtime-policy-session-key.ts
+++ b/src/auto-reply/reply/runtime-policy-session-key.ts
@@ -1,4 +1,5 @@
 import { normalizeChatType } from "../../channels/chat-type.js";
+import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   buildAgentMainSessionKey,
@@ -121,5 +122,66 @@ export function resolveRuntimePolicySessionKey(params: {
     peerId,
     dmScope: "per-account-channel-peer",
     identityLinks: params.cfg?.session?.identityLinks,
+  });
+}
+
+export function resolveRuntimePolicySessionKeyForSessionEntry(params: {
+  cfg?: OpenClawConfig;
+  sessionKey: string;
+  entry?: SessionEntry;
+}): string | undefined {
+  const entry = params.entry;
+  if (!entry) {
+    return undefined;
+  }
+  const origin = entry.origin;
+  const delivery = entry.deliveryContext;
+  const channel =
+    normalizeOptionalString(delivery?.channel) ??
+    normalizeOptionalString(origin?.provider) ??
+    normalizeOptionalString(entry.channel) ??
+    normalizeOptionalString(entry.lastChannel);
+  const to =
+    normalizeOptionalString(delivery?.to) ??
+    normalizeOptionalString(origin?.to) ??
+    normalizeOptionalString(entry.lastTo);
+  const hasStoredRuntimeContext = Boolean(
+    channel ||
+    to ||
+    delivery?.accountId ||
+    origin?.accountId ||
+    entry.lastAccountId ||
+    origin?.chatType ||
+    entry.chatType ||
+    origin?.from ||
+    origin?.nativeDirectUserId ||
+    origin?.senderId ||
+    origin?.surface,
+  );
+  if (!hasStoredRuntimeContext) {
+    return undefined;
+  }
+  return resolveRuntimePolicySessionKey({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    ctx: {
+      AccountId:
+        normalizeOptionalString(delivery?.accountId) ??
+        normalizeOptionalString(origin?.accountId) ??
+        normalizeOptionalString(entry.lastAccountId),
+      ChatType: origin?.chatType ?? entry.chatType,
+      From: normalizeOptionalString(origin?.from),
+      NativeDirectUserId: normalizeOptionalString(origin?.nativeDirectUserId),
+      OriginatingChannel: channel,
+      OriginatingTo: to,
+      Provider: normalizeOptionalString(origin?.provider) ?? channel,
+      SenderId: normalizeOptionalString(origin?.senderId) ?? normalizeOptionalString(origin?.from),
+      SessionKey: params.sessionKey,
+      Surface:
+        normalizeOptionalString(origin?.surface) ??
+        normalizeOptionalString(origin?.provider) ??
+        channel,
+      To: to,
+    },
   });
 }

--- a/src/auto-reply/reply/session-hooks-context.test.ts
+++ b/src/auto-reply/reply/session-hooks-context.test.ts
@@ -97,6 +97,7 @@ async function createStoredSession(params: {
   sessionId: string;
   text?: string;
   updatedAt?: number;
+  entry?: Partial<SessionEntry>;
 }): Promise<{ storePath: string; transcriptPath: string }> {
   const storePath = await createStorePath(params.prefix);
   const transcriptPath = await writeTranscript(storePath, params.sessionId, params.text);
@@ -105,6 +106,7 @@ async function createStoredSession(params: {
       sessionId: params.sessionId,
       sessionFile: transcriptPath,
       updatedAt: params.updatedAt ?? Date.now(),
+      ...params.entry,
     },
   });
   return { storePath, transcriptPath };
@@ -233,6 +235,74 @@ describe("session hook context wiring", () => {
     expectFields(startEvent, { resumedFrom: "old-session" });
     expect(event?.nextSessionId).toBe(startEvent?.sessionId);
     expectFields(startContext, { sessionId: startEvent?.sessionId });
+  });
+
+  it("passes the runtime-policy session key to agent harness reset hooks", async () => {
+    const sessionKey = "agent:main:main";
+    const { storePath } = await createStoredSession({
+      prefix: "openclaw-session-hook-runtime-policy-reset",
+      sessionKey,
+      sessionId: "old-session",
+    });
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    await initSessionState({
+      ctx: {
+        Body: "/new",
+        SessionKey: sessionKey,
+        ChatType: "direct",
+        Provider: "telegram",
+        AccountId: "default",
+        SenderId: "12345",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(sessionCleanupMocks.resetRegisteredAgentHarnessSessions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey,
+        sandboxSessionKey: "agent:main:telegram:default:direct:12345",
+      }),
+    );
+  });
+
+  it("uses the previous session origin for agent harness reset isolation", async () => {
+    const sessionKey = "agent:main:main";
+    const { storePath } = await createStoredSession({
+      prefix: "openclaw-session-hook-previous-origin-reset",
+      sessionKey,
+      sessionId: "old-session",
+      entry: {
+        origin: {
+          provider: "telegram",
+          chatType: "direct",
+          from: "old-user",
+          accountId: "default",
+        },
+      },
+    });
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    await initSessionState({
+      ctx: {
+        Body: "/new",
+        SessionKey: sessionKey,
+        ChatType: "direct",
+        Provider: "telegram",
+        AccountId: "default",
+        SenderId: "new-user",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(sessionCleanupMocks.resetRegisteredAgentHarnessSessions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey,
+        sandboxSessionKey: "agent:main:telegram:default:direct:old-user",
+      }),
+    );
   });
 
   it("marks explicit /reset rollovers with reason reset", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -62,6 +62,10 @@ import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { isResetAuthorizedForContext } from "./reset-authorization.js";
 import {
+  resolveRuntimePolicySessionKey,
+  resolveRuntimePolicySessionKeyForSessionEntry,
+} from "./runtime-policy-session-key.js";
+import {
   maybeRetireLegacyMainDeliveryRoute,
   resolveLastChannelRaw,
   resolveLastToRaw,
@@ -851,6 +855,17 @@ export async function initSessionState(params: {
     await resetRegisteredAgentHarnessSessions({
       sessionId: previousSessionEntry.sessionId,
       sessionKey,
+      sandboxSessionKey:
+        resolveRuntimePolicySessionKeyForSessionEntry({
+          cfg,
+          sessionKey,
+          entry: previousSessionEntry,
+        }) ??
+        resolveRuntimePolicySessionKey({
+          cfg,
+          ctx: sessionCtxForState,
+          sessionKey,
+        }),
       sessionFile: previousSessionEntry.sessionFile,
       reason: previousSessionEndReason ?? "unknown",
     });

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -33,6 +33,9 @@ const mergeOrigin = (
   if (next?.from) {
     merged.from = next.from;
   }
+  if (next?.senderId) {
+    merged.senderId = next.senderId;
+  }
   if (next?.to) {
     merged.to = next.to;
   }
@@ -69,6 +72,7 @@ export function deriveSessionOrigin(
   const surface = normalizeOptionalLowercaseString(ctx.Surface);
   const chatType = normalizeChatType(ctx.ChatType) ?? undefined;
   const from = normalizeOptionalString(ctx.From);
+  const senderId = normalizeOptionalString(ctx.SenderId);
   const to = normalizeOptionalString(
     typeof ctx.OriginatingTo === "string" ? ctx.OriginatingTo : ctx.To,
   );
@@ -92,6 +96,9 @@ export function deriveSessionOrigin(
   }
   if (from) {
     origin.from = from;
+  }
+  if (senderId) {
+    origin.senderId = senderId;
   }
   if (to) {
     origin.to = to;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -18,6 +18,7 @@ export type SessionOrigin = {
   surface?: string;
   chatType?: SessionChatType;
   from?: string;
+  senderId?: string;
   to?: string;
   nativeChannelId?: string;
   nativeDirectUserId?: string;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -81,6 +81,7 @@ import {
   listSessionCompactionCheckpoints,
 } from "../session-compaction-checkpoints.js";
 import { triggerSessionPatchHook } from "../session-patch-hooks.js";
+import { resolveGatewaySessionRuntimePolicySessionKey } from "../session-runtime-policy-session-key.js";
 import {
   resolveSessionStoreAgentId,
   resolveSessionStoreKey,
@@ -2292,6 +2293,11 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         result = await compactEmbeddedPiSession({
           sessionId,
           sessionKey: target.canonicalKey,
+          sandboxSessionKey: resolveGatewaySessionRuntimePolicySessionKey({
+            cfg,
+            sessionKey: target.canonicalKey,
+            entry,
+          }),
           allowGatewaySubagentBinding: true,
           sessionFile: filePath,
           workspaceDir,

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -245,6 +245,17 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
       main: sessionStoreEntry("sess-main", {
         thinkingLevel: "medium",
         reasoningLevel: "stream",
+        chatType: "direct",
+        deliveryContext: {
+          channel: "whatsapp",
+          accountId: "default",
+          to: "15550001",
+        },
+        origin: {
+          provider: "whatsapp",
+          accountId: "default",
+          nativeDirectUserId: "15550001",
+        },
       }),
     },
   });
@@ -317,6 +328,7 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
         model?: string;
         provider?: string;
         reasoningLevel?: string;
+        sandboxSessionKey?: string;
         sessionFile?: string;
         sessionId?: string;
         sessionKey?: string;
@@ -333,6 +345,7 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
   };
   expect(compactionCall.sessionId).toBe("sess-main");
   expect(compactionCall.sessionKey).toBe("agent:main:main");
+  expect(compactionCall.sandboxSessionKey).toBe("agent:main:whatsapp:default:direct:15550001");
   if (!compactionCall.sessionFile) {
     throw new Error("expected embedded compaction session file");
   }

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from "vitest";
 import { embeddedRunMock, testState, writeSessionStore } from "./test-helpers.js";
 import {
   setupGatewaySessionsTestHarness,
+  agentHarnessMocks,
   bootstrapCacheMocks,
   sessionHookMocks,
   beforeResetHookMocks,
@@ -112,6 +113,126 @@ test("sessions.reset emits internal command hook with reason", async () => {
   expect(event.sessionKey).toBe("agent:main:main");
   expect(event.context?.commandSource).toBe("gateway:sessions.reset");
   expect(event.context?.previousSessionEntry?.sessionId).toBe("sess-main");
+});
+
+test("sessions.reset notifies agent harness cleanup with the runtime-policy session key", async () => {
+  const { dir } = await createSessionStoreDir();
+  const transcriptPath = path.join(dir, "sess-main.jsonl");
+  await fs.writeFile(transcriptPath, `${JSON.stringify({ role: "user", content: "hello" })}\n`);
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main", {
+        sessionFile: transcriptPath,
+        chatType: "direct",
+        deliveryContext: {
+          channel: "whatsapp",
+          accountId: "default",
+          to: "15550001",
+        },
+        origin: {
+          provider: "whatsapp",
+          accountId: "default",
+          nativeDirectUserId: "15550001",
+        },
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{ ok: true; key: string }>("sessions.reset", {
+    key: "main",
+    reason: "new",
+  });
+
+  expect(reset.ok).toBe(true);
+  expect(agentHarnessMocks.resetRegisteredAgentHarnessSessions).toHaveBeenCalledWith({
+    sessionId: "sess-main",
+    sessionKey: "agent:main:main",
+    sandboxSessionKey: "agent:main:whatsapp:default:direct:15550001",
+    sessionFile: transcriptPath,
+    reason: "new",
+  });
+});
+
+test("sessions.reset reconstructs direct runtime-policy keys from stored sender identity", async () => {
+  const { dir } = await createSessionStoreDir();
+  const transcriptPath = path.join(dir, "sess-main.jsonl");
+  await fs.writeFile(transcriptPath, `${JSON.stringify({ role: "user", content: "hello" })}\n`);
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main", {
+        sessionFile: transcriptPath,
+        chatType: "direct",
+        deliveryContext: {
+          channel: "telegram",
+          accountId: "default",
+          to: "bot-dm-channel",
+        },
+        origin: {
+          provider: "telegram",
+          accountId: "default",
+          chatType: "direct",
+          from: "sender-legacy",
+          senderId: "12345",
+          to: "bot-dm-channel",
+        },
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{ ok: true; key: string }>("sessions.reset", {
+    key: "main",
+    reason: "new",
+  });
+
+  expect(reset.ok).toBe(true);
+  expect(agentHarnessMocks.resetRegisteredAgentHarnessSessions).toHaveBeenCalledWith({
+    sessionId: "sess-main",
+    sessionKey: "agent:main:main",
+    sandboxSessionKey: "agent:main:telegram:default:direct:12345",
+    sessionFile: transcriptPath,
+    reason: "new",
+  });
+});
+
+test("sessions.delete notifies agent harness cleanup for the deleted session", async () => {
+  const { dir } = await createSessionStoreDir();
+  const sessionKey = "agent:main:telegram:direct:42";
+  const transcriptPath = path.join(dir, "sess-direct.jsonl");
+  await fs.writeFile(transcriptPath, `${JSON.stringify({ role: "user", content: "hello" })}\n`);
+
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry("sess-direct", {
+        sessionFile: transcriptPath,
+        origin: {
+          chatType: "direct",
+          provider: "telegram",
+          accountId: "default",
+          nativeDirectUserId: "42",
+        },
+      }),
+    },
+  });
+
+  const deleted = await directSessionReq<{ ok: true; key: string; deleted: boolean }>(
+    "sessions.delete",
+    {
+      key: sessionKey,
+      deleteTranscript: false,
+    },
+  );
+
+  expect(deleted.ok).toBe(true);
+  expect(deleted.payload?.deleted).toBe(true);
+  expect(agentHarnessMocks.resetRegisteredAgentHarnessSessions).toHaveBeenCalledWith({
+    sessionId: "sess-direct",
+    sessionKey,
+    sandboxSessionKey: sessionKey,
+    sessionFile: transcriptPath,
+    reason: "deleted",
+  });
 });
 
 test("sessions.reset emits before_reset hook with transcript context", async () => {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -7,6 +7,7 @@ import { getAcpRuntimeBackend } from "../acp/runtime/registry.js";
 import { readAcpSessionEntry, upsertAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
+import { resetRegisteredAgentHarnessSessions } from "../agents/harness/registry.js";
 import { retireSessionMcpRuntime } from "../agents/pi-bundle-mcp-tools.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../auto-reply/reply/abort.js";
@@ -47,6 +48,7 @@ import {
   noteActiveSessionForShutdown,
 } from "./active-sessions-shutdown-tracker.js";
 import { ErrorCodes, errorShape } from "./protocol/index.js";
+import { resolveGatewaySessionRuntimePolicySessionKey } from "./session-runtime-policy-session-key.js";
 import {
   archiveSessionTranscriptsDetailed,
   resolveStableSessionEndTranscript,
@@ -562,7 +564,9 @@ export async function cleanupSessionBeforeMutation(params: {
   legacyKey?: string;
   canonicalKey?: string;
   reason: "session-reset" | "session-delete";
+  harnessResetReason?: "new" | "reset" | "deleted";
 }) {
+  const sessionKey = params.target.canonicalKey ?? params.canonicalKey ?? params.key;
   const cleanupError = await ensureSessionRuntimeCleanup({
     cfg: params.cfg,
     key: params.key,
@@ -572,6 +576,17 @@ export async function cleanupSessionBeforeMutation(params: {
   if (cleanupError) {
     return cleanupError;
   }
+  await resetRegisteredAgentHarnessSessions({
+    sessionId: params.entry?.sessionId,
+    sessionKey,
+    sandboxSessionKey: resolveGatewaySessionRuntimePolicySessionKey({
+      cfg: params.cfg,
+      sessionKey,
+      entry: params.entry,
+    }),
+    sessionFile: params.entry?.sessionFile,
+    reason: params.harnessResetReason ?? (params.reason === "session-delete" ? "deleted" : "reset"),
+  });
   const pluginCleanup = await runPluginHostCleanup({
     cfg: params.cfg,
     registry: getActivePluginRegistry(),
@@ -680,6 +695,7 @@ export async function performGatewaySessionReset(params: {
     legacyKey,
     canonicalKey,
     reason: "session-reset",
+    harnessResetReason: params.reason,
   });
   if (mutationCleanupError) {
     return { ok: false, error: mutationCleanupError };

--- a/src/gateway/session-runtime-policy-session-key.ts
+++ b/src/gateway/session-runtime-policy-session-key.ts
@@ -1,0 +1,31 @@
+import { resolveRuntimePolicySessionKey } from "../auto-reply/reply/runtime-policy-session-key.js";
+import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+export function resolveGatewaySessionRuntimePolicySessionKey(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  entry?: SessionEntry;
+}): string | undefined {
+  const origin = params.entry?.origin;
+  const delivery = params.entry?.deliveryContext;
+  const channel = delivery?.channel ?? origin?.provider ?? params.entry?.lastChannel;
+  const to = delivery?.to ?? origin?.to ?? params.entry?.lastTo;
+  return resolveRuntimePolicySessionKey({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    ctx: {
+      SessionKey: params.sessionKey,
+      AccountId: delivery?.accountId ?? origin?.accountId ?? params.entry?.lastAccountId,
+      ChatType: origin?.chatType ?? params.entry?.chatType,
+      From: origin?.from,
+      NativeDirectUserId: origin?.nativeDirectUserId,
+      OriginatingChannel: channel,
+      OriginatingTo: to,
+      Provider: origin?.provider ?? channel,
+      SenderId: origin?.senderId ?? origin?.from,
+      Surface: origin?.surface ?? origin?.provider ?? channel,
+      To: to,
+    },
+  });
+}

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -61,6 +61,10 @@ const sessionCleanupMocks = vi.hoisted(() => ({
   stopSubagentsForRequester: vi.fn(() => ({ stopped: 0 })),
 }));
 
+const agentHarnessMocks = vi.hoisted(() => ({
+  resetRegisteredAgentHarnessSessions: vi.fn(async () => undefined),
+}));
+
 const bootstrapCacheMocks = vi.hoisted(() => ({
   clearBootstrapSnapshot: vi.fn(),
 }));
@@ -154,6 +158,16 @@ vi.mock("../../agents/bootstrap-cache.js", async () => {
   return {
     ...actual,
     clearBootstrapSnapshot: bootstrapCacheMocks.clearBootstrapSnapshot,
+  };
+});
+
+vi.mock("../../agents/harness/registry.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/harness/registry.js")>(
+    "../../agents/harness/registry.js",
+  );
+  return {
+    ...actual,
+    resetRegisteredAgentHarnessSessions: agentHarnessMocks.resetRegisteredAgentHarnessSessions,
   };
 });
 
@@ -263,6 +277,7 @@ export function setupGatewaySessionsTestHarness() {
     clearConfigCache();
     sessionCleanupMocks.clearSessionQueues.mockClear();
     sessionCleanupMocks.stopSubagentsForRequester.mockClear();
+    agentHarnessMocks.resetRegisteredAgentHarnessSessions.mockClear();
     bootstrapCacheMocks.clearBootstrapSnapshot.mockReset();
     sessionHookMocks.hasInternalHookListeners.mockReset();
     sessionHookMocks.hasInternalHookListeners.mockReturnValue(true);
@@ -501,6 +516,7 @@ export function isInternalHookEvent(value: unknown): value is InternalHookEvent 
 }
 
 export {
+  agentHarnessMocks,
   bootstrapCacheMocks,
   sessionHookMocks,
   beforeResetHookMocks,

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -1106,6 +1106,110 @@ describe("registerPluginCommand", () => {
     expect(receivedCtx?.sessionId).toBe("session-123");
   });
 
+  it("derives a direct runtime-policy session key for native plugin commands", async () => {
+    let receivedCtx:
+      | {
+          runtimePolicySessionKey?: string;
+        }
+      | undefined;
+    const handler = async (ctx: { runtimePolicySessionKey?: string }) => {
+      receivedCtx = ctx;
+      return { text: "ok" };
+    };
+
+    const result = await executePluginCommand({
+      command: {
+        name: "policycheck",
+        description: "Demo command",
+        acceptsArgs: false,
+        handler,
+        pluginId: "demo-plugin",
+      },
+      channel: "telegram",
+      senderId: "12345",
+      isAuthorizedSender: true,
+      sessionKey: "agent:main:main",
+      commandBody: "/policycheck",
+      config: {} as never,
+      from: "telegram:12345",
+      to: "telegram:12345",
+      accountId: "default",
+    });
+
+    expect(result).toEqual({ text: "ok" });
+    expect(receivedCtx?.runtimePolicySessionKey).toBe("agent:main:telegram:default:direct:12345");
+  });
+
+  it("derives direct runtime-policy session keys for threaded Telegram DM plugin commands", async () => {
+    let receivedCtx:
+      | {
+          runtimePolicySessionKey?: string;
+        }
+      | undefined;
+    const handler = async (ctx: { runtimePolicySessionKey?: string }) => {
+      receivedCtx = ctx;
+      return { text: "ok" };
+    };
+
+    const result = await executePluginCommand({
+      command: {
+        name: "policycheck",
+        description: "Demo command",
+        acceptsArgs: false,
+        handler,
+        pluginId: "demo-plugin",
+      },
+      channel: "telegram",
+      senderId: "12345",
+      isAuthorizedSender: true,
+      sessionKey: "agent:main:main",
+      commandBody: "/policycheck",
+      config: {} as never,
+      from: "telegram:12345",
+      to: "telegram:12345",
+      accountId: "default",
+      messageThreadId: 77,
+    });
+
+    expect(result).toEqual({ text: "ok" });
+    expect(receivedCtx?.runtimePolicySessionKey).toBe("agent:main:telegram:default:direct:12345");
+  });
+
+  it("does not derive direct runtime-policy session keys for threaded group plugin commands", async () => {
+    let receivedCtx:
+      | {
+          runtimePolicySessionKey?: string;
+        }
+      | undefined;
+    const handler = async (ctx: { runtimePolicySessionKey?: string }) => {
+      receivedCtx = ctx;
+      return { text: "ok" };
+    };
+
+    const result = await executePluginCommand({
+      command: {
+        name: "policycheck",
+        description: "Demo command",
+        acceptsArgs: false,
+        handler,
+        pluginId: "demo-plugin",
+      },
+      channel: "telegram",
+      senderId: "12345",
+      isAuthorizedSender: true,
+      sessionKey: "agent:main:main",
+      commandBody: "/policycheck",
+      config: {} as never,
+      from: "telegram:group:-10012345:topic:77",
+      to: "slash:12345",
+      accountId: "default",
+      messageThreadId: 77,
+    });
+
+    expect(result).toEqual({ text: "ok" });
+    expect(receivedCtx?.runtimePolicySessionKey).toBeUndefined();
+  });
+
   it("normalizes undefined plugin command handler results to an empty reply payload", async () => {
     const handler = async () => undefined as never;
 

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -9,7 +9,17 @@ import { resolveConversationBindingContext } from "../channels/conversation-bind
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { ADMIN_SCOPE, isOperatorScope } from "../gateway/operator-scopes.js";
 import { logVerbose } from "../globals.js";
-import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import {
+  buildAgentMainSessionKey,
+  buildAgentPeerSessionKey,
+  normalizeAgentId,
+  normalizeMainKey,
+  resolveAgentIdFromSessionKey,
+} from "../routing/session-key.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
 import {
   clearPluginCommands,
   clearPluginCommandsForPlugin,
@@ -169,6 +179,88 @@ function resolveBindingConversationFromCommand(params: {
   });
 }
 
+function isMainSessionAlias(params: {
+  config?: OpenClawConfig;
+  agentId: string;
+  sessionKey: string;
+}): boolean {
+  const raw = normalizeLowercaseStringOrEmpty(params.sessionKey);
+  if (!raw) {
+    return false;
+  }
+  const agentId = normalizeAgentId(params.agentId);
+  const mainKey = normalizeMainKey(params.config?.session?.mainKey);
+  return (
+    raw === "main" ||
+    raw === mainKey ||
+    raw === buildAgentMainSessionKey({ agentId, mainKey }) ||
+    raw === buildAgentMainSessionKey({ agentId, mainKey: "main" }) ||
+    raw === buildAgentMainSessionKey({ agentId: "main", mainKey }) ||
+    raw === buildAgentMainSessionKey({ agentId: "main", mainKey: "main" }) ||
+    (params.config?.session?.scope === "global" && raw === "global")
+  );
+}
+
+function isLikelyDirectPluginCommandContext(params: {
+  from?: string;
+  messageThreadId?: string | number;
+  threadParentId?: string;
+}): boolean {
+  const from = normalizeOptionalString(params.from);
+  if (from) {
+    return !/(^|:)(?:group|channel)(?::|$)/i.test(from);
+  }
+  if (params.messageThreadId != null || normalizeOptionalString(params.threadParentId)) {
+    return false;
+  }
+  return true;
+}
+
+function resolvePluginCommandRuntimePolicySessionKey(params: {
+  config?: OpenClawConfig;
+  sessionKey?: string;
+  runtimePolicySessionKey?: string;
+  channel: string;
+  accountId?: string;
+  senderId?: string;
+  from?: string;
+  to?: string;
+  messageThreadId?: string | number;
+  threadParentId?: string;
+}): string | undefined {
+  const explicitPolicySessionKey = normalizeOptionalString(params.runtimePolicySessionKey);
+  if (explicitPolicySessionKey) {
+    return explicitPolicySessionKey;
+  }
+  const sessionKey = normalizeOptionalString(params.sessionKey);
+  if (!sessionKey) {
+    return undefined;
+  }
+  const agentId = resolveAgentIdFromSessionKey(sessionKey);
+  if (!isMainSessionAlias({ config: params.config, agentId, sessionKey })) {
+    return undefined;
+  }
+  if (!isLikelyDirectPluginCommandContext(params)) {
+    return undefined;
+  }
+  const channel = normalizeLowercaseStringOrEmpty(params.channel);
+  const peerId = [params.senderId, params.from, params.to]
+    .map((value) => normalizeOptionalString(value))
+    .find(Boolean);
+  if (!channel || !peerId) {
+    return undefined;
+  }
+  return buildAgentPeerSessionKey({
+    agentId,
+    channel,
+    accountId: params.accountId,
+    peerKind: "direct",
+    peerId,
+    dmScope: "per-account-channel-peer",
+    identityLinks: params.config?.session?.identityLinks,
+  });
+}
+
 /**
  * Execute a plugin command handler.
  *
@@ -185,6 +277,7 @@ export async function executePluginCommand(params: {
   senderIsOwner?: boolean;
   gatewayClientScopes?: PluginCommandContext["gatewayClientScopes"];
   sessionKey?: PluginCommandContext["sessionKey"];
+  runtimePolicySessionKey?: PluginCommandContext["runtimePolicySessionKey"];
   sessionId?: PluginCommandContext["sessionId"];
   sessionFile?: PluginCommandContext["sessionFile"];
   commandBody: string;
@@ -254,6 +347,18 @@ export async function executePluginCommand(params: {
     threadParentId: params.threadParentId,
   });
   const effectiveAccountId = bindingConversation?.accountId ?? params.accountId;
+  const runtimePolicySessionKey = resolvePluginCommandRuntimePolicySessionKey({
+    config,
+    channel,
+    senderId,
+    sessionKey: params.sessionKey,
+    runtimePolicySessionKey: params.runtimePolicySessionKey,
+    accountId: effectiveAccountId,
+    from: params.from,
+    to: params.to,
+    messageThreadId: params.messageThreadId,
+    threadParentId: params.threadParentId,
+  });
   const senderIsOwnerForCommand =
     requiredScopes.length > 0 ||
     (isTrustedReservedCommandOwner(command) &&
@@ -292,6 +397,7 @@ export async function executePluginCommand(params: {
     ...(senderIsOwnerForCommand === undefined ? {} : { senderIsOwner: senderIsOwnerForCommand }),
     gatewayClientScopes: params.gatewayClientScopes,
     sessionKey: params.sessionKey,
+    runtimePolicySessionKey,
     sessionId: params.sessionId,
     sessionFile: params.sessionFile,
     args: sanitizedArgs,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1912,6 +1912,8 @@ export type OpenClawPluginGatewayMethod = {
 export type PluginCommandDiagnosticsSession = {
   /** Stable host session key when available. */
   sessionKey?: string;
+  /** Runtime-policy session key used for per-origin runtime isolation when it differs from sessionKey. */
+  runtimePolicySessionKey?: string;
   /** Ephemeral OpenClaw session id when available. */
   sessionId?: string;
   /** Transcript file for this OpenClaw session when available. */
@@ -1948,6 +1950,8 @@ export type PluginCommandContext = {
   gatewayClientScopes?: string[];
   /** Stable host session key for the active conversation when available. */
   sessionKey?: string;
+  /** Runtime-policy session key for per-origin runtime isolation when it differs from sessionKey. */
+  runtimePolicySessionKey?: string;
   /** Ephemeral host session id for the active conversation when available. */
   sessionId?: string;
   /** Transcript file for the active OpenClaw session when available. */


### PR DESCRIPTION
## Summary
- add opt-in `appServer.clientIsolation=session` so Codex app-server clients and thread bindings can be isolated per OpenClaw runtime-policy session/topic instead of shared per agent
- route run attempts, queued follow-ups, native compaction, `/btw`, `/compact`, Codex plugin commands, bound conversation turns, diagnostics, gateway compaction, and reset/delete cleanup through the same runtime-policy isolation key
- expose `appServer.turnTerminalIdleTimeoutMs` and `appServer.nativeCompaction`; keep existing defaults (`clientIsolation=agent`, native compaction on, 30 minute terminal idle timeout)

## Why
Codex app-server workers can silently stop producing terminal events (see openai/codex#21937). OpenClaw previously reused one shared Codex app-server client per agent, so a wedged worker could poison unrelated topics. This keeps old behavior by default and lets operators opt into per-session/topic isolation.

## Real behavior proof
- Behavior or issue addressed: Multiple concurrent Telegram topics using Codex could eventually stall because OpenClaw reused one shared Codex app-server client per agent. When one Codex worker stopped producing terminal events, unrelated topics could inherit the same wedged client. This patch adds opt-in per-runtime-session/topic isolation with `appServer.clientIsolation="session"`.
- Real environment tested: Human-run local production OpenClaw setup on a Linux host using a user-level `openclaw-gateway` systemd service, the bundled Codex plugin, `@openai/codex` 0.130.0, and a Telegram group with multiple active topics. Hostname, account identifiers, topic ids, and tokens are redacted.
- Exact steps or command run after this patch: Applied the source-equivalent patch to the installed Codex plugin bundle and manifest, enabled `appServer.clientIsolation="session"`, restarted `openclaw-gateway`, checked `systemctl --user show openclaw-gateway`, checked `journalctl --user -u openclaw-gateway`, then exercised multiple Telegram topics with Codex enabled.
- Evidence after fix: Redacted terminal output and runtime log excerpt from the real gateway after the patched service restart:
  ```text
  $ systemctl --user show openclaw-gateway --property=ActiveState --property=SubState --property=MainPID
  ActiveState=active
  SubState=running
  MainPID=<redacted>

  $ journalctl --user -u openclaw-gateway
  [gateway] http server listening (5 plugins: acpx, codex, memory-core, openai, telegram; 5.9s)
  [gateway] ready
  ```
- Observed result after fix: Concurrent Telegram topics no longer cascade-stalled through one shared frozen Codex app-server client after enabling session isolation.
- What was not tested: Real WebSocket remote app-server isolation and non-Codex providers/extensions.

Not tested in CI/local suite:
- CI full suite clean on this machine; local `pnpm test` still fails on unrelated existing non-Codex failures listed below.

## Validation
- `pnpm exec vitest run extensions/codex/src/commands.test.ts --reporter=dot` (1 file / 89 tests passed)
- `pnpm exec vitest run extensions/codex/src/app-server/compact.test.ts --reporter=dot` (1 file / 15 tests passed)
- `pnpm exec vitest run src/gateway/server.sessions.reset-hooks.test.ts src/gateway/server.sessions.compaction.test.ts --reporter=dot` (2 files / 15 tests passed)
- `pnpm test src/plugins/commands.test.ts` (1 file / 42 tests passed)
- `pnpm test extensions/codex/src/commands.test.ts` (1 file / 89 tests passed)
- `pnpm test extensions/codex/src/app-server/session-binding.test.ts extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/compact.test.ts extensions/codex/src/app-server/run-attempt.test.ts` (4 files / 134 tests passed)
- `pnpm test src/gateway/server.sessions.reset-hooks.test.ts src/gateway/server.sessions.compaction.test.ts` (2 files / 15 tests passed)
- `pnpm test:extension codex` (50 files / 681 tests passed)
- `pnpm check` (passed)
- `pnpm build` (passed)
- `codex review --base upstream/main` (no actionable correctness issues)
- `pnpm test` (failed after 76 shards on unrelated existing non-Codex failures: Telegram durable-final proof, NVIDIA/LM Studio provider expectations, oc-path perf threshold, acpx source-vs-dist path, gateway credential/auth env expectations, Discord patch summary truncation, IPv6 loopback `EADDRNOTAVAIL ::1`, and agent/config test mocks missing unrelated exports.)

## AI-assisted
Yes. Codex implemented and locally reviewed the change; the production behavior proof above was run by a human operator on their own OpenClaw instance. I understand the code paths changed.
