### PR TITLE
feat(spec-center): add markdown-first spec management plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,6 +36,11 @@
       - any-glob-to-any-file:
           - "extensions/google-meet/**"
           - "docs/plugins/google-meet.md"
+"plugin: spec-center":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/spec-center/**"
+          - "docs/plugins/spec-center.md"
 "plugin: migrate-hermes":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/plugins/spec-center.md
+++ b/docs/plugins/spec-center.md
@@ -1,0 +1,78 @@
+---
+summary: "Markdown-first Spec Center plugin for auditable workflow previews"
+read_when:
+  - You want to import or preview Markdown-first specs
+  - You are evaluating Spec Center, Daily Run Spec, or workflow-spec behavior
+  - You are connecting repo-backed validation specs to OpenClaw
+title: "Spec Center"
+---
+
+Spec Center is a bundled plugin for Markdown-first specs. It gives teams a
+chat-first way to import a repo-backed spec, check the contract, and create a
+run preview before wiring deeper execution.
+
+P0 keeps the scope narrow: Spec Center is a plugin-owned surface, not a new core
+workflow language. It uses existing OpenClaw primitives where available and
+stores plugin state under the OpenClaw state directory.
+
+## Current P0
+
+- `/spec init` records team, owner, and approver metadata.
+- `/spec import` imports a local repo-backed Markdown spec directory.
+- legacy `daily.yaml`, `spec.yaml`, `daily.yml`, or `spec.yml` can be converted
+  into generated Markdown artifact metadata for review.
+- `/spec check` validates required artifacts, steps, dependencies, and missing
+  approval gates for high-risk steps.
+- `/spec preview` creates a run preview and, when a session key is available,
+  creates a managed Task Flow record for observability.
+- `/spec schedule`, `/spec pause`, and `/spec resume` store the Feishu-facing
+  schedule state before real Cron binding is wired.
+- `/spec report` summarizes the latest run, schedule, validation lanes, and
+  pending spec optimization.
+- `/spec optimize` creates a preview-only spec change proposal from a natural
+  language instruction.
+- `/spec approve` records the approval decision for a spec optimization
+  proposal.
+
+Remote Git import, real Cron execution, Feishu interactive cards, MR creation,
+and the full Native Spec Runtime are follow-up slices.
+
+## Markdown artifacts
+
+Spec Center expects these files when they exist:
+
+- `overview.md`
+- `requirements.md`
+- `design.md`
+- `tasks.md`
+- `coverage.md`
+- `runbook.md`
+
+`tasks.md` can use a compact table:
+
+```markdown
+| id                | type       | title                 | dependsOn         | outputs          |
+| ----------------- | ---------- | --------------------- | ----------------- | ---------------- |
+| validate_api      | tool_task  | Run API validation    | -                 | api_result       |
+| diagnose_failures | agent_task | Diagnose failed lanes | validate_api      | diagnosis_report |
+| approve_submit    | approval   | Approve submission    | diagnose_failures | -                |
+```
+
+## Commands
+
+```bash
+/spec init team=arkclaw owner=plugins-platform approvers=@alice,@bob
+/spec import id=arkclaw-plugins-daily-run repo=/path/to/arkclaw_plugins_spec path=specs/arkclaw-plugins-daily targetRepo=openclaw/openclaw
+/spec check arkclaw-plugins-daily-run
+/spec preview arkclaw-plugins-daily-run
+/spec schedule arkclaw-plugins-daily-run cron="0 9 * * 1-5" timezone=Asia/Shanghai reportTo=this_chat
+/spec report arkclaw-plugins-daily-run
+/spec optimize arkclaw-plugins-daily-run "add fixture validation lane"
+/spec approve opt-1234567890
+/spec pause arkclaw-plugins-daily-run
+/spec resume arkclaw-plugins-daily-run
+/spec status arkclaw-plugins-daily-run
+```
+
+Use the same text commands from Feishu. Feishu does not require native slash
+command registration for this P0 flow.

--- a/extensions/spec-center/api.ts
+++ b/extensions/spec-center/api.ts
@@ -1,0 +1,2 @@
+export { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+export { resolveStateDir } from "openclaw/plugin-sdk/state-paths";

--- a/extensions/spec-center/index.test.ts
+++ b/extensions/spec-center/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+describe("spec-center plugin", () => {
+  it("registers the /spec command", () => {
+    const registerCommand = vi.fn();
+    plugin.register({
+      id: "spec-center",
+      name: "Spec Center",
+      source: "bundled",
+      registrationMode: "full",
+      config: {},
+      pluginConfig: {},
+      runtime: {
+        state: {
+          resolveStateDir: () => "/tmp/openclaw-spec-center",
+        },
+      },
+      logger: console,
+      registerCommand,
+    } as never);
+
+    expect(registerCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "spec",
+        acceptsArgs: true,
+      }),
+    );
+  });
+});

--- a/extensions/spec-center/index.ts
+++ b/extensions/spec-center/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry, type OpenClawPluginApi } from "./api.js";
+import { registerSpecCommand } from "./src/command.js";
+
+export default definePluginEntry({
+  id: "spec-center",
+  name: "Spec Center",
+  description: "Markdown-first specs for auditable OpenClaw workflow runs.",
+  register(api: OpenClawPluginApi) {
+    registerSpecCommand(api);
+  },
+});

--- a/extensions/spec-center/openclaw.plugin.json
+++ b/extensions/spec-center/openclaw.plugin.json
@@ -1,0 +1,29 @@
+{
+  "id": "spec-center",
+  "activation": {
+    "onStartup": true
+  },
+  "name": "Spec Center",
+  "description": "Markdown-first specs for auditable OpenClaw workflow runs.",
+  "commandAliases": [
+    {
+      "name": "spec",
+      "kind": "runtime-slash"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "defaultSpecRoot": {
+        "type": "string"
+      }
+    }
+  },
+  "uiHints": {
+    "defaultSpecRoot": {
+      "label": "Default Spec Root",
+      "help": "Optional local directory used when /spec import omits repo."
+    }
+  }
+}

--- a/extensions/spec-center/package.json
+++ b/extensions/spec-center/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openclaw/spec-center",
+  "version": "2026.5.14",
+  "private": true,
+  "description": "OpenClaw Spec Center plugin",
+  "type": "module",
+  "dependencies": {
+    "yaml": "2.9.0"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*",
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/spec-center/src/command.test.ts
+++ b/extensions/spec-center/src/command.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+  OpenClawPluginApi,
+  OpenClawPluginCommandDefinition,
+  PluginCommandContext,
+} from "openclaw/plugin-sdk/core";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { describe, expect, it, vi } from "vitest";
+import { createSpecCommand } from "./command.js";
+
+async function makeMarkdownSpec() {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "spec-center-state-"));
+  const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "spec-center-repo-"));
+  const specDir = path.join(repoDir, "specs", "daily");
+  await fs.mkdir(specDir, { recursive: true });
+  await fs.writeFile(
+    path.join(specDir, "overview.md"),
+    "# Daily Validation\n\nRuns checks.",
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(specDir, "requirements.md"),
+    "# Requirements\n\nAll lanes are recorded.",
+    "utf8",
+  );
+  await fs.writeFile(path.join(specDir, "design.md"), "# Design\n\nNative runtime.", "utf8");
+  await fs.writeFile(
+    path.join(specDir, "tasks.md"),
+    [
+      "# Tasks",
+      "",
+      "| id | type | title | dependsOn | outputs |",
+      "| - | - | - | - | - |",
+      "| validate_api | tool_task | Run API validation | - | api_result |",
+      "| diagnose_failures | agent_task | Diagnose failures | validate_api | diagnosis_report |",
+      "| approve_submit | approval | Approve submission | diagnose_failures | - |",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(path.join(specDir, "coverage.md"), "# Coverage\n\nAPI lane.", "utf8");
+  await fs.writeFile(path.join(specDir, "runbook.md"), "# Runbook\n\nUse /spec preview.", "utf8");
+  return { stateDir, repoDir };
+}
+
+function createContext(args: string): PluginCommandContext {
+  return {
+    channel: "feishu",
+    isAuthorizedSender: true,
+    args,
+    commandBody: `/spec ${args}`,
+    config: {},
+    sessionKey: "agent:main:spec-test",
+    requestConversationBinding: async () => ({ status: "error", message: "unsupported" }),
+    detachConversationBinding: async () => ({ removed: false }),
+    getCurrentConversationBinding: async () => null,
+  };
+}
+
+async function run(command: OpenClawPluginCommandDefinition, args: string): Promise<string> {
+  const result = await command.handler(createContext(args));
+  if (typeof result.text !== "string") {
+    throw new Error("command did not return text");
+  }
+  return result.text;
+}
+
+describe("/spec command", () => {
+  it("imports, checks, previews, and stores a run for a local Markdown spec", async () => {
+    const { stateDir, repoDir } = await makeMarkdownSpec();
+    const createManaged = vi.fn(() => ({ flowId: "flow-spec-1" }));
+    const api = createTestPluginApi({
+      runtime: {
+        state: { resolveStateDir: () => stateDir },
+        tasks: {
+          managedFlows: {
+            bindSession: () =>
+              ({
+                createManaged,
+              }) as never,
+          },
+        },
+      } as unknown as OpenClawPluginApi["runtime"],
+    });
+    const command = createSpecCommand(api);
+
+    await expect(run(command, "init team=arkclaw owner=plugins-platform")).resolves.toContain(
+      "Spec Center initialized.",
+    );
+
+    const imported = await run(
+      command,
+      `import id=arkclaw-plugins-daily-run repo=${repoDir} path=specs/daily targetRepo=openclaw/openclaw`,
+    );
+    expect(imported).toContain("Spec imported.");
+    expect(imported).toContain("- steps: 3");
+    expect(imported).toContain("Spec check passed.");
+
+    await expect(run(command, "check arkclaw-plugins-daily-run")).resolves.toBe(
+      "Spec check passed.",
+    );
+
+    const preview = await run(command, "preview arkclaw-plugins-daily-run");
+    expect(preview).toContain("Spec run preview created.");
+    expect(preview).toContain("- flowId: flow-spec-1");
+    expect(preview).toContain("- Wave 1: validate_api");
+    expect(preview).toContain("- Wave 2: diagnose_failures");
+    expect(preview).toContain("- Wave 3: approve_submit");
+    expect(createManaged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        controllerId: "spec-center",
+        goal: "Preview Spec Center run for arkclaw-plugins-daily-run",
+      }),
+    );
+
+    await expect(run(command, "status arkclaw-plugins-daily-run")).resolves.toContain(
+      "latest run: spec-run-",
+    );
+
+    const scheduled = await run(
+      command,
+      'schedule arkclaw-plugins-daily-run cron="0 9 * * 1-5" timezone=Asia/Shanghai reportTo=this_chat',
+    );
+    expect(scheduled).toContain("Spec schedule updated.");
+    expect(scheduled).toContain("- status: active");
+
+    const report = await run(command, "report arkclaw-plugins-daily-run today");
+    expect(report).toContain("Spec Daily Report: Daily Validation");
+    expect(report).toContain("- schedule: 0 9 * * 1-5 Asia/Shanghai (active)");
+    expect(report).toContain("- validation lanes: validate_api");
+
+    const optimization = await run(
+      command,
+      'optimize arkclaw-plugins-daily-run "add fixture validation lane"',
+    );
+    expect(optimization).toContain("Spec optimization preview created.");
+    expect(optimization).toContain("- proposed files: requirements.md, coverage.md, tasks.md");
+    const optimizationId = optimization.match(/optimizationId: (opt-\d+)/)?.[1];
+    expect(optimizationId).toBeDefined();
+
+    const approved = await run(command, `approve ${optimizationId}`);
+    expect(approved).toContain("Spec approval recorded.");
+    expect(approved).toContain("- decision: approved");
+
+    await expect(run(command, "pause arkclaw-plugins-daily-run")).resolves.toContain(
+      "- status: paused",
+    );
+    await expect(run(command, "resume arkclaw-plugins-daily-run")).resolves.toContain(
+      "- status: active",
+    );
+  });
+});

--- a/extensions/spec-center/src/command.ts
+++ b/extensions/spec-center/src/command.ts
@@ -1,0 +1,472 @@
+import type {
+  OpenClawPluginApi,
+  OpenClawPluginCommandDefinition,
+  PluginCommandContext,
+  PluginCommandResult,
+} from "openclaw/plugin-sdk/core";
+import { resolveStateDir } from "../api.js";
+import { importSpecFromSource } from "./importer.js";
+import { checkSpec, formatRunPreview, formatSpecCheck } from "./preview.js";
+import { createPreviewRun } from "./runtime.js";
+import { createSpecCenterStore } from "./store.js";
+import type {
+  ImportSpecInput,
+  SpecApprovalRecord,
+  SpecArtifactName,
+  SpecCenterState,
+  SpecOptimizationRecord,
+  SpecRecord,
+  SpecScheduleRecord,
+} from "./types.js";
+
+export function registerSpecCommand(api: OpenClawPluginApi): void {
+  api.registerCommand(createSpecCommand(api));
+}
+
+export function createSpecCommand(api: OpenClawPluginApi): OpenClawPluginCommandDefinition {
+  return {
+    name: "spec",
+    description: "Manage Markdown-first specs and run previews.",
+    acceptsArgs: true,
+    handler: async (ctx) => handleSpecCommand({ api, ctx }),
+  };
+}
+
+async function handleSpecCommand(params: {
+  api: OpenClawPluginApi;
+  ctx: PluginCommandContext;
+}): Promise<PluginCommandResult> {
+  const args = tokenize(params.ctx.args ?? "");
+  const action = args[0]?.toLowerCase() ?? "help";
+  const store = createSpecCenterStore({
+    stateDir: params.api.runtime.state?.resolveStateDir?.() ?? resolveStateDir(),
+  });
+
+  try {
+    switch (action) {
+      case "init":
+        return await handleInit({ store, args });
+      case "import":
+        return await handleImport({ store, args });
+      case "list":
+        return { text: formatSpecList(await store.load()) };
+      case "status":
+        return { text: formatStatus(await store.load(), args[1]) };
+      case "check":
+        return { text: await handleCheck({ store, args }) };
+      case "preview":
+      case "run":
+        return { text: await handleRunPreview({ api: params.api, store, args, ctx: params.ctx }) };
+      case "schedule":
+        return { text: await handleSchedule({ store, args }) };
+      case "pause":
+        return { text: await handleScheduleStatus({ store, args, status: "paused" }) };
+      case "resume":
+        return { text: await handleScheduleStatus({ store, args, status: "active" }) };
+      case "report":
+        return { text: await handleReport({ store, args }) };
+      case "optimize":
+        return { text: await handleOptimize({ store, args }) };
+      case "approve":
+        return { text: await handleApprove({ store, args, ctx: params.ctx }) };
+      case "help":
+      default:
+        return { text: formatHelp() };
+    }
+  } catch (error) {
+    return { text: `Spec Center error: ${(error as Error).message}` };
+  }
+}
+
+async function handleInit(params: {
+  store: ReturnType<typeof createSpecCenterStore>;
+  args: string[];
+}): Promise<PluginCommandResult> {
+  const flags = parseFlags(params.args.slice(1));
+  const state = await params.store.load();
+  const next: SpecCenterState = {
+    ...state,
+    ...(flags.team ? { team: flags.team } : {}),
+    ...(flags.owner ? { owner: flags.owner } : {}),
+    approvers: flags.approvers ? flags.approvers.split(",").filter(Boolean) : state.approvers,
+  };
+  await params.store.save(next);
+  return {
+    text: [
+      "Spec Center initialized.",
+      `- team: ${next.team ?? "unset"}`,
+      `- owner: ${next.owner ?? "unset"}`,
+      `- approvers: ${next.approvers.length > 0 ? next.approvers.join(", ") : "unset"}`,
+    ].join("\n"),
+  };
+}
+
+async function handleImport(params: {
+  store: ReturnType<typeof createSpecCenterStore>;
+  args: string[];
+}): Promise<PluginCommandResult> {
+  const input = parseImportInput(params.args.slice(1));
+  const result = await importSpecFromSource(input);
+  await params.store.upsertSpec(result.spec);
+  return {
+    text: [
+      "Spec imported.",
+      `- specId: ${result.spec.id}`,
+      `- title: ${result.spec.title}`,
+      `- source: ${result.spec.source.repo}${result.spec.source.path === "." ? "" : `/${result.spec.source.path}`}`,
+      `- artifacts: ${result.spec.artifacts.length}`,
+      `- steps: ${result.spec.steps.length}`,
+      `- check: ${result.check.ok ? "passed" : "failed"}`,
+      result.spec.warnings.length > 0
+        ? `- warnings: ${result.spec.warnings.map((warning) => warning.code).join(", ")}`
+        : undefined,
+      "",
+      formatRunPreview(result.preview),
+    ]
+      .filter((line): line is string => line !== undefined)
+      .join("\n"),
+  };
+}
+
+async function handleCheck(params: {
+  store: ReturnType<typeof createSpecCenterStore>;
+  args: string[];
+}): Promise<string> {
+  const spec = await requireSpec(params.store, params.args[1]);
+  return formatSpecCheck(checkSpec(spec));
+}
+
+async function handleRunPreview(params: {
+  api: OpenClawPluginApi;
+  store: ReturnType<typeof createSpecCenterStore>;
+  args: string[];
+  ctx: PluginCommandContext;
+}): Promise<string> {
+  const spec = await requireSpec(params.store, params.args[1]);
+  const run = createPreviewRun({
+    api: params.api,
+    spec,
+    sessionKey: params.ctx.sessionKey,
+  });
+  await params.store.appendRun(run);
+  return [
+    "Spec run preview created.",
+    `- runId: ${run.runId}`,
+    run.flowId ? `- flowId: ${run.flowId}` : "- flowId: not created (no sessionKey/runtime)",
+    "",
+    formatRunPreview(run.preview),
+  ].join("\n");
+}
+
+async function handleSchedule(params: {
+  store: ReturnType<typeof createSpecCenterStore>;
+  args: string[];
+}): Promise<string> {
+  const spec = await requireSpec(params.store, params.args[1]);
+  const flags = parseFlags(params.args.slice(2));
+  const now = new Date().toISOString();
+  const schedule: SpecScheduleRecord = {
+    specId: spec.id,
+    cron: flags.cron ?? "0 9 * * 1-5",
+    timezone: flags.timezone ?? "Asia/Shanghai",
+    reportTo: flags.reportTo ?? "this_chat",
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+  };
+  await params.store.upsertSchedule(schedule);
+  return formatSchedule(schedule);
+}
+
+async function handleScheduleStatus(params: {
+  store: ReturnType<typeof createSpecCenterStore>;
+  args: string[];
+  status: SpecScheduleRecord["status"];
+}): Promise<string> {
+  const spec = await requireSpec(params.store, params.args[1]);
+  const state = await params.store.updateScheduleStatus(spec.id, params.status);
+  const schedule = state.schedules[spec.id];
+  if (!schedule) {
+    throw new Error(`No schedule found for spec: ${spec.id}`);
+  }
+  return formatSchedule(schedule);
+}
+
+async function handleReport(params: {
+  store: ReturnType<typeof createSpecCenterStore>;
+  args: string[];
+}): Promise<string> {
+  const state = await params.store.load();
+  const spec = requireSpecFromState(state, params.args[1]);
+  const latestRun = state.runs.find((run) => run.specId === spec.id);
+  const latestOptimization = state.optimizations.find((item) => item.specId === spec.id);
+  const schedule = state.schedules[spec.id];
+
+  return [
+    `Spec Daily Report: ${spec.title}`,
+    `- specId: ${spec.id}`,
+    `- targetRepo: ${spec.targetRepo ?? "unset"}`,
+    `- schedule: ${schedule ? `${schedule.cron} ${schedule.timezone} (${schedule.status})` : "not scheduled"}`,
+    `- latestRun: ${latestRun ? `${latestRun.runId} (${latestRun.status})` : "none"}`,
+    `- validation lanes: ${formatInlineList(latestRun?.preview.validationSteps ?? [])}`,
+    `- approval steps: ${formatInlineList(latestRun?.preview.approvalSteps ?? [])}`,
+    `- latest optimization: ${latestOptimization ? `${latestOptimization.optimizationId} (${latestOptimization.status})` : "none"}`,
+  ].join("\n");
+}
+
+async function handleOptimize(params: {
+  store: ReturnType<typeof createSpecCenterStore>;
+  args: string[];
+}): Promise<string> {
+  const spec = await requireSpec(params.store, params.args[1]);
+  const instruction = params.args.slice(2).join(" ").trim();
+  if (!instruction) {
+    throw new Error("Usage: /spec optimize <specId> <instruction>");
+  }
+  const state = await params.store.load();
+  const latestRun = state.runs.find((run) => run.specId === spec.id);
+  const optimization = buildOptimizationPreview({
+    spec,
+    instruction,
+    sourceRunId: latestRun?.runId,
+  });
+  await params.store.appendOptimization(optimization);
+  return formatOptimizationPreview(optimization);
+}
+
+async function handleApprove(params: {
+  store: ReturnType<typeof createSpecCenterStore>;
+  args: string[];
+  ctx: PluginCommandContext;
+}): Promise<string> {
+  const flags = parseFlags(params.args.slice(1));
+  const targetId = params.args.find((arg) => arg.startsWith("opt-")) ?? flags.optimizationId;
+  if (!targetId) {
+    throw new Error("Usage: /spec approve <optimizationId> [decision=approved|rejected]");
+  }
+  const decision = normalizeApprovalDecision(flags.decision ?? "approved");
+  const state = await params.store.updateOptimization(targetId, { status: decision });
+  const optimization = state.optimizations.find((item) => item.optimizationId === targetId);
+  if (!optimization) {
+    throw new Error(`Spec optimization not found: ${targetId}`);
+  }
+  const approval: SpecApprovalRecord = {
+    approvalId: `approval-${Date.now()}`,
+    specId: optimization.specId,
+    targetType: "spec_optimization",
+    targetId,
+    decision,
+    createdAt: new Date().toISOString(),
+    ...(params.ctx.senderId ? { actor: params.ctx.senderId } : {}),
+    ...(flags.note ? { note: flags.note } : {}),
+  };
+  await params.store.appendApproval(approval);
+  return [
+    "Spec approval recorded.",
+    `- approvalId: ${approval.approvalId}`,
+    `- target: ${approval.targetId}`,
+    `- decision: ${approval.decision}`,
+    `- next: ${approval.decision === "approved" ? "create an MR with the proposed Markdown spec changes" : "keep the current spec unchanged"}`,
+  ].join("\n");
+}
+
+async function requireSpec(
+  store: ReturnType<typeof createSpecCenterStore>,
+  maybeId: string | undefined,
+): Promise<SpecRecord> {
+  return requireSpecFromState(await store.load(), maybeId);
+}
+
+function requireSpecFromState(state: SpecCenterState, maybeId: string | undefined): SpecRecord {
+  const id = maybeId ?? Object.keys(state.specs)[0];
+  if (!id) {
+    throw new Error("No spec imported yet. Use /spec import first.");
+  }
+  const spec = state.specs[id];
+  if (!spec) {
+    throw new Error(`Spec not found: ${id}`);
+  }
+  return spec;
+}
+
+function parseImportInput(args: string[]): ImportSpecInput {
+  const flags = parseFlags(args);
+  const positional = args.filter((arg) => !arg.includes("="));
+  return {
+    id: flags.id ?? positional[0],
+    repo: flags.repo,
+    ref: flags.ref,
+    path: flags.path,
+    targetRepo: flags.targetRepo,
+  };
+}
+
+function formatSpecList(state: SpecCenterState): string {
+  const specs = Object.values(state.specs);
+  if (specs.length === 0) {
+    return "No specs imported.";
+  }
+  return [
+    "Imported specs:",
+    ...specs.map((spec) => `- ${spec.id}: ${spec.title} (${spec.status})`),
+  ].join("\n");
+}
+
+function formatStatus(state: SpecCenterState, maybeId: string | undefined): string {
+  const specs = Object.values(state.specs);
+  const spec = maybeId ? state.specs[maybeId] : specs[0];
+  if (!spec) {
+    return "No specs imported.";
+  }
+  const latestRun = state.runs.find((run) => run.specId === spec.id);
+  const schedule = state.schedules[spec.id];
+  const latestOptimization = state.optimizations.find((item) => item.specId === spec.id);
+  return [
+    `Spec status: ${spec.title}`,
+    `- specId: ${spec.id}`,
+    `- status: ${spec.status}`,
+    `- source: ${spec.source.repo}${spec.source.path === "." ? "" : `/${spec.source.path}`}`,
+    `- steps: ${spec.steps.length}`,
+    `- schedule: ${schedule ? `${schedule.cron} ${schedule.timezone} (${schedule.status})` : "none"}`,
+    `- latest run: ${latestRun ? `${latestRun.runId} (${latestRun.status})` : "none"}`,
+    `- latest optimization: ${latestOptimization ? `${latestOptimization.optimizationId} (${latestOptimization.status})` : "none"}`,
+  ].join("\n");
+}
+
+function formatSchedule(schedule: SpecScheduleRecord): string {
+  return [
+    "Spec schedule updated.",
+    `- specId: ${schedule.specId}`,
+    `- cron: ${schedule.cron}`,
+    `- timezone: ${schedule.timezone}`,
+    `- reportTo: ${schedule.reportTo}`,
+    `- status: ${schedule.status}`,
+  ].join("\n");
+}
+
+function buildOptimizationPreview(params: {
+  spec: SpecRecord;
+  instruction: string;
+  sourceRunId?: string;
+}): SpecOptimizationRecord {
+  const lower = params.instruction.toLowerCase();
+  const proposedFiles = new Set<SpecArtifactName>();
+  proposedFiles.add("requirements.md");
+  proposedFiles.add("coverage.md");
+  if (
+    lower.includes("task") ||
+    lower.includes("lane") ||
+    lower.includes("\u6821\u9a8c") ||
+    lower.includes("\u9a8c\u8bc1") ||
+    lower.includes("validation")
+  ) {
+    proposedFiles.add("tasks.md");
+  }
+  if (lower.includes("runbook") || lower.includes("\u5ba1\u6279") || lower.includes("approval")) {
+    proposedFiles.add("runbook.md");
+  }
+
+  return {
+    optimizationId: `opt-${Date.now()}`,
+    specId: params.spec.id,
+    instruction: params.instruction,
+    status: "previewed",
+    createdAt: new Date().toISOString(),
+    ...(params.sourceRunId ? { sourceRunId: params.sourceRunId } : {}),
+    proposedFiles: [...proposedFiles],
+    proposedChanges: [
+      "Add or update the requirement that captures the missing coverage.",
+      "Update coverage.md so future reports can track whether the gap is closed.",
+      proposedFiles.has("tasks.md")
+        ? "Add or update a validation task in tasks.md for the newly required lane."
+        : "Keep the existing execution tasks unchanged.",
+    ],
+    risk: "Changes scheduled validation behavior; approval is required before MR creation.",
+    dryRun: "passed",
+    dryRunReason: "Preview only; no repository files, branches, or schedules were modified.",
+  };
+}
+
+function formatOptimizationPreview(optimization: SpecOptimizationRecord): string {
+  return [
+    "Spec optimization preview created.",
+    `- optimizationId: ${optimization.optimizationId}`,
+    `- specId: ${optimization.specId}`,
+    `- sourceRunId: ${optimization.sourceRunId ?? "none"}`,
+    `- proposed files: ${optimization.proposedFiles.join(", ")}`,
+    `- risk: ${optimization.risk}`,
+    `- dry-run: ${optimization.dryRun} (${optimization.dryRunReason})`,
+    "",
+    "Proposed changes:",
+    ...optimization.proposedChanges.map((change) => `- ${change}`),
+    "",
+    `Approve with: /spec approve ${optimization.optimizationId}`,
+  ].join("\n");
+}
+
+function formatHelp(): string {
+  return [
+    "Spec Center commands:",
+    "- /spec init team=<team> owner=<owner> approvers=@a,@b",
+    "- /spec import id=<specId> repo=<local path> path=<spec dir> targetRepo=<owner/repo>",
+    "- /spec list",
+    "- /spec check <specId>",
+    "- /spec preview <specId>",
+    '- /spec schedule <specId> cron="0 9 * * 1-5" timezone=Asia/Shanghai reportTo=this_chat',
+    "- /spec report <specId>",
+    '- /spec optimize <specId> "describe the missing coverage or spec change"',
+    "- /spec approve <optimizationId> decision=approved|rejected",
+    "- /spec pause <specId>",
+    "- /spec resume <specId>",
+    "- /spec status <specId>",
+    "",
+    "P0 supports local repo-backed Markdown specs, legacy YAML conversion, run previews, schedule records, report summaries, and spec optimization previews. Remote Git import, real Cron execution, interactive Feishu cards, and MR creation are follow-up slices.",
+  ].join("\n");
+}
+
+function normalizeApprovalDecision(value: string): SpecOptimizationRecord["status"] {
+  switch (value) {
+    case "approved":
+    case "rejected":
+    case "changes_requested":
+      return value;
+    default:
+      throw new Error("decision must be approved, rejected, or changes_requested");
+  }
+}
+
+function formatInlineList(values: string[]): string {
+  return values.length > 0 ? values.join(", ") : "none";
+}
+
+function parseFlags(args: string[]): Record<string, string> {
+  const flags: Record<string, string> = {};
+  for (const arg of args) {
+    const index = arg.indexOf("=");
+    if (index <= 0) {
+      continue;
+    }
+    flags[arg.slice(0, index)] = unquote(arg.slice(index + 1));
+  }
+  return flags;
+}
+
+function tokenize(input: string): string[] {
+  const tokens = input.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? [];
+  return tokens.map(unquote);
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function createArkclawImportExample(repoPath: string): string {
+  return `/spec import id=arkclaw-plugins-daily-run repo=${repoPath} path=specs/arkclaw-plugins-daily targetRepo=openclaw/openclaw`;
+}

--- a/extensions/spec-center/src/importer.test.ts
+++ b/extensions/spec-center/src/importer.test.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { importSpecFromSource } from "./importer.js";
+
+async function makeSpecRepo() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "spec-center-import-"));
+  const specDir = path.join(dir, "specs", "arkclaw-plugins-daily");
+  await fs.mkdir(specDir, { recursive: true });
+  await fs.writeFile(
+    path.join(specDir, "daily.yaml"),
+    [
+      "id: arkclaw-plugins-daily-run",
+      "title: ArkClaw plugins daily validation and repair",
+      "type: daily_run",
+      "status: approved",
+      "version: 3",
+      "owner:",
+      "  team: arkclaw",
+      "  maintainer: plugins-platform",
+      "inputs:",
+      "  - id: targetRepo",
+      "    type: string",
+      "    default: openclaw/openclaw",
+      "steps:",
+      "  - id: validate_api",
+      "    type: tool_task",
+      "    title: Run API validation",
+      "    outputs:",
+      "      - api_result",
+      "  - id: validate_frontend",
+      "    type: tool_task",
+      "    title: Run frontend validation",
+      "    outputs:",
+      "      - frontend_result",
+      "  - id: diagnose_failures",
+      "    type: agent_task",
+      "    title: Diagnose failed lanes",
+      "    dependsOn:",
+      "      - validate_api",
+      "      - validate_frontend",
+      "    outputs:",
+      "      - diagnosis_report",
+      "  - id: approve_submit",
+      "    type: approval",
+      "    title: Approve code submission",
+      "    dependsOn:",
+      "      - diagnose_failures",
+      "  - id: publish_daily_report",
+      "    type: notify",
+      "    title: Publish daily report",
+      "    dependsOn:",
+      "      - approve_submit",
+      "",
+    ].join("\n"),
+  );
+  return { dir, specDir };
+}
+
+describe("importSpecFromSource", () => {
+  it("imports an arkclaw_plugins_spec-style legacy YAML as Markdown-first spec metadata", async () => {
+    const { dir } = await makeSpecRepo();
+
+    const result = await importSpecFromSource({
+      id: "arkclaw-plugins-daily-run",
+      repo: dir,
+      path: "specs/arkclaw-plugins-daily",
+      targetRepo: "openclaw/openclaw",
+    });
+
+    expect(result.spec).toMatchObject({
+      id: "arkclaw-plugins-daily-run",
+      title: "ArkClaw plugins daily validation and repair",
+      type: "daily_run",
+      status: "approved",
+      targetRepo: "openclaw/openclaw",
+      owner: {
+        team: "arkclaw",
+        maintainer: "plugins-platform",
+      },
+    });
+    expect(result.spec.artifacts.map((artifact) => artifact.name)).toEqual([
+      "overview.md",
+      "requirements.md",
+      "design.md",
+      "tasks.md",
+      "coverage.md",
+      "runbook.md",
+    ]);
+    expect(result.spec.warnings.map((warning) => warning.code)).toContain("legacy_yaml_imported");
+    expect(result.preview.waves.map((wave) => wave.steps)).toEqual([
+      ["validate_api", "validate_frontend"],
+      ["diagnose_failures"],
+      ["approve_submit"],
+      ["publish_daily_report"],
+    ]);
+    expect(result.check.ok).toBe(true);
+  });
+});

--- a/extensions/spec-center/src/importer.ts
+++ b/extensions/spec-center/src/importer.ts
@@ -1,0 +1,263 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { parseLegacyYamlSpec } from "./legacy-yaml.js";
+import {
+  extractMarkdownTitle,
+  isSpecArtifactName,
+  parseTasksMarkdown,
+  summarizeMarkdown,
+} from "./markdown.js";
+import { buildRunPreview, checkSpec } from "./preview.js";
+import {
+  SPEC_ARTIFACT_NAMES,
+  type ImportSpecInput,
+  type SpecArtifact,
+  type SpecImportResult,
+  type SpecRecord,
+  type SpecSource,
+  type SpecStep,
+} from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+export async function importSpecFromSource(input: ImportSpecInput): Promise<SpecImportResult> {
+  const artifactDir = resolveArtifactDir(input);
+  const now = new Date().toISOString();
+  const legacy = await readLegacySpec(artifactDir);
+  const markdownFiles = await readMarkdownArtifacts(artifactDir, legacy?.artifacts);
+  const tasksMarkdown = markdownFiles.get("tasks.md")?.content ?? "";
+  const steps = normalizeSteps(
+    legacy?.steps.length ? legacy.steps : parseTasksMarkdown(tasksMarkdown),
+  );
+  const id = normalizeSpecId(input.id ?? legacy?.id ?? path.basename(artifactDir));
+  const source = await buildSource({ input, artifactDir });
+  const artifacts: SpecArtifact[] = SPEC_ARTIFACT_NAMES.flatMap((name) => {
+    const artifact = markdownFiles.get(name);
+    if (!artifact) {
+      return [];
+    }
+    return [
+      {
+        name,
+        path: path.join(artifactDir, name),
+        ...(artifact.title ? { title: artifact.title } : {}),
+        ...(artifact.summary ? { summary: artifact.summary } : {}),
+        generated: artifact.generated,
+      },
+    ];
+  });
+  const targetRepo = input.targetRepo ?? legacy?.targetRepo;
+
+  const spec: SpecRecord = {
+    id,
+    title:
+      legacy?.title ??
+      markdownFiles.get("overview.md")?.title ??
+      markdownFiles.get("requirements.md")?.title ??
+      id,
+    type: legacy?.type ?? inferSpecType(id),
+    status: normalizeStatus(legacy?.status),
+    version: legacy?.version ?? 1,
+    ...(legacy?.owner ? { owner: legacy.owner } : {}),
+    ...(targetRepo ? { targetRepo } : {}),
+    source,
+    artifacts,
+    artifactDir,
+    steps,
+    warnings: collectWarnings({ artifacts, steps, legacyLoaded: Boolean(legacy) }),
+    importedAt: now,
+    updatedAt: now,
+  };
+  const check = checkSpec(spec);
+  const preview = buildRunPreview(spec);
+  return { spec, check, preview };
+}
+
+function resolveArtifactDir(input: ImportSpecInput): string {
+  const repo = input.repo?.trim();
+  const specPath = input.path?.trim() || ".";
+  if (repo && isLocalPath(repo)) {
+    return path.resolve(expandHome(repo), specPath);
+  }
+  if (!repo && input.path) {
+    return path.resolve(expandHome(specPath));
+  }
+  throw new Error("P0 import requires repo=<local path> or path=<local spec directory>.");
+}
+
+async function readMarkdownArtifacts(
+  artifactDir: string,
+  generated: Record<string, string> | undefined,
+): Promise<Map<string, { content: string; title?: string; summary?: string; generated: boolean }>> {
+  const result = new Map<
+    string,
+    { content: string; title?: string; summary?: string; generated: boolean }
+  >();
+  for (const name of SPEC_ARTIFACT_NAMES) {
+    const filePath = path.join(artifactDir, name);
+    const content = await readOptionalFile(filePath);
+    const fallback = generated?.[name];
+    const selected = content ?? fallback;
+    if (!selected) {
+      continue;
+    }
+    result.set(name, {
+      content: selected,
+      ...(extractMarkdownTitle(selected) ? { title: extractMarkdownTitle(selected) } : {}),
+      ...(summarizeMarkdown(selected) ? { summary: summarizeMarkdown(selected) } : {}),
+      generated: content === undefined,
+    });
+  }
+
+  const entries = await fs.readdir(artifactDir, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".md") || !isSpecArtifactName(entry.name)) {
+      continue;
+    }
+    if (result.has(entry.name)) {
+      continue;
+    }
+    const content = await fs.readFile(path.join(artifactDir, entry.name), "utf8");
+    result.set(entry.name, {
+      content,
+      ...(extractMarkdownTitle(content) ? { title: extractMarkdownTitle(content) } : {}),
+      ...(summarizeMarkdown(content) ? { summary: summarizeMarkdown(content) } : {}),
+      generated: false,
+    });
+  }
+  return result;
+}
+
+async function readLegacySpec(artifactDir: string) {
+  for (const name of ["daily.yaml", "daily.yml", "spec.yaml", "spec.yml"]) {
+    const content = await readOptionalFile(path.join(artifactDir, name));
+    if (content) {
+      return parseLegacyYamlSpec(content);
+    }
+  }
+  return undefined;
+}
+
+async function buildSource(params: {
+  input: ImportSpecInput;
+  artifactDir: string;
+}): Promise<SpecSource> {
+  const repo = params.input.repo?.trim();
+  const commit = await resolveGitCommit(params.artifactDir);
+  return {
+    kind: repo && isLocalPath(repo) ? "local" : "git",
+    repo: repo ?? params.artifactDir,
+    ...(params.input.ref ? { ref: params.input.ref } : {}),
+    path: params.input.path?.trim() || ".",
+    ...(commit ? { commit } : {}),
+  };
+}
+
+async function resolveGitCommit(cwd: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+      cwd,
+      timeout: 2_000,
+    });
+    const commit = stdout.trim();
+    return commit || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readOptionalFile(filePath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function normalizeSteps(steps: SpecStep[]): SpecStep[] {
+  const seen = new Set<string>();
+  return steps.filter((step) => {
+    if (!step.id || seen.has(step.id)) {
+      return false;
+    }
+    seen.add(step.id);
+    return true;
+  });
+}
+
+function collectWarnings(params: {
+  artifacts: SpecArtifact[];
+  steps: SpecStep[];
+  legacyLoaded: boolean;
+}) {
+  const warnings = [];
+  if (params.legacyLoaded) {
+    warnings.push({
+      code: "legacy_yaml_imported",
+      message: "Imported legacy YAML and generated Markdown-first artifacts for review.",
+    });
+  }
+  for (const artifact of params.artifacts) {
+    if (artifact.generated) {
+      warnings.push({
+        code: "generated_artifact",
+        message: `${artifact.name} was generated from legacy input and should be reviewed.`,
+      });
+    }
+  }
+  if (params.steps.length === 0) {
+    warnings.push({
+      code: "no_steps_detected",
+      message: "No executable steps were detected.",
+    });
+  }
+  return warnings;
+}
+
+function normalizeSpecId(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.:-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function normalizeStatus(value: string | undefined): SpecRecord["status"] {
+  switch (value) {
+    case "approved":
+    case "running":
+    case "succeeded":
+    case "failed":
+    case "blocked":
+    case "archived":
+    case "review":
+    case "draft":
+      return value;
+    default:
+      return "draft";
+  }
+}
+
+function inferSpecType(id: string): string {
+  return id.includes("daily") ? "daily_run" : "workflow";
+}
+
+function isLocalPath(value: string): boolean {
+  return value.startsWith(".") || value.startsWith("/") || value.startsWith("~");
+}
+
+function expandHome(value: string): string {
+  if (value === "~") {
+    return os.homedir();
+  }
+  if (value.startsWith("~/")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return value;
+}

--- a/extensions/spec-center/src/legacy-yaml.ts
+++ b/extensions/spec-center/src/legacy-yaml.ts
@@ -1,0 +1,266 @@
+import { parse as parseYaml } from "yaml";
+import type { SpecOwner, SpecStep } from "./types.js";
+
+type LegacyYamlRecord = Record<string, unknown>;
+
+export type LegacySpecDraft = {
+  id: string;
+  title: string;
+  type: string;
+  status: string;
+  version: number;
+  owner?: SpecOwner;
+  targetRepo?: string;
+  steps: SpecStep[];
+  artifacts: Record<string, string>;
+};
+
+export function parseLegacyYamlSpec(content: string): LegacySpecDraft {
+  const raw = parseYaml(content);
+  if (!isRecord(raw)) {
+    throw new Error("legacy YAML spec must be an object");
+  }
+
+  const id = readString(raw.id) ?? "imported-spec";
+  const title = readString(raw.title) ?? id;
+  const type = readString(raw.type) ?? "daily_run";
+  const status = readString(raw.status) ?? "draft";
+  const version = readNumber(raw.version) ?? 1;
+  const owner = readOwner(raw.owner);
+  const targetRepo = readInputsDefault(raw.inputs, "targetRepo");
+  const steps = readSteps(raw.steps);
+
+  return {
+    id,
+    title,
+    type,
+    status,
+    version,
+    ...(owner ? { owner } : {}),
+    ...(targetRepo ? { targetRepo } : {}),
+    steps,
+    artifacts: {
+      "overview.md": renderOverview({ id, title, type, status, version, owner, raw }),
+      "requirements.md": renderRequirements({ title, raw }),
+      "design.md": renderDesign({ raw }),
+      "tasks.md": renderTasks({ steps }),
+      "coverage.md": renderCoverage({ raw, steps }),
+      "runbook.md": renderRunbook({ id, raw }),
+    },
+  };
+}
+
+function renderOverview(params: {
+  id: string;
+  title: string;
+  type: string;
+  status: string;
+  version: number;
+  owner?: SpecOwner;
+  raw: LegacyYamlRecord;
+}): string {
+  const source = isRecord(params.raw.source) ? params.raw.source : {};
+  return [
+    `# ${params.title}`,
+    "",
+    `- id: ${params.id}`,
+    `- type: ${params.type}`,
+    `- status: ${params.status}`,
+    `- version: ${params.version}`,
+    params.owner?.team ? `- owner team: ${params.owner.team}` : undefined,
+    params.owner?.maintainer ? `- maintainer: ${params.owner.maintainer}` : undefined,
+    readString(source.repo) ? `- source repo: ${readString(source.repo)}` : undefined,
+    readString(source.path) ? `- source path: ${readString(source.path)}` : undefined,
+    "",
+    "This Markdown artifact was generated from a legacy YAML spec so it can be reviewed as a human-readable contract.",
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join("\n");
+}
+
+function renderRequirements(params: { title: string; raw: LegacyYamlRecord }): string {
+  const validation = isRecord(params.raw.validation) ? params.raw.validation : {};
+  const success = Array.isArray(validation.success) ? validation.success : [];
+  const lines = [
+    `# Requirements for ${params.title}`,
+    "",
+    "## Execution Requirements",
+    "",
+    "- The run must record every validation lane before producing a report.",
+    "- Failed lanes must be diagnosed before any fix is proposed.",
+    "- Code or spec changes must require approval before branch push or MR creation.",
+    "",
+    "## Success Signals",
+    "",
+    ...success.map((item) => `- ${String(item)}`),
+  ];
+  return lines.join("\n");
+}
+
+function renderDesign(params: { raw: LegacyYamlRecord }): string {
+  const trigger = isRecord(params.raw.trigger) ? params.raw.trigger : {};
+  const execution = isRecord(params.raw.execution) ? params.raw.execution : {};
+  return [
+    "# Design",
+    "",
+    "## Trigger",
+    "",
+    `- type: ${readString(trigger.type) ?? "manual"}`,
+    readString(trigger.schedule) ? `- schedule: ${readString(trigger.schedule)}` : undefined,
+    readString(trigger.timezone) ? `- timezone: ${readString(trigger.timezone)}` : undefined,
+    "",
+    "## Runtime",
+    "",
+    `- runtime: ${readString(execution.runtime) ?? "native-spec"}`,
+    readNumber(execution.maxParallelSteps)
+      ? `- max parallel steps: ${readNumber(execution.maxParallelSteps)}`
+      : undefined,
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join("\n");
+}
+
+function renderTasks(params: { steps: SpecStep[] }): string {
+  return [
+    "# Tasks",
+    "",
+    "| id | type | title | dependsOn | outputs |",
+    "| - | - | - | - | - |",
+    ...params.steps.map((step) =>
+      [
+        "|",
+        step.id,
+        "|",
+        step.type,
+        "|",
+        step.title.replaceAll("|", "/"),
+        "|",
+        step.dependsOn.length > 0 ? step.dependsOn.join(",") : "-",
+        "|",
+        step.outputs.length > 0 ? step.outputs.join(",") : "-",
+        "|",
+      ].join(" "),
+    ),
+  ].join("\n");
+}
+
+function renderCoverage(params: { raw: LegacyYamlRecord; steps: SpecStep[] }): string {
+  const laneSteps = params.steps.filter((step) => step.id.startsWith("validate_"));
+  return [
+    "# Coverage",
+    "",
+    "## Validation Lanes",
+    "",
+    ...(laneSteps.length > 0
+      ? laneSteps.map((step) => `- ${step.id}: ${step.title}`)
+      : ["- No validation lane was detected."]),
+    "",
+    "## Gap Detection",
+    "",
+    "- Daily runs should report missing validation lanes, stale rules, uncovered changed paths, and flaky masking.",
+  ].join("\n");
+}
+
+function renderRunbook(params: { id: string; raw: LegacyYamlRecord }): string {
+  return [
+    `# Runbook for ${params.id}`,
+    "",
+    "## Feishu Commands",
+    "",
+    `- /spec check ${params.id}`,
+    `- /spec preview ${params.id}`,
+    `- /spec run ${params.id}`,
+    "",
+    "## Approval",
+    "",
+    "- Branch push, MR creation, release, and changes to scheduled validation behavior require explicit approval.",
+  ].join("\n");
+}
+
+function readSteps(value: unknown): SpecStep[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((entry): SpecStep[] => {
+    if (!isRecord(entry)) {
+      return [];
+    }
+    const id = readString(entry.id);
+    if (!id) {
+      return [];
+    }
+    const type = normalizeStepType(readString(entry.type));
+    return [
+      {
+        id,
+        type,
+        title: readString(entry.title) ?? id,
+        dependsOn: readStringArray(entry.dependsOn),
+        outputs: readStringArray(entry.outputs),
+        ...(readString(entry.task) ? { task: readString(entry.task) } : {}),
+        ...(readString(entry.tool) ? { tool: readString(entry.tool) } : {}),
+        ...(isRecord(entry.condition) ? { condition: JSON.stringify(entry.condition) } : {}),
+      },
+    ];
+  });
+}
+
+function normalizeStepType(value: string | undefined): SpecStep["type"] {
+  switch (value) {
+    case "tool_task":
+    case "agent_task":
+    case "approval":
+    case "validation":
+    case "notify":
+      return value;
+    default:
+      return "agent_task";
+  }
+}
+
+function readOwner(value: unknown): SpecOwner | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const team = readString(value.team);
+  const maintainer = readString(value.maintainer);
+  if (!team && !maintainer) {
+    return undefined;
+  }
+  return {
+    ...(team ? { team } : {}),
+    ...(maintainer ? { maintainer } : {}),
+  };
+}
+
+function readInputsDefault(value: unknown, id: string): string | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  for (const input of value) {
+    if (!isRecord(input) || readString(input.id) !== id) {
+      continue;
+    }
+    return readString(input.default);
+  }
+  return undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((item) => (typeof item === "string" ? item.trim() : "")).filter(Boolean);
+}
+
+function isRecord(value: unknown): value is LegacyYamlRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/extensions/spec-center/src/markdown.ts
+++ b/extensions/spec-center/src/markdown.ts
@@ -1,0 +1,114 @@
+import { SPEC_ARTIFACT_NAMES, type SpecArtifactName, type SpecStep } from "./types.js";
+
+export function extractMarkdownTitle(markdown: string): string | undefined {
+  const lines = markdown.split(/\r?\n/);
+  for (const line of lines) {
+    const match = line.match(/^#\s+(.+?)\s*$/);
+    if (match?.[1]) {
+      return match[1].trim();
+    }
+  }
+  return undefined;
+}
+
+export function summarizeMarkdown(markdown: string): string | undefined {
+  const lines = markdown
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#") && !line.startsWith("|"));
+  const first = lines[0];
+  if (!first) {
+    return undefined;
+  }
+  return first.length > 160 ? `${first.slice(0, 157)}...` : first;
+}
+
+export function isSpecArtifactName(name: string): name is SpecArtifactName {
+  return (SPEC_ARTIFACT_NAMES as readonly string[]).includes(name);
+}
+
+export function parseTasksMarkdown(markdown: string): SpecStep[] {
+  const steps: SpecStep[] = [];
+  const lines = markdown.split(/\r?\n/);
+
+  for (const line of lines) {
+    const table = parseTableStepLine(line);
+    if (table) {
+      steps.push(table);
+      continue;
+    }
+
+    const heading = line.match(/^#{2,4}\s+([a-zA-Z0-9_.:-]+)\s*[-:]\s*(.+?)\s*$/);
+    if (!heading?.[1] || !heading[2]) {
+      continue;
+    }
+    steps.push({
+      id: heading[1],
+      type: "agent_task",
+      title: heading[2].trim(),
+      dependsOn: [],
+      outputs: [],
+    });
+  }
+
+  return dedupeSteps(steps);
+}
+
+function parseTableStepLine(line: string): SpecStep | undefined {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|") || /^\|\s*-+/.test(trimmed)) {
+    return undefined;
+  }
+  const cells = trimmed
+    .slice(1, trimmed.endsWith("|") ? -1 : undefined)
+    .split("|")
+    .map((cell) => cell.trim());
+  if (cells.length < 3) {
+    return undefined;
+  }
+  const [idCell, typeCell, titleCell, dependsCell = "", outputsCell = ""] = cells;
+  if (!idCell || idCell.toLowerCase() === "id" || !/^[a-zA-Z0-9_.:-]+$/.test(idCell)) {
+    return undefined;
+  }
+  return {
+    id: idCell,
+    type: normalizeStepType(typeCell),
+    title: titleCell || idCell,
+    dependsOn: parseListCell(dependsCell),
+    outputs: parseListCell(outputsCell),
+  };
+}
+
+function normalizeStepType(raw: string): SpecStep["type"] {
+  switch (raw.trim()) {
+    case "tool_task":
+    case "agent_task":
+    case "approval":
+    case "validation":
+    case "notify":
+      return raw.trim() as SpecStep["type"];
+    default:
+      return "agent_task";
+  }
+}
+
+function parseListCell(raw: string): string[] {
+  return raw
+    .split(/[,\s]+/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .filter((item) => item !== "-");
+}
+
+function dedupeSteps(steps: SpecStep[]): SpecStep[] {
+  const seen = new Set<string>();
+  const result: SpecStep[] = [];
+  for (const step of steps) {
+    if (seen.has(step.id)) {
+      continue;
+    }
+    seen.add(step.id);
+    result.push(step);
+  }
+  return result;
+}

--- a/extensions/spec-center/src/preview.ts
+++ b/extensions/spec-center/src/preview.ts
@@ -1,0 +1,141 @@
+import type {
+  SpecCheckIssue,
+  SpecCheckResult,
+  SpecRecord,
+  SpecRunPreview,
+  SpecStep,
+} from "./types.js";
+
+export function checkSpec(spec: SpecRecord): SpecCheckResult {
+  const issues: SpecCheckIssue[] = [];
+  const artifactNames = new Set(spec.artifacts.map((artifact) => artifact.name));
+
+  for (const required of ["overview.md", "requirements.md", "tasks.md", "runbook.md"] as const) {
+    if (!artifactNames.has(required)) {
+      issues.push({
+        severity: "error",
+        code: "missing_artifact",
+        message: `Missing required spec artifact: ${required}`,
+      });
+    }
+  }
+
+  if (spec.steps.length === 0) {
+    issues.push({
+      severity: "error",
+      code: "missing_steps",
+      message: "Spec must define at least one executable step in tasks.md or legacy YAML.",
+    });
+  }
+
+  const ids = new Set(spec.steps.map((step) => step.id));
+  for (const step of spec.steps) {
+    for (const dependency of step.dependsOn) {
+      if (!ids.has(dependency)) {
+        issues.push({
+          severity: "error",
+          code: "unknown_dependency",
+          message: `Step ${step.id} depends on unknown step ${dependency}.`,
+        });
+      }
+    }
+  }
+
+  if (spec.steps.some(isHighRiskStep) && !spec.steps.some((step) => step.type === "approval")) {
+    issues.push({
+      severity: "warning",
+      code: "approval_recommended",
+      message: "Spec includes high-risk submission or fix steps but has no approval step.",
+    });
+  }
+
+  return {
+    ok: issues.every((issue) => issue.severity !== "error"),
+    issues,
+  };
+}
+
+export function buildRunPreview(spec: SpecRecord): SpecRunPreview {
+  const check = checkSpec(spec);
+  return {
+    specId: spec.id,
+    title: spec.title,
+    stepCount: spec.steps.length,
+    waves: buildWaves(spec.steps),
+    approvalSteps: spec.steps.filter((step) => step.type === "approval").map((step) => step.id),
+    validationSteps: spec.steps
+      .filter((step) => step.type === "validation" || step.id.startsWith("validate_"))
+      .map((step) => step.id),
+    issues: check.issues,
+  };
+}
+
+export function formatSpecCheck(result: SpecCheckResult): string {
+  if (result.issues.length === 0) {
+    return "Spec check passed.";
+  }
+  return [
+    result.ok ? "Spec check passed with warnings:" : "Spec check failed:",
+    ...result.issues.map((issue) => `- ${issue.severity}: ${issue.code} - ${issue.message}`),
+  ].join("\n");
+}
+
+export function formatRunPreview(preview: SpecRunPreview): string {
+  const waves =
+    preview.waves.length > 0
+      ? preview.waves.map((wave) => `- Wave ${wave.wave}: ${wave.steps.join(", ")}`).join("\n")
+      : "- No executable waves.";
+  const approvals = preview.approvalSteps.length > 0 ? preview.approvalSteps.join(", ") : "none";
+  const validations =
+    preview.validationSteps.length > 0 ? preview.validationSteps.join(", ") : "none";
+  return [
+    `Spec Run Preview: ${preview.title}`,
+    `- specId: ${preview.specId}`,
+    `- steps: ${preview.stepCount}`,
+    `- validation steps: ${validations}`,
+    `- approval steps: ${approvals}`,
+    "",
+    waves,
+    "",
+    formatSpecCheck({
+      ok: preview.issues.every((issue) => issue.severity !== "error"),
+      issues: preview.issues,
+    }),
+  ].join("\n");
+}
+
+function buildWaves(steps: SpecStep[]): Array<{ wave: number; steps: string[] }> {
+  const remaining = new Map(steps.map((step) => [step.id, step]));
+  const completed = new Set<string>();
+  const waves: Array<{ wave: number; steps: string[] }> = [];
+
+  while (remaining.size > 0) {
+    const ready = [...remaining.values()].filter((step) =>
+      step.dependsOn.every((dependency) => completed.has(dependency)),
+    );
+    if (ready.length === 0) {
+      waves.push({ wave: waves.length + 1, steps: [...remaining.keys()] });
+      break;
+    }
+    for (const step of ready) {
+      remaining.delete(step.id);
+      completed.add(step.id);
+    }
+    waves.push({ wave: waves.length + 1, steps: ready.map((step) => step.id) });
+  }
+
+  return waves;
+}
+
+function isHighRiskStep(step: SpecStep): boolean {
+  const text = `${step.id} ${step.title} ${step.task ?? ""} ${step.tool ?? ""}`.toLowerCase();
+  return (
+    text.includes("fix") ||
+    text.includes("submit") ||
+    text.includes("push") ||
+    text.includes("merge") ||
+    text.includes("publish") ||
+    text.includes("mr") ||
+    text.includes("pr")
+  );
+}

--- a/extensions/spec-center/src/runtime.ts
+++ b/extensions/spec-center/src/runtime.ts
@@ -1,0 +1,43 @@
+import type { OpenClawPluginApi } from "../api.js";
+import { buildRunPreview } from "./preview.js";
+import type { SpecRecord, SpecRunRecord } from "./types.js";
+
+export function createPreviewRun(params: {
+  api: Pick<OpenClawPluginApi, "runtime" | "config">;
+  spec: SpecRecord;
+  sessionKey?: string;
+}): SpecRunRecord {
+  const preview = buildRunPreview(params.spec);
+  const runId = `spec-run-${Date.now()}`;
+  const createdAt = new Date().toISOString();
+  const sessionKey = params.sessionKey?.trim();
+  let flowId: string | undefined;
+
+  if (sessionKey) {
+    try {
+      const flow = params.api.runtime.tasks.managedFlows.bindSession({ sessionKey }).createManaged({
+        controllerId: "spec-center",
+        goal: `Preview Spec Center run for ${params.spec.id}`,
+        status: "queued",
+        currentStep: preview.waves[0]?.steps[0] ?? null,
+        stateJson: {
+          specId: params.spec.id,
+          previewOnly: true,
+          waves: preview.waves,
+        },
+      });
+      flowId = flow.flowId;
+    } catch {
+      flowId = undefined;
+    }
+  }
+
+  return {
+    runId,
+    specId: params.spec.id,
+    status: "previewed",
+    createdAt,
+    ...(flowId ? { flowId } : {}),
+    preview,
+  };
+}

--- a/extensions/spec-center/src/store.ts
+++ b/extensions/spec-center/src/store.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+  SpecApprovalRecord,
+  SpecCenterState,
+  SpecOptimizationRecord,
+  SpecRecord,
+  SpecRunRecord,
+  SpecScheduleRecord,
+} from "./types.js";
+
+const STATE_FILE = "spec-center.json";
+
+export type SpecCenterStore = {
+  load: () => Promise<SpecCenterState>;
+  save: (state: SpecCenterState) => Promise<void>;
+  upsertSpec: (spec: SpecRecord) => Promise<SpecCenterState>;
+  appendRun: (run: SpecRunRecord) => Promise<SpecCenterState>;
+  upsertSchedule: (schedule: SpecScheduleRecord) => Promise<SpecCenterState>;
+  updateScheduleStatus: (
+    specId: string,
+    status: SpecScheduleRecord["status"],
+  ) => Promise<SpecCenterState>;
+  appendOptimization: (optimization: SpecOptimizationRecord) => Promise<SpecCenterState>;
+  updateOptimization: (
+    optimizationId: string,
+    patch: Partial<SpecOptimizationRecord>,
+  ) => Promise<SpecCenterState>;
+  appendApproval: (approval: SpecApprovalRecord) => Promise<SpecCenterState>;
+};
+
+export function createEmptyState(): SpecCenterState {
+  return {
+    version: 1,
+    approvers: [],
+    specs: {},
+    runs: [],
+    schedules: {},
+    optimizations: [],
+    approvals: [],
+  };
+}
+
+export function resolveSpecCenterStatePath(stateDir: string): string {
+  return path.join(stateDir, "spec-center", STATE_FILE);
+}
+
+export function createSpecCenterStore(params: { stateDir: string }): SpecCenterStore {
+  const statePath = resolveSpecCenterStatePath(params.stateDir);
+
+  async function load(): Promise<SpecCenterState> {
+    try {
+      const parsed = JSON.parse(await fs.readFile(statePath, "utf8")) as unknown;
+      return normalizeState(parsed);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return createEmptyState();
+      }
+      throw error;
+    }
+  }
+
+  async function save(state: SpecCenterState): Promise<void> {
+    await fs.mkdir(path.dirname(statePath), { recursive: true });
+    const tmpPath = `${statePath}.${process.pid}.tmp`;
+    await fs.writeFile(tmpPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+    await fs.rename(tmpPath, statePath);
+  }
+
+  return {
+    load,
+    save,
+    async upsertSpec(spec) {
+      const state = await load();
+      const next: SpecCenterState = {
+        ...state,
+        specs: {
+          ...state.specs,
+          [spec.id]: spec,
+        },
+      };
+      await save(next);
+      return next;
+    },
+    async appendRun(run) {
+      const state = await load();
+      const next: SpecCenterState = {
+        ...state,
+        runs: [run, ...state.runs].slice(0, 100),
+      };
+      await save(next);
+      return next;
+    },
+    async upsertSchedule(schedule) {
+      const state = await load();
+      const next: SpecCenterState = {
+        ...state,
+        schedules: {
+          ...state.schedules,
+          [schedule.specId]: schedule,
+        },
+      };
+      await save(next);
+      return next;
+    },
+    async updateScheduleStatus(specId, status) {
+      const state = await load();
+      const existing = state.schedules[specId];
+      if (!existing) {
+        throw new Error(`No schedule found for spec: ${specId}`);
+      }
+      const next: SpecCenterState = {
+        ...state,
+        schedules: {
+          ...state.schedules,
+          [specId]: {
+            ...existing,
+            status,
+            updatedAt: new Date().toISOString(),
+          },
+        },
+      };
+      await save(next);
+      return next;
+    },
+    async appendOptimization(optimization) {
+      const state = await load();
+      const next: SpecCenterState = {
+        ...state,
+        optimizations: [optimization, ...state.optimizations].slice(0, 100),
+      };
+      await save(next);
+      return next;
+    },
+    async updateOptimization(optimizationId, patch) {
+      const state = await load();
+      let found = false;
+      const optimizations = state.optimizations.map((optimization) => {
+        if (optimization.optimizationId !== optimizationId) {
+          return optimization;
+        }
+        found = true;
+        return {
+          ...optimization,
+          ...patch,
+        };
+      });
+      if (!found) {
+        throw new Error(`Spec optimization not found: ${optimizationId}`);
+      }
+      const next: SpecCenterState = {
+        ...state,
+        optimizations,
+      };
+      await save(next);
+      return next;
+    },
+    async appendApproval(approval) {
+      const state = await load();
+      const next: SpecCenterState = {
+        ...state,
+        approvals: [approval, ...state.approvals].slice(0, 100),
+      };
+      await save(next);
+      return next;
+    },
+  };
+}
+
+function normalizeState(value: unknown): SpecCenterState {
+  if (!isRecord(value)) {
+    return createEmptyState();
+  }
+  const specs = isRecord(value.specs) ? (value.specs as Record<string, SpecRecord>) : {};
+  const runs = Array.isArray(value.runs) ? (value.runs as SpecRunRecord[]) : [];
+  const schedules = isRecord(value.schedules)
+    ? (value.schedules as Record<string, SpecScheduleRecord>)
+    : {};
+  const optimizations = Array.isArray(value.optimizations)
+    ? (value.optimizations as SpecOptimizationRecord[])
+    : [];
+  const approvals = Array.isArray(value.approvals) ? (value.approvals as SpecApprovalRecord[]) : [];
+  return {
+    version: 1,
+    ...(typeof value.team === "string" ? { team: value.team } : {}),
+    ...(typeof value.owner === "string" ? { owner: value.owner } : {}),
+    approvers: Array.isArray(value.approvers)
+      ? value.approvers.filter((entry): entry is string => typeof entry === "string")
+      : [],
+    specs,
+    runs,
+    schedules,
+    optimizations,
+    approvals,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/extensions/spec-center/src/types.ts
+++ b/extensions/spec-center/src/types.ts
@@ -1,0 +1,178 @@
+export const SPEC_ARTIFACT_NAMES = [
+  "overview.md",
+  "requirements.md",
+  "design.md",
+  "tasks.md",
+  "coverage.md",
+  "runbook.md",
+] as const;
+
+export type SpecArtifactName = (typeof SPEC_ARTIFACT_NAMES)[number];
+
+export type SpecLifecycleStatus =
+  | "draft"
+  | "review"
+  | "approved"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "blocked"
+  | "archived";
+
+export type SpecSource = {
+  kind: "git" | "local";
+  repo: string;
+  ref?: string;
+  path: string;
+  commit?: string;
+};
+
+export type SpecOwner = {
+  team?: string;
+  maintainer?: string;
+};
+
+export type SpecArtifact = {
+  name: SpecArtifactName;
+  path: string;
+  title?: string;
+  summary?: string;
+  generated: boolean;
+};
+
+export type SpecStepType = "agent_task" | "tool_task" | "approval" | "validation" | "notify";
+
+export type SpecStep = {
+  id: string;
+  type: SpecStepType;
+  title: string;
+  dependsOn: string[];
+  condition?: string;
+  outputs: string[];
+  task?: string;
+  tool?: string;
+};
+
+export type SpecImportWarning = {
+  code: string;
+  message: string;
+};
+
+export type SpecRecord = {
+  id: string;
+  title: string;
+  type: string;
+  status: SpecLifecycleStatus;
+  version: number;
+  owner?: SpecOwner;
+  targetRepo?: string;
+  source: SpecSource;
+  artifacts: SpecArtifact[];
+  artifactDir: string;
+  steps: SpecStep[];
+  warnings: SpecImportWarning[];
+  importedAt: string;
+  updatedAt: string;
+};
+
+export type SpecCheckIssueSeverity = "error" | "warning";
+
+export type SpecCheckIssue = {
+  severity: SpecCheckIssueSeverity;
+  code: string;
+  message: string;
+};
+
+export type SpecCheckResult = {
+  ok: boolean;
+  issues: SpecCheckIssue[];
+};
+
+export type SpecPreviewWave = {
+  wave: number;
+  steps: string[];
+};
+
+export type SpecRunPreview = {
+  specId: string;
+  title: string;
+  stepCount: number;
+  waves: SpecPreviewWave[];
+  approvalSteps: string[];
+  validationSteps: string[];
+  issues: SpecCheckIssue[];
+};
+
+export type SpecRunStatus = "previewed" | "queued" | "running" | "succeeded" | "failed" | "blocked";
+
+export type SpecRunRecord = {
+  runId: string;
+  specId: string;
+  status: SpecRunStatus;
+  createdAt: string;
+  flowId?: string;
+  preview: SpecRunPreview;
+};
+
+export type SpecScheduleRecord = {
+  specId: string;
+  cron: string;
+  timezone: string;
+  reportTo: string;
+  status: "active" | "paused";
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type SpecOptimizationStatus = "previewed" | "approved" | "rejected" | "changes_requested";
+
+export type SpecOptimizationRecord = {
+  optimizationId: string;
+  specId: string;
+  instruction: string;
+  status: SpecOptimizationStatus;
+  createdAt: string;
+  sourceRunId?: string;
+  proposedFiles: SpecArtifactName[];
+  proposedChanges: string[];
+  risk: string;
+  dryRun: "passed" | "blocked";
+  dryRunReason: string;
+};
+
+export type SpecApprovalRecord = {
+  approvalId: string;
+  specId: string;
+  targetType: "spec_optimization";
+  targetId: string;
+  decision: SpecOptimizationStatus;
+  createdAt: string;
+  actor?: string;
+  note?: string;
+};
+
+export type SpecCenterState = {
+  version: 1;
+  team?: string;
+  owner?: string;
+  approvers: string[];
+  specs: Record<string, SpecRecord>;
+  runs: SpecRunRecord[];
+  schedules: Record<string, SpecScheduleRecord>;
+  optimizations: SpecOptimizationRecord[];
+  approvals: SpecApprovalRecord[];
+};
+
+export type ImportSpecInput = {
+  id?: string;
+  repo?: string;
+  ref?: string;
+  path?: string;
+  targetRepo?: string;
+};
+
+export type SpecImportResult = {
+  spec: SpecRecord;
+  check: SpecCheckResult;
+  preview: SpecRunPreview;
+};

--- a/extensions/spec-center/tsconfig.json
+++ b/extensions/spec-center/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1060,6 +1060,19 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/spec-center:
+    dependencies:
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/mistral:
     devDependencies:
       '@openclaw/plugin-sdk':


### PR DESCRIPTION
## Summary

- add a bundled `spec-center` plugin for Markdown-first workflow specs
- support Feishu/chat-first `/spec` commands for import, check, preview, schedule state, report summaries, optimization previews, and approvals
- import `arkclaw_plugins_spec`-style legacy YAML into reviewable Markdown artifact metadata
- add focused tests and plugin docs

## Scope

This is intentionally plugin-owned P0 scaffolding. It does not add a new core workflow language, real Cron execution, MR creation, or interactive Feishu cards yet.

## Validation

Ran in the main local workspace with Node v24.8.0:

- `pnpm test extensions/spec-center`
- `pnpm exec oxfmt --check --threads=1 extensions/spec-center docs/plugins/spec-center.md .github/labeler.yml`
- `git diff --check -- extensions/spec-center docs/plugins/spec-center.md .github/labeler.yml`
- `pnpm openclaw --version` -> `OpenClaw 2026.4.27 (c718e44)`
- `pnpm openclaw --help`

Clean worktree note: targeted checks could not be rerun there because pnpm 11 attempted dependency install and failed on registry metadata (`lit` missing `time`) / node_modules purge behavior. The PR branch itself is based on a clean `origin/main` worktree and only contains the spec-center plugin, docs, labeler, and lockfile importer changes.
