### PR TITLE
[Refactor] Split channel schema imports

### DIFF
--- a/src/config/zod-schema.channels-config.ts
+++ b/src/config/zod-schema.channels-config.ts
@@ -3,10 +3,6 @@ import type { ChannelsConfig } from "./types.channels.js";
 import { ChannelHeartbeatVisibilitySchema } from "./zod-schema.channels.js";
 import { ContextVisibilityModeSchema, GroupPolicySchema } from "./zod-schema.core.js";
 
-export * from "./zod-schema.providers-core.js";
-export * from "./zod-schema.providers-whatsapp.js";
-export { ChannelHeartbeatVisibilitySchema } from "./zod-schema.channels.js";
-
 const ChannelModelByChannelSchema = z
   .record(z.string(), z.record(z.string(), z.string()))
   .optional();

--- a/src/config/zod-schema.providers.lazy-runtime.test.ts
+++ b/src/config/zod-schema.providers.lazy-runtime.test.ts
@@ -17,9 +17,9 @@ describe("ChannelsSchema bundled runtime loading", () => {
   });
 
   it("skips bundled channel runtime discovery when only core channel keys are present", async () => {
-    const runtime = await importFreshModule<typeof import("./zod-schema.providers.js")>(
+    const runtime = await importFreshModule<typeof import("./zod-schema.channels-config.js")>(
       import.meta.url,
-      "./zod-schema.providers.js?scope=channels-core-only",
+      "./zod-schema.channels-config.js?scope=channels-core-only",
     );
 
     const parsed = runtime.ChannelsSchema.parse({
@@ -45,9 +45,9 @@ describe("ChannelsSchema bundled runtime loading", () => {
   });
 
   it("does not discover bundled channel runtime metadata during raw schema parsing", async () => {
-    const runtime = await importFreshModule<typeof import("./zod-schema.providers.js")>(
+    const runtime = await importFreshModule<typeof import("./zod-schema.channels-config.js")>(
       import.meta.url,
-      "./zod-schema.providers.js?scope=channels-plugin-owned",
+      "./zod-schema.channels-config.js?scope=channels-plugin-owned",
     );
 
     runtime.ChannelsSchema.parse({

--- a/src/config/zod-schema.startup-import.test.ts
+++ b/src/config/zod-schema.startup-import.test.ts
@@ -1,0 +1,45 @@
+import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const providersWhatsappImportMock = vi.hoisted(() => vi.fn());
+const providersCoreImportMock = vi.hoisted(() => vi.fn());
+
+describe("OpenClawSchema startup imports", () => {
+  beforeEach(() => {
+    providersWhatsappImportMock.mockClear();
+    providersCoreImportMock.mockClear();
+    vi.doMock("./zod-schema.providers-core.js", () => {
+      providersCoreImportMock();
+      return {};
+    });
+    vi.doMock("./zod-schema.providers-whatsapp.js", () => {
+      providersWhatsappImportMock();
+      return {};
+    });
+  });
+
+  it("does not load provider-specific channel schemas for generic channel validation", async () => {
+    const runtime = await importFreshModule<typeof import("./zod-schema.js")>(
+      import.meta.url,
+      "./zod-schema.js?scope=startup-generic-channels",
+    );
+
+    const parsed = runtime.OpenClawSchema.safeParse({
+      channels: {
+        defaults: {
+          groupPolicy: "open",
+          botLoopProtection: {
+            maxEventsPerWindow: 4,
+            windowSeconds: 90,
+            cooldownSeconds: 30,
+          },
+        },
+        discord: {},
+      },
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(providersCoreImportMock).not.toHaveBeenCalled();
+    expect(providersWhatsappImportMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -16,6 +16,7 @@ import {
 import { ToolsSchema } from "./zod-schema.agent-runtime.js";
 import { AgentsSchema, AudioSchema, BindingsSchema, BroadcastSchema } from "./zod-schema.agents.js";
 import { ApprovalsSchema } from "./zod-schema.approvals.js";
+import { ChannelsSchema } from "./zod-schema.channels-config.js";
 import {
   HexColorSchema,
   ModelsConfigSchema,
@@ -23,7 +24,6 @@ import {
   SecretsConfigSchema,
 } from "./zod-schema.core.js";
 import { HookMappingSchema, HooksGmailSchema, InternalHooksSchema } from "./zod-schema.hooks.js";
-import { ChannelsSchema } from "./zod-schema.providers.js";
 import { ProxyConfigSchema } from "./zod-schema.proxy.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 import {


### PR DESCRIPTION
## Summary

- Problem: `OpenClawSchema` pulled the generic `ChannelsSchema` through `zod-schema.providers.ts`, so validating generic channel defaults depended on the provider schema barrel.
- Why it matters: The generic channel config shape does not need provider-specific schema modules.
- What changed: Moved the generic channel schema into `zod-schema.channels-config.ts`, imported it directly from `zod-schema.ts`, and pointed the existing lazy-runtime guard at the new module.
- What did NOT change (scope boundary): This does not change the broader `config/io -> validation` startup path or its generated bundled channel config metadata import.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: `OpenClawSchema` generic channel validation no longer imports the provider schema barrel just to validate `channels.defaults`.
- Real environment tested: Local OpenClaw worktree on macOS with Node v24.14.0.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/config/zod-schema.startup-import.test.ts src/config/zod-schema.providers.lazy-runtime.test.ts src/config/config.acp-binding-cutover.test.ts src/config/group-policy.test.ts src/config/context-visibility.test.ts`; `node scripts/build-all.mjs cliStartup`; `pnpm deadcode:unused-files`; `rg -n "providers-whatsapp|providers-core|channels-config|zod-schema\\.providers" dist -g 'zod-schema*.js'`.
- Evidence after fix: Copied terminal output from the built-chunk import check: `dist/zod-schema-U0Wq5vAP.js:420://#region src/config/zod-schema.channels-config.ts`; the same command produced no `zod-schema.providers-core` or `zod-schema.providers-whatsapp` lines.
- Observed result after fix: Generic `OpenClawSchema.safeParse({ channels: { defaults: ..., discord: {} } })` succeeds without loading provider-specific channel schema modules, and the deadcode check accepts the removed internal provider barrel.
- What was not tested: This PR does not lazily load `src/config/bundled-channel-config-metadata.generated.ts` from the broader `config/io -> validation` gateway startup path; that broader startup-boundary split is intentionally left out of this PR.

## Root Cause (if applicable)

N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/zod-schema.startup-import.test.ts`, `src/config/zod-schema.providers.lazy-runtime.test.ts`
- Scenario the test should lock in: `OpenClawSchema` can validate generic channel defaults without loading provider-specific schema modules.
- Why this is the smallest reliable guardrail: The import boundary is the behavior under refactor.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v24.14.0, local worktree
- Model/provider: N/A
- Integration/channel (if any): Generic channel config schema
- Relevant config (redacted): N/A

### Steps

1. `node scripts/run-vitest.mjs src/config/zod-schema.startup-import.test.ts src/config/zod-schema.providers.lazy-runtime.test.ts src/config/config.acp-binding-cutover.test.ts src/config/group-policy.test.ts src/config/context-visibility.test.ts`
2. `node scripts/build-all.mjs cliStartup`
3. `pnpm deadcode:unused-files`
4. `git diff --check HEAD~1..HEAD`
5. `pnpm changed:lanes --json`
6. `rg -n "providers-whatsapp|providers-core|channels-config|zod-schema\\.providers" dist -g 'zod-schema*.js'`

### Expected

- Generic channel validation uses `zod-schema.channels-config.ts` directly.
- The build output for this schema chunk has no provider schema references.
- Deadcode does not report an unused provider barrel.

### Actual

- All targeted tests passed: 5 files, 34 tests.
- `node scripts/build-all.mjs cliStartup` passed.
- `pnpm deadcode:unused-files` passed.
- `git diff --check HEAD~1..HEAD` passed.
- `pnpm changed:lanes --json` reported `core` and `coreTests` only.
- The built schema chunk references `src/config/zod-schema.channels-config.ts` and no provider schema modules for this path.

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Targeted Vitest files, deadcode unused-file gate, CLI startup build, whitespace check, changed-lane scope, built chunk import references.
- Edge cases checked: Raw channel schema parsing still avoids bundled channel runtime metadata discovery.
- What you did **not** verify: Full gateway startup metadata lazy-loading beyond this schema import split.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes; no package export or production import used the removed internal `src/config/zod-schema.providers.ts` barrel.
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
