### PR TITLE
fix: keep command cron turns lightweight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/Codex: default exact-command scheduled agent turns to lightweight bootstrap context so automation runs the command before loading workspace identity or memory context.
 - Codex plugin/Gateway: strip unpaired UTF-16 surrogates from Codex app-server JSON-RPC payloads and let stale reply-work recovery abort stalled reply runs, preventing malformed media turns from wedging gateway lanes.
 - Bind gateway approval access to requester metadata [AI]. (#81380) Thanks @pgondhi987.
 - Telegram: let isolated polling drain independent topics, DMs, and status/control commands concurrently while preserving same-lane order. (#81849) Thanks @VACInc.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5899,7 +5899,7 @@ describe("runCodexAppServerAttempt", () => {
       "If it asks you to run an exact command, run that command before doing any investigation",
     );
     expect(cronCollaborationMode.settings.developer_instructions).toContain(
-      "Do not read AGENTS.md, SOUL.md, USER.md, PROJECTS.md, MEMORY.md",
+      "Use context already provided by the runtime",
     );
   });
 

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -571,7 +571,7 @@ function buildCronCollaborationInstructions(): string {
   return [
     "This is an OpenClaw cron automation turn. Apply these instructions only to this scheduled job; ordinary chat turns should stay in Codex Default mode.",
     "Execute the cron payload directly. If it asks you to run an exact command, run that command before doing any investigation, planning, memory review, or workspace bootstrap.",
-    "Do not read AGENTS.md, SOUL.md, USER.md, PROJECTS.md, MEMORY.md, day logs, entity summaries, or other workspace memory/bootstrap files unless the cron payload explicitly asks you to inspect them or the requested command fails and the file is needed to diagnose that failure.",
+    "Use context already provided by the runtime, but do not spend time loading or re-reading workspace bootstrap, memory, or project-doc files before executing the cron payload. Inspect those files only if the payload asks for them or the command fails and they are needed to diagnose it.",
     "Keep output concise and automation-oriented. Prefer the final command result or a short failure summary over status narration.",
   ].join("\n\n");
 }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -163,6 +163,8 @@ export async function prepareCliRunContext(
     config: params.config,
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
+    contextMode: params.bootstrapContextMode,
+    runKind: params.bootstrapContextRunKind,
     warn: prepareDeps.makeBootstrapWarn({
       sessionLabel,
       workspaceDir,

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -8,6 +8,7 @@ import type { CliBackendConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
+import type { BootstrapContextMode } from "../bootstrap-files.js";
 import type { ResolvedCliBackend } from "../cli-backends.js";
 import type {
   CurrentTurnPromptContext,
@@ -48,6 +49,8 @@ export type RunCliAgentParams = {
   authProfileId?: string;
   bootstrapPromptWarningSignaturesSeen?: string[];
   bootstrapPromptWarningSignature?: string;
+  bootstrapContextMode?: BootstrapContextMode;
+  bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
   skillsSnapshot?: SkillSnapshot;

--- a/src/cron/isolated-agent.session-identity.test.ts
+++ b/src/cron/isolated-agent.session-identity.test.ts
@@ -24,6 +24,7 @@ setupRunCronIsolatedAgentTurnSuite();
 
 function lastEmbeddedAgentCall(): {
   agentDir?: string;
+  bootstrapContextMode?: "full" | "lightweight";
   prompt?: string;
   sessionKey?: string;
   workspaceDir?: string;
@@ -40,6 +41,7 @@ function lastEmbeddedAgentCall(): {
   }
   return value as {
     agentDir?: string;
+    bootstrapContextMode?: "full" | "lightweight";
     prompt?: string;
     sessionKey?: string;
     workspaceDir?: string;
@@ -137,6 +139,43 @@ describe("runCronIsolatedAgentTurn session identity", () => {
         path.join(home, ".openclaw", "agents", "main", "sessions"),
       );
       expect(String(call.sessionFile).endsWith(".jsonl")).toBe(true);
+    });
+  });
+
+  it("uses lightweight bootstrap context for command-style cron payloads", async () => {
+    await withTempHome(async (home) => {
+      await runCronTurn(home, {
+        jobPayload: {
+          kind: "agentTurn",
+          message: "cd /srv/openclaw && ./scripts/nightly-report.sh",
+        },
+      });
+
+      expect(lastEmbeddedAgentCall().bootstrapContextMode).toBe("lightweight");
+    });
+  });
+
+  it("does not force lightweight bootstrap context for natural-language cron payloads", async () => {
+    await withTempHome(async (home) => {
+      await runCronTurn(home, {
+        jobPayload: { kind: "agentTurn", message: "Prepare the nightly status summary" },
+      });
+
+      expect(lastEmbeddedAgentCall().bootstrapContextMode).toBeUndefined();
+    });
+  });
+
+  it("honors explicit full bootstrap context for command-style cron payloads", async () => {
+    await withTempHome(async (home) => {
+      await runCronTurn(home, {
+        jobPayload: {
+          kind: "agentTurn",
+          message: "pnpm run nightly-report",
+          lightContext: false,
+        },
+      });
+
+      expect(lastEmbeddedAgentCall().bootstrapContextMode).toBeUndefined();
     });
   });
 

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -1,3 +1,4 @@
+import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
 import { normalizeToolList } from "../../agents/tool-policy.js";
@@ -58,6 +59,29 @@ function resolveCronOwnerOnlyToolAllowlist(toolsAllow: string[] | undefined): st
     return undefined;
   }
   return ["cron"];
+}
+
+const COMMAND_STYLE_CRON_PREFIX =
+  /^(?:(?:[A-Z_][A-Z0-9_]*=\S+\s+)+)?(?:cd\s+\S+|(?:\.{1,2}|~)?\/\S+|[A-Za-z]:[\\/]\S+|(?:bash|bun|cargo|deno|docker|gh|git|go|make|node|npm|npx|pnpm|python|python3|ruby|sh|tsx|uv|zsh)\b)/u;
+
+export function isCommandStyleCronMessage(message: string): boolean {
+  const trimmed = message.trim();
+  if (!trimmed || trimmed.includes("\n")) {
+    return false;
+  }
+  return COMMAND_STYLE_CRON_PREFIX.test(trimmed);
+}
+
+function resolveCronBootstrapContextMode(
+  payload: AgentTurnPayload,
+): BootstrapContextMode | undefined {
+  if (payload?.lightContext === true) {
+    return "lightweight";
+  }
+  if (payload?.lightContext === false) {
+    return undefined;
+  }
+  return isCommandStyleCronMessage(payload?.message ?? "") ? "lightweight" : undefined;
 }
 
 export type CronExecutionResult = {
@@ -180,6 +204,8 @@ export function createCronPromptExecutor(params: {
             onExecutionPhase: params.onExecutionPhase,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
+            bootstrapContextMode: resolveCronBootstrapContextMode(params.agentPayload),
+            bootstrapContextRunKind: "cron",
             senderIsOwner: params.senderIsOwner,
           });
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
@@ -234,7 +260,7 @@ export function createCronPromptExecutor(params: {
           verboseLevel: params.resolvedVerboseLevel,
           timeoutMs: params.timeoutMs,
           runTimeoutOverrideMs: params.runTimeoutOverrideMs,
-          bootstrapContextMode: params.agentPayload?.lightContext ? "lightweight" : undefined,
+          bootstrapContextMode: resolveCronBootstrapContextMode(params.agentPayload),
           bootstrapContextRunKind: "cron",
           toolsAllow: params.agentPayload?.toolsAllow,
           execOverrides: params.suppressExecNotifyOnExit


### PR DESCRIPTION
## Summary

- Default command-style cron payloads to lightweight bootstrap context unless the job explicitly sets `lightContext: false`.
- Propagate cron bootstrap context mode through both embedded and CLI agent execution paths.
- Reword Codex cron instructions so the model uses injected context but does not reload workspace bootstrap, memory, or project-doc files before executing an exact cron command.
- Add a changelog entry for the cron/Codex behavior fix.

## Verification

Behavior addressed: exact-command cron jobs could time out after the Codex migration because scheduled turns loaded workspace identity/bootstrap context before running the command.

Real environment tested: local OpenClaw source checkout, with focused cron isolated-agent tests and Codex app-server turn construction tests.

Exact steps or command run after this patch: `pnpm test src/cron/isolated-agent.session-identity.test.ts`; `pnpm test extensions/codex/src/app-server/run-attempt.test.ts -t "cron Codex|lightweight cron"`; `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.ts src/agents/cli-runner/prepare.ts src/agents/cli-runner/types.ts src/cron/isolated-agent.session-identity.test.ts src/cron/isolated-agent/run-executor.ts`; `node scripts/run-oxlint.mjs extensions/codex/src/app-server/thread-lifecycle.ts src/agents/cli-runner/prepare.ts src/agents/cli-runner/types.ts src/cron/isolated-agent.session-identity.test.ts src/cron/isolated-agent/run-executor.ts`; `git diff --check`.

Evidence after fix: cron regression tests assert command-style payloads get `bootstrapContextMode=lightweight`, natural-language cron payloads keep the default context, and `lightContext: false` opts out; the Codex app-server test asserts the revised cron instructions.

Observed result after fix: all listed checks passed.

What was not tested: live gateway cron execution against a real scheduled job; this PR covers the focused cron/Codex execution seams.
