### PR TITLE
fix(image): route MiniMax chat image refs to VLM

### DIFF
--- a/src/agents/tools/image-tool.helpers.ts
+++ b/src/agents/tools/image-tool.helpers.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { estimateBase64DecodedBytes } from "../../media/base64.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
+import { isMinimaxVlmProvider } from "../minimax-vlm.js";
 import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
 import { extractAssistantText } from "../pi-embedded-utils.js";
 import { coerceToolModelConfig, type ToolModelConfig } from "./model-config.helpers.js";
@@ -17,6 +18,8 @@ const IMAGE_REASONING_FALLBACK_SIGNATURES = new Set([
 const MAX_IMAGE_REASONING_FALLBACK_BLOCKS = 50;
 const MAX_IMAGE_REASONING_SIGNATURE_PARSE_CHARS = 2_048;
 const MAX_IMAGE_REASONING_SIGNATURE_SCAN_CHARS = 65_536;
+const MINIMAX_VLM_MODEL_ID = "MiniMax-VL-01";
+const MINIMAX_TEXT_MODEL_IDS = new Set(["minimax-m2.7", "minimax-m2.7-highspeed"]);
 
 function hasResponsesReasoningSignatureMarkers(value: string): boolean {
   const scanned = value.slice(0, MAX_IMAGE_REASONING_SIGNATURE_SCAN_CHARS);
@@ -210,20 +213,48 @@ function resolveProviderlessConfiguredImageModelRef(params: {
   );
 }
 
+function coerceMinimaxTextModelImageRef(ref: string): string {
+  const trimmed = ref.trim();
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0) {
+    return trimmed;
+  }
+  const provider = normalizeProviderId(trimmed.slice(0, slash));
+  const model = trimmed.slice(slash + 1).trim();
+  if (!isMinimaxVlmProvider(provider)) {
+    return trimmed;
+  }
+  if (
+    normalizeLowercaseStringOrEmpty(model) === normalizeLowercaseStringOrEmpty(MINIMAX_VLM_MODEL_ID)
+  ) {
+    return `${provider}/${MINIMAX_VLM_MODEL_ID}`;
+  }
+  if (!MINIMAX_TEXT_MODEL_IDS.has(normalizeLowercaseStringOrEmpty(model))) {
+    return trimmed;
+  }
+  return `${provider}/${MINIMAX_VLM_MODEL_ID}`;
+}
+
+function resolveConfiguredImageModelRef(params: { cfg?: OpenClawConfig; ref: string }): string {
+  return coerceMinimaxTextModelImageRef(
+    resolveProviderlessConfiguredImageModelRef({ cfg: params.cfg, ref: params.ref }),
+  );
+}
+
 export function resolveConfiguredImageModelRefs(params: {
   cfg?: OpenClawConfig;
   imageModelConfig: ImageModelConfig;
 }): ImageModelConfig {
   const primary = params.imageModelConfig.primary?.trim();
   const fallbacks = params.imageModelConfig.fallbacks
-    ?.map((ref) => resolveProviderlessConfiguredImageModelRef({ cfg: params.cfg, ref }))
+    ?.map((ref) => resolveConfiguredImageModelRef({ cfg: params.cfg, ref }))
     .filter((ref) => ref.length > 0);
 
   return {
     ...(params.imageModelConfig.primary !== undefined
       ? {
           primary: primary
-            ? resolveProviderlessConfiguredImageModelRef({ cfg: params.cfg, ref: primary })
+            ? resolveConfiguredImageModelRef({ cfg: params.cfg, ref: primary })
             : primary,
         }
       : {}),

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -764,6 +764,31 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("routes explicit MiniMax chat imageModel refs through the VLM image model", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const fetch = stubMinimaxOkFetch();
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            imageModel: { primary: "minimax/MiniMax-M2.7" },
+          },
+        },
+      };
+      expect(resolveImageModelConfigForTool({ cfg, agentDir })).toEqual({
+        primary: "minimax/MiniMax-VL-01",
+      });
+
+      const tool = createRequiredImageTool({ config: cfg, agentDir });
+      await expectImageToolExecOk(tool, `data:image/png;base64,${ONE_PIXEL_PNG_B64}`);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      const [url, options] = fetchCallAt(fetch, 0);
+      expect(url).toBe("https://api.minimax.io/v1/coding_plan/vlm");
+      const body = JSON.parse((options as RequestInit).body as string) as { image_url?: string };
+      expect(body.image_url).toMatch(/^data:image\/png;base64,/);
+    });
+  });
+
   it("passes the configured image timeout to provider calls", async () => {
     await withTempWorkspacePng(async ({ workspaceDir, imagePath }) => {
       await withTempAgentDir(async (agentDir) => {


### PR DESCRIPTION
Fixes #81695.

## Summary
- map explicit MiniMax chat model refs used as imageModel to MiniMax-VL-01
- keep the existing VLM/data-URI image path for those requests
- add coverage that the image tool sends a base64 data URI to the MiniMax VLM endpoint

## Real behavior proof
Behavior or issue addressed: A user can configure agents.defaults.imageModel.primary to minimax/MiniMax-M2.7, but image generation still needs to route the image request through the MiniMax VLM image model instead of treating the chat model as the image endpoint.

Real environment tested: Local OpenClaw image tool code from this PR branch on macOS, with the MiniMax provider endpoint intercepted by the existing provider test harness so the request URL and payload can be inspected without live MiniMax credentials.

Exact steps or command run after this patch:
- pnpm test src/agents/tools/image-tool.test.ts

Evidence after fix: The focused test suite passed, including the regression that configures minimax/MiniMax-M2.7 as imageModel, resolves the effective image model to minimax/MiniMax-VL-01, and verifies the outgoing MiniMax request uses the VLM endpoint with a base64 data URI.

Observed result after fix: Explicit MiniMax chat image model refs are coerced to MiniMax-VL-01 before the image tool sends the request, so the existing VLM image path is used.

What was not tested: I did not call the live MiniMax API because this local environment does not have usable MiniMax credentials. The proof covers OpenClaw configuration resolution and outbound request construction.

## Verification
- pnpm test src/agents/tools/image-tool.test.ts
- pnpm exec oxfmt --write src/agents/tools/image-tool.helpers.ts src/agents/tools/image-tool.test.ts
- git diff --check origin/main...HEAD