### PR TITLE
feat(protocol): allow opaque `paperclip` integration field on AgentParams

### DIFF
--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -182,6 +182,9 @@ export const AgentParamsSchema = Type.Object(
     voiceWakeTrigger: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
+    // Forward-compat: external clients (e.g. Paperclip's openclaw-gateway adapter)
+    // attach an opaque integration payload here. Gateway ignores its content.
+    paperclip: Type.Optional(Type.Unknown()),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
- **Date:** 2026-05-14
- **Files:** `src/gateway/protocol/schema/agent.ts`
- **Change:** Add an optional `paperclip: Type.Unknown()` field to `AgentParamsSchema`. The schema is otherwise `{ additionalProperties: false }`, which means external integrations that want to attach a small opaque payload alongside agent calls (e.g. Paperclip's openclaw-gateway adapter passing a workflow/task ID) are rejected at the protocol layer. Allowing one well-known opaque key keeps the closed-schema discipline while giving integrators a stable place to hang per-call metadata. Gateway-side comment makes explicit that the contents are ignored — no behavior coupling, no parsing.
- **Purpose:** Enable Paperclip → OpenClaw gateway adapter (and similar external integrations) to forward per-invocation metadata without each integration needing its own merged schema change. Forward-compatible: no new required fields, no breaking change to existing clients.

## Real behavior proof

**Behavior or issue addressed:** Before this change, the gateway rejects any `agent.*` request that carries a non-schema key (e.g. Paperclip's adapter attaching a workflow/correlation ID) because `AgentParamsSchema` is declared `additionalProperties: false`. External integrations have to either strip the metadata at the client or get their own merged schema field. This PR reserves one well-known opaque key (`paperclip`) so integrators have a stable place to hang per-call metadata without weakening the closed-schema discipline for unknown keys.

**Real environment tested:** OpenClaw gateway service `openclaw-gateway.service` running on WSL2 Ubuntu 24.04, Node v22.22.0, PID 789158, `127.0.0.1:18789`, runtime version `2026.5.12-beta.1`, built from `sparkeros/openclaw:mods` at `aac563e56a` (a fast-forward of `upstream/main` at the time of the test) — i.e. the live, production-shape gateway after this patch.

**Exact steps or command run after this patch:** Wrote a small Node script that imports the **same compiled validator the running gateway is using** — `validateAgentParams` (an `ajv.compile(AgentParamsSchema)`) from `dist/protocol-Cvi9i6LL.js` — and exercises it with three payloads. Then `node /home/rkt2/openclaw/.paperclip-proof.mjs`.

**After-fix evidence:** Stdout from the live-validator run captured below — real console output from the production-shape gateway build (the same `dist/` bytes systemd is executing as PID 789158):

```
with paperclip field: ACCEPTED
without paperclip field (baseline): ACCEPTED
with an unknown stray field (must still be rejected, closed-schema preserved): REJECTED
   error: (root) - must NOT have additional properties {"additionalProperty":"someUnknownField"}
```

**Observed result after fix:** `paperclip` field is accepted at the protocol layer with arbitrary opaque contents (`{ workflowId, correlationId }` in the test). Backward-compat: absence of `paperclip` continues to validate. Closed-schema enforcement is preserved: any *other* unknown field is still rejected with the same `additionalProperties` error as before.

**What was not tested:** macOS Swift bindings — regenerated via `pnpm protocol:gen:swift` in the same commit (the new `paperclip: AnyCodable?` field on `AgentParams`), but not exercised at runtime (no Mac in this test environment). Round-trip serialization on Mac would be the natural follow-up but is independent of the JS gateway accepting the field.

---
_Filed by openclaw-repo-topic-branch-handoff. Originating topic branch: `alex/protocol-paperclip-field` (now merged into sparkeros/openclaw mods at aac563e56a; upstream-PR head force-updated 2026-05-14 with regenerated Swift bindings)._
