### PR TITLE
feat(agents): expose inbound turn identifiers to CLI subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/WebChat: add a persisted auto-scroll mode selector so users can keep the current near-bottom behavior, always follow streaming output, or turn automatic streaming scroll off and use the New messages button manually. Fixes #7648 and #81287. Thanks @BunsDev.
 - ACP: add `acp.fallbacks` so ACP turns can try configured backup runtime backends when the primary backend is unavailable before any output is emitted. (#69542) Thanks @kaseonedge.
 - Gateway/startup: add owner-level startup trace attribution for auth, plugin loading, lookup counts, and plugin sidecar services. (#81738) Thanks @samzong.
+- Agents/CLI runtime: write the current inbound turn's identifiers (message id, sender id/e164, chat id, reply-to id, channel, provider) to a session-scoped per-turn file and point CLI agent subprocesses at it via `OPENCLAW_INBOUND_TURN_FILE`, so shell wrappers can thread replies without scraping the prompt — correct even for backends that keep a long-lived process across turns.
 
 ### Fixes
 

--- a/src/agents/cli-runner/inbound-turn-file.test.ts
+++ b/src/agents/cli-runner/inbound-turn-file.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  INBOUND_TURN_FILE_ENV_KEY,
+  resolveInboundTurnFilePath,
+  writeInboundTurnFile,
+} from "./inbound-turn-file.js";
+
+describe("resolveInboundTurnFilePath", () => {
+  it("derives a stable session-scoped path under the state dir", () => {
+    const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" } as NodeJS.ProcessEnv;
+    const p = resolveInboundTurnFilePath({ sessionId: "agent:main:whatsapp:direct:peer", env });
+    expect(p).toBe(
+      path.join(
+        "/tmp/openclaw-state",
+        "tmp",
+        "inbound-turn",
+        "agent_main_whatsapp_direct_peer.json",
+      ),
+    );
+    // Stable across calls — the env var is set once at spawn, contents change per turn.
+    expect(resolveInboundTurnFilePath({ sessionId: "agent:main:whatsapp:direct:peer", env })).toBe(
+      p,
+    );
+  });
+
+  it("sanitizes path-unsafe characters out of the session id", () => {
+    const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" } as NodeJS.ProcessEnv;
+    expect(resolveInboundTurnFilePath({ sessionId: "a/b:c d", env })).toBe(
+      path.join("/tmp/openclaw-state", "tmp", "inbound-turn", "a_b_c_d.json"),
+    );
+  });
+
+  it("falls back to 'default' when the session id is empty", () => {
+    const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" } as NodeJS.ProcessEnv;
+    expect(resolveInboundTurnFilePath({ sessionId: "", env })).toBe(
+      path.join("/tmp/openclaw-state", "tmp", "inbound-turn", "default.json"),
+    );
+  });
+});
+
+describe("writeInboundTurnFile", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "openclaw-inbound-turn-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes the current turn identifiers as schema-tagged JSON, creating parent dirs", () => {
+    const filePath = path.join(dir, "tmp", "inbound-turn", "session.json");
+    writeInboundTurnFile(
+      filePath,
+      {
+        messageId: "AAA",
+        senderId: "15551234567@s.whatsapp.net",
+        senderE164: "+15551234567",
+        chatId: "whatsapp:15551234567@s.whatsapp.net",
+        replyToId: "wamid.PARENT",
+        channel: "whatsapp",
+        provider: "whatsapp",
+      },
+      { runId: "run-123" },
+    );
+
+    const payload = JSON.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      schema: "openclaw.inbound_turn.v1",
+      messageId: "AAA",
+      senderId: "15551234567@s.whatsapp.net",
+      senderE164: "+15551234567",
+      chatId: "whatsapp:15551234567@s.whatsapp.net",
+      replyToId: "wamid.PARENT",
+      channel: "whatsapp",
+      provider: "whatsapp",
+      runId: "run-123",
+    });
+    expect(typeof payload["writtenAt"]).toBe("number");
+  });
+
+  it("overwrites the file in place so each turn sees fresh values", () => {
+    const filePath = path.join(dir, "session.json");
+    writeInboundTurnFile(filePath, { messageId: "first", channel: "whatsapp" });
+    writeInboundTurnFile(filePath, { messageId: "second", channel: "whatsapp" });
+    const payload = JSON.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>;
+    expect(payload["messageId"]).toBe("second");
+  });
+
+  it("omits runId when no run metadata is supplied", () => {
+    const filePath = path.join(dir, "session.json");
+    writeInboundTurnFile(filePath, { messageId: "AAA", channel: "whatsapp" });
+    const payload = JSON.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("runId");
+  });
+});
+
+describe("INBOUND_TURN_FILE_ENV_KEY", () => {
+  it("is the documented env var name", () => {
+    expect(INBOUND_TURN_FILE_ENV_KEY).toBe("OPENCLAW_INBOUND_TURN_FILE");
+  });
+});

--- a/src/agents/cli-runner/inbound-turn-file.ts
+++ b/src/agents/cli-runner/inbound-turn-file.ts
@@ -1,0 +1,69 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { InboundTurnContext } from "../../auto-reply/reply/inbound-meta.js";
+import { resolveStateDir } from "../../config/paths.js";
+
+/**
+ * Environment variable that points a CLI agent subprocess at the on-disk file
+ * holding the *current* inbound turn's identifiers.
+ *
+ * The value is a stable, session-scoped path. CLI backends that keep a
+ * long-lived "live session" process across turns only see spawn-time
+ * environment once, so the identifiers themselves cannot ride on env vars —
+ * they would go stale after the first turn. Instead the path is stable and the
+ * file behind it is rewritten every turn (see `writeInboundTurnFile`), so a
+ * shell wrapper run by the agent always reads the live turn's values.
+ */
+export const INBOUND_TURN_FILE_ENV_KEY = "OPENCLAW_INBOUND_TURN_FILE";
+
+const INBOUND_TURN_FILE_SCHEMA = "openclaw.inbound_turn.v1";
+const INBOUND_TURN_DIR_MODE = 0o700;
+const INBOUND_TURN_FILE_MODE = 0o600;
+
+function sanitizeSessionIdForPath(sessionId: string): string {
+  const cleaned = sessionId.replace(/[^A-Za-z0-9._-]/g, "_");
+  return cleaned.length > 0 ? cleaned : "default";
+}
+
+/**
+ * Stable, session-scoped path for the current turn's inbound identifiers.
+ * Keyed by session id so the path survives across turns of the same session
+ * (the env var is set once at spawn) while the contents are rewritten per turn.
+ */
+export function resolveInboundTurnFilePath(params: {
+  sessionId: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  const stateDir = resolveStateDir(params.env ?? process.env);
+  return path.join(
+    stateDir,
+    "tmp",
+    "inbound-turn",
+    `${sanitizeSessionIdForPath(params.sessionId)}.json`,
+  );
+}
+
+export type InboundTurnFilePayload = InboundTurnContext & {
+  schema: typeof INBOUND_TURN_FILE_SCHEMA;
+  runId?: string;
+  writtenAt: number;
+};
+
+/** Rewrite the per-turn inbound file with the current turn's identifiers. */
+export function writeInboundTurnFile(
+  filePath: string,
+  turn: InboundTurnContext,
+  meta?: { runId?: string },
+): void {
+  const payload: InboundTurnFilePayload = {
+    schema: INBOUND_TURN_FILE_SCHEMA,
+    ...turn,
+    ...(meta?.runId ? { runId: meta.runId } : {}),
+    writtenAt: Date.now(),
+  };
+  mkdirSync(path.dirname(filePath), { recursive: true, mode: INBOUND_TURN_DIR_MODE });
+  writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: INBOUND_TURN_FILE_MODE,
+  });
+}

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -966,6 +966,76 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
+  it("writes a per-turn inbound file and points OPENCLAW_INBOUND_TURN_FILE at it", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:whatsapp:direct:peer",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-inbound-turn",
+        config: createCliBackendConfig(),
+        inboundTurn: {
+          messageId: "AAA",
+          messageIdFull: "wamid.AAA",
+          senderId: "15551234567@s.whatsapp.net",
+          senderE164: "+15551234567",
+          chatId: "whatsapp:15551234567@s.whatsapp.net",
+          replyToId: "wamid.PARENT",
+          channel: "whatsapp",
+          provider: "whatsapp",
+        },
+      });
+
+      const turnFilePath = context.preparedBackend.env?.["OPENCLAW_INBOUND_TURN_FILE"];
+      expect(turnFilePath).toBeTruthy();
+      const payload = JSON.parse(fs.readFileSync(turnFilePath as string, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      expect(payload).toMatchObject({
+        schema: "openclaw.inbound_turn.v1",
+        messageId: "AAA",
+        messageIdFull: "wamid.AAA",
+        senderId: "15551234567@s.whatsapp.net",
+        senderE164: "+15551234567",
+        chatId: "whatsapp:15551234567@s.whatsapp.net",
+        replyToId: "wamid.PARENT",
+        channel: "whatsapp",
+        provider: "whatsapp",
+        runId: "run-inbound-turn",
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves preparedBackend env undefined when no inbound turn is provided", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-no-inbound-turn",
+        config: createCliBackendConfig(),
+      });
+
+      expect(context.preparedBackend.env).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not probe the transcript for non-claude-cli providers", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -48,6 +48,11 @@ import { appendModelIdentitySystemPrompt } from "../system-prompt.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { buildCliAgentSystemPrompt, normalizeCliModel } from "./helpers.js";
+import {
+  INBOUND_TURN_FILE_ENV_KEY,
+  resolveInboundTurnFilePath,
+  writeInboundTurnFile,
+} from "./inbound-turn-file.js";
 import { cliBackendLog } from "./log.js";
 import {
   buildCliSessionHistoryPrompt,
@@ -238,10 +243,31 @@ export async function prepareCliRunContext(
     authProfileId: effectiveAuthProfileId,
     skipLocalCredential: skipLocalCredentialEpoch,
   });
+  // Refresh the per-turn inbound file every run (CLI backends may keep a
+  // long-lived process across turns, so the identifiers cannot ride on
+  // spawn-time env vars). The env var only carries the stable path.
+  let inboundTurnEnv: Record<string, string> | undefined;
+  if (params.inboundTurn) {
+    const inboundTurnFilePath = resolveInboundTurnFilePath({ sessionId: params.sessionId });
+    try {
+      writeInboundTurnFile(inboundTurnFilePath, params.inboundTurn, { runId: params.runId });
+      inboundTurnEnv = { [INBOUND_TURN_FILE_ENV_KEY]: inboundTurnFilePath };
+    } catch (error) {
+      cliBackendLog.warn(`failed to write inbound turn file: ${String(error)}`);
+    }
+  }
+  const preparedBackendEnvSources = [
+    preparedBackend.env,
+    preparedExecution?.env,
+    inboundTurnEnv,
+  ].filter(
+    (entry): entry is Record<string, string> =>
+      Boolean(entry) && Object.keys(entry as Record<string, string>).length > 0,
+  );
   const preparedBackendEnv =
-    preparedExecution?.env && Object.keys(preparedExecution.env).length > 0
-      ? { ...preparedBackend.env, ...preparedExecution.env }
-      : preparedBackend.env;
+    preparedBackendEnvSources.length > 0
+      ? Object.assign({}, ...preparedBackendEnvSources)
+      : undefined;
   const preparedBackendCleanup =
     preparedBackend.cleanup || preparedExecution?.cleanup
       ? async () => {

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -1,5 +1,6 @@
 import type { ImageContent } from "@earendil-works/pi-ai";
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
+import type { InboundTurnContext } from "../../auto-reply/reply/inbound-meta.js";
 import type { ReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { CliSessionBinding } from "../../config/sessions.js";
@@ -55,6 +56,12 @@ export type RunCliAgentParams = {
   messageProvider?: string;
   agentAccountId?: string;
   senderIsOwner?: boolean;
+  /**
+   * Identifiers for the current inbound turn, exposed to the CLI subprocess as
+   * `OPENCLAW_INBOUND_*` environment variables so a shell wrapper can thread its
+   * reply without scraping the prompt.
+   */
+  inboundTurn?: InboundTurnContext;
   /** Runtime tool allow-list. CLI harnesses fail closed when this is set. */
   toolsAllow?: string[];
   disableTools?: boolean;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -77,6 +77,7 @@ import {
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
 import { type BlockReplyPipeline } from "./block-reply-pipeline.js";
+import { buildInboundTurnContext } from "./inbound-meta.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
@@ -1586,6 +1587,7 @@ export async function runAgentTurnWithFallback(params: {
                   messageProvider: hookMessageProvider,
                   agentAccountId: params.followupRun.run.agentAccountId,
                   senderIsOwner: params.followupRun.run.senderIsOwner,
+                  inboundTurn: buildInboundTurnContext(params.sessionCtx),
                   disableTools: params.opts?.disableTools,
                   abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
                   replyOperation: params.replyOperation,

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -3,7 +3,11 @@ import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../p
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { withEnv } from "../../test-utils/env.js";
 import type { TemplateContext } from "../templating.js";
-import { buildInboundMetaSystemPrompt, buildInboundUserContextPrefix } from "./inbound-meta.js";
+import {
+  buildInboundMetaSystemPrompt,
+  buildInboundTurnContext,
+  buildInboundUserContextPrefix,
+} from "./inbound-meta.js";
 
 vi.mock("../../channels/plugins/registry-loaded.js", () => ({
   getLoadedChannelPluginById: (channelId: string) =>
@@ -961,5 +965,59 @@ describe("buildInboundUserContextPrefix", () => {
     expect(history).toHaveLength(20);
     expect(history[0]?.["body"]).toBe("body-5");
     expect(history.at(-1)?.["body"]).toBe("body-24");
+  });
+});
+
+describe("buildInboundTurnContext", () => {
+  it("lifts the current turn identifiers into a flat shape", () => {
+    const turn = buildInboundTurnContext({
+      MessageSid: "AAA",
+      MessageSidFull: "wamid.AAA",
+      SenderId: "15551234567@s.whatsapp.net",
+      SenderE164: "+15551234567",
+      SenderUsername: "gado",
+      OriginatingTo: "whatsapp:15551234567@s.whatsapp.net",
+      ReplyToId: "wamid.PARENT",
+      OriginatingChannel: "whatsapp",
+      Provider: "whatsapp",
+      AccountId: "default",
+    } as TemplateContext);
+
+    expect(turn).toEqual({
+      messageId: "AAA",
+      messageIdFull: "wamid.AAA",
+      senderId: "15551234567@s.whatsapp.net",
+      senderE164: "+15551234567",
+      senderUsername: "gado",
+      chatId: "whatsapp:15551234567@s.whatsapp.net",
+      replyToId: "wamid.PARENT",
+      channel: "whatsapp",
+      provider: "whatsapp",
+      accountId: "default",
+    });
+  });
+
+  it("leaves absent identifiers undefined", () => {
+    const turn = buildInboundTurnContext({
+      MessageSid: "AAA",
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+    } as TemplateContext);
+
+    expect(turn.messageId).toBe("AAA");
+    expect(turn.channel).toBe("telegram");
+    expect(turn.senderId).toBeUndefined();
+    expect(turn.replyToId).toBeUndefined();
+    expect(turn.chatId).toBeUndefined();
+  });
+
+  it("falls back to surface, then provider, when no explicit channel is set", () => {
+    expect(
+      buildInboundTurnContext({ Surface: "discord", Provider: "discord" } as TemplateContext)
+        .channel,
+    ).toBe("discord");
+    expect(buildInboundTurnContext({ Provider: "signal" } as TemplateContext).channel).toBe(
+      "signal",
+    );
   });
 });

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -600,3 +600,40 @@ export function buildInboundUserContextPrefix(
 
   return blocks.filter(Boolean).join("\n\n");
 }
+
+/**
+ * Stable, channel-agnostic identifiers for the current inbound turn.
+ *
+ * These are the same values surfaced inside the prompt by
+ * `buildInboundUserContextPrefix`, lifted into a flat shape so the runtime can
+ * expose them to an agent subprocess out-of-band (e.g. as environment
+ * variables). That lets a shell wrapper thread its reply deterministically
+ * instead of scraping identifiers back out of the prompt text.
+ */
+export type InboundTurnContext = {
+  messageId?: string;
+  messageIdFull?: string;
+  senderId?: string;
+  senderE164?: string;
+  senderUsername?: string;
+  chatId?: string;
+  replyToId?: string;
+  channel?: string;
+  provider?: string;
+  accountId?: string;
+};
+
+export function buildInboundTurnContext(ctx: TemplateContext): InboundTurnContext {
+  return {
+    messageId: normalizePromptMetadataString(ctx.MessageSid),
+    messageIdFull: normalizePromptMetadataString(ctx.MessageSidFull),
+    senderId: normalizePromptMetadataString(ctx.SenderId),
+    senderE164: normalizePromptMetadataString(ctx.SenderE164),
+    senderUsername: normalizePromptMetadataString(ctx.SenderUsername),
+    chatId: normalizePromptMetadataString(ctx.OriginatingTo),
+    replyToId: normalizePromptMetadataString(ctx.ReplyToId),
+    channel: resolveInboundChannel(ctx),
+    provider: normalizePromptMetadataString(ctx.Provider),
+    accountId: normalizePromptMetadataString(ctx.AccountId),
+  };
+}


### PR DESCRIPTION
## Summary

CLI agent backends often run a shell wrapper to do channel-side work (e.g.
sending a threaded reply). Until now that wrapper had no deterministic way to
learn the current inbound turn's identifiers — message id, sender, chat id — so
it had to scrape them back out of the prompt text.

This change lifts those identifiers into a small, channel-agnostic
`InboundTurnContext` and, for CLI backends, writes them to a session-scoped
per-turn JSON file. The subprocess is pointed at the file via a single stable
`OPENCLAW_INBOUND_TURN_FILE` environment variable.

A **file rewritten every turn** is used rather than per-turn env vars on
purpose: CLI backends may keep a long-lived process across turns (the
`claude-cli` live-session path does exactly this), so per-turn values placed in
spawn-time env would go stale after the first turn. `prepareCliRunContext` runs
every turn even when the live session is reused, so it refreshes the file
contents each turn; only the stable path rides on the env var.

### Changes

- `src/auto-reply/reply/inbound-meta.ts` — add `InboundTurnContext` type and
  `buildInboundTurnContext(ctx)`, derived from the same `TemplateContext`
  fields already surfaced in the prompt.
- `src/agents/cli-runner/inbound-turn-file.ts` (new) — `resolveInboundTurnFilePath`
  (stable, session-scoped path under the state dir) and `writeInboundTurnFile`
  (schema-tagged JSON, rewritten per turn).
- `src/agents/cli-runner/prepare.ts` — write the per-turn file and set
  `OPENCLAW_INBOUND_TURN_FILE` when an inbound turn is present.
- `src/agents/cli-runner/types.ts` — optional `inboundTurn` on `RunCliAgentParams`.
- `src/auto-reply/reply/agent-runner-execution.ts` — populate `inboundTurn`
  from the turn's `TemplateContext` at the `runCliAgent` call site.
- Unit tests for all three units; changelog entry.

No behavior change for backends that do not receive an `inboundTurn`.

## Real behavior proof

**Behavior addressed:** a shell wrapper run by a CLI agent had no deterministic,
non-prompt-scraping source for the current inbound turn's message id / sender /
chat id; this writes them to a per-turn file referenced by
`OPENCLAW_INBOUND_TURN_FILE`.

**Real environment tested:** macOS; openclaw gateway built from this branch and
run live; WhatsApp channel connected; agent on the `claude-cli/claude-sonnet-4-6`
backend, which runs in long-lived "live session" mode (the case spawn-time env
vars would get wrong).

**Exact steps or command run after the patch:**

```text
pnpm build
node openclaw.mjs gateway run --port 18789
// sent a real WhatsApp message ("how is the weather") to the assistant
cat ~/.openclaw/tmp/inbound-turn/<sessionId>.json
OPENCLAW_INBOUND_TURN_FILE=~/.openclaw/tmp/inbound-turn/<sessionId>.json gado-reply "<reply text>"
```

**After-fix evidence (copied terminal output):**

Gateway log for the turn — confirms the live-session CLI backend path:

```text
[agent/cli-backend] cli exec: provider=claude-cli model=sonnet trigger=user ...
[agent/cli-backend] claude live session start: provider=claude-cli model=claude-sonnet-4-6 activeSessions=1
[agent/cli-backend] claude live session turn: provider=claude-cli ... durationMs=28788
```

The per-turn file written by `prepareCliRunContext` (phone-number fields
redacted):

```text
{
  "schema": "openclaw.inbound_turn.v1",
  "messageId": "3EB0EB4716C3ACADE0A572",
  "senderId": "+41XXXXXXXXX",
  "senderE164": "+41XXXXXXXXX",
  "chatId": "+41XXXXXXXXX",
  "channel": "whatsapp",
  "provider": "whatsapp",
  "accountId": "default",
  "runId": "eee4c9b9-68ce-4df0-9864-7ac34b8cab7b",
  "writtenAt": 1778752568806
}
```

Wrapper consuming only that file to send a threaded reply:

```text
Sent to 41XXXXXXXXX@s.whatsapp.net (id 3EB055D9F3263CBC34CC98)
```

**Observed result after fix:** for a real WhatsApp turn through the live-session
`claude-cli` backend, `prepareCliRunContext` wrote the session-scoped per-turn
file with the turn's real `messageId` / `senderId` / `chatId` / `channel`, and a
shell wrapper read that file (no prompt scraping) and sent a correctly threaded
WhatsApp reply via `--reply-to`.

**What was not tested:** non-WhatsApp channels end-to-end (Telegram/Slack/etc.)
— only WhatsApp was exercised live. The `buildInboundTurnContext` builder is
channel-agnostic and unit-tested across channel/surface/provider fallbacks, but
no other channel was run through a live gateway.

## Verification

```text
pnpm test src/auto-reply/reply/inbound-meta.test.ts src/agents/cli-runner/inbound-turn-file.test.ts src/agents/cli-runner/prepare.test.ts
pnpm tsgo:core
pnpm tsgo:test:src
pnpm build
```

All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
