### PR TITLE
Fix Control UI agent thinking defaults

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4112,9 +4112,9 @@ public struct AgentSummary: Codable, Sendable {
         workspace: String?,
         model: [String: AnyCodable]?,
         agentruntime: [String: AnyCodable]?,
-        thinkinglevels: [[String: AnyCodable]]?,
-        thinkingoptions: [String]?,
-        thinkingdefault: String?)
+        thinkinglevels: [[String: AnyCodable]]? = nil,
+        thinkingoptions: [String]? = nil,
+        thinkingdefault: String? = nil)
     {
         self.id = id
         self.name = name

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4101,6 +4101,9 @@ public struct AgentSummary: Codable, Sendable {
     public let workspace: String?
     public let model: [String: AnyCodable]?
     public let agentruntime: [String: AnyCodable]?
+    public let thinkinglevels: [[String: AnyCodable]]?
+    public let thinkingoptions: [String]?
+    public let thinkingdefault: String?
 
     public init(
         id: String,
@@ -4108,7 +4111,10 @@ public struct AgentSummary: Codable, Sendable {
         identity: [String: AnyCodable]?,
         workspace: String?,
         model: [String: AnyCodable]?,
-        agentruntime: [String: AnyCodable]?)
+        agentruntime: [String: AnyCodable]?,
+        thinkinglevels: [[String: AnyCodable]]?,
+        thinkingoptions: [String]?,
+        thinkingdefault: String?)
     {
         self.id = id
         self.name = name
@@ -4116,6 +4122,9 @@ public struct AgentSummary: Codable, Sendable {
         self.workspace = workspace
         self.model = model
         self.agentruntime = agentruntime
+        self.thinkinglevels = thinkinglevels
+        self.thinkingoptions = thinkingoptions
+        self.thinkingdefault = thinkingdefault
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -4125,6 +4134,9 @@ public struct AgentSummary: Codable, Sendable {
         case workspace
         case model
         case agentruntime = "agentRuntime"
+        case thinkinglevels = "thinkingLevels"
+        case thinkingoptions = "thinkingOptions"
+        case thinkingdefault = "thinkingDefault"
     }
 }
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -1,6 +1,7 @@
 import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import {
+  AgentsListResultSchema,
   SkillsProposalInspectResultSchema,
   ToolsEffectiveResultSchema,
 } from "./agents-models-skills.js";
@@ -27,6 +28,31 @@ function toolsEffectiveResult() {
     ],
   };
 }
+
+describe("AgentsListResultSchema", () => {
+  it("accepts resolved per-agent thinking metadata", () => {
+    const result = {
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [
+        {
+          id: "investment-master",
+          name: "Investment Master",
+          model: { primary: "deepseek/deepseek-v4-flash" },
+          thinkingLevels: [
+            { id: "off", label: "off" },
+            { id: "xhigh", label: "xhigh" },
+          ],
+          thinkingOptions: ["off", "xhigh"],
+          thinkingDefault: "xhigh",
+        },
+      ],
+    };
+
+    expect(Value.Check(AgentsListResultSchema, result)).toBe(true);
+  });
+});
 
 describe("ToolsEffectiveResultSchema", () => {
   it("accepts runtime tool quarantine notices", () => {

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -56,6 +56,19 @@ export const AgentSummarySchema = Type.Object(
         { additionalProperties: false },
       ),
     ),
+    thinkingLevels: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            id: NonEmptyString,
+            label: NonEmptyString,
+          },
+          { additionalProperties: false },
+        ),
+      ),
+    ),
+    thinkingOptions: Type.Optional(Type.Array(NonEmptyString)),
+    thinkingDefault: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },
 );

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -77,6 +77,7 @@ const DEFAULTED_OPTIONAL_INIT_PARAM_ENTRIES: readonly [string, readonly string[]
   ["MessageActionParams", ["inboundTurnKind"]],
   ["CronRunLogEntry", ["errorReason", "failureNotificationDelivery"]],
   ["ExecApprovalRequestParams", ["requireDeliveryRoute", "suppressDelivery"]],
+  ["AgentSummary", ["thinkingLevels", "thinkingOptions", "thinkingDefault"]],
 ];
 
 const DEFAULTED_OPTIONAL_INIT_PARAMS: Record<string, Set<string>> = Object.fromEntries(

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -52,7 +52,7 @@ import {
   isConfiguredAgent,
   updateAgentConfigEntry,
 } from "./agents-config-mutations.js";
-import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 
 const BOOTSTRAP_FILE_NAMES = [
   DEFAULT_AGENTS_FILENAME,
@@ -71,6 +71,41 @@ const agentsHandlerDeps = {
   root,
   isWorkspaceSetupCompleted,
 };
+
+let loggedSlowAgentsListCatalog = false;
+
+const AGENTS_LIST_MODEL_CATALOG_TIMEOUT_MS = 750;
+
+async function loadOptionalAgentsListModelCatalog(
+  context: GatewayRequestContext,
+): Promise<Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>> | undefined> {
+  let timeout: NodeJS.Timeout | undefined;
+  const timedOut = Symbol("agents-list-model-catalog-timeout");
+  const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
+    timeout = setTimeout(() => resolve(timedOut), AGENTS_LIST_MODEL_CATALOG_TIMEOUT_MS);
+    timeout.unref?.();
+  });
+  try {
+    const result = await Promise.race([
+      context.loadGatewayModelCatalog().catch(() => undefined),
+      timeoutPromise,
+    ]);
+    if (result === timedOut) {
+      if (!loggedSlowAgentsListCatalog) {
+        loggedSlowAgentsListCatalog = true;
+        context.logGateway.debug(
+          `agents.list continuing without model catalog after ${AGENTS_LIST_MODEL_CATALOG_TIMEOUT_MS}ms`,
+        );
+      }
+      return undefined;
+    }
+    return Array.isArray(result) ? result : undefined;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
 
 export const testing = {
   setDepsForTests(
@@ -446,7 +481,7 @@ async function buildIdentityMarkdownOrRespondUnsafe(params: {
 }
 
 export const agentsHandlers: GatewayRequestHandlers = {
-  "agents.list": ({ params, respond, context }) => {
+  "agents.list": async ({ params, respond, context }) => {
     if (!validateAgentsListParams(params)) {
       respond(
         false,
@@ -460,7 +495,8 @@ export const agentsHandlers: GatewayRequestHandlers = {
     }
 
     const cfg = context.getRuntimeConfig();
-    const result = listAgentsForGateway(cfg);
+    const modelCatalog = await loadOptionalAgentsListModelCatalog(context);
+    const result = listAgentsForGateway(cfg, modelCatalog);
     respond(true, result, undefined);
   },
   "agents.create": async ({ params, respond, context }) => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1511,6 +1511,26 @@ describe("gateway session utils", () => {
     );
     expect(agent?.thinkingOptions).toEqual(agent?.thinkingLevels?.map((level) => level.label));
   });
+
+  test("listAgentsForGateway uses the model catalog for per-agent thinking metadata", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: {
+        defaults: {
+          model: { primary: "local/custom-reasoner" },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+
+    const result = listAgentsForGateway(cfg, [
+      { provider: "local", id: "custom-reasoner", reasoning: true },
+    ]);
+    const agent = result.agents.find((row) => row.id === "main");
+
+    expect(agent?.thinkingDefault).toBe("medium");
+    expect(agent?.thinkingLevels?.map((level) => level.id)).toContain("medium");
+  });
 });
 
 describe("resolveSessionModelRef", () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1481,6 +1481,36 @@ describe("gateway session utils", () => {
     const ops = result.agents.find((agent) => agent.id === "ops");
     expect(ops?.model).toEqual({ primary: "anthropic/claude-opus-4-6" });
   });
+
+  test("listAgentsForGateway reports per-agent thinking defaults from the agent model", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: {
+        defaults: {
+          model: { primary: "minimax/MiniMax-M2.7" },
+          thinkingDefault: "off",
+        },
+        list: [
+          { id: "main", default: true },
+          {
+            id: "investment-master",
+            model: { primary: "deepseek/deepseek-v4-flash" },
+            thinkingDefault: "xhigh",
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const result = listAgentsForGateway(cfg);
+    const agent = result.agents.find((row) => row.id === "investment-master");
+
+    expect(agent?.model).toEqual({ primary: "deepseek/deepseek-v4-flash" });
+    expect(agent?.thinkingDefault).toBe("xhigh");
+    expect(agent?.thinkingLevels?.map((level) => level.id)).toEqual(
+      expect.arrayContaining(["off", "minimal", "low", "medium", "high", "xhigh"]),
+    );
+    expect(agent?.thinkingOptions).toEqual(agent?.thinkingLevels?.map((level) => level.label));
+  });
 });
 
 describe("resolveSessionModelRef", () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1524,7 +1524,7 @@ describe("gateway session utils", () => {
     } as OpenClawConfig;
 
     const result = listAgentsForGateway(cfg, [
-      { provider: "local", id: "custom-reasoner", reasoning: true },
+      { provider: "local", id: "custom-reasoner", name: "Custom Reasoner", reasoning: true },
     ]);
     const agent = result.agents.find((row) => row.id === "main");
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1167,7 +1167,10 @@ function resolveGatewayAgentModel(
   };
 }
 
-export function listAgentsForGateway(cfg: OpenClawConfig): {
+export function listAgentsForGateway(
+  cfg: OpenClawConfig,
+  modelCatalog?: ModelCatalogEntry[],
+): {
   defaultId: string;
   mainKey: string;
   scope: SessionScope;
@@ -1219,7 +1222,11 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
     const meta = configuredById.get(id);
     const model = resolveGatewayAgentModel(cfg, id);
     const resolvedModel = resolveDefaultModelForAgent({ cfg, agentId: id });
-    const thinkingLevels = listThinkingLevelOptions(resolvedModel.provider, resolvedModel.model);
+    const thinkingLevels = listThinkingLevelOptions(
+      resolvedModel.provider,
+      resolvedModel.model,
+      modelCatalog,
+    );
     return Object.assign(
       {
         id,
@@ -1241,6 +1248,7 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
           provider: resolvedModel.provider,
           model: resolvedModel.model,
           agentId: id,
+          modelCatalog,
         }),
       },
       model ? { model } : {},

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1219,6 +1219,7 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
     const meta = configuredById.get(id);
     const model = resolveGatewayAgentModel(cfg, id);
     const resolvedModel = resolveDefaultModelForAgent({ cfg, agentId: id });
+    const thinkingLevels = listThinkingLevelOptions(resolvedModel.provider, resolvedModel.model);
     return Object.assign(
       {
         id,
@@ -1232,6 +1233,14 @@ export function listAgentsForGateway(cfg: OpenClawConfig): {
           model: resolvedModel.model,
           sessionKey: resolveAgentMainSessionKey({ cfg, agentId: id }),
           acpRuntime: false,
+        }),
+        thinkingLevels,
+        thinkingOptions: thinkingLevels.map((level) => level.label),
+        thinkingDefault: resolveGatewaySessionThinkingDefault({
+          cfg,
+          provider: resolvedModel.provider,
+          model: resolvedModel.model,
+          agentId: id,
         }),
       },
       model ? { model } : {},

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -8,6 +8,7 @@ import type { PluginSessionExtensionProjection } from "../plugins/host-hooks.js"
 import type {
   GatewayAgentRuntime,
   GatewayAgentRow as SharedGatewayAgentRow,
+  GatewayThinkingLevelOption,
   SessionsListResultBase,
   SessionsPatchResultBase,
 } from "../shared/session-types.js";
@@ -20,11 +21,6 @@ export type GatewaySessionsDefaults = {
   thinkingLevels?: GatewayThinkingLevelOption[];
   thinkingOptions?: string[];
   thinkingDefault?: string;
-};
-
-type GatewayThinkingLevelOption = {
-  id: string;
-  label: string;
 };
 
 export type SessionRunStatus = "running" | "done" | "failed" | "killed" | "timeout";

--- a/src/shared/session-types.ts
+++ b/src/shared/session-types.ts
@@ -17,6 +17,11 @@ export type GatewayAgentRuntime = {
   source: "env" | "agent" | "defaults" | "model" | "provider" | "implicit" | "session-key";
 };
 
+export type GatewayThinkingLevelOption = {
+  id: string;
+  label: string;
+};
+
 export type GatewayAgentRow = {
   id: string;
   name?: string;
@@ -24,6 +29,9 @@ export type GatewayAgentRow = {
   workspace?: string;
   model?: GatewayAgentModel;
   agentRuntime?: GatewayAgentRuntime;
+  thinkingLevels?: GatewayThinkingLevelOption[];
+  thinkingOptions?: string[];
+  thinkingDefault?: string;
 };
 
 export type SessionsListResultBase<TDefaults, TRow> = {

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -862,6 +862,16 @@ function resolveThinkingTargetModel(state: AppViewState): {
   };
 }
 
+function sessionModelMatchesDefaults(
+  row: SessionsListResult["sessions"][number] | undefined,
+  defaults: SessionsListResult["defaults"] | undefined,
+): boolean {
+  return (
+    (!row?.modelProvider || row.modelProvider === defaults?.modelProvider) &&
+    (!row?.model || row.model === defaults?.model)
+  );
+}
+
 function buildThinkingOptions(
   levels: readonly GatewayThinkingLevelOption[],
   currentOverride: string,
@@ -944,17 +954,22 @@ export function resolveChatThinkingSelectState(state: AppViewState): ChatThinkin
     typeof persisted === "string" && persisted.trim()
       ? (normalizeThinkLevel(persisted) ?? persisted.trim())
       : "";
+  const defaults = state.sessionsResult?.defaults;
   const { provider, model } = resolveThinkingTargetModel(state);
   const levels = resolveThinkingLevelOptions(
     activeRow,
-    state.sessionsResult?.defaults,
+    defaults,
     provider,
     model,
     state.chatModelCatalog ?? [],
   );
+  const defaultFromSessionDefaults =
+    (!activeRow || sessionModelMatchesDefaults(activeRow, defaults)) && defaults?.thinkingDefault
+      ? defaults.thinkingDefault
+      : undefined;
   const defaultLevel =
     activeRow?.thinkingDefault ??
-    state.sessionsResult?.defaults?.thinkingDefault ??
+    defaultFromSessionDefaults ??
     (provider && model
       ? resolveThinkingDefaultForModel({
           provider,

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -657,7 +657,7 @@ describe("executeSlashCommand directives", () => {
     );
 
     expect(status.content).toBe(
-      "Current thinking level: off.\nOptions: default, off, minimal, low, medium, high, xhigh, max.",
+      "Current thinking level: low.\nOptions: default, off, minimal, low, medium, high, xhigh, max.",
     );
     expect(setMax.content).toBe("Thinking level set to **max**.");
   });
@@ -709,7 +709,44 @@ describe("executeSlashCommand directives", () => {
     );
 
     expect(status.content).toBe(
-      "Current thinking level: high.\nOptions: default, off, minimal, low, medium, high.",
+      "Current thinking level: low.\nOptions: default, off, minimal, low, medium, high.",
+    );
+  });
+
+  it("does not report global thinkingDefault for a session with a different model", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          defaults: {
+            modelProvider: "minimax",
+            model: "MiniMax-M2.7",
+            thinkingDefault: "off",
+          },
+          sessions: [
+            row("agent:main:main", {
+              modelProvider: "deepseek",
+              model: "deepseek-v4-flash",
+            }),
+          ],
+        };
+      }
+      if (method === "models.list") {
+        return {
+          models: [{ id: "deepseek-v4-flash", provider: "deepseek", reasoning: true }],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const status = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "think",
+      "",
+    );
+
+    expect(status.content).toBe(
+      "Current thinking level: low.\nOptions: default, off, minimal, low, medium, high.",
     );
   });
 

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -587,17 +587,13 @@ function resolveThinkingLevelOptionsForSession(
   if (session?.thinkingLevels?.length) {
     return session.thinkingLevels;
   }
-  const sessionModelMatchesDefaults =
-    (!session?.modelProvider || session.modelProvider === defaults?.modelProvider) &&
-    (!session?.model || session.model === defaults?.model);
-  if (sessionModelMatchesDefaults && defaults?.thinkingLevels?.length) {
+  const matchesDefaults = sessionModelMatchesDefaults(session, defaults);
+  if (matchesDefaults && defaults?.thinkingLevels?.length) {
     return defaults.thinkingLevels;
   }
   const labels =
     (session?.thinkingOptions?.length ? session.thinkingOptions : null) ??
-    (sessionModelMatchesDefaults && defaults?.thinkingOptions?.length
-      ? defaults.thinkingOptions
-      : null) ??
+    (matchesDefaults && defaults?.thinkingOptions?.length ? defaults.thinkingOptions : null) ??
     formatThinkingLevels(
       session?.modelProvider ?? defaults?.modelProvider,
       session?.model ?? defaults?.model,
@@ -606,6 +602,16 @@ function resolveThinkingLevelOptionsForSession(
     id: normalizeThinkLevel(label) ?? normalizeLowercaseStringOrEmpty(label),
     label,
   }));
+}
+
+function sessionModelMatchesDefaults(
+  session: GatewaySessionRow | undefined,
+  defaults: SessionsListResult["defaults"] | undefined,
+): boolean {
+  return (
+    (!session?.modelProvider || session.modelProvider === defaults?.modelProvider) &&
+    (!session?.model || session.model === defaults?.model)
+  );
 }
 
 async function loadCurrentSession(
@@ -691,7 +697,7 @@ function resolveCurrentThinkingLevel(
   if (session?.thinkingDefault) {
     return session.thinkingDefault;
   }
-  if (defaults?.thinkingDefault) {
+  if ((!session || sessionModelMatchesDefaults(session, defaults)) && defaults?.thinkingDefault) {
     return defaults.thinkingDefault;
   }
   const provider = session?.modelProvider ?? defaults?.modelProvider;

--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -83,6 +83,7 @@ export function renderAgentOverview(params: {
   const skillFilter = Array.isArray(config.entry?.skills) ? config.entry?.skills : null;
   const skillCount = skillFilter?.length ?? null;
   const disabled = !configForm || configLoading || configSaving;
+  const thinkingDefault = agent.thinkingDefault ?? "-";
 
   const removeChip = (index: number) => {
     const next = fallbackChips.filter((_, i) => i !== index);
@@ -127,6 +128,10 @@ export function renderAgentOverview(params: {
         <div class="agent-kv">
           <div class="label">Runtime</div>
           <div class="mono">${runtime}</div>
+        </div>
+        <div class="agent-kv">
+          <div class="label">Thinking Default</div>
+          <div class="mono">${thinkingDefault}</div>
         </div>
         <div class="agent-kv">
           <div class="label">Skills Filter</div>

--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -272,6 +272,35 @@ describe("renderAgents", () => {
     expect(alphaSelect).not.toBe(betaSelect);
   });
 
+  it("renders the resolved per-agent thinking default in the overview", async () => {
+    const container = document.createElement("div");
+
+    render(
+      renderAgents(
+        createProps({
+          agentsList: {
+            defaultId: "alpha",
+            mainKey: "main",
+            scope: "workspace",
+            agents: [
+              { id: "alpha", name: "Alpha", thinkingDefault: "off" } as never,
+              { id: "beta", name: "Beta", thinkingDefault: "xhigh" } as never,
+            ],
+          },
+          selectedAgentId: "beta",
+        }),
+      ),
+      container,
+    );
+
+    await Promise.resolve();
+
+    const thinkingKv = Array.from(container.querySelectorAll(".agent-kv")).find(
+      (entry) => entry.querySelector(".label")?.textContent?.trim() === "Thinking Default",
+    );
+    expect(thinkingKv?.textContent).toContain("xhigh");
+  });
+
   it("shows the skills count only for the selected agent's report", async () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -2615,6 +2615,37 @@ describe("chat session controls", () => {
     ).toEqual(["Inherited: Off"]);
   });
 
+  it("does not label a non-default chat model from global thinking defaults", () => {
+    const { state } = createChatHeaderState({
+      model: "deepseek-v4-flash",
+      modelProvider: "deepseek",
+      defaultsThinkingDefault: "off",
+      models: [
+        {
+          id: "deepseek-v4-flash",
+          name: "DeepSeek V4 Flash",
+          provider: "deepseek",
+          reasoning: true,
+        },
+      ],
+    });
+    state.sessionsResult = createSessionsListResult({
+      model: "deepseek-v4-flash",
+      modelProvider: "deepseek",
+      defaultsModel: "MiniMax-M2.7",
+      defaultsProvider: "minimax",
+      defaultsThinkingDefault: "off",
+    });
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const thinkingSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-thinking-select="true"]',
+    );
+
+    expect(thinkingSelect?.options[0]?.textContent?.trim()).toBe("Inherited: Low");
+  });
+
   it("always renders full thinking labels", () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",


### PR DESCRIPTION
Fixes #81760

## Summary
- include resolved thinking defaults and levels in agents.list rows
- show the resolved thinking default in the Agents overview
- stop chat UI and /think status fallbacks from using global thinking defaults for sessions on a different model

## Real behavior proof
Behavior or issue addressed: Control UI should show and inherit the effective thinking default for the selected agent/session, not the global default from a different model.

Real environment tested: Local OpenClaw gateway from PR head `e4806661795f81e12849864fe227b9f4b5ef92f1` on macOS, with Control UI rebuilt by `pnpm ui:build`, a temporary `OPENCLAW_HOME`, token auth on `127.0.0.1:18895`, and a proof config containing:

```json
{
  "agents": {
    "defaults": {
      "model": { "primary": "minimax/MiniMax-M2.7" },
      "thinkingDefault": "off"
    },
    "list": [
      { "id": "main", "default": true },
      {
        "id": "investment-master",
        "model": { "primary": "deepseek/deepseek-v4-flash" },
        "thinkingDefault": "xhigh"
      }
    ]
  }
}
```

For the local headless browser run only, `gateway.controlUi.dangerouslyDisableDeviceAuth=true` was set so Chrome could connect over local HTTP without a one-time pairing ceremony. The gateway still used token auth; the behavior under test was the live `agents.list` payload and Control UI rendering.

Exact steps or command run after this patch:

```bash
pnpm ui:build
COREPACK_HOME=/Users/betala/.cache/node/corepack HOME=/private/tmp/openclaw-proof-81795-home OPENCLAW_HOME=/private/tmp/openclaw-proof-81795-home/.openclaw OPENCLAW_STATE_DIR=/private/tmp/openclaw-proof-81795-home/.openclaw OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-proof-81795-home/.openclaw/openclaw.json OPENCLAW_GATEWAY_TOKEN=proof-token-81795 OPENCLAW_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway --port 18895 --bind loopback --allow-unconfigured --verbose --cli-backend-logs
curl -sS -i http://127.0.0.1:18895/healthz
COREPACK_HOME=/Users/betala/.cache/node/corepack HOME=/private/tmp/openclaw-proof-81795-home OPENCLAW_HOME=/private/tmp/openclaw-proof-81795-home/.openclaw OPENCLAW_STATE_DIR=/private/tmp/openclaw-proof-81795-home/.openclaw OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-proof-81795-home/.openclaw/openclaw.json OPENCLAW_GATEWAY_TOKEN=proof-token-81795 node --import tsx /private/tmp/openclaw-81795-client-proof.ts
node /private/tmp/openclaw-81795-ui-proof.mjs
```

Evidence after fix:

Live gateway output:

```text
$ curl -sS -i http://127.0.0.1:18895/healthz
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Cache-Control: no-store
Content-Length: 27

{"ok":true,"status":"live"}

$ node --import tsx /private/tmp/openclaw-81795-client-proof.ts
{
  "gatewayUrl": "ws://127.0.0.1:18895",
  "helloOk": "hello-ok",
  "authRole": "operator",
  "authScopes": ["operator.read"],
  "investmentMaster": {
    "id": "investment-master",
    "model": { "primary": "deepseek/deepseek-v4-flash" },
    "thinkingDefault": "xhigh",
    "thinkingLevels": ["off", "minimal", "low", "medium", "high", "xhigh", "max"],
    "thinkingOptions": ["off", "minimal", "low", "medium", "high", "xhigh", "max"]
  }
}
```

Live Control UI browser output:

```text
$ node /private/tmp/openclaw-81795-ui-proof.mjs
{
  "url": "http://127.0.0.1:18895/agents",
  "matchedExpectedText": true,
  "sawInvestmentMaster": true,
  "sawThinkingDefault": true,
  "sawXhigh": true,
  "thinkingSnippet": "Workspace ... /private/tmp/openclaw-proof-81795-workspace/investment-master\nPrimary Model\ndeepseek/deepseek-v4-flash\nRuntime\nauto\nThinking Default\nxhigh\nSkills Filter\nall skills ...",
  "consoleMessages": [
    "debug: [openclaw] control-ui.rpc {... method: agents.list, ok: true, durationMs: 235, slow: false}",
    "debug: [openclaw] control-ui.rpc {... method: agents.list, ok: true, durationMs: 74, slow: false}"
  ]
}
```

Observed result after fix: The running gateway returns the `investment-master` row with `thinkingDefault: "xhigh"` and model-specific thinking levels instead of the global `off` default. The running Control UI `/agents` page, connected to that gateway, renders the selected `investment-master` overview with `Thinking Default` shown as `xhigh`.

What was not tested: I did not run a live LLM chat turn or `/think` command against a provider because the proof config intentionally has no provider API keys. The focused tests below cover the chat selector and `/think` fallback paths.

Re-verified on current head `634b90d5a2e422e778592949e07d9339fba1095b` (2026-05-25): the branch was rebased onto current `origin/main`, reconciling `resolveThinkingLevelOptions` with main's added model-catalog argument while keeping the `defaultFromSessionDefaults` fix. The live gateway and Control UI transcripts above were captured on the pre-rebase head `e4806661795f81e12849864fe227b9f4b5ef92f1`; the rebase only reconciled the merge and did not change the user-facing behavior under test. The focused regression suite re-runs green on the current head:

```console
$ pnpm test src/gateway/session-utils.test.ts ui/src/ui/views/agents.test.ts ui/src/ui/views/chat.test.ts ui/src/ui/chat/slash-command-executor.node.test.ts
[test] starting test/vitest/vitest.gateway.config.ts   -> Test Files 1 passed (1)  Tests 94 passed (94)
[test] starting test/vitest/vitest.ui.config.ts        -> Test Files 1 passed (1)  Tests 8 passed (8)
[test] starting test/vitest/vitest.unit-ui.config.ts   -> Test Files 2 passed (2)  Tests 86 passed (86)
[test] passed 3 Vitest shards
```

## Verification
- pnpm test src/gateway/session-utils.test.ts ui/src/ui/views/agents.test.ts ui/src/ui/views/chat.test.ts ui/src/ui/chat/slash-command-executor.node.test.ts
- pnpm exec oxfmt --write src/shared/session-types.ts src/gateway/session-utils.types.ts src/gateway/session-utils.ts src/gateway/session-utils.test.ts ui/src/ui/views/agents-panels-overview.ts ui/src/ui/views/agents.test.ts ui/src/ui/chat/session-controls.ts ui/src/ui/views/chat.test.ts ui/src/ui/chat/slash-command-executor.ts ui/src/ui/chat/slash-command-executor.node.test.ts
- git diff --check
- pnpm ui:build
- live gateway RPC and live Control UI browser transcripts above


