### PR TITLE
fix: replace regex in isValidBase64 with Buffer round-trip to prevent stack overflow on large attachments

### DIFF
--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -118,7 +118,12 @@ function isValidBase64(value: string): boolean {
   if (value.length === 0 || value.length % 4 !== 0) {
     return false;
   }
-  return /^[A-Za-z0-9+/]+={0,2}$/.test(value);
+  // Avoid regex stack overflow on very large base64 strings; use Buffer round-trip instead.
+  try {
+    return Buffer.from(value, 'base64').toString('base64') === value;
+  } catch {
+    return false;
+  }
 }
 
 function verifyDecodedSize(buffer: Buffer, estimatedBytes: number, label: string): void {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -118,12 +118,26 @@ function isValidBase64(value: string): boolean {
   if (value.length === 0 || value.length % 4 !== 0) {
     return false;
   }
-  // Avoid regex stack overflow on very large base64 strings; use Buffer round-trip instead.
-  try {
-    return Buffer.from(value, 'base64').toString('base64') === value;
-  } catch {
-    return false;
+  // Walk character codes instead of regex to avoid V8 stack overflow on large strings.
+  const len = value.length;
+  const padStart =
+    value[len - 1] === '=' ? (value[len - 2] === '=' ? len - 2 : len - 1) : len;
+  for (let i = 0; i < padStart; i++) {
+    const c = value.charCodeAt(i);
+    if (
+      !(c >= 65 && c <= 90) && // A-Z
+      !(c >= 97 && c <= 122) && // a-z
+      !(c >= 48 && c <= 57) && // 0-9
+      c !== 43 && // +
+      c !== 47 // /
+    ) {
+      return false;
+    }
   }
+  for (let i = padStart; i < len; i++) {
+    if (value.charCodeAt(i) !== 61) return false; // =
+  }
+  return true;
 }
 
 function verifyDecodedSize(buffer: Buffer, estimatedBytes: number, label: string): void {


### PR DESCRIPTION
## Summary

The `isValidBase64` function in `src/gateway/chat-attachments.ts` uses a regex to validate base64 strings:

```ts
return /^[A-Za-z0-9+\/]+={0,2}$/.test(value);
```

On very large attachment payloads this regex can cause a V8 stack overflow because the engine processes the entire string in one shot.

## Fix

Replace the whole-string regex with a character-code walk — no `Buffer.from`, no decoding, just an O(n) loop:

```ts
const len = value.length;
const padStart =
  value[len - 1] === '=' ? (value[len - 2] === '=' ? len - 2 : len - 1) : len;
for (let i = 0; i < padStart; i++) {
  const c = value.charCodeAt(i);
  if (
    !(c >= 65 && c <= 90) && // A-Z
    !(c >= 97 && c <= 122) && // a-z
    !(c >= 48 && c <= 57) && // 0-9
    c !== 43 && // +
    c !== 47 // /
  ) return false;
}
for (let i = padStart; i < len; i++) {
  if (value.charCodeAt(i) !== 61) return false; // =
}
return true;
```

This preserves the existing behavior (no decoding, size limits still reject before validation) while eliminating the stack overflow risk on large payloads.

## Real behavior proof

Behavior addressed: `isValidBase64` throws `RangeError: Maximum call stack size exceeded` when called with a base64 string representing a large attachment (10 MB+).

Real environment tested: Local OpenClaw gateway, large file attachment via WebChat.