### PR TITLE
docs(voyage): clarify API key setup

### DIFF
--- a/docs/plugins/reference/voyage.md
+++ b/docs/plugins/reference/voyage.md
@@ -9,6 +9,54 @@ title: "Voyage plugin"
 
 Adds memory embedding provider support.
 
+## Setup
+
+Voyage is a remote memory embedding provider, so it needs a Voyage API key before
+memory search can use it.
+
+Set the key with either:
+
+- Environment variable: `VOYAGE_API_KEY`
+- Config key: `models.providers.voyage.apiKey`
+
+For an interactive setup, run:
+
+```bash
+openclaw configure --section model
+```
+
+To make memory search use Voyage explicitly, set the memory search provider to
+`voyage` and choose a Voyage embedding model:
+
+```ts
+{
+  agents: {
+    defaults: {
+      memorySearch: {
+        provider: "voyage",
+        model: "voyage-3-large",
+      },
+    },
+  },
+  models: {
+    providers: {
+      voyage: {
+        apiKey: "${VOYAGE_API_KEY}",
+      },
+    },
+  },
+}
+```
+
+Verify the runtime credential and embedding provider path with:
+
+```bash
+openclaw memory status --deep
+```
+
+For the full memory embedding provider matrix and API key resolution order, see
+[Memory config](/reference/memory-config).
+
 ## Distribution
 
 - Package: `@openclaw/voyage-provider`


### PR DESCRIPTION
## Summary

Fixes #81798.

Clarifies the Voyage plugin reference with the existing credential contract:

- `VOYAGE_API_KEY`
- `models.providers.voyage.apiKey`
- explicit `agents.defaults.memorySearch.provider: "voyage"` setup
- `openclaw configure --section model`
- `openclaw memory status --deep`
- link to the memory config API key matrix

## Real behavior proof

**Behavior or issue addressed:** The public Voyage plugin reference now gives a direct setup path for the existing Voyage memory embedding credential contract instead of only saying that the plugin adds memory embedding provider support.

**Real environment tested:** Local OpenClaw checkout on Linux, branch `wolf/voyage-api-key-docs`, commit `444acb7a90`.

**Exact steps or command run after this patch:**

```text
node scripts/docs-list.js
node scripts/check-docs-mdx.mjs docs README.md
git diff --check
```

**Evidence after fix:** Terminal output from the docs checks:

```text
node scripts/docs-list.js
Listing all markdown files in docs folder:
...
plugins/reference/voyage.md - Adds memory embedding provider support.
...

node scripts/check-docs-mdx.mjs docs README.md
Docs MDX check passed (640 files, 15891ms).

git diff --check
<no output>
```

Source-backed credential evidence checked in the same checkout:

```text
docs/reference/memory-config.md:
Voyage | VOYAGE_API_KEY | models.providers.voyage.apiKey

extensions/voyage/openclaw.plugin.json:
"providerAuthEnvVars": {
  "voyage": ["VOYAGE_API_KEY"]
}
```

**Observed result after fix:** The changed Voyage page renders as valid MDX and now contains the env var, config key, explicit memory search provider snippet, configure command, runtime verification command, and link to the full memory config reference.

**What was not tested:** No live Voyage API request was made because this PR changes documentation only and does not modify runtime credential resolution.
