### PR TITLE
Add wait mode for manual cron runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Providers/xAI: add xAI Grok OAuth login for SuperGrok subscribers, letting `xai/*` models and xAI media/tool providers authenticate without `XAI_API_KEY`.
+- CLI/cron: add `openclaw cron run --wait` with timeout and poll interval controls, plus exact `cron.runs --run-id` filtering so automation can block on one queued manual run. (#81929) Thanks @ificator.
 - Maintainer tooling: route Crabbox skill defaults through the repo brokered AWS config, leaving Blacksmith Testbox as an explicit opt-in instead of the broad-proof default.
 - CLI/onboarding: localize the setup wizard and bundled channel setup flows for English, Simplified Chinese, and Traditional Chinese. (#80645) Thanks @GaosCode.
 - Agents/skills: cache hydrated `resolvedSkills` across warm gateway turns while keying reuse by the redacted effective config, reducing redundant skill snapshot rebuilds without crossing config-gated skill boundaries. (#81451) Thanks @solodmd.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5232,6 +5232,7 @@ public struct CronRunsParams: Codable, Sendable {
     public let scope: AnyCodable?
     public let id: String?
     public let jobid: String?
+    public let runid: String?
     public let limit: Int?
     public let offset: Int?
     public let statuses: [AnyCodable]?
@@ -5245,6 +5246,7 @@ public struct CronRunsParams: Codable, Sendable {
         scope: AnyCodable?,
         id: String?,
         jobid: String?,
+        runid: String?,
         limit: Int?,
         offset: Int?,
         statuses: [AnyCodable]?,
@@ -5257,6 +5259,7 @@ public struct CronRunsParams: Codable, Sendable {
         self.scope = scope
         self.id = id
         self.jobid = jobid
+        self.runid = runid
         self.limit = limit
         self.offset = offset
         self.statuses = statuses
@@ -5271,6 +5274,7 @@ public struct CronRunsParams: Codable, Sendable {
         case scope
         case id
         case jobid = "jobId"
+        case runid = "runId"
         case limit
         case offset
         case statuses

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -372,11 +372,17 @@ openclaw cron edit <jobId> --message "Updated prompt" --model "opus"
 # Force run a job now
 openclaw cron run <jobId>
 
+# Force run a job now and wait for its terminal status
+openclaw cron run <jobId> --wait --wait-timeout 10m
+
 # Run only if due
 openclaw cron run <jobId> --due
 
 # View run history
 openclaw cron runs --id <jobId> --limit 50
+
+# View one exact run
+openclaw cron runs --id <jobId> --run-id <runId>
 
 # Delete a job
 openclaw cron remove <jobId>

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -373,7 +373,7 @@ openclaw cron edit <jobId> --message "Updated prompt" --model "opus"
 openclaw cron run <jobId>
 
 # Force run a job now and wait for its terminal status
-openclaw cron run <jobId> --wait --wait-timeout 10m
+openclaw cron run <jobId> --wait --wait-timeout 10m --poll-interval 2s
 
 # Run only if due
 openclaw cron run <jobId> --due
@@ -391,6 +391,8 @@ openclaw cron remove <jobId>
 openclaw cron add --name "Ops sweep" --cron "0 6 * * *" --session isolated --message "Check ops queue" --agent ops
 openclaw cron edit <jobId> --clear-agent
 ```
+
+`openclaw cron run <jobId>` returns after enqueueing the manual run. Use `--wait` for shutdown hooks, maintenance scripts, or other automation that must block until the queued run finishes. Wait mode polls the exact returned `runId`; it exits `0` for status `ok` and non-zero for `error`, `skipped`, or a wait timeout.
 
 <Note>
 Model override note:

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -100,16 +100,23 @@ Note: cron job definitions live in `jobs.json`, while pending runtime state live
 
 ### Manual runs
 
-`openclaw cron run` returns as soon as the manual run is queued. Successful responses include `{ ok: true, enqueued: true, runId }`. Use `openclaw cron runs --id <job-id>` to follow the eventual outcome, or add `--wait` to keep the CLI open until that queued run records a terminal status.
+`openclaw cron run <job-id>` force-runs by default and returns as soon as the manual run is queued. Successful responses include `{ ok: true, enqueued: true, runId }`. Use the returned `runId` to inspect the later result:
+
+```bash
+openclaw cron run <job-id>
+openclaw cron runs --id <job-id> --run-id <run-id>
+```
+
+Add `--wait` when a script should block until that exact queued run records a terminal status:
 
 ```bash
 openclaw cron run <job-id> --wait --wait-timeout 10m --poll-interval 2s
 ```
 
-With `--wait`, the command exits `0` only when the run finishes with `ok`; `error`, `skipped`, or a wait timeout exit non-zero. `openclaw cron runs --id <job-id> --run-id <run-id>` filters history to one exact run.
+With `--wait`, the CLI still calls `cron.run` first, then polls `cron.runs` for the returned `runId`. The command exits `0` only when the run finishes with status `ok`. It exits non-zero when the run finishes with `error` or `skipped`, when the Gateway response does not include a `runId`, or when `--wait-timeout` expires. `--poll-interval` must be greater than zero.
 
 <Note>
-`openclaw cron run <job-id>` force-runs by default. Use `--due` to keep the older "only run if due" behavior.
+Use `--due` when you want the manual command to run only if the job is currently due. If `--due --wait` does not enqueue a run, the command returns the normal non-run response instead of polling.
 </Note>
 
 ## Models
@@ -233,6 +240,7 @@ openclaw cron show <job-id>
 openclaw cron run <job-id>
 openclaw cron run <job-id> --due
 openclaw cron run <job-id> --wait --wait-timeout 10m
+openclaw cron run <job-id> --wait --wait-timeout 10m --poll-interval 2s
 openclaw cron runs --id <job-id> --limit 50
 openclaw cron runs --id <job-id> --run-id <run-id>
 ```

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -100,7 +100,13 @@ Note: cron job definitions live in `jobs.json`, while pending runtime state live
 
 ### Manual runs
 
-`openclaw cron run` returns as soon as the manual run is queued. Successful responses include `{ ok: true, enqueued: true, runId }`. Use `openclaw cron runs --id <job-id>` to follow the eventual outcome.
+`openclaw cron run` returns as soon as the manual run is queued. Successful responses include `{ ok: true, enqueued: true, runId }`. Use `openclaw cron runs --id <job-id>` to follow the eventual outcome, or add `--wait` to keep the CLI open until that queued run records a terminal status.
+
+```bash
+openclaw cron run <job-id> --wait --wait-timeout 10m --poll-interval 2s
+```
+
+With `--wait`, the command exits `0` only when the run finishes with `ok`; `error`, `skipped`, or a wait timeout exit non-zero. `openclaw cron runs --id <job-id> --run-id <run-id>` filters history to one exact run.
 
 <Note>
 `openclaw cron run <job-id>` force-runs by default. Use `--due` to keep the older "only run if due" behavior.
@@ -226,7 +232,9 @@ openclaw cron get <job-id>
 openclaw cron show <job-id>
 openclaw cron run <job-id>
 openclaw cron run <job-id> --due
+openclaw cron run <job-id> --wait --wait-timeout 10m
 openclaw cron runs --id <job-id> --limit 50
+openclaw cron runs --id <job-id> --run-id <run-id>
 ```
 
 `openclaw cron list` shows all matching jobs by default. Pass `--agent <id>` to show only jobs whose effective normalized agent id matches; jobs without a stored agent id count as the configured default agent.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -460,7 +460,8 @@ enumeration of `src/gateway/server-methods/*.ts`.
 
   <Accordion title="Automation, skills, and tools">
     - Automation: `wake` schedules an immediate or next-heartbeat wake text injection; `cron.get`, `cron.list`, `cron.status`, `cron.add`, `cron.update`, `cron.remove`, `cron.run`, `cron.runs` manage scheduled work.
-    - `cron.runs` accepts an optional `runId` filter so clients can follow one queued manual run without racing against other history entries for the same job.
+    - `cron.run` remains an enqueue-style RPC for manual runs. Clients that need completion semantics should read the returned `runId` and poll `cron.runs`.
+    - `cron.runs` accepts an optional non-empty `runId` filter so clients can follow one queued manual run without racing against other history entries for the same job.
     - Skills and tools: `commands.list`, `skills.*`, `tools.catalog`, `tools.effective`, `tools.invoke`.
 
   </Accordion>

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -460,6 +460,7 @@ enumeration of `src/gateway/server-methods/*.ts`.
 
   <Accordion title="Automation, skills, and tools">
     - Automation: `wake` schedules an immediate or next-heartbeat wake text injection; `cron.get`, `cron.list`, `cron.status`, `cron.add`, `cron.update`, `cron.remove`, `cron.run`, `cron.runs` manage scheduled work.
+    - `cron.runs` accepts an optional `runId` filter so clients can follow one queued manual run without racing against other history entries for the same job.
     - Skills and tools: `commands.list`, `skills.*`, `tools.catalog`, `tools.effective`, `tools.invoke`.
 
   </Accordion>

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -340,6 +340,22 @@ describe("cron cli", () => {
     },
   );
 
+  it("rejects zero poll interval for cron run wait before enqueueing", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "run",
+      "job-1",
+      "--wait",
+      "--wait-timeout",
+      "1s",
+      "--poll-interval",
+      "0ms",
+    ]);
+
+    expectRuntimeErrorContaining("invalid --poll-interval");
+    expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.run")).toBe(false);
+  });
+
   it("trims model and thinking on cron add", { timeout: CRON_CLI_TEST_TIMEOUT_MS }, async () => {
     await runCronCommand([
       "cron",

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -227,6 +227,8 @@ async function expectCronEditWithScheduleLookupExit(
 async function runCronRunAndCaptureExit(params: {
   ran?: boolean;
   enqueued?: boolean;
+  runId?: string;
+  runStatus?: "ok" | "error" | "skipped";
   args?: string[];
 }) {
   resetGatewayMock();
@@ -241,6 +243,12 @@ async function runCronRunAndCaptureExit(params: {
           params: callParams,
           ...(typeof params.ran === "boolean" ? { ran: params.ran } : {}),
           ...(typeof params.enqueued === "boolean" ? { enqueued: params.enqueued } : {}),
+          ...(typeof params.runId === "string" ? { runId: params.runId } : {}),
+        };
+      }
+      if (method === "cron.runs") {
+        return {
+          entries: params.runStatus ? [{ status: params.runStatus }] : [],
         };
       }
       return { ok: true, params: callParams };
@@ -261,6 +269,7 @@ async function runCronRunAndCaptureExit(params: {
   return {
     exitSpy,
     runOpts: (runCall?.[1] ?? {}) as { timeout?: string },
+    calls: callGatewayFromCli.mock.calls,
   };
 }
 
@@ -295,6 +304,41 @@ describe("cron cli", () => {
     const { exitSpy } = await runCronRunAndCaptureExit({ ran, enqueued });
     expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);
   });
+
+  it.each([
+    { status: "ok" as const, expectedExitCode: 0 },
+    { status: "error" as const, expectedExitCode: 1 },
+    { status: "skipped" as const, expectedExitCode: 1 },
+  ])(
+    "waits for queued cron run completion with status $status",
+    async ({ status, expectedExitCode }) => {
+      const { calls, exitSpy } = await runCronRunAndCaptureExit({
+        enqueued: true,
+        runId: "manual:job-1:123:0",
+        runStatus: status,
+        args: [
+          "cron",
+          "run",
+          "job-1",
+          "--wait",
+          "--wait-timeout",
+          "1s",
+          "--poll-interval",
+          "1ms",
+        ],
+      });
+
+      expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);
+      const runsCall = calls.find((call) => call[0] === "cron.runs");
+      expect(runsCall?.[2]).toMatchObject({
+        id: "job-1",
+        runId: "manual:job-1:123:0",
+        limit: 1,
+      });
+      expect(stdoutText()).toContain('"completed": true');
+      expect(stdoutText()).toContain(`"status": "${status}"`);
+    },
+  );
 
   it("trims model and thinking on cron add", { timeout: CRON_CLI_TEST_TIMEOUT_MS }, async () => {
     await runCronCommand([

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -41,6 +41,14 @@ function parseCronRunWaitDuration(raw: unknown, label: string): number {
   return durationMs;
 }
 
+function parseCronRunPollInterval(raw: unknown): number {
+  const durationMs = parseCronRunWaitDuration(raw, "--poll-interval");
+  if (durationMs <= 0) {
+    throw new Error("invalid --poll-interval");
+  }
+  return durationMs;
+}
+
 async function waitForCronRunCompletion(params: {
   opts: GatewayRpcOpts;
   jobId: string;
@@ -242,6 +250,12 @@ export function registerCronSimpleCommands(cron: Command) {
       )
       .action(async (id, opts, command) => {
         try {
+          let waitTimeoutMs = 0;
+          let pollIntervalMs = 0;
+          if (opts.wait) {
+            waitTimeoutMs = parseCronRunWaitDuration(opts.waitTimeout, "--wait-timeout");
+            pollIntervalMs = parseCronRunPollInterval(opts.pollInterval);
+          }
           if (command.getOptionValueSource("timeout") === "default") {
             opts.timeout = "600000";
           }
@@ -258,8 +272,8 @@ export function registerCronSimpleCommands(cron: Command) {
               opts,
               jobId: String(id),
               runId: result.runId,
-              timeoutMs: parseCronRunWaitDuration(opts.waitTimeout, "--wait-timeout"),
-              pollIntervalMs: parseCronRunWaitDuration(opts.pollInterval, "--poll-interval"),
+              timeoutMs: waitTimeoutMs,
+              pollIntervalMs,
             });
             printCronJson({ ...res, completed: true, status: run.status, run });
             defaultRuntime.exit(run.status === "ok" ? 0 : 1);

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -34,7 +34,11 @@ function sleep(ms: number): Promise<void> {
 }
 
 function parseCronRunWaitDuration(raw: unknown, label: string): number {
-  const durationMs = parseDurationMs(String(raw ?? ""), { defaultUnit: "ms" });
+  const input =
+    typeof raw === "string" || typeof raw === "number" || typeof raw === "bigint"
+      ? String(raw)
+      : "";
+  const durationMs = parseDurationMs(input, { defaultUnit: "ms" });
   if (!Number.isFinite(durationMs) || durationMs < 0) {
     throw new Error(`invalid ${label}`);
   }

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -4,6 +4,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
+import { parseDurationMs } from "../parse-duration.js";
 import {
   coerceCronDeliveryPreviews,
   enrichCronJsonWithStatus,
@@ -14,6 +15,56 @@ import {
 } from "./shared.js";
 
 const CRON_SHOW_PAGE_SIZE = 200;
+const CRON_RUN_WAIT_TIMEOUT_DEFAULT = "10m";
+const CRON_RUN_WAIT_POLL_INTERVAL_DEFAULT = "2s";
+
+type CronRunCommandResult = {
+  ok?: boolean;
+  ran?: boolean;
+  enqueued?: boolean;
+  runId?: string;
+};
+
+type CronRunLogEntryResult = {
+  status?: "ok" | "error" | "skipped";
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseCronRunWaitDuration(raw: unknown, label: string): number {
+  const durationMs = parseDurationMs(String(raw ?? ""), { defaultUnit: "ms" });
+  if (!Number.isFinite(durationMs) || durationMs < 0) {
+    throw new Error(`invalid ${label}`);
+  }
+  return durationMs;
+}
+
+async function waitForCronRunCompletion(params: {
+  opts: GatewayRpcOpts;
+  jobId: string;
+  runId: string;
+  timeoutMs: number;
+  pollIntervalMs: number;
+}): Promise<CronRunLogEntryResult> {
+  const startedAt = Date.now();
+  for (;;) {
+    const page = (await callGatewayFromCli("cron.runs", params.opts, {
+      id: params.jobId,
+      runId: params.runId,
+      limit: 1,
+    })) as { entries?: CronRunLogEntryResult[] };
+    const entry = page.entries?.[0];
+    if (entry?.status === "ok" || entry?.status === "error" || entry?.status === "skipped") {
+      return entry;
+    }
+    if (Date.now() - startedAt >= params.timeoutMs) {
+      throw new Error(`timed out waiting for cron run ${params.runId}`);
+    }
+    await sleep(params.pollIntervalMs);
+  }
+}
 
 function findCronJobInPage(jobs: CronJob[], idOrName: string): CronJob | undefined {
   const needle = normalizeLowercaseStringOrEmpty(idOrName);
@@ -153,6 +204,7 @@ export function registerCronSimpleCommands(cron: Command) {
       .command("runs")
       .description("Show cron run history (JSONL-backed)")
       .requiredOption("--id <id>", "Job id")
+      .option("--run-id <runId>", "Filter by cron run id")
       .option("--limit <n>", "Max entries (default 50)", "50")
       .action(async (opts) => {
         try {
@@ -161,6 +213,7 @@ export function registerCronSimpleCommands(cron: Command) {
           const id = String(opts.id);
           const res = await callGatewayFromCli("cron.runs", opts, {
             id,
+            ...(typeof opts.runId === "string" && opts.runId.trim() ? { runId: opts.runId } : {}),
             limit,
           });
           printCronJson(res);
@@ -176,6 +229,17 @@ export function registerCronSimpleCommands(cron: Command) {
       .description("Run a cron job now (debug)")
       .argument("<id>", "Job id")
       .option("--due", "Run only when due (default behavior in older versions)", false)
+      .option("--wait", "Wait for the queued run to finish", false)
+      .option(
+        "--wait-timeout <duration>",
+        "Maximum time to wait for --wait",
+        CRON_RUN_WAIT_TIMEOUT_DEFAULT,
+      )
+      .option(
+        "--poll-interval <duration>",
+        "Polling interval for --wait",
+        CRON_RUN_WAIT_POLL_INTERVAL_DEFAULT,
+      )
       .action(async (id, opts, command) => {
         try {
           if (command.getOptionValueSource("timeout") === "default") {
@@ -185,8 +249,23 @@ export function registerCronSimpleCommands(cron: Command) {
             id,
             mode: opts.due ? "due" : "force",
           });
+          const result = res as CronRunCommandResult | undefined;
+          if (opts.wait && result?.ok && result.enqueued) {
+            if (!result.runId) {
+              throw new Error("cron run did not return a runId to wait for");
+            }
+            const run = await waitForCronRunCompletion({
+              opts,
+              jobId: String(id),
+              runId: result.runId,
+              timeoutMs: parseCronRunWaitDuration(opts.waitTimeout, "--wait-timeout"),
+              pollIntervalMs: parseCronRunWaitDuration(opts.pollInterval, "--poll-interval"),
+            });
+            printCronJson({ ...res, completed: true, status: run.status, run });
+            defaultRuntime.exit(run.status === "ok" ? 0 : 1);
+            return;
+          }
           printCronJson(res);
-          const result = res as { ok?: boolean; ran?: boolean; enqueued?: boolean } | undefined;
           defaultRuntime.exit(result?.ok && (result?.ran || result?.enqueued) ? 0 : 1);
         } catch (err) {
           handleCronCliError(err);

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -225,6 +225,36 @@ describe("cron run log", () => {
     });
   });
 
+  it("filters run-log pages by runId", async () => {
+    await withRunLogDir("openclaw-cron-log-runid-", async (dir) => {
+      const logPath = path.join(dir, "runs", "job-1.jsonl");
+
+      await appendCronRunLog(logPath, {
+        ts: 1,
+        jobId: "job-1",
+        action: "finished",
+        status: "error",
+        runId: "manual:job-1:1:0",
+      });
+      await appendCronRunLog(logPath, {
+        ts: 2,
+        jobId: "job-1",
+        action: "finished",
+        status: "ok",
+        runId: "manual:job-1:2:0",
+      });
+
+      const page = await readCronRunLogEntriesPage(logPath, {
+        runId: "manual:job-1:2:0",
+        limit: 10,
+      });
+
+      expect(page.entries).toHaveLength(1);
+      expect(page.entries[0]?.runId).toBe("manual:job-1:2:0");
+      expect(page.entries[0]?.status).toBe("ok");
+    });
+  });
+
   it("ignores invalid and non-finished lines while preserving delivery fields", async () => {
     await withRunLogDir("openclaw-cron-log-filter-", async (dir) => {
       const logPath = path.join(dir, "runs", "job-1.jsonl");

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -48,6 +48,7 @@ type ReadCronRunLogPageOptions = {
   limit?: number;
   offset?: number;
   jobId?: string;
+  runId?: string;
   status?: CronRunLogStatusFilter;
   statuses?: CronRunStatus[];
   deliveryStatus?: CronDeliveryStatus;
@@ -392,9 +393,15 @@ function parseAllRunLogEntries(raw: string, opts?: { jobId?: string }): CronRunL
   return parsed;
 }
 
+function runIdMatches(entry: CronRunLogEntry, runId?: string): boolean {
+  const normalized = normalizeOptionalString(runId);
+  return !normalized || entry.runId === normalized;
+}
+
 function filterRunLogEntries(
   entries: CronRunLogEntry[],
   opts: {
+    runId?: string;
     statuses: CronRunStatus[] | null;
     deliveryStatuses: CronDeliveryStatus[] | null;
     query: string;
@@ -402,6 +409,9 @@ function filterRunLogEntries(
   },
 ): CronRunLogEntry[] {
   return entries.filter((entry) => {
+    if (!runIdMatches(entry, opts.runId)) {
+      return false;
+    }
     if (opts.statuses && (!entry.status || !opts.statuses.includes(entry.status))) {
       return false;
     }
@@ -431,6 +441,7 @@ export async function readCronRunLogEntriesPage(
   const sortDir: CronRunLogSortDir = opts?.sortDir === "asc" ? "asc" : "desc";
   const all = parseAllRunLogEntries(raw, { jobId: opts?.jobId });
   const filtered = filterRunLogEntries(all, {
+    runId: opts?.runId,
     statuses,
     deliveryStatuses,
     query,
@@ -517,6 +528,7 @@ export async function readCronRunLogEntriesPageAll(
   );
   const all = chunks.flat();
   const filtered = filterRunLogEntries(all, {
+    runId: opts.runId,
     statuses,
     deliveryStatuses,
     query,

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -144,6 +144,7 @@ describe("cron protocol validators", () => {
     expect(
       validateCronRunsParams({
         id: "job-1",
+        runId: "manual:job-1:123:0",
         limit: 50,
         offset: 0,
         status: "error",
@@ -152,6 +153,7 @@ describe("cron protocol validators", () => {
       }),
     ).toBe(true);
     expect(validateCronRunsParams({ id: "job-1", offset: -1 })).toBe(false);
+    expect(validateCronRunsParams({ id: "job-1", runId: "" })).toBe(false);
   });
 
   it("accepts all-scope runs with multi-select filters", () => {

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -412,6 +412,7 @@ export const CronRunsParamsSchema = Type.Object(
     scope: Type.Optional(Type.Union([Type.Literal("job"), Type.Literal("all")])),
     id: Type.Optional(CronRunLogJobIdSchema),
     jobId: Type.Optional(CronRunLogJobIdSchema),
+    runId: Type.Optional(NonEmptyString),
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
     offset: Type.Optional(Type.Integer({ minimum: 0 })),
     statuses: Type.Optional(Type.Array(CronRunsStatusValueSchema, { minItems: 1, maxItems: 3 })),

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -532,6 +532,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       scope?: "job" | "all";
       id?: string;
       jobId?: string;
+      runId?: string;
       limit?: number;
       offset?: number;
       statuses?: Array<"ok" | "error" | "skipped">;
@@ -565,6 +566,7 @@ export const cronHandlers: GatewayRequestHandlers = {
         offset: p.offset,
         statuses: p.statuses,
         status: p.status,
+        runId: p.runId,
         deliveryStatuses: p.deliveryStatuses,
         deliveryStatus: p.deliveryStatus,
         query: p.query,
@@ -594,6 +596,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       jobId: jobId as string,
       statuses: p.statuses,
       status: p.status,
+      runId: p.runId,
       deliveryStatuses: p.deliveryStatuses,
       deliveryStatus: p.deliveryStatus,
       query: p.query,


### PR DESCRIPTION
## Summary

- Problem: `openclaw cron run <job-id>` returned after enqueueing a manual run, so shutdown/pre-stop automation could not directly wait for the cron work to finish.
- Why it matters: container idle-shutdown hooks need a deterministic way to block until critical maintenance jobs, such as memory flush cron jobs, reach a terminal status.
- What changed: added `openclaw cron run --wait`, configurable `--wait-timeout` and `--poll-interval`, exact `runId` filtering for `cron.runs`, protocol/schema wiring, generated Swift protocol sync, focused tests, and docs.
- What did NOT change (scope boundary): default `openclaw cron run <job-id>` behavior remains non-blocking; the Gateway `cron.run` RPC still enqueues rather than holding the request open; no cron scheduler semantics changed.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: `openclaw cron run <job-id> --wait` waits for the returned manual run `runId` to finish, returns `completed: true`, reports the terminal status, and exits successfully only for `ok`. `openclaw cron runs --run-id` can retrieve the exact completed run.
- Real environment tested: Docker Desktop Linux container using `node:24-bookworm`, repository copied into a Linux volume, isolated `OPENCLAW_STATE_DIR`, real OpenClaw Gateway on loopback with token auth, and CLI commands run through `corepack pnpm openclaw` against that Gateway. Token value below is redacted.
- Exact steps or command run after this patch: Started `openclaw gateway run --dev --reset --port 18789 --bind loopback --auth token --token [redacted-test-token]`, created a real system-event cron job with `openclaw cron add --token [redacted-test-token] --name "wait proof" --every 1h --system-event "cron wait proof" --json`, ran `openclaw cron run <job-id> --token [redacted-test-token] --wait --wait-timeout 30s --poll-interval 500ms`, then queried `openclaw cron runs --token [redacted-test-token] --id <job-id> --run-id <run-id> --limit 1`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
container_node=v24.15.0
pnpm=11.1.0
dependencies_already_installed
starting_gateway
gateway_port_ready=127.0.0.1:18789
creating_cron_job
$ node scripts/run-node.mjs cron add --token [redacted-test-token] --name 'wait proof' --every 1h --system-event 'cron wait proof' --json
cron add output:
{
  "id": "8674012e-1ad6-4856-ad76-08856d1e61f8",
  "name": "wait proof",
  "enabled": true,
  "createdAtMs": 1778798176117,
  "updatedAtMs": 1778798176117,
  "schedule": {
    "kind": "every",
    "everyMs": 3600000,
    "anchorMs": 1778798176117
  },
  "sessionTarget": "main",
  "wakeMode": "now",
  "payload": {
    "kind": "systemEvent",
    "text": "cron wait proof"
  },
  "state": {
    "nextRunAtMs": 1778801776117
  }
}
job_id=8674012e-1ad6-4856-ad76-08856d1e61f8
health_after_cron_add:
$ node scripts/run-node.mjs gateway call health --token [redacted-test-token] --json
{
  "ok": true,
  "plugins": {
    "loaded": [
      "acpx",
      "browser",
      "canvas",
      "device-pair",
      "file-transfer",
      "memory-core",
      "phone-control",
      "talk-voice"
    ],
    "errors": []
  },
  "defaultAgentId": "dev"
}
running_cron_with_wait
$ node scripts/run-node.mjs cron run 8674012e-1ad6-4856-ad76-08856d1e61f8 --token [redacted-test-token] --wait --wait-timeout 30s --poll-interval 500ms
cron run --wait output:
{
  "ok": true,
  "enqueued": true,
  "runId": "manual:8674012e-1ad6-4856-ad76-08856d1e61f8:1778798183694:1",
  "completed": true,
  "status": "ok",
  "run": {
    "ts": 1778798183707,
    "jobId": "8674012e-1ad6-4856-ad76-08856d1e61f8",
    "action": "finished",
    "status": "ok",
    "summary": "cron wait proof",
    "runId": "manual:8674012e-1ad6-4856-ad76-08856d1e61f8:1778798183694:1",
    "runAtMs": 1778798183695,
    "durationMs": 9,
    "nextRunAtMs": 1778801776117,
    "deliveryStatus": "not-requested"
  }
}
exit_code=0
run_id=manual:8674012e-1ad6-4856-ad76-08856d1e61f8:1778798183694:1
terminal_status=ok
cron runs --run-id output:
$ node scripts/run-node.mjs cron runs --token [redacted-test-token] --id 8674012e-1ad6-4856-ad76-08856d1e61f8 --run-id manual:8674012e-1ad6-4856-ad76-08856d1e61f8:1778798183694:1 --limit 1
{
  "entries": [
    {
      "ts": 1778798183707,
      "jobId": "8674012e-1ad6-4856-ad76-08856d1e61f8",
      "action": "finished",
      "status": "ok",
      "summary": "cron wait proof",
      "runId": "manual:8674012e-1ad6-4856-ad76-08856d1e61f8:1778798183694:1",
      "runAtMs": 1778798183695,
      "durationMs": 9,
      "nextRunAtMs": 1778801776117,
      "deliveryStatus": "not-requested"
    }
  ],
  "total": 1,
  "offset": 0,
  "limit": 1,
  "hasMore": false,
  "nextOffset": null
}
```

- Observed result after fix: The real Gateway accepted a cron job, `cron run --wait` returned the manual `runId`, blocked until the run log entry reached terminal status `ok`, returned `completed: true`, exited with `exit_code=0`, and `cron runs --run-id` returned exactly one matching finished entry.
- What was not tested: No external provider/channel delivery was exercised; proof used a local system-event cron job against a real loopback Gateway.
- Before evidence (optional but encouraged): Existing code path returned `{ ok: true, enqueued: true, runId }` immediately from `enqueueRun`, leaving wrappers to poll run history manually.

## Root Cause (if applicable)

- Root cause: N/A; this is an additive CLI capability.
- Missing detection / guardrail: Manual cron runs already emitted `runId`, but the CLI did not provide a first-party wait mode or exact-run history filter.
- Contributing context (if known): Operational shutdown hooks need completion semantics without changing the default non-blocking Gateway RPC contract.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/cron-cli.test.ts`, `src/cron/run-log.test.ts`, `src/gateway/protocol/cron-validators.test.ts`, `src/gateway/protocol/native-protocol-levels.guard.test.ts`.
- Scenario the test should lock in: `--wait` polls the exact `runId`, exits `0` for `ok`, exits non-zero for `error` and `skipped`, and protocol/run-log filtering accepts and applies `runId`.
- Why this is the smallest reliable guardrail: The behavior is a CLI wait loop over the existing cron run-log contract, so mocked Gateway responses and run-log filtering tests cover the new logic without requiring a live scheduler.
- Existing test that already covers this (if any): Existing cron CLI run tests covered queued/non-queued exit behavior; this PR extends them for wait behavior.
- If no new test is added, why not: N/A; focused tests were added.

## User-visible / Behavior Changes

`openclaw cron run <job-id>` remains non-blocking by default. Users can now pass `--wait`, `--wait-timeout <duration>`, and `--poll-interval <duration>` to block until the queued manual run completes. `openclaw cron runs --id <job-id> --run-id <run-id>` filters run history to one exact run.

## Diagram (if applicable)

```text
Before:
openclaw cron run <job-id> -> enqueue run -> print runId -> exit

After:
openclaw cron run <job-id> --wait -> enqueue run -> poll cron.runs by runId -> terminal status -> exit code
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Docker Desktop Linux container from Windows checkout
- Runtime/container: `node:24-bookworm`, Node v24.15.0, pnpm 11.1.0 through Corepack
- Model/provider: N/A
- Integration/channel (if any): local OpenClaw Gateway loopback with token auth
- Relevant config (redacted): isolated `OPENCLAW_STATE_DIR`; test token redacted in evidence

### Steps

1. Run focused cron CLI, run-log, protocol validator, and native protocol guard tests.
2. Run changed checks and docs list.
3. Start a real Gateway in Docker and run `cron add`, `cron run --wait`, and `cron runs --run-id` against it.
4. Inspect the PR diff for the CLI, Gateway protocol, run-log, generated Swift model, and docs updates.

### Expected

- `--wait` polls the exact returned run id and maps terminal statuses to the documented exit codes.
- `cron.runs` accepts and filters by `runId`.
- Protocol validators and generated Swift models stay in sync.
- Real Gateway proof shows returned `runId`, terminal status, and exit code.

### Actual

- Focused tests passed.
- Changed checks passed.
- Docs list passed.
- Whitespace check passed.
- Docker Gateway proof passed with returned `runId`, terminal status `ok`, `completed: true`, `exit_code=0`, and exact `cron runs --run-id` history lookup.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `ok`, `error`, and `skipped` terminal statuses for `cron run --wait`; exact `runId` filtering in cron run-log pages; protocol validator acceptance/rejection; generated Swift model includes `runId`; docs cover new CLI usage; real Gateway cron wait path returns `completed: true`, status `ok`, and exit code `0`.
- Edge cases checked: missing or empty `runId` validation, non-`ok` terminal statuses exiting non-zero, default non-wait behavior remaining unchanged.
- What you did **not** verify: External provider/channel delivery; proof used a local system-event cron job.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: `--wait` could hang longer than expected if a run never records a terminal log entry.
  - Mitigation: `--wait-timeout` defaults to a bounded duration and exits non-zero on timeout.
- Risk: polling could observe another run for the same job.
  - Mitigation: `cron.runs` now supports exact `runId` filtering and `--wait` uses it.
