### PR TITLE
fix(telegram): guard reactionApi against REACTION_INVALID errors (fixes #81765)

### DIFF
--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -1,4 +1,4 @@
-import type { ReactionTypeEmoji } from "@grammyjs/types";
+import type { ReactionType, ReactionTypeEmoji } from "@grammyjs/types";
 import {
   resolveAckReaction,
   shouldAckReaction as shouldAckReactionGate,
@@ -146,10 +146,23 @@ export const buildTelegramMessageContext = async ({
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const senderId = msg.from?.id ? String(msg.from.id) : "";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
-  const reactionApi =
+  const rawReactionApi =
     typeof bot.api.setMessageReaction === "function"
       ? bot.api.setMessageReaction.bind(bot.api)
       : null;
+  const reactionApi = rawReactionApi
+    ? async (chatId: number | string, messageId: number, reactions: ReactionType[]) => {
+        try {
+          await rawReactionApi(chatId, messageId, reactions);
+        } catch (err: unknown) {
+          const msg = String(err);
+          if (/REACTION_INVALID/i.test(msg)) {
+            return;
+          }
+          throw err;
+        }
+      }
+    : null;
   const getChatApi =
     typeof bot.api.getChat === "function"
       ? (bot.api.getChat.bind(bot.api) as TelegramGetChat)


### PR DESCRIPTION
## Summary

Fixes #81765 — Telegram group messages fail with REACTION_INVALID and replies are not shown.

## Root Cause

The `reactionApi` binding in `bot-message-context.ts` wraps grammY's raw `setMessageReaction` API directly. When called with an emoji that's invalid for a group chat context (e.g., emojis from the new WhatsApp status reactions feature), grammY throws `REACTION_INVALID` which propagates and can interrupt the reply delivery pipeline.

While the `send.ts` reaction wrapper already handles REACTION_INVALID gracefully, the internal ack/status reaction paths in `bot-message-context.ts` bypass that wrapper and use the raw API binding directly.

## Fix

Wrap the `reactionApi` at the binding point in `bot-message-context.ts` to silently catch and swallow `REACTION_INVALID` errors. All downstream callers (ack reaction, status reaction controller, clear reaction) are automatically protected since they all use the same wrapped binding.

## Changes

- `extensions/telegram/src/bot-message-context.ts`: Wrap `reactionApi` binding to catch `REACTION_INVALID` errors and silently return instead of throwing
- Added `ReactionType` import for the wrapper's type signature

## Testing

Existing tests should continue to pass — the wrapper is transparent for successful calls and only changes behavior for REACTION_INVALID errors (which were previously unhandled throws).