### PR TITLE
fix(config): preserve numeric patch object keys

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1973,6 +1973,43 @@ describe("config cli", () => {
       });
     });
 
+    it("keeps numeric config patch object keys as object keys", async () => {
+      const resolved = {
+        channels: {
+          discord: {
+            enabled: true,
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      const pathname = writeTempJson5File("openclaw-config-patch-numeric-object-key", {
+        channels: {
+          discord: {
+            guilds: {
+              "123456789012345678": {
+                token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+              },
+            },
+          },
+        },
+      });
+      try {
+        await runConfigCommand(["config", "patch", "--file", pathname]);
+      } finally {
+        fs.rmSync(pathname, { force: true });
+      }
+
+      const written = firstWrittenConfig() as {
+        channels?: { discord?: { guilds?: unknown } };
+      };
+      expect(written.channels?.discord?.guilds).toEqual({
+        "123456789012345678": {
+          token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+        },
+      });
+    });
+
     it("dry-runs config patch and resolves changed SecretRefs", async () => {
       const resolved = {
         secrets: {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -453,12 +453,19 @@ function getAtPath(root: unknown, path: PathSegment[]): { found: boolean; value?
   return { found: true, value: current };
 }
 
-function setAtPath(root: Record<string, unknown>, path: PathSegment[], value: unknown): void {
+type SetAtPathOptions = { numericObjectKeys?: boolean };
+
+function setAtPath(
+  root: Record<string, unknown>,
+  path: PathSegment[],
+  value: unknown,
+  options?: SetAtPathOptions,
+): void {
   let current: unknown = root;
   for (let i = 0; i < path.length - 1; i += 1) {
     const segment = path[i];
     const next = path[i + 1];
-    const nextIsIndex = Boolean(next && isIndexSegment(next));
+    const nextIsIndex = !options?.numericObjectKeys && Boolean(next && isIndexSegment(next));
     if (Array.isArray(current)) {
       if (!isIndexSegment(segment)) {
         throw new Error(`Expected numeric index for array segment "${segment}"`);
@@ -554,13 +561,18 @@ function mergeConfigValue(existing: unknown, patch: unknown, path: PathSegment[]
   throw new Error(`Cannot merge ${toDotPath(path)}; use --replace to replace intentionally.`);
 }
 
-function mergeAtPath(root: Record<string, unknown>, path: PathSegment[], value: unknown): void {
+function mergeAtPath(
+  root: Record<string, unknown>,
+  path: PathSegment[],
+  value: unknown,
+  options?: SetAtPathOptions,
+): void {
   const existing = getAtPath(root, path);
   if (!existing.found) {
-    setAtPath(root, path, value);
+    setAtPath(root, path, value, options);
     return;
   }
-  setAtPath(root, path, mergeConfigValue(existing.value, value, path));
+  setAtPath(root, path, mergeConfigValue(existing.value, value, path), options);
 }
 
 function isProviderModelListPath(path: PathSegment[]): boolean {
@@ -1675,7 +1687,9 @@ async function runConfigOperations(params: {
     }
     explicitSetPaths.push(operation.setPath);
     if (operation.mutation === "merge" || (options.merge && operation.mutation !== "replace")) {
-      mergeAtPath(next, operation.setPath, operation.value);
+      mergeAtPath(next, operation.setPath, operation.value, {
+        numericObjectKeys: params.successMode === "patch",
+      });
     } else {
       assertNonDestructiveReplacement({
         root: next,
@@ -1683,7 +1697,9 @@ async function runConfigOperations(params: {
         value: operation.value,
         allowReplace: options.replace || operation.mutation === "replace",
       });
-      setAtPath(next, operation.setPath, operation.value);
+      setAtPath(next, operation.setPath, operation.value, {
+        numericObjectKeys: params.successMode === "patch",
+      });
     }
   }
   const removedGatewayAuthPaths = pruneInactiveGatewayAuthCredentials({


### PR DESCRIPTION
## Summary
- treat numeric path segments from `config patch` JSON objects as object keys while creating missing containers
- preserve existing numeric array-index behavior for path-based config set/unset operations
- add regression coverage for Discord-style numeric guild IDs under `channels.discord.guilds`

Addresses the config patch recursive-merge portion of #81926.

## Real behavior proof

**Behavior or issue addressed:** `openclaw config patch` now preserves numeric-looking JSON object keys such as Discord guild IDs under `channels.discord.guilds` instead of creating an array container during recursive merge.

**Real environment tested:** WSL Ubuntu-24.04 worktree `/root/src/openclaw-branches/fix-config-patch-numeric-keys-81926`, PR branch commit `3c677c6`, using fresh temp config and patch files.

**Exact steps or command run after this patch:** Created a temp config, applied a JSON patch containing guild ID `123456789012345678`, then inspected the written config:

```console
$ cat > "$patch" <<'JSON'
{"channels":{"discord":{"guilds":{"123456789012345678":{"channels":{"maintainers":{"enabled":true}}}}}}}
JSON
$ OPENCLAW_CONFIG_PATH="$cfg" pnpm --silent openclaw config patch --file "$patch"
$ node -e "const fs=require('fs'); const cfg=JSON.parse(fs.readFileSync(process.argv[1],'utf8')); console.log(JSON.stringify(cfg.channels.discord.guilds, null, 2)); console.log('isArray=' + Array.isArray(cfg.channels.discord.guilds));" "$cfg"
```

**Evidence after fix:** Copied live terminal output from the changed branch:

```console
🦞 OpenClaw 2026.5.14 (3c677c6) — Half butler, half debugger, full crustacean.
Config overwrite: /tmp/openclaw-81926-c8dtjx.json (... -> ..., backup=/tmp/openclaw-81926-c8dtjx.json.bak)
Config write anomaly: /tmp/openclaw-81926-c8dtjx.json (missing-meta-before-write)
Applied 1 config update(s). Restart the gateway to apply.
{
  "123456789012345678": {
    "channels": {
      "maintainers": {
        "enabled": true
      }
    }
  }
}
isArray=false
```

**Observed result after fix:** The written `guilds` value is a JSON object with key `123456789012345678`, and `Array.isArray(cfg.channels.discord.guilds)` printed `false`.

**What was not tested:** None

## Validation
- `pnpm exec vitest run src/cli/config-cli.test.ts --config test/vitest/vitest.cli.config.ts`
- `pnpm check:changed`