### PR TITLE
fix(plugin-sdk): expose skills helper surfaces

### DIFF
--- a/src/plugin-sdk/sandbox.test.ts
+++ b/src/plugin-sdk/sandbox.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isDangerousHostEnvOverrideVarName, sanitizeSystemRunEnvOverrides } from "./sandbox.js";
+
+describe("plugin SDK sandbox exports", () => {
+  it("re-exports host env override guards", () => {
+    expect(isDangerousHostEnvOverrideVarName("HOME")).toBe(true);
+    expect(isDangerousHostEnvOverrideVarName("OPENCLAW_SAFE_FLAG")).toBe(false);
+  });
+
+  it("re-exports system-run env override sanitization", () => {
+    expect(
+      sanitizeSystemRunEnvOverrides({
+        shellWrapper: true,
+        overrides: { LANG: "en_US.UTF-8", PATH: "/tmp/bin", TERM: "xterm-256color" },
+      }),
+    ).toStrictEqual({ LANG: "en_US.UTF-8", TERM: "xterm-256color" });
+  });
+});

--- a/src/plugin-sdk/sandbox.ts
+++ b/src/plugin-sdk/sandbox.ts
@@ -46,6 +46,10 @@ export {
 } from "../agents/sandbox.js";
 
 export {
+  isDangerousHostEnvOverrideVarName,
+  sanitizeSystemRunEnvOverrides,
+} from "../infra/host-env-security.js";
+export {
   runPluginCommandWithTimeout,
   type PluginCommandRunOptions,
   type PluginCommandRunResult,

--- a/src/plugin-sdk/skills-runtime.test.ts
+++ b/src/plugin-sdk/skills-runtime.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type {
+  OpenClawSkillMetadata,
+  ParsedSkillFrontmatter,
+  Skill,
+  SkillEntry,
+} from "./skills-runtime.js";
+import {
+  loadVisibleWorkspaceSkillEntries,
+  loadWorkspaceSkillEntries,
+  parseFrontmatter,
+  resolveOpenClawMetadata,
+  resolveSkillKey,
+} from "./skills-runtime.js";
+
+describe("plugin SDK skills runtime exports", () => {
+  it("re-exports workspace skill loaders", () => {
+    expect(typeof loadWorkspaceSkillEntries).toBe("function");
+    expect(typeof loadVisibleWorkspaceSkillEntries).toBe("function");
+  });
+
+  it("re-exports skill frontmatter helpers", () => {
+    const frontmatter = parseFrontmatter(
+      `---\nname: Demo\nmetadata: '{"openclaw":{"skillKey":"demo-key"}}'\n---\n`,
+    );
+
+    expect(frontmatter.name).toBe("Demo");
+    expect(resolveOpenClawMetadata(frontmatter)?.skillKey).toBe("demo-key");
+    expect(
+      resolveSkillKey(
+        { name: "fallback" } as Skill,
+        { metadata: { skillKey: "demo" } } as SkillEntry,
+      ),
+    ).toBe("demo");
+  });
+
+  it("exposes the public skill runtime types", () => {
+    expectTypeOf<ParsedSkillFrontmatter>().toEqualTypeOf<Record<string, string>>();
+    expectTypeOf<SkillEntry["metadata"]>().toEqualTypeOf<OpenClawSkillMetadata | undefined>();
+  });
+});

--- a/src/plugin-sdk/skills-runtime.ts
+++ b/src/plugin-sdk/skills-runtime.ts
@@ -5,3 +5,19 @@ export {
   shouldRefreshSnapshotForVersion,
   type SkillsChangeEvent,
 } from "../skills/runtime/refresh-state.js";
+export {
+  parseFrontmatter,
+  resolveOpenClawMetadata,
+  resolveSkillKey,
+} from "../skills/loading/frontmatter.js";
+export {
+  loadVisibleWorkspaceSkillEntries,
+  loadWorkspaceSkillEntries,
+} from "../skills/loading/workspace.js";
+export type { Skill } from "../skills/loading/skill-contract.js";
+export type {
+  OpenClawSkillMetadata,
+  ParsedSkillFrontmatter,
+  SkillEligibilityContext,
+  SkillEntry,
+} from "../skills/types.js";


### PR DESCRIPTION
Fixes #81913

## Summary
- re-export workspace skill loaders and frontmatter metadata helpers from `openclaw/plugin-sdk/skills-runtime`
- re-export host env override sanitizer helpers from `openclaw/plugin-sdk/sandbox`
- add focused SDK contract tests for the new public helper surface

## Real behavior proof
Behavior addressed: third-party plugins can import OpenClaw's supported skills registry, SKILL.md frontmatter, and system-run env sanitizer helpers through public plugin SDK subpaths instead of deep-importing internals or reimplementing them.

Real environment tested: local OpenClaw package build from PR head `a12f2aa1b8` (rebased onto current `main` `ed4c4afc0f` for the Dependency Guard check; SDK patch unchanged) on macOS. I built the dist entrypoints, generated plugin SDK declarations, ran runtime postbuild shims, then imported the package through the public self-reference specifiers `openclaw/plugin-sdk/skills-runtime` and `openclaw/plugin-sdk/sandbox`.

Exact steps or command run after this patch:

```bash
node scripts/tsdown-build.mjs
node scripts/run-tsgo.mjs -p tsconfig.plugin-sdk.dts.json --declaration true
node --experimental-strip-types scripts/write-plugin-sdk-entry-dts.ts
node scripts/runtime-postbuild.mjs
node scripts/check-plugin-sdk-exports.mjs
node --input-type=module -e 'const skills = await import("openclaw/plugin-sdk/skills-runtime"); const sandbox = await import("openclaw/plugin-sdk/sandbox"); const frontmatter = skills.parseFrontmatter("---\nname: Demo\nmetadata: '\''{\"openclaw\":{\"skillKey\":\"demo-key\"}}'\''\n---\n"); console.log(JSON.stringify({ skillsRuntime: { hasLoadWorkspaceSkillEntries: typeof skills.loadWorkspaceSkillEntries === "function", hasParseFrontmatter: typeof skills.parseFrontmatter === "function", skillKey: skills.resolveOpenClawMetadata(frontmatter)?.skillKey }, sandbox: { dangerousHome: sandbox.isDangerousHostEnvOverrideVarName("HOME"), sanitized: sandbox.sanitizeSystemRunEnvOverrides({ shellWrapper: true, overrides: { LANG: "en_US.UTF-8", PATH: "/tmp/bin", TERM: "xterm-256color" } }) } }, null, 2));'
```

Evidence after fix:

```text
OK: All 4 required plugin-sdk exports verified.
```

```json
{
  "skillsRuntime": {
    "hasLoadWorkspaceSkillEntries": true,
    "hasParseFrontmatter": true,
    "skillKey": "demo-key"
  },
  "sandbox": {
    "dangerousHome": true,
    "sanitized": {
      "LANG": "en_US.UTF-8",
      "TERM": "xterm-256color"
    }
  }
}
```

Observed result after fix: the built package self-reference imports resolve from the public SDK subpaths, the new skills helpers are callable, the frontmatter metadata resolver returns the expected `skillKey`, and the sandbox env sanitizer filters `PATH` while preserving allowed shell-wrapper variables.

What was not tested: I did not install the package into a separate third-party plugin repo; the proof uses the built local package self-reference and the plugin SDK export checker.

## Verification
- `node scripts/run-vitest.mjs run src/plugin-sdk/skills-runtime.test.ts src/plugin-sdk/sandbox.test.ts`
- `node scripts/run-vitest.mjs run src/plugin-sdk/skills-runtime.test.ts src/plugin-sdk/sandbox.test.ts src/plugins/contracts/plugin-sdk-index.test.ts`
- `node scripts/sync-plugin-sdk-exports.mjs --check`
- `node scripts/tsdown-build.mjs`
- `node scripts/run-tsgo.mjs -p tsconfig.plugin-sdk.dts.json --declaration true`
- `node --experimental-strip-types scripts/write-plugin-sdk-entry-dts.ts`
- `node scripts/runtime-postbuild.mjs`
- `node scripts/check-plugin-sdk-exports.mjs`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugin-sdk/skills-runtime.ts src/plugin-sdk/sandbox.ts src/plugin-sdk/skills-runtime.test.ts src/plugin-sdk/sandbox.test.ts`
- `git diff --check`
- `CI=1 pnpm check:changed`

_Re-verified at head `a12f2aa1b8` on 2026-06-03: full SDK build/dts/postbuild pipeline and the public self-reference import proof above were re-run from this exact branch head and reproduce identically (`All 4 required plugin-sdk exports verified`, PATH stripped by the sandbox sanitizer, helpers callable, `skillKey` resolved)._
