### PR TITLE
fix(whatsapp): lower upload-file media sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@ Docs: https://docs.openclaw.ai
 - Agents/tools: keep the `message` tool available in embedded runs when it is explicitly allowed through `tools.alsoAllow` or runtime tool allowlists, so channel plugins with custom reply delivery can still use configured message sends. Fixes #82833. Thanks @cn1313113.
 - WhatsApp: honor forced document delivery for outbound image, GIF, and video media so `forceDocument`/`asDocument` sends preserve original media bytes instead of using compressed media payloads. (#79272) Thanks @itsuzef.
 - WhatsApp: name outbound document attachments from their MIME type when no filename is provided, so PDF and CSV sends arrive as `file.pdf` and `file.csv` instead of an extensionless `file`. Thanks @mcaxtr.
+- WhatsApp: treat `upload-file` as a supported media send intent by lowering path/URL uploads through the channel's normal send-media transport.
 - Process/diagnostics: report active lane blockers in lane wait warnings so `queueAhead=0` no longer hides commands waiting behind active work. Fixes #82791. (#82792) Thanks @galiniliev.
 - Process/diagnostics: stop counting the active processing turn as queued backlog in liveness warnings so transient max-only event-loop spikes do not surface as gateway warnings.
 - Agents/replies: classify provider conversation-state rejections and return a clear message-channel error instead of auto-resetting or falling back to a generic runner failure. (#82616) Thanks @dutifulbob.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,7 +204,6 @@ Docs: https://docs.openclaw.ai
 - Agents/tools: keep the `message` tool available in embedded runs when it is explicitly allowed through `tools.alsoAllow` or runtime tool allowlists, so channel plugins with custom reply delivery can still use configured message sends. Fixes #82833. Thanks @cn1313113.
 - WhatsApp: honor forced document delivery for outbound image, GIF, and video media so `forceDocument`/`asDocument` sends preserve original media bytes instead of using compressed media payloads. (#79272) Thanks @itsuzef.
 - WhatsApp: name outbound document attachments from their MIME type when no filename is provided, so PDF and CSV sends arrive as `file.pdf` and `file.csv` instead of an extensionless `file`. Thanks @mcaxtr.
-- WhatsApp: treat `upload-file` as a supported media send intent by lowering path/URL uploads through the channel's normal send-media transport.
 - Process/diagnostics: report active lane blockers in lane wait warnings so `queueAhead=0` no longer hides commands waiting behind active work. Fixes #82791. (#82792) Thanks @galiniliev.
 - Process/diagnostics: stop counting the active processing turn as queued backlog in liveness warnings so transient max-only event-loop spikes do not surface as gateway warnings.
 - Agents/replies: classify provider conversation-state rejections and return a clear message-channel error instead of auto-resetting or falling back to a generic runner failure. (#82616) Thanks @dutifulbob.
@@ -215,6 +214,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: bundle `openclaw/plugin-sdk/zod` into the published package artifact and verify the packed zod subpath stays self-contained, so pnpm global installs can register plugins without a package-local `zod` symlink. Fixes #78398. (#78515) Thanks @ggzeng.
 - Providers/Google: drop compaction-truncated Gemini thought signatures before replay so malformed Base64 no longer aborts the next assistant turn. (#82995) Thanks @wAngByg.
 - Gateway/mobile: allow paired iOS and Android clients to refresh same-family OS metadata on authenticated reconnect instead of requiring a new approval. (#83490) Thanks @ngutman.
+- WhatsApp: treat `upload-file` as a supported media send intent by lowering path/URL uploads through the channel's normal send-media transport. (#81883) Thanks @ngutman.
 
 ## 2026.5.17
 

--- a/extensions/whatsapp/src/channel-actions.test.ts
+++ b/extensions/whatsapp/src/channel-actions.test.ts
@@ -130,6 +130,7 @@ describe("whatsapp channel action helpers", () => {
     expect(describeWhatsAppMessageActions({ cfg, accountId: "default" })?.actions).toEqual([
       "react",
       "poll",
+      "upload-file",
     ]);
   });
 
@@ -151,6 +152,7 @@ describe("whatsapp channel action helpers", () => {
 
     expect(describeWhatsAppMessageActions({ cfg, accountId: "default" })?.actions).toEqual([
       "poll",
+      "upload-file",
     ]);
   });
 
@@ -172,6 +174,7 @@ describe("whatsapp channel action helpers", () => {
     expect(describeWhatsAppMessageActions({ cfg, accountId: "work" })?.actions).toEqual([
       "react",
       "poll",
+      "upload-file",
     ]);
   });
 
@@ -191,7 +194,11 @@ describe("whatsapp channel action helpers", () => {
     } as OpenClawConfig;
     hoisted.listWhatsAppAccountIds.mockReturnValue(["default", "work"]);
 
-    expect(describeWhatsAppMessageActions({ cfg })?.actions).toEqual(["react", "poll"]);
+    expect(describeWhatsAppMessageActions({ cfg })?.actions).toEqual([
+      "react",
+      "poll",
+      "upload-file",
+    ]);
   });
 
   it("omits react in global discovery when only disabled accounts enable agent reactions", () => {
@@ -211,6 +218,6 @@ describe("whatsapp channel action helpers", () => {
     } as OpenClawConfig;
     hoisted.listWhatsAppAccountIds.mockReturnValue(["default", "work"]);
 
-    expect(describeWhatsAppMessageActions({ cfg })?.actions).toEqual(["poll"]);
+    expect(describeWhatsAppMessageActions({ cfg })?.actions).toEqual(["poll", "upload-file"]);
   });
 });

--- a/extensions/whatsapp/src/channel-actions.ts
+++ b/extensions/whatsapp/src/channel-actions.ts
@@ -80,5 +80,6 @@ export function describeWhatsAppMessageActions(params: {
   if (gate("polls")) {
     actions.add("poll");
   }
+  actions.add("upload-file");
   return { actions: Array.from(actions) };
 }

--- a/extensions/whatsapp/src/channel-react-action.runtime.ts
+++ b/extensions/whatsapp/src/channel-react-action.runtime.ts
@@ -4,4 +4,5 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 export { resolveReactionMessageId } from "openclaw/plugin-sdk/channel-actions";
 export { handleWhatsAppAction } from "./action-runtime.js";
 export { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "./normalize.js";
+export { sendMessageWhatsApp } from "./send.js";
 export { readStringOrNumberParam, readStringParam, type OpenClawConfig };

--- a/extensions/whatsapp/src/channel-react-action.runtime.ts
+++ b/extensions/whatsapp/src/channel-react-action.runtime.ts
@@ -3,6 +3,8 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 
 export { resolveReactionMessageId } from "openclaw/plugin-sdk/channel-actions";
 export { handleWhatsAppAction } from "./action-runtime.js";
+export { resolveAuthorizedWhatsAppOutboundTarget } from "./action-runtime-target-auth.js";
+export { resolveWhatsAppAccount, resolveWhatsAppMediaMaxBytes } from "./accounts.js";
 export { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "./normalize.js";
 export { sendMessageWhatsApp } from "./send.js";
 export { readStringOrNumberParam, readStringParam, type OpenClawConfig };

--- a/extensions/whatsapp/src/channel-react-action.test.ts
+++ b/extensions/whatsapp/src/channel-react-action.test.ts
@@ -4,11 +4,16 @@ import type { OpenClawConfig } from "./runtime-api.js";
 
 const hoisted = vi.hoisted(() => ({
   handleWhatsAppAction: vi.fn(async () => ({ content: [{ type: "text", text: '{"ok":true}' }] })),
+  sendMessageWhatsApp: vi.fn(async () => ({
+    messageId: "msg-media-1",
+    toJid: "1555@s.whatsapp.net",
+  })),
 }));
 
 vi.mock("./channel-react-action.runtime.js", async () => {
   return {
     handleWhatsAppAction: hoisted.handleWhatsAppAction,
+    sendMessageWhatsApp: hoisted.sendMessageWhatsApp,
     resolveReactionMessageId: ({
       args,
       toolContext,
@@ -41,7 +46,7 @@ vi.mock("./channel-react-action.runtime.js", async () => {
     readStringParam: (
       params: Record<string, unknown>,
       key: string,
-      options?: { required?: boolean; allowEmpty?: boolean },
+      options?: { required?: boolean; allowEmpty?: boolean; trim?: boolean },
     ) => {
       const value = params[key];
       if (value == null) {
@@ -73,6 +78,72 @@ describe("whatsapp react action messageId resolution", () => {
 
   beforeEach(() => {
     hoisted.handleWhatsAppAction.mockClear();
+    hoisted.sendMessageWhatsApp.mockClear();
+  });
+
+  it("sends upload-file through the WhatsApp media send path", async () => {
+    const mediaReadFile = vi.fn(async () => Buffer.from("media"));
+
+    const result = await handleWhatsAppReactAction({
+      action: "upload-file",
+      params: {
+        to: "+1555",
+        filePath: "/tmp/pic.png",
+        caption: "picture caption",
+      },
+      cfg: baseCfg,
+      accountId: "default",
+      mediaLocalRoots: ["/tmp"],
+      mediaReadFile,
+    });
+
+    expect(hoisted.sendMessageWhatsApp).toHaveBeenCalledWith("+1555", "picture caption", {
+      verbose: false,
+      cfg: baseCfg,
+      mediaUrl: "/tmp/pic.png",
+      mediaAccess: undefined,
+      mediaLocalRoots: ["/tmp"],
+      mediaReadFile,
+      accountId: "default",
+    });
+    expect(result.details).toMatchObject({
+      ok: true,
+      channel: "whatsapp",
+      action: "upload-file",
+      messageId: "msg-media-1",
+      toJid: "1555@s.whatsapp.net",
+    });
+  });
+
+  it("rejects upload-file buffer payloads without a media path", async () => {
+    await expect(
+      handleWhatsAppReactAction({
+        action: "upload-file",
+        params: {
+          to: "+1555",
+          buffer: Buffer.from("hello").toString("base64"),
+          filename: "hello.txt",
+        },
+        cfg: baseCfg,
+        accountId: "default",
+      }),
+    ).rejects.toThrow("WhatsApp upload-file cannot send buffer payloads");
+    expect(hoisted.sendMessageWhatsApp).not.toHaveBeenCalled();
+  });
+
+  it("requires upload-file media path input", async () => {
+    await expect(
+      handleWhatsAppReactAction({
+        action: "upload-file",
+        params: {
+          to: "+1555",
+          caption: "missing media",
+        },
+        cfg: baseCfg,
+        accountId: "default",
+      }),
+    ).rejects.toThrow("WhatsApp upload-file requires media");
+    expect(hoisted.sendMessageWhatsApp).not.toHaveBeenCalled();
   });
 
   it("uses explicit messageId when provided", async () => {

--- a/extensions/whatsapp/src/channel-react-action.test.ts
+++ b/extensions/whatsapp/src/channel-react-action.test.ts
@@ -4,6 +4,20 @@ import type { OpenClawConfig } from "./runtime-api.js";
 
 const hoisted = vi.hoisted(() => ({
   handleWhatsAppAction: vi.fn(async () => ({ content: [{ type: "text", text: '{"ok":true}' }] })),
+  resolveAuthorizedWhatsAppOutboundTarget: vi.fn(
+    ({
+      chatJid,
+      accountId,
+    }: {
+      chatJid: string;
+      accountId?: string;
+    }): { to: string; accountId: string } => ({
+      to: chatJid,
+      accountId: accountId ?? "default",
+    }),
+  ),
+  resolveWhatsAppAccount: vi.fn(() => ({ accountId: "default", mediaMaxMb: 50 })),
+  resolveWhatsAppMediaMaxBytes: vi.fn(() => 50 * 1024 * 1024),
   sendMessageWhatsApp: vi.fn(async () => ({
     messageId: "msg-media-1",
     toJid: "1555@s.whatsapp.net",
@@ -13,6 +27,9 @@ const hoisted = vi.hoisted(() => ({
 vi.mock("./channel-react-action.runtime.js", async () => {
   return {
     handleWhatsAppAction: hoisted.handleWhatsAppAction,
+    resolveAuthorizedWhatsAppOutboundTarget: hoisted.resolveAuthorizedWhatsAppOutboundTarget,
+    resolveWhatsAppAccount: hoisted.resolveWhatsAppAccount,
+    resolveWhatsAppMediaMaxBytes: hoisted.resolveWhatsAppMediaMaxBytes,
     sendMessageWhatsApp: hoisted.sendMessageWhatsApp,
     resolveReactionMessageId: ({
       args,
@@ -78,6 +95,11 @@ describe("whatsapp react action messageId resolution", () => {
 
   beforeEach(() => {
     hoisted.handleWhatsAppAction.mockClear();
+    hoisted.resolveAuthorizedWhatsAppOutboundTarget.mockClear();
+    hoisted.resolveWhatsAppAccount.mockClear();
+    hoisted.resolveWhatsAppMediaMaxBytes.mockClear();
+    hoisted.resolveWhatsAppAccount.mockReturnValue({ accountId: "default", mediaMaxMb: 50 });
+    hoisted.resolveWhatsAppMediaMaxBytes.mockReturnValue(50 * 1024 * 1024);
     hoisted.sendMessageWhatsApp.mockClear();
   });
 
@@ -90,6 +112,9 @@ describe("whatsapp react action messageId resolution", () => {
         to: "+1555",
         filePath: "/tmp/pic.png",
         caption: "picture caption",
+        forceDocument: "true",
+        gifPlayback: true,
+        asVoice: "true",
       },
       cfg: baseCfg,
       accountId: "default",
@@ -97,6 +122,12 @@ describe("whatsapp react action messageId resolution", () => {
       mediaReadFile,
     });
 
+    expect(hoisted.resolveAuthorizedWhatsAppOutboundTarget).toHaveBeenCalledWith({
+      cfg: baseCfg,
+      chatJid: "+1555",
+      accountId: "default",
+      actionLabel: "upload-file",
+    });
     expect(hoisted.sendMessageWhatsApp).toHaveBeenCalledWith("+1555", "picture caption", {
       verbose: false,
       cfg: baseCfg,
@@ -104,6 +135,9 @@ describe("whatsapp react action messageId resolution", () => {
       mediaAccess: undefined,
       mediaLocalRoots: ["/tmp"],
       mediaReadFile,
+      gifPlayback: true,
+      audioAsVoice: true,
+      forceDocument: true,
       accountId: "default",
     });
     expect(result.details).toMatchObject({
@@ -115,19 +149,75 @@ describe("whatsapp react action messageId resolution", () => {
     });
   });
 
-  it("rejects upload-file buffer payloads without a media path", async () => {
+  it("does not send upload-file when target authorization fails", async () => {
+    hoisted.resolveAuthorizedWhatsAppOutboundTarget.mockImplementationOnce(() => {
+      throw new Error("WhatsApp upload-file blocked");
+    });
+
+    await expect(
+      handleWhatsAppReactAction({
+        action: "upload-file",
+        params: {
+          to: "+1555",
+          filePath: "/tmp/pic.png",
+        },
+        cfg: baseCfg,
+        accountId: "default",
+      }),
+    ).rejects.toThrow("WhatsApp upload-file blocked");
+    expect(hoisted.sendMessageWhatsApp).not.toHaveBeenCalled();
+  });
+
+  it("sends upload-file from the hydrated buffer payload", async () => {
+    await handleWhatsAppReactAction({
+      action: "upload-file",
+      params: {
+        to: "+1555",
+        buffer: Buffer.from("hello").toString("base64"),
+        contentType: "text/plain",
+        filename: "hello.txt",
+        filePath: "/tmp/hello.txt",
+        forceDocument: true,
+        message: "file caption",
+      },
+      cfg: baseCfg,
+      accountId: "default",
+    });
+
+    expect(hoisted.sendMessageWhatsApp).toHaveBeenCalledWith("+1555", "file caption", {
+      verbose: false,
+      cfg: baseCfg,
+      mediaPayload: {
+        buffer: Buffer.from("hello"),
+        contentType: "text/plain",
+        fileName: "hello.txt",
+      },
+      mediaAccess: undefined,
+      mediaLocalRoots: undefined,
+      mediaReadFile: undefined,
+      gifPlayback: undefined,
+      audioAsVoice: undefined,
+      forceDocument: true,
+      accountId: "default",
+    });
+  });
+
+  it("rejects upload-file buffers above the WhatsApp media limit", async () => {
+    hoisted.resolveWhatsAppMediaMaxBytes.mockReturnValueOnce(4);
+
     await expect(
       handleWhatsAppReactAction({
         action: "upload-file",
         params: {
           to: "+1555",
           buffer: Buffer.from("hello").toString("base64"),
+          contentType: "text/plain",
           filename: "hello.txt",
         },
         cfg: baseCfg,
         accountId: "default",
       }),
-    ).rejects.toThrow("WhatsApp upload-file cannot send buffer payloads");
+    ).rejects.toThrow("WhatsApp upload-file buffer exceeds configured media limit");
     expect(hoisted.sendMessageWhatsApp).not.toHaveBeenCalled();
   });
 

--- a/extensions/whatsapp/src/channel-react-action.ts
+++ b/extensions/whatsapp/src/channel-react-action.ts
@@ -1,3 +1,4 @@
+import { jsonResult } from "openclaw/plugin-sdk/channel-actions";
 import {
   isWhatsAppGroupJid,
   resolveReactionMessageId,
@@ -5,23 +6,83 @@ import {
   normalizeWhatsAppTarget,
   readStringOrNumberParam,
   readStringParam,
+  sendMessageWhatsApp,
   type OpenClawConfig,
 } from "./channel-react-action.runtime.js";
 
 const WHATSAPP_CHANNEL = "whatsapp" as const;
 
-export async function handleWhatsAppReactAction(params: {
+type WhatsAppMessageActionParams = {
   action: string;
   params: Record<string, unknown>;
   cfg: OpenClawConfig;
   accountId?: string | null;
   requesterSenderId?: string | null;
+  mediaAccess?: {
+    localRoots?: readonly string[];
+    readFile?: (filePath: string) => Promise<Buffer>;
+  };
+  mediaLocalRoots?: readonly string[];
+  mediaReadFile?: (filePath: string) => Promise<Buffer>;
   toolContext?: {
     currentChannelId?: string | null;
     currentChannelProvider?: string | null;
     currentMessageId?: string | number | null;
   };
-}) {
+};
+
+function readUploadFileMediaSource(args: Record<string, unknown>): string | undefined {
+  return (
+    readStringParam(args, "media", { trim: false }) ??
+    readStringParam(args, "mediaUrl", { trim: false }) ??
+    readStringParam(args, "filePath", { trim: false }) ??
+    readStringParam(args, "path", { trim: false }) ??
+    readStringParam(args, "fileUrl", { trim: false })
+  );
+}
+
+function readUploadFileCaptionText(args: Record<string, unknown>): string {
+  return (
+    readStringParam(args, "message", { allowEmpty: true }) ??
+    readStringParam(args, "content", { allowEmpty: true }) ??
+    readStringParam(args, "caption", { allowEmpty: true }) ??
+    ""
+  );
+}
+
+async function handleWhatsAppUploadFileAction(params: WhatsAppMessageActionParams) {
+  const mediaUrl = readUploadFileMediaSource(params.params);
+  if (!mediaUrl) {
+    if (readStringParam(params.params, "buffer", { trim: false })) {
+      throw new Error(
+        "WhatsApp upload-file cannot send buffer payloads. Use media, mediaUrl, filePath, path, or fileUrl instead.",
+      );
+    }
+    throw new Error("WhatsApp upload-file requires media, mediaUrl, filePath, path, or fileUrl.");
+  }
+  const to = readStringParam(params.params, "to", { required: true });
+  const result = await sendMessageWhatsApp(to, readUploadFileCaptionText(params.params), {
+    verbose: false,
+    cfg: params.cfg,
+    mediaUrl,
+    mediaAccess: params.mediaAccess,
+    mediaLocalRoots: params.mediaLocalRoots,
+    mediaReadFile: params.mediaReadFile,
+    accountId: params.accountId ?? undefined,
+  });
+  return jsonResult({
+    ok: true,
+    channel: WHATSAPP_CHANNEL,
+    action: "upload-file",
+    messageId: result.messageId,
+    toJid: result.toJid,
+  });
+}
+
+export async function handleWhatsAppMessageAction(params: WhatsAppMessageActionParams) {
+  if (params.action === "upload-file") {
+    return await handleWhatsAppUploadFileAction(params);
+  }
   if (params.action !== "react") {
     throw new Error(`Action ${params.action} is not supported for provider ${WHATSAPP_CHANNEL}.`);
   }
@@ -82,3 +143,5 @@ export async function handleWhatsAppReactAction(params: {
     params.cfg,
   );
 }
+
+export const handleWhatsAppReactAction = handleWhatsAppMessageAction;

--- a/extensions/whatsapp/src/channel-react-action.ts
+++ b/extensions/whatsapp/src/channel-react-action.ts
@@ -1,6 +1,9 @@
 import { jsonResult } from "openclaw/plugin-sdk/channel-actions";
 import {
   isWhatsAppGroupJid,
+  resolveAuthorizedWhatsAppOutboundTarget,
+  resolveWhatsAppAccount,
+  resolveWhatsAppMediaMaxBytes,
   resolveReactionMessageId,
   handleWhatsAppAction,
   normalizeWhatsAppTarget,
@@ -50,25 +53,122 @@ function readUploadFileCaptionText(args: Record<string, unknown>): string {
   );
 }
 
-async function handleWhatsAppUploadFileAction(params: WhatsAppMessageActionParams) {
-  const mediaUrl = readUploadFileMediaSource(params.params);
-  if (!mediaUrl) {
-    if (readStringParam(params.params, "buffer", { trim: false })) {
+function readBooleanParam(args: Record<string, unknown>, key: string): boolean | undefined {
+  const value = args[key];
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true") {
+    return true;
+  }
+  if (normalized === "false") {
+    return false;
+  }
+  return undefined;
+}
+
+function hasUploadFileBufferPayload(args: Record<string, unknown>): boolean {
+  return readStringParam(args, "buffer", { trim: false }) !== undefined;
+}
+
+function extractBase64Payload(encoded: string): string {
+  const match = /^data:[^;]+;base64,(.*)$/i.exec(encoded.trim());
+  return match ? match[1] : encoded;
+}
+
+function estimateBase64DecodedBytes(encoded: string): number {
+  const compact = extractBase64Payload(encoded).replace(/\s/g, "");
+  if (!compact) {
+    return 0;
+  }
+  const padding = compact.endsWith("==") ? 2 : compact.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((compact.length * 3) / 4) - padding);
+}
+
+function decodeUploadFileMediaPayload(params: {
+  args: Record<string, unknown>;
+  encoded: string;
+  maxBytes?: number;
+}):
+  | {
+      buffer: Buffer;
+      contentType?: string;
+      fileName?: string;
+    }
+  | undefined {
+  if (params.maxBytes !== undefined) {
+    const estimatedBytes = estimateBase64DecodedBytes(params.encoded);
+    if (estimatedBytes > params.maxBytes) {
       throw new Error(
-        "WhatsApp upload-file cannot send buffer payloads. Use media, mediaUrl, filePath, path, or fileUrl instead.",
+        `WhatsApp upload-file buffer exceeds configured media limit (${estimatedBytes} bytes > ${params.maxBytes} bytes).`,
       );
     }
-    throw new Error("WhatsApp upload-file requires media, mediaUrl, filePath, path, or fileUrl.");
+  }
+  const contentType =
+    readStringParam(params.args, "contentType") ?? readStringParam(params.args, "mimeType");
+  const fileName =
+    readStringParam(params.args, "filename") ?? readStringParam(params.args, "fileName");
+  const buffer = Buffer.from(extractBase64Payload(params.encoded), "base64");
+  if (params.maxBytes !== undefined && buffer.byteLength > params.maxBytes) {
+    throw new Error(
+      `WhatsApp upload-file buffer exceeds configured media limit (${buffer.byteLength} bytes > ${params.maxBytes} bytes).`,
+    );
+  }
+  return {
+    buffer,
+    ...(contentType ? { contentType } : {}),
+    ...(fileName ? { fileName } : {}),
+  };
+}
+
+async function handleWhatsAppUploadFileAction(params: WhatsAppMessageActionParams) {
+  const mediaUrl = readUploadFileMediaSource(params.params);
+  const encodedPayload = readStringParam(params.params, "buffer", { trim: false });
+  if (!mediaUrl && !hasUploadFileBufferPayload(params.params)) {
+    throw new Error(
+      "WhatsApp upload-file requires media, mediaUrl, filePath, path, fileUrl, or buffer.",
+    );
   }
   const to = readStringParam(params.params, "to", { required: true });
-  const result = await sendMessageWhatsApp(to, readUploadFileCaptionText(params.params), {
+  const resolved = resolveAuthorizedWhatsAppOutboundTarget({
+    cfg: params.cfg,
+    chatJid: to,
+    accountId: params.accountId ?? undefined,
+    actionLabel: "upload-file",
+  });
+  const account = resolveWhatsAppAccount({
+    cfg: params.cfg,
+    accountId: resolved.accountId,
+  });
+  const mediaPayload = encodedPayload
+    ? decodeUploadFileMediaPayload({
+        args: params.params,
+        encoded: encodedPayload,
+        maxBytes: resolveWhatsAppMediaMaxBytes(account),
+      })
+    : undefined;
+  const result = await sendMessageWhatsApp(resolved.to, readUploadFileCaptionText(params.params), {
     verbose: false,
     cfg: params.cfg,
-    mediaUrl,
+    ...(mediaUrl && !mediaPayload ? { mediaUrl } : {}),
+    ...(mediaPayload ? { mediaPayload } : {}),
     mediaAccess: params.mediaAccess,
     mediaLocalRoots: params.mediaLocalRoots,
     mediaReadFile: params.mediaReadFile,
-    accountId: params.accountId ?? undefined,
+    gifPlayback: readBooleanParam(params.params, "gifPlayback") ?? undefined,
+    audioAsVoice:
+      readBooleanParam(params.params, "asVoice") ??
+      readBooleanParam(params.params, "audioAsVoice") ??
+      undefined,
+    forceDocument:
+      readBooleanParam(params.params, "forceDocument") ??
+      readBooleanParam(params.params, "asDocument") ??
+      undefined,
+    accountId: resolved.accountId,
   });
   return jsonResult({
     ok: true,

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -151,17 +151,31 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
       actions: {
         describeMessageTool: ({ cfg, accountId }) =>
           describeWhatsAppMessageActions({ cfg, accountId }),
-        supportsAction: ({ action }) => action === "react",
-        resolveExecutionMode: ({ action }) => (action === "react" ? "gateway" : "local"),
-        handleAction: async ({ action, params, cfg, accountId, requesterSenderId, toolContext }) =>
+        supportsAction: ({ action }) => action === "react" || action === "upload-file",
+        resolveExecutionMode: ({ action }) =>
+          action === "react" || action === "upload-file" ? "gateway" : "local",
+        handleAction: async ({
+          action,
+          params,
+          cfg,
+          accountId,
+          requesterSenderId,
+          mediaAccess,
+          mediaLocalRoots,
+          mediaReadFile,
+          toolContext,
+        }) =>
           await (
             await loadWhatsAppChannelReactAction()
-          ).handleWhatsAppReactAction({
+          ).handleWhatsAppMessageAction({
             action,
             params,
             cfg,
             accountId,
             requesterSenderId,
+            mediaAccess,
+            mediaLocalRoots,
+            mediaReadFile,
             toolContext,
           }),
       },

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -110,14 +110,35 @@ export function normalizeWhatsAppOutboundPayload<T extends WhatsAppOutboundPaylo
   };
 }
 
+function inferWhatsAppMediaKind(
+  media: WhatsAppLoadedMediaLike,
+): "image" | "audio" | "video" | "document" {
+  if (
+    media.kind === "image" ||
+    media.kind === "audio" ||
+    media.kind === "video" ||
+    media.kind === "document"
+  ) {
+    return media.kind;
+  }
+  const contentType = normalizeContentType(media.contentType);
+  if (contentType.startsWith("image/")) {
+    return "image";
+  }
+  if (contentType.startsWith("audio/")) {
+    return "audio";
+  }
+  if (contentType.startsWith("video/")) {
+    return "video";
+  }
+  return "document";
+}
+
 function normalizeWhatsAppLoadedMedia(
   media: WhatsAppLoadedMediaLike,
   mediaUrl?: string,
 ): CanonicalWhatsAppLoadedMedia {
-  const kind =
-    media.kind === "image" || media.kind === "audio" || media.kind === "video"
-      ? media.kind
-      : "document";
+  const kind = inferWhatsAppMediaKind(media);
   const mimetype =
     kind === "audio" && isWhatsAppNativeVoiceAudio({ contentType: media.contentType, mediaUrl })
       ? WHATSAPP_VOICE_MIMETYPE

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -365,6 +365,51 @@ describe("web outbound", () => {
     });
   });
 
+  it("sends prehydrated media without loading the original media URL again", async () => {
+    const buf = Buffer.from("hydrated");
+    await sendMessageWhatsApp("+1555", "hydrated caption", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "https://one-shot.test/photo.png",
+      mediaPayload: {
+        buffer: buf,
+        contentType: "image/png",
+        fileName: "photo.png",
+      },
+    });
+
+    expect(hoisted.loadOutboundMediaFromUrl).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "hydrated caption", buf, "image/png");
+  });
+
+  it("uses prehydrated media for forced document sends", async () => {
+    const hydrated = Buffer.from("hydrated-original");
+
+    await sendMessageWhatsApp("+1555", "document caption", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/photo.png",
+      mediaPayload: {
+        buffer: hydrated,
+        contentType: "image/png",
+        fileName: "photo.png",
+      },
+      forceDocument: true,
+    });
+
+    expect(hoisted.loadOutboundMediaFromUrl).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenLastCalledWith(
+      "+1555",
+      "document caption",
+      hydrated,
+      "image/png",
+      {
+        asDocument: true,
+        fileName: "photo.png",
+      },
+    );
+  });
+
   it("maps image with caption", async () => {
     const buf = Buffer.from("img");
     loadWebMediaMock.mockResolvedValueOnce({
@@ -449,6 +494,25 @@ describe("web outbound", () => {
     });
     expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf", {
       fileName: "file.pdf",
+    });
+  });
+
+  it("keeps explicit document kind for prehydrated image payloads", async () => {
+    const buf = Buffer.from("image-as-document");
+
+    await sendMessageWhatsApp("+1555", "doc", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaPayload: {
+        buffer: buf,
+        contentType: "image/png",
+        kind: "document",
+        fileName: "photo.png",
+      },
+    });
+
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "image/png", {
+      fileName: "photo.png",
     });
   });
 

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -73,6 +73,12 @@ export async function sendMessageWhatsApp(
     };
     mediaLocalRoots?: readonly string[];
     mediaReadFile?: (filePath: string) => Promise<Buffer>;
+    mediaPayload?: {
+      buffer: Buffer;
+      contentType?: string;
+      kind?: "image" | "audio" | "video" | "document";
+      fileName?: string;
+    };
     gifPlayback?: boolean;
     audioAsVoice?: boolean;
     forceDocument?: boolean;
@@ -90,8 +96,10 @@ export async function sendMessageWhatsApp(
   let text = options.preserveLeadingWhitespace ? body : normalizeWhatsAppPayloadText(body);
   const jid = toWhatsappJid(to);
   const mediaUrls = resolveWhatsAppOutboundMediaUrls(options);
-  const primaryMediaUrl = mediaUrls[0];
-  if (!text && !primaryMediaUrl) {
+  const mediaPayload = options.mediaPayload;
+  const primaryMediaUrl = mediaUrls[0] ?? mediaPayload?.fileName;
+  const hasMedia = Boolean(mediaPayload || primaryMediaUrl);
+  if (!text && !hasMedia) {
     return { messageId: "", toJid: jid };
   }
   const correlationId = generateSecureUuid();
@@ -125,7 +133,30 @@ export async function sendMessageWhatsApp(
     let documentFileName: string | undefined;
     let visibleTextAfterVoice: string | undefined;
     let forceDocumentDelivery = false;
-    if (primaryMediaUrl) {
+    if (mediaPayload) {
+      const media = await prepareWhatsAppOutboundMedia(mediaPayload, primaryMediaUrl);
+      const caption = text || undefined;
+      mediaBuffer = media.buffer;
+      mediaType = media.mimetype;
+      forceDocumentDelivery = Boolean(
+        options.forceDocument && supportsForcedDocumentDelivery(media.kind),
+      );
+      if (media.kind === "audio" && caption) {
+        visibleTextAfterVoice = caption;
+        text = "";
+      } else if (media.kind === "document") {
+        text = caption ?? "";
+        documentFileName = media.fileName;
+      } else {
+        text = caption ?? "";
+      }
+      if (forceDocumentDelivery) {
+        documentFileName ??= resolveWhatsAppDocumentFileName({
+          fileName: media.fileName,
+          mimetype: media.mimetype,
+        });
+      }
+    } else if (primaryMediaUrl) {
       const media = await prepareWhatsAppOutboundMedia(
         await loadOutboundMediaFromUrl(primaryMediaUrl, {
           maxBytes: resolveWhatsAppMediaMaxBytes(account),
@@ -158,8 +189,8 @@ export async function sendMessageWhatsApp(
         });
       }
     }
-    outboundLog.info(`Sending message -> ${redactedJid}${primaryMediaUrl ? " (media)" : ""}`);
-    logger.info({ jid: redactedJid, hasMedia: Boolean(primaryMediaUrl) }, "sending message");
+    outboundLog.info(`Sending message -> ${redactedJid}${hasMedia ? " (media)" : ""}`);
+    logger.info({ jid: redactedJid, hasMedia }, "sending message");
     if (!isWhatsAppNewsletterJid(jid)) {
       await active.sendComposingTo(to);
     }
@@ -192,15 +223,12 @@ export async function sendMessageWhatsApp(
     const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
     const durationMs = Date.now() - startedAt;
     outboundLog.info(
-      `Sent message ${messageId} -> ${redactedJid}${primaryMediaUrl ? " (media)" : ""} (${durationMs}ms)`,
+      `Sent message ${messageId} -> ${redactedJid}${hasMedia ? " (media)" : ""} (${durationMs}ms)`,
     );
     logger.info({ jid: redactedJid, messageId }, "sent message");
     return { messageId, toJid: jid };
   } catch (err) {
-    logger.error(
-      { err: String(err), to: redactedTo, hasMedia: Boolean(primaryMediaUrl) },
-      "failed to send via web session",
-    );
+    logger.error({ err: String(err), to: redactedTo, hasMedia }, "failed to send via web session");
     throw err;
   }
 }

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -204,9 +204,11 @@ export function resolveAttachmentMediaPolicy(params: {
 function buildAttachmentMediaLoadOptions(params: {
   policy: AttachmentMediaPolicy;
   maxBytes?: number;
+  optimizeImages?: boolean;
 }):
   | {
       maxBytes?: number;
+      optimizeImages?: boolean;
       sandboxValidated: true;
       readFile: (filePath: string) => Promise<Buffer>;
     }
@@ -215,6 +217,7 @@ function buildAttachmentMediaLoadOptions(params: {
       localRoots?: readonly string[] | "any";
       readFile?: OutboundMediaReadFile;
       hostReadCapability?: boolean;
+      optimizeImages?: boolean;
     } {
   if (params.policy.mode === "sandbox") {
     const sandboxRoot = params.policy.sandboxRoot.trim();
@@ -225,6 +228,7 @@ function buildAttachmentMediaLoadOptions(params: {
     };
     return {
       maxBytes: params.maxBytes,
+      ...(params.optimizeImages !== undefined ? { optimizeImages: params.optimizeImages } : {}),
       sandboxValidated: true,
       readFile: readSandboxFile,
     };
@@ -234,6 +238,7 @@ function buildAttachmentMediaLoadOptions(params: {
     mediaAccess: params.policy.mediaAccess,
     mediaLocalRoots: params.policy.mediaLocalRoots,
     mediaReadFile: params.policy.mediaReadFile,
+    optimizeImages: params.optimizeImages,
   });
 }
 
@@ -247,6 +252,7 @@ async function hydrateAttachmentPayload(params: {
   mediaHint?: string | null;
   fileHint?: string | null;
   mediaPolicy: AttachmentMediaPolicy;
+  optimizeImages?: boolean;
 }) {
   const contentTypeParam = params.contentTypeParam ?? undefined;
   const rawBuffer = readStringParam(params.args, "buffer", { trim: false });
@@ -272,7 +278,11 @@ async function hydrateAttachmentPayload(params: {
     });
     const media = await loadWebMedia(
       mediaSource,
-      buildAttachmentMediaLoadOptions({ policy: params.mediaPolicy, maxBytes }),
+      buildAttachmentMediaLoadOptions({
+        policy: params.mediaPolicy,
+        maxBytes,
+        optimizeImages: params.optimizeImages,
+      }),
     );
     params.args.buffer = media.buffer.toString("base64");
     if (!contentTypeParam && media.contentType) {
@@ -349,6 +359,7 @@ async function hydrateAttachmentActionPayload(params: {
   /** If caption is missing, copy message -> caption. */
   allowMessageCaptionFallback?: boolean;
   mediaPolicy: AttachmentMediaPolicy;
+  optimizeImages?: boolean;
 }): Promise<void> {
   const mediaHint = readAttachmentMediaHint(params.args);
   const fileHint = readAttachmentFileHint(params.args);
@@ -373,6 +384,7 @@ async function hydrateAttachmentActionPayload(params: {
     mediaHint,
     fileHint,
     mediaPolicy: params.mediaPolicy,
+    optimizeImages: params.optimizeImages,
   });
 }
 
@@ -398,6 +410,10 @@ export async function hydrateAttachmentParamsForAction(params: {
   ) {
     return;
   }
+  const forceDocument =
+    readBooleanParamShared(params.args, "forceDocument") ??
+    readBooleanParamShared(params.args, "asDocument") ??
+    false;
   await hydrateAttachmentActionPayload({
     cfg: params.cfg,
     channel: params.channel,
@@ -405,6 +421,7 @@ export async function hydrateAttachmentParamsForAction(params: {
     args: params.args,
     dryRun: params.dryRun,
     mediaPolicy: params.mediaPolicy,
+    optimizeImages: shouldHydrateUploadFile && forceDocument ? false : undefined,
     allowMessageCaptionFallback: params.action === "sendAttachment" || shouldHydrateUploadFile,
   });
 }

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -515,6 +515,22 @@ describe("runMessageAction media behavior", () => {
       expectAttachmentRemoteMediaPayload(result);
     });
 
+    it("keeps original upload-file bytes when forced to send as a document", async () => {
+      await runMessageAction({
+        cfg,
+        action: "upload-file",
+        params: {
+          channel: "attachmentchat",
+          target: "+15551234567",
+          media: "https://example.com/pic.png",
+          message: "caption",
+          forceDocument: true,
+        },
+      });
+
+      expect(requireLoadWebMediaOptions().optimizeImages).toBe(false);
+    });
+
     it("enforces sandboxed attachment paths for attachment actions", async () => {
       for (const testCase of [
         {


### PR DESCRIPTION
## Summary

- Lower WhatsApp-targeted `message(action="upload-file")` calls with path/URL media into the existing `send` + `media` path.
- Preserve hydrated media buffers for gateway/document sends so scoped file reads are not repeated inside the WhatsApp runtime.
- Preserve explicit document media kind, and enforce WhatsApp media size limits for direct base64 buffer upload-file payloads.
- Keep WhatsApp's native action discovery unchanged; this only handles shared-message-tool calls that resolve to WhatsApp at execution time.

## Verification

- `node scripts/run-vitest.mjs extensions/whatsapp/src/channel-react-action.test.ts extensions/whatsapp/src/channel-actions.test.ts extensions/whatsapp/src/send.test.ts src/infra/outbound/message-action-runner.media.test.ts src/infra/outbound/message-action-params.test.ts`
- `pnpm plugin-sdk:api:check`
- `pnpm check:changed`
- `$codex-review`: clean after accepted review fixes
- Live source-build WhatsApp direct send from `ssh guti@100.65.30.41:~/projects/openclaw` at `d043bd519e`: `pnpm openclaw message send --channel whatsapp --target +972523594699 --media /tmp/openclaw-wa-upload-test.md --force-document --message "PR 81883 source-build live upload test" --json` returned WhatsApp message id `3EB09D321AFFE4F9F48473`.
- Live source-build WhatsApp agent/message-tool send from the same checkout using `message(action="upload-file", channel="whatsapp", filePath="/Users/guti/.openclaw/media/outbound/openclaw-wa-upload-test-source-build.md")` returned WhatsApp message id `3EB0A344E3B27AD4BE9460`.

Behavior addressed: A shared `message` tool call using `action=upload-file` with a media path/URL no longer fails after resolving to WhatsApp; it is delivered through WhatsApp's supported send-media path while preserving scoped hydrated media and document semantics.

Real environment tested: Local OpenClaw source checkout with targeted Vitest coverage and changed-file validation; remote source install running this branch at `d043bd519e` with a configured WhatsApp channel and running gateway service.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/whatsapp/src/channel-react-action.test.ts extensions/whatsapp/src/channel-actions.test.ts extensions/whatsapp/src/send.test.ts src/infra/outbound/message-action-runner.media.test.ts src/infra/outbound/message-action-params.test.ts`; `pnpm plugin-sdk:api:check`; `pnpm check:changed`; fast-forward remote source checkout, rebuild via `pnpm openclaw --version`, then run direct WhatsApp CLI media send and a WhatsApp-bound agent prompt that calls the shared `message` tool once with `action=upload-file` and a Markdown file under OpenClaw's managed media directory.

Evidence after fix: Regression tests pass for WhatsApp upload-file path lowering, hydrated buffer reuse, explicit document media kind, and buffer size enforcement. The direct source-build WhatsApp send returned message id `3EB09D321AFFE4F9F48473`; the agent/message-tool upload-file path returned tool result `{ ok: true, channel: "whatsapp", action: "upload-file", messageId: "3EB0A344E3B27AD4BE9460" }`.

Observed result after fix: Focused tests report 5 passed files / 101 passed tests. The final code review pass reported no accepted/actionable findings. The configured WhatsApp chat receives the uploaded Markdown file from both the direct CLI send path and the agent `message(action="upload-file")` path when the file is under an allowed OpenClaw media root.

What was not tested: The live WhatsApp proof used managed local Markdown files rather than a direct base64 buffer payload. Buffer payload behavior is covered by focused tests, including WhatsApp media size-limit rejection.
