### PR TITLE
fix(maintainer): gate body notifications after redaction

### DIFF
--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -34,10 +34,10 @@ Supports single or multiple alerts. For multiple alerts, process in ascending or
 For each alert:
 
 1. **Identify** — `fetch-alert` + `fetch-content` to get metadata and body
-2. **Decide** — Agent reads the body file, identifies all secrets, produces redacted version
-3. **Redact** — `redact-body` for issue/PR body; skip for comments (delete directly)
+2. **Decide** — Agent reads the body file, identifies whether plaintext secrets remain, and produces a redacted version only when needed
+3. **Redact** — `redact-body-if-needed` for issue/PR body; skip for comments (delete directly)
 4. **Purge** — `delete-comment` + `recreate-comment` for comments; cannot purge body history
-5. **Notify** — `notify` posts the right template per location type
+5. **Notify** — `notify` posts the right template per location type, unless the current issue/PR body is already redacted
 6. **Resolve** — `resolve` closes the alert
 7. **Summary** — `summary` prints formatted results
 
@@ -81,10 +81,19 @@ The `fetch-content` output includes:
 The agent reads the body file from `fetch-content` output and:
 
 1. Identifies ALL secrets in the content (there may be more than the alert flagged)
-2. Replaces each secret with `[REDACTED <secret_type>]` — **no partial values, no prefix/suffix**
-3. Saves the redacted content to a new temp file
+2. Determines whether any plaintext credential remains in the current body
+3. Replaces each remaining secret with `[REDACTED <secret_type>]` — **no partial values, no prefix/suffix**
+4. Saves the redacted content to a new temp file
 
 This is the only step that requires semantic understanding. Everything else is mechanical.
+
+For `issue_body` and `pull_request_body`: if the current body has already been redacted by the author and no plaintext credential remains, **do not post a public notification comment**. Resolve the alert with a maintainer-only resolution comment such as:
+
+```bash
+node secret-scanning.mjs resolve <ALERT_NUMBER> revoked "Current issue/PR body is already redacted; no public notification posted."
+```
+
+This avoids creating a fresh public pointer to historical sensitive content.
 
 ## Step 3: Redact
 
@@ -95,8 +104,10 @@ This is the only step that requires semantic understanding. Everything else is m
 ### For issue_body / pull_request_body
 
 ```bash
-node secret-scanning.mjs redact-body <issue|pr> <NUMBER> <redacted-body-file>
+node secret-scanning.mjs redact-body-if-needed <issue|pr> <NUMBER> <current-body-file> <redacted-body-file> <result-file>
 ```
+
+Use the `body_file` from `fetch-content` as `<current-body-file>`. The command writes `notify_required` to `<result-file>` and only PATCHes the body when the redacted file differs from the current body.
 
 ## Step 4: Purge Edit History
 
@@ -138,7 +149,7 @@ The recreated comment should follow this format:
 
 Editing creates an edit history revision with the pre-edit plaintext. This cannot be cleared via API.
 
-**The `notify` step already advises the author to delete and recreate (issues) or close and reopen (PRs) instead of relying on editing alone.** If the author does not act, maintainer should follow up.
+Do not advise authors publicly to delete/recreate issues or close/reopen PRs. That can draw attention to historical content. Keep purge guidance maintainer-only.
 
 **Output to maintainer terminal only (never in public comments):**
 
@@ -157,12 +168,13 @@ Cannot clean. Notify author to delete branch or force-push (for unmerged PRs).
 ## Step 5: Notify
 
 ```bash
-node secret-scanning.mjs notify <TARGET> <AUTHOR> <LOCATION_TYPE> <SECRET_TYPES> [REPLY_TO_NODE_ID]
+node secret-scanning.mjs notify <TARGET> <AUTHOR> <LOCATION_TYPE> <SECRET_TYPES> [REPLY_TO_NODE_ID|BODY_REDACTION_RESULT_FILE]
 ```
 
 - For non-discussion types, `<TARGET>` is the issue/PR number.
 - For `discussion_comment`, `<TARGET>` is the `discussion_node_id` returned by `fetch-content`.
 - For reply-style `discussion_comment` locations, pass the optional `reply_to_node_id` from `fetch-content` so the notification stays in the same thread.
+- For `issue_body` and `pull_request_body`, pass the `<result-file>` from `redact-body-if-needed`. The script skips notification when `notify_required` is `false` and refuses body notifications without this file.
 
 Secret types are comma-separated: `"Discord Bot Token,Feishu App Secret"`
 
@@ -172,6 +184,8 @@ The script picks the right template:
 - **body types**: "your issue/PR description … redacted in place"
 - **commit**: "code you committed"
 
+For `issue_body` and `pull_request_body`, only notify when the current body still contained plaintext and maintainers redacted it. If the user already redacted the current body, skip this step and resolve silently.
+
 ## Step 6: Resolve
 
 ```bash
@@ -180,7 +194,7 @@ node secret-scanning.mjs resolve <ALERT_NUMBER>
 node secret-scanning.mjs resolve <ALERT_NUMBER> revoked "Custom comment"
 ```
 
-Resolution is `revoked` by default. As maintainers we cannot control whether users rotate — our responsibility is to redact + notify. The `revoked` means "this secret should be considered leaked", not "I confirmed it was revoked".
+Resolution is `revoked` by default. As maintainers we cannot control whether users rotate — our responsibility is to remove current plaintext exposure and notify only when public notification is useful. The `revoked` means "this secret should be considered leaked", not "I confirmed it was revoked".
 
 ## Step 7: Summary
 

--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -134,9 +134,11 @@ The recreated comment should follow this format:
 <redacted original content>
 ```
 
-### issue_body / pull_request_body — Cannot Purge
+### issue_body / pull_request_body — Cannot Purge Edit History
 
 Editing creates an edit history revision with the pre-edit plaintext. This cannot be cleared via API.
+
+**The `notify` step already advises the author to delete and recreate (issues) or close and reopen (PRs) instead of relying on editing alone.** If the author does not act, maintainer should follow up.
 
 **Output to maintainer terminal only (never in public comments):**
 

--- a/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
@@ -7,6 +7,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 const REPO = "openclaw/openclaw";
 const REPO_URL = `https://github.com/${REPO}`;
@@ -48,6 +49,34 @@ function gh(args, { json = true, allowFailure = false } = {}) {
 
 function ghGraphQL(query, options = {}) {
   return gh(["api", "graphql", "-f", `query=${query}`], options);
+}
+
+function isBodyLocationType(locationType) {
+  return locationType === "issue_body" || locationType === "pull_request_body";
+}
+
+export function decideBodyRedaction(currentBody, redactedBody) {
+  const bodyChanged = String(currentBody) !== String(redactedBody);
+  return {
+    body_changed: bodyChanged,
+    notify_required: bodyChanged,
+  };
+}
+
+export function loadBodyRedactionResult(locationType, resultFile) {
+  if (!isBodyLocationType(locationType)) {
+    return { notify_required: true };
+  }
+  if (!resultFile) {
+    fail("Body notifications require a redaction result file from redact-body-if-needed");
+  }
+  if (!fs.existsSync(resultFile)) fail(`File not found: ${resultFile}`);
+
+  const result = JSON.parse(fs.readFileSync(resultFile, "utf8"));
+  if (typeof result.notify_required !== "boolean") {
+    fail(`Invalid redaction result file: missing boolean notify_required in ${resultFile}`);
+  }
+  return result;
 }
 
 function failOnGraphQLFailure(result, message) {
@@ -471,6 +500,43 @@ function cmdRedactBody(kind, number, bodyFile) {
 }
 
 /**
+ * redact-body-if-needed <issue|pr> <number> <current-body-file> <redacted-body-file> <result-file>
+ * PATCH only when the agent-produced redacted body differs from the current body.
+ */
+function cmdRedactBodyIfNeeded(kind, number, currentBodyFile, redactedBodyFile, resultFile) {
+  if (!kind || !number || !currentBodyFile || !redactedBodyFile || !resultFile) {
+    fail(
+      "Usage: redact-body-if-needed <issue|pr> <number> <current-body-file> <redacted-body-file> <result-file>",
+    );
+  }
+  if (!fs.existsSync(currentBodyFile)) fail(`File not found: ${currentBodyFile}`);
+  if (!fs.existsSync(redactedBodyFile)) fail(`File not found: ${redactedBodyFile}`);
+
+  const currentBody = fs.readFileSync(currentBodyFile, "utf8");
+  const redactedBody = fs.readFileSync(redactedBodyFile, "utf8");
+  const decision = decideBodyRedaction(currentBody, redactedBody);
+  const result = {
+    ok: true,
+    kind,
+    number: Number(number),
+    ...decision,
+  };
+
+  if (decision.body_changed) {
+    const endpoint =
+      kind === "pr" ? `repos/${REPO}/pulls/${number}` : `repos/${REPO}/issues/${number}`;
+    gh(["api", endpoint, "-X", "PATCH", "-F", `body=@${redactedBodyFile}`]);
+    result.redacted = true;
+  } else {
+    result.redacted = false;
+    result.reason = "current_body_already_redacted";
+  }
+
+  fs.writeFileSync(resultFile, `${JSON.stringify(result, null, 2)}\n`, { mode: 0o600 });
+  console.log(JSON.stringify(result));
+}
+
+/**
  * delete-comment <comment-id>
  * Delete a comment (and all its edit history).
  */
@@ -555,10 +621,20 @@ function cmdNotify(target, author, locationType, secretTypes, replyToNodeId) {
 
   const types = secretTypes.split(",").map((s) => s.trim());
   const typeList = types.map((t, i) => `${i + 1}. **${t}**`).join("\n");
+  const redactionResult = loadBodyRedactionResult(locationType, replyToNodeId);
+  if (isBodyLocationType(locationType) && !redactionResult.notify_required) {
+    console.log(
+      JSON.stringify({
+        ok: true,
+        skipped: true,
+        reason: "current_body_already_redacted",
+      }),
+    );
+    return;
+  }
 
   let locationDesc;
   let actionDesc;
-  let extraAdvice = "";
   if (
     locationType === "issue_comment" ||
     locationType === "pull_request_comment" ||
@@ -570,15 +646,9 @@ function cmdNotify(target, author, locationType, secretTypes, replyToNodeId) {
   } else if (locationType === "issue_body") {
     locationDesc = "your issue description";
     actionDesc = "The affected content has been redacted in place.";
-    extraAdvice =
-      "Editing an issue description does not remove the secret from its edit history. " +
-      "**We strongly recommend deleting this issue and recreating it** with the redacted content to ensure the secret is fully removed.";
   } else if (locationType === "pull_request_body") {
     locationDesc = "your pull request description";
     actionDesc = "The affected content has been redacted in place.";
-    extraAdvice =
-      "Editing a pull request description does not remove the secret from its edit history. " +
-      "**We strongly recommend closing this PR and opening a new one** with the redacted content to ensure the secret is fully removed.";
   } else if (locationType === "commit") {
     locationDesc = "code you committed";
     actionDesc = "";
@@ -597,7 +667,6 @@ function cmdNotify(target, author, locationType, secretTypes, replyToNodeId) {
     typeList,
     "",
     actionDesc,
-    ...(extraAdvice ? ["", extraAdvice] : []),
     "",
     "**Please rotate these credentials immediately.**",
     "",
@@ -766,12 +835,13 @@ function cmdSummary(jsonFile) {
 
 // ─── Dispatch ───────────────────────────────────────────────────────────────
 
-const [command, ...args] = process.argv.slice(2);
+const args = [];
 
-const commands = {
+export const commands = {
   "fetch-alert": () => cmdFetchAlert(args[0]),
   "fetch-content": () => cmdFetchContent(args[0]),
   "redact-body": () => cmdRedactBody(args[0], args[1], args[2]),
+  "redact-body-if-needed": () => cmdRedactBodyIfNeeded(args[0], args[1], args[2], args[3], args[4]),
   "delete-comment": () => cmdDeleteComment(args[0]),
   "delete-discussion-comment": () => cmdDeleteDiscussionComment(args[0]),
   "recreate-comment": () => cmdRecreateComment(args[0], args[1]),
@@ -782,26 +852,37 @@ const commands = {
   summary: () => cmdSummary(args[0]),
 };
 
-if (!command || !commands[command]) {
-  console.error(
-    [
-      "Usage: node secret-scanning.mjs <command> [args]",
-      "",
-      "Commands:",
-      "  fetch-alert <number>             Fetch alert metadata + locations",
-      "  fetch-content '<location-json>'   Fetch content for a location",
-      "  redact-body <issue|pr> <n> <file> PATCH body with redacted file",
-      "  delete-comment <comment-id>       Delete a comment",
-      "  delete-discussion-comment <node-id> Delete a discussion comment (GraphQL)",
-      "  recreate-comment <issue-n> <file> Create replacement comment",
-      "  recreate-discussion-comment <disc-node-id> <file> [reply-to-node-id] Create discussion comment (GraphQL)",
-      "  notify <target> <author> <type> <types> [reply-to-node-id] Post notification",
-      "  resolve <n> [resolution] [comment] Close alert",
-      "  list-open                          List open alerts",
-      "  summary <json-file>               Print formatted summary",
-    ].join("\n"),
-  );
-  process.exit(1);
+function main(argv = process.argv.slice(2)) {
+  const [command, ...commandArgs] = argv;
+  args.length = 0;
+  args.push(...commandArgs);
+
+  if (!command || !commands[command]) {
+    console.error(
+      [
+        "Usage: node secret-scanning.mjs <command> [args]",
+        "",
+        "Commands:",
+        "  fetch-alert <number>             Fetch alert metadata + locations",
+        "  fetch-content '<location-json>'   Fetch content for a location",
+        "  redact-body <issue|pr> <n> <file> PATCH body with redacted file",
+        "  redact-body-if-needed <issue|pr> <n> <current-file> <redacted-file> <result-file> PATCH body only if redaction changed it",
+        "  delete-comment <comment-id>       Delete a comment",
+        "  delete-discussion-comment <node-id> Delete a discussion comment (GraphQL)",
+        "  recreate-comment <issue-n> <file> Create replacement comment",
+        "  recreate-discussion-comment <disc-node-id> <file> [reply-to-node-id] Create discussion comment (GraphQL)",
+        "  notify <target> <author> <type> <types> [reply-to-node-id|body-result-file] Post notification",
+        "  resolve <n> [resolution] [comment] Close alert",
+        "  list-open                          List open alerts",
+        "  summary <json-file>               Print formatted summary",
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+
+  commands[command]();
 }
 
-commands[command]();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
@@ -558,6 +558,7 @@ function cmdNotify(target, author, locationType, secretTypes, replyToNodeId) {
 
   let locationDesc;
   let actionDesc;
+  let extraAdvice = "";
   if (
     locationType === "issue_comment" ||
     locationType === "pull_request_comment" ||
@@ -569,9 +570,15 @@ function cmdNotify(target, author, locationType, secretTypes, replyToNodeId) {
   } else if (locationType === "issue_body") {
     locationDesc = "your issue description";
     actionDesc = "The affected content has been redacted in place.";
+    extraAdvice =
+      "Editing an issue description does not remove the secret from its edit history. " +
+      "**We strongly recommend deleting this issue and recreating it** with the redacted content to ensure the secret is fully removed.";
   } else if (locationType === "pull_request_body") {
     locationDesc = "your pull request description";
     actionDesc = "The affected content has been redacted in place.";
+    extraAdvice =
+      "Editing a pull request description does not remove the secret from its edit history. " +
+      "**We strongly recommend closing this PR and opening a new one** with the redacted content to ensure the secret is fully removed.";
   } else if (locationType === "commit") {
     locationDesc = "code you committed";
     actionDesc = "";
@@ -590,6 +597,7 @@ function cmdNotify(target, author, locationType, secretTypes, replyToNodeId) {
     typeList,
     "",
     actionDesc,
+    ...(extraAdvice ? ["", extraAdvice] : []),
     "",
     "**Please rotate these credentials immediately.**",
     "",

--- a/test/scripts/secret-scanning-maintainer.test.ts
+++ b/test/scripts/secret-scanning-maintainer.test.ts
@@ -1,0 +1,108 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const scriptPath = ".agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs";
+const { createTempDir } = createScriptTestHarness();
+
+describe("secret scanning maintainer script", () => {
+  it("marks body alerts as not requiring notification when redaction is unchanged", () => {
+    const tempDir = createTempDir("openclaw-secret-scan-");
+    const currentBody = path.join(tempDir, "current.md");
+    const redactedBody = path.join(tempDir, "redacted.md");
+    const resultFile = path.join(tempDir, "redaction-result.json");
+    fs.writeFileSync(currentBody, "token: [REDACTED Discord Bot Token]\n");
+    fs.writeFileSync(redactedBody, "token: [REDACTED Discord Bot Token]\n");
+
+    const output = execFileSync(
+      process.execPath,
+      [scriptPath, "redact-body-if-needed", "issue", "123", currentBody, redactedBody, resultFile],
+      { encoding: "utf8" },
+    );
+
+    expect(JSON.parse(output)).toMatchObject({
+      body_changed: false,
+      notify_required: false,
+      reason: "current_body_already_redacted",
+      redacted: false,
+    });
+    expect(JSON.parse(fs.readFileSync(resultFile, "utf8"))).toMatchObject({
+      notify_required: false,
+    });
+  });
+
+  it("patches body alerts and requires notification when redaction changes the current body", () => {
+    const tempDir = createTempDir("openclaw-secret-scan-");
+    const binDir = path.join(tempDir, "bin");
+    const ghLog = path.join(tempDir, "gh.log");
+    fs.mkdirSync(binDir);
+    fs.writeFileSync(
+      path.join(binDir, "gh"),
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${ghLog}"\nprintf '{}\\n'\n`,
+      { mode: 0o755 },
+    );
+
+    const currentBody = path.join(tempDir, "current.md");
+    const redactedBody = path.join(tempDir, "redacted.md");
+    const resultFile = path.join(tempDir, "redaction-result.json");
+    fs.writeFileSync(currentBody, "token: plaintext-secret\n");
+    fs.writeFileSync(redactedBody, "token: [REDACTED Discord Bot Token]\n");
+
+    const output = execFileSync(
+      process.execPath,
+      [scriptPath, "redact-body-if-needed", "issue", "123", currentBody, redactedBody, resultFile],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+      },
+    );
+
+    expect(JSON.parse(output)).toMatchObject({
+      body_changed: true,
+      notify_required: true,
+      redacted: true,
+    });
+    expect(fs.readFileSync(ghLog, "utf8")).toContain(
+      `api repos/openclaw/openclaw/issues/123 -X PATCH -F body=@${redactedBody}`,
+    );
+  });
+
+  it("skips body notification when the redaction result says the current body was already redacted", () => {
+    const tempDir = createTempDir("openclaw-secret-scan-");
+    const resultFile = path.join(tempDir, "redaction-result.json");
+    fs.writeFileSync(
+      resultFile,
+      JSON.stringify({
+        body_changed: false,
+        notify_required: false,
+      }),
+    );
+
+    const output = execFileSync(
+      process.execPath,
+      [scriptPath, "notify", "123", "contributor", "issue_body", "Discord Bot Token", resultFile],
+      { encoding: "utf8" },
+    );
+
+    expect(JSON.parse(output)).toStrictEqual({
+      ok: true,
+      reason: "current_body_already_redacted",
+      skipped: true,
+    });
+  });
+
+  it("requires body notifications to include a redaction result file", () => {
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        [scriptPath, "notify", "123", "contributor", "issue_body", "Discord Bot Token"],
+        { encoding: "utf8", stdio: "pipe" },
+      ),
+    ).toThrow(/Body notifications require a redaction result file/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a script-controlled body redaction gate for the secret-scanning maintainer workflow.
- `redact-body-if-needed` compares the current issue/PR body with the agent-produced redacted body, patches only when the body changes, and writes a result file with `notify_required`.
- `notify` now requires that result file for issue/PR body locations and skips public comments when the current body was already redacted.
- Updates the maintainer skill docs to keep historical purge guidance maintainer-only and avoid creating a fresh public pointer when no current plaintext remains.

## Verification

- `node --check .agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs`
- `git diff --check`
- `node scripts/run-vitest.mjs test/scripts/secret-scanning-maintainer.test.ts`

## Behavior addressed

Issue/PR body alert handling now avoids posting a public notification when the current body is already redacted, while still allowing notification after maintainers actually redact current plaintext.

## Real environment tested

Local script-level workflow with mocked GitHub CLI calls for mutation paths.

## Exact steps or command run after this patch

```bash
node --check .agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
git diff --check
node scripts/run-vitest.mjs test/scripts/secret-scanning-maintainer.test.ts
```

## Evidence after fix

The focused Vitest file passed 4 tests covering already-redacted body handling, changed-body patching, skipped body notification, and refusal to notify body locations without a redaction result file.

## Observed result after fix

When the redacted body is unchanged, the script writes `notify_required:false` and `notify` returns a skipped result instead of posting a comment. When the body changes, the script patches the body and writes `notify_required:true`.

## What was not tested

Live GitHub API execution against a real secret-scanning alert was not run.
