### PR TITLE
fix(whatsapp): mark text slash commands as command turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord/channels: make `openclaw channels list --all` prefer reachable Gateway runtime account status and mark configured-but-unavailable credentials, avoiding false `not configured` output when Discord is running from service-only env. Fixes #79343. Thanks @EricY019.
+- WhatsApp: mark text slash commands as command turns so authorized group command replies stay visible under message-tool-only group reply mode. (#81972) Thanks @barbarhan.
 - Installer: handle noninteractive git installs from moving refs without tag-fetch conflicts, while keeping immutable refs on frozen lockfile installs. (#81875) Thanks @keshavbotagent.
 - Codex app-server: inject native client factories per run and compaction attempt instead of using module-scope test state, avoiding temporal-dead-zone reads during cyclic startup. (#81148) Thanks @bdjben.
 - Plugin skills: replace generated Windows plugin-skill directories before publishing the current skill link, avoiding repeated `EINVAL` warnings from stale non-symlink entries. Fixes #81432. (#81446) Thanks @hclsys and @vincentkoc.

--- a/extensions/brave/src/brave-web-search-provider.test.ts
+++ b/extensions/brave/src/brave-web-search-provider.test.ts
@@ -58,7 +58,7 @@ function installBraveLlmContextFetch() {
         },
         sources: [],
       }),
-    } as Response;
+    } as unknown as Response;
   });
   global.fetch = mockFetch as typeof global.fetch;
   return mockFetch;
@@ -357,7 +357,7 @@ describe("brave web search provider", () => {
       return {
         ok: true,
         json: async () => ({ web: { results: [] } }),
-      } as Response;
+      } as unknown as Response;
     });
     global.fetch = mockFetch as typeof global.fetch;
 
@@ -502,7 +502,7 @@ describe("brave web search provider", () => {
       return {
         ok: true,
         json: async () => ({ web: { results: [] } }),
-      } as Response;
+      } as unknown as Response;
     });
     global.fetch = mockFetch as typeof global.fetch;
 
@@ -661,7 +661,7 @@ describe("brave web search provider", () => {
       return {
         ok: true,
         json: async () => ({ web: { results: [] } }),
-      } as Response;
+      } as unknown as Response;
     });
     global.fetch = mockFetch as typeof global.fetch;
 
@@ -703,7 +703,7 @@ describe("brave web search provider", () => {
             ],
           },
         }),
-      } as Response;
+      } as unknown as Response;
     });
     global.fetch = mockFetch as typeof global.fetch;
 

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -27,6 +27,18 @@ vi.mock("./token.js", () => ({
   resolveMSTeamsCredentials: resolveMSTeamsCredentialsMock,
 }));
 
+vi.mock("../runtime-api.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../runtime-api.js")>();
+  return {
+    ...original,
+    fetchWithSsrFGuard: async (params: { url: string; init?: RequestInit }) => ({
+      response: await globalThis.fetch(params.url, params.init),
+      finalUrl: params.url,
+      release: async () => undefined,
+    }),
+  };
+});
+
 import { searchGraphUsers } from "./graph-users.js";
 import {
   deleteGraphRequest,
@@ -119,6 +131,14 @@ function fetchCallHeader(index: number, name: string) {
 
 function expectFetchPathContains(index: number, expectedPath: string) {
   expect(fetchCallUrl(index)).toContain(expectedPath);
+}
+
+function fetchCallSearchParam(index: number, name: string): string | null {
+  const url = fetchCallUrl(index);
+  if (!url) {
+    throw new Error(`Expected fetch call ${index}`);
+  }
+  return new URL(url).searchParams.get(name);
 }
 
 async function expectSearchGraphUsers(
@@ -305,10 +325,10 @@ describe("msteams graph helpers", () => {
       deploymentsChannel,
     ]);
 
-    expectFetchPathContains(
-      0,
-      "/groups?$filter=resourceProvisioningOptions%2FAny(x%3Ax%20eq%20'Team')%20and%20startsWith(displayName%2C'Bob''s%20Team')&$select=id,displayName",
+    expect(fetchCallSearchParam(0, "$filter")).toBe(
+      "resourceProvisioningOptions/Any(x:x eq 'Team') and startsWith(displayName,'Bob''s Team')",
     );
+    expect(fetchCallSearchParam(0, "$select")).toBe("id,displayName");
     expectFetchPathContains(1, "/teams/team%2Fops/channels?$select=id,displayName");
   });
 
@@ -324,10 +344,10 @@ describe("msteams graph helpers", () => {
     await expectSearchGraphUsers("alice.o'hara@example.com", [userOne], {
       token: "token-2",
     });
-    expectFetchPathContains(
-      0,
-      "/users?$filter=(mail%20eq%20'alice.o''hara%40example.com'%20or%20userPrincipalName%20eq%20'alice.o''hara%40example.com')&$select=id,displayName,mail,userPrincipalName",
+    expect(fetchCallSearchParam(0, "$filter")).toBe(
+      "(mail eq 'alice.o''hara@example.com' or userPrincipalName eq 'alice.o''hara@example.com')",
     );
+    expect(fetchCallSearchParam(0, "$select")).toBe("id,displayName,mail,userPrincipalName");
   });
 
   it("uses displayName search with eventual consistency and default top handling", async () => {

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -81,13 +81,13 @@ async function requestGraph(params: {
   }
 }
 
-async function readOptionalGraphJson<T>(res: Response): Promise<T> {
+async function readOptionalGraphJson<T>(res: Response, label: string): Promise<T> {
   // Use optional chaining to stay resilient to partial test mocks that do not
   // provide a status or Headers instance (they only shim `ok` + `json()`).
   if (res.status === 204 || res.headers?.get?.("content-length") === "0") {
     return undefined as T;
   }
-  return (await res.json()) as T;
+  return await readProviderJsonResponse<T>(res, label);
 }
 
 export async function fetchGraphJson<T>(params: {
@@ -106,7 +106,7 @@ export async function fetchGraphJson<T>(params: {
     body: params.body,
     headers: params.headers,
   });
-  return await readOptionalGraphJson<T>(res);
+  return await readOptionalGraphJson<T>(res, `Graph ${params.path} failed`);
 }
 
 /**
@@ -258,7 +258,7 @@ export async function postGraphJson<T>(params: {
     body: params.body,
     errorPrefix: "Graph POST",
   });
-  return readOptionalGraphJson<T>(res);
+  return readOptionalGraphJson<T>(res, `Graph POST ${params.path} failed`);
 }
 
 export async function postGraphBetaJson<T>(params: {
@@ -274,7 +274,7 @@ export async function postGraphBetaJson<T>(params: {
     body: params.body,
     errorPrefix: "Graph beta POST",
   });
-  return readOptionalGraphJson<T>(res);
+  return readOptionalGraphJson<T>(res, `Graph beta POST ${params.path} failed`);
 }
 
 export async function deleteGraphRequest(params: { token: string; path: string }): Promise<void> {
@@ -298,10 +298,7 @@ export async function patchGraphJson<T>(params: {
     body: params.body,
     errorPrefix: "Graph PATCH",
   });
-  if (res.status === 204 || res.headers.get("content-length") === "0") {
-    return undefined as T;
-  }
-  return (await res.json()) as T;
+  return readOptionalGraphJson<T>(res, `Graph PATCH ${params.path} failed`);
 }
 
 export async function listChannelsForTeam(token: string, teamId: string): Promise<GraphChannel[]> {

--- a/extensions/msteams/src/user-agent.test.ts
+++ b/extensions/msteams/src/user-agent.test.ts
@@ -78,10 +78,11 @@ describe("buildUserAgent", () => {
   });
 
   it("sends the generated User-Agent in Graph requests by default", async () => {
-    const mockFetch = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ value: [] }),
-    });
+    const mockFetch = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ value: [] }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
     vi.stubGlobal("fetch", mockFetch);
 
     await fetchGraphJson({ token: "test-token", path: "/groups" });
@@ -93,10 +94,11 @@ describe("buildUserAgent", () => {
   });
 
   it("lets caller headers override the default Graph User-Agent", async () => {
-    const mockFetch = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ value: [] }),
-    });
+    const mockFetch = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ value: [] }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
     vi.stubGlobal("fetch", mockFetch);
 
     await fetchGraphJson({

--- a/extensions/msteams/src/user-agent.test.ts
+++ b/extensions/msteams/src/user-agent.test.ts
@@ -9,6 +9,18 @@ vi.mock("./runtime.js", () => ({
   getMSTeamsRuntime: vi.fn(() => mockRuntime),
 }));
 
+vi.mock("../runtime-api.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../runtime-api.js")>();
+  return {
+    ...original,
+    fetchWithSsrFGuard: async (params: { url: string; init?: RequestInit }) => ({
+      response: await globalThis.fetch(params.url, params.init),
+      finalUrl: params.url,
+      release: async () => undefined,
+    }),
+  };
+});
+
 import { fetchGraphJson } from "./graph.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import { buildUserAgent, ensureUserAgentHeader, resetUserAgentCache } from "./user-agent.js";

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -60,9 +60,12 @@ vi.mock("./runtime-api.js", () => ({
         groupChat?: { visibleReplies?: "automatic" | "message_tool" };
       };
     };
-    ctx: { ChatType?: string; CommandSource?: "native" };
+    ctx: { ChatType?: string; CommandSource?: "native" | "text"; CommandAuthorized?: boolean };
   }) => {
-    if (ctx.CommandSource === "native") {
+    if (
+      ctx.CommandSource === "native" ||
+      (ctx.CommandSource === "text" && ctx.CommandAuthorized === true)
+    ) {
       return "automatic";
     }
     if (ctx.ChatType === "group" || ctx.ChatType === "channel") {
@@ -377,6 +380,37 @@ describe("whatsapp inbound dispatch", () => {
       CommandBody: "<media:audio>",
       RawBody: "<media:audio>",
       Transcript: "spoken transcript",
+    });
+  });
+
+  it("marks authorized text slash commands as text command turns", () => {
+    const ctx = buildWhatsAppInboundContext({
+      combinedBody: "/status",
+      commandBody: "/status",
+      commandAuthorized: true,
+      commandSource: "text",
+      conversationId: "+1000",
+      msg: makeMsg({
+        body: "/status",
+      }),
+      rawBody: "/status",
+      route: makeRoute(),
+      sender: {
+        e164: "+1000",
+      },
+    });
+
+    expectRecordFields(requireRecord(ctx, "slash command context"), {
+      Body: "/status",
+      BodyForAgent: "/status",
+      BodyForCommands: "/status",
+      CommandBody: "/status",
+      RawBody: "/status",
+      CommandAuthorized: true,
+      CommandSource: "text",
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      OriginatingChannel: "whatsapp",
     });
   });
 
@@ -827,6 +861,31 @@ describe("whatsapp inbound dispatch", () => {
     expectRecordFields(requireRecord(getCapturedReplyOptions(), "reply options"), {
       sourceReplyDeliveryMode: "message_tool_only",
       disableBlockStreaming: true,
+    });
+  });
+
+  it("delivers authorized WhatsApp group text slash command replies visibly", async () => {
+    await dispatchBufferedReply({
+      cfg: {
+        channels: { whatsapp: { blockStreaming: true } },
+        messages: { groupChat: { visibleReplies: "message_tool" } },
+      } as never,
+      context: {
+        Body: "/status",
+        ChatType: "group",
+        CommandAuthorized: true,
+        CommandSource: "text",
+      },
+      msg: makeMsg({
+        body: "/status",
+        from: "120363000000000000@g.us",
+        chatType: "group",
+      }),
+    });
+
+    expectRecordFields(requireRecord(getCapturedReplyOptions(), "reply options"), {
+      sourceReplyDeliveryMode: "automatic",
+      disableBlockStreaming: false,
     });
   });
 

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -225,6 +225,7 @@ export function buildWhatsAppInboundContext(params: {
   combinedBody: string;
   commandBody?: string;
   commandAuthorized?: boolean;
+  commandSource?: "text";
   conversationId: string;
   groupHistory?: GroupHistoryEntry[];
   groupMemberRoster?: Map<string, string>;
@@ -279,6 +280,7 @@ export function buildWhatsAppInboundContext(params: {
     SenderId: params.sender.id ?? params.sender.e164,
     SenderE164: params.sender.e164,
     CommandAuthorized: params.commandAuthorized,
+    CommandSource: params.commandSource,
     ReplyThreading: params.replyThreading,
     WasMentioned: params.msg.wasMentioned,
     GroupSystemPrompt: params.groupSystemPrompt,
@@ -421,13 +423,22 @@ export async function dispatchWhatsAppBufferedReply(params: {
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(params.cfg, params.route.agentId);
   const sourceReplyChatType =
     typeof params.context.ChatType === "string" ? params.context.ChatType : params.msg.chatType;
+  const sourceReplyCommandSource =
+    params.context.CommandSource === "native" || params.context.CommandSource === "text"
+      ? params.context.CommandSource
+      : undefined;
+  const sourceReplyCommandAuthorized =
+    typeof params.context.CommandAuthorized === "boolean"
+      ? params.context.CommandAuthorized
+      : undefined;
   const sourceReplyDeliveryMode =
     sourceReplyChatType === "group" || sourceReplyChatType === "channel"
       ? resolveChannelMessageSourceReplyDeliveryMode({
           cfg: params.cfg,
           ctx: {
             ChatType: sourceReplyChatType,
-            CommandSource: params.context.CommandSource === "native" ? "native" : undefined,
+            CommandSource: sourceReplyCommandSource,
+            CommandAuthorized: sourceReplyCommandAuthorized,
           },
         })
       : undefined;

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
@@ -2,13 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WhatsAppSendResult } from "../../inbound/send-result.js";
 
 // Hoisted mocks used across tests so vi.mock factories can reference them.
-const { resolvePolicyMock, buildContextMock, runMessageReceivedMock, trackBackgroundTaskMock } =
-  vi.hoisted(() => ({
-    resolvePolicyMock: vi.fn(),
-    buildContextMock: vi.fn(),
-    runMessageReceivedMock: vi.fn(async () => undefined),
-    trackBackgroundTaskMock: vi.fn(),
-  }));
+const {
+  resolvePolicyMock,
+  buildContextMock,
+  isControlCommandMessageMock,
+  runMessageReceivedMock,
+  shouldComputeCommandAuthorizedMock,
+  trackBackgroundTaskMock,
+} = vi.hoisted(() => ({
+  resolvePolicyMock: vi.fn(),
+  buildContextMock: vi.fn(),
+  isControlCommandMessageMock: vi.fn(() => false),
+  runMessageReceivedMock: vi.fn(async () => undefined),
+  shouldComputeCommandAuthorizedMock: vi.fn(() => false),
+  trackBackgroundTaskMock: vi.fn(),
+}));
 
 function acceptedSendResult(kind: "media" | "text", id: string): WhatsAppSendResult {
   return {
@@ -131,7 +139,8 @@ vi.mock("./runtime-api.js", async (importOriginal) => {
       previousTimestamp: undefined,
     }),
     resolvePinnedMainDmOwnerFromAllowlist: () => null,
-    shouldComputeCommandAuthorized: () => false,
+    isControlCommandMessage: isControlCommandMessageMock,
+    shouldComputeCommandAuthorized: shouldComputeCommandAuthorizedMock,
     shouldLogVerbose: () => false,
   };
 });
@@ -193,10 +202,10 @@ const baseRoute = {
   matchedBy: "default",
 };
 
-function callProcessMessage(overrides: { cfg?: unknown } = {}) {
+function callProcessMessage(overrides: { cfg?: unknown; msg?: unknown } = {}) {
   return processMessage({
     cfg: (overrides.cfg ?? {}) as never,
-    msg: baseMsg as never,
+    msg: (overrides.msg ?? baseMsg) as never,
     route: baseRoute as never,
     groupHistoryKey: "whatsapp:default:group:123@g.us",
     groupHistories: new Map(),
@@ -232,8 +241,12 @@ function mockCallArg(mockFn: ReturnType<typeof vi.fn>, label: string, callIndex 
 describe("processMessage group system prompt wiring", () => {
   beforeEach(() => {
     buildContextMock.mockReset();
+    isControlCommandMessageMock.mockReset();
+    isControlCommandMessageMock.mockReturnValue(false);
     resolvePolicyMock.mockReset();
     runMessageReceivedMock.mockClear();
+    shouldComputeCommandAuthorizedMock.mockReset();
+    shouldComputeCommandAuthorizedMock.mockReturnValue(false);
     trackBackgroundTaskMock.mockClear();
     clearInternalHooks();
     buildContextMock.mockImplementation(
@@ -262,6 +275,48 @@ describe("processMessage group system prompt wiring", () => {
         }
       ).groupSystemPrompt,
     ).toBe("from config");
+  });
+
+  it("marks detected WhatsApp slash messages as text command turns", async () => {
+    resolvePolicyMock.mockReturnValue(makePolicy(makeAccount()));
+    isControlCommandMessageMock.mockReturnValue(true);
+    shouldComputeCommandAuthorizedMock.mockReturnValue(true);
+
+    await callProcessMessage({
+      msg: {
+        ...baseMsg,
+        body: "/status",
+      },
+    });
+
+    expect(shouldComputeCommandAuthorizedMock).toHaveBeenCalledWith("/status", {});
+    expect(isControlCommandMessageMock).toHaveBeenCalledWith("/status", {});
+    expect(buildContextMock.mock.calls[0][0]).toMatchObject({
+      commandBody: "/status",
+      commandAuthorized: true,
+      commandSource: "text",
+      rawBody: "/status",
+    });
+  });
+
+  it("checks auth for inline command tokens without marking them as command-source turns", async () => {
+    resolvePolicyMock.mockReturnValue(makePolicy(makeAccount()));
+    isControlCommandMessageMock.mockReturnValue(false);
+    shouldComputeCommandAuthorizedMock.mockReturnValue(true);
+
+    await callProcessMessage({
+      msg: {
+        ...baseMsg,
+        body: "please inspect `/tmp/foo`",
+      },
+    });
+
+    expect(buildContextMock.mock.calls[0][0]).toMatchObject({
+      commandBody: "please inspect `/tmp/foo`",
+      commandAuthorized: true,
+      rawBody: "please inspect `/tmp/foo`",
+    });
+    expect(buildContextMock.mock.calls[0][0].commandSource).toBeUndefined();
   });
 
   it("fires message_received hooks with canonical WhatsApp correlation fields", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -55,6 +55,7 @@ import {
   resolveChannelContextVisibilityMode,
   resolveInboundSessionEnvelopeContext,
   resolvePinnedMainDmOwnerFromAllowlist,
+  isControlCommandMessage,
   shouldComputeCommandAuthorized,
   shouldLogVerbose,
   type getChildLogger,
@@ -407,7 +408,9 @@ export async function processMessage(params: {
     senderE164: sender.e164 ?? undefined,
     normalizeE164,
   });
-  const commandAuthorized = shouldComputeCommandAuthorized(params.msg.body, params.cfg)
+  const shouldCheckCommandAuth = shouldComputeCommandAuthorized(params.msg.body, params.cfg);
+  const isTextCommand = isControlCommandMessage(params.msg.body, params.cfg);
+  const commandAuthorized = shouldCheckCommandAuth
     ? await resolveWhatsAppCommandAuthorized({
         cfg: params.cfg,
         msg: params.msg,
@@ -448,6 +451,7 @@ export async function processMessage(params: {
     combinedBody,
     commandBody: params.msg.body,
     commandAuthorized,
+    commandSource: isTextCommand ? "text" : undefined,
     conversationId,
     groupHistory: visibleGroupHistory,
     groupMemberRoster: params.groupMemberNames.get(params.groupHistoryKey),

--- a/extensions/whatsapp/src/auto-reply/monitor/runtime-api.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/runtime-api.ts
@@ -6,7 +6,10 @@ export {
   createChannelMessageReplyPipeline,
   resolveChannelMessageSourceReplyDeliveryMode,
 } from "openclaw/plugin-sdk/channel-message";
-export { shouldComputeCommandAuthorized } from "openclaw/plugin-sdk/command-detection";
+export {
+  isControlCommandMessage,
+  shouldComputeCommandAuthorized,
+} from "openclaw/plugin-sdk/command-detection";
 export { resolveChannelContextVisibilityMode } from "../config.runtime.js";
 export { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 export type LoadConfigFn = typeof import("../config.runtime.js").getRuntimeConfig;

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -10,6 +10,34 @@ import { wrapXaiWebSearchError } from "./src/web-search-shared.js";
 import { __testing } from "./test-api.js";
 import { createXaiWebSearchProvider } from "./web-search.js";
 
+vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
+  const original = await importOriginal<typeof import("openclaw/plugin-sdk/provider-web-search")>();
+  return {
+    ...original,
+    postTrustedWebToolsJson: async (
+      params: {
+        url: string;
+        apiKey: string;
+        body: Record<string, unknown>;
+        extraHeaders?: Record<string, string>;
+      },
+      parseResponse: (response: Response) => Promise<unknown>,
+    ) => {
+      const response = await globalThis.fetch(params.url, {
+        method: "POST",
+        headers: {
+          ...params.extraHeaders,
+          Accept: "application/json",
+          Authorization: `Bearer ${params.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(params.body),
+      });
+      return await parseResponse(response);
+    },
+  };
+});
+
 const {
   extractXaiWebSearchContent,
   resolveXaiInlineCitations,
@@ -349,8 +377,11 @@ describe("xai web search config resolution", () => {
       },
       searchConfig: { provider: "grok" },
     });
+    if (!tool) {
+      throw new Error("Expected xAI web search tool");
+    }
 
-    await tool?.execute({ query: "OpenClaw Grok proxy test" });
+    await tool.execute({ query: "OpenClaw Grok proxy test" });
 
     expect(firstFetchUrl(mockFetch)).toBe("https://api.x.ai/proxy/v1/responses");
   });


### PR DESCRIPTION
## Summary
- Tag recognized WhatsApp text slash commands with `CommandSource: "text"` while preserving command authorization.
- Pass command source and authorization into group source-reply delivery mode resolution so authorized text commands can reply visibly.
- Add focused WhatsApp monitor tests for command context and group reply delivery.

## Real behavior proof
Behavior addressed: Authorized WhatsApp text slash commands such as `/status` should produce a visible channel reply instead of being suppressed by group source-reply delivery mode.

Real environment tested: Local OpenClaw WhatsApp runtime connected to a real WhatsApp chat after applying the same command-source patch.

Exact steps or command run after this patch: Sent `/status` as a WhatsApp text message to the OpenClaw WhatsApp runtime and observed the channel reply in WhatsApp.

Evidence after fix: Redacted WhatsApp screenshot attached below showing `/status` producing a visible OpenClaw status reply. Sensitive account, auth, model, provider, usage, session, path, and chat metadata are removed.

Observed result after fix: The `/status` command produced a visible OpenClaw status reply in the WhatsApp conversation.

What was not tested: A public reproducible live WhatsApp session is not included because it would expose private account/chat state; CI and focused unit tests cover the command-source and reply-delivery wiring.

<img width="738" height="275" alt="WhatsApp Image 2026-05-15 at 11 11 18" src="https://github.com/user-attachments/assets/edd82a95-b8e9-4a31-85b9-beb4c63c92d4" />

## Tests
- `pnpm test extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts extensions/whatsapp/src/auto-reply/monitor/process-message.ts extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts extensions/whatsapp/src/auto-reply/monitor/runtime-api.ts`
- `pnpm tsgo:extensions --pretty false`
- `pnpm test extensions/brave/src/brave-web-search-provider.test.ts extensions/xai/web-search.test.ts extensions/msteams/src/graph.test.ts extensions/msteams/src/user-agent.test.ts -- --reporter=verbose`
- `pnpm check:test-types`
- `pnpm run lint:tmp:no-raw-channel-fetch`
- `OPENCLAW_ADDITIONAL_BOUNDARY_SHARD=2/4 node scripts/run-additional-boundary-checks.mjs`
