### PR TITLE
fix: prevent Codex app-server surrogate stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex plugin/Gateway: strip unpaired UTF-16 surrogates from Codex app-server JSON-RPC payloads and let stale reply-work recovery abort stalled reply runs, preventing malformed media turns from wedging gateway lanes.
 - Bind gateway approval access to requester metadata [AI]. (#81380) Thanks @pgondhi987.
 - Telegram: let isolated polling drain independent topics, DMs, and status/control commands concurrently while preserving same-lane order. (#81849) Thanks @VACInc.
 - Doctor/Codex: stop warning that the message tool is unavailable for source-reply paths where OpenClaw grants `message` at runtime, keeping update and doctor output aligned with the OpenAI happy path. Thanks @pashpashpash.

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -49,6 +49,31 @@ describe("CodexAppServerClient", () => {
     expect(outbound.method).toBe("model/list");
   });
 
+  it("removes unpaired surrogate code units from outbound JSON-RPC strings", async () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    const high = String.fromCharCode(0xd83d);
+    const low = String.fromCharCode(0xdc00);
+
+    const request = harness.client.request("thread/start", {
+      prompt: `left${high}right`,
+      nested: [`low${low}end`, "emoji 🙈 ok"],
+    });
+
+    expect(harness.writes[0]).not.toContain("\\ud83d");
+    expect(harness.writes[0]).not.toContain("\\udc00");
+    const outbound = JSON.parse(harness.writes[0] ?? "{}") as {
+      params?: { prompt?: string; nested?: string[] };
+    };
+    expect(outbound.params?.prompt).toBe("leftright");
+    expect(outbound.params?.nested).toEqual(["lowend", "emoji 🙈 ok"]);
+    harness.send({
+      id: JSON.parse(harness.writes[0] ?? "{}").id,
+      result: { threadId: "thread-1" },
+    });
+    await expect(request).resolves.toEqual({ threadId: "thread-1" });
+  });
+
   it("logs a redacted preview for malformed app-server messages", async () => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const harness = createClientHarness();

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -29,6 +29,8 @@ const CODEX_APP_SERVER_PARSE_BUFFER_MAX = 1_000_000;
 const CODEX_APP_SERVER_PARSE_BUFFER_MAX_LINES = 1_000;
 const CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS = 600_000;
 const CODEX_APP_SERVER_STDERR_TAIL_MAX = 2_000;
+const UNPAIRED_SURROGATE_RE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
 
 type PendingRequest = {
   method: string;
@@ -300,11 +302,14 @@ export class CodexAppServerClient {
     }
     const id = "id" in message ? message.id : undefined;
     const method = "method" in message ? message.method : undefined;
-    this.child.stdin.write(`${JSON.stringify(message)}\n`, (error?: Error | null) => {
-      if (error) {
-        embeddedAgentLog.warn("codex app-server write failed", { error, id, method });
-      }
-    });
+    this.child.stdin.write(
+      `${stringifyCodexAppServerMessage(message)}\n`,
+      (error?: Error | null) => {
+        if (error) {
+          embeddedAgentLog.warn("codex app-server write failed", { error, id, method });
+        }
+      },
+    );
   }
 
   private handleLine(line: string): void {
@@ -536,6 +541,14 @@ function defaultServerRequestResponse(
     };
   }
   return {};
+}
+
+function stringifyCodexAppServerMessage(message: RpcRequest | RpcResponse): string {
+  return (
+    JSON.stringify(message, (_key, value) =>
+      typeof value === "string" ? value.replace(UNPAIRED_SURROGATE_RE, "") : value,
+    ) ?? "null"
+  );
 }
 
 function timeoutServerRequestResponse(

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -262,6 +262,32 @@ describe("stuck session recovery", () => {
     ]);
   });
 
+  it("aborts stale reply work without an embedded handle when active abort recovery is enabled", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedPiRunActive.mockReturnValue(true);
+    mocks.isEmbeddedPiRunHandleActive.mockReturnValue(false);
+    mocks.abortEmbeddedPiRun.mockReturnValue(true);
+    mocks.waitForEmbeddedPiRunEnd.mockResolvedValue(true);
+
+    await recoverStuckDiagnosticSession({
+      sessionId: "queued-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    expect(mocks.abortEmbeddedPiRun).toHaveBeenCalledWith("queued-reply-session");
+    expect(mocks.waitForEmbeddedPiRunEnd).toHaveBeenCalledWith("queued-reply-session", 15_000);
+    expect(mocks.forceClearEmbeddedPiRun).not.toHaveBeenCalled();
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
+    expect(warnLogMessages()).toEqual([
+      "stuck session recovery: sessionId=queued-reply-session sessionKey=agent:main:main age=720s action=abort_embedded_run aborted=true drained=true released=0",
+      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=0",
+    ]);
+  });
+
   it("does not release the session lane while unregistered lane work is active", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -89,7 +89,7 @@ export async function recoverStuckDiagnosticSession(
       params.sessionId && isEmbeddedPiRunHandleActive(params.sessionId)
         ? params.sessionId
         : undefined;
-    const activeSessionId = params.sessionKey
+    let activeSessionId = params.sessionKey
       ? (resolveActiveEmbeddedRunHandleSessionId(params.sessionKey) ?? fallbackActiveSessionId)
       : fallbackActiveSessionId;
     const activeWorkSessionId = params.sessionKey
@@ -131,17 +131,31 @@ export async function recoverStuckDiagnosticSession(
     }
 
     if (!activeSessionId && activeWorkSessionId && isEmbeddedPiRunActive(activeWorkSessionId)) {
-      const outcome: StuckSessionRecoveryOutcome = {
-        status: "skipped",
-        action: "keep_lane",
-        reason: "active_reply_work",
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        activeSessionId: activeWorkSessionId,
-        activeWorkKind: "embedded_run",
-      };
-      diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-      return outcome;
+      if (params.allowActiveAbort === true) {
+        const result = await abortAndDrainEmbeddedPiRun({
+          sessionId: activeWorkSessionId,
+          sessionKey: params.sessionKey,
+          settleMs: STUCK_SESSION_ABORT_SETTLE_MS,
+          forceClear: true,
+          reason: "stuck_recovery",
+        });
+        aborted = result.aborted;
+        drained = result.drained;
+        forceCleared = result.forceCleared;
+        activeSessionId = activeWorkSessionId;
+      } else {
+        const outcome: StuckSessionRecoveryOutcome = {
+          status: "skipped",
+          action: "keep_lane",
+          reason: "active_reply_work",
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          activeSessionId: activeWorkSessionId,
+          activeWorkKind: "embedded_run",
+        };
+        diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
+        return outcome;
+      }
     }
 
     if (!activeSessionId && sessionLane) {
@@ -167,8 +181,8 @@ export async function recoverStuckDiagnosticSession(
 
     const clearStaleQueuedSession = !aborted && released === 0 && (params.queueDepth ?? 0) > 0;
 
-    if (aborted || released > 0 || clearStaleQueuedSession) {
-      const action = aborted ? "abort_embedded_run" : "release_lane";
+    if (aborted || forceCleared || released > 0 || clearStaleQueuedSession) {
+      const action = aborted || forceCleared ? "abort_embedded_run" : "release_lane";
       const stoppedFields = formatStoppedCronSessionDiagnosticFields(
         resolveCronSessionDiagnosticContext({ sessionKey: params.sessionKey, activeSessionId }),
       );
@@ -179,28 +193,29 @@ export async function recoverStuckDiagnosticSession(
           stoppedFields ? ` ${stoppedFields}` : ""
         }`,
       );
-      const outcome: StuckSessionRecoveryOutcome = aborted
-        ? {
-            status: "aborted",
-            action: "abort_embedded_run",
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            activeSessionId,
-            activeWorkKind: "embedded_run",
-            aborted,
-            drained,
-            forceCleared,
-            released,
-            lane: sessionLane ?? undefined,
-          }
-        : {
-            status: "released",
-            action: "release_lane",
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            released,
-            lane: sessionLane ?? undefined,
-          };
+      const outcome: StuckSessionRecoveryOutcome =
+        aborted || forceCleared
+          ? {
+              status: "aborted",
+              action: "abort_embedded_run",
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              activeSessionId,
+              activeWorkKind: "embedded_run",
+              aborted,
+              drained,
+              forceCleared,
+              released,
+              lane: sessionLane ?? undefined,
+            }
+          : {
+              status: "released",
+              action: "release_lane",
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              released,
+              lane: sessionLane ?? undefined,
+            };
       diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
       return outcome;
     }


### PR DESCRIPTION
## What

Prevents malformed Codex app-server JSON-RPC payloads from wedging gateway reply lanes when a turn contains an unpaired UTF-16 surrogate, and lets stale reply work be abort-drained after the existing active-abort recovery threshold.

## Why

A live Telegram audio turn in topic 47 remained stuck across a gateway restart. The restart replay surfaced the underlying Codex app-server parse failure: `Failed to deserialize JSONRPCMessage: lone leading surrogate`. Recovery then kept the lane because the active work existed only as reply-work bookkeeping.

## Changes

- Sanitize Codex JSON-RPC strings
- Preserve valid surrogate pairs
- Abort stale reply work
- Add regression coverage
- Add changelog entry

## Testing

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/client.test.ts src/logging/diagnostic.test.ts src/logging/diagnostic-session-attention.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts`
- `./node_modules/.bin/oxfmt --write --threads=1 extensions/codex/src/app-server/client.ts extensions/codex/src/app-server/client.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`
- `git diff --check -- CHANGELOG.md extensions/codex/src/app-server/client.ts extensions/codex/src/app-server/client.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`

## Summary

- Problem: malformed/unpaired UTF-16 in Codex JSON-RPC could make Codex app-server reject a turn and leave topic 47 wedged.
- Why it matters: a single malformed media turn could leave Telegram typing active and block gateway reply lanes.
- What changed: app-server JSON-RPC strings are sanitized, and stale reply work can be abort-drained after the active abort threshold.
- What did NOT change (scope boundary): provider model selection, media transcription fallback behavior, and Telegram routing/dedupe policy are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A live Telegram topic 47 audio turn left OpenClaw stuck in `processing` with `active_reply_work`; after restart the same turn failed Codex app-server JSON-RPC deserialization with `lone leading surrogate`, so the gateway lane stayed blocked.
- Real environment tested: Local macOS OpenClaw gateway, live Telegram integration, OpenAI Codex app-server runtime, `/tmp/openclaw/openclaw-2026-05-14.log`.
- Exact steps or command run after this patch:
  ```sh
  node scripts/run-vitest.mjs extensions/codex/src/app-server/client.test.ts src/logging/diagnostic.test.ts src/logging/diagnostic-session-attention.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts
  tail -120 /tmp/openclaw/openclaw-2026-05-14.log
  ```
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied live output from the local gateway log after recovery:
  ```text
  2026-05-14T18:08:01.696Z debug telegram {"module":"telegram","channelId":"telegram:bot:8076018623","chatId":"-1003774691294"} telegram sendMessage ok chat=-1003774691294 message=25040
  2026-05-14T18:08:03.615Z debug telegram {"module":"telegram","channelId":"telegram:bot:8076018623","chatId":"-1003774691294"} telegram ingress: chatId=-1003774691294 dispatchCompleteMs=123449 buffer=inbound-debounce
  2026-05-14T18:08:04.177Z debug telegram {"module":"telegram","channelId":"telegram:bot:8076018623","chatId":"-1003774691294"} telegram sendMessage ok chat=-1003774691294 message=25042
  2026-05-14T18:09:52.514Z warn diagnostic {"subsystem":"diagnostic"} session liveness: active=2 waiting=0 queued=2 longest=2s keys=agent:main:telegram:group:-1003774691294:topic:47(processing/embedded_run,q=1,age=8s last=codex_app_server:notification:item/started)
  ```
- Observed result after fix: The previously wedged Telegram lane resumed sending messages, and topic 47 progressed to Codex app-server notification telemetry instead of remaining stuck at only `embedded_run:started` / `active_reply_work` with no progress.
- What was not tested: I did not run a full gateway build or full suite, and I did not replay the exact malformed audio payload through a freshly built gateway binary. The live evidence is from the current local gateway after recovery; the new unit tests cover the exact surrogate serialization and stale reply-work recovery contracts.
- Before evidence (optional but encouraged):
  ```text
  2026-05-14T17:53:23.495Z warn codex {"module":"codex","providerId":"codex","agentId":"main","sessionId":"d1f293a4-840d-4283-8f85-3e51aff00d77"} codex app-server stderr: Failed to deserialize JSONRPCMessage: lone leading surrogate in hex escape at line 1 column 165690
  2026-05-14T17:57:12.835Z warn diagnostic {"subsystem":"diagnostic"} stalled session: sessionId=unknown sessionKey=agent:main:telegram:group:-1003774691294:topic:47 state=processing age=79s queueDepth=1 reason=active_work_without_progress classification=stalled_agent_run activeWorkKind=embedded_run lastProgress=embedded_run:started lastProgressAge=75s recovery=none
  ```

## Root Cause (if applicable)

- Root cause: OpenClaw wrote JSON-RPC to Codex app-server with raw JavaScript strings; `JSON.stringify` can emit `\ud83d` / `\udc00` for unpaired UTF-16 code units, which Rust JSON decoding rejects as invalid. Recovery also treated active reply-work bookkeeping as non-abortable even when diagnostics had already made the run eligible for active abort.
- Missing detection / guardrail: There was no Codex app-server client test for well-formed outbound JSON-RPC strings, and no recovery test for `allowActiveAbort` with active reply work but no embedded handle.
- Contributing context (if known): The stalled turn came from a Telegram audio message; media understanding fallback succeeded, so the failure occurred after prompt assembly during Codex app-server handoff.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/client.test.ts`; `src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`; `src/logging/diagnostic-stuck-session-recovery.integration.test.ts`.
- Scenario the test should lock in: outbound Codex JSON-RPC strips unpaired surrogates while preserving emoji; stale reply work aborts when active abort recovery is enabled.
- Why this is the smallest reliable guardrail: The failure occurred at the JSON-RPC serialization boundary and at diagnostic recovery decision logic; both are deterministic without a live provider.
- Existing test that already covers this (if any): No previous test covered these exact paths.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Malformed or unusual text in Codex app-server turns should no longer wedge Telegram/gateway reply lanes due to invalid JSON-RPC string encoding. Stale reply work can now be abort-drained after the existing active-abort threshold.

## Diagram (if applicable)

```text
Before:
Telegram media turn -> Codex JSON-RPC with unpaired surrogate -> app-server decode error -> stale reply work keeps lane

After:
Telegram media turn -> sanitized Codex JSON-RPC -> app-server can parse
Stale reply work past abort threshold -> abort/drain recovery -> lane can clear
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Local OpenClaw gateway from this checkout; Node 22
- Model/provider: OpenAI Codex app-server runtime with `gpt-5.5`
- Integration/channel (if any): Telegram topic 47 in a group
- Relevant config (redacted): Default local gateway configuration; secrets redacted

### Steps

1. Observe live logs for the stuck Telegram topic 47 run.
2. Confirm Codex app-server rejected a JSON-RPC message with a lone leading surrogate.
3. Apply this patch and run targeted diagnostics/Codex app-server tests.
4. Confirm live Telegram output resumed from `/tmp/openclaw/openclaw-2026-05-14.log`.

### Expected

- Codex app-server JSON-RPC payloads do not contain unpaired surrogate escapes.
- Stale reply work becomes abortable after the active abort threshold.
- Gateway lanes recover instead of staying wedged.

### Actual

- Targeted tests passed.
- Live logs showed Telegram `sendMessage ok` output resumed and topic 47 had Codex app-server notification progress.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: malformed unpaired-surrogate Codex JSON-RPC serialization; stale reply-work active abort recovery; live gateway log recovery from the stuck Telegram lane.
- Edge cases checked: valid surrogate pairs/emoji are preserved while lone high and low surrogates are stripped.
- What you did **not** verify: full suite/build and exact live audio replay through a freshly built gateway binary.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Sanitizing strings removes malformed UTF-16 code units before Codex sees the prompt.
  - Mitigation: Only unpaired surrogate code units are stripped; valid surrogate pairs are preserved by regression coverage.
