### PR TITLE
fix(skills): bound installer downloads

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -462,7 +462,8 @@ metadata:
       env vars are read but never overwritten.
     - **Download:** `url` (required), `archive` (`tar.gz` | `tar.bz2` | `zip`),
       `extract` (default: auto when archive detected), `stripComponents`,
-      `targetDir` (default: `~/.openclaw/tools/<skillKey>`).
+      `targetDir` (default: `~/.openclaw/tools/<skillKey>`). Downloads are
+      rejected when the advertised or streamed response exceeds 256 MiB.
   </Accordion>
   <Accordion title="Sandboxing notes">
     `requires.bins` is checked on the **host** at skill load time. If an agent

--- a/src/skills/lifecycle/install-download.test.ts
+++ b/src/skills/lifecycle/install-download.test.ts
@@ -13,7 +13,9 @@ import {
 } from "../test-support/install-test-mocks.js";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
 import type { SkillEntry, SkillInstallSpec } from "../types.js";
-import { installDownloadSpec } from "./install-download.js";
+import { installDownloadSpec, installDownloadTesting } from "./install-download.js";
+
+const MAX_SKILL_DOWNLOAD_BYTES = 256 * 1024 * 1024;
 
 vi.mock("../../process/exec.js", () => ({
   runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
@@ -90,6 +92,7 @@ function mockArchiveResponse(buffer: Uint8Array): void {
       ok: true,
       status: 200,
       statusText: "OK",
+      headers: new Headers(),
       body: Readable.from([Buffer.from(buffer)]),
     },
     release: async () => undefined,
@@ -212,6 +215,132 @@ describe("installDownloadSpec extraction safety", () => {
     ).toBe("payload");
   });
 
+  it("rejects downloads whose advertised size exceeds the skill download limit", async () => {
+    const response = new Response("payload", {
+      status: 200,
+      headers: { "content-length": String(MAX_SKILL_DOWNLOAD_BYTES + 1) },
+    });
+    const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response,
+      release: async () => undefined,
+    });
+    const entry = buildEntry("oversized-download-header");
+    const toolsRoot = resolveSkillToolsRootDir(entry);
+
+    const result = await installDownloadSpec({
+      entry,
+      spec: {
+        kind: "download",
+        id: "dl",
+        url: "https://example.invalid/payload.bin",
+        extract: false,
+        targetDir: "runtime",
+      },
+      timeoutMs: 30_000,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      stderr: `download too large: ${MAX_SKILL_DOWNLOAD_BYTES + 1} bytes (limit: ${MAX_SKILL_DOWNLOAD_BYTES} bytes)`,
+    });
+    expect(cancel).toHaveBeenCalledOnce();
+    await expect(fileExists(path.join(toolsRoot, "runtime", "payload.bin"))).resolves.toBe(false);
+    await expect(fs.readdir(path.join(toolsRoot, ".openclaw-download-staging"))).resolves.toEqual(
+      [],
+    );
+  });
+
+  it("rejects malformed advertised sizes before reading the response body", async () => {
+    const response = new Response("payload", {
+      status: 200,
+      headers: { "content-length": "1e9" },
+    });
+    const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response,
+      release: async () => undefined,
+    });
+    const entry = buildEntry("malformed-download-header");
+    const toolsRoot = resolveSkillToolsRootDir(entry);
+
+    const result = await installDownloadSpec({
+      entry,
+      spec: {
+        kind: "download",
+        id: "dl",
+        url: "https://example.invalid/payload.bin",
+        extract: false,
+        targetDir: "runtime",
+      },
+      timeoutMs: 30_000,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      stderr: "invalid content-length header: 1e9",
+    });
+    expect(cancel).toHaveBeenCalledOnce();
+    await expect(fileExists(path.join(toolsRoot, "runtime", "payload.bin"))).resolves.toBe(false);
+    await expect(fs.readdir(path.join(toolsRoot, ".openclaw-download-staging"))).resolves.toEqual(
+      [],
+    );
+  });
+
+  it("rejects headerless streamed overflow and removes the partial staging file", async () => {
+    const maxBytes = 8;
+    const partialChunk = Buffer.from("partial");
+    const overflowChunk = Buffer.from("!!");
+    const chunks = [partialChunk, overflowChunk];
+    let chunkIndex = 0;
+    const body = new Readable({
+      read() {
+        if (chunkIndex < chunks.length) {
+          this.push(chunks[chunkIndex++]);
+        }
+      },
+    });
+    const destroy = vi.spyOn(body, "destroy");
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers(),
+        body,
+      },
+      release: async () => undefined,
+    });
+    const entry = buildEntry("oversized-download-stream");
+    const toolsRoot = resolveSkillToolsRootDir(entry);
+
+    const result = await installDownloadTesting.installDownloadSpecWithLimit(
+      {
+        entry,
+        spec: {
+          kind: "download",
+          id: "dl",
+          url: "https://example.invalid/payload.bin",
+          extract: false,
+          targetDir: "runtime",
+        },
+        timeoutMs: 30_000,
+      },
+      maxBytes,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      stderr: `download too large: ${partialChunk.byteLength + overflowChunk.byteLength} bytes (limit: ${maxBytes} bytes)`,
+    });
+    expect(destroy).toHaveBeenCalled();
+    expect(body.destroyed).toBe(true);
+    await expect(fileExists(path.join(toolsRoot, "runtime", "payload.bin"))).resolves.toBe(false);
+    await expect(fs.readdir(path.join(toolsRoot, ".openclaw-download-staging"))).resolves.toEqual(
+      [],
+    );
+  });
+
   it("cancels failed download response bodies before returning the error", async () => {
     const { stream, wasCanceled } = createCancelableBody();
     const release = vi.fn(async () => undefined);
@@ -256,6 +385,7 @@ describe("installDownloadSpec extraction safety", () => {
           ok: true,
           status: 200,
           statusText: "OK",
+          headers: new Headers(),
           body: Readable.from(
             (async function* () {
               yield Buffer.from("payload");

--- a/src/skills/lifecycle/install-download.ts
+++ b/src/skills/lifecycle/install-download.ts
@@ -2,9 +2,10 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { parseMediaContentLength } from "@openclaw/media-core/content-length";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { isWindowsDrivePath } from "../../infra/archive-path.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -18,6 +19,14 @@ import { resolveSkillToolsRootDir } from "../runtime/tools-dir.js";
 import type { SkillEntry, SkillInstallSpec } from "../types.js";
 import { formatInstallFailureMessage } from "./install-output.js";
 import type { SkillInstallResult } from "./install-types.js";
+
+const MAX_SKILL_DOWNLOAD_BYTES = 256 * 1024 * 1024;
+
+type InstallDownloadSpecParams = {
+  entry: SkillEntry;
+  spec: SkillInstallSpec;
+  timeoutMs: number;
+};
 
 const extractModuleLoader = createLazyImportLoader(() => import("./install-extract.js"));
 
@@ -39,6 +48,38 @@ async function cancelIgnoredResponseBody(response: Response): Promise<void> {
     return;
   }
   await Promise.resolve(cancel.call(body)).catch(() => undefined);
+}
+
+function formatDownloadTooLargeError(bytes: number, maxBytes: number): string {
+  return `download too large: ${bytes} bytes (limit: ${maxBytes} bytes)`;
+}
+
+async function assertDownloadResponseSize(response: Response, maxBytes: number): Promise<void> {
+  let contentLength: number | null;
+  try {
+    contentLength = parseMediaContentLength(response.headers.get("content-length"));
+  } catch (err) {
+    await cancelIgnoredResponseBody(response);
+    throw err;
+  }
+  if (contentLength !== null && contentLength > maxBytes) {
+    await cancelIgnoredResponseBody(response);
+    throw new Error(formatDownloadTooLargeError(contentLength, maxBytes));
+  }
+}
+
+function createDownloadSizeLimitTransform(maxBytes: number): Transform {
+  let downloadedBytes = 0;
+  return new Transform({
+    transform(chunk: Uint8Array, _encoding, callback) {
+      downloadedBytes += chunk.byteLength;
+      if (downloadedBytes > maxBytes) {
+        callback(new Error(formatDownloadTooLargeError(downloadedBytes, maxBytes)));
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
 }
 
 function resolveDownloadTargetDir(entry: SkillEntry, spec: SkillInstallSpec): string {
@@ -88,6 +129,7 @@ async function downloadFile(params: {
   rootDir: string;
   relativePath: string;
   timeoutMs: number;
+  maxBytes: number;
 }): Promise<{ bytes: number }> {
   const destPath = path.resolve(params.rootDir, params.relativePath);
   const stagingDir = path.join(params.rootDir, ".openclaw-download-staging");
@@ -107,12 +149,13 @@ async function downloadFile(params: {
       await cancelIgnoredResponseBody(response);
       throw new Error(`Download failed (${response.status} ${response.statusText})`);
     }
+    await assertDownloadResponseSize(response, params.maxBytes);
     const file = fs.createWriteStream(tempPath);
     const body = response.body as unknown;
     const readable = isNodeReadableStream(body)
       ? body
       : Readable.fromWeb(body as NodeReadableStream);
-    await pipeline(readable, file);
+    await pipeline(readable, createDownloadSizeLimitTransform(params.maxBytes), file);
     const root = await fsRoot(params.rootDir);
     await root.copyIn(params.relativePath, tempPath);
     const stat = await fs.promises.stat(destPath);
@@ -123,11 +166,10 @@ async function downloadFile(params: {
   }
 }
 
-export async function installDownloadSpec(params: {
-  entry: SkillEntry;
-  spec: SkillInstallSpec;
-  timeoutMs: number;
-}): Promise<SkillInstallResult> {
+async function installDownloadSpecWithLimit(
+  params: InstallDownloadSpecParams,
+  maxBytes: number,
+): Promise<SkillInstallResult> {
   const { entry, spec, timeoutMs } = params;
   const root = resolveSkillToolsRootDir(entry);
   const url = spec.url?.trim();
@@ -200,6 +242,7 @@ export async function installDownloadSpec(params: {
       rootDir: canonicalRoot,
       relativePath: archiveRelativePath,
       timeoutMs,
+      maxBytes,
     });
     downloaded = result.bytes;
   } catch (err) {
@@ -259,3 +302,13 @@ export async function installDownloadSpec(params: {
     code: extractResult.code,
   };
 }
+
+export async function installDownloadSpec(
+  params: InstallDownloadSpecParams,
+): Promise<SkillInstallResult> {
+  return installDownloadSpecWithLimit(params, MAX_SKILL_DOWNLOAD_BYTES);
+}
+
+export const installDownloadTesting = {
+  installDownloadSpecWithLimit,
+};


### PR DESCRIPTION
## What Problem This Solves

Fixes #81817.

The skill installer streamed remote download responses directly into
`.openclaw-download-staging` without a byte limit. A remote skill download could
therefore become an unbounded local disk write when the server omitted or lied
about `Content-Length`.

## Why This Change Was Made

The owning boundary is `src/skills/lifecycle/install-download.ts`, reached by
`installSkill()` before copy or archive extraction. The previous PR
implementation targeted the former `src/agents/skills-install-download.ts`
location; that stale path is not carried forward.

The canonical repair:

- caps skill installer downloads at 256 MiB;
- reuses `parseMediaContentLength` for strict advertised-size validation;
- cancels response bodies rejected by malformed or oversized lengths;
- streams through one byte-counting `Transform` so headerless and misleading
  responses cannot exceed the same limit;
- keeps cleanup in the downloader's existing `finally` path; and
- documents the operator-visible limit.

No fallback downloader, compatibility shim, or duplicate policy remains.

## User Impact

Oversized skill downloads now fail before they can consume unbounded disk
space. Partial staging files are removed, and the installer returns the size
limit in its error.

Production delta: **+60/-7, net +53**. The growth establishes the download
security boundary at its lifecycle owner and a small internal test seam that
proves streamed overflow without allocating the production-sized limit. Tests
are counted separately.

## Maintainer Decision

Accepted the documented 256 MiB compatibility boundary. It is deliberately generous for skill packages, closes the unbounded disk-write class, and returns an explicit operator-visible error.

## Evidence

Validated exact head:
`e3320ba98cfc6b3772162ecadb56c80c28850c4f`

- Signed maintainer rebase onto `1f3d45b76f51298699423b8a3331b42b6d51b962`
  preserved Andrii Furmanets co-author credit. Later `main` drift through
  `72fd25d47d1d5ae772de8af052623cc869bf2af0` had no touched-path overlap and
  produced a clean merge tree, so the reviewed head was not churned again.
- Post-rebase `node scripts/run-vitest.mjs src/skills/lifecycle/install-download.test.ts -- --reporter=verbose` passed 10/10 tests; `git diff --check` passed.

- Failure-first on current `main`: both an advertised 268435457-byte response
  and a headerless 268435463-byte stream returned `ok: true`.
- `node scripts/run-vitest.mjs src/skills/lifecycle/install-download.test.ts packages/media-core/src/content-length.test.ts -- --reporter=verbose`
  passed 25/25 tests.
- A second focused owner run covering
  `src/skills/lifecycle/install-download.test.ts` and
  `src/skills/lifecycle/install.test.ts` passed 16/16 tests.
- The streamed-overflow integration test uses a 7-byte partial chunk and a
  2-byte overflow against an injected 8-byte limit. It asserts that `pipeline`
  destroys the still-open upstream stream, installs nothing, and removes the
  partial staging file.
- Direct `oxfmt`, focused `oxlint`, `node scripts/docs-list.js`, and
  `git diff --check`: passed.
- Fresh exact-branch autoreview: no accepted or actionable findings; patch
  correct at 0.99 confidence.

Real installer-boundary proof used a real loopback `node:http` server and native
`fetch`/Response streaming while leaving production download, staging, copy,
limit, and cleanup code unmodified:

- Advertised `Content-Length: 268435457` failed with
  `download too large: 268435457 bytes (limit: 268435456 bytes)`;
  response closed, no install occurred, and staging was empty.
- A headerless chunked response created a real nonempty partial staging file,
  then crossed the limit at 268435463 bytes and failed with
  `download too large: 268435463 bytes (limit: 268435456 bytes)`;
  the response closed, no install occurred, and cleanup removed every staging
  entry.
- Runtime proof suite: 2/2 passed.

The shared TUI PTY scheduler repair landed on `main` as
`17ef7771a66d21af51d26558a9a01ec7d01a227d`. This branch includes that
repair; fresh exact-head hosted CI and ClawSweeper review are running.



Punchcard-Session: cobalt-brook-meadow-m9
