### PR TITLE
[AI-assisted] fix(gateway): recognize shell-wrapped LaunchAgent command

### DIFF
--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -256,6 +256,40 @@ describe("auditGatewayServiceConfig", () => {
     ).toBe(false);
   });
 
+  it("accepts shell-wrapped LaunchAgent commands that exec the OpenClaw gateway", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp/openclaw-testuser" },
+      platform: "darwin",
+      command: {
+        programArguments: [
+          "/bin/zsh",
+          "-lc",
+          'set -a; [ -f "$HOME/.config/openclaw.env" ] && . "$HOME/.config/openclaw.env"; set +a; exec /opt/homebrew/opt/node/bin/node /opt/openclaw/dist/index.js gateway --port 18890',
+        ],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayCommandMissing)).toBe(false);
+  });
+
+  it("does not accept shell payloads that only mention gateway outside OpenClaw argv", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp/openclaw-testuser" },
+      platform: "darwin",
+      command: {
+        programArguments: [
+          "/bin/zsh",
+          "-lc",
+          "echo gateway; exec /usr/bin/node /opt/openclaw/dist/index.js node --port 18890",
+        ],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayCommandMissing)).toBe(true);
+  });
+
   it("reads gateway service ports from split and equals-form arguments", () => {
     expect(
       readGatewayServiceCommandPort(["/usr/bin/node", "entry.js", "gateway", "--port", "18888"]),

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isGatewayArgv } from "../infra/gateway-process-argv.js";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { resolveLaunchAgentPlistPath } from "./launchd.js";
@@ -70,8 +71,115 @@ export function needsNodeRuntimeMigration(issues: ServiceConfigIssue[]): boolean
   );
 }
 
+const SUPPORTED_SHELL_COMMANDS = new Set(["bash", "dash", "ksh", "sh", "zsh"]);
+
+function getShellCommandName(command: string | undefined): string {
+  const executable = (command ?? "").trim().replaceAll("\\", "/").split("/").pop() ?? "";
+  return executable.replace(/\.(?:exe|cmd|bat)$/i, "").toLowerCase();
+}
+
+function isShellCommandFlag(arg: string | undefined): boolean {
+  return /^-[A-Za-z]*c[A-Za-z]*$/.test((arg ?? "").trim());
+}
+
+function readSupportedShellPayload(programArguments: string[]): string | undefined {
+  if (!SUPPORTED_SHELL_COMMANDS.has(getShellCommandName(programArguments[0]))) {
+    return undefined;
+  }
+  for (let index = 1; index < programArguments.length - 1; index += 1) {
+    if (isShellCommandFlag(programArguments[index])) {
+      return programArguments[index + 1];
+    }
+  }
+  return undefined;
+}
+
+function splitShellPayloadIntoCommandSegments(payload: string): string[][] {
+  const segments: string[][] = [];
+  let segment: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escapeNext = false;
+
+  const pushToken = () => {
+    if (current) {
+      segment.push(current);
+      current = "";
+    }
+  };
+  const pushSegment = () => {
+    pushToken();
+    if (segment.length > 0) {
+      segments.push(segment);
+      segment = [];
+    }
+  };
+
+  for (let index = 0; index < payload.length; index += 1) {
+    const char = payload[index] ?? "";
+    if (escapeNext) {
+      current += char;
+      escapeNext = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escapeNext = true;
+      continue;
+    }
+    if ((char === "'" || char === '"') && quote === null) {
+      quote = char;
+      continue;
+    }
+    if (char === quote) {
+      quote = null;
+      continue;
+    }
+    if (quote === null) {
+      if (char === ";" || char === "\n" || char === "\r") {
+        pushSegment();
+        continue;
+      }
+      if ((char === "&" || char === "|") && payload[index + 1] === char) {
+        pushSegment();
+        index += 1;
+        continue;
+      }
+      if (/\s/.test(char)) {
+        pushToken();
+        continue;
+      }
+    }
+    current += char;
+  }
+  if (escapeNext) {
+    current += "\\";
+  }
+  pushSegment();
+  return segments;
+}
+
+function stripShellCommandPrefix(segment: string[]): string[] {
+  const command = segment[0]?.toLowerCase();
+  if (command === "exec" || command === "command") {
+    return segment.slice(1);
+  }
+  return segment;
+}
+
 function hasGatewaySubcommand(programArguments?: string[]): boolean {
-  return Boolean(programArguments?.some((arg) => arg === "gateway"));
+  if (programArguments?.some((arg) => arg === "gateway")) {
+    return true;
+  }
+  if (!programArguments || programArguments.length === 0) {
+    return false;
+  }
+  const payload = readSupportedShellPayload(programArguments);
+  if (!payload) {
+    return false;
+  }
+  return splitShellPayloadIntoCommandSegments(payload).some((segment) =>
+    isGatewayArgv(stripShellCommandPrefix(segment), { allowGatewayBinary: true }),
+  );
 }
 
 function parseSystemdUnit(content: string): {


### PR DESCRIPTION
## Summary

- Problem: `gateway status` can report `Service command does not include the gateway subcommand` for macOS LaunchAgent commands wrapped as `/bin/zsh -lc "... exec node .../dist/index.js gateway --port ..."`.
- Why it matters: the warning makes a healthy gateway service look malformed during recovery and status checks.
- What changed: the service audit now derives a supported shell wrapper's effective command before deciding whether the gateway subcommand is missing, then validates it with the existing OpenClaw gateway argv recognizer.
- What did NOT change: this does not execute shell payloads, change LaunchAgent generation, change service install behavior, or broaden provider/plugin/config handling.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #81751
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: shell-wrapped LaunchAgent argv containing `exec node .../dist/index.js gateway --port ...` no longer produces `gateway-command-missing`.
- Real environment tested: isolated Linux OpenClaw checkout using Node `v22.16.0` and pnpm `11.1.0`; local Windows checkout for targeted diff/format checks.
- Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs src/daemon/service-audit.test.ts
node scripts/run-vitest.mjs src/daemon/launchd.test.ts src/cli/daemon-cli/status.gather.test.ts
git diff --check
./node_modules/.bin/oxfmt --check --threads=1 src/daemon/service-audit.ts src/daemon/service-audit.test.ts
node scripts/check-changed.mjs
```

- Evidence after fix: all commands above completed with exit code 0 in a fresh checkout with this patch applied.
- Observed result after fix: the regression test accepts the reported shell-wrapper shape and still rejects a payload that only mentions `gateway` outside the actual OpenClaw argv.
- What was not tested: a live macOS LaunchAgent on a macOS host.
- Before evidence: source inspection showed the previous audit only accepted an argv element exactly equal to `gateway`, so `/bin/zsh -lc` stored the subcommand inside one shell payload string and triggered the false positive.

## Root Cause

- Root cause: `hasGatewaySubcommand` only checked top-level `ProgramArguments` entries for an exact `gateway` token.
- Missing detection / guardrail: no regression test covered shell-wrapped LaunchAgent commands where the real OpenClaw argv is inside a supported shell `-c` payload.
- Contributing context: OpenClaw's generated env wrapper is already unwrapped elsewhere, but user-provided `/bin/zsh -lc` wrappers remained opaque to the audit.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/daemon/service-audit.test.ts`
- Scenario the test should lock in: a supported shell wrapper that ultimately `exec`s `node .../dist/index.js gateway --port ...` must not produce `gateway-command-missing`.
- Why this is the smallest reliable guardrail: the false positive is produced directly by the service audit, so testing the audit keeps the fix narrow and avoids requiring a live macOS LaunchAgent.
- Existing test that already covers this: none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`gateway status` no longer shows the misleading missing-gateway-subcommand service config issue for supported shell-wrapped LaunchAgent commands that execute the OpenClaw gateway.

## Diagram

N/A

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux test environment; Windows local checkout for supplemental checks
- Runtime/container: Node `v22.16.0`, pnpm `11.1.0`
- Model/provider: N/A
- Integration/channel: macOS LaunchAgent service audit path
- Relevant config: shell-wrapped LaunchAgent argv with `/bin/zsh -lc`

### Steps

1. Audit a service command with `programArguments` shaped like `/bin/zsh`, `-lc`, `exec node /opt/openclaw/dist/index.js gateway --port 18890`.
2. Check the audit issues.

### Expected

- No `gateway-command-missing` issue when the shell payload executes the OpenClaw gateway command.

### Actual

- After this patch, the audit accepts the shell-wrapped OpenClaw gateway command.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets

## Human Verification

- Verified scenarios: direct audit regression, shell-wrapped positive case, shell-wrapped negative case, status gather coverage, LaunchAgent-related unit coverage, format, diff whitespace, changed-file checks.
- Edge cases checked: payload mentioning `gateway` outside the OpenClaw argv still reports `gateway-command-missing`.
- What you did **not** verify: live macOS LaunchAgent behavior on a macOS host.

## Review Conversations

- [x] N/A - no bot review conversations existed when opening this PR.
- [x] N/A - no unresolved bot review conversations existed when opening this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: parsing shell payloads too broadly could hide a malformed service command.
  - Mitigation: only supported shell `-c` wrappers are inspected, the payload is split into command segments, and each candidate segment must pass the existing OpenClaw gateway argv recognizer instead of a broad substring check.
