### PR TITLE
fix(doctor): exit non-zero on final invalid config (#77804)

### DIFF
--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -1,6 +1,6 @@
 // Register maintenance tests cover maintenance command registration in the CLI program.
 import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerMaintenanceCommands } from "./register.maintenance.js";
 
 const mocks = vi.hoisted(() => ({
@@ -58,6 +58,8 @@ function commandCall(mock: ReturnType<typeof vi.fn>): [typeof runtime, Record<st
 }
 
 describe("registerMaintenanceCommands doctor action", () => {
+  const previousExitCode = process.exitCode;
+
   async function runMaintenanceCli(args: string[]) {
     const program = new Command();
     registerMaintenanceCommands(program);
@@ -66,6 +68,11 @@ describe("registerMaintenanceCommands doctor action", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = previousExitCode;
   });
 
   it("exits with code 0 after successful doctor run", async () => {
@@ -80,6 +87,17 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(options.yes).toBe(true);
     expect(options.allowExec).toBe(true);
     expect(runtime.exit).toHaveBeenCalledWith(0);
+  });
+
+  it("propagates a non-zero process.exitCode set during doctor run (#77804)", async () => {
+    doctorCommand.mockImplementation(async () => {
+      process.exitCode = 1;
+    });
+
+    await runMaintenanceCli(["doctor", "--non-interactive"]);
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.exit).not.toHaveBeenCalledWith(0);
   });
 
   it("exits with code 1 when doctor fails", async () => {

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -173,7 +173,7 @@ export function registerMaintenanceCommands(program: Command) {
           sessionSqliteGithubIssue: Boolean(opts.githubIssue),
           json: Boolean(opts.json),
         });
-        defaultRuntime.exit(0);
+        defaultRuntime.exit(typeof process.exitCode === "number" ? process.exitCode : 0);
       });
     });
   setCommandJsonMode(doctor, "output", isDoctorMachineOutput);

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -190,5 +190,11 @@ export async function runFinalConfigValidationHealth(ctx: DoctorHealthFlowContex
     for (const issue of finalSnapshot.issues) {
       ctx.runtime.error(`- ${issue.path || "<root>"}: ${issue.message}`);
     }
+    // Automation contract (#77804): plain `openclaw doctor` must exit non-zero
+    // when the final on-disk config is still invalid. Preserve an earlier
+    // nonzero exit code if one was already selected.
+    if (!process.exitCode) {
+      process.exitCode = 1;
+    }
   }
 }

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -3565,6 +3565,90 @@ describe("doctor health contributions", () => {
       });
     });
 
+    describe("final-config-validation exit code (#77804)", () => {
+      const previousExitCode = process.exitCode;
+
+      afterEach(() => {
+        process.exitCode = previousExitCode;
+      });
+
+      function runFinalConfigValidation() {
+        const contribution = requireDoctorContribution("doctor:final-config-validation");
+        return contribution.run({
+          cfg: {},
+          cfgForPersistence: {},
+          configResult: { cfg: {} },
+          configPath: "/tmp/fake-openclaw.json",
+          sourceConfigValid: true,
+          prompter: buildDoctorPrompter(true),
+          runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+          options: {},
+          env: {},
+        } as Parameters<(typeof contribution)["run"]>[0]);
+      }
+
+      it("sets process.exitCode to 1 when the final config snapshot is invalid", async () => {
+        process.exitCode = 0;
+        mocks.readConfigFileSnapshot.mockResolvedValue({
+          exists: true,
+          valid: false,
+          config: {},
+          issues: [
+            {
+              path: "models.providers.bailian.models.0.compat.thinkingFormat",
+              message: "Invalid input",
+            },
+          ],
+        });
+
+        await runFinalConfigValidation();
+
+        expect(process.exitCode).toBe(1);
+      });
+
+      it("leaves process.exitCode at 0 when the final config snapshot is valid", async () => {
+        process.exitCode = 0;
+        mocks.readConfigFileSnapshot.mockResolvedValue({
+          exists: true,
+          valid: true,
+          config: {},
+          issues: [],
+        });
+
+        await runFinalConfigValidation();
+
+        expect(process.exitCode).toBe(0);
+      });
+
+      it("leaves process.exitCode at 0 when the config file does not exist", async () => {
+        process.exitCode = 0;
+        mocks.readConfigFileSnapshot.mockResolvedValue({
+          exists: false,
+          valid: false,
+          config: {},
+          issues: [],
+        });
+
+        await runFinalConfigValidation();
+
+        expect(process.exitCode).toBe(0);
+      });
+
+      it("does not lower a non-zero process.exitCode set earlier in the run", async () => {
+        process.exitCode = 2;
+        mocks.readConfigFileSnapshot.mockResolvedValue({
+          exists: true,
+          valid: false,
+          config: {},
+          issues: [{ path: "<root>", message: "Invalid input" }],
+        });
+
+        await runFinalConfigValidation();
+
+        expect(process.exitCode).toBe(2);
+      });
+    });
+
     it("allows allowConfigSizeDrop when not in update", async () => {
       const ctx = buildWriteConfigCtx({});
       await writeConfigContribution.run(ctx);


### PR DESCRIPTION
## Summary

`openclaw doctor` printed `Invalid config:` validation errors but still exited `0`. CI/CD pipelines and wrapper scripts that key off doctor's exit code to detect an unhealthy configuration were therefore falsely reassured. This PR sets `process.exitCode = 1` from `runFinalConfigValidationHealth` when the final on-disk config snapshot is still invalid, and makes the `doctor` command wrapper at `src/cli/program/register.maintenance.ts` honor `process.exitCode` instead of unconditionally exiting `0`.

Fixes #77804.

The change is small and localized:

- `src/flows/doctor-health-contributions.ts` (+3): set `process.exitCode = 1` only if not already non-zero.
- `src/cli/program/register.maintenance.ts` (+1/-1): pass `process.exitCode` through to `defaultRuntime.exit(...)`.
- `src/flows/doctor-health-contributions.test.ts` (+84): four new vitest cases grafted into main's existing `doctor:final-config-validation` block.
- `src/cli/program/register.maintenance.test.ts` (+19): regression for the command-wrapper exit-code passthrough.

Rebased onto current `main` (was ~12k commits behind). Resolved the test-file conflict by taking main's evolved version and re-grafting the four exit-code cases; dropped the contributor `CHANGELOG.md` entry per repo policy.

## Still-needed validation (against current main)

Confirmed still unfixed upstream: `runFinalConfigValidationHealth` on current `main` reads the final snapshot and prints `Invalid config:` issues but never sets `process.exitCode`, and the `doctor` wrapper still calls `defaultRuntime.exit(0)` unconditionally.

## Real behavior proof

Workspace deps are installed, so I exercised the **real** code path live (no mocks): a real invalid `openclaw.json` on disk, read by the real `readConfigFileSnapshot`, run through the real `doctor:final-config-validation` contribution.

Behavior addressed: `openclaw doctor` returned exit code 0 even after printing `Invalid config:` errors from final validation.
Real environment tested: macOS, node 22.22.2, openclaw source at the rebased-onto-main HEAD. Ran the real `resolveDoctorHealthContributions()` contribution against a real on-disk invalid config via tsx.
Exact steps or command run after this patch: wrote an invalid `openclaw.json`, then ran the real final-config-validation contribution against it with `node --import tsx`.
Evidence after fix: live terminal output below.

```
$ cat $OPENCLAW_CONFIG_PATH
{"models":{"providers":{"bailian":{"models":[{"compat":{"thinkingFormat":12345}}]}}}}
$ node --import tsx doctor-live-proof.mts
INVALID config -> process.exitCode = 1
first reported errors: ["Invalid config:",
  "- models.providers.bailian.models.0.id: Invalid input: expected string, received undefined",
  "- models.providers.bailian.models.0.name: Invalid input: expected string, received undefined"]
```

Observed result after fix: the real contribution reads the real invalid file via the real `readConfigFileSnapshot`, prints the `Invalid config:` block, and sets `process.exitCode = 1`. With a valid or missing config it leaves `process.exitCode` at 0, and a non-zero code set earlier in the run is never lowered.
What was not tested: a full `openclaw doctor` CLI bootstrap end-to-end (the from-source CLI boot pulls the entire plugin/gateway graph and was impractical to transpile live in this checkout); the focused run exercises the exact code path the CLI uses, and the wrapper passthrough is covered by `register.maintenance.test.ts`.

## Automated tests

Both touched test files pass with deps reconciled:

```
$ node scripts/run-vitest.mjs run src/flows/doctor-health-contributions.test.ts src/cli/program/register.maintenance.test.ts
 Test Files  2 passed (2)
      Tests  40 passed (40)
```

## Risks

Low. Strictly widens the exit-code surface: `doctor` now returns non-zero only on a state the user already sees printed as errors. The wrapper change preserves the existing healthy-run path (when `process.exitCode` is undefined or 0).

No `CHANGELOG.md` entry, per repo policy (release-owned).
