### PR TITLE
fix(commands): restore bare /new and /reset model fallthrough

### DIFF
--- a/src/auto-reply/reply/commands-reset-hooks.test.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.test.ts
@@ -458,7 +458,7 @@ describe("handleCommands reset hooks", () => {
     expect(resetMocks.resetConfiguredBindingTargetInPlace).not.toHaveBeenCalled();
   });
 
-  it("acknowledges bare /reset without falling through to model execution", async () => {
+  it("lets bare /reset fall through to model execution", async () => {
     const params = buildResetParams("/reset", {
       commands: { text: true },
       channels: { whatsapp: { allowFrom: ["*"] } },
@@ -466,14 +466,11 @@ describe("handleCommands reset hooks", () => {
 
     const result = await maybeHandleResetCommand(params);
 
-    expect(result).toEqual({
-      shouldContinue: false,
-      reply: { text: "✅ Session reset." },
-    });
+    expect(result).toBeNull();
     expectObjectFields(firstHookEvent(), { type: "command", action: "reset" }, "hook event");
   });
 
-  it("acknowledges bare /new without falling through to model execution", async () => {
+  it("lets bare /new fall through to model execution", async () => {
     const params = buildResetParams("/new", {
       commands: { text: true },
       channels: { whatsapp: { allowFrom: ["*"] } },
@@ -481,10 +478,7 @@ describe("handleCommands reset hooks", () => {
 
     const result = await maybeHandleResetCommand(params);
 
-    expect(result).toEqual({
-      shouldContinue: false,
-      reply: { text: "✅ New session started." },
-    });
+    expect(result).toBeNull();
     expectObjectFields(firstHookEvent(), { type: "command", action: "new" }, "hook event");
   });
 

--- a/src/auto-reply/reply/commands-reset.ts
+++ b/src/auto-reply/reply/commands-reset.ts
@@ -166,17 +166,8 @@ export async function maybeHandleResetCommand(
     previousSessionEntry: params.previousSessionEntry,
     workspaceDir: params.workspaceDir,
   });
-  if (!resetTail) {
-    return {
-      shouldContinue: false,
-      ...(hookResult.routedReply
-        ? {}
-        : {
-            reply: {
-              text: commandAction === "reset" ? "✅ Session reset." : "✅ New session started.",
-            },
-          }),
-    };
+  if (!resetTail && hookResult.routedReply) {
+    return { shouldContinue: false };
   }
   return null;
 }


### PR DESCRIPTION
## Summary

- Restore bare `/new` and `/reset` fallthrough to the model/startup path after reset hooks run.
- Keep hook-routed reset replies terminal, so integrations that already sent a reset response do not also trigger a model turn.
- Update reset command tests to lock in the fallthrough behavior for bare `/new` and `/reset`.

Closes #77733.
Replaces closed/unmerged #77758 with a fresh branch against current `main`.

## Why

Current `main` still returns a canned acknowledgement for bare `/new` and `/reset`:

- `✅ New session started.`
- `✅ Session reset.`

That prevents the existing startup/model turn from running, so persona/session boot behavior does not happen after a bare reset/new command.

## Real behavior proof

**Behavior or issue addressed:** Bare `/new` should run reset hooks and then fall through into the normal model/startup turn. It should not terminate with the static `✅ New session started.` acknowledgement.

**Real environment tested:** Real installed OpenClaw gateway on Linux, installed version `2026.5.7`, Node `v24.15.0`, local loopback Gateway. I applied the same one-line behavior change locally to that installed gateway before running the proof.

**Exact steps or command run after this patch:**

1. Start from the installed OpenClaw gateway with the bare `/new` fallthrough hotfix applied.
2. Send a bare `/new` through the Gateway `agent` method using an operator-admin scoped client.
3. Inspect the returned payload from the live Gateway run.

**Evidence after fix:** Copied terminal output from the live setup:

```text
OpenClaw real setup: installed OpenClaw v24.15.0, sessionKey=agent:main:webchat:direct:proof-77733-1778797740642
Command equivalent: Gateway agent call with operator.admin scope, message=/new
{
  "status": "ok",
  "summary": "completed",
  "payloadCount": 1
}
--- payload 1 ---
Hey BlagoMan 👽 COOL online — calm, vigilant, mildly sassy, ready to build.

What are we doing next?
```

**Observed result after fix:** The live Gateway returned a real startup/model response for bare `/new`, proving the reset hook path still runs and then falls through into the model turn instead of returning the static ack.

**What was not tested:** I did not run a screenshot/recording proof in Control UI for this PR. Unit tests below cover both bare `/new` and bare `/reset`; the live proof above demonstrates the real Gateway `/new` behavior after the fix.

## Scope boundary

This keeps ACP reset behavior unchanged, keeps reset tails falling through as before, and keeps hook-routed replies terminal.

## Tests

```bash
pnpm exec vitest run src/auto-reply/reply/commands-reset-hooks.test.ts
pnpm exec oxfmt --check src/auto-reply/reply/commands-reset.ts src/auto-reply/reply/commands-reset-hooks.test.ts
git diff --check
```