### PR TITLE
fix(discord): warn on send threadName no-op

### DIFF
--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -167,6 +167,41 @@ describe("handleDiscordMessageAction", () => {
     });
   });
 
+  it("forwards send threadName so Discord can report unsupported rename intent", async () => {
+    const cfg = discordConfig();
+    await handleDiscordMessageAction({
+      action: "send",
+      params: {
+        target: "channel:thread-123",
+        message: "hello",
+        threadName: "renamed thread",
+      },
+      cfg,
+      toolContext: { currentChannelProvider: "discord" },
+    });
+
+    expectDiscordActionCall({
+      payload: {
+        action: "sendMessage",
+        accountId: undefined,
+        to: "channel:thread-123",
+        content: "hello",
+        mediaUrl: undefined,
+        filename: undefined,
+        replyTo: undefined,
+        threadName: "renamed thread",
+        components: undefined,
+        embeds: undefined,
+        asVoice: false,
+        silent: false,
+        __sessionKey: undefined,
+        __agentId: undefined,
+      },
+      cfg,
+      options: defaultActionOptions(),
+    });
+  });
+
   it("maps upload-file to Discord sendMessage with media read context", async () => {
     const mediaReadFile = vi.fn(async () => Buffer.from("image"));
     const mediaAccess = {

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -99,6 +99,7 @@ export async function handleDiscordMessageAction(
     });
     const filename = readStringParam(params, "filename");
     const replyTo = readStringParam(params, "replyTo");
+    const threadName = readStringParam(params, "threadName");
     const rawEmbeds = params.embeds;
     const embeds = Array.isArray(rawEmbeds) ? rawEmbeds : undefined;
     const silent = readBooleanParam(params, "silent") === true;
@@ -113,6 +114,7 @@ export async function handleDiscordMessageAction(
         mediaUrl: mediaUrl ?? undefined,
         filename: filename ?? undefined,
         replyTo: replyTo ?? undefined,
+        threadName: threadName ?? undefined,
         components,
         embeds,
         asVoice,

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -88,6 +88,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
       });
       const filename = readStringParam(ctx.params, "filename");
       const replyTo = readStringParam(ctx.params, "replyTo");
+      const threadName = readStringParam(ctx.params, "threadName");
       const rawEmbeds = ctx.params.embeds;
       const embeds: DiscordSendEmbeds | undefined = Array.isArray(rawEmbeds)
         ? (rawEmbeds as DiscordSendEmbeds)
@@ -157,7 +158,14 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
         embeds,
         silent,
       });
-      return jsonResult({ ok: true, result });
+      const warning = threadName
+        ? "Discord message send does not rename existing threads; use channel-edit to rename a thread."
+        : undefined;
+      return jsonResult({
+        ok: true,
+        result,
+        ...(warning ? { warning } : {}),
+      });
     }
     case "threadCreate": {
       if (!ctx.isActionEnabled("threads")) {

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -594,6 +594,27 @@ describe("handleDiscordMessagingAction", () => {
     expect(sendOptions.filename).toBe("image.png");
   });
 
+  it("warns when threadName is supplied on message send", async () => {
+    sendMessageDiscord.mockClear();
+    const result = await handleMessagingAction(
+      "sendMessage",
+      {
+        to: "channel:thread-123",
+        content: "hello",
+        threadName: "renamed thread",
+      },
+      enableAllActions,
+    );
+
+    expect(sendMessageDiscord).toHaveBeenCalledTimes(1);
+    expect(result.details).toEqual({
+      ok: true,
+      result: {},
+      warning:
+        "Discord message send does not rename existing threads; use channel-edit to rename a thread.",
+    });
+  });
+
   it("rejects voice messages that include content", async () => {
     await expect(
       handleMessagingAction(


### PR DESCRIPTION
## Summary
- forward `threadName` from the Discord message tool send adapter into the Discord action runtime
- return an explicit warning when `threadName` is supplied on `sendMessage`, because send does not rename existing threads
- cover both adapter forwarding and runtime warning behavior

Closes #81836.

## Real behavior proof

- **Behavior or issue addressed**: Discord `message` tool `send` accepted `threadName` but silently ignored it for existing thread sends. After this patch, the same call still sends the message and returns an explicit warning that send does not rename existing threads.
- **Real environment tested**: Local OpenClaw checkout at commit `f57e72d893` on branch `fix/discord-send-threadname-warning-81836`, Node/vitest through repo scripts.
- **Exact steps or command run after the patch**:
  1. Ran the Discord action adapter test with `target: "channel:thread-123"`, `message: "hello"`, and `threadName: "renamed thread"`.
  2. Ran the Discord runtime send action with `to: "channel:thread-123"`, `content: "hello"`, and `threadName: "renamed thread"`.
  3. Ran the focused Discord action test files and changed-file validation.
- **Evidence after fix**:
  ```text
  node scripts/run-vitest.mjs extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/actions/runtime.test.ts

  Test Files  2 passed (2)
       Tests  62 passed (62)
  ```
  Runtime observed result from the new coverage:
  ```json
  {
    "ok": true,
    "result": {},
    "warning": "Discord message send does not rename existing threads; use channel-edit to rename a thread."
  }
  ```
- **Observed result after fix**: `threadName` is no longer silently dropped. The adapter forwards the value to the runtime, the message send still executes, and the tool result includes the warning shown above.
- **What was not tested**: Live Discord API delivery was not run. The patch intentionally avoids a live thread rename; it only makes the previously silent unsupported rename intent explicit in the Discord action result.

## Supplemental verification
- `node scripts/run-vitest.mjs extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/actions/runtime.test.ts`
- `pnpm tsgo:extensions:test`
- `node scripts/check-changed.mjs`

## Pre-implement audit
- Audit A (existing helper): existing `editChannelDiscord` found, deliberately not used from send path to avoid renaming arbitrary channel targets.
- Audit B (shared callers): `sendMessage` runtime path is shared; contract preserved by adding an optional warning only when `threadName` is present.
- Audit C (broader rival): no open PR found for #81836; broad Discord thread-title PRs are unrelated to message send `threadName`.