### PR TITLE
fix(memory): stop watcher write-polling fd pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: derive readable plain-text retries from HTML fallback sends so parse failures show `label (url)` links instead of raw anchors. (#81764) Thanks @alexph-dev.
 - Ollama/Doctor: copy explicit native Ollama `contextWindow` or `maxTokens` provider/model budgets into `params.num_ctx` during `openclaw doctor --fix`, preserving large-context configs after native Ollama stopped inferring per-request `num_ctx`. Fixes #81878. (#81928) Thanks @joshavant and @ArthurusDent.
 - Discord: honor `threadName` on `message send` to existing threads by renaming the thread after successful delivery, and warn when the rename cannot be applied. Fixes #81836. (#81933) Thanks @joshavant.
-- Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors while the existing debounce still batches re-indexing. Fixes #77327 and #78224. Thanks @loyur and @JanPlessow.
+- Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @loyur and @JanPlessow.
 - Build: keep externalized Slack, OpenShell sandbox, and Anthropic Vertex runtime dependency declarations out of the root dist artifact build.
 - ClawHub: include Amazon Bedrock and Bedrock Mantle provider packages in the published registry metadata so the externalized providers are discoverable from ClawHub as well as npm.
 - Codex account/status: hide empty rate-limit buckets and show server-reported usage-limit blocks without calling them available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Changes
+
+### Fixes
+
+- Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @loyur and @JanPlessow.
+
 ## 2026.5.14
 
 ### Changes
@@ -91,7 +99,6 @@ Docs: https://docs.openclaw.ai
 - Telegram: derive readable plain-text retries from HTML fallback sends so parse failures show `label (url)` links instead of raw anchors. (#81764) Thanks @alexph-dev.
 - Ollama/Doctor: copy explicit native Ollama `contextWindow` or `maxTokens` provider/model budgets into `params.num_ctx` during `openclaw doctor --fix`, preserving large-context configs after native Ollama stopped inferring per-request `num_ctx`. Fixes #81878. (#81928) Thanks @joshavant and @ArthurusDent.
 - Discord: honor `threadName` on `message send` to existing threads by renaming the thread after successful delivery, and warn when the rename cannot be applied. Fixes #81836. (#81933) Thanks @joshavant.
-- Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @loyur and @JanPlessow.
 - Build: keep externalized Slack, OpenShell sandbox, and Anthropic Vertex runtime dependency declarations out of the root dist artifact build.
 - ClawHub: include Amazon Bedrock and Bedrock Mantle provider packages in the published registry metadata so the externalized providers are discoverable from ClawHub as well as npm.
 - Codex account/status: hide empty rate-limit buckets and show server-reported usage-limit blocks without calling them available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @loyur and @JanPlessow.
+- Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
 
 ## 2026.5.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: derive readable plain-text retries from HTML fallback sends so parse failures show `label (url)` links instead of raw anchors. (#81764) Thanks @alexph-dev.
 - Ollama/Doctor: copy explicit native Ollama `contextWindow` or `maxTokens` provider/model budgets into `params.num_ctx` during `openclaw doctor --fix`, preserving large-context configs after native Ollama stopped inferring per-request `num_ctx`. Fixes #81878. (#81928) Thanks @joshavant and @ArthurusDent.
 - Discord: honor `threadName` on `message send` to existing threads by renaming the thread after successful delivery, and warn when the rename cannot be applied. Fixes #81836. (#81933) Thanks @joshavant.
+- Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors while the existing debounce still batches re-indexing. Fixes #77327 and #78224. Thanks @loyur and @JanPlessow.
 - Build: keep externalized Slack, OpenShell sandbox, and Anthropic Vertex runtime dependency declarations out of the root dist artifact build.
 - ClawHub: include Amazon Bedrock and Bedrock Mantle provider packages in the published registry metadata so the externalized providers are discoverable from ClawHub as well as npm.
 - Codex account/status: hide empty rate-limit buckets and show server-reported usage-limit blocks without calling them available.

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -450,10 +450,6 @@ export abstract class MemoryManagerSyncOps {
       ignoreInitial: true,
       ignored: (watchPath, stats) =>
         shouldIgnoreMemoryWatchPath(watchPath, stats, this.settings.multimodal),
-      awaitWriteFinish: {
-        stabilityThreshold: this.settings.sync.watchDebounceMs,
-        pollInterval: 100,
-      },
     });
     const markDirty = () => {
       this.dirty = true;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -59,6 +59,12 @@ import {
   resolveMemorySourceExistingHash,
 } from "./manager-source-state.js";
 import { runMemoryTargetedSessionSync } from "./manager-targeted-sync.js";
+import {
+  recordMemoryWatchEventPath,
+  settleMemoryWatchEventPaths,
+  type MemoryWatchEventStats,
+  type MemoryWatchSettleQueue,
+} from "./watch-settle.js";
 
 type MemorySyncProgressState = {
   completed: number;
@@ -192,6 +198,7 @@ export abstract class MemoryManagerSyncOps {
   protected intervalTimer: NodeJS.Timeout | null = null;
   protected closed = false;
   protected dirty = false;
+  protected pendingWatchPaths: MemoryWatchSettleQueue = new Map();
   protected sessionsDirty = false;
   protected sessionsDirtyFiles = new Set<string>();
   protected sessionPendingFiles = new Set<string>();
@@ -451,7 +458,8 @@ export abstract class MemoryManagerSyncOps {
       ignored: (watchPath, stats) =>
         shouldIgnoreMemoryWatchPath(watchPath, stats, this.settings.multimodal),
     });
-    const markDirty = () => {
+    const markDirty = (watchPath?: string, stats?: MemoryWatchEventStats) => {
+      recordMemoryWatchEventPath(this.pendingWatchPaths, watchPath, stats);
       this.dirty = true;
       this.scheduleWatchSync();
     };
@@ -705,7 +713,21 @@ export abstract class MemoryManagerSyncOps {
     }
     this.watchTimer = setTimeout(() => {
       this.watchTimer = null;
-      runDetachedMemorySync(() => this.sync({ reason: "watch" }), "watch");
+      runDetachedMemorySync(async () => {
+        if (this.closed) {
+          return;
+        }
+        if (!(await settleMemoryWatchEventPaths(this.pendingWatchPaths))) {
+          if (!this.closed) {
+            this.scheduleWatchSync();
+          }
+          return;
+        }
+        if (this.closed) {
+          return;
+        }
+        await this.sync({ reason: "watch" });
+      }, "watch");
     }, this.settings.sync.watchDebounceMs);
   }
 

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -11,7 +11,7 @@ type WatchIgnoredFn = (watchPath: string, stats?: { isDirectory?: () => boolean 
 
 const { createdWatchers, memoryLoggerWarn, watchMock } = vi.hoisted(() => {
   type WatchEvent = "add" | "change" | "unlink" | "unlinkDir" | "error";
-  type WatchCallback = (value?: unknown) => void;
+  type WatchCallback = (...args: unknown[]) => void;
   function createMockWatcher() {
     const handlers = new Map<WatchEvent, WatchCallback[]>();
     const watcher = {
@@ -20,9 +20,9 @@ const { createdWatchers, memoryLoggerWarn, watchMock } = vi.hoisted(() => {
         return watcher;
       }),
       close: vi.fn(async () => undefined),
-      emit: (event: WatchEvent, value?: unknown) => {
+      emit: (event: WatchEvent, ...args: unknown[]) => {
         for (const callback of handlers.get(event) ?? []) {
-          callback(value);
+          callback(...args);
         }
       },
     };
@@ -260,6 +260,37 @@ describe("memory watcher config", () => {
       expect(syncSpy).toHaveBeenCalledWith({ reason: "watch" });
     },
   );
+
+  it("settles changed file stats before running watch sync", async () => {
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const cfg = createWatcherConfig();
+
+    await expectWatcherManager(cfg);
+    vi.useFakeTimers();
+    const notesPath = path.join(extraDir, "notes.md");
+    const initialStats = await fs.stat(notesPath);
+    const syncSpy = vi
+      .spyOn(
+        manager as unknown as {
+          sync: (params?: { reason?: string }) => Promise<void>;
+        },
+        "sync",
+      )
+      .mockResolvedValue(undefined);
+
+    createdWatchers[0]?.emit("change", notesPath, {
+      size: initialStats.size,
+      mtimeMs: initialStats.mtimeMs,
+      isDirectory: () => false,
+    });
+    await fs.writeFile(notesPath, "hello updated");
+
+    await vi.advanceTimersByTimeAsync(25);
+    expect(syncSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(25);
+    expect(syncSpy).toHaveBeenCalledWith({ reason: "watch" });
+  });
 
   it("attaches a logging non-throwing watcher error listener", async () => {
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -172,7 +172,7 @@ describe("memory watcher config", () => {
     ]);
     expect(watchedPaths.filter((watchedPath) => watchedPath.includes("*"))).toEqual([]);
     expect(options.ignoreInitial).toBe(true);
-    expect(options.awaitWriteFinish).toEqual({ stabilityThreshold: 25, pollInterval: 100 });
+    expect(options).not.toHaveProperty("awaitWriteFinish");
 
     const ignored = options.ignored as WatchIgnoredFn | undefined;
     expect(ignored).toBeTypeOf("function");

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -493,6 +493,7 @@ describe("QmdMemoryManager", () => {
     const initialUpdateCalls = spawnMock.mock.calls.filter((call) => call[1]?.[0] === "update");
     expect(initialUpdateCalls).toHaveLength(0);
     const watchOptions = firstWatchOptions();
+    expect(watchOptions).not.toHaveProperty("awaitWriteFinish");
     expect(watchOptions.ignored?.(path.join(workspaceDir, "node_modules", "pkg", "note.md"))).toBe(
       true,
     );

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -503,7 +503,14 @@ describe("QmdMemoryManager", () => {
     expect(watchOptions.ignored?.(path.join(workspaceDir, "build", "note.md"))).toBe(true);
     expect(watchOptions.ignored?.(path.join(workspaceDir, "notes.md"))).toBe(false);
 
-    watcher.emit("change", path.join(workspaceDir, "notes.md"));
+    const notesPath = path.join(workspaceDir, "notes.md");
+    await fs.writeFile(notesPath, "hello");
+    const initialStats = await fs.stat(notesPath);
+    watcher.emit("change", notesPath, {
+      size: initialStats.size,
+      mtimeMs: initialStats.mtimeMs,
+      isDirectory: () => false,
+    });
     expect(manager.status().dirty).toBe(true);
 
     await vi.advanceTimersByTimeAsync(25);
@@ -511,6 +518,55 @@ describe("QmdMemoryManager", () => {
     const updateCalls = spawnMock.mock.calls.filter((call) => call[1]?.[0] === "update");
     expect(updateCalls).toHaveLength(1);
     expect(manager.status().dirty).toBe(false);
+
+    await manager.close();
+  });
+
+  it("delays qmd watch sync until changed file stats settle", async () => {
+    vi.useFakeTimers();
+    cfg = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: path.join(workspaceDir, "index.sqlite"), vector: { enabled: false } },
+            sync: { watch: true, watchDebounceMs: 25, onSessionStart: false, onSearch: false },
+          },
+        },
+        list: [{ id: agentId, default: true, workspace: workspaceDir }],
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 0, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const notesPath = path.join(workspaceDir, "notes.md");
+    await fs.writeFile(notesPath, "hello");
+    const initialStats = await fs.stat(notesPath);
+    const { manager } = await createManager({ mode: "full" });
+    const watcher = watchMock.mock.results[0]?.value as {
+      emit: (event: string, ...args: unknown[]) => boolean;
+    };
+
+    watcher.emit("change", notesPath, {
+      size: initialStats.size,
+      mtimeMs: initialStats.mtimeMs,
+      isDirectory: () => false,
+    });
+    await fs.writeFile(notesPath, "hello updated");
+
+    await vi.advanceTimersByTimeAsync(25);
+    expect(spawnMock.mock.calls.filter((call) => call[1]?.[0] === "update")).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(25);
+    expect(spawnMock.mock.calls.filter((call) => call[1]?.[0] === "update")).toHaveLength(1);
 
     await manager.close();
   });

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -55,6 +55,12 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { asRecord } from "../dreaming-shared.js";
 import { resolveQmdCollectionPatternFlags, type QmdCollectionPatternFlag } from "./qmd-compat.js";
+import {
+  recordMemoryWatchEventPath,
+  settleMemoryWatchEventPaths,
+  type MemoryWatchEventStats,
+  type MemoryWatchSettleQueue,
+} from "./watch-settle.js";
 
 type SqliteDatabase = import("node:sqlite").DatabaseSync;
 
@@ -323,6 +329,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private embedTimer: NodeJS.Timeout | null = null;
   private watcher: FSWatcher | null = null;
   private watchTimer: NodeJS.Timeout | null = null;
+  private readonly pendingWatchPaths: MemoryWatchSettleQueue = new Map();
   private pendingUpdate: Promise<void> | null = null;
   private queuedForcedUpdate: Promise<void> | null = null;
   private queuedForcedRuns = 0;
@@ -1560,7 +1567,8 @@ export class QmdMemoryManager implements MemorySearchManager {
       ignoreInitial: true,
       ignored: (watchPath) => shouldIgnoreMemoryWatchPath(watchPath),
     });
-    const markDirty = () => {
+    const markDirty = (watchPath?: string, stats?: MemoryWatchEventStats) => {
+      recordMemoryWatchEventPath(this.pendingWatchPaths, watchPath, stats);
       this.dirty = true;
       this.scheduleWatchSync();
     };
@@ -1587,7 +1595,21 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     this.watchTimer = setTimeout(() => {
       this.watchTimer = null;
-      void this.sync({ reason: "watch" }).catch((err) => {
+      void (async () => {
+        if (this.closed) {
+          return;
+        }
+        if (!(await settleMemoryWatchEventPaths(this.pendingWatchPaths))) {
+          if (!this.closed) {
+            this.scheduleWatchSync();
+          }
+          return;
+        }
+        if (this.closed) {
+          return;
+        }
+        await this.sync({ reason: "watch" });
+      })().catch((err) => {
         log.warn(`qmd watch sync failed: ${String(err)}`);
       });
     }, this.syncSettings.watchDebounceMs);

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -62,7 +62,6 @@ const log = createSubsystemLogger("memory");
 
 const SNIPPET_HEADER_RE = /@@\s*-([0-9]+),([0-9]+)/;
 const SEARCH_PENDING_UPDATE_WAIT_MS = 500;
-const QMD_WATCH_STABILITY_MS = 200;
 const MAX_QMD_OUTPUT_CHARS = 200_000;
 const NUL_MARKER_RE = /(?:\^@|\\0|\\x00|\\u0000|null\s*byte|nul\s*byte)/i;
 const QMD_EMBED_BACKOFF_BASE_MS = 60_000;
@@ -1560,10 +1559,6 @@ export class QmdMemoryManager implements MemorySearchManager {
     this.watcher = chokidar.watch(watchPathList, {
       ignoreInitial: true,
       ignored: (watchPath) => shouldIgnoreMemoryWatchPath(watchPath),
-      awaitWriteFinish: {
-        stabilityThreshold: QMD_WATCH_STABILITY_MS,
-        pollInterval: 100,
-      },
     });
     const markDirty = () => {
       this.dirty = true;

--- a/extensions/memory-core/src/memory/watch-settle.ts
+++ b/extensions/memory-core/src/memory/watch-settle.ts
@@ -1,0 +1,102 @@
+import fsSync from "node:fs";
+import path from "node:path";
+
+export type MemoryWatchEventStats = {
+  isDirectory?: () => boolean;
+  size?: number;
+  mtimeMs?: number;
+};
+
+type WatchPathSnapshot = {
+  size: number;
+  mtimeMs: number;
+};
+
+export type MemoryWatchSettleQueue = Map<string, WatchPathSnapshot | null>;
+
+const MEMORY_WATCH_SETTLE_RECHECK_MS = 100;
+
+function snapshotFromStats(stats?: MemoryWatchEventStats): WatchPathSnapshot | null {
+  if (!stats || stats.isDirectory?.()) {
+    return null;
+  }
+  if (typeof stats.size !== "number" || typeof stats.mtimeMs !== "number") {
+    return null;
+  }
+  return { size: stats.size, mtimeMs: stats.mtimeMs };
+}
+
+function snapshotsMatch(left: WatchPathSnapshot | null, right: WatchPathSnapshot | null): boolean {
+  if (left === null || right === null) {
+    return left === right;
+  }
+  return left.size === right.size && left.mtimeMs === right.mtimeMs;
+}
+
+function snapshotPath(filePath: string): WatchPathSnapshot | null {
+  try {
+    const stats = fsSync.statSync(filePath);
+    if (stats.isDirectory()) {
+      return null;
+    }
+    return { size: stats.size, mtimeMs: stats.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export function recordMemoryWatchEventPath(
+  queue: MemoryWatchSettleQueue,
+  watchPath?: string,
+  stats?: MemoryWatchEventStats,
+): void {
+  if (!watchPath) {
+    return;
+  }
+  const trimmed = watchPath.trim();
+  if (!trimmed) {
+    return;
+  }
+  queue.set(path.resolve(trimmed), snapshotFromStats(stats));
+}
+
+export async function settleMemoryWatchEventPaths(queue: MemoryWatchSettleQueue): Promise<boolean> {
+  if (queue.size === 0) {
+    return true;
+  }
+
+  const entries = Array.from(queue.entries());
+  queue.clear();
+  const missingBaseline: Array<{ filePath: string; snapshot: WatchPathSnapshot }> = [];
+
+  for (const [filePath, previousSnapshot] of entries) {
+    const currentSnapshot = snapshotPath(filePath);
+    if (previousSnapshot === null) {
+      if (currentSnapshot !== null) {
+        missingBaseline.push({ filePath, snapshot: currentSnapshot });
+      }
+      continue;
+    }
+    if (!snapshotsMatch(previousSnapshot, currentSnapshot)) {
+      queue.set(filePath, currentSnapshot);
+    }
+  }
+
+  if (missingBaseline.length > 0) {
+    await delay(MEMORY_WATCH_SETTLE_RECHECK_MS);
+    for (const entry of missingBaseline) {
+      const currentSnapshot = snapshotPath(entry.filePath);
+      if (!snapshotsMatch(entry.snapshot, currentSnapshot)) {
+        queue.set(entry.filePath, currentSnapshot);
+      }
+    }
+  }
+
+  return queue.size === 0;
+}


### PR DESCRIPTION
## Summary
- remove chokidar `awaitWriteFinish` polling from built-in memory and QMD watchers
- record only changed watcher paths, then settle those paths by size/mtime before watch-triggered sync
- keep the existing debounced watch sync so bursts still batch before re-indexing
- update watcher tests and changelog for the FD-pressure fix

## Why
Issue #78224 gives the concrete reproduction for the same failure class behind #77327: large Markdown `extraPaths` trees with `memorySearch.sync.watch: true` build up thousands of regular-file descriptors, then gateway child-process spawns fail with `EBADF`.

The linked PR #78029 only changes bounded QMD read-stream cleanup. I could not reproduce a leak from that narrow path on Node v25.9.0, so this PR targets the watcher polling surface called out by the large-tree report instead.

The follow-up keeps chokidar from polling the whole tree while still avoiding obvious partial-write indexing: the watcher queue compares only paths that emitted events, and reschedules the watch sync if a changed file is still moving.

Fixes #77327.
Fixes #78224.
Alternative to #78029.

## Verification
- `/opt/homebrew/bin/node` v25.9.0 standalone bounded QMD read loop, 1,000 iterations: target file FDs stayed at 0
- `/opt/homebrew/bin/node` v25.9.0 standalone chokidar watch over 500 wiki Markdown files + 500 `SKILL.md` files: target `REG` FDs stayed at 0 before/after close
- `OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD=1 OPENCLAW_TEST_WORKERS=1 pnpm test extensions/memory-core/src/memory/manager.watcher-config.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts`
- `pnpm exec oxfmt --check CHANGELOG.md extensions/memory-core/src/memory/watch-settle.ts extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/qmd-manager.ts extensions/memory-core/src/memory/manager.watcher-config.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts`
- `git diff --check`
- `OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD=1 OPENCLAW_TEST_WORKERS=1 pnpm check:changed`
