### PR TITLE
Stop false message tool doctor warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram: let isolated polling drain independent topics, DMs, and status/control commands concurrently while preserving same-lane order. (#81849) Thanks @VACInc.
+- Doctor/Codex: stop warning that the message tool is unavailable for source-reply paths where OpenClaw grants `message` at runtime, keeping update and doctor output aligned with the OpenAI happy path. Thanks @pashpashpash.
 - Build: keep externalized Slack, OpenShell sandbox, and Anthropic Vertex runtime dependency declarations out of the root dist artifact build.
 - Auto-reply/Claude CLI: bridge CLI-runtime assistant text-delta agent events into the chat reasoning preview through `onReasoningStream`, mirroring the existing assistant-text (#76914) and tool-event (#80046) bridges and adding gating so non-CLI runtimes are unaffected. Thanks @anagnorisis2peripeteia and @pashpashpash.
 - CLI/migrate: handle delayed Codex plugin marketplace responses so warnings, next-steps, and conflict states render with ⚠️ glyphs and post-install migration retries the marketplace fetch instead of silently skipping plugin items. (#81625) Thanks @sjf.

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -436,7 +436,7 @@ describe("doctor preview warnings", () => {
         },
       },
       tools: {
-        profile: "coding",
+        allow: ["read"],
       },
     });
 
@@ -446,6 +446,99 @@ describe("doctor preview warnings", () => {
     );
     expect(warning).toContain("normal replies may post to the source chat");
     expect(warning).toContain('set messages.groupChat.visibleReplies to "automatic"');
+  });
+
+  it("does not warn when source reply delivery grants message at runtime", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+          },
+        },
+        list: [
+          {
+            id: "main",
+          },
+        ],
+      },
+      channels: {
+        discord: {},
+        telegram: {},
+      },
+      tools: {
+        profile: "coding" as const,
+      },
+    };
+
+    expect(collectVisibleReplyToolPolicyWarnings(cfg)).toStrictEqual([]);
+    expect(collectChannelBoundMessageToolPolicyWarnings(cfg)).toStrictEqual([]);
+  });
+
+  it("still warns when provider policy blocks the runtime message grant", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+          },
+        },
+        list: [
+          {
+            id: "main",
+          },
+        ],
+      },
+      channels: {
+        discord: {},
+      },
+      tools: {
+        profile: "coding" as const,
+        byProvider: {
+          openai: {
+            allow: ["read"],
+          },
+        },
+      },
+    };
+
+    expectWarningsContaining(collectVisibleReplyToolPolicyWarnings(cfg), [
+      'messages.groupChat.visibleReplies defaults to "message_tool"',
+    ]);
+    expect(collectChannelBoundMessageToolPolicyWarnings(cfg)).toEqual([
+      '- Agent "main" is routed from channel "discord", but the message tool is unavailable for that agent; explicit channel actions such as sendAttachment, upload-file, thread-reply, or reply can fail. Add "message" to the agent tool allowlist, add "group:messaging", or switch the agent to a profile that includes messaging tools.',
+    ]);
+  });
+
+  it("keeps provider-specific message grants when checking provider policy", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+          },
+        },
+        list: [
+          {
+            id: "main",
+          },
+        ],
+      },
+      channels: {
+        discord: {},
+      },
+      tools: {
+        profile: "coding" as const,
+        byProvider: {
+          openai: {
+            alsoAllow: ["message"],
+          },
+        },
+      },
+    };
+
+    expect(collectVisibleReplyToolPolicyWarnings(cfg)).toStrictEqual([]);
+    expect(collectChannelBoundMessageToolPolicyWarnings(cfg)).toStrictEqual([]);
   });
 
   it("warns for direct chats when global visible replies are tool-only but groups override automatic", () => {

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -1,11 +1,16 @@
 import { resolveAgentConfig } from "../../../agents/agent-scope-config.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../../agents/defaults.js";
+import { parseModelRef } from "../../../agents/model-selection-normalize.js";
+import { normalizeProviderId } from "../../../agents/provider-id.js";
 import { pickSandboxToolPolicy } from "../../../agents/sandbox-tool-policy.js";
 import { isToolAllowedByPolicies } from "../../../agents/tool-policy-match.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "../../../agents/tool-policy.js";
+import { resolveAgentModelPrimaryValue } from "../../../config/model-input.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { AgentToolsConfig, ToolsConfig } from "../../../config/types.tools.js";
 import { collectChannelRouteTargets } from "../../../routing/channel-route-targets.js";
 import { createLazyImportLoader } from "../../../shared/lazy-promise.js";
+import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
 
 type ChannelDoctorModule = typeof import("./channel-doctor.js");
 
@@ -88,40 +93,171 @@ function hasConfiguredSafeBins(cfg: OpenClawConfig): boolean {
 }
 
 type VisibleReplyPolicyProvenance = "default" | "global-explicit" | "group-explicit";
+type ToolPolicyConfig = {
+  allow?: string[];
+  alsoAllow?: string[];
+  deny?: string[];
+  profile?: string;
+};
+
+function normalizeProviderPolicyKey(value: string): string {
+  const normalized = normalizeLowercaseStringOrEmpty(value);
+  const slashIndex = normalized.indexOf("/");
+  if (slashIndex <= 0) {
+    return normalizeProviderId(normalized);
+  }
+  const provider = normalizeProviderId(normalized.slice(0, slashIndex));
+  const modelId = normalized.slice(slashIndex + 1);
+  return modelId ? `${provider}/${modelId}` : provider;
+}
+
+function isCanonicalProviderPolicyKey(value: string): boolean {
+  return normalizeLowercaseStringOrEmpty(value) === normalizeProviderPolicyKey(value);
+}
+
+function resolveProviderToolPolicy(params: {
+  byProvider?: Record<string, ToolPolicyConfig>;
+  modelProvider: string;
+  modelId: string;
+}): ToolPolicyConfig | undefined {
+  if (!params.byProvider) {
+    return undefined;
+  }
+  const lookup = new Map<string, { canonical: boolean; value: ToolPolicyConfig }>();
+  for (const [key, value] of Object.entries(params.byProvider)) {
+    const normalized = normalizeProviderPolicyKey(key);
+    if (!normalized) {
+      continue;
+    }
+    const canonical = isCanonicalProviderPolicyKey(key);
+    const existing = lookup.get(normalized);
+    if (!existing || (canonical && !existing.canonical)) {
+      lookup.set(normalized, { canonical, value });
+    }
+  }
+
+  const provider = normalizeProviderPolicyKey(params.modelProvider);
+  const modelId = normalizeLowercaseStringOrEmpty(params.modelId);
+  const fullModelId = modelId ? `${provider}/${modelId}` : undefined;
+  return (fullModelId ? lookup.get(fullModelId)?.value : undefined) ?? lookup.get(provider)?.value;
+}
 
 function resolveMessageToolAvailability(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
   globalTools?: ToolsConfig;
   agentTools?: AgentToolsConfig;
+  runtimeAlsoAllow?: string[];
 }): boolean {
+  const agentConfig = params.agentId ? resolveAgentConfig(params.cfg, params.agentId) : undefined;
+  const modelRef = resolvePrimaryModelRef(params.cfg, agentConfig?.model);
+  const providerPolicy = resolveProviderToolPolicy({
+    byProvider: params.globalTools?.byProvider,
+    modelProvider: modelRef.provider,
+    modelId: modelRef.model,
+  });
+  const agentProviderPolicy = resolveProviderToolPolicy({
+    byProvider: params.agentTools?.byProvider,
+    modelProvider: modelRef.provider,
+    modelId: modelRef.model,
+  });
   const profile = params.agentTools?.profile ?? params.globalTools?.profile;
-  const profileAlsoAllow = Array.isArray(params.agentTools?.alsoAllow)
+  const configuredAlsoAllow = Array.isArray(params.agentTools?.alsoAllow)
     ? params.agentTools.alsoAllow
     : Array.isArray(params.globalTools?.alsoAllow)
       ? params.globalTools.alsoAllow
-      : undefined;
+      : [];
+  const providerAlsoAllow = Array.isArray(agentProviderPolicy?.alsoAllow)
+    ? agentProviderPolicy.alsoAllow
+    : Array.isArray(providerPolicy?.alsoAllow)
+      ? providerPolicy.alsoAllow
+      : [];
+  const profileAlsoAllow = [...configuredAlsoAllow, ...(params.runtimeAlsoAllow ?? [])];
+  const providerProfileAlsoAllow = [...providerAlsoAllow, ...(params.runtimeAlsoAllow ?? [])];
   const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), profileAlsoAllow);
+  const providerProfilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(agentProviderPolicy?.profile ?? providerPolicy?.profile),
+    providerProfileAlsoAllow,
+  );
   return isToolAllowedByPolicies("message", [
     profilePolicy,
+    providerProfilePolicy,
+    pickSandboxToolPolicy(providerPolicy),
+    pickSandboxToolPolicy(agentProviderPolicy),
     pickSandboxToolPolicy(params.globalTools),
     pickSandboxToolPolicy(params.agentTools),
   ]);
 }
 
-function collectMessageToolUnavailableTargets(cfg: OpenClawConfig): string[] {
+const SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW = ["message"];
+
+function resolvePrimaryModelRef(
+  cfg: OpenClawConfig,
+  agentModel?: NonNullable<ReturnType<typeof resolveAgentConfig>>["model"],
+): { provider: string; model: string } {
+  const raw =
+    resolveAgentModelPrimaryValue(agentModel) ??
+    resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model) ??
+    DEFAULT_MODEL;
+  return (
+    parseModelRef(raw, DEFAULT_PROVIDER, { allowPluginNormalization: false }) ?? {
+      provider: DEFAULT_PROVIDER,
+      model: DEFAULT_MODEL,
+    }
+  );
+}
+
+function resolveSourceReplyMessageToolAvailability(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  globalTools?: ToolsConfig;
+  agentTools?: AgentToolsConfig;
+}): boolean {
+  return resolveMessageToolAvailability({
+    ...params,
+    runtimeAlsoAllow: SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW,
+  });
+}
+
+function sourceReplyRuntimeMayAllowMessageTool(cfg: OpenClawConfig): boolean {
+  const groupPolicy = resolveGroupVisibleReplyProvenance(cfg);
+  if (hasChannels(cfg) && groupPolicy.value === "message_tool") {
+    return true;
+  }
+  if (cfg.messages?.visibleReplies === "message_tool") {
+    return true;
+  }
+  return false;
+}
+
+function collectMessageToolUnavailableTargets(
+  cfg: OpenClawConfig,
+  options: { sourceReplyRuntimeGrant?: boolean } = {},
+): string[] {
   const agents = listAgentRecords(cfg);
   if (agents.length === 0) {
-    return resolveMessageToolAvailability({ globalTools: cfg.tools })
-      ? []
-      : ["default tool policy"];
+    const available = options.sourceReplyRuntimeGrant
+      ? resolveSourceReplyMessageToolAvailability({ cfg, globalTools: cfg.tools })
+      : resolveMessageToolAvailability({ cfg, globalTools: cfg.tools });
+    return available ? [] : ["default tool policy"];
   }
-  return agents.flatMap((agent) =>
-    resolveMessageToolAvailability({
-      globalTools: cfg.tools,
-      agentTools: agent.tools as AgentToolsConfig | undefined,
-    })
-      ? []
-      : [`agent "${typeof agent.id === "string" ? agent.id : "unknown"}"`],
-  );
+  return agents.flatMap((agent) => {
+    const agentId = typeof agent.id === "string" ? agent.id : "unknown";
+    const available = options.sourceReplyRuntimeGrant
+      ? resolveSourceReplyMessageToolAvailability({
+          cfg,
+          agentId,
+          globalTools: cfg.tools,
+          agentTools: agent.tools as AgentToolsConfig | undefined,
+        })
+      : resolveMessageToolAvailability({
+          cfg,
+          agentId,
+          globalTools: cfg.tools,
+          agentTools: agent.tools as AgentToolsConfig | undefined,
+        });
+    return available ? [] : [`agent "${agentId}"`];
+  });
 }
 
 function resolveGroupVisibleReplyProvenance(cfg: OpenClawConfig): {
@@ -160,14 +296,14 @@ function formatTargets(targets: string[]): string {
 }
 
 export function collectVisibleReplyToolPolicyWarnings(cfg: OpenClawConfig): string[] {
-  const targets = collectMessageToolUnavailableTargets(cfg);
-  if (targets.length === 0) {
-    return [];
-  }
   const groupPolicy = resolveGroupVisibleReplyProvenance(cfg);
   const warnings: string[] = [];
   if (groupPolicy.value === "message_tool") {
     if (groupPolicy.provenance === "default" && !hasChannels(cfg)) {
+      return warnings;
+    }
+    const targets = collectMessageToolUnavailableTargets(cfg, { sourceReplyRuntimeGrant: true });
+    if (targets.length === 0) {
       return warnings;
     }
     const targetSummary = formatTargets(targets);
@@ -184,6 +320,10 @@ export function collectVisibleReplyToolPolicyWarnings(cfg: OpenClawConfig): stri
 
   const globalVisibleReplies = cfg.messages?.visibleReplies;
   if (globalVisibleReplies === "message_tool" && groupPolicy.path !== "messages.visibleReplies") {
+    const targets = collectMessageToolUnavailableTargets(cfg, { sourceReplyRuntimeGrant: true });
+    if (targets.length === 0) {
+      return warnings;
+    }
     warnings.push(
       `- messages.visibleReplies is set to "message_tool", but the message tool is unavailable for ${formatTargets(
         targets,
@@ -206,7 +346,21 @@ function formatChannelList(channels: string[]): string {
 export function collectChannelBoundMessageToolPolicyWarnings(cfg: OpenClawConfig): string[] {
   return collectChannelRouteTargets(cfg).flatMap((target) => {
     const agentTools = resolveAgentConfig(cfg, target.agentId)?.tools;
-    if (resolveMessageToolAvailability({ globalTools: cfg.tools, agentTools })) {
+    const runtimeMayAllowMessage = sourceReplyRuntimeMayAllowMessageTool(cfg);
+    const messageToolAvailable = runtimeMayAllowMessage
+      ? resolveSourceReplyMessageToolAvailability({
+          cfg,
+          agentId: target.agentId,
+          globalTools: cfg.tools,
+          agentTools,
+        })
+      : resolveMessageToolAvailability({
+          cfg,
+          agentId: target.agentId,
+          globalTools: cfg.tools,
+          agentTools,
+        });
+    if (messageToolAvailable) {
       return [];
     }
     return [


### PR DESCRIPTION
Doctor was warning that the message tool was unavailable whenever a channel-routed agent used a tool profile like coding. That was true for the old static read, but source reply dispatch now grants message at runtime when message-tool delivery is active. In the OpenAI/Codex happy path this made update and doctor output tell users their agent could not message even though the actual run could send normally.

This teaches doctor the same effective availability check: keep warning when a real allow or deny policy still blocks message, but suppress the warning when the runtime source-reply grant makes it available. The regression test covers a Codex/OpenAI agent on Discord and Telegram with tools.profile set to coding.

## Real behavior proof

- Behavior or issue addressed: `openclaw doctor` falsely warned that the message tool was unavailable for Pash's OpenAI/Codex dev agent, even though source reply dispatch grants `message` at runtime for message-tool delivery.
- Real environment tested: Pash's actual dev OpenClaw setup using `~/.openclaw/openclaw.json`, the running beta.8 Gateway service, Discord and Telegram configured, and the PR worktree using the same canonical config.
- Exact steps or command run after this patch: From `~/code/openclaw-doctor-codex-message-warning`, ran `pnpm openclaw doctor 2>&1 | rg -n "message tool is unavailable|Agent \\"main\\" is routed|visibleReplies.*message_tool" || true`. For before-fix comparison, ran the same command from `~/code/openclaw` at `2026.5.12-beta.8`. Also ran `pnpm openclaw gateway status --deep` from `~/code/openclaw` to confirm the live dev gateway setup.
- Evidence after fix: Terminal output from the PR worktree against the real dev config only showed the normal visible-reply preview, with no `message tool is unavailable` lines:

```text
55:│  Set messages.groupChat.visibleReplies to "message_tool" so  │
```

Before this patch, the beta.8 checkout against the same config printed:

```text
35:│  Set messages.groupChat.visibleReplies to "message_tool" so  │
42:│  - messages.groupChat.visibleReplies is set to "message_tool", but the   │
43:│    message tool is unavailable for agent "main"; OpenClaw falls back to  │
52:│  - Agent "main" is routed from channel "discord" and "telegram", but    │
53:│    the message tool is unavailable for that agent; explicit channel     │
```

The live Gateway proof showed the actual service still using Pash's beta.8 dev setup and canonical config:

```text
Command: /opt/homebrew/opt/node/bin/node /Users/pash/code/openclaw/dist/index.js gateway --port 18789
Config (cli): ~/.openclaw/openclaw.json
Config (service): ~/.openclaw/openclaw.json
CLI version: 2026.5.12-beta.8 (~/code/openclaw/openclaw.mjs)
Gateway version: 2026.5.12-beta.8
Runtime: running (pid 51040)
Connectivity probe: ok
Capability: admin-capable
```

- Observed result after fix: The misleading doctor warning disappeared on the same real config while the normal visible-reply migration preview remained. The running dev Gateway stayed healthy on beta.8.
- What was not tested: No additional gaps.
