### PR TITLE
Fix Telegram isolated polling lane drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: let isolated polling drain independent topics, DMs, and status/control commands concurrently while preserving same-lane order. (#81849) Thanks @VACInc.
 - Build: keep externalized Slack, OpenShell sandbox, and Anthropic Vertex runtime dependency declarations out of the root dist artifact build.
 - Auto-reply/Claude CLI: bridge CLI-runtime assistant text-delta agent events into the chat reasoning preview through `onReasoningStream`, mirroring the existing assistant-text (#76914) and tool-event (#80046) bridges and adding gating so non-CLI runtimes are unaffected. Thanks @anagnorisis2peripeteia and @pashpashpash.
 - CLI/migrate: handle delayed Codex plugin marketplace responses so warnings, next-steps, and conflict states render with ⚠️ glyphs and post-install migration retries the marketplace fetch instead of silently skipping plugin items. (#81625) Thanks @sjf.

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -28,11 +28,25 @@ vi.mock("./api-logging.js", () => ({
 
 vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
   computeBackoff: computeBackoffMock,
+  createSubsystemLogger: vi.fn(() => {
+    const logger = {
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+      isEnabled: vi.fn(() => false),
+      child: vi.fn(() => logger),
+    };
+    return logger;
+  }),
   formatDurationPrecise: vi.fn((ms: number) => `${ms}ms`),
   sleepWithAbort: sleepWithAbortMock,
 }));
 
 let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;
+let listTelegramSpooledUpdates: typeof import("./telegram-ingress-spool.js").listTelegramSpooledUpdates;
 let writeTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").writeTelegramSpooledUpdate;
 
 type TelegramApiMiddleware = (
@@ -268,7 +282,8 @@ async function waitForApiMiddleware(
 describe("TelegramPollingSession", () => {
   beforeAll(async () => {
     ({ TelegramPollingSession } = await import("./polling-session.js"));
-    ({ writeTelegramSpooledUpdate } = await import("./telegram-ingress-spool.js"));
+    ({ listTelegramSpooledUpdates, writeTelegramSpooledUpdate } =
+      await import("./telegram-ingress-spool.js"));
   });
 
   beforeEach(() => {
@@ -416,6 +431,7 @@ describe("TelegramPollingSession", () => {
 
       const runPromise = session.runUntilAbort();
       await vi.waitFor(() => expect(handleUpdate).toHaveBeenCalledTimes(1));
+      await vi.waitFor(async () => expect(await fs.readdir(tempDir)).toEqual([]));
       abort.abort();
       await runPromise;
 
@@ -430,8 +446,353 @@ describe("TelegramPollingSession", () => {
         mockObjectArg(createTelegramBotMock, "createTelegramBot").updateOffset,
       ).toBeUndefined();
       expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } });
-      await expect(fs.readdir(tempDir)).resolves.toEqual([]);
     } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("lets isolated ingress drain interleave different Telegram topic lanes", async () => {
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const events: string[] = [];
+    let releaseTopicTenTurn: (() => void) | undefined;
+    const topicTenTurnDone = new Promise<void>((resolve) => {
+      releaseTopicTenTurn = resolve;
+    });
+    const handleUpdate = vi.fn(async (update: { update_id?: number }) => {
+      if (update.update_id === 42) {
+        events.push("topic10:start");
+        await topicTenTurnDone;
+        events.push("topic10:end");
+        return;
+      }
+      if (update.update_id === 43) {
+        events.push("topic11");
+        return;
+      }
+      if (update.update_id === 44) {
+        events.push("topic10:second");
+      }
+    });
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      handleUpdate,
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValueOnce(bot);
+    for (const { updateId, threadId, text } of [
+      { updateId: 42, threadId: 10, text: "long topic 10 turn" },
+      { updateId: 43, threadId: 11, text: "topic 11 turn" },
+      { updateId: 44, threadId: 10, text: "second topic 10 turn" },
+    ]) {
+      await writeTelegramSpooledUpdate({
+        spoolDir: tempDir,
+        update: {
+          update_id: updateId,
+          message: {
+            text,
+            message_thread_id: threadId,
+            is_topic_message: true,
+            chat: { id: -100, type: "supergroup" },
+          },
+        },
+      });
+    }
+    let stopWorker: (() => void) | undefined;
+    const workerDone = new Promise<void>((resolve) => {
+      stopWorker = resolve;
+    });
+    const createWorker = vi.fn(() => ({
+      onMessage: vi.fn(() => () => undefined),
+      stop: vi.fn(async () => {
+        stopWorker?.();
+      }),
+      task: vi.fn(async () => {
+        await workerDone;
+      }),
+    }));
+
+    try {
+      const session = createPollingSession({
+        abortSignal: abort.signal,
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 10,
+        },
+      });
+
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(events).toEqual(["topic10:start", "topic11"]));
+      expect(
+        (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map((update) => update.updateId),
+      ).toEqual([42, 44]);
+
+      releaseTopicTenTurn?.();
+      await vi.waitFor(() =>
+        expect(events).toEqual(["topic10:start", "topic11", "topic10:end", "topic10:second"]),
+      );
+      await vi.waitFor(async () =>
+        expect(
+          (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map(
+            (update) => update.updateId,
+          ),
+        ).toEqual([]),
+      );
+      abort.abort();
+      await runPromise;
+    } finally {
+      releaseTopicTenTurn?.();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("lets isolated ingress control updates bypass an active spooled turn", async () => {
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const events: string[] = [];
+    let releaseRegularTurn: (() => void) | undefined;
+    const regularTurnDone = new Promise<void>((resolve) => {
+      releaseRegularTurn = resolve;
+    });
+    const handleUpdate = vi.fn(async (update: { update_id?: number }) => {
+      if (update.update_id === 42) {
+        events.push("regular:start");
+        await regularTurnDone;
+        events.push("regular:end");
+        return;
+      }
+      if (update.update_id === 43) {
+        events.push("status");
+      }
+    });
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      handleUpdate,
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValueOnce(bot);
+    await writeTelegramSpooledUpdate({
+      spoolDir: tempDir,
+      update: {
+        update_id: 42,
+        message: { text: "summarize this", chat: { id: -100, type: "supergroup" } },
+      },
+    });
+    let stopWorker: (() => void) | undefined;
+    const workerDone = new Promise<void>((resolve) => {
+      stopWorker = resolve;
+    });
+    const createWorker = vi.fn(() => ({
+      onMessage: vi.fn(() => () => undefined),
+      stop: vi.fn(async () => {
+        stopWorker?.();
+      }),
+      task: vi.fn(async () => {
+        await workerDone;
+      }),
+    }));
+
+    try {
+      const session = createPollingSession({
+        abortSignal: abort.signal,
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 10,
+        },
+      });
+
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(events).toEqual(["regular:start"]));
+      await writeTelegramSpooledUpdate({
+        spoolDir: tempDir,
+        update: {
+          update_id: 43,
+          message: { text: "/status", chat: { id: -100, type: "supergroup" } },
+        },
+      });
+
+      await vi.waitFor(() => expect(events).toEqual(["regular:start", "status"]));
+      expect(
+        (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map((update) => update.updateId),
+      ).toEqual([42]);
+
+      releaseRegularTurn?.();
+      await vi.waitFor(async () =>
+        expect(
+          (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map(
+            (update) => update.updateId,
+          ),
+        ).toEqual([]),
+      );
+      abort.abort();
+      await runPromise;
+    } finally {
+      releaseRegularTurn?.();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves spool order when a control update is already queued after a regular turn", async () => {
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const events: string[] = [];
+    let releaseRegularTurn: (() => void) | undefined;
+    const regularTurnDone = new Promise<void>((resolve) => {
+      releaseRegularTurn = resolve;
+    });
+    const handleUpdate = vi.fn(async (update: { update_id?: number }) => {
+      if (update.update_id === 42) {
+        events.push("regular:start");
+        await regularTurnDone;
+        events.push("regular:end");
+        return;
+      }
+      if (update.update_id === 43) {
+        events.push("status");
+      }
+    });
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      handleUpdate,
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValueOnce(bot);
+    await writeTelegramSpooledUpdate({
+      spoolDir: tempDir,
+      update: {
+        update_id: 42,
+        message: { text: "summarize this", chat: { id: -100, type: "supergroup" } },
+      },
+    });
+    await writeTelegramSpooledUpdate({
+      spoolDir: tempDir,
+      update: {
+        update_id: 43,
+        message: { text: "/status", chat: { id: -100, type: "supergroup" } },
+      },
+    });
+    let stopWorker: (() => void) | undefined;
+    const workerDone = new Promise<void>((resolve) => {
+      stopWorker = resolve;
+    });
+    const createWorker = vi.fn(() => ({
+      onMessage: vi.fn(() => () => undefined),
+      stop: vi.fn(async () => {
+        stopWorker?.();
+      }),
+      task: vi.fn(async () => {
+        await workerDone;
+      }),
+    }));
+
+    try {
+      const session = createPollingSession({
+        abortSignal: abort.signal,
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 10,
+        },
+      });
+
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(events).toEqual(["regular:start", "status"]));
+
+      releaseRegularTurn?.();
+      await vi.waitFor(async () =>
+        expect(
+          (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map(
+            (update) => update.updateId,
+          ),
+        ).toEqual([]),
+      );
+      abort.abort();
+      await runPromise;
+    } finally {
+      releaseRegularTurn?.();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("waits for active spooled handlers before stopping the bot", async () => {
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const events: string[] = [];
+    let releaseRegularTurn: (() => void) | undefined;
+    const regularTurnDone = new Promise<void>((resolve) => {
+      releaseRegularTurn = resolve;
+    });
+    const handleUpdate = vi.fn(async () => {
+      events.push("regular:start");
+      await regularTurnDone;
+      events.push("regular:end");
+    });
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      handleUpdate,
+      stop: vi.fn(async () => {
+        events.push("bot:stop");
+      }),
+    };
+    createTelegramBotMock.mockReturnValueOnce(bot);
+    await writeTelegramSpooledUpdate({
+      spoolDir: tempDir,
+      update: {
+        update_id: 42,
+        message: { text: "summarize this", chat: { id: -100, type: "supergroup" } },
+      },
+    });
+    let stopWorker: (() => void) | undefined;
+    const workerDone = new Promise<void>((resolve) => {
+      stopWorker = resolve;
+    });
+    const createWorker = vi.fn(() => ({
+      onMessage: vi.fn(() => () => undefined),
+      stop: vi.fn(async () => {
+        stopWorker?.();
+      }),
+      task: vi.fn(async () => {
+        await workerDone;
+      }),
+    }));
+
+    try {
+      const session = createPollingSession({
+        abortSignal: abort.signal,
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 10,
+        },
+      });
+
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(events).toEqual(["regular:start"]));
+      abort.abort();
+      releaseRegularTurn?.();
+      await runPromise;
+
+      expect(events).toEqual(["regular:start", "regular:end", "bot:stop"]);
+    } finally {
+      releaseRegularTurn?.();
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -16,10 +16,12 @@ import { TelegramPollingLivenessTracker } from "./polling-liveness.js";
 import { createTelegramPollingStatusPublisher } from "./polling-status.js";
 import { TelegramPollingTransportState } from "./polling-transport-state.js";
 import { TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS } from "./request-timeouts.js";
+import { getTelegramSequentialKey } from "./sequential-key.js";
 import {
   deleteTelegramSpooledUpdate,
   listTelegramSpooledUpdates,
   resolveTelegramIngressSpoolDir,
+  type TelegramSpooledUpdate,
 } from "./telegram-ingress-spool.js";
 import {
   createTelegramIngressWorker,
@@ -108,6 +110,9 @@ export class TelegramPollingSession {
   #forceRestarted = false;
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
+  #spooledUpdatesInFlight = new Set<number>();
+  #spooledUpdateLanesInFlight = new Set<string>();
+  #spooledUpdateHandlerPromises = new Set<Promise<boolean>>();
   #transportState: TelegramPollingTransportState;
   #status: ReturnType<typeof createTelegramPollingStatusPublisher>;
   #stallThresholdMs: number;
@@ -258,27 +263,67 @@ export class TelegramPollingSession {
     }
   }
 
+  async #handleSpooledUpdate(params: {
+    bot: TelegramBot;
+    update: TelegramSpooledUpdate;
+    laneKey: string;
+  }): Promise<boolean> {
+    try {
+      await params.bot.handleUpdate(
+        params.update.update as Parameters<typeof params.bot.handleUpdate>[0],
+      );
+      await deleteTelegramSpooledUpdate(params.update);
+      return true;
+    } catch (err) {
+      this.opts.log(
+        `[telegram][diag] spooled update ${params.update.updateId} failed; keeping for retry: ${formatErrorMessage(err)}`,
+      );
+      return false;
+    } finally {
+      this.#spooledUpdatesInFlight.delete(params.update.updateId);
+      this.#spooledUpdateLanesInFlight.delete(params.laneKey);
+    }
+  }
+
+  async #waitForSpooledUpdateHandlers(): Promise<void> {
+    const pending = [...this.#spooledUpdateHandlerPromises];
+    if (pending.length === 0) {
+      return;
+    }
+    await Promise.allSettled(pending);
+  }
+
   async #drainSpooledUpdates(params: { bot: TelegramBot; spoolDir: string }): Promise<number> {
-    let handled = 0;
     const updates = await listTelegramSpooledUpdates({ spoolDir: params.spoolDir, limit: 100 });
+    let started = 0;
     for (const update of updates) {
+      const laneKey = getTelegramSequentialKey({
+        update: update.update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
+        ...(this.opts.botInfo ? { me: this.opts.botInfo } : {}),
+      });
       if (this.opts.abortSignal?.aborted) {
         break;
       }
-      try {
-        await params.bot.handleUpdate(
-          update.update as Parameters<typeof params.bot.handleUpdate>[0],
-        );
-        await deleteTelegramSpooledUpdate(update);
-        handled += 1;
-      } catch (err) {
-        this.opts.log(
-          `[telegram][diag] spooled update ${update.updateId} handler failed; keeping for retry: ${formatErrorMessage(err)}`,
-        );
-        break;
+      if (this.#spooledUpdatesInFlight.has(update.updateId)) {
+        continue;
       }
+      if (this.#spooledUpdateLanesInFlight.has(laneKey)) {
+        continue;
+      }
+      this.#spooledUpdatesInFlight.add(update.updateId);
+      this.#spooledUpdateLanesInFlight.add(laneKey);
+      const handler = this.#handleSpooledUpdate({
+        bot: params.bot,
+        update,
+        laneKey,
+      });
+      this.#spooledUpdateHandlerPromises.add(handler);
+      void handler.finally(() => {
+        this.#spooledUpdateHandlerPromises.delete(handler);
+      });
+      started += 1;
     }
-    return handled;
+    return started;
   }
 
   async #runIsolatedIngressCycle(bot: TelegramBot): Promise<"continue" | "exit"> {
@@ -383,6 +428,7 @@ export class TelegramPollingSession {
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
       await worker.stop();
       await drainOnce();
+      await waitForGracefulStop(() => this.#waitForSpooledUpdateHandlers());
       await waitForGracefulStop(stopBot);
     }
   }

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -110,9 +110,7 @@ export class TelegramPollingSession {
   #forceRestarted = false;
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
-  #spooledUpdatesInFlight = new Set<number>();
-  #spooledUpdateLanesInFlight = new Set<string>();
-  #spooledUpdateHandlerPromises = new Set<Promise<boolean>>();
+  #spooledUpdateHandlersByLane = new Map<string, Promise<boolean>>();
   #transportState: TelegramPollingTransportState;
   #status: ReturnType<typeof createTelegramPollingStatusPublisher>;
   #stallThresholdMs: number;
@@ -266,7 +264,6 @@ export class TelegramPollingSession {
   async #handleSpooledUpdate(params: {
     bot: TelegramBot;
     update: TelegramSpooledUpdate;
-    laneKey: string;
   }): Promise<boolean> {
     try {
       await params.bot.handleUpdate(
@@ -279,18 +276,11 @@ export class TelegramPollingSession {
         `[telegram][diag] spooled update ${params.update.updateId} failed; keeping for retry: ${formatErrorMessage(err)}`,
       );
       return false;
-    } finally {
-      this.#spooledUpdatesInFlight.delete(params.update.updateId);
-      this.#spooledUpdateLanesInFlight.delete(params.laneKey);
     }
   }
 
   async #waitForSpooledUpdateHandlers(): Promise<void> {
-    const pending = [...this.#spooledUpdateHandlerPromises];
-    if (pending.length === 0) {
-      return;
-    }
-    await Promise.allSettled(pending);
+    await Promise.allSettled(this.#spooledUpdateHandlersByLane.values());
   }
 
   async #drainSpooledUpdates(params: { bot: TelegramBot; spoolDir: string }): Promise<number> {
@@ -304,22 +294,16 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         break;
       }
-      if (this.#spooledUpdatesInFlight.has(update.updateId)) {
+      if (this.#spooledUpdateHandlersByLane.has(laneKey)) {
         continue;
       }
-      if (this.#spooledUpdateLanesInFlight.has(laneKey)) {
-        continue;
-      }
-      this.#spooledUpdatesInFlight.add(update.updateId);
-      this.#spooledUpdateLanesInFlight.add(laneKey);
       const handler = this.#handleSpooledUpdate({
         bot: params.bot,
         update,
-        laneKey,
       });
-      this.#spooledUpdateHandlerPromises.add(handler);
+      this.#spooledUpdateHandlersByLane.set(laneKey, handler);
       void handler.finally(() => {
-        this.#spooledUpdateHandlerPromises.delete(handler);
+        this.#spooledUpdateHandlersByLane.delete(laneKey);
       });
       started += 1;
     }

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -49,6 +49,21 @@ function resolveStatusCommandControlLane(params: {
   return command?.category === "status" && command.key !== "export-session";
 }
 
+export function isTelegramControlLaneText(params: {
+  rawText?: string;
+  botUsername?: string;
+}): boolean {
+  if (
+    isAbortRequestText(
+      params.rawText,
+      params.botUsername ? { botUsername: params.botUsername } : undefined,
+    )
+  ) {
+    return true;
+  }
+  return resolveStatusCommandControlLane(params);
+}
+
 export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): string {
   const reaction = ctx.update?.message_reaction;
   if (reaction?.chat?.id) {
@@ -67,13 +82,7 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   const chatId = msg?.chat?.id ?? ctx.chat?.id;
   const rawText = msg?.text ?? msg?.caption;
   const botUsername = ctx.me?.username;
-  if (isAbortRequestText(rawText, botUsername ? { botUsername } : undefined)) {
-    if (typeof chatId === "number") {
-      return `telegram:${chatId}:control`;
-    }
-    return "telegram:control";
-  }
-  if (resolveStatusCommandControlLane({ rawText, botUsername })) {
+  if (isTelegramControlLaneText({ rawText, botUsername })) {
     if (typeof chatId === "number") {
       return `telegram:${chatId}:control`;
     }


### PR DESCRIPTION
## Summary
- Restore Telegram isolated-polling spool draining to dispatch independent Telegram lanes concurrently instead of blocking every update behind the first active turn.
- Reuse Telegram's existing sequential lane key so same-topic/DM ordering is preserved while different topics, DMs, and control lanes can make progress.
- Track active spooled handlers during shutdown so the bot is not stopped while an accepted update is still finishing.

## Root Cause
Telegram isolated polling split getUpdates into a worker that writes update files and a main-thread drain that awaited each spooled update serially. That bypassed the bot's normal per-chat/topic sequentializer: one long topic or DM turn could block unrelated topics, DMs, `/status`, and `/stop` before they reached the existing control-lane logic.

## Regression Blame
Introduced by `fd244fd76de3a62ff08c26c8fd9aab2ae250b3a4` / #81746, `Fix Telegram polling ingress under event-loop stalls`, merged `2026-05-14T08:35:07Z`.

Evidence:
- `git log -S '#drainSpooledUpdates' -- extensions/telegram/src/polling-session.ts` points to `fd244fd76de3a62ff08c26c8fd9aab2ae250b3a4`.
- Blame for the serial spool drain shows the added `await params.bot.handleUpdate(...)` loop here: https://github.com/openclaw/openclaw/blame/fd244fd76de3a62ff08c26c8fd9aab2ae250b3a4/extensions/telegram/src/polling-session.ts#L261-L281
- Introducing PR: https://github.com/openclaw/openclaw/pull/81746

## Real behavior proof
Behavior addressed: Telegram isolated-polling spool drain no longer blocks status/control lanes behind an active slow agent turn.
Real environment tested: Local OpenClaw gateway from PR head `405052f7b7`, real Telegram bot-to-bot group traffic, isolated polling ingress enabled by default, OpenAI-compatible local test model server.
Exact steps or command run after this patch: `node ~/.codex/skills/custom/telegram-e2e-bot-to-bot/scripts/run-mock-sut-e2e.mjs --text '@{sut} Please answer with OPENCLAW_E2E_OK only. Run {run}' --expect OPENCLAW_E2E_OK --timeout-ms 90000`, plus a maintainer bot-to-bot lane probe that delayed model responses by 25s and sent `/status@foremanclawbot` while the slow turn was active.
Evidence after fix: Terminal output from the real Telegram probe showed driver message `8223`, SUT reply `8224`, reply text `OPENCLAW_E2E_OK`, and RTT `6188ms`. Terminal output from the lane probe showed slow turn message `8225`, status command message `8226`, status reply `8227` about 2.0s after status send, and slow model reply `8228` about 31.7s after slow send.
Observed result after fix: Live output showed `/status` replied before the active slow spooled model turn completed, while the slow turn still completed with `OPENCLAW_E2E_OK_MP5NXK2I`. Gateway runtime log output included `isolated polling ingress started spool=/var/.../state/telegram/ingress-spool-default`.
What was not tested: cross-topic forum concurrency with two real Telegram topics in the shared group; the added unit regression covers different-topic lane interleaving.


## Verification
- `node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/sequential-key.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `git diff --check -- extensions/telegram/src/polling-session.ts extensions/telegram/src/sequential-key.ts extensions/telegram/src/polling-session.test.ts`
- Scoped Codex review accepted two findings; both were fixed and covered by added tests. A second scoped review rerun was started but stopped after it remained active for several minutes without producing findings.
