### PR TITLE
Improve derived session titles for generic greetings

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1796,6 +1796,17 @@ describe("deriveSessionTitle", () => {
     expect(deriveSessionTitle(entry, "Hello, how are you?")).toBe("Hello, how are you?");
   });
 
+  test("ignores generic greeting-only first user messages", () => {
+    const entry = {
+      sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
+      updatedAt: new Date("2024-03-15T10:30:00Z").getTime(),
+    } as SessionEntry;
+
+    expect(deriveSessionTitle(entry, "hi")).toBe("abcd1234 (2024-03-15)");
+    expect(deriveSessionTitle(entry, "hello")).toBe("abcd1234 (2024-03-15)");
+    expect(deriveSessionTitle(entry, "hey")).toBe("abcd1234 (2024-03-15)");
+  });
+
   test("truncates long first user message to 60 chars with ellipsis", () => {
     const entry = {
       sessionId: "abc123",

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -213,6 +213,14 @@ function truncateTitle(text: string, maxLen: number): string {
   return cut + "…";
 }
 
+function isGenericSessionTitleMessage(text: string): boolean {
+  const normalized = text
+    .toLowerCase()
+    .replace(/[.!?]+$/g, "")
+    .trim();
+  return /^(hi|hello|hey|yo|sup|thanks|thank you)$/.test(normalized);
+}
+
 export function deriveSessionTitle(
   entry: SessionEntry | undefined,
   firstUserMessage?: string | null,
@@ -231,7 +239,9 @@ export function deriveSessionTitle(
 
   if (firstUserMessage?.trim()) {
     const normalized = firstUserMessage.replace(/\s+/g, " ").trim();
-    return truncateTitle(normalized, DERIVED_TITLE_MAX_LEN);
+    if (!isGenericSessionTitleMessage(normalized)) {
+      return truncateTitle(normalized, DERIVED_TITLE_MAX_LEN);
+    }
   }
 
   if (entry.sessionId) {


### PR DESCRIPTION
Fixes #81781.

Improves deriveSessionTitle() by ignoring low-information greeting-only messages such as "hi", "hello", and "hey" when generating derived session titles.

Previously, greeting-only prompts could become the session title, which provided little semantic value for identifying conversations later.

This update:
- adds filtering for generic greeting-only messages
- preserves existing title derivation behavior for meaningful prompts
- adds automated test coverage for the new logic
- keeps existing truncation and fallback behavior intact

Tested:
npm test -- src/gateway/session-utils.test.ts