### PR TITLE
fix(cron): treat attempt dispatch as execution start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram: apply method-aware Bot API request timeouts to direct message/action clients so `openclaw message delete --channel telegram` no longer waits on grammY's 500-second default when the API request wedges. Fixes #81908. Thanks @DashLabsDev.
+- Cron: treat attempt dispatch and assembled context as execution-start milestones so isolated agent jobs that have reached backend dispatch are governed by their configured job timeout instead of the 60s pre-execution watchdog. Fixes #81368. (#81871) Thanks @alexph-dev.
 - Discord/channels: make `openclaw channels list --all` prefer reachable Gateway runtime account status and mark configured-but-unavailable credentials, avoiding false `not configured` output when Discord is running from service-only env. Fixes #79343. Thanks @EricY019.
 - WhatsApp: mark text slash commands as command turns so authorized group command replies stay visible under message-tool-only group reply mode. (#81972) Thanks @barbarhan.
 - Installer: handle noninteractive git installs from moving refs without tag-fetch conflicts, while keeping immutable refs on frozen lockfile installs. (#81875) Thanks @keshavbotagent.

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1606,6 +1606,88 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("clears the pre-execution watchdog when isolated cron reaches attempt dispatch (#81368)", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-05-13T09:56:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "isolated-attempt-dispatch-81368",
+        name: "attempt dispatch regression",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 1_200 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const started = createDeferred<void>();
+      let abortObserved = false;
+      const cleanupTimedOutAgentRun = vi.fn(async () => {});
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        cleanupTimedOutAgentRun,
+        runIsolatedAgentJob: vi.fn(
+          async ({
+            abortSignal,
+            onExecutionStarted,
+            onExecutionPhase,
+          }: {
+            abortSignal?: AbortSignal;
+            onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
+            onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
+          }) => {
+            onExecutionStarted?.({
+              jobId: "isolated-attempt-dispatch-81368",
+              phase: "runner_entered",
+            });
+            onExecutionPhase?.({
+              jobId: "isolated-attempt-dispatch-81368",
+              phase: "attempt_dispatch",
+              backend: "codex-app-server",
+            });
+            started.resolve();
+            abortSignal?.addEventListener(
+              "abort",
+              () => {
+                abortObserved = true;
+              },
+              { once: true },
+            );
+            return await new Promise<never>(() => {});
+          },
+        ),
+      });
+
+      const timerPromise = onTimer(state);
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      expect(abortObserved).toBe(false);
+      expect(cleanupTimedOutAgentRun).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_140_000);
+      now += 1_140_000;
+      await timerPromise;
+
+      const job = requireJob(state, "isolated-attempt-dispatch-81368");
+      expect(abortObserved).toBe(true);
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.lastError).toContain("job execution timed out");
+      expect(job.state.lastError).toContain("attempt-dispatch");
+      expect(cleanupTimedOutAgentRun).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps state updates when cron next-run computation throws after a successful run (#30905)", () => {
     const startedAt = Date.parse("2026-03-02T12:00:00.000Z");
     const endedAt = startedAt + 50;

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -14,6 +14,7 @@ import {
 import { HEARTBEAT_SKIP_LANES_BUSY, type HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import * as schedule from "../schedule.js";
 import type {
+  CronAgentExecutionPhase,
   CronAgentExecutionPhaseUpdate,
   CronAgentExecutionStarted,
   CronJob,
@@ -1606,87 +1607,108 @@ describe("cron service timer regressions", () => {
     }
   });
 
-  it("clears the pre-execution watchdog when isolated cron reaches attempt dispatch (#81368)", async () => {
-    vi.useFakeTimers();
-    try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-05-13T09:56:00.000Z");
-      const cronJob = createIsolatedRegressionJob({
-        id: "isolated-attempt-dispatch-81368",
-        name: "attempt dispatch regression",
-        scheduledAt,
-        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 1_200 },
-        state: { nextRunAtMs: scheduledAt },
-      });
-      await writeCronJobs(store.storePath, [cronJob]);
+  it.each([
+    {
+      phase: "attempt_dispatch",
+      phaseText: "attempt-dispatch",
+      id: "isolated-attempt-dispatch-81368",
+      name: "attempt dispatch regression",
+    },
+    {
+      phase: "context_assembled",
+      phaseText: "context-assembled",
+      id: "isolated-context-assembled-81368",
+      name: "context assembled regression",
+    },
+  ] satisfies Array<{
+    phase: CronAgentExecutionPhase;
+    phaseText: string;
+    id: string;
+    name: string;
+  }>)(
+    "clears the pre-execution watchdog when isolated cron reaches $phaseText (#81368)",
+    async ({ phase, phaseText, id, name }) => {
+      vi.useFakeTimers();
+      try {
+        const store = timerRegressionFixtures.makeStorePath();
+        const scheduledAt = Date.parse("2026-05-13T09:56:00.000Z");
+        const cronJob = createIsolatedRegressionJob({
+          id,
+          name,
+          scheduledAt,
+          schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+          payload: { kind: "agentTurn", message: "work", timeoutSeconds: 1_200 },
+          state: { nextRunAtMs: scheduledAt },
+        });
+        await writeCronJobs(store.storePath, [cronJob]);
 
-      vi.setSystemTime(scheduledAt);
-      let now = scheduledAt;
-      const started = createDeferred<void>();
-      let abortObserved = false;
-      const cleanupTimedOutAgentRun = vi.fn(async () => {});
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        cleanupTimedOutAgentRun,
-        runIsolatedAgentJob: vi.fn(
-          async ({
-            abortSignal,
-            onExecutionStarted,
-            onExecutionPhase,
-          }: {
-            abortSignal?: AbortSignal;
-            onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
-            onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
-          }) => {
-            onExecutionStarted?.({
-              jobId: "isolated-attempt-dispatch-81368",
-              phase: "runner_entered",
-            });
-            onExecutionPhase?.({
-              jobId: "isolated-attempt-dispatch-81368",
-              phase: "attempt_dispatch",
-              backend: "codex-app-server",
-            });
-            started.resolve();
-            abortSignal?.addEventListener(
-              "abort",
-              () => {
-                abortObserved = true;
-              },
-              { once: true },
-            );
-            return await new Promise<never>(() => {});
-          },
-        ),
-      });
+        vi.setSystemTime(scheduledAt);
+        let now = scheduledAt;
+        const started = createDeferred<void>();
+        let abortObserved = false;
+        const cleanupTimedOutAgentRun = vi.fn(async () => {});
+        const state = createCronServiceState({
+          cronEnabled: true,
+          storePath: store.storePath,
+          log: noopLogger,
+          nowMs: () => now,
+          enqueueSystemEvent: vi.fn(),
+          requestHeartbeat: vi.fn(),
+          cleanupTimedOutAgentRun,
+          runIsolatedAgentJob: vi.fn(
+            async ({
+              abortSignal,
+              onExecutionStarted,
+              onExecutionPhase,
+            }: {
+              abortSignal?: AbortSignal;
+              onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
+              onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
+            }) => {
+              onExecutionStarted?.({
+                jobId: id,
+                phase: "runner_entered",
+              });
+              onExecutionPhase?.({
+                jobId: id,
+                phase,
+                backend: "codex-app-server",
+              });
+              started.resolve();
+              abortSignal?.addEventListener(
+                "abort",
+                () => {
+                  abortObserved = true;
+                },
+                { once: true },
+              );
+              return await new Promise<never>(() => {});
+            },
+          ),
+        });
 
-      const timerPromise = onTimer(state);
-      await started.promise;
-      await vi.advanceTimersByTimeAsync(60_100);
-      now += 60_100;
-      expect(abortObserved).toBe(false);
-      expect(cleanupTimedOutAgentRun).not.toHaveBeenCalled();
+        const timerPromise = onTimer(state);
+        await started.promise;
+        await vi.advanceTimersByTimeAsync(60_100);
+        now += 60_100;
+        expect(abortObserved).toBe(false);
+        expect(cleanupTimedOutAgentRun).not.toHaveBeenCalled();
 
-      await vi.advanceTimersByTimeAsync(1_140_000);
-      now += 1_140_000;
-      await timerPromise;
+        await vi.advanceTimersByTimeAsync(1_140_000);
+        now += 1_140_000;
+        await timerPromise;
 
-      const job = requireJob(state, "isolated-attempt-dispatch-81368");
-      expect(abortObserved).toBe(true);
-      expect(job.state.lastStatus).toBe("error");
-      expect(job.state.lastError).toContain("job execution timed out");
-      expect(job.state.lastError).toContain("attempt-dispatch");
-      expect(cleanupTimedOutAgentRun).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+        const job = requireJob(state, id);
+        expect(abortObserved).toBe(true);
+        expect(job.state.lastStatus).toBe("error");
+        expect(job.state.lastError).toContain("job execution timed out");
+        expect(job.state.lastError).toContain(phaseText);
+        expect(cleanupTimedOutAgentRun).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("keeps state updates when cron next-run computation throws after a successful run (#30905)", () => {
     const startedAt = Date.parse("2026-03-02T12:00:00.000Z");

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -22,6 +22,7 @@ import {
 import { createCronExecutionId } from "../run-id.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
 import type {
+  CronAgentExecutionPhase,
   CronAgentExecutionPhaseUpdate,
   CronAgentExecutionStarted,
   CronDeliveryStatus,
@@ -304,21 +305,27 @@ function formatCronAgentExecutionPhase(execution?: CronAgentExecutionStarted): s
   return execution?.phase?.replaceAll("_", "-");
 }
 
+const CRON_AGENT_EXECUTION_STARTED_BY_PHASE = {
+  runner_entered: false,
+  workspace: false,
+  runtime_plugins: false,
+  model_resolution: false,
+  auth: false,
+  context_engine: false,
+  attempt_dispatch: true,
+  context_assembled: true,
+  turn_accepted: true,
+  process_spawned: true,
+  tool_execution_started: true,
+  assistant_output_started: true,
+  model_call_started: true,
+} as const satisfies Record<CronAgentExecutionPhase, boolean>;
+
 function isCronAgentExecutionStarted(info: CronAgentExecutionStarted): boolean {
   if (info.firstModelCallStarted) {
     return true;
   }
-  switch (info.phase) {
-    case "attempt_dispatch":
-    case "turn_accepted":
-    case "process_spawned":
-    case "tool_execution_started":
-    case "assistant_output_started":
-    case "model_call_started":
-      return true;
-    default:
-      return false;
-  }
+  return info.phase ? CRON_AGENT_EXECUTION_STARTED_BY_PHASE[info.phase] : false;
 }
 
 function resolveCronAgentPreExecutionWatchdogMs(jobTimeoutMs: number): number {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -309,6 +309,7 @@ function isCronAgentExecutionStarted(info: CronAgentExecutionStarted): boolean {
     return true;
   }
   switch (info.phase) {
+    case "attempt_dispatch":
     case "turn_accepted":
     case "process_spawned":
     case "tool_execution_started":


### PR DESCRIPTION
AI-assisted: yes (Codex).

This refreshes the narrow fix from the closed-but-unmerged #81371 after #81368 was still reported as reproducing on `2026.5.12-beta.8`.

## Summary

- Treat the existing cron `attempt_dispatch` phase as an execution-start milestone for isolated agent cron jobs.
- Clear the 60s pre-execution watchdog once dispatch has started, so long-running jobs rely on the configured job timeout instead of failing as a false pre-execution stall.
- Add a regression for the `attempt_dispatch` path.
- Scope boundary: no watchdog duration, scheduler, retry, model, or runner emission changes.

Fixes #81368.

## Root Cause

The embedded runner can emit `attempt_dispatch` immediately before backend attempt dispatch, and the phase is already part of `CronAgentExecutionPhase`. The cron timer's `isCronAgentExecutionStarted()` helper did not classify that phase as execution-started, so an isolated run could progress to dispatch and still be killed by the 60s pre-execution watchdog with `last phase: attempt-dispatch`.

## Regression Test Plan

- Coverage level that should have caught this: unit/regression test at the cron timer watchdog boundary.
- Target test file: `src/cron/service/timer.regression.test.ts`.
- Scenario locked in: a non-main isolated agent cron run emits `runner_entered` then `attempt_dispatch`, survives the pre-execution watchdog window, and only times out at the configured job timeout.
- Why this is the smallest reliable guardrail: the bug is private timer classification behavior; no channel, scheduler, or model integration is needed to reproduce the false classification.

## Real behavior proof

- Behavior or issue addressed: isolated cron jobs that reach `attempt_dispatch` can be aborted around 60s as `cron: isolated agent run stalled before execution start (last phase: attempt-dispatch)` even though they are progressing and the job timeout is longer.
- Real environment tested: reporter live setup from #81368, npm global OpenClaw install on Linux with isolated cron and `openai/gpt-5.5`. The issue now also has a beta.8 user report that the bug still reproduces.
- Exact steps or command run after this patch: Apply the same one-line classifier change as this source patch to the installed `server-cron-*.js` bundle (`case "attempt_dispatch":` in `isCronAgentExecutionStarted()`), restart the gateway, then create a no-delivery isolated cron job whose agent command runs `sleep 75` with `--timeout-seconds 240`.
- Evidence after fix: Copied live output from #81368 after the installed-bundle hotfix equivalent to this source patch:

```json
{
  "status": "ok",
  "summary": "OK_CRON_WATCHDOG_HOTFIX",
  "durationMs": 128739,
  "model": "gpt-5.5",
  "provider": "openai",
  "deliveryStatus": "not-requested"
}
```

- Observed result after fix: the same shape of isolated cron run continued past the old 60s false-stall cutoff and completed successfully.
- What was not tested: I did not rerun a full live cron smoke from this source branch; the live proof above is from the installed bundle hotfix with the same one-line classifier change. I verified the source patch with the focused cron regression test and changed-file checks.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local source checkout
- Model/provider: not needed for local regression; live proof used `openai/gpt-5.5`
- Integration/channel: cron isolated agent run

### Steps

1. Trigger an isolated cron agent job that reaches `attempt_dispatch` but continues running past 60s.
2. Before this change, cron can report `stalled before execution start (last phase: attempt-dispatch)`.
3. After this change, `attempt_dispatch` clears the pre-execution watchdog; the configured job timeout remains the active limit.

### Expected

- `attempt_dispatch` is classified as execution started.
- The pre-execution watchdog does not abort the run after 60s.

### Actual Before Fix

- The run can fail around the pre-execution watchdog window with `last phase: attempt-dispatch`.

## Validation

- `node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts -- -t "attempt dispatch"` — completed with `1 passed`, `36 passed` in this file. The wrapper ran the full file instead of filtering to one test.
- `pnpm format:check src/cron/service/timer.ts src/cron/service/timer.regression.test.ts`
- `git diff --check`
- `node scripts/test-projects.mjs src/cron/service/timer.regression.test.ts`
- `GOMEMLIMIT=2GiB GOGC=30 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`
- `codex review --base origin/main` — ran per contributor guide; it returned an unrelated Telegram finding against `extensions/telegram/src/send.ts`, which is not part of this branch's diff (`git diff --name-status origin/main` lists only the two cron files).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: a post-dispatch/pre-model hang now waits for the configured job timeout instead of the shorter pre-execution watchdog.
  Mitigation: this is intentional for a phase where backend dispatch has started, and it honors the user's explicit cron timeout.
