### PR TITLE
feat(control-ui): compress static assets

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { gunzipSync } from "node:zlib";
 import { describe, expect, it, vi } from "vitest";
 import { resolveStateDir } from "../config/paths.js";
 import {
@@ -74,11 +75,16 @@ describe("handleControlUiHttpRequest", () => {
     method: "GET" | "HEAD" | "POST";
     rootPath: string;
     basePath?: string;
+    headers?: IncomingMessage["headers"];
     rootKind?: "resolved" | "bundled";
   }) {
     const { res, end } = makeMockHttpResponse();
     const handled = await handleControlUiHttpRequest(
-      { url: params.url, method: params.method } as IncomingMessage,
+      {
+        url: params.url,
+        method: params.method,
+        headers: params.headers ?? {},
+      } as IncomingMessage,
       res,
       {
         ...(params.basePath ? { basePath: params.basePath } : {}),
@@ -1139,6 +1145,70 @@ describe("handleControlUiHttpRequest", () => {
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
         expect(firstEndCallLength(end)).toBe(0);
+      },
+    });
+  });
+
+  it("compresses text control-ui assets when the client accepts gzip", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const script = "const answer = 42;\n".repeat(200);
+        await writeAssetFile(tmp, "app.js", script);
+
+        const { res, end, handled } = await runControlUiRequest({
+          url: "/assets/app.js",
+          method: "GET",
+          rootPath: tmp,
+          headers: { "accept-encoding": "gzip" },
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(res.setHeader).toHaveBeenCalledWith("Content-Encoding", "gzip");
+        expect(res.setHeader).toHaveBeenCalledWith("Vary", "Accept-Encoding");
+        const body = end.mock.calls[0]?.[0];
+        expect(Buffer.isBuffer(body)).toBe(true);
+        expect(gunzipSync(body as Buffer).toString("utf8")).toBe(script);
+      },
+    });
+  });
+
+  it("advertises negotiated compression on HEAD requests for text assets", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        await writeAssetFile(tmp, "actual.css", "body { color: red; }\n");
+
+        const { res, end, handled } = await runControlUiRequest({
+          url: "/assets/actual.css",
+          method: "HEAD",
+          rootPath: tmp,
+          headers: { "accept-encoding": "gzip" },
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(res.setHeader).toHaveBeenCalledWith("Content-Encoding", "gzip");
+        expect(firstEndCallLength(end)).toBe(0);
+      },
+    });
+  });
+
+  it("does not compress already-compressed image assets", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        await writeAssetFile(tmp, "photo.png", "png-bytes");
+
+        const { res, end, handled } = await runControlUiRequest({
+          url: "/assets/photo.png",
+          method: "GET",
+          rootPath: tmp,
+          headers: { "accept-encoding": "gzip" },
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(res.setHeader).not.toHaveBeenCalledWith("Content-Encoding", "gzip");
+        expect(responseBody(end)).toBe("png-bytes");
       },
     });
   });

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { gunzipSync } from "node:zlib";
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
 import { describe, expect, it, vi } from "vitest";
 import { resolveStateDir } from "../config/paths.js";
 import {
@@ -78,7 +78,7 @@ describe("handleControlUiHttpRequest", () => {
     headers?: IncomingMessage["headers"];
     rootKind?: "resolved" | "bundled";
   }) {
-    const { res, end } = makeMockHttpResponse();
+    const { res, end, setHeader } = makeMockHttpResponse();
     const handled = await handleControlUiHttpRequest(
       {
         url: params.url,
@@ -91,7 +91,7 @@ describe("handleControlUiHttpRequest", () => {
         root: { kind: params.rootKind ?? "resolved", path: params.rootPath },
       },
     );
-    return { res, end, handled };
+    return { res, end, setHeader, handled };
   }
 
   async function runBootstrapConfigRequest(params: {
@@ -1155,7 +1155,7 @@ describe("handleControlUiHttpRequest", () => {
         const script = "const answer = 42;\n".repeat(200);
         await writeAssetFile(tmp, "app.js", script);
 
-        const { res, end, handled } = await runControlUiRequest({
+        const { res, end, setHeader, handled } = await runControlUiRequest({
           url: "/assets/app.js",
           method: "GET",
           rootPath: tmp,
@@ -1164,8 +1164,8 @@ describe("handleControlUiHttpRequest", () => {
 
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
-        expect(res.setHeader).toHaveBeenCalledWith("Content-Encoding", "gzip");
-        expect(res.setHeader).toHaveBeenCalledWith("Vary", "Accept-Encoding");
+        expect(setHeader).toHaveBeenCalledWith("Content-Encoding", "gzip");
+        expect(setHeader).toHaveBeenCalledWith("Vary", "Accept-Encoding");
         const body = end.mock.calls[0]?.[0];
         expect(Buffer.isBuffer(body)).toBe(true);
         expect(gunzipSync(body as Buffer).toString("utf8")).toBe(script);
@@ -1178,7 +1178,7 @@ describe("handleControlUiHttpRequest", () => {
       fn: async (tmp) => {
         await writeAssetFile(tmp, "actual.css", "body { color: red; }\n");
 
-        const { res, end, handled } = await runControlUiRequest({
+        const { res, end, setHeader, handled } = await runControlUiRequest({
           url: "/assets/actual.css",
           method: "HEAD",
           rootPath: tmp,
@@ -1187,8 +1187,54 @@ describe("handleControlUiHttpRequest", () => {
 
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
-        expect(res.setHeader).toHaveBeenCalledWith("Content-Encoding", "gzip");
+        expect(setHeader).toHaveBeenCalledWith("Content-Encoding", "gzip");
         expect(firstEndCallLength(end)).toBe(0);
+      },
+    });
+  });
+
+  it("prefers the highest-q accepted control-ui asset encoding", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const script = "const answer = 42;\n".repeat(200);
+        await writeAssetFile(tmp, "app.js", script);
+
+        const { res, end, setHeader, handled } = await runControlUiRequest({
+          url: "/assets/app.js",
+          method: "GET",
+          rootPath: tmp,
+          headers: { "accept-encoding": "br;q=0.1, gzip;q=1" },
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(setHeader).toHaveBeenCalledWith("Content-Encoding", "gzip");
+        const body = end.mock.calls[0]?.[0];
+        expect(Buffer.isBuffer(body)).toBe(true);
+        expect(gunzipSync(body as Buffer).toString("utf8")).toBe(script);
+      },
+    });
+  });
+
+  it("does not revive explicitly rejected gzip through wildcard encoding", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const script = "const answer = 42;\n".repeat(200);
+        await writeAssetFile(tmp, "app.js", script);
+
+        const { res, end, setHeader, handled } = await runControlUiRequest({
+          url: "/assets/app.js",
+          method: "GET",
+          rootPath: tmp,
+          headers: { "accept-encoding": "gzip;q=0, *;q=1" },
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(setHeader).toHaveBeenCalledWith("Content-Encoding", "br");
+        const body = end.mock.calls[0]?.[0];
+        expect(Buffer.isBuffer(body)).toBe(true);
+        expect(brotliDecompressSync(body as Buffer).toString("utf8")).toBe(script);
       },
     });
   });
@@ -1198,7 +1244,7 @@ describe("handleControlUiHttpRequest", () => {
       fn: async (tmp) => {
         await writeAssetFile(tmp, "photo.png", "png-bytes");
 
-        const { res, end, handled } = await runControlUiRequest({
+        const { res, end, setHeader, handled } = await runControlUiRequest({
           url: "/assets/photo.png",
           method: "GET",
           rootPath: tmp,
@@ -1207,7 +1253,7 @@ describe("handleControlUiHttpRequest", () => {
 
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
-        expect(res.setHeader).not.toHaveBeenCalledWith("Content-Encoding", "gzip");
+        expect(setHeader).not.toHaveBeenCalledWith("Content-Encoding", "gzip");
         expect(responseBody(end)).toBe("png-bytes");
       },
     });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -2,11 +2,13 @@ import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
+import { brotliCompressSync, constants as zlibConstants, gzipSync } from "node:zlib";
 import { detectMime } from "@openclaw/media-core/mime";
 import {
   asDateTimestampMs,
   resolveTimestampMsToIsoString,
 } from "@openclaw/normalization-core/number-coercion";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentAvatar, resolvePublicAgentAvatarSource } from "../agents/identity-avatar.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { matchRootFileOpenFailure, openRootFileSync } from "../infra/boundary-file-read.js";
@@ -141,6 +143,16 @@ const STATIC_ASSET_EXTENSIONS = new Set([
   ".txt",
   ".webmanifest",
 ]);
+const COMPRESSIBLE_STATIC_ASSET_EXTENSIONS = new Set([
+  ".css",
+  ".html",
+  ".js",
+  ".json",
+  ".map",
+  ".svg",
+  ".txt",
+  ".webmanifest",
+]);
 
 const CONTROL_UI_NAMESPACE_PREFIX = "/__openclaw__/";
 const CONTROL_UI_ROOT_PUBLIC_ASSETS = new Set([
@@ -215,6 +227,10 @@ function respondHeadForFile(req: IncomingMessage, res: ServerResponse, filePath:
   }
   res.statusCode = 200;
   setStaticFileHeaders(res, filePath);
+  const encoding = selectStaticAssetEncoding(req, filePath);
+  if (encoding) {
+    res.setHeader("Content-Encoding", encoding);
+  }
   res.end();
   return true;
 }
@@ -724,7 +740,7 @@ export async function handleControlUiAvatarRequest(
     return true;
   }
 
-  serveResolvedFile(res, safeAvatar.path, safeAvatar.buffer);
+  serveResolvedFile(req, res, safeAvatar.path, safeAvatar.buffer);
   return true;
 }
 
@@ -734,14 +750,80 @@ function setStaticFileHeaders(res: ServerResponse, filePath: string) {
   // Static UI should never be cached aggressively while iterating; allow the
   // browser to revalidate.
   res.setHeader("Cache-Control", "no-cache");
+  if (isCompressibleStaticAsset(filePath)) {
+    res.setHeader("Vary", "Accept-Encoding");
+  }
 }
 
-function serveResolvedFile(res: ServerResponse, filePath: string, body: Buffer) {
+function isCompressibleStaticAsset(filePath: string): boolean {
+  return COMPRESSIBLE_STATIC_ASSET_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+function parseAcceptEncoding(req: IncomingMessage): Set<string> {
+  const rawHeader = req.headers?.["accept-encoding"];
+  const raw = Array.isArray(rawHeader) ? rawHeader.join(",") : (rawHeader ?? "");
+  const accepted = new Set<string>();
+  for (const item of raw.split(",")) {
+    const parts = item.split(";").map((part) => part.trim());
+    const encoding = normalizeLowercaseStringOrEmpty(parts[0] ?? "");
+    if (!encoding) {
+      continue;
+    }
+    const q = parts
+      .slice(1)
+      .find((part) => part.toLowerCase().startsWith("q="))
+      ?.slice(2)
+      .trim();
+    if (q !== undefined && Number(q) <= 0) {
+      continue;
+    }
+    accepted.add(encoding);
+  }
+  return accepted;
+}
+
+function selectStaticAssetEncoding(req: IncomingMessage, filePath: string): "br" | "gzip" | null {
+  if (!isCompressibleStaticAsset(filePath)) {
+    return null;
+  }
+  const accepted = parseAcceptEncoding(req);
+  if (accepted.has("br")) {
+    return "br";
+  }
+  if (accepted.has("gzip") || accepted.has("*")) {
+    return "gzip";
+  }
+  return null;
+}
+
+function compressStaticAssetBody(body: Buffer, encoding: "br" | "gzip"): Buffer {
+  if (encoding === "br") {
+    return brotliCompressSync(body, {
+      params: {
+        [zlibConstants.BROTLI_PARAM_QUALITY]: 5,
+      },
+    });
+  }
+  return gzipSync(body);
+}
+
+function serveResolvedFile(
+  req: IncomingMessage,
+  res: ServerResponse,
+  filePath: string,
+  body: Buffer,
+) {
   setStaticFileHeaders(res, filePath);
-  res.end(body);
+  const encoding = selectStaticAssetEncoding(req, filePath);
+  if (!encoding) {
+    res.end(body);
+    return;
+  }
+  res.setHeader("Content-Encoding", encoding);
+  res.end(compressStaticAssetBody(body, encoding));
 }
 
-function serveResolvedIndexHtml(res: ServerResponse, body: string) {
+function serveResolvedIndexHtml(req: IncomingMessage, res: ServerResponse, body: string) {
   const hashes = computeInlineScriptHashes(body);
   if (hashes.length > 0) {
     res.setHeader(
@@ -749,9 +831,15 @@ function serveResolvedIndexHtml(res: ServerResponse, body: string) {
       buildControlUiCspHeader({ inlineScriptHashes: hashes }),
     );
   }
-  res.setHeader("Content-Type", "text/html; charset=utf-8");
-  res.setHeader("Cache-Control", "no-cache");
-  res.end(body);
+  const filePath = "index.html";
+  setStaticFileHeaders(res, filePath);
+  const encoding = selectStaticAssetEncoding(req, filePath);
+  if (!encoding) {
+    res.end(body);
+    return;
+  }
+  res.setHeader("Content-Encoding", encoding);
+  res.end(compressStaticAssetBody(Buffer.from(body, "utf8"), encoding));
 }
 
 function readOpenedFile(fd: number): Promise<Buffer> {
@@ -1011,10 +1099,10 @@ export async function handleControlUiHttpRequest(
         return true;
       }
       if (path.basename(safeFile.path) === "index.html") {
-        serveResolvedIndexHtml(res, await readOpenedFileText(safeFile.fd));
+        serveResolvedIndexHtml(req, res, await readOpenedFileText(safeFile.fd));
         return true;
       }
-      serveResolvedFile(res, safeFile.path, await readOpenedFile(safeFile.fd));
+      serveResolvedFile(req, res, safeFile.path, await readOpenedFile(safeFile.fd));
       return true;
     } finally {
       fs.closeSync(safeFile.fd);
@@ -1039,7 +1127,7 @@ export async function handleControlUiHttpRequest(
       if (respondHeadForFile(req, res, safeIndex.path)) {
         return true;
       }
-      serveResolvedIndexHtml(res, await readOpenedFileText(safeIndex.fd));
+      serveResolvedIndexHtml(req, res, await readOpenedFileText(safeIndex.fd));
       return true;
     } finally {
       fs.closeSync(safeIndex.fd);

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -759,10 +759,10 @@ function isCompressibleStaticAsset(filePath: string): boolean {
   return COMPRESSIBLE_STATIC_ASSET_EXTENSIONS.has(path.extname(filePath).toLowerCase());
 }
 
-function parseAcceptEncoding(req: IncomingMessage): Set<string> {
+function parseAcceptEncoding(req: IncomingMessage): Map<string, number> {
   const rawHeader = req.headers?.["accept-encoding"];
   const raw = Array.isArray(rawHeader) ? rawHeader.join(",") : (rawHeader ?? "");
-  const accepted = new Set<string>();
+  const accepted = new Map<string, number>();
   for (const item of raw.split(",")) {
     const parts = item.split(";").map((part) => part.trim());
     const encoding = normalizeLowercaseStringOrEmpty(parts[0] ?? "");
@@ -774,10 +774,11 @@ function parseAcceptEncoding(req: IncomingMessage): Set<string> {
       .find((part) => part.toLowerCase().startsWith("q="))
       ?.slice(2)
       .trim();
-    if (q !== undefined && Number(q) <= 0) {
+    const quality = q === undefined ? 1 : Number(q);
+    if (!Number.isFinite(quality)) {
       continue;
     }
-    accepted.add(encoding);
+    accepted.set(encoding, Math.min(Math.max(quality, 0), 1));
   }
   return accepted;
 }
@@ -787,11 +788,14 @@ function selectStaticAssetEncoding(req: IncomingMessage, filePath: string): "br"
     return null;
   }
   const accepted = parseAcceptEncoding(req);
-  if (accepted.has("br")) {
-    return "br";
-  }
-  if (accepted.has("gzip") || accepted.has("*")) {
-    return "gzip";
+  const wildcardQuality = accepted.get("*");
+  const supported = [
+    { encoding: "br" as const, quality: accepted.get("br") ?? wildcardQuality ?? 0 },
+    { encoding: "gzip" as const, quality: accepted.get("gzip") ?? wildcardQuality ?? 0 },
+  ].filter((candidate) => candidate.quality > 0);
+  supported.sort((a, b) => b.quality - a.quality);
+  if (supported[0]) {
+    return supported[0].encoding;
   }
   return null;
 }


### PR DESCRIPTION
Fixes #81754.

## Summary
- add Accept-Encoding negotiation for Control UI static assets
- serve gzip or brotli for compressible text assets while leaving images raw
- advertise negotiated encoding on HEAD requests

## Real behavior proof
Behavior or issue addressed: Control UI static text assets should return a compressed response when the client advertises gzip or br support, while already-compressed image assets should remain unencoded.

Real environment tested: Local OpenClaw gateway from PR head `38e2bbd2464168d0214a1d4f06556449d83e1fe5` on macOS, with Control UI rebuilt by `pnpm ui:build`, a temporary `OPENCLAW_HOME`, and the gateway bound to `127.0.0.1:18894`.

Exact steps or command run after this patch:

```bash
pnpm install
pnpm ui:build
COREPACK_HOME=/Users/betala/.cache/node/corepack HOME=/private/tmp/openclaw-proof-81794-home OPENCLAW_HOME=/private/tmp/openclaw-proof-81794-home/.openclaw OPENCLAW_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway --port 18894 --bind loopback --allow-unconfigured --verbose --cli-backend-logs

curl -sS -i http://127.0.0.1:18894/healthz
curl -sS --raw -D - -o /private/tmp/openclaw-81794-gzip.bin -H 'Accept-Encoding: gzip' http://127.0.0.1:18894/assets/index-9OOzqwMD.js
curl -sS --raw -D - -o /private/tmp/openclaw-81794-q-gzip.bin -H 'Accept-Encoding: br;q=0.1, gzip;q=1' http://127.0.0.1:18894/assets/index-9OOzqwMD.js
curl -sS --raw -D - -o /private/tmp/openclaw-81794-wildcard.bin -H 'Accept-Encoding: gzip;q=0, *;q=1' http://127.0.0.1:18894/assets/index-9OOzqwMD.js
curl -sS -I -H 'Accept-Encoding: gzip' http://127.0.0.1:18894/assets/index-9OOzqwMD.js
curl -sS --raw -D - -o /private/tmp/openclaw-81794-icon.bin -H 'Accept-Encoding: gzip, br' http://127.0.0.1:18894/favicon.ico
node -e 'const fs=require("fs"); const zlib=require("zlib"); const crypto=require("crypto"); const raw=fs.readFileSync("dist/control-ui/assets/index-9OOzqwMD.js"); const gz=zlib.gunzipSync(fs.readFileSync("/private/tmp/openclaw-81794-gzip.bin")); const gzq=zlib.gunzipSync(fs.readFileSync("/private/tmp/openclaw-81794-q-gzip.bin")); const br=zlib.brotliDecompressSync(fs.readFileSync("/private/tmp/openclaw-81794-wildcard.bin")); const sha=(b)=>crypto.createHash("sha256").update(b).digest("hex").slice(0,16); console.log(JSON.stringify({rawBytes:raw.length,gzipBytes:fs.statSync("/private/tmp/openclaw-81794-gzip.bin").size,gzipMatches:Buffer.compare(raw,gz)===0,qGzipMatches:Buffer.compare(raw,gzq)===0,wildcardBrotliMatches:Buffer.compare(raw,br)===0,rawSha16:sha(raw),gzipDecodedSha16:sha(gz),qGzipDecodedSha16:sha(gzq),wildcardDecodedSha16:sha(br),iconBytes:fs.statSync("/private/tmp/openclaw-81794-icon.bin").size},null,2));'
```

Evidence after fix:

Live gateway output:

```text
$ curl -sS -i http://127.0.0.1:18894/healthz
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Cache-Control: no-store
Content-Length: 27

{"ok":true,"status":"live"}

$ curl -sS --raw -D - -o /private/tmp/openclaw-81794-gzip.bin -H 'Accept-Encoding: gzip' http://127.0.0.1:18894/assets/index-9OOzqwMD.js
HTTP/1.1 200 OK
Content-Type: application/javascript; charset=utf-8
Cache-Control: no-cache
Vary: Accept-Encoding
Content-Encoding: gzip
Content-Length: 306296

$ curl -sS --raw -D - -o /private/tmp/openclaw-81794-q-gzip.bin -H 'Accept-Encoding: br;q=0.1, gzip;q=1' http://127.0.0.1:18894/assets/index-9OOzqwMD.js
HTTP/1.1 200 OK
Content-Type: application/javascript; charset=utf-8
Cache-Control: no-cache
Vary: Accept-Encoding
Content-Encoding: gzip
Content-Length: 306296

$ curl -sS --raw -D - -o /private/tmp/openclaw-81794-wildcard.bin -H 'Accept-Encoding: gzip;q=0, *;q=1' http://127.0.0.1:18894/assets/index-9OOzqwMD.js
HTTP/1.1 200 OK
Content-Type: application/javascript; charset=utf-8
Cache-Control: no-cache
Vary: Accept-Encoding
Content-Encoding: br
Content-Length: 278637

$ curl -sS -I -H 'Accept-Encoding: gzip' http://127.0.0.1:18894/assets/index-9OOzqwMD.js
HTTP/1.1 200 OK
Content-Type: application/javascript; charset=utf-8
Cache-Control: no-cache
Vary: Accept-Encoding
Content-Encoding: gzip
Content-Length: 306296

$ curl -sS --raw -D - -o /private/tmp/openclaw-81794-icon.bin -H 'Accept-Encoding: gzip, br' http://127.0.0.1:18894/favicon.ico
HTTP/1.1 200 OK
Content-Type: image/x-icon
Cache-Control: no-cache
Content-Length: 96542

$ node -e '...decompress and compare captured responses...'
{
  "rawBytes": 1092084,
  "gzipBytes": 306296,
  "gzipMatches": true,
  "qGzipMatches": true,
  "wildcardBrotliMatches": true,
  "rawSha16": "bcd6aa03884ecd30",
  "gzipDecodedSha16": "bcd6aa03884ecd30",
  "qGzipDecodedSha16": "bcd6aa03884ecd30",
  "wildcardDecodedSha16": "bcd6aa03884ecd30",
  "iconBytes": 96542
}
```

Observed result after fix: The running gateway serves the built JavaScript asset with `Content-Encoding: gzip` when gzip is requested, honors q-values by choosing gzip over low-priority br, falls back to brotli through the wildcard path when gzip is explicitly disabled, advertises the negotiated encoding on HEAD, and leaves `favicon.ico` uncompressed. The decoded gzip and brotli response bodies match the built Control UI asset exactly.

What was not tested: I did not run a browser transfer-size benchmark; this proof exercises the live gateway HTTP surface with curl and verifies response bodies byte-for-byte.

## Verification
- pnpm test src/gateway/control-ui.http.test.ts
- pnpm exec oxfmt --write src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts
- git diff --check origin/main...HEAD
- pnpm ui:build
- live gateway curl transcript above

