### PR TITLE
fix: preserve ACP metadata across stale session-store writes

### DIFF
--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -657,6 +657,141 @@ describe("session store writer queue", () => {
     expect(store[key]?.model).toBe("gpt-5.4");
   });
 
+  it("preserves ACP metadata already written on disk during a stale session-store update", async () => {
+    const key = "agent:gemini:acp:race";
+    const acp: NonNullable<SessionEntry["acp"]> = {
+      backend: "acpx",
+      agent: "gemini",
+      runtimeSessionName: "gemini-runtime",
+      mode: "oneshot",
+      state: "idle",
+      lastActivityAt: 100,
+    };
+    const { storePath } = await makeTmpStore({
+      [key]: {
+        sessionId: "sess-acp-race",
+        updatedAt: 100,
+      },
+    });
+
+    await updateSessionStore(storePath, (store) => {
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify(
+          {
+            [key]: {
+              sessionId: "sess-acp-race",
+              updatedAt: 101,
+              acp,
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      store[key].label = "touched by gateway agent handler";
+      store[key].updatedAt = Date.now();
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[key]?.label).toBe("touched by gateway agent handler");
+    expect(store[key]?.acp).toEqual(acp);
+  });
+
+  it("uses fresh ACP metadata when disk changes during an in-place stale session-store update", async () => {
+    const key = "agent:gemini:acp:updated-on-disk";
+    const staleAcp: NonNullable<SessionEntry["acp"]> = {
+      backend: "acpx",
+      agent: "gemini",
+      runtimeSessionName: "stale-runtime",
+      mode: "oneshot",
+      state: "idle",
+      lastActivityAt: 100,
+    };
+    const freshAcp: NonNullable<SessionEntry["acp"]> = {
+      backend: "acpx",
+      agent: "gemini",
+      runtimeSessionName: "fresh-runtime",
+      mode: "oneshot",
+      state: "running",
+      lastActivityAt: 200,
+    };
+    const { storePath } = await makeTmpStore({
+      [key]: {
+        sessionId: "sess-acp-updated-on-disk",
+        updatedAt: 100,
+        acp: staleAcp,
+      },
+    });
+
+    await updateSessionStore(storePath, (store) => {
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify(
+          {
+            [key]: {
+              sessionId: "sess-acp-updated-on-disk",
+              updatedAt: 101,
+              acp: freshAcp,
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      store[key].label = "touched after disk ACP update";
+      store[key].updatedAt = Date.now();
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[key]?.label).toBe("touched after disk ACP update");
+    expect(store[key]?.acp).toEqual(freshAcp);
+  });
+
+  it("does not resurrect ACP metadata removed on disk during an in-place stale session-store update", async () => {
+    const key = "agent:gemini:acp:removed-on-disk";
+    const acp: NonNullable<SessionEntry["acp"]> = {
+      backend: "acpx",
+      agent: "gemini",
+      runtimeSessionName: "gemini-runtime",
+      mode: "oneshot",
+      state: "idle",
+      lastActivityAt: 100,
+    };
+    const { storePath } = await makeTmpStore({
+      [key]: {
+        sessionId: "sess-acp-removed-on-disk",
+        updatedAt: 100,
+        acp,
+      },
+    });
+
+    await updateSessionStore(storePath, (store) => {
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify(
+          {
+            [key]: {
+              sessionId: "sess-acp-removed-on-disk",
+              updatedAt: 101,
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      store[key].label = "touched after disk removal";
+      store[key].updatedAt = Date.now();
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[key]?.label).toBe("touched after disk removal");
+    expect(store[key]?.acp).toBeUndefined();
+  });
+
   it("allows explicit ACP metadata removal through the ACP session helper", async () => {
     const key = "agent:codex:acp:binding:discord:default:deadbeef";
     const { storePath } = await makeTmpStore({

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -16,7 +16,12 @@ import {
 } from "./paths.js";
 import { evaluateSessionFreshness, resolveSessionResetPolicy } from "./reset.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
-import { clearSessionStoreCacheForTest, loadSessionStore, updateSessionStore } from "./store.js";
+import {
+  clearSessionStoreCacheForTest,
+  loadSessionStore,
+  saveSessionStore,
+  updateSessionStore,
+} from "./store.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
 import { mergeSessionEntry, mergeSessionEntryWithPolicy, type SessionEntry } from "./types.js";
 
@@ -655,6 +660,53 @@ describe("session store writer queue", () => {
     expect(store[key]?.acp).toEqual(acp);
     expect(store[key]?.modelProvider).toBe("openai-codex");
     expect(store[key]?.model).toBe("gpt-5.4");
+  });
+
+  it("preserves caller-provided ACP metadata on direct session-store saves", async () => {
+    const key = "agent:codex:acp:direct-save";
+    const initialAcp: NonNullable<SessionEntry["acp"]> = {
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "codex-direct-initial",
+      mode: "persistent",
+      state: "idle",
+      lastActivityAt: 100,
+    };
+    const updatedAcp: NonNullable<SessionEntry["acp"]> = {
+      ...initialAcp,
+      runtimeSessionName: "codex-direct-updated",
+      state: "running",
+      lastActivityAt: 200,
+    };
+    const now = Date.now();
+    const { storePath } = await makeTmpStore({
+      [key]: {
+        sessionId: "sess-acp-direct-save",
+        updatedAt: now,
+      },
+    });
+
+    await saveSessionStore(storePath, {
+      [key]: {
+        sessionId: "sess-acp-direct-save",
+        updatedAt: now,
+        acp: initialAcp,
+      },
+    });
+
+    let store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[key]?.acp).toEqual(initialAcp);
+
+    await saveSessionStore(storePath, {
+      [key]: {
+        sessionId: "sess-acp-direct-save",
+        updatedAt: now,
+        acp: updatedAcp,
+      },
+    });
+
+    store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[key]?.acp).toEqual(updatedAcp);
   });
 
   it("preserves ACP metadata already written on disk during a stale session-store update", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -111,6 +111,8 @@ export {
 };
 export type { ResolvedSessionMaintenanceConfig, SessionMaintenanceWarning };
 
+type SessionStoreFileStatSnapshot = ReturnType<typeof getFileStatSnapshot>;
+
 type SaveSessionStoreOptions = {
   /** Skip pruning, capping, and rotation (e.g. during one-time migrations). */
   skipMaintenance?: boolean;
@@ -122,6 +124,13 @@ type SaveSessionStoreOptions = {
    * whole session entry without carrying ACP state forward.
    */
   allowDropAcpMetaSessionKeys?: string[];
+  /** Fallback ACP metadata snapshot used only when the fresh disk snapshot cannot be read. */
+  preserveAcpMetadataFallback?: Map<string, NonNullable<SessionEntry["acp"]>>;
+  /**
+   * When present, read fresh ACP metadata only if the store file changed since this
+   * baseline. `null` represents a missing file at writer load time.
+   */
+  refreshAcpMetadataIfFileChangedSince?: SessionStoreFileStatSnapshot | null;
   /** Optional callback for warn-only maintenance. */
   onWarn?: (warning: SessionMaintenanceWarning) => void | Promise<void>;
   /** Optional callback with maintenance stats after a save. */
@@ -152,19 +161,37 @@ function updateSessionStoreWriteCaches(params: {
   });
 }
 
-function loadMutableSessionStoreForWriter(storePath: string): Record<string, SessionEntry> {
+type MutableSessionStoreForWriter = {
+  store: Record<string, SessionEntry>;
+  fileStat: SessionStoreFileStatSnapshot;
+};
+
+function loadMutableSessionStoreForWriter(storePath: string): MutableSessionStoreForWriter {
+  const currentFileStat = getFileStatSnapshot(storePath);
   if (isSessionStoreCacheEnabled()) {
-    const currentFileStat = getFileStatSnapshot(storePath);
     const cached = takeMutableSessionStoreCache({
       storePath,
       mtimeMs: currentFileStat?.mtimeMs,
       sizeBytes: currentFileStat?.sizeBytes,
     });
     if (cached) {
-      return cached;
+      return { store: cached, fileStat: currentFileStat };
     }
   }
-  return loadSessionStore(storePath, { skipCache: true, clone: false });
+  return {
+    store: loadSessionStore(storePath, { skipCache: true, clone: false }),
+    fileStat: currentFileStat,
+  };
+}
+
+function hasSessionStoreFileStatChanged(
+  before: SessionStoreFileStatSnapshot | null,
+  after: SessionStoreFileStatSnapshot,
+): boolean {
+  if (!before && !after) {
+    return false;
+  }
+  return before?.mtimeMs !== after?.mtimeMs || before?.sizeBytes !== after?.sizeBytes;
 }
 
 function resolveMutableSessionStoreKey(
@@ -191,23 +218,23 @@ function collectAcpMetadataSnapshot(
   const snapshot = new Map<string, NonNullable<SessionEntry["acp"]>>();
   for (const [sessionKey, entry] of Object.entries(store)) {
     if (entry?.acp) {
-      snapshot.set(sessionKey, entry.acp);
+      snapshot.set(normalizeStoreSessionKey(sessionKey), entry.acp);
     }
   }
   return snapshot;
 }
 
+function normalizeAllowedAcpDropKeys(keys: string[] | undefined): Set<string> {
+  return new Set((keys ?? []).map((key) => normalizeStoreSessionKey(key)));
+}
+
 function preserveExistingAcpMetadata(params: {
   previousAcpByKey: Map<string, NonNullable<SessionEntry["acp"]>>;
   nextStore: Record<string, SessionEntry>;
-  allowDropSessionKeys?: string[];
+  allowDrop: Set<string>;
 }): void {
-  const allowDrop = new Set(
-    (params.allowDropSessionKeys ?? []).map((key) => normalizeStoreSessionKey(key)),
-  );
   for (const [previousKey, previousAcp] of params.previousAcpByKey.entries()) {
-    const normalizedKey = normalizeStoreSessionKey(previousKey);
-    if (allowDrop.has(normalizedKey)) {
+    if (params.allowDrop.has(previousKey)) {
       continue;
     }
     const nextKey = resolveMutableSessionStoreKey(params.nextStore, previousKey);
@@ -222,6 +249,49 @@ function preserveExistingAcpMetadata(params: {
       ...nextEntry,
       acp: previousAcp,
     };
+  }
+}
+
+function reconcileAcpMetadataAuthoritatively(params: {
+  freshAcpByKey: Map<string, NonNullable<SessionEntry["acp"]>>;
+  nextStore: Record<string, SessionEntry>;
+  allowDrop: Set<string>;
+}): void {
+  for (const [storeKey, entry] of Object.entries(params.nextStore)) {
+    const normalizedKey = normalizeStoreSessionKey(storeKey);
+    if (params.allowDrop.has(normalizedKey)) {
+      continue;
+    }
+    const freshAcp = params.freshAcpByKey.get(normalizedKey);
+    if (freshAcp) {
+      if (entry?.acp !== freshAcp) {
+        params.nextStore[storeKey] = { ...entry, acp: freshAcp };
+      }
+      continue;
+    }
+    if (entry?.acp) {
+      const nextEntry = { ...entry };
+      delete nextEntry.acp;
+      params.nextStore[storeKey] = nextEntry;
+    }
+  }
+}
+
+function collectFreshAcpMetadataSnapshot(
+  storePath: string,
+): { ok: true; snapshot: Map<string, NonNullable<SessionEntry["acp"]>> } | { ok: false } {
+  try {
+    const raw = fs.readFileSync(storePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { ok: false };
+    }
+    return {
+      ok: true,
+      snapshot: collectAcpMetadataSnapshot(parsed as Record<string, SessionEntry>),
+    };
+  } catch {
+    return { ok: false };
   }
 }
 
@@ -370,6 +440,34 @@ async function saveSessionStoreUnlocked(
     }
   }
 
+  const allowDropAcp = normalizeAllowedAcpDropKeys(opts?.allowDropAcpMetaSessionKeys);
+  const hasRefreshBaseline = Object.prototype.hasOwnProperty.call(
+    opts ?? {},
+    "refreshAcpMetadataIfFileChangedSince",
+  );
+  const shouldRefreshAcpMetadataFromDisk = hasRefreshBaseline
+    ? hasSessionStoreFileStatChanged(
+        opts?.refreshAcpMetadataIfFileChangedSince ?? null,
+        getFileStatSnapshot(storePath),
+      )
+    : true;
+  const freshAcpSnapshot = shouldRefreshAcpMetadataFromDisk
+    ? collectFreshAcpMetadataSnapshot(storePath)
+    : { ok: false as const };
+  if (freshAcpSnapshot.ok) {
+    reconcileAcpMetadataAuthoritatively({
+      freshAcpByKey: freshAcpSnapshot.snapshot,
+      nextStore: store,
+      allowDrop: allowDropAcp,
+    });
+  } else {
+    preserveExistingAcpMetadata({
+      previousAcpByKey: opts?.preserveAcpMetadataFallback ?? new Map(),
+      nextStore: store,
+      allowDrop: allowDropAcp,
+    });
+  }
+
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
   const json = JSON.stringify(store, null, 2);
   if (getSerializedSessionStore(storePath) === json) {
@@ -440,15 +538,14 @@ export async function updateSessionStore<T>(
   opts?: SaveSessionStoreOptions,
 ): Promise<T> {
   return await runExclusiveSessionStoreWrite(storePath, async () => {
-    const store = loadMutableSessionStoreForWriter(storePath);
-    const previousAcpByKey = collectAcpMetadataSnapshot(store);
-    const result = await mutator(store);
-    preserveExistingAcpMetadata({
-      previousAcpByKey,
-      nextStore: store,
-      allowDropSessionKeys: opts?.allowDropAcpMetaSessionKeys,
+    const mutable = loadMutableSessionStoreForWriter(storePath);
+    const previousAcpByKey = collectAcpMetadataSnapshot(mutable.store);
+    const result = await mutator(mutable.store);
+    await saveSessionStoreUnlocked(storePath, mutable.store, {
+      ...opts,
+      preserveAcpMetadataFallback: previousAcpByKey,
+      refreshAcpMetadataIfFileChangedSince: mutable.fileStat ?? null,
     });
-    await saveSessionStoreUnlocked(storePath, store, opts);
     return result;
   });
 }
@@ -536,6 +633,7 @@ async function persistResolvedSessionEntry(params: {
   store: Record<string, SessionEntry>;
   resolved: ReturnType<typeof resolveSessionStoreEntry>;
   next: SessionEntry;
+  refreshAcpMetadataIfFileChangedSince?: SessionStoreFileStatSnapshot | null;
 }): Promise<SessionEntry> {
   params.store[params.resolved.normalizedKey] = params.next;
   for (const legacyKey of params.resolved.legacyKeys) {
@@ -543,6 +641,7 @@ async function persistResolvedSessionEntry(params: {
   }
   await saveSessionStoreUnlocked(params.storePath, params.store, {
     activeSessionKey: params.resolved.normalizedKey,
+    refreshAcpMetadataIfFileChangedSince: params.refreshAcpMetadataIfFileChangedSince ?? null,
   });
   return params.next;
 }
@@ -554,8 +653,8 @@ export async function updateSessionStoreEntry(params: {
 }): Promise<SessionEntry | null> {
   const { storePath, sessionKey, update } = params;
   return await runExclusiveSessionStoreWrite(storePath, async () => {
-    const store = loadMutableSessionStoreForWriter(storePath);
-    const resolved = resolveSessionStoreEntry({ store, sessionKey });
+    const mutable = loadMutableSessionStoreForWriter(storePath);
+    const resolved = resolveSessionStoreEntry({ store: mutable.store, sessionKey });
     const existing = resolved.existing;
     if (!existing) {
       return null;
@@ -567,9 +666,10 @@ export async function updateSessionStoreEntry(params: {
     const next = mergeSessionEntry(existing, patch);
     return await persistResolvedSessionEntry({
       storePath,
-      store,
+      store: mutable.store,
       resolved,
       next,
+      refreshAcpMetadataIfFileChangedSince: mutable.fileStat ?? null,
     });
   });
 }
@@ -636,8 +736,8 @@ export async function updateLastRoute(params: {
   const { storePath, sessionKey, channel, to, accountId, threadId, ctx } = params;
   const createIfMissing = params.createIfMissing ?? true;
   return await runExclusiveSessionStoreWrite(storePath, async () => {
-    const store = loadMutableSessionStoreForWriter(storePath);
-    const resolved = resolveSessionStoreEntry({ store, sessionKey });
+    const mutable = loadMutableSessionStoreForWriter(storePath);
+    const resolved = resolveSessionStoreEntry({ store: mutable.store, sessionKey });
     const existing = resolved.existing;
     if (!existing && !createIfMissing) {
       return null;
@@ -701,9 +801,10 @@ export async function updateLastRoute(params: {
     );
     return await persistResolvedSessionEntry({
       storePath,
-      store,
+      store: mutable.store,
       resolved,
       next,
+      refreshAcpMetadataIfFileChangedSince: mutable.fileStat ?? null,
     });
   });
 }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -445,12 +445,12 @@ async function saveSessionStoreUnlocked(
     opts ?? {},
     "refreshAcpMetadataIfFileChangedSince",
   );
-  const shouldRefreshAcpMetadataFromDisk = hasRefreshBaseline
-    ? hasSessionStoreFileStatChanged(
-        opts?.refreshAcpMetadataIfFileChangedSince ?? null,
-        getFileStatSnapshot(storePath),
-      )
-    : true;
+  const shouldRefreshAcpMetadataFromDisk =
+    hasRefreshBaseline &&
+    hasSessionStoreFileStatChanged(
+      opts?.refreshAcpMetadataIfFileChangedSince ?? null,
+      getFileStatSnapshot(storePath),
+    );
   const freshAcpSnapshot = shouldRefreshAcpMetadataFromDisk
     ? collectFreshAcpMetadataSnapshot(storePath)
     : { ok: false as const };
@@ -460,9 +460,9 @@ async function saveSessionStoreUnlocked(
       nextStore: store,
       allowDrop: allowDropAcp,
     });
-  } else {
+  } else if (opts?.preserveAcpMetadataFallback) {
     preserveExistingAcpMetadata({
-      previousAcpByKey: opts?.preserveAcpMetadataFallback ?? new Map(),
+      previousAcpByKey: opts.preserveAcpMetadataFallback,
       nextStore: store,
       allowDrop: allowDropAcp,
     });


### PR DESCRIPTION
## Summary

- Problem: ACP sessions could intermittently lose their persisted `entry.acp` metadata when another session-store writer saved a stale snapshot of the same session entry.
- Why it matters: the next ACP turn then fails with `ACP metadata is missing`, even though the ACP runtime session was created successfully. This can degrade config-backed panel/review runs and other ACP spawn flows.
- What changed: session-store saves now reconcile ACP metadata at the final write boundary using a strict fresh disk snapshot. Fresh disk ACP metadata is authoritative for normal writes, while explicit ACP helper removals still opt out through `allowDropAcpMetaSessionKeys`.
- What did NOT change: this does not add a broad cross-process CAS/lock for all session-store fields, and it does not change ACP runtime/protocol behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #81957
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: ACP session metadata is preserved when a stale session-store writer saves after ACP metadata has already been written by another process, preventing the later `ACP metadata is missing` failure mode for that race.
- Real environment tested: Disposable OpenClaw source checkout on Linux/arm64, Node v22.22.0, comparing current `upstream/main` (`48b4e5b3614f`) with this PR head (`fb2568d651e7e186b15ed183a3fd45bab7aaeeeb`). The proof uses a temporary `sessions.json` file and the real `src/config/sessions/store.ts` `updateSessionStore` / `loadSessionStore` path from each checkout. No production Gateway, live ACP runtime, live config, or user session store was used or modified.
- Exact steps or command run after this patch: Ran the same standalone source-level stale-writer proof script twice from the disposable checkout: first on `upstream/main` with `--expect=loss`, then on PR head `fb2568d651e7e186b15ed183a3fd45bab7aaeeeb` with `--expect=preserve`. The script creates a real temp `sessions.json`, starts an `updateSessionStore` writer from a stale in-memory entry without `acp`, writes ACP metadata to disk before the stale writer saves, then reads the final store from disk.
- Evidence after fix: Terminal capture from the disposable checkout (`proofStore` temp root redacted by the script):

```text
$ git checkout --quiet upstream/main
$ ./node_modules/.bin/tsx /tmp/stale-acp-proof.ts --expect=loss
$ git checkout --quiet fb2568d651e7e186b15ed183a3fd45bab7aaeeeb
$ ./node_modules/.bin/tsx /tmp/stale-acp-proof.ts --expect=preserve

Baseline upstream/main (expected loss)
gitHead=48b4e5b3614f
proofStore=<temp>/sessions.json
initialDiskAcp=missing
concurrentDiskAcp=present runtimeSessionName=gemini-runtime-proof-81970
finalLabel="stale writer touched entry after ACP metadata arrived on disk"
finalAcpRuntimeSessionName=null
RESULT acpPreserved=false

Candidate PR #81970 head (expected preserve)
gitHead=fb2568d651e7
proofStore=<temp>/sessions.json
initialDiskAcp=missing
concurrentDiskAcp=present runtimeSessionName=gemini-runtime-proof-81970
finalLabel="stale writer touched entry after ACP metadata arrived on disk"
finalAcpRuntimeSessionName="gemini-runtime-proof-81970"
RESULT acpPreserved=true
```

- Observed result after fix: Current `upstream/main` loses the concurrently written ACP metadata (`finalAcpRuntimeSessionName=null`, `RESULT acpPreserved=false`). The same real session-store write path on this PR head preserves the concurrently written ACP metadata while still applying the stale writer's ordinary label update (`finalAcpRuntimeSessionName="gemini-runtime-proof-81970"`, `RESULT acpPreserved=true`).
- What was not tested: No production Gateway, live Gemini ACP panel, or live config-backed jury was run. That would mutate the local deployment/runtime state; this proof intentionally stays in a disposable non-production source checkout while exercising the real session-store module and real temp disk writes.
- Before evidence (optional but encouraged): The baseline `upstream/main` half of the terminal capture above demonstrates the pre-fix behavior: a stale writer overwrites the freshly written `entry.acp` block and the final disk store has `finalAcpRuntimeSessionName=null`.

## Root Cause (if applicable)

- Root cause: `updateSessionStore` already preserved ACP metadata present in the writer's in-memory snapshot, but it did not account for ACP metadata written to disk by another process after the writer loaded a stale store snapshot and before the writer saved.
- Missing detection / guardrail: Tests covered wholesale entry replacement preserving existing ACP metadata, but not cross-process stale writer cases where the authoritative ACP metadata existed only on disk at save time.
- Contributing context (if known): ACP spawn can create the session entry, persist ACP metadata, and then trigger a gateway `agent` turn that touches the same session entry from another process/context. Under unlucky timing, the later touch could save a stale entry and drop the ACP metadata.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/sessions/sessions.test.ts`
- Scenario the test should lock in:
  - preserve ACP metadata written on disk while a stale writer is active
  - prefer updated disk ACP metadata over stale in-memory ACP metadata
  - do not resurrect ACP metadata that was removed on disk
  - continue allowing explicit ACP helper removal through `allowDropAcpMetaSessionKeys`
- Why this is the smallest reliable guardrail: the bug is at the session-store write boundary, so exercising `updateSessionStore` directly isolates the race without depending on a live ACP backend.
- Existing test that already covers this (if any): existing tests covered preserving ACP metadata during wholesale replacement and explicit helper removal; this PR adds stale-writer coverage.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

ACP spawns should be less likely to fail with `ACP metadata is missing` after a successful runtime session creation. No user-facing command or config shape changes.

## Diagram (if applicable)

```text
Before:
ACP metadata writer -> sessions.json has entry.acp
stale session touch -> saves old entry without acp -> next ACP turn fails

After:
ACP metadata writer -> sessions.json has entry.acp
stale session touch -> final write-boundary reconciliation reads fresh disk ACP -> saves entry with acp -> next ACP turn can dispatch
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux arm64
- Runtime/container: disposable source checkout, Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `corepack pnpm exec vitest run src/config/sessions/sessions.test.ts src/agents/acp-spawn.test.ts`.
2. Run `corepack pnpm tsgo:core:test`.

### Expected

- Session-store regression tests preserve authoritative ACP metadata and avoid resurrecting removed ACP metadata.
- Existing ACP spawn tests remain green.
- Core test TypeScript check passes.

### Actual

- `src/config/sessions/sessions.test.ts` + `src/agents/acp-spawn.test.ts`: 141 tests passed.
- `tsgo:core:test`: passed with exit code 0.

