### PR TITLE
build: stabilize gateway stop hook runner entry

### DIFF
--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -99,6 +99,7 @@ describe("tsdown config", () => {
       "index",
       "commands/status.summary.runtime",
       "provider-dispatcher.runtime",
+      "plugins/hook-runner-global",
       "plugins/provider-discovery.runtime",
       "plugins/provider-runtime.runtime",
       "plugins/runtime/index",
@@ -135,6 +136,14 @@ describe("tsdown config", () => {
 
     expect(entrySources(distGraph)["provider-dispatcher.runtime"]).toBe(
       "src/auto-reply/reply/provider-dispatcher.runtime.ts",
+    );
+  });
+
+  it("keeps gateway stop hook runner behind one stable dist entry", () => {
+    const distGraph = requireUnifiedDistGraph();
+
+    expect(entrySources(distGraph)["plugins/hook-runner-global"]).toBe(
+      "src/plugins/hook-runner-global.ts",
     );
   });
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -221,6 +221,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "provider-dispatcher.runtime": "src/auto-reply/reply/provider-dispatcher.runtime.ts",
     "server-close.runtime": "src/gateway/server-close.runtime.ts",
     "plugins/memory-state": "src/plugins/memory-state.ts",
+    "plugins/hook-runner-global": "src/plugins/hook-runner-global.ts",
     "subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",
     "task-registry-control.runtime": "src/tasks/task-registry-control.runtime.ts",
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",


### PR DESCRIPTION
## Summary

  - Problem: #81819 reported update-survivor failures where a long-lived gateway could later resolve stale/missing
    shutdown chunks after a package tree swap.
  - Why it matters: gateway shutdown should not depend on a hashed hook-runner-global chunk name that can disappear
    across package updates.
  - What changed: added a stable plugins/hook-runner-global tsdown entry and a config guard test for that entry.
  - What did NOT change (scope boundary): no plugin loader, TTS/speech-core packaging, package-manager update flow, or
    gateway shutdown behavior changes.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [x] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [x] CI/CD / infra

  ## Linked Issue/PR

  - Closes #81819
  - Related #
  - [x] This PR fixes a bug or regression

  ## Real behavior proof (required for external PRs)

  - Behavior or issue addressed: gateway shutdown lazy boundary now resolves through stable dist/plugins/hook-runner-
    global.js.
  - Real environment tested: local OpenClaw checkout on macOS with Node/pnpm.
  - Exact steps or command run after this patch:
      - pnpm build
      - ls dist dist/plugins | rg 'server.impl|hook-runner-global'
      - rg -n 'hook-runner-global-[A-Za-z0-9_-]+.js|plugins/hook-runner-global.js|plugins/hook-runner-global' dist
  - Evidence after fix:
      - Build passed.
      - dist/plugins/hook-runner-global.js exists.
      - Built dist/server.impl-DAopunJz.js imports ./plugins/hook-runner-global.js.
  - Observed result after fix: gateway shutdown path no longer imports the hook runner through a hashed filename from
    server.impl.
  - What was not tested: remote Blacksmith/Crabbox Docker upgrade-survivor lane was intentionally skipped.
  - Before evidence: beta.8 issue log reported stale hashed hook-runner-global chunk resolution failure.

  ## Root Cause (if applicable)

  - Root cause: the gateway shutdown path lazy-loaded ../plugins/hook-runner-global.js, but the build did not expose that
    module as a stable dist entry, so package swaps could leave long-lived gateway code resolving a stale hashed hook-
    runner chunk.
  - Missing detection / guardrail: no tsdown config guard required plugins/hook-runner-global to remain a stable package
    entry.
  - Contributing context (if known): clean beta.8 tarball already contains dist/extensions/speech-core/runtime-api.js, so
    the speech-core error appears consistent with a mixed/stale dist tree rather than a missing package artifact.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
      - [x] Unit test
      - [x] Seam / integration test
      - [ ] End-to-end test
      - [ ] Existing coverage already sufficient
  - Target test or file: src/infra/tsdown-config.test.ts
  - Scenario the test should lock in: plugins/hook-runner-global remains in the unified tsdown dist entry map.
  - Why this is the smallest reliable guardrail: the fix is a build-entry contract; checking the entry directly catches
    removal without adding broader runtime machinery.
  - Existing test that already covers this (if any): src/gateway/server-import-boundary.test.ts
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  None.

  ## Diagram (if applicable)

  Before:
  [gateway shutdown] -> [server.impl hashed chunk] -> [hashed hook-runner chunk] -> [may be stale after update]

  After:
  [gateway shutdown] -> [server.impl hashed chunk] -> [dist/plugins/hook-runner-global.js] -> [stable boundary]

  ## Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No
  - If any Yes, explain risk + mitigation: N/A

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: local Node/pnpm checkout
  - Model/provider: N/A
  - Integration/channel (if any): N/A
  - Relevant config (redacted): N/A

  ### Steps

  1. Build the project with pnpm build.
  2. Inspect generated dist entries with ls dist dist/plugins | rg 'server.impl|hook-runner-global'.
  3. Inspect generated imports with rg -n 'hook-runner-global-[A-Za-z0-9_-]+.js|plugins/hook-runner-global.js|plugins/
     hook-runner-global' dist.

  ### Expected

  - dist/plugins/hook-runner-global.js exists.
  - Built server.impl imports ./plugins/hook-runner-global.js.

  ### Actual

  - dist/plugins/hook-runner-global.js exists.
  - Built dist/server.impl-DAopunJz.js imports ./plugins/hook-runner-global.js.

  ## Evidence

  Attach at least one:

  - [ ] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios:
      - node scripts/run-vitest.mjs run src/gateway/server-import-boundary.test.ts src/infra/tsdown-config.test.ts test/
        scripts/bundled-plugin-build-entries.test.ts src/plugins/public-surface-runtime.test.ts src/plugin-sdk/facade-
        runtime.test.ts src/tts/tts.test.ts
      - pnpm build
      - codex review --base origin/main
      - Confirmed clean beta.8 tarball contains package/dist/extensions/speech-core/runtime-api.js.
      - Confirmed built server.impl imports stable ./plugins/hook-runner-global.js.
  - Edge cases checked:
      - Verified the wrapper fallback was unnecessary because the one-line stable entry fixed built output.
      - Verified the speech-core artifact was already present in the published beta.8 package.
  - What you did not verify:
      - Remote Blacksmith/Crabbox Docker upgrade-survivor proof.
      - A live package update from version N to N+1.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review
  conversation cleanup for maintainers.

  ## Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  - Risk: stable entry could add one more packaged dist file.
      - Mitigation: limited to an existing internal hook-runner module and covered by pnpm build plus tsdown config test.

### Built with Codex