### PR TITLE
fix(sessions): preserve compatible auth overrides

### DIFF
--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -1434,6 +1434,59 @@ describe("normalizeCompatibilityConfigValues", () => {
     ]);
   });
 
+  it("keeps native Ollama params prototype-safe while setting num_ctx", () => {
+    const providerParams: Record<string, unknown> = { temperature: 0.2 };
+    Object.defineProperty(providerParams, "__proto__", {
+      enumerable: true,
+      value: { think: "high" },
+    });
+    const modelParams: Record<string, unknown> = { top_p: 0.9 };
+    Object.defineProperty(modelParams, "__proto__", {
+      enumerable: true,
+      value: { keep_alive: "forever" },
+    });
+
+    const res = normalizeCompatibilityConfigValues({
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://localhost:11434",
+            api: "ollama",
+            contextWindow: 65536,
+            params: providerParams,
+            models: [
+              ollamaModel({
+                contextWindow: 32768,
+                params: modelParams,
+              }),
+            ],
+          },
+        },
+      },
+    });
+
+    const nextProviderParams = res.config.models?.providers?.ollama?.params as Record<
+      string,
+      unknown
+    >;
+    const nextModelParams = res.config.models?.providers?.ollama?.models?.[0]?.params as Record<
+      string,
+      unknown
+    >;
+    expect(Object.getPrototypeOf(nextProviderParams)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(nextModelParams)).toBe(Object.prototype);
+    expect(Object.getOwnPropertyDescriptor(nextProviderParams, "__proto__")?.value).toEqual({
+      think: "high",
+    });
+    expect(Object.getOwnPropertyDescriptor(nextModelParams, "__proto__")?.value).toEqual({
+      keep_alive: "forever",
+    });
+    expect(nextProviderParams.think).toBeUndefined();
+    expect(nextModelParams.keep_alive).toBeUndefined();
+    expect(nextProviderParams.num_ctx).toBe(65536);
+    expect(nextModelParams.num_ctx).toBe(32768);
+  });
+
   it("keeps existing provider-level native Ollama params.num_ctx ahead of inherited provider budgets", () => {
     const res = normalizeCompatibilityConfigValues({
       models: {

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -1248,7 +1248,7 @@ function applyLegacyOllamaProviderNumCtxParams(params: {
   return {
     provider: {
       ...params.provider,
-      params: rawParams ? { ...rawParams, num_ctx: numCtx } : { num_ctx: numCtx },
+      params: Object.assign({}, rawParams, { num_ctx: numCtx }),
     },
     changed: true,
   };
@@ -1327,9 +1327,9 @@ export function normalizeLegacyOllamaNativeNumCtxParams(
       changes.push(
         `Set models.providers.${sanitizeForLog(providerId)}.models[${index}].params.num_ctx to ${numCtx} for native Ollama compatibility.`,
       );
-      return Object.assign({}, model, {
-        params: rawParams ? { ...rawParams, num_ctx: numCtx } : { num_ctx: numCtx },
-      });
+      const nextModel = Object.assign({}, model);
+      nextModel.params = Object.assign({}, rawParams, { num_ctx: numCtx });
+      return nextModel;
     });
 
     if (!modelsChanged && !providerParams.changed) {

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -1248,7 +1248,7 @@ function applyLegacyOllamaProviderNumCtxParams(params: {
   return {
     provider: {
       ...params.provider,
-      params: Object.assign({}, rawParams, { num_ctx: numCtx }),
+      params: rawParams ? { ...rawParams, num_ctx: numCtx } : { num_ctx: numCtx },
     },
     changed: true,
   };
@@ -1327,9 +1327,9 @@ export function normalizeLegacyOllamaNativeNumCtxParams(
       changes.push(
         `Set models.providers.${sanitizeForLog(providerId)}.models[${index}].params.num_ctx to ${numCtx} for native Ollama compatibility.`,
       );
-      const nextModel = Object.assign({}, model);
-      nextModel.params = Object.assign({}, rawParams, { num_ctx: numCtx });
-      return nextModel;
+      return Object.assign({}, model, {
+        params: rawParams ? { ...rawParams, num_ctx: numCtx } : { num_ctx: numCtx },
+      });
     });
 
     if (!modelsChanged && !providerParams.changed) {

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "vitest";
+import { resetProviderAuthAliasMapCacheForTest } from "../agents/provider-auth-aliases.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
@@ -108,6 +109,7 @@ function createAllowlistedAnthropicModelCfg(): OpenClawConfig {
 
 describe("gateway sessions patch", () => {
   afterEach(() => {
+    resetProviderAuthAliasMapCacheForTest();
     resetPluginRuntimeStateForTest();
   });
 
@@ -297,6 +299,34 @@ describe("gateway sessions patch", () => {
     expect(entry.authProfileOverride).toBe("anthropic:default");
     expect(entry.authProfileOverrideSource).toBe("user");
     expect(entry.authProfileOverrideCompactionCount).toBe(3);
+  });
+
+  test("preserves auth overrides for provider-auth aliases when model patch changes", async () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "sess-alias",
+        updatedAt: 1,
+        providerOverride: "byteplus",
+        modelOverride: "seedance-1-0-lite-t2v-250428",
+        authProfileOverride: "byteplus:work",
+        authProfileOverrideSource: "user",
+        authProfileOverrideCompactionCount: 2,
+      } as SessionEntry,
+    };
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        patch: { key: MAIN_SESSION_KEY, model: "byteplus-plan/ark-code-latest" },
+        loadGatewayModelCatalog: async () => [
+          { provider: "byteplus-plan", id: "ark-code-latest", name: "ark-code-latest" },
+        ],
+      }),
+    );
+    expect(entry.providerOverride).toBe("byteplus-plan");
+    expect(entry.modelOverride).toBe("ark-code-latest");
+    expect(entry.authProfileOverride).toBe("byteplus:work");
+    expect(entry.authProfileOverrideSource).toBe("user");
+    expect(entry.authProfileOverrideCompactionCount).toBe(2);
   });
 
   test("clears provider-prefixed auth overrides when model patch changes provider", async () => {

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -271,7 +271,7 @@ describe("gateway sessions patch", () => {
     expectPatchError(result, "invalid elevatedLevel");
   });
 
-  test("clears auth overrides when model patch changes", async () => {
+  test("preserves same-provider auth overrides when model patch changes", async () => {
     const store: Record<string, SessionEntry> = {
       "agent:main:main": {
         sessionId: "sess",
@@ -294,6 +294,34 @@ describe("gateway sessions patch", () => {
     );
     expect(entry.providerOverride).toBe("anthropic");
     expect(entry.modelOverride).toBe("claude-sonnet-4-6");
+    expect(entry.authProfileOverride).toBe("anthropic:default");
+    expect(entry.authProfileOverrideSource).toBe("user");
+    expect(entry.authProfileOverrideCompactionCount).toBe(3);
+  });
+
+  test("clears provider-prefixed auth overrides when model patch changes provider", async () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "sess-provider-change",
+        updatedAt: 1,
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-6",
+        authProfileOverride: "anthropic:default",
+        authProfileOverrideSource: "user",
+        authProfileOverrideCompactionCount: 3,
+      } as SessionEntry,
+    };
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        patch: { key: MAIN_SESSION_KEY, model: "openai/gpt-5.4" },
+        loadGatewayModelCatalog: async () => [
+          { provider: "openai", id: "gpt-5.4", name: "gpt-5.4" },
+        ],
+      }),
+    );
+    expect(entry.providerOverride).toBe("openai");
+    expect(entry.modelOverride).toBe("gpt-5.4");
     expect(entry.authProfileOverride).toBeUndefined();
     expect(entry.authProfileOverrideSource).toBeUndefined();
     expect(entry.authProfileOverrideCompactionCount).toBeUndefined();

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -329,6 +329,95 @@ describe("gateway sessions patch", () => {
     expect(entry.authProfileOverrideCompactionCount).toBe(2);
   });
 
+  test("preserves unprefixed auth overrides when existing provider matches model patch", async () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "sess-unprefixed-same-provider",
+        updatedAt: 1,
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-6",
+        authProfileOverride: "work",
+        authProfileOverrideSource: "user",
+        authProfileOverrideCompactionCount: 4,
+      } as SessionEntry,
+    };
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        patch: { key: MAIN_SESSION_KEY, model: "anthropic/claude-sonnet-4-6" },
+        loadGatewayModelCatalog: async () => [
+          { provider: "anthropic", id: "claude-sonnet-4-6", name: "sonnet" },
+        ],
+      }),
+    );
+    expect(entry.providerOverride).toBe("anthropic");
+    expect(entry.modelOverride).toBe("claude-sonnet-4-6");
+    expect(entry.authProfileOverride).toBe("work");
+    expect(entry.authProfileOverrideSource).toBe("user");
+    expect(entry.authProfileOverrideCompactionCount).toBe(4);
+  });
+
+  test("preserves unprefixed auth overrides when existing provider is the default", async () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "sess-unprefixed-default-provider",
+        updatedAt: 1,
+        authProfileOverride: "work",
+        authProfileOverrideSource: "user",
+        authProfileOverrideCompactionCount: 4,
+      } as SessionEntry,
+    };
+    const entry = expectPatchOk(
+      await runPatch({
+        cfg: {
+          agents: {
+            defaults: {
+              model: { primary: "anthropic/claude-opus-4-6" },
+            },
+          },
+        } as OpenClawConfig,
+        store,
+        patch: { key: MAIN_SESSION_KEY, model: "anthropic/claude-sonnet-4-6" },
+        loadGatewayModelCatalog: async () => [
+          { provider: "anthropic", id: "claude-sonnet-4-6", name: "sonnet" },
+        ],
+      }),
+    );
+    expect(entry.providerOverride).toBe("anthropic");
+    expect(entry.modelOverride).toBe("claude-sonnet-4-6");
+    expect(entry.authProfileOverride).toBe("work");
+    expect(entry.authProfileOverrideSource).toBe("user");
+    expect(entry.authProfileOverrideCompactionCount).toBe(4);
+  });
+
+  test("clears unprefixed auth overrides when model patch changes provider", async () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "sess-unprefixed-provider-change",
+        updatedAt: 1,
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-6",
+        authProfileOverride: "work",
+        authProfileOverrideSource: "user",
+        authProfileOverrideCompactionCount: 4,
+      } as SessionEntry,
+    };
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        patch: { key: MAIN_SESSION_KEY, model: "openai/gpt-5.4" },
+        loadGatewayModelCatalog: async () => [
+          { provider: "openai", id: "gpt-5.4", name: "gpt-5.4" },
+        ],
+      }),
+    );
+    expect(entry.providerOverride).toBe("openai");
+    expect(entry.modelOverride).toBe("gpt-5.4");
+    expect(entry.authProfileOverride).toBeUndefined();
+    expect(entry.authProfileOverrideSource).toBeUndefined();
+    expect(entry.authProfileOverrideCompactionCount).toBeUndefined();
+  });
+
   test("clears provider-prefixed auth overrides when model patch changes provider", async () => {
     const store: Record<string, SessionEntry> = {
       "agent:main:main": {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -74,6 +74,7 @@ function normalizeExecAsk(raw: string): "off" | "on-miss" | "always" | undefined
 function shouldPreserveSessionAuthProfileOverride(params: {
   cfg: OpenClawConfig;
   entry: SessionEntry;
+  currentProvider: string;
   provider: string;
 }): boolean {
   const profileOverride = normalizeOptionalString(params.entry.authProfileOverride);
@@ -84,9 +85,19 @@ function shouldPreserveSessionAuthProfileOverride(params: {
   if (!provider) {
     return false;
   }
+  const resolvesToTargetProvider = (rawProvider: string | undefined): boolean => {
+    const candidate = normalizeOptionalLowercaseString(rawProvider);
+    if (!candidate) {
+      return false;
+    }
+    return (
+      resolveProviderIdForAuth(candidate, { config: params.cfg }) ===
+      resolveProviderIdForAuth(provider, { config: params.cfg })
+    );
+  };
   const delimiterIndex = profileOverride.indexOf(":");
   if (delimiterIndex < 0) {
-    return true;
+    return resolvesToTargetProvider(params.currentProvider);
   }
   const profileProvider = normalizeOptionalLowercaseString(
     profileOverride.slice(0, delimiterIndex),
@@ -94,10 +105,7 @@ function shouldPreserveSessionAuthProfileOverride(params: {
   if (!profileProvider) {
     return false;
   }
-  return (
-    resolveProviderIdForAuth(profileProvider, { config: params.cfg }) ===
-    resolveProviderIdForAuth(provider, { config: params.cfg })
-  );
+  return resolvesToTargetProvider(profileProvider);
 }
 
 function supportsSpawnLineage(storeKey: string): boolean {
@@ -493,6 +501,7 @@ export async function applySessionsPatchToStore(params: {
         },
         preserveAuthProfileOverride: shouldPreserveSessionAuthProfileOverride({
           cfg,
+          currentProvider: next.providerOverride ?? next.modelProvider ?? resolvedDefault.provider,
           entry: next,
           provider: resolvedDefault.provider,
         }),
@@ -538,6 +547,7 @@ export async function applySessionsPatchToStore(params: {
         },
         preserveAuthProfileOverride: shouldPreserveSessionAuthProfileOverride({
           cfg,
+          currentProvider: next.providerOverride ?? next.modelProvider ?? resolvedDefault.provider,
           entry: next,
           provider: resolved.ref.provider,
         }),

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -70,6 +70,28 @@ function normalizeExecAsk(raw: string): "off" | "on-miss" | "always" | undefined
   return undefined;
 }
 
+function shouldPreserveSessionAuthProfileOverride(params: {
+  entry: SessionEntry;
+  provider: string;
+}): boolean {
+  const profileOverride = normalizeOptionalString(params.entry.authProfileOverride);
+  if (!profileOverride) {
+    return false;
+  }
+  const provider = normalizeOptionalLowercaseString(params.provider);
+  if (!provider) {
+    return false;
+  }
+  const delimiterIndex = profileOverride.indexOf(":");
+  if (delimiterIndex < 0) {
+    return true;
+  }
+  const profileProvider = normalizeOptionalLowercaseString(
+    profileOverride.slice(0, delimiterIndex),
+  );
+  return profileProvider === provider;
+}
+
 function supportsSpawnLineage(storeKey: string): boolean {
   return isSubagentSessionKey(storeKey) || isAcpSessionKey(storeKey);
 }
@@ -461,6 +483,10 @@ export async function applySessionsPatchToStore(params: {
           model: resolvedDefault.model,
           isDefault: true,
         },
+        preserveAuthProfileOverride: shouldPreserveSessionAuthProfileOverride({
+          entry: next,
+          provider: resolvedDefault.provider,
+        }),
         markLiveSwitchPending: true,
       });
     } else if (raw !== undefined) {
@@ -501,6 +527,10 @@ export async function applySessionsPatchToStore(params: {
           model: resolved.ref.model,
           isDefault,
         },
+        preserveAuthProfileOverride: shouldPreserveSessionAuthProfileOverride({
+          entry: next,
+          provider: resolved.ref.provider,
+        }),
         markLiveSwitchPending: true,
       });
     }

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -10,6 +10,7 @@ import {
   resolveDefaultModelForAgent,
   resolveSubagentConfiguredModelSelection,
 } from "../agents/model-selection.js";
+import { resolveProviderIdForAuth } from "../agents/provider-auth-aliases.js";
 import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import {
   formatThinkingLevels,
@@ -71,6 +72,7 @@ function normalizeExecAsk(raw: string): "off" | "on-miss" | "always" | undefined
 }
 
 function shouldPreserveSessionAuthProfileOverride(params: {
+  cfg: OpenClawConfig;
   entry: SessionEntry;
   provider: string;
 }): boolean {
@@ -89,7 +91,13 @@ function shouldPreserveSessionAuthProfileOverride(params: {
   const profileProvider = normalizeOptionalLowercaseString(
     profileOverride.slice(0, delimiterIndex),
   );
-  return profileProvider === provider;
+  if (!profileProvider) {
+    return false;
+  }
+  return (
+    resolveProviderIdForAuth(profileProvider, { config: params.cfg }) ===
+    resolveProviderIdForAuth(provider, { config: params.cfg })
+  );
 }
 
 function supportsSpawnLineage(storeKey: string): boolean {
@@ -484,6 +492,7 @@ export async function applySessionsPatchToStore(params: {
           isDefault: true,
         },
         preserveAuthProfileOverride: shouldPreserveSessionAuthProfileOverride({
+          cfg,
           entry: next,
           provider: resolvedDefault.provider,
         }),
@@ -528,6 +537,7 @@ export async function applySessionsPatchToStore(params: {
           isDefault,
         },
         preserveAuthProfileOverride: shouldPreserveSessionAuthProfileOverride({
+          cfg,
           entry: next,
           provider: resolved.ref.provider,
         }),

--- a/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
@@ -95,9 +95,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
 
     expect(body).toContain("<!-- mantis-telegram-desktop-proof -->");
     expect(body).toContain("## Mantis Telegram Desktop Proof");
-    expect(body).toContain(
-      "- Baseline: `pass` at `aaa`, expected baseline visual proof captured",
-    );
+    expect(body).toContain("- Baseline: `pass` at `aaa`, expected baseline visual proof captured");
     expect(body).toContain(
       "- Candidate: `pass` at `bbb`, expected candidate visual proof captured",
     );

--- a/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
@@ -82,8 +82,9 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     expect(manifest.artifacts.map((artifact) => artifact.targetPath)).toContain(
       "candidate/telegram-desktop-proof.gif",
     );
+    const artifactUrl = "https://github.com/openclaw/openclaw/actions/runs/1/artifacts/2";
     const body = renderEvidenceComment({
-      artifactUrl: "https://github.com/openclaw/openclaw/actions/runs/1/artifacts/2",
+      artifactUrl,
       manifest,
       marker: "<!-- mantis-telegram-desktop-proof -->",
       rawBase: "https://qa.openclaw.ai/mantis/telegram-desktop/pr-1/run-1",
@@ -92,9 +93,15 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
       treeUrl: "https://qa.openclaw.ai/mantis/telegram-desktop/pr-1/run-1/index.json",
     });
 
+    expect(body).toContain("<!-- mantis-telegram-desktop-proof -->");
+    expect(body).toContain("## Mantis Telegram Desktop Proof");
     expect(body).toContain(
-      "- Artifact: https://github.com/openclaw/openclaw/actions/runs/1/artifacts/2",
+      "- Baseline: `pass` at `aaa`, expected baseline visual proof captured",
     );
+    expect(body).toContain(
+      "- Candidate: `pass` at `bbb`, expected candidate visual proof captured",
+    );
+    expect(body).toContain(`- Artifact: ${artifactUrl}`);
     expect(body).toContain('<table width="100%">');
     expect(body).toContain(
       '<img src="https://qa.openclaw.ai/mantis/telegram-desktop/pr-1/run-1/baseline/telegram-desktop-proof.gif" width="100%"',


### PR DESCRIPTION
## Summary

- Preserve an existing session auth profile when `sessions.patch` switches to another model for the same provider.
- Continue clearing provider-prefixed auth profiles when the patched model changes to a different provider.
- Add gateway regression coverage for both same-provider preservation and cross-provider cleanup.

Fixes #81837.

## Real behavior proof

- Behavior or issue addressed: Dashboard/Control UI model switches call `sessions.patch` with only a model ref; that path no longer drops a compatible `authProfileOverride` and no longer forces the selected model into an auth failure/fallback path.
- Real environment tested: Local OpenClaw checkout on macOS using the real `applySessionsPatchToStore` implementation from `src/gateway/sessions-patch.ts`.
- Exact steps or command run after this patch: Ran `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx --input-type=module` with a local proof harness that applies two `sessions.patch` model updates to real session entries: Anthropic-to-Anthropic and Anthropic-to-OpenAI.
- Evidence after fix: Console output from the local OpenClaw `sessions.patch` proof harness:

```json
{
  "sameProvider": {
    "providerOverride": "anthropic",
    "modelOverride": "claude-sonnet-4-6",
    "authProfileOverride": "anthropic:default",
    "authProfileOverrideSource": "user",
    "authProfileOverrideCompactionCount": 3,
    "liveModelSwitchPending": true
  },
  "providerChange": {
    "providerOverride": "openai",
    "modelOverride": "gpt-5.4",
    "authProfileOverride": null,
    "authProfileOverrideSource": null,
    "authProfileOverrideCompactionCount": null,
    "liveModelSwitchPending": true
  }
}
```

- Observed result after fix: A same-provider model patch from `anthropic/claude-opus-4-6` to `anthropic/claude-sonnet-4-6` preserved `authProfileOverride: "anthropic:default"`, while a patch from Anthropic to OpenAI cleared the provider-prefixed auth profile.
- What was not tested: Live browser Dashboard interaction against a running gateway; the proof exercises the server-side `sessions.patch` RPC implementation used by the Dashboard.

## Validation

- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm test src/gateway/sessions-patch.test.ts src/sessions/model-overrides.test.ts src/auto-reply/reply/directive-handling.model.test.ts src/agents/auth-profiles/session-override.test.ts`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec oxfmt --check --threads=1 src/gateway/sessions-patch.ts src/gateway/sessions-patch.test.ts`
- `git diff --check`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm check:changed -- --base upstream/main --head HEAD`

## Notes

Local Homebrew Node is currently missing `libsimdjson.31.dylib`, so validation and proof commands used the bundled Node runtime path shown above. If this PR is squashed or reworked, please preserve author attribution or include:

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
