### PR TITLE
fix: retry silent reasoning and empty-error turns with feedback

### DIFF
--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -350,7 +350,7 @@ Replying to a bot message counts as an implicit mention when the channel support
     - Mention gating is only enforced when mention detection is possible (native mentions or `mentionPatterns` are configured).
     - Allowlisting a group or sender does not disable mention gating; set that group's `requireMention` to `false` when all messages should trigger.
     - Group chat prompt context carries the resolved silent-reply instruction every turn; workspace files should not duplicate `NO_REPLY` mechanics.
-    - Groups where silent replies are allowed treat clean empty or reasoning-only model turns as silent, equivalent to `NO_REPLY`. Direct chats do the same only when direct silent replies are explicitly allowed; otherwise empty replies remain failed agent turns.
+    - Groups where silent replies are allowed treat only clean intentional empty model turns as silent, equivalent to `NO_REPLY`. Reasoning-only/signed-thinking turns are not silent: they stay on the retry-feedback path so the model receives an instruction to produce a visible answer. Direct chats use the same clean-empty rule only when direct silent replies are explicitly allowed; otherwise empty replies remain failed agent turns.
     - Discord defaults live in `channels.discord.guilds."*"` (overridable per guild/channel).
     - Group history context is wrapped uniformly across channels. Mention-gated groups keep pending skipped messages; always-on groups may also retain recent processed room messages when the channel supports it. Use `messages.groupChat.historyLimit` for the global default and `channels.<channel>.historyLimit` (or `channels.<channel>.accounts.*.historyLimit`) for overrides. Set `0` to disable.
 

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -450,7 +450,7 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expectWarnMessageWith("reasoning-only assistant turn detected");
   });
 
-  it("returns NO_REPLY without retrying reasoning-only assistant turns when silence is allowed", async () => {
+  it("retries reasoning-only assistant turns with an instruction even when silence is allowed", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
@@ -471,7 +471,20 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedPiAgent({
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Visible answer after reasoning-only retry."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "openai-codex",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: "Visible answer after reasoning-only retry." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    await runEmbeddedPiAgent({
       ...overflowBaseRunParams,
       allowEmptyAssistantReplyAsSilent: true,
       provider: "openai-codex",
@@ -479,14 +492,11 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
       runId: "run-reasoning-only-silent",
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    const onlyCall = runAttemptCall(0);
-    expect(onlyCall.prompt).not.toContain(REASONING_ONLY_RETRY_INSTRUCTION);
-    expect(onlyCall.prompt).not.toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
-    expectNoWarnMessageWith("reasoning-only assistant turn detected");
-    expect(result.payloads).toEqual([{ text: "NO_REPLY" }]);
-    expect(result.meta.terminalReplyKind).toBe("silent-empty");
-    expect(result.meta.livenessState).toBe("working");
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    const secondCall = runAttemptCall(1);
+    expect(secondCall.prompt).toContain(REASONING_ONLY_RETRY_INSTRUCTION);
+    expect(secondCall.prompt).not.toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+    expectWarnMessageWith("reasoning-only assistant turn detected");
   });
 
   it("does not retry or warn on reasoning-only turns when a messaging tool already delivered", async () => {
@@ -815,6 +825,60 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     const secondCall = runAttemptCall(1);
     expect(secondCall.prompt).toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
     expectWarnMessageWith("empty response detected");
+  });
+
+  it("retries zero-output empty error turns with a visible-answer instruction", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "error",
+          provider: "ollama",
+          model: "glm-5.1",
+          content: [],
+          usage: {
+            input: 2048,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2048,
+          },
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Visible answer after empty error retry."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "ollama",
+          model: "glm-5.1",
+          content: [{ type: "text", text: "Visible answer after empty error retry." }],
+          usage: {
+            input: 2300,
+            output: 8,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2308,
+          },
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "ollama",
+      model: "glm-5.1",
+      runId: "run-empty-error-continuation",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    const secondCall = runAttemptCall(1);
+    expect(secondCall.prompt).toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+    expectWarnMessageWith("[empty-error-retry]");
   });
 
   it("surfaces an error after exhausting empty-response retries", async () => {
@@ -1825,7 +1889,7 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
-  it("treats reasoning-only assistant turns as silent only when the caller allows it", () => {
+  it("does not treat reasoning-only assistant turns as silent even when the caller allows it", () => {
     const attempt = makeAttemptResult({
       assistantTexts: [],
       lastAssistant: {
@@ -1851,7 +1915,7 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
         timedOut: false,
         attempt,
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldTreatEmptyAssistantReplyAsSilent({
         allowEmptyAssistantReplyAsSilent: false,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -142,6 +142,7 @@ import {
 import {
   DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT,
   DEFAULT_REASONING_ONLY_RETRY_LIMIT,
+  EMPTY_RESPONSE_RETRY_INSTRUCTION,
   resolveAckExecutionFastPathInstruction,
   resolveAttemptReplayMetadata,
   extractPlanningOnlyPlanDetails,
@@ -2872,8 +2873,8 @@ export async function runEmbeddedPiAgent(
           // and zero output tokens AND empty content after a successful
           // tool-call sequence, producing no user-visible text at all. This
           // path is narrower than the empty-response continuation retry:
-          // same prompt, same session transcript (tool results already
-          // captured), no instruction injection. Placed before the
+          // same session transcript (tool results already captured) with an
+          // explicit visible-answer continuation instruction. Placed before the
           // incompleteTurnText return so it actually gets a chance to fire.
           //
           // Content-empty guard: a reasoning-only error (content has thinking
@@ -2899,6 +2900,7 @@ export async function runEmbeddedPiAgent(
             emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES
           ) {
             emptyErrorRetries += 1;
+            emptyResponseRetryInstruction = EMPTY_RESPONSE_RETRY_INSTRUCTION;
             log.warn(
               `[empty-error-retry] stopReason=error output=0; resubmitting ` +
                 `attempt=${emptyErrorRetries}/${MAX_EMPTY_ERROR_RETRIES} ` +

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -470,7 +470,16 @@ function isNonVisibleAssistantTurnEligibleForSilentReply(params: {
   ) {
     return false;
   }
-  return isReasoningOnlyAssistantTurn(assistant);
+
+  // A signed-thinking-only assistant message means the model produced hidden
+  // reasoning but failed to emit visible text. Treating that as silent drops the
+  // only model-visible recovery signal and can make the next attempt look like
+  // a byte-identical retry/discard. Let the reasoning-only retry guard inject
+  // REASONING_ONLY_RETRY_INSTRUCTION instead.
+  if (isReasoningOnlyAssistantTurn(assistant)) {
+    return false;
+  }
+  return false;
 }
 
 function shouldSkipPlanningOnlyRetry(params: {


### PR DESCRIPTION
## Summary
- keep signed-thinking/reasoning-only assistant turns out of the silent `NO_REPLY` path so the retry guard injects model-visible feedback
- inject `EMPTY_RESPONSE_RETRY_INSTRUCTION` for zero-output empty `stopReason=error` retries instead of resubmitting byte-identical context
- add regression coverage for reasoning-only allowed-silence recovery and empty-error continuation retries

## Validation
- `pnpm exec vitest run src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`
- `pnpm lint:core`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm exec oxfmt --check src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/incomplete-turn.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`

## Real behavior proof

- **Behavior or issue addressed:** Signed-thinking/reasoning-only assistant turns and zero-output empty turns must not disappear as silent `NO_REPLY`; they should get model-visible retry feedback so the next attempt can produce a visible answer.
- **Real environment tested:** Local OpenClaw checkout on PR head `37c5b9c7c72b49179cb59957acb316991fa68a33`, macOS Darwin arm64, Node `v22.22.0`, pnpm `11.1.0`. Provider reasoning text in the reproduced assistant turn was redacted.
- **Exact steps or command run after this patch:** From the checked-out PR branch, installed dependencies with `pnpm install --frozen-lockfile`, then ran a local OpenClaw runtime-path probe with `pnpm exec tsx tmp/pr81841-real-behavior-proof.mjs`. The probe imports the patched OpenClaw incomplete-turn runtime helpers and feeds recorded provider-shaped assistant turns through the same retry/silent-decision functions used by `runEmbeddedPiAgent`.
- **Evidence after fix:** Terminal capture / console output from the patched local OpenClaw checkout:

```console
$ pnpm exec tsx tmp/pr81841-real-behavior-proof.mjs
{
  "source": "local OpenClaw checkout runtime helper on PR #81841 head 37c5b9c7",
  "node": "v22.22.0",
  "reasoning_only_signed_thinking_turn": {
    "allow_silent_flag": true,
    "classified_as_silent_no_reply": false,
    "retry_instruction_selected": true,
    "retry_instruction_prefix": "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Contin"
  },
  "empty_zero_output_turn": {
    "retry_instruction_selected": true,
    "retry_instruction_prefix": "The previous attempt did not produce a user-visible answer. Continue from the current state and "
  }
}
```

- **Observed result after fix:** The signed-thinking-only turn is no longer classified as silent `NO_REPLY` even with the silence flag enabled (`classified_as_silent_no_reply: false`), and the retry path selects a visible retry instruction (`retry_instruction_selected: true`). The zero-output empty-turn path also selects the explicit empty-response retry instruction instead of retrying with no feedback.
- **What was not tested:** I did not force a live hosted model/provider to emit the exact signed-thinking-only empty response on demand; the after-fix proof uses local OpenClaw runtime-path output with provider-shaped recorded/redacted assistant-turn data. Full live provider nondeterminism was not exercised.

Supplemental local gate from the same checkout:

```console
$ pnpm exec vitest run src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
✓ agents-core ../../src/agents/pi-embedded-runner/run.incomplete-turn.test.ts (93 tests) 4019ms
✓ agents-pi-embedded ../../src/agents/pi-embedded-runner/run.incomplete-turn.test.ts (93 tests) 3471ms

Test Files  2 passed (2)
Tests       186 passed (186)
```
