### PR TITLE
fix(ui): add guarded dashboard shortcuts

### DIFF
--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -137,6 +137,30 @@ declare global {
 const bootAssistantIdentity = normalizeAssistantIdentity({});
 const bootLocalUserIdentity = loadLocalUserIdentity();
 
+const DASHBOARD_SHORTCUT_EDITABLE_SELECTOR =
+  'input, textarea, select, [contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"], [role="textbox"], .cm-editor';
+
+function isDashboardShortcutEditableElement(element: Element): boolean {
+  if (element instanceof HTMLElement && element.isContentEditable) {
+    return true;
+  }
+  return element.matches(DASHBOARD_SHORTCUT_EDITABLE_SELECTOR);
+}
+
+function isDashboardShortcutEditableTarget(event: KeyboardEvent): boolean {
+  const path = event.composedPath();
+  for (const item of path) {
+    if (!(item instanceof Element)) {
+      continue;
+    }
+    if (isDashboardShortcutEditableElement(item)) {
+      return true;
+    }
+  }
+  const active = document.activeElement;
+  return active instanceof Element && isDashboardShortcutEditableElement(active);
+}
+
 function resolveOnboardingMode(): boolean {
   if (!window.location.search) {
     return false;
@@ -620,10 +644,62 @@ export class OpenClawApp extends LitElement {
         this.paletteQuery = "";
         this.paletteActiveIndex = 0;
       }
+      return;
+    }
+
+    if (isDashboardShortcutEditableTarget(e) || e.altKey || e.ctrlKey || e.metaKey) {
+      return;
+    }
+
+    if (e.key === "/") {
+      e.preventDefault();
+      this.focusChatComposer();
+      return;
+    }
+
+    if (e.key.toLowerCase() === "n" && this.tab === "chat" && this.chatNewMessagesBelow) {
+      e.preventDefault();
+      this.scrollToBottom();
+      return;
+    }
+
+    if (e.key !== "Escape") {
+      return;
+    }
+
+    if (this.paletteOpen) {
+      e.preventDefault();
+      this.paletteOpen = false;
+      this.paletteQuery = "";
+      return;
+    }
+
+    if (this.chatMobileControlsOpen) {
+      e.preventDefault();
+      this.setChatMobileControlsOpen(false, { restoreFocus: true });
+      return;
+    }
+
+    if (this.sessionSwitchNotice) {
+      e.preventDefault();
+      this.sessionSwitchNotice = null;
+      return;
+    }
+
+    if (this.settings.chatFocusMode) {
+      e.preventDefault();
+      this.applySettings({
+        ...this.settings,
+        chatFocusMode: false,
+      });
     }
   };
   private chatMobileControlsKeydownHandler = (e: KeyboardEvent) => {
-    if (e.key !== "Escape" || !this.chatMobileControlsOpen) {
+    if (
+      e.key !== "Escape" ||
+      !this.chatMobileControlsOpen ||
+      isDashboardShortcutEditableTarget(e)
+    ) {
       return;
     }
     e.preventDefault();
@@ -803,6 +879,20 @@ export class OpenClawApp extends LitElement {
     requestAnimationFrame(() => {
       if (focusTarget.isConnected) {
         focusTarget.focus();
+      }
+    });
+  }
+
+  private focusChatComposer() {
+    if (this.tab !== "chat") {
+      this.setTab("chat");
+    }
+    void this.updateComplete.then(() => {
+      const composer = this.querySelector<HTMLTextAreaElement>(
+        ".agent-chat__composer-combobox textarea",
+      );
+      if (composer && !composer.disabled) {
+        composer.focus();
       }
     });
   }

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -488,6 +488,111 @@ describe("control UI routing", () => {
     expect(app.chatMobileControlsOpen).toBe(false);
   });
 
+  it("dispatches guarded dashboard chat shortcuts", async () => {
+    const app = mountApp("/overview");
+    await app.updateComplete;
+
+    const scrollToBottom = vi.spyOn(app, "scrollToBottom");
+    app.chatNewMessagesBelow = true;
+    const overviewJump = new KeyboardEvent("keydown", {
+      key: "N",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(overviewJump);
+
+    expect(overviewJump.defaultPrevented).toBe(false);
+    expect(scrollToBottom).not.toHaveBeenCalled();
+
+    const slash = new KeyboardEvent("keydown", {
+      key: "/",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(slash);
+    await app.updateComplete;
+    await nextFrame();
+
+    const composer = expectElement(
+      app,
+      ".agent-chat__composer-combobox textarea",
+      HTMLTextAreaElement,
+    );
+    expect(app.tab).toBe("chat");
+    expect(slash.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(composer);
+
+    app.chatNewMessagesBelow = true;
+    composer.blur();
+    app.requestUpdate();
+    await app.updateComplete;
+
+    const jump = new KeyboardEvent("keydown", {
+      key: "N",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(jump);
+
+    expect(jump.defaultPrevented).toBe(true);
+    expect(scrollToBottom).toHaveBeenCalledOnce();
+
+    const editableJump = new KeyboardEvent("keydown", {
+      key: "N",
+      bubbles: true,
+      cancelable: true,
+    });
+    composer.dispatchEvent(editableJump);
+
+    expect(editableJump.defaultPrevented).toBe(false);
+    expect(scrollToBottom).toHaveBeenCalledOnce();
+
+    app.paletteOpen = true;
+    const escape = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(escape);
+
+    expect(escape.defaultPrevented).toBe(true);
+    expect(app.paletteOpen).toBe(false);
+
+    app.chatMobileControlsOpen = true;
+    composer.focus();
+    const editableEscape = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    composer.dispatchEvent(editableEscape);
+
+    expect(editableEscape.defaultPrevented).toBe(false);
+    expect(app.chatMobileControlsOpen).toBe(true);
+
+    const plaintextOnly = document.createElement("div");
+    plaintextOnly.setAttribute("contenteditable", "plaintext-only");
+    plaintextOnly.tabIndex = 0;
+    app.append(plaintextOnly);
+    plaintextOnly.focus();
+    app.paletteOpen = true;
+    app.chatMobileControlsOpen = true;
+
+    for (const key of ["/", "N", "Escape"]) {
+      const event = new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+      });
+      plaintextOnly.dispatchEvent(event);
+      expect(event.defaultPrevented, key).toBe(false);
+    }
+
+    expect(app.paletteOpen).toBe(true);
+    expect(app.chatMobileControlsOpen).toBe(true);
+    expect(scrollToBottom).toHaveBeenCalledOnce();
+  });
+
   it("preserves session navigation and keeps focus mode scoped to chat", async () => {
     const app = mountApp("/sessions?session=agent:main:subagent:task-123");
     await app.updateComplete;


### PR DESCRIPTION
Fixes #81946

## Summary
- add a guarded document-level dispatcher for dashboard chat shortcuts
- `/` moves focus to the chat composer, switching to Chat first when needed
- `N` triggers the same new-message jump path only when the affordance is active
- `Esc` dismisses palette/mobile controls/session notice/focus mode without stealing editable-field keys
- treat `contenteditable="plaintext-only"` targets as editable so the dispatcher does not intercept editor input

## Real behavior proof
- **Behavior or issue addressed**: Control UI dashboard shortcuts now handle `/`, `N`, and `Esc` through a guarded document-level dispatcher while ignoring editable text targets, including `contenteditable="plaintext-only"`.
- **Real environment tested**: Local OpenClaw Control UI Vite dev server from this checkout, loaded in Chromium at `http://127.0.0.1:5174/overview`.
- **Exact steps or command run after this patch**:
  1. Ran `pnpm --dir ui dev --host 127.0.0.1 --port 5174`.
  2. Opened `http://127.0.0.1:5174/overview` in Chromium headless shell via Playwright.
  3. In the live page, set `<openclaw-app>` to connected, dispatched `/`, `N`, and `Escape` from document scope, the chat composer textarea, and a focused `contenteditable="plaintext-only"` element.
- **Evidence after fix**: Browser console output from the live Control UI page:

  ```json
  {
    "slash": {
      "beforeTab": "overview",
      "defaultPrevented": true,
      "afterTab": "chat",
      "hasComposer": true,
      "focusedComposer": true
    },
    "newMessagesShortcut": {
      "jumpDefaultPrevented": true,
      "editableJumpDefaultPrevented": false,
      "scrollCalls": 1
    },
    "escape": {
      "escapeDefaultPrevented": true,
      "paletteAfterEscape": false,
      "editableEscapeDefaultPrevented": false,
      "mobileAfterEditableEscape": true
    },
    "plaintextOnly": {
      "slash": false,
      "n": false,
      "escape": false,
      "paletteOpen": true,
      "mobileOpen": true,
      "scrollCalls": 1
    }
  }
  ```

- **Observed result after fix**: `/` routed the real Control UI shell from Overview to Chat and focused the composer; `N` invoked `scrollToBottom()` exactly once when not editing; `Esc` closed the palette at document scope; `/`, `N`, and `Esc` inside the composer and a `contenteditable="plaintext-only"` target were ignored by the global dispatcher.
- **What was not tested**: No additional gaps.

## Audit
- Audit A (existing helper): none found for editable-target dashboard shortcut guarding
- Audit B (shared callers): 0 shared-helper callers; existing app-level dispatcher contract preserved
- Audit C (broader rival): no open rival PR found for #81946

## Tests
- `node scripts/run-vitest.mjs ui/src/ui/navigation.browser.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/app.ts ui/src/ui/navigation.browser.test.ts`
- `pnpm tsgo:test:ui`
- `pnpm test:changed --changed origin/main`
- `git diff --check`