### PR TITLE
fix(google): canonicalize Gemini 3.1 Flash-Lite bare id

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -435,16 +435,16 @@ Time format in system prompt. Default: `auto` (OS preference).
 
 **Built-in alias shorthands** (only apply when the model is in `agents.defaults.models`):
 
-| Alias               | Model                                  |
-| ------------------- | -------------------------------------- |
-| `opus`              | `anthropic/claude-opus-4-6`            |
-| `sonnet`            | `anthropic/claude-sonnet-4-6`          |
-| `gpt`               | `openai/gpt-5.5`                       |
-| `gpt-mini`          | `openai/gpt-5.4-mini`                  |
-| `gpt-nano`          | `openai/gpt-5.4-nano`                  |
-| `gemini`            | `google/gemini-3.1-pro-preview`        |
-| `gemini-flash`      | `google/gemini-3-flash-preview`        |
-| `gemini-flash-lite` | `google/gemini-3.1-flash-lite-preview` |
+| Alias               | Model                           |
+| ------------------- | ------------------------------- |
+| `opus`              | `anthropic/claude-opus-4-6`     |
+| `sonnet`            | `anthropic/claude-sonnet-4-6`   |
+| `gpt`               | `openai/gpt-5.5`                |
+| `gpt-mini`          | `openai/gpt-5.4-mini`           |
+| `gpt-nano`          | `openai/gpt-5.4-nano`           |
+| `gemini`            | `google/gemini-3.1-pro-preview` |
+| `gemini-flash`      | `google/gemini-3-flash-preview` |
+| `gemini-flash-lite` | `google/gemini-3.1-flash-lite`  |
 
 Your configured aliases always win over defaults.
 

--- a/docs/help/faq-models.md
+++ b/docs/help/faq-models.md
@@ -289,7 +289,7 @@ troubleshooting, see the main [FAQ](/help/faq).
     - `gpt-nano` → `openai/gpt-5.4-nano`
     - `gemini` → `google/gemini-3.1-pro-preview`
     - `gemini-flash` → `google/gemini-3-flash-preview`
-    - `gemini-flash-lite` → `google/gemini-3.1-flash-lite-preview`
+    - `gemini-flash-lite` → `google/gemini-3.1-flash-lite`
 
     If you set your own alias with the same name, your value wins.
 

--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -132,7 +132,7 @@ describe("google generative ai helpers", () => {
         {
           contextWindow: 1,
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          id: "gemini-3.1-flash-lite-preview",
+          id: "gemini-3.1-flash-lite",
           input: ["text"],
           maxTokens: 1,
           name: "Gemini Flash Lite",

--- a/extensions/google/cli-backend.test.ts
+++ b/extensions/google/cli-backend.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCliModel } from "../../src/agents/cli-runner/helpers.js";
+import { buildGoogleGeminiCliBackend } from "./test-api.js";
+
+describe("google gemini cli backend", () => {
+  it("maps flash-lite shorthand to the bare Gemini 3.1 Flash-Lite id", () => {
+    const backend = buildGoogleGeminiCliBackend();
+
+    expect(normalizeCliModel("flash-lite", backend.config)).toBe("gemini-3.1-flash-lite");
+  });
+});

--- a/extensions/google/cli-backend.test.ts
+++ b/extensions/google/cli-backend.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { normalizeCliModel } from "../../src/agents/cli-runner/helpers.js";
 import { buildGoogleGeminiCliBackend } from "./test-api.js";
 
 describe("google gemini cli backend", () => {
-  it("maps flash-lite shorthand to the bare Gemini 3.1 Flash-Lite id", () => {
+  it("configures flash-lite shorthand to the bare Gemini 3.1 Flash-Lite id", () => {
     const backend = buildGoogleGeminiCliBackend();
 
-    expect(normalizeCliModel("flash-lite", backend.config)).toBe("gemini-3.1-flash-lite");
+    expect(backend.config.modelAliases?.["flash-lite"]).toBe("gemini-3.1-flash-lite");
   });
 });

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -7,7 +7,7 @@ import {
 const GEMINI_MODEL_ALIASES: Record<string, string> = {
   pro: "gemini-3.1-pro-preview",
   flash: "gemini-3.1-flash-preview",
-  "flash-lite": "gemini-3.1-flash-lite-preview",
+  "flash-lite": "gemini-3.1-flash-lite",
 };
 const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3-flash-preview";
 

--- a/extensions/google/model-id.test.ts
+++ b/extensions/google/model-id.test.ts
@@ -36,7 +36,8 @@ describe("google model id helpers", () => {
     );
   });
 
-  it("adds the preview suffix for gemini 3.1 flash-lite", () => {
-    expect(normalizeGoogleModelId("gemini-3.1-flash-lite")).toBe("gemini-3.1-flash-lite-preview");
+  it("normalizes discontinued gemini 3.1 flash-lite preview id to the bare id", () => {
+    expect(normalizeGoogleModelId("gemini-3.1-flash-lite-preview")).toBe("gemini-3.1-flash-lite");
+    expect(normalizeGoogleModelId("gemini-3.1-flash-lite")).toBe("gemini-3.1-flash-lite");
   });
 });

--- a/extensions/google/model-id.ts
+++ b/extensions/google/model-id.ts
@@ -18,8 +18,8 @@ export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3.1-pro") {
     return "gemini-3.1-pro-preview";
   }
-  if (id === "gemini-3.1-flash-lite") {
-    return "gemini-3.1-flash-lite-preview";
+  if (id === "gemini-3.1-flash-lite-preview") {
+    return "gemini-3.1-flash-lite";
   }
   if (id === "gemini-3.1-flash" || id === "gemini-3.1-flash-preview") {
     return "gemini-3-flash-preview";

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -14,7 +14,7 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+          "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }
@@ -25,7 +25,7 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+          "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }
@@ -36,7 +36,7 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+          "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }
@@ -133,12 +133,12 @@
       {
         "provider": "google",
         "model": "gemini-2.5-flash-lite-preview-09-25",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite."
       },
       {
         "provider": "google",
         "model": "gemini-2.5-flash-lite-preview-09-2025",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite."
       },
       {
         "provider": "google",
@@ -298,12 +298,12 @@
       {
         "provider": "google-gemini-cli",
         "model": "gemini-2.5-flash-lite-preview-09-25",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-gemini-cli",
         "model": "gemini-2.5-flash-lite-preview-09-2025",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-gemini-cli",
@@ -463,12 +463,12 @@
       {
         "provider": "google-vertex",
         "model": "gemini-2.5-flash-lite-preview-09-25",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-vertex",
         "model": "gemini-2.5-flash-lite-preview-09-2025",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-vertex",

--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -64,7 +64,7 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
         provider: "google-gemini-cli",
         modelId: "gemini-2.5-flash-lite",
         models: [
-          createTemplateModel("google-gemini-cli", "gemini-3.1-flash-lite-preview", {
+          createTemplateModel("google-gemini-cli", "gemini-3.1-flash-lite", {
             contextWindow: 1_048_576,
             api: "google-gemini-cli",
             baseUrl: "https://cloudcode-pa.googleapis.com",
@@ -286,7 +286,7 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
     const models = [
       createTemplateModel("google", "gemini-3-pro-preview", { reasoning: true }),
       createTemplateModel("google", "gemini-3-flash-preview", { reasoning: true }),
-      createTemplateModel("google", "gemini-3.1-flash-lite-preview", { reasoning: true }),
+      createTemplateModel("google", "gemini-3.1-flash-lite", { reasoning: true }),
     ];
 
     expectModelFields(
@@ -409,13 +409,13 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
         providerId: "google-antigravity",
         ctx: createContext({
           provider: "google-antigravity",
-          modelId: "gemini-3.1-flash-lite-preview",
+          modelId: "gemini-3.1-flash-lite",
           models,
         }),
       }),
       {
         provider: "google-antigravity",
-        id: "gemini-3.1-flash-lite-preview",
+        id: "gemini-3.1-flash-lite",
         api: "openai-completions",
         contextWindow: 1_048_576,
       },
@@ -440,12 +440,12 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
       providerId: "google-vertex",
       ctx: createContext({
         provider: "google-vertex",
-        modelId: "gemini-3.1-flash-lite-preview",
+        modelId: "gemini-3.1-flash-lite",
         models: [
           createTemplateModel("google-gemini-cli", "gemini-3-flash-preview", {
             contextWindow: 128_000,
           }),
-          createTemplateModel("google-gemini-cli", "gemini-3.1-flash-lite-preview", {
+          createTemplateModel("google-gemini-cli", "gemini-3.1-flash-lite", {
             contextWindow: 1_048_576,
           }),
         ],
@@ -454,7 +454,7 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
 
     expectModelFields(model, {
       provider: "google-vertex",
-      id: "gemini-3.1-flash-lite-preview",
+      id: "gemini-3.1-flash-lite",
       contextWindow: 1_048_576,
       reasoning: false,
     });

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -23,7 +23,10 @@ const GEMINI_2_5_PRO_TEMPLATE_IDS = ["gemini-2.5-pro"] as const;
 const GEMINI_2_5_FLASH_LITE_TEMPLATE_IDS = ["gemini-2.5-flash-lite"] as const;
 const GEMINI_2_5_FLASH_TEMPLATE_IDS = ["gemini-2.5-flash"] as const;
 const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3.1-pro-preview", "gemini-3-pro-preview"] as const;
-const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = ["gemini-3.1-flash-lite-preview"] as const;
+const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = [
+  "gemini-3.1-flash-lite",
+  "gemini-3.1-flash-lite-preview",
+] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview", "gemini-2.5-flash"] as const;
 const GEMINI_3_PRO_ANTIGRAVITY_TEMPLATE_IDS = ["gemini-3-pro-low", "gemini-3-pro-high"] as const;
 const GEMINI_3_FLASH_ANTIGRAVITY_TEMPLATE_IDS = ["gemini-3-flash"] as const;

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1248,8 +1248,8 @@ describe("applyLocalNoAuthHeaderOverride", () => {
 
 describe("applyAuthHeaderOverride", () => {
   const baseModel: Model<"openai-completions"> = {
-    id: "gemini-3.1-flash-lite-preview",
-    name: "gemini-3.1-flash-lite-preview",
+    id: "gemini-3.1-flash-lite",
+    name: "gemini-3.1-flash-lite",
     api: "openai-completions" as const,
     provider: "google",
     baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -48,7 +48,7 @@ const manifestNormalizationSnapshot = vi.hoisted(() => ({
               "gemini-3-pro": "gemini-3.1-pro-preview",
               "gemini-3-flash": "gemini-3-flash-preview",
               "gemini-3.1-pro": "gemini-3.1-pro-preview",
-              "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+              "gemini-3.1-flash-lite": "gemini-3.1-flash-lite",
               "gemini-3.1-flash": "gemini-3-flash-preview",
               "gemini-3.1-flash-preview": "gemini-3-flash-preview",
             },
@@ -58,7 +58,7 @@ const manifestNormalizationSnapshot = vi.hoisted(() => ({
               "gemini-3-pro": "gemini-3.1-pro-preview",
               "gemini-3-flash": "gemini-3-flash-preview",
               "gemini-3.1-pro": "gemini-3.1-pro-preview",
-              "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+              "gemini-3.1-flash-lite": "gemini-3.1-flash-lite",
               "gemini-3.1-flash": "gemini-3-flash-preview",
               "gemini-3.1-flash-preview": "gemini-3-flash-preview",
             },
@@ -333,7 +333,7 @@ describe("model-selection", () => {
         name: "normalizes gemini 3.1 flash-lite ids",
         variants: ["google/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"],
         defaultProvider: "google",
-        expected: { provider: "google", model: "gemini-3.1-flash-lite-preview" },
+        expected: { provider: "google", model: "gemini-3.1-flash-lite" },
       },
       {
         name: "normalizes deprecated xai grok 4.20 beta ids",
@@ -408,7 +408,7 @@ describe("model-selection", () => {
         name: "normalizes gemini 3.1 flash-lite ids for google-vertex",
         variants: ["google-vertex/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"],
         defaultProvider: "google-vertex",
-        expected: { provider: "google-vertex", model: "gemini-3.1-flash-lite-preview" },
+        expected: { provider: "google-vertex", model: "gemini-3.1-flash-lite" },
       },
       {
         name: "normalizes anthropic-cli refs to the Claude CLI provider alias",
@@ -1738,7 +1738,7 @@ describe("model-selection", () => {
 
       expect(result).toEqual({
         provider: "google-vertex",
-        model: "gemini-3.1-flash-lite-preview",
+        model: "gemini-3.1-flash-lite",
       });
     });
 

--- a/src/agents/models-config.providers.google-antigravity.test.ts
+++ b/src/agents/models-config.providers.google-antigravity.test.ts
@@ -8,7 +8,7 @@ vi.mock("../plugins/provider-runtime.js", () => {
       return /^(gemini-3(?:[.-]1)?-pro)$/.test(modelId) ? `${modelId}-low` : modelId;
     }
     if (provider === "google-vertex" && modelId === "gemini-3.1-flash-lite") {
-      return "gemini-3.1-flash-lite-preview";
+      return "gemini-3.1-flash-lite";
     }
     return modelId;
   }
@@ -125,7 +125,7 @@ describe("google-vertex provider normalization", () => {
 
     expect(normalized).not.toBe(providers);
     expect(normalized?.["google-vertex"]?.models.map((model) => model.id)).toEqual([
-      "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite",
       "gemini-3-flash-preview",
     ]);
     expect(normalized?.openai).toBe(providers.openai);
@@ -133,7 +133,7 @@ describe("google-vertex provider normalization", () => {
 
   it("returns original providers object when no google-vertex IDs need normalization", () => {
     const providers = {
-      "google-vertex": buildProvider(["gemini-3.1-flash-lite-preview", "gemini-3-flash-preview"], {
+      "google-vertex": buildProvider(["gemini-3.1-flash-lite", "gemini-3-flash-preview"], {
         api: undefined,
       }),
     };

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -929,7 +929,7 @@ describe("isFailoverErrorMessage", () => {
 
   it("matches google INTERNAL status errors as timeout", () => {
     const sample =
-      "provider=google model=gemini-3.1-flash-lite-preview got status: INTERNAL upstream failure code:500";
+      "provider=google model=gemini-3.1-flash-lite got status: INTERNAL upstream failure code:500";
     expect(isTimeoutErrorMessage(sample)).toBe(true);
     expect(classifyFailoverReason(sample)).toBe("timeout");
     expect(isFailoverErrorMessage(sample)).toBe(true);
@@ -1552,7 +1552,7 @@ describe("classifyProviderRuntimeFailureKind", () => {
   it("classifies google-style INTERNAL status payloads as timeout", () => {
     expect(
       classifyFailoverReason(
-        'ERROR provider=google model=gemini-3.1-flash-lite-preview: got status: INTERNAL, details: {"code":500,"status":"INTERNAL"}',
+        'ERROR provider=google model=gemini-3.1-flash-lite: got status: INTERNAL, details: {"code":500,"status":"INTERNAL"}',
       ),
     ).toBe("timeout");
     expect(

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -614,7 +614,7 @@ describe("modelsListCommand forward-compat", () => {
       mocks.loadModelCatalog.mockResolvedValueOnce([
         {
           provider: "google",
-          id: "gemini-3.1-flash-lite-preview",
+          id: "gemini-3.1-flash-lite",
           name: "Gemini 3.1 Flash Lite Preview",
           input: ["text"],
           contextWindow: 1_000_000,
@@ -629,11 +629,11 @@ describe("modelsListCommand forward-compat", () => {
       expectRowKeys(rows, [
         "xiaomi/mimo-v2.5-pro",
         "xiaomi/mimo-v2.5",
-        "google/gemini-3.1-flash-lite-preview",
+        "google/gemini-3.1-flash-lite",
       ]);
       expectRowFields(rows, "xiaomi/mimo-v2.5-pro", { name: "MiMo V2.5 Pro" });
       expectRowFields(rows, "xiaomi/mimo-v2.5", { name: "MiMo V2.5" });
-      expectRowFields(rows, "google/gemini-3.1-flash-lite-preview", {
+      expectRowFields(rows, "google/gemini-3.1-flash-lite", {
         name: "Gemini 3.1 Flash Lite Preview",
         available: true,
       });

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -32,7 +32,7 @@ const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   // Google Gemini (3.x are preview ids in the catalog)
   gemini: "google/gemini-3.1-pro-preview",
   "gemini-flash": "google/gemini-3-flash-preview",
-  "gemini-flash-lite": "google/gemini-3.1-flash-lite-preview",
+  "gemini-flash-lite": "google/gemini-3.1-flash-lite",
 };
 
 const DEFAULT_MODEL_COST: ModelDefinitionConfig["cost"] = {

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -110,7 +110,7 @@ describe("applyModelDefaults", () => {
           models: {
             "google/gemini-3.1-pro-preview": { alias: "" },
             "google/gemini-3-flash-preview": {},
-            "google/gemini-3.1-flash-lite-preview": {},
+            "google/gemini-3.1-flash-lite": {},
           },
         },
       },
@@ -122,7 +122,7 @@ describe("applyModelDefaults", () => {
     expect(next.agents?.defaults?.models?.["google/gemini-3-flash-preview"]?.alias).toBe(
       "gemini-flash",
     );
-    expect(next.agents?.defaults?.models?.["google/gemini-3.1-flash-lite-preview"]?.alias).toBe(
+    expect(next.agents?.defaults?.models?.["google/gemini-3.1-flash-lite"]?.alias).toBe(
       "gemini-flash-lite",
     );
   });

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -94,7 +94,7 @@ const GATEWAY_LIVE_HEARTBEAT_MS = Math.max(
 );
 const GATEWAY_LIVE_STRIP_SCAFFOLDING_MODEL_KEYS = new Set([
   "google/gemini-3-flash-preview",
-  "google/gemini-3.1-flash-lite-preview",
+  "google/gemini-3.1-flash-lite",
   "google/gemini-3.1-pro-preview",
   "google/gemini-3.1-pro-preview-customtools",
   "openai/gpt-5.4-pro",
@@ -104,7 +104,7 @@ const GATEWAY_LIVE_EXEC_READ_NONCE_MISS_SKIP_MODEL_KEYS = new Set([
   "fireworks/accounts/fireworks/models/kimi-k2p5",
   "fireworks/accounts/fireworks/models/kimi-k2p6",
   "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
-  "google/gemini-3.1-flash-lite-preview",
+  "google/gemini-3.1-flash-lite",
 ]);
 const GATEWAY_LIVE_TOOL_NONCE_MISS_SKIP_MODEL_KEYS = new Set(["google/gemini-3-flash-preview"]);
 const GATEWAY_LIVE_MAX_MODELS = resolveGatewayLiveMaxModels();
@@ -503,7 +503,7 @@ describe("maybeStripAssistantScaffoldingForLiveModel", () => {
     expect(
       maybeStripAssistantScaffoldingForLiveModel(
         "<think>hidden</think>Visible",
-        "google/gemini-3.1-flash-lite-preview",
+        "google/gemini-3.1-flash-lite",
       ),
     ).toBe("Visible");
     expect(
@@ -573,9 +573,7 @@ describe("maybeStripAssistantScaffoldingForLiveModel", () => {
 
 describe("shouldSkipExecReadNonceMissForLiveModel", () => {
   it("matches the known Gemini lite exec/read isolation case", () => {
-    expect(shouldSkipExecReadNonceMissForLiveModel("google/gemini-3.1-flash-lite-preview")).toBe(
-      true,
-    );
+    expect(shouldSkipExecReadNonceMissForLiveModel("google/gemini-3.1-flash-lite")).toBe(true);
     expect(shouldSkipExecReadNonceMissForLiveModel("google/gemini-3.1-flash-lite")).toBe(true);
     expect(shouldSkipExecReadNonceMissForLiveModel("google/gemini-3.1-flash-preview")).toBe(false);
   });

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -752,10 +752,10 @@ describe("describeImageWithModel", () => {
   it("normalizes gemini 3.1 flash-lite ids before lookup and keeps profile auth selection", async () => {
     const findMock = vi.fn((provider: string, modelId: string) => {
       expect(provider).toBe("google");
-      expect(modelId).toBe("gemini-3.1-flash-lite-preview");
+      expect(modelId).toBe("gemini-3.1-flash-lite");
       return {
         provider: "google",
-        id: "gemini-3.1-flash-lite-preview",
+        id: "gemini-3.1-flash-lite",
         input: ["text", "image"],
         baseUrl: "https://generativelanguage.googleapis.com/v1beta",
       };
@@ -765,7 +765,7 @@ describe("describeImageWithModel", () => {
       role: "assistant",
       api: "google-generative-ai",
       provider: "google",
-      model: "gemini-3.1-flash-lite-preview",
+      model: "gemini-3.1-flash-lite",
       stopReason: "stop",
       timestamp: Date.now(),
       content: [{ type: "text", text: "flash lite ok" }],
@@ -786,7 +786,7 @@ describe("describeImageWithModel", () => {
 
     expect(result).toEqual({
       text: "flash lite ok",
-      model: "gemini-3.1-flash-lite-preview",
+      model: "gemini-3.1-flash-lite",
     });
     expect(findMock).toHaveBeenCalledOnce();
     const authRequest = getApiKeyForModelCall();

--- a/src/plugin-sdk/provider-model-id-normalize.ts
+++ b/src/plugin-sdk/provider-model-id-normalize.ts
@@ -16,8 +16,8 @@ export function normalizeGooglePreviewModelId(id: string): string {
   if (id === "gemini-3.1-pro") {
     return "gemini-3.1-pro-preview";
   }
-  if (id === "gemini-3.1-flash-lite") {
-    return "gemini-3.1-flash-lite-preview";
+  if (id === "gemini-3.1-flash-lite-preview") {
+    return "gemini-3.1-flash-lite";
   }
   if (id === "gemini-3.1-flash" || id === "gemini-3.1-flash-preview") {
     return "gemini-3-flash-preview";


### PR DESCRIPTION
## Summary

- Problem: OpenClaw canonicalized `gemini-3.1-flash-lite` back to `gemini-3.1-flash-lite-preview`, and the Gemini CLI `flash-lite` shorthand also pointed at the preview id.
- Why it matters: Gemini 3.1 Flash Lite Preview is scheduled for discontinuation on May 25, 2026, so OpenClaw should route users to the bare canonical API id.
- What changed: Updated Google model normalization, provider aliases, default alias docs, provider template fallback, and Gemini CLI shorthand to prefer `gemini-3.1-flash-lite` while preserving preview-id compatibility aliases.
- What did NOT change (scope boundary): This does not change Gemini 3.1 Pro or Gemini 3 Flash canonicalization, auth behavior, provider transport behavior, or non-Google providers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenClaw should execute Google Gemini 3.1 Flash-Lite with the canonical bare model id `gemini-3.1-flash-lite`, not normalize or fall back to the discontinued preview id `gemini-3.1-flash-lite-preview`.
- Real environment tested: Real OpenClaw setup on a Linux VPS using the installed pnpm global OpenClaw package and user systemd gateway.

```text
Command: /home/linuxbrew/.linuxbrew/opt/node/bin/node /home/mcgheeai/.local/share/pnpm/global/5/node_modules/openclaw/dist/index.js gateway --port 18789
Config (service): ~/.openclaw/openclaw.json
Runtime: running (pid 756581, state active, sub running, last exit 0, reason 0)
Connectivity probe: ok
Installed package path: /home/mcgheeai/.local/share/pnpm/global/5/node_modules/openclaw
Service config: ~/.openclaw/openclaw.json
```

- Exact steps or command run after this patch:

```bash
openclaw agent --local --agent max \
  --session-id pr-81831-structured-proof-1778768798 \
  --model google/gemini-3.1-flash-lite \
  --thinking off \
  --message 'Model smoke test. Reply with exactly: GEMINI_MODEL_OK' \
  --json
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
payload_text: GEMINI_MODEL_OK
agent_provider: google
agent_model: gemini-3.1-flash-lite
executionTrace.winnerProvider: google
executionTrace.winnerModel: gemini-3.1-flash-lite
executionTrace.fallbackUsed: False
sessionId: pr-81831-structured-proof-1778768798
```

- Observed result after fix: The live OpenClaw run succeeded, returned `GEMINI_MODEL_OK`, used provider `google`, and reported both `agent_model` and `executionTrace.winnerModel` as `gemini-3.1-flash-lite` with `executionTrace.fallbackUsed: False`.
- What was not tested: I did not run a real `google-gemini-cli` backend invocation or a real Vertex invocation in this proof. This PR includes source changes and focused unit coverage for the Gemini CLI `flash-lite` shorthand, but the real behavior proof above is for the OpenClaw embedded Google provider path on a live setup.
- Before evidence (optional but encouraged): Before this fix, an OpenClaw embedded smoke test using `google/gemini-3.1-flash-lite` succeeded functionally but reported `winnerModel` / model resolution as `gemini-3.1-flash-lite-preview`.

## Root Cause (if applicable)

- Root cause: Google provider normalization and bundled plugin aliases still treated the preview-suffixed Flash-Lite id as canonical, and the Gemini CLI backend had a separate `flash-lite` alias table that also targeted the preview id.
- Missing detection / guardrail: Tests covered preview normalization expectations but did not assert the bare Gemini 3.1 Flash-Lite id remains canonical or that the Gemini CLI shorthand maps to the bare id.
- Contributing context (if known): Gemini 3.1 Flash Lite Preview deprecation changes the preferred/canonical runtime id.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/google/model-id.test.ts`, `src/agents/model-selection.test.ts`, `src/plugins/provider-runtime.test.ts`, `extensions/google/provider-models.test.ts`, `extensions/google/cli-backend.test.ts`, and related model alias/list tests.
- Scenario the test should lock in: Bare `gemini-3.1-flash-lite` remains canonical, preview `gemini-3.1-flash-lite-preview` remains a compatibility alias to the bare id, and Gemini CLI shorthand `flash-lite` maps to the bare id.
- Why this is the smallest reliable guardrail: The behavior is model-id normalization/catalog aliasing, so focused unit tests lock the routing contract without requiring live provider calls in CI.
- Existing test that already covers this (if any): Existing tests covered adjacent model normalization but expected preview as canonical, so they were updated.
- If no new test is added, why not: New focused coverage was added for the Gemini CLI shorthand.

## User-visible / Behavior Changes

Users selecting Gemini 3.1 Flash-Lite through Google provider aliases, default `gemini-flash-lite`, or Gemini CLI shorthand now resolve to `gemini-3.1-flash-lite` instead of the preview-suffixed id. Preview-suffixed ids remain accepted as compatibility aliases.

## Diagram (if applicable)

```text
Before:
user selects gemini-3.1-flash-lite -> OpenClaw normalization -> gemini-3.1-flash-lite-preview
Gemini CLI flash-lite shorthand -> gemini-3.1-flash-lite-preview

After:
user selects gemini-3.1-flash-lite -> OpenClaw normalization -> gemini-3.1-flash-lite -> Google
user selects gemini-3.1-flash-lite-preview -> compatibility alias -> gemini-3.1-flash-lite -> Google
Gemini CLI flash-lite shorthand -> gemini-3.1-flash-lite
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux VPS, kernel 6.17.0-1011-oracle arm64
- Runtime/container: OpenClaw installed via pnpm global package, gateway running under user systemd
- Model/provider: `google/gemini-3.1-flash-lite`
- Integration/channel (if any): OpenClaw embedded Google provider path
- Relevant config (redacted): service config `~/.openclaw/openclaw.json`; no secrets included

### Steps

1. Apply the equivalent local dist hotfix for this PR on a real OpenClaw install.
2. Verify gateway health with `openclaw gateway status`.
3. Run the smoke-test command shown in the Real behavior proof section.

### Expected

- OpenClaw returns `GEMINI_MODEL_OK` and reports model resolution as `gemini-3.1-flash-lite`.

### Actual

- OpenClaw returned `GEMINI_MODEL_OK` and reported `agent_model` / `executionTrace.winnerModel` as `gemini-3.1-flash-lite` with no fallback.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

See copied live terminal output in **Real behavior proof** above.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Real OpenClaw gateway health after local hotfix/reload; live embedded Google provider smoke test using `google/gemini-3.1-flash-lite`; targeted Vitest coverage for Google model normalization, provider runtime, model selection, provider catalog, CLI alias, docs/list behavior, and media-understanding call paths.
- Edge cases checked: Preview id remains accepted as a compatibility alias to the bare id; Gemini CLI `flash-lite` shorthand now maps to the bare id.
- What you did **not** verify: Real Gemini CLI backend invocation; real Vertex invocation.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Some users may still configure the preview-suffixed Flash-Lite id explicitly.
  - Mitigation: Preview-suffixed `gemini-3.1-flash-lite-preview` remains accepted and normalizes forward to `gemini-3.1-flash-lite`.
- Risk: The real behavior proof covers Google embedded provider but not Gemini CLI or Vertex live execution.
  - Mitigation: Source changes cover those aliases and focused unit tests lock the Gemini CLI shorthand mapping; `notTested` calls out the live coverage boundary.
