### PR TITLE
telegram: bound default send client timeouts

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -38,7 +38,10 @@ import type { TelegramBotOptions } from "./bot.types.js";
 import { buildTelegramGroupPeerId, resolveTelegramStreamMode } from "./bot/helpers.js";
 import { resolveTelegramTransport } from "./fetch.js";
 import { tagTelegramNetworkError } from "./network-errors.js";
-import { resolveTelegramRequestTimeoutMs } from "./request-timeouts.js";
+import {
+  resolveTelegramOutboundClientTimeoutSeconds,
+  resolveTelegramRequestTimeoutMs,
+} from "./request-timeouts.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import { createTelegramThreadBindingManager } from "./thread-bindings.js";
@@ -167,11 +170,6 @@ function resolveTelegramClientTimeoutMinimumSeconds(values: readonly (number | u
     minimum = minimum === undefined ? normalized : Math.max(minimum, normalized);
   }
   return minimum;
-}
-
-function resolveTelegramOutboundClientTimeoutFloorSeconds(timeoutSeconds: unknown) {
-  const timeoutMs = resolveTelegramRequestTimeoutMs("sendmessage", timeoutSeconds);
-  return timeoutMs === undefined ? undefined : timeoutMs / 1000;
 }
 
 export function createTelegramBotCore(
@@ -336,7 +334,7 @@ export function createTelegramBotCore(
     value: telegramCfg?.timeoutSeconds,
     minimum: resolveTelegramClientTimeoutMinimumSeconds([
       opts.minimumClientTimeoutSeconds,
-      resolveTelegramOutboundClientTimeoutFloorSeconds(telegramCfg?.timeoutSeconds),
+      resolveTelegramOutboundClientTimeoutSeconds(telegramCfg?.timeoutSeconds),
     ]),
   });
   const apiRoot = normalizeOptionalString(telegramCfg.apiRoot);

--- a/extensions/telegram/src/request-timeouts.test.ts
+++ b/extensions/telegram/src/request-timeouts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  resolveTelegramOutboundClientTimeoutSeconds,
   resolveTelegramRequestTimeoutMs,
   resolveTelegramStartupProbeTimeoutMs,
 } from "./request-timeouts.js";
@@ -54,5 +55,19 @@ describe("resolveTelegramStartupProbeTimeoutMs", () => {
 
   it("honors higher configured timeoutSeconds", () => {
     expect(resolveTelegramStartupProbeTimeoutMs(60)).toBe(60_000);
+  });
+});
+
+describe("resolveTelegramOutboundClientTimeoutSeconds", () => {
+  it("uses the outbound sendMessage guard by default", () => {
+    expect(resolveTelegramOutboundClientTimeoutSeconds(undefined)).toBe(60);
+  });
+
+  it("does not let low timeoutSeconds shorten the outbound floor", () => {
+    expect(resolveTelegramOutboundClientTimeoutSeconds(10)).toBe(60);
+  });
+
+  it("honors higher configured timeoutSeconds", () => {
+    expect(resolveTelegramOutboundClientTimeoutSeconds(90)).toBe(90);
   });
 });

--- a/extensions/telegram/src/request-timeouts.ts
+++ b/extensions/telegram/src/request-timeouts.ts
@@ -50,6 +50,13 @@ export function resolveTelegramRequestTimeoutMs(
   return Math.max(baseTimeoutMs, resolveConfiguredTelegramRequestTimeoutMs(timeoutSeconds) ?? 0);
 }
 
+export function resolveTelegramOutboundClientTimeoutSeconds(
+  timeoutSeconds: unknown,
+): number | undefined {
+  const timeoutMs = resolveTelegramRequestTimeoutMs("sendmessage", timeoutSeconds);
+  return timeoutMs === undefined ? undefined : timeoutMs / 1000;
+}
+
 export function resolveTelegramStartupProbeTimeoutMs(timeoutSeconds: unknown): number {
   const getMeTimeoutMs = resolveTelegramRequestTimeoutMs("getme") ?? 15_000;
   if (typeof timeoutSeconds !== "number" || !Number.isFinite(timeoutSeconds)) {

--- a/extensions/telegram/src/send.proxy.test.ts
+++ b/extensions/telegram/src/send.proxy.test.ts
@@ -91,7 +91,9 @@ describe("telegram proxy client", () => {
   }) => {
     expect(makeProxyFetch).toHaveBeenCalledWith(proxyUrl);
     expect(resolveTelegramFetch).toHaveBeenCalledWith(params.proxyFetch, { network: undefined });
-    expect(botCtorSpy).toHaveBeenCalledWith("tok", { client: { fetch: params.fetchImpl } });
+    expect(botCtorSpy).toHaveBeenCalledWith("tok", {
+      client: { fetch: params.fetchImpl, timeoutSeconds: 60 },
+    });
   };
 
   beforeAll(async () => {
@@ -136,8 +138,12 @@ describe("telegram proxy client", () => {
     expect(resolveTelegramFetch).toHaveBeenCalledTimes(1);
     expect(botCtorSpy).toHaveBeenCalledTimes(2);
     expect(resolveTelegramFetch).toHaveBeenCalledWith(proxyFetch, { network: undefined });
-    expect(botCtorSpy).toHaveBeenNthCalledWith(1, "tok", { client: { fetch: fetchImpl } });
-    expect(botCtorSpy).toHaveBeenNthCalledWith(2, "tok", { client: { fetch: fetchImpl } });
+    expect(botCtorSpy).toHaveBeenNthCalledWith(1, "tok", {
+      client: { fetch: fetchImpl, timeoutSeconds: 60 },
+    });
+    expect(botCtorSpy).toHaveBeenNthCalledWith(2, "tok", {
+      client: { fetch: fetchImpl, timeoutSeconds: 60 },
+    });
   });
 
   it.each([

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -540,6 +540,12 @@ describe("sendMessageTelegram", () => {
   it("applies timeoutSeconds config precedence", async () => {
     const cases = [
       {
+        name: "default outbound timeout floor",
+        cfg: { channels: { telegram: {} } },
+        opts: { cfg: TELEGRAM_TEST_CFG, token: "tok" },
+        expectedTimeout: 60,
+      },
+      {
         name: "global telegram timeout",
         cfg: { channels: { telegram: { timeoutSeconds: 60 } } },
         opts: { cfg: TELEGRAM_TEST_CFG, token: "tok" },

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -30,6 +30,7 @@ import {
   buildTelegramThreadReplyParams,
   resolveTelegramSendThreadSpec,
 } from "./reply-parameters.js";
+import { resolveTelegramOutboundClientTimeoutSeconds } from "./request-timeouts.js";
 import {
   buildOutboundMediaLoadOptions,
   getImageMetadata,
@@ -248,11 +249,7 @@ function setCachedTelegramClientOptions(
 function resolveTelegramClientOptions(
   account: ResolvedTelegramAccount,
 ): ApiClientOptions | undefined {
-  const timeoutSeconds =
-    typeof account.config.timeoutSeconds === "number" &&
-    Number.isFinite(account.config.timeoutSeconds)
-      ? Math.max(1, Math.floor(account.config.timeoutSeconds))
-      : undefined;
+  const timeoutSeconds = resolveTelegramOutboundClientTimeoutSeconds(account.config.timeoutSeconds);
 
   const cacheEnabled = shouldUseTelegramClientOptionsCache();
   const cacheKey = cacheEnabled


### PR DESCRIPTION
## Summary

- Problem: `deleteMessageTelegram` and the other Telegram send helpers only passed `client.timeoutSeconds` through when users explicitly configured `channels.telegram.timeoutSeconds`, so default installs fell back to grammY's 500-second client timeout and could appear to hang for minutes on a stuck Bot API request.
- Why it matters: issue #81908 shows `openclaw message delete --channel telegram` can hang indefinitely in real use; leaving send clients on the upstream 500-second default makes failure handling far too slow even when OpenClaw already defines tighter outbound request guards.
- What changed: moved the outbound send-client timeout floor into `request-timeouts.ts`, reused it in both bot-core and send helpers, and added focused regression coverage for the default 60-second floor plus proxy/send client construction.
- What did NOT change (scope boundary): this does not change retry counts, Telegram delete noop handling, or require a live Telegram account/config migration.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #81908
- Related #61151
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: default Telegram send/delete helpers no longer inherit grammY's 500-second client timeout when OpenClaw has no explicit `channels.telegram.timeoutSeconds` configured.
- Real environment tested: local OpenClaw checkout on Windows 11 with Node 22 / pnpm workspace.
- Exact steps or command run after this patch:
  1. `pnpm test -- extensions/telegram/src/request-timeouts.test.ts`
  2. `pnpm test -- extensions/telegram/src/send.proxy.test.ts`
  3. `pnpm test -- extensions/telegram/src/send.test.ts`
  4. `pnpm check:changed`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  - `extensions/telegram/src/request-timeouts.test.ts` now proves the outbound client floor resolves to `60` by default and honors higher configured values.
  - `extensions/telegram/src/send.test.ts` now proves send clients construct grammY with `timeoutSeconds=60` even when the Telegram config leaves it unset.
  - `extensions/telegram/src/send.proxy.test.ts` shows the same 60-second floor is preserved when Telegram uses the proxy/custom-fetch path.
- Observed result after fix: the Telegram send/delete client path is bounded by OpenClaw's outbound timeout policy instead of grammY's multi-minute default, so stuck delete requests fail on the normal OpenClaw timeout horizon instead of appearing to hang indefinitely.
- What was not tested: a live Telegram API call on an actually wedged network path.
- Before evidence (optional but encouraged): `node_modules/grammy/out/core/client.js` defaults `timeoutSeconds` to `500`, while `extensions/telegram/src/send.ts` previously only forwarded a timeout when the user configured one.

## Root Cause (if applicable)

- Root cause: `resolveTelegramClientOptions()` in `extensions/telegram/src/send.ts` only forwarded `client.timeoutSeconds` when Telegram config explicitly set it, so default send/delete helpers inherited grammY's 500-second API timeout.
- Missing detection / guardrail: OpenClaw already had method-level outbound timeout policy in `extensions/telegram/src/request-timeouts.ts`, but the send helper client construction did not reuse that floor.
- Contributing context (if known): bot-core already enforced an outbound timeout floor, so the send helper path drifted from the stricter runtime behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/request-timeouts.test.ts`, `extensions/telegram/src/send.test.ts`, `extensions/telegram/src/send.proxy.test.ts`
- Scenario the test should lock in: default Telegram send clients must construct with a 60-second outbound timeout floor, and higher configured values must still win.
- Why this is the smallest reliable guardrail: the regression lives in client option construction, so constructor-level tests catch it without needing a flaky live Telegram setup.
- Existing test that already covers this (if any): the prior timeout precedence test covered configured values only.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Telegram send/delete commands now fail on OpenClaw's normal outbound timeout floor even when `channels.telegram.timeoutSeconds` is unset, instead of waiting on grammY's 500-second default.

## Diagram (if applicable)

```text
Before:
[telegram send/delete helper] -> [no configured timeout] -> [grammY default 500s client timeout] -> [stuck request appears hung]

After:
[telegram send/delete helper] -> [OpenClaw outbound timeout floor 60s] -> [stuck request times out on OpenClaw horizon]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node 22, pnpm workspace checkout
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): default Telegram send config with no explicit `timeoutSeconds`

### Steps

1. Construct a Telegram send/delete helper without `channels.telegram.timeoutSeconds`.
2. Observe the grammY client options used for the helper.
3. Run the focused Telegram tests above.

### Expected

- Send/delete helpers should inherit OpenClaw's outbound timeout floor rather than grammY's 500-second default.

### Actual

- After this patch, send helper construction uses `timeoutSeconds=60` by default and still respects higher configured values.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: default Telegram send client timeout floor, configured timeout override precedence, proxy/send client construction, and changed-file gate.
- Edge cases checked: unset timeout config, low timeout config, higher per-account timeout config.
- What you did **not** verify: live Telegram deletion against a hung Bot API request.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a future Telegram send helper might need a longer default than the shared outbound floor.
  - Mitigation: the new helper still honors any higher configured `channels.telegram.timeoutSeconds`, and the floor stays centralized in `request-timeouts.ts`.

Made with Copilot | fully reviewed by human
