### PR TITLE
fix(telegram): initialize isolated polling bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Config/doctor: rotate capped `.clobbered.*` repair snapshots by artifact timestamp so repeated repairs keep the newest forensic copy instead of preserving only the first capped set. (#82012) Thanks @Kaspre.
+- Telegram: initialize the bot before isolated polling drains spooled updates so default isolated polling no longer retries every update with `Bot not initialized` and stalls replies. Fixes #81973. (#81975) Thanks @neeravmakwana.
 - Telegram: apply method-aware Bot API request timeouts to direct message/action clients so `openclaw message delete --channel telegram` no longer waits on grammY's 500-second default when the API request wedges. Fixes #81908. Thanks @DashLabsDev.
 - Cron: treat attempt dispatch and assembled context as execution-start milestones so isolated agent jobs that have reached backend dispatch are governed by their configured job timeout instead of the 60s pre-execution watchdog. Fixes #81368. (#81871) Thanks @alexph-dev.
 - Doctor/auth: warn about stale per-agent OAuth auth profile shadows and let `openclaw doctor --fix` remove the local shadow so agents inherit the fresher main-agent credential.

--- a/extensions/telegram/src/bot-handlers.media.ts
+++ b/extensions/telegram/src/bot-handlers.media.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@grammyjs/types";
+import type { Message } from "grammy/types";
 import { MediaFetchError } from "openclaw/plugin-sdk/media-runtime";
 
 export function isMediaSizeLimitError(err: unknown): boolean {

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1,4 +1,4 @@
-import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
+import type { Message, ReactionTypeEmoji } from "grammy/types";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-helpers";
 import {

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -1,4 +1,4 @@
-import type { ReactionTypeEmoji } from "@grammyjs/types";
+import type { ReactionTypeEmoji } from "grammy/types";
 import {
   resolveAckReaction,
   shouldAckReaction as shouldAckReactionGate,

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
-import type { LanguageCode } from "@grammyjs/types";
 import type { Bot } from "grammy";
+import type { LanguageCode } from "grammy/types";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {

--- a/extensions/telegram/src/bot-updates.ts
+++ b/extensions/telegram/src/bot-updates.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@grammyjs/types";
+import type { Message } from "grammy/types";
 import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import type { TelegramContext } from "./bot/types.js";
 

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -1,4 +1,4 @@
-import type { Chat, Message, MessageOrigin, User } from "@grammyjs/types";
+import type { Chat, Message, MessageOrigin, User } from "grammy/types";
 import type { NormalizedLocation } from "openclaw/plugin-sdk/channel-inbound";
 import {
   normalizeLowercaseStringOrEmpty,

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@grammyjs/types";
+import type { Message } from "grammy/types";
 import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveMedia } from "./delivery.resolve-media.js";

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -1,4 +1,4 @@
-import type { Chat, Message } from "@grammyjs/types";
+import type { Chat, Message } from "grammy/types";
 import { formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
 import {
   resolveCommandAuthorization,

--- a/extensions/telegram/src/bot/types.ts
+++ b/extensions/telegram/src/bot/types.ts
@@ -1,4 +1,4 @@
-import type { ChatFullInfo, Message, UserFromGetMe } from "@grammyjs/types";
+import type { ChatFullInfo, Message, UserFromGetMe } from "grammy/types";
 
 /** App-specific stream mode for Telegram stream previews. */
 export type TelegramStreamMode = "off" | "partial" | "block" | "progress";

--- a/extensions/telegram/src/dm-access.test.ts
+++ b/extensions/telegram/src/dm-access.test.ts
@@ -31,7 +31,7 @@ vi.mock("./api-logging.js", () => ({
   withTelegramApiErrorLogging: withTelegramApiErrorLoggingMock,
 }));
 
-import type { Message } from "@grammyjs/types";
+import type { Message } from "grammy/types";
 import { normalizeAllowFrom } from "./bot-access.js";
 let enforceTelegramDmAccess: typeof import("./dm-access.js").enforceTelegramDmAccess;
 

--- a/extensions/telegram/src/dm-access.ts
+++ b/extensions/telegram/src/dm-access.ts
@@ -1,5 +1,5 @@
-import type { Message } from "@grammyjs/types";
 import type { Bot } from "grammy";
+import type { Message } from "grammy/types";
 import { createChannelPairingChallengeIssuer } from "openclaw/plugin-sdk/channel-pairing";
 import type { DmPolicy } from "openclaw/plugin-sdk/config-contracts";
 import { upsertChannelPairingRequest } from "openclaw/plugin-sdk/conversation-runtime";

--- a/extensions/telegram/src/inline-keyboard.ts
+++ b/extensions/telegram/src/inline-keyboard.ts
@@ -1,4 +1,4 @@
-import type { InlineKeyboardButton, InlineKeyboardMarkup } from "@grammyjs/types";
+import type { InlineKeyboardButton, InlineKeyboardMarkup } from "grammy/types";
 import type { TelegramInlineButtons } from "./button-types.js";
 
 function toInlineKeyboardButton(

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -1,5 +1,5 @@
 import { readFile, rm, writeFile } from "node:fs/promises";
-import type { Message } from "@grammyjs/types";
+import type { Message } from "grammy/types";
 import { describe, expect, it } from "vitest";
 import {
   buildTelegramConversationContext,

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import type { Message } from "@grammyjs/types";
+import type { Message } from "grammy/types";
 import { formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -387,7 +387,7 @@ describe("TelegramPollingSession", () => {
     expect(bot.api.getUpdates).not.toHaveBeenCalled();
   });
 
-  it("drains isolated ingress spool through the main-thread bot without offset watermark skipping", async () => {
+  it("initializes the main-thread bot before draining isolated ingress spool", async () => {
     const abort = new AbortController();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
     const handleUpdate = vi.fn(async () => undefined);

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -391,11 +391,13 @@ describe("TelegramPollingSession", () => {
     const abort = new AbortController();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
     const handleUpdate = vi.fn(async () => undefined);
+    const init = vi.fn(async () => undefined);
     const bot = {
       api: {
         deleteWebhook: vi.fn(async () => true),
         config: { use: vi.fn() },
       },
+      init,
       handleUpdate,
       stop: vi.fn(async () => undefined),
     };
@@ -445,6 +447,7 @@ describe("TelegramPollingSession", () => {
       expect(
         mockObjectArg(createTelegramBotMock, "createTelegramBot").updateOffset,
       ).toBeUndefined();
+      expect(init).toHaveBeenCalledBefore(handleUpdate);
       expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } });
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
@@ -479,6 +482,7 @@ describe("TelegramPollingSession", () => {
         deleteWebhook: vi.fn(async () => true),
         config: { use: vi.fn() },
       },
+      init: vi.fn(async () => undefined),
       handleUpdate,
       stop: vi.fn(async () => undefined),
     };
@@ -575,6 +579,7 @@ describe("TelegramPollingSession", () => {
         deleteWebhook: vi.fn(async () => true),
         config: { use: vi.fn() },
       },
+      init: vi.fn(async () => undefined),
       handleUpdate,
       stop: vi.fn(async () => undefined),
     };
@@ -666,6 +671,7 @@ describe("TelegramPollingSession", () => {
         deleteWebhook: vi.fn(async () => true),
         config: { use: vi.fn() },
       },
+      init: vi.fn(async () => undefined),
       handleUpdate,
       stop: vi.fn(async () => undefined),
     };
@@ -746,6 +752,7 @@ describe("TelegramPollingSession", () => {
         deleteWebhook: vi.fn(async () => true),
         config: { use: vi.fn() },
       },
+      init: vi.fn(async () => undefined),
       handleUpdate,
       stop: vi.fn(async () => {
         events.push("bot:stop");

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -315,6 +315,15 @@ export class TelegramPollingSession {
     if (!ingress?.enabled) {
       return this.#runPollingCycle(bot);
     }
+    try {
+      await bot.init();
+    } catch (err) {
+      const shouldRetry = await this.#waitBeforeRetryOnRecoverableSetupError(
+        err,
+        "Telegram bot init failed",
+      );
+      return shouldRetry ? "continue" : "exit";
+    }
     const spoolDir =
       ingress.spoolDir ?? resolveTelegramIngressSpoolDir({ accountId: this.opts.accountId });
     const workerFactory = ingress.createWorker ?? createTelegramIngressWorker;

--- a/extensions/telegram/src/reply-parameters.ts
+++ b/extensions/telegram/src/reply-parameters.ts
@@ -1,4 +1,4 @@
-import type { MessageEntity } from "@grammyjs/types";
+import type { MessageEntity } from "grammy/types";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
 import { normalizeTelegramReplyToMessageId } from "./outbound-params.js";
 

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1,6 +1,6 @@
-import type { ReactionType, ReactionTypeEmoji } from "@grammyjs/types";
 import * as grammy from "grammy";
 import { type ApiClientOptions, Bot, HttpError } from "grammy";
+import type { ReactionType, ReactionTypeEmoji } from "grammy/types";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { formatUncaughtError } from "openclaw/plugin-sdk/error-runtime";

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -1,4 +1,4 @@
-import type { Chat, Message } from "@grammyjs/types";
+import type { Chat, Message } from "grammy/types";
 import { describe, expect, it } from "vitest";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -1,4 +1,4 @@
-import type { Message, UserFromGetMe } from "@grammyjs/types";
+import type { Message, UserFromGetMe } from "grammy/types";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import {
   listChatCommands,

--- a/extensions/telegram/src/status-reaction-variants.ts
+++ b/extensions/telegram/src/status-reaction-variants.ts
@@ -1,4 +1,4 @@
-import type { ReactionTypeEmoji } from "@grammyjs/types";
+import type { ReactionTypeEmoji } from "grammy/types";
 import { DEFAULT_EMOJIS, type StatusReactionEmojis } from "openclaw/plugin-sdk/channel-feedback";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { TelegramChatDetails, TelegramGetChat } from "./bot/types.js";

--- a/test/tsconfig/tsconfig.test.json
+++ b/test/tsconfig/tsconfig.test.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../.."
+  },
   "include": [
     "../../src/**/*.d.ts",
     "../../src/**/*.test.ts",


### PR DESCRIPTION
## Summary
- Initialize the grammY bot before isolated polling ingress drains spooled updates through `handleUpdate`.
- Keep the existing recoverable setup retry path for init failures so transient Telegram/network errors restart the polling cycle instead of wedging the drain.
- Add a focused Telegram polling-session regression that asserts init completes before the spooled update handler runs.

## Root Cause
Isolated polling ingress bypasses `@grammyjs/runner` and dispatches spooled updates directly through `bot.handleUpdate(update)`. grammY requires `bot.init()` or constructor `botInfo` before `handleUpdate`; most polling bots are created without `botInfo`, so isolated ingress could repeatedly fail with `Bot not initialized!` and leave spool files in place.

## Linked Issue
Fixes #81973.

## Why This Is Safe
`bot.init()` is grammY's normal initialization path and is idempotent when bot info is already available. The change runs only in the isolated-ingress path, before the worker and drain timer start, and reuses the existing recoverable setup retry behavior.

## Security / Runtime Controls
Security posture and runtime policy are unchanged. This does not change Telegram token handling, webhook cleanup policy, ingress spool file ownership, message filtering, command authorization, or prompt text; it only initializes the existing bot instance before dispatching updates.

## Real Behavior Proof
Behavior addressed: isolated polling ingress no longer calls `handleUpdate` on an uninitialized grammY bot.
Real environment tested: local PR checkout/package `OpenClaw 2026.5.14 (cbba677)` with a real Telegram bot token from local env, public Telegram config, and default isolated polling ingress.
Exact steps or command run after this patch: verified Bot API `getMe`; ran focused Telegram tests; attempted the official direct Telegram QA env lane; then started the PR gateway with `TELEGRAM_BOT_TOKEN` and sent a real Telegram `/status` DM to the bot.
Evidence after fix: redacted runtime log and terminal output from a real Telegram gateway run after this patch:

```text
$ openclaw --version
OpenClaw 2026.5.14 (cbba677)
$ openclaw gateway start
[telegram][diag] isolated polling ingress started spool=<redacted>
[telegram] sendMessage ok chat=<redacted> message=<redacted>
$ rg "Bot not initialized" /tmp/openclaw/openclaw-<redacted>.log
(no matches)
```

Observed result after fix: Telegram isolated polling initialized the grammY bot, processed the inbound update, and sent a Telegram reply successfully.
What was not tested: the official bot-to-bot `openclaw qa telegram` lane did not run from this local env because it requires `OPENCLAW_QA_TELEGRAM_GROUP_ID` plus distinct driver/SUT bot tokens; the provided env had only the SUT-style `telegram_bot_token`.

## Out Of Scope
- Changing isolated ingress worker polling behavior or spool persistence format.
- Changing Telegram webhook cleanup, token resolution, or delivery policy.
- Adding live Telegram E2E coverage.

AI-assisted: yes.

Made with [Cursor](https://cursor.com)
