### PR TITLE
fix(config): materialize subagent archive default

### DIFF
--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -1,5 +1,6 @@
 import fsSync, { promises as fs } from "node:fs";
 import path from "node:path";
+import { DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES } from "../config/agent-limits.js";
 import { getRuntimeConfig } from "../config/config.js";
 import {
   loadSessionStore,
@@ -345,7 +346,9 @@ export function reconcileOrphanedRestoredRuns(params: {
 
 export function resolveArchiveAfterMs(cfg?: OpenClawConfig) {
   const config = cfg ?? getRuntimeConfig();
-  const minutes = config.agents?.defaults?.subagents?.archiveAfterMinutes ?? 60;
+  const minutes =
+    config.agents?.defaults?.subagents?.archiveAfterMinutes ??
+    DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES;
   if (!Number.isFinite(minutes) || minutes < 0) {
     return undefined;
   }

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -950,6 +950,26 @@ describe("config cli", () => {
 
       expect(mockLog).toHaveBeenCalledWith("__OPENCLAW_REDACTED__");
     });
+
+    it("prints materialized subagent archive default", async () => {
+      const resolved: OpenClawConfig = {};
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: {
+            maxConcurrent: 4,
+            subagents: {
+              maxConcurrent: 8,
+              archiveAfterMinutes: 60,
+            },
+          },
+        },
+      };
+      setSnapshot(resolved, config);
+
+      await runConfigCommand(["config", "get", "agents.defaults.subagents.archiveAfterMinutes"]);
+
+      expect(mockLog).toHaveBeenCalledWith("60");
+    });
   });
 
   describe("config validate", () => {

--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "./types.js";
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
 export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5;
+export const DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES = 60;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;
 

--- a/src/config/config.agent-concurrency-defaults.test.ts
+++ b/src/config/config.agent-concurrency-defaults.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES,
   DEFAULT_SUBAGENT_MAX_CONCURRENT,
   resolveAgentMaxConcurrent,
   resolveSubagentMaxConcurrent,
@@ -48,5 +49,8 @@ describe("agent concurrency defaults", () => {
 
     expect(cfg.agents?.defaults?.maxConcurrent).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
     expect(cfg.agents?.defaults?.subagents?.maxConcurrent).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+    expect(cfg.agents?.defaults?.subagents?.archiveAfterMinutes).toBe(
+      DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES,
+    );
   });
 });

--- a/src/config/defaults.test.ts
+++ b/src/config/defaults.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_AGENT_MAX_CONCURRENT, DEFAULT_SUBAGENT_MAX_CONCURRENT } from "./agent-limits.js";
+import {
+  DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES,
+  DEFAULT_SUBAGENT_MAX_CONCURRENT,
+} from "./agent-limits.js";
 import {
   applyAgentDefaults,
   applyContextPruningDefaults,
@@ -111,6 +115,18 @@ describe("config defaults", () => {
     const next = applyAgentDefaults({ messages: {} } as never);
 
     expect(next.agents?.defaults?.maxConcurrent).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+    expect(next.agents?.defaults?.subagents?.maxConcurrent).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+    expect(next.agents?.defaults?.subagents?.archiveAfterMinutes).toBe(
+      DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES,
+    );
+  });
+
+  it("preserves explicit subagent archive default", () => {
+    const next = applyAgentDefaults({
+      agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
+    } as never);
+
+    expect(next.agents?.defaults?.subagents?.archiveAfterMinutes).toBe(0);
     expect(next.agents?.defaults?.subagents?.maxConcurrent).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
   });
 });

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -2,7 +2,11 @@ import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import { normalizeConfiguredProviderCatalogModelId } from "../agents/model-ref-shared.js";
 import { normalizeProviderId } from "../agents/provider-id.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
-import { DEFAULT_AGENT_MAX_CONCURRENT, DEFAULT_SUBAGENT_MAX_CONCURRENT } from "./agent-limits.js";
+import {
+  DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES,
+  DEFAULT_SUBAGENT_MAX_CONCURRENT,
+} from "./agent-limits.js";
 import { normalizeAgentModelMapForConfig, normalizeAgentModelRefForConfig } from "./model-input.js";
 import {
   applyProviderConfigDefaultsForConfig,
@@ -394,7 +398,10 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
   const hasSubMax =
     typeof defaults?.subagents?.maxConcurrent === "number" &&
     Number.isFinite(defaults.subagents.maxConcurrent);
-  if (hasMax && hasSubMax) {
+  const hasSubArchive =
+    typeof defaults?.subagents?.archiveAfterMinutes === "number" &&
+    Number.isFinite(defaults.subagents.archiveAfterMinutes);
+  if (hasMax && hasSubMax && hasSubArchive) {
     return cfg;
   }
 
@@ -408,6 +415,10 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
   const nextSubagents = defaults?.subagents ? { ...defaults.subagents } : {};
   if (!hasSubMax) {
     nextSubagents.maxConcurrent = DEFAULT_SUBAGENT_MAX_CONCURRENT;
+    mutated = true;
+  }
+  if (!hasSubArchive) {
+    nextSubagents.archiveAfterMinutes = DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES;
     mutated = true;
   }
 


### PR DESCRIPTION
## Summary

- Materialize `agents.defaults.subagents.archiveAfterMinutes` with the documented default of `60` for fresh configs.
- Share the default constant with subagent archive runtime behavior.
- Add config defaults and `config get` regression coverage.

Fixes #77693.

## Real behavior proof

- Behavior or issue addressed: `openclaw config get agents.defaults.subagents.archiveAfterMinutes` should be able to return the documented default `60` for a fresh config instead of treating the path as absent.
- Real environment tested: WSL Ubuntu-24.04 source worktrees created from `upstream/main` and PR head `6f85e4e26d958fad46e075d1e66a207e09c79a93`.
- Exact steps or command run after this patch: created clean detached worktrees for `upstream/main` and `fork/fix-subagent-archive-default-77693`; in each worktree ran `node --import ./node_modules/tsx/dist/loader.mjs ./probe-subagent-archive-default.mjs`. The probe imported the real `applyAgentDefaults({})` materialization path used for resolved config snapshots and printed the subagent defaults that `config get` can read.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

![PR #81998 subagent archive default before/after proof](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-81998-fresh/pr-81998/pr-81998-subagent-archive-default-before-after-proof.png)

```text
Fresh proof artifact: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-81998-fresh/pr-81998/pr-81998-subagent-archive-default-before-after-proof.png
Proof summary: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-81998-fresh/pr-81998/summary.txt

BEFORE upstream/main:
status=0
archiveDefault=<missing>
subagentMaxConcurrent=8
agentMaxConcurrent=4
configGetWouldPrint=<path missing>
ok=false

AFTER PR #81998 head:
status=0
archiveDefault=60
subagentMaxConcurrent=8
agentMaxConcurrent=4
configGetWouldPrint=60
ok=true
```

- Observed result after fix: `upstream/main` materializes existing agent/subagent concurrency defaults but leaves `agents.defaults.subagents.archiveAfterMinutes` missing; PR head materializes `archiveAfterMinutes=60`, so the config path has the documented default value to print.
- What was not tested: this proof image exercises the config materialization seam directly rather than launching the full CLI process. The PR includes focused CLI regression coverage for `openclaw config get agents.defaults.subagents.archiveAfterMinutes`.

## Validation

- `pnpm exec vitest run src/config/defaults.test.ts src/config/config.agent-concurrency-defaults.test.ts --config test/vitest/vitest.runtime-config.config.ts`
- `pnpm exec vitest run src/cli/config-cli.test.ts --config test/vitest/vitest.cli.config.ts`
- `pnpm check:changed`