### PR TITLE
fix(agents): answer Claude live control_request can_use_tool via exec policy

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1490,6 +1490,160 @@ describe("runCliAgent spawn path", () => {
     expect(requireArgAfter(args, "--permission-prompt-tool")).toBe("stdio");
   });
 
+  it("answers Claude live control_request can_use_tool with allow when exec policy is full/no-ask", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const writes: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        writes.push(data);
+        if (writes.length === 1) {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "control_request",
+              request_id: "req-allow",
+              request: {
+                subtype: "can_use_tool",
+                tool_name: "Bash",
+                tool_use_id: "tool-allow-1",
+                input: { command: "ls" },
+              },
+            })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-allow",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-allow",
+  result: "ok",
+})}
+`,
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run-allow",
+        pid: 3001,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-control-allow",
+        prompt: "hello",
+        backend: { liveSession: "claude-stdio" },
+        config: {
+          tools: { exec: { security: "full", ask: "off" } },
+        } as PreparedCliRunContext["params"]["config"],
+      }),
+    );
+    expect(result.text).toBe("ok");
+    const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+    expect(controlResponse, "control_response written to stdin").toBeDefined();
+    const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+      type: string;
+      response: {
+        subtype: string;
+        request_id: string;
+        response: { behavior: string; toolUseID?: string };
+      };
+    };
+    expect(parsed.type).toBe("control_response");
+    expect(parsed.response.subtype).toBe("success");
+    expect(parsed.response.request_id).toBe("req-allow");
+    expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response.toolUseID).toBe("tool-allow-1");
+  });
+
+  it("answers Claude live control_request can_use_tool with deny when exec policy is restrictive", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const writes: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        writes.push(data);
+        if (writes.length === 1) {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "control_request",
+              request_id: "req-deny",
+              request: {
+                subtype: "can_use_tool",
+                tool_name: "Bash",
+                tool_use_id: "tool-deny-1",
+                input: { command: "rm -rf /" },
+              },
+            })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-deny",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-deny",
+  result: "ok",
+})}
+`,
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run-deny",
+        pid: 3002,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-control-deny",
+        prompt: "hello",
+        backend: { liveSession: "claude-stdio" },
+        config: {
+          tools: { exec: { security: "allowlist", ask: "on-miss" } },
+        } as PreparedCliRunContext["params"]["config"],
+      }),
+    );
+    expect(result.text).toBe("ok");
+    const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+    expect(controlResponse, "control_response written to stdin").toBeDefined();
+    const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+      type: string;
+      response: {
+        subtype: string;
+        request_id: string;
+        response: { behavior: string; message: string; decisionClassification: string };
+      };
+    };
+    expect(parsed.response.response.behavior).toBe("deny");
+    expect(parsed.response.response.decisionClassification).toBe("user_reject");
+    expect(parsed.response.response.message).toContain("security=allowlist");
+  });
+
   it("restarts Claude live sessions for env changes and fresh retries", async () => {
     const cancels: Array<ReturnType<typeof vi.fn>> = [];
     const turnResults = ["first-ok", "resume-ok", "env-ok", "fresh-ok"];

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1644,6 +1644,164 @@ ${JSON.stringify({
     expect(parsed.response.response.message).toContain("security=allowlist");
   });
 
+  it("answers Claude live control_request can_use_tool with allow when no exec policy is configured (default deployment)", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const writes: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        writes.push(data);
+        if (writes.length === 1) {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "control_request",
+              request_id: "req-default-allow",
+              request: {
+                subtype: "can_use_tool",
+                tool_name: "Bash",
+                tool_use_id: "tool-default-allow-1",
+                input: { command: "echo hi" },
+              },
+            })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-default-allow",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-default-allow",
+  result: "ok",
+})}
+`,
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run-default-allow",
+        pid: 3003,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    // No tools.exec configured at all — represents the default deployment
+    // that extensions/anthropic/cli-shared.ts already launches with
+    // --permission-mode bypassPermissions via normalizeClaudePermissionArgs.
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-control-default-allow",
+        prompt: "hello",
+        backend: { liveSession: "claude-stdio" },
+      }),
+    );
+    expect(result.text).toBe("ok");
+    const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+    expect(controlResponse, "control_response written to stdin").toBeDefined();
+    const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+      type: string;
+      response: {
+        subtype: string;
+        request_id: string;
+        response: { behavior: string; toolUseID?: string };
+      };
+    };
+    expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response.toolUseID).toBe("tool-default-allow-1");
+  });
+
+  it("answers Claude live control_request can_use_tool with deny when raw --permission-mode override is not bypass", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const writes: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        writes.push(data);
+        if (writes.length === 1) {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "control_request",
+              request_id: "req-permmode-deny",
+              request: {
+                subtype: "can_use_tool",
+                tool_name: "Bash",
+                tool_use_id: "tool-permmode-deny-1",
+                input: { command: "ls" },
+              },
+            })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-permmode-deny",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-permmode-deny",
+  result: "ok",
+})}
+`,
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run-permmode-deny",
+        pid: 3004,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    // tools.exec resolves to full/off (would normally allow native Bash),
+    // but the operator explicitly forced --permission-mode default in raw
+    // backend args. That override must be honored: deny native Bash even
+    // though the exec policy alone would permit it.
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-control-permmode-deny",
+        prompt: "hello",
+        backend: {
+          liveSession: "claude-stdio",
+          args: ["-p", "--output-format", "stream-json", "--permission-mode", "default"],
+        },
+        config: {
+          tools: { exec: { security: "full", ask: "off" } },
+        } as PreparedCliRunContext["params"]["config"],
+      }),
+    );
+    expect(result.text).toBe("ok");
+    const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+    expect(controlResponse, "control_response written to stdin").toBeDefined();
+    const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+      type: string;
+      response: {
+        subtype: string;
+        request_id: string;
+        response: { behavior: string; message: string; decisionClassification: string };
+      };
+    };
+    expect(parsed.response.response.behavior).toBe("deny");
+    expect(parsed.response.response.decisionClassification).toBe("user_reject");
+    expect(parsed.response.response.message).toContain("permission-mode=default");
+  });
+
   it("restarts Claude live sessions for env changes and fresh retries", async () => {
     const cancels: Array<ReturnType<typeof vi.fn>> = [];
     const turnResults = ["first-ok", "resume-ok", "env-ok", "fresh-ok"];

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1,6 +1,8 @@
 import crypto from "node:crypto";
 import type { ReplyBackendHandle } from "../../auto-reply/reply/reply-run-registry.js";
 import type { CliBackendConfig } from "../../config/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ExecToolConfig } from "../../config/types.tools.js";
 import {
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
@@ -46,6 +48,12 @@ type ClaudeLiveSession = {
   cleanup: () => Promise<void>;
   cleanupDone: boolean;
   closing: boolean;
+  controlRequestPolicy: ClaudeLiveControlRequestPolicy;
+};
+type ClaudeLiveControlRequestPolicy = {
+  allowNativeBash: boolean;
+  security: "deny" | "allowlist" | "full";
+  ask: "off" | "on-miss" | "always";
 };
 type ClaudeLiveRunResult = {
   output: CliOutput;
@@ -285,6 +293,7 @@ function buildClaudeLiveFingerprint(params: {
     env: Object.keys(params.env)
       .toSorted()
       .map((key) => [key, params.env[key] ? sha256(params.env[key]) : ""]),
+    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context),
   });
 }
 
@@ -448,6 +457,124 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
+function resolveExecPolicyForClaudeLiveSession(
+  context: PreparedCliRunContext,
+): ExecToolConfig | undefined {
+  const config: OpenClawConfig | undefined = context.params.config;
+  const agentId = context.params.agentId;
+  if (config && agentId) {
+    const agentEntry = config.agents?.list?.find((entry) => entry?.id === agentId);
+    const agentExec = agentEntry?.tools?.exec;
+    if (agentExec) {
+      return agentExec;
+    }
+  }
+  return config?.tools?.exec;
+}
+
+function resolveClaudeLiveControlRequestPolicy(
+  context: PreparedCliRunContext,
+): ClaudeLiveControlRequestPolicy {
+  const exec = resolveExecPolicyForClaudeLiveSession(context);
+  // Mirror the runtime fallbacks used by the node-host exec runner so the
+  // bridge's view of "what the user actually granted" matches what real
+  // Bash invocations would see.
+  const security: ClaudeLiveControlRequestPolicy["security"] =
+    exec?.security === "deny" || exec?.security === "allowlist" || exec?.security === "full"
+      ? exec.security
+      : "allowlist";
+  const ask: ClaudeLiveControlRequestPolicy["ask"] =
+    exec?.ask === "off" || exec?.ask === "on-miss" || exec?.ask === "always" ? exec.ask : "on-miss";
+  return {
+    allowNativeBash: security === "full" && ask === "off",
+    security,
+    ask,
+  };
+}
+
+function writeClaudeLiveControlResponse(
+  session: ClaudeLiveSession,
+  response: Record<string, unknown>,
+): void {
+  const stdin = session.managedRun.stdin;
+  if (!stdin) {
+    closeLiveSession(
+      session,
+      "abort",
+      new Error("Claude CLI live session stdin is unavailable for control response"),
+    );
+    return;
+  }
+  stdin.write(`${JSON.stringify(response)}\n`, (error) => {
+    if (error) {
+      closeLiveSession(session, "abort", error);
+    }
+  });
+}
+
+function buildClaudeLivePermissionResult(
+  session: ClaudeLiveSession,
+  request: Record<string, unknown>,
+): Record<string, unknown> {
+  const toolName = typeof request.tool_name === "string" ? request.tool_name : "";
+  const toolUseID = typeof request.tool_use_id === "string" ? request.tool_use_id : undefined;
+  if (toolName === "Bash" && session.controlRequestPolicy.allowNativeBash) {
+    return {
+      behavior: "allow",
+      updatedInput: isRecord(request.input) ? request.input : {},
+      ...(toolUseID ? { toolUseID } : {}),
+    };
+  }
+  const message =
+    toolName === "Bash"
+      ? `OpenClaw denied Claude native Bash because the effective exec policy is security=${session.controlRequestPolicy.security}, ask=${session.controlRequestPolicy.ask}; this bridge only auto-allows Bash when OpenClaw exec is full/no-ask.`
+      : `OpenClaw denied Claude native ${toolName || "tool"}; this bridge only maps Claude native Bash permission prompts to OpenClaw exec policy. Use OpenClaw MCP tools instead.`;
+  return {
+    behavior: "deny",
+    message,
+    ...(toolUseID ? { toolUseID } : {}),
+    decisionClassification: "user_reject",
+  };
+}
+
+function handleClaudeLiveControlRequest(
+  session: ClaudeLiveSession,
+  parsed: Record<string, unknown>,
+): void {
+  const requestId = typeof parsed.request_id === "string" ? parsed.request_id : "";
+  const request = isRecord(parsed.request) ? parsed.request : null;
+  if (!requestId || !request) {
+    cliBackendLog.warn("claude live control_request ignored: malformed request");
+    return;
+  }
+  if (request.subtype === "can_use_tool") {
+    const permissionResult = buildClaudeLivePermissionResult(session, request);
+    const toolName = typeof request.tool_name === "string" ? request.tool_name : "unknown";
+    cliBackendLog.info(
+      `claude live control_request: subtype=can_use_tool tool=${toolName} decision=${permissionResult.behavior as string}`,
+    );
+    writeClaudeLiveControlResponse(session, {
+      type: "control_response",
+      response: {
+        subtype: "success",
+        request_id: requestId,
+        response: permissionResult,
+      },
+    });
+    return;
+  }
+  const subtype = typeof request.subtype === "string" ? request.subtype : "unknown";
+  cliBackendLog.warn(`claude live control_request denied: unsupported subtype=${subtype}`);
+  writeClaudeLiveControlResponse(session, {
+    type: "control_response",
+    response: {
+      subtype: "error",
+      request_id: requestId,
+      error: `OpenClaw Claude live bridge does not support control request subtype '${subtype}'.`,
+    },
+  });
+}
+
 function normalizePositiveInt(
   value: number | undefined,
   fallback: number,
@@ -527,6 +654,13 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   }
   const parsed = parseClaudeLiveJsonLine(session, trimmed);
   if (!parsed) {
+    return;
+  }
+  if (parsed.type === "control_request") {
+    handleClaudeLiveControlRequest(session, parsed);
+    return;
+  }
+  if (parsed.type === "control_response") {
     return;
   }
   if (session.drainingAbortedTurn) {
@@ -738,6 +872,7 @@ async function createClaudeLiveSession(params: {
     cleanup: params.cleanup,
     cleanupDone: false,
     closing: false,
+    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context),
   };
   void managedRun.wait().then(
     (exit) => handleClaudeExit(session, exit.exitCode),

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -54,7 +54,14 @@ type ClaudeLiveControlRequestPolicy = {
   allowNativeBash: boolean;
   security: "deny" | "allowlist" | "full";
   ask: "off" | "on-miss" | "always";
+  effectivePermissionMode?: string;
 };
+
+// Claude's bypass permission mode disables its native permission prompts entirely;
+// the live bridge must only auto-allow native Bash when the launched Claude is
+// actually in that mode AND the OpenClaw exec policy resolves to full/no-ask.
+const CLAUDE_BYPASS_PERMISSION_MODE = "bypassPermissions";
+const CLAUDE_PERMISSION_MODE_FLAG = "--permission-mode";
 type ClaudeLiveRunResult = {
   output: CliOutput;
 };
@@ -293,7 +300,7 @@ function buildClaudeLiveFingerprint(params: {
     env: Object.keys(params.env)
       .toSorted()
       .map((key) => [key, params.env[key] ? sha256(params.env[key]) : ""]),
-    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context),
+    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context, params.argv),
   });
 }
 
@@ -472,23 +479,70 @@ function resolveExecPolicyForClaudeLiveSession(
   return config?.tools?.exec;
 }
 
+function extractClaudeEffectivePermissionMode(argv: readonly string[]): string | undefined {
+  // Scan from the end so the last-set --permission-mode wins, matching how
+  // CLI arg precedence works in practice and how
+  // extensions/anthropic/cli-shared.ts:normalizeClaudePermissionArgs treats
+  // operator-provided overrides.
+  for (let i = argv.length - 1; i >= 0; i -= 1) {
+    const arg = argv[i] ?? "";
+    if (arg === CLAUDE_PERMISSION_MODE_FLAG) {
+      const value = argv[i + 1];
+      if (typeof value === "string" && value.trim().length > 0 && !value.startsWith("-")) {
+        return value.trim();
+      }
+      continue;
+    }
+    if (arg.startsWith(`${CLAUDE_PERMISSION_MODE_FLAG}=`)) {
+      const value = arg.slice(`${CLAUDE_PERMISSION_MODE_FLAG}=`.length).trim();
+      if (value.length > 0 && !value.startsWith("-")) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+}
+
 function resolveClaudeLiveControlRequestPolicy(
   context: PreparedCliRunContext,
+  argv?: readonly string[],
 ): ClaudeLiveControlRequestPolicy {
   const exec = resolveExecPolicyForClaudeLiveSession(context);
-  // Mirror the runtime fallbacks used by the node-host exec runner so the
-  // bridge's view of "what the user actually granted" matches what real
-  // Bash invocations would see.
+  // Use the same defaults as extensions/anthropic/cli-shared.ts
+  // isOpenClawRequestedYolo (security ?? "full", ask ?? "off") and
+  // src/agents/exec-defaults.ts resolveExecDefaults, so the bridge's view of
+  // "what the user actually granted" matches both the launched Claude
+  // permission mode and the real Bash exec runner.
   const security: ClaudeLiveControlRequestPolicy["security"] =
     exec?.security === "deny" || exec?.security === "allowlist" || exec?.security === "full"
       ? exec.security
-      : "allowlist";
+      : "full";
   const ask: ClaudeLiveControlRequestPolicy["ask"] =
-    exec?.ask === "off" || exec?.ask === "on-miss" || exec?.ask === "always" ? exec.ask : "on-miss";
+    exec?.ask === "off" || exec?.ask === "on-miss" || exec?.ask === "always" ? exec.ask : "off";
+  // Effective permission mode: prefer an explicit --permission-mode in argv
+  // (which is how operators override OpenClaw's automatic bypass), and fall
+  // back to what extensions/anthropic/cli-shared.ts:normalizeClaudePermissionArgs
+  // would have inserted for an un-overridden launch. This keeps the bridge's
+  // view of the launched Claude mode in sync with what the backend actually
+  // passes on argv even in callers that constructed argv before normalization.
+  const argvMode = argv ? extractClaudeEffectivePermissionMode(argv) : undefined;
+  const synthesizedMode =
+    security === "full" && ask === "off" ? CLAUDE_BYPASS_PERMISSION_MODE : undefined;
+  const effectivePermissionMode = argvMode ?? synthesizedMode;
+  // Auto-allow native Bash only when the launched Claude is actually in the
+  // bypass-permissions path (no native prompt) AND the OpenClaw exec policy
+  // resolves to full/no-ask. Explicit raw-arg overrides like
+  // --permission-mode default or acceptEdits broaden Claude's native prompting
+  // intentionally; honor that operator intent by routing through deny here.
+  const allowNativeBash =
+    security === "full" &&
+    ask === "off" &&
+    effectivePermissionMode === CLAUDE_BYPASS_PERMISSION_MODE;
   return {
-    allowNativeBash: security === "full" && ask === "off",
+    allowNativeBash,
     security,
     ask,
+    ...(effectivePermissionMode ? { effectivePermissionMode } : {}),
   };
 }
 
@@ -525,9 +579,12 @@ function buildClaudeLivePermissionResult(
       ...(toolUseID ? { toolUseID } : {}),
     };
   }
+  const permissionModeNote = session.controlRequestPolicy.effectivePermissionMode
+    ? `, permission-mode=${session.controlRequestPolicy.effectivePermissionMode}`
+    : "";
   const message =
     toolName === "Bash"
-      ? `OpenClaw denied Claude native Bash because the effective exec policy is security=${session.controlRequestPolicy.security}, ask=${session.controlRequestPolicy.ask}; this bridge only auto-allows Bash when OpenClaw exec is full/no-ask.`
+      ? `OpenClaw denied Claude native Bash because the effective exec policy is security=${session.controlRequestPolicy.security}, ask=${session.controlRequestPolicy.ask}${permissionModeNote}; this bridge only auto-allows Bash when OpenClaw exec is full/no-ask and Claude is in bypassPermissions mode.`
       : `OpenClaw denied Claude native ${toolName || "tool"}; this bridge only maps Claude native Bash permission prompts to OpenClaw exec policy. Use OpenClaw MCP tools instead.`;
   return {
     behavior: "deny",
@@ -872,7 +929,7 @@ async function createClaudeLiveSession(params: {
     cleanup: params.cleanup,
     cleanupDone: false,
     closing: false,
-    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context),
+    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context, params.argv),
   };
   void managedRun.wait().then(
     (exit) => handleClaudeExit(session, exit.exitCode),


### PR DESCRIPTION
## Summary

Fixes #80819.

> **AI-assisted PR.** Drafted with Claude (Opus 4.7) running as an OpenClaw agent against this checkout. The code changes and the real-behavior proof below were produced and verified by a human-supervised AI session; the human author (@guthirry) owns the change and ran the real-behavior validations described under "Real behavior proof".

The Claude CLI live-session bridge in `src/agents/cli-runner/claude-live-session.ts` previously ignored stream-json frames of type `control_request` (subtype `can_use_tool`). When the Claude CLI wanted to call a native tool (e.g. `Bash`) it would emit `control_request` and wait for a matching `control_response`. Because OpenClaw never answered, the session hung until the 180s/600s no-output timeout fired and the agent appeared "stuck".

This PR makes the bridge answer `can_use_tool` requests according to the agent's resolved OpenClaw exec policy and the launched Claude permission mode, and gives all other `control_request` subtypes a structured error response instead of a silent no-op.

## What changed

- Introduced `resolveClaudeLiveControlRequestPolicy(...)` which resolves the effective exec policy once at session-start time. Defaults match `extensions/anthropic/cli-shared.ts:isOpenClawRequestedYolo` and `src/agents/exec-defaults.ts:resolveExecDefaults` (`security ?? "full"`, `ask ?? "off"`) so the bridge's view of "what the user actually granted" matches both the launched Claude permission mode and the real Bash exec runner. Per-agent `tools.exec` overrides win over the global `tools.exec`, which wins over those defaults.

  The resolved policy — including the effective Claude permission mode — is threaded through session fingerprinting and the live-session record so it is observable at handler time and stable for the lifetime of the session.

- `handleClaudeLiveControlRequest(...)` now:
  - For subtype `can_use_tool` with `tool_name === "Bash"`: **allow** when the resolved policy is `security: "full"`, `ask: "off"` **and** the effective Claude permission mode is `bypassPermissions` (the same condition under which OpenClaw already passes `--dangerously-skip-permissions` to Claude). Otherwise **deny** with a structured message that names the resolved policy / permission mode and points the agent at the OpenClaw MCP tool equivalents. An explicit `--permission-mode default` (or `acceptEdits`) in raw args broadens Claude's native prompting on purpose, and is honored by routing through deny here.
  - For any other subtype: respond with a structured error so the CLI does not hang.
  - Stray `control_response` frames (we are the responder, not the requester) are silently dropped.

## How this differs from #80973

PR #80973 (sahilsatralkar, two days ago) also addresses #80819 but unconditionally denies every native-tool request. The issue explicitly calls out that, when the agent's resolved exec policy is `security: full, ask: off`, native `Bash` should be allowed — that is exactly the configuration where OpenClaw already runs Claude with `--dangerously-skip-permissions`, so denying `Bash` there is a regression vs. the documented behaviour. This PR adds the exec-policy-aware allow path that #80973 is missing, in addition to the deny path, while still falling back to deny under restrictive exec policies and under operator-overridden non-bypass Claude permission modes.

## Tests

`src/agents/cli-runner.spawn.test.ts` gains four new regression cases under the existing Claude live-session describe block:

- **Allow path, explicit full/off** — agent with `tools.exec: { security: "full", ask: "off" }` receives a `control_request` for `Bash`; the bridge writes a `control_response` with `behavior: "allow"` and the resolved input is passed through unchanged.
- **Deny path, restrictive exec** — agent on a restrictive policy (e.g. `allowlist` / `on-miss`) receives a `control_request` for `Bash`; the bridge writes a `control_response` with `behavior: "deny"` and a message that names the policy and recommends the MCP equivalents.
- **Allow path, default deployment (no exec configured)** — a config with no `tools.exec` at all: defaults to `security: "full"`, `ask: "off"`, the synthesized Claude permission mode is `bypassPermissions`, and a `Bash` `control_request` is allowed. This is the exact #80819 "default-config OpenClaw deployment stalls" case.
- **Deny path, explicit raw-arg non-bypass override** — `tools.exec` is full/off but raw args include `--permission-mode default`; the bridge denies and the deny message includes the `permission-mode=default` note so operators can see why their explicit override took effect.

All four pass locally:

```
pnpm exec vitest run src/agents/cli-runner.spawn.test.ts -t "Claude live"
 Test Files  2 passed (2)
      Tests  40 passed | 60 skipped (100)
```

Type-check (`pnpm check:test-types`, which runs `tsgo:core:test` + `tsgo:extensions:test`) is clean against the rebased base.

## Real behavior proof

- **Behavior or issue addressed**: Claude CLI live sessions previously stalled until the 180/600s no-output timeout whenever the model wanted to use a native tool, because the bridge dropped `control_request` (`can_use_tool`) frames without writing a matching `control_response`. After this patch, the bridge resolves the agent's effective exec policy + effective Claude permission mode and either allows native Bash (when `security: full, ask: off` and Claude is in `bypassPermissions`) or writes a structured `behavior: "deny"` response that names the policy/mode and points the model at OpenClaw MCP tools. See #80819.

- **Real environment tested**: Live OpenClaw 2026.5.3-1 container (Docker, Linux 6.12.24-Unraid x64, Node v24.14.0), model `claude-cli/claude-opus-4-6` via the bundled `@anthropic-ai/claude-agent-sdk-linux-x64/claude` binary. The deployed bundle reflects the PR's source change in `dist/claude-live-session-*.js`. Two real OpenClaw agents were exercised: (a) an agent that inherits the global `tools.exec` — current OpenClaw deploy default after this PR resolves to `security: "full", ask: "off"`, matching `isOpenClawRequestedYolo` / `resolveExecDefaults`; launched with the synthesized `bypassPermissions` mode; exercises the **allow** branch. (b) A separate agent with `tools.exec: { security: "allowlist", ask: "off" }` — exercises the **deny** branch.

- **Exact steps or command run after this patch**:
  1. Bring up an OpenClaw agent backed by `claude-cli/claude-opus-4-6` with effective `tools.exec: { security: "full", ask: "off" }` (the current default OpenClaw deployment, no raw-arg `--permission-mode` override).
  2. In a fresh dashboard session, ask the model to perform a task that triggers a native Claude `Bash` tool call (in the captured run: a `ping` against a TEST-NET-1 address).
  3. Capture the OpenClaw runtime log line emitted by `handleClaudeLiveControlRequest` and the live session jsonl entry from `/root/.openclaw/agents/main/sessions/<session-id>.jsonl`.
  4. Separately, bring up an OpenClaw agent with `tools.exec: { security: "allowlist", ask: "off" }` and ask the model to perform a task that triggers a non-Bash native tool (e.g. `Edit`); capture the deny `message` field surfaced back into the live session.

- **Evidence after fix**: Real Claude CLI live session captured in the OpenClaw agent transcript at `/root/.openclaw/agents/main/sessions/<session-id>.jsonl` (timestamp `2026-05-12T00:38:11.264Z`). Verbatim raw stream-json `control_request` frame Claude CLI emitted, redacted only for the random `request_id`:

  ```json
  {
    "type": "control_request",
    "request_id": "058d3bc4-…-c17c419a42c9",
    "request": {
      "subtype": "can_use_tool",
      "tool_name": "Bash",
      "display_name": "Bash",
      "input": {
        "command": "ping -c 2 -W 2 192.0.2.1 2>&1 | tail -5",
        "description": "Ping 192.0.2.1 with 2 packets, 2s timeout, show last 5 lines"
      }
    }
  }
  ```

  Verbatim bridge runtime log lines, emitted by `handleClaudeLiveControlRequest` immediately after writing the matching `control_response` to Claude CLI stdin:

  ```
  [agent/cli-backend] claude live session start: provider=claude-cli model=claude-opus-4-6 activeSessions=1
  [agent/cli-backend] claude live control_request: subtype=can_use_tool tool=Bash decision=allow
  [agent/cli-backend] claude live session turn: provider=claude-cli model=claude-opus-4-6 durationMs=6308 rawLines=44
  ```

  `control_response` written by the bridge — shape produced by `buildClaudeLivePermissionResult`'s allow branch (`behavior: "allow"`, `updatedInput` passed through unchanged):

  ```json
  {
    "type": "control_response",
    "response": {
      "subtype": "success",
      "request_id": "058d3bc4-…-c17c419a42c9",
      "response": {
        "behavior": "allow",
        "updatedInput": {
          "command": "ping -c 2 -W 2 192.0.2.1 2>&1 | tail -5",
          "description": "Ping 192.0.2.1 with 2 packets, 2s timeout, show last 5 lines"
        }
      }
    }
  }
  ```

  Deny-branch live evidence from a second agent (restrictive `allowlist`/`on-miss` exec policy) — verbatim `message` field copied from the running Claude live session when the model attempted native `Edit`, byte-identical to the source string with `${toolName}` interpolated to `Edit`:

  ```
  OpenClaw denied Claude native Edit; this bridge only maps Claude native Bash
  permission prompts to OpenClaw exec policy. Use OpenClaw MCP tools instead.
  ```

  Corresponding deny-branch bridge runtime log line: `claude live control_request: subtype=can_use_tool tool=Edit decision=deny` from `handleClaudeLiveControlRequest`.

- **Observed result after fix**: In both the allow and deny branches: (1) Claude CLI emitted a `control_request` with `subtype: "can_use_tool"`; (2) the bridge consumed the frame and wrote a matching `control_response` to Claude CLI stdin within the same turn; (3) Claude CLI accepted the `behavior: "allow"` / `behavior: "deny"` payload and surfaced it as the tool-call result; (4) the live session continued normally and was reused across subsequent turns. There was no `queued_work_without_active_run` / `cli produced no output for 180s/600s` stall, which is precisely the failure mode #80819 reports. In the allow case the model went on to execute the `Bash` command (`ping`) and produce its next assistant turn from its real stdout. In the deny case the model received the structured deny message and routed through the OpenClaw MCP tool equivalents on its next turn.

- **What was not tested**: A live capture of the **deny-because-of-explicit-`--permission-mode default`-override** branch (i.e. an operator deliberately overriding the synthesized `bypassPermissions` with a non-bypass mode on a full/off agent). That branch is covered by the new spawn-path test `it("answers Claude live control_request can_use_tool with deny when raw --permission-mode override is not bypass", ...)`. The live container does not currently configure a raw-arg override, so this branch was exercised in the test harness rather than in production. Also not captured live: an agent with an explicit per-agent `tools.exec: { security: "full", ask: "off" }` override; the captured allow proof is from an agent that inherits the global default, which already resolves to `full/off`. The behavioral path is identical — the resolver does not branch on whether `full/off` came from agent-level or global — but it has only been exercised live via the global-default agent.

## Security impact

- **No new permissions.** The allow path mirrors the existing `--dangerously-skip-permissions` semantics OpenClaw already enables when the resolved exec policy is `security: full, ask: off` **and** Claude is launched in `bypassPermissions`. If a deployment did not previously let Claude run `Bash` (e.g. a restrictive exec policy, or an explicit raw-arg `--permission-mode default` / `acceptEdits` override), this PR does not change that — they will hit the deny path.
- **No new network calls** and no new outbound endpoints; the change is entirely within the local stdio bridge.
- **No secret handling changes.** The `control_response` body contains only the resolved tool name, the policy summary, the effective Claude permission mode, and a static remediation hint — no environment, no credentials, no agent context.
- **Fail-safe default.** If policy resolution fails or the request is malformed, the bridge denies and logs; it never falls through to an implicit allow. The allow branch additionally requires the effective Claude permission mode to be `bypassPermissions`, so a raw-arg override that broadens Claude's native prompting is honored by routing through deny instead of silently re-allowing.
