### PR TITLE
feat(whatsapp): add post-link 'next steps' note and hello-world docs (#75082)

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -80,8 +80,31 @@ openclaw gateway
 
   </Step>
 
+  <Step title="Send your first message">
+
+    Verify routing. Onboarding will not auto-send anything.
+
+    Inbound depends on your `dmPolicy`:
+
+    - `pairing` (default): message the linked assistant number from any phone. First contact triggers a pairing code that you approve in the next step.
+    - `allowlist`: message from a sender included in `allowFrom`. Senders outside the list are dropped.
+    - `open`: any sender can message and is routed.
+    - `disabled`: inbound DMs are ignored. Use the outbound CLI path below to verify.
+
+    Outbound (any policy): replace the target with a destination number or group JID.
+
+```bash
+openclaw message send --channel whatsapp \
+  --target +15551234567 --message "hi"
+```
+
+    See [Message](/cli/message) for `--account`, `--media`, presentation payloads, and other options.
+
+  </Step>
+
   <Step title="Approve the first DM access request (pairing mode)">
 
+    In `pairing` mode, the first inbound message above creates a pending request.
     Open **Settings → Channels → DM access requests**, find the WhatsApp account,
     and approve the sender. If you prefer the CLI:
 

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -149,6 +149,23 @@ openclaw message send --channel msteams \
   --presentation '{"title":"Status update","blocks":[{"type":"text","text":"Build completed"}]}'
 ```
 
+Send a WhatsApp hello-world after onboarding:
+
+```bash
+openclaw message send --channel whatsapp \
+  --target +15551234567 --message "hi"
+```
+
+The target is an E.164 number for direct chats. For groups, use the group JID
+(e.g. `120363045678901234@g.us`) — this is what the gateway logs when a group
+message is received. For multi-account setups, add `--account <id>` to pick
+the linked account.
+
+```bash
+openclaw message send --channel whatsapp \
+  --target 120363045678901234@g.us --message "hello group"
+```
+
 ### Poll
 
 ```bash

--- a/extensions/whatsapp/src/channel.setup.test.ts
+++ b/extensions/whatsapp/src/channel.setup.test.ts
@@ -16,8 +16,10 @@ import {
   createWhatsAppPersonalPhoneHarness,
   createWhatsAppRootAllowFromConfig,
   expectNoWhatsAppLoginFollowup,
+  expectNoWhatsAppNextStepsNote,
   expectWhatsAppAllowlistModeSetup,
   expectWhatsAppLoginFollowup,
+  expectWhatsAppNextStepsNote,
   expectWhatsAppOpenPolicySetup,
   expectWhatsAppOwnerAllowlistSetup,
   expectWhatsAppPersonalPhoneSetup,
@@ -429,6 +431,7 @@ describe("whatsapp setup wizard", () => {
     expect(hoisted.loginWeb).toHaveBeenCalledWith(false, undefined, runtime, DEFAULT_ACCOUNT_ID, {
       beforeCredentialPersistence: undefined,
     });
+    expectWhatsAppNextStepsNote(harness);
   });
 
   it("skips relink note when already linked and relink is declined", async () => {
@@ -443,6 +446,7 @@ describe("whatsapp setup wizard", () => {
 
     expect(hoisted.loginWeb).not.toHaveBeenCalled();
     expectNoWhatsAppLoginFollowup(harness);
+    expectWhatsAppNextStepsNote(harness);
   });
 
   it("shows follow-up login command note when not linked and linking is skipped", async () => {
@@ -456,6 +460,20 @@ describe("whatsapp setup wizard", () => {
     });
 
     expectWhatsAppLoginFollowup(harness);
+    expectNoWhatsAppNextStepsNote(harness);
+  });
+
+  it("does not show next steps note when WhatsApp login fails", async () => {
+    hoisted.hasWebCredsSync.mockReturnValue(false);
+    hoisted.loginWeb.mockRejectedValueOnce(new Error("login failed"));
+    const harness = createWhatsAppLinkingHarness(createQueuedWizardPrompter);
+
+    await runConfigureWithHarness({
+      harness,
+    });
+
+    expect(hoisted.loginWeb).toHaveBeenCalled();
+    expectNoWhatsAppNextStepsNote(harness);
   });
 
   it("heartbeat readiness uses configured defaultAccount for active listener checks", async () => {

--- a/extensions/whatsapp/src/setup-finalize.ts
+++ b/extensions/whatsapp/src/setup-finalize.ts
@@ -27,6 +27,8 @@ type SetupRuntime = Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0]["
 type WhatsAppConfig = NonNullable<NonNullable<OpenClawConfig["channels"]>["whatsapp"]>;
 type WhatsAppAccountConfig = NonNullable<NonNullable<WhatsAppConfig["accounts"]>[string]>;
 
+export const WHATSAPP_NEXT_STEPS_NOTE_TITLE = "WhatsApp next steps";
+
 function trimPromptText(value: string | null | undefined): string {
   return value?.trim() ?? "";
 }
@@ -432,6 +434,7 @@ export async function finalizeWhatsAppSetup(params: {
     message: linked ? t("wizard.whatsapp.relinkPrompt") : t("wizard.whatsapp.linkNowPrompt"),
     initialValue: !linked,
   });
+  let linkSucceeded = linked && !wantsLink;
   if (wantsLink) {
     const reportLoginFailure = async (error: unknown) => {
       params.runtime.error(`WhatsApp login failed: ${String(error)}`);
@@ -462,6 +465,7 @@ export async function finalizeWhatsAppSetup(params: {
         await loginWeb(false, undefined, params.runtime, accountId, {
           beforeCredentialPersistence,
         });
+        linkSucceeded = true;
       } catch (error) {
         if (persistenceGuardFailure) {
           throw persistenceGuardFailure.error;
@@ -484,5 +488,38 @@ export async function finalizeWhatsAppSetup(params: {
     forceAllowFrom: params.forceAllowFrom,
     prompter: params.prompter,
   });
+
+  if (linkSucceeded) {
+    const finalAccount = resolveWhatsAppAccount({ cfg: next, accountId });
+    const finalPolicy = finalAccount.dmPolicy ?? "pairing";
+    const sendCommand = formatCliCommand(
+      "openclaw message send --channel whatsapp --target +15551234567 --message hi",
+    );
+    const inboundLine = describeWhatsAppInboundLine(finalPolicy);
+    await params.prompter.note(
+      [
+        ...(inboundLine ? [inboundLine] : []),
+        `Outbound from the CLI: \`${sendCommand}\` (replace the target with a destination number or group JID).`,
+        `Docs: ${formatDocsLink("/cli/message", "cli/message")}`,
+      ].join("\n"),
+      WHATSAPP_NEXT_STEPS_NOTE_TITLE,
+    );
+  }
+
   return { cfg: next };
+}
+
+function describeWhatsAppInboundLine(policy: DmPolicy): string | undefined {
+  switch (policy) {
+    case "disabled":
+      return undefined;
+    case "pairing":
+      return `Inbound: message the linked assistant number; first contact from a new sender will trigger a pairing code you approve via \`${formatCliCommand("openclaw pairing approve whatsapp <CODE>")}\`.`;
+    case "allowlist":
+      return "Inbound: message the linked assistant number from a sender included in your `allowFrom` list to verify routing.";
+    case "open":
+      return "Inbound: message the linked assistant number from any number to verify routing (`dmPolicy=open`).";
+    default:
+      return "Inbound: message the linked assistant number to verify routing.";
+  }
 }

--- a/extensions/whatsapp/src/setup-test-helpers.ts
+++ b/extensions/whatsapp/src/setup-test-helpers.ts
@@ -1,5 +1,6 @@
 // Whatsapp helper module supports setup test helpers behavior.
 import { expect } from "vitest";
+import { WHATSAPP_NEXT_STEPS_NOTE_TITLE } from "./setup-finalize.js";
 
 type WhatsAppSetupConfig = {
   channels?: {
@@ -12,10 +13,14 @@ type WhatsAppSetupConfig = {
   };
 };
 
+type MockFn = ((...args: unknown[]) => unknown) & {
+  mock: { calls: unknown[][] };
+};
+
 type WizardPromptHarness = {
-  text: (...args: unknown[]) => unknown;
-  select: (...args: unknown[]) => unknown;
-  note: (...args: unknown[]) => unknown;
+  text: MockFn;
+  select: MockFn;
+  note: MockFn;
 };
 
 type QueuedWizardPrompterFactory<T extends WizardPromptHarness> = (params: {
@@ -197,6 +202,22 @@ export function expectWhatsAppLoginFollowup(harness: WizardPromptHarness): void 
     expect.stringContaining("openclaw channels login"),
     WHATSAPP_LOGIN_NOTE_TITLE,
   );
+}
+
+export function expectWhatsAppNextStepsNote(harness: WizardPromptHarness): void {
+  expect(harness.note).toHaveBeenCalledWith(
+    expect.stringContaining("openclaw message send --channel whatsapp"),
+    WHATSAPP_NEXT_STEPS_NOTE_TITLE,
+  );
+}
+
+export function expectNoWhatsAppNextStepsNote(harness: WizardPromptHarness): void {
+  // Inspect mock.calls directly so a hypothetical note(null, TITLE) call is also
+  // caught (expect.any(String) and expect.anything() both miss null/undefined).
+  const calledWithTitle = harness.note.mock.calls.some(
+    (args) => args[1] === WHATSAPP_NEXT_STEPS_NOTE_TITLE,
+  );
+  expect(calledWithTitle).toBe(false);
 }
 
 export function expectWhatsAppWorkAccountAccessNote(harness: WizardPromptHarness): void {


### PR DESCRIPTION
## Summary

After a successful WhatsApp link (or a declined relink on an already-linked account), this PR emits a dmPolicy-aware **"WhatsApp next steps"** note that tells the operator how to verify routing: the inbound path for the effective `dmPolicy` (pairing / allowlist / open / disabled) and the outbound `openclaw message send` CLI path. Onboarding never auto-sends anything.

It also adds a "Send your first message" step to the WhatsApp quick-setup docs and a WhatsApp example to the message CLI docs.

Per review feedback, the docs "Send your first message" step is now ordered **before** "Approve first pairing request", since in default `pairing` mode the first inbound message is what creates the pairing request.

Rebased onto current `main` (was ~12k commits behind); fixed a rebase-integration bug in the new test (stale `hoisted.pathExists` reference → switched to main's `hasWebCredsSync` harness) and dropped the contributor `CHANGELOG.md` entry per repo policy.

Fixes #74413. Supersedes the earlier closed PR #75082 (the gap is confirmed present on current `main`).

## Real behavior proof

I do not have a live WhatsApp account/number to perform a real pairing, so the live proof here is the **actual rendered next-steps note** produced by the real `finalizeWhatsAppSetup` code path (the setup wizard finalize, with only the network login I/O stubbed). The note content is asserted by the setup tests.

Behavior addressed: WhatsApp setup finalized linking without telling the operator how to verify routing or send a first message.
Real environment tested: ran the real `finalizeWhatsAppSetup` from `extensions/whatsapp/src/setup-finalize.ts` through the WhatsApp setup-wizard harness on node 22.22.2; captured the actual emitted note.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs run extensions/whatsapp/src/channel.setup.test.ts` exercises the real finalize and asserts the emitted note; the rendered note body for the default `pairing` policy is:
Evidence after fix: rendered "WhatsApp next steps" note (default `pairing` dmPolicy) emitted by the real finalize path:

```
[note title] WhatsApp next steps
Inbound: message the linked assistant number; first contact from a new sender
will trigger a pairing code you approve via `openclaw pairing approve whatsapp <CODE>`.
Outbound from the CLI: `openclaw message send --channel whatsapp --target +15551234567 --message hi`
(replace the target with a destination number or group JID).
Docs: cli/message
```

Observed result after fix: on a successful link (or declined relink) the wizard now emits the dmPolicy-aware next-steps note shown above via `openclaw message send` / `openclaw pairing approve` guidance; when login fails or linking is skipped, no note is emitted.
What was not tested: a live end-to-end WhatsApp pairing and inbound/outbound message round-trip was not performed (no WhatsApp number available to the contributor). Requesting a maintainer proof override for the live-pairing portion, per the review's stated path; the note-rendering and policy branching are exercised by the setup tests below.

## Automated tests

```
$ node scripts/run-vitest.mjs run extensions/whatsapp/src/channel.setup.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

## Risks

Low. Additive: a post-link informational note plus docs. No auto-send, no new outbound surface. The note is gated on `linkSucceeded`, so failed/declined links emit nothing.

No `CHANGELOG.md` entry, per repo policy (release-owned).
