### PR TITLE
fix(channels): pass resolved channel runtime to external plugins before startAccount

### DIFF
--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -340,6 +340,8 @@ export type ChannelLogoutContext<ResolvedAccount = unknown> = {
 };
 
 export type ChannelGatewayAdapter<ResolvedAccount = unknown> = {
+  /** Called before each startAccount with the resolved runtime. Throwing logs a warning and does not block start. */
+  setChannelRuntime?: (channelRuntime: ChannelRuntimeSurface) => void;
   startAccount?: (ctx: ChannelGatewayContext<ResolvedAccount>) => Promise<unknown>;
   stopAccount?: (ctx: ChannelGatewayContext<ResolvedAccount>) => Promise<void>;
   /** Keep gateway auth bypass resolution mirrored through a lightweight top-level `gateway-auth-api.ts` artifact. */

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -340,7 +340,7 @@ export type ChannelLogoutContext<ResolvedAccount = unknown> = {
 };
 
 export type ChannelGatewayAdapter<ResolvedAccount = unknown> = {
-  /** Called before each startAccount with the resolved runtime. Throwing logs a warning and does not block start. */
+  /** Called synchronously before each startAccount with the resolved runtime. Throwing logs a warning and does not block start. */
   setChannelRuntime?: (channelRuntime: ChannelRuntimeSurface) => void;
   startAccount?: (ctx: ChannelGatewayContext<ResolvedAccount>) => Promise<unknown>;
   stopAccount?: (ctx: ChannelGatewayContext<ResolvedAccount>) => Promise<void>;

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -51,6 +51,7 @@ function createTestPlugin(params?: {
   id?: ChannelId;
   order?: number;
   account?: TestAccount;
+  setChannelRuntime?: NonNullable<ChannelPlugin<TestAccount>["gateway"]>["setChannelRuntime"];
   startAccount?: NonNullable<ChannelPlugin<TestAccount>["gateway"]>["startAccount"];
   listAccountIds?: ChannelPlugin<TestAccount>["config"]["listAccountIds"];
   includeDescribeAccount?: boolean;
@@ -77,6 +78,9 @@ function createTestPlugin(params?: {
       }));
   }
   const gateway: NonNullable<ChannelPlugin<TestAccount>["gateway"]> = {};
+  if (params?.setChannelRuntime) {
+    gateway.setChannelRuntime = params.setChannelRuntime;
+  }
   if (params?.startAccount) {
     gateway.startAccount = params.startAccount;
   }
@@ -1010,5 +1014,48 @@ describe("server-channels auto restart", () => {
     });
 
     expect(manager.isHealthMonitorEnabled("discord", "")).toBe(true);
+  });
+
+  it("calls setChannelRuntime before startAccount with the resolved runtime", async () => {
+    const callOrder: string[] = [];
+    const mockChannelRuntime = {
+      runtimeContexts: createChannelRuntimeContextRegistry(),
+    } as unknown as ChannelRuntimeSurface;
+
+    const setChannelRuntime = vi.fn(() => {
+      callOrder.push("setChannelRuntime");
+    });
+    const startAccount = vi.fn(async () => {
+      callOrder.push("startAccount");
+    });
+
+    installTestRegistry(createTestPlugin({ setChannelRuntime, startAccount }));
+    const manager = createManager({ channelRuntime: mockChannelRuntime });
+
+    await manager.startChannels();
+
+    expect(setChannelRuntime).toHaveBeenCalledTimes(1);
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    // setChannelRuntime must be called before startAccount
+    expect(callOrder).toEqual(["setChannelRuntime", "startAccount"]);
+  });
+
+  it("does not fail channel start when setChannelRuntime throws", async () => {
+    const mockChannelRuntime = {
+      runtimeContexts: createChannelRuntimeContextRegistry(),
+    } as unknown as ChannelRuntimeSurface;
+    const setChannelRuntime = vi.fn(() => {
+      throw new Error("simulated plugin error");
+    });
+    const startAccount = vi.fn(async () => {});
+
+    installTestRegistry(createTestPlugin({ setChannelRuntime, startAccount }));
+    const manager = createManager({ channelRuntime: mockChannelRuntime });
+
+    // should not throw
+    await manager.startChannels();
+
+    expect(setChannelRuntime).toHaveBeenCalledTimes(1);
+    expect(startAccount).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1058,4 +1058,21 @@ describe("server-channels auto restart", () => {
     expect(setChannelRuntime).toHaveBeenCalledTimes(1);
     expect(startAccount).toHaveBeenCalledTimes(1);
   });
+
+  it("catches async setChannelRuntime rejections without unhandled rejection", async () => {
+    const mockChannelRuntime = {
+      runtimeContexts: createChannelRuntimeContextRegistry(),
+    } as unknown as ChannelRuntimeSurface;
+    const setChannelRuntime = vi.fn(() =>
+      Promise.reject(new Error("async plugin error")),
+    ) as unknown as NonNullable<ChannelPlugin["gateway"]>["setChannelRuntime"];
+    const startAccount = vi.fn(async () => {});
+
+    installTestRegistry(createTestPlugin({ setChannelRuntime, startAccount }));
+    const manager = createManager({ channelRuntime: mockChannelRuntime });
+    await manager.startChannels();
+
+    // startAccount should proceed despite the async rejection caught by gateway
+    expect(startAccount).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -512,6 +512,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             lastError: null,
             reconnectAttempts: preserveRestartAttempts ? (restartAttempts.get(rKey) ?? 0) : 0,
           });
+          if (channelRuntimeForTask && plugin.gateway?.setChannelRuntime) {
+            try {
+              plugin.gateway.setChannelRuntime(channelRuntimeForTask);
+            } catch (err) {
+              log.warn?.(`[${id}] setChannelRuntime failed: ${formatErrorMessage(err)}`);
+            }
+          }
           const task = Promise.resolve().then(() =>
             measureStartup(`channels.${channelId}.start-account`, () =>
               startAccount({

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -514,7 +514,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           });
           if (channelRuntimeForTask && plugin.gateway?.setChannelRuntime) {
             try {
-              plugin.gateway.setChannelRuntime(channelRuntimeForTask);
+              const result = plugin.gateway.setChannelRuntime(channelRuntimeForTask) as unknown;
+              if (result && typeof (result as Promise<unknown>).then === "function") {
+                void (result as Promise<unknown>).catch((err: unknown) => {
+                  log.warn?.(`[${id}] setChannelRuntime failed: ${formatErrorMessage(err)}`);
+                });
+              }
             } catch (err) {
               log.warn?.(`[${id}] setChannelRuntime failed: ${formatErrorMessage(err)}`);
             }


### PR DESCRIPTION
## Summary

- **Problem:** External channel plugins that capture `api.runtime` during `register()` receive an empty `{}` stub. The real PluginRuntime does not exist at registration time, so `pluginRuntime.channel` is `undefined` when accessed later.
- **Why it matters:** Plugins that store the stub and use it in their message loop silently fail. The only workaround is per-plugin boilerplate passing `ctx.channelRuntime` from `startAccount` through internal plumbing.
- **What changed:** Added `setChannelRuntime?(channelRuntime: ChannelRuntimeSurface)` to `ChannelGatewayAdapter`. Called synchronously before each `startAccount`. Sync throws and thenable rejections are guarded with `log.warn`; neither blocks startup. Tests cover ordering, sync failure, and async rejection.
- **What did NOT change:** `api.runtime` during `register()` remains the empty stub. This PR only adds a new hook (`setChannelRuntime`) called before `startAccount`; it does not alter the `register()` lifecycle semantics. The `channelRuntime` field on `ChannelGatewayContext` also remains unchanged. Bundled channel loading paths are untouched.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Integrations
- [x] API / contracts

## Real behavior proof

Behavior addressed: External channel plugin (`@tencent-weixin/openclaw-weixin` v2.4.1) times out during startup because `waitForWeixinRuntime()` loops on an empty runtime stub captured from `register(api)`.

Real environment tested: OpenClaw 2026.5.12-beta.7 on WSL2 (Node.js 22.22.2). The compiled `server-channels` dist module was patched in-place with this PR's change; the plugin was patched to implement `setChannelRuntime`.

Exact steps or command run after this patch:
1. Restart gateway (`systemctl --user restart openclaw-gateway`)
2. Observe channel startup via `openclaw channels status` and `journalctl`
3. Verify channel state transitions from `waiting for Weixin runtime` to `weixin monitor started`

Evidence after fix:
```
[openclaw-weixin] weixin monitor started (https://ilinkai.weixin.qq.com, account=......)
[openclaw-weixin] [weixin] resuming from previous sync buf (104 bytes)
[openclaw-weixin] [weixin] config cached for o9cq80x...@im.wechat
```
Channel status: `enabled, configured, running, in:just now`

Observed result after fix: Channel starts immediately with no timeout loop, receives inbound messages, and caches config normally.

What was not tested: Other external channel plugins; Real-world validation was not run for other third-party external channel plugins that do not implement `setChannelRuntime`.

Note: Full message round-trip required a separate plugin-side fix in `@tencent-weixin/openclaw-weixin` (removed manually-set `Content-Length` header rejected by Node.js undici as forbidden). That fix is unrelated to this PR.

## Root Cause

- **Root cause:** `api.runtime` is set to `{} as PluginRuntime` during `register()` because the real runtime is not yet constructed. Plugins that capture this stub and later access `.channel` get `undefined`.
- **Missing detection/guardrail:** No unit test covering the path "plugin stores runtime from register → accesses it in startAccount → gets real surface".
- **Contributing context:** The same root cause was addressed for bundled channels via `defineChannelPluginEntry` (see `codex/confirm-issue-with-openclaw-wechat-plugin` branch), but non-bundled channels using `ChannelGatewayAdapter` (e.g., `openclaw-weixin`) were not covered.

## Regression Test Plan

- **Coverage level:** Unit test
- **Target test:** `src/gateway/server-channels.test.ts`
- **Scenario:**
  1. `setChannelRuntime` called before `startAccount` in correct order
  2. Sync throw in `setChannelRuntime` does not block `startAccount`
  3. Async `Promise.reject` return does not cause unhandled rejection

## User-visible / Behavior Changes

None. Existing plugins that do not implement `setChannelRuntime` are unaffected.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: Node.js 22.22.2
- Integration/channel: `openclaw-weixin` (`@tencent-weixin/openclaw-weixin`)

### Steps

1. Install an external channel plugin that captures `api.runtime` during `register()`
2. Configure and start the channel
3. Observe `startAccount` context — `ctx.channelRuntime` is populated
4. Implement `setChannelRuntime` in the plugin's `gateway` adapter

### Expected

Plugin receives real `channelRuntime` via `setChannelRuntime` before `startAccount` begins.

### Actual (before fix)

Plugin receives empty `{}` stub at `register()` time; real runtime is only available inside `startAccount` via `ctx.channelRuntime`.

## Human Verification

- Verified: `setChannelRuntime` eliminates timeout on real `openclaw-weixin` channel
- Edge cases: `setChannelRuntime` throws → `startAccount` still called; uses `formatErrorMessage`
- Verified real message send/receive through the channel after applying this PR + plugin-side header fix.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** Plugin implements `setChannelRuntime` incorrectly, silently fails.
  - **Mitigation:** Error caught and logged with account ID; does not block `startAccount`. Plugin can fall back to `ctx.channelRuntime`.
