### PR TITLE
docs: consolidate plugin management docs

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -341,7 +341,7 @@ Updates apply to tracked plugin installs in the managed plugin index and tracked
 
   </Accordion>
   <Accordion title="Beta channel updates">
-    `openclaw plugins update` reuses the tracked plugin spec unless you pass a new spec. `openclaw update` additionally knows the active OpenClaw update channel: on the beta channel, default-line npm and ClawHub plugin records try `@beta` first, then fall back to the recorded default/latest spec if no plugin beta release exists. That fallback is reported as a warning and does not fail the core update. Exact versions and explicit tags stay pinned to that selector.
+    `openclaw plugins update` reuses the tracked plugin spec unless you pass a new spec. `openclaw update` additionally knows the active OpenClaw update channel: on the beta channel, default-line npm and ClawHub plugin records try `@beta` first. They fall back to the recorded default/latest spec if no plugin beta release exists; npm plugins also fall back when the beta package exists but fails install validation. That fallback is reported as a warning and does not fail the core update. Exact versions and explicit tags stay pinned to that selector.
 
   </Accordion>
   <Accordion title="Version checks and integrity drift">

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -1,7 +1,8 @@
 ---
-summary: "Find community-maintained OpenClaw plugins"
+summary: "Find and publish community-maintained OpenClaw plugins"
 read_when:
   - You want to find third-party OpenClaw plugins
+  - You want to publish or list your own plugin on ClawHub
 title: "Community plugins"
 doc-schema-version: 1
 ---
@@ -34,7 +35,34 @@ Use [Manage plugins](/plugins/manage-plugins) for common install, update,
 inspect, and uninstall examples. Use [`openclaw plugins`](/cli/plugins) for the
 full command reference and source-selection rules.
 
+## Publish plugins
+
+Publish public community plugins on ClawHub when you want OpenClaw users to
+discover and install them. ClawHub owns the live package listing, release
+history, scan status, and install hints; the docs do not maintain a static
+third-party plugin catalog.
+
+```bash
+clawhub package publish your-org/your-plugin --dry-run
+clawhub package publish your-org/your-plugin
+```
+
+Before publishing, make sure the plugin has package metadata, a plugin manifest,
+setup docs, and a clear maintenance owner. ClawHub validates owner scope,
+package name, version, file limits, and source metadata before it creates a
+release, then keeps new releases hidden from normal install and download
+surfaces until review and verification finish.
+
+Use these pages for the full publishing contract:
+
+- [ClawHub publishing](/clawhub/publishing) explains owners, scopes, releases,
+  review, package validation, and package transfer.
+- [Building plugins](/plugins/building-plugins) shows the plugin package shape
+  and first publish workflow.
+- [Plugin manifest](/plugins/manifest) defines native plugin manifest fields.
+
 ## Related
 
 - [Plugins](/tools/plugin) - install, configure, restart, and troubleshoot
 - [Manage plugins](/plugins/manage-plugins) - command examples
+- [ClawHub publishing](/clawhub/publishing) - publish and release rules

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -53,6 +53,15 @@ package name, version, file limits, and source metadata before it creates a
 release, then keeps new releases hidden from normal install and download
 surfaces until review and verification finish.
 
+Use this checklist before you publish:
+
+| Requirement          | Why                                                 |
+| -------------------- | --------------------------------------------------- |
+| Published on ClawHub | Users need `openclaw plugins install` hints to work |
+| Public GitHub repo   | Source review, issue tracking, transparency         |
+| Setup and usage docs | Users need to know how to configure it              |
+| Active maintenance   | Recent updates or responsive issue handling         |
+
 Use these pages for the full publishing contract:
 
 - [ClawHub publishing](/clawhub/publishing) explains owners, scopes, releases,

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -1,9 +1,7 @@
 ---
-summary: "Find community-maintained OpenClaw plugins and understand when to submit docs changes"
+summary: "Find community-maintained OpenClaw plugins"
 read_when:
   - You want to find third-party OpenClaw plugins
-  - You want to publish or list your own plugin
-  - You want to know when a docs PR is appropriate for a community plugin
 title: "Community plugins"
 doc-schema-version: 1
 ---
@@ -11,10 +9,6 @@ doc-schema-version: 1
 Community plugins are third-party packages that extend OpenClaw with channels,
 tools, providers, hooks, or other capabilities. Use [ClawHub](/clawhub) as the
 primary discovery surface for public community plugins.
-
-Do not open a docs-only PR just to add your plugin here for discoverability.
-Publish it on ClawHub instead so users can see current metadata, releases,
-scan status, and install hints in one place.
 
 ## Find plugins
 
@@ -40,53 +34,7 @@ Use [Manage plugins](/plugins/manage-plugins) for common install, update,
 inspect, and uninstall examples. Use [`openclaw plugins`](/cli/plugins) for the
 full command reference and source-selection rules.
 
-## Publish your plugin
-
-Publish public plugins to ClawHub when you want OpenClaw users to discover and
-install them. ClawHub owns the live package listing, release history, and scan
-state; this docs page does not maintain a static third-party package catalog.
-
-Use these references:
-
-- [Building plugins](/plugins/building-plugins) for the native plugin package
-  shape and first publish workflow.
-- [ClawHub publishing](/clawhub/publishing) for owner scope, release review,
-  package validation, and transfer rules.
-- [Plugin manifest](/plugins/manifest) for native `openclaw.plugin.json`
-  requirements.
-
-## Open a docs PR only for source-doc changes
-
-Open a docs PR when the OpenClaw docs themselves need to change. Good examples:
-
-- correcting install or configuration guidance in an OpenClaw-owned page
-- adding cross-repo documentation that belongs in the main docs set
-- updating a bundled or official external plugin guide after behavior changes
-- improving a troubleshooting page with a reproduced OpenClaw failure mode
-
-Do not open a docs PR only to list a new third-party plugin. Static catalogs
-drift quickly and are not treated as canonical OpenClaw-owned metadata.
-
-## Submission quality bar
-
-Community plugins should be useful, documented, and safe to operate before you
-publish them or ask the docs to reference them.
-
-| Requirement                 | Why                                           |
-| --------------------------- | --------------------------------------------- |
-| Published on ClawHub or npm | Users need `openclaw plugins install` to work |
-| Public source repo          | Source review, issue tracking, transparency   |
-| Setup and usage docs        | Users need to know how to configure it        |
-| Clear maintenance owner     | Users need a place to report issues           |
-| Safe install behavior       | Registry and local scans should not block use |
-
-Low-effort wrappers, unclear ownership, missing setup docs, or unmaintained
-packages are poor candidates for OpenClaw docs links.
-
 ## Related
 
 - [Plugins](/tools/plugin) - install, configure, restart, and troubleshoot
 - [Manage plugins](/plugins/manage-plugins) - command examples
-- [Building plugins](/plugins/building-plugins) - create your own plugin
-- [Plugin manifest](/plugins/manifest) - manifest schema
-- [ClawHub publishing](/clawhub/publishing) - publish and release rules

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -1,193 +1,92 @@
 ---
-summary: "Community-maintained OpenClaw plugins: browse, install, and submit your own"
+summary: "Find community-maintained OpenClaw plugins and understand when to submit docs changes"
 read_when:
   - You want to find third-party OpenClaw plugins
   - You want to publish or list your own plugin
+  - You want to know when a docs PR is appropriate for a community plugin
 title: "Community plugins"
+doc-schema-version: 1
 ---
 
-Community plugins are third-party packages that extend OpenClaw with new
-channels, tools, providers, or other capabilities. They are built and maintained
-by the community, usually published on [ClawHub](/clawhub), and installable
-with a single command. Npm remains the launch default for bare package specs
-while ClawHub pack installs roll out.
+Community plugins are third-party packages that extend OpenClaw with channels,
+tools, providers, hooks, or other capabilities. Use [ClawHub](/clawhub) as the
+primary discovery surface for public community plugins.
 
-ClawHub is the canonical discovery surface for community plugins. Do not open
-docs-only PRs just to add your plugin here for discoverability; publish it on
-ClawHub instead.
+Do not open a docs-only PR just to add your plugin here for discoverability.
+Publish it on ClawHub instead so users can see current metadata, releases,
+scan status, and install hints in one place.
+
+## Find plugins
+
+Search ClawHub from the CLI:
+
+```bash
+openclaw plugins search "calendar"
+```
+
+Install a ClawHub plugin with an explicit source prefix:
 
 ```bash
 openclaw plugins install clawhub:<package-name>
 ```
 
-Use `openclaw plugins install <package-name>` for npm-hosted packages.
-
-## Listed plugins
-
-### Apify
-
-Scrape data from any website with 20,000+ ready-made scrapers. Let your agent
-extract data from Instagram, Facebook, TikTok, YouTube, Google Maps, Google
-Search, e-commerce sites, and more — just by asking.
-
-- **npm:** `@apify/apify-openclaw-plugin`
-- **repo:** [github.com/apify/apify-openclaw-plugin](https://github.com/apify/apify-openclaw-plugin)
+npm remains a supported direct-install path during the launch cutover:
 
 ```bash
-openclaw plugins install @apify/apify-openclaw-plugin
+openclaw plugins install npm:<package-name>
 ```
 
-### Codex App Server Bridge
+Use [Manage plugins](/plugins/manage-plugins) for common install, update,
+inspect, and uninstall examples. Use [`openclaw plugins`](/cli/plugins) for the
+full command reference and source-selection rules.
 
-Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to
-a Codex thread, talk to it with plain text, and control it with chat-native
-commands for resume, planning, review, model selection, compaction, and more.
+## Publish your plugin
 
-- **npm:** `openclaw-codex-app-server`
-- **repo:** [github.com/pwrdrvr/openclaw-codex-app-server](https://github.com/pwrdrvr/openclaw-codex-app-server)
+Publish public plugins to ClawHub when you want OpenClaw users to discover and
+install them. ClawHub owns the live package listing, release history, and scan
+state; this docs page does not maintain a static third-party package catalog.
 
-```bash
-openclaw plugins install openclaw-codex-app-server
-```
+Use these references:
 
-### DingTalk
+- [Building plugins](/plugins/building-plugins) for the native plugin package
+  shape and first publish workflow.
+- [ClawHub publishing](/clawhub/publishing) for owner scope, release review,
+  package validation, and transfer rules.
+- [Plugin manifest](/plugins/manifest) for native `openclaw.plugin.json`
+  requirements.
 
-Enterprise robot integration using Stream mode. Supports text, images, and
-file messages via any DingTalk client.
+## Open a docs PR only for source-doc changes
 
-- **npm:** `@largezhou/ddingtalk`
-- **repo:** [github.com/largezhou/openclaw-dingtalk](https://github.com/largezhou/openclaw-dingtalk)
+Open a docs PR when the OpenClaw docs themselves need to change. Good examples:
 
-```bash
-openclaw plugins install @largezhou/ddingtalk
-```
+- correcting install or configuration guidance in an OpenClaw-owned page
+- adding cross-repo documentation that belongs in the main docs set
+- updating a bundled or official external plugin guide after behavior changes
+- improving a troubleshooting page with a reproduced OpenClaw failure mode
 
-### Lossless Claw (LCM)
+Do not open a docs PR only to list a new third-party plugin. Static catalogs
+drift quickly and are not treated as canonical OpenClaw-owned metadata.
 
-Lossless Context Management plugin for OpenClaw. DAG-based conversation
-summarization with incremental compaction — preserves full context fidelity
-while reducing token usage.
+## Submission quality bar
 
-- **npm:** `@martian-engineering/lossless-claw`
-- **repo:** [github.com/Martian-Engineering/lossless-claw](https://github.com/Martian-Engineering/lossless-claw)
-
-```bash
-openclaw plugins install @martian-engineering/lossless-claw
-```
-
-### Opik
-
-Official plugin that exports agent traces to Opik. Monitor agent behavior,
-cost, tokens, errors, and more.
-
-- **npm:** `@opik/opik-openclaw`
-- **repo:** [github.com/comet-ml/opik-openclaw](https://github.com/comet-ml/opik-openclaw)
-
-```bash
-openclaw plugins install @opik/opik-openclaw
-```
-
-### Prometheus Avatar
-
-Give your OpenClaw agent a Live2D avatar with real-time lip-sync, emotion
-expressions, and text-to-speech. Includes creator tools for AI asset generation
-and one-click deployment to the Prometheus Marketplace. Currently in alpha.
-
-- **npm:** `@prometheusavatar/openclaw-plugin`
-- **repo:** [github.com/myths-labs/prometheus-avatar](https://github.com/myths-labs/prometheus-avatar)
-
-```bash
-openclaw plugins install @prometheusavatar/openclaw-plugin
-```
-
-### QQbot
-
-Connect OpenClaw to QQ via the QQ Bot API. Supports private chats, group
-mentions, channel messages, and rich media including voice, images, videos,
-and files.
-
-Current OpenClaw releases bundle QQ Bot. Use the bundled setup in
-[QQ Bot](/channels/qqbot) for normal installs; install this external plugin only
-when you intentionally want the Tencent-maintained standalone package.
-
-- **npm:** `@tencent-connect/openclaw-qqbot`
-- **repo:** [github.com/tencent-connect/openclaw-qqbot](https://github.com/tencent-connect/openclaw-qqbot)
-
-```bash
-openclaw plugins install @tencent-connect/openclaw-qqbot
-```
-
-### wecom
-
-WeCom channel plugin for OpenClaw by the Tencent WeCom team. Powered by
-WeCom Bot WebSocket persistent connections, it supports direct messages & group
-chats, streaming replies, proactive messaging, image/file processing, Markdown
-formatting, built-in access control, and document/meeting/messaging skills.
-
-- **npm:** `@wecom/wecom-openclaw-plugin`
-- **repo:** [github.com/WecomTeam/wecom-openclaw-plugin](https://github.com/WecomTeam/wecom-openclaw-plugin)
-
-```bash
-openclaw plugins install @wecom/wecom-openclaw-plugin
-```
-
-### Yuanbao
-
-Yuanbao channel plugin for OpenClaw by the Tencent Yuanbao team. Powered by
-WebSocket persistent connections, it supports direct messages & group chats,
-streaming replies, proactive messaging, image/file/audio/video processing,
-Markdown formatting, built-in access control, and slash-command menus.
-
-- **npm:** `openclaw-plugin-yuanbao`
-- **repo:** [github.com/YuanbaoTeam/yuanbao-openclaw-plugin](https://github.com/YuanbaoTeam/yuanbao-openclaw-plugin)
-
-```bash
-openclaw plugins install openclaw-plugin-yuanbao
-```
-
-## Submit your plugin
-
-We welcome community plugins that are useful, documented, and safe to operate.
-
-<Steps>
-  <Step title="Publish to ClawHub or npm">
-    Your plugin must be installable via `openclaw plugins install \<package-name\>`.
-    Publish to [ClawHub](/clawhub) unless you specifically need npm-only
-    distribution.
-    See [Building Plugins](/plugins/building-plugins) for the full guide.
-
-  </Step>
-
-  <Step title="Host on GitHub">
-    Source code must be in a public repository with setup docs and an issue
-    tracker.
-
-  </Step>
-
-  <Step title="Use docs PRs only for source-doc changes">
-    You do not need a docs PR just to make your plugin discoverable. Publish it
-    on ClawHub instead.
-
-    Open a docs PR only when OpenClaw's source docs need an actual content
-    change, such as correcting install guidance or adding cross-repo
-    documentation that belongs in the main docs set.
-
-  </Step>
-</Steps>
-
-## Quality bar
+Community plugins should be useful, documented, and safe to operate before you
+publish them or ask the docs to reference them.
 
 | Requirement                 | Why                                           |
 | --------------------------- | --------------------------------------------- |
 | Published on ClawHub or npm | Users need `openclaw plugins install` to work |
-| Public GitHub repo          | Source review, issue tracking, transparency   |
+| Public source repo          | Source review, issue tracking, transparency   |
 | Setup and usage docs        | Users need to know how to configure it        |
-| Active maintenance          | Recent updates or responsive issue handling   |
+| Clear maintenance owner     | Users need a place to report issues           |
+| Safe install behavior       | Registry and local scans should not block use |
 
-Low-effort wrappers, unclear ownership, or unmaintained packages may be declined.
+Low-effort wrappers, unclear ownership, missing setup docs, or unmaintained
+packages are poor candidates for OpenClaw docs links.
 
 ## Related
 
-- [Install and Configure Plugins](/tools/plugin) — how to install any plugin
-- [Building Plugins](/plugins/building-plugins) — create your own
-- [Plugin Manifest](/plugins/manifest) — manifest schema
+- [Plugins](/tools/plugin) - install, configure, restart, and troubleshoot
+- [Manage plugins](/plugins/manage-plugins) - command examples
+- [Building plugins](/plugins/building-plugins) - create your own plugin
+- [Plugin manifest](/plugins/manifest) - manifest schema
+- [ClawHub publishing](/clawhub/publishing) - publish and release rules

--- a/docs/plugins/manage-plugins.md
+++ b/docs/plugins/manage-plugins.md
@@ -1,28 +1,36 @@
 ---
-summary: "Quick examples for installing, listing, uninstalling, updating, and publishing OpenClaw plugins"
+summary: "Quick examples for listing, installing, updating, inspecting, and uninstalling OpenClaw plugins"
 read_when:
-  - You want quick plugin install, list, update, or uninstall examples
-  - You want to choose between ClawHub and npm plugin distribution
-  - You are publishing a plugin package
+  - You want quick plugin list, install, update, inspect, or uninstall examples
+  - You want to choose a plugin install source
+  - You want the right reference for publishing plugin packages
 title: "Manage plugins"
 sidebarTitle: "Manage plugins"
+doc-schema-version: 1
 ---
 
-Most plugin workflows are a few commands: search, install, restart the Gateway,
-verify, and uninstall when you no longer need the plugin.
+Use this page for common plugin management commands. For the exhaustive command
+contract, flags, source-selection rules, and edge cases, see
+[`openclaw plugins`](/cli/plugins).
 
-## List plugins
+Most install workflows are:
+
+1. find a package
+2. install it from ClawHub, npm, git, or a local path
+3. restart the Gateway that serves your channels
+4. verify the plugin's runtime registrations
+
+## List and search plugins
 
 ```bash
 openclaw plugins list
 openclaw plugins list --enabled
 openclaw plugins list --verbose
 openclaw plugins list --json
+openclaw plugins search "calendar"
 ```
 
-Use `--json` for scripts. It includes registry diagnostics and each plugin's
-static `dependencyStatus` when the plugin package declares `dependencies` or
-`optionalDependencies`.
+Use `--json` for scripts:
 
 ```bash
 openclaw plugins list --json \
@@ -31,7 +39,12 @@ openclaw plugins list --json \
 
 `plugins list` is a cold inventory check. It shows what OpenClaw can discover
 from config, manifests, and the plugin registry; it does not prove that an
-already-running Gateway process imported the plugin runtime.
+already-running Gateway imported the plugin runtime. The JSON output includes
+registry diagnostics and each plugin's static `dependencyStatus` when the
+plugin package declares `dependencies` or `optionalDependencies`.
+
+`plugins search` queries ClawHub for installable plugin packages and prints
+install hints such as `openclaw plugins install clawhub:<package>`.
 
 ## Install plugins
 
@@ -39,24 +52,35 @@ already-running Gateway process imported the plugin runtime.
 # Search ClawHub for plugin packages.
 openclaw plugins search "calendar"
 
-# Bare package specs try ClawHub first, then npm fallback.
-openclaw plugins install <package>
-
-# Force one source.
+# Install from ClawHub.
 openclaw plugins install clawhub:<package>
-openclaw plugins install npm:<package>
-
-# Install a specific version or dist-tag.
 openclaw plugins install clawhub:<package>@1.2.3
 openclaw plugins install clawhub:<package>@beta
+
+# Install from npm.
+openclaw plugins install npm:<package>
 openclaw plugins install npm:@scope/openclaw-plugin@1.2.3
 openclaw plugins install npm:@openclaw/codex
+
+# Install from a local npm pack artifact.
+openclaw plugins install npm-pack:<path.tgz>
 
 # Install from git or a local development checkout.
 openclaw plugins install git:github.com/acme/openclaw-plugin@v1.0.0
 openclaw plugins install ./my-plugin
 openclaw plugins install --link ./my-plugin
 ```
+
+Bare package specs install from npm during the launch cutover. Use `clawhub:`,
+`npm:`, `git:`, or `npm-pack:` when you need deterministic source selection.
+If the bare name matches an official plugin id, OpenClaw can install the
+catalog entry directly.
+
+Use `--force` only when you intentionally want to overwrite an existing install
+target. For routine upgrades of tracked npm, ClawHub, or hook-pack installs, use
+`openclaw plugins update`.
+
+## Restart and inspect
 
 After installing plugin code, restart the Gateway that serves your channels:
 
@@ -66,8 +90,9 @@ openclaw plugins inspect <plugin-id> --runtime --json
 ```
 
 Use `inspect --runtime` when you need proof that the plugin registered runtime
-surfaces such as tools, hooks, services, Gateway methods, or plugin-owned CLI
-commands.
+surfaces such as tools, hooks, services, Gateway methods, HTTP routes, or
+plugin-owned CLI commands. Plain `inspect` and `list` are cold manifest,
+config, and registry checks.
 
 ## Update plugins
 
@@ -75,11 +100,15 @@ commands.
 openclaw plugins update <plugin-id>
 openclaw plugins update <npm-package-or-spec>
 openclaw plugins update --all
+openclaw plugins update <plugin-id> --dry-run
 ```
 
-If a plugin was installed from an npm dist-tag such as `@beta`, later
-`update <plugin-id>` calls reuse that recorded tag. Passing an explicit npm spec
-switches the tracked install to that spec for future updates.
+When you pass a plugin id, OpenClaw reuses the tracked install spec. Stored
+dist-tags such as `@beta` and exact pinned versions continue to be used on
+later `update <plugin-id>` runs.
+
+For npm installs, you can pass an explicit package spec to switch the tracked
+record:
 
 ```bash
 openclaw plugins update @scope/openclaw-plugin@beta
@@ -89,12 +118,9 @@ openclaw plugins update @scope/openclaw-plugin
 The second command moves a plugin back to the registry's default release line
 when it was previously pinned to an exact version or tag.
 
-When `openclaw update` runs on the beta channel, default-line npm and ClawHub
-plugin records try the matching plugin `@beta` release first. If that beta
-release does not exist, OpenClaw falls back to the recorded default/latest spec.
-For npm plugins, OpenClaw also falls back when the beta package exists but fails
-install validation. Exact versions and explicit tags such as `@rc` or `@beta`
-are preserved.
+When `openclaw update` runs on the beta channel, plugin records can prefer
+matching `@beta` releases. For the exact fallback and pinning rules, see
+[`openclaw plugins`](/cli/plugins#update).
 
 ## Uninstall plugins
 
@@ -105,25 +131,30 @@ openclaw plugins uninstall <plugin-id> --keep-files
 openclaw gateway restart
 ```
 
-Uninstall removes the plugin's config entry, plugin index record, allow/deny list
-entries, and linked load paths when applicable. Managed install directories are
-removed unless you pass `--keep-files`.
+Uninstall removes the plugin's config entry, persisted plugin index record,
+allow/deny list entries, and linked load paths when applicable. Managed install
+directories are removed unless you pass `--keep-files`.
 
 In Nix mode (`OPENCLAW_NIX_MODE=1`), plugin install, update, uninstall, enable,
 and disable commands are disabled. Manage those choices in the Nix source for
-the install instead; for nix-openclaw, use the agent-first
-[Quick Start](https://github.com/openclaw/nix-openclaw#quick-start).
+the install instead.
+
+## Choose a source
+
+| Source      | Use when                                                                    | Example                                                        |
+| ----------- | --------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| ClawHub     | You want OpenClaw-native discovery, scan summaries, versions, and hints     | `openclaw plugins install clawhub:<package>`                   |
+| npmjs.com   | You already ship JavaScript packages or need npm dist-tags/private registry | `openclaw plugins install npm:@acme/openclaw-plugin`           |
+| git         | You want a branch, tag, or commit from a repository                         | `openclaw plugins install git:github.com/<owner>/<repo>@<ref>` |
+| local path  | You are developing or testing a plugin on the same machine                  | `openclaw plugins install --link ./my-plugin`                  |
+| npm pack    | You are proving a local package artifact through npm install semantics      | `openclaw plugins install npm-pack:<path.tgz>`                 |
+| marketplace | You are installing a Claude-compatible marketplace plugin                   | `openclaw plugins install <plugin> --marketplace <source>`     |
 
 ## Publish plugins
 
-You can publish external plugins to [ClawHub](https://clawhub.ai), npmjs.com, or
-both.
-
-### Publish to ClawHub
-
-ClawHub is the primary public discovery surface for OpenClaw plugins. It gives
-users searchable metadata, version history, and registry scan results before
-install.
+ClawHub is the primary public discovery surface for OpenClaw plugins. Publish
+there when you want users to find plugin metadata, version history, registry
+scan results, and install hints before they install.
 
 ```bash
 npm i -g clawhub
@@ -133,19 +164,8 @@ clawhub package publish your-org/your-plugin
 clawhub package publish your-org/your-plugin@v1.0.0
 ```
 
-Users install from ClawHub with:
-
-```bash
-openclaw plugins install clawhub:<package>
-openclaw plugins install <package>
-```
-
-The bare form still checks ClawHub first.
-
-### Publish to npmjs.com
-
-Native npm plugins must include a plugin manifest and `package.json` OpenClaw
-entrypoint metadata.
+Native npm plugins must include a plugin manifest and package metadata before
+publishing:
 
 ```json package.json
 {
@@ -160,33 +180,28 @@ entrypoint metadata.
 
 ```bash
 npm publish --access public
-```
-
-Users install npm-only with:
-
-```bash
 openclaw plugins install npm:@acme/openclaw-plugin
 openclaw plugins install npm:@acme/openclaw-plugin@beta
 openclaw plugins install npm:@acme/openclaw-plugin@1.0.0
 ```
 
-If the same package is also available on ClawHub, `npm:` skips ClawHub lookup and
-forces npm resolution.
+Use these pages for the full publishing contract instead of treating this page
+as the publishing reference:
 
-## Source choice
+- [ClawHub publishing](/clawhub/publishing) explains owners, scopes, releases,
+  review, package validation, and package transfer.
+- [Building plugins](/plugins/building-plugins) shows the plugin package shape
+  and first publish workflow.
+- [Plugin manifest](/plugins/manifest) defines native plugin manifest fields.
 
-- **ClawHub**: use when you want OpenClaw-native discovery, scan summaries,
-  versions, and install hints.
-- **npmjs.com**: use when you already ship JavaScript packages or need npm
-  dist-tags/private registry workflows.
-- **Git**: use when you want to install directly from a branch, tag, or commit.
-- **Local path**: use when you are developing or testing a plugin on the same
-  machine.
+If the same package is available on both ClawHub and npm, use the explicit
+`clawhub:` or `npm:` prefix when you need to force one source.
 
 ## Related
 
-- [Plugins](/tools/plugin) - overview and troubleshooting
+- [Plugins](/tools/plugin) - install, configure, restart, and troubleshoot
 - [`openclaw plugins`](/cli/plugins) - full CLI reference
-- [ClawHub](/clawhub/cli) - publish and registry operations
+- [Community plugins](/plugins/community) - public discovery and submission rules
+- [ClawHub](/clawhub/cli) - registry CLI operations
 - [Building plugins](/plugins/building-plugins) - create a plugin package
 - [Plugin manifest](/plugins/manifest) - manifest and package metadata

--- a/docs/plugins/manage-plugins.md
+++ b/docs/plugins/manage-plugins.md
@@ -201,7 +201,7 @@ If the same package is available on both ClawHub and npm, use the explicit
 
 - [Plugins](/tools/plugin) - install, configure, restart, and troubleshoot
 - [`openclaw plugins`](/cli/plugins) - full CLI reference
-- [Community plugins](/plugins/community) - public discovery and submission rules
+- [Community plugins](/plugins/community) - public discovery and ClawHub publishing
 - [ClawHub](/clawhub/cli) - registry CLI operations
 - [Building plugins](/plugins/building-plugins) - create a plugin package
 - [Plugin manifest](/plugins/manifest) - manifest and package metadata


### PR DESCRIPTION
## Summary

- Problem: plugin install, community-discovery, and publishing guidance had grown into overlapping pages with stale static community listings.
- Why it matters: readers need the main plugin docs to cover common workflows, while edge cases and source-selection rules belong in the CLI reference.
- What changed: rewrote `docs/plugins/manage-plugins.md` and `docs/plugins/community.md`, kept community discovery and ClawHub publishing guidance together, removed docs-PR plugin submission guidance, and restored the npm beta install-validation fallback detail in `docs/cli/plugins.md`.
- What did NOT change (scope boundary): no runtime plugin install/update behavior changed.

<img width="3306" height="1356" alt="CleanShot 2026-05-14 at 14 14 33@2x" src="https://github.com/user-attachments/assets/4a8f65c3-394e-4669-beec-70dd12fc0115" />


## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof

Behavior addressed: OpenClaw plugin docs consolidation for install/manage/community plugin workflows, with `docs/plugins/community.md` now covering community discovery plus ClawHub-focused publishing guidance and no docs-PR plugin submission workflow.
Real environment tested: macOS local OpenClaw Codex worktree on branch `codex/taskdocs92`, commit `e1a8b4a3d2`.
Exact steps or command run after this patch: `pnpm openclaw plugins --help`; `pnpm openclaw plugins install --help`; `sed -n '1,90p' docs/plugins/community.md`; `node /Users/kevinlin/.codex/skills/docs-audit-v2/scripts/dist/docs-audit-v2.mjs validate --data .mem/main/specs/9-plugin-docs-refactor/audits/9.2-manage-community/audit.hydrated.json --out .mem/main/specs/9-plugin-docs-refactor/audits/9.2-manage-community/audit.validated.json --force && pnpm exec oxfmt --check --threads=1 docs/plugins/manage-plugins.md docs/plugins/community.md docs/cli/plugins.md && pnpm docs:check-mdx && pnpm docs:check-links && pnpm docs:check-i18n-glossary && pnpm lint:docs && git diff --check`
Evidence after fix: Copied live terminal output from the local OpenClaw CLI and docs file:

```text
$ pnpm openclaw plugins --help
Usage: openclaw plugins [options] [command]
Commands:
  inspect      Inspect plugin details
  install      Install a plugin or hook pack (path, archive, npm spec, git repo,
               clawhub:package, or marketplace entry)
  list         List discovered plugins
  search       Search ClawHub plugin packages
  uninstall    Uninstall a plugin
  update       Update installed plugins and tracked hook packs
Docs: https://docs.openclaw.ai/cli/plugins

$ sed -n '1,80p' docs/plugins/community.md
summary: "Find and publish community-maintained OpenClaw plugins"
read_when:
  - You want to find third-party OpenClaw plugins
  - You want to publish or list your own plugin on ClawHub
title: "Community plugins"
...
Find plugins section:
openclaw plugins search "calendar"
openclaw plugins install clawhub:<package-name>
openclaw plugins install npm:<package-name>
Publish plugins section:
clawhub package publish your-org/your-plugin --dry-run
clawhub package publish your-org/your-plugin
ClawHub validates owner scope, package name, version, file limits, and source metadata before it creates a release.
Publishing readiness checklist:
- Published on ClawHub | Users need `openclaw plugins install` hints to work
- Public GitHub repo | Source review, issue tracking, transparency
- Setup and usage docs | Users need to know how to configure it
- Active maintenance | Recent updates or responsive issue handling
Related links:
- [Plugins](/tools/plugin) - install, configure, restart, and troubleshoot
- [Manage plugins](/plugins/manage-plugins) - command examples
- [ClawHub publishing](/clawhub/publishing) - publish and release rules
```

Supplemental checks: audit validation reported `0 error(s), 0 warning(s)`; oxfmt reported both touched files formatted; MDX check passed for 640 files; docs link audit reported `broken_links=0`; markdownlint reported `Summary: 0 error(s)`; `git diff --check` passed.
Observed result after fix: `openclaw plugins --help` still exposes the install/search/update command surface and docs URL, while `docs/plugins/community.md` contains discovery/install guidance, ClawHub publish guidance, the publishing-readiness checklist, and no docs-PR plugin submission workflow.
What was not tested: full runtime plugin install/update flows; this is a docs-only change.

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: docs audit validation plus docs checks.
- Scenario the test should lock in: source-line preservation for moved/simplified plugin docs content.
- Why this is the smallest reliable guardrail: the docs-audit artifact maps source lines to destination evidence, while docs checks validate publishability.
- Existing test that already covers this (if any): `docs-audit-v2` validation and docs check scripts listed above.
- If no new test is added, why not: docs-only rewrite with no runtime behavior change.

## User-visible / Behavior Changes

Plugin docs are reorganized and simplified; community publishing guidance now points to ClawHub instead of docs PRs. No product behavior changes.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw Codex worktree
- Model/provider: N/A
- Integration/channel (if any): docs
- Relevant config (redacted): N/A

### Steps

1. Validate the generated docs-preservation audit.
2. Run docs format, MDX, link, i18n glossary, markdownlint, and diff whitespace checks.
3. Confirm CLI help exists for referenced `openclaw plugins` commands.

### Expected

- Audit validation and docs checks pass.

### Actual

- Audit validation and docs checks passed.

## Evidence

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: audit validation, docs formatting, MDX, links, i18n glossary, markdownlint, diff whitespace, and plugin CLI help for `plugins`, `list`, `install`, `inspect`, `update`, and `uninstall`.
- Edge cases checked: beta-channel npm install-validation fallback is preserved in `docs/cli/plugins.md`; bare npm package default, ClawHub publishing guidance, publishing-readiness checklist rows, and nix-openclaw Quick Start proof are preserved in reference mappings.
- What you did **not** verify: full runtime plugin install/update execution.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.


