### PR TITLE
fix(skills): allow update size-drop cleanup

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -592,7 +592,11 @@ terminal summary, and sanitized error text.
   - ClawHub mode updates one tracked slug or all tracked ClawHub installs in
     the default agent workspace.
   - Config mode patches `skills.entries.<skillKey>` values such as `enabled`,
-    `apiKey`, and `env`.
+    `apiKey`, and `env`. Trusted admin clients may also pass
+    `allowConfigSizeDrop: true` when the update intentionally removes large
+    skill env secrets, such as an integration disconnect cleanup. The flag only
+    opts into the config writer's size-drop allowance; other destructive config
+    write guards still apply.
 
 ### `models.list` views
 

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -310,6 +310,7 @@ export const SkillsUpdateParamsSchema = Type.Union([
       enabled: Type.Optional(Type.Boolean()),
       apiKey: Type.Optional(Type.String()),
       env: Type.Optional(Type.Record(NonEmptyString, Type.String())),
+      allowConfigSizeDrop: Type.Optional(Type.Boolean()),
     },
     { additionalProperties: false },
   ),

--- a/src/gateway/server-methods/skills-config-mutations.ts
+++ b/src/gateway/server-methods/skills-config-mutations.ts
@@ -7,9 +7,13 @@ export async function updateSkillConfigEntry(params: {
   enabled?: boolean;
   apiKey?: string;
   env?: Record<string, string>;
+  allowConfigSizeDrop?: boolean;
 }): Promise<Record<string, unknown>> {
   const committed = await mutateConfigFileWithRetry<Record<string, unknown>>({
     afterWrite: { mode: "auto" },
+    writeOptions: {
+      allowConfigSizeDrop: params.allowConfigSizeDrop === true,
+    },
     mutate: (draft) => {
       const skills = draft.skills ? { ...draft.skills } : {};
       const entries = skills.entries ? { ...skills.entries } : {};

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -328,6 +328,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
       enabled?: boolean;
       apiKey?: string;
       env?: Record<string, string>;
+      allowConfigSizeDrop?: boolean;
     };
     const updated = await updateSkillConfigEntry(p);
     respond(

--- a/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
+++ b/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { REDACTED_SENTINEL } from "../../config/redact-snapshot.js";
 
 let writtenConfig: unknown = null;
+let lastWriteOptions: unknown = null;
 let loadedConfig: unknown = {
   skills: {
     entries: {},
@@ -20,11 +21,13 @@ vi.mock("../../config/config.js", () => {
       writtenConfig = nextConfig;
     },
     mutateConfigFileWithRetry: async (params: {
+      writeOptions?: unknown;
       mutate: (
         draft: OpenClawConfig,
         context: { snapshot: { path: string }; previousHash: string; attempt: number },
       ) => unknown;
     }) => {
+      lastWriteOptions = params.writeOptions;
       const draft = structuredClone(loadedConfig) as OpenClawConfig;
       const snapshot = { path: "/tmp/openclaw/config.json" };
       const result = await params.mutate(draft, {
@@ -66,6 +69,7 @@ function expectWrittenSkillEntry(skillKey: string, entry: unknown) {
 describe("skills.update", () => {
   it("strips embedded CR/LF from apiKey", async () => {
     writtenConfig = null;
+    lastWriteOptions = null;
     loadedConfig = {
       skills: {
         entries: {},
@@ -98,6 +102,7 @@ describe("skills.update", () => {
 
   it("redacts apiKey and secret env values from the response but writes full values to config", async () => {
     writtenConfig = null;
+    lastWriteOptions = null;
     loadedConfig = {
       skills: {
         entries: {},
@@ -143,6 +148,7 @@ describe("skills.update", () => {
 
   it("keeps existing secrets when clients submit redacted sentinel values", async () => {
     writtenConfig = null;
+    lastWriteOptions = null;
     loadedConfig = {
       skills: {
         entries: {
@@ -179,6 +185,69 @@ describe("skills.update", () => {
         GEMINI_API_KEY: "secret-env-key-456",
         BRAVE_REGION: "eu",
       },
+    });
+  });
+
+  it("allows intentional config size drops when requested", async () => {
+    writtenConfig = null;
+    lastWriteOptions = null;
+    loadedConfig = {
+      skills: {
+        entries: {
+          "demo-skill": {
+            env: {
+              OBSOLETE_KEY: "remove-me",
+            },
+          },
+        },
+      },
+    };
+
+    await skillsHandlers["skills.update"]({
+      params: {
+        skillKey: "demo-skill",
+        env: {
+          OBSOLETE_KEY: "",
+        },
+        allowConfigSizeDrop: true,
+      },
+      req: {} as never,
+      client: null as never,
+      isWebchatConnect: () => false,
+      context: { getRuntimeConfig: () => loadedConfig } as never,
+      respond: () => {},
+    });
+
+    expect(lastWriteOptions).toEqual({ allowConfigSizeDrop: true });
+    expectWrittenSkillEntry("demo-skill", {
+      env: {},
+    });
+  });
+
+  it("keeps the size-drop override disabled by default", async () => {
+    writtenConfig = null;
+    lastWriteOptions = null;
+    loadedConfig = {
+      skills: {
+        entries: {},
+      },
+    };
+
+    await skillsHandlers["skills.update"]({
+      params: {
+        skillKey: "demo-skill",
+        enabled: true,
+      },
+      req: {} as never,
+      client: null as never,
+      isWebchatConnect: () => false,
+      context: { getRuntimeConfig: () => loadedConfig } as never,
+      respond: () => {},
+    });
+
+    expect(lastWriteOptions).toEqual({ allowConfigSizeDrop: false });
+    expectWrittenSkillEntry("demo-skill", {
+      enabled: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- add optional `allowConfigSizeDrop` to non-ClawHub `skills.update` params
- forward the flag to the existing config writer `writeOptions` path
- cover requested true behavior and default disabled behavior in the existing skills.update test

Closes #81828.

## Real behavior proof

- **Behavior or issue addressed**: A trusted `skills.update` cleanup can delete large skill env secrets and disable the skill when `allowConfigSizeDrop: true`, while the same large size-drop cleanup stays blocked without the flag.
- **Real environment tested**: Local OpenClaw checkout at commit `97f9b5c416`, Node via repo `tsx`, temp config file `OPENCLAW_CONFIG_PATH=/tmp/tmp.5GEUBHHbGZ/openclaw.json`.
- **Exact steps or command run after the patch**:
  1. Created a temp `openclaw.json` with `skills.entries.demo-cleanup-skill.enabled=true` and two 1600-byte env secret values.
  2. Called the real `updateSkillConfigEntry` path without `allowConfigSizeDrop` while clearing both env values and setting `enabled=false`.
  3. Repeated the same cleanup with `allowConfigSizeDrop: true`.
  4. Read the resulting config file from disk.
- **Evidence after fix**:
  ```text
  Config write rejected: /tmp/tmp.5GEUBHHbGZ/openclaw.json (size-drop:3402->238). Rejected payload saved to /tmp/tmp.5GEUBHHbGZ/openclaw.json.rejected.2026-05-14T14-07-57-639Z.
  Config overwrite: /tmp/tmp.5GEUBHHbGZ/openclaw.json (sha256 17a9cf72b1fb45b0884f5d5dde39a64bcfc15d519389cbf997a95113c425567b -> 501f690f0096e834222853548e5f8af89e920c1640d4c27ce47cd3e77ff21efa, backup=/tmp/tmp.5GEUBHHbGZ/openclaw.json.bak)
  Config write anomaly: /tmp/tmp.5GEUBHHbGZ/openclaw.json (size-drop:3402->238, missing-meta-before-write)
  Config observe anomaly: /tmp/tmp.5GEUBHHbGZ/openclaw.json (size-drop-vs-last-good:3402->238)
  {
    "configPath": "/tmp/tmp.5GEUBHHbGZ/openclaw.json",
    "beforeBytes": 3402,
    "afterBytes": 238,
    "rejectedWithoutFlag": true,
    "enabled": false,
    "envKeys": []
  }
  ```
- **Observed result after fix**: The default cleanup was rejected with `size-drop:3402->238`. The flagged cleanup wrote the config, left `enabled=false`, and removed all target env keys (`envKeys: []`). Other destructive guards stayed active; the writer still logged size-drop anomaly information.
- **What was not tested**: Full browser/UI integration manager flow was not run. The proof exercises the real server-side config mutation path and disk writer with an isolated temp config.

## Supplemental verification
- `pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/skills.update.normalizes-api-key.test.ts`
- `pnpm tsgo:core:test`

## Safety
- `skills.update` is already gated by `ADMIN_SCOPE` in `src/gateway/method-scopes.ts`.
- The flag only reaches `allowConfigSizeDrop`; other destructive config write guards remain active.