### PR TITLE
Policy: add secret and auth conformance checks

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -996,6 +996,14 @@
     "target": "ACP Agents 设置"
   },
   {
+    "source": "Policy CLI",
+    "target": "Policy CLI"
+  },
+  {
+    "source": "Doctor lint mode",
+    "target": "Doctor lint mode"
+  },
+  {
     "source": "ds4 (local DeepSeek V4)",
     "target": "ds4（本地 DeepSeek V4）"
   },

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -18,13 +18,14 @@ report drift through `doctor --lint`. The final conformance signal is a clean
 instead of creating a separate health gate.
 
 Policy currently manages configured channels, MCP servers, model providers,
-network SSRF posture, redacted secrets/auth provenance, and governed tool
-declarations. For example, IT or a workspace operator can record that Telegram
-is not an approved channel provider, restrict MCP servers and model refs to
-approved entries, require private-network fetch/browser access to remain
-disabled, require secrets to use managed references, require auth profiles to
-carry provider/mode metadata, require governed tools to carry risk and
-sensitivity metadata, then use `doctor --lint` as the shared conformance gate.
+network SSRF posture, OpenClaw config secret provider/auth profile posture,
+and governed tool declarations. For example, IT or a workspace operator can
+record that Telegram is not an approved channel provider, restrict MCP servers
+and model refs to approved entries, require private-network fetch/browser
+access to remain disabled, require OpenClaw config SecretRefs to use managed
+providers, require config auth profiles to carry provider/mode metadata,
+require governed tools to carry risk and sensitivity metadata, then use
+`doctor --lint` as the shared conformance gate.
 
 Use policy when a workspace needs a durable statement such as "these channels
 must not be enabled" or "governed tools must declare approval metadata" and a
@@ -46,7 +47,8 @@ doctor can report the missing artifact.
 
 Policy is authored, not generated from the user's current settings. A minimal
 policy for channels, MCP servers, model providers, network posture,
-secrets/auth provenance, and tool metadata looks like this:
+OpenClaw config secret provider/auth profile posture, and tool metadata looks
+like this:
 
 ```jsonc
 {
@@ -77,7 +79,6 @@ secrets/auth provenance, and tool metadata looks like this:
     },
   },
   "secrets": {
-    "disallowInline": true,
     "requireManagedProviders": true,
     "denySources": ["exec"],
     "allowInsecureProviders": false,
@@ -97,10 +98,12 @@ secrets/auth provenance, and tool metadata looks like this:
 The rules are the authority. A category block is only a namespace; checks run
 when a concrete rule is present. OpenClaw reads current `channels.*` settings
 `mcp.servers.*`, `models.providers.*`, selected agent model refs, network SSRF
-settings, secret provider/input provenance, auth profile metadata, and
-`TOOLS.md` declarations as evidence, then reports observed state that does not
-conform. Secret evidence is redacted: policy records inline-vs-SecretRef
-posture and provider/source provenance, never raw secret values.
+settings, OpenClaw config secret provider and SecretRef provenance, config auth
+profile metadata, and `TOOLS.md` declarations as evidence, then reports
+observed state that does not conform. Secret evidence records provider/source
+posture and SecretRef metadata, never raw secret values. Policy does not read
+or attest per-agent credential stores such as `auth-profiles.json`; those
+stores remain owned by the existing auth and credential flows.
 
 Run policy-only checks during authoring:
 
@@ -238,7 +241,7 @@ Example JSON output:
         "id": "vault",
         "kind": "provider",
         "source": "oc://openclaw.config/secrets/providers/vault",
-        "providerSource": "file"
+        "providerSource": "env"
       },
       {
         "id": "oc://openclaw.config/models/providers/openai/apiKey",
@@ -269,7 +272,7 @@ Example JSON output:
       }
     ]
   },
-  "checksRun": 21,
+  "checksRun": 20,
   "checksSkipped": 0,
   "findings": []
 }
@@ -317,29 +320,28 @@ choose a different interval.
 
 Policy currently verifies:
 
-| Check id                                 | Finding                                                                   |
-| ---------------------------------------- | ------------------------------------------------------------------------- |
-| `policy/policy-jsonc-missing`            | Policy is enabled but `policy.jsonc` is missing.                          |
-| `policy/policy-jsonc-invalid`            | Policy cannot be parsed or contains malformed rule entries.               |
-| `policy/policy-hash-mismatch`            | Policy does not match configured `expectedHash`.                          |
-| `policy/attestation-hash-mismatch`       | Current policy evidence no longer matches the accepted attestation.       |
-| `policy/channels-denied-provider`        | An enabled channel matches a channel deny rule.                           |
-| `policy/mcp-denied-server`               | A configured MCP server is denied by policy.                              |
-| `policy/mcp-unapproved-server`           | A configured MCP server is outside the allowlist.                         |
-| `policy/models-denied-provider`          | A configured model provider or model ref uses a denied provider.          |
-| `policy/models-unapproved-provider`      | A configured model provider or model ref is outside the allowlist.        |
-| `policy/network-private-access-enabled`  | A private-network SSRF escape hatch is enabled when policy denies it.     |
-| `policy/secrets-inline-value`            | A secret input uses an inline value when policy requires a SecretRef.     |
-| `policy/secrets-unmanaged-provider`      | A SecretRef references a provider not declared under `secrets.providers`. |
-| `policy/secrets-denied-provider-source`  | A secret provider or reference uses a source denied by policy.            |
-| `policy/secrets-insecure-provider`       | A secret provider opts into insecure posture when policy denies it.       |
-| `policy/auth-profile-invalid-metadata`   | An auth profile is missing valid provider or mode metadata.               |
-| `policy/auth-profile-unapproved-mode`    | An auth profile mode is outside the policy allowlist.                     |
-| `policy/tools-missing-risk-level`        | A governed tool declaration is missing risk metadata.                     |
-| `policy/tools-unknown-risk-level`        | A governed tool declaration uses an unknown risk value.                   |
-| `policy/tools-missing-sensitivity-token` | A governed tool declaration is missing sensitivity metadata.              |
-| `policy/tools-missing-owner`             | A governed tool declaration is missing owner metadata.                    |
-| `policy/tools-unknown-sensitivity-token` | A governed tool declaration uses an unknown sensitivity value.            |
+| Check id                                 | Finding                                                                          |
+| ---------------------------------------- | -------------------------------------------------------------------------------- |
+| `policy/policy-jsonc-missing`            | Policy is enabled but `policy.jsonc` is missing.                                 |
+| `policy/policy-jsonc-invalid`            | Policy cannot be parsed or contains malformed rule entries.                      |
+| `policy/policy-hash-mismatch`            | Policy does not match configured `expectedHash`.                                 |
+| `policy/attestation-hash-mismatch`       | Current policy evidence no longer matches the accepted attestation.              |
+| `policy/channels-denied-provider`        | An enabled channel matches a channel deny rule.                                  |
+| `policy/mcp-denied-server`               | A configured MCP server is denied by policy.                                     |
+| `policy/mcp-unapproved-server`           | A configured MCP server is outside the allowlist.                                |
+| `policy/models-denied-provider`          | A configured model provider or model ref uses a denied provider.                 |
+| `policy/models-unapproved-provider`      | A configured model provider or model ref is outside the allowlist.               |
+| `policy/network-private-access-enabled`  | A private-network SSRF escape hatch is enabled when policy denies it.            |
+| `policy/secrets-unmanaged-provider`      | A config SecretRef references a provider not declared under `secrets.providers`. |
+| `policy/secrets-denied-provider-source`  | A config secret provider or SecretRef uses a source denied by policy.            |
+| `policy/secrets-insecure-provider`       | A secret provider opts into insecure posture when policy denies it.              |
+| `policy/auth-profile-invalid-metadata`   | A config auth profile is missing valid provider or mode metadata.                |
+| `policy/auth-profile-unapproved-mode`    | A config auth profile mode is outside the policy allowlist.                      |
+| `policy/tools-missing-risk-level`        | A governed tool declaration is missing risk metadata.                            |
+| `policy/tools-unknown-risk-level`        | A governed tool declaration uses an unknown risk value.                          |
+| `policy/tools-missing-sensitivity-token` | A governed tool declaration is missing sensitivity metadata.                     |
+| `policy/tools-missing-owner`             | A governed tool declaration is missing owner metadata.                           |
+| `policy/tools-unknown-sensitivity-token` | A governed tool declaration uses an unknown sensitivity value.                   |
 
 Policy findings can include both `target` and `requirement`. `target` is the
 observed workspace thing that does not conform. `requirement` is the authored
@@ -421,21 +423,6 @@ Example network finding:
   "ocPath": "oc://openclaw.config/browser/ssrfPolicy/dangerouslyAllowPrivateNetwork",
   "target": "oc://openclaw.config/browser/ssrfPolicy/dangerouslyAllowPrivateNetwork",
   "requirement": "oc://policy.jsonc/network/privateNetwork/allow"
-}
-```
-
-Example redacted secret finding:
-
-```json
-{
-  "checkId": "policy/secrets-inline-value",
-  "severity": "error",
-  "message": "A configured secret input uses an inline value where policy requires a SecretRef.",
-  "source": "policy",
-  "path": "openclaw config",
-  "ocPath": "oc://openclaw.config/models/providers/openai/apiKey",
-  "target": "oc://openclaw.config/models/providers/openai/apiKey",
-  "requirement": "oc://policy.jsonc/secrets/disallowInline"
 }
 ```
 

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -18,12 +18,13 @@ report drift through `doctor --lint`. The final conformance signal is a clean
 instead of creating a separate health gate.
 
 Policy currently manages configured channels, MCP servers, model providers,
-network SSRF posture, and governed tool declarations. For example, IT or a
-workspace operator can record that Telegram is not an approved channel
-provider, restrict MCP servers and model refs to approved entries, require
-private-network fetch/browser access to remain disabled, require governed tools
-to carry risk and sensitivity metadata, then use `doctor --lint` as the shared
-conformance gate.
+network SSRF posture, redacted secrets/auth provenance, and governed tool
+declarations. For example, IT or a workspace operator can record that Telegram
+is not an approved channel provider, restrict MCP servers and model refs to
+approved entries, require private-network fetch/browser access to remain
+disabled, require secrets to use managed references, require auth profiles to
+carry provider/mode metadata, require governed tools to carry risk and
+sensitivity metadata, then use `doctor --lint` as the shared conformance gate.
 
 Use policy when a workspace needs a durable statement such as "these channels
 must not be enabled" or "governed tools must declare approval metadata" and a
@@ -44,8 +45,8 @@ arbitrary plugins. The plugin remains enabled if `policy.jsonc` is missing, so
 doctor can report the missing artifact.
 
 Policy is authored, not generated from the user's current settings. A minimal
-policy for channels, MCP servers, model providers, network posture, and tool
-metadata looks like this:
+policy for channels, MCP servers, model providers, network posture,
+secrets/auth provenance, and tool metadata looks like this:
 
 ```jsonc
 {
@@ -75,6 +76,18 @@ metadata looks like this:
       "allow": false,
     },
   },
+  "secrets": {
+    "disallowInline": true,
+    "requireManagedProviders": true,
+    "denySources": ["exec"],
+    "allowInsecureProviders": false,
+  },
+  "auth": {
+    "profiles": {
+      "requireMetadata": ["provider", "mode"],
+      "allowModes": ["api_key", "token"],
+    },
+  },
   "tools": {
     "requireMetadata": ["risk", "sensitivity", "owner"],
   },
@@ -84,8 +97,10 @@ metadata looks like this:
 The rules are the authority. A category block is only a namespace; checks run
 when a concrete rule is present. OpenClaw reads current `channels.*` settings
 `mcp.servers.*`, `models.providers.*`, selected agent model refs, network SSRF
-settings, and `TOOLS.md` declarations as evidence, then reports observed state
-that does not conform.
+settings, secret provider/input provenance, auth profile metadata, and
+`TOOLS.md` declarations as evidence, then reports observed state that does not
+conform. Secret evidence is redacted: policy records inline-vs-SecretRef
+posture and provider/source provenance, never raw secret values.
 
 Run policy-only checks during authoring:
 
@@ -218,6 +233,31 @@ Example JSON output:
         "value": false
       }
     ],
+    "secrets": [
+      {
+        "id": "vault",
+        "kind": "provider",
+        "source": "oc://openclaw.config/secrets/providers/vault",
+        "providerSource": "file"
+      },
+      {
+        "id": "oc://openclaw.config/models/providers/openai/apiKey",
+        "kind": "input",
+        "source": "oc://openclaw.config/models/providers/openai/apiKey",
+        "provenance": "secretRef",
+        "refSource": "env",
+        "refProvider": "vault"
+      }
+    ],
+    "authProfiles": [
+      {
+        "id": "github",
+        "source": "oc://openclaw.config/auth/profiles/github",
+        "validMetadata": true,
+        "provider": "github",
+        "mode": "token"
+      }
+    ],
     "tools": [
       {
         "id": "deploy",
@@ -229,7 +269,7 @@ Example JSON output:
       }
     ]
   },
-  "checksRun": 15,
+  "checksRun": 21,
   "checksSkipped": 0,
   "findings": []
 }
@@ -277,23 +317,29 @@ choose a different interval.
 
 Policy currently verifies:
 
-| Check id                                 | Finding                                                               |
-| ---------------------------------------- | --------------------------------------------------------------------- |
-| `policy/policy-jsonc-missing`            | Policy is enabled but `policy.jsonc` is missing.                      |
-| `policy/policy-jsonc-invalid`            | Policy cannot be parsed or contains malformed rule entries.           |
-| `policy/policy-hash-mismatch`            | Policy does not match configured `expectedHash`.                      |
-| `policy/attestation-hash-mismatch`       | Current policy evidence no longer matches the accepted attestation.   |
-| `policy/channels-denied-provider`        | An enabled channel matches a channel deny rule.                       |
-| `policy/mcp-denied-server`               | A configured MCP server is denied by policy.                          |
-| `policy/mcp-unapproved-server`           | A configured MCP server is outside the allowlist.                     |
-| `policy/models-denied-provider`          | A configured model provider or model ref uses a denied provider.      |
-| `policy/models-unapproved-provider`      | A configured model provider or model ref is outside the allowlist.    |
-| `policy/network-private-access-enabled`  | A private-network SSRF escape hatch is enabled when policy denies it. |
-| `policy/tools-missing-risk-level`        | A governed tool declaration is missing risk metadata.                 |
-| `policy/tools-unknown-risk-level`        | A governed tool declaration uses an unknown risk value.               |
-| `policy/tools-missing-sensitivity-token` | A governed tool declaration is missing sensitivity metadata.          |
-| `policy/tools-missing-owner`             | A governed tool declaration is missing owner metadata.                |
-| `policy/tools-unknown-sensitivity-token` | A governed tool declaration uses an unknown sensitivity value.        |
+| Check id                                 | Finding                                                                   |
+| ---------------------------------------- | ------------------------------------------------------------------------- |
+| `policy/policy-jsonc-missing`            | Policy is enabled but `policy.jsonc` is missing.                          |
+| `policy/policy-jsonc-invalid`            | Policy cannot be parsed or contains malformed rule entries.               |
+| `policy/policy-hash-mismatch`            | Policy does not match configured `expectedHash`.                          |
+| `policy/attestation-hash-mismatch`       | Current policy evidence no longer matches the accepted attestation.       |
+| `policy/channels-denied-provider`        | An enabled channel matches a channel deny rule.                           |
+| `policy/mcp-denied-server`               | A configured MCP server is denied by policy.                              |
+| `policy/mcp-unapproved-server`           | A configured MCP server is outside the allowlist.                         |
+| `policy/models-denied-provider`          | A configured model provider or model ref uses a denied provider.          |
+| `policy/models-unapproved-provider`      | A configured model provider or model ref is outside the allowlist.        |
+| `policy/network-private-access-enabled`  | A private-network SSRF escape hatch is enabled when policy denies it.     |
+| `policy/secrets-inline-value`            | A secret input uses an inline value when policy requires a SecretRef.     |
+| `policy/secrets-unmanaged-provider`      | A SecretRef references a provider not declared under `secrets.providers`. |
+| `policy/secrets-denied-provider-source`  | A secret provider or reference uses a source denied by policy.            |
+| `policy/secrets-insecure-provider`       | A secret provider opts into insecure posture when policy denies it.       |
+| `policy/auth-profile-invalid-metadata`   | An auth profile is missing valid provider or mode metadata.               |
+| `policy/auth-profile-unapproved-mode`    | An auth profile mode is outside the policy allowlist.                     |
+| `policy/tools-missing-risk-level`        | A governed tool declaration is missing risk metadata.                     |
+| `policy/tools-unknown-risk-level`        | A governed tool declaration uses an unknown risk value.                   |
+| `policy/tools-missing-sensitivity-token` | A governed tool declaration is missing sensitivity metadata.              |
+| `policy/tools-missing-owner`             | A governed tool declaration is missing owner metadata.                    |
+| `policy/tools-unknown-sensitivity-token` | A governed tool declaration uses an unknown sensitivity value.            |
 
 Policy findings can include both `target` and `requirement`. `target` is the
 observed workspace thing that does not conform. `requirement` is the authored
@@ -375,6 +421,21 @@ Example network finding:
   "ocPath": "oc://openclaw.config/browser/ssrfPolicy/dangerouslyAllowPrivateNetwork",
   "target": "oc://openclaw.config/browser/ssrfPolicy/dangerouslyAllowPrivateNetwork",
   "requirement": "oc://policy.jsonc/network/privateNetwork/allow"
+}
+```
+
+Example redacted secret finding:
+
+```json
+{
+  "checkId": "policy/secrets-inline-value",
+  "severity": "error",
+  "message": "A configured secret input uses an inline value where policy requires a SecretRef.",
+  "source": "policy",
+  "path": "openclaw config",
+  "ocPath": "oc://openclaw.config/models/providers/openai/apiKey",
+  "target": "oc://openclaw.config/models/providers/openai/apiKey",
+  "requirement": "oc://policy.jsonc/secrets/disallowInline"
 }
 ```
 

--- a/docs/plugins/reference/policy.md
+++ b/docs/plugins/reference/policy.md
@@ -23,7 +23,8 @@ plugin; CLI command: [`openclaw policy`](/cli/policy)
 The Policy plugin contributes doctor health checks for policy-managed OpenClaw
 settings and governed workspace declarations. Policy currently covers channel
 conformance, governed tool metadata, MCP server posture, model-provider posture,
-private-network access posture, and redacted secrets/auth provenance posture.
+private-network access posture, and OpenClaw config secret provider/auth
+profile posture.
 
 Policy stores authored requirements in `policy.jsonc`, observes existing
 OpenClaw settings and workspace declarations as evidence, and reports drift

--- a/docs/plugins/reference/policy.md
+++ b/docs/plugins/reference/policy.md
@@ -16,8 +16,22 @@ Adds policy-backed doctor checks for workspace conformance.
 
 ## Surface
 
-plugin
+plugin; CLI command: [`openclaw policy`](/cli/policy)
+
+## Behavior
+
+The Policy plugin contributes doctor health checks for policy-managed OpenClaw
+settings and governed workspace declarations. Policy currently covers channel
+conformance, governed tool metadata, MCP server posture, model-provider posture,
+private-network access posture, and redacted secrets/auth provenance posture.
+
+Policy stores authored requirements in `policy.jsonc`, observes existing
+OpenClaw settings and workspace declarations as evidence, and reports drift
+through `openclaw policy check` and `openclaw doctor --lint`. A clean policy
+check emits policy, evidence, findings, and attestation hashes that operators
+can record for audit.
 
 ## Related docs
 
-- [policy](/cli/policy)
+- [Policy CLI](/cli/policy)
+- [Doctor lint mode](/cli/doctor#lint-mode)

--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -78,8 +78,6 @@ describe("policy commands", () => {
       modelProviders: [],
       modelRefs: [],
       network: [],
-      secrets: [],
-      authProfiles: [],
     };
     const workspaceHash = policyWorkspaceHash(evidence);
     const findingsHash = policyFindingsHash([]);

--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -78,6 +78,8 @@ describe("policy commands", () => {
       modelProviders: [],
       modelRefs: [],
       network: [],
+      secrets: [],
+      authProfiles: [],
     };
     const workspaceHash = policyWorkspaceHash(evidence);
     const findingsHash = policyFindingsHash([]);

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -1734,6 +1734,47 @@ describe("registerPolicyDoctorChecks", () => {
           },
         },
       },
+      tools: {
+        media: {
+          models: [
+            {
+              request: {
+                headers: {
+                  Authorization: "Bearer inline-media-model-token",
+                },
+              },
+            },
+          ],
+          audio: {
+            models: [
+              {
+                request: {
+                  proxy: {
+                    tls: {
+                      passphrase: "inline-audio-model-proxy-passphrase",
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          image: {
+            request: {
+              auth: {
+                mode: "authorization-bearer",
+                value: "inline-image-auth-value",
+              },
+            },
+          },
+          video: {
+            request: {
+              tls: {
+                key: "inline-video-tls-key",
+              },
+            },
+          },
+        },
+      },
       plugins: {
         ...baseCfg.plugins,
         entries: {
@@ -1782,6 +1823,10 @@ describe("registerPolicyDoctorChecks", () => {
     expect(JSON.stringify(evidence)).not.toContain("inline-token");
     expect(JSON.stringify(evidence)).not.toContain("inline-auth-value");
     expect(JSON.stringify(evidence)).not.toContain("inline-tls-key");
+    expect(JSON.stringify(evidence)).not.toContain("inline-media-model-token");
+    expect(JSON.stringify(evidence)).not.toContain("inline-audio-model-proxy-passphrase");
+    expect(JSON.stringify(evidence)).not.toContain("inline-image-auth-value");
+    expect(JSON.stringify(evidence)).not.toContain("inline-video-tls-key");
     expect(JSON.stringify(evidence)).not.toContain("inline-plugin-secret");
     expect(JSON.stringify(evidence)).not.toContain("inline-mcp-secret");
     expect(evidence.secrets).toEqual(
@@ -1811,6 +1856,26 @@ describe("registerPolicyDoctorChecks", () => {
         expect.objectContaining({
           kind: "input",
           provenance: "inline",
+          source: 'oc://openclaw.config/tools/media/models/"#0"/request/headers/Authorization',
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
+          source: 'oc://openclaw.config/tools/media/audio/models/"#0"/request/proxy/tls/passphrase',
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
+          source: "oc://openclaw.config/tools/media/image/request/auth/value",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
+          source: "oc://openclaw.config/tools/media/video/request/tls/key",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
           source:
             "oc://openclaw.config/plugins/entries/acpx/config/mcpServers/github/env/CUSTOM_CREDENTIAL",
         }),
@@ -1834,6 +1899,22 @@ describe("registerPolicyDoctorChecks", () => {
         expect.objectContaining({
           checkId: "policy/secrets-inline-value",
           ocPath: "oc://openclaw.config/models/providers/openai/request/tls/key",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath: 'oc://openclaw.config/tools/media/models/"#0"/request/headers/Authorization',
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath: 'oc://openclaw.config/tools/media/audio/models/"#0"/request/proxy/tls/passphrase',
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath: "oc://openclaw.config/tools/media/image/request/auth/value",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath: "oc://openclaw.config/tools/media/video/request/tls/key",
         }),
         expect.objectContaining({
           checkId: "policy/secrets-inline-value",

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -1629,6 +1629,43 @@ describe("registerPolicyDoctorChecks", () => {
     );
   });
 
+  it("uses raw config secret markers instead of resolved env values", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      models: {
+        providers: {
+          openai: { apiKey: "sk-resolved-from-env" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        models: {
+          providers: {
+            openai: { apiKey: "${OPENAI_API_KEY}" },
+          },
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        secrets: {
+          disallowInline: true,
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+  });
+
   it.each([
     ["dollar shorthand", "$OPENAI_API_KEY"],
     ["template shorthand", "${OPENAI_API_KEY}"],
@@ -1671,6 +1708,152 @@ describe("registerPolicyDoctorChecks", () => {
       ]),
     );
     expect(result.findings).toEqual([]);
+  });
+
+  it("reports secret-bearing headers and TLS refs without relying on key names", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const baseCfg = cfgWithPolicy();
+    const cfg = {
+      ...baseCfg,
+      models: {
+        providers: {
+          openai: {
+            headers: {
+              Authorization: "Bearer inline-token",
+            },
+            request: {
+              auth: {
+                mode: "authorization-bearer",
+                value: "inline-auth-value",
+              },
+              tls: {
+                key: "inline-tls-key",
+                passphrase: { source: "exec", provider: "rogue", id: "tls/passphrase" },
+              },
+            },
+          },
+        },
+      },
+      plugins: {
+        ...baseCfg.plugins,
+        entries: {
+          ...baseCfg.plugins?.entries,
+          acpx: {
+            config: {
+              mcpServers: {
+                github: {
+                  env: {
+                    CUSTOM_CREDENTIAL: "inline-plugin-secret",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      mcp: {
+        servers: {
+          docs: {
+            args: ["$HOME"],
+            env: {
+              CUSTOM_CREDENTIAL: "inline-mcp-secret",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        secrets: {
+          disallowInline: true,
+          requireManagedProviders: true,
+          denySources: ["exec"],
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+
+    expect(JSON.stringify(evidence)).not.toContain("inline-token");
+    expect(JSON.stringify(evidence)).not.toContain("inline-auth-value");
+    expect(JSON.stringify(evidence)).not.toContain("inline-tls-key");
+    expect(JSON.stringify(evidence)).not.toContain("inline-plugin-secret");
+    expect(JSON.stringify(evidence)).not.toContain("inline-mcp-secret");
+    expect(evidence.secrets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
+          source: "oc://openclaw.config/models/providers/openai/headers/Authorization",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
+          source: "oc://openclaw.config/models/providers/openai/request/auth/value",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
+          source: "oc://openclaw.config/models/providers/openai/request/tls/key",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "secretRef",
+          refSource: "exec",
+          refProvider: "rogue",
+          source: "oc://openclaw.config/models/providers/openai/request/tls/passphrase",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
+          source:
+            "oc://openclaw.config/plugins/entries/acpx/config/mcpServers/github/env/CUSTOM_CREDENTIAL",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
+          source: "oc://openclaw.config/mcp/servers/docs/env/CUSTOM_CREDENTIAL",
+        }),
+      ]),
+    );
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath: "oc://openclaw.config/models/providers/openai/headers/Authorization",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath: "oc://openclaw.config/models/providers/openai/request/auth/value",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath: "oc://openclaw.config/models/providers/openai/request/tls/key",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath:
+            "oc://openclaw.config/plugins/entries/acpx/config/mcpServers/github/env/CUSTOM_CREDENTIAL",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath: "oc://openclaw.config/mcp/servers/docs/env/CUSTOM_CREDENTIAL",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-unmanaged-provider",
+          ocPath: "oc://openclaw.config/models/providers/openai/request/tls/passphrase",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-denied-provider-source",
+          ocPath: "oc://openclaw.config/models/providers/openai/request/tls/passphrase",
+        }),
+      ]),
+    );
   });
 
   it("honors configured secret default providers when checking managed providers", async () => {

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -1554,6 +1554,81 @@ describe("registerPolicyDoctorChecks", () => {
     expect(result.findings).toHaveLength(4);
   });
 
+  it("reports inline sandbox SSH secret data without leaking values", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      agents: {
+        defaults: {
+          sandbox: {
+            backend: "ssh",
+            mode: "on",
+            ssh: {
+              identityData: "inline-private-key",
+              certificateData: "inline-certificate",
+              knownHostsData: "inline-known-hosts",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        secrets: {
+          disallowInline: true,
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+
+    expect(JSON.stringify(evidence)).not.toContain("inline-private-key");
+    expect(JSON.stringify(result.findings)).not.toContain("inline-private-key");
+    expect(evidence.secrets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
+          source: "oc://openclaw.config/agents/defaults/sandbox/ssh/identityData",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
+          source: "oc://openclaw.config/agents/defaults/sandbox/ssh/certificateData",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "inline",
+          source: "oc://openclaw.config/agents/defaults/sandbox/ssh/knownHostsData",
+        }),
+      ]),
+    );
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath: "oc://openclaw.config/agents/defaults/sandbox/ssh/identityData",
+          requirement: "oc://policy.jsonc/secrets/disallowInline",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath: "oc://openclaw.config/agents/defaults/sandbox/ssh/certificateData",
+          requirement: "oc://policy.jsonc/secrets/disallowInline",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          ocPath: "oc://openclaw.config/agents/defaults/sandbox/ssh/knownHostsData",
+          requirement: "oc://policy.jsonc/secrets/disallowInline",
+        }),
+      ]),
+    );
+  });
+
   it.each([
     ["dollar shorthand", "$OPENAI_API_KEY"],
     ["template shorthand", "${OPENAI_API_KEY}"],

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -1607,6 +1607,10 @@ describe("registerPolicyDoctorChecks", () => {
         providers: {
           openai: {
             request: {
+              auth: {
+                mode: "authorization-bearer",
+                token: { source: "exec", provider: "rogue", id: "openai/bearer-token" },
+              },
               tls: {
                 passphrase: { source: "exec", provider: "rogue", id: "tls/passphrase" },
               },
@@ -1624,12 +1628,36 @@ describe("registerPolicyDoctorChecks", () => {
           models: [
             {
               request: {
+                auth: {
+                  mode: "authorization-bearer",
+                  token: { source: "exec", provider: "rogue", id: "media/shared-token" },
+                },
                 tls: {
                   key: { source: "exec", provider: "rogue", id: "media/tls/key" },
                 },
               },
             },
           ],
+          audio: {
+            request: {
+              auth: {
+                mode: "authorization-bearer",
+                token: { source: "exec", provider: "rogue", id: "media/audio-token" },
+              },
+            },
+          },
+          image: {
+            models: [
+              {
+                request: {
+                  auth: {
+                    mode: "authorization-bearer",
+                    token: { source: "exec", provider: "rogue", id: "media/image-token" },
+                  },
+                },
+              },
+            ],
+          },
         },
       },
       plugins: {
@@ -1673,6 +1701,13 @@ describe("registerPolicyDoctorChecks", () => {
           provenance: "secretRef",
           refSource: "exec",
           refProvider: "rogue",
+          source: "oc://openclaw.config/models/providers/openai/request/auth/token",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "secretRef",
+          refSource: "exec",
+          refProvider: "rogue",
           source: "oc://openclaw.config/models/providers/openai/request/tls/passphrase",
         }),
         expect.objectContaining({
@@ -1695,12 +1730,41 @@ describe("registerPolicyDoctorChecks", () => {
           provenance: "secretRef",
           refSource: "exec",
           refProvider: "rogue",
+          source: "oc://openclaw.config/tools/media/models/#0/request/auth/token",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "secretRef",
+          refSource: "exec",
+          refProvider: "rogue",
           source: "oc://openclaw.config/tools/media/models/#0/request/tls/key",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "secretRef",
+          refSource: "exec",
+          refProvider: "rogue",
+          source: "oc://openclaw.config/tools/media/audio/request/auth/token",
+        }),
+        expect.objectContaining({
+          kind: "input",
+          provenance: "secretRef",
+          refSource: "exec",
+          refProvider: "rogue",
+          source: "oc://openclaw.config/tools/media/image/models/#0/request/auth/token",
         }),
       ]),
     );
     expect(result.findings).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/secrets-unmanaged-provider",
+          ocPath: "oc://openclaw.config/models/providers/openai/request/auth/token",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-denied-provider-source",
+          ocPath: "oc://openclaw.config/models/providers/openai/request/auth/token",
+        }),
         expect.objectContaining({
           checkId: "policy/secrets-unmanaged-provider",
           ocPath: "oc://openclaw.config/models/providers/openai/request/tls/passphrase",
@@ -1717,6 +1781,18 @@ describe("registerPolicyDoctorChecks", () => {
           checkId: "policy/secrets-denied-provider-source",
           ocPath:
             "oc://openclaw.config/plugins/entries/acpx/config/mcpServers/github/env/GITHUB_TOKEN",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-unmanaged-provider",
+          ocPath: "oc://openclaw.config/tools/media/models/#0/request/auth/token",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-denied-provider-source",
+          ocPath: "oc://openclaw.config/tools/media/audio/request/auth/token",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-unmanaged-provider",
+          ocPath: "oc://openclaw.config/tools/media/image/models/#0/request/auth/token",
         }),
         expect.objectContaining({
           checkId: "policy/secrets-unmanaged-provider",

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -125,7 +125,6 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/models-denied-provider",
       "policy/models-unapproved-provider",
       "policy/network-private-access-enabled",
-      "policy/secrets-inline-value",
       "policy/secrets-unmanaged-provider",
       "policy/secrets-denied-provider-source",
       "policy/secrets-insecure-provider",
@@ -419,7 +418,7 @@ describe("registerPolicyDoctorChecks", () => {
       checkedAt: "2026-05-10T20:00:00.000Z",
       policyPath: "policy.jsonc",
       policyHash,
-      evidence: collectPolicyEvidence({}),
+      evidence: collectPolicyEvidence({}, { includeSecrets: false, includeAuthProfiles: false }),
       findings: [],
     }).attestationHash;
     await fs.writeFile(configPath, "{}", "utf-8");
@@ -441,7 +440,7 @@ describe("registerPolicyDoctorChecks", () => {
       checkedAt: "2026-05-10T20:00:00.000Z",
       policyPath: "policy.jsonc",
       policyHash,
-      evidence: collectPolicyEvidence({}),
+      evidence: collectPolicyEvidence({}, { includeSecrets: false, includeAuthProfiles: false }),
       findings: [],
     }).attestationHash;
     await fs.writeFile(configPath, "{}", "utf-8");
@@ -453,6 +452,59 @@ describe("registerPolicyDoctorChecks", () => {
     );
 
     expect(result.findings).toEqual([]);
+  });
+
+  it("does not include unrelated secret or auth evidence in channel-only attestations", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const policy = { channels: { denyRules: [] } };
+    const policyHash = policyDocumentHash(policy);
+    const acceptedAttestationHash = createPolicyAttestation({
+      ok: true,
+      checkedAt: "2026-05-10T20:00:00.000Z",
+      policyPath: "policy.jsonc",
+      policyHash,
+      evidence: collectPolicyEvidence(
+        {
+          secrets: {
+            providers: {
+              vault: { source: "env" },
+            },
+          },
+          auth: {
+            profiles: {
+              github: { provider: "github", mode: "token" },
+            },
+          },
+        },
+        { includeSecrets: false, includeAuthProfiles: false },
+      ),
+      findings: [],
+    }).attestationHash;
+    const cfg = {
+      ...cfgWithPolicy({ expectedAttestationHash: acceptedAttestationHash }),
+      secrets: {
+        providers: {
+          changed: { source: "exec", command: "vault" },
+        },
+      },
+      auth: {
+        profiles: {
+          changed: { provider: "github", mode: "oauth" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+
+    const result = await runPolicyChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>, {
+      includeSecrets: false,
+      includeAuthProfiles: false,
+    });
+    expect(evidence).not.toHaveProperty("secrets");
+    expect(evidence).not.toHaveProperty("authProfiles");
   });
 
   it("reports configured channels denied by policy", async () => {
@@ -1486,7 +1538,7 @@ describe("registerPolicyDoctorChecks", () => {
     ]);
   });
 
-  it("reports secret provenance findings without leaking secret values", async () => {
+  it("reports secret provider conformance findings without leaking secret values", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
@@ -1498,7 +1550,6 @@ describe("registerPolicyDoctorChecks", () => {
       },
       models: {
         providers: {
-          openai: { apiKey: "plain-secret-value" },
           anthropic: { apiKey: { source: "env", provider: "missing", id: "ANTHROPIC_API_KEY" } },
         },
       },
@@ -1508,7 +1559,6 @@ describe("registerPolicyDoctorChecks", () => {
       join(workspaceDir, "policy.jsonc"),
       JSON.stringify({
         secrets: {
-          disallowInline: true,
           requireManagedProviders: true,
           denySources: ["exec"],
           allowInsecureProviders: false,
@@ -1521,16 +1571,10 @@ describe("registerPolicyDoctorChecks", () => {
     const result = await runDoctorLintChecks(ctx(configPath, cfg));
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
 
-    expect(JSON.stringify(evidence)).not.toContain("plain-secret-value");
-    expect(JSON.stringify(result.findings)).not.toContain("plain-secret-value");
+    expect(JSON.stringify(evidence)).not.toContain("ANTHROPIC_API_KEY");
+    expect(JSON.stringify(result.findings)).not.toContain("ANTHROPIC_API_KEY");
     expect(result.findings).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          severity: "error",
-          ocPath: "oc://openclaw.config/models/providers/openai/apiKey",
-          requirement: "oc://policy.jsonc/secrets/disallowInline",
-        }),
         expect.objectContaining({
           checkId: "policy/secrets-unmanaged-provider",
           severity: "error",
@@ -1551,166 +1595,10 @@ describe("registerPolicyDoctorChecks", () => {
         }),
       ]),
     );
-    expect(result.findings).toHaveLength(4);
+    expect(result.findings).toHaveLength(3);
   });
 
-  it("reports inline sandbox SSH secret data without leaking values", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    const cfg = {
-      ...cfgWithPolicy(),
-      agents: {
-        defaults: {
-          sandbox: {
-            backend: "ssh",
-            mode: "on",
-            ssh: {
-              identityData: "inline-private-key",
-              certificateData: "inline-certificate",
-              knownHostsData: "inline-known-hosts",
-            },
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        secrets: {
-          disallowInline: true,
-        },
-      }),
-      "utf-8",
-    );
-
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
-
-    expect(JSON.stringify(evidence)).not.toContain("inline-private-key");
-    expect(JSON.stringify(result.findings)).not.toContain("inline-private-key");
-    expect(evidence.secrets).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          kind: "input",
-          provenance: "inline",
-          source: "oc://openclaw.config/agents/defaults/sandbox/ssh/identityData",
-        }),
-        expect.objectContaining({
-          kind: "input",
-          provenance: "inline",
-          source: "oc://openclaw.config/agents/defaults/sandbox/ssh/certificateData",
-        }),
-        expect.objectContaining({
-          kind: "input",
-          provenance: "inline",
-          source: "oc://openclaw.config/agents/defaults/sandbox/ssh/knownHostsData",
-        }),
-      ]),
-    );
-    expect(result.findings).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath: "oc://openclaw.config/agents/defaults/sandbox/ssh/identityData",
-          requirement: "oc://policy.jsonc/secrets/disallowInline",
-        }),
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath: "oc://openclaw.config/agents/defaults/sandbox/ssh/certificateData",
-          requirement: "oc://policy.jsonc/secrets/disallowInline",
-        }),
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath: "oc://openclaw.config/agents/defaults/sandbox/ssh/knownHostsData",
-          requirement: "oc://policy.jsonc/secrets/disallowInline",
-        }),
-      ]),
-    );
-  });
-
-  it("uses raw config secret markers instead of resolved env values", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    const cfg = {
-      ...cfgWithPolicy(),
-      models: {
-        providers: {
-          openai: { apiKey: "sk-resolved-from-env" },
-        },
-      },
-    } as unknown as OpenClawConfig;
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        models: {
-          providers: {
-            openai: { apiKey: "${OPENAI_API_KEY}" },
-          },
-        },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        secrets: {
-          disallowInline: true,
-        },
-      }),
-      "utf-8",
-    );
-
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
-
-    expect(result.findings).toEqual([]);
-  });
-
-  it.each([
-    ["dollar shorthand", "$OPENAI_API_KEY"],
-    ["template shorthand", "${OPENAI_API_KEY}"],
-    ["legacy marker", "secretref-env:OPENAI_API_KEY"],
-    ["legacy double underscore marker", "__env__:OPENAI_API_KEY"],
-  ])("treats %s as SecretRef evidence, not inline secret evidence", async (_label, apiKey) => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    const cfg = {
-      ...cfgWithPolicy(),
-      models: {
-        providers: {
-          openai: { apiKey },
-        },
-      },
-    } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        secrets: {
-          disallowInline: true,
-        },
-      }),
-      "utf-8",
-    );
-
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
-    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
-
-    expect(evidence.secrets).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          kind: "input",
-          provenance: "secretRef",
-          refSource: "env",
-          refProvider: "default",
-          source: "oc://openclaw.config/models/providers/openai/apiKey",
-        }),
-      ]),
-    );
-    expect(result.findings).toEqual([]);
-  });
-
-  it("reports secret-bearing headers and TLS refs without relying on key names", async () => {
+  it("checks managed providers for structured provider request SecretRefs", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const baseCfg = cfgWithPolicy();
     const cfg = {
@@ -1718,18 +1606,15 @@ describe("registerPolicyDoctorChecks", () => {
       models: {
         providers: {
           openai: {
-            headers: {
-              Authorization: "Bearer inline-token",
-            },
             request: {
-              auth: {
-                mode: "authorization-bearer",
-                value: "inline-auth-value",
-              },
               tls: {
-                key: "inline-tls-key",
                 passphrase: { source: "exec", provider: "rogue", id: "tls/passphrase" },
               },
+            },
+          },
+          "z.ai": {
+            headers: {
+              Authorization: { source: "exec", provider: "rogue", id: "zai/authorization" },
             },
           },
         },
@@ -1739,40 +1624,12 @@ describe("registerPolicyDoctorChecks", () => {
           models: [
             {
               request: {
-                headers: {
-                  Authorization: "Bearer inline-media-model-token",
+                tls: {
+                  key: { source: "exec", provider: "rogue", id: "media/tls/key" },
                 },
               },
             },
           ],
-          audio: {
-            models: [
-              {
-                request: {
-                  proxy: {
-                    tls: {
-                      passphrase: "inline-audio-model-proxy-passphrase",
-                    },
-                  },
-                },
-              },
-            ],
-          },
-          image: {
-            request: {
-              auth: {
-                mode: "authorization-bearer",
-                value: "inline-image-auth-value",
-              },
-            },
-          },
-          video: {
-            request: {
-              tls: {
-                key: "inline-video-tls-key",
-              },
-            },
-          },
         },
       },
       plugins: {
@@ -1784,20 +1641,10 @@ describe("registerPolicyDoctorChecks", () => {
               mcpServers: {
                 github: {
                   env: {
-                    CUSTOM_CREDENTIAL: "inline-plugin-secret",
+                    GITHUB_TOKEN: { source: "exec", provider: "rogue", id: "github/token" },
                   },
                 },
               },
-            },
-          },
-        },
-      },
-      mcp: {
-        servers: {
-          docs: {
-            args: ["$HOME"],
-            env: {
-              CUSTOM_CREDENTIAL: "inline-mcp-secret",
             },
           },
         },
@@ -1808,7 +1655,6 @@ describe("registerPolicyDoctorChecks", () => {
       join(workspaceDir, "policy.jsonc"),
       JSON.stringify({
         secrets: {
-          disallowInline: true,
           requireManagedProviders: true,
           denySources: ["exec"],
         },
@@ -1820,32 +1666,8 @@ describe("registerPolicyDoctorChecks", () => {
     const result = await runDoctorLintChecks(ctx(configPath, cfg));
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
 
-    expect(JSON.stringify(evidence)).not.toContain("inline-token");
-    expect(JSON.stringify(evidence)).not.toContain("inline-auth-value");
-    expect(JSON.stringify(evidence)).not.toContain("inline-tls-key");
-    expect(JSON.stringify(evidence)).not.toContain("inline-media-model-token");
-    expect(JSON.stringify(evidence)).not.toContain("inline-audio-model-proxy-passphrase");
-    expect(JSON.stringify(evidence)).not.toContain("inline-image-auth-value");
-    expect(JSON.stringify(evidence)).not.toContain("inline-video-tls-key");
-    expect(JSON.stringify(evidence)).not.toContain("inline-plugin-secret");
-    expect(JSON.stringify(evidence)).not.toContain("inline-mcp-secret");
     expect(evidence.secrets).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          kind: "input",
-          provenance: "inline",
-          source: "oc://openclaw.config/models/providers/openai/headers/Authorization",
-        }),
-        expect.objectContaining({
-          kind: "input",
-          provenance: "inline",
-          source: "oc://openclaw.config/models/providers/openai/request/auth/value",
-        }),
-        expect.objectContaining({
-          kind: "input",
-          provenance: "inline",
-          source: "oc://openclaw.config/models/providers/openai/request/tls/key",
-        }),
         expect.objectContaining({
           kind: "input",
           provenance: "secretRef",
@@ -1855,76 +1677,30 @@ describe("registerPolicyDoctorChecks", () => {
         }),
         expect.objectContaining({
           kind: "input",
-          provenance: "inline",
-          source: 'oc://openclaw.config/tools/media/models/"#0"/request/headers/Authorization',
+          provenance: "secretRef",
+          refSource: "exec",
+          refProvider: "rogue",
+          source: 'oc://openclaw.config/models/providers/"z.ai"/headers/Authorization',
         }),
         expect.objectContaining({
           kind: "input",
-          provenance: "inline",
-          source: 'oc://openclaw.config/tools/media/audio/models/"#0"/request/proxy/tls/passphrase',
-        }),
-        expect.objectContaining({
-          kind: "input",
-          provenance: "inline",
-          source: "oc://openclaw.config/tools/media/image/request/auth/value",
-        }),
-        expect.objectContaining({
-          kind: "input",
-          provenance: "inline",
-          source: "oc://openclaw.config/tools/media/video/request/tls/key",
-        }),
-        expect.objectContaining({
-          kind: "input",
-          provenance: "inline",
+          provenance: "secretRef",
+          refSource: "exec",
+          refProvider: "rogue",
           source:
-            "oc://openclaw.config/plugins/entries/acpx/config/mcpServers/github/env/CUSTOM_CREDENTIAL",
+            "oc://openclaw.config/plugins/entries/acpx/config/mcpServers/github/env/GITHUB_TOKEN",
         }),
         expect.objectContaining({
           kind: "input",
-          provenance: "inline",
-          source: "oc://openclaw.config/mcp/servers/docs/env/CUSTOM_CREDENTIAL",
+          provenance: "secretRef",
+          refSource: "exec",
+          refProvider: "rogue",
+          source: "oc://openclaw.config/tools/media/models/#0/request/tls/key",
         }),
       ]),
     );
     expect(result.findings).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath: "oc://openclaw.config/models/providers/openai/headers/Authorization",
-        }),
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath: "oc://openclaw.config/models/providers/openai/request/auth/value",
-        }),
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath: "oc://openclaw.config/models/providers/openai/request/tls/key",
-        }),
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath: 'oc://openclaw.config/tools/media/models/"#0"/request/headers/Authorization',
-        }),
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath: 'oc://openclaw.config/tools/media/audio/models/"#0"/request/proxy/tls/passphrase',
-        }),
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath: "oc://openclaw.config/tools/media/image/request/auth/value",
-        }),
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath: "oc://openclaw.config/tools/media/video/request/tls/key",
-        }),
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath:
-            "oc://openclaw.config/plugins/entries/acpx/config/mcpServers/github/env/CUSTOM_CREDENTIAL",
-        }),
-        expect.objectContaining({
-          checkId: "policy/secrets-inline-value",
-          ocPath: "oc://openclaw.config/mcp/servers/docs/env/CUSTOM_CREDENTIAL",
-        }),
         expect.objectContaining({
           checkId: "policy/secrets-unmanaged-provider",
           ocPath: "oc://openclaw.config/models/providers/openai/request/tls/passphrase",
@@ -1932,6 +1708,19 @@ describe("registerPolicyDoctorChecks", () => {
         expect.objectContaining({
           checkId: "policy/secrets-denied-provider-source",
           ocPath: "oc://openclaw.config/models/providers/openai/request/tls/passphrase",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-unmanaged-provider",
+          ocPath: 'oc://openclaw.config/models/providers/"z.ai"/headers/Authorization',
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-denied-provider-source",
+          ocPath:
+            "oc://openclaw.config/plugins/entries/acpx/config/mcpServers/github/env/GITHUB_TOKEN",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-unmanaged-provider",
+          ocPath: "oc://openclaw.config/tools/media/models/#0/request/tls/key",
         }),
       ]),
     );
@@ -1946,7 +1735,7 @@ describe("registerPolicyDoctorChecks", () => {
           env: "vault",
         },
         providers: {
-          vault: { source: "file", path: ".secrets.json" },
+          vault: { source: "env" },
         },
       },
       models: {
@@ -1982,6 +1771,121 @@ describe("registerPolicyDoctorChecks", () => {
       ]),
     );
     expect(result.findings).toEqual([]);
+  });
+
+  it("reports SecretRefs that use a managed provider alias with the wrong source", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      secrets: {
+        providers: {
+          vault: { source: "file", path: ".secrets.json" },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            apiKey: { source: "env", provider: "vault", id: "OPENAI_API_KEY" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        secrets: {
+          requireManagedProviders: true,
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/secrets-unmanaged-provider",
+        severity: "error",
+        ocPath: "oc://openclaw.config/models/providers/openai/apiKey",
+        requirement: "oc://policy.jsonc/secrets/requireManagedProviders",
+      }),
+    ]);
+  });
+
+  it("does not treat raw MCP env values as SecretRefs", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      mcp: {
+        servers: {
+          "corp.github": {
+            env: {
+              APP_ID: "$GITHUB_APP_ID",
+              GITHUB_TOKEN: "$GITHUB_TOKEN",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        secrets: {
+          requireManagedProviders: true,
+          denySources: ["env"],
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+
+    expect(evidence.secrets).toEqual([]);
+    expect(result.findings).toEqual([]);
+  });
+
+  it("checks configured channel encryptKey SecretRefs", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      channels: {
+        feishu: {
+          encryptKey: { source: "exec", provider: "rogue", id: "feishu/encrypt-key" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        secrets: {
+          requireManagedProviders: true,
+          denySources: ["exec"],
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/secrets-unmanaged-provider",
+          ocPath: "oc://openclaw.config/channels/feishu/encryptKey",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-denied-provider-source",
+          ocPath: "oc://openclaw.config/channels/feishu/encryptKey",
+        }),
+      ]),
+    );
   });
 
   it("reports auth profiles missing required metadata or using unapproved modes", async () => {
@@ -2032,7 +1936,6 @@ describe("registerPolicyDoctorChecks", () => {
       join(workspaceDir, "policy.jsonc"),
       JSON.stringify({
         secrets: {
-          disallowInline: "true",
           requireManagedProviders: "yes",
           denySources: "exec",
           allowInsecureProviders: "false",
@@ -2048,10 +1951,6 @@ describe("registerPolicyDoctorChecks", () => {
       expect.arrayContaining([
         expect.objectContaining({
           checkId: "policy/policy-jsonc-invalid",
-          target: "oc://policy.jsonc/secrets/disallowInline",
-        }),
-        expect.objectContaining({
-          checkId: "policy/policy-jsonc-invalid",
           target: "oc://policy.jsonc/secrets/requireManagedProviders",
         }),
         expect.objectContaining({
@@ -2061,6 +1960,51 @@ describe("registerPolicyDoctorChecks", () => {
         expect.objectContaining({
           checkId: "policy/policy-jsonc-invalid",
           target: "oc://policy.jsonc/secrets/allowInsecureProviders",
+        }),
+      ]),
+    );
+  });
+
+  it("keeps secret conformance checks active when auth policy shape is invalid", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      models: {
+        providers: {
+          openai: {
+            apiKey: { source: "exec", provider: "rogue", id: "openai/api-key" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        secrets: {
+          requireManagedProviders: true,
+        },
+        auth: {
+          profiles: {
+            allowModes: "token",
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/secrets-unmanaged-provider",
+          ocPath: "oc://openclaw.config/models/providers/openai/apiKey",
+        }),
+        expect.objectContaining({
+          checkId: "policy/policy-jsonc-invalid",
+          target: "oc://policy.jsonc/auth/profiles/allowModes",
         }),
       ]),
     );

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -9,6 +9,7 @@ import {
   type HealthRepairContext,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/health";
+import { clearHealthChecksForTest } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   collectPolicyEvidence,
@@ -93,12 +94,14 @@ async function runDeniedChannelRepair(repairCheckCtx: HealthRepairContext) {
 
 describe("registerPolicyDoctorChecks", () => {
   beforeEach(async () => {
+    clearHealthChecksForTest();
     resetPolicyDoctorChecksForTest();
     workspaceDir = await fs.mkdtemp(join(tmpdir(), "policy-doctor-"));
   });
 
   afterEach(async () => {
     await fs.rm(workspaceDir, { recursive: true, force: true });
+    clearHealthChecksForTest();
     resetPolicyDoctorChecksForTest();
   });
 
@@ -122,6 +125,12 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/models-denied-provider",
       "policy/models-unapproved-provider",
       "policy/network-private-access-enabled",
+      "policy/secrets-inline-value",
+      "policy/secrets-unmanaged-provider",
+      "policy/secrets-denied-provider-source",
+      "policy/secrets-insecure-provider",
+      "policy/auth-profile-invalid-metadata",
+      "policy/auth-profile-unapproved-mode",
       "policy/tools-missing-risk-level",
       "policy/tools-unknown-risk-level",
       "policy/tools-missing-sensitivity-token",
@@ -233,11 +242,7 @@ describe("registerPolicyDoctorChecks", () => {
       "oc://policy.jsonc/mcp/servers/deny/#1",
     ],
     ["models array", { models: [] }, "oc://policy.jsonc/models"],
-    [
-      "models providers array",
-      { models: { providers: [] } },
-      "oc://policy.jsonc/models/providers",
-    ],
+    ["models providers array", { models: { providers: [] } }, "oc://policy.jsonc/models/providers"],
     [
       "models providers allow string",
       { models: { providers: { allow: "openai" } } },
@@ -259,6 +264,9 @@ describe("registerPolicyDoctorChecks", () => {
       { network: { privateNetwork: { allow: "false" } } },
       "oc://policy.jsonc/network/privateNetwork/allow",
     ],
+    ["secrets array", { secrets: [] }, "oc://policy.jsonc/secrets"],
+    ["auth array", { auth: [] }, "oc://policy.jsonc/auth"],
+    ["auth profiles array", { auth: { profiles: [] } }, "oc://policy.jsonc/auth/profiles"],
   ])("reports malformed policy shape for %s", async (_label, policy, target) => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     await fs.writeFile(configPath, "{}", "utf-8");
@@ -1217,7 +1225,9 @@ describe("registerPolicyDoctorChecks", () => {
     );
     await fs.writeFile(join(workspaceDir, "TOOLS.md"), "## Tools\n\n### deploy\n", "utf-8");
 
-    const result = await runPolicyDoctorLint(ctx(configPath, cfgWithPolicy({ enabled: undefined })));
+    const result = await runPolicyDoctorLint(
+      ctx(configPath, cfgWithPolicy({ enabled: undefined })),
+    );
 
     expect(result.findings).toEqual([]);
   });
@@ -1472,6 +1482,320 @@ describe("registerPolicyDoctorChecks", () => {
         severity: "error",
         ocPath: "oc://openclaw.config/tools/web/fetch/ssrfPolicy/allowIpv6UniqueLocalRange",
         requirement: "oc://policy.jsonc/network/privateNetwork/allow",
+      }),
+    ]);
+  });
+
+  it("reports secret provenance findings without leaking secret values", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      secrets: {
+        providers: {
+          vault: { source: "file", path: ".secrets.json", allowInsecurePath: true },
+          command: { source: "exec", command: "vault", args: ["read", "openai/api-key"] },
+        },
+      },
+      models: {
+        providers: {
+          openai: { apiKey: "plain-secret-value" },
+          anthropic: { apiKey: { source: "env", provider: "missing", id: "ANTHROPIC_API_KEY" } },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        secrets: {
+          disallowInline: true,
+          requireManagedProviders: true,
+          denySources: ["exec"],
+          allowInsecureProviders: false,
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+
+    expect(JSON.stringify(evidence)).not.toContain("plain-secret-value");
+    expect(JSON.stringify(result.findings)).not.toContain("plain-secret-value");
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/secrets-inline-value",
+          severity: "error",
+          ocPath: "oc://openclaw.config/models/providers/openai/apiKey",
+          requirement: "oc://policy.jsonc/secrets/disallowInline",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-unmanaged-provider",
+          severity: "error",
+          ocPath: "oc://openclaw.config/models/providers/anthropic/apiKey",
+          requirement: "oc://policy.jsonc/secrets/requireManagedProviders",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-denied-provider-source",
+          severity: "error",
+          ocPath: "oc://openclaw.config/secrets/providers/command",
+          requirement: "oc://policy.jsonc/secrets/denySources",
+        }),
+        expect.objectContaining({
+          checkId: "policy/secrets-insecure-provider",
+          severity: "error",
+          ocPath: "oc://openclaw.config/secrets/providers/vault",
+          requirement: "oc://policy.jsonc/secrets/allowInsecureProviders",
+        }),
+      ]),
+    );
+    expect(result.findings).toHaveLength(4);
+  });
+
+  it.each([
+    ["dollar shorthand", "$OPENAI_API_KEY"],
+    ["template shorthand", "${OPENAI_API_KEY}"],
+    ["legacy marker", "secretref-env:OPENAI_API_KEY"],
+    ["legacy double underscore marker", "__env__:OPENAI_API_KEY"],
+  ])("treats %s as SecretRef evidence, not inline secret evidence", async (_label, apiKey) => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      models: {
+        providers: {
+          openai: { apiKey },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        secrets: {
+          disallowInline: true,
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+
+    expect(evidence.secrets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "input",
+          provenance: "secretRef",
+          refSource: "env",
+          refProvider: "default",
+          source: "oc://openclaw.config/models/providers/openai/apiKey",
+        }),
+      ]),
+    );
+    expect(result.findings).toEqual([]);
+  });
+
+  it("honors configured secret default providers when checking managed providers", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      secrets: {
+        defaults: {
+          env: "vault",
+        },
+        providers: {
+          vault: { source: "file", path: ".secrets.json" },
+        },
+      },
+      models: {
+        providers: {
+          openai: { apiKey: "$OPENAI_API_KEY" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        secrets: {
+          requireManagedProviders: true,
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+
+    expect(evidence.secrets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "input",
+          provenance: "secretRef",
+          refSource: "env",
+          refProvider: "vault",
+          source: "oc://openclaw.config/models/providers/openai/apiKey",
+        }),
+      ]),
+    );
+    expect(result.findings).toEqual([]);
+  });
+
+  it("reports auth profiles missing required metadata or using unapproved modes", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      auth: {
+        profiles: {
+          missingMode: { provider: "github" },
+          oauth: { provider: "github", mode: "oauth" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        auth: {
+          profiles: { requireMetadata: ["provider", "mode"], allowModes: ["api_key", "token"] },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/auth-profile-invalid-metadata",
+        severity: "error",
+        ocPath: "oc://openclaw.config/auth/profiles/missingMode",
+        requirement: "oc://policy.jsonc/auth/profiles/requireMetadata",
+      }),
+      expect.objectContaining({
+        checkId: "policy/auth-profile-unapproved-mode",
+        severity: "error",
+        ocPath: "oc://openclaw.config/auth/profiles/oauth",
+        requirement: "oc://policy.jsonc/auth/profiles/allowModes",
+      }),
+    ]);
+  });
+
+  it("reports malformed secrets policy values before applying secrets checks", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        secrets: {
+          disallowInline: "true",
+          requireManagedProviders: "yes",
+          denySources: "exec",
+          allowInsecureProviders: "false",
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/policy-jsonc-invalid",
+          target: "oc://policy.jsonc/secrets/disallowInline",
+        }),
+        expect.objectContaining({
+          checkId: "policy/policy-jsonc-invalid",
+          target: "oc://policy.jsonc/secrets/requireManagedProviders",
+        }),
+        expect.objectContaining({
+          checkId: "policy/policy-jsonc-invalid",
+          target: "oc://policy.jsonc/secrets/denySources",
+        }),
+        expect.objectContaining({
+          checkId: "policy/policy-jsonc-invalid",
+          target: "oc://policy.jsonc/secrets/allowInsecureProviders",
+        }),
+      ]),
+    );
+  });
+
+  it("reports blank secrets deny source policy entries", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ secrets: { denySources: ["exec", " "] } }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/policy-jsonc-invalid",
+        target: "oc://policy.jsonc/secrets/denySources/#1",
+      }),
+    ]);
+  });
+
+  it("reports malformed auth profile policy values", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        auth: {
+          profiles: {
+            requireMetadata: ["provider", ""],
+            allowModes: ["api_key", "unsupported"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/policy-jsonc-invalid",
+          target: "oc://policy.jsonc/auth/profiles/requireMetadata/#1",
+        }),
+        expect.objectContaining({
+          checkId: "policy/policy-jsonc-invalid",
+          target: "oc://policy.jsonc/auth/profiles/allowModes/#1",
+        }),
+      ]),
+    );
+  });
+
+  it("reports non-array auth mode allowlists", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ auth: { profiles: { allowModes: "token" } } }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/policy-jsonc-invalid",
+        target: "oc://policy.jsonc/auth/profiles/allowModes",
       }),
     ]);
   });

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -372,9 +372,10 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
   const settings = policySettings(ctx);
   const policyPath = policyDisplayName(ctx);
   const secretsConfig = await readConfigFileForSecretEvidence(ctx);
-  let evidence: PolicyEvidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
-    ...(secretsConfig ? { secretsConfig } : {}),
-  });
+  let evidence: PolicyEvidence =
+    secretsConfig === undefined
+      ? collectPolicyEvidence(ctx.cfg as Record<string, unknown>)
+      : collectPolicyEvidence(ctx.cfg as Record<string, unknown>, { secretsConfig });
   const findings: HealthFinding[] = [];
 
   if (!policyChecksEnabled(ctx, settings)) {

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -1,16 +1,17 @@
 import { basename, isAbsolute, resolve } from "node:path";
 import JSON5 from "json5";
-import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   registerHealthCheck as registerPluginHealthCheck,
   type HealthCheck,
   type HealthCheckContext,
   type HealthFinding,
 } from "openclaw/plugin-sdk/health";
+import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   collectPolicyEvidence,
   createPolicyAttestation,
   policyDocumentHash,
+  type PolicyAuthProfileEvidence,
   type PolicyEvidence,
 } from "../policy-state.js";
 
@@ -25,6 +26,12 @@ const CHECK_IDS = {
   policyDeniedModelProvider: "policy/models-denied-provider",
   policyUnapprovedModelProvider: "policy/models-unapproved-provider",
   policyPrivateNetworkAccess: "policy/network-private-access-enabled",
+  policySecretsInlineValue: "policy/secrets-inline-value",
+  policySecretsUnmanagedProvider: "policy/secrets-unmanaged-provider",
+  policySecretsDeniedProviderSource: "policy/secrets-denied-provider-source",
+  policySecretsInsecureProvider: "policy/secrets-insecure-provider",
+  policyAuthProfileInvalidMetadata: "policy/auth-profile-invalid-metadata",
+  policyAuthProfileUnapprovedMode: "policy/auth-profile-unapproved-mode",
   policyMissingToolOwner: "policy/tools-missing-owner",
   policyMissingToolRisk: "policy/tools-missing-risk-level",
   policyMissingToolSensitivity: "policy/tools-missing-sensitivity-token",
@@ -43,6 +50,12 @@ export const POLICY_CHECK_IDS = [
   CHECK_IDS.policyDeniedModelProvider,
   CHECK_IDS.policyUnapprovedModelProvider,
   CHECK_IDS.policyPrivateNetworkAccess,
+  CHECK_IDS.policySecretsInlineValue,
+  CHECK_IDS.policySecretsUnmanagedProvider,
+  CHECK_IDS.policySecretsDeniedProviderSource,
+  CHECK_IDS.policySecretsInsecureProvider,
+  CHECK_IDS.policyAuthProfileInvalidMetadata,
+  CHECK_IDS.policyAuthProfileUnapprovedMode,
   CHECK_IDS.policyMissingToolRisk,
   CHECK_IDS.policyUnknownToolRisk,
   CHECK_IDS.policyMissingToolSensitivity,
@@ -53,6 +66,8 @@ export const POLICY_CHECK_IDS = [
 const KNOWN_RISK_LEVELS = ["low", "medium", "high", "critical"] as const;
 const KNOWN_SENSITIVITY_LEVELS = ["public", "internal", "confidential", "restricted"] as const;
 const SUPPORTED_TOOL_METADATA = ["risk", "sensitivity", "owner"] as const;
+const SUPPORTED_AUTH_PROFILE_METADATA = ["provider", "mode"] as const;
+const SUPPORTED_AUTH_PROFILE_MODES = ["api_key", "aws-sdk", "oauth", "token"] as const;
 
 let registered = false;
 const policyEvaluationCache = new WeakMap<HealthCheckContext, Promise<PolicyEvaluation>>();
@@ -88,6 +103,12 @@ export function registerPolicyDoctorChecks(host?: PolicyDoctorRegistrationHost):
   registerHealthCheck(policyModelsDeniedProviderCheck);
   registerHealthCheck(policyModelsUnapprovedProviderCheck);
   registerHealthCheck(policyNetworkPrivateAccessCheck);
+  registerHealthCheck(policySecretsInlineValueCheck);
+  registerHealthCheck(policySecretsUnmanagedProviderCheck);
+  registerHealthCheck(policySecretsDeniedProviderSourceCheck);
+  registerHealthCheck(policySecretsInsecureProviderCheck);
+  registerHealthCheck(policyAuthProfileInvalidMetadataCheck);
+  registerHealthCheck(policyAuthProfileUnapprovedModeCheck);
   registerHealthCheck(policyToolsMissingRiskCheck);
   registerHealthCheck(policyToolsUnknownRiskCheck);
   registerHealthCheck(policyToolsMissingSensitivityCheck);
@@ -235,6 +256,68 @@ const policyNetworkPrivateAccessCheck: HealthCheck = {
   },
 };
 
+const policySecretsInlineValueCheck: HealthCheck = {
+  id: CHECK_IDS.policySecretsInlineValue,
+  kind: "plugin",
+  description: "Secret inputs use managed references when policy disallows inline values.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policySecretsInlineValue);
+  },
+};
+
+const policySecretsUnmanagedProviderCheck: HealthCheck = {
+  id: CHECK_IDS.policySecretsUnmanagedProvider,
+  kind: "plugin",
+  description:
+    "Secret references use configured secret providers when policy requires managed providers.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policySecretsUnmanagedProvider);
+  },
+};
+
+const policySecretsDeniedProviderSourceCheck: HealthCheck = {
+  id: CHECK_IDS.policySecretsDeniedProviderSource,
+  kind: "plugin",
+  description: "Secret providers and references do not use sources denied by policy.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policySecretsDeniedProviderSource);
+  },
+};
+
+const policySecretsInsecureProviderCheck: HealthCheck = {
+  id: CHECK_IDS.policySecretsInsecureProvider,
+  kind: "plugin",
+  description:
+    "Configured secret providers do not opt into insecure posture unless policy allows it.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policySecretsInsecureProvider);
+  },
+};
+
+const policyAuthProfileInvalidMetadataCheck: HealthCheck = {
+  id: CHECK_IDS.policyAuthProfileInvalidMetadata,
+  kind: "plugin",
+  description: "Auth profiles declare required provider and mode metadata.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyAuthProfileInvalidMetadata);
+  },
+};
+
+const policyAuthProfileUnapprovedModeCheck: HealthCheck = {
+  id: CHECK_IDS.policyAuthProfileUnapprovedMode,
+  kind: "plugin",
+  description: "Auth profile modes stay within the policy allowlist.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyAuthProfileUnapprovedMode);
+  },
+};
+
 const policyToolsMissingRiskCheck: HealthCheck = {
   id: CHECK_IDS.policyMissingToolRisk,
   kind: "plugin",
@@ -365,6 +448,11 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     policyFile.displayName,
     policyFile.ocDocName,
   );
+  const authMetadataRequirementFindings = authProfileMetadataRequirementFindings(
+    policy,
+    policyFile.displayName,
+    policyFile.ocDocName,
+  );
   const requiredMetadata =
     metadataRequirementFindings.length === 0 ? requiredToolMetadata(policy) : new Set<string>();
   if (requiredMetadata.size > 0) {
@@ -379,6 +467,8 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     ...mcpServerFindings(policy, policyFile.ocDocName, evidence),
     ...modelProviderFindings(policy, policyFile.ocDocName, evidence),
     ...networkFindings(policy, policyFile.ocDocName, evidence),
+    ...secretAuthProvenanceFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
+    ...authMetadataRequirementFindings,
     ...metadataRequirementFindings,
   ];
   if (requiredMetadata.has("risk")) {
@@ -716,6 +806,40 @@ function policyContainerShapeFindings(
       ];
     }
   }
+  if (policy.secrets !== undefined && !isRecord(policy.secrets)) {
+    return [
+      policyShapeFinding(
+        policyPath,
+        `oc://${policyDocName}/secrets`,
+        `${policyPath} secrets must be an object.`,
+        `Fix ${policyPath} so secrets is an object.`,
+      ),
+    ];
+  }
+  if (policy.auth !== undefined && !isRecord(policy.auth)) {
+    return [
+      policyShapeFinding(
+        policyPath,
+        `oc://${policyDocName}/auth`,
+        `${policyPath} auth must be an object.`,
+        `Fix ${policyPath} so auth is an object.`,
+      ),
+    ];
+  }
+  if (
+    isRecord(policy.auth) &&
+    policy.auth.profiles !== undefined &&
+    !isRecord(policy.auth.profiles)
+  ) {
+    return [
+      policyShapeFinding(
+        policyPath,
+        `oc://${policyDocName}/auth/profiles`,
+        `${policyPath} auth.profiles must be an object.`,
+        `Fix ${policyPath} so auth.profiles is an object.`,
+      ),
+    ];
+  }
   return [];
 }
 
@@ -784,6 +908,55 @@ function policyShapeFinding(
     target,
     fixHint,
   };
+}
+
+function authProfileMetadataRequirementFindings(
+  policy: unknown,
+  policyPath: string,
+  policyDocName: string,
+): readonly HealthFinding[] {
+  if (
+    !isRecord(policy) ||
+    !isRecord(policy.auth) ||
+    !isRecord(policy.auth.profiles) ||
+    policy.auth.profiles.requireMetadata === undefined
+  ) {
+    return [];
+  }
+  if (!Array.isArray(policy.auth.profiles.requireMetadata)) {
+    return [
+      {
+        checkId: CHECK_IDS.policyInvalidFile,
+        severity: "error",
+        message: `${policyPath} auth.profiles.requireMetadata must be an array of metadata keys.`,
+        source: "policy",
+        path: policyPath,
+        target: `oc://${policyDocName}/auth/profiles/requireMetadata`,
+        fixHint: `Use supported metadata keys: ${SUPPORTED_AUTH_PROFILE_METADATA.join(", ")}.`,
+      },
+    ];
+  }
+  const invalidIndex = policy.auth.profiles.requireMetadata.findIndex(
+    (entry) =>
+      typeof entry !== "string" ||
+      !SUPPORTED_AUTH_PROFILE_METADATA.includes(
+        entry.trim().toLowerCase() as (typeof SUPPORTED_AUTH_PROFILE_METADATA)[number],
+      ),
+  );
+  if (invalidIndex < 0) {
+    return [];
+  }
+  return [
+    {
+      checkId: CHECK_IDS.policyInvalidFile,
+      severity: "error",
+      message: `${policyPath} auth.profiles.requireMetadata[${invalidIndex}] must be a supported metadata key.`,
+      source: "policy",
+      path: policyPath,
+      target: `oc://${policyDocName}/auth/profiles/requireMetadata/#${invalidIndex}`,
+      fixHint: `Use supported metadata keys: ${SUPPORTED_AUTH_PROFILE_METADATA.join(", ")}.`,
+    },
+  ];
 }
 
 function invalidChannelDenyRuleFindings(
@@ -985,6 +1158,297 @@ function networkFindings(
         target: setting.source,
         requirement: `oc://${policyDocName}/network/privateNetwork/allow`,
         fixHint: "Disable this private-network access setting or update policy after review.",
+      };
+    });
+}
+
+function secretAuthProvenanceFindings(
+  policy: unknown,
+  policyPath: string,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const invalidShapes = [
+    ...secretPolicyShapeFindings(policy, policyPath, policyDocName),
+    ...authProfileAllowModesShapeFindings(policy, policyPath, policyDocName),
+  ];
+  if (invalidShapes.length > 0) {
+    return invalidShapes;
+  }
+  return [
+    ...secretInlineFindings(policy, policyDocName, evidence),
+    ...secretManagedProviderFindings(policy, policyDocName, evidence),
+    ...secretDeniedSourceFindings(policy, policyDocName, evidence),
+    ...secretInsecureProviderFindings(policy, policyDocName, evidence),
+    ...authProfileMetadataFindings(policy, policyDocName, evidence),
+    ...authProfileModeFindings(policy, policyDocName, evidence),
+  ];
+}
+
+function secretPolicyShapeFindings(
+  policy: unknown,
+  policyPath: string,
+  policyDocName: string,
+): readonly HealthFinding[] {
+  if (!isRecord(policy) || !isRecord(policy.secrets)) {
+    return [];
+  }
+  const findings: HealthFinding[] = [];
+  for (const key of [
+    "disallowInline",
+    "requireManagedProviders",
+    "allowInsecureProviders",
+  ] as const) {
+    if (policy.secrets[key] !== undefined && typeof policy.secrets[key] !== "boolean") {
+      findings.push(
+        policyShapeFinding(
+          policyPath,
+          `oc://${policyDocName}/secrets/${key}`,
+          `${policyPath} secrets.${key} must be a boolean.`,
+          `Set secrets.${key} to true or false.`,
+        ),
+      );
+    }
+  }
+  if (policy.secrets.denySources !== undefined && !Array.isArray(policy.secrets.denySources)) {
+    findings.push(
+      policyShapeFinding(
+        policyPath,
+        `oc://${policyDocName}/secrets/denySources`,
+        `${policyPath} secrets.denySources must be an array of source names.`,
+        'Use an array such as ["exec"] or remove secrets.denySources.',
+      ),
+    );
+  } else if (Array.isArray(policy.secrets.denySources)) {
+    const invalidIndex = policy.secrets.denySources.findIndex(
+      (entry) => typeof entry !== "string" || entry.trim() === "",
+    );
+    if (invalidIndex >= 0) {
+      findings.push(
+        policyShapeFinding(
+          policyPath,
+          `oc://${policyDocName}/secrets/denySources/#${invalidIndex}`,
+          `${policyPath} secrets.denySources[${invalidIndex}] must be a non-empty source name.`,
+          "Use non-empty source names such as env, file, exec, or openclaw.",
+        ),
+      );
+    }
+  }
+  return findings;
+}
+
+function authProfileAllowModesShapeFindings(
+  policy: unknown,
+  policyPath: string,
+  policyDocName: string,
+): readonly HealthFinding[] {
+  if (
+    !isRecord(policy) ||
+    !isRecord(policy.auth) ||
+    !isRecord(policy.auth.profiles) ||
+    policy.auth.profiles.allowModes === undefined
+  ) {
+    return [];
+  }
+  if (!Array.isArray(policy.auth.profiles.allowModes)) {
+    return [
+      policyShapeFinding(
+        policyPath,
+        `oc://${policyDocName}/auth/profiles/allowModes`,
+        `${policyPath} auth.profiles.allowModes must be an array of auth modes.`,
+        `Use supported auth modes: ${SUPPORTED_AUTH_PROFILE_MODES.join(", ")}.`,
+      ),
+    ];
+  }
+  const invalidIndex = policy.auth.profiles.allowModes.findIndex(
+    (entry) =>
+      typeof entry !== "string" ||
+      !SUPPORTED_AUTH_PROFILE_MODES.includes(
+        entry.trim().toLowerCase() as (typeof SUPPORTED_AUTH_PROFILE_MODES)[number],
+      ),
+  );
+  if (invalidIndex < 0) {
+    return [];
+  }
+  return [
+    policyShapeFinding(
+      policyPath,
+      `oc://${policyDocName}/auth/profiles/allowModes/#${invalidIndex}`,
+      `${policyPath} auth.profiles.allowModes[${invalidIndex}] must be a supported auth mode.`,
+      `Use supported auth modes: ${SUPPORTED_AUTH_PROFILE_MODES.join(", ")}.`,
+    ),
+  ];
+}
+
+function secretInlineFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  if (readPolicyBoolean(policy, ["secrets", "disallowInline"]) !== true) {
+    return [];
+  }
+  return evidence.secrets
+    .filter((secret) => secret.kind === "input" && secret.provenance === "inline")
+    .map((secret): HealthFinding => {
+      return {
+        checkId: CHECK_IDS.policySecretsInlineValue,
+        severity: "error",
+        message:
+          "A configured secret input uses an inline value where policy requires a SecretRef.",
+        source: "policy",
+        path: "openclaw config",
+        ocPath: secret.source,
+        target: secret.source,
+        requirement: `oc://${policyDocName}/secrets/disallowInline`,
+        fixHint: "Move the value into a managed secret provider and replace it with a SecretRef.",
+      };
+    });
+}
+
+function secretManagedProviderFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  if (readPolicyBoolean(policy, ["secrets", "requireManagedProviders"]) !== true) {
+    return [];
+  }
+  const providerIds = new Set(
+    evidence.secrets.filter((secret) => secret.kind === "provider").map((secret) => secret.id),
+  );
+  return evidence.secrets
+    .filter(
+      (secret) =>
+        secret.kind === "input" &&
+        secret.provenance === "secretRef" &&
+        (secret.refProvider === undefined || !providerIds.has(secret.refProvider)),
+    )
+    .map((secret): HealthFinding => {
+      return {
+        checkId: CHECK_IDS.policySecretsUnmanagedProvider,
+        severity: "error",
+        message: `SecretRef uses unmanaged provider '${secret.refProvider ?? "default"}'.`,
+        source: "policy",
+        path: "openclaw config",
+        ocPath: secret.source,
+        target: secret.source,
+        requirement: `oc://${policyDocName}/secrets/requireManagedProviders`,
+        fixHint:
+          "Declare the referenced provider under secrets.providers or update policy after review.",
+      };
+    });
+}
+
+function secretDeniedSourceFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const deniedSources = new Set(readStringList(policy, ["secrets", "denySources"]));
+  if (deniedSources.size === 0) {
+    return [];
+  }
+  return evidence.secrets
+    .filter((secret) => {
+      const source = secret.kind === "provider" ? secret.providerSource : secret.refSource;
+      return source !== undefined && deniedSources.has(source);
+    })
+    .map((secret): HealthFinding => {
+      const source = secret.kind === "provider" ? secret.providerSource : secret.refSource;
+      return {
+        checkId: CHECK_IDS.policySecretsDeniedProviderSource,
+        severity: "error",
+        message: `Secret ${secret.kind} '${secret.id}' uses denied source '${source}'.`,
+        source: "policy",
+        path: "openclaw config",
+        ocPath: secret.source,
+        target: secret.source,
+        requirement: `oc://${policyDocName}/secrets/denySources`,
+        fixHint: "Move this secret to an approved source or update policy after review.",
+      };
+    });
+}
+
+function secretInsecureProviderFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  if (readPolicyBoolean(policy, ["secrets", "allowInsecureProviders"]) !== false) {
+    return [];
+  }
+  return evidence.secrets
+    .filter((secret) => secret.kind === "provider" && (secret.insecure?.length ?? 0) > 0)
+    .map((secret): HealthFinding => {
+      return {
+        checkId: CHECK_IDS.policySecretsInsecureProvider,
+        severity: "error",
+        message: `Secret provider '${secret.id}' enables insecure posture: ${(secret.insecure ?? []).join(", ")}.`,
+        source: "policy",
+        path: "openclaw config",
+        ocPath: secret.source,
+        target: secret.source,
+        requirement: `oc://${policyDocName}/secrets/allowInsecureProviders`,
+        fixHint: "Remove insecure provider overrides or update policy after review.",
+      };
+    });
+}
+
+function authProfileMetadataFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const requiredMetadata = requiredAuthProfileMetadata(policy);
+  if (requiredMetadata.size === 0) {
+    return [];
+  }
+  return evidence.authProfiles.flatMap((profile): HealthFinding[] => {
+    const missing = [...requiredMetadata].filter(
+      (metadata) => !authProfileHasMetadata(profile, metadata),
+    );
+    if (missing.length === 0) {
+      return [];
+    }
+    return [
+      {
+        checkId: CHECK_IDS.policyAuthProfileInvalidMetadata,
+        severity: "error",
+        message: `Auth profile '${profile.id}' is missing required metadata: ${missing.join(", ")}.`,
+        source: "policy",
+        path: "openclaw config",
+        ocPath: profile.source,
+        target: profile.source,
+        requirement: `oc://${policyDocName}/auth/profiles/requireMetadata`,
+        fixHint: "Set auth.profiles.<id>.provider and a supported auth profile mode.",
+      },
+    ];
+  });
+}
+
+function authProfileModeFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const allowedModes = new Set(readStringList(policy, ["auth", "profiles", "allowModes"]));
+  if (allowedModes.size === 0) {
+    return [];
+  }
+  return evidence.authProfiles
+    .filter((profile) => profile.mode !== undefined && !allowedModes.has(profile.mode))
+    .map((profile): HealthFinding => {
+      return {
+        checkId: CHECK_IDS.policyAuthProfileUnapprovedMode,
+        severity: "error",
+        message: `Auth profile '${profile.id}' uses mode '${profile.mode}' outside the policy allowlist.`,
+        source: "policy",
+        path: "openclaw config",
+        ocPath: profile.source,
+        target: profile.source,
+        requirement: `oc://${policyDocName}/auth/profiles/allowModes`,
+        fixHint: "Change the auth profile mode or update policy after review.",
       };
     });
 }
@@ -1313,6 +1777,31 @@ function policyChecksEnabled(ctx: HealthCheckContext, settings: PolicySettings):
 
 function requiredToolMetadata(policy: unknown): ReadonlySet<string> {
   return new Set(readPolicyStringArray(policy, ["tools", "requireMetadata"]) ?? []);
+}
+
+function requiredAuthProfileMetadata(
+  policy: unknown,
+): ReadonlySet<(typeof SUPPORTED_AUTH_PROFILE_METADATA)[number]> {
+  const entries = readPolicyStringArray(policy, ["auth", "profiles", "requireMetadata"]) ?? [];
+  return new Set(
+    entries.filter((entry): entry is (typeof SUPPORTED_AUTH_PROFILE_METADATA)[number] =>
+      SUPPORTED_AUTH_PROFILE_METADATA.includes(
+        entry as (typeof SUPPORTED_AUTH_PROFILE_METADATA)[number],
+      ),
+    ),
+  );
+}
+
+function authProfileHasMetadata(
+  profile: PolicyAuthProfileEvidence,
+  metadata: (typeof SUPPORTED_AUTH_PROFILE_METADATA)[number],
+): boolean {
+  if (metadata === "provider") {
+    return profile.provider !== undefined && profile.provider.trim() !== "";
+  }
+  return SUPPORTED_AUTH_PROFILE_MODES.includes(
+    profile.mode as (typeof SUPPORTED_AUTH_PROFILE_MODES)[number],
+  );
 }
 
 function readPolicyStringArray(

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -26,7 +26,6 @@ const CHECK_IDS = {
   policyDeniedModelProvider: "policy/models-denied-provider",
   policyUnapprovedModelProvider: "policy/models-unapproved-provider",
   policyPrivateNetworkAccess: "policy/network-private-access-enabled",
-  policySecretsInlineValue: "policy/secrets-inline-value",
   policySecretsUnmanagedProvider: "policy/secrets-unmanaged-provider",
   policySecretsDeniedProviderSource: "policy/secrets-denied-provider-source",
   policySecretsInsecureProvider: "policy/secrets-insecure-provider",
@@ -50,7 +49,6 @@ export const POLICY_CHECK_IDS = [
   CHECK_IDS.policyDeniedModelProvider,
   CHECK_IDS.policyUnapprovedModelProvider,
   CHECK_IDS.policyPrivateNetworkAccess,
-  CHECK_IDS.policySecretsInlineValue,
   CHECK_IDS.policySecretsUnmanagedProvider,
   CHECK_IDS.policySecretsDeniedProviderSource,
   CHECK_IDS.policySecretsInsecureProvider,
@@ -103,7 +101,6 @@ export function registerPolicyDoctorChecks(host?: PolicyDoctorRegistrationHost):
   registerHealthCheck(policyModelsDeniedProviderCheck);
   registerHealthCheck(policyModelsUnapprovedProviderCheck);
   registerHealthCheck(policyNetworkPrivateAccessCheck);
-  registerHealthCheck(policySecretsInlineValueCheck);
   registerHealthCheck(policySecretsUnmanagedProviderCheck);
   registerHealthCheck(policySecretsDeniedProviderSourceCheck);
   registerHealthCheck(policySecretsInsecureProviderCheck);
@@ -256,21 +253,11 @@ const policyNetworkPrivateAccessCheck: HealthCheck = {
   },
 };
 
-const policySecretsInlineValueCheck: HealthCheck = {
-  id: CHECK_IDS.policySecretsInlineValue,
-  kind: "plugin",
-  description: "Secret inputs use managed references when policy disallows inline values.",
-  source: "policy",
-  async detect(ctx) {
-    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policySecretsInlineValue);
-  },
-};
-
 const policySecretsUnmanagedProviderCheck: HealthCheck = {
   id: CHECK_IDS.policySecretsUnmanagedProvider,
   kind: "plugin",
   description:
-    "Secret references use configured secret providers when policy requires managed providers.",
+    "OpenClaw config SecretRefs use configured secret providers when policy requires managed providers.",
   source: "policy",
   async detect(ctx) {
     return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policySecretsUnmanagedProvider);
@@ -280,7 +267,8 @@ const policySecretsUnmanagedProviderCheck: HealthCheck = {
 const policySecretsDeniedProviderSourceCheck: HealthCheck = {
   id: CHECK_IDS.policySecretsDeniedProviderSource,
   kind: "plugin",
-  description: "Secret providers and references do not use sources denied by policy.",
+  description:
+    "OpenClaw config secret providers and SecretRefs do not use sources denied by policy.",
   source: "policy",
   async detect(ctx) {
     return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policySecretsDeniedProviderSource);
@@ -301,7 +289,7 @@ const policySecretsInsecureProviderCheck: HealthCheck = {
 const policyAuthProfileInvalidMetadataCheck: HealthCheck = {
   id: CHECK_IDS.policyAuthProfileInvalidMetadata,
   kind: "plugin",
-  description: "Auth profiles declare required provider and mode metadata.",
+  description: "OpenClaw config auth profiles declare required provider and mode metadata.",
   source: "policy",
   async detect(ctx) {
     return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyAuthProfileInvalidMetadata);
@@ -311,7 +299,7 @@ const policyAuthProfileInvalidMetadataCheck: HealthCheck = {
 const policyAuthProfileUnapprovedModeCheck: HealthCheck = {
   id: CHECK_IDS.policyAuthProfileUnapprovedMode,
   kind: "plugin",
-  description: "Auth profile modes stay within the policy allowlist.",
+  description: "OpenClaw config auth profile modes stay within the policy allowlist.",
   source: "policy",
   async detect(ctx) {
     return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyAuthProfileUnapprovedMode);
@@ -371,11 +359,10 @@ const policyToolsMissingOwnerCheck: HealthCheck = {
 async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEvaluation> {
   const settings = policySettings(ctx);
   const policyPath = policyDisplayName(ctx);
-  const secretsConfig = await readConfigFileForSecretEvidence(ctx);
-  let evidence: PolicyEvidence =
-    secretsConfig === undefined
-      ? collectPolicyEvidence(ctx.cfg as Record<string, unknown>)
-      : collectPolicyEvidence(ctx.cfg as Record<string, unknown>, { secretsConfig });
+  let evidence: PolicyEvidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
+    includeSecrets: false,
+    includeAuthProfiles: false,
+  });
   const findings: HealthFinding[] = [];
 
   if (!policyChecksEnabled(ctx, settings)) {
@@ -459,11 +446,19 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
   );
   const requiredMetadata =
     metadataRequirementFindings.length === 0 ? requiredToolMetadata(policy) : new Set<string>();
+  const includeSecrets = policyHasSecretRules(policy);
+  const includeAuthProfiles = policyHasAuthProfileRules(policy);
   if (requiredMetadata.size > 0) {
     const toolsFile = await readWorkspaceFile(ctx, "TOOLS.md");
     evidence = await collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
       toolsRaw: toolsFile?.raw ?? "",
-      ...(secretsConfig ? { secretsConfig } : {}),
+      includeSecrets,
+      includeAuthProfiles,
+    });
+  } else {
+    evidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
+      includeSecrets,
+      includeAuthProfiles,
     });
   }
   const policyFindings: HealthFinding[] = [
@@ -1173,21 +1168,44 @@ function secretAuthProvenanceFindings(
   policyDocName: string,
   evidence: PolicyEvidence,
 ): readonly HealthFinding[] {
-  const invalidShapes = [
-    ...secretPolicyShapeFindings(policy, policyPath, policyDocName),
-    ...authProfileAllowModesShapeFindings(policy, policyPath, policyDocName),
-  ];
-  if (invalidShapes.length > 0) {
-    return invalidShapes;
-  }
+  const secretShapeFindings = secretPolicyShapeFindings(policy, policyPath, policyDocName);
+  const authShapeFindings = authProfileAllowModesShapeFindings(policy, policyPath, policyDocName);
   return [
-    ...secretInlineFindings(policy, policyDocName, evidence),
-    ...secretManagedProviderFindings(policy, policyDocName, evidence),
-    ...secretDeniedSourceFindings(policy, policyDocName, evidence),
-    ...secretInsecureProviderFindings(policy, policyDocName, evidence),
-    ...authProfileMetadataFindings(policy, policyDocName, evidence),
-    ...authProfileModeFindings(policy, policyDocName, evidence),
+    ...(secretShapeFindings.length > 0
+      ? secretShapeFindings
+      : [
+          ...secretManagedProviderFindings(policy, policyDocName, evidence),
+          ...secretDeniedSourceFindings(policy, policyDocName, evidence),
+          ...secretInsecureProviderFindings(policy, policyDocName, evidence),
+        ]),
+    ...(authShapeFindings.length > 0
+      ? authShapeFindings
+      : [
+          ...authProfileMetadataFindings(policy, policyDocName, evidence),
+          ...authProfileModeFindings(policy, policyDocName, evidence),
+        ]),
   ];
+}
+
+function policyHasSecretRules(policy: unknown): boolean {
+  if (!isRecord(policy) || !isRecord(policy.secrets)) {
+    return false;
+  }
+  return (
+    policy.secrets.requireManagedProviders !== undefined ||
+    policy.secrets.denySources !== undefined ||
+    policy.secrets.allowInsecureProviders !== undefined
+  );
+}
+
+function policyHasAuthProfileRules(policy: unknown): boolean {
+  return (
+    isRecord(policy) &&
+    isRecord(policy.auth) &&
+    isRecord(policy.auth.profiles) &&
+    (policy.auth.profiles.requireMetadata !== undefined ||
+      policy.auth.profiles.allowModes !== undefined)
+  );
 }
 
 function secretPolicyShapeFindings(
@@ -1199,11 +1217,7 @@ function secretPolicyShapeFindings(
     return [];
   }
   const findings: HealthFinding[] = [];
-  for (const key of [
-    "disallowInline",
-    "requireManagedProviders",
-    "allowInsecureProviders",
-  ] as const) {
+  for (const key of ["requireManagedProviders", "allowInsecureProviders"] as const) {
     if (policy.secrets[key] !== undefined && typeof policy.secrets[key] !== "boolean") {
       findings.push(
         policyShapeFinding(
@@ -1285,32 +1299,6 @@ function authProfileAllowModesShapeFindings(
   ];
 }
 
-function secretInlineFindings(
-  policy: unknown,
-  policyDocName: string,
-  evidence: PolicyEvidence,
-): readonly HealthFinding[] {
-  if (readPolicyBoolean(policy, ["secrets", "disallowInline"]) !== true) {
-    return [];
-  }
-  return evidence.secrets
-    .filter((secret) => secret.kind === "input" && secret.provenance === "inline")
-    .map((secret): HealthFinding => {
-      return {
-        checkId: CHECK_IDS.policySecretsInlineValue,
-        severity: "error",
-        message:
-          "A configured secret input uses an inline value where policy requires a SecretRef.",
-        source: "policy",
-        path: "openclaw config",
-        ocPath: secret.source,
-        target: secret.source,
-        requirement: `oc://${policyDocName}/secrets/disallowInline`,
-        fixHint: "Move the value into a managed secret provider and replace it with a SecretRef.",
-      };
-    });
-}
-
 function secretManagedProviderFindings(
   policy: unknown,
   policyDocName: string,
@@ -1319,15 +1307,20 @@ function secretManagedProviderFindings(
   if (readPolicyBoolean(policy, ["secrets", "requireManagedProviders"]) !== true) {
     return [];
   }
-  const providerIds = new Set(
-    evidence.secrets.filter((secret) => secret.kind === "provider").map((secret) => secret.id),
+  const secrets = evidence.secrets ?? [];
+  const providerKeys = new Set(
+    secrets
+      .filter((secret) => secret.kind === "provider" && secret.providerSource !== undefined)
+      .map((secret) => `${secret.providerSource}:${secret.id}`),
   );
-  return evidence.secrets
+  return secrets
     .filter(
       (secret) =>
         secret.kind === "input" &&
         secret.provenance === "secretRef" &&
-        (secret.refProvider === undefined || !providerIds.has(secret.refProvider)),
+        (secret.refProvider === undefined ||
+          secret.refSource === undefined ||
+          !providerKeys.has(`${secret.refSource}:${secret.refProvider}`)),
     )
     .map((secret): HealthFinding => {
       return {
@@ -1354,7 +1347,7 @@ function secretDeniedSourceFindings(
   if (deniedSources.size === 0) {
     return [];
   }
-  return evidence.secrets
+  return (evidence.secrets ?? [])
     .filter((secret) => {
       const source = secret.kind === "provider" ? secret.providerSource : secret.refSource;
       return source !== undefined && deniedSources.has(source);
@@ -1383,7 +1376,7 @@ function secretInsecureProviderFindings(
   if (readPolicyBoolean(policy, ["secrets", "allowInsecureProviders"]) !== false) {
     return [];
   }
-  return evidence.secrets
+  return (evidence.secrets ?? [])
     .filter((secret) => secret.kind === "provider" && (secret.insecure?.length ?? 0) > 0)
     .map((secret): HealthFinding => {
       return {
@@ -1409,7 +1402,7 @@ function authProfileMetadataFindings(
   if (requiredMetadata.size === 0) {
     return [];
   }
-  return evidence.authProfiles.flatMap((profile): HealthFinding[] => {
+  return (evidence.authProfiles ?? []).flatMap((profile): HealthFinding[] => {
     const missing = [...requiredMetadata].filter(
       (metadata) => !authProfileHasMetadata(profile, metadata),
     );
@@ -1441,7 +1434,7 @@ function authProfileModeFindings(
   if (allowedModes.size === 0) {
     return [];
   }
-  return evidence.authProfiles
+  return (evidence.authProfiles ?? [])
     .filter((profile) => profile.mode !== undefined && !allowedModes.has(profile.mode))
     .map((profile): HealthFinding => {
       return {
@@ -1572,41 +1565,6 @@ function toolOwnerFindings(
         fixHint: "Declare owner:<team-or-person> for this tool.",
       };
     });
-}
-
-async function readConfigFileForSecretEvidence(
-  ctx: HealthCheckContext,
-): Promise<Record<string, unknown> | undefined> {
-  if (ctx.configPath === undefined) {
-    return undefined;
-  }
-  try {
-    const fs = await import("node:fs/promises");
-    const parsed = JSON5.parse(await fs.readFile(ctx.configPath, "utf-8"));
-    if (!isRecord(parsed) || !hasSecretEvidenceSurface(parsed)) {
-      return undefined;
-    }
-    return parsed;
-  } catch {
-    return undefined;
-  }
-}
-
-function hasSecretEvidenceSurface(value: Record<string, unknown>): boolean {
-  return [
-    "agents",
-    "auth",
-    "channels",
-    "cron",
-    "diagnostics",
-    "gateway",
-    "mcp",
-    "models",
-    "plugins",
-    "secrets",
-    "skills",
-    "tools",
-  ].some((key) => value[key] !== undefined);
 }
 
 async function readPolicyFile(

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -371,7 +371,10 @@ const policyToolsMissingOwnerCheck: HealthCheck = {
 async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEvaluation> {
   const settings = policySettings(ctx);
   const policyPath = policyDisplayName(ctx);
-  let evidence: PolicyEvidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>);
+  const secretsConfig = await readConfigFileForSecretEvidence(ctx);
+  let evidence: PolicyEvidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
+    ...(secretsConfig ? { secretsConfig } : {}),
+  });
   const findings: HealthFinding[] = [];
 
   if (!policyChecksEnabled(ctx, settings)) {
@@ -459,6 +462,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     const toolsFile = await readWorkspaceFile(ctx, "TOOLS.md");
     evidence = await collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
       toolsRaw: toolsFile?.raw ?? "",
+      ...(secretsConfig ? { secretsConfig } : {}),
     });
   }
   const policyFindings: HealthFinding[] = [
@@ -1567,6 +1571,41 @@ function toolOwnerFindings(
         fixHint: "Declare owner:<team-or-person> for this tool.",
       };
     });
+}
+
+async function readConfigFileForSecretEvidence(
+  ctx: HealthCheckContext,
+): Promise<Record<string, unknown> | undefined> {
+  if (ctx.configPath === undefined) {
+    return undefined;
+  }
+  try {
+    const fs = await import("node:fs/promises");
+    const parsed = JSON5.parse(await fs.readFile(ctx.configPath, "utf-8"));
+    if (!isRecord(parsed) || !hasSecretEvidenceSurface(parsed)) {
+      return undefined;
+    }
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasSecretEvidenceSurface(value: Record<string, unknown>): boolean {
+  return [
+    "agents",
+    "auth",
+    "channels",
+    "cron",
+    "diagnostics",
+    "gateway",
+    "mcp",
+    "models",
+    "plugins",
+    "secrets",
+    "skills",
+    "tools",
+  ].some((key) => value[key] !== undefined);
 }
 
 async function readPolicyFile(

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
+import { coerceSecretRef } from "openclaw/plugin-sdk/secret-input";
 
 export type PolicyAttestation = {
   readonly checkedAt: string;
@@ -22,6 +23,8 @@ export type PolicyEvidence = {
   readonly modelProviders: readonly PolicyModelProviderEvidence[];
   readonly modelRefs: readonly PolicyModelRefEvidence[];
   readonly network: readonly PolicyNetworkEvidence[];
+  readonly secrets: readonly PolicySecretEvidence[];
+  readonly authProfiles: readonly PolicyAuthProfileEvidence[];
 };
 
 export type PolicyChannelEvidence = {
@@ -66,6 +69,32 @@ export type PolicyNetworkEvidence = {
   readonly source: string;
   readonly value: boolean;
 };
+
+export type PolicySecretEvidence = {
+  readonly id: string;
+  readonly kind: "input" | "provider";
+  readonly source: string;
+  readonly provenance?: "inline" | "secretRef";
+  readonly refSource?: "env" | "file" | "exec";
+  readonly refProvider?: string;
+  readonly providerSource?: string;
+  readonly insecure?: readonly string[];
+};
+
+export type PolicyAuthProfileEvidence = {
+  readonly id: string;
+  readonly source: string;
+  readonly validMetadata: boolean;
+  readonly provider?: string;
+  readonly mode?: string;
+};
+
+type SecretRefEvidence = {
+  readonly source: "env" | "file" | "exec";
+  readonly provider: string;
+  readonly id: string;
+};
+type SecretRefDefaults = NonNullable<Parameters<typeof coerceSecretRef>[1]>;
 
 const RESERVED_CHANNEL_CONFIG_KEYS = new Set(["defaults", "modelByChannel"]);
 const NON_SLUG_CHARS = /[^a-z0-9-]+/g;
@@ -145,6 +174,8 @@ export function collectPolicyEvidence(
     modelProviders: scanPolicyModelProviders(cfg),
     modelRefs: scanPolicyModelRefs(cfg),
     network: scanPolicyNetwork(cfg),
+    secrets: scanPolicySecrets(cfg),
+    authProfiles: scanPolicyAuthProfiles(cfg),
   };
   if (options.toolsRaw === undefined) {
     return evidence;
@@ -266,6 +297,197 @@ export function scanPolicyNetwork(cfg: Record<string, unknown>): readonly Policy
       "oc://openclaw.config/tools/web/fetch/ssrfPolicy/allowIpv6UniqueLocalRange",
     ),
   ].filter((entry): entry is PolicyNetworkEvidence => entry !== undefined);
+}
+
+export function scanPolicySecrets(cfg: Record<string, unknown>): readonly PolicySecretEvidence[] {
+  return [...scanPolicySecretProviders(cfg), ...scanPolicySecretInputs(cfg)].toSorted((a, b) =>
+    a.source.localeCompare(b.source),
+  );
+}
+
+export function scanPolicyAuthProfiles(
+  cfg: Record<string, unknown>,
+): readonly PolicyAuthProfileEvidence[] {
+  const auth = isRecord(cfg.auth) ? cfg.auth : {};
+  const profiles = isRecord(auth.profiles) ? auth.profiles : {};
+  return Object.entries(profiles)
+    .toSorted(([a], [b]) => a.localeCompare(b))
+    .map(([id, value]) => {
+      const entry: {
+        id: string;
+        source: string;
+        validMetadata: boolean;
+        provider?: string;
+        mode?: string;
+      } = {
+        id,
+        source: `oc://openclaw.config/auth/profiles/${ocPathSegment(id)}`,
+        validMetadata: isValidAuthProfileMetadata(value),
+      };
+      if (isRecord(value)) {
+        if (typeof value.provider === "string") {
+          entry.provider = value.provider;
+        }
+        if (typeof value.mode === "string") {
+          entry.mode = value.mode;
+        }
+      }
+      return entry;
+    });
+}
+
+function scanPolicySecretProviders(cfg: Record<string, unknown>): readonly PolicySecretEvidence[] {
+  const secrets = isRecord(cfg.secrets) ? cfg.secrets : {};
+  const providers = isRecord(secrets.providers) ? secrets.providers : {};
+  return Object.entries(providers).map(([id, value]) => {
+    const insecure = secretProviderInsecureFlags(value);
+    const entry: {
+      id: string;
+      kind: "provider";
+      source: string;
+      providerSource?: string;
+      insecure?: readonly string[];
+    } = {
+      id,
+      kind: "provider",
+      source: `oc://openclaw.config/secrets/providers/${ocPathSegment(id)}`,
+    };
+    if (isRecord(value) && typeof value.source === "string") {
+      entry.providerSource = value.source;
+    }
+    if (insecure.length > 0) {
+      entry.insecure = insecure;
+    }
+    return entry;
+  });
+}
+
+function scanPolicySecretInputs(cfg: Record<string, unknown>): readonly PolicySecretEvidence[] {
+  const entries: PolicySecretEvidence[] = [];
+  const secrets = isRecord(cfg.secrets) ? cfg.secrets : {};
+  collectSecretInputs(entries, cfg, [], secretRefDefaults(secrets.defaults));
+  return entries;
+}
+
+function collectSecretInputs(
+  entries: PolicySecretEvidence[],
+  value: unknown,
+  path: readonly string[],
+  defaults: SecretRefDefaults | undefined,
+): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectSecretInputs(entries, item, [...path, `#${index}`], defaults),
+    );
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = [...path, key];
+    if (isSecretInputKey(key)) {
+      const source = configPathSource(childPath);
+      const ref = secretRefEvidence(child, defaults);
+      if (ref !== undefined) {
+        entries.push({
+          id: source,
+          kind: "input",
+          source,
+          provenance: "secretRef",
+          refSource: ref.source,
+          refProvider: ref.provider,
+        });
+        continue;
+      }
+      if (typeof child === "string" && child.trim() !== "") {
+        entries.push({
+          id: source,
+          kind: "input",
+          source,
+          provenance: "inline",
+        });
+        continue;
+      }
+    }
+    collectSecretInputs(entries, child, childPath, defaults);
+  }
+}
+
+function configPathSource(path: readonly string[]): string {
+  return `oc://openclaw.config/${path.map(ocPathSegment).join("/")}`;
+}
+
+function isSecretInputKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return (
+    normalized === "apikey" ||
+    normalized === "keyref" ||
+    normalized === "token" ||
+    normalized === "tokenref" ||
+    normalized === "password" ||
+    normalized === "secret" ||
+    normalized === "webhooksecret" ||
+    normalized === "serviceaccount" ||
+    normalized === "serviceaccountref" ||
+    normalized === "privatekey" ||
+    normalized === "certificate" ||
+    normalized === "knownhosts" ||
+    normalized.endsWith("apikey") ||
+    normalized.endsWith("token") ||
+    normalized.endsWith("secret") ||
+    normalized.endsWith("password")
+  );
+}
+
+function secretRefDefaults(value: unknown): SecretRefDefaults | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const defaults: SecretRefDefaults = {};
+  if (typeof value.env === "string") {
+    defaults.env = value.env;
+  }
+  if (typeof value.file === "string") {
+    defaults.file = value.file;
+  }
+  if (typeof value.exec === "string") {
+    defaults.exec = value.exec;
+  }
+  return defaults;
+}
+
+function secretRefEvidence(
+  value: unknown,
+  defaults: SecretRefDefaults | undefined,
+): SecretRefEvidence | undefined {
+  const ref = coerceSecretRef(value, defaults);
+  return ref === null ? undefined : { source: ref.source, provider: ref.provider, id: ref.id };
+}
+
+function secretProviderInsecureFlags(value: unknown): readonly string[] {
+  if (!isRecord(value)) {
+    return [];
+  }
+  return [
+    ...(value.allowInsecurePath === true ? ["allowInsecurePath"] : []),
+    ...(value.allowSymlinkCommand === true ? ["allowSymlinkCommand"] : []),
+  ];
+}
+
+function isValidAuthProfileMetadata(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    typeof value.provider === "string" &&
+    value.provider.trim() !== "" &&
+    isAuthProfileMode(value.mode)
+  );
+}
+
+function isAuthProfileMode(value: unknown): boolean {
+  return value === "api_key" || value === "aws-sdk" || value === "oauth" || value === "token";
 }
 
 export function scanPolicyTools(raw: string): Promise<readonly PolicyToolEvidence[]> {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -158,15 +158,15 @@ export function createPolicyAttestation(input: {
 
 export function collectPolicyEvidence(
   cfg: Record<string, unknown>,
-  options?: { readonly toolsRaw?: undefined },
+  options?: { readonly toolsRaw?: undefined; readonly secretsConfig?: Record<string, unknown> },
 ): PolicyEvidence;
 export function collectPolicyEvidence(
   cfg: Record<string, unknown>,
-  options: { readonly toolsRaw: string },
+  options: { readonly toolsRaw: string; readonly secretsConfig?: Record<string, unknown> },
 ): Promise<PolicyEvidence>;
 export function collectPolicyEvidence(
   cfg: Record<string, unknown>,
-  options: { readonly toolsRaw?: string } = {},
+  options: { readonly toolsRaw?: string; readonly secretsConfig?: Record<string, unknown> } = {},
 ): PolicyEvidence | Promise<PolicyEvidence> {
   const evidence: PolicyEvidence = {
     channels: scanPolicyChannels(cfg),
@@ -174,7 +174,7 @@ export function collectPolicyEvidence(
     modelProviders: scanPolicyModelProviders(cfg),
     modelRefs: scanPolicyModelRefs(cfg),
     network: scanPolicyNetwork(cfg),
-    secrets: scanPolicySecrets(cfg),
+    secrets: scanPolicySecrets(options.secretsConfig ?? cfg),
     authProfiles: scanPolicyAuthProfiles(cfg),
   };
   if (options.toolsRaw === undefined) {
@@ -386,29 +386,28 @@ function collectSecretInputs(
   }
   for (const [key, child] of Object.entries(value)) {
     const childPath = [...path, key];
-    if (isSecretInputKey(key)) {
-      const source = configPathSource(childPath);
-      const ref = secretRefEvidence(child, defaults);
-      if (ref !== undefined) {
-        entries.push({
-          id: source,
-          kind: "input",
-          source,
-          provenance: "secretRef",
-          refSource: ref.source,
-          refProvider: ref.provider,
-        });
-        continue;
-      }
-      if (typeof child === "string" && child.trim() !== "") {
-        entries.push({
-          id: source,
-          kind: "input",
-          source,
-          provenance: "inline",
-        });
-        continue;
-      }
+    const source = configPathSource(childPath);
+    const secretInputPath = isSecretInputPath(childPath);
+    const ref = secretInputPath ? secretRefEvidence(child, defaults) : undefined;
+    if (ref !== undefined) {
+      entries.push({
+        id: source,
+        kind: "input",
+        source,
+        provenance: "secretRef",
+        refSource: ref.source,
+        refProvider: ref.provider,
+      });
+      continue;
+    }
+    if (secretInputPath && typeof child === "string" && child.trim() !== "") {
+      entries.push({
+        id: source,
+        kind: "input",
+        source,
+        provenance: "inline",
+      });
+      continue;
     }
     collectSecretInputs(entries, child, childPath, defaults);
   }
@@ -416,6 +415,32 @@ function collectSecretInputs(
 
 function configPathSource(path: readonly string[]): string {
   return `oc://openclaw.config/${path.map(ocPathSegment).join("/")}`;
+}
+
+function isSecretInputPath(path: readonly string[]): boolean {
+  const key = path.at(-1);
+  if (key === undefined) {
+    return false;
+  }
+  if (isSecretInputKey(key)) {
+    return true;
+  }
+  const joined = path.join(".");
+  return (
+    /^models\.providers\.[^.]+\.headers\.[^.]+$/.test(joined) ||
+    /^models\.providers\.[^.]+\.request\.headers\.[^.]+$/.test(joined) ||
+    /^models\.providers\.[^.]+\.request\.auth\.value$/.test(joined) ||
+    /^models\.providers\.[^.]+\.request\.(?:proxy\.)?tls\.(?:ca|cert|key|passphrase)$/.test(
+      joined,
+    ) ||
+    /^tools\.media\.audio\.request\.headers\.[^.]+$/.test(joined) ||
+    /^tools\.media\.audio\.request\.auth\.value$/.test(joined) ||
+    /^tools\.media\.audio\.request\.(?:proxy\.)?tls\.(?:ca|cert|key|passphrase)$/.test(joined) ||
+    /^agents\.defaults\.memorySearch\.remote\.headers\.[^.]+$/.test(joined) ||
+    /^diagnostics\.otel\.headers\.[^.]+$/.test(joined) ||
+    /^mcp\.servers\.[^.]+\.env\.[^.]+$/.test(joined) ||
+    /^plugins\.entries\.[^.]+\.config\.mcpServers\.[^.]+\.env\.[^.]+$/.test(joined)
+  );
 }
 
 function isSecretInputKey(key: string): boolean {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -23,8 +23,8 @@ export type PolicyEvidence = {
   readonly modelProviders: readonly PolicyModelProviderEvidence[];
   readonly modelRefs: readonly PolicyModelRefEvidence[];
   readonly network: readonly PolicyNetworkEvidence[];
-  readonly secrets: readonly PolicySecretEvidence[];
-  readonly authProfiles: readonly PolicyAuthProfileEvidence[];
+  readonly secrets?: readonly PolicySecretEvidence[];
+  readonly authProfiles?: readonly PolicyAuthProfileEvidence[];
 };
 
 export type PolicyChannelEvidence = {
@@ -74,7 +74,7 @@ export type PolicySecretEvidence = {
   readonly id: string;
   readonly kind: "input" | "provider";
   readonly source: string;
-  readonly provenance?: "inline" | "secretRef";
+  readonly provenance?: "secretRef";
   readonly refSource?: "env" | "file" | "exec";
   readonly refProvider?: string;
   readonly providerSource?: string;
@@ -158,24 +158,36 @@ export function createPolicyAttestation(input: {
 
 export function collectPolicyEvidence(
   cfg: Record<string, unknown>,
-  options?: { readonly toolsRaw?: undefined; readonly secretsConfig?: Record<string, unknown> },
+  options?: {
+    readonly toolsRaw?: undefined;
+    readonly includeSecrets?: boolean;
+    readonly includeAuthProfiles?: boolean;
+  },
 ): PolicyEvidence;
 export function collectPolicyEvidence(
   cfg: Record<string, unknown>,
-  options: { readonly toolsRaw: string; readonly secretsConfig?: Record<string, unknown> },
+  options: {
+    readonly toolsRaw: string;
+    readonly includeSecrets?: boolean;
+    readonly includeAuthProfiles?: boolean;
+  },
 ): Promise<PolicyEvidence>;
 export function collectPolicyEvidence(
   cfg: Record<string, unknown>,
-  options: { readonly toolsRaw?: string; readonly secretsConfig?: Record<string, unknown> } = {},
+  options: {
+    readonly toolsRaw?: string;
+    readonly includeSecrets?: boolean;
+    readonly includeAuthProfiles?: boolean;
+  } = {},
 ): PolicyEvidence | Promise<PolicyEvidence> {
-  const evidence: PolicyEvidence = {
+  const evidence = {
     channels: scanPolicyChannels(cfg),
     mcpServers: scanPolicyMcpServers(cfg),
     modelProviders: scanPolicyModelProviders(cfg),
     modelRefs: scanPolicyModelRefs(cfg),
     network: scanPolicyNetwork(cfg),
-    secrets: scanPolicySecrets(options.secretsConfig ?? cfg),
-    authProfiles: scanPolicyAuthProfiles(cfg),
+    ...(options.includeSecrets === false ? {} : { secrets: scanPolicySecrets(cfg) }),
+    ...(options.includeAuthProfiles === false ? {} : { authProfiles: scanPolicyAuthProfiles(cfg) }),
   };
   if (options.toolsRaw === undefined) {
     return evidence;
@@ -400,15 +412,6 @@ function collectSecretInputs(
       });
       continue;
     }
-    if (secretInputPath && typeof child === "string" && child.trim() !== "") {
-      entries.push({
-        id: source,
-        kind: "input",
-        source,
-        provenance: "inline",
-      });
-      continue;
-    }
     collectSecretInputs(entries, child, childPath, defaults);
   }
 }
@@ -422,19 +425,28 @@ function isSecretInputPath(path: readonly string[]): boolean {
   if (key === undefined) {
     return false;
   }
+  if (
+    matchesConfigPath(path, ["plugins", "entries", "acpx", "config", "mcpServers", "*", "env", "*"])
+  ) {
+    return true;
+  }
+  if (isRawEnvMapValuePath(path)) {
+    return false;
+  }
   if (isSecretInputKey(key)) {
     return true;
   }
-  const joined = path.join(".");
   return (
-    /^models\.providers\.[^.]+\.headers\.[^.]+$/.test(joined) ||
+    matchesConfigPath(path, ["models", "providers", "*", "headers", "*"]) ||
     isConfiguredProviderRequestSecretPath(path, ["models", "providers", "*"]) ||
     isMediaConfiguredProviderRequestSecretPath(path) ||
-    /^agents\.defaults\.memorySearch\.remote\.headers\.[^.]+$/.test(joined) ||
-    /^diagnostics\.otel\.headers\.[^.]+$/.test(joined) ||
-    /^mcp\.servers\.[^.]+\.env\.[^.]+$/.test(joined) ||
-    /^plugins\.entries\.[^.]+\.config\.mcpServers\.[^.]+\.env\.[^.]+$/.test(joined)
+    matchesConfigPath(path, ["agents", "defaults", "memorySearch", "remote", "headers", "*"]) ||
+    matchesConfigPath(path, ["diagnostics", "otel", "headers", "*"])
   );
+}
+
+function isRawEnvMapValuePath(path: readonly string[]): boolean {
+  return path.length >= 2 && path.at(-2) === "env";
 }
 
 function isMediaConfiguredProviderRequestSecretPath(path: readonly string[]): boolean {
@@ -497,6 +509,10 @@ function matchesConfigPathPrefix(path: readonly string[], prefix: readonly strin
   });
 }
 
+function matchesConfigPath(path: readonly string[], pattern: readonly string[]): boolean {
+  return path.length === pattern.length && matchesConfigPathPrefix(path, pattern);
+}
+
 function isConfiguredProviderTlsSecretKey(key: string | undefined): boolean {
   return key === "ca" || key === "cert" || key === "key" || key === "passphrase";
 }
@@ -510,6 +526,7 @@ function isSecretInputKey(key: string): boolean {
     normalized === "tokenref" ||
     normalized === "password" ||
     normalized === "secret" ||
+    normalized === "encryptkey" ||
     normalized === "webhooksecret" ||
     normalized === "serviceaccount" ||
     normalized === "serviceaccountref" ||
@@ -869,7 +886,7 @@ function isModelSettingKey(key: string): boolean {
 }
 
 function ocPathSegment(value: string): string {
-  if (/^[A-Za-z0-9_-]+$/.test(value)) {
+  if (/^(?:[A-Za-z0-9_-]+|#\d+)$/.test(value)) {
     return value;
   }
   if (value.includes('"') || value.includes("\\")) {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -479,7 +479,7 @@ function isConfiguredProviderRequestSecretPath(
   if (suffix.length === 2 && suffix[0] === "headers") {
     return true;
   }
-  if (suffix.length === 2 && suffix[0] === "auth" && suffix[1] === "value") {
+  if (suffix.length === 2 && suffix[0] === "auth" && isConfiguredProviderAuthSecretKey(suffix[1])) {
     return true;
   }
   if (suffix.length === 2 && suffix[0] === "tls" && isConfiguredProviderTlsSecretKey(suffix[1])) {
@@ -515,6 +515,10 @@ function matchesConfigPath(path: readonly string[], pattern: readonly string[]):
 
 function isConfiguredProviderTlsSecretKey(key: string | undefined): boolean {
   return key === "ca" || key === "cert" || key === "key" || key === "passphrase";
+}
+
+function isConfiguredProviderAuthSecretKey(key: string | undefined): boolean {
+  return key === "token" || key === "value";
 }
 
 function isSecretInputKey(key: string): boolean {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -491,7 +491,7 @@ function matchesConfigPathPrefix(path: readonly string[], prefix: readonly strin
       return value !== undefined && value !== "";
     }
     if (segment === "#") {
-      return value?.startsWith("#") === true;
+      return value?.startsWith("#") ?? false;
     }
     return value === segment;
   });

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -428,19 +428,77 @@ function isSecretInputPath(path: readonly string[]): boolean {
   const joined = path.join(".");
   return (
     /^models\.providers\.[^.]+\.headers\.[^.]+$/.test(joined) ||
-    /^models\.providers\.[^.]+\.request\.headers\.[^.]+$/.test(joined) ||
-    /^models\.providers\.[^.]+\.request\.auth\.value$/.test(joined) ||
-    /^models\.providers\.[^.]+\.request\.(?:proxy\.)?tls\.(?:ca|cert|key|passphrase)$/.test(
-      joined,
-    ) ||
-    /^tools\.media\.audio\.request\.headers\.[^.]+$/.test(joined) ||
-    /^tools\.media\.audio\.request\.auth\.value$/.test(joined) ||
-    /^tools\.media\.audio\.request\.(?:proxy\.)?tls\.(?:ca|cert|key|passphrase)$/.test(joined) ||
+    isConfiguredProviderRequestSecretPath(path, ["models", "providers", "*"]) ||
+    isMediaConfiguredProviderRequestSecretPath(path) ||
     /^agents\.defaults\.memorySearch\.remote\.headers\.[^.]+$/.test(joined) ||
     /^diagnostics\.otel\.headers\.[^.]+$/.test(joined) ||
     /^mcp\.servers\.[^.]+\.env\.[^.]+$/.test(joined) ||
     /^plugins\.entries\.[^.]+\.config\.mcpServers\.[^.]+\.env\.[^.]+$/.test(joined)
   );
+}
+
+function isMediaConfiguredProviderRequestSecretPath(path: readonly string[]): boolean {
+  return (
+    isConfiguredProviderRequestSecretPath(path, ["tools", "media", "models", "#"]) ||
+    isConfiguredProviderRequestSecretPath(path, ["tools", "media", "audio"]) ||
+    isConfiguredProviderRequestSecretPath(path, ["tools", "media", "audio", "models", "#"]) ||
+    isConfiguredProviderRequestSecretPath(path, ["tools", "media", "image"]) ||
+    isConfiguredProviderRequestSecretPath(path, ["tools", "media", "image", "models", "#"]) ||
+    isConfiguredProviderRequestSecretPath(path, ["tools", "media", "video"]) ||
+    isConfiguredProviderRequestSecretPath(path, ["tools", "media", "video", "models", "#"])
+  );
+}
+
+function isConfiguredProviderRequestSecretPath(
+  path: readonly string[],
+  prefix: readonly string[],
+): boolean {
+  if (path.length < prefix.length + 3) {
+    return false;
+  }
+  if (!matchesConfigPathPrefix(path, prefix)) {
+    return false;
+  }
+  const requestIndex = prefix.length;
+  if (path[requestIndex] !== "request") {
+    return false;
+  }
+  const suffix = path.slice(requestIndex + 1);
+  if (suffix.length === 2 && suffix[0] === "headers") {
+    return true;
+  }
+  if (suffix.length === 2 && suffix[0] === "auth" && suffix[1] === "value") {
+    return true;
+  }
+  if (suffix.length === 2 && suffix[0] === "tls" && isConfiguredProviderTlsSecretKey(suffix[1])) {
+    return true;
+  }
+  return (
+    suffix.length === 3 &&
+    suffix[0] === "proxy" &&
+    suffix[1] === "tls" &&
+    isConfiguredProviderTlsSecretKey(suffix[2])
+  );
+}
+
+function matchesConfigPathPrefix(path: readonly string[], prefix: readonly string[]): boolean {
+  if (path.length < prefix.length) {
+    return false;
+  }
+  return prefix.every((segment, index) => {
+    const value = path[index];
+    if (segment === "*") {
+      return value !== undefined && value !== "";
+    }
+    if (segment === "#") {
+      return value?.startsWith("#") === true;
+    }
+    return value === segment;
+  });
+}
+
+function isConfiguredProviderTlsSecretKey(key: string | undefined): boolean {
+  return key === "ca" || key === "cert" || key === "key" || key === "passphrase";
 }
 
 function isSecretInputKey(key: string): boolean {

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -432,7 +432,10 @@ function isSecretInputKey(key: string): boolean {
     normalized === "serviceaccountref" ||
     normalized === "privatekey" ||
     normalized === "certificate" ||
+    normalized === "certificatedata" ||
+    normalized === "identitydata" ||
     normalized === "knownhosts" ||
+    normalized === "knownhostsdata" ||
     normalized.endsWith("apikey") ||
     normalized.endsWith("token") ||
     normalized.endsWith("secret") ||

--- a/src/plugin-sdk/plugin-test-runtime.ts
+++ b/src/plugin-sdk/plugin-test-runtime.ts
@@ -36,6 +36,7 @@ export {
   resetFacadeRuntimeStateForTest,
 } from "./facade-runtime.js";
 export { capturePluginRegistration } from "../plugins/captured-registration.js";
+export { clearHealthChecksForTest } from "../flows/health-check-registry.js";
 export { runProviderCatalog } from "../plugins/provider-discovery.js";
 export {
   buildProviderPluginMethodChoice,


### PR DESCRIPTION
## Summary

Adds Policy 1.0 secret provenance and auth-profile conformance checks with redacted config evidence.

Logical base: merged #80783. This PR intentionally stays config-level only: it reads existing OpenClaw config and reports policy conformance findings through `doctor --lint`; it does not add runtime enforcement and it does not take on secrets management.

- Records managed SecretRef/provider provenance without storing secret values.
- Reports unmanaged SecretRefs, denied secret provider sources, insecure secret provider posture, missing auth profile metadata, and unapproved auth profile modes.
- Documents the offered policy syntax and evidence shape.

## Policy syntax

```jsonc
{
  "secrets": {
    "requireManagedProviders": true,
    "denySources": ["exec"],
    "allowInsecureProviders": false
  },
  "auth": {
    "profiles": {
      "requireMetadata": ["provider", "mode"],
      "allowModes": ["api_key", "token"]
    }
  }
}
```

## Safety

This is policy conformance, not secrets regulation or storage management. `doctor --lint` reads config-level declarations, emits redacted findings, and leaves credential stores and runtime behavior to the existing auth/credential systems.

## Real behavior proof

Behavior addressed: config-level Policy conformance for redacted secret provenance and auth-profile metadata/mode rules.

Real environment tested: WSL checkout at `/root/src/openclaw-81974-policy` on Ubuntu-24.04; PR head `d72baa8115b12041a1c532479e919480c46eda57` is signed and GitHub-verified.

Exact steps or command run after this patch:

- `git push fork policy-81974-config:policy-secrets-auth-provenance`
- `OPENCLAW_CONFIG_PATH=/tmp/policy-proof-81974/openclaw.json timeout 180 node scripts/run-node.mjs doctor --lint --json --severity-min error`
- Earlier same-head verification: `pnpm exec oxfmt extensions/policy/src/doctor/register.ts extensions/policy/src/policy-state.ts`
- Earlier same-head verification: `git diff --check`
- Earlier same-head verification: `pnpm run lint:extensions:bundled`
- Earlier same-head verification: `node scripts/run-vitest.mjs extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts --run --reporter=dot`
- Earlier same-head verification: `node node_modules/@typescript/native-preview/bin/tsgo.js -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test-policy-81974-original-lint.tsbuildinfo`
- Earlier same-head verification: autoreview local pass #1 and #2 clean, no accepted/actionable findings

Evidence after fix: the real `doctor --lint` CLI run loaded a temp workspace policy and config, ran 37 checks, and returned four redacted policy errors:

```json
{
  "ok": false,
  "checksRun": 37,
  "checksSkipped": 0,
  "findings": [
    {
      "checkId": "policy/auth-profile-unapproved-mode",
      "ocPath": "oc://openclaw.config/auth/profiles/oauth",
      "requirement": "oc://policy.jsonc/auth/profiles/allowModes",
      "message": "Auth profile 'oauth' uses mode 'oauth' outside the policy allowlist."
    },
    {
      "checkId": "policy/secrets-denied-provider-source",
      "ocPath": "oc://openclaw.config/secrets/providers/command",
      "requirement": "oc://policy.jsonc/secrets/denySources",
      "message": "Secret provider 'command' uses denied source 'exec'."
    },
    {
      "checkId": "policy/secrets-insecure-provider",
      "ocPath": "oc://openclaw.config/secrets/providers/vault",
      "requirement": "oc://policy.jsonc/secrets/allowInsecureProviders",
      "message": "Secret provider 'vault' enables insecure posture: allowInsecurePath."
    },
    {
      "checkId": "policy/secrets-unmanaged-provider",
      "ocPath": "oc://openclaw.config/models/providers/anthropic/apiKey",
      "requirement": "oc://policy.jsonc/secrets/requireManagedProviders",
      "message": "SecretRef uses unmanaged provider 'missing'."
    }
  ]
}
```

Observed result after fix: the CLI reported the expected secret/auth conformance findings through `doctor --lint` without printing private secret values.

What was not tested: no live Gateway was launched; this is config-level policy conformance proof only.

## Related

- #80783 - Policy: add model, network, and MCP conformance checks
- #81981 - Policy: add gateway exposure checks
