### PR TITLE
fix(whatsapp): support upload-file media sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -586,6 +586,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals: omit generated command highlights for non-POSIX Windows and shell-wrapper approval commands until those command languages have native highlighting support. (#80566) Thanks @jesse-merhi.
 - Telegram: keep verbose tool progress and result drafts separate from the final assistant answer so tool output no longer blends into the final Telegram message. (#80294) Thanks @jalehman.
 - Plugin SDK/Windows: enable the native require fast path for root `openclaw/plugin-sdk` dist aliases instead of forcing Jiti transforms. (#80878) Thanks @medns.
+- WhatsApp: treat `upload-file` as a supported media send intent by lowering path/URL uploads through the channel's normal send-media transport.
 
 ## 2026.5.9
 

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-1cf7ca2ee1db3bf44682c487c780c6b1c47bbce27e74fb6f455cef445544c84f  plugin-sdk-api-baseline.json
-24b8e3e4773579e5a184dd5f91a5ad2f8e92519b6fe314820a94d7a64bd1141e  plugin-sdk-api-baseline.jsonl
+2f7e36ab9a99d4c9075e20316ed42fc732448c243e335439339487383d4f3862  plugin-sdk-api-baseline.json
+0b173650edbe61b4f74e26481c33ba0b3918d434948f57ee09871dce5fd95697  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -144,7 +144,7 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/channel-location` | Channel location context and formatting helpers |
     | `plugin-sdk/channel-logging` | Channel logging helpers for inbound drops and typing/ack failures |
     | `plugin-sdk/channel-send-result` | Reply result types |
-    | `plugin-sdk/channel-actions` | Channel message-action helpers, plus deprecated native schema helpers kept for plugin compatibility |
+    | `plugin-sdk/channel-actions` | Channel message-action helpers, upload-file-to-send-media lowering, plus deprecated native schema helpers kept for plugin compatibility |
     | `plugin-sdk/channel-route` | Shared route normalization, parser-driven target resolution, thread-id stringification, dedupe/compact route keys, parsed-target types, and route/target comparison helpers |
     | `plugin-sdk/channel-targets` | Target parsing helpers; route comparison callers should use `plugin-sdk/channel-route` |
     | `plugin-sdk/channel-contract` | Channel contract types |

--- a/extensions/whatsapp/src/channel-actions.test.ts
+++ b/extensions/whatsapp/src/channel-actions.test.ts
@@ -128,6 +128,7 @@ describe("whatsapp channel action helpers", () => {
     } as OpenClawConfig;
 
     expect(describeWhatsAppMessageActions({ cfg, accountId: "default" })?.actions).toEqual([
+      "upload-file",
       "react",
       "poll",
     ]);
@@ -150,6 +151,7 @@ describe("whatsapp channel action helpers", () => {
     } as OpenClawConfig;
 
     expect(describeWhatsAppMessageActions({ cfg, accountId: "default" })?.actions).toEqual([
+      "upload-file",
       "poll",
     ]);
   });
@@ -170,6 +172,7 @@ describe("whatsapp channel action helpers", () => {
     } as OpenClawConfig;
 
     expect(describeWhatsAppMessageActions({ cfg, accountId: "work" })?.actions).toEqual([
+      "upload-file",
       "react",
       "poll",
     ]);
@@ -191,7 +194,11 @@ describe("whatsapp channel action helpers", () => {
     } as OpenClawConfig;
     hoisted.listWhatsAppAccountIds.mockReturnValue(["default", "work"]);
 
-    expect(describeWhatsAppMessageActions({ cfg })?.actions).toEqual(["react", "poll"]);
+    expect(describeWhatsAppMessageActions({ cfg })?.actions).toEqual([
+      "upload-file",
+      "react",
+      "poll",
+    ]);
   });
 
   it("omits react in global discovery when only disabled accounts enable agent reactions", () => {
@@ -211,6 +218,6 @@ describe("whatsapp channel action helpers", () => {
     } as OpenClawConfig;
     hoisted.listWhatsAppAccountIds.mockReturnValue(["default", "work"]);
 
-    expect(describeWhatsAppMessageActions({ cfg })?.actions).toEqual(["poll"]);
+    expect(describeWhatsAppMessageActions({ cfg })?.actions).toEqual(["upload-file", "poll"]);
   });
 });

--- a/extensions/whatsapp/src/channel-actions.ts
+++ b/extensions/whatsapp/src/channel-actions.ts
@@ -66,7 +66,7 @@ export function describeWhatsAppMessageActions(params: {
     return null;
   }
   const gate = createActionGate(params.cfg.channels.whatsapp.actions);
-  const actions = new Set<ChannelMessageActionName>();
+  const actions = new Set<ChannelMessageActionName>(["upload-file"]);
   const canReact =
     params.accountId != null
       ? areWhatsAppAgentReactionsEnabled({

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { buildDmGroupAccountAllowlistAdapter } from "openclaw/plugin-sdk/allowlist-config-edit";
+import { resolveUploadFileActionAsSendMedia } from "openclaw/plugin-sdk/channel-actions";
 import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
@@ -151,6 +152,8 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
       actions: {
         describeMessageTool: ({ cfg, accountId }) =>
           describeWhatsAppMessageActions({ cfg, accountId }),
+        resolveMessageActionRequest: ({ action, args }) =>
+          resolveUploadFileActionAsSendMedia({ action, args, channelLabel: "WhatsApp" }),
         supportsAction: ({ action }) => action === "react",
         resolveExecutionMode: ({ action }) => (action === "react" ? "gateway" : "local"),
         handleAction: async ({ action, params, cfg, accountId, requesterSenderId, toolContext }) =>

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -728,6 +728,31 @@ export type ChannelMessageActionAdapter = {
     action: ChannelMessageActionName;
     args: Record<string, unknown>;
   };
+  /**
+   * Translate generic shared-message actions after core has resolved the
+   * destination channel. Use this for channel-owned compatibility lowering,
+   * such as treating upload-file as send-with-media on media-capable channels
+   * that do not expose a native file-upload action.
+   */
+  resolveMessageActionRequest?: (params: {
+    action: ChannelMessageActionName;
+    args: Record<string, unknown>;
+    channel: string;
+    cfg: OpenClawConfig;
+    accountId?: string | null;
+    sessionKey?: string | null;
+    sessionId?: string | null;
+    agentId?: string | null;
+    requesterSenderId?: string | null;
+    senderIsOwner?: boolean;
+    toolContext?: ChannelThreadingToolContext;
+  }) =>
+    | {
+        action: ChannelMessageActionName;
+        args: Record<string, unknown>;
+      }
+    | null
+    | undefined;
   messageActionTargetAliases?: Partial<
     Record<
       ChannelMessageActionName,

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -7,6 +7,7 @@ import { jsonResult } from "../../agents/tools/common.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadWebMedia } from "../../media/web-media.js";
+import { resolveUploadFileActionAsSendMedia } from "../../plugin-sdk/channel-actions.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
@@ -269,6 +270,201 @@ describe("runMessageAction media behavior", () => {
     });
     vi.mocked(loadWebMedia).mockReset();
     vi.mocked(loadWebMedia).mockImplementation(actualLoadWebMedia);
+  });
+
+  it("lowers upload-file through a channel compatibility hook before media send", async () => {
+    const compatPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "compatmedia",
+        label: "CompatMedia",
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => ({ enabled: true }),
+          isConfigured: () => true,
+        },
+      }),
+      outbound: {
+        deliveryMode: "direct",
+        resolveTarget: ({ to }) => ({ ok: true, to: to ?? "" }),
+        sendText: async () => ({ channel: "compatmedia", messageId: "msg-test" }),
+        sendMedia: async () => ({ channel: "compatmedia", messageId: "msg-test" }),
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["upload-file"] }),
+        resolveMessageActionRequest: ({ action, args }) =>
+          resolveUploadFileActionAsSendMedia({ action, args, channelLabel: "CompatMedia" }),
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "compatmedia",
+          source: "test",
+          plugin: compatPlugin,
+        },
+      ]),
+    );
+
+    const result = await runMessageAction({
+      cfg: { channels: { compatmedia: { enabled: true } } } as OpenClawConfig,
+      action: "upload-file",
+      params: {
+        channel: "compatmedia",
+        target: "12345678",
+        filePath: "https://example.com/pic.png",
+        caption: "picture caption",
+      },
+      dryRun: true,
+    });
+
+    expect(result.kind).toBe("send");
+    const sendArgs = firstMockArg(channelResolutionMocks.executeSendAction, "executeSendAction");
+    expect(sendArgs.message).toBe("picture caption");
+    expect(sendArgs.mediaUrl).toBe("https://example.com/pic.png");
+  });
+
+  it("rejects upload-file buffer payloads when a channel lowers to send media", async () => {
+    const compatPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "compatmedia",
+        label: "CompatMedia",
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => ({ enabled: true }),
+          isConfigured: () => true,
+        },
+      }),
+      actions: {
+        describeMessageTool: () => ({ actions: ["upload-file"] }),
+        resolveMessageActionRequest: ({ action, args }) =>
+          resolveUploadFileActionAsSendMedia({ action, args, channelLabel: "CompatMedia" }),
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "compatmedia",
+          source: "test",
+          plugin: compatPlugin,
+        },
+      ]),
+    );
+
+    await expect(
+      runMessageAction({
+        cfg: { channels: { compatmedia: { enabled: true } } } as OpenClawConfig,
+        action: "upload-file",
+        params: {
+          channel: "compatmedia",
+          target: "12345678",
+          buffer: Buffer.from("hello").toString("base64"),
+          filename: "hello.txt",
+        },
+      }),
+    ).rejects.toThrow("cannot lower upload-file buffer payloads");
+    expect(channelResolutionMocks.executeSendAction).not.toHaveBeenCalled();
+  });
+
+  it("dispatches a plugin-owned action produced by the compatibility hook", async () => {
+    const dispatchedActions: string[] = [];
+    const compatPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "compatplugin",
+        label: "CompatPlugin",
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => ({ enabled: true }),
+          isConfigured: () => true,
+        },
+      }),
+      outbound: {
+        deliveryMode: "direct",
+        resolveTarget: ({ to }) => ({ ok: true, to: to ?? "" }),
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["upload-file", "sendAttachment"] }),
+        supportsAction: ({ action }) => action === "sendAttachment",
+        resolveMessageActionRequest: ({ action, args }) =>
+          action === "upload-file"
+            ? { action: "sendAttachment", args: { ...args, action: "sendAttachment" } }
+            : null,
+        handleAction: async ({ action }) => {
+          dispatchedActions.push(action);
+          return jsonResult({ ok: true, action });
+        },
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "compatplugin",
+          source: "test",
+          plugin: compatPlugin,
+        },
+      ]),
+    );
+
+    const result = await runMessageAction({
+      cfg: { channels: { compatplugin: { enabled: true } } } as OpenClawConfig,
+      action: "upload-file",
+      params: {
+        channel: "compatplugin",
+        target: "12345678",
+      },
+    });
+
+    expect(result.kind).toBe("action");
+    expect(result.action).toBe("sendAttachment");
+    expect(requireActionPayload(result).action).toBe("sendAttachment");
+    expect(dispatchedActions).toEqual(["sendAttachment"]);
+  });
+
+  it("uses a plugin-owned resolved action for dry-run results", async () => {
+    const compatPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "compatplugin",
+        label: "CompatPlugin",
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => ({ enabled: true }),
+          isConfigured: () => true,
+        },
+      }),
+      outbound: {
+        deliveryMode: "direct",
+        resolveTarget: ({ to }) => ({ ok: true, to: to ?? "" }),
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["upload-file", "sendAttachment"] }),
+        resolveMessageActionRequest: ({ action, args }) =>
+          action === "upload-file"
+            ? { action: "sendAttachment", args: { ...args, action: "sendAttachment" } }
+            : null,
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "compatplugin",
+          source: "test",
+          plugin: compatPlugin,
+        },
+      ]),
+    );
+
+    const result = await runMessageAction({
+      cfg: { channels: { compatplugin: { enabled: true } } } as OpenClawConfig,
+      action: "upload-file",
+      params: {
+        channel: "compatplugin",
+        target: "12345678",
+      },
+      dryRun: true,
+    });
+
+    expect(result.kind).toBe("action");
+    expect(result.action).toBe("sendAttachment");
+    expect(requireActionPayload(result).action).toBe("sendAttachment");
   });
 
   it("forwards asVoice from send actions into core delivery", async () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1052,7 +1052,11 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
   };
 }
 
-async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
+async function handlePluginAction(
+  ctx: ResolvedActionContext & {
+    action: Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
+  },
+): Promise<MessageActionRunResult> {
   const {
     cfg,
     params,
@@ -1065,8 +1069,8 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
     abortSignal,
     agentId,
   } = ctx;
+  const { action } = ctx;
   throwIfAborted(abortSignal);
-  const action = input.action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
   if (dryRun) {
     return {
       kind: "action",
@@ -1152,7 +1156,7 @@ export async function runMessageAction(
   parseJsonMessageParam(params, "delivery");
   parseInteractiveParam(params);
 
-  const action = input.action;
+  let action = input.action;
   enforceMessageActionAllowlist({
     cfg,
     agentId: resolvedAgentId,
@@ -1185,6 +1189,35 @@ export async function runMessageAction(
   }
   if (accountId) {
     params.accountId = accountId;
+  }
+  const actionRequest = resolveOutboundChannelPlugin({
+    channel,
+    cfg,
+  })?.actions?.resolveMessageActionRequest?.({
+    action,
+    args: params,
+    channel,
+    cfg,
+    accountId,
+    sessionKey: input.sessionKey,
+    sessionId: input.sessionId,
+    agentId: resolvedAgentId,
+    requesterSenderId: input.requesterSenderId,
+    senderIsOwner: input.senderIsOwner,
+    toolContext: input.toolContext,
+  });
+  if (actionRequest) {
+    action = actionRequest.action;
+    params = normalizeMessageActionInput({
+      action,
+      args: actionRequest.args,
+      toolContext: input.toolContext,
+    });
+    enforceMessageActionAllowlist({
+      cfg,
+      agentId: resolvedAgentId,
+      action,
+    });
   }
   const dryRun = Boolean(input.dryRun ?? readBooleanParam(params, "dryRun"));
   const normalizationPolicy = resolveAttachmentMediaPolicy({
@@ -1290,6 +1323,7 @@ export async function runMessageAction(
     cfg,
     params,
     channel,
+    action: action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">,
     mediaAccess,
     accountId,
     dryRun,

--- a/src/plugin-sdk/channel-actions.ts
+++ b/src/plugin-sdk/channel-actions.ts
@@ -1,6 +1,7 @@
 import { Type } from "typebox";
 import type { TSchema } from "typebox";
 import { stringEnum as createStringEnum } from "../agents/schema/typebox.js";
+import type { ChannelMessageActionName } from "../channels/plugins/types.public.js";
 
 export {
   createUnionActionGate,
@@ -24,6 +25,58 @@ export { withNormalizedTimestamp } from "../agents/date-time.js";
 export { assertMediaNotDataUrl } from "../agents/sandbox-paths.js";
 export { resolvePollMaxSelections } from "../polls.js";
 export { optionalStringEnum, stringEnum } from "../agents/schema/typebox.js";
+
+function readOptionalStringField(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return value.trim() ? value : undefined;
+}
+
+function readOptionalMessageText(args: Record<string, unknown>): string {
+  for (const key of ["message", "content", "caption"] as const) {
+    const value = args[key];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return "";
+}
+
+export function resolveUploadFileActionAsSendMedia(params: {
+  action: ChannelMessageActionName;
+  args: Record<string, unknown>;
+  channelLabel?: string;
+}): { action: "send"; args: Record<string, unknown> } | null {
+  if (params.action !== "upload-file") {
+    return null;
+  }
+  const label = params.channelLabel?.trim() || "This channel";
+  if (readOptionalStringField(params.args, "buffer")) {
+    throw new Error(
+      `${label} cannot lower upload-file buffer payloads to send+media. Use media, mediaUrl, filePath, path, or fileUrl instead.`,
+    );
+  }
+  const media =
+    readOptionalStringField(params.args, "media") ??
+    readOptionalStringField(params.args, "mediaUrl") ??
+    readOptionalStringField(params.args, "filePath") ??
+    readOptionalStringField(params.args, "path") ??
+    readOptionalStringField(params.args, "fileUrl");
+  if (!media) {
+    throw new Error(`${label} upload-file requires media, mediaUrl, filePath, path, or fileUrl.`);
+  }
+  return {
+    action: "send",
+    args: {
+      ...params.args,
+      action: "send",
+      media,
+      message: readOptionalMessageText(params.args),
+    },
+  };
+}
 
 /**
  * @deprecated Use semantic `presentation` capabilities instead of exposing


### PR DESCRIPTION
## Summary

- Treat `upload-file` as a channel-resolved media send intent so channels can lower it before execution.
- Add a shared Plugin SDK helper for lowering path/URL uploads to `send` with media while rejecting buffer-only payloads that cannot be safely lowered.
- Advertise and support `upload-file` for WhatsApp by lowering it to the existing WhatsApp send-media transport, with regression coverage.

## Verification

- `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.media.test.ts extensions/whatsapp/src/channel-actions.test.ts`
- `pnpm plugin-sdk:api:check`
- `pnpm check:changed`

Behavior addressed: WhatsApp message tool calls using `action=upload-file` with a path or URL now resolve to WhatsApp's supported send-media path instead of failing as an unsupported action.

Real environment tested: Local OpenClaw source checkout with targeted Vitest coverage and changed-file validation.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.media.test.ts extensions/whatsapp/src/channel-actions.test.ts`; `pnpm plugin-sdk:api:check`; `pnpm check:changed`.

Evidence after fix: The new regression tests pass for upload-file lowering to send media, plugin-owned resolved action propagation, dry-run resolved actions, WhatsApp discovery, and buffer rejection.

Observed result after fix: Targeted tests report 2 passed files / 37 passed tests, Plugin SDK API baseline check reports OK, and `pnpm check:changed` completes successfully.

What was not tested: A live WhatsApp Web send was not run from this branch; coverage uses the existing outbound runner and WhatsApp action discovery tests.
