### PR TITLE
feat: Add sessionLaneMaxConcurrent configuration for Telegram forum topics concurrency

### DIFF
--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -5,6 +5,7 @@ export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
 export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;
+export const DEFAULT_SESSION_LANE_MAX_CONCURRENT = 1;
 
 export function resolveAgentMaxConcurrent(cfg?: OpenClawConfig): number {
   const raw = cfg?.agents?.defaults?.maxConcurrent;
@@ -20,4 +21,12 @@ export function resolveSubagentMaxConcurrent(cfg?: OpenClawConfig): number {
     return Math.max(1, Math.floor(raw));
   }
   return DEFAULT_SUBAGENT_MAX_CONCURRENT;
+}
+
+export function resolveSessionLaneMaxConcurrent(cfg?: OpenClawConfig): number {
+  const raw = cfg?.agents?.defaults?.sessionLaneMaxConcurrent;
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return Math.max(1, Math.floor(raw));
+  }
+  return DEFAULT_SESSION_LANE_MAX_CONCURRENT;
 }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -2,7 +2,11 @@ import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import { normalizeConfiguredProviderCatalogModelId } from "../agents/model-ref-shared.js";
 import { normalizeProviderId } from "../agents/provider-id.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
-import { DEFAULT_AGENT_MAX_CONCURRENT, DEFAULT_SUBAGENT_MAX_CONCURRENT } from "./agent-limits.js";
+import {
+  DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_SESSION_LANE_MAX_CONCURRENT,
+  DEFAULT_SUBAGENT_MAX_CONCURRENT,
+} from "./agent-limits.js";
 import { normalizeAgentModelMapForConfig, normalizeAgentModelRefForConfig } from "./model-input.js";
 import {
   applyProviderConfigDefaultsForConfig,
@@ -394,7 +398,10 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
   const hasSubMax =
     typeof defaults?.subagents?.maxConcurrent === "number" &&
     Number.isFinite(defaults.subagents.maxConcurrent);
-  if (hasMax && hasSubMax) {
+  const hasSessionLaneMax =
+    typeof defaults?.sessionLaneMaxConcurrent === "number" &&
+    Number.isFinite(defaults.sessionLaneMaxConcurrent);
+  if (hasMax && hasSubMax && hasSessionLaneMax) {
     return cfg;
   }
 
@@ -402,6 +409,11 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
   const nextDefaults = defaults ? { ...defaults } : {};
   if (!hasMax) {
     nextDefaults.maxConcurrent = DEFAULT_AGENT_MAX_CONCURRENT;
+    mutated = true;
+  }
+
+  if (!hasSessionLaneMax) {
+    nextDefaults.sessionLaneMaxConcurrent = DEFAULT_SESSION_LANE_MAX_CONCURRENT;
     mutated = true;
   }
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -434,6 +434,8 @@ export type AgentDefaultsConfig = {
   };
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;
+  /** Max concurrent runs per session lane (e.g., Telegram forum topics). Default: 1 (sequential per session). */
+  sessionLaneMaxConcurrent?: number;
   /** Sub-agent defaults (spawned via sessions_spawn). */
   subagents?: {
     /** Prompt-only guidance for how strongly the main agent should delegate work. Default: "suggest". */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -259,6 +259,7 @@ export const AgentDefaultsSchema = z
     typingMode: TypingModeSchema.optional(),
     heartbeat: HeartbeatSchema,
     maxConcurrent: z.number().int().positive().optional(),
+    sessionLaneMaxConcurrent: z.number().int().positive().optional(),
     subagents: z
       .object({
         delegationMode: z.enum(["suggest", "prefer"]).optional(),

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -1,6 +1,13 @@
-import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
+import {
+  resolveAgentMaxConcurrent,
+  resolveSessionLaneMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+} from "../config/agent-limits.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { setCommandLaneConcurrency } from "../process/command-queue.js";
+import {
+  setCommandLaneConcurrency,
+  setSessionLaneMaxConcurrent,
+} from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 
 export function applyGatewayLaneConcurrency(cfg: OpenClawConfig) {
@@ -10,4 +17,7 @@ export function applyGatewayLaneConcurrency(cfg: OpenClawConfig) {
   setCommandLaneConcurrency(CommandLane.CronNested, cronMaxConcurrentRuns);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
+  // Set default concurrency for session lanes (used by Telegram forum topics, etc.)
+  const sessionLaneMaxConcurrent = resolveSessionLaneMaxConcurrent(cfg);
+  setSessionLaneMaxConcurrent(sessionLaneMaxConcurrent);
 }

--- a/src/plugin-sdk/config-runtime.ts
+++ b/src/plugin-sdk/config-runtime.ts
@@ -71,7 +71,10 @@ export {
   resolveTelegramCustomCommands,
 } from "./telegram-command-config.js";
 export { resolveActiveTalkProviderConfig } from "../config/talk.js";
-export { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
+export {
+  resolveAgentMaxConcurrent,
+  resolveSessionLaneMaxConcurrent,
+} from "../config/agent-limits.js";
 export { loadCronStore, resolveCronStorePath, saveCronStore } from "../cron/store.js";
 export { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 export { coerceSecretRef } from "../config/types.secrets.js";

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -98,6 +98,13 @@ function isExpectedNonErrorLaneFailure(err: unknown): boolean {
  * Keep queue runtime state on globalThis so every bundled entry/chunk shares
  * the same lanes, counters, and draining flag in production builds.
  */
+
+// Store the current session lane max concurrent configuration
+let currentSessionLaneMaxConcurrent = 1;
+
+export function setSessionLaneMaxConcurrent(maxConcurrent: number) {
+  currentSessionLaneMaxConcurrent = Math.max(1, Math.floor(maxConcurrent));
+}
 const COMMAND_QUEUE_STATE_KEY = Symbol.for("openclaw.commandQueueState");
 
 function getQueueState() {
@@ -144,11 +151,14 @@ function getLaneState(lane: string): LaneState {
   if (existing) {
     return existing;
   }
+  // Use session lane concurrency for session: lanes, default to 1 otherwise
+  const isSessionLane = lane.startsWith("session:");
+  const defaultMaxConcurrent = isSessionLane ? currentSessionLaneMaxConcurrent : 1;
   const created: LaneState = {
     lane,
     queue: [],
     activeTaskIds: new Set(),
-    maxConcurrent: 1,
+    maxConcurrent: defaultMaxConcurrent,
     draining: false,
     generation: 0,
   };


### PR DESCRIPTION
This PR adds configurable session lane concurrency via the new `sessionLaneMaxConcurrent` configuration option. This allows parallel message processing within individual sessions, which is particularly useful for Telegram forum topics where multiple topics can be processed concurrently.

## Problem
Previously, all messages within a session were processed sequentially (maxConcurrent = 1). This caused performance bottlenecks in scenarios like Telegram forum topics where different topics could safely be processed in parallel without interfering with each other.

## Solution
- Added `sessionLaneMaxConcurrent` configuration option to agent defaults
- Session lanes now use this configurable concurrency instead of hardcoded value
- Default value is 1 to maintain backward compatibility
- Each session gets its own lane with the configured concurrency

## Real Behavior Proof
- **Behavior or issue addressed**: Telegram forum topics concurrency - allow parallel processing of messages in different forum topics within the same group
- **Real environment tested**: Local development environment with OpenClaw gateway and Telegram bot integration
- **Exact steps or command run after this patch**:
  1. Set `agents.defaults.sessionLaneMaxConcurrent: 3` in config
  2. Start OpenClaw gateway with Telegram bot
  3. Send simultaneous messages to multiple forum topics in the same Telegram group
  4. Observe message processing in gateway logs
- **Evidence after fix**: Gateway logs show multiple messages from different forum topics being processed concurrently (e.g., 3 messages processed in parallel instead of sequentially)
- **Observed result after fix**: Messages from different forum topics are now processed in parallel based on the configured `sessionLaneMaxConcurrent` value, improving throughput and reducing latency

## Configuration Example
```yaml
agents:
  defaults:
    sessionLaneMaxConcurrent: 3  # Allow 3 concurrent messages per session
```

## Files Changed
- `src/config/agent-limits.ts`: Added `resolveSessionLaneMaxConcurrent()` function and constant
- `src/config/types.agent-defaults.ts`: Added `sessionLaneMaxConcurrent` config option
- `src/config/defaults.ts`: Added default value handling for new config
- `src/config/zod-schema.agent-defaults.ts`: Added schema validation
- `src/gateway/server-lanes.ts`: Updated to apply session lane concurrency on startup
- `src/plugin-sdk/config-runtime.ts`: Exported the resolver for plugin use
- `src/process/command-queue.ts`: Added `setSessionLaneMaxConcurrent()` and updated lane creation logic

## Backward Compatibility
This change is fully backward compatible:
- Default value is 1 (sequential processing), matching previous behavior
- No changes required to existing configurations
- Only affects behavior when explicitly configured

Fixes #81985