### PR TITLE
[AI-assisted] fix: preserve rate-limit classification when idle timer races with 429 response

### DIFF
--- a/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
@@ -293,3 +293,48 @@ describe("handleAssistantFailover", () => {
     });
   });
 });
+
+describe("handleAssistantFailover – idle timeout with rate-limit signal (#81902)", () => {
+  it("marks profile failure with rate_limit when idle timer fires but error was classified as rate_limit", async () => {
+    const markSpy = vi.fn(async () => {});
+    const advanceSpy = vi.fn(async () => true);
+    const outcome = await handleAssistantFailover(
+      makeParams({
+        initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+        failoverReason: "rate_limit",
+        assistantProfileFailureReason: "rate_limit",
+        rateLimitFailure: true,
+        billingFailure: false,
+        timedOut: true,
+        idleTimedOut: true,
+        lastProfileId: "sha256:deadbeef",
+        maybeMarkAuthProfileFailure: markSpy,
+        advanceAuthProfile: advanceSpy,
+      }),
+    );
+
+    expect(outcome.action).toBe("retry");
+    // The profile failure should have been marked with "rate_limit", not skipped
+    expect(markSpy).toHaveBeenCalledWith(expect.objectContaining({ reason: "rate_limit" }));
+  });
+
+  it("still skips profile failure mark when timeout fires with no classified reason", async () => {
+    const markSpy = vi.fn(async () => {});
+    const advanceSpy = vi.fn(async () => true);
+    await handleAssistantFailover(
+      makeParams({
+        initialDecision: { action: "rotate_profile", reason: "timeout" },
+        failoverReason: "timeout",
+        assistantProfileFailureReason: null,
+        timedOut: true,
+        idleTimedOut: true,
+        lastProfileId: "sha256:deadbeef",
+        maybeMarkAuthProfileFailure: markSpy,
+        advanceAuthProfile: advanceSpy,
+      }),
+    );
+
+    // With no classified reason, timeout fallback should skip marking
+    expect(markSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/pi-embedded-runner/run/assistant-failover.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.ts
@@ -99,7 +99,16 @@ export async function handleAssistantFailover(params: {
   if (decision.action === "rotate_profile") {
     const failedProfileId = params.lastProfileId;
     const timeoutFailure = params.timedOut || params.idleTimedOut;
-    const failureReason = timeoutFailure ? "timeout" : params.assistantProfileFailureReason;
+    // When the idle timer fires but the raw error message carried an
+    // actionable classification (rate_limit, billing, auth, …), preserve
+    // the real reason so `markAuthProfileFailure` applies the correct
+    // cooldown instead of silently skipping it.  Only fall back to
+    // "timeout" when no better signal was extracted from the response.
+    // Fixes: openclaw#81902
+    const failureReason =
+      timeoutFailure && !params.assistantProfileFailureReason
+        ? "timeout"
+        : params.assistantProfileFailureReason;
     const markFailedProfile = async () => {
       if (!failedProfileId || !failureReason || failureReason === "timeout") {
         return;


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: Google API 429 rate-limit responses are silently misclassified as timeouts when the idle timer fires concurrently, preventing auth profile cooldown from triggering and causing every subsequent request to retry the same rate-limited provider.
- Why it matters: Users with multiple Google auth profiles never see provider rotation under rate limits — every request times out instead of switching to the backup provider, making multi-profile setups ineffective.
- What changed: In `assistant-failover.ts`, the failure reason override now preserves the classified reason (rate_limit, billing, auth, etc.) when the idle timer also fires, only defaulting to "timeout" when no actionable classification was extracted.
- What did NOT change (scope boundary): No changes to error classification logic, idle timeout behavior, or the `extractLeadingHttpStatus` regex. The fix is strictly in the failover decision path where the classified reason was being discarded.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Agents

## Linked Issue/PR
- Closes #81902
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: In `handleAssistantFailover`, when `timedOut || idleTimedOut` was true, `failureReason` was unconditionally set to `"timeout"` regardless of what `classifyFailoverReason` had already determined from the error message. Since `markAuthProfileFailure` explicitly skips `"timeout"` reasons, the rate-limit cooldown was never applied.
- Missing detection / guardrail: No test covered the case where both `timedOut=true` and `assistantProfileFailureReason="rate_limit"` were set simultaneously — the race condition between idle timer and error classification.
- Contributing context (if known): The idle timeout and provider error response can race when providers return errors slowly (e.g., Google returning 429 near the idle watchdog threshold).

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/pi-embedded-runner/run/assistant-failover.test.ts`
- Scenario the test should lock in: When `timedOut=true` and `assistantProfileFailureReason="rate_limit"`, the profile failure must be marked with `rate_limit` (not skipped). When `timedOut=true` and `assistantProfileFailureReason=null`, marking must still be skipped.
- Why this is the smallest reliable guardrail: Tests the exact decision point where the classified reason was being discarded, without needing a full embedded runner.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A — two new tests added.

## User-visible / Behavior Changes
- Google (and other) provider rate-limit responses now correctly trigger auth profile cooldown and rotation even when the idle timeout fires concurrently. Users with multiple auth profiles will see faster failover instead of repeated timeouts.

## Security Impact (required)
- New permissions/capabilities? No
- This fix only changes which string value is used for profile failure classification. No new permissions, no credential handling changes, no security surface changes.
