### PR TITLE
ci: harden GitHub Actions supply-chain boundaries

### DIFF
--- a/.github/workflows/ci-build-artifacts-testbox.yml
+++ b/.github/workflows/ci-build-artifacts-testbox.yml
@@ -90,6 +90,7 @@ jobs:
 
       - name: Resolve release dist cache seeds
         id: dist-cache-seeds
+        if: github.event_name != 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
@@ -140,7 +141,8 @@ jobs:
 
       - name: Restore dist build cache
         id: dist-cache
-        uses: actions/cache/restore@v5
+        if: github.event_name != 'pull_request'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             .artifacts/build-all-cache/
@@ -150,13 +152,13 @@ jobs:
           restore-keys: ${{ steps.dist-cache-seeds.outputs.restore-keys }}
 
       - name: Build dist on cache miss
-        if: steps.dist-cache.outputs.cache-hit != 'true'
+        if: github.event_name == 'pull_request' || steps.dist-cache.outputs.cache-hit != 'true'
         env:
           NODE_OPTIONS: --max-old-space-size=8192
         run: pnpm build:ci-artifacts
 
       - name: Build Control UI on cache miss
-        if: steps.dist-cache.outputs.cache-hit != 'true'
+        if: github.event_name == 'pull_request' || steps.dist-cache.outputs.cache-hit != 'true'
         run: pnpm ui:build
 
       - name: Verify build artifacts
@@ -174,8 +176,8 @@ jobs:
           test -f dist/control-ui/index.html
 
       - name: Save dist build cache
-        if: steps.dist-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        if: github.event_name != 'pull_request' && steps.dist-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             .artifacts/build-all-cache/

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -314,7 +314,7 @@ on:
 
 permissions:
   contents: read
-  packages: write
+  packages: read
   pull-requests: read
 
 env:
@@ -329,8 +329,9 @@ jobs:
       trusted_reason: ${{ steps.validate.outputs.trusted_reason }}
     steps:
       - name: Checkout workflow repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Validate selected ref
@@ -522,8 +523,9 @@ jobs:
       OPENCLAW_LIVE_TEST: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
@@ -569,8 +571,9 @@ jobs:
       OPENCLAW_VITEST_MAX_WORKERS: "2"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
@@ -613,8 +616,9 @@ jobs:
       OPENCLAW_VITEST_MAX_WORKERS: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
@@ -739,7 +743,7 @@ jobs:
     steps:
       - name: Checkout selected ref
         if: contains(matrix.profiles, inputs.release_test_profile)
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
@@ -747,7 +751,7 @@ jobs:
 
       - name: Checkout trusted release harness
         if: contains(matrix.profiles, inputs.release_test_profile)
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           ref: ${{ github.sha }}
@@ -800,7 +804,7 @@ jobs:
 
       - name: Download OpenClaw Docker E2E package
         if: contains(matrix.profiles, inputs.release_test_profile) && steps.plan.outputs.needs_package == '1'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
           path: .artifacts/docker-e2e-package
@@ -893,7 +897,7 @@ jobs:
 
       - name: Upload Docker E2E chunk artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docker-e2e-${{ matrix.chunk_id }}
           path: .artifacts/docker-tests/
@@ -909,7 +913,7 @@ jobs:
       groups_json: ${{ steps.groups.outputs.groups_json }}
     steps:
       - name: Checkout trusted release harness
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           ref: ${{ github.sha }}
@@ -1001,14 +1005,14 @@ jobs:
       DOCKER_E2E_LANES: ${{ matrix.group.docker_lanes }}
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
       - name: Checkout trusted release harness
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           ref: ${{ github.sha }}
@@ -1061,7 +1065,7 @@ jobs:
 
       - name: Download OpenClaw Docker E2E package
         if: steps.plan.outputs.needs_package == '1'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
           path: .artifacts/docker-e2e-package
@@ -1153,7 +1157,7 @@ jobs:
 
       - name: Upload targeted Docker E2E artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docker-e2e-${{ steps.plan.outputs.artifact_suffix }}
           path: .artifacts/docker-tests/
@@ -1178,14 +1182,16 @@ jobs:
       OPENCLAW_SKIP_DOCKER_BUILD: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
       - name: Checkout trusted release harness
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ github.sha }}
           fetch-depth: 1
           path: .release-harness
@@ -1228,7 +1234,7 @@ jobs:
 
       - name: Download OpenClaw Docker E2E package
         if: steps.plan.outputs.needs_package == '1'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
           path: .artifacts/docker-e2e-package
@@ -1280,7 +1286,7 @@ jobs:
 
       - name: Upload Open WebUI Docker E2E artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docker-e2e-openwebui
           path: .artifacts/docker-tests/
@@ -1311,14 +1317,16 @@ jobs:
       OPENCLAW_DOCKER_E2E_REPO_ROOT: ${{ github.workspace }}
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
       - name: Checkout trusted release harness
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ github.sha }}
           fetch-depth: 1
           path: .release-harness
@@ -1363,14 +1371,14 @@ jobs:
 
       - name: Download current-run OpenClaw Docker E2E package
         if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name != '' && inputs.package_artifact_run_id == ''
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ inputs.package_artifact_name }}
           path: .artifacts/docker-e2e-package
 
       - name: Download previous-run OpenClaw Docker E2E package
         if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_run_id != ''
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
           path: .artifacts/docker-e2e-package
@@ -1420,7 +1428,7 @@ jobs:
 
       - name: Upload OpenClaw Docker E2E package
         if: steps.plan.outputs.needs_package == '1' && (inputs.package_artifact_name == '' || inputs.package_artifact_run_id != '')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
           path: .artifacts/docker-e2e-package/openclaw-current.tgz
@@ -1580,8 +1588,9 @@ jobs:
       DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
@@ -1692,15 +1701,17 @@ jobs:
     steps:
       - name: Checkout selected ref
         if: contains(matrix.profiles, inputs.release_test_profile)
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
       - name: Checkout trusted live Docker harness
         if: contains(matrix.profiles, inputs.release_test_profile)
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ github.sha }}
           fetch-depth: 1
           path: .release-harness
@@ -1813,14 +1824,16 @@ jobs:
       OPENCLAW_VITEST_MAX_WORKERS: "2"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
       - name: Checkout trusted live Docker harness
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ github.sha }}
           fetch-depth: 1
           path: .release-harness
@@ -2178,15 +2191,17 @@ jobs:
     steps:
       - name: Checkout selected ref
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'native-live-src-gateway-profiles-anthropic' && startsWith(matrix.suite_id, 'native-live-src-gateway-profiles-anthropic-')) || (inputs.live_suite_filter == 'native-live-src-gateway-profiles-opencode-go' && startsWith(matrix.suite_id, 'native-live-src-gateway-profiles-opencode-go-')))
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
       - name: Checkout trusted live shard harness
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'native-live-src-gateway-profiles-anthropic' && startsWith(matrix.suite_id, 'native-live-src-gateway-profiles-anthropic-')) || (inputs.live_suite_filter == 'native-live-src-gateway-profiles-opencode-go' && startsWith(matrix.suite_id, 'native-live-src-gateway-profiles-opencode-go-')))
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ github.sha }}
           fetch-depth: 1
           path: .release-harness
@@ -2396,15 +2411,17 @@ jobs:
     steps:
       - name: Checkout selected ref
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'live-gateway-advisory-docker' && startsWith(matrix.suite_id, 'live-gateway-advisory-docker-')))
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
       - name: Checkout trusted live shard harness
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'live-gateway-advisory-docker' && startsWith(matrix.suite_id, 'live-gateway-advisory-docker-')))
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ github.sha }}
           fetch-depth: 1
           path: .release-harness
@@ -2606,15 +2623,17 @@ jobs:
     steps:
       - name: Checkout selected ref
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'native-live-extensions-media-video' && startsWith(matrix.suite_id, 'native-live-extensions-media-video-')))
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
       - name: Checkout trusted live shard harness
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'native-live-extensions-media-video' && startsWith(matrix.suite_id, 'native-live-extensions-media-video-')))
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           ref: ${{ github.sha }}
           fetch-depth: 1
           path: .release-harness

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -38,6 +38,8 @@ concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && inputs.preflight_only && format('openclaw-npm-release-{0}-{1}-preflight', inputs.tag, inputs.npm_dist_tag) || github.event_name == 'workflow_dispatch' && format('openclaw-npm-release-{0}-{1}-publish-{2}', inputs.tag, inputs.npm_dist_tag, github.run_id) || format('openclaw-npm-release-{0}', github.ref) }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && inputs.preflight_only && inputs.npm_dist_tag == 'alpha' }}
 
+permissions: {}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.15.0"
@@ -87,10 +89,11 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate Tideclaw alpha preflight target
         if: startsWith(github.ref, 'refs/heads/tideclaw/alpha/')
@@ -338,7 +341,7 @@ jobs:
           node --import tsx scripts/openclaw-npm-prepublish-verify.ts "$TARBALL_PATH" "$PACKAGE_VERSION"
 
       - name: Upload dependency release evidence
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-release-dependency-evidence-${{ inputs.tag }}
           path: ${{ steps.dependency_evidence.outputs.dir }}
@@ -346,14 +349,14 @@ jobs:
 
       - name: Upload dependency release evidence tag alias
         if: ${{ steps.packed_tarball.outputs.release_tag != inputs.tag }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-release-dependency-evidence-${{ steps.packed_tarball.outputs.release_tag }}
           path: ${{ steps.dependency_evidence.outputs.dir }}
           if-no-files-found: error
 
       - name: Upload prepared npm publish bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-npm-preflight-${{ inputs.tag }}
           path: ${{ steps.packed_tarball.outputs.dir }}
@@ -361,7 +364,7 @@ jobs:
 
       - name: Upload prepared npm publish bundle tag alias
         if: ${{ steps.packed_tarball.outputs.release_tag != inputs.tag }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-npm-preflight-${{ steps.packed_tarball.outputs.release_tag }}
           path: ${{ steps.packed_tarball.outputs.dir }}
@@ -476,10 +479,11 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: refs/tags/${{ inputs.tag }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate Tideclaw alpha publish target
         if: startsWith(github.ref, 'refs/heads/tideclaw/alpha/')
@@ -595,7 +599,7 @@ jobs:
 
       - name: Download full release validation manifest
         if: ${{ inputs.full_release_validation_run_id != '' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: full-release-validation-${{ inputs.full_release_validation_run_id }}
           path: full-release-validation

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -88,6 +88,8 @@ concurrency:
   group: openclaw-release-checks-${{ inputs.expected_sha || inputs.ref }}-${{ inputs.rerun_group }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/heads/tideclaw/alpha/') }}
 
+permissions: {}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.15.0"
@@ -152,7 +154,7 @@ jobs:
           fi
 
       - name: Checkout trusted workflow helper
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           ref: ${{ github.ref_name }}
@@ -173,7 +175,7 @@ jobs:
 
       - name: Checkout selected ref for reachability fallback
         if: steps.fast_ref.outputs.fallback == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           ref: ${{ inputs.ref }}
@@ -507,7 +509,7 @@ jobs:
       source_sha: ${{ steps.package.outputs.source_sha }}
     steps:
       - name: Checkout trusted workflow ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
           ref: ${{ github.ref_name }}
@@ -559,7 +561,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload release package artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-package-under-test
           path: |
@@ -582,7 +584,11 @@ jobs:
   cross_os_release_checks:
     needs: [resolve_target, prepare_release_package]
     if: contains(fromJSON('["all","cross-os"]'), needs.resolve_target.outputs.rerun_group)
-    permissions: read-all
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+      pull-requests: read
     uses: ./.github/workflows/openclaw-cross-os-release-checks-reusable.yml
     with:
       advisory: ${{ startsWith(github.ref, 'refs/heads/tideclaw/alpha/') }}
@@ -798,7 +804,7 @@ jobs:
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
           ref: ${{ needs.resolve_target.outputs.revision }}
@@ -849,7 +855,7 @@ jobs:
       - name: Upload parity lane artifacts
         id: upload_parity_lane_artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-qa-parity-${{ matrix.lane }}-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
@@ -917,7 +923,7 @@ jobs:
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
           ref: ${{ needs.resolve_target.outputs.revision }}
@@ -930,7 +936,7 @@ jobs:
           install-bun: "true"
 
       - name: Download parity lane artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: release-qa-parity-*-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
@@ -955,7 +961,7 @@ jobs:
       - name: Upload parity artifacts
         id: upload_parity_artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-qa-parity-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
@@ -1028,7 +1034,7 @@ jobs:
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
           ref: ${{ needs.resolve_target.outputs.revision }}
@@ -1127,7 +1133,7 @@ jobs:
       - name: Upload runtime parity artifacts
         id: upload_runtime_parity_artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-qa-runtime-parity-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
@@ -1192,7 +1198,7 @@ jobs:
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
           ref: ${{ needs.resolve_target.outputs.revision }}
@@ -1205,7 +1211,7 @@ jobs:
           install-bun: "true"
 
       - name: Download runtime parity artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-qa-runtime-parity-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
@@ -1221,7 +1227,7 @@ jobs:
 
       - name: Upload runtime tool coverage artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-qa-runtime-tool-coverage-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/runtime-parity-standard-report/
@@ -1244,7 +1250,7 @@ jobs:
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
           ref: ${{ needs.resolve_target.outputs.revision }}
@@ -1301,7 +1307,7 @@ jobs:
       - name: Upload Matrix QA artifacts
         id: upload_matrix_qa_artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-qa-live-matrix-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
@@ -1368,7 +1374,7 @@ jobs:
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
           ref: ${{ needs.resolve_target.outputs.revision }}
@@ -1442,7 +1448,7 @@ jobs:
       - name: Upload Telegram QA artifacts
         id: upload_telegram_qa_artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-qa-live-telegram-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
@@ -1509,7 +1515,7 @@ jobs:
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
           ref: ${{ needs.resolve_target.outputs.revision }}
@@ -1582,7 +1588,7 @@ jobs:
       - name: Upload Discord QA artifacts
         id: upload_discord_qa_artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-qa-live-discord-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
@@ -1652,7 +1658,7 @@ jobs:
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
           ref: ${{ needs.resolve_target.outputs.revision }}
@@ -1725,7 +1731,7 @@ jobs:
       - name: Upload WhatsApp QA artifacts
         id: upload_whatsapp_qa_artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-qa-live-whatsapp-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/
@@ -1792,7 +1798,7 @@ jobs:
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
     steps:
       - name: Checkout selected ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
           ref: ${{ needs.resolve_target.outputs.revision }}
@@ -1865,7 +1871,7 @@ jobs:
       - name: Upload Slack QA artifacts
         id: upload_slack_qa_artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-qa-live-slack-${{ needs.resolve_target.outputs.revision }}
           path: .artifacts/qa-e2e/

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -61,9 +61,7 @@ on:
         default: false
         type: boolean
 
-permissions:
-  actions: write
-  contents: write
+permissions: {}
 
 concurrency:
   group: openclaw-release-publish-${{ inputs.tag }}
@@ -78,6 +76,9 @@ jobs:
     name: Resolve release target
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
     outputs:
       sha: ${{ steps.manifest.outputs.sha || steps.ref.outputs.sha }}
       preflight_artifact_name: ${{ steps.preflight_artifact.outputs.name }}
@@ -119,8 +120,8 @@ jobs:
           if [[ "${RELEASE_TAG}" == *"-alpha."* && "${RELEASE_NPM_DIST_TAG}" == "alpha" && "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
             tideclaw_alpha_publish=true
           fi
-          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${WORKFLOW_REF}" != "refs/heads/main" && ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ && "${tideclaw_alpha_publish}" != "true" ]]; then
-            echo "publish_openclaw_npm=true requires dispatching this workflow from main, release/YYYY.M.PATCH, or a Tideclaw alpha branch for alpha prereleases." >&2
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" && ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ && "${tideclaw_alpha_publish}" != "true" ]]; then
+            echo "Release publish must be dispatched from main, release/YYYY.M.PATCH, or a Tideclaw alpha branch for alpha prereleases so write-scoped publish jobs use trusted workflow logic." >&2
             exit 1
           fi
           if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${PLUGIN_PUBLISH_SCOPE}" != "all-publishable" ]]; then
@@ -196,7 +197,7 @@ jobs:
 
       - name: Download full release validation manifest
         if: ${{ inputs.publish_openclaw_npm }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: full-release-validation-${{ inputs.full_release_validation_run_id }}
           path: ${{ runner.temp }}/full-release-validation-manifest
@@ -205,7 +206,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Checkout release tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: refs/tags/${{ inputs.tag }}
           fetch-depth: 0
@@ -355,9 +356,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: npm-release
+    permissions:
+      actions: write
+      contents: write
     steps:
       - name: Checkout release SHA
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.resolve_release_target.outputs.sha }}
           fetch-depth: 1
@@ -1033,7 +1037,7 @@ jobs:
 
       - name: Upload postpublish evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-release-postpublish-evidence-${{ inputs.tag }}
           path: ${{ runner.temp }}/openclaw-release-postpublish-evidence

--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -34,6 +34,8 @@ concurrency:
   group: plugin-clawhub-release-${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
   cancel-in-progress: false
 
+permissions: {}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.15.0"
@@ -54,8 +56,18 @@ jobs:
       skipped_published_count: ${{ steps.plan.outputs.skipped_published_count }}
       matrix: ${{ steps.plan.outputs.matrix }}
     steps:
+      - name: Require trusted workflow ref for manual publish
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
+            echo "Plugin ClawHub publishes must be dispatched from main, release/YYYY.M.D, or a Tideclaw alpha branch so workflow logic stays trusted." >&2
+            exit 1
+          fi
+
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           ref: ${{ github.ref }}
@@ -71,6 +83,10 @@ jobs:
             +refs/heads/main:refs/remotes/origin/main \
             '+refs/heads/release/*:refs/remotes/origin/release/*'
           if [[ -n "${TARGET_REF}" ]]; then
+            if [[ ! "${TARGET_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "Manual plugin ClawHub publish ref must be a full 40-character commit SHA from main, release/*, or the matching Tideclaw alpha branch." >&2
+              exit 1
+            fi
             if git rev-parse --verify --quiet "${TARGET_REF}^{commit}" >/dev/null; then
               target_sha="$(git rev-parse "${TARGET_REF}^{commit}")"
             elif git rev-parse --verify --quiet "origin/${TARGET_REF}^{commit}" >/dev/null; then
@@ -247,7 +263,7 @@ jobs:
         plugin: ${{ fromJson(needs.preview_plugins_clawhub.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           ref: ${{ github.ref }}
@@ -271,7 +287,7 @@ jobs:
           install-deps: "true"
 
       - name: Checkout ClawHub CLI source
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           repository: ${{ env.CLAWHUB_REPOSITORY }}
@@ -338,7 +354,7 @@ jobs:
         plugin: ${{ fromJson(needs.preview_plugins_clawhub.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           ref: ${{ github.ref }}
@@ -362,7 +378,7 @@ jobs:
           install-deps: "true"
 
       - name: Checkout ClawHub CLI source
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           repository: ${{ env.CLAWHUB_REPOSITORY }}
@@ -402,6 +418,11 @@ jobs:
           EOF
           chmod +x "$RUNNER_TEMP/clawhub"
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+
+      - name: Enforce OIDC-only ClawHub publish auth
+        run: |
+          set -euo pipefail
+          echo "ClawHub publishes use GitHub OIDC trusted publishing; long-lived token fallback is intentionally disabled."
 
       - name: Pack ClawHub package artifact
         env:

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -56,48 +56,69 @@ jobs:
       candidate_count: ${{ steps.plan.outputs.candidate_count }}
       matrix: ${{ steps.plan.outputs.matrix }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - name: Require trusted workflow ref for manual publish
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
+            echo "Manual plugin npm publishes must be dispatched from main, release/YYYY.M.D, or a Tideclaw alpha branch so workflow logic stays trusted." >&2
+            exit 1
+          fi
+
+      - name: Checkout trusted workflow ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
+
+      - name: Validate and checkout trusted publish ref
+        id: ref
+        env:
+          TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || '' }}
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin             +refs/heads/main:refs/remotes/origin/main             '+refs/heads/release/*:refs/remotes/origin/release/*'
+          if [[ "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
+            alpha_branch="${WORKFLOW_REF#refs/heads/}"
+            git fetch --no-tags origin "+refs/heads/${alpha_branch}:refs/remotes/origin/${alpha_branch}"
+          fi
+          if [[ -n "${TARGET_REF}" ]]; then
+            if [[ ! "${TARGET_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "Manual plugin npm publish ref must be a full 40-character commit SHA from main, release/*, or the matching Tideclaw alpha branch." >&2
+              exit 1
+            fi
+            if ! git rev-parse --verify --quiet "${TARGET_REF}^{commit}" >/dev/null; then
+              echo "Unable to resolve requested publish ref: ${TARGET_REF}" >&2
+              exit 1
+            fi
+            git checkout --detach "${TARGET_REF}"
+          fi
+          if git merge-base --is-ancestor HEAD origin/main; then
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          while IFS= read -r release_ref; do
+            if git merge-base --is-ancestor HEAD "${release_ref}"; then
+              echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/release)
+          if [[ "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]] && git merge-base --is-ancestor HEAD "refs/remotes/origin/${alpha_branch}"; then
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Plugin npm publishes must target a commit reachable from main, release/*, or the matching Tideclaw alpha branch." >&2
+          exit 1
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
-
-      - name: Resolve checked-out ref
-        id: ref
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Validate ref is on a trusted publish branch
-        env:
-          WORKFLOW_REF: ${{ github.ref }}
-        run: |
-          set -euo pipefail
-          git fetch --no-tags origin \
-            +refs/heads/main:refs/remotes/origin/main \
-            '+refs/heads/release/*:refs/remotes/origin/release/*'
-          if git merge-base --is-ancestor HEAD origin/main; then
-            exit 0
-          fi
-          while IFS= read -r release_ref; do
-            if git merge-base --is-ancestor HEAD "${release_ref}"; then
-              exit 0
-            fi
-          done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/release)
-          if [[ "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
-            alpha_branch="${WORKFLOW_REF#refs/heads/}"
-            git fetch --no-tags origin "+refs/heads/${alpha_branch}:refs/remotes/origin/${alpha_branch}"
-            if git merge-base --is-ancestor HEAD "refs/remotes/origin/${alpha_branch}"; then
-              exit 0
-            fi
-          fi
-          echo "Plugin npm publishes must target a commit reachable from main, release/*, or the matching Tideclaw alpha branch." >&2
-          exit 1
 
       - name: Validate publishable plugin metadata
         env:
@@ -283,13 +304,21 @@ jobs:
             echo "already_published=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish
+      - name: Publish package with npm trusted publishing
         if: steps.npm_package_version.outputs.already_published != 'true'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Confirm mirror auth exists before OIDC package publish, without
+          # exposing the long-lived npm token to the publish subprocess.
+          OPENCLAW_NPM_DIST_TAG_MIRROR_AUTH_AVAILABLE: ${{ secrets.NPM_TOKEN != '' && '1' || '0' }}
           OPENCLAW_NPM_PUBLISH_AUTH_MODE: trusted-publisher
-        run: bash scripts/plugin-npm-publish.sh --publish "${{ matrix.plugin.packageDir }}"
+        run: bash scripts/plugin-npm-publish.sh --publish-package "${{ matrix.plugin.packageDir }}"
+
+      - name: Mirror stable-release npm dist-tags
+        env:
+          # Long-lived npm auth is isolated to dist-tag mirroring and is not
+          # present while the trusted-publishing package publish subprocess runs.
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bash scripts/plugin-npm-publish.sh --mirror-dist-tags "${{ matrix.plugin.packageDir }}"
 
       - name: Verify published runtime
         env:

--- a/scripts/lib/plugin-npm-package-manifest.mjs
+++ b/scripts/lib/plugin-npm-package-manifest.mjs
@@ -140,15 +140,21 @@ function listConfiguredBundledDependencyNames(packageJson) {
 
 /** Resolve an npm command invocation for plugin package scripts. */
 export function resolvePluginNpmCommand(args, params = {}) {
+  const env = params.env ?? process.env;
+  const testNpmCommand = env.OPENCLAW_PLUGIN_NPM_MANIFEST_OVERLAY_NPM;
+  if (testNpmCommand) {
+    return { args, command: testNpmCommand };
+  }
   return resolveNpmRunner({
     comSpec: params.comSpec,
-    env: params.env,
+    env,
     execPath: params.execPath,
     existsSync: params.existsSync,
     npmArgs: args,
     platform: params.platform,
   });
 }
+
 
 function spawnNpmSync(args, options = {}) {
   const invocation = resolvePluginNpmCommand(args, { env: options.env ?? process.env });

--- a/scripts/plugin-npm-publish.sh
+++ b/scripts/plugin-npm-publish.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 mode="${1:-}"
 package_dir="${2:-}"
 
-if [[ "${mode}" != "--dry-run" && "${mode}" != "--pack-dry-run" && "${mode}" != "--publish" ]]; then
-  echo "usage: bash scripts/plugin-npm-publish.sh [--dry-run|--pack-dry-run|--publish] <package-dir>" >&2
+if [[ "${mode}" != "--dry-run" && "${mode}" != "--pack-dry-run" && "${mode}" != "--publish" && "${mode}" != "--publish-package" && "${mode}" != "--mirror-dist-tags" ]]; then
+  echo "usage: bash scripts/plugin-npm-publish.sh [--dry-run|--pack-dry-run|--publish|--publish-package|--mirror-dist-tags] <package-dir>" >&2
   exit 2
 fi
 
@@ -41,10 +41,18 @@ const auth = resolveNpmDistTagMirrorAuth({
   nodeAuthToken: process.env.NODE_AUTH_TOKEN,
   npmToken: process.env.NPM_TOKEN,
 });
+const publishMode = process.env.PUBLISH_MODE;
+const mirrorAuthPresenceFlag = ["1", "true", "yes", "available"]
+  .includes((process.env.OPENCLAW_NPM_DIST_TAG_MIRROR_AUTH_AVAILABLE ?? "").trim().toLowerCase());
 const shouldRequireMirrorAuth = shouldRequireNpmDistTagMirrorAuth({
-  mode: process.env.PUBLISH_MODE === "--publish" ? "--publish" : "--dry-run",
+  mode:
+    publishMode === "--publish" ||
+    publishMode === "--publish-package" ||
+    publishMode === "--mirror-dist-tags"
+      ? "--publish"
+      : "--dry-run",
   mirrorDistTags: plan.mirrorDistTags,
-  hasAuth: auth.hasAuth,
+  hasAuth: auth.hasAuth || mirrorAuthPresenceFlag,
 });
 console.log(plan.channel);
 console.log(plan.publishTag);
@@ -72,7 +80,21 @@ log "Current beta dist-tag: ${current_beta_version:-<missing>}"
 log "Resolved release channel: ${release_channel}"
 log "Resolved publish tag: ${publish_tag}"
 log "Resolved mirror dist-tags: ${mirror_dist_tags_csv:-<none>}"
+mirror_auth_presence_flag="${OPENCLAW_NPM_DIST_TAG_MIRROR_AUTH_AVAILABLE:-}"
+case "${mirror_auth_presence_flag,,}" in
+  1|true|yes|available)
+    mirror_auth_available="true"
+    ;;
+  *)
+    mirror_auth_available="false"
+    ;;
+esac
+if [[ "${mirror_auth_source}" != "none" ]]; then
+  mirror_auth_available="true"
+fi
+
 log "Mirror dist-tag auth source: ${mirror_auth_source}"
+log "Mirror dist-tag auth availability: ${mirror_auth_available}"
 log "Mirror dist-tag auth requirement: ${mirror_auth_requirement}"
 
 build_package_runtime() {
@@ -108,36 +130,56 @@ publish_provenance="without provenance"
 if [[ " ${publish_cmd[*]} " == *" --provenance "* ]]; then
   publish_provenance="with provenance"
 fi
-if [[ -n "${publish_auth_token}" ]]; then
-  log "Publish auth: ${publish_auth_source} ${publish_provenance}"
-else
-  log "Publish auth: GitHub OIDC trusted publishing"
+if [[ "${mode}" != "--mirror-dist-tags" ]]; then
+  if [[ -n "${publish_auth_token}" ]]; then
+    log "Publish auth: ${publish_auth_source} ${publish_provenance}"
+  else
+    log "Publish auth: GitHub OIDC trusted publishing"
+  fi
 fi
 
-if [[ "${mirror_auth_requirement}" == "required" && -z "${mirror_auth_token}" ]]; then
-  echo "npm dist-tag mirroring requires explicit npm auth via NODE_AUTH_TOKEN or NPM_TOKEN." >&2
-  echo "Refusing publish before npm latest/beta promotion can diverge." >&2
+if [[ "${mirror_auth_requirement}" == "required" ]]; then
+  if [[ "${mode}" == "--publish-package" ]]; then
+    echo "npm dist-tag mirroring requires confirmed npm auth availability before package publish." >&2
+    echo "Set OPENCLAW_NPM_DIST_TAG_MIRROR_AUTH_AVAILABLE=1 only after confirming the later mirror step has npm auth." >&2
+  elif [[ "${mode}" == "--mirror-dist-tags" ]]; then
+    echo "npm dist-tag mirroring requires explicit npm auth via NODE_AUTH_TOKEN or NPM_TOKEN." >&2
+    echo "Refusing npm latest/beta promotion without npm auth." >&2
+  else
+    echo "npm dist-tag mirroring requires explicit npm auth via NODE_AUTH_TOKEN or NPM_TOKEN." >&2
+    echo "Refusing publish before npm latest/beta promotion can diverge." >&2
+  fi
   exit 1
 fi
 
-if [[ "${mode}" == "--pack-dry-run" ]]; then
-  {
+if [[ "${mode}" == "--mirror-dist-tags" && -n "${mirror_dist_tags_csv}" && -z "${mirror_auth_token}" ]]; then
+  echo "npm dist-tag mirroring requires explicit npm auth via NODE_AUTH_TOKEN or NPM_TOKEN." >&2
+  echo "Refusing npm latest/beta promotion without npm auth." >&2
+  exit 1
+fi
+
+if [[ "${mode}" != "--mirror-dist-tags" ]]; then
+  if [[ "${mode}" == "--pack-dry-run" ]]; then
+    {
+      printf 'Publish command:'
+      printf ' %q' "${publish_cmd[@]}"
+      printf '\n'
+    } >&2
+  else
     printf 'Publish command:'
     printf ' %q' "${publish_cmd[@]}"
     printf '\n'
-  } >&2
-else
-  printf 'Publish command:'
-  printf ' %q' "${publish_cmd[@]}"
-  printf '\n'
+  fi
 fi
 
 if [[ "${mode}" == "--dry-run" ]]; then
   exit 0
 fi
 
-build_package_runtime
-check_package_shrinkwrap
+if [[ "${mode}" != "--mirror-dist-tags" ]]; then
+  build_package_runtime
+  check_package_shrinkwrap
+fi
 
 if [[ "${mode}" == "--pack-dry-run" ]]; then
   OPENCLAW_PLUGIN_NPM_BUNDLE_DEPENDENCIES=1 \
@@ -153,18 +195,20 @@ fi
     OPENCLAW_PLUGIN_NPM_BUNDLE_DEPENDENCIES=1 \
       node scripts/lib/plugin-npm-package-manifest.mjs --run "${package_dir}" -- "$@"
   }
-  publish_userconfig=""
-  if [[ -n "${publish_auth_token}" ]]; then
-    publish_userconfig="$(mktemp)"
-    cleanup_files+=("${publish_userconfig}")
-    chmod 0600 "${publish_userconfig}"
-    printf '%s\n' "//registry.npmjs.org/:_authToken=${publish_auth_token}" > "${publish_userconfig}"
-    NPM_CONFIG_USERCONFIG="${publish_userconfig}" run_with_manifest_overlay "${publish_cmd[@]}"
-  else
-    run_with_manifest_overlay "${publish_cmd[@]}"
-  fi
+  run_publish_with_manifest_overlay() {
+    if [[ "${OPENCLAW_NPM_PUBLISH_AUTH_MODE:-}" == "trusted-publisher" ]]; then
+      env -u NODE_AUTH_TOKEN -u NPM_TOKEN -u NPM_CONFIG_USERCONFIG \
+        node scripts/lib/plugin-npm-package-manifest.mjs --run "${package_dir}" -- "$@"
+    else
+      run_with_manifest_overlay "$@"
+    fi
+  }
+  mirror_dist_tags() {
+    if [[ -z "${mirror_dist_tags_csv}" ]]; then
+      log "Mirror dist-tags: <none>"
+      return
+    fi
 
-  if [[ -n "${mirror_dist_tags_csv}" ]]; then
     mirror_userconfig="$(mktemp)"
     cleanup_files+=("${mirror_userconfig}")
     chmod 0600 "${mirror_userconfig}"
@@ -182,5 +226,22 @@ fi
         echo "Warning: optional npm dist-tag mirror failed for ${package_name}@${package_version} -> ${dist_tag}; published package remains live." >&2
       fi
     done
+  }
+
+  if [[ "${mode}" != "--mirror-dist-tags" ]]; then
+    publish_userconfig=""
+    if [[ -n "${publish_auth_token}" ]]; then
+      publish_userconfig="$(mktemp)"
+      cleanup_files+=("${publish_userconfig}")
+      chmod 0600 "${publish_userconfig}"
+      printf '%s\n' "//registry.npmjs.org/:_authToken=${publish_auth_token}" > "${publish_userconfig}"
+      NPM_CONFIG_USERCONFIG="${publish_userconfig}" run_publish_with_manifest_overlay "${publish_cmd[@]}"
+    else
+      run_publish_with_manifest_overlay "${publish_cmd[@]}"
+    fi
+  fi
+
+  if [[ "${mode}" == "--publish" || "${mode}" == "--mirror-dist-tags" ]]; then
+    mirror_dist_tags
   fi
 )

--- a/test/scripts/plugin-npm-publish-token-boundary.test.ts
+++ b/test/scripts/plugin-npm-publish-token-boundary.test.ts
@@ -1,0 +1,230 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PUBLISH_SCRIPT = "scripts/plugin-npm-publish.sh";
+const WORKFLOW = ".github/workflows/plugin-npm-release.yml";
+
+function writePackage(packageDir: string, version: string) {
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(
+    join(packageDir, "package.json"),
+    `${JSON.stringify({ name: "@openclaw/test-plugin", version }, null, 2)}\n`,
+  );
+}
+
+function writeFakeNpm(binDir: string, record: string) {
+  mkdirSync(binDir, { recursive: true });
+  process.env.OPENCLAW_PLUGIN_NPM_MANIFEST_OVERLAY_NPM = join(binDir, "npm");
+  process.env.OPENCLAW_TEST_NPM_RECORD = record;
+  writeFileSync(
+    join(binDir, "npm"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+: "\${OPENCLAW_TEST_NPM_RECORD:?}"
+case "\${1:-}" in
+  view)
+    exit 1
+    ;;
+  publish)
+    if [[ -n "\${NPM_TOKEN:-}" || -n "\${NODE_AUTH_TOKEN:-}" || -n "\${NPM_CONFIG_USERCONFIG:-}" ]]; then
+      echo "trusted publish subprocess received npm auth env" >&2
+      env | sort > "\${OPENCLAW_TEST_NPM_RECORD}"
+      exit 66
+    fi
+    printf '%s\n' "publish token env absent" > "\${OPENCLAW_TEST_NPM_RECORD}"
+    ;;
+  dist-tag)
+    if [[ -z "\${NPM_CONFIG_USERCONFIG:-}" ]]; then
+      echo "dist-tag mirror missing npm userconfig" >&2
+      exit 67
+    fi
+    echo "dist-tag \${*}" >> "\${OPENCLAW_TEST_NPM_RECORD}"
+    ;;
+  install)
+    if [[ "\${*}" != "install --package-lock-only --ignore-scripts --no-audit --no-fund" ]]; then
+      echo "unexpected npm install command: \${*}" >&2
+      exit 64
+    fi
+    ;;
+  shrinkwrap)
+    if [[ "\${*}" != "shrinkwrap --ignore-scripts --no-audit --no-fund" ]]; then
+      echo "unexpected npm shrinkwrap command: \${*}" >&2
+      exit 64
+    fi
+    node --input-type=module <<'NODE'
+import { readFileSync, writeFileSync } from "node:fs";
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+writeFileSync(
+  "npm-shrinkwrap.json",
+  JSON.stringify({ lockfileVersion: 3, packages: { "": pkg } }, null, 2) + "\\n",
+);
+NODE
+    ;;
+  *)
+    echo "unexpected npm command: \${*}" >&2
+    exit 64
+    ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+}
+
+type Fixture = { root: string; binDir: string; packageDir: string; record: string };
+
+function writeFixtureShrinkwrap({ binDir, packageDir, record }: Fixture) {
+  const result = spawnSync(
+    "node",
+    ["scripts/generate-npm-shrinkwrap.mjs", "--package-dir", packageDir],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        OPENCLAW_TEST_NPM_RECORD: record,
+      },
+    },
+  );
+  expect(
+    result.status,
+    `${result.stdout}
+${result.stderr}`,
+  ).toBe(0);
+}
+
+function withFixture(testBody: (fixture: Fixture) => void) {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-plugin-npm-token-boundary-"));
+  try {
+    const binDir = join(root, "bin");
+    const packageDir = join(root, "package");
+    const record = join(root, "record.txt");
+    writeFakeNpm(binDir, record);
+    testBody({ root, binDir, packageDir, record });
+    delete process.env.OPENCLAW_PLUGIN_NPM_MANIFEST_OVERLAY_NPM;
+    delete process.env.OPENCLAW_TEST_NPM_RECORD;
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("plugin npm trusted-publishing token boundary", () => {
+  it("keeps npm auth env out of the trusted-publishing package publish subprocess", () => {
+    withFixture((fixture) => {
+      const { binDir, packageDir, record } = fixture;
+      writePackage(packageDir, "2026.4.1-beta.1");
+      writeFixtureShrinkwrap(fixture);
+
+      const result = spawnSync("bash", [PUBLISH_SCRIPT, "--publish-package", packageDir], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          OPENCLAW_NPM_PUBLISH_AUTH_MODE: "trusted-publisher",
+          OPENCLAW_PLUGIN_NPM_RUNTIME_BUILD: "0",
+          OPENCLAW_TEST_NPM_RECORD: record,
+          NODE_AUTH_TOKEN: "node-auth-secret",
+          NPM_CONFIG_USERCONFIG: "/tmp/should-not-leak-to-publish",
+          NPM_TOKEN: "npm-secret",
+        },
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(readFileSync(record, "utf8")).toBe("publish token env absent\n");
+    });
+  });
+
+  it("refuses stable package publish before mirror auth availability is confirmed", () => {
+    withFixture(({ binDir, packageDir, record }) => {
+      writePackage(packageDir, "2026.4.1");
+
+      const result = spawnSync("bash", [PUBLISH_SCRIPT, "--publish-package", packageDir], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          OPENCLAW_NPM_PUBLISH_AUTH_MODE: "trusted-publisher",
+          OPENCLAW_PLUGIN_NPM_RUNTIME_BUILD: "0",
+          OPENCLAW_TEST_NPM_RECORD: record,
+        },
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+      expect(result.stderr).toContain(
+        "requires confirmed npm auth availability before package publish",
+      );
+      expect(existsSync(record) ? readFileSync(record, "utf8") : "").toBe("");
+    });
+  });
+
+  it("allows stable trusted-publisher package publish with only mirror auth availability", () => {
+    withFixture((fixture) => {
+      const { binDir, packageDir, record } = fixture;
+      writePackage(packageDir, "2026.4.1");
+      writeFixtureShrinkwrap(fixture);
+
+      const result = spawnSync("bash", [PUBLISH_SCRIPT, "--publish-package", packageDir], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          OPENCLAW_NPM_DIST_TAG_MIRROR_AUTH_AVAILABLE: "1",
+          OPENCLAW_NPM_PUBLISH_AUTH_MODE: "trusted-publisher",
+          OPENCLAW_PLUGIN_NPM_RUNTIME_BUILD: "0",
+          OPENCLAW_TEST_NPM_RECORD: record,
+        },
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(readFileSync(record, "utf8")).toBe("publish token env absent\n");
+    });
+  });
+
+  it("runs dist-tag mirroring as a separate npm-authenticated path", () => {
+    withFixture(({ binDir, packageDir, record }) => {
+      writePackage(packageDir, "2026.4.1");
+
+      const result = spawnSync("bash", [PUBLISH_SCRIPT, "--mirror-dist-tags", packageDir], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          OPENCLAW_TEST_NPM_RECORD: record,
+          NPM_TOKEN: "npm-secret",
+        },
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(readFileSync(record, "utf8")).toContain(
+        "dist-tag dist-tag add @openclaw/test-plugin@2026.4.1 beta",
+      );
+    });
+  });
+
+  it("does not expose NPM_TOKEN on the trusted-publishing workflow step", () => {
+    const workflow = readFileSync(WORKFLOW, "utf8");
+    const publishStep =
+      workflow.match(
+        /- name: Publish package with npm trusted publishing[\s\S]*?(?=\n\s*- name: Mirror stable-release npm dist-tags)/,
+      )?.[0] ?? "";
+    const mirrorStep =
+      workflow.match(
+        /- name: Mirror stable-release npm dist-tags[\s\S]*?(?=\n\s*- name: Verify published runtime)/,
+      )?.[0] ?? "";
+
+    expect(publishStep).not.toBe("");
+    expect(publishStep).not.toContain("NPM_TOKEN: ${{ secrets.NPM_TOKEN }}");
+    expect(publishStep).toContain("--publish-package");
+    expect(publishStep).toContain("OPENCLAW_NPM_DIST_TAG_MIRROR_AUTH_AVAILABLE");
+    expect(mirrorStep).not.toBe("");
+    expect(mirrorStep).toContain("NPM_TOKEN");
+    expect(mirrorStep).toContain("--mirror-dist-tags");
+  });
+});


### PR DESCRIPTION
## Summary

This PR is release/publish supply-chain security-boundary hardening for high-risk GitHub Actions release, publish, live/e2e, and build-artifact paths.

Changes are intentionally scoped to CI/release plumbing:

- tighten release/publish workflow permissions and trusted-ref checks
- remove the ClawHub long-lived token fallback in favor of OIDC trusted publishing
- force plugin npm package publish to use OIDC trusted publishing
- keep plugin npm stable dist-tag mirror auth as a pre-publish availability guard without exposing npm auth to the package publish subprocess
- split stable dist-tag mirroring into a separate authenticated path
- harden cache/artifact boundaries so untrusted PR paths do not consume executable build caches before secret-bearing/testbox paths
- pin external Actions in the high-risk workflow scope to commit SHAs, with version comments retained for readability
- add focused regression coverage for the plugin npm token/precheck boundary

## Scope boundary

This is a release/publish supply-chain security-boundary hardening PR, not a test/CI-only PR and not a red-CI chasing PR. The workflow/script changes are limited to credential scoping, trusted-ref admission, OIDC/trusted publishing, cache/artifact trust boundaries, and external Action pinning in the touched high-risk release/publish/live/testbox paths.

It intentionally does not include unrelated fixes for known red `main` CI, lint/test flakes, or dependency advisories outside this boundary. If a check is also failing on `main` or is not caused by this diff, it remains out of scope for this PR.

## Details

### Publish / OIDC / ref hardening

- Add explicit default `permissions: {}` in high-risk workflows and move write permissions to job scope only where required.
- Require manual plugin publish workflows to be dispatched from `main` or `release/YYYY.M.D`.
- Require manual publish target overrides to be full 40-character commit SHAs reachable from `main` or `release/*`.
- Gate the write-scoped release publish path unconditionally on a trusted workflow ref.
- Remove the ClawHub token fallback so plugin ClawHub publish uses OIDC trusted publishing.
- Force plugin npm package publish to use OIDC trusted publishing.
- Preserve the stable-release mirror-auth precheck before package publish via a boolean availability flag, while keeping the long-lived npm token out of the package publish environment.
- Run actual stable dist-tag mirroring through `--mirror-dist-tags` as a separate npm-authenticated step/path.

### Cache / artifact boundary hardening

- Change the CI dist build cache to save-only after build, preventing an existing cache restore from overwriting freshly built artifacts before upload.
- Remove broad restore keys from the extension package boundary executable cache.
- Disable dist cache restore/save on pull request testbox runs and force PR runs to rebuild dist/UI before the testbox path.

### Action pinning

- Pin external Actions in the touched high-risk workflows to 40-character commit SHAs.
- Keep version comments such as `# v6` next to pins for maintainability.

## Validation

Initial stage validation included:

- `git diff --check`
- `actionlint` v1.7.11 on the 8 modified workflows
- PyYAML parse of the scoped workflows
- `python3 scripts/check-composite-action-input-interpolation.py`
- `node scripts/check-no-conflict-markers.mjs`
- focused invariants for trusted refs, cache predicates, SHA pins, and publish-token boundaries
- verification that the pinned `actions/cache/save` and `actions/cache/restore` commits contain their sub-action `action.yml` files

Latest current-head CI follow-up validation (2026-05-16):

- Corrected branch-update path to use SSH for GitHub pushes: `git@github.com:anyech/openclaw.git`, not HTTPS/PAT. The branch was force-updated with explicit `--force-with-lease` from `527378799c7a5507a6a01a2eb5ba549e7908e889` to `370c084cf76af8724cbfd52636285b0e6249c8a6`.
- Rebased the PR branch onto current upstream `main` at `532e42213d03cde6e02a8e3ecf08ad511a8aba93`. The earlier temporary Telegram type-fix fallback commit dropped during rebase because the patch contents are already upstream.
- Preserved this PR's release/publish hardening changes and added one follow-up pinning commit for the newly introduced release runtime parity `actions/checkout@v6` and `actions/upload-artifact@v4` steps.
- `bash -n scripts/plugin-npm-publish.sh`
- PyYAML parse of the 8 changed workflow files
- `actionlint` v1.7.11 on the 8 changed workflow files
- `python3 scripts/check-composite-action-input-interpolation.py`
- focused audit that every external Action reference in the 8 changed high-risk workflows is pinned to a 40-character SHA (`113` checked references, `0` violations)
- `git diff --check upstream/main...HEAD`
- `node scripts/check-no-conflict-markers.mjs`
- fake-npm proof for the plugin npm trusted-publishing token/precheck boundary (details below)

## Real behavior proof

- Behavior addressed: GitHub Actions release/publish/cache hardening plus the plugin npm token/precheck boundary. The latest follow-up rebases this branch onto current upstream `main`, uses SSH for the public branch push path, and keeps all touched high-risk workflow `uses:` references pinned to 40-character commit SHAs.
- Real setup tested: Disposable OpenClaw source checkout using this PR branch at commit `370c084cf76af8724cbfd52636285b0e6249c8a6`; current upstream `main` was `532e42213d03cde6e02a8e3ecf08ad511a8aba93`. No production OpenClaw Gateway/runtime/config/state was used.
- Exact steps or command run after this patch: Rebases were performed locally in the disposable checkout; validation covered shell syntax, workflow YAML parsing, `actionlint`, composite-action input interpolation, conflict-marker scanning, and a focused external Action SHA-pin audit. The fake-npm proof harness created a synthetic stable package, put a fake `npm` first on `PATH`, confirmed `bash scripts/plugin-npm-publish.sh --publish-package <synthetic-package>` refuses before package publish when mirror auth availability is not confirmed, confirmed the same package publish proceeds with only `OPENCLAW_NPM_DIST_TAG_MIRROR_AUTH_AVAILABLE=1` and no npm auth token, then ran `bash scripts/plugin-npm-publish.sh --mirror-dist-tags <synthetic-package>` with synthetic npm auth. Because the disposable checkout did not have repository dependencies installed and the guarded heavy install path was unavailable, the proof used local dependency-resolution stubs only for missing `json5`/`tsdown`; `OPENCLAW_PLUGIN_NPM_RUNTIME_BUILD=0` ensured the `tsdown` stub was not exercised.
- Evidence after fix: Terminal proof showed:

```text
Current PR head: 370c084cf76af8724cbfd52636285b0e6249c8a6
Current upstream main: 532e42213d03cde6e02a8e3ecf08ad511a8aba93
SSH push target: git@github.com:anyech/openclaw.git
Force-with-lease: 527378799c7a5507a6a01a2eb5ba549e7908e889 -> 370c084cf76af8724cbfd52636285b0e6249c8a6

Local validation after this patch:
- bash -n scripts/plugin-npm-publish.sh: pass
- PyYAML parse of touched workflows: parsed 8 files
- actionlint v1.7.11 on touched workflows: pass
- composite-action input interpolation guard: pass
- external Action SHA-pin audit: PASS, 113 external action/workflow uses pinned across 8 touched workflows
- git diff --check: pass
- conflict-marker scan: pass

Trusted-publisher package publish precheck:
- npm dist-tag mirroring requires confirmed npm auth availability before package publish.
- stable package publish refuses before mirror auth availability is confirmed

Trusted-publisher package publish path:
- publish subprocess saw no NPM_TOKEN, NODE_AUTH_TOKEN, or NPM_CONFIG_USERCONFIG

Separate dist-tag mirror path:
- dist-tag mirror used a separate npm userconfig auth path for dist-tag add
```

- CI/lint follow-up: The branch is now rebased onto current upstream `main` and pushed via SSH with explicit `--force-with-lease`. GitHub CI is expected to rerun on the new head.
- Observed result after fix: Local proof confirms the plugin publish token/precheck boundary still holds after rebase, and the touched high-risk workflow set has no unpinned external Action references under the focused audit.
- What was not tested: No live npm publish, npm dist-tag mutation, ClawHub publish, release publish, or production Gateway run was performed. Those paths can publish or mutate external release state, so this PR intentionally uses fake npm plus disposable source-checkout validation and leaves the first real release/publish run to maintainer-controlled CI/release process.
- Before evidence (optional but encouraged): Before the token-boundary/precheck fix, stable plugin publishes could publish before missing mirror auth was discovered in the later mirror step. Before the broader hardening patch, the touched workflows allowed tag/branch-pinned external Actions in the high-risk scope, PR testbox dist cache restore/save was enabled, and the ClawHub plugin publish path retained a long-lived token fallback.

## Rollback

If this breaks release or publish workflow behavior, revert this PR and re-run the affected workflow from the previous known-good release branch or tag.

The highest-risk rollback surface is expected to be:

- ClawHub OIDC-only publishing
- the stricter trusted workflow-ref gates
- narrowed job/workflow permissions
- plugin npm mirror-auth availability precheck plus the split package-publish/mirror flow

## Follow-up

The remaining known security debt is that stable npm dist-tag mirroring still requires long-lived npm auth. This PR narrows that token to the explicit mirror step/path and adds a pre-publish availability guard, but a later hardening pass should move mirroring into a more restricted workflow/environment or redesign it to avoid long-lived npm auth entirely.
