### PR TITLE
Stream Codex preambles in channel progress drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/i18n: add a `pnpm ui:i18n:report` baseline report for hardcoded-copy focus areas and locale fallback metadata. (#81320) Thanks @samzong.
 - Maintainer tooling: add a repo-local `codex-review` skill for Codex closeout reviews, including local dirty-work and PR-branch review helpers that rerun until no accepted/actionable findings remain and avoid unsupported inline prompts with `--base`.
 - Maintainer tooling: fail CI when pull requests add package patch files or pnpm patched dependencies, preserving the upstream-and-bump dependency workflow.
+- Codex app-server: stream commentary preambles into editable channel progress drafts without promoting them to final answers.
 - Amazon Bedrock: externalize the Bedrock and Bedrock Mantle provider packages so core installs no longer pull AWS SDK dependencies unless those providers are installed.
 - Plugins: externalize Slack, OpenShell sandbox, and Anthropic Vertex so their runtime dependency cones install only when those plugins are installed.
 - Codex migration: remove the bundled `codex-cli` backend and repair legacy `codex-cli/*` model refs to the Codex app-server route on `openai/*`.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-2d533ebe2e617002a98ef4f24dc663fdbdd07bdd5a920d16900f8500f359118c  plugin-sdk-api-baseline.json
-4899b67cb4eec8814e39c2700a917d4231a7eac9522b40edee2649cc10b445d0  plugin-sdk-api-baseline.jsonl
+9a5b14ebb8d1443ebf4620a811e7de0099a71f7891de8a6a5330fd12b3417d70  plugin-sdk-api-baseline.json
+d28f0cba321bf267bfb10e4ee4d4639655dc92899b9f889b8b552397a7f01a1d  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-1cf7ca2ee1db3bf44682c487c780c6b1c47bbce27e74fb6f455cef445544c84f  plugin-sdk-api-baseline.json
-24b8e3e4773579e5a184dd5f91a5ad2f8e92519b6fe314820a94d7a64bd1141e  plugin-sdk-api-baseline.jsonl
+2d533ebe2e617002a98ef4f24dc663fdbdd07bdd5a920d16900f8500f359118c  plugin-sdk-api-baseline.json
+4899b67cb4eec8814e39c2700a917d4231a7eac9522b40edee2649cc10b445d0  plugin-sdk-api-baseline.jsonl

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -315,7 +315,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `streaming.preview.commandText` controls command/exec detail inside those tool-progress lines: `raw` (default, preserves released behavior) or `status` (tool label only)
     - legacy `channels.telegram.streamMode` and boolean `streaming` values are detected; run `openclaw doctor --fix` to migrate them to `channels.telegram.streaming.mode`
 
-    Tool-progress preview updates are the short status lines shown while tools run, for example command execution, file reads, planning updates, or patch summaries. Telegram keeps these enabled by default to match released OpenClaw behavior from `v2026.4.22` and later. To keep the edited preview for answer text but hide tool-progress lines, set:
+    Tool-progress preview updates are the short status lines shown while tools run, for example command execution, file reads, planning updates, patch summaries, or Codex preamble/commentary text in Codex app-server mode. Telegram keeps these enabled by default to match released OpenClaw behavior from `v2026.4.22` and later. To keep the edited preview for answer text but hide tool-progress lines, set:
 
     ```json
     {

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -195,11 +195,11 @@ Matrix:
 
 ### Tool-progress preview updates
 
-Preview streaming can also include **tool-progress** updates - short status lines like "searching the web", "reading file", or "calling tool" - that appear in the same preview message while tools are running, ahead of the final reply. This keeps multi-step tool turns visually alive rather than silent between the first thinking preview and the final answer.
+Preview streaming can also include **tool-progress** updates - short status lines like "searching the web", "reading file", or "calling tool" - that appear in the same preview message while tools are running, ahead of the final reply. In Codex app-server mode, Codex preamble/commentary messages use this same preview path, so short "I am checking..." progress notes can stream into the editable draft without becoming part of the final answer. This keeps multi-step tool turns visually alive rather than silent between the first thinking preview and the final answer.
 
 Supported surfaces:
 
-- **Discord**, **Slack**, **Telegram**, and **Matrix** stream tool-progress into the live preview edit by default when preview streaming is active. Microsoft Teams uses its native progress stream in personal chats.
+- **Discord**, **Slack**, **Telegram**, and **Matrix** stream tool-progress and Codex preamble updates into the live preview edit by default when preview streaming is active. Microsoft Teams uses its native progress stream in personal chats.
 - Telegram has shipped with tool-progress preview updates enabled since `v2026.4.22`; keeping them enabled preserves that released behavior.
 - **Mattermost** already folds tool activity into its single draft preview post (see above).
 - Tool-progress edits follow the active preview streaming mode; they are skipped when preview streaming is `off` or when block streaming has taken over the message. On Telegram, `streaming.mode: "off"` is final-only: generic progress chatter is also suppressed instead of being delivered as standalone status messages, while approval prompts, media payloads, and errors still route normally.

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -679,6 +679,99 @@ describe("CodexAppServerEventProjector", () => {
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("checking thread context");
   });
 
+  it("streams commentary agent messages as keyed progress events", async () => {
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+      onPartialReply,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "agentMessage",
+          id: "msg-commentary",
+          phase: "commentary",
+          text: "",
+        },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("Checking", "msg-commentary"));
+    await projector.handleNotification(
+      agentMessageDelta(" the app-server stream", "msg-commentary"),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "agentMessage",
+          id: "msg-commentary",
+          phase: "commentary",
+          text: "Checking the app-server stream",
+        },
+        {
+          type: "agentMessage",
+          id: "msg-final",
+          phase: "final_answer",
+          text: "final answer",
+        },
+      ]),
+    );
+
+    const progressEvents = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.stream === "item" && event.data.kind === "preamble");
+
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(progressEvents.map((event) => event.data)).toEqual([
+      {
+        itemId: "msg-commentary",
+        kind: "preamble",
+        title: "Preamble",
+        phase: "update",
+        progressText: "Checking",
+        source: "codex-app-server",
+      },
+      {
+        itemId: "msg-commentary",
+        kind: "preamble",
+        title: "Preamble",
+        phase: "update",
+        progressText: "Checking the app-server stream",
+        source: "codex-app-server",
+      },
+    ]);
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual(["final answer"]);
+  });
+
+  it("does not resolve commentary-phase assistant text as the final reply", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "agentMessage",
+          id: "msg-final",
+          phase: "final_answer",
+          text: "final answer",
+        },
+        {
+          type: "agentMessage",
+          id: "msg-commentary",
+          phase: "commentary",
+          text: "I am checking one more thing.",
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.assistantTexts).toEqual(["final answer"]);
+  });
+
   it("ignores notifications for other turns", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -108,6 +108,8 @@ type ToolTranscriptResultInput = {
 export class CodexAppServerEventProjector {
   private readonly assistantTextByItem = new Map<string, string>();
   private readonly assistantItemOrder: string[] = [];
+  private readonly assistantPhaseByItem = new Map<string, string>();
+  private readonly lastCommentaryProgressTextByItem = new Map<string, string>();
   private readonly reasoningTextByItem = new Map<string, string>();
   private readonly planTextByItem = new Map<string, string>();
   private readonly activeItemIds = new Set<string>();
@@ -395,6 +397,9 @@ export class CodexAppServerEventProjector {
     this.rememberAssistantItem(itemId);
     const text = `${this.assistantTextByItem.get(itemId) ?? ""}${delta}`;
     this.assistantTextByItem.set(itemId, text);
+    if (this.isCommentaryAssistantItem(itemId)) {
+      this.emitCommentaryProgress({ itemId, text });
+    }
     // Codex app-server can emit multiple agentMessage items per turn, including
     // intermediate coordination/progress prose. Keep those deltas internal until
     // turn completion chooses the last assistant item as the user-visible reply.
@@ -445,6 +450,7 @@ export class CodexAppServerEventProjector {
   private async handleItemStarted(params: JsonObject): Promise<void> {
     const item = readItem(params.item);
     const itemId = item?.id ?? readString(params, "itemId") ?? readString(params, "id");
+    this.rememberAssistantPhase(item);
     if (itemId) {
       this.activeItemIds.add(itemId);
     }
@@ -492,9 +498,13 @@ export class CodexAppServerEventProjector {
       this.activeItemIds.delete(itemId);
       this.completedItemIds.add(itemId);
     }
+    this.rememberAssistantPhase(item);
     if (item?.type === "agentMessage" && typeof item.text === "string" && item.text) {
       this.rememberAssistantItem(item.id);
       this.assistantTextByItem.set(item.id, item.text);
+      if (this.isCommentaryAssistantItem(item.id)) {
+        this.emitCommentaryProgress({ itemId: item.id, text: item.text });
+      }
     }
     this.recordNativeGeneratedMedia(item);
     if (item?.type === "plan" && typeof item.text === "string" && item.text) {
@@ -628,6 +638,7 @@ export class CodexAppServerEventProjector {
       this.promptErrorSource = "prompt";
     }
     for (const item of turn.items ?? []) {
+      this.rememberAssistantPhase(item);
       if (item.type === "agentMessage" && typeof item.text === "string" && item.text) {
         this.rememberAssistantItem(item.id);
         this.assistantTextByItem.set(item.id, item.text);
@@ -751,6 +762,42 @@ export class CodexAppServerEventProjector {
         source: "codex-app-server",
         ...(params.explanation ? { explanation: params.explanation } : {}),
         ...(params.steps && params.steps.length > 0 ? { steps: params.steps } : {}),
+      },
+    });
+  }
+
+  private rememberAssistantPhase(item: CodexThreadItem | undefined): void {
+    if (item?.type !== "agentMessage") {
+      return;
+    }
+    const phase = readItemString(item, "phase");
+    if (phase) {
+      this.assistantPhaseByItem.set(item.id, phase);
+    }
+  }
+
+  private isCommentaryAssistantItem(itemId: string): boolean {
+    return this.assistantPhaseByItem.get(itemId) === "commentary";
+  }
+
+  private emitCommentaryProgress(params: { itemId: string; text: string }): void {
+    const progressText = params.text.replace(/\s+/g, " ").trim();
+    if (
+      !progressText ||
+      this.lastCommentaryProgressTextByItem.get(params.itemId) === progressText
+    ) {
+      return;
+    }
+    this.lastCommentaryProgressTextByItem.set(params.itemId, progressText);
+    this.emitAgentEvent({
+      stream: "item",
+      data: {
+        itemId: params.itemId,
+        kind: "preamble",
+        title: "Preamble",
+        phase: "update",
+        progressText,
+        source: "codex-app-server",
       },
     });
   }
@@ -1118,6 +1165,9 @@ export class CodexAppServerEventProjector {
         continue;
       }
       const text = this.assistantTextByItem.get(itemId)?.trim();
+      if (this.assistantPhaseByItem.get(itemId) === "commentary") {
+        continue;
+      }
       if (text && !this.toolProgressTexts.has(text)) {
         return text;
       }

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -4,6 +4,8 @@ import {
   type ChannelProgressDraftLine,
   formatChannelProgressDraftText,
   isChannelProgressDraftWorkToolName,
+  mergeChannelProgressDraftLine,
+  normalizeChannelProgressDraftLineIdentity,
   resolveChannelProgressDraftMaxLines,
   resolveChannelStreamingBlockEnabled,
   resolveChannelStreamingPreviewToolProgress,
@@ -173,7 +175,7 @@ export function createDiscordDraftPreviewController(params: {
       if (isEmptyDiscordProgressLine(line)) {
         return;
       }
-      const normalized = normalizeProgressLineIdentity(line);
+      const normalized = normalizeChannelProgressDraftLineIdentity(line);
       if (!normalized) {
         return;
       }
@@ -183,13 +185,13 @@ export function createDiscordDraftPreviewController(params: {
         if (!previewToolProgressEnabled || previewToolProgressSuppressed) {
           return;
         }
-        const previous = normalizeProgressLineIdentity(previewToolProgressLines.at(-1));
-        if (previous === normalized) {
+        const nextLines = mergeChannelProgressDraftLine(previewToolProgressLines, progressLine, {
+          maxLines: resolveChannelProgressDraftMaxLines(params.discordConfig),
+        });
+        if (nextLines === previewToolProgressLines) {
           return;
         }
-        previewToolProgressLines = [...previewToolProgressLines, progressLine].slice(
-          -resolveChannelProgressDraftMaxLines(params.discordConfig),
-        );
+        previewToolProgressLines = nextLines;
         const previewText = formatChannelProgressDraftText({
           entry: params.discordConfig,
           lines: previewToolProgressLines,
@@ -203,12 +205,13 @@ export function createDiscordDraftPreviewController(params: {
         return;
       }
       if (previewToolProgressEnabled && !previewToolProgressSuppressed && normalized) {
-        const previous = normalizeProgressLineIdentity(previewToolProgressLines.at(-1));
-        if (previous !== normalized) {
-          previewToolProgressLines = [...previewToolProgressLines, progressLine].slice(
-            -resolveChannelProgressDraftMaxLines(params.discordConfig),
-          );
-        }
+        previewToolProgressLines = mergeChannelProgressDraftLine(
+          previewToolProgressLines,
+          progressLine,
+          {
+            maxLines: resolveChannelProgressDraftMaxLines(params.discordConfig),
+          },
+        );
       }
       const alreadyStarted = progressDraftGate.hasStarted;
       if (shouldStartDiscordProgressDraftNow(line)) {
@@ -404,13 +407,6 @@ function mergeReasoningProgressText(current: string, incoming: string): string {
 
 function isReasoningSnapshotText(text: string): boolean {
   return /^\s*(?:>\s*)?Reasoning:\s*/i.test(text);
-}
-
-function normalizeProgressLineIdentity(
-  line: string | ChannelProgressDraftLine | undefined,
-): string {
-  const text = typeof line === "string" ? line : line?.text;
-  return text?.replace(/\s+/g, " ").trim() ?? "";
 }
 
 function isEmptyDiscordProgressLine(line: string | ChannelProgressDraftLine | undefined): boolean {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -709,6 +709,7 @@ export async function processDiscordMessage(
                   await draftPreview.pushToolProgress(
                     buildChannelProgressDraftLineForEntry(discordConfig, {
                       event: "item",
+                      itemId: payload.itemId,
                       itemKind: payload.kind,
                       title: payload.title,
                       name: payload.name,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -5,11 +5,15 @@ import {
   type MessageReceipt,
 } from "openclaw/plugin-sdk/channel-message";
 import {
+  buildChannelProgressDraftLineForEntry,
   createChannelProgressDraftGate,
+  type ChannelProgressDraftLine,
   formatChannelProgressDraftLine,
   formatChannelProgressDraftLineForEntry,
   formatChannelProgressDraftText,
   isChannelProgressDraftWorkToolName,
+  mergeChannelProgressDraftLine,
+  normalizeChannelProgressDraftLineIdentity,
   resolveChannelProgressDraftMaxLines,
 } from "openclaw/plugin-sdk/channel-streaming";
 import {
@@ -1493,7 +1497,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const latestQueuedDraftBoundaryOffsets = new Map<number, number>();
       let currentDraftReplyToId = draftReplyToId;
       let previewToolProgressSuppressed = false;
-      let previewToolProgressLines: string[] = [];
+      let previewToolProgressLines: Array<string | ChannelProgressDraftLine> = [];
       const progressConfigEntry = params.accountConfig ?? cfg.channels?.matrix;
       const progressSeed = `${_route.accountId}:${roomId}`;
       // Set after the first final payload consumes or discards the draft event
@@ -1519,7 +1523,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         onStart: renderProgressDraft,
       });
 
-      const pushPreviewToolProgress = async (line?: string, options?: { toolName?: string }) => {
+      const pushPreviewToolProgress = async (
+        line?: string | ChannelProgressDraftLine,
+        options?: { toolName?: string },
+      ) => {
         if (!draftStream) {
           return;
         }
@@ -1529,18 +1536,19 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         ) {
           return;
         }
-        const normalized = line?.replace(/\s+/g, " ").trim();
+        const normalized = normalizeChannelProgressDraftLineIdentity(line);
+        const progressLine = typeof line === "object" && line !== undefined ? line : normalized;
         if (!progressDraftStreaming) {
           if (!shouldStreamPreviewToolProgress || previewToolProgressSuppressed || !normalized) {
             return;
           }
-          const previous = previewToolProgressLines.at(-1);
-          if (previous === normalized) {
+          const nextLines = mergeChannelProgressDraftLine(previewToolProgressLines, progressLine, {
+            maxLines: resolveChannelProgressDraftMaxLines(progressConfigEntry),
+          });
+          if (nextLines === previewToolProgressLines) {
             return;
           }
-          previewToolProgressLines = [...previewToolProgressLines, normalized].slice(
-            -resolveChannelProgressDraftMaxLines(progressConfigEntry),
-          );
+          previewToolProgressLines = nextLines;
           draftStream.update(
             formatChannelProgressDraftText({
               entry: progressConfigEntry,
@@ -1553,12 +1561,13 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           return;
         }
         if (shouldStreamPreviewToolProgress && !previewToolProgressSuppressed && normalized) {
-          const previous = previewToolProgressLines.at(-1);
-          if (previous !== normalized) {
-            previewToolProgressLines = [...previewToolProgressLines, normalized].slice(
-              -resolveChannelProgressDraftMaxLines(progressConfigEntry),
-            );
-          }
+          previewToolProgressLines = mergeChannelProgressDraftLine(
+            previewToolProgressLines,
+            progressLine,
+            {
+              maxLines: resolveChannelProgressDraftMaxLines(progressConfigEntry),
+            },
+          );
         }
         const alreadyStarted = progressDraftGate.hasStarted;
         await progressDraftGate.noteWork();
@@ -1610,8 +1619,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           },
           onItemEvent: async (payload) => {
             await pushPreviewToolProgress(
-              formatChannelProgressDraftLineForEntry(progressConfigEntry, {
+              buildChannelProgressDraftLineForEntry(progressConfigEntry, {
                 event: "item",
+                itemId: payload.itemId,
                 itemKind: payload.kind,
                 title: payload.title,
                 name: payload.name,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -2,7 +2,10 @@ import {
   defineFinalizableLivePreviewAdapter,
   deliverWithFinalizableLivePreviewAdapter,
 } from "openclaw/plugin-sdk/channel-message";
-import { resolveChannelStreamingPreviewToolProgress } from "openclaw/plugin-sdk/channel-streaming";
+import {
+  formatChannelProgressDraftLineForEntry,
+  resolveChannelStreamingPreviewToolProgress,
+} from "openclaw/plugin-sdk/channel-streaming";
 import { isLoopbackHost } from "openclaw/plugin-sdk/gateway-runtime";
 import { createClaimableDedupe, type ClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
 import { isReasoningReplyPayload } from "openclaw/plugin-sdk/reply-payload";
@@ -1861,6 +1864,29 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                                 config: account.config,
                               }),
                             );
+                          },
+                          onItemEvent: async (payload) => {
+                            if (!draftToolProgressEnabled) {
+                              return;
+                            }
+                            const progressText = formatChannelProgressDraftLineForEntry(
+                              account.config,
+                              {
+                                event: "item",
+                                itemId: payload.itemId,
+                                itemKind: payload.kind,
+                                title: payload.title,
+                                name: payload.name,
+                                phase: payload.phase,
+                                status: payload.status,
+                                summary: payload.summary,
+                                progressText: payload.progressText,
+                                meta: payload.meta,
+                              },
+                            );
+                            if (progressText) {
+                              draftStream.update(progressText);
+                            }
                           },
                         },
                       }),

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -399,6 +399,7 @@ export function createMSTeamsReplyDispatcher(params: {
               );
             },
             onItemEvent: async (payload: {
+              itemId?: string;
               kind?: string;
               progressText?: string;
               meta?: string;
@@ -411,6 +412,7 @@ export function createMSTeamsReplyDispatcher(params: {
               await streamController.pushProgressLine(
                 buildChannelProgressDraftLineForEntry(msteamsCfg, {
                   event: "item",
+                  itemId: payload.itemId,
                   itemKind: payload.kind,
                   title: payload.title,
                   name: payload.name,

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -11,6 +11,8 @@ import {
   type ChannelProgressDraftLine,
   formatChannelProgressDraftText,
   isChannelProgressDraftWorkToolName,
+  mergeChannelProgressDraftLine,
+  normalizeChannelProgressDraftLineIdentity,
   resolveChannelPreviewStreamMode,
   resolveChannelProgressDraftMaxLines,
   resolveChannelProgressDraftLabel,
@@ -136,16 +138,13 @@ export function createTeamsReplyStreamController(params: {
       return;
     }
     if (shouldStreamPreviewToolProgress) {
-      const normalized = normalizeProgressLineIdentity(line);
+      const normalized = normalizeChannelProgressDraftLineIdentity(line);
       if (normalized) {
-        const previous = normalizeProgressLineIdentity(progressLines.at(-1));
-        if (previous !== normalized) {
-          const progressLine: string | ChannelProgressDraftLine =
-            typeof line === "object" && line !== undefined ? line : normalized;
-          progressLines = [...progressLines, progressLine].slice(
-            -resolveChannelProgressDraftMaxLines(params.msteamsConfig),
-          );
-        }
+        const progressLine: string | ChannelProgressDraftLine =
+          typeof line === "object" && line !== undefined ? line : normalized;
+        progressLines = mergeChannelProgressDraftLine(progressLines, progressLine, {
+          maxLines: resolveChannelProgressDraftMaxLines(params.msteamsConfig),
+        });
       }
     }
     await noteProgressWork();
@@ -332,11 +331,4 @@ export function createTeamsReplyStreamController(params: {
       return streamReceivedTokens;
     },
   };
-}
-
-function normalizeProgressLineIdentity(
-  line: string | ChannelProgressDraftLine | undefined,
-): string {
-  const text = typeof line === "string" ? line : line?.text;
-  return text?.replace(/\s+/g, " ").trim() ?? "";
 }

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -463,6 +463,25 @@ vi.mock("openclaw/plugin-sdk/channel-streaming", () => ({
   resolveChannelProgressDraftMaxLines: (entry?: {
     streaming?: { progress?: { maxLines?: number } };
   }) => entry?.streaming?.progress?.maxLines ?? 8,
+  mergeChannelProgressDraftLine: <TLine extends string | { id?: string; text: string }>(
+    lines: TLine[],
+    line: TLine,
+    params: { maxLines: number },
+  ) => {
+    const normalized = typeof line === "string" ? line.trim() : line.text.trim();
+    const lineId = typeof line === "object" ? line.id : undefined;
+    if (lineId) {
+      const index = lines.findIndex((entry) => typeof entry === "object" && entry.id === lineId);
+      if (index >= 0) {
+        const next = [...lines];
+        next[index] = line;
+        return next.slice(-params.maxLines);
+      }
+    }
+    const previous = lines.at(-1);
+    const previousText = typeof previous === "string" ? previous.trim() : previous?.text.trim();
+    return previousText === normalized ? lines : [...lines, line].slice(-params.maxLines);
+  },
   resolveChannelProgressDraftRender: (entry?: {
     streaming?: { progress?: { render?: "text" | "rich" } };
   }) => entry?.streaming?.progress?.render ?? "text",

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -19,6 +19,7 @@ import {
   createChannelProgressDraftGate,
   formatChannelProgressDraftText,
   isChannelProgressDraftWorkToolName,
+  mergeChannelProgressDraftLine,
   resolveChannelProgressDraftMaxLines,
   resolveChannelProgressDraftLabel,
   resolveChannelProgressDraftRender,
@@ -1061,13 +1062,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       if (!previewToolProgressEnabled || previewToolProgressSuppressed) {
         return;
       }
-      const previous = previewToolProgressLines.at(-1);
-      if (previous?.text === normalized) {
+      const nextLines = mergeChannelProgressDraftLine(previewToolProgressLines, line, {
+        maxLines: resolveChannelProgressDraftMaxLines(account.config),
+      });
+      if (nextLines === previewToolProgressLines) {
         return;
       }
-      previewToolProgressLines = [...previewToolProgressLines, line].slice(
-        -resolveChannelProgressDraftMaxLines(account.config),
-      );
+      previewToolProgressLines = nextLines;
       draftStream.update(
         formatChannelProgressDraftText({
           entry: account.config,
@@ -1080,12 +1081,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       return;
     }
     if (previewToolProgressEnabled && !previewToolProgressSuppressed) {
-      const previous = previewToolProgressLines.at(-1);
-      if (previous?.text !== normalized) {
-        previewToolProgressLines = [...previewToolProgressLines, line].slice(
-          -resolveChannelProgressDraftMaxLines(account.config),
-        );
-      }
+      previewToolProgressLines = mergeChannelProgressDraftLine(previewToolProgressLines, line, {
+        maxLines: resolveChannelProgressDraftMaxLines(account.config),
+      });
     }
     const alreadyStarted = progressDraftGate.hasStarted;
     await progressDraftGate.noteWork();
@@ -1234,6 +1232,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
                   await pushPreviewToolProgress(
                     buildChannelProgressDraftLineForEntry(account.config, {
                       event: "item",
+                      itemId: payload.itemId,
                       itemKind: payload.kind,
                       title: payload.title,
                       name: payload.name,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -15,11 +15,14 @@ import {
   deriveDurableFinalDeliveryRequirements,
 } from "openclaw/plugin-sdk/channel-message";
 import {
+  buildChannelProgressDraftLineForEntry,
   createChannelProgressDraftGate,
+  type ChannelProgressDraftLine,
   formatChannelProgressDraftLine,
   formatChannelProgressDraftLineForEntry,
   formatChannelProgressDraftText,
   isChannelProgressDraftWorkToolName,
+  mergeChannelProgressDraftLine,
   resolveChannelProgressDraftMaxLines,
   resolveChannelStreamingBlockEnabled,
   resolveChannelStreamingPreviewToolProgress,
@@ -586,7 +589,7 @@ export const dispatchTelegramMessage = async ({
   const streamToolProgressEnabled =
     Boolean(answerLane.stream) && resolveChannelStreamingPreviewToolProgress(telegramCfg);
   let streamToolProgressSuppressed = false;
-  let streamToolProgressLines: string[] = [];
+  let streamToolProgressLines: Array<string | ChannelProgressDraftLine> = [];
   let lastAnswerPartialText = "";
   let activeAnswerDraftIsToolProgressOnly = false;
   function resetAnswerToolProgressDraft() {
@@ -627,7 +630,7 @@ export const dispatchTelegramMessage = async ({
     onStart: () => renderProgressDraft({ flush: true }),
   });
   const pushStreamToolProgress = async (
-    line?: string,
+    line?: string | ChannelProgressDraftLine,
     options?: { toolName?: string; startImmediately?: boolean },
   ) => {
     if (!answerLane.stream) {
@@ -636,18 +639,21 @@ export const dispatchTelegramMessage = async ({
     if (options?.toolName !== undefined && !isChannelProgressDraftWorkToolName(options.toolName)) {
       return;
     }
-    const normalized = sanitizeProgressMarkdownText(line?.replace(/\s+/g, " ").trim() ?? "");
+    const rawText = typeof line === "string" ? line : line?.text;
+    const normalized = sanitizeProgressMarkdownText(rawText?.replace(/\s+/g, " ").trim() ?? "");
+    const progressLine =
+      typeof line === "object" && line !== undefined ? { ...line, text: normalized } : normalized;
     if (streamMode !== "progress") {
       if (!streamToolProgressEnabled || streamToolProgressSuppressed || !normalized) {
         return;
       }
-      const previous = streamToolProgressLines.at(-1);
-      if (previous === normalized) {
+      const nextLines = mergeChannelProgressDraftLine(streamToolProgressLines, progressLine, {
+        maxLines: resolveChannelProgressDraftMaxLines(telegramCfg),
+      });
+      if (nextLines === streamToolProgressLines) {
         return;
       }
-      streamToolProgressLines = [...streamToolProgressLines, normalized].slice(
-        -resolveChannelProgressDraftMaxLines(telegramCfg),
-      );
+      streamToolProgressLines = nextLines;
       const streamText = formatChannelProgressDraftText({
         entry: telegramCfg,
         lines: streamToolProgressLines,
@@ -662,12 +668,13 @@ export const dispatchTelegramMessage = async ({
       return;
     }
     if (streamToolProgressEnabled && !streamToolProgressSuppressed && normalized) {
-      const previous = streamToolProgressLines.at(-1);
-      if (previous !== normalized) {
-        streamToolProgressLines = [...streamToolProgressLines, normalized].slice(
-          -resolveChannelProgressDraftMaxLines(telegramCfg),
-        );
-      }
+      streamToolProgressLines = mergeChannelProgressDraftLine(
+        streamToolProgressLines,
+        progressLine,
+        {
+          maxLines: resolveChannelProgressDraftMaxLines(telegramCfg),
+        },
+      );
     }
     if (
       options?.startImmediately &&
@@ -1490,8 +1497,9 @@ export const dispatchTelegramMessage = async ({
                   },
                   onItemEvent: async (payload) => {
                     await pushStreamToolProgress(
-                      formatChannelProgressDraftLineForEntry(telegramCfg, {
+                      buildChannelProgressDraftLineForEntry(telegramCfg, {
                         event: "item",
+                        itemId: payload.itemId,
                         itemKind: payload.kind,
                         title: payload.title,
                         name: payload.name,

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -8,6 +8,7 @@ import {
   formatChannelProgressDraftText,
   getChannelStreamingConfigObject,
   isChannelProgressDraftWorkToolName,
+  mergeChannelProgressDraftLine,
   resolveChannelPreviewStreamMode,
   resolveChannelProgressDraftLabel,
   resolveChannelProgressDraftMaxLines,
@@ -393,6 +394,42 @@ describe("channel-streaming", () => {
         progressText: "Reading the code path",
       }),
     ).toBe("Reading the code path");
+  });
+
+  it("updates keyed progress lines in place", () => {
+    const first = buildChannelProgressDraftLine({
+      event: "item",
+      itemId: "preamble-1",
+      itemKind: "preamble",
+      title: "Preamble",
+      progressText: "Checking the",
+    });
+    const second = buildChannelProgressDraftLine({
+      event: "item",
+      itemId: "preamble-1",
+      itemKind: "preamble",
+      title: "Preamble",
+      progressText: "Checking the app-server stream",
+    });
+    if (!first || !second) {
+      throw new Error("expected preamble progress lines");
+    }
+
+    const initialLines: Array<string | typeof first> = ["🛠️ Exec"];
+    const lines = mergeChannelProgressDraftLine(initialLines, first, { maxLines: 4 });
+    const updated = mergeChannelProgressDraftLine(lines, second, { maxLines: 4 });
+
+    expect(updated).toHaveLength(2);
+    expect(updated.at(-1)).toMatchObject({
+      id: "preamble-1",
+      text: "Checking the app-server stream",
+    });
+    expect(
+      formatChannelProgressDraftText({
+        lines: updated,
+        entry: { streaming: { progress: { label: false } } },
+      }),
+    ).toBe("🛠️ Exec\n• Checking the app-server stream");
   });
 
   it("starts progress drafts after five seconds or a second work event", async () => {

--- a/src/plugin-sdk/channel-streaming.ts
+++ b/src/plugin-sdk/channel-streaming.ts
@@ -149,6 +149,7 @@ export type ChannelProgressDraftLineInput =
     }
   | {
       event: "item";
+      itemId?: string;
       itemKind?: string;
       title?: string;
       name?: string;
@@ -195,6 +196,7 @@ export type ChannelProgressDraftLineInput =
 export type ChannelProgressDraftLineKind = ChannelProgressDraftLineInput["event"];
 
 export type ChannelProgressDraftLine = {
+  id?: string;
   kind: ChannelProgressDraftLineKind;
   text: string;
   label: string;
@@ -371,6 +373,7 @@ export function buildChannelProgressDraftLine(
       const text = compactStrings([meta, input.title]).at(0);
       return text
         ? {
+            ...(input.itemId ? { id: input.itemId } : {}),
             kind: input.event,
             text,
             label: input.title?.trim() || input.itemKind?.trim() || "Update",
@@ -796,6 +799,44 @@ function getProgressDraftLineText(line: string | ChannelProgressDraftLine): stri
     return text;
   }
   return `${prefix}${label}`.trim();
+}
+
+export function normalizeChannelProgressDraftLineIdentity(
+  line: string | ChannelProgressDraftLine | undefined,
+): string {
+  const text = typeof line === "string" ? line : line?.text;
+  return text?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+export function mergeChannelProgressDraftLine<TLine extends string | ChannelProgressDraftLine>(
+  lines: TLine[],
+  line: TLine,
+  params: { maxLines: number },
+): TLine[] {
+  const normalized = normalizeChannelProgressDraftLineIdentity(line);
+  if (!normalized) {
+    return lines;
+  }
+  const maxLines = Math.max(1, params.maxLines);
+  const lineId = typeof line === "object" ? line.id?.trim() : undefined;
+  if (lineId) {
+    const existingIndex = lines.findIndex(
+      (entry) => typeof entry === "object" && entry.id?.trim() === lineId,
+    );
+    if (existingIndex >= 0) {
+      if (normalizeChannelProgressDraftLineIdentity(lines[existingIndex]) === normalized) {
+        return lines;
+      }
+      const next = [...lines];
+      next[existingIndex] = line;
+      return next.slice(-maxLines);
+    }
+  }
+  const previous = normalizeChannelProgressDraftLineIdentity(lines.at(-1));
+  if (previous === normalized) {
+    return lines;
+  }
+  return [...lines, line].slice(-maxLines);
 }
 
 export function formatChannelProgressDraftText(params: {

--- a/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
@@ -83,22 +83,28 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
       "candidate/telegram-desktop-proof.gif",
     );
     const body = renderEvidenceComment({
+      artifactUrl: "https://github.com/openclaw/openclaw/actions/runs/1/artifacts/2",
       artifactRoot: "mantis/telegram-desktop/pr-1/run-1",
       manifest,
       marker: "<!-- mantis-telegram-desktop-proof -->",
-      rawBase:
-        "https://raw.githubusercontent.com/openclaw/openclaw/qa-artifacts/mantis/telegram-desktop/pr-1/run-1",
       requestSource: "workflow_dispatch",
       runUrl: "https://github.com/openclaw/openclaw/actions/runs/1",
       treeUrl:
         "https://github.com/openclaw/openclaw/tree/qa-artifacts/mantis/telegram-desktop/pr-1/run-1",
     });
 
+    expect(body).toContain(
+      "- Artifact: https://github.com/openclaw/openclaw/actions/runs/1/artifacts/2",
+    );
     expect(body).toContain("Artifact files:");
     expect(body).toContain("- Main: `baseline/telegram-desktop-proof.gif`");
     expect(body).toContain("- This PR: `candidate/telegram-desktop-proof.gif`");
     expect(body).toContain("baseline/telegram-desktop-proof.gif");
     expect(body).toContain("candidate/telegram-desktop-proof.gif");
+    expect(body).toContain(
+      "Raw QA files: https://github.com/openclaw/openclaw/actions/runs/1/artifacts/2",
+    );
+    expect(body).not.toContain("<img ");
     expect(body).not.toContain("| Main | This PR |");
   });
 });


### PR DESCRIPTION
## Summary

Codex app-server already marks preamble and progress narration as commentary-phase agent messages. OpenClaw was preserving those messages internally, so channel progress drafts could show tools but not Codex's own "I am checking..." narration.

This teaches the Codex projector to remember agent-message phases from item lifecycle events, stream commentary deltas as keyed progress updates, and keep commentary out of final reply selection. The shared progress renderer now supports stable line ids so one preamble updates in place instead of stacking partial prefixes, and the edit-capable channel surfaces pass those ids through.

The streaming docs and changelog now describe Codex preambles as part of the tool-progress preview path.

<img width="1702" height="986" alt="image" src="https://github.com/user-attachments/assets/7f2f575b-f0cc-41eb-83ea-e1677b455b27" />
