### PR TITLE
fix(cron): treat attempt dispatch as execution start

### DIFF
--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1524,6 +1524,88 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("clears the pre-execution watchdog once runtime dispatch starts", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-05-10T09:08:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "isolated-attempt-dispatch-start",
+        name: "attempt dispatch start regression",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 1_200 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const started = createDeferred<void>();
+      let abortObserved = false;
+      const cleanupTimedOutAgentRun = vi.fn(async () => {});
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        cleanupTimedOutAgentRun,
+        runIsolatedAgentJob: vi.fn(
+          async ({
+            abortSignal,
+            onExecutionStarted,
+            onExecutionPhase,
+          }: {
+            abortSignal?: AbortSignal;
+            onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
+            onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
+          }) => {
+            onExecutionStarted?.({
+              jobId: "isolated-attempt-dispatch-start",
+              phase: "runner_entered",
+            });
+            onExecutionPhase?.({
+              jobId: "isolated-attempt-dispatch-start",
+              phase: "attempt_dispatch",
+              backend: "codex-app-server",
+            });
+            started.resolve();
+            abortSignal?.addEventListener(
+              "abort",
+              () => {
+                abortObserved = true;
+              },
+              { once: true },
+            );
+            return await new Promise<never>(() => {});
+          },
+        ),
+      });
+
+      const timerPromise = onTimer(state);
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      expect(abortObserved).toBe(false);
+      expect(cleanupTimedOutAgentRun).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_140_000);
+      now += 1_140_000;
+      await timerPromise;
+
+      const job = requireJob(state, "isolated-attempt-dispatch-start");
+      expect(abortObserved).toBe(true);
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.lastError).toContain("job execution timed out");
+      expect(job.state.lastError).toContain("attempt-dispatch");
+      expect(cleanupTimedOutAgentRun).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("clears the pre-execution watchdog on explicit execution milestones (#80283)", async () => {
     vi.useFakeTimers();
     try {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -309,6 +309,7 @@ function isCronAgentExecutionStarted(info: CronAgentExecutionStarted): boolean {
     return true;
   }
   switch (info.phase) {
+    case "attempt_dispatch":
     case "turn_accepted":
     case "process_spawned":
     case "tool_execution_started":


### PR DESCRIPTION
## Summary
- Treat the cron isolated-agent `attempt_dispatch` phase as execution progress for the pre-execution watchdog.
- Add regression coverage so the watchdog clears once the embedded runtime begins dispatching an attempt.

## Why
`attempt_dispatch` means the isolated agent runner has reached the runtime handoff path. Today the pre-execution watchdog only clears on later milestones like `turn_accepted` or `model_call_started`, so slow Codex app-server dispatches can be aborted after the 60s pre-execution window with `cron: isolated agent run stalled before execution start (last phase: attempt-dispatch)`, even though useful execution has already begun.

## Real behavior proof
- **Behavior or issue addressed**: Isolated cron agent turns using the Codex app-server runtime were being aborted by the pre-execution watchdog after reaching `attempt_dispatch`, producing `cron: isolated agent run stalled before execution start (last phase: attempt-dispatch)`.
- **Real environment tested**: Local macOS OpenClaw install, `openclaw 2026.5.12`, global npm install at `/Users/leli/.npm-global/lib/node_modules/openclaw`, Gateway on `127.0.0.1:18789`.
- **Exact steps or command run after this patch**: Applied the same one-line local patch to the installed `server-cron-*.js`, restarted the Gateway, then manually ran the two cron jobs that had failed earlier:

```console
$ openclaw cron run daily-sleep-health-analysis --expect-final --timeout 900000
$ openclaw cron run 66bb4954-48e7-437f-bf88-a99eab41d7f9 --timeout 120000
$ openclaw tasks list --runtime cron --json | jq '.tasks[:2] | map({status, taskId, runId, createdAt, endedAt, deliveryStatus})'
[
  {
    "status": "succeeded",
    "taskId": "d8d5e0c8-7fe0-4eeb-8a7c-94176789436d",
    "runId": "cron:66bb4954-48e7-437f-bf88-a99eab41d7f9:1778811837175",
    "createdAt": 1778811837175,
    "endedAt": 1778812256599,
    "deliveryStatus": "not_applicable"
  },
  {
    "status": "succeeded",
    "taskId": "50976122-4361-4c95-924c-5ee2637d5cec",
    "runId": "cron:daily-sleep-health-analysis:1778811750773",
    "createdAt": 1778811750773,
    "endedAt": 1778811825657,
    "deliveryStatus": "not_applicable"
  }
]
```

- **Evidence after fix**: The copied terminal output above is the live OpenClaw task list after rerunning the two affected cron jobs. Both previously failing isolated cron runs completed successfully after the patch; the news job ran for about seven minutes, well past the old 60s pre-execution watchdog failure point.
- **Observed result after fix**: No new `isolated agent run stalled before execution start (last phase: attempt-dispatch)` error occurred. The sleep cron produced a sleep-health summary, and the news cron produced a daily-news summary.
- **What was not tested**: I did not verify channel delivery from the task registry because these manual runs reported `deliveryStatus: not_applicable`; this PR only changes the pre-execution watchdog boundary.

## Validation
- Added `src/cron/service/timer.regression.test.ts` coverage for `attempt_dispatch`.
- Manual validation on a 2026.5.12 install: applying this same milestone change allowed two previously failing isolated cron runs to complete successfully after they had failed at `attempt-dispatch`.
