### PR TITLE
fix: preserve reasoning_content for MiMo models in OpenAI-compatible replay

### DIFF
--- a/src/agents/openai-completions-string-content.ts
+++ b/src/agents/openai-completions-string-content.ts
@@ -47,6 +47,18 @@ export function stripCompletionMessagesToRoleContent(messages: unknown[]): unkno
     if (Object.prototype.hasOwnProperty.call(record, "content")) {
       stripped.content = record.content;
     }
+    if (Object.prototype.hasOwnProperty.call(record, "reasoning_content")) {
+      stripped.reasoning_content = record.reasoning_content;
+    } else if (record.role === "assistant" && Array.isArray(record.content)) {
+      const thinkingBlocks = (record.content as Array<Record<string, unknown>>).filter(
+        (b) => b.type === "thinking" && typeof b.thinking === "string" && b.thinking,
+      );
+      if (thinkingBlocks.length > 0) {
+        stripped.reasoning_content = thinkingBlocks.map((b) => b.thinking).join("\n");
+      } else {
+        stripped.reasoning_content = "";
+      }
+    }
     return stripped;
   });
 }

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -143,7 +143,7 @@ function buildUnownedProviderTransportReplayFallback(params: {
     ...(isAnthropic && modelDisablesReasoningEffort(params.model)
       ? { dropThinkingBlocks: true }
       : {}),
-    ...(isStrictOpenAiCompatible ? { dropReasoningFromHistory: true } : {}),
+    ...(isStrictOpenAiCompatible && !modelId.includes("mimo") ? { dropReasoningFromHistory: true } : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { applyAssistantFirstOrderingFix: true } : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { validateGeminiTurns: true } : {}),
     ...(isAnthropic || isStrictOpenAiCompatible || isClaudeOpenAiResponses

--- a/src/plugins/provider-replay-helpers.ts
+++ b/src/plugins/provider-replay-helpers.ts
@@ -52,7 +52,8 @@ export function buildOpenAICompatibleReplayPolicy(
           validateAnthropicTurns: false,
         }),
     ...(modelApi === "openai-completions" &&
-    (dropReasoningFromHistory || isGemma4ModelId(options.modelId))
+    (dropReasoningFromHistory || isGemma4ModelId(options.modelId)) &&
+    !normalizeLowercaseStringOrEmpty(options.modelId).includes("mimo")
       ? { dropReasoningFromHistory: true }
       : {}),
   };


### PR DESCRIPTION
MiMo models (xiaomi-coding/mimo-*) require reasoning_content field to be present in assistant messages during multi-turn conversations. Without this field, the model hangs and eventually times out with 'LLM idle timeout'.

## Changes
- `stripCompletionMessagesToRoleContent`: preserve reasoning_content and synthesize it from thinking blocks when missing
- `buildUnownedProviderTransportReplayFallback`: skip dropReasoningFromHistory for MiMo models
- `buildOpenAICompatibleReplayPolicy`: skip dropReasoningFromHistory for MiMo models

## Testing
Tested with xiaomi-coding/mimo-v2.5 on OpenClaw 2026.5.14-beta.1. Before this fix, multi-turn conversations would fail with 'LLM idle timeout (120s)' after the first assistant response. After the fix, multi-turn conversations work correctly.

Fixes #79608 for MiMo (similar to DeepSeek V4 fix in 2026.5.14)