### PR TITLE
fix(plugins): scope tool lookup to loaded plugins

### DIFF
--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -3508,6 +3508,53 @@ describe("resolvePluginTools optional tools", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
+  it("cold-loads defaults when a request registry contains only unrelated plugins", () => {
+    const config = createContext().config;
+    installToolManifestSnapshot({
+      config,
+      plugin: {
+        id: "default-plugin",
+        origin: "bundled",
+        enabledByDefault: true,
+        channels: [],
+        providers: [],
+        contracts: { tools: ["default_tool"] },
+      },
+    });
+    const defaultFactory = vi.fn(() => makeTool("default_tool"));
+    const unrelatedFactory = vi.fn(() => makeTool("unrelated_tool"));
+    const runtimeRegistry = createToolRegistry([
+      {
+        pluginId: "unrelated-plugin",
+        optional: false,
+        source: "/tmp/unrelated-plugin.js",
+        names: ["unrelated_tool"],
+        factory: unrelatedFactory,
+      },
+    ]);
+    loadOpenClawPluginsMock.mockReturnValue(
+      createToolRegistry([
+        {
+          pluginId: "default-plugin",
+          optional: false,
+          source: "/tmp/default-plugin.js",
+          names: ["default_tool"],
+          factory: defaultFactory,
+        },
+      ]),
+    );
+
+    const tools = resolvePluginTools({
+      ...createResolveToolsParams({ toolAllowlist: ["group:plugins"] }),
+      runtimeRegistry: runtimeRegistry as never,
+    });
+
+    expectResolvedToolNames(tools, ["default_tool"]);
+    expect(defaultFactory).toHaveBeenCalledTimes(1);
+    expect(unrelatedFactory).not.toHaveBeenCalled();
+    expectLoaderSelectedOnlyPluginIds(["default-plugin"]);
+  });
+
   it("cold-loads config-origin tools with the complete eligible plugin set", () => {
     const baseContext = createContext();
     const config = {

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -3428,6 +3428,41 @@ describe("resolvePluginTools optional tools", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
+  it("cold-loads default-enabled plugin tools without an ambient registry", () => {
+    const config = createContext().config;
+    installToolManifestSnapshot({
+      config,
+      plugin: {
+        id: "default-plugin",
+        origin: "bundled",
+        enabledByDefault: true,
+        channels: [],
+        providers: [],
+        contracts: { tools: ["default_tool"] },
+      },
+    });
+    const factory = vi.fn(() => makeTool("default_tool"));
+    loadOpenClawPluginsMock.mockReturnValue(
+      createToolRegistry([
+        {
+          pluginId: "default-plugin",
+          optional: false,
+          source: "/tmp/default-plugin.js",
+          names: ["default_tool"],
+          factory,
+        },
+      ]),
+    );
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({ toolAllowlist: ["group:plugins"] }),
+    );
+
+    expectResolvedToolNames(tools, ["default_tool"]);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expectLoaderSelectedOnlyPluginIds(["default-plugin"]);
+  });
+
   it("preserves tools from a caller-supplied request registry", () => {
     const baseContext = createContext();
     const config = {
@@ -3581,6 +3616,7 @@ describe("resolvePluginTools optional tools", () => {
         contracts: { tools: ["stale_tool"] },
       },
     });
+    loadOpenClawPluginsMock.mockReturnValue(createToolRegistry([]));
 
     const tools = resolvePluginTools(
       createResolveToolsParams({ toolAllowlist: ["group:plugins"] }),
@@ -3588,7 +3624,7 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(tools, []);
     expect(staleFactory).not.toHaveBeenCalled();
-    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+    expectLoaderSelectedOnlyPluginIds(["stale-plugin"]);
   });
 
   it("ignores a pinned channel plugin registry from another workspace", () => {
@@ -3627,6 +3663,7 @@ describe("resolvePluginTools optional tools", () => {
         contracts: { tools: ["stale_tool"] },
       },
     });
+    loadOpenClawPluginsMock.mockReturnValue(createToolRegistry([]));
 
     const tools = resolvePluginTools(
       createResolveToolsParams({ toolAllowlist: ["group:plugins"] }),
@@ -3634,7 +3671,7 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(tools, []);
     expect(staleFactory).not.toHaveBeenCalled();
-    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+    expectLoaderSelectedOnlyPluginIds(["stale-plugin"]);
   });
 
   it("cold-loads slot-selected plugin tools when an unrelated plugin is already loaded", () => {

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -3588,6 +3588,87 @@ describe("resolvePluginTools optional tools", () => {
     expectLoaderSelectedOnlyPluginIds(["loaded-plugin", "path-plugin"]);
   });
 
+  it("cold-loads configured default plugins beside loaded siblings", () => {
+    const baseContext = createContext();
+    const config = {
+      ...baseContext.config,
+      plugins: {
+        ...baseContext.config.plugins,
+        allow: undefined,
+        entries: {
+          "configured-plugin": { config: { mode: "test" } },
+        },
+      },
+    };
+    installToolManifestSnapshots({
+      config,
+      plugins: [
+        {
+          id: "loaded-plugin",
+          origin: "bundled",
+          enabledByDefault: true,
+          channels: [],
+          providers: [],
+          contracts: { tools: ["loaded_tool"] },
+        },
+        {
+          id: "configured-plugin",
+          origin: "bundled",
+          enabledByDefault: true,
+          channels: [],
+          providers: [],
+          contracts: { tools: ["configured_tool"] },
+        },
+      ],
+    });
+    const loadedFactory = vi.fn(() => makeTool("loaded_tool"));
+    const configuredFactory = vi.fn(() => makeTool("configured_tool"));
+    setActivePluginRegistry(
+      createToolRegistry([
+        {
+          pluginId: "loaded-plugin",
+          optional: false,
+          source: "/tmp/loaded-plugin.js",
+          names: ["loaded_tool"],
+          factory: loadedFactory,
+        },
+      ]) as never,
+      "test-tool-registry",
+      "gateway-bindable",
+      "/tmp",
+    );
+    loadOpenClawPluginsMock.mockReturnValue(
+      createToolRegistry([
+        {
+          pluginId: "loaded-plugin",
+          optional: false,
+          source: "/tmp/loaded-plugin.js",
+          names: ["loaded_tool"],
+          factory: loadedFactory,
+        },
+        {
+          pluginId: "configured-plugin",
+          optional: false,
+          source: "/tmp/configured-plugin.js",
+          names: ["configured_tool"],
+          factory: configuredFactory,
+        },
+      ]),
+    );
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        context: { ...baseContext, config } as never,
+        toolAllowlist: ["group:plugins"],
+      }),
+    );
+
+    expectResolvedToolNames(tools, ["loaded_tool", "configured_tool"]);
+    expect(loadedFactory).toHaveBeenCalledTimes(1);
+    expect(configuredFactory).toHaveBeenCalledTimes(1);
+    expectLoaderSelectedOnlyPluginIds(["configured-plugin", "loaded-plugin"]);
+  });
+
   it("ignores an active plugin registry from another workspace", () => {
     const staleFactory = vi.fn(() => makeTool("stale_tool"));
     setActivePluginRegistry(

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -3428,6 +3428,51 @@ describe("resolvePluginTools optional tools", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
+  it("preserves tools from a caller-supplied request registry", () => {
+    const baseContext = createContext();
+    const config = {
+      ...baseContext.config,
+      plugins: {
+        ...baseContext.config.plugins,
+        allow: undefined,
+        load: { paths: [] },
+      },
+    };
+    installToolManifestSnapshot({
+      config,
+      plugin: {
+        id: "request-plugin",
+        origin: "bundled",
+        enabledByDefault: true,
+        channels: [],
+        providers: [],
+        contracts: { tools: ["request_tool"] },
+      },
+    });
+    const factory = vi.fn(() => makeTool("request_tool"));
+    const runtimeRegistry = createToolRegistry([
+      {
+        pluginId: "request-plugin",
+        optional: false,
+        source: "/tmp/request-plugin.js",
+        names: ["request_tool"],
+        factory,
+      },
+    ]);
+
+    const tools = resolvePluginTools({
+      ...createResolveToolsParams({
+        context: { ...baseContext, config } as never,
+        toolAllowlist: ["group:plugins"],
+      }),
+      runtimeRegistry: runtimeRegistry as never,
+    });
+
+    expectResolvedToolNames(tools, ["request_tool"]);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
   it("cold-loads config-origin tools with the complete eligible plugin set", () => {
     const baseContext = createContext();
     const config = {

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -3377,6 +3377,141 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(tools, ["optional_tool"]);
   });
+
+  it("returns tools for loaded plugins even when manifest snapshot has unloaded siblings", () => {
+    const config = createContext().config;
+    installToolManifestSnapshots({
+      config,
+      plugins: [
+        {
+          id: "loaded-plugin",
+          origin: "bundled",
+          enabledByDefault: true,
+          channels: [],
+          providers: [],
+          contracts: { tools: ["loaded_tool"] },
+        },
+        {
+          id: "unloaded-plugin",
+          origin: "bundled",
+          enabledByDefault: true,
+          channels: [],
+          providers: [],
+          contracts: { tools: ["unloaded_tool"] },
+        },
+      ],
+    });
+    const loadedFactory = vi.fn(() => makeTool("loaded_tool"));
+    setActivePluginRegistry(
+      {
+        plugins: [{ id: "loaded-plugin", status: "loaded" }],
+        tools: [
+          {
+            pluginId: "loaded-plugin",
+            optional: false,
+            source: "/tmp/loaded-plugin.js",
+            names: ["loaded_tool"],
+            factory: loadedFactory,
+          },
+        ],
+        diagnostics: [],
+      } as never,
+      "test-tool-registry",
+      "gateway-bindable",
+      "/tmp",
+    );
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({ toolAllowlist: ["group:plugins"] }),
+    );
+
+    expectResolvedToolNames(tools, ["loaded_tool"]);
+    expect(loadedFactory).toHaveBeenCalledTimes(1);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
+  it("cold-loads slot-selected plugin tools when an unrelated plugin is already loaded", () => {
+    const baseContext = createContext();
+    const config = {
+      ...baseContext.config,
+      plugins: {
+        ...baseContext.config.plugins,
+        allow: ["loaded-plugin"],
+        slots: { memory: "memory-core" },
+      },
+    };
+    installToolManifestSnapshots({
+      config,
+      plugins: [
+        {
+          id: "loaded-plugin",
+          origin: "bundled",
+          enabledByDefault: true,
+          channels: [],
+          providers: [],
+          contracts: { tools: ["loaded_tool"] },
+        },
+        {
+          id: "memory-core",
+          origin: "bundled",
+          enabledByDefault: true,
+          channels: [],
+          providers: [],
+          contracts: { tools: ["memory_search"] },
+        },
+      ],
+    });
+    const loadedFactory = vi.fn(() => makeTool("loaded_tool"));
+    const memoryFactory = vi.fn(() => makeTool("memory_search"));
+    setActivePluginRegistry(
+      {
+        plugins: [{ id: "loaded-plugin", status: "loaded" }],
+        tools: [
+          {
+            pluginId: "loaded-plugin",
+            optional: false,
+            source: "/tmp/loaded-plugin.js",
+            names: ["loaded_tool"],
+            factory: loadedFactory,
+          },
+        ],
+        diagnostics: [],
+      } as never,
+      "test-tool-registry",
+      "gateway-bindable",
+      "/tmp",
+    );
+    loadOpenClawPluginsMock.mockReturnValue(
+      createToolRegistry([
+        {
+          pluginId: "memory-core",
+          optional: false,
+          source: "/tmp/memory-core.js",
+          names: ["memory_search"],
+          factory: memoryFactory,
+        },
+      ]),
+    );
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        context: { ...baseContext, config } as never,
+        toolAllowlist: ["group:plugins"],
+      }),
+    );
+
+    expectResolvedToolNames(tools, ["memory_search"]);
+    expect(loadedFactory).not.toHaveBeenCalled();
+    expect(memoryFactory).toHaveBeenCalledTimes(1);
+    expect(
+      loadOpenClawPluginsMock.mock.calls.map(
+        ([params]) => (params as { onlyPluginIds?: string[] }).onlyPluginIds,
+      ),
+    ).toStrictEqual([
+      ["loaded-plugin", "memory-core"],
+      ["loaded-plugin", "memory-core"],
+    ]);
+  });
 });
 
 describe("buildPluginToolMetadataKey", () => {

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -499,9 +499,7 @@ describe("resolvePluginTools optional tools", () => {
   beforeEach(() => {
     loadOpenClawPluginsMock.mockReset();
     resolveRuntimePluginRegistryMock.mockReset();
-    resolveRuntimePluginRegistryMock.mockImplementation((params) =>
-      loadOpenClawPluginsMock(params),
-    );
+    resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
     applyPluginAutoEnableMock.mockReset();
     applyPluginAutoEnableMock.mockImplementation(({ config }: { config: unknown }) => ({
       config,
@@ -3430,6 +3428,170 @@ describe("resolvePluginTools optional tools", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
+  it("cold-loads config-origin tools with the complete eligible plugin set", () => {
+    const baseContext = createContext();
+    const config = {
+      ...baseContext.config,
+      plugins: {
+        ...baseContext.config.plugins,
+        allow: ["loaded-plugin", "path-plugin"],
+        load: { paths: ["/tmp/path-plugin.js"] },
+      },
+    };
+    installToolManifestSnapshots({
+      config,
+      plugins: [
+        {
+          id: "loaded-plugin",
+          origin: "bundled",
+          enabledByDefault: true,
+          channels: [],
+          providers: [],
+          contracts: { tools: ["loaded_tool"] },
+        },
+        {
+          id: "path-plugin",
+          origin: "config",
+          enabledByDefault: undefined,
+          channels: [],
+          providers: [],
+          contracts: { tools: ["path_tool"] },
+        },
+      ],
+    });
+    const loadedFactory = vi.fn(() => makeTool("loaded_tool"));
+    const pathFactory = vi.fn(() => makeTool("path_tool"));
+    setActivePluginRegistry(
+      createToolRegistry([
+        {
+          pluginId: "loaded-plugin",
+          optional: false,
+          source: "/tmp/loaded-plugin.js",
+          names: ["loaded_tool"],
+          factory: loadedFactory,
+        },
+      ]) as never,
+      "test-tool-registry",
+      "gateway-bindable",
+      "/tmp",
+    );
+    resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
+    loadOpenClawPluginsMock.mockReturnValue(
+      createToolRegistry([
+        {
+          pluginId: "loaded-plugin",
+          optional: false,
+          source: "/tmp/loaded-plugin.js",
+          names: ["loaded_tool"],
+          factory: loadedFactory,
+        },
+        {
+          pluginId: "path-plugin",
+          optional: false,
+          source: "/tmp/path-plugin.js",
+          names: ["path_tool"],
+          factory: pathFactory,
+        },
+      ]),
+    );
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        context: { ...baseContext, config } as never,
+        toolAllowlist: ["group:plugins"],
+      }),
+    );
+
+    expectResolvedToolNames(tools, ["loaded_tool", "path_tool"]);
+    expect(loadedFactory).toHaveBeenCalledTimes(1);
+    expect(pathFactory).toHaveBeenCalledTimes(1);
+    expectLoaderSelectedOnlyPluginIds(["loaded-plugin", "path-plugin"]);
+  });
+
+  it("ignores an active plugin registry from another workspace", () => {
+    const staleFactory = vi.fn(() => makeTool("stale_tool"));
+    setActivePluginRegistry(
+      createToolRegistry([
+        {
+          pluginId: "stale-plugin",
+          optional: false,
+          source: "/tmp/stale-plugin.js",
+          names: ["stale_tool"],
+          factory: staleFactory,
+        },
+      ]) as never,
+      "stale-tool-registry",
+      "gateway-bindable",
+      "/tmp/other-workspace",
+    );
+    const config = createContext().config;
+    installToolManifestSnapshot({
+      config,
+      plugin: {
+        id: "stale-plugin",
+        origin: "bundled",
+        enabledByDefault: true,
+        channels: [],
+        providers: [],
+        contracts: { tools: ["stale_tool"] },
+      },
+    });
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({ toolAllowlist: ["group:plugins"] }),
+    );
+
+    expectResolvedToolNames(tools, []);
+    expect(staleFactory).not.toHaveBeenCalled();
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores a pinned channel plugin registry from another workspace", () => {
+    const staleFactory = vi.fn(() => makeTool("stale_tool"));
+    const staleRegistry = createToolRegistry([
+      {
+        pluginId: "stale-plugin",
+        optional: false,
+        source: "/tmp/stale-plugin.js",
+        names: ["stale_tool"],
+        factory: staleFactory,
+      },
+    ]);
+    setActivePluginRegistry(
+      staleRegistry as never,
+      "stale-tool-registry",
+      "gateway-bindable",
+      "/tmp/other-workspace",
+    );
+    pinActivePluginChannelRegistry(staleRegistry as never);
+    setActivePluginRegistry(
+      createEmptyPluginRegistry(),
+      "replacement-registry",
+      "default",
+      "/tmp/other-workspace",
+    );
+    const config = createContext().config;
+    installToolManifestSnapshot({
+      config,
+      plugin: {
+        id: "stale-plugin",
+        origin: "bundled",
+        enabledByDefault: true,
+        channels: [],
+        providers: [],
+        contracts: { tools: ["stale_tool"] },
+      },
+    });
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({ toolAllowlist: ["group:plugins"] }),
+    );
+
+    expectResolvedToolNames(tools, []);
+    expect(staleFactory).not.toHaveBeenCalled();
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
   it("cold-loads slot-selected plugin tools when an unrelated plugin is already loaded", () => {
     const baseContext = createContext();
     const config = {
@@ -3484,6 +3646,13 @@ describe("resolvePluginTools optional tools", () => {
     loadOpenClawPluginsMock.mockReturnValue(
       createToolRegistry([
         {
+          pluginId: "loaded-plugin",
+          optional: false,
+          source: "/tmp/loaded-plugin.js",
+          names: ["loaded_tool"],
+          factory: loadedFactory,
+        },
+        {
           pluginId: "memory-core",
           optional: false,
           source: "/tmp/memory-core.js",
@@ -3500,17 +3669,14 @@ describe("resolvePluginTools optional tools", () => {
       }),
     );
 
-    expectResolvedToolNames(tools, ["memory_search"]);
-    expect(loadedFactory).not.toHaveBeenCalled();
+    expectResolvedToolNames(tools, ["loaded_tool", "memory_search"]);
+    expect(loadedFactory).toHaveBeenCalledTimes(1);
     expect(memoryFactory).toHaveBeenCalledTimes(1);
     expect(
       loadOpenClawPluginsMock.mock.calls.map(
         ([params]) => (params as { onlyPluginIds?: string[] }).onlyPluginIds,
       ),
-    ).toStrictEqual([
-      ["loaded-plugin", "memory-core"],
-      ["loaded-plugin", "memory-core"],
-    ]);
+    ).toStrictEqual([["loaded-plugin", "memory-core"]]);
   });
 });
 

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1236,8 +1236,8 @@ export function resolvePluginTools(params: {
       ),
     ),
   );
-  const explicitlyConfiguredPluginIds = new Set<string>();
   const normalizedPlugins = normalizePluginsConfig(context.config.plugins);
+  const explicitlyConfiguredPluginIds = new Set(normalizedPlugins.allow);
   for (const slotPluginId of [
     normalizedPlugins.slots.memory,
     normalizedPlugins.slots.contextEngine,
@@ -1246,27 +1246,9 @@ export function resolvePluginTools(params: {
       explicitlyConfiguredPluginIds.add(slotPluginId);
     }
   }
-  const pluginsConfig = (context.config as { plugins?: unknown } | undefined)?.plugins as
-    | { allow?: unknown; entries?: unknown }
-    | undefined;
-  if (pluginsConfig) {
-    if (Array.isArray(pluginsConfig.allow)) {
-      for (const id of pluginsConfig.allow) {
-        if (typeof id === "string") {
-          explicitlyConfiguredPluginIds.add(id);
-        }
-      }
-    }
-    if (pluginsConfig.entries && typeof pluginsConfig.entries === "object") {
-      for (const [id, entry] of Object.entries(pluginsConfig.entries as Record<string, unknown>)) {
-        if (
-          entry &&
-          typeof entry === "object" &&
-          (entry as { enabled?: unknown }).enabled === true
-        ) {
-          explicitlyConfiguredPluginIds.add(id);
-        }
-      }
+  for (const [pluginId, entry] of Object.entries(normalizedPlugins.entries)) {
+    if (entry.enabled === true) {
+      explicitlyConfiguredPluginIds.add(pluginId);
     }
   }
   for (const plugin of snapshot.plugins) {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1256,8 +1256,13 @@ export function resolvePluginTools(params: {
       explicitlyConfiguredPluginIds.add(plugin.id);
     }
   }
+  // A caller-supplied registry is the result of an explicit request-local load, not
+  // ambient active/channel state. Preserve its selected tools without treating it as
+  // evidence that any global registry is compatible with this request.
+  const retainedPluginIds = new Set(params.runtimeRegistry?.tools.map((entry) => entry.pluginId));
   const eligiblePluginIds = runtimePluginIds.filter(
-    (id) => loadedPluginIds.has(id) || explicitlyConfiguredPluginIds.has(id),
+    (id) =>
+      loadedPluginIds.has(id) || explicitlyConfiguredPluginIds.has(id) || retainedPluginIds.has(id),
   );
   if (eligiblePluginIds.length === 0) {
     return tools;

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1220,56 +1220,88 @@ export function resolvePluginTools(params: {
   if (runtimePluginIds.length === 0) {
     return tools;
   }
-  const loadOptions = buildPluginRuntimeLoadOptions(context, {
+  // Check candidates independently so an unloaded manifest sibling cannot make the
+  // registry's strict required-id lookup hide a loaded sibling.
+  const loadedPluginIds = new Set(
+    runtimePluginIds.filter((pluginId) =>
+      (["channel", "active"] as const).some(
+        (surface) =>
+          getLoadedRuntimePluginRegistry({
+            env,
+            loadOptions: loadState.loadOptions,
+            workspaceDir: loadState.loadOptions.workspaceDir,
+            requiredPluginIds: [pluginId],
+            surface,
+          }) !== undefined,
+      ),
+    ),
+  );
+  const explicitlyConfiguredPluginIds = new Set<string>();
+  const normalizedPlugins = normalizePluginsConfig(context.config.plugins);
+  for (const slotPluginId of [
+    normalizedPlugins.slots.memory,
+    normalizedPlugins.slots.contextEngine,
+  ]) {
+    if (slotPluginId) {
+      explicitlyConfiguredPluginIds.add(slotPluginId);
+    }
+  }
+  const pluginsConfig = (context.config as { plugins?: unknown } | undefined)?.plugins as
+    | { allow?: unknown; entries?: unknown }
+    | undefined;
+  if (pluginsConfig) {
+    if (Array.isArray(pluginsConfig.allow)) {
+      for (const id of pluginsConfig.allow) {
+        if (typeof id === "string") {
+          explicitlyConfiguredPluginIds.add(id);
+        }
+      }
+    }
+    if (pluginsConfig.entries && typeof pluginsConfig.entries === "object") {
+      for (const [id, entry] of Object.entries(pluginsConfig.entries as Record<string, unknown>)) {
+        if (
+          entry &&
+          typeof entry === "object" &&
+          (entry as { enabled?: unknown }).enabled === true
+        ) {
+          explicitlyConfiguredPluginIds.add(id);
+        }
+      }
+    }
+  }
+  for (const plugin of snapshot.plugins) {
+    if (plugin.origin === "config") {
+      explicitlyConfiguredPluginIds.add(plugin.id);
+    }
+  }
+  const eligiblePluginIds = runtimePluginIds.filter(
+    (id) => loadedPluginIds.has(id) || explicitlyConfiguredPluginIds.has(id),
+  );
+  if (eligiblePluginIds.length === 0) {
+    return tools;
+  }
+  const eligibleLoadOptions = buildPluginRuntimeLoadOptions(context, {
     activate: false,
     toolDiscovery: true,
-    onlyPluginIds: runtimePluginIds,
+    onlyPluginIds: eligiblePluginIds,
     runtimeOptions,
   });
-  let registry = registryHasScopedPluginTools(params.runtimeRegistry, runtimePluginIds)
+  const registry = registryHasScopedPluginTools(params.runtimeRegistry, eligiblePluginIds)
     ? params.runtimeRegistry
-    : undefined;
-  if (!registry) {
-    registry = resolvePluginToolRegistry({
-      loadOptions,
-      onlyPluginIds: runtimePluginIds,
-    });
-  }
-  if (!registry) {
-    // Cold registry: path-based plugins (origin "config") registered via plugins.load.paths
-    // are not pinned to any active channel/surface registry until explicitly loaded.
-    // Trigger a standalone load so their tool factories become available, then retry.
-    try {
-      ensureStandaloneRuntimePluginRegistryLoaded({
-        surface: "channel",
-        requiredPluginIds: runtimePluginIds,
-        loadOptions,
+    : resolvePluginToolRegistry({
+        loadOptions: eligibleLoadOptions,
+        onlyPluginIds: eligiblePluginIds,
       });
-    } catch (error) {
-      context.logger.error(
-        `failed to cold-load plugin tool registry for plugin ids [${runtimePluginIds.join(", ")}]: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      throw error;
-    }
-    registry = resolvePluginToolRegistry({
-      loadOptions,
-      onlyPluginIds: runtimePluginIds,
-    });
-    if (!registry) {
-      context.logger.warn(
-        `plugin tool registry still unavailable after cold load for plugin ids [${runtimePluginIds.join(
-          ", ",
-        )}]`,
-      );
-      return tools;
-    }
+  if (!registry) {
+    context.logger.warn(
+      `plugin tool registry unavailable for eligible plugin ids [${eligiblePluginIds.join(", ")}]`,
+    );
+    return tools;
   }
 
-  const scopedPluginIds = new Set(runtimePluginIds);
+  const scopedPluginIds = new Set(eligiblePluginIds);
   const registryToolPluginIds = new Set(registry.tools.map((entry) => entry.pluginId));
-  const missingRegistryToolPluginIds = runtimePluginIds.filter(
+  const missingRegistryToolPluginIds = eligiblePluginIds.filter(
     (pluginId) => !registryToolPluginIds.has(pluginId),
   );
   for (const pluginId of missingRegistryToolPluginIds) {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1260,10 +1260,15 @@ export function resolvePluginTools(params: {
   // ambient active/channel state. Preserve its selected tools without treating it as
   // evidence that any global registry is compatible with this request.
   const retainedPluginIds = new Set(params.runtimeRegistry?.tools.map((entry) => entry.pluginId));
-  const eligiblePluginIds = runtimePluginIds.filter(
-    (id) =>
-      loadedPluginIds.has(id) || explicitlyConfiguredPluginIds.has(id) || retainedPluginIds.has(id),
-  );
+  const hasCompatibleRegistry = loadedPluginIds.size > 0 || retainedPluginIds.size > 0;
+  const eligiblePluginIds = hasCompatibleRegistry
+    ? runtimePluginIds.filter(
+        (id) =>
+          loadedPluginIds.has(id) ||
+          explicitlyConfiguredPluginIds.has(id) ||
+          retainedPluginIds.has(id),
+      )
+    : runtimePluginIds;
   if (eligiblePluginIds.length === 0) {
     return tools;
   }

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1260,7 +1260,8 @@ export function resolvePluginTools(params: {
   // ambient active/channel state. Preserve its selected tools without treating it as
   // evidence that any global registry is compatible with this request.
   const retainedPluginIds = new Set(params.runtimeRegistry?.tools.map((entry) => entry.pluginId));
-  const hasCompatibleRegistry = loadedPluginIds.size > 0 || retainedPluginIds.size > 0;
+  const hasCompatibleRetainedPlugin = runtimePluginIds.some((id) => retainedPluginIds.has(id));
+  const hasCompatibleRegistry = loadedPluginIds.size > 0 || hasCompatibleRetainedPlugin;
   const eligiblePluginIds = hasCompatibleRegistry
     ? runtimePluginIds.filter(
         (id) =>

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1247,7 +1247,7 @@ export function resolvePluginTools(params: {
     }
   }
   for (const [pluginId, entry] of Object.entries(normalizedPlugins.entries)) {
-    if (entry.enabled === true) {
+    if (entry.enabled !== false) {
       explicitlyConfiguredPluginIds.add(pluginId);
     }
   }


### PR DESCRIPTION
## Summary

- Problem: with `tools.allow: ["group:core", "group:plugins"]` and `plugins.slots.memory: "memory-core"`, plugin tool resolution returned zero tools whenever the manifest snapshot also included a bundled-but-not-loaded sibling such as `memory-lancedb`. Active Memory recall reported `status=unavailable` for every turn because `memory_recall`, `memory_search`, and `memory_get` were silently filtered out of the runtime allowlist.
- Why it matters: the `tools.allow` contract documented in `docs/tools/index.md` is "load matters, allowlist gates" — an unloaded sibling should never be able to revoke a loaded plugin's tools. The bug breaks `group:plugins` for any configuration that bundles more than one plugin per slot family, which is the common case for memory, providers, and channel plugins.
- What changed: in `src/plugins/tools.ts`, before consulting the active and channel surface registries via `resolvePluginToolRegistry`, filter `runtimePluginIds` down to the ids actually present in `getActiveRuntimePluginRegistry()` or `getActivePluginChannelRegistry()`. The strict `every()` check in `registryContainsPluginIds` no longer fails the entire lookup because one bundled sibling happens to be unloaded. The inner `for (const entry of registry.tools)` loop already filters by `scopedPluginIds`, so loaded-plugin semantics are unchanged.
- What did NOT change (scope boundary): the standalone cold-load fallback (`ensureStandaloneRuntimePluginRegistryLoaded`) still receives the full manifest-resolved `runtimePluginIds`. That path exists to materialize plugins that are not yet present in any registry (e.g. path-based or standalone plugins), so it must keep the broader plugin set. The loaded-registry filter is applied only before the active/channel registry lookup, never before cold-load.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `tools.allow: ["group:core", "group:plugins"]` with `plugins.slots.memory: "memory-core"` and `memory-lancedb` bundled-but-unloaded caused Active Memory recall to return `status=unavailable` for every turn. After this patch, the same configuration materializes `memory_recall`, `memory_search`, and `memory_get`, and Active Memory recall returns `status=ok` with hits.

- Real environment tested: Mac Mini with OpenClaw v2026.5.2 built from source, managed gateway service, Telegram channel agent exercising the Active Memory subagent path. Memory backend `memory-core` selected via `plugins.slots.memory`; `memory-lancedb` bundled and unselected.

- Exact steps or command run after this patch:

    ```bash
    git checkout v2026.5.2
    git apply 0001-Fix-Active-Memory-memory-core-tool-lookup.patch
    pnpm install
    pnpm ui:build
    pnpm build
    pnpm test src/plugins/tools.optional.test.ts
    openclaw gateway restart
    ```

    Then in Telegram, ask the agent a question that can only be answered from memory (i.e. not from currently loaded project context).

- Evidence after fix (screenshot):
 
    <img width="754" height="1016" alt="after" src="https://github.com/user-attachments/assets/6c8e2b1a-030f-4e1b-89a1-25867aa23904" />

    - Telegram screenshot showing Active Memory returning `status=ok elapsed=10.4s query=recent summary=186 chars` and the debug line `backend=qmd configuredMode=search effectiveMode=search searchMs=349 hits=1` followed by the memory-sourced answer. The user question and skill names are redacted; project-internal terms (`memory-lancedb`, `group:plugins`, `memory-core`) are kept because they identify the fix and are not sensitive.

- Observed result after fix: Active Memory recall completes with `status=ok` and a non-empty hit count, and the agent answers from memory rather than from loaded project context. The previous `[agent/embedded] [tools] No callable tools remain ...` warning no longer appears in `~/.openclaw/logs/gateway.log` for memory-recall attempts.

- What was not tested: Linux/systemd managed-service behavior was not verified live; the fix path is plugin-runtime code with no platform-specific behavior, and the regression test in `tools.optional.test.ts` runs on all platforms. Non-memory plugin slots (e.g. providers, channels) were not exercised live, but the fix is generic over plugin ids — any bundled-but-unloaded sibling with declared `contracts.tools` previously triggered the same failure mode.

- Before evidence (optional but encouraged):

    <img width="733" height="955" alt="before" src="https://github.com/user-attachments/assets/ff0b0d42-c62b-4912-9e6c-1b624a55a503" />

    - Telegram screenshot showing Active Memory returning `status=unavailable elapsed=937ms query=recent` even though `/active-memory status` reports the plugin is on for the session. The agent confirms no `active_memory_plugin` nudge was injected for the turn. The user question body inside `/trace raw` is redacted.

## Root Cause (if applicable)

- Root cause: `resolvePluginTools` (`src/plugins/tools.ts`) built `runtimePluginIds` from the manifest snapshot, and the manifest filter at `resolvePluginToolRuntimePluginIds` matches every bundled plugin that declares tool contracts — including unselected siblings — because `isManifestPluginAvailableForControlPlane` is a control-plane availability signal, not a runtime activation signal. `resolvePluginToolRegistry` then consults the active runtime registry via `getLoadedRuntimePluginRegistry`, whose `registryContainsPluginIds` helper requires **every** requested plugin id to be present (strict `every()`). One unloaded bundled sibling poisoned the whole lookup and the loaded plugin's tools were discarded along with it.
- Missing detection / guardrail: the optional-tool resolver tests covered single-plugin and explicit-name allowlists, but did not cover the `group:plugins` expansion case where the manifest snapshot legitimately contains an unloaded bundled sibling. The new regression test in `tools.optional.test.ts` locks that scenario in.
- Contributing context (if known): the bug surfaced strongly for Active Memory because its subagent attempts run with a per-attempt `sessionKey`/`sessionId`, so the plugin tool descriptor cache (keyed on those fields) was cold and the cached-tools path could not mask the registry failure. The main agent's tool list was frequently warm from prior turns and silently masked the same bug, which delayed detection.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/tools.optional.test.ts` — new case `returns tools for loaded plugins even when manifest snapshot has unloaded siblings`.
- Scenario the test should lock in: when the manifest snapshot declares a loaded plugin plus an unloaded bundled sibling and `tools.allow` includes `group:plugins`, the resolver must still return the loaded plugin's tools.
- Why this is the smallest reliable guardrail: the failure mode is entirely inside `resolvePluginTools` and reproduces with one loaded plugin + one unloaded sibling + a wildcard-style allowlist. No gateway, runtime, or channel wiring is required to expose it.
- Existing test that already covers this (if any): None — prior cases all paired the allowlist with a fully-loaded plugin set.
- If no new test is added, why not: N/A, the new case is added in this PR.

## User-visible / Behavior Changes

`tools.allow: ["group:plugins"]` (and any allowlist that expands to a manifest-resolved set with unloaded bundled siblings) now behaves as documented: loaded plugin tools are materialized, unloaded siblings are silently skipped. Operators who previously saw `[agent/embedded] [tools] No callable tools remain ...` after enabling `group:plugins` should see their agent regain access to all loaded plugin tools. No config or default change is required.

## Diagram (if applicable)

```text
Before:
  manifest -> runtimePluginIds = [memory-core, memory-lancedb]
            -> resolvePluginToolRegistry(active-registry)
            -> registryContainsPluginIds.every([memory-core, memory-lancedb])
            -> memory-lancedb not loaded -> false
            -> registry = undefined
            -> tools = [] (memory-core's tools discarded along with the sibling)

After:
  manifest -> runtimePluginIds = [memory-core, memory-lancedb]
            -> filter to active+channel registries -> presentPluginIds = [memory-core]
            -> resolvePluginToolRegistry(presentPluginIds)
            -> registry returns memory-core entries
            -> scopedPluginIds = {memory-core}
            -> tools = [memory_recall, memory_search, memory_get]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No.
- Secrets/tokens handling changed? (`Yes/No`) No.
- New/changed network calls? (`Yes/No`) No.
- Command/tool execution surface changed? (`Yes/No`) Yes (restorative).
- Data access scope changed? (`Yes/No`) No.
- If any `Yes`, explain risk + mitigation: the change restores the documented behavior of `tools.allow` — loaded plugin tools are materialized when explicitly allowed. It does not broaden tool access beyond what the existing manifest, denylist, and per-plugin allowlist checks already permit; the inner `for` loop still filters by `scopedPluginIds` and applies denylist, name-conflict, and availability checks unchanged.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: OpenClaw v2026.5.2 built from source, managed gateway service
- Model/provider: N/A (failure is in plugin tool resolution, model-independent)
- Integration/channel (if any): Telegram channel agent exercising the Active Memory subagent
- Relevant config (redacted): `tools.allow: ["group:core","group:plugins"]`, `plugins.slots.memory: "memory-core"`, `memory-lancedb` bundled but unselected.

### Steps

1. Configure as above and start the managed gateway on the pre-fix code.
2. From Telegram, ask a question that can only be answered from memory.
3. Observe Active Memory reporting `status=unavailable` and the gateway log emitting `[agent/embedded] [tools] No callable tools remain ...`.
4. Apply this patch, rebuild, restart the gateway, repeat the question.

### Expected

- Active Memory returns `status=ok` with a non-empty hit count.
- `memory_recall`, `memory_search`, and `memory_get` are materialized in the agent's tool list.
- No `No callable tools remain` warning in the gateway log.

### Actual

- After the patch, Active Memory returns `status=ok elapsed=10.4s query=recent summary=186 chars` and the debug line shows `backend=qmd ... hits=1`.
- The agent answers from memory rather than from currently loaded project context.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence files prepared for upload:

- `before.jpg`
- `after.jpg`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Active Memory recall returns `status=ok` and the agent answers from memory after the patch.
  - The new regression test in `tools.optional.test.ts` fails on the pre-patch code and passes on the patched code.
  - The existing `tools.optional.test.ts` cases continue to pass.
- Edge cases checked:
  - All-unloaded plugin set: filter reduces `presentPluginIds` to empty and the function returns early with `tools` unchanged (no regression).
  - All-loaded plugin set: `presentPluginIds === runtimePluginIds`, behavior is byte-identical to the pre-patch path.
  - Cold-load fallback path still receives the full `runtimePluginIds` so standalone/path-based plugins remain discoverable.
- What you did **not** verify:
  - Linux/systemd managed-service live behavior — the change is platform-agnostic plugin-runtime code with unit coverage that runs on all platforms.
  - Non-memory plugin slots in a live environment, although the fix is generic over plugin ids.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes.
- Config/env changes? (`Yes/No`) No.
- Migration needed? (`Yes/No`) No.
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: a plugin that should have been loaded but failed to register in the active or channel registry will now be silently filtered out of the resolver instead of poisoning the whole lookup.
  - Mitigation: the existing `missingRegistryToolPluginIds` diagnostic still records a `warn` for any `presentPluginIds` entry that doesn't appear in the resolved registry's tool list, so silent regressions remain observable in `registry.diagnostics`. The cold-load fallback also still runs against the full `runtimePluginIds` set.
- Risk: the change shifts the meaning of `runtimePluginIds` vs `presentPluginIds` inside `resolvePluginTools`, which could confuse future readers.
  - Mitigation: an in-source comment explains the two-set distinction and points to the active/channel registries the filter consults.
