### PR TITLE
perf(channels,secrets): opt-in lazy mode to skip eager bundled channel artifact loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Gateway: add an authenticated `node.presence.alive` protocol event and `node.list` last-seen fields so background iOS wakes can mark paired nodes recently alive without treating them as connected. Carries forward #63123. Thanks @ngutman.
 - Gateway/chat: accept non-image attachments through `chat.send` by staging them as agent-readable media paths, while keeping unsupported RPC attachment paths explicit instead of silently dropping files. Fixes #48123. (#67572) Thanks @samzong.
 - Security/networking: add opt-in operator-managed outbound proxy routing (proxy.enabled + proxy.proxyUrl/OPENCLAW_PROXY_URL) with strict http:// forward-proxy validation, loopback-only Gateway bypass, and cleanup of proxy env/dispatcher state on exit. (#70044) Thanks @jesse-merhi and @joshavant.
+- Channels/Secrets: add opt-in `OPENCLAW_LAZY_BUNDLED_CHANNEL_ARTIFACTS=1` env gate that short-circuits the cold-path `loadBundledChannelPublicArtifact` wrappers to `undefined`, so thin clients (e.g. Happy) issuing `openclaw status --json` with a 10s `execFileSync` timeout no longer ETIMEDOUT on 4.27 installs with the full `plugin-runtime-deps` tree extracted. Thanks @chphch.
 
 ### Fixes
 

--- a/src/channels/plugins/doctor-contract-api.ts
+++ b/src/channels/plugins/doctor-contract-api.ts
@@ -18,6 +18,12 @@ function loadBundledChannelPublicArtifact(
   channelId: string,
   artifactBasenames: readonly string[],
 ): BundledChannelDoctorContractApi | undefined {
+  // Opt-in lazy mode: cold control-plane paths (CLI startup, doctor scans across all
+  // bundled channels) skip eager barrel materialization. Callers already handle
+  // `undefined` by falling through to bootstrap registry / metadata-only paths.
+  if (process.env.OPENCLAW_LAZY_BUNDLED_CHANNEL_ARTIFACTS === "1") {
+    return undefined;
+  }
   for (const artifactBasename of artifactBasenames) {
     try {
       return loadBundledPluginPublicArtifactModuleSync<BundledChannelDoctorContractApi>({

--- a/src/secrets/channel-contract-api.ts
+++ b/src/secrets/channel-contract-api.ts
@@ -25,6 +25,13 @@ function loadBundledChannelPublicArtifact(
   channelId: string,
   artifactBasenames: readonly string[],
 ): BundledChannelContractApi | undefined {
+  // Opt-in lazy mode: cold control-plane paths (CLI startup target-registry build,
+  // runtime config collectors iterating all bundled channels, security-surface
+  // scans) skip eager barrel materialization. Callers already handle `undefined`
+  // by falling through to bootstrap registry / metadata-only paths.
+  if (process.env.OPENCLAW_LAZY_BUNDLED_CHANNEL_ARTIFACTS === "1") {
+    return undefined;
+  }
   for (const artifactBasename of artifactBasenames) {
     try {
       return loadBundledPluginPublicArtifactModuleSync<BundledChannelContractApi>({


### PR DESCRIPTION
## Summary

Cold control-plane paths (CLI startup target-registry build, runtime config collectors iterating bundled channels, doctor scans) currently load every bundled channel's `contract-api.js` / `doctor-contract-api.js` barrel through `loadBundledChannelPublicArtifact`, regardless of which channels are enabled. On installs with the full `plugin-runtime-deps/openclaw-<ver>-<hash>/` tree extracted (~1.9 GB / ~70K files on 4.27), this blows past the 10s timeout that thin clients impose on `openclaw status --json` discovery calls.

- Problem: `openclaw status --json` exceeds the 10s `execFileSync` timeout enforced by thin clients (e.g. Happy's `runOpenClaw.ts`) on 4.27 installs with bundled plugin-runtime-deps extracted. Without the gate: ETIMEDOUT at ~10.06s. With the gate enabled: returns `gateway.url=ws://127.0.0.1:18789` in ~5.82s.
- Why it matters: After upgrading to 4.27, thin clients (Happy, scripts that wrap the CLI) cannot discover the local OpenClaw gateway. `src/plugins/CLAUDE.md` documents that discovery/activation flows should stay lazy: "do not eagerly import bundled plugin runtime barrels".
- What changed: `OPENCLAW_LAZY_BUNDLED_CHANNEL_ARTIFACTS=1` env gate at the top of both `loadBundledChannelPublicArtifact` wrappers (`src/channels/plugins/doctor-contract-api.ts`, `src/secrets/channel-contract-api.ts`). When set, the wrappers short-circuit to `undefined` before invoking `loadBundledPluginPublicArtifactModuleSync`. Existing callers (`legacy-config`, `target-registry-data`, `runtime-config-collectors-channels`) already gracefully handle `undefined` by falling through to bootstrap registry / metadata-only paths.
- What did NOT change (scope boundary): Default behavior is unchanged — env var is opt-in. Warm-path execution (`openclaw start`, channel send/receive, doctor when explicitly run) is not gated; the gate only applies at the entry of `loadBundledChannelPublicArtifact`, which serves cold-startup barrel materialization. No public API or type signature changes.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Integrations
- [x] Auth / tokens
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A (no upstream issue filed — happy to file if maintainers prefer issue-first triage for opt-in tuning gates).
- Related #N/A
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `loadBundledChannelPublicArtifact` iterates every bundled channel's contract-api barrel at the entry of cold-startup paths, regardless of which channels are enabled in the user's config. With `~/.openclaw/plugin-runtime-deps/openclaw-<ver>-<hash>/` containing ~70K files on 4.27, each barrel load triggers transitive imports that aggregate past the 10s thin-client timeout on cold disk caches.
- Missing detection / guardrail: There is no existing test asserting that `openclaw status --json` completes within a thin-client timeout budget. The invariant in `src/plugins/CLAUDE.md` ("Preserve laziness in discovery and activation flows... do not eagerly import bundled plugin runtime barrels") was not enforced at the channel-contract-api boundary.
- Contributing context: 4.27's plugin-runtime-deps extraction substantially increased on-disk footprint of bundled channels (~70K files for the full set), pushing eager-load latency over a timeout that earlier versions stayed under.

## Regression Test Plan

- Coverage level: [x] Existing coverage already sufficient (env-gate-specific unit tests welcome on request)
- Target test or file: `src/channels/plugins/doctor-contract-api.fast-path.test.ts`, `src/secrets/channel-contract-api.fast-path.test.ts`
- Scenario the test should lock in: when `OPENCLAW_LAZY_BUNDLED_CHANNEL_ARTIFACTS` is unset (default), the wrappers return the loaded artifact as today; when `=1`, they short-circuit to `undefined` before invoking `loadBundledPluginPublicArtifactModuleSync`.
- Why this is the smallest reliable guardrail: the gate is a single `if` at the wrapper entry, default behavior is preserved by existing fast-path tests, and the opt-in `return undefined` path is exercised by adjacent callers (`legacy-config`, `target-registry-data`, `runtime-config-collectors-channels`) that already cover the `undefined` fallback codepath.
- Existing test that already covers this (default path): yes — `doctor-contract-api.fast-path.test.ts`, `channel-contract-api.fast-path.test.ts`.
- If no new test is added, why not: keeping diff minimal; happy to add `OPENCLAW_LAZY_BUNDLED_CHANNEL_ARTIFACTS=1` env-stubbed cases on request.

## User-visible / Behavior Changes

None by default. Adds opt-in env var `OPENCLAW_LAZY_BUNDLED_CHANNEL_ARTIFACTS=1` for operators who hit the symptom. Happy to follow up with docs in `docs/install/` if accepted, or to make the default behavior contingent on a thin-client detection signal — open to maintainer preference.

## Diagram

```text
Before (default, 4.27 install w/ plugin-runtime-deps extracted):
  thin-client `openclaw status --json` (10s timeout)
    -> CLI startup
      -> loadBundledChannelDoctorContractApi(<every bundled channel>)
        -> loadBundledPluginPublicArtifactModuleSync (transitively heavy)
      -> ETIMEDOUT ~10.06s

After (OPENCLAW_LAZY_BUNDLED_CHANNEL_ARTIFACTS=1):
  thin-client `openclaw status --json` (10s timeout)
    -> CLI startup
      -> loadBundledChannelDoctorContractApi
        -> wrapper short-circuit -> undefined
      -> caller falls through to bootstrap registry / metadata-only path
    -> returns gateway.url in ~5.82s
```

## Security Impact

- New permissions/capabilities? **No.** Env var strictly reduces what is loaded.
- New trust boundaries? **No.**
- Secrets handling: unchanged. `src/secrets/channel-contract-api.ts` retains its existing behavior except for the opt-in short-circuit, which causes downstream consumers to fall through to bootstrap registry paths they already handle.

## Reproduction

Tested on a 4.27 install (`~/.openclaw/`) with full `plugin-runtime-deps/openclaw-2026.4.27-208b24df67f7/` extracted (~1.9 GB):

```js
// Happy's exact call shape (apps/cli/src/runOpenClaw.ts):
execFileSync("openclaw", ["status", "--json"], { timeout: 10_000 });
```

- Without env: ETIMEDOUT after 10.06s.
- With `OPENCLAW_LAZY_BUNDLED_CHANNEL_ARTIFACTS=1`: SUCCESS in 5.82s, returns `gateway.url=ws://127.0.0.1:18789`.

## AI-Assisted

This PR was authored with Claude Code assistance (author-driven). Status: **fully tested** against the reproduction above. Local verification:

- `pnpm install` clean (5.3s)
- `pnpm exec oxfmt --check --threads=1 src/channels/plugins/doctor-contract-api.ts src/secrets/channel-contract-api.ts` — pass
- `pnpm build` — pass
- `pnpm check:changed` — pass
- `OPENCLAW_VITEST_MAX_WORKERS=4 pnpm test:changed` — 308/309 files pass, 2531/2534 tests pass. Single failing file `src/video-generation/provider-registry.test.ts` (3 tests) **passes in isolation** (`pnpm exec vitest run --config test/vitest/vitest.unit-fast.config.ts src/video-generation/provider-registry.test.ts` → 3/3 pass in 1.18s). Failure mode is "MORE bundled providers loaded than expected" — opposite direction from what this PR's gate could affect (gate is opt-in default-off and only reduces what is loaded). Treating as pre-existing test isolation flakiness, unrelated to this change. Happy to investigate or attach a reproducer if maintainers want.
- `codex review --base origin/main` — not run; local `codex-cli 0.120.0` rejects current API (`gpt-5.5` model 400). Happy to re-run after upgrade if reviewer asks.
