### PR TITLE
Fix heartbeat fallback scaffolding delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram: let isolated polling drain independent topics, DMs, and status/control commands concurrently while preserving same-lane order. (#81849) Thanks @VACInc.
+- Heartbeat: sanitize fallback delivery text so Codex/app-server tool and file scaffolding such as `<tool_calls>` and `<file_contents>` is suppressed before chat delivery. Fixes #81369. (#81860) Thanks @joshavant.
 - Build: keep externalized Slack, OpenShell sandbox, and Anthropic Vertex runtime dependency declarations out of the root dist artifact build.
 - Auto-reply/Claude CLI: bridge CLI-runtime assistant text-delta agent events into the chat reasoning preview through `onReasoningStream`, mirroring the existing assistant-text (#76914) and tool-event (#80046) bridges and adding gating so non-CLI runtimes are unaffected. Thanks @anagnorisis2peripeteia and @pashpashpash.
 - CLI/migrate: handle delayed Codex plugin marketplace responses so warnings, next-steps, and conflict states render with ⚠️ glyphs and post-install migration retries the marketplace fetch instead of silently skipping plugin items. (#81625) Thanks @sjf.

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -690,6 +690,69 @@ describe("Ghost reminder bug (issue #13317)", () => {
     });
   });
 
+  it("suppresses sanitized-empty exec-event fallback scaffolding", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:2175",
+            lastThreadId: 2175,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn();
+      const getReplySpy = vi.fn().mockResolvedValue({
+        text: [
+          "<file_contents path='.../HEARTBEAT.md' isStale=false isFullFile=true>",
+          " 1|# HEARTBEAT.md",
+          "</file_contents>",
+        ].join("\n"),
+      });
+      enqueueSystemEvent("Exec completed (review-run, code 0) :: review-worker spawn finished", {
+        sessionKey,
+        trusted: false,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          threadId: 47,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("suppresses metadata-only successful exec completions", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
       const cfg: OpenClawConfig = {

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -356,6 +356,61 @@ describe("runHeartbeatOnce ack handling", () => {
     });
   });
 
+  it.each([
+    {
+      title: "repeated tool-call marker scaffolding",
+      replyText: "<tool_calls>\n<tool_calls>\n<tool_calls>",
+      expectedText: undefined,
+    },
+    {
+      title: "file contents wrapper scaffolding",
+      replyText: [
+        "<file_contents path='.../HEARTBEAT.md' isStale=false isFullFile=true>",
+        " 1|# HEARTBEAT.md",
+        "</file_contents>",
+      ].join("\n"),
+      expectedText: undefined,
+    },
+    {
+      title: "mixed visible text and file contents wrapper scaffolding",
+      replyText: [
+        "Visible update",
+        "<file_contents path='/tmp/HEARTBEAT.md' isStale=false isFullFile=true>",
+        "secret-ish scaffold",
+        "</file_contents>",
+      ].join("\n"),
+      expectedText: "Visible update",
+    },
+  ])("sanitizes heartbeat fallback delivery for $title", async ({ replyText, expectedText }) => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = await createSeededWhatsAppHeartbeatConfig({
+        tmpDir,
+        storePath,
+      });
+
+      replySpy.mockResolvedValue({ text: replyText });
+      const sendWhatsApp = createMessageSendSpy();
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: {
+          ...makeWhatsAppDeps({ sendWhatsApp }),
+          getReplyFromConfig: replySpy,
+        },
+      });
+
+      if (expectedText === undefined) {
+        expect(sendWhatsApp).not.toHaveBeenCalled();
+        return;
+      }
+      expectWhatsAppMessageSend(sendWhatsApp, {
+        to: WHATSAPP_GROUP,
+        text: expectedText,
+        cfg,
+      });
+    });
+  });
+
   it("does not regress updatedAt when restoring heartbeat sessions", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const originalUpdatedAt = 1000;

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -784,6 +784,70 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("preserves heartbeat media when fallback text sanitizes empty", async () => {
+    const tmpDir = await createCaseDir("hb-sanitized-media");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.fn();
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue({
+        text: [
+          "<file_contents path='.../HEARTBEAT.md' isStale=false isFullFile=true>",
+          " 1|# HEARTBEAT.md",
+          "</file_contents>",
+        ].join("\n"),
+        mediaUrl: "https://example.test/heartbeat.png",
+      });
+      const sendWhatsApp = vi
+        .fn<
+          (
+            to: string,
+            text: string,
+            opts?: Record<string, unknown>,
+          ) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({
+          messageId: "m1",
+          toJid: "jid",
+        });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+      expect(sendWhatsApp.mock.calls[0]?.[0]).toBe("120363401234567890@g.us");
+      expect(sendWhatsApp.mock.calls[0]?.[1]).toBe("");
+      expect(sendWhatsApp.mock.calls[0]?.[2]?.mediaUrl).toBe("https://example.test/heartbeat.png");
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
   it("uses per-agent heartbeat overrides and session keys", async () => {
     const tmpDir = await createCaseDir("hb-agent-overrides");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -85,6 +85,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
+import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import { escapeRegExp } from "../utils.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS, resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { loadOrCreateDeviceIdentity } from "./device-identity.js";
@@ -784,7 +785,14 @@ function normalizeHeartbeatReply(
       hasMedia,
     };
   }
-  let finalText = stripped.text;
+  let finalText = sanitizeAssistantVisibleText(stripped.text);
+  if (!finalText && !hasMedia) {
+    return {
+      shouldSkip: true,
+      text: "",
+      hasMedia,
+    };
+  }
   if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
     finalText = `${responsePrefix} ${finalText}`;
   }
@@ -1803,14 +1811,13 @@ export async function runHeartbeatOnce(opts: {
       hasRelayableExecCompletion &&
       !normalized.text.trim() &&
       replyPayload?.text?.trim()
-        ? replyPayload.text.trim()
+        ? sanitizeAssistantVisibleText(replyPayload.text.trim())
         : null;
     if (execFallbackText) {
       normalized.text = execFallbackText;
       normalized.shouldSkip = false;
     }
-    const shouldSkipMain =
-      normalized.shouldSkip && !normalized.hasMedia && !hasRelayableExecCompletion;
+    const shouldSkipMain = normalized.shouldSkip && !normalized.hasMedia;
     if (shouldSkipMain && reasoningPayloads.length === 0) {
       await restoreHeartbeatUpdatedAt({
         storePath,

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -608,6 +608,33 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
   });
 
+  it("strips Codex file contents wrappers on the canonical user-visible path", () => {
+    const input = [
+      "Visible update",
+      "<file_contents path='.../HEARTBEAT.md' isStale=false isFullFile=true>",
+      " 1|# HEARTBEAT.md",
+      "</file_contents>",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible update");
+  });
+
+  it("strips line-only protocol marker scaffolding", () => {
+    expect(sanitizeAssistantVisibleText("<tool_calls>\n<tool_calls>\n<tool_calls>")).toBe("");
+  });
+
+  it("preserves file contents wrappers inside fenced code", () => {
+    const input = [
+      "```xml",
+      "<file_contents path='sample.md'>",
+      " 1|# sample",
+      "</file_contents>",
+      "```",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
   it("drops malformed reasoning before orphan close tags when final text follows", () => {
     expect(sanitizeAssistantVisibleText("private chain of thought </think> Visible answer")).toBe(
       "Visible answer",

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -11,6 +11,12 @@ import {
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
 const LEGACY_BRACKET_TOOL_BLOCK_QUICK_RE = /\[\s*\/?\s*TOOL_(?:CALL|RESULT)\s*\]/i;
+const FILE_CONTENTS_TAG_RE = /<\s*(\/?)\s*file_contents\b[^<>]*>/gi;
+const FILE_CONTENTS_QUICK_RE = /<\s*\/?\s*file_contents\b/i;
+const STANDALONE_PROTOCOL_MARKER_LINE_RE =
+  /^[ \t]*<\s*\/?\s*(?:tool_calls?|function_calls?)\b[^<>]*>[ \t]*(?:\r?\n|$)/gim;
+const STANDALONE_PROTOCOL_MARKER_QUICK_RE =
+  /^[ \t]*<\s*\/?\s*(?:tool_calls?|function_calls?)\b[^<>]*>[ \t]*(?:\r?\n|$)/im;
 
 /**
  * Strip XML-style tool call tags that models sometimes emit as plain text.
@@ -623,6 +629,63 @@ function stripRelevantMemoriesTags(text: string): string {
   return result;
 }
 
+function stripFileContentsTags(text: string): string {
+  if (!text || !FILE_CONTENTS_QUICK_RE.test(text)) {
+    return text;
+  }
+  FILE_CONTENTS_TAG_RE.lastIndex = 0;
+
+  const codeRegions = findCodeRegions(text);
+  let result = "";
+  let lastIndex = 0;
+  let inFileContentsBlock = false;
+
+  for (const match of text.matchAll(FILE_CONTENTS_TAG_RE)) {
+    const idx = match.index ?? 0;
+    if (isInsideCode(idx, codeRegions)) {
+      continue;
+    }
+
+    const isClose = match[1] === "/";
+    if (!inFileContentsBlock) {
+      result += text.slice(lastIndex, idx);
+      if (!isClose) {
+        inFileContentsBlock = true;
+      }
+    } else if (isClose) {
+      inFileContentsBlock = false;
+    }
+
+    lastIndex = idx + match[0].length;
+  }
+
+  if (!inFileContentsBlock) {
+    result += text.slice(lastIndex);
+  }
+
+  return result;
+}
+
+function stripStandaloneProtocolMarkerLines(text: string): string {
+  if (!text || !STANDALONE_PROTOCOL_MARKER_QUICK_RE.test(text)) {
+    return text;
+  }
+
+  const codeRegions = findCodeRegions(text);
+  let result = "";
+  let cursor = 0;
+  for (const match of text.matchAll(STANDALONE_PROTOCOL_MARKER_LINE_RE)) {
+    const start = match.index ?? 0;
+    if (isInsideCode(start, codeRegions)) {
+      continue;
+    }
+    result += text.slice(cursor, start);
+    cursor = start + match[0].length;
+  }
+  result += text.slice(cursor);
+  return result;
+}
+
 export type AssistantVisibleTextSanitizerProfile = "delivery" | "history" | "internal-scaffolding";
 
 type AssistantVisibleTextPipelineOptions = {
@@ -690,9 +753,11 @@ function applyAssistantVisibleTextStagePipeline(
     }
     cleaned = stripModelSpecialTokens(cleaned);
     cleaned = stripRelevantMemoriesTags(cleaned);
+    cleaned = stripFileContentsTags(cleaned);
     cleaned = stripToolCallXmlTags(cleaned, {
       stripFunctionCallsXmlPayloads: options.stripFunctionCallsXmlPayloads,
     });
+    cleaned = stripStandaloneProtocolMarkerLines(cleaned);
     cleaned = stripLegacyBracketToolCallBlocks(cleaned);
     cleaned = stripPlainTextToolCallBlocks(cleaned);
     if (!options.preserveDowngradedToolText) {


### PR DESCRIPTION
## Summary

- Sanitize heartbeat fallback delivery text through the canonical assistant-visible text sanitizer before chat delivery.
- Strip Codex/app-server scaffolding such as line-only `<tool_calls>` markers and `<file_contents ...>` blocks while preserving real visible text and media-bearing heartbeat payloads.
- Add regression coverage for scaffold-only, mixed visible/scaffold, exec-event fallback, and media-preservation heartbeat cases.

Fixes #81369.

## Verification

- `node scripts/run-vitest.mjs src/shared/text/assistant-visible-text.test.ts src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
- `pnpm format:check src/shared/text/assistant-visible-text.ts src/shared/text/assistant-visible-text.test.ts src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts`
- `git diff --check`
- `npx -y @openai/codex@0.130.0 review --base origin/main`
- Crabbox AWS repro before fix: `run_e07175308a1b` confirmed raw `<tool_calls>` and `<file_contents ...>` delivery on `83b8289ee274fa826fe633f0ba96ff0112001ab9`.
- Crabbox AWS repro after fix: `run_d1afdf4dcbeb` confirmed scaffold-only cases suppress delivery, mixed visible/scaffold sends only visible text, and `HEARTBEAT_OK` stays suppressed.

## Real behavior proof

Behavior addressed: Heartbeat fallback delivery no longer posts raw Codex/app-server protocol scaffolding such as `<tool_calls>` and `<file_contents ...>` to visible chat targets.

Real environment tested: Crabbox AWS Linux lease running the OpenClaw checkout with this branch's dirty patch synced before commit; local focused Vitest on macOS after rebase onto latest `origin/main`.

Exact steps or command run after this patch: Ran the same `runHeartbeatOnce` reproduction used to validate #81369, with cases for repeated `<tool_calls>`, `<file_contents ...>...</file_contents>`, mixed visible text plus file wrapper, and `HEARTBEAT_OK`; then reran the focused Vitest command listed above after rebasing.

Evidence after fix: Crabbox AWS `run_d1afdf4dcbeb` exited 0. The reproduced heartbeat sends were: no send for repeated `<tool_calls>`, no send for file-contents-only wrapper, one send with text `Visible update` for mixed visible/scaffold, and no send for `HEARTBEAT_OK`.

Observed result after fix: No raw protocol scaffolding was delivered by the heartbeat fallback path; only sanitized visible text or valid non-text content remains deliverable.

What was not tested: A live Discord/Codex credential-backed heartbeat was not run because the bug is provider/channel independent after `getReplyFromConfig` returns a `ReplyPayload`; the reproduction exercises the real heartbeat delivery path with a stubbed reply provider and outbound channel adapter.
