### PR TITLE
fix(webchat): preserve code block whitespace

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1622,6 +1622,29 @@ describe("handleSendChat", () => {
     );
   });
 
+  it("preserves user-authored whitespace (code blocks / ASCII) in chat.send", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return { status: "started" };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    // Leading spaces and a trailing newline that `.trim()` would strip; the
+    // send payload must keep them so code blocks and ASCII diagrams survive.
+    const rawMessage = "```\n    indented one\n        indented two\n```\n";
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: `   ${rawMessage}`,
+    });
+
+    await handleSendChat(host);
+
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({ message: `   ${rawMessage}` }),
+    );
+  });
+
   it("records pending send paint timing before a delayed chat.send ACK", async () => {
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
       queueMicrotask(() => callback(0));

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -434,14 +434,16 @@ function enqueuePendingSendMessage(
     : "waiting-reconnect",
   skillWorkshopRevision?: ChatQueueSkillWorkshopRevision,
 ): ChatQueueItem | null {
-  const trimmed = text.trim();
   const hasAttachments = Boolean(attachments && attachments.length > 0);
-  if (!trimmed && !hasAttachments) {
+  if (!text.trim() && !hasAttachments) {
     return null;
   }
+  // Preserve user-authored whitespace (leading spaces in code blocks / ASCII
+  // diagrams). Emptiness is judged on the trimmed text, but the queued payload
+  // and the eventual chat.send keep the raw text.
   const pending: ChatQueueItem = {
     id: generateUUID(),
-    text: trimmed,
+    text,
     createdAt: Date.now(),
     attachments: hasAttachments ? attachments : undefined,
     refreshSessions,
@@ -1000,10 +1002,12 @@ async function sendQueuedChatMessage(
     return "failed";
   }
   const prepared = ensureQueuedSendState(host, queued, queuedSessionKey);
-  const message = prepared.text.trim();
+  // Send the raw queued text so code-block whitespace survives; emptiness is
+  // still judged on the trimmed form.
+  const message = prepared.text;
   const attachments = prepared.attachments ?? [];
   const hasAttachments = attachments.length > 0;
-  if (!message && !hasAttachments) {
+  if (!message.trim() && !hasAttachments) {
     removeQueuedMessageWithoutReleasing(host, id, prepared.sessionKey ?? host.sessionKey);
     return "sent";
   }
@@ -1390,10 +1394,11 @@ export async function steerQueuedChatMessage(host: ChatHost, id: string) {
   if (!item) {
     return;
   }
-  const message = item.text.trim();
+  // Steer the raw queued text so code-block whitespace survives.
+  const message = item.text;
   const attachments = item.attachments ?? [];
   const hasAttachments = attachments.length > 0;
-  if (!message && !hasAttachments) {
+  if (!message.trim() && !hasAttachments) {
     return;
   }
 
@@ -1699,7 +1704,10 @@ export async function handleSendChat(
   opts?: ChatSendOptions,
 ) {
   const previousDraft = host.chatMessage;
-  const message = (messageOverride ?? host.chatMessage).trim();
+  // Command detection, dedup, and history run on the trimmed text; the normal
+  // send path keeps the raw text so user whitespace (code blocks) is preserved.
+  const rawMessage = messageOverride ?? host.chatMessage;
+  const message = rawMessage.trim();
   const submittedAtMs = controlUiNowMs();
   const submittedSessionKey = host.sessionKey;
   const attachments = host.chatAttachments ?? [];
@@ -1806,7 +1814,7 @@ export async function handleSendChat(
     const waitingForModel = modelSwitchReady !== true;
     const queued = enqueuePendingSendMessage(
       host,
-      message,
+      rawMessage,
       hasAttachments ? attachmentsToSend : undefined,
       refreshSessions,
       submittedAtMs,
@@ -1853,7 +1861,7 @@ export async function handleSendChat(
       return;
     }
 
-    await sendChatMessageNow(host, message, {
+    await sendChatMessageNow(host, rawMessage, {
       queueItemId: queued.id,
       previousDraft: cleared.previousDraft,
       restoreDraft: Boolean(messageOverride && opts?.restoreDraft),

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1082,9 +1082,9 @@ export async function sendChatMessage(
   if (!state.client || !state.connected) {
     return null;
   }
-  const msg = message.trim();
+  const hasText = message.trim().length > 0;
   const hasAttachments = attachments && attachments.length > 0;
-  if (!msg && !hasAttachments) {
+  if (!hasText && !hasAttachments) {
     return null;
   }
   if (state.chatSending) {
@@ -1092,7 +1092,9 @@ export async function sendChatMessage(
   }
 
   const now = Date.now();
-  appendUserChatMessage(state, msg, attachments, now);
+  // Preserve user-authored whitespace (code blocks); emptiness uses trimmed text.
+  const messageToSend = hasText ? message : "";
+  appendUserChatMessage(state, messageToSend, attachments, now);
 
   state.chatSending = true;
   setChatError(state, null);
@@ -1105,7 +1107,7 @@ export async function sendChatMessage(
   state.chatStreamStartedAt = now;
 
   try {
-    const ack = await requestChatSend(state, { message: msg, attachments, runId });
+    const ack = await requestChatSend(state, { message: messageToSend, attachments, runId });
     if (ack.status === "ok") {
       reconcileChatRunLifecycle(
         state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],
@@ -1172,15 +1174,20 @@ async function sendChatMessageWithGeneratedRunId(
   if (!state.client || !state.connected) {
     return null;
   }
-  const msg = message.trim();
+  const hasText = message.trim().length > 0;
   const hasAttachments = attachments && attachments.length > 0;
-  if (!msg && !hasAttachments) {
+  if (!hasText && !hasAttachments) {
     return null;
   }
   setChatError(state, null);
   const runId = generateUUID();
   try {
-    const ack = await requestChatSend(state, { message: msg, attachments, runId });
+    // Send the raw text so user-authored whitespace survives.
+    const ack = await requestChatSend(state, {
+      message: hasText ? message : "",
+      attachments,
+      runId,
+    });
     return ack.runId;
   } catch (err) {
     setChatError(state, formatConnectError(err));


### PR DESCRIPTION
Fixes #81339

## Summary
- stop trimming normal WebChat send payloads before `chat.send`
- keep slash/local command matching, dedup, and history on the trimmed text while preserving the user-authored chat text on the wire
- preserve queued and steered queued message whitespace for code blocks and ASCII diagrams

## Real behavior proof

Re-implemented and re-proven on current `main` (rebased to head `6da9e274c2`; the prior head was ~690 commits behind and `main` has refactored the Control UI composer pipeline since the original proof).

**Behavior addressed:** WebChat must send fenced code blocks / ASCII diagrams exactly as typed, so leading spaces and trailing newlines survive instead of being stripped by `.trim()` before `chat.send`.

**Real environment tested:** local OpenClaw gateway built from this PR head on macOS. Control UI rebuilt with `pnpm ui:build`; isolated `OPENCLAW_STATE_DIR`/`OPENCLAW_HOME`; `gateway run --auth token` on `127.0.0.1:18897` with `gateway.controlUi.dangerouslyDisableDeviceAuth=true` so headless Chrome could connect over local HTTP. The served `/chat` Control UI was driven with Playwright (system Chrome, headless) and the outgoing `chat.send` WebSocket frame was captured via CDP.

**Exact steps or command run after this patch:**
1. `pnpm ui:build`
2. `OPENCLAW_STATE_DIR=$H OPENCLAW_HOME=$H pnpm openclaw gateway run --port 18897 --token <tok> --auth token --force --bind loopback`
3. Playwright: open `http://127.0.0.1:18897/chat#token=<tok>`, type `` ```\n    indented one\n        indented two\n```\n `` (with extra leading spaces and a trailing newline) into the composer, send, capture the `framesent` WebSocket payload whose method is `chat.send`.

**Evidence after fix:** captured `chat.send` frame (verbatim, token/ids redacted):
```json
{"type":"req","method":"chat.send","params":{"sessionKey":"agent:main:main","message":"```\n    indented one\n        indented two\n```\n","deliver":false}}
```
Programmatic assertions on the captured frame: `sentMessageEqualsRaw: true`, `keepsLeadingSpaces: true`, `keepsTrailingNewline: true`, `pageErrors: []`.

**Observed result after fix:** the served Control UI sends the user text byte-for-byte; the 4-space and 8-space code-block indentation and the trailing newline are preserved on the wire. The whitespace-preservation contract is also locked by a regression test asserting the emitted `chat.send` payload keeps leading/trailing whitespace: `ui/src/ui/app-chat.test.ts` -> "preserves user-authored whitespace (code blocks / ASCII) in chat.send" (85/85 `app-chat` tests pass; `oxfmt --check` clean; `git diff --check` clean).

**What was not tested:** end-to-end model response rendering (no live model was configured for the proof gateway; the proof targets the client send path, which is where this fix lives). Local browser run used `dangerouslyDisableDeviceAuth` only to bypass the pairing ceremony over local HTTP; production device auth is unchanged.
