### PR TITLE
[Refactor] Lazy-load Canvas startup modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Dependencies: route root ambient Node proxy agents through `@openclaw/proxyline` and drop root `proxy-agent`, `https-proxy-agent`, and `minimatch` dependencies.
+- Canvas: lazy-load HTTP host, hosted media resolver, CLI implementation, and tool runtime modules so Gateway startup only pays Canvas implementation cost on first use. (#82001) Thanks @samzong.
 - Control UI/i18n: add a `pnpm ui:i18n:report` baseline report for hardcoded-copy focus areas and locale fallback metadata. (#81320) Thanks @samzong.
 - Maintainer tooling: add a repo-local `codex-review` skill for Codex closeout reviews, including local dirty-work and PR-branch review helpers that rerun until no accepted/actionable findings remain and avoid unsupported inline prompts with `--base`.
 - Maintainer tooling: fail CI when pull requests add package patch files or pnpm patched dependencies, preserving the upstream-and-bump dependency workflow.

--- a/extensions/canvas/index.test.ts
+++ b/extensions/canvas/index.test.ts
@@ -1,0 +1,137 @@
+import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import canvasPlugin from "./index.js";
+
+const mocks = vi.hoisted(() => {
+  const httpHandler = {
+    handleHttpRequest: vi.fn(async () => true),
+    handleUpgrade: vi.fn(async () => true),
+    close: vi.fn(async () => {}),
+  };
+  const toolExecute = vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] }));
+  return {
+    httpHandler,
+    createCanvasHttpRouteHandler: vi.fn(() => httpHandler),
+    resolveCanvasHttpPathToLocalPath: vi.fn(() => "/tmp/canvas-asset"),
+    createDefaultCanvasCliDependencies: vi.fn(() => ({ deps: true })),
+    registerNodesCanvasCommands: vi.fn(),
+    toolExecute,
+    createCanvasTool: vi.fn(() => ({
+      label: "Canvas",
+      name: "canvas",
+      description: "Canvas",
+      parameters: {},
+      execute: toolExecute,
+    })),
+  };
+});
+
+vi.mock("./src/http-route.js", () => ({
+  createCanvasHttpRouteHandler: mocks.createCanvasHttpRouteHandler,
+}));
+
+vi.mock("./src/documents.js", () => ({
+  resolveCanvasHttpPathToLocalPath: mocks.resolveCanvasHttpPathToLocalPath,
+}));
+
+vi.mock("./src/cli.js", () => ({
+  createDefaultCanvasCliDependencies: mocks.createDefaultCanvasCliDependencies,
+  registerNodesCanvasCommands: mocks.registerNodesCanvasCommands,
+}));
+
+vi.mock("./src/tool.js", () => ({
+  createCanvasTool: mocks.createCanvasTool,
+}));
+
+function registerCanvas() {
+  const routes: Array<Parameters<OpenClawPluginApi["registerHttpRoute"]>[0]> = [];
+  const services: Array<Parameters<OpenClawPluginApi["registerService"]>[0]> = [];
+  const resolvers: Array<Parameters<OpenClawPluginApi["registerHostedMediaResolver"]>[0]> = [];
+  const tools: Array<Parameters<OpenClawPluginApi["registerTool"]>[0]> = [];
+  const cliFeatures: Array<{
+    registrar: Parameters<OpenClawPluginApi["registerNodeCliFeature"]>[0];
+    opts: Parameters<OpenClawPluginApi["registerNodeCliFeature"]>[1];
+  }> = [];
+  canvasPlugin.register?.(
+    createTestPluginApi({
+      id: "canvas",
+      name: "Canvas",
+      config: {},
+      registerHttpRoute: (route) => routes.push(route),
+      registerService: (service) => services.push(service),
+      registerHostedMediaResolver: (resolver) => resolvers.push(resolver),
+      registerTool: (tool) => tools.push(tool),
+      registerNodeCliFeature: (registrar, opts) => cliFeatures.push({ registrar, opts }),
+      registerNodeInvokePolicy: vi.fn(),
+    }),
+  );
+  return { routes, services, resolvers, tools, cliFeatures };
+}
+
+describe("Canvas plugin entry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defers Canvas host implementation until a registered route is used", async () => {
+    const { routes, services } = registerCanvas();
+
+    expect(routes).toHaveLength(3);
+    expect(services).toHaveLength(1);
+    expect(mocks.createCanvasHttpRouteHandler).not.toHaveBeenCalled();
+
+    await services[0]?.stop?.({} as never);
+    expect(mocks.createCanvasHttpRouteHandler).not.toHaveBeenCalled();
+
+    await routes[0]?.handler({ url: "/__openclaw__/canvas" } as never, {} as never);
+    expect(mocks.createCanvasHttpRouteHandler).toHaveBeenCalledTimes(1);
+    expect(mocks.httpHandler.handleHttpRequest).toHaveBeenCalledTimes(1);
+
+    await services[0]?.stop?.({} as never);
+    expect(mocks.httpHandler.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers Canvas resolver, CLI, and tool implementations until use", async () => {
+    const { resolvers, tools, cliFeatures } = registerCanvas();
+
+    expect(resolvers).toHaveLength(1);
+    expect(tools).toHaveLength(1);
+    expect(cliFeatures).toHaveLength(1);
+    expect(mocks.resolveCanvasHttpPathToLocalPath).not.toHaveBeenCalled();
+    expect(mocks.createDefaultCanvasCliDependencies).not.toHaveBeenCalled();
+    expect(mocks.createCanvasTool).not.toHaveBeenCalled();
+
+    await expect(resolvers[0]?.("/__openclaw__/canvas/documents/id/index.html")).resolves.toBe(
+      "/tmp/canvas-asset",
+    );
+    expect(mocks.resolveCanvasHttpPathToLocalPath).toHaveBeenCalledTimes(1);
+
+    await cliFeatures[0]?.registrar({
+      program: {} as never,
+      parentPath: ["nodes"],
+      config: {},
+      workspaceDir: undefined,
+      logger: { info() {}, warn() {}, error() {}, debug() {} },
+    });
+    expect(mocks.createDefaultCanvasCliDependencies).toHaveBeenCalledTimes(1);
+    expect(mocks.registerNodesCanvasCommands).toHaveBeenCalledTimes(1);
+
+    const toolFactory = tools[0];
+    expect(typeof toolFactory).toBe("function");
+    const tool = (toolFactory as Exclude<typeof toolFactory, AnyAgentTool>)({
+      config: {},
+      workspaceDir: "/tmp/workspace",
+    });
+    expect(Array.isArray(tool)).toBe(false);
+    expect((tool as AnyAgentTool).name).toBe("canvas");
+    expect(mocks.createCanvasTool).not.toHaveBeenCalled();
+
+    await (tool as AnyAgentTool).execute("tool-call", { action: "hide" });
+    expect(mocks.createCanvasTool).toHaveBeenCalledWith({
+      config: {},
+      workspaceDir: "/tmp/workspace",
+    });
+    expect(mocks.toolExecute).toHaveBeenCalledWith("tool-call", { action: "hide" });
+  });
+});

--- a/extensions/canvas/index.ts
+++ b/extensions/canvas/index.ts
@@ -1,10 +1,10 @@
-import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import { createDefaultCanvasCliDependencies, registerNodesCanvasCommands } from "./src/cli.js";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Duplex } from "node:stream";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import { canvasConfigSchema, isCanvasHostEnabled } from "./src/config.js";
-import { resolveCanvasHttpPathToLocalPath } from "./src/documents.js";
-import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "./src/host/a2ui.js";
-import { createCanvasHttpRouteHandler } from "./src/http-route.js";
-import { createCanvasTool } from "./src/tool.js";
+import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "./src/host/a2ui-shared.js";
+import { CanvasToolSchema } from "./src/tool-schema.js";
 
 const CANVAS_NODE_COMMANDS = [
   "canvas.present",
@@ -17,6 +17,31 @@ const CANVAS_NODE_COMMANDS = [
   "canvas.a2ui.reset",
 ];
 
+function createLazyCanvasTool(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+}): AnyAgentTool {
+  let toolPromise: Promise<AnyAgentTool> | undefined;
+  const loadTool = async () => {
+    toolPromise ??= import("./src/tool.js").then(({ createCanvasTool }) =>
+      createCanvasTool({
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+      }),
+    );
+    return await toolPromise;
+  };
+  return {
+    label: "Canvas",
+    name: "canvas",
+    description:
+      "Control node canvases (present/hide/navigate/eval/snapshot/A2UI). Use snapshot to capture the rendered UI.",
+    parameters: CanvasToolSchema,
+    execute: async (...args: Parameters<AnyAgentTool["execute"]>) =>
+      await (await loadTool()).execute(...args),
+  };
+}
+
 export default definePluginEntry({
   id: "canvas",
   name: "Canvas",
@@ -27,46 +52,72 @@ export default definePluginEntry({
   },
   register(api) {
     if (isCanvasHostEnabled(api.config)) {
-      const httpRouteHandler = createCanvasHttpRouteHandler({
-        config: api.config,
-        pluginConfig: api.pluginConfig,
-        runtime: {
-          log: (...args) => api.logger.info(args.map(String).join(" ")),
-          error: (...args) => api.logger.error(args.map(String).join(" ")),
-          exit: (code) => {
-            throw new Error(`canvas host requested process exit ${code}`);
-          },
-        },
-      });
+      let httpRouteHandlerPromise:
+        | Promise<
+            ReturnType<(typeof import("./src/http-route.js"))["createCanvasHttpRouteHandler"]>
+          >
+        | undefined;
+      const loadHttpRouteHandler = async () => {
+        httpRouteHandlerPromise ??= import("./src/http-route.js").then(
+          ({ createCanvasHttpRouteHandler }) =>
+            createCanvasHttpRouteHandler({
+              config: api.config,
+              pluginConfig: api.pluginConfig,
+              runtime: {
+                log: (...args) => api.logger.info(args.map(String).join(" ")),
+                error: (...args) => api.logger.error(args.map(String).join(" ")),
+                exit: (code) => {
+                  throw new Error(`canvas host requested process exit ${code}`);
+                },
+              },
+            }),
+        );
+        return await httpRouteHandlerPromise;
+      };
+      const handleHttpRequest = async (req: IncomingMessage, res: ServerResponse) =>
+        await (await loadHttpRouteHandler()).handleHttpRequest(req, res);
+      const handleUpgrade = async (req: IncomingMessage, socket: Duplex, head: Buffer) =>
+        await (await loadHttpRouteHandler()).handleUpgrade(req, socket, head);
       const nodeCapability = { surface: "canvas" };
       api.registerHttpRoute({
         path: A2UI_PATH,
         auth: "plugin",
         match: "prefix",
         nodeCapability,
-        handler: httpRouteHandler.handleHttpRequest,
+        handler: handleHttpRequest,
       });
       api.registerHttpRoute({
         path: CANVAS_HOST_PATH,
         auth: "plugin",
         match: "prefix",
         nodeCapability,
-        handler: httpRouteHandler.handleHttpRequest,
+        handler: handleHttpRequest,
       });
       api.registerHttpRoute({
         path: CANVAS_WS_PATH,
         auth: "plugin",
         match: "exact",
         nodeCapability,
-        handler: httpRouteHandler.handleHttpRequest,
-        handleUpgrade: httpRouteHandler.handleUpgrade,
+        handler: handleHttpRequest,
+        handleUpgrade,
       });
       api.registerService({
         id: "canvas-host",
         start: () => {},
-        stop: () => httpRouteHandler.close(),
+        stop: async () => {
+          const httpRouteHandler = httpRouteHandlerPromise ? await httpRouteHandlerPromise : null;
+          await httpRouteHandler?.close();
+        },
       });
-      api.registerHostedMediaResolver((mediaUrl) => resolveCanvasHttpPathToLocalPath(mediaUrl));
+      let resolveCanvasHttpPathToLocalPathPromise:
+        | Promise<(typeof import("./src/documents.js"))["resolveCanvasHttpPathToLocalPath"]>
+        | undefined;
+      api.registerHostedMediaResolver(async (mediaUrl) => {
+        resolveCanvasHttpPathToLocalPathPromise ??= import("./src/documents.js").then(
+          ({ resolveCanvasHttpPathToLocalPath }) => resolveCanvasHttpPathToLocalPath,
+        );
+        return (await resolveCanvasHttpPathToLocalPathPromise)(mediaUrl);
+      });
     }
     api.registerNodeInvokePolicy({
       commands: CANVAS_NODE_COMMANDS,
@@ -75,13 +126,15 @@ export default definePluginEntry({
       handle: (ctx) => ctx.invokeNode(),
     });
     api.registerTool((ctx) =>
-      createCanvasTool({
+      createLazyCanvasTool({
         config: ctx.runtimeConfig ?? ctx.config,
         workspaceDir: ctx.workspaceDir,
       }),
     );
     api.registerNodeCliFeature(
-      ({ program }) => {
+      async ({ program }) => {
+        const { createDefaultCanvasCliDependencies, registerNodesCanvasCommands } =
+          await import("./src/cli.js");
         registerNodesCanvasCommands(program, createDefaultCanvasCliDependencies());
       },
       {

--- a/extensions/canvas/src/tool-schema.ts
+++ b/extensions/canvas/src/tool-schema.ts
@@ -1,0 +1,41 @@
+import { Type } from "typebox";
+
+export const CANVAS_ACTIONS = [
+  "present",
+  "hide",
+  "navigate",
+  "eval",
+  "snapshot",
+  "a2ui_push",
+  "a2ui_reset",
+] as const;
+
+export const CANVAS_SNAPSHOT_FORMATS = ["png", "jpg", "jpeg"] as const;
+
+function stringEnum<T extends readonly string[]>(values: T) {
+  return Type.Unsafe<T[number]>({
+    type: "string",
+    enum: [...values],
+  });
+}
+
+export const CanvasToolSchema = Type.Object({
+  action: stringEnum(CANVAS_ACTIONS),
+  gatewayUrl: Type.Optional(Type.String()),
+  gatewayToken: Type.Optional(Type.String()),
+  timeoutMs: Type.Optional(Type.Number()),
+  node: Type.Optional(Type.String()),
+  target: Type.Optional(Type.String()),
+  x: Type.Optional(Type.Number()),
+  y: Type.Optional(Type.Number()),
+  width: Type.Optional(Type.Number()),
+  height: Type.Optional(Type.Number()),
+  url: Type.Optional(Type.String()),
+  javaScript: Type.Optional(Type.String()),
+  outputFormat: Type.Optional(stringEnum(CANVAS_SNAPSHOT_FORMATS)),
+  maxWidth: Type.Optional(Type.Number()),
+  quality: Type.Optional(Type.Number()),
+  delayMs: Type.Optional(Type.Number()),
+  jsonl: Type.Optional(Type.String()),
+  jsonlPath: Type.Optional(Type.String()),
+});

--- a/extensions/canvas/src/tool.ts
+++ b/extensions/canvas/src/tool.ts
@@ -9,25 +9,11 @@ import {
 import {
   imageResultFromFile,
   jsonResult,
-  optionalStringEnum,
   readStringParam,
-  stringEnum,
 } from "openclaw/plugin-sdk/channel-actions";
 import type { AnyAgentTool, OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
-import { Type } from "typebox";
-
-const CANVAS_ACTIONS = [
-  "present",
-  "hide",
-  "navigate",
-  "eval",
-  "snapshot",
-  "a2ui_push",
-  "a2ui_reset",
-] as const;
-
-const CANVAS_SNAPSHOT_FORMATS = ["png", "jpg", "jpeg"] as const;
+import { CanvasToolSchema } from "./tool-schema.js";
 
 type CanvasToolOptions = {
   config?: OpenClawConfig;
@@ -114,28 +100,6 @@ function resolveCanvasImageSanitizationLimits(
   }
   return { maxDimensionPx: Math.max(1, Math.floor(configured)) };
 }
-
-// Flattened schema: runtime validates per-action requirements.
-const CanvasToolSchema = Type.Object({
-  action: stringEnum(CANVAS_ACTIONS),
-  gatewayUrl: Type.Optional(Type.String()),
-  gatewayToken: Type.Optional(Type.String()),
-  timeoutMs: Type.Optional(Type.Number()),
-  node: Type.Optional(Type.String()),
-  target: Type.Optional(Type.String()),
-  x: Type.Optional(Type.Number()),
-  y: Type.Optional(Type.Number()),
-  width: Type.Optional(Type.Number()),
-  height: Type.Optional(Type.Number()),
-  url: Type.Optional(Type.String()),
-  javaScript: Type.Optional(Type.String()),
-  outputFormat: optionalStringEnum(CANVAS_SNAPSHOT_FORMATS),
-  maxWidth: Type.Optional(Type.Number()),
-  quality: Type.Optional(Type.Number()),
-  delayMs: Type.Optional(Type.Number()),
-  jsonl: Type.Optional(Type.String()),
-  jsonlPath: Type.Optional(Type.String()),
-});
 
 export function createCanvasTool(options?: CanvasToolOptions): AnyAgentTool {
   const imageSanitization = resolveCanvasImageSanitizationLimits(options?.config);


### PR DESCRIPTION
## Summary

- Problem: Canvas imported host, route, document, CLI, and real tool implementations during plugin registration, adding avoidable work to gateway startup.
- Why it matters: the default gateway startup trace pays this cost even when no Canvas route, CLI command, hosted media resolver, or tool call is used.
- What changed: Canvas now registers lightweight routes, resolver, CLI descriptors, and tool metadata up front, then lazy-loads the concrete implementations on first use.
- What did NOT change (scope boundary): Canvas commands, route paths, node invoke policy, schema shape, and user-facing behavior stay unchanged.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: N/A
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: Canvas plugin startup implementation imports are deferred; Canvas routes, resolver, CLI descriptors, node invoke policy, and tool metadata remain registered.
- Real environment tested: local OpenClaw worktree on Darwin 25.4.0 arm64, Node v25.9.0.
- Exact steps or command run after this patch: `node --import tsx scripts/bench-gateway-startup.ts --case default --runs 7 --warmup 2 --output .artifacts/gateway-startup-canvas-lazy-runs7.json`
- Evidence after fix: copied terminal output from the real local OpenClaw benchmark run after this patch:

```text
OpenClaw gateway startup benchmark (default case, runs=7, warmup=2)
Environment: Darwin 25.4.0 arm64, Node v25.9.0
Command after patch: node --import tsx scripts/bench-gateway-startup.ts --case default --runs 7 --warmup 2 --output .artifacts/gateway-startup-canvas-lazy-runs7.json

metric                                                    baseline p50   after p50   delta      improvement
plugins.gateway-load.plugin.canvas.loadMs               37.5ms        9.5ms       -28.0ms    74.7%
plugins.gateway-load.plugin.canvas.loadAndRegisterMs    38.3ms        10.2ms      -28.1ms    73.4%
plugins.gateway-load.loadMs                             160.4ms       142.5ms     -17.9ms    11.2%
maxRssMb                                                632.3MB       623.0MB     -9.2MB     1.5%
readyzMs (not used as proof)                            2293.1ms      2370.9ms    +77.8ms    slower/noisy
```
- Observed result after fix: Canvas plugin load p50 dropped by `28.0ms` (`37.5ms` to `9.5ms`, about `74.7%`), Canvas load+register p50 dropped by `28.1ms` (`38.3ms` to `10.2ms`, about `73.4%`), total gateway plugin-load p50 dropped by `17.9ms` (`160.4ms` to `142.5ms`, about `11.2%`), and p50 max RSS dropped by about `9.2MB`.
- What was not tested: real first-use Canvas HTTP/WS route behavior, paired node command invocation, and snapshot output were not exercised; `/readyz` is not used as proof because it was noisy and slower in this run (`2293.1ms` before, `2370.9ms` after).
- Before evidence (optional but encouraged): same benchmark harness against the pre-change tracked files wrote `.artifacts/gateway-startup-canvas-baseline-runs7.json` with `plugins.gateway-load.plugin.canvas.loadMs` p50 `37.5ms`, `plugins.gateway-load.plugin.canvas.loadAndRegisterMs` p50 `38.3ms`, and `plugins.gateway-load.loadMs` p50 `160.4ms`.

## Root Cause (if applicable)

N/A - this is a startup performance refactor, not a bug fix.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/canvas/index.test.ts`
- Scenario the test should lock in: registering the Canvas plugin must not instantiate the Canvas host, document resolver, CLI implementation, or real tool until the corresponding route, resolver, CLI registrar, or tool execution path is used.
- Why this is the smallest reliable guardrail: the startup regression is caused by plugin entrypoint imports and registration-time construction, so an entrypoint-level test catches the intended boundary directly.
- Existing test that already covers this (if any): existing `extensions/canvas/src/tool.test.ts`, `extensions/canvas/src/cli.test.ts`, `extensions/canvas/src/documents.test.ts`, and `extensions/canvas/src/config.test.ts` continue covering the implementation modules.
- If no new test is added, why not: N/A - a new entrypoint test is added.

## User-visible / Behavior Changes

None for functional behavior. Canvas implementation modules are loaded on first Canvas route, hosted media resolver, CLI, or tool use instead of during gateway plugin registration.

## Diagram (if applicable)

```text
Before:
[gateway plugin load] -> [Canvas entrypoint] -> [host/docs/http/tool/CLI imports]

After:
[gateway plugin load] -> [lightweight Canvas registrations] -> [first Canvas use] -> [implementation import]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Darwin 25.4.0 arm64
- Runtime/container: Node v25.9.0 local worktree
- Model/provider: N/A
- Integration/channel (if any): Canvas plugin
- Relevant config (redacted): default gateway startup benchmark case

### Steps

1. `node scripts/run-vitest.mjs extensions/canvas/index.test.ts extensions/canvas/src/tool.test.ts extensions/canvas/src/cli.test.ts extensions/canvas/src/documents.test.ts extensions/canvas/src/config.test.ts`
2. `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/canvas/index.ts extensions/canvas/src/tool.ts extensions/canvas/src/tool-schema.ts extensions/canvas/index.test.ts`
3. `node scripts/build-all.mjs cliStartup`
4. `pnpm changed:lanes --json`
5. `git diff --check`
6. `node --import tsx scripts/bench-gateway-startup.ts --case default --runs 7 --warmup 2 --output .artifacts/gateway-startup-canvas-lazy-runs7.json`

### Expected

- Canvas plugin registration stays lightweight while preserving the registered Canvas route, resolver, CLI, node invoke policy, and tool metadata contracts.
- Focused tests, lint, and CLI startup build pass.
- Gateway startup trace shows lower Canvas plugin load and register time.

### Actual

- Focused Canvas tests passed: 5 files, 19 tests.
- Focused oxlint passed.
- `node scripts/build-all.mjs cliStartup` passed.
- `pnpm changed:lanes --json` reported only `extensions` and `extensionTests` lanes.
- `git diff --check` passed.
- Canvas plugin load p50 improved from `37.5ms` to `9.5ms`; Canvas load+register p50 improved from `38.3ms` to `10.2ms`; total gateway plugin-load p50 improved from `160.4ms` to `142.5ms`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified:

- Verified scenarios: Canvas plugin entrypoint lazy registration, first route use, service stop without route load, hosted media resolver lazy load, CLI registrar lazy load, lazy Canvas tool construction on execute, focused implementation tests, lint, CLI startup build, changed-lane scope, and startup benchmark trace.
- Edge cases checked: service stop before the HTTP route handler is instantiated; async CLI registrar contract; async HTTP route and upgrade handler contract; async hosted media resolver contract; flat string enum schema shape.
- What I did not verify: real first-use Canvas HTTP/WS route behavior, paired node command invocation, snapshot output, full suite, and `/readyz` improvement.

## Review Conversations

- [x] No review conversations exist yet.
- [x] No bot review conversations exist yet.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the deferred import cost moves to first Canvas use.
  - Mitigation: route, resolver, CLI, and tool registrations remain present up front; focused tests lock in lazy construction and first-use loading paths.
- Risk: startup benchmark noise could hide unrelated readiness changes.
  - Mitigation: this PR only claims Canvas plugin-load and total plugin-load trace improvements; `/readyz` is explicitly not used as proof.

