### PR TITLE
fix(compaction): bound stale transcript usage

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1593,6 +1593,75 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
   });
 
+  it("drops marker-proven stale output and tail even when prompt usage is moderate", async () => {
+    const sessionFile = path.join(rootDir, "moderate-stale-usage-after-compaction.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "pre-compaction moderate turn" }],
+            usage: { input: 9_000, output: 80_000 },
+          },
+        }),
+        JSON.stringify({
+          message: {
+            role: "tool",
+            content: `pre-compaction stale tool result ${"x".repeat(450_000)}`,
+          },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          timestamp: new Date(1_700_000_000_000).toISOString(),
+          result: { summary: "compacted" },
+        }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "post-compaction summary with a small active replay" }],
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
   it("skips OpenClaw preflight compaction for persisted Codex runtime sessions", async () => {
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1524,6 +1524,75 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(refreshQueuedFollowupSessionMock).not.toHaveBeenCalled();
   });
 
+  it("drops stale transcript usage and pre-compaction tail before preflight compaction", async () => {
+    const sessionFile = path.join(rootDir, "stale-usage-after-compaction.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "pre-compaction giant turn" }],
+            usage: { input: 240_000, output: 120_000 },
+          },
+        }),
+        JSON.stringify({
+          message: {
+            role: "tool",
+            content: `pre-compaction stale tool result ${"x".repeat(450_000)}`,
+          },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          timestamp: new Date(1_700_000_000_000).toISOString(),
+          result: { summary: "compacted" },
+        }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "post-compaction summary with a small active replay" }],
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
   it("skips OpenClaw preflight compaction for persisted Codex runtime sessions", async () => {
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1662,6 +1662,78 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
   });
 
+  it("does not treat ordinary transcript text echoing the refresh phrase as a compaction marker", async () => {
+    const sessionFile = path.join(rootDir, "phrase-echo-without-marker.jsonl");
+    // Same stale-usage shape as the marker tests, but the post-compaction phrases
+    // appear only as ordinary user/assistant message text — there is NO structured
+    // {type:"compaction"} record. The estimator must keep the stale usage active and
+    // still compact, instead of being fooled into dropping pressure.
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "pre-compaction giant turn" }],
+            usage: { input: 240_000, output: 120_000 },
+          },
+        }),
+        JSON.stringify({
+          message: {
+            role: "tool",
+            content: `pre-compaction stale tool result ${"x".repeat(450_000)}`,
+          },
+        }),
+        JSON.stringify({
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "[Post-compaction context refresh]\n\nSession was just compacted.",
+              },
+            ],
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalled();
+  });
+
   it("skips OpenClaw preflight compaction for persisted Codex runtime sessions", async () => {
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -329,6 +329,8 @@ export type SessionTranscriptUsageSnapshot = {
   promptTokens?: number;
   outputTokens?: number;
   trailingBytesTokens?: number;
+  postCompactionTrailingBytesTokens?: number;
+  hasPostUsageCompactionMarker?: boolean;
 };
 
 // Keep a generous near-threshold window so large assistant outputs still trigger
@@ -356,6 +358,74 @@ function parseUsageFromTranscriptLine(line: string): ReturnType<typeof normalize
     // ignore bad lines
   }
   return undefined;
+}
+
+function collectTranscriptText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (!Array.isArray(value)) {
+    return "";
+  }
+  return value
+    .map((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        return "";
+      }
+      const text = (item as { text?: unknown }).text;
+      return typeof text === "string" ? text : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function transcriptLineHasPostUsageCompactionMarker(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      type?: unknown;
+      message?: { content?: unknown };
+      payload?: { type?: unknown; text?: unknown };
+    };
+    if (parsed.type === "compaction" || parsed.type === "session.compacted") {
+      return true;
+    }
+    const payloadType = parsed.payload?.type;
+    if (payloadType === "compaction" || payloadType === "session.compacted") {
+      return true;
+    }
+    const text = [
+      collectTranscriptText(parsed.message?.content),
+      collectTranscriptText(parsed.payload?.text),
+    ]
+      .filter(Boolean)
+      .join("\n");
+    return (
+      text.includes("[Post-compaction context refresh]") ||
+      text.includes("Session was just compacted.")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function estimateTranscriptLinesBytes(lines: string[]): number {
+  if (lines.length === 0) {
+    return 0;
+  }
+  return Buffer.byteLength(lines.join("\n"), "utf8") + lines.length;
+}
+
+function findLastPostUsageCompactionMarkerIndex(lines: string[]): number {
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (transcriptLineHasPostUsageCompactionMarker(lines[index] ?? "")) {
+      return index;
+    }
+  }
+  return -1;
 }
 
 function resolveSessionLogPath(
@@ -395,6 +465,8 @@ function deriveTranscriptUsageSnapshot(
     | {
         usage?: ReturnType<typeof normalizeUsage>;
         trailingBytes?: number;
+        postCompactionTrailingBytes?: number;
+        hasPostUsageCompactionMarker?: boolean;
       }
     | undefined,
 ): SessionTranscriptUsageSnapshot | undefined {
@@ -414,11 +486,18 @@ function deriveTranscriptUsageSnapshot(
   return {
     promptTokens,
     outputTokens,
+    hasPostUsageCompactionMarker: snapshot.hasPostUsageCompactionMarker === true ? true : undefined,
     trailingBytesTokens:
       typeof snapshot.trailingBytes === "number" &&
       Number.isFinite(snapshot.trailingBytes) &&
       snapshot.trailingBytes >= 0
         ? Math.ceil(snapshot.trailingBytes / FALLBACK_TRANSCRIPT_BYTES_PER_TOKEN)
+        : undefined,
+    postCompactionTrailingBytesTokens:
+      typeof snapshot.postCompactionTrailingBytes === "number" &&
+      Number.isFinite(snapshot.postCompactionTrailingBytes) &&
+      snapshot.postCompactionTrailingBytes > 0
+        ? Math.ceil(snapshot.postCompactionTrailingBytes / FALLBACK_TRANSCRIPT_BYTES_PER_TOKEN)
         : undefined,
   };
 }
@@ -496,6 +575,10 @@ type SessionLogUsageScan = {
   usage?: ReturnType<typeof normalizeUsage>;
   trailingBytes?: number;
   byteSize: number;
+  // Set when a compaction marker follows the last usage line, so the estimator can
+  // treat that usage as stale pre-compaction state instead of current active context.
+  hasPostUsageCompactionMarker?: boolean;
+  postCompactionTrailingBytes?: number;
 };
 
 async function readSessionLogByteSize(logPath: string): Promise<number | undefined> {
@@ -518,6 +601,8 @@ async function readLastNonzeroUsageFromSessionLog(logPath: string): Promise<Sess
     const stat = await handle.stat();
     let position = stat.size;
     let leadingPartial = "";
+    let postUsageCompactionMarkerSeen = false;
+    let postCompactionTrailingBytes: number | undefined;
     while (position > 0) {
       const chunkSize = Math.min(TRANSCRIPT_TAIL_CHUNK_BYTES, position);
       const start = position - chunkSize;
@@ -544,11 +629,29 @@ async function readLastNonzeroUsageFromSessionLog(logPath: string): Promise<Sess
         if (usage) {
           const trailingLines = lines.slice(i + 1);
           const trailingBytesInChunk = estimatePostUsageTrailingBytes(trailingLines);
+          const markerIndex = findLastPostUsageCompactionMarkerIndex(trailingLines);
+          const hasMarkerInTrailingLines = markerIndex >= 0;
+          const postCompactionTrailingBytesInChunk = hasMarkerInTrailingLines
+            ? suffixBytesOutsideCombined +
+              estimateTranscriptLinesBytes(trailingLines.slice(markerIndex + 1))
+            : undefined;
           return {
             usage,
             trailingBytes: suffixBytesOutsideCombined + trailingBytesInChunk,
             byteSize: stat.size,
+            hasPostUsageCompactionMarker: postUsageCompactionMarkerSeen || hasMarkerInTrailingLines,
+            postCompactionTrailingBytes: postUsageCompactionMarkerSeen
+              ? postCompactionTrailingBytes
+              : postCompactionTrailingBytesInChunk,
           };
+        }
+      }
+      if (!postUsageCompactionMarkerSeen) {
+        const markerIndex = findLastPostUsageCompactionMarkerIndex(lines);
+        if (markerIndex >= 0) {
+          postUsageCompactionMarkerSeen = true;
+          postCompactionTrailingBytes =
+            suffixBytesOutsideCombined + estimateTranscriptLinesBytes(lines.slice(markerIndex + 1));
         }
       }
       position = start;
@@ -559,6 +662,8 @@ async function readLastNonzeroUsageFromSessionLog(logPath: string): Promise<Sess
           usage,
           trailingBytes: Math.max(0, stat.size - Buffer.byteLength(leadingPartial, "utf8")),
           byteSize: stat.size,
+          hasPostUsageCompactionMarker: postUsageCompactionMarkerSeen,
+          postCompactionTrailingBytes,
         }
       : { byteSize: stat.size };
   } finally {
@@ -614,6 +719,7 @@ async function estimatePromptTokensFromSessionTranscript(params: {
     const promptTokens = snapshot.usage?.promptTokens;
     const trailingBytesTokens = snapshot.usage?.trailingBytesTokens;
     const outputTokens = snapshot.usage?.outputTokens;
+    const postCompactionTrailingBytesTokens = snapshot.usage?.postCompactionTrailingBytesTokens;
     if (
       typeof promptTokens === "number" &&
       Number.isFinite(promptTokens) &&
@@ -648,11 +754,30 @@ async function estimatePromptTokensFromSessionTranscript(params: {
       return Number.isFinite(tokens) && tokens > 0 ? Math.ceil(tokens) : undefined;
     })();
     if (typeof promptTokens === "number" && Number.isFinite(promptTokens) && promptTokens > 0) {
-      const usagePromptTokens = Math.ceil(promptTokens) + (trailingBytesTokens ?? 0);
+      const rawUsagePromptTokens = Math.ceil(promptTokens);
+      // After a compaction marker, the last persisted usage line still records the
+      // pre-compaction prompt size. Treat it as stale when it dwarfs the live replayed
+      // message estimate, and bound the estimate to post-compaction context so preflight
+      // does not repeatedly compact a session that is already well under the model limit.
+      const hasStaleUsageSnapshot =
+        snapshot.usage?.hasPostUsageCompactionMarker === true &&
+        typeof estimatedMessageTokens === "number" &&
+        rawUsagePromptTokens > estimatedMessageTokens * 2 + 10_000;
+      const boundedUsagePromptTokens =
+        hasStaleUsageSnapshot && typeof estimatedMessageTokens === "number"
+          ? estimatedMessageTokens
+          : rawUsagePromptTokens;
+      const tailTokens = hasStaleUsageSnapshot
+        ? (postCompactionTrailingBytesTokens ?? 0)
+        : (trailingBytesTokens ?? 0);
+      const usagePromptTokens = boundedUsagePromptTokens + tailTokens;
       return {
         promptTokens: Math.max(usagePromptTokens, estimatedMessageTokens ?? 0),
         outputTokens:
-          typeof outputTokens === "number" && Number.isFinite(outputTokens) && outputTokens > 0
+          !hasStaleUsageSnapshot &&
+          typeof outputTokens === "number" &&
+          Number.isFinite(outputTokens) &&
+          outputTokens > 0
             ? Math.ceil(outputTokens)
             : undefined,
         transcriptByteSize: snapshot.byteSize,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -755,26 +755,29 @@ async function estimatePromptTokensFromSessionTranscript(params: {
     })();
     if (typeof promptTokens === "number" && Number.isFinite(promptTokens) && promptTokens > 0) {
       const rawUsagePromptTokens = Math.ceil(promptTokens);
+      const hasPostUsageCompactionMarker = snapshot.usage?.hasPostUsageCompactionMarker === true;
       // After a compaction marker, the last persisted usage line still records the
       // pre-compaction prompt size. Treat it as stale when it dwarfs the live replayed
       // message estimate, and bound the estimate to post-compaction context so preflight
       // does not repeatedly compact a session that is already well under the model limit.
       const hasStaleUsageSnapshot =
-        snapshot.usage?.hasPostUsageCompactionMarker === true &&
+        hasPostUsageCompactionMarker &&
         typeof estimatedMessageTokens === "number" &&
         rawUsagePromptTokens > estimatedMessageTokens * 2 + 10_000;
       const boundedUsagePromptTokens =
         hasStaleUsageSnapshot && typeof estimatedMessageTokens === "number"
           ? estimatedMessageTokens
           : rawUsagePromptTokens;
-      const tailTokens = hasStaleUsageSnapshot
+      // With a marker present, the bytes before it belong to stale pre-compaction state;
+      // only count post-marker trailing bytes so the tail does not re-inflate the estimate.
+      const tailTokens = hasPostUsageCompactionMarker
         ? (postCompactionTrailingBytesTokens ?? 0)
         : (trailingBytesTokens ?? 0);
       const usagePromptTokens = boundedUsagePromptTokens + tailTokens;
       return {
         promptTokens: Math.max(usagePromptTokens, estimatedMessageTokens ?? 0),
         outputTokens:
-          !hasStaleUsageSnapshot &&
+          !hasPostUsageCompactionMarker &&
           typeof outputTokens === "number" &&
           Number.isFinite(outputTokens) &&
           outputTokens > 0

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -360,52 +360,27 @@ function parseUsageFromTranscriptLine(line: string): ReturnType<typeof normalize
   return undefined;
 }
 
-function collectTranscriptText(value: unknown): string {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (!Array.isArray(value)) {
-    return "";
-  }
-  return value
-    .map((item) => {
-      if (!item || typeof item !== "object" || Array.isArray(item)) {
-        return "";
-      }
-      const text = (item as { text?: unknown }).text;
-      return typeof text === "string" ? text : "";
-    })
-    .filter(Boolean)
-    .join("\n");
-}
-
 function transcriptLineHasPostUsageCompactionMarker(line: string): boolean {
   const trimmed = line.trim();
   if (!trimmed) {
     return false;
   }
   try {
+    // Only trust structured compaction records (written by the runtime at
+    // compaction time, e.g. transcript-file-state / session-manager). The
+    // post-compaction refresh phrases are prompt-injected context, so matching
+    // them in free message text would let ordinary user/tool content that
+    // echoes the phrase masquerade as a marker and wrongly drop stale-usage
+    // pressure.
     const parsed = JSON.parse(trimmed) as {
       type?: unknown;
-      message?: { content?: unknown };
-      payload?: { type?: unknown; text?: unknown };
+      payload?: { type?: unknown };
     };
-    if (parsed.type === "compaction" || parsed.type === "session.compacted") {
-      return true;
-    }
-    const payloadType = parsed.payload?.type;
-    if (payloadType === "compaction" || payloadType === "session.compacted") {
-      return true;
-    }
-    const text = [
-      collectTranscriptText(parsed.message?.content),
-      collectTranscriptText(parsed.payload?.text),
-    ]
-      .filter(Boolean)
-      .join("\n");
     return (
-      text.includes("[Post-compaction context refresh]") ||
-      text.includes("Session was just compacted.")
+      parsed.type === "compaction" ||
+      parsed.type === "session.compacted" ||
+      parsed.payload?.type === "compaction" ||
+      parsed.payload?.type === "session.compacted"
     );
   } catch {
     return false;


### PR DESCRIPTION
Fixes #81178

## Summary
- bound stale raw transcript prompt-usage snapshots against the recent active replay estimate
- keep post-usage tail pressure additive for fresh usage records so interrupted tool output after the latest usage record remains conservative
- when a post-usage compaction marker proves the latest usage snapshot is stale, count only the post-marker tail bytes instead of stale pre-compaction tail bytes
- drop marker-proven stale output pressure even when the stale prompt usage is moderate and does not trip the prompt-disparity heuristic
- add preflight compaction regressions for both giant stale usage and moderate stale prompt usage with large stale output/pre-marker tail

## Real behavior proof
Behavior addressed: stale pre-compaction transcript usage, stale pre-marker tail bytes, and stale output tokens should not force another preflight compaction when a post-usage compaction marker proves that the active post-compaction replay is small and no explicit transcript-byte policy is exceeded.

Real environment tested: local OpenClaw source runtime from PR head `74ba2e34ec` on macOS, using a real temporary JSONL session transcript and the actual `runPreflightCompactionIfNeeded` path. The compact dependency was instrumented only to count whether the runtime attempted compaction.

Exact steps or command run after this patch: from the PR checkout at `74ba2e34ec`, ran a `node --import tsx` source-runtime proof that wrote a transcript with stale assistant usage `input=9000`, stale assistant usage `output=80000`, a 450000-byte stale pre-marker tool result, a compaction marker, and a small post-compaction replay; then it invoked `runPreflightCompactionIfNeeded` with a 100000-token context window.

Evidence after fix: copied terminal output from the direct source-runtime proof:

```json
{
  "head": "74ba2e34ec",
  "behavior": "post-usage compaction marker drops stale output and pre-marker tail pressure",
  "staleUsageInputTokens": 9000,
  "staleOutputTokens": 80000,
  "preMarkerTailBytes": 450000,
  "contextWindowTokens": 100000,
  "compactCalls": 0,
  "phaseCalls": [],
  "returnedOriginalEntry": true
}
```

Observed result after fix: the source-runtime preflight call returned the original session entry, never entered the `preflight_compacting` phase, and made zero compaction calls despite stale output plus stale pre-marker tail pressure that would otherwise exceed the configured 100k context window.

What was not tested: I did not run a live Discord/Pi provider session because the failure is in the local preflight estimator and the source-runtime proof exercises that estimator path directly.

## Verification
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts` (25 passed)
- `node_modules/.bin/oxfmt --check --threads=1 src/auto-reply/reply/agent-runner-memory.ts src/auto-reply/reply/agent-runner-memory.test.ts`
- `git diff --check`
- `git diff --cached --check`
- `git merge-tree --write-tree HEAD origin/main`
- `node --import tsx -e ...` source-runtime proof copied above

---

_Re-verified at exact branch head `74ba2e34ec` on 2026-06-03 (the earlier proof referenced `b90c31584d`, the head before the Dependency Guard rebase; the patch is unchanged — two commits on top of current `main` `ed4c4afc0f`)._

**Before fix** (origin/main estimator, same standalone source-runtime harness and transcript): `runPreflightCompactionIfNeeded` **throws** `Preflight compaction required but failed: not_compacted` — i.e. main forces preflight compaction for the stale-after-compaction transcript (the bug).

**After fix** (PR head `74ba2e34ec`), both regression scenarios via the real source-runtime path (`node --import tsx`, compaction action instrumented only to count attempts):

```json
{ "head": "74ba2e34ec", "behavior": "post-usage compaction marker drops stale output and pre-marker tail pressure",
  "staleUsageInputTokens": 9000, "staleOutputTokens": 80000, "preMarkerTailBytes": 450000,
  "contextWindowTokens": 100000, "compactCalls": 0, "phaseCalls": [], "returnedOriginalEntry": true }
{ "head": "74ba2e34ec", "behavior": "giant stale pre-compaction usage dropped after compaction marker",
  "staleUsageInputTokens": 240000, "staleOutputTokens": 120000, "preMarkerTailBytes": 450000,
  "contextWindowTokens": 100000, "compactCalls": 0, "phaseCalls": [], "returnedOriginalEntry": true }
PROOF_RESULT: PASS
```

Focused suite at this head: `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts` → 42 passed.


---

### Update 2026-06-03 — addressed ClawSweeper P1 (head `26d1293708`)

ClawSweeper re-review (proof judged `diamond lobster`) raised a P1 patch-quality
risk: `transcriptLineHasPostUsageCompactionMarker` also matched the post-compaction
refresh phrases (`[Post-compaction context refresh]`, `Session was just compacted.`)
in free message text, so ordinary user/tool content echoing them could masquerade
as a marker and wrongly drop stale-usage pressure.

Fix: detect **only structured compaction records** (`type`/`payload.type` ===
`"compaction"` | `"session.compacted"` — the records the runtime actually persists
via `transcript-file-state.ts` / `session-manager.ts`). Dropped the free-text
fallback and the now-unused `collectTranscriptText` helper (net -? prod LOC).
The refresh phrases come from `post-compaction-context.ts` and are prompt-injected
context, not persisted transcript markers, so structured detection fully covers the
real signal.

Real behavior proof at head `26d1293708` (`node --import tsx`, real
`runPreflightCompactionIfNeeded`, compaction instrumented to count attempts):

```text
# structured {type:"compaction"} markers still suppress compaction (feature preserved)
moderate stale (in=9000 out=80000, 450k tail): compactCalls=0, returnedOriginalEntry=true
giant   stale (in=240000 out=120000, 450k tail): compactCalls=0, returnedOriginalEntry=true
PROOF_RESULT: PASS

# NEW: ordinary user text echoing the refresh phrases, NO structured marker -> still compacts
text-only phrase echo: compactCalls=1
NEG_PROOF_RESULT: PASS (compaction attempted, not fooled)
```

Focused suite: `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts` → 43 passed (adds the "does not treat ordinary transcript text echoing the refresh phrase as a compaction marker" regression). `oxfmt --check` clean.
