### PR TITLE
fix(agent): continue after empty final tool turn

### DIFF
--- a/src/agents/pi-embedded-runner/run.empty-tool-final-answer-continuation.test.ts
+++ b/src/agents/pi-embedded-runner/run.empty-tool-final-answer-continuation.test.ts
@@ -1,0 +1,102 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedClassifyFailoverReason,
+  mockedGlobalHookRunner,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
+
+let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+
+function emptyFinalAfterToolsAttempt(provider: string, model: string): EmbeddedRunAttemptResult {
+  return makeAttemptResult({
+    assistantTexts: [],
+    toolMetas: [{ toolName: "exec", meta: "echo ok" }],
+    itemLifecycle: {
+      startedCount: 4,
+      completedCount: 4,
+      activeCount: 0,
+    },
+    lastAssistant: {
+      stopReason: "stop",
+      provider,
+      model,
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+  });
+}
+
+function successAttempt(provider: string, model: string): EmbeddedRunAttemptResult {
+  return makeAttemptResult({
+    assistantTexts: ["Done."],
+    lastAssistant: {
+      stopReason: "stop",
+      provider,
+      model,
+      content: [{ type: "text", text: "Done." }],
+      usage: { input: 100, output: 5, totalTokens: 105 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+  });
+}
+
+describe("runEmbeddedPiAgent empty-final continuation after completed tools", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+    mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
+    mockedClassifyFailoverReason.mockReturnValue(null);
+  });
+
+  it("runs exactly one no-tool continuation instead of surfacing the side-effect warning", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyFinalAfterToolsAttempt("openai-codex", "gpt-5.5"),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(successAttempt("openai-codex", "gpt-5.5"));
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      runId: "run-empty-final-after-tools-continuation",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    const secondAttemptParams = mockedRunEmbeddedAttempt.mock.calls[1]?.[0] as {
+      prompt?: string;
+      disableTools?: boolean;
+    };
+    expect(secondAttemptParams.disableTools).toBe(true);
+    expect(secondAttemptParams.prompt).toContain(
+      "The previous attempt completed tool calls but produced no user-visible answer",
+    );
+    expect(result.payloads).toBeUndefined();
+  });
+
+  it("surfaces the existing incomplete-turn warning if the no-tool continuation is empty too", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyFinalAfterToolsAttempt("openai-codex", "gpt-5.5"),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyFinalAfterToolsAttempt("openai-codex", "gpt-5.5"),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      runId: "run-empty-final-after-tools-continuation-exhausted",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("Agent couldn't generate a response");
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -185,6 +185,8 @@ const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
 const EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS = 30_000;
 const MID_TURN_PRECHECK_CONTINUATION_PROMPT =
   "Continue from the current transcript after the latest tool result. Do not repeat the original user request, and do not rerun completed tools unless the transcript shows they are still needed.";
+const EMPTY_TOOL_FINAL_ANSWER_CONTINUATION_PROMPT =
+  "The previous attempt completed tool calls but produced no user-visible answer. Continue from the existing transcript and tool results, and produce the final answer now. Do not call tools again.";
 const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
 type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
@@ -257,6 +259,44 @@ function hasCompletedModelProgressForIdleBreaker(attempt: EmbeddedRunAttemptForR
     hasMessagingToolDeliveryEvidence(attempt) ||
     attempt.itemLifecycle.completedCount > 0
   );
+}
+
+function shouldRetryEmptyFinalAnswerAfterCompletedTools(params: {
+  attempt: EmbeddedRunAttemptForRunner;
+  payloadCount: number;
+  aborted: boolean;
+  promptError: unknown;
+  timedOut: boolean;
+}): boolean {
+  const { attempt, payloadCount, aborted, promptError, timedOut } = params;
+  if (payloadCount !== 0 || aborted || promptError || timedOut) {
+    return false;
+  }
+  if (
+    attempt.clientToolCalls ||
+    attempt.yieldDetected ||
+    attempt.didSendDeterministicApprovalPrompt ||
+    attempt.lastToolError
+  ) {
+    return false;
+  }
+  if (attempt.didSendViaMessagingTool || hasMessagingToolDeliveryEvidence(attempt)) {
+    return false;
+  }
+  if ((attempt.itemLifecycle?.activeCount ?? 0) > 0) {
+    return false;
+  }
+  if ((attempt.itemLifecycle?.completedCount ?? 0) <= 0 && (attempt.toolMetas?.length ?? 0) <= 0) {
+    return false;
+  }
+  if ((attempt.assistantTexts ?? []).some((text) => text.trim().length > 0)) {
+    return false;
+  }
+  const assistant = attempt.currentAttemptAssistant ?? attempt.lastAssistant;
+  if (assistant?.stopReason === "error") {
+    return false;
+  }
+  return true;
 }
 
 function createEmptyAuthProfileStore(): AuthProfileStore {
@@ -918,6 +958,8 @@ export async function runEmbeddedPiAgent(
       let reasoningOnlyRetryAttempts = 0;
       let emptyResponseRetryAttempts = 0;
       let compactionContinuationRetryAttempts = 0;
+      let emptyToolFinalAnswerContinuationAttempts = 0;
+      let forceDisableToolsForNextAttempt = false;
       let sameModelIdleTimeoutRetries = 0;
       // Cost-runaway breaker for #76293. State lives at the run-loop level
       // on purpose so it survives across attempt boundaries and across
@@ -1304,7 +1346,7 @@ export async function runEmbeddedPiAgent(
             images: params.images,
             imageOrder: params.imageOrder,
             clientTools: params.clientTools,
-            disableTools: params.disableTools,
+            disableTools: params.disableTools || forceDisableToolsForNextAttempt,
             provider,
             modelId,
             // Use the harness selected before model/auth setup for the actual
@@ -1394,6 +1436,7 @@ export async function runEmbeddedPiAgent(
           if (postCompactionAbortError) {
             throw postCompactionAbortError;
           }
+          forceDisableToolsForNextAttempt = false;
           const attempt = normalizeEmbeddedRunAttemptResult(rawAttempt);
 
           const {
@@ -2743,6 +2786,29 @@ export async function runEmbeddedPiAgent(
             continue;
           }
           compactionContinuationRetryInstruction = null;
+          if (
+            !emptyAssistantReplyIsSilent &&
+            incompleteTurnText &&
+            emptyToolFinalAnswerContinuationAttempts < 1 &&
+            shouldRetryEmptyFinalAnswerAfterCompletedTools({
+              payloadCount,
+              aborted,
+              promptError,
+              timedOut,
+              attempt,
+            })
+          ) {
+            emptyToolFinalAnswerContinuationAttempts += 1;
+            nextAttemptPromptOverride = EMPTY_TOOL_FINAL_ANSWER_CONTINUATION_PROMPT;
+            suppressNextUserMessagePersistence = true;
+            forceDisableToolsForNextAttempt = true;
+            log.warn(
+              `empty final answer after completed tools: runId=${params.runId} sessionId=${params.sessionId} ` +
+                `tools=${attempt.toolMetas?.length ?? 0} completed=${attempt.itemLifecycle?.completedCount ?? 0} ` +
+                `— retrying 1/1 with no-tool final-answer continuation`,
+            );
+            continue;
+          }
           if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
             log.warn(
               `reasoning-only retries exhausted: runId=${params.runId} sessionId=${params.sessionId} ` +


### PR DESCRIPTION
## Summary
- retry once when a Pi run completes tool calls but returns an empty final assistant message
- continue from the existing transcript/tool results with tools disabled for the retry
- keep existing messaging-tool delivery suppression and real error fallback behavior intact

## Real behavior proof
- **Behavior or issue addressed:** Live OpenClaw could complete non-message tool calls successfully, then produce an empty final assistant turn and surface the generic `Agent couldn't generate a response` warning. This patch retries that exact empty-final-after-tools case once from existing tool results, with tools disabled for the retry.
- **Real environment tested:** Jack's Mac Mini running installed `OpenClaw 2026.5.7 (eeef486)` from `/usr/local/lib/node_modules/openclaw`, Telegram gateway on port `18789`.
- **Exact steps or command run after this patch:** Applied the installed-dist hotfix to `/usr/local/lib/node_modules/openclaw/dist/pi-embedded-Bcz04p2i.js`, ran the live syntax/proof commands below, then restarted the local gateway to load the patched runtime.
- **Evidence after fix:** Terminal output / live output from the real installed setup:

```text
$ node --check /usr/local/lib/node_modules/openclaw/dist/pi-embedded-Bcz04p2i.js
$ node tmp/task-129-empty-tool-turn-regression.mjs
task-129 regression proof passed

$ openclaw gateway status
Runtime: running (pid 95818)
Connectivity probe: ok

/tmp/openclaw/openclaw-2026-05-14.log:
2026-05-14T20:19:02.358Z gateway ready
```

- **Observed result after fix:** The patched installed runtime loaded successfully after gateway restart; the local proof confirmed the new branch performs the no-tool continuation predicate for successful tools + empty final answer and preserves existing skip cases for visible text, tool errors, active tools, message-tool delivery, and provider errors.
- **What was not tested:** No additional manual Telegram reproduction was run after restart because the source regression and installed live proof covered the target branch, and Jack explicitly said no QA was needed for this handoff.

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/run.empty-tool-final-answer-continuation.test.ts src/agents/pi-embedded-runner/run.empty-error-retry.test.ts` (8 tests passed)
- `node_modules/.bin/oxfmt --check src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run.empty-tool-final-answer-continuation.test.ts`

## Notes
- Full project `tsc`/`tsgo` did not complete within the local agent 60s command cap; the first default-heap `tsc` attempt OOMed, and 8GB `tsc`/`tsgo` attempts hit the enforced 60s timeout with no diagnostics emitted.
