### PR TITLE
fix(installer): handle noninteractive git installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Installer: handle noninteractive git installs from moving refs without tag-fetch conflicts, while keeping immutable refs on frozen lockfile installs. (#81875) Thanks @keshavbotagent.
 - Codex app-server: inject native client factories per run and compaction attempt instead of using module-scope test state, avoiding temporal-dead-zone reads during cyclic startup. (#81148) Thanks @bdjben.
 - Plugin skills: replace generated Windows plugin-skill directories before publishing the current skill link, avoiding repeated `EINVAL` warnings from stale non-symlink entries. Fixes #81432. (#81446) Thanks @hclsys and @vincentkoc.
 - Channels/config: treat channel entries with only `enabled: true` as configured state so plugin-backed channels can auto-enable from an explicit on switch. Fixes #81323. (#81331) Thanks @EvanYao826 and @vincentkoc.

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -423,18 +423,19 @@ checkout_git_openclaw_ref() {
     return 0
   fi
 
+  if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
+    git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"
+    git -C "$repo_dir" checkout -B "$ref" "origin/$ref"
+    if [[ "$GIT_UPDATE" == "1" ]]; then
+      git -C "$repo_dir" pull --rebase --no-tags || true
+    fi
+    return 0
+  fi
+
   git -C "$repo_dir" fetch --tags origin
 
   if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
     git -C "$repo_dir" checkout --detach "$ref"
-    return 0
-  fi
-
-  if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
-    git -C "$repo_dir" checkout -B "$ref" "origin/$ref"
-    if [[ "$GIT_UPDATE" == "1" ]]; then
-      git -C "$repo_dir" pull --rebase || true
-    fi
     return 0
   fi
 

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -414,15 +414,16 @@ checkout_git_openclaw_ref() {
     return 0
   fi
 
-  git -C "$repo_dir" fetch --tags origin
-
   if [[ "$ref" == "main" ]]; then
+    git -C "$repo_dir" fetch --no-tags origin main
     git -C "$repo_dir" checkout main
     if [[ "$GIT_UPDATE" == "1" ]]; then
-      git -C "$repo_dir" pull --rebase || true
+      git -C "$repo_dir" pull --rebase --no-tags || true
     fi
     return 0
   fi
+
+  git -C "$repo_dir" fetch --tags origin
 
   if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
     git -C "$repo_dir" checkout --detach "$ref"
@@ -443,6 +444,18 @@ checkout_git_openclaw_ref() {
   fi
 
   fail "Requested git version not found: ${ref}"
+}
+
+git_install_lockfile_flag() {
+  local repo_dir="$1"
+  local ref="$2"
+
+  if [[ "$ref" == "main" ]] || git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
+    echo "--no-frozen-lockfile"
+    return 0
+  fi
+
+  echo "--frozen-lockfile"
 }
 
 repo_pnpm_spec() {
@@ -723,7 +736,9 @@ install_openclaw_from_git() {
   ensure_pnpm_git_prepare_allowlist "$repo_dir"
   activate_repo_pnpm_version "$repo_dir"
 
-  SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_pnpm -C "$repo_dir" install --frozen-lockfile
+  local install_lockfile_flag
+  install_lockfile_flag="$(git_install_lockfile_flag "$repo_dir" "$git_ref")"
+  CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"
 
   if ! run_pnpm -C "$repo_dir" ui:build; then
     log "UI build failed; continuing (CLI may still work)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2369,7 +2369,7 @@ install_openclaw_from_git() {
     cleanup_legacy_submodules "$repo_dir"
     activate_repo_pnpm_version "$repo_dir"
 
-    CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install --frozen-lockfile
+    CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install --no-frozen-lockfile
 
     if ! run_quiet_step "Building UI" run_pnpm -C "$repo_dir" ui:build; then
         ui_warn "UI build failed; continuing (CLI may still work)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1969,18 +1969,19 @@ checkout_git_openclaw_ref() {
         return 0
     fi
 
+    if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
+        run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"
+        run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout -B "$ref" "origin/$ref"
+        if [[ "$GIT_UPDATE" == "1" ]]; then
+            run_quiet_step "Updating repository" git -C "$repo_dir" pull --rebase --no-tags || true
+        fi
+        return 0
+    fi
+
     run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --tags origin
 
     if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
         run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
-        return 0
-    fi
-
-    if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
-        run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout -B "$ref" "origin/$ref"
-        if [[ "$GIT_UPDATE" == "1" ]]; then
-            run_quiet_step "Updating repository" git -C "$repo_dir" pull --rebase || true
-        fi
         return 0
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2369,7 +2369,7 @@ install_openclaw_from_git() {
     cleanup_legacy_submodules "$repo_dir"
     activate_repo_pnpm_version "$repo_dir"
 
-    SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install --frozen-lockfile
+    CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install --frozen-lockfile
 
     if ! run_quiet_step "Building UI" run_pnpm -C "$repo_dir" ui:build; then
         ui_warn "UI build failed; continuing (CLI may still work)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1993,6 +1993,18 @@ checkout_git_openclaw_ref() {
     return 1
 }
 
+git_install_lockfile_flag() {
+    local repo_dir="$1"
+    local ref="$2"
+
+    if [[ "$ref" == "main" ]] || git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
+        echo "--no-frozen-lockfile"
+        return 0
+    fi
+
+    echo "--frozen-lockfile"
+}
+
 repo_pnpm_spec() {
     local repo_dir="$1"
     local package_json="${repo_dir}/package.json"
@@ -2369,7 +2381,9 @@ install_openclaw_from_git() {
     cleanup_legacy_submodules "$repo_dir"
     activate_repo_pnpm_version "$repo_dir"
 
-    CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install --no-frozen-lockfile
+    local install_lockfile_flag
+    install_lockfile_flag="$(git_install_lockfile_flag "$repo_dir" "$git_ref")"
+    CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"
 
     if ! run_quiet_step "Building UI" run_pnpm -C "$repo_dir" ui:build; then
         ui_warn "UI build failed; continuing (CLI may still work)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1960,15 +1960,16 @@ checkout_git_openclaw_ref() {
         return 0
     fi
 
-    run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --tags origin
-
     if [[ "$ref" == "main" ]]; then
+        run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin main
         run_quiet_step "Checking out main" git -C "$repo_dir" checkout main
         if [[ "$GIT_UPDATE" == "1" ]]; then
-            run_quiet_step "Updating repository" git -C "$repo_dir" pull --rebase || true
+            run_quiet_step "Updating repository" git -C "$repo_dir" pull --rebase --no-tags || true
         fi
         return 0
     fi
+
+    run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --tags origin
 
     if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
         run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -47,9 +47,18 @@ describe("install-cli.sh", () => {
     expect(result.stdout).toContain("main=main");
   });
 
-  it("fetches main without tags for git installs", () => {
+  it("fetches moving git refs without tags for git installs", () => {
     expect(script).toContain('git -C "$repo_dir" fetch --no-tags origin main');
+    expect(script).toContain(
+      'git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"',
+    );
     expect(script).toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
+
+    const branchCheckIndex = script.indexOf('ls-remote --exit-code --heads origin "$ref"');
+    const tagFetchIndex = script.indexOf("fetch --tags origin");
+    expect(branchCheckIndex).toBeGreaterThan(-1);
+    expect(tagFetchIndex).toBeGreaterThan(-1);
+    expect(branchCheckIndex).toBeLessThan(tagFetchIndex);
   });
 
   it("uses non-frozen lockfile installs only for moving git refs", () => {

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -47,8 +47,33 @@ describe("install-cli.sh", () => {
     expect(result.stdout).toContain("main=main");
   });
 
-  it("uses frozen lockfile installs for git installs", () => {
-    expect(script).toContain('run_pnpm -C "$repo_dir" install --frozen-lockfile');
+  it("fetches main without tags for git installs", () => {
+    expect(script).toContain('git -C "$repo_dir" fetch --no-tags origin main');
+    expect(script).toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
+  });
+
+  it("uses non-frozen lockfile installs only for moving git refs", () => {
+    const result = runInstallCliShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      git() {
+        if [[ "$1" == "-C" && "$3" == "ls-remote" && "\${7:-}" == "feature" ]]; then
+          return 0
+        fi
+        return 1
+      }
+      printf 'main=%s\\n' "$(git_install_lockfile_flag /repo main)"
+      printf 'branch=%s\\n' "$(git_install_lockfile_flag /repo feature)"
+      printf 'tag=%s\\n' "$(git_install_lockfile_flag /repo v2026.5.12)"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("main=--no-frozen-lockfile");
+    expect(result.stdout).toContain("branch=--no-frozen-lockfile");
+    expect(result.stdout).toContain("tag=--frozen-lockfile");
+    expect(script).toContain(
+      'CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"',
+    );
   });
 
   it("aligns pnpm to the checked-out repo packageManager before installing", () => {

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -381,9 +381,18 @@ describe("install.sh", () => {
     expect(result.stdout).toContain("main=main");
   });
 
-  it("fetches main without tags for git installs", () => {
+  it("fetches moving git refs without tags for git installs", () => {
     expect(script).toContain('git -C "$repo_dir" fetch --no-tags origin main');
+    expect(script).toContain(
+      'git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"',
+    );
     expect(script).toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
+
+    const branchCheckIndex = script.indexOf('ls-remote --exit-code --heads origin "$ref"');
+    const tagFetchIndex = script.indexOf("fetch --tags origin");
+    expect(branchCheckIndex).toBeGreaterThan(-1);
+    expect(tagFetchIndex).toBeGreaterThan(-1);
+    expect(branchCheckIndex).toBeLessThan(tagFetchIndex);
   });
 
   it("uses non-frozen lockfile installs only for moving git refs", () => {

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -381,9 +381,32 @@ describe("install.sh", () => {
     expect(result.stdout).toContain("main=main");
   });
 
-  it("uses frozen lockfile installs for git installs", () => {
+  it("fetches main without tags for git installs", () => {
+    expect(script).toContain('git -C "$repo_dir" fetch --no-tags origin main');
+    expect(script).toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
+  });
+
+  it("uses non-frozen lockfile installs only for moving git refs", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      git() {
+        if [[ "$1" == "-C" && "$3" == "ls-remote" && "\${7:-}" == "feature" ]]; then
+          return 0
+        fi
+        return 1
+      }
+      printf 'main=%s\\n' "$(git_install_lockfile_flag /repo main)"
+      printf 'branch=%s\\n' "$(git_install_lockfile_flag /repo feature)"
+      printf 'tag=%s\\n' "$(git_install_lockfile_flag /repo v2026.5.12)"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("main=--no-frozen-lockfile");
+    expect(result.stdout).toContain("branch=--no-frozen-lockfile");
+    expect(result.stdout).toContain("tag=--frozen-lockfile");
     expect(script).toContain(
-      'run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install --frozen-lockfile',
+      'CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"',
     );
   });
 


### PR DESCRIPTION
## Summary
- Avoid `git fetch --tags origin` before handling the `main` git install ref.
- Fetch and pull `main` with `--no-tags` so moved local tags do not block branch installs.
- Mirror the git installer fix in both published Bash installers: `scripts/install.sh` and `scripts/install-cli.sh`.
- Run git dependency installs with `CI=true` by default so pnpm can recreate `node_modules` in curl-piped/non-TTY installs.
- Use `--no-frozen-lockfile` only for moving git refs (`main` and remote branches); keep tag/semver/commit installs on `--frozen-lockfile`.

## Verification
- `bash -n scripts/install.sh scripts/install-cli.sh`
- `git diff --check`
- `CI=true COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm vitest run test/scripts/install-sh.test.ts test/scripts/install-cli.test.ts` -> 2 files / 24 tests passed
- Full isolated curl-piped git install from the PR branch completed successfully

## Real behavior proof
- Behavior or issue addressed: `--install-method git --version main` can fail during "Fetching requested version" when a local tag conflicts with upstream, during "Installing dependencies" when pnpm needs to purge `node_modules` in a non-TTY curl-piped install, and during frozen install when a moving source branch needs lockfile refresh.
- Real environment tested: Fresh isolated temp HOME and temp git checkout on Keshav's OpenClaw host, using git 2.43.0, node v26.1.0, npm 11.13.0, and pnpm 11.1.0.
- Exact steps or command run after this patch: Ran the PR-branch `scripts/install.sh` through curl into bash with `--install-method git --version main --no-onboard --no-prompt`, using isolated `HOME` and `OPENCLAW_GIT_DIR`.
- Evidence after fix (copied live terminal output; ANSI color stripped):
```text
$ HOME=/tmp/openclaw-pr81875-proof.Djkhhh/home OPENCLAW_GIT_DIR=/tmp/openclaw-pr81875-proof.Djkhhh/openclaw CI=true PATH=/usr/local/bin:/usr/bin:/bin curl -fsSL --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/keshavbotagent/openclaw/fix/install-main-no-tags/scripts/install.sh | HOME=/tmp/openclaw-pr81875-proof.Djkhhh/home OPENCLAW_GIT_DIR=/tmp/openclaw-pr81875-proof.Djkhhh/openclaw CI=true PATH=/usr/local/bin:/usr/bin:/bin bash -s -- --install-method git --version main --no-onboard --no-prompt

OpenClaw Installer
Detected: linux

Install plan
OS: linux
Install method: git
Requested version: main
Git directory: /tmp/openclaw-pr81875-proof.Djkhhh/openclaw
Git update: 1
Onboarding: skipped

[1/3] Preparing environment
Node.js v26.1.0 found
Active Node.js: v26.1.0 (/usr/bin/node)
Active npm: 11.13.0 (/usr/bin/npm)

[2/3] Installing OpenClaw
Installing OpenClaw from GitHub (https://github.com/openclaw/openclaw.git)
Git already installed
Installing pnpm via npm
pnpm ready (pnpm)
Cloning OpenClaw
Using git ref: main
Fetching requested version
Checking out main
Updating repository
Installing dependencies
Building UI
Building OpenClaw
OpenClaw wrapper installed to $HOME/.local/bin/openclaw

[3/3] Finalizing setup
Running doctor to migrate settings
Running doctor
Doctor complete
OpenClaw installed successfully (2026.5.12-beta.1)!

Source install details
Checkout: /tmp/openclaw-pr81875-proof.Djkhhh/openclaw
Wrapper: /tmp/openclaw-pr81875-proof.Djkhhh/home/.local/bin/openclaw
Update command: openclaw update

$ /tmp/openclaw-pr81875-proof.Djkhhh/home/.local/bin/openclaw --version
OpenClaw 2026.5.12-beta.1 (686b93e)
proof complete
```
- Observed result after fix: The curl-piped git installer completed successfully from a fresh temp checkout, including the no-tag `main` fetch/update path, noninteractive dependency install, build, doctor, wrapper creation, and `openclaw --version`.
- What was not tested: A separate full `install-cli.sh` curl-piped install was not run; the fix is mirrored there and covered by the focused `install-cli.sh` shell regression tests.
