### PR TITLE
feat(agents): trace bundle MCP catalog discovery

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -454,6 +454,87 @@ describe("session MCP runtime", () => {
     });
   });
 
+  it("emits nested diagnostics timeline spans for server catalog discovery", async () => {
+    const tempDir = tempDirTracker.make("bundle-mcp-timeline-");
+    const serverPath = path.join(tempDir, "server.mjs");
+    const serverLogPath = path.join(tempDir, "server.log");
+    const timelinePath = path.join(tempDir, "timeline.jsonl");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath: serverLogPath,
+      tools: [{ name: "timeline_tool", inputSchema: { type: "object" } }],
+    });
+    const previousTimelinePath = process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH;
+    let runtime: SessionMcpRuntime | undefined;
+
+    try {
+      process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = timelinePath;
+      runtime = createSessionMcpRuntime({
+        sessionId: "session-timeline",
+        workspaceDir: tempDir,
+        cfg: {
+          diagnostics: { flags: ["timeline"] },
+          mcp: {
+            servers: {
+              bundleProbe: {
+                command: process.execPath,
+                args: [serverPath],
+              },
+            },
+          },
+        },
+      });
+      const catalog = await runtime.getCatalog();
+      expect(catalog.tools.map((tool) => tool.toolName)).toEqual(["timeline_tool"]);
+      const timelineText = await fs.readFile(timelinePath, "utf8");
+      const events = timelineText
+        .trim()
+        .split("\n")
+        .map(
+          (line) =>
+            JSON.parse(line) as {
+              attributes?: Record<string, unknown>;
+              durationMs?: number;
+              name: string;
+              parentSpanId?: string;
+              spanId?: string;
+              type: string;
+            },
+        );
+      const endEvent = (name: string) =>
+        events.find((event) => event.name === name && event.type === "span.end");
+      const serverSpan = endEvent("bundle-mcp.server");
+      const connectSpan = endEvent("bundle-mcp.connect");
+      const toolsListSpan = endEvent("bundle-mcp.tools-list");
+
+      expect(serverSpan).toMatchObject({
+        attributes: {
+          reusedSession: false,
+          safeServerName: "bundleProbe",
+          serverName: "bundleProbe",
+          transportType: "stdio",
+        },
+        durationMs: expect.any(Number),
+      });
+      expect(connectSpan).toMatchObject({
+        durationMs: expect.any(Number),
+        parentSpanId: serverSpan?.spanId,
+      });
+      expect(toolsListSpan).toMatchObject({
+        durationMs: expect.any(Number),
+        parentSpanId: serverSpan?.spanId,
+      });
+      expect(timelineText).not.toContain(serverPath);
+    } finally {
+      await runtime?.dispose();
+      if (previousTimelinePath === undefined) {
+        delete process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH;
+      } else {
+        process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = previousTimelinePath;
+      }
+    }
+  });
+
   it("catalogs canonical and deprecated MCP App tool metadata", async () => {
     const tempDir = tempDirTracker.make("bundle-mcp-app-metadata-");
     const serverPath = path.join(tempDir, "app-metadata.mjs");

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -16,6 +16,7 @@ import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensit
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { SessionToolOverrides } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { measureDiagnosticsTimelineSpan } from "../infra/diagnostics-timeline.js";
 import { logWarn } from "../logger.js";
 import { redactToolPayloadText } from "../logging/redact.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
@@ -816,19 +817,49 @@ export function createSessionMcpRuntime(params: {
               }
               session.catalogUseCount += 1;
               try {
-                failIfDisposed();
-                await ensureSessionConnected(session, resolved.connectionTimeoutMs);
-                failIfDisposed();
-                const capabilities = summarizeServerCapabilities(
-                  session.client.getServerCapabilities(),
+                const timelineSpanOptions = {
+                  attributes: {
+                    reusedSession,
+                    safeServerName,
+                    serverName,
+                    transportType: resolved.transportType,
+                  },
+                  ...(params.cfg ? { config: params.cfg } : {}),
+                  omitErrorMessage: true,
+                };
+                const { capabilities, listedTools } = await measureDiagnosticsTimelineSpan(
+                  "bundle-mcp.server",
+                  async () => {
+                    failIfDisposed();
+                    await measureDiagnosticsTimelineSpan(
+                      "bundle-mcp.connect",
+                      () => ensureSessionConnected(session, resolved.connectionTimeoutMs),
+                      timelineSpanOptions,
+                    );
+                    failIfDisposed();
+                    const serverCapabilities = summarizeServerCapabilities(
+                      session.client.getServerCapabilities(),
+                    );
+                    const serverTools = await measureDiagnosticsTimelineSpan(
+                      "bundle-mcp.tools-list",
+                      () =>
+                        listAllToolsBestEffort({
+                          client: session.client,
+                          timeoutMs: getCatalogListTimeoutMs(rawServer, resolved.requestTimeoutMs),
+                          suppressUnsupported: Boolean(
+                            !serverCapabilities.tools &&
+                            (serverCapabilities.resources || serverCapabilities.prompts),
+                          ),
+                        }),
+                      timelineSpanOptions,
+                    );
+                    return {
+                      capabilities: serverCapabilities,
+                      listedTools: serverTools,
+                    };
+                  },
+                  timelineSpanOptions,
                 );
-                const listedTools = await listAllToolsBestEffort({
-                  client: session.client,
-                  timeoutMs: getCatalogListTimeoutMs(rawServer, resolved.requestTimeoutMs),
-                  suppressUnsupported: Boolean(
-                    !capabilities.tools && (capabilities.resources || capabilities.prompts),
-                  ),
-                });
                 failIfDisposed();
                 const selection = getMcpToolSelection(rawServer);
                 const denialMap = params.toolOverrides?.mcpToolsDeny;


### PR DESCRIPTION
Closes #81595

## What Problem This Solves

Bundle MCP catalog discovery currently contributes to an aggregate agent-preparation timing bucket, so operators cannot identify which configured MCP server—or whether its connection or `tools/list` request—caused a cold-start, reconnect, or session-switch delay.

PR #94230 reduced cumulative latency by parallelizing server discovery, but it did not close this diagnostics gap.

## Why This Change Was Made

Emit existing diagnostics-timeline spans for each MCP server catalog task, with nested spans around connection and `tools/list`:

```text
bundle-mcp.server
├── bundle-mcp.connect
└── bundle-mcp.tools-list
```

The spans sit inside the current bounded parallel fan-out and preserve session reuse, catalog invalidation/retry, capability suppression, filtering, timeouts, and failure diagnostics. They use the existing timeline gate and include only the server name, its safe name, transport type, and whether the session was reused; URLs, headers, credentials, and error messages are not included.

This is an observability change, not an MCP performance or protocol change. It adds no config, default logging, network calls, or user-facing behavior.

## User Impact

When diagnostics timeline output is enabled, operators can distinguish a slow MCP connection from a slow `tools/list` request and identify the responsible server. Users who do not enable timeline diagnostics see no behavior change.

## Evidence

Validated after rebasing onto `origin/main` at `91dca69dae` in an isolated `node:24-bookworm-slim` Docker container. No host OpenClaw config or credentials were mounted; validation runs used `--network=none`, dropped all capabilities, and enabled `no-new-privileges`.

```text
node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts
Test Files  1 passed (1)
Tests       88 passed (88)
```

The new regression test starts a real stdio MCP probe, reads the diagnostics JSONL, and verifies all three `span.end` events, numeric durations, child-parent relationships, safe server attributes, and absence of the probe path.

```text
node scripts/run-oxlint.mjs \
  src/agents/agent-bundle-mcp-runtime.ts \
  src/agents/agent-bundle-mcp-runtime.test.ts
0 warnings, 0 errors

oxfmt (both touched files)
passed

git diff --check
passed
```

The focused Vitest file was run again after the final rebase and passed 88/88. The full repository suite was not run locally; GitHub CI is the full-suite gate.

Autoreview preflight and TruffleHog completed with a clean secret scan. The configured review engines could not produce a review because the local Codex CLI was logged out and the Claude account had reached its usage limit; the final two-file diff was manually reviewed before push.

## AI Assistance

This PR is AI-assisted. I reviewed the final implementation and tests and understand the behavior and scope.
