### PR TITLE
fix(commitments): serialize store writers

### DIFF
--- a/src/commitments/store.test.ts
+++ b/src/commitments/store.test.ts
@@ -2,11 +2,15 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { drainFileLockStateForTest, resetFileLockStateForTest } from "../infra/file-lock.js";
 import {
   listCommitments,
   listDueCommitmentsForSession,
   loadCommitmentStore,
+  markCommitmentsAttempted,
+  markCommitmentsStatus,
   saveCommitmentStore,
+  upsertInferredCommitments,
 } from "./store.js";
 import type { CommitmentRecord } from "./types.js";
 
@@ -17,6 +21,8 @@ describe("commitment store delivery selection", () => {
 
   afterEach(async () => {
     vi.unstubAllEnvs();
+    await drainFileLockStateForTest();
+    resetFileLockStateForTest();
     await Promise.all(tmpDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
     tmpDirs.length = 0;
   });
@@ -188,5 +194,123 @@ describe("commitment store delivery selection", () => {
     expect(expiredCommitments).toHaveLength(1);
     expect(expiredCommitments[0]?.id).toBe("cm_interview");
     expect(expiredCommitments[0]?.status).toBe("expired");
+  });
+
+  it("preserves disjoint status updates from concurrent writers", async () => {
+    await useTempStateDir();
+    await saveCommitmentStore(undefined, {
+      version: 1,
+      commitments: [
+        commitment({ id: "cm_race_a", dedupeKey: "race:a" }),
+        commitment({ id: "cm_race_b", dedupeKey: "race:b" }),
+      ],
+    });
+
+    await Promise.all([
+      markCommitmentsStatus({
+        ids: ["cm_race_a"],
+        status: "dismissed",
+        nowMs: nowMs + 1,
+      }),
+      markCommitmentsStatus({
+        ids: ["cm_race_b"],
+        status: "dismissed",
+        nowMs: nowMs + 2,
+      }),
+    ]);
+
+    const store = await loadCommitmentStore();
+    const byId = new Map(store.commitments.map((entry) => [entry.id, entry]));
+    expect(byId.get("cm_race_a")?.status).toBe("dismissed");
+    expect(byId.get("cm_race_a")?.dismissedAtMs).toBe(nowMs + 1);
+    expect(byId.get("cm_race_b")?.status).toBe("dismissed");
+    expect(byId.get("cm_race_b")?.dismissedAtMs).toBe(nowMs + 2);
+  });
+
+  it("preserves concurrent attempt and sent-status updates", async () => {
+    await useTempStateDir();
+    await saveCommitmentStore(undefined, {
+      version: 1,
+      commitments: [
+        commitment({ id: "cm_attempted", dedupeKey: "race:attempted" }),
+        commitment({ id: "cm_sent", dedupeKey: "race:sent" }),
+      ],
+    });
+
+    await Promise.all([
+      markCommitmentsAttempted({ ids: ["cm_attempted"], nowMs: nowMs + 3 }),
+      markCommitmentsStatus({
+        ids: ["cm_sent"],
+        status: "sent",
+        nowMs: nowMs + 4,
+      }),
+    ]);
+
+    const store = await loadCommitmentStore();
+    const byId = new Map(store.commitments.map((entry) => [entry.id, entry]));
+    expect(byId.get("cm_attempted")?.attempts).toBe(1);
+    expect(byId.get("cm_attempted")?.lastAttemptAtMs).toBe(nowMs + 3);
+    expect(byId.get("cm_sent")?.status).toBe("sent");
+    expect(byId.get("cm_sent")?.sentAtMs).toBe(nowMs + 4);
+  });
+
+  it("preserves inferred upserts when another writer changes status", async () => {
+    await useTempStateDir();
+    await saveCommitmentStore(undefined, {
+      version: 1,
+      commitments: [commitment({ id: "cm_existing", dedupeKey: "race:existing" })],
+    });
+
+    const [created] = await Promise.all([
+      upsertInferredCommitments({
+        item: {
+          itemId: "turn-upserted",
+          agentId: "main",
+          sessionKey,
+          channel: "telegram",
+          to: "155462274",
+          nowMs,
+          timezone: "America/Los_Angeles",
+          userText: "I have a project demo tomorrow.",
+          existingPending: [],
+        },
+        candidates: [
+          {
+            candidate: {
+              itemId: "turn-upserted",
+              kind: "event_check_in",
+              sensitivity: "routine",
+              source: "inferred_user_context",
+              reason: "The user mentioned a project demo.",
+              suggestedText: "How did the project demo go?",
+              dedupeKey: "race:upserted",
+              confidence: 0.91,
+              dueWindow: {
+                earliest: "2026-04-30T17:01:00.000Z",
+                latest: "2026-04-30T17:02:00.000Z",
+                timezone: "America/Los_Angeles",
+              },
+            },
+            earliestMs: nowMs + 60_000,
+            latestMs: nowMs + 120_000,
+            timezone: "America/Los_Angeles",
+          },
+        ],
+        nowMs: nowMs + 5,
+      }),
+      markCommitmentsStatus({
+        ids: ["cm_existing"],
+        status: "dismissed",
+        nowMs: nowMs + 6,
+      }),
+    ]);
+
+    expect(created).toHaveLength(1);
+    const store = await loadCommitmentStore();
+    const byDedupe = new Map(store.commitments.map((entry) => [entry.dedupeKey, entry]));
+    expect(byDedupe.get("race:existing")?.status).toBe("dismissed");
+    expect(byDedupe.get("race:existing")?.dismissedAtMs).toBe(nowMs + 6);
+    expect(byDedupe.get("race:upserted")?.status).toBe("pending");
+    expect(byDedupe.get("race:upserted")?.suggestedText).toBe("How did the project demo go?");
   });
 });

--- a/src/commitments/store.ts
+++ b/src/commitments/store.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
+import { withFileLock, type FileLockOptions } from "../infra/file-lock.js";
 import { expandHomePrefix } from "../infra/home-dir.js";
 import { privateFileStore } from "../infra/private-file-store.js";
 import {
@@ -20,6 +21,17 @@ import type {
 
 const STORE_VERSION = 1 as const;
 const ROLLING_DAY_MS = 24 * 60 * 60 * 1000;
+const COMMITMENT_STORE_LOCK_OPTIONS: FileLockOptions = {
+  retries: {
+    retries: 20,
+    factor: 1.2,
+    minTimeout: 10,
+    maxTimeout: 250,
+    randomize: true,
+  },
+  stale: 30_000,
+};
+const COMMITMENT_STORE_WRITE_QUEUES = new Map<string, Promise<unknown>>();
 
 type LoadedCommitmentStore = {
   store: CommitmentStoreFile;
@@ -39,6 +51,30 @@ export function resolveCommitmentStorePath(storePath?: string): string {
     return path.resolve(expandHomePrefix(trimmed));
   }
   return path.resolve(trimmed);
+}
+
+function enqueueCommitmentStoreWrite<T>(storePath: string, fn: () => Promise<T>): Promise<T> {
+  const prev = COMMITMENT_STORE_WRITE_QUEUES.get(storePath) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  COMMITMENT_STORE_WRITE_QUEUES.set(storePath, next);
+  next
+    .finally(() => {
+      if (COMMITMENT_STORE_WRITE_QUEUES.get(storePath) === next) {
+        COMMITMENT_STORE_WRITE_QUEUES.delete(storePath);
+      }
+    })
+    .catch(() => {});
+  return next;
+}
+
+async function runExclusiveCommitmentStoreWrite<T>(
+  storePath: string | undefined,
+  fn: (resolvedStorePath: string) => Promise<T>,
+): Promise<T> {
+  const resolved = resolveCommitmentStorePath(storePath);
+  return await enqueueCommitmentStoreWrite(resolved, () =>
+    withFileLock(resolved, COMMITMENT_STORE_LOCK_OPTIONS, async () => await fn(resolved)),
+  );
 }
 
 function emptyStore(): CommitmentStoreFile {
@@ -150,6 +186,15 @@ export async function saveCommitmentStore(
   store: CommitmentStoreFile,
 ): Promise<void> {
   const resolved = resolveCommitmentStorePath(storePath);
+  await runExclusiveCommitmentStoreWrite(resolved, async () => {
+    await writeCommitmentStoreFile(resolved, store);
+  });
+}
+
+async function writeCommitmentStoreFile(
+  resolved: string,
+  store: CommitmentStoreFile,
+): Promise<void> {
   await privateFileStore(path.dirname(resolved)).writeJson(
     path.basename(resolved),
     sanitizeStoreForWrite(store),
@@ -243,12 +288,22 @@ function expireStaleCommitmentsInStore(store: CommitmentStoreFile, nowMs: number
   return changed;
 }
 
-async function loadCommitmentStoreWithExpiredMarked(nowMs: number): Promise<CommitmentStoreFile> {
-  const { store, hadLegacySourceText } = await loadCommitmentStoreInternal();
+async function loadCommitmentStoreWithExpiredMarkedUnsafe(
+  nowMs: number,
+  storePath?: string,
+): Promise<CommitmentStoreFile> {
+  const resolved = resolveCommitmentStorePath(storePath);
+  const { store, hadLegacySourceText } = await loadCommitmentStoreInternal(resolved);
   if (expireStaleCommitmentsInStore(store, nowMs) || hadLegacySourceText) {
-    await saveCommitmentStore(undefined, store);
+    await writeCommitmentStoreFile(resolved, store);
   }
   return store;
+}
+
+async function loadCommitmentStoreWithExpiredMarked(nowMs: number): Promise<CommitmentStoreFile> {
+  return await runExclusiveCommitmentStoreWrite(undefined, async (resolved) =>
+    loadCommitmentStoreWithExpiredMarkedUnsafe(nowMs, resolved),
+  );
 }
 
 export async function listPendingCommitmentsForScope(params: {
@@ -289,47 +344,49 @@ export async function upsertInferredCommitments(params: {
     return [];
   }
   const nowMs = params.nowMs ?? Date.now();
-  const store = await loadCommitmentStoreWithExpiredMarked(nowMs);
-  const created: CommitmentRecord[] = [];
-  const scopeKey = buildCommitmentScopeKey(params.item);
+  return await runExclusiveCommitmentStoreWrite(undefined, async (resolved) => {
+    const store = await loadCommitmentStoreWithExpiredMarkedUnsafe(nowMs, resolved);
+    const created: CommitmentRecord[] = [];
+    const scopeKey = buildCommitmentScopeKey(params.item);
 
-  for (const entry of params.candidates) {
-    const dedupeKey = entry.candidate.dedupeKey.trim();
-    const existingIndex = store.commitments.findIndex(
-      (commitment) =>
-        buildCommitmentScopeKey(commitment) === scopeKey &&
-        commitment.dedupeKey === dedupeKey &&
-        isActiveStatus(commitment.status),
-    );
-    if (existingIndex >= 0) {
-      const existing = store.commitments[existingIndex];
-      store.commitments[existingIndex] = {
-        ...existing,
-        reason: entry.candidate.reason.trim() || existing.reason,
-        suggestedText: entry.candidate.suggestedText.trim() || existing.suggestedText,
-        confidence: Math.max(existing.confidence, entry.candidate.confidence),
-        dueWindow: {
-          earliestMs: Math.min(existing.dueWindow.earliestMs, entry.earliestMs),
-          latestMs: Math.max(existing.dueWindow.latestMs, entry.latestMs),
-          timezone: entry.timezone,
-        },
-        updatedAtMs: nowMs,
-      };
-      continue;
+    for (const entry of params.candidates) {
+      const dedupeKey = entry.candidate.dedupeKey.trim();
+      const existingIndex = store.commitments.findIndex(
+        (commitment) =>
+          buildCommitmentScopeKey(commitment) === scopeKey &&
+          commitment.dedupeKey === dedupeKey &&
+          isActiveStatus(commitment.status),
+      );
+      if (existingIndex >= 0) {
+        const existing = store.commitments[existingIndex];
+        store.commitments[existingIndex] = {
+          ...existing,
+          reason: entry.candidate.reason.trim() || existing.reason,
+          suggestedText: entry.candidate.suggestedText.trim() || existing.suggestedText,
+          confidence: Math.max(existing.confidence, entry.candidate.confidence),
+          dueWindow: {
+            earliestMs: Math.min(existing.dueWindow.earliestMs, entry.earliestMs),
+            latestMs: Math.max(existing.dueWindow.latestMs, entry.latestMs),
+            timezone: entry.timezone,
+          },
+          updatedAtMs: nowMs,
+        };
+        continue;
+      }
+      const record = candidateToRecord({
+        item: params.item,
+        candidate: entry.candidate,
+        nowMs,
+        earliestMs: entry.earliestMs,
+        latestMs: entry.latestMs,
+        timezone: entry.timezone,
+      });
+      store.commitments.push(record);
+      created.push(record);
     }
-    const record = candidateToRecord({
-      item: params.item,
-      candidate: entry.candidate,
-      nowMs,
-      earliestMs: entry.earliestMs,
-      latestMs: entry.latestMs,
-      timezone: entry.timezone,
-    });
-    store.commitments.push(record);
-    created.push(record);
-  }
-  await saveCommitmentStore(undefined, store);
-  return created;
+    await writeCommitmentStoreFile(resolved, store);
+    return created;
+  });
 }
 
 function countSentCommitmentsForSession(params: {
@@ -441,23 +498,25 @@ export async function markCommitmentsAttempted(params: {
   }
   const idSet = new Set(params.ids);
   const nowMs = params.nowMs ?? Date.now();
-  const store = await loadCommitmentStore();
-  let changed = false;
-  store.commitments = store.commitments.map((commitment) => {
-    if (!idSet.has(commitment.id)) {
-      return commitment;
+  await runExclusiveCommitmentStoreWrite(undefined, async (resolved) => {
+    const store = await loadCommitmentStore(resolved);
+    let changed = false;
+    store.commitments = store.commitments.map((commitment) => {
+      if (!idSet.has(commitment.id)) {
+        return commitment;
+      }
+      changed = true;
+      return {
+        ...commitment,
+        attempts: commitment.attempts + 1,
+        lastAttemptAtMs: nowMs,
+        updatedAtMs: nowMs,
+      };
+    });
+    if (changed) {
+      await writeCommitmentStoreFile(resolved, store);
     }
-    changed = true;
-    return {
-      ...commitment,
-      attempts: commitment.attempts + 1,
-      lastAttemptAtMs: nowMs,
-      updatedAtMs: nowMs,
-    };
   });
-  if (changed) {
-    await saveCommitmentStore(undefined, store);
-  }
 }
 
 export async function markCommitmentsStatus(params: {
@@ -471,25 +530,27 @@ export async function markCommitmentsStatus(params: {
   }
   const idSet = new Set(params.ids);
   const nowMs = params.nowMs ?? Date.now();
-  const store = await loadCommitmentStore();
-  let changed = false;
-  store.commitments = store.commitments.map((commitment) => {
-    if (!idSet.has(commitment.id) || !isActiveStatus(commitment.status)) {
-      return commitment;
+  await runExclusiveCommitmentStoreWrite(undefined, async (resolved) => {
+    const store = await loadCommitmentStore(resolved);
+    let changed = false;
+    store.commitments = store.commitments.map((commitment) => {
+      if (!idSet.has(commitment.id) || !isActiveStatus(commitment.status)) {
+        return commitment;
+      }
+      changed = true;
+      return {
+        ...commitment,
+        status: params.status,
+        updatedAtMs: nowMs,
+        ...(params.status === "sent" ? { sentAtMs: nowMs } : {}),
+        ...(params.status === "dismissed" ? { dismissedAtMs: nowMs } : {}),
+        ...(params.status === "expired" ? { expiredAtMs: nowMs } : {}),
+      };
+    });
+    if (changed) {
+      await writeCommitmentStoreFile(resolved, store);
     }
-    changed = true;
-    return {
-      ...commitment,
-      status: params.status,
-      updatedAtMs: nowMs,
-      ...(params.status === "sent" ? { sentAtMs: nowMs } : {}),
-      ...(params.status === "dismissed" ? { dismissedAtMs: nowMs } : {}),
-      ...(params.status === "expired" ? { expiredAtMs: nowMs } : {}),
-    };
   });
-  if (changed) {
-    await saveCommitmentStore(undefined, store);
-  }
 }
 
 export async function listCommitments(params?: {


### PR DESCRIPTION
Fixes #81145

## Summary
- serialize commitments-store read/modify/write sections with a per-store in-process writer queue
- wrap those serialized sections in the existing file-lock implementation so separate CLI/gateway processes cannot overwrite stale snapshots
- route status, attempt, inferred upsert, expiry, and legacy-field rewrite mutations through the protected path
- add concurrent writer regressions for status/status, attempt/status, and upsert/status races

## Real behavior proof
Behavior addressed: concurrent commitments-store writers should preserve independent updates instead of silently reverting one writer's dismissal/sent/attempt state.

Real environment tested: local OpenClaw source runtime from PR head `2e123a9dbd` on macOS, using the actual `src/commitments/store.ts` module with a temporary `OPENCLAW_STATE_DIR`. The proof starts two independent Node processes at the same time, each calling the real `markCommitmentsStatus` API against the same commitments file.

Exact command run after this patch:

```bash
node --import tsx /private/tmp/openclaw-81145-commitments-proof.ts
```

Proof output:

```json
{
  "children": [
    { "id": "cm_raceA", "code": 0, "stdout": "", "stderr": "" },
    { "id": "cm_raceB", "code": 0, "stdout": "", "stderr": "" }
  ],
  "final": {
    "cm_raceA": {
      "status": "dismissed",
      "dismissedAtMs": 1778790000001,
      "attempts": 0
    },
    "cm_raceB": {
      "status": "dismissed",
      "dismissedAtMs": 1778790000002,
      "attempts": 0
    }
  },
  "bothDismissed": true
}
```

Observed result after fix: both child processes exited successfully, and the shared on-disk commitments store retained both dismissals with their distinct timestamps.

What was not tested: I did not run a live heartbeat delivery against an LLM provider; the focused heartbeat test covers the heartbeat commitments path without external provider credentials.

## Verification
- `pnpm test src/commitments/store.test.ts`
- `pnpm test src/infra/heartbeat-runner.commitments.test.ts`
- `pnpm exec oxfmt --write --threads=1 src/commitments/store.ts src/commitments/store.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/commitments/store.ts src/commitments/store.test.ts`
- `git diff --check`
- `CI=1 pnpm check:changed`
- cross-process source-runtime proof above
