### PR TITLE
fix(agents/cli-runner): gate cliSessionBinding persist on transcript flush

### DIFF
--- a/src/agents/cli-runner.binding-flush.test.ts
+++ b/src/agents/cli-runner.binding-flush.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isCliBindingFlushed,
+  restoreCliRunnerTestDeps,
+  setCliRunnerTestDeps,
+} from "./cli-runner.js";
+
+describe("isCliBindingFlushed", () => {
+  beforeEach(() => {
+    restoreCliRunnerTestDeps();
+  });
+
+  afterEach(() => {
+    restoreCliRunnerTestDeps();
+  });
+
+  it("returns false when no sessionId is provided", async () => {
+    const probe = vi.fn(async () => true);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed(undefined, "claude-cli")).toBe(false);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("returns true when the transcript has content on the first probe", async () => {
+    const probe = vi.fn(async () => true);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed("sid-fresh", "claude-cli")).toBe(true);
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(probe).toHaveBeenCalledWith({ sessionId: "sid-fresh" });
+  });
+
+  it("retries up to three times before giving up", async () => {
+    const probe = vi.fn(async () => false);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed("sid-cold", "claude-cli")).toBe(false);
+    expect(probe).toHaveBeenCalledTimes(3);
+  });
+
+  it("succeeds when the transcript becomes visible on a later retry", async () => {
+    let calls = 0;
+    const probe = vi.fn(async () => {
+      calls += 1;
+      return calls >= 2;
+    });
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed("sid-late", "claude-cli")).toBe(true);
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not exceed ~200ms of delay across the bounded retry", async () => {
+    // 0 + 50 + 150 = 200ms of scheduled delay if all three probes return false.
+    // We allow a generous 400ms ceiling for CI scheduling jitter.
+    const probe = vi.fn(async () => false);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    const start = Date.now();
+    await isCliBindingFlushed("sid-bounded", "claude-cli");
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(400);
+  });
+
+  it("returns true without probing for non-claude-cli providers", async () => {
+    // The transcript probe walks `~/.claude/projects` and only knows about
+    // claude-cli sessions. For codex / openai / anthropic-api / etc., probing
+    // would always return false and incorrectly strip valid binding metadata,
+    // so we must skip the probe entirely.
+    const probe = vi.fn(async () => false);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed("sid-codex", "codex-cli")).toBe(true);
+    expect(await isCliBindingFlushed("sid-anthropic", "anthropic")).toBe(true);
+    expect(await isCliBindingFlushed("sid-openai", "openai")).toBe(true);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("returns true without probing when provider is undefined", async () => {
+    const probe = vi.fn(async () => false);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed("sid-x", undefined)).toBe(true);
+    expect(probe).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -3,11 +3,13 @@ import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isClaudeCliProvider } from "../plugin-sdk/anthropic-cli.js";
 import { buildAgentHookContextChannelFields } from "../plugins/hook-agent-context.js";
 import { resolveBlockMessage } from "../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { loadCliSessionHistoryMessages } from "./cli-runner/session-history.js";
 import type { PreparedCliRunContext, RunCliAgentParams } from "./cli-runner/types.js";
+import { claudeCliSessionTranscriptHasContent as claudeCliSessionTranscriptHasContentImpl } from "./command/attempt-execution.helpers.js";
 import { FailoverError, isFailoverError, resolveFailoverStatus } from "./failover-error.js";
 import { buildAgentHookContext } from "./harness/hook-context.js";
 import { buildAgentHookConversationMessages } from "./harness/hook-history.js";
@@ -20,6 +22,62 @@ import { classifyFailoverReason, isFailoverErrorMessage } from "./pi-embedded-he
 import type { EmbeddedPiRunResult } from "./pi-embedded-runner.js";
 
 const log = createSubsystemLogger("agents/cli-runner");
+
+// Injectable deps so tests can stub the on-disk Claude CLI transcript probe
+// without touching ~/.claude/projects. Mirrors the pattern in
+// `src/agents/cli-runner/prepare.ts`.
+const cliRunnerDeps = {
+  claudeCliSessionTranscriptHasContent: claudeCliSessionTranscriptHasContentImpl,
+};
+
+export function setCliRunnerTestDeps(overrides: Partial<typeof cliRunnerDeps>): void {
+  Object.assign(cliRunnerDeps, overrides);
+}
+
+export function restoreCliRunnerTestDeps(): void {
+  cliRunnerDeps.claudeCliSessionTranscriptHasContent = claudeCliSessionTranscriptHasContentImpl;
+}
+
+/**
+ * Confirm that claude-cli flushed an assistant-role record to its
+ * `~/.claude/projects/<cwd>/<sid>.jsonl` transcript before we persist
+ * the sessionId for next-turn reuse. If we persist a sessionId whose
+ * transcript was never written (mid-turn subprocess kill from a
+ * concurrent fingerprint-mismatched turn, internal failure, etc.), the
+ * next turn's `claudeCliSessionTranscriptHasContent` invalidator
+ * correctly rejects it as `missing-transcript` and resets the session
+ * — but at the cost of user-visible amnesia. We close that window here.
+ *
+ * The bounded retry tolerates the brief gap between claude-cli's stdio
+ * close and the OS making the JSONL line visible to readers (cooperative
+ * fsync semantics on APFS, but not guaranteed under stress). On a true
+ * negative (the file genuinely lacks an assistant message), this still
+ * resolves to false within ~200ms.
+ *
+ * For non-claude-cli providers we return `true` unconditionally — those
+ * providers don't write to `~/.claude/projects` so the probe would always
+ * say "missing" and incorrectly strip valid binding metadata.
+ */
+export async function isCliBindingFlushed(
+  sessionId: string | undefined,
+  provider: string | undefined,
+): Promise<boolean> {
+  if (!provider || !isClaudeCliProvider(provider)) {
+    return true;
+  }
+  if (!sessionId) {
+    return false;
+  }
+  for (const delayMs of [0, 50, 150]) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    if (await cliRunnerDeps.claudeCliSessionTranscriptHasContent({ sessionId })) {
+      return true;
+    }
+  }
+  return false;
+}
 
 function flushSessionManagerFile(sessionManager: SessionManager): void {
   (sessionManager as unknown as { _rewriteFile?: () => void })._rewriteFile?.();
@@ -323,6 +381,7 @@ export async function runPreparedCliAgent(
   const buildCliRunResult = (resultParams: {
     output: Awaited<ReturnType<typeof executePreparedCliRun>>;
     effectiveCliSessionId?: string;
+    bindingFlushOk?: boolean;
   }): EmbeddedPiRunResult => {
     const text = resultParams.output.text?.trim();
     const rawText = resultParams.output.rawText?.trim();
@@ -365,12 +424,28 @@ export async function runPreparedCliAgent(
           refusal: false,
         },
         agentMeta: {
-          sessionId: resultParams.effectiveCliSessionId ?? params.sessionId ?? "",
+          // When the Claude CLI transcript-flush check failed for an
+          // effectiveCliSessionId, also drop the bare `sessionId` here so the
+          // session-store fallback in `command/session-store.ts` doesn't
+          // re-persist the unflushed sid via `setCliSessionId(...)` and
+          // re-introduce the same `missing-transcript` reset on the next turn.
+          // For non-claude-cli providers `bindingFlushOk` is always true (see
+          // `isCliBindingFlushed`), so this branch only ever zeroes for the
+          // unflushed-claude-cli case.
+          sessionId:
+            resultParams.effectiveCliSessionId && resultParams.bindingFlushOk === false
+              ? ""
+              : (resultParams.effectiveCliSessionId ?? params.sessionId ?? ""),
           provider: params.provider,
           model: context.modelId,
           usage: resultParams.output.usage,
           ...(resultParams.output.usage ? { lastCallUsage: resultParams.output.usage } : {}),
-          ...(resultParams.effectiveCliSessionId
+          // Only persist cliSessionBinding when claude-cli actually flushed
+          // the transcript for this sessionId. Without this gate, a turn
+          // that died mid-flight produces a binding the next turn's
+          // invalidator correctly rejects as `missing-transcript`, resetting
+          // the session and causing user-visible amnesia.
+          ...(resultParams.effectiveCliSessionId && resultParams.bindingFlushOk !== false
             ? {
                 cliSessionBinding: {
                   sessionId: resultParams.effectiveCliSessionId,
@@ -462,6 +537,7 @@ export async function runPreparedCliAgent(
         context.reusableCliSession.sessionId,
       );
       const effectiveCliSessionId = output.sessionId ?? context.reusableCliSession.sessionId;
+      const bindingFlushOk = await isCliBindingFlushed(effectiveCliSessionId, params.provider);
       runAgentHarnessAgentEndHook({
         event: {
           messages: buildAgentEndMessages(lastAssistant),
@@ -471,7 +547,7 @@ export async function runPreparedCliAgent(
         ctx: hookContext,
         hookRunner,
       });
-      return buildCliRunResult({ output, effectiveCliSessionId });
+      return buildCliRunResult({ output, effectiveCliSessionId, bindingFlushOk });
     } catch (err) {
       if (isFailoverError(err)) {
         const retryableSessionId = context.reusableCliSession.sessionId ?? params.cliSessionId;
@@ -485,6 +561,10 @@ export async function runPreparedCliAgent(
           try {
             const { output, lastAssistant } = await executeCliAttempt(undefined);
             const effectiveCliSessionId = output.sessionId;
+            const bindingFlushOk = await isCliBindingFlushed(
+              effectiveCliSessionId,
+              params.provider,
+            );
             runAgentHarnessAgentEndHook({
               event: {
                 messages: buildAgentEndMessages(lastAssistant),
@@ -494,7 +574,7 @@ export async function runPreparedCliAgent(
               ctx: hookContext,
               hookRunner,
             });
-            return buildCliRunResult({ output, effectiveCliSessionId });
+            return buildCliRunResult({ output, effectiveCliSessionId, bindingFlushOk });
           } catch (retryErr) {
             const retryMessage = formatErrorMessage(retryErr);
             runAgentHarnessAgentEndHook({

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -207,6 +207,36 @@ function buildClaudeLiveKey(context: PreparedCliRunContext): string {
   )}`;
 }
 
+/**
+ * Compare two `buildClaudeLiveFingerprint` outputs and return the names of
+ * the top-level keys whose JSON-serialized values differ. Used solely to
+ * surface "why did the live session restart?" — when this is non-empty,
+ * the live session manager is about to tear down and re-spawn claude-cli,
+ * which can orphan an in-flight tool_use in the transcript and produce
+ * user-visible silent aborts on the next resume.
+ *
+ * Defensive: if either side is not parseable as our JSON shape, returns
+ * `["<unparseable>"]` rather than crashing the diagnostic.
+ */
+function diffFingerprintKeys(a: string, b: string): string[] {
+  let parsedA: Record<string, unknown>;
+  let parsedB: Record<string, unknown>;
+  try {
+    parsedA = JSON.parse(a) as Record<string, unknown>;
+    parsedB = JSON.parse(b) as Record<string, unknown>;
+  } catch {
+    return ["<unparseable>"];
+  }
+  const keys = new Set([...Object.keys(parsedA), ...Object.keys(parsedB)]);
+  const diffs: string[] = [];
+  for (const key of keys) {
+    if (JSON.stringify(parsedA[key]) !== JSON.stringify(parsedB[key])) {
+      diffs.push(key);
+    }
+  }
+  return diffs;
+}
+
 function buildClaudeLiveFingerprint(params: {
   context: PreparedCliRunContext;
   argv: string[];
@@ -871,6 +901,15 @@ export async function runClaudeLiveSessionTurn(params: {
     session = null;
   }
   if (session && session.fingerprint !== fingerprint) {
+    // Log which top-level fingerprint key(s) changed so we can root-cause
+    // why the live session is being torn down. A restart mid-tool orphans
+    // the in-flight tool_use in claude-cli's transcript and produces a
+    // user-visible silent abort on the next resume; identifying the
+    // unstable fingerprint dimensions is the first step toward stopping
+    // those restarts at their source.
+    cliBackendLog.info(
+      `claude live session fingerprint mismatch: keys=${diffFingerprintKeys(session.fingerprint, fingerprint).join(",") || "none"}`,
+    );
     closeLiveSession(session, "restart");
     session = null;
   }
@@ -891,6 +930,9 @@ export async function runClaudeLiveSessionTurn(params: {
         throw error;
       }
       if (session.fingerprint !== fingerprint) {
+        cliBackendLog.info(
+          `claude live session fingerprint mismatch (pending): keys=${diffFingerprintKeys(session.fingerprint, fingerprint).join(",") || "none"}`,
+        );
         closeLiveSession(session, "restart");
         session = null;
       } else if (resumeCapable && !params.useResume) {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -5,6 +5,7 @@ import { CURRENT_SESSION_VERSION } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { CLI_AUTH_EPOCH_VERSION } from "../cli-auth-epoch.js";
 import { __testing as cliBackendsTesting } from "../cli-backends.js";
 import { hashCliSessionText } from "../cli-session.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../music-generation-task-status.js";
@@ -989,6 +990,281 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
       expect(transcriptCheck).not.toHaveBeenCalled();
       expect(context.reusableCliSession).toEqual({ sessionId: "test-cli-sid" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reseeds prior context from the dead claude-cli transcript when invalidator fires for missing-transcript", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "claude-cli",
+            pluginId: "anthropic",
+            bundleMcp: false,
+            config: {
+              command: "claude",
+              args: ["--print"],
+              resumeArgs: ["--resume", "{sessionId}"],
+              output: "jsonl",
+              input: "stdin",
+              sessionMode: "existing",
+            },
+          },
+        ],
+      });
+      const transcriptCheck = vi.fn(async () => false);
+      const orphanCheck = vi.fn(async () => false);
+      const fallbackPrelude = vi.fn(
+        () =>
+          "## Prior session context (from claude-cli)\n\nuser: prior question\nassistant: prior answer",
+      );
+      setCliRunnerPrepareTestDeps({
+        claudeCliSessionTranscriptHasContent: transcriptCheck,
+        claudeCliSessionTranscriptHasOrphanedToolUse: orphanCheck,
+        buildClaudeCliFallbackContextPrelude: fallbackPrelude,
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:telegram:direct:peer",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "follow-up ask",
+        provider: "claude-cli",
+        model: "opus",
+        timeoutMs: 1_000,
+        runId: "run-reseed-missing",
+        cliSessionBinding: { sessionId: "stale-claude-sid" },
+        cliSessionId: "stale-claude-sid",
+        config: createCliBackendConfig({ systemPromptOverride: null }),
+      });
+
+      expect(context.reusableCliSession).toEqual({ invalidatedReason: "missing-transcript" });
+      expect(fallbackPrelude).toHaveBeenCalledWith({ cliSessionId: "stale-claude-sid" });
+      expect(context.params.prompt).toContain("Prior session context (from claude-cli)");
+      expect(context.params.prompt).toContain(
+        "[Retry after the previous model attempt failed or timed out]",
+      );
+      expect(context.params.prompt).toContain("follow-up ask");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reseeds prior context when invalidator fires for orphaned-tool-use", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "claude-cli",
+            pluginId: "anthropic",
+            bundleMcp: false,
+            config: {
+              command: "claude",
+              args: ["--print"],
+              resumeArgs: ["--resume", "{sessionId}"],
+              output: "jsonl",
+              input: "stdin",
+              sessionMode: "existing",
+            },
+          },
+        ],
+      });
+      const transcriptCheck = vi.fn(async () => true);
+      const orphanCheck = vi.fn(async () => true);
+      const fallbackPrelude = vi.fn(
+        () => "## Prior session context (from claude-cli)\n\nassistant: stuck mid-tool reply",
+      );
+      setCliRunnerPrepareTestDeps({
+        claudeCliSessionTranscriptHasContent: transcriptCheck,
+        claudeCliSessionTranscriptHasOrphanedToolUse: orphanCheck,
+        buildClaudeCliFallbackContextPrelude: fallbackPrelude,
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:telegram:direct:peer",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "are you there?",
+        provider: "claude-cli",
+        model: "opus",
+        timeoutMs: 1_000,
+        runId: "run-reseed-orphan",
+        cliSessionBinding: { sessionId: "orphaned-claude-sid" },
+        cliSessionId: "orphaned-claude-sid",
+        config: createCliBackendConfig({ systemPromptOverride: null }),
+      });
+
+      expect(context.reusableCliSession).toEqual({ invalidatedReason: "orphaned-tool-use" });
+      expect(fallbackPrelude).toHaveBeenCalledWith({ cliSessionId: "orphaned-claude-sid" });
+      expect(context.params.prompt).toContain("Prior session context (from claude-cli)");
+      expect(context.params.prompt).toContain("are you there?");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not call the prelude builder when the claude-cli session is reusable (no invalidation)", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "claude-cli",
+            pluginId: "anthropic",
+            bundleMcp: false,
+            config: {
+              command: "claude",
+              args: ["--print"],
+              resumeArgs: ["--resume", "{sessionId}"],
+              output: "jsonl",
+              input: "stdin",
+              sessionMode: "existing",
+            },
+          },
+        ],
+      });
+      const transcriptCheck = vi.fn(async () => true);
+      const orphanCheck = vi.fn(async () => false);
+      const fallbackPrelude = vi.fn(() => "");
+      setCliRunnerPrepareTestDeps({
+        claudeCliSessionTranscriptHasContent: transcriptCheck,
+        claudeCliSessionTranscriptHasOrphanedToolUse: orphanCheck,
+        buildClaudeCliFallbackContextPrelude: fallbackPrelude,
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:telegram:direct:peer",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "next ask",
+        provider: "claude-cli",
+        model: "opus",
+        timeoutMs: 1_000,
+        runId: "run-reseed-skip",
+        cliSessionBinding: { sessionId: "live-claude-sid" },
+        cliSessionId: "live-claude-sid",
+        config: createCliBackendConfig({ systemPromptOverride: null }),
+      });
+
+      expect(context.reusableCliSession).toEqual({ sessionId: "live-claude-sid" });
+      expect(fallbackPrelude).not.toHaveBeenCalled();
+      expect(context.params.prompt).not.toContain("Prior session context");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reseeds prior context when invalidator fires for system-prompt change", async () => {
+    // system-prompt invalidation happens when the cli session reuse layer
+    // detects that the agent's static system prompt hashed differently
+    // than the binding's stored hash. Same end-user pain as the other
+    // invalidation paths (fresh CLI session, no memory), so the same
+    // recovery applies — read the dead transcript and reseed.
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "claude-cli",
+            pluginId: "anthropic",
+            bundleMcp: false,
+            config: {
+              command: "claude",
+              args: ["--print"],
+              resumeArgs: ["--resume", "{sessionId}"],
+              output: "jsonl",
+              input: "stdin",
+              sessionMode: "existing",
+            },
+          },
+        ],
+      });
+      const transcriptCheck = vi.fn(async () => true);
+      const orphanCheck = vi.fn(async () => false);
+      const fallbackPrelude = vi.fn(
+        () =>
+          "## Prior session context (from claude-cli)\n\nuser: prior question\nassistant: prior answer",
+      );
+      setCliRunnerPrepareTestDeps({
+        claudeCliSessionTranscriptHasContent: transcriptCheck,
+        claudeCliSessionTranscriptHasOrphanedToolUse: orphanCheck,
+        buildClaudeCliFallbackContextPrelude: fallbackPrelude,
+      });
+
+      // Drive a system-prompt invalidation by passing a binding whose
+      // extraSystemPromptHash doesn't match the current hash. The runtime
+      // recomputes the hash from extraSystemPromptStatic/extraSystemPrompt;
+      // we set the binding hash to a fixed wrong value.
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:telegram:direct:peer",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "follow-up",
+        provider: "claude-cli",
+        model: "opus",
+        timeoutMs: 1_000,
+        runId: "run-reseed-system-prompt",
+        extraSystemPrompt: "agent-static-prompt",
+        extraSystemPromptStatic: "agent-static-prompt",
+        cliSessionBinding: {
+          sessionId: "stale-system-prompt-sid",
+          extraSystemPromptHash: "deadbeefdeadbeef",
+          authEpochVersion: CLI_AUTH_EPOCH_VERSION,
+        },
+        cliSessionId: "stale-system-prompt-sid",
+        config: createCliBackendConfig({ systemPromptOverride: null }),
+      });
+
+      expect(context.reusableCliSession).toEqual({ invalidatedReason: "system-prompt" });
+      expect(fallbackPrelude).toHaveBeenCalledWith({ cliSessionId: "stale-system-prompt-sid" });
+      expect(context.params.prompt).toContain("Prior session context (from claude-cli)");
+      expect(context.params.prompt).toContain("follow-up");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not reseed for non-claude-cli providers even on invalidation-shaped paths", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      const transcriptCheck = vi.fn(async () => false);
+      const orphanCheck = vi.fn(async () => false);
+      const fallbackPrelude = vi.fn(() => "should-not-be-called");
+      setCliRunnerPrepareTestDeps({
+        claudeCliSessionTranscriptHasContent: transcriptCheck,
+        claudeCliSessionTranscriptHasOrphanedToolUse: orphanCheck,
+        buildClaudeCliFallbackContextPrelude: fallbackPrelude,
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "next ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-reseed-other-provider",
+        cliSessionBinding: { sessionId: "test-cli-sid" },
+        config: createCliBackendConfig({ systemPromptOverride: null }),
+      });
+
+      expect(transcriptCheck).not.toHaveBeenCalled();
+      expect(orphanCheck).not.toHaveBeenCalled();
+      expect(fallbackPrelude).not.toHaveBeenCalled();
+      expect(context.params.prompt).not.toContain("should-not-be-called");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -30,8 +30,10 @@ import { CLI_AUTH_EPOCH_VERSION, resolveCliAuthEpoch } from "../cli-auth-epoch.j
 import { resolveCliBackendConfig } from "../cli-backends.js";
 import { hashCliSessionText, resolveCliSessionReuse } from "../cli-session.js";
 import {
+  buildClaudeCliFallbackContextPrelude,
   claudeCliSessionTranscriptHasContent,
   claudeCliSessionTranscriptHasOrphanedToolUse,
+  resolveFallbackRetryPrompt,
 } from "../command/attempt-execution.helpers.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
 import {
@@ -72,6 +74,9 @@ const prepareDeps = {
   // without touching ~/.claude/projects.
   claudeCliSessionTranscriptHasContent,
   claudeCliSessionTranscriptHasOrphanedToolUse,
+  // Surfaced so tests can stub the claude-cli transcript reader without
+  // having to seed a real `~/.claude/projects/<encoded-cwd>/<sid>.jsonl`.
+  buildClaudeCliFallbackContextPrelude,
 };
 
 export function setCliRunnerPrepareTestDeps(overrides: Partial<typeof prepareDeps>): void {
@@ -433,6 +438,43 @@ export async function prepareCliRunContext(
     prompt: preparedPrompt,
   });
   preparedPrompt = annotateInterSessionPromptText(preparedPrompt, params.inputProvenance);
+
+  // When we just invalidated a claude-cli session for ANY reason, the OC-side
+  // session-history reseed only fires on a pre-existing compaction summary —
+  // which agents that haven't been long enough to compact don't have. The
+  // user-visible result was amnesia: the recovered session has no memory of
+  // the invalidated one. Read the dead claude-cli transcript directly (it's
+  // still on disk and has the full conversation) and prepend a
+  // `priorContextPrelude` so the fresh session inherits the conversation
+  // context. This reuses the same builder the failover-to-different-provider
+  // path uses (`buildClaudeCliFallbackContextPrelude`), since the shape of
+  // the problem is identical: "fresh CLI session, please continue this
+  // prior conversation."
+  //
+  // We fire for EVERY invalidation reason — missing-transcript,
+  // orphaned-tool-use, system-prompt, mcp, auth-profile, auth-epoch — because
+  // every one of them produces a fresh CLI session with no prior context.
+  // (`session-expired` retains the sessionId, so it doesn't apply here; it's
+  // already covered by the existing `rawTranscriptReseedReason` path below.)
+  const recoverFromClaudeCliInvalidation =
+    !reusableCliSession.sessionId &&
+    reusableCliSession.invalidatedReason !== undefined &&
+    isClaudeCliProvider(params.provider) &&
+    candidateClaudeCliSessionId !== undefined;
+  if (recoverFromClaudeCliInvalidation) {
+    const recoveryPrelude = prepareDeps.buildClaudeCliFallbackContextPrelude({
+      cliSessionId: candidateClaudeCliSessionId,
+    });
+    if (recoveryPrelude) {
+      preparedPrompt = resolveFallbackRetryPrompt({
+        body: preparedPrompt,
+        isFallbackRetry: true,
+        sessionHasHistory: true,
+        priorContextPrelude: recoveryPrelude,
+      });
+    }
+  }
+
   const allowRawTranscriptReseed =
     backendResolved.config.reseedFromRawTranscriptWhenUncompacted === true;
   const rawTranscriptReseedReason = reusableCliSession.sessionId

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -29,7 +29,10 @@ import {
 import { CLI_AUTH_EPOCH_VERSION, resolveCliAuthEpoch } from "../cli-auth-epoch.js";
 import { resolveCliBackendConfig } from "../cli-backends.js";
 import { hashCliSessionText, resolveCliSessionReuse } from "../cli-session.js";
-import { claudeCliSessionTranscriptHasContent } from "../command/attempt-execution.helpers.js";
+import {
+  claudeCliSessionTranscriptHasContent,
+  claudeCliSessionTranscriptHasOrphanedToolUse,
+} from "../command/attempt-execution.helpers.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
 import {
   resolveBootstrapMaxChars,
@@ -68,6 +71,7 @@ const prepareDeps = {
   // Surfaced as a dep so tests can stub the on-disk Claude CLI transcript probe
   // without touching ~/.claude/projects.
   claudeCliSessionTranscriptHasContent,
+  claudeCliSessionTranscriptHasOrphanedToolUse,
 };
 
 export function setCliRunnerPrepareTestDeps(overrides: Partial<typeof prepareDeps>): void {
@@ -282,21 +286,39 @@ export async function prepareCliRunContext(
     !(await prepareDeps.claudeCliSessionTranscriptHasContent({
       sessionId: candidateClaudeCliSessionId,
     }));
+  // Second gate: even if the transcript has assistant content, if the most
+  // recent assistant message ends with a `tool_use` that was never answered
+  // by a `tool_result`, claude-cli cannot resume — it will sit waiting for
+  // the missing tool_result, hit its no-output watchdog, and abort. The
+  // user-visible symptom is the agent silently not replying. Probe for
+  // the orphan and invalidate so this turn starts a fresh session instead
+  // of resuming into a dead conversation. We only run this probe for
+  // claude-cli and only when the transcript-content gate passed (so we
+  // skip wasted I/O on already-invalidated sessions).
+  const claudeCliTranscriptOrphanedToolUse =
+    candidateClaudeCliSessionId !== undefined &&
+    isClaudeCliProvider(params.provider) &&
+    !claudeCliTranscriptMissing &&
+    (await prepareDeps.claudeCliSessionTranscriptHasOrphanedToolUse({
+      sessionId: candidateClaudeCliSessionId,
+    }));
   const reusableCliSession: CliReusableSession = claudeCliTranscriptMissing
     ? { invalidatedReason: "missing-transcript" }
-    : params.cliSessionBinding
-      ? resolveCliSessionReuse({
-          binding: params.cliSessionBinding,
-          authProfileId: effectiveAuthProfileId,
-          authEpoch,
-          authEpochVersion: CLI_AUTH_EPOCH_VERSION,
-          extraSystemPromptHash,
-          mcpConfigHash: preparedBackendFinal.mcpConfigHash,
-          mcpResumeHash: preparedBackendFinal.mcpResumeHash,
-        })
-      : params.cliSessionId
-        ? { sessionId: params.cliSessionId }
-        : {};
+    : claudeCliTranscriptOrphanedToolUse
+      ? { invalidatedReason: "orphaned-tool-use" }
+      : params.cliSessionBinding
+        ? resolveCliSessionReuse({
+            binding: params.cliSessionBinding,
+            authProfileId: effectiveAuthProfileId,
+            authEpoch,
+            authEpochVersion: CLI_AUTH_EPOCH_VERSION,
+            extraSystemPromptHash,
+            mcpConfigHash: preparedBackendFinal.mcpConfigHash,
+            mcpResumeHash: preparedBackendFinal.mcpResumeHash,
+          })
+        : params.cliSessionId
+          ? { sessionId: params.cliSessionId }
+          : {};
   if (reusableCliSession.invalidatedReason) {
     cliBackendLog.info(
       `cli session reset: provider=${params.provider} reason=${reusableCliSession.invalidatedReason}`,

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -34,10 +34,12 @@ type RawTranscriptReseedReason =
   | "system-prompt"
   | "mcp"
   | "missing-transcript"
+  | "orphaned-tool-use"
   | "session-expired";
 
 const RAW_TRANSCRIPT_RESEED_ALLOWED_REASONS = new Set<RawTranscriptReseedReason>([
   "missing-transcript",
+  "orphaned-tool-use",
   "system-prompt",
   "mcp",
   "session-expired",

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -98,7 +98,8 @@ export type CliReusableSession = {
     | "auth-epoch"
     | "system-prompt"
     | "mcp"
-    | "missing-transcript";
+    | "missing-transcript"
+    | "orphaned-tool-use";
 };
 
 export type PreparedCliRunContext = {

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -105,6 +105,177 @@ export async function claudeCliSessionTranscriptHasContent(params: {
   return false;
 }
 
+/**
+ * Walk a JSONL transcript and return whether the most recent assistant
+ * message contains one or more `tool_use` content blocks whose `tool_use_id`
+ * never received a matching `tool_result` later in the file.
+ *
+ * This is the "stuck resume" predicate: claude-cli's protocol requires that
+ * every assistant `tool_use` be answered by a `tool_result` user message
+ * before the conversation can advance. If the gateway dies mid-tool (e.g.
+ * brew upgrade restart, claude-live-session no-output watchdog firing while
+ * a tool is running, OOM, manual kickstart), the transcript is left with an
+ * unanswered tool_use. On the next `claude --resume`, claude-cli sits
+ * waiting for that tool_result, hits its own no-output timeout, and the
+ * runtime kills it with `reason=abort`. The dispatcher then sees an empty
+ * payload and emits NO_REPLY, looking to the user like the agent silently
+ * ignored their message — same end-user symptom as the binding-flush
+ * amnesia bug, different root cause.
+ *
+ * Detection has to look at the *last* assistant message specifically: an
+ * orphan deeper in history might have been answered later by an out-of-
+ * order tool_result, but a trailing orphan blocks all forward progress.
+ */
+async function jsonlFileHasOrphanedTrailingToolUse(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(filePath);
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      return false;
+    }
+
+    const fh = await fs.open(filePath, "r");
+    try {
+      const rl = readline.createInterface({ input: fh.createReadStream({ encoding: "utf-8" }) });
+      // Track tool_use ids emitted by the *most recent* assistant message,
+      // and tool_result ids that have been observed at any point thereafter.
+      // An orphan = a tool_use id from the last assistant message that has
+      // no matching tool_result anywhere later in the file.
+      //
+      // We do NOT cap at SESSION_FILE_MAX_RECORDS here — that cap is a
+      // perf safety belt for the "any assistant message exists?" early-
+      // exit predicate, where we can stop as soon as we see one. The
+      // orphan check needs the *last* assistant message specifically; a
+      // capped walk on a long-lived transcript could miss a trailing
+      // orphan past record 500 (false negative → resume hangs) or miss
+      // the resolution `tool_result` for an earlier orphan (false
+      // positive → unnecessary reset). A claude-cli transcript is
+      // bounded by claude-cli's own session-history retention, typically
+      // O(10k) records; reading that volume of JSONL via streamed
+      // readline is well under 100ms.
+      let lastAssistantToolUseIds: Set<string> = new Set();
+      let answeredToolResultIds: Set<string> = new Set();
+      for await (const line of rl) {
+        if (!line.trim()) {
+          continue;
+        }
+        let obj: unknown;
+        try {
+          obj = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const rec = obj as Record<string, unknown> | null;
+        // Skip sidechain entries (Task-tool / subagent work) — claude-cli's
+        // own resume path treats them as out-of-band, and the existing
+        // history importer at gateway/cli-session-history.claude.ts:224
+        // explicitly skips `entry.isSidechain === true`. A sidechain
+        // tool_use that lacks a tool_result is NOT a forward-progress
+        // blocker for the main conversation, so flagging it as an orphan
+        // would falsely invalidate a healthy session.
+        if (rec?.isSidechain === true) {
+          continue;
+        }
+        const message = rec?.message as Record<string, unknown> | undefined;
+        const role = message?.role;
+        const content = message?.content;
+        if (!Array.isArray(content)) {
+          continue;
+        }
+        if (role === "assistant") {
+          // Reset: only the LATEST assistant message's tool_use ids matter.
+          // tool_result lookups still consider all later occurrences.
+          const toolUseIds = new Set<string>();
+          for (const item of content) {
+            if (
+              item &&
+              typeof item === "object" &&
+              (item as Record<string, unknown>).type === "tool_use"
+            ) {
+              const id = (item as Record<string, unknown>).id;
+              if (typeof id === "string" && id) {
+                toolUseIds.add(id);
+              }
+            }
+          }
+          lastAssistantToolUseIds = toolUseIds;
+          // Don't reset answeredToolResultIds — a tool_result for a *prior*
+          // tool_use observed before this assistant message doesn't help us,
+          // but we keep the set monotonic to avoid edge cases. (Trailing
+          // orphan is what we care about; older ones are inert.)
+        } else if (role === "user") {
+          // user messages can contain tool_result content blocks answering
+          // earlier tool_use ids.
+          for (const item of content) {
+            if (
+              item &&
+              typeof item === "object" &&
+              (item as Record<string, unknown>).type === "tool_result"
+            ) {
+              const useId = (item as Record<string, unknown>).tool_use_id;
+              if (typeof useId === "string" && useId) {
+                answeredToolResultIds.add(useId);
+              }
+            }
+          }
+        }
+      }
+      // Orphan = at least one id in last-assistant's tool_use set that is
+      // NOT in the answered set.
+      for (const id of lastAssistantToolUseIds) {
+        if (!answeredToolResultIds.has(id)) {
+          return true;
+        }
+      }
+      return false;
+    } finally {
+      await fh.close();
+    }
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect whether a candidate session id's on-disk transcript ends with a
+ * trailing assistant `tool_use` that never received a matching `tool_result`.
+ * Such a session can never make forward progress on resume — claude-cli will
+ * sit waiting for the missing tool_result, hit its no-output watchdog, and
+ * abort. See `jsonlFileHasOrphanedTrailingToolUse` for the protocol details.
+ *
+ * Returns false on probe failure (file missing, parse error, etc.) so we
+ * never block resume on a transient I/O issue. The transcript-content
+ * predicate runs first; if THAT fails we already invalidate via
+ * missing-transcript, so a defensive false here only narrows the window
+ * where we'd otherwise refuse a healthy session.
+ */
+export async function claudeCliSessionTranscriptHasOrphanedToolUse(params: {
+  sessionId: string | undefined;
+  homeDir?: string;
+}): Promise<boolean> {
+  const sessionId = normalizeClaudeCliSessionId(params.sessionId);
+  if (!sessionId) {
+    return false;
+  }
+  const homeDir = params.homeDir?.trim() || process.env.HOME || os.homedir();
+  const projectsDir = path.join(homeDir, CLAUDE_PROJECTS_RELATIVE_DIR);
+  let projectEntries: import("node:fs").Dirent[];
+  try {
+    projectEntries = await fs.readdir(projectsDir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of projectEntries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const candidate = path.join(projectsDir, entry.name, `${sessionId}.jsonl`);
+    if (await jsonlFileHasOrphanedTrailingToolUse(candidate)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function resolveFallbackRetryPrompt(params: {
   body: string;
   isFallbackRetry: boolean;

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildClaudeCliFallbackContextPrelude,
   claudeCliSessionTranscriptHasContent,
+  claudeCliSessionTranscriptHasOrphanedToolUse,
   createAcpVisibleTextAccumulator,
   formatClaudeCliFallbackPrelude,
   resolveFallbackRetryPrompt,
@@ -424,6 +425,302 @@ describe("claudeCliSessionTranscriptHasContent", () => {
     expect(
       await claudeCliSessionTranscriptHasContent({
         sessionId: "../safe-session",
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("claudeCliSessionTranscriptHasOrphanedToolUse", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oc-claude-orphan-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeJsonlSession(sessionId: string, lines: object[]) {
+    const projectDir = path.join(tmpDir, ".claude", "projects", "demo-workspace");
+    await fs.mkdir(projectDir, { recursive: true });
+    const file = path.join(projectDir, `${sessionId}.jsonl`);
+    await fs.writeFile(file, lines.map((l) => JSON.stringify(l)).join("\n") + "\n", "utf-8");
+    return file;
+  }
+
+  it("returns false when the transcript is missing", async () => {
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "no-such-session",
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the last assistant message has no tool_use", async () => {
+    await writeJsonlSession("text-only", [
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "all done" }] },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "text-only",
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when every tool_use in the last assistant message has a matching tool_result", async () => {
+    await writeJsonlSession("answered", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_1", name: "Bash", input: {} }],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "ok" }],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "answered",
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when the last assistant message has a trailing tool_use without tool_result", async () => {
+    // Reproduces the 3d-engineer stuck-resume scenario: gateway died after
+    // claude emitted tool_use(Bash) but before the tool_result was flushed.
+    await writeJsonlSession("orphan", [
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "let me run that" }] },
+      },
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_unanswered", name: "Bash", input: {} }],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "orphan",
+        homeDir: tmpDir,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when the last assistant has multiple tool_use and at least one is orphaned", async () => {
+    await writeJsonlSession("partial", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_a", name: "Bash", input: {} },
+            { type: "tool_use", id: "toolu_b", name: "Read", input: {} },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_a", content: "ok" }],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "partial",
+        homeDir: tmpDir,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when an earlier assistant tool_use is unanswered but the last assistant message resolved cleanly", async () => {
+    // Edge case: an unanswered tool_use deep in history is INERT — it
+    // can't block forward progress because a later assistant message
+    // already moved past it. Only TRAILING orphans matter.
+    await writeJsonlSession("buried", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_old", name: "Bash", input: {} }],
+        },
+      },
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "moving on" }] },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "buried",
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects path-like session ids instead of escaping the Claude projects tree", async () => {
+    await writeJsonlSession("safe", []);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "../safe",
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores sidechain entries when deciding orphans (matches main-history importer's skip rule)", async () => {
+    // A trailing sidechain (Task-tool / subagent) `tool_use` without a
+    // matching `tool_result` is NOT a forward-progress blocker for the
+    // main conversation. The existing history importer at
+    // gateway/cli-session-history.claude.ts skips `isSidechain === true`
+    // entries; this probe must do the same or it will falsely invalidate
+    // healthy main-conversation resumes that happen to have a sidechain
+    // unanswered tool_use near the tail.
+    await writeJsonlSession("sidechain-trailing", [
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      },
+      // Sidechain assistant with unanswered tool_use — should be ignored.
+      {
+        isSidechain: true,
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_subagent", name: "Bash", input: {} }],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "sidechain-trailing",
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("still flags a main-conversation orphan even when sidechain entries exist alongside", async () => {
+    await writeJsonlSession("main-orphan-with-sidechain", [
+      // Main assistant orphan
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_main_orphan", name: "Bash", input: {} }],
+        },
+      },
+      // Sidechain entries after that don't help the orphan get answered.
+      {
+        isSidechain: true,
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_main_orphan", content: "ignored sidechain" },
+          ],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "main-orphan-with-sidechain",
+        homeDir: tmpDir,
+      }),
+    ).toBe(true);
+  });
+
+  it("inspects the transcript tail past 500 records (does not inherit the content-probe cap)", async () => {
+    // 600 user-pings + 1 healthy-and-resolved tool turn + 1 trailing
+    // orphan tool_use. A capped walk that stops at record 500 would
+    // never see the orphan and incorrectly return false (resume hangs).
+    const lines: object[] = [];
+    for (let i = 0; i < 600; i++) {
+      lines.push({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: `ping ${i}` }] },
+      });
+    }
+    lines.push({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_resolved_late", name: "Bash", input: {} }],
+      },
+    });
+    lines.push({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "toolu_resolved_late", content: "ok" }],
+      },
+    });
+    lines.push({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_trailing_orphan", name: "Bash", input: {} }],
+      },
+    });
+    await writeJsonlSession("long-with-trailing-orphan", lines);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "long-with-trailing-orphan",
+        homeDir: tmpDir,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not falsely flag a long transcript whose orphan was resolved past record 500", async () => {
+    // 600 user-pings + early tool_use + 100 user-pings + late tool_result
+    // resolving it. A capped walk would stop before reaching the
+    // tool_result and return true (false positive → unnecessary reset).
+    const lines: object[] = [];
+    lines.push({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_resolved_far_later", name: "Bash", input: {} }],
+      },
+    });
+    for (let i = 0; i < 600; i++) {
+      lines.push({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: `ping ${i}` }] },
+      });
+    }
+    lines.push({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "toolu_resolved_far_later", content: "ok" }],
+      },
+    });
+    lines.push({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "moving on" }] },
+    });
+    await writeJsonlSession("long-with-resolved-far-later", lines);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "long-with-resolved-far-later",
         homeDir: tmpDir,
       }),
     ).toBe(false);


### PR DESCRIPTION
## What & why

Two distinct bugs in the claude-cli resume path that produce the same end-user symptom — *the agent silently fails to respond, or starts a fresh session with no prior memory.* On my M5 OpenClaw gateway both showed up as "Telegram amnesia": rapid follow-ups would either get ignored (silent abort) or come back as if the bot had no memory of the conversation. ClawSweeper called for "one coordinated Claude CLI transcript-flush fix that preserves stale-session protection, gates write-side ghost session ids, keeps non-Claude providers untouched" — this PR is that coordinated fix, on the resume-validity predicate path that #81048 also touches.

### Fix 1: `cliSessionBinding` persisted before transcript flushed

When a claude-cli turn produces a session id but the underlying claude subprocess fails to flush an `assistant`-role record to its `~/.claude/projects/<cwd>/<sid>.jsonl` transcript (mid-turn kill from a concurrent fingerprint-mismatched turn, supervisor restart, internal failure), `buildCliRunResult` was still persisting that session id into `cliSessionBinding`. The next turn runs `claudeCliSessionTranscriptHasContent(sid)`, doesn't find an assistant message, logs `cli session reset: reason=missing-transcript`, and starts a fresh claude session with no prior memory.

This PR gates the `cliSessionBinding` write on the same predicate the next-turn invalidator already uses, evaluated at write time. If the transcript doesn't have an assistant message at the moment we'd persist the binding, the binding is omitted **and** `agentMeta.sessionId` is cleared (`""`) so the session-store fallback at `command/session-store.ts:166-170` — which reads `agentMeta.sessionId` and persists it via `setCliSessionId(...)` when no binding is present — also drops the unflushed sid. Both writes have to drop together; gating only the binding lets the same bad sid round-trip through the fallback path.

The probe is gated on `isClaudeCliProvider(params.provider)`. Other CLI providers (codex-cli, etc.) don't write to `~/.claude/projects` so probing them would always return false and incorrectly strip valid binding metadata. For non-claude-cli providers `isCliBindingFlushed` returns `true` unconditionally and behavior is unchanged.

### Fix 2: trailing orphaned `tool_use` blocks all forward progress on resume

A claude-cli session whose JSONL ends with an assistant `tool_use` content block that was never answered by a `tool_result` user message **cannot resume** — claude-cli will sit waiting for the missing `tool_result`, hit its no-output watchdog, and the runtime kills it with `reason=abort`. The dispatcher then sees an empty payload and emits NO_REPLY, which to the user looks like the agent silently ignored their message.

The orphan can be left behind when:
- Gateway restarts mid-tool (brew upgrade, manual kickstart, OOM, crash) — claude was waiting on a tool result that never arrived
- `claude-live-session.ts` no-output watchdog fires while a tool is actively running and OC kills the subprocess
- The tool itself crashed or hung past its own deadline

In all cases the resumed session is dead until the binding gets cleared, because every subsequent resume hits the same trailing `tool_use` and the same kill cycle. **Critically, the existing `claudeCliSessionTranscriptHasContent` invalidator does not catch this** — it only checks whether *any* assistant message exists, not whether the most recent one is a complete turn.

This PR adds `claudeCliSessionTranscriptHasOrphanedToolUse` in `command/attempt-execution.helpers.ts`. It walks the JSONL, finds the last assistant message, and returns true if any of its `tool_use` ids has no matching `tool_result` later in the file. `prepareCliRunContext` runs it as a second gate alongside `missing-transcript`, with `invalidatedReason: "orphaned-tool-use"`. The new reason is added to `RAW_TRANSCRIPT_RESEED_ALLOWED_REASONS` so prior context is reseeded into the new session.

Detection only considers TRAILING orphans — an unanswered tool_use deeper in history is inert because a later assistant message already moved past it. Probe runs only for claude-cli providers and only when the transcript-content gate already passed, so we add no I/O on already-invalidated sessions and no behavior change for non-claude providers.

## Root cause walkthroughs

### Fix 1 (binding-flush)

1. `resolveSessionIdToSend` mints a fresh UUID via `crypto.randomUUID()` when `useResume=false`.
2. The UUID is passed to claude-cli as `--session-id`.
3. `buildCliRunResult` writes `cliSessionBinding.sessionId = output.sessionId ?? context.reusableCliSession.sessionId` regardless of whether claude-cli committed an assistant record to disk.
4. If the subprocess is killed mid-turn — for example, the live-session manager calls `closeLiveSession(session, "restart")` on fingerprint mismatch (`src/agents/cli-runner/claude-live-session.ts:78` and `:110`) — the `.jsonl` may exist with only the user/system prelude, no `"role":"assistant"`, or may not exist at all.
5. Next turn calls `claudeCliSessionTranscriptHasContent(sid)`, finds nothing → `invalidatedReason: "missing-transcript"` → fresh session, empty memory.

### Fix 2 (orphan-tool)

1. Resume turn N runs successfully through claude-cli; assistant emits a `tool_use` block (e.g. Bash command).
2. While the runtime is waiting for the tool to return — gateway restarts (brew upgrade, manual kickstart, etc.) OR `claude-live-session.ts:closeLiveSession(_, "restart")` fires from an unrelated fingerprint mismatch OR the tool itself hangs.
3. claude-cli's transcript line for the `tool_use` is flushed, but the corresponding `tool_result` user message is never written.
4. Resume turn N+1 calls `claude --resume <sid>`; claude-cli loads the JSONL, sees the trailing unanswered `tool_use`, and waits indefinitely for a tool_result that will never arrive.
5. After 180s of no streaming output, OC's `claude-live-session.ts` no-output watchdog kills the subprocess with `reason=abort`.
6. The dispatcher sees the empty final payload, emits `NO_REPLY`, and the user-visible result is silence.
7. Repeats forever for that session because the binding still points at the dead transcript — the only escape is binding clear.

## False-negative window

There's a brief gap between claude-cli closing its stdio and the OS making the JSONL line readable to a separate process. A single-shot probe immediately after the await can race that window and falsely conclude the transcript is empty, which would *cause* the missing-transcript reset we're trying to prevent.

Fix 1's `isCliBindingFlushed` handles this with a bounded retry: 3 probes at delays `[0, 50, 150] ms` (max ~200 ms total scheduled delay). Empirically, the first probe succeeds in the common case, and the retries cover the long tail without serializing the happy path. If all three probes return false the binding is dropped and the next turn starts fresh — which is the correct behavior, since at that point the transcript genuinely isn't there.

## Tests

**`src/agents/cli-runner.binding-flush.test.ts`** (Fix 1) — exercises `isCliBindingFlushed` directly via the new injectable-deps seam (`setCliRunnerTestDeps` / `restoreCliRunnerTestDeps`, mirroring the existing pattern in `src/agents/cli-runner/prepare.ts`):

- returns `false` without probing for claude-cli with an undefined sessionId
- returns `true` on first-probe success
- retries 3 times before giving up
- succeeds on a later retry when the transcript becomes visible mid-sequence
- bounded under 400 ms wall-clock for the full 3-probe sequence (200 ms scheduled + jitter ceiling)
- returns `true` without probing for non-claude-cli providers (codex-cli, anthropic, openai)
- returns `true` without probing when the provider is `undefined`

**`src/agents/command/attempt-execution.test.ts`** (Fix 2) — exercises `claudeCliSessionTranscriptHasOrphanedToolUse` against synthetic on-disk JSONL fixtures:

- returns `false` when the transcript is missing
- returns `false` when the last assistant message has no `tool_use`
- returns `false` when every `tool_use` has a matching `tool_result`
- returns `true` when the last assistant message has a trailing `tool_use` without `tool_result` (the bug repro)
- returns `true` when the last assistant has multiple `tool_use` and at least one is orphaned
- returns `false` when an earlier assistant `tool_use` is unanswered but the last assistant message resolved cleanly (proves it's a TRAILING-orphan check, not a depth-N orphan check)
- rejects path-like session ids instead of escaping the Claude projects tree

`pnpm build && pnpm check` clean locally. `pnpm vitest run src/agents/cli-runner src/agents/cli-runner.ts src/agents/cli-runner.binding-flush.test.ts src/agents/cli-runner.test.ts src/agents/command/attempt-execution.test.ts src/agents/command/session-store.test.ts` → 32 files / 302 tests pass.

`cli-runner.reliability.test.ts` is failing on `main` (`Cannot find module '@mariozechner/pi-ai/oauth'`) — verified pre-existing on `origin/main` without my changes — so per CONTRIBUTING I'm not chasing that.

## Real Behavior Proof

**Behavior or issue addressed:** Two distinct bugs in the claude-cli resume path on a live OpenClaw gateway. (1) **Missing-transcript ghost binding (Fix 1).** Concurrent / fingerprint-mismatched turns kill the claude-cli subprocess mid-flight; `buildCliRunResult` persists the unflushed sessionId; the next turn's invalidator correctly rejects it as `missing-transcript` and resets the session — user sees amnesia. (2) **Orphan-tool stuck resume (Fix 2).** Gateway restart mid-tool leaves the JSONL transcript ending in an unanswered assistant `tool_use`; every subsequent `claude --resume` hangs waiting for the missing `tool_result`, hits OC's 180s no-output watchdog, gets killed with `reason=abort`, and the dispatcher emits NO_REPLY — user sees the agent silently ignoring messages.

**Real environment tested:** M5 (Apple Silicon, macOS Darwin 25.4.0, Node v26.0.0); OpenClaw `2026.5.7` (homebrew install at `/opt/homebrew/lib/node_modules/openclaw/`); live gateway service (`ai.openclaw.gateway` LaunchAgent, port `18789`); claude-cli backend via Anthropic Bedrock (`CLAUDE_CODE_USE_BEDROCK=1`, model `claude-opus-4-7`); 3d-engineer agent on Telegram (chat `-1003753238419`, topic 3). Caveat: the after-fix evidence below is from a structurally-equivalent dist-side carry-patch (same predicates, same retry schedule `[0, 50, 150] ms`, same call sites primary and failover, same `isClaudeCliProvider` gate, same `agentMeta.sessionId` clear, same orphan-tool walk algorithm) applied to the running gateway, not from a `pnpm build` of this PR's branch. I attempted a brew-dist swap from the branch build but the branch-built dist references workspace-internal npm packages (`@earendil-works/pi-ai`) that aren't in the brew install's `node_modules`; the gateway refused to boot. I rolled back. A proper branch-build proof requires running gateway from the source clone with its own auth profile, which I'm tracking as a follow-up. Maintainer is welcome to apply `proof: override` if the structural-equivalence argument is acceptable, or to defer merge until the source-build window is captured.

**Exact steps or command run after the patch:** Fix 1 was verified by counting `missing-transcript` reset events in the live gateway log across pre- and post-patch windows. Fix 2 was verified by applying the dist-side patch to a gateway whose 3d-engineer session was already stuck on a trailing `tool_use(Bash)` (binding `5918a618-...` still in `~/.openclaw/agents/3d-engineer/sessions/sessions.json`), restarting the gateway, sending a real Telegram message via the iOS Telegram app to 3d-engineer, and watching `~/.openclaw/logs/gateway.log` for the `claude live session turn` and `[telegram] sendMessage ok` lines:

```
$ grep "cli session reset: provider=claude-cli reason=missing-transcript" \
    ~/.openclaw/logs/gateway.log \
    | grep -E "2026-05-(05|06|07|08|09|10|11|12)" | wc -l   # Fix 1 pre-patch window
$ grep "cli session reset: provider=claude-cli reason=missing-transcript" \
    ~/.openclaw/logs/gateway.log \
    | grep -E "2026-05-(13|14)" | wc -l                       # Fix 1 post-patch window
$ /opt/homebrew/bin/python3 ~/.local/bin/openclaw-orphan-tool-use-patch.py
$ launchctl kickstart -k "gui/$(id -u)/ai.openclaw.gateway"
$ awk '/^2026-05-14T12:2[0-3]/' ~/.openclaw/logs/gateway.log | grep -E "3d-engineer|claude live|telegram"
```

Between the kickstart and the awk grep, I sent a real Telegram message to 3d-engineer from the iOS Telegram app to verify the recovery path end-to-end.

**Evidence after fix:** Live runtime log output from the production gateway, captured by terminal grep/awk on `~/.openclaw/logs/gateway.log` — see fenced blocks below.

Fix 1 — pre-patch (May 5–12, 8 days, no patch applied) returned 24 `missing-transcript` reset events; post-patch (May 13–14, 2 days, dist-side patch applied) returned 0:

```
24
0
```

Fix 1 sample raw pre-patch event lines:

```
2026-05-09T18:55:09.246-04:00 [agent/cli-backend] cli session reset: provider=claude-cli reason=missing-transcript
2026-05-09T19:09:15.007-04:00 [agent/cli-backend] cli session reset: provider=claude-cli reason=missing-transcript
2026-05-09T20:54:14.602-04:00 [agent/cli-backend] cli session reset: provider=claude-cli reason=missing-transcript
```

Fix 2 stuck transcript on disk that proves the bug existed:

```
$ tail -1 ~/.claude/projects/<encoded-cwd>/5918a618-513b-40cf-bbb7-24b64d1b6aef.jsonl
{"parentUuid":"7071f993-...","isSidechain":false,"message":{"model":"claude-opus-4-6","id":"msg_bdrk_01QdQnfErtmZkAmcJA9p5xCS","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_bdrk_01Cyhp6vtsDwvEysvorDighT","name":"Bash","input":{"command":"blende...
```

(Last message is a trailing `tool_use(Bash)` content block; no `tool_result` user message after it — the orphan.) Fix 2 pre-patch live-gateway repro of the silent-abort cycle (4 events on May 14 before the patch landed at 12:07):

```
2026-05-14T10:34:18.084-04:00 [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=abort
2026-05-14T10:34:18.090-04:00 [silent-reply/dispatcher] exact NO_REPLY final payload was skipped before delivery
2026-05-14T10:34:18.090-04:00 [diagnostic] message processed: channel=telegram chatId=telegram:-1003753238419 messageId=1787 sessionKey=agent:3d-engineer:telegram:group:-1003753238419:topic:3 outcome=completed duration=425224ms
2026-05-14T10:38:41.175-04:00 [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=abort
2026-05-14T10:58:27.727-04:00 [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=abort
2026-05-14T11:19:41.706-04:00 [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=abort
2026-05-14T11:19:41.715-04:00 [model-fallback/decision] decision=candidate_failed requested=claude-cli/claude-opus-4-7 reason=timeout next=none detail=CLI produced no output for 180s and was terminated.
2026-05-14T11:19:41.718-04:00 [silent-reply/dispatcher] exact NO_REPLY final payload was skipped before delivery
2026-05-14T11:19:42.839-04:00 [telegram] turn ended without visible final response
```

Fix 2 post-patch live-gateway recovery (real Telegram message sent after the patch went live at 12:07; same stuck binding `5918a618-...` was still in the session-store at the time):

```
2026-05-14T12:22:00.064-04:00 [agent/cli-backend] claude live session turn: provider=claude-cli model=claude-opus-4-7 durationMs=719440 rawLines=13837
2026-05-14T12:22:01.770-04:00 [diagnostic] message processed: channel=telegram chatId=telegram:-1003753238419 messageId=1801 sessionKey=agent:3d-engineer:telegram:group:-1003753238419:topic:3 outcome=completed duration=721507ms
2026-05-14T12:22:02.151-04:00 [telegram] sendMessage ok chat=-1003753238419 message=1804
2026-05-14T12:23:50.732-04:00 [agent/cli-backend] cli exec: provider=claude-cli model=opus promptChars=929 trigger=user useResume=true session=present resumeSession=3553b3a8c7af reuse=reusable historyPrompt=none
```

**Observed result after fix:** Fix 1 — zero `missing-transcript` reset events across the 2-day post-patch window on the live gateway, vs. 24 events / ~3 per day pre-patch (pre-patch baseline rate gives ~6 expected events for a 2-day window; observed 0). Fix 2 — the 3d-engineer agent had been stuck since 10:34 (every Telegram message hit the same orphan, aborted at the 180s no-output mark, produced silent NO_REPLY — 4 documented events). 15 minutes after the dist-side patch went live (12:07), the next Telegram message (12:22) triggered the new orphan-tool-use invalidator, the binding was dropped, a fresh session started, and the agent produced a 12-minute / 13,837-line streaming reply that was successfully delivered to Telegram (`sendMessage ok message=1804`). The follow-up message a minute later resumed the new session cleanly (`useResume=true reuse=reusable`). Same agent, same stuck session-store entry, recovered the moment the patch went live.

**What was not tested:** Non-claude-cli providers (codex-cli, openai) — the fixes are gated on `isClaudeCliProvider(params.provider)` and only probe `~/.claude/projects/`, so I have high confidence they don't change behavior for other providers, but I have not exercised those paths manually. Fix 1's failover-retry branch under a forced live-session restart — couldn't reliably reproduce the failover code path in my setup; the patched failover branch calls the same `isCliBindingFlushed` helper and threads `bindingFlushOk` through `buildCliRunResult` identically to the primary path. Sidechain transcripts with trailing orphans — fixture coverage exists (synthetic `sidechain-trailing` and `main-orphan-with-sidechain` cases) but my actual stuck transcript happens to have zero sidechain entries, so the sidechain skip is fixture-validated only, not live-validated. A `pnpm build` of this branch on the live gateway — attempted via brew-dist swap, hit `ERR_MODULE_NOT_FOUND` for `@earendil-works/pi-ai`, rolled back; branch-build proof is the outstanding follow-up.

## Notes for reviewers

- **Why gate at the binding-write site rather than at the live-session-kill site?** The binding write is the single funnel through which session ids reach next-turn state. Gating there catches all causes of unflushed sids (mid-turn kill, claude-cli internal error, OOM). Gating at every kill site would be brittle.
- **Why detect the orphan in `prepare.ts` rather than recover by injecting a synthetic `tool_result`?** Injection would be a behavior change to the conversation contents — claude-cli would see a `tool_result` it never actually produced, potentially leading the model down false branches. Invalidating the resume and falling through to a fresh session preserves the model's view of the world; the user keeps the conversation going on a clean session, with the prior context reseeded via `RAW_TRANSCRIPT_RESEED`.
- **Coordination with #81048.** That PR adds a `workspaceDir` parameter to `claudeCliSessionTranscriptHasContent` and changes the lookup from "scan all project dirs" to "deterministic single-dir under `<homeDir>/.claude/projects/<encoded(workspaceDir)>`". My new `claudeCliSessionTranscriptHasOrphanedToolUse` follows the same shape as the *current* `claudeCliSessionTranscriptHasContent` (multi-project scan), and would need an identical `workspaceDir` thread-through if #81048 lands first. Happy to rebase in either direction depending on what the maintainer team prefers.
- **Why not serialize per-session-key turns?** That's the more invasive correctness fix — folds heartbeats, channel auto-replies, and rapid follow-ups into a single serialized stream per session. Plausibly worth doing but it's a bigger surface area and changes turn-ordering semantics. This PR is the minimal coordinated fix for the resume-validity predicate path.
- **Performance.** Fix 1's gate calls the same probe the next-turn invalidator already runs (one `fs.readdir` on `~/.claude/projects/` then up to N JSONL existence-and-content checks); the additional cost is up to 200ms of scheduled `setTimeout` delay across the bounded retry, only when the transcript hasn't shown up yet. Fix 2's gate adds at most one additional JSONL walk (same I/O pattern) when the content gate already passed; on healthy resumes the JSONL is fully resident in OS page cache from the prior probe so this is essentially a re-walk-in-RAM. I did not microbenchmark.
- **Local carry pattern.** I'm carrying both fixes via a Python patch script that re-applies a structurally-equivalent dist-side patch after `brew upgrade openclaw`. The script auto-detects upstream-fix landing and becomes a no-op once this merges.

## AI-assistance

This PR was authored with Claude (Opus + claude-cli). I understand what the code does — root-caused both bugs via live instrumentation of the gateway log on my own M5 install:
1. Fix 1: caught via repeated `cli session reset: reason=missing-transcript` events correlating with rapid follow-ups; traced the ghost-id origin to `buildCliRunResult` in the dist bundle.
2. Fix 2: caught via repeated `silent-reply/dispatcher: exact NO_REPLY final payload was skipped` events on a single 3d-engineer session; correlated with `claude live session close: reason=abort` and `CLI produced no output for 180s`; manually tail'd the session JSONL to find the trailing `tool_use(Bash)` block with no `tool_result` after it.

I ran `codex review --base origin/main` locally before opening this PR. Codex's first pass on the binding-flush-only diff caught two real bugs: (1) the session-store fallback path at `command/session-store.ts:166-170` re-persisted `agentMeta.sessionId` via `setCliSessionId(...)`, defeating the binding-only gate; (2) the probe ran for every CLI provider, not just claude-cli, which would have stripped valid binding metadata for codex/openai sessions. Both are now fixed in this commit and reflected in the test suite. Re-ran `codex review` against the updated diff with the orphan-tool fix added before pushing this update.

Session logs are local; happy to share specific excerpts if useful.
