### PR TITLE
fix(status): avoid false shell-wrapper audit warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.
 - **Gateway client watchdog:** keep transport-stall detection active for unbounded and mixed pending requests so dead sockets reject pending requests, reconnect, and never replay rejected requests. (#103407) Thanks @NianJiuZst.

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -343,6 +343,42 @@ describe("auditGatewayServiceConfig", () => {
     ).toBe(false);
   });
 
+  it("treats zsh -lc LaunchAgent commands as opaque for the gateway token audit", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "darwin",
+      expectedPort: 18889,
+      command: {
+        programArguments: [
+          "/bin/zsh",
+          "-lc",
+          "exec /usr/bin/node /opt/openclaw/dist/index.js gateway --port 18890",
+        ],
+        environment: {},
+      },
+    });
+
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayCommandMissing)).toBe(false);
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayPortMismatch)).toBe(false);
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayPathMissing)).toBe(true);
+  });
+
+  it.each([
+    ["non-shell command", ["/usr/local/bin/helper", "-lc", "exec node gateway"]],
+    ["shell without an inline-command flag", ["/bin/zsh", "-l", "exec node gateway"]],
+  ])("keeps exact gateway token audit for %s", async (_name, programArguments) => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "darwin",
+      command: {
+        programArguments,
+        environment: {},
+      },
+    });
+
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayCommandMissing)).toBe(true);
+  });
+
   it("flags gateway service port drift from the expected config port", async () => {
     const audit = await auditGatewayServiceConfig({
       env: { HOME: "/tmp" },

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -10,6 +10,8 @@ import {
   sortUniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
+import { resolveInlineCommandMatch } from "../infra/shell-inline-command.js";
+import { POSIX_SHELL_WRAPPERS } from "../infra/shell-wrapper-resolution.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
 import { VERSION } from "../version.js";
 import { resolveLaunchAgentPlistPath } from "./launchd.js";
@@ -85,6 +87,22 @@ export function needsNodeRuntimeMigration(issues: ServiceConfigIssue[]): boolean
 
 function hasGatewaySubcommand(programArguments?: string[]): boolean {
   return Boolean(programArguments?.some((arg) => arg === "gateway"));
+}
+
+const POSIX_SERVICE_INLINE_COMMAND_FLAGS = new Set(["-c"]);
+const POSIX_SERVICE_SHELL_WRAPPERS: ReadonlySet<string> = POSIX_SHELL_WRAPPERS;
+
+function isOpaquePosixShellInlineCommand(programArguments: string[]): boolean {
+  const executable = programArguments[0]?.trim();
+  const shellName = executable ? path.posix.basename(executable).toLowerCase() : "";
+  if (!POSIX_SERVICE_SHELL_WRAPPERS.has(shellName)) {
+    return false;
+  }
+  return (
+    resolveInlineCommandMatch(programArguments, POSIX_SERVICE_INLINE_COMMAND_FLAGS, {
+      allowCombinedC: true,
+    }).command !== null
+  );
 }
 
 function parseSystemdUnit(content: string): {
@@ -249,7 +267,10 @@ function auditGatewayCommand(programArguments: string[] | undefined, issues: Ser
   if (!programArguments || programArguments.length === 0) {
     return;
   }
-  if (!hasGatewaySubcommand(programArguments)) {
+  if (
+    !hasGatewaySubcommand(programArguments) &&
+    !isOpaquePosixShellInlineCommand(programArguments)
+  ) {
     issues.push({
       code: SERVICE_AUDIT_CODES.gatewayCommandMissing,
       message: "Service command does not include the gateway subcommand",


### PR DESCRIPTION
Fixes #81751

## What Problem This Solves

`gateway status` reports that the gateway subcommand is missing when a macOS LaunchAgent intentionally invokes OpenClaw through a POSIX shell inline command such as `/bin/zsh -lc "... exec node ... gateway"`. The audit only sees the outer argv and cannot safely prove the inner shell command.

## Why This Change Was Made

Treat recognized POSIX shell `-c`/combined-`c` wrappers as opaque for only the aggressive `gateway-command-missing` assertion. The audit does not parse shell text, infer inner ports, or change status/doctor/runtime behavior. Non-shell commands and shell invocations without an inline-command flag retain the exact existing audit.

## User Impact

Healthy shell-wrapped LaunchAgents no longer emit the misleading missing-gateway warning. Other service diagnostics remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/daemon/service-audit.test.ts` — 46/46 passed.
- `oxfmt --check src/daemon/service-audit.ts src/daemon/service-audit.test.ts` — passed.
- `git diff --check` — passed.
- Regression coverage includes the reported `zsh -lc` shape plus non-shell and missing-inline-flag negatives.