### PR TITLE
fix: address high-priority ops findings

### DIFF
--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -38,6 +38,7 @@ jobs:
           OPENGREP_VERSION: v1.19.0
           OPENGREP_INSTALL_SHA: 9a4c0a68220618441608cd2bad4ff2eddccf8113
         run: |
+          set -euo pipefail
           curl -fsSL "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
             | bash -s -- -v "$OPENGREP_VERSION"
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4134,6 +4134,48 @@ describe("QmdMemoryManager", () => {
     readFileSpy.mockRestore();
   });
 
+  it("destroys bounded qmd read streams after early line-window exit", async () => {
+    const text = Array.from({ length: 50 }, (_, index) => `line-${index + 1}`).join("\n");
+    const relPath = path.join("memory", "stream-window.md");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, relPath), text, "utf-8");
+
+    const openedHandles: Array<Awaited<ReturnType<typeof fs.open>>> = [];
+    const streamDestroySpy = vi.fn();
+    const realOpen = fs.open.bind(fs);
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      openedHandles.push(handle);
+      const realCreateReadStream = handle.createReadStream.bind(handle);
+      vi.spyOn(handle, "createReadStream").mockImplementation((options) => {
+        const stream = realCreateReadStream(options);
+        const realDestroy = stream.destroy.bind(stream);
+        vi.spyOn(stream, "destroy").mockImplementation((error?: Error) => {
+          streamDestroySpy();
+          return realDestroy(error);
+        });
+        return stream;
+      });
+      return handle;
+    });
+
+    const { manager } = await createManager();
+
+    try {
+      await manager.readFile({ relPath, from: 10, lines: 3 });
+
+      expect(openedHandles).toHaveLength(1);
+      expect(openedHandles[0]?.createReadStream).toHaveBeenCalledWith({
+        encoding: "utf-8",
+        autoClose: false,
+      });
+      expect(streamDestroySpy).toHaveBeenCalled();
+    } finally {
+      await manager.close();
+      openSpy.mockRestore();
+    }
+  });
+
   it("returns a bounded default excerpt for qmd memory reads without explicit lines", async () => {
     const relPath = path.join("memory", "default-window.md");
     await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2159,7 +2159,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
       throw err;
     }
-    const stream = handle.createReadStream({ encoding: "utf-8" });
+    const stream = handle.createReadStream({ encoding: "utf-8", autoClose: false });
     const rl = readline.createInterface({
       input: stream,
       crlfDelay: Infinity,
@@ -2181,6 +2181,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
     } finally {
       rl.close();
+      stream.destroy();
       await handle.close();
     }
     return {

--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -289,6 +289,42 @@ describe("web session", () => {
     expect(passed.defaultQueryTimeoutMs).toBe(120_000);
   });
 
+  it("chunks large auth key reads between event loop turns", async () => {
+    vi.stubEnv("OPENCLAW_WHATSAPP_AUTH_KEY_READ_CHUNK_SIZE", "2");
+    const get = vi.fn(async (type: string, ids: string[]) =>
+      Object.fromEntries(ids.map((id) => [id, `${type}:${id}`])),
+    );
+    useMultiFileAuthStateMock.mockResolvedValueOnce({
+      state: {
+        creds: {} as never,
+        keys: {
+          get: get as never,
+          set: vi.fn(),
+        },
+      },
+      saveCreds: vi.fn(),
+    });
+
+    await createWaSocket(false, false);
+
+    const makeCacheableSignalKeyStore = baileys.makeCacheableSignalKeyStore as ReturnType<
+      typeof vi.fn
+    >;
+    const wrappedKeys = makeCacheableSignalKeyStore.mock.calls[0]?.[0] as {
+      get: (type: "session", ids: string[]) => Promise<Record<string, string>>;
+    };
+    const result = await wrappedKeys.get("session", ["a", "b", "c", "d", "e"]);
+
+    expect(result).toEqual({
+      a: "session:a",
+      b: "session:b",
+      c: "session:c",
+      d: "session:d",
+      e: "session:e",
+    });
+    expect(get.mock.calls.map(([, ids]) => ids)).toEqual([["a", "b"], ["c", "d"], ["e"]]);
+  });
+
   it("uses ambient env proxy agent when HTTPS_PROXY is configured", async () => {
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
 

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import type { Agent } from "node:https";
+import type { SignalDataTypeMap, SignalKeyStore } from "baileys";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import { VERSION } from "openclaw/plugin-sdk/cli-runtime";
@@ -65,8 +66,56 @@ export type { CredsQueueWaitResult } from "./creds-persistence.js";
 
 const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
 const WHATSAPP_WEBSOCKET_PROXY_TARGET = "https://mmg.whatsapp.net/";
+export const WHATSAPP_AUTH_KEY_READ_CHUNK_SIZE_ENV = "OPENCLAW_WHATSAPP_AUTH_KEY_READ_CHUNK_SIZE";
+const DEFAULT_WHATSAPP_AUTH_KEY_READ_CHUNK_SIZE = 32;
 const CREDS_FLUSH_TIMEOUT_MESSAGE =
   "Queued WhatsApp creds save did not finish before auth bootstrap; skipping repair and continuing with primary creds.";
+
+function resolveWhatsAppAuthKeyReadChunkSize(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[WHATSAPP_AUTH_KEY_READ_CHUNK_SIZE_ENV]?.trim();
+  if (!raw) {
+    return DEFAULT_WHATSAPP_AUTH_KEY_READ_CHUNK_SIZE;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_WHATSAPP_AUTH_KEY_READ_CHUNK_SIZE;
+  }
+  return parsed > 0 ? parsed : Number.MAX_SAFE_INTEGER;
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+export function createYieldingSignalKeyStore(
+  store: SignalKeyStore,
+  options: {
+    chunkSize?: number;
+    yieldBetweenChunks?: () => Promise<void>;
+  } = {},
+): SignalKeyStore {
+  const chunkSize = options.chunkSize ?? resolveWhatsAppAuthKeyReadChunkSize();
+  const yieldBetweenChunks = options.yieldBetweenChunks ?? yieldToEventLoop;
+  return {
+    ...store,
+    async get<T extends keyof SignalDataTypeMap>(type: T, ids: string[]) {
+      if (ids.length <= chunkSize) {
+        return await store.get(type, ids);
+      }
+      const result: Record<string, SignalDataTypeMap[T]> = {};
+      for (let offset = 0; offset < ids.length; offset += chunkSize) {
+        const chunk = ids.slice(offset, offset + chunkSize);
+        Object.assign(result, await store.get(type, chunk));
+        if (offset + chunkSize < ids.length) {
+          await yieldBetweenChunks();
+        }
+      }
+      return result;
+    },
+  };
+}
 
 function enqueueSaveCreds(
   authDir: string,
@@ -166,7 +215,7 @@ export async function createWaSocket(
   const sock = makeWASocket({
     auth: {
       creds: state.creds,
-      keys: makeCacheableSignalKeyStore(state.keys, logger),
+      keys: makeCacheableSignalKeyStore(createYieldingSignalKeyStore(state.keys), logger),
     },
     version,
     logger,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -17,7 +17,7 @@ import {
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import { classifyFailoverReason } from "../pi-embedded-helpers.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
-import { applySkillEnvOverridesFromSnapshot } from "../skills.js";
+import { applySkillEnvOverridesFromSnapshot, getActiveSkillEnvKeys } from "../skills.js";
 import { runClaudeLiveSessionTurn, shouldUseClaudeLiveSession } from "./claude-live-session.js";
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
 import {
@@ -386,9 +386,11 @@ export async function executePreparedCliRun(
           isTruthyEnvValue(process.env[CLI_BACKEND_LOG_OUTPUT_ENV]) ||
           isTruthyEnvValue(process.env[LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV]);
         const env = (() => {
+          const activeSkillEnvKeys = getActiveSkillEnvKeys();
           const next = sanitizeHostExecEnv({
             baseEnv: process.env,
             blockPathOverrides: true,
+            blockedInheritedKeys: activeSkillEnvKeys,
           });
           const preservedEnv = parseCliBackendPreserveEnv(process.env[CLI_BACKEND_PRESERVE_ENV]);
           for (const key of backend.clearEnv ?? []) {
@@ -404,6 +406,7 @@ export async function executePreparedCliRun(
                 baseEnv: {},
                 overrides: backend.env,
                 blockPathOverrides: true,
+                blockedInheritedKeys: activeSkillEnvKeys,
               }),
             );
           }

--- a/src/agents/pi-bundle-lsp-runtime.ts
+++ b/src/agents/pi-bundle-lsp-runtime.ts
@@ -16,6 +16,7 @@ import {
   describeStdioMcpServerLaunchConfig,
   type StdioMcpServerLaunchConfig,
 } from "./mcp-stdio.js";
+import { getActiveSkillEnvKeys } from "./skills.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 // Minimal LSP JSON-RPC framing over stdio (Content-Length header + JSON body).
@@ -70,7 +71,11 @@ function delay(ms: number): Promise<void> {
 }
 
 export function spawnLspServerProcess(config: StdioMcpServerLaunchConfig): ChildProcess {
-  const mergedEnv = sanitizeHostExecEnv({ baseEnv: process.env, overrides: config.env ?? null });
+  const mergedEnv = sanitizeHostExecEnv({
+    baseEnv: process.env,
+    overrides: config.env ?? null,
+    blockedInheritedKeys: getActiveSkillEnvKeys(),
+  });
   const program = resolveWindowsSpawnProgram({
     command: config.command,
     env: mergedEnv,

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -17,6 +17,7 @@ export {
 export {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
+  getActiveSkillEnvKeys,
 } from "./skills/env-overrides.js";
 export type {
   OpenClawSkillMetadata,

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -16,6 +16,7 @@ type ExecApprovalsModule = typeof import("./exec-approvals.js");
 let addAllowlistEntry: ExecApprovalsModule["addAllowlistEntry"];
 let addDurableCommandApproval: ExecApprovalsModule["addDurableCommandApproval"];
 let ensureExecApprovals: ExecApprovalsModule["ensureExecApprovals"];
+let loadExecApprovals: ExecApprovalsModule["loadExecApprovals"];
 let mergeExecApprovalsSocketDefaults: ExecApprovalsModule["mergeExecApprovalsSocketDefaults"];
 let normalizeExecApprovals: ExecApprovalsModule["normalizeExecApprovals"];
 let persistAllowAlwaysPatterns: ExecApprovalsModule["persistAllowAlwaysPatterns"];
@@ -35,6 +36,7 @@ beforeAll(async () => {
     addAllowlistEntry,
     addDurableCommandApproval,
     ensureExecApprovals,
+    loadExecApprovals,
     mergeExecApprovalsSocketDefaults,
     normalizeExecApprovals,
     persistAllowAlwaysPatterns,
@@ -173,6 +175,40 @@ describe("exec approvals store helpers", () => {
     expect(invalid.exists).toBe(true);
     expect(invalid.raw).toBe("{invalid");
     expect(invalid.file).toEqual(normalizeExecApprovals({ version: 1, agents: {} }));
+  });
+
+  it("treats read-time ENOENT as a missing approvals snapshot", () => {
+    const dir = createHomeDir();
+    fs.mkdirSync(path.dirname(approvalsFilePath(dir)), { recursive: true });
+    fs.writeFileSync(approvalsFilePath(dir), '{"version":1,"agents":{}}\n', "utf8");
+    const actualReadFileSync = fs.readFileSync.bind(fs);
+    vi.spyOn(fs, "readFileSync").mockImplementation((file, options) => {
+      if (String(file) === approvalsFilePath(dir)) {
+        throw Object.assign(new Error("swapped away before read"), { code: "ENOENT" });
+      }
+      return actualReadFileSync(file, options as never);
+    });
+
+    const snapshot = readExecApprovalsSnapshot();
+
+    expect(snapshot.exists).toBe(false);
+    expect(snapshot.raw).toBeNull();
+    expect(snapshot.file).toEqual(normalizeExecApprovals({ version: 1, agents: {} }));
+  });
+
+  it("does not silently ignore non-missing approvals read errors", () => {
+    const dir = createHomeDir();
+    fs.mkdirSync(path.dirname(approvalsFilePath(dir)), { recursive: true });
+    fs.writeFileSync(approvalsFilePath(dir), '{"version":1,"agents":{}}\n', "utf8");
+    const actualReadFileSync = fs.readFileSync.bind(fs);
+    vi.spyOn(fs, "readFileSync").mockImplementation((file, options) => {
+      if (String(file) === approvalsFilePath(dir)) {
+        throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+      }
+      return actualReadFileSync(file, options as never);
+    });
+
+    expect(() => loadExecApprovals()).toThrow(/permission denied/);
   });
 
   it("ensures approvals file with default socket path and generated token", () => {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -651,7 +651,13 @@ function generateToken(): string {
 
 export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
   const filePath = resolveExecApprovalsPath();
-  if (!fs.existsSync(filePath)) {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
     const file = normalizeExecApprovals({ version: 1, agents: {} });
     return {
       path: filePath,
@@ -661,7 +667,6 @@ export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
       hash: hashExecApprovalsRaw(null),
     };
   }
-  const raw = fs.readFileSync(filePath, "utf8");
   let parsed: ExecApprovalsFile | null = null;
   try {
     parsed = JSON.parse(raw) as ExecApprovalsFile;
@@ -683,11 +688,16 @@ export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
 
 export function loadExecApprovals(): ExecApprovalsFile {
   const filePath = resolveExecApprovalsPath();
+  let raw: string;
   try {
-    if (!fs.existsSync(filePath)) {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return normalizeExecApprovals({ version: 1, agents: {} });
     }
-    const raw = fs.readFileSync(filePath, "utf8");
+    throw err;
+  }
+  try {
     const parsed = JSON.parse(raw) as ExecApprovalsFile;
     if (parsed?.version !== 1) {
       return normalizeExecApprovals({ version: 1, agents: {} });

--- a/src/infra/host-env-security.ts
+++ b/src/infra/host-env-security.ts
@@ -207,11 +207,18 @@ export function sanitizeHostExecEnvWithDiagnostics(params?: {
   baseEnv?: Record<string, string | undefined>;
   overrides?: Record<string, string> | null;
   blockPathOverrides?: boolean;
+  blockedInheritedKeys?: Iterable<string>;
 }): HostExecEnvSanitizationResult {
   const baseEnv = params?.baseEnv ?? process.env;
+  const blockedInheritedKeys = new Set(
+    Array.from(params?.blockedInheritedKeys ?? [], (key) => key.toUpperCase()),
+  );
 
   const merged: Record<string, string> = {};
   for (const [key, value] of listNormalizedEnvEntries(baseEnv)) {
+    if (blockedInheritedKeys.has(key.toUpperCase())) {
+      continue;
+    }
     if (isDangerousHostInheritedEnvVarName(key)) {
       continue;
     }
@@ -250,6 +257,7 @@ export function sanitizeHostExecEnv(params?: {
   baseEnv?: Record<string, string | undefined>;
   overrides?: Record<string, string> | null;
   blockPathOverrides?: boolean;
+  blockedInheritedKeys?: Iterable<string>;
 }): Record<string, string> {
   return sanitizeHostExecEnvWithDiagnostics(params).env;
 }

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -28,7 +28,7 @@ describe("sqlite WAL maintenance", () => {
     );
   });
 
-  it("runs periodic TRUNCATE checkpoints and stops them on close", () => {
+  it("runs periodic PASSIVE checkpoints and TRUNCATE on close by default", () => {
     vi.useFakeTimers();
     const db = createMockDb();
 
@@ -36,10 +36,11 @@ describe("sqlite WAL maintenance", () => {
     expect(db.exec).toHaveBeenCalledTimes(2);
 
     vi.advanceTimersByTime(100);
-    expect(db.exec).toHaveBeenLastCalledWith("PRAGMA wal_checkpoint(TRUNCATE);");
+    expect(db.exec).toHaveBeenLastCalledWith("PRAGMA wal_checkpoint(PASSIVE);");
     expect(db.exec).toHaveBeenCalledTimes(3);
 
     expect(maintenance.close()).toBe(true);
+    expect(db.exec).toHaveBeenLastCalledWith("PRAGMA wal_checkpoint(TRUNCATE);");
     expect(db.exec).toHaveBeenCalledTimes(4);
 
     vi.advanceTimersByTime(200);

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -41,6 +41,8 @@ export function configureSqliteWalMaintenance(
     "checkpointIntervalMs",
   );
   const checkpointMode = options.checkpointMode ?? "TRUNCATE";
+  const timerCheckpointMode: SqliteWalCheckpointMode =
+    checkpointMode === "TRUNCATE" ? "PASSIVE" : checkpointMode;
 
   db.exec("PRAGMA journal_mode = WAL;");
   db.exec(`PRAGMA wal_autocheckpoint = ${autoCheckpointPages};`);
@@ -57,7 +59,13 @@ export function configureSqliteWalMaintenance(
 
   let timer: IntervalHandle | null = null;
   if (checkpointIntervalMs > 0) {
-    timer = setInterval(checkpoint, checkpointIntervalMs) as IntervalHandle;
+    timer = setInterval(() => {
+      try {
+        db.exec(`PRAGMA wal_checkpoint(${timerCheckpointMode});`);
+      } catch (error) {
+        options.onCheckpointError?.(error);
+      }
+    }, checkpointIntervalMs) as IntervalHandle;
     timer.unref?.();
   }
 

--- a/src/node-host/invoke.sanitize-env.test.ts
+++ b/src/node-host/invoke.sanitize-env.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { applySkillEnvOverrides } from "../agents/skills.js";
 import { parseWindowsCodePage } from "../infra/windows-encoding.js";
 import { withEnv } from "../test-utils/env.js";
 import { decodeCapturedOutputBuffer, sanitizeEnv } from "./invoke.js";
@@ -50,6 +51,52 @@ describe("node-host sanitizeEnv", () => {
       const env = sanitizeEnv(undefined);
       expect(env.PATH).toBe("/usr/bin:/bin");
       expect(env.BASH_ENV).toBeUndefined();
+    });
+  });
+
+  it("drops active skill SecretRef-derived env keys from exec children", () => {
+    withEnv({ OPENAI_API_KEY: undefined }, () => {
+      const restore = applySkillEnvOverrides({
+        skills: [
+          {
+            skill: {
+              name: "openai-whisper-api",
+              description: "test skill",
+              filePath: "/virtual/openai-whisper-api/SKILL.md",
+              baseDir: "/virtual/openai-whisper-api",
+              source: "test",
+              sourceInfo: {
+                path: "/virtual/openai-whisper-api/SKILL.md",
+                source: "test",
+                scope: "temporary",
+                origin: "top-level",
+              },
+              disableModelInvocation: false,
+            },
+            frontmatter: {},
+            metadata: {
+              primaryEnv: "OPENAI_API_KEY",
+              requires: { env: ["OPENAI_API_KEY"] },
+            },
+          },
+        ],
+        config: {
+          skills: {
+            entries: {
+              "openai-whisper-api": {
+                apiKey: "sk-skill-secret", // pragma: allowlist secret
+              },
+            },
+          },
+        },
+      });
+      try {
+        expect(process.env.OPENAI_API_KEY).toBe("sk-skill-secret");
+        const env = sanitizeEnv(undefined);
+        expect(env.OPENAI_API_KEY).toBeUndefined();
+      } finally {
+        restore();
+      }
     });
   });
 

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { getActiveSkillEnvKeys } from "../agents/skills.js";
 import { GatewayClient } from "../gateway/client.js";
 import {
   ensureExecApprovals,
@@ -89,7 +90,11 @@ function resolveExecAsk(value?: string): ExecAsk {
 }
 
 export function sanitizeEnv(overrides?: Record<string, string> | null): Record<string, string> {
-  return sanitizeHostExecEnv({ overrides, blockPathOverrides: true });
+  return sanitizeHostExecEnv({
+    overrides,
+    blockPathOverrides: true,
+    blockedInheritedKeys: getActiveSkillEnvKeys(),
+  });
 }
 
 function truncateOutput(raw: string, maxChars: number): { text: string; truncated: boolean } {

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -4,13 +4,17 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
 import { loadInstalledPluginIndex, type InstalledPluginIndex } from "./installed-plugin-index.js";
-import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry-snapshot.js";
+import {
+  clearPluginRegistrySnapshotCacheForTests,
+  loadPluginRegistrySnapshotWithMetadata,
+} from "./plugin-registry-snapshot.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 import { writeManagedNpmPlugin } from "./test-helpers/managed-npm-plugin.js";
 
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  clearPluginRegistrySnapshotCacheForTests();
   vi.restoreAllMocks();
   cleanupTrackedTempDirs(tempDirs);
 });

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -49,6 +49,15 @@ export type PluginRegistrySnapshotResult = {
 };
 
 export const DISABLE_PERSISTED_PLUGIN_REGISTRY_ENV = "OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY";
+export const PLUGIN_REGISTRY_SNAPSHOT_TTL_ENV = "OPENCLAW_PLUGIN_REGISTRY_SNAPSHOT_TTL_MS";
+export const DEFAULT_PLUGIN_REGISTRY_SNAPSHOT_TTL_MS = 1_000;
+
+type CachedPluginRegistrySnapshotResult = {
+  result: PluginRegistrySnapshotResult;
+  expiresAtMs: number;
+};
+
+const pluginRegistrySnapshotCache = new Map<string, CachedPluginRegistrySnapshotResult>();
 
 function formatDeprecatedPersistedRegistryDisableWarning(): string {
   return `${DISABLE_PERSISTED_PLUGIN_REGISTRY_ENV} is a deprecated break-glass compatibility switch; use \`openclaw plugins registry --refresh\` or \`openclaw doctor --fix\` to repair registry state.`;
@@ -67,6 +76,62 @@ export type GetPluginRecordParams = LoadPluginRegistryParams & {
 function hasEnvFlag(env: NodeJS.ProcessEnv, name: string): boolean {
   const value = env[name]?.trim().toLowerCase();
   return Boolean(value && value !== "0" && value !== "false" && value !== "no");
+}
+
+function resolveSnapshotCacheTtlMs(env: NodeJS.ProcessEnv): number {
+  const raw = env[PLUGIN_REGISTRY_SNAPSHOT_TTL_ENV]?.trim();
+  if (!raw) {
+    return DEFAULT_PLUGIN_REGISTRY_SNAPSHOT_TTL_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_PLUGIN_REGISTRY_SNAPSHOT_TTL_MS;
+  }
+  return Math.floor(parsed);
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .join(",")}}`;
+}
+
+function resolvePluginRegistrySnapshotCacheKey(
+  params: LoadPluginRegistryParams,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  if (
+    params.index ||
+    params.candidates ||
+    params.installRecords ||
+    params.diagnostics ||
+    params.now
+  ) {
+    return null;
+  }
+  return stableJson({
+    bundledPluginsDir: resolveBundledPluginsDir(env) ?? null,
+    configPolicyHash: params.config ? resolveInstalledPluginIndexPolicyHash(params.config) : null,
+    disablePersisted: hasEnvFlag(env, DISABLE_PERSISTED_PLUGIN_REGISTRY_ENV),
+    filePath: params.filePath ?? null,
+    pluginIndexFilePath: params.pluginIndexFilePath ?? null,
+    preferPersisted: params.preferPersisted ?? null,
+    stateDir: params.stateDir ?? null,
+    version: env.OPENCLAW_VERSION ?? null,
+    workspaceDir: params.workspaceDir ?? null,
+  });
+}
+
+export function clearPluginRegistrySnapshotCacheForTests(): void {
+  pluginRegistrySnapshotCache.clear();
 }
 
 function hasMissingPersistedPluginSource(index: InstalledPluginIndex): boolean {
@@ -237,6 +302,17 @@ export function loadPluginRegistrySnapshotWithMetadata(
   }
 
   const env = params.env ?? process.env;
+  const cacheTtlMs = resolveSnapshotCacheTtlMs(env);
+  const cacheKey = cacheTtlMs > 0 ? resolvePluginRegistrySnapshotCacheKey(params, env) : null;
+  if (cacheKey) {
+    const cached = pluginRegistrySnapshotCache.get(cacheKey);
+    if (cached && cached.expiresAtMs > Date.now()) {
+      return cached.result;
+    }
+    if (cached) {
+      pluginRegistrySnapshotCache.delete(cacheKey);
+    }
+  }
   const diagnostics: PluginRegistrySnapshotDiagnostic[] = [];
   const disabledByCaller = params.preferPersisted === false;
   const disabledByEnv = hasEnvFlag(env, DISABLE_PERSISTED_PLUGIN_REGISTRY_ENV);
@@ -298,11 +374,18 @@ export function loadPluginRegistrySnapshotWithMetadata(
             "Persisted plugin registry is missing recoverable managed npm plugins; using derived plugin index. Run `openclaw plugins registry --refresh` to update the persisted registry.",
         });
       } else {
-        return {
+        const result: PluginRegistrySnapshotResult = {
           snapshot: persistedIndex,
           source: "persisted",
           diagnostics,
         };
+        if (cacheKey) {
+          pluginRegistrySnapshotCache.set(cacheKey, {
+            result,
+            expiresAtMs: Date.now() + cacheTtlMs,
+          });
+        }
+        return result;
       }
     } else if (persistedReadsEnabled) {
       diagnostics.push({
@@ -321,7 +404,7 @@ export function loadPluginRegistrySnapshotWithMetadata(
     });
   }
 
-  return {
+  const result: PluginRegistrySnapshotResult = {
     snapshot: loadInstalledPluginIndex({
       ...params,
       ...(persistedInstallRecordReadsEnabled
@@ -331,6 +414,13 @@ export function loadPluginRegistrySnapshotWithMetadata(
     source: "derived",
     diagnostics,
   };
+  if (cacheKey) {
+    pluginRegistrySnapshotCache.set(cacheKey, {
+      result,
+      expiresAtMs: Date.now() + cacheTtlMs,
+    });
+  }
+  return result;
 }
 
 function resolveSnapshot(params: LoadPluginRegistryParams = {}): PluginRegistrySnapshot {

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -14,6 +14,7 @@ import {
 import { loadPluginLookUpTable } from "./plugin-lookup-table.js";
 import {
   DISABLE_PERSISTED_PLUGIN_REGISTRY_ENV,
+  clearPluginRegistrySnapshotCacheForTests,
   createPluginRegistryIdNormalizer,
   getPluginRecord,
   inspectPluginRegistry,
@@ -39,6 +40,8 @@ import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fi
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  vi.useRealTimers();
+  clearPluginRegistrySnapshotCacheForTests();
   cleanupTrackedTempDirs(tempDirs);
 });
 
@@ -699,7 +702,9 @@ describe("plugin registry facade", () => {
     expectSnapshotPluginIds(result.snapshot, ["demo"]);
   });
 
-  it("derives fresh config-scoped registries when the persisted registry is missing", () => {
+  it("coalesces config-scoped registry derivation when the persisted registry is missing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T00:00:00Z"));
     const stateDir = makeTempDir();
     const workspaceDir = makeTempDir();
     const bundledRoot = makeTempDir();
@@ -732,9 +737,22 @@ describe("plugin registry facade", () => {
 
     expect(first.source).toBe("derived");
     expect(second.source).toBe("derived");
-    expect(second).not.toBe(first);
+    expect(second).toBe(first);
     expect(manifestReadsAfterFirst).toBeGreaterThan(0);
-    expect(manifestReadsAfterSecond).toBeGreaterThan(manifestReadsAfterFirst);
+    expect(manifestReadsAfterSecond).toBe(manifestReadsAfterFirst);
+
+    vi.advanceTimersByTime(1_001);
+    const third = loadPluginRegistrySnapshotWithMetadata({
+      stateDir,
+      workspaceDir,
+      config,
+      env,
+    });
+    const manifestReadsAfterThird = readFileSyncSpy.mock.calls.filter((call) =>
+      String(call[0]).endsWith("openclaw.plugin.json"),
+    ).length;
+    expect(third).not.toBe(first);
+    expect(manifestReadsAfterThird).toBeGreaterThan(manifestReadsAfterSecond);
   });
 
   it("falls back to the derived registry when persisted reads are disabled", async () => {

--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -63,11 +63,13 @@ describe("safeEqualSecret", () => {
     ["secret-token", "secret-token", true],
     ["secret-token", "secret-tokEn", false],
     ["short", "much-longer", false],
-    ["", "", true],
+    ["", "", false],
     ["", "secret", false],
+    ["secret", "", false],
     [undefined, "secret", false],
     ["secret", undefined, false],
     [null, "secret", false],
+    [null, null, false],
   ] as const)("compares %o and %o", (left, right, expected) => {
     expect(safeEqualSecret(left, right)).toBe(expected);
   });

--- a/src/security/secret-equal.ts
+++ b/src/security/secret-equal.ts
@@ -20,7 +20,7 @@ export function safeEqualSecret(
   const expectedBytes = Buffer.from(expected, "utf8");
   const byteLength = Math.max(providedBytes.length, expectedBytes.length);
   if (byteLength === 0) {
-    return true;
+    return false;
   }
   return (
     timingSafeEqual(


### PR DESCRIPTION
## Summary
- block active skill SecretRef env keys from host/CLI child environments
- avoid blocking gateway hot paths with SQLite WAL TRUNCATE checkpoints and plugin registry snapshot re-derivation
- yield large WhatsApp auth key reads and close bounded QMD read streams on early exit

## Validation
- env CI=true pnpm vitest run extensions/whatsapp/src/session.test.ts extensions/whatsapp/src/connection-controller.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts src/plugins/plugin-registry.test.ts src/plugins/plugin-registry-snapshot.test.ts src/node-host/invoke.sanitize-env.test.ts src/infra/sqlite-wal.test.ts
- pnpm tsgo:core
- pnpm tsgo:extensions
- pnpm tsgo:extensions:test