### PR TITLE
fix(gateway): forward response_format through OpenAI-compatible chat completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Control UI: rotate browser service-worker caches per build so updated Gateways are less likely to keep serving stale dashboard bundles that trigger protocol mismatch errors.
 - Discord: report unresolved configured bot-token SecretRefs during startup instead of treating the account as unconfigured. (#82009) Thanks @giodl73-repo.
 - CLI/config: preserve numeric-looking object keys such as Discord guild IDs during `config patch` recursive merges. (#81999) Thanks @giodl73-repo.
+- Gateway/OpenAI-compatible HTTP: forward `response_format` from `/v1/chat/completions` requests through agent stream params to upstream Chat Completions and Responses transports, restoring structured-output support. Fixes #82003. (#82004) Thanks @Lellansin.
 - Control UI/WebChat: let sidebar markdown code-block Copy buttons use the same delegated clipboard handler as chat messages. (#58709) Thanks @tikitoki.
 - Discord/streaming: only mark partial draft previews delivered after final edit or fallback delivery succeeds, so failed finalization cleanup removes stale truncated drafts instead of leaving them as the visible reply. Fixes #82035. Thanks @compoodment.
 - macOS/Gateway: surface leftover `ai.openclaw.update.*` launchd updater jobs in `openclaw gateway status --deep` and doctor so post-update launchd loops point at the stale job cleanup. Fixes #81859. Thanks @BKF-Gitty.

--- a/src/agents/command/shared-types.ts
+++ b/src/agents/command/shared-types.ts
@@ -5,6 +5,7 @@ export type AgentStreamParams = {
   maxTokens?: number;
   /** Provider fast-mode override (best-effort). */
   fastMode?: boolean;
+  responseFormat?: Record<string, unknown>;
 };
 
 // Simplified tool definition for client-provided tools (OpenResponses hosted tools)

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1609,7 +1609,7 @@ describe("openai transport stream", () => {
       prompt_cache_retention: "24h",
       service_tier: "auto",
       temperature: 0.2,
-      text: { format: { type: "json_object" } },
+      text: { format: { type: "json_object" }, verbosity: "low" },
       top_p: 0.85,
     };
 
@@ -1635,7 +1635,7 @@ describe("openai transport stream", () => {
     expect(sanitized).not.toHaveProperty("prompt_cache_retention");
     expect(sanitized).not.toHaveProperty("service_tier");
     expect(sanitized).not.toHaveProperty("temperature");
-    expect(sanitized).not.toHaveProperty("text");
+    expect(sanitized.text).toEqual({ verbosity: "low" });
     expect(sanitized).not.toHaveProperty("top_p");
   });
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1403,6 +1403,46 @@ describe("openai transport stream", () => {
     expect(params.top_p).toBe(0.9);
   });
 
+  it("forwards response_format to chat completions request params", () => {
+    const model = {
+      id: "gpt-5.4",
+      name: "GPT-5.4",
+      api: "openai-completions",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    const context = {
+      systemPrompt: "system",
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      tools: [],
+    } as never;
+
+    {
+      const params = buildOpenAICompletionsParams(model, context, {
+        responseFormat: { type: "json_object" },
+      });
+      expect(params.response_format).toEqual({ type: "json_object" });
+    }
+
+    {
+      const params = buildOpenAICompletionsParams(model, context, {
+        responseFormat: { type: "json_schema", json_schema: {} },
+      });
+      expect(params.response_format).toEqual({ type: "json_schema", json_schema: {} });
+    }
+
+    {
+      const params = buildOpenAICompletionsParams(model, context, {});
+      expect(params).not.toHaveProperty("response_format");
+    }
+  });
+
   it("does not build OpenRouter reasoning params for Hunter Alpha when reasoning is disabled", () => {
     const params = buildOpenAICompletionsParams(
       {
@@ -1569,6 +1609,7 @@ describe("openai transport stream", () => {
       prompt_cache_retention: "24h",
       service_tier: "auto",
       temperature: 0.2,
+      text: { format: { type: "json_object" } },
       top_p: 0.85,
     };
 
@@ -1594,6 +1635,7 @@ describe("openai transport stream", () => {
     expect(sanitized).not.toHaveProperty("prompt_cache_retention");
     expect(sanitized).not.toHaveProperty("service_tier");
     expect(sanitized).not.toHaveProperty("temperature");
+    expect(sanitized).not.toHaveProperty("text");
     expect(sanitized).not.toHaveProperty("top_p");
   });
 
@@ -1638,6 +1680,51 @@ describe("openai transport stream", () => {
     expect(params.max_output_tokens).toBe(1024);
     expect(params.temperature).toBe(0.2);
     expect(params.top_p).toBe(0.85);
+  });
+
+  it("forwards response_format to responses text format request params", () => {
+    const model = {
+      id: "gpt-5.4",
+      name: "GPT-5.4",
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 65_536,
+    } satisfies Model<"openai-responses">;
+
+    const context = {
+      systemPrompt: "system",
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      tools: [],
+    } as never;
+
+    {
+      const params = buildOpenAIResponsesParams(model, context, {
+        responseFormat: { type: "json_object" },
+      }) as Record<string, unknown>;
+      expect(params.text).toEqual({ format: { type: "json_object" } });
+    }
+
+    {
+      const params = buildOpenAIResponsesParams(model, context, {
+        responseFormat: {
+          type: "json_schema",
+          json_schema: { name: "test", schema: { type: "object" } },
+        },
+      }) as Record<string, unknown>;
+      expect(params.text).toEqual({
+        format: { type: "json_schema", name: "test", schema: { type: "object" } },
+      });
+    }
+
+    {
+      const params = buildOpenAIResponsesParams(model, context, {}) as Record<string, unknown>;
+      expect(params).not.toHaveProperty("text");
+    }
   });
 
   it("preserves custom Codex-compatible responses params after payload hooks mutate them", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1271,9 +1271,22 @@ const OPENAI_CODEX_RESPONSES_UNSUPPORTED_PARAMS = [
   "prompt_cache_retention",
   "service_tier",
   "temperature",
-  "text",
   "top_p",
 ] as const;
+
+function stripOpenAICodexResponsesUnsupportedTextFields(params: Record<string, unknown>): void {
+  const text = params.text;
+  if (!text || typeof text !== "object" || Array.isArray(text)) {
+    return;
+  }
+  const sanitizedText = { ...(text as Record<string, unknown>) };
+  delete sanitizedText.format;
+  if (Object.keys(sanitizedText).length > 0) {
+    params.text = sanitizedText;
+  } else {
+    delete params.text;
+  }
+}
 
 function sanitizeOpenAICodexResponsesParams<T extends Record<string, unknown>>(
   model: Model<Api>,
@@ -1285,6 +1298,7 @@ function sanitizeOpenAICodexResponsesParams<T extends Record<string, unknown>>(
   for (const key of OPENAI_CODEX_RESPONSES_UNSUPPORTED_PARAMS) {
     delete params[key];
   }
+  stripOpenAICodexResponsesUnsupportedTextFields(params);
   return params;
 }
 

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -15,6 +15,7 @@ import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
 import type {
   FunctionTool,
   ResponseCreateParamsStreaming,
+  ResponseFormatTextConfig,
   ResponseFunctionCallOutputItemList,
   ResponseInput,
   ResponseInputItem,
@@ -87,6 +88,7 @@ type BaseStreamOptions = {
   onPayload?: (payload: unknown, model: Model<Api>) => unknown;
   headers?: Record<string, string>;
   openclawCodeModeToolSurface?: boolean;
+  responseFormat?: Record<string, unknown>;
 };
 
 type OpenAIResponsesOptions = BaseStreamOptions & {
@@ -1269,6 +1271,7 @@ const OPENAI_CODEX_RESPONSES_UNSUPPORTED_PARAMS = [
   "prompt_cache_retention",
   "service_tier",
   "temperature",
+  "text",
   "top_p",
 ] as const;
 
@@ -1306,6 +1309,23 @@ function ensureOpenAICodexResponsesInput(messages: ResponseInput, context: Conte
     role: "user",
     content: [{ type: "input_text", text: OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT }],
   });
+}
+
+function resolveOpenAIResponsesTextFormat(
+  responseFormat: Record<string, unknown>,
+): ResponseFormatTextConfig {
+  if (
+    responseFormat.type === "json_schema" &&
+    responseFormat.json_schema &&
+    typeof responseFormat.json_schema === "object" &&
+    !Array.isArray(responseFormat.json_schema)
+  ) {
+    return {
+      ...(responseFormat.json_schema as Record<string, unknown>),
+      type: "json_schema",
+    } as unknown as ResponseFormatTextConfig;
+  }
+  return responseFormat as unknown as ResponseFormatTextConfig;
 }
 
 export function buildOpenAIResponsesParams(
@@ -1355,6 +1375,12 @@ export function buildOpenAIResponsesParams(
   }
   if (options?.topP !== undefined) {
     params.top_p = options.topP;
+  }
+  if (options?.responseFormat !== undefined) {
+    params.text = {
+      ...params.text,
+      format: resolveOpenAIResponsesTextFormat(options.responseFormat),
+    };
   }
   if (options?.serviceTier !== undefined && payloadPolicy.allowsServiceTier) {
     params.service_tier = options.serviceTier;
@@ -2190,6 +2216,7 @@ type OpenAIResponsesRequestParams = {
   max_output_tokens?: number;
   temperature?: number;
   top_p?: number;
+  text?: ResponseCreateParamsStreaming["text"];
   service_tier?: ResponseCreateParamsStreaming["service_tier"];
   tools?: FunctionTool[];
   tool_choice?: ResponseCreateParamsStreaming["tool_choice"];
@@ -2424,6 +2451,9 @@ export function buildOpenAICompletionsParams(
   }
   if (options?.topP !== undefined) {
     params.top_p = options.topP;
+  }
+  if (options?.responseFormat !== undefined) {
+    params.response_format = options.responseFormat;
   }
   if (context.tools) {
     params.tools = convertTools(context.tools, compat, model);

--- a/src/agents/pi-embedded-runner-extraparams-resolve.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams-resolve.test.ts
@@ -193,6 +193,41 @@ describe("resolveExtraParams", () => {
     });
   });
 
+  it("canonicalizes response format alias styles with agent override precedence", () => {
+    const result = resolveExtraParams({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.4": {
+                params: {
+                  response_format: { type: "text" },
+                },
+              },
+            },
+          },
+          list: [
+            {
+              id: "main",
+              params: {
+                responseFormat: { type: "json_object" },
+              },
+            },
+          ],
+        },
+      },
+      provider: "openai",
+      modelId: "gpt-5.4",
+      agentId: "main",
+    });
+
+    expect(result).toEqual({
+      parallel_tool_calls: true,
+      response_format: { type: "json_object" },
+      text_verbosity: "low",
+    });
+  });
+
   it("ignores per-agent params when agentId does not match", () => {
     const result = resolveExtraParams({
       cfg: {

--- a/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
@@ -1,7 +1,11 @@
 import type { StreamFn } from "@earendil-works/pi-agent-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPiAiStreamSimpleMock } from "../../../test/helpers/agents/pi-ai-stream-simple-mock.js";
-import { __testing as extraParamsTesting, applyExtraParamsToAgent } from "./extra-params.js";
+import {
+  __testing as extraParamsTesting,
+  applyExtraParamsToAgent,
+  resolvePreparedExtraParams,
+} from "./extra-params.js";
 
 vi.mock("./logger.js", () => ({
   log: {
@@ -97,9 +101,72 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     })) as unknown as StreamFn;
     const agent: { streamFn?: StreamFn } = { streamFn: underlying };
 
-    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5.4", {
-      response_format: { type: "json_object" },
-    });
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "openai",
+      "gpt-5.4",
+      {
+        response_format: { type: "json_object" },
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { preparedExtraParams: { temperature: 0.4 } },
+    );
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      { id: "gpt-5.4", api: "openai-completions", provider: "openai" } as never,
+      { messages: [], tools: [] } as never,
+      undefined,
+    );
+
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as
+      | { responseFormat?: Record<string, unknown>; temperature?: number }
+      | undefined;
+    expect(callOptions?.responseFormat).toEqual({ type: "json_object" });
+    expect(callOptions?.temperature).toBe(0.4);
+  });
+
+  it("lets request responseFormat override configured response_format", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.4": {
+                params: {
+                  response_format: { type: "text" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "openai",
+      "gpt-5.4",
+      {
+        responseFormat: { type: "json_object" },
+      },
+    );
 
     if (!agent.streamFn) {
       throw new Error("expected extra params to wrap streamFn");
@@ -114,5 +181,49 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
       .calls[0]?.[2] as { responseFormat?: Record<string, unknown> } | undefined;
     expect(callOptions?.responseFormat).toEqual({ type: "json_object" });
+  });
+
+  it("keeps request-scoped response_format out of prepared extra params cache", () => {
+    const prepareProviderExtraParams = vi.fn((params) => ({
+      ...params.context.extraParams,
+      prepared: true,
+    }));
+    extraParamsTesting.setProviderRuntimeDepsForTest({
+      prepareProviderExtraParams,
+      resolveProviderExtraParamsForTransport: () => undefined,
+      wrapProviderStreamFn: () => undefined,
+    });
+
+    const cfg = { agents: { defaults: {} } } as never;
+    const first = resolvePreparedExtraParams({
+      cfg,
+      provider: "openai",
+      modelId: "gpt-5.4",
+      extraParamsOverride: {
+        temperature: 0.4,
+        response_format: {
+          type: "json_schema",
+          json_schema: { name: "one", schema: { type: "object" } },
+        },
+      },
+    });
+    const second = resolvePreparedExtraParams({
+      cfg,
+      provider: "openai",
+      modelId: "gpt-5.4",
+      extraParamsOverride: {
+        temperature: 0.4,
+        response_format: {
+          type: "json_schema",
+          json_schema: { name: "two", schema: { type: "object" } },
+        },
+      },
+    });
+
+    expect(prepareProviderExtraParams).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+    expect(first).not.toHaveProperty("response_format");
+    expect(first).not.toHaveProperty("responseFormat");
+    expect(first.temperature).toBe(0.4);
   });
 });

--- a/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
@@ -86,4 +86,33 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     expect(callOptions?.temperature).toBe(0.4);
     expect(callOptions?.topP).toBe(0.9);
   });
+
+  it("forwards response_format aliases into the underlying streamFn options", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5.4", {
+      response_format: { type: "json_object" },
+    });
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      { id: "gpt-5.4", api: "openai-completions", provider: "openai" } as never,
+      { messages: [], tools: [] } as never,
+      undefined,
+    );
+
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as { responseFormat?: Record<string, unknown> } | undefined;
+    expect(callOptions?.responseFormat).toEqual({ type: "json_object" });
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -44,6 +44,7 @@ const providerRuntimeDeps = {
 };
 
 let preparedExtraParamsCache = new WeakMap<OpenClawConfig, Map<string, Record<string, unknown>>>();
+const REQUEST_SCOPED_EXTRA_PARAM_KEYS = new Set(["response_format", "responseFormat"]);
 
 export const __testing = {
   setProviderRuntimeDepsForTest(
@@ -110,6 +111,16 @@ export function resolveExtraParams(params: {
   if (resolvedTextVerbosity !== undefined) {
     merged.text_verbosity = resolvedTextVerbosity;
     delete merged.textVerbosity;
+  }
+
+  const resolvedResponseFormat = resolveAliasedParamValue(
+    [defaultParams, globalParams, agentParams],
+    "response_format",
+    "responseFormat",
+  );
+  if (resolvedResponseFormat !== undefined) {
+    merged.response_format = resolvedResponseFormat;
+    delete merged.responseFormat;
   }
 
   const resolvedCachedContent = resolveAliasedParamValue(
@@ -194,7 +205,8 @@ function resolvePreparedExtraParamsCacheKey(params: {
     workspaceDir: params.workspaceDir ?? "",
     thinkingLevel: params.thinkingLevel ?? "",
     resolvedTransport: params.resolvedTransport ?? "",
-    extraParamsOverride: params.extraParamsOverride ?? null,
+    extraParamsOverride:
+      stripRequestScopedExtraParams(sanitizeExtraParamsRecord(params.extraParamsOverride)) ?? null,
     resolvedExtraParams: params.resolvedExtraParams ?? null,
     model: fingerprintPreparedExtraParamsModel(params.model),
   });
@@ -224,9 +236,11 @@ export function resolvePreparedExtraParams(params: {
     });
   const override =
     params.extraParamsOverride && Object.keys(params.extraParamsOverride).length > 0
-      ? sanitizeExtraParamsRecord(
-          Object.fromEntries(
-            Object.entries(params.extraParamsOverride).filter(([, value]) => value !== undefined),
+      ? stripRequestScopedExtraParams(
+          sanitizeExtraParamsRecord(
+            Object.fromEntries(
+              Object.entries(params.extraParamsOverride).filter(([, value]) => value !== undefined),
+            ),
           ),
         )
       : undefined;
@@ -312,6 +326,24 @@ function sanitizeExtraParamsRecord(
   );
 }
 
+function stripRequestScopedExtraParams(
+  value: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const filtered = Object.fromEntries(
+    Object.entries(value).filter(([key]) => !REQUEST_SCOPED_EXTRA_PARAM_KEYS.has(key)),
+  );
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
+function hasRequestScopedExtraParams(value: Record<string, unknown> | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  return [...REQUEST_SCOPED_EXTRA_PARAM_KEYS].some((key) => Object.hasOwn(value, key));
+}
 function shouldApplyDefaultOpenAIGptRuntimeParams(params: {
   provider: string;
   modelId: string;
@@ -674,9 +706,14 @@ type ApplyExtraParamsContext = {
 };
 
 function applyPrePluginStreamWrappers(ctx: ApplyExtraParamsContext): void {
+  const baseExtraParams =
+    ctx.override && hasRequestScopedExtraParams(ctx.override)
+      ? stripRequestScopedExtraParams(ctx.effectiveExtraParams)
+      : ctx.effectiveExtraParams;
+  const streamParams = ctx.override ? { ...baseExtraParams, ...ctx.override } : baseExtraParams;
   const wrappedStreamFn = createStreamFnWithExtraParams(
     ctx.agent.streamFn,
-    ctx.effectiveExtraParams,
+    streamParams,
     ctx.provider,
     ctx.model,
   );
@@ -822,8 +859,10 @@ export function applyExtraParamsToAgent(
   });
   const override =
     extraParamsOverride && Object.keys(extraParamsOverride).length > 0
-      ? Object.fromEntries(
-          Object.entries(extraParamsOverride).filter(([, value]) => value !== undefined),
+      ? sanitizeExtraParamsRecord(
+          Object.fromEntries(
+            Object.entries(extraParamsOverride).filter(([, value]) => value !== undefined),
+          ),
         )
       : undefined;
   const effectiveExtraParams =

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -134,6 +134,7 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
   cacheRetention?: "none" | "short" | "long";
   cachedContent?: string;
   topP?: number;
+  responseFormat?: Record<string, unknown>;
 };
 export type SupportedTransport = AgentRuntimeTransport;
 
@@ -385,6 +386,18 @@ function createStreamFnWithExtraParams(
   }
   if (typeof extraParams.maxTokens === "number") {
     streamParams.maxTokens = extraParams.maxTokens;
+  }
+  const resolvedResponseFormat = resolveAliasedParamValue(
+    [extraParams],
+    "response_format",
+    "responseFormat",
+  );
+  if (
+    resolvedResponseFormat &&
+    typeof resolvedResponseFormat === "object" &&
+    !Array.isArray(resolvedResponseFormat)
+  ) {
+    streamParams.responseFormat = resolvedResponseFormat as Record<string, unknown>;
   }
   const transport = resolveSupportedTransport(extraParams.transport);
   if (transport) {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -112,7 +112,12 @@ type FirstAgentCommandOptions = {
   model?: string;
   senderIsOwner?: boolean;
   sessionKey?: string;
-  streamParams?: { maxTokens?: number; temperature?: number; topP?: number };
+  streamParams?: {
+    maxTokens?: number;
+    responseFormat?: Record<string, unknown>;
+    temperature?: number;
+    topP?: number;
+  };
 };
 
 function firstAgentCommandOptions() {
@@ -1428,6 +1433,81 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     expect(json.error?.code).toBe("decimal_above_max_value");
     expect(json.error?.message).toContain("Invalid 'temperature'");
     expect(agentCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards response_format into streamParams", async () => {
+    const port = enabledPort;
+    const mockAgentOnce = (payloads: Array<{ text: string }>) => {
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({ payloads } as never);
+    };
+    const getStreamParams = () => firstAgentCommandOptions()?.streamParams;
+
+    {
+      mockAgentOnce([{ text: "{}" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        response_format: { type: "json_object" },
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getStreamParams()).toMatchObject({ responseFormat: { type: "json_object" } });
+      await res.text();
+    }
+
+    {
+      mockAgentOnce([{ text: "{}" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        response_format: {
+          type: "json_schema",
+          json_schema: { name: "test", schema: { type: "object" } },
+        },
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getStreamParams()).toMatchObject({
+        responseFormat: { type: "json_schema" },
+      });
+      await res.text();
+    }
+
+    {
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        response_format: { type: "text" },
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getStreamParams()).toMatchObject({ responseFormat: { type: "text" } });
+      await res.text();
+    }
+
+    {
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getStreamParams()).toBeUndefined();
+      await res.text();
+    }
+
+    {
+      agentCommand.mockClear();
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        response_format: { type: "xml" },
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(400);
+      const json = (await res.json()) as { error?: { type?: string; message?: string } };
+      expect(json.error?.type).toBe("invalid_request_error");
+      expect(json.error?.message).toMatch(/response_format/);
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+    }
   });
 
   it("returns 429 for repeated failed auth when gateway.auth.rateLimit is configured", async () => {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -78,6 +78,7 @@ type OpenAiChatCompletionRequest = {
   max_completion_tokens?: unknown;
   temperature?: unknown;
   top_p?: unknown;
+  response_format?: unknown;
 };
 
 const DEFAULT_OPENAI_CHAT_COMPLETIONS_BODY_BYTES = 20 * 1024 * 1024;
@@ -137,7 +138,12 @@ function buildAgentCommandInput(params: {
   messageChannel: string;
   senderIsOwner: boolean;
   abortSignal?: AbortSignal;
-  streamParams?: { maxTokens?: number; temperature?: number; topP?: number };
+  streamParams?: {
+    maxTokens?: number;
+    temperature?: number;
+    topP?: number;
+    responseFormat?: Record<string, unknown>;
+  };
 }) {
   return {
     message: params.prompt.message,
@@ -777,6 +783,21 @@ function resolveIncludeUsageForStreaming(payload: OpenAiChatCompletionRequest): 
   return (streamOptions as { include_usage?: unknown }).include_usage === true;
 }
 
+function resolveResponseFormat(value: unknown): Record<string, unknown> | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("response_format must be an object");
+  }
+  const obj = value as Record<string, unknown>;
+  const type = obj.type;
+  if (type !== "text" && type !== "json_object" && type !== "json_schema") {
+    throw new Error("response_format.type must be text, json_object, or json_schema");
+  }
+  return obj;
+}
+
 function resolveErrorMessage(err: unknown): string {
   if (err instanceof Error) {
     const message = err.message.trim();
@@ -828,6 +849,18 @@ export async function handleOpenAiHttpRequest(
         : undefined;
   const temperature = typeof payload.temperature === "number" ? payload.temperature : undefined;
   const topP = typeof payload.top_p === "number" ? payload.top_p : undefined;
+  let responseFormat: Record<string, unknown> | undefined;
+  try {
+    responseFormat = resolveResponseFormat(payload.response_format);
+  } catch (err) {
+    sendJson(res, 400, {
+      error: {
+        message: `Invalid response_format: ${resolveErrorMessage(err)}`,
+        type: "invalid_request_error",
+      },
+    });
+    return true;
+  }
   const samplingError = validateOpenAiSamplingParams({
     temperature: payload.temperature,
     topP: payload.top_p,
@@ -839,11 +872,15 @@ export async function handleOpenAiHttpRequest(
     return true;
   }
   const streamParams =
-    maxTokens !== undefined || temperature !== undefined || topP !== undefined
+    maxTokens !== undefined ||
+    temperature !== undefined ||
+    topP !== undefined ||
+    responseFormat !== undefined
       ? {
           ...(maxTokens !== undefined ? { maxTokens } : {}),
           ...(temperature !== undefined ? { temperature } : {}),
           ...(topP !== undefined ? { topP } : {}),
+          ...(responseFormat !== undefined ? { responseFormat } : {}),
         }
       : undefined;
 


### PR DESCRIPTION
## Summary

- Thread `response_format` from inbound `POST /v1/chat/completions` through `streamParams` -> runtime stream wrapper -> OpenAI transport, so client-supplied structured-output preferences reach the upstream provider.
- Extend `AgentStreamParams` with `responseFormat` and fix `createStreamFnWithExtraParams` in `src/agents/pi-embedded-runner/extra-params.ts` to forward `response_format` / `responseFormat` aliases to the underlying stream function.
- Map the forwarded option to both OpenAI transport shapes: Chat Completions receives `response_format`, while Responses-backed model transports receive `text.format` with the Responses API `json_schema` shape.
- Add `text` to `OPENAI_CODEX_RESPONSES_UNSUPPORTED_PARAMS` so the native ChatGPT-based Codex Responses backend strips structured-output text config server-side, matching how unsupported sampling params are handled there.
- Add gateway-level `response_format` validation for non-object values and unsupported types before provider dispatch.

Fixes #82003.

Follows the same parameter plumbing pattern as #81275 (`temperature` / `top_p`) and #81013 (`max_completion_tokens` / `max_tokens`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82003
- Related #81275
- Related #81013
- [x] This PR fixes a bug or regression

## Verification

- `pnpm test src/gateway/openai-http.test.ts src/agents/openai-transport-stream.test.ts src/agents/pi-embedded-runner/extra-params.sampling.test.ts` — gateway shard 16/16, agents shard 126/126.
- `pnpm check:changed` — clean (core/coreTests lanes; typecheck core, typecheck core tests, lint core, duplicate scan, dependency-pin guard, package patch guard, runtime import-cycle guard, runtime sidecar loader guard, media download helper guard, webhook body guard, pairing guards).
- `git diff --check origin/main...HEAD` — clean.
- `codex review --base origin/main` — no discrete actionable regressions found.

## Real behavior proof

- Behavior or issue addressed: OpenAI-compatible Gateway HTTP requests now forward client-supplied `response_format` from `POST /v1/chat/completions` through `streamParams` to the upstream OpenAI-compatible provider instead of silently dropping it. Chat Completions transports receive `response_format`; Responses-backed model transports receive the equivalent `text.format` payload. Invalid `response_format` values are rejected at the gateway with OpenAI-compatible 400 errors before provider dispatch.
- Real environment tested: Local OpenClaw managed gateway on loopback port `18793` after building PR head `4337a32081` with `pnpm build` and starting the gateway with a temporary config enabling `gateway.http.endpoints.chatCompletions.enabled`. Runtime was Node `v24.14.1`; CLI and gateway reported OpenClaw `2026.5.14` (build `4337a32`). The default agent model was `deepseek/deepseek-v4-flash`, using the configured `deepseek:default` API-key auth profile. Gateway token and provider key were read from local OpenClaw config/auth storage and were not printed.
- Exact steps or command run after this patch: Ran `pnpm build`, then started the dev gateway via tmux on port `18793` with `OPENCLAW_CONFIG_PATH=/tmp/openclaw-test-config.json pnpm openclaw gateway --port 18793 --auth none`. Then posted three local requests to `http://127.0.0.1:18793/v1/chat/completions`: a happy-path request with `response_format: { "type": "json_object" }`, an invalid-type probe with `response_format: { "type": "xml" }`, and an invalid-shape probe with `response_format: "json_object"`.
- Evidence after fix: Live gateway output from the happy-path request:

  ```json
  {
    "id": "chatcmpl_f50b9b4c-eb54-4d97-9bfb-0196b7e5bf96",
    "object": "chat.completion",
    "created": 1778815171,
    "model": "openclaw",
    "choices": [
      {
        "index": 0,
        "message": {
          "role": "assistant",
          "content": "{\"answer\":\"hi\"}"
        },
        "finish_reason": "stop"
      }
    ],
    "usage": {
      "prompt_tokens": 34572,
      "completion_tokens": 215,
      "total_tokens": 34787
    }
  }
  ```

  Live gateway output from the two validation probes:

  ```json
  {"error":{"message":"Invalid response_format: response_format.type must be text, json_object, or json_schema","type":"invalid_request_error"}}
  {"error":{"message":"Invalid response_format: response_format must be an object","type":"invalid_request_error"}}
  ```

- Observed result after fix: The valid `response_format: { "type": "json_object" }` request completed successfully and returned structured JSON from the upstream provider. The invalid-type probe (`xml`) was rejected at the gateway with a clear supported-types error. The invalid-shape probe (string value) was rejected with a clear `response_format must be an object` error. These behaviors prove the gateway now validates and forwards `response_format` correctly for the live `/v1/chat/completions` flow.
- What was not tested: Live native ChatGPT Codex Responses backend behavior was not exercised; that strip path is covered by targeted tests. Live `/v1/responses` endpoint behavior was not manually probed in this run; this PR does not change `src/gateway/openresponses-http.ts`. The Responses `text.format` mapping is covered by targeted transport-stream tests because `/v1/chat/completions` can dispatch to a Responses-backed model transport internally. The `response_format: { "type": "text" }` path was not live-tested because it is the default behavior and is covered by targeted tests.
- Before evidence: The issue was traceable in code before this patch: `src/gateway/openai-http.ts` did not read `payload.response_format` into `streamParams`, and `src/agents/pi-embedded-runner/extra-params.ts` did not copy a `responseFormat` option into the wrapped stream function.

## Root Cause (if applicable)

- Root cause: The OpenAI-compatible chat completions gateway accepted the wire-format field but the gateway/runtime stream parameter contract only forwarded token and sampling controls. `response_format` never crossed the `streamParams` boundary.
- Missing detection / guardrail: There was no endpoint-level regression test asserting `response_format` reaches agent command options, and no transport-builder test asserting the option reaches both OpenAI Chat Completions and Responses request shapes.
- Contributing context (if known): This parameter belongs to the same family of OpenAI-compatible request controls previously fixed for sampling and token-limit params.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/openai-http.test.ts`, `src/agents/openai-transport-stream.test.ts`, `src/agents/pi-embedded-runner/extra-params.sampling.test.ts`.
- Scenario the test should lock in: `response_format` is validated at the gateway, forwarded into `streamParams.responseFormat`, preserved by the embedded runner wrapper, and emitted as `response_format` for Chat Completions or `text.format` for Responses-backed transports.
- Why this is the smallest reliable guardrail: It exercises each ownership boundary without requiring live provider credentials in CI.
- Existing test that already covers this (if any): Added in this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

OpenAI-compatible Gateway clients can now rely on `response_format` for `/v1/chat/completions` requests. Unsupported gateway values return a 400 `invalid_request_error` before provider dispatch.

## Diagram (if applicable)

```text
Before:
client /v1/chat/completions response_format -> gateway -> streamParams without responseFormat -> provider request omits structured-output config

After:
client /v1/chat/completions response_format -> gateway validation -> streamParams.responseFormat -> runtime wrapper -> Chat Completions response_format or Responses text.format
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local development environment
- Runtime/container: Node `v24.14.1`, source checkout
- Model/provider: `deepseek/deepseek-v4-flash` for live proof; OpenAI transport builders covered by tests
- Integration/channel (if any): OpenAI-compatible Gateway HTTP API
- Relevant config (redacted): temporary gateway config enabling `gateway.http.endpoints.chatCompletions.enabled`; credentials read from local OpenClaw auth storage and not printed

### Steps

1. Start the OpenAI-compatible Gateway with Chat Completions enabled.
2. POST `/v1/chat/completions` with `response_format: { "type": "json_object" }`.
3. POST invalid probes with `{ "type": "xml" }` and a string `response_format` value.

### Expected

- Valid structured-output requests reach the provider and are honored.
- Invalid values are rejected by the gateway with 400 `invalid_request_error`.

### Actual

- Valid request returned structured JSON.
- Invalid type and invalid shape probes returned gateway-level 400 errors before dispatch.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused gateway/transport/runner regression tests, `pnpm check:changed`, `git diff --check`, and Codex review against `origin/main`.
- Edge cases checked: `json_object`, `json_schema`, `text`, omitted `response_format`, unsupported type, non-object shape, Chat Completions request shape, Responses request shape, native Codex Responses strip behavior.
- What you did **not** verify: live native ChatGPT Codex Responses backend; live `/v1/responses` endpoint.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Some clients may have been sending unsupported `response_format.type` values that were previously ignored.
  - Mitigation: The gateway now returns an OpenAI-compatible 400 `invalid_request_error`, matching the compat API contract more closely than silently ignoring the field.
