### PR TITLE
Default bootstrap truncation warnings to always

### DIFF
--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -124,7 +124,7 @@ By default, OpenClaw injects a fixed set of workspace files (if present):
 
 Large files are truncated per-file using `agents.defaults.bootstrapMaxChars` (default `12000` chars). OpenClaw also enforces a total bootstrap injection cap across files with `agents.defaults.bootstrapTotalMaxChars` (default `60000` chars). `/context` shows **raw vs injected** sizes and whether truncation happened.
 
-When truncation occurs, the runtime can inject an in-prompt warning block under Project Context. Configure this with `agents.defaults.bootstrapPromptTruncationWarning` (`off`, `once`, `always`; default `once`).
+When truncation occurs, the runtime can inject an in-prompt warning block under Project Context. Configure this with `agents.defaults.bootstrapPromptTruncationWarning` (`off`, `once`, `always`; default `always`).
 
 ## Skills: injected vs loaded on-demand
 

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -204,7 +204,7 @@ content across files is capped by `agents.defaults.bootstrapTotalMaxChars`
 (default: 60000). Missing files inject a short missing-file marker. When truncation
 occurs, OpenClaw can inject a concise system-prompt warning notice; control this with
 `agents.defaults.bootstrapPromptTruncationWarning` (`off`, `once`, `always`;
-default: `once`). Detailed raw/injected counts stay in diagnostics such as
+default: `always`). Detailed raw/injected counts stay in diagnostics such as
 `/context`, `/status`, doctor, and logs.
 
 For memory files, truncation is not data loss: the file remains intact on disk,

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -156,11 +156,11 @@ injection behavior from the shared defaults. Omitted fields inherit from
 ### `agents.defaults.bootstrapPromptTruncationWarning`
 
 Controls the agent-visible system-prompt notice when bootstrap context is truncated.
-Default: `"once"`.
+Default: `"always"`.
 
 - `"off"`: never inject truncation notice text into the system prompt.
-- `"once"`: inject a concise notice once per unique truncation signature (recommended).
-- `"always"`: inject a concise notice on every run when truncation exists.
+- `"once"`: inject a concise notice once per unique truncation signature.
+- `"always"`: inject a concise notice on every run when truncation exists (recommended).
 
 Detailed raw/injected counts and config tuning fields stay in diagnostics such
 as context/status reports and logs; routine WebChat user/runtime context only
@@ -168,7 +168,7 @@ gets the concise recovery notice.
 
 ```json5
 {
-  agents: { defaults: { bootstrapPromptTruncationWarning: "once" } }, // off | once | always
+  agents: { defaults: { bootstrapPromptTruncationWarning: "always" } }, // off | once | always
 }
 ```
 

--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -293,10 +293,9 @@ describe("bootstrap limit resolvers", () => {
 });
 
 describe("resolveBootstrapPromptTruncationWarningMode", () => {
-  it("defaults to once", () => {
-    expect(resolveBootstrapPromptTruncationWarningMode()).toBe(
-      DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE,
-    );
+  it("defaults to always", () => {
+    expect(resolveBootstrapPromptTruncationWarningMode()).toBe("always");
+    expect(DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE).toBe("always");
   });
 
   it("accepts explicit valid modes", () => {
@@ -305,6 +304,11 @@ describe("resolveBootstrapPromptTruncationWarningMode", () => {
         agents: { defaults: { bootstrapPromptTruncationWarning: "off" } },
       } as OpenClawConfig),
     ).toBe("off");
+    expect(
+      resolveBootstrapPromptTruncationWarningMode({
+        agents: { defaults: { bootstrapPromptTruncationWarning: "once" } },
+      } as OpenClawConfig),
+    ).toBe("once");
     expect(
       resolveBootstrapPromptTruncationWarningMode({
         agents: { defaults: { bootstrapPromptTruncationWarning: "always" } },

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -87,7 +87,7 @@ export function stripThoughtSignatures<T>(
 
 export const DEFAULT_BOOTSTRAP_MAX_CHARS = 12_000;
 export const DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS = 60_000;
-export const DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE = "once";
+export const DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE = "always";
 const MIN_BOOTSTRAP_FILE_BUDGET_CHARS = 64;
 // Ratios split `contentBudget` (= maxChars − marker.length − join separators), not `maxChars`.
 // The marker and "\n" separators are already reserved before this split runs; these ratios

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1077,7 +1077,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.experimental.localModelLean":
     "Experimental local-model prompt trim. When enabled, OpenClaw drops heavyweight default tools like browser, cron, and message for weaker or smaller local-model backends.",
   "agents.defaults.bootstrapPromptTruncationWarning":
-    'Inject agent-visible warning text when bootstrap files are truncated: "off", "once" (default), or "always".',
+    'Inject agent-visible warning text when bootstrap files are truncated: "off", "once", or "always" (default).',
   "agents.defaults.startupContext":
     'Runtime-owned first-turn prelude for bare "/new" and "/reset". Use this to control whether recent daily memory files are preloaded into the first prompt instead of asking the model to decide what to read.',
   "agents.defaults.startupContext.enabled":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -273,8 +273,8 @@ export type AgentDefaultsConfig = {
   /**
    * Agent-visible bootstrap truncation warning mode:
    * - off: do not inject warning text
-   * - once: inject once per unique truncation signature (default)
-   * - always: inject on every run with truncation
+   * - once: inject once per unique truncation signature
+   * - always: inject on every run with truncation (default)
    */
   bootstrapPromptTruncationWarning?: "off" | "once" | "always";
   /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */


### PR DESCRIPTION
## Summary

- Change the default bootstrap truncation warning mode from `once` to `always`.
- Preserve explicit `off`, `once`, and `always` configuration behavior.
- Update config help/type docs and concept docs to describe the new default.

Fixes #78211.

## Real behavior proof

- Behavior or issue addressed: bootstrap-injected files that exceed the per-file or total injection budget were only warning once per truncation signature by default, so oversized files like `MEMORY.md` or `AGENTS.md` could keep degrading fresh sessions without a visible warning.
- Real environment tested: WSL Ubuntu-24.04 source worktrees created from `upstream/main` and PR head `92e48bc6889a7251ba4acc2fc67a6cbcf319ff2b`.
- Exact steps or command run after this patch: created clean detached worktrees for `upstream/main` and `fork/fix/bootstrap-truncation-warning-78211`; in each worktree ran `node --import ./node_modules/tsx/dist/loader.mjs ./probe-bootstrap-truncation-warning.mjs`. The probe imported the real `resolveBootstrapPromptTruncationWarningMode()` and checked no-config default, explicit `off`, explicit `once`, explicit `always`, and invalid fallback behavior.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

![PR #81918 bootstrap truncation warning before/after proof](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-81918-fresh/pr-81918/pr-81918-bootstrap-truncation-warning-before-after-proof.png)

```text
Fresh proof artifact: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-81918-fresh/pr-81918/pr-81918-bootstrap-truncation-warning-before-after-proof.png
Proof summary: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-81918-fresh/pr-81918/summary.txt

BEFORE upstream/main:
status=0
defaultConstant=once
noConfig=once
explicitOff=off
explicitOnce=once
explicitAlways=always
invalidFallsBack=once
ok=false

AFTER PR #81918 head:
status=0
defaultConstant=always
noConfig=always
explicitOff=off
explicitOnce=once
explicitAlways=always
invalidFallsBack=always
ok=true
```

- Observed result after fix: `upstream/main` defaults and invalid fallback resolve to `once`; PR head defaults and invalid fallback resolve to `always`, while explicit `off`, `once`, and `always` continue to resolve as configured.
- What was not tested: no live long-running chat channel was exercised. The proof verifies the runtime resolver used by prompt warning behavior.

## Validation

- `node scripts/test-projects.mjs src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts src/agents/bootstrap-budget.test.ts src/agents/prompt-composition.test.ts`
- `node --import tsx -e "import { resolveBootstrapPromptTruncationWarningMode } from './src/agents/pi-embedded-helpers/bootstrap.ts'; console.log(resolveBootstrapPromptTruncationWarningMode());"`
- `pnpm check:changed`