### PR TITLE
fix(discord): report unresolved token refs at startup

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -502,6 +502,22 @@ describe("discordPlugin outbound", () => {
     expect(runtimeMonitorDiscordProvider).not.toHaveBeenCalled();
   });
 
+  it("fails loudly before provider startup when a token SecretRef is configured but unresolved", async () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await expect(startDiscordAccount(cfg)).rejects.toThrow(
+      'Discord bot token configured for account "default" is unavailable',
+    );
+    expect(probeDiscordMock).not.toHaveBeenCalled();
+    expect(monitorDiscordProviderMock).not.toHaveBeenCalled();
+  });
+
   it("does not block Discord monitor startup on the startup probe", async () => {
     let resolveProbe:
       | ((value: {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -651,6 +651,11 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
       gateway: {
         startAccount: async (ctx) => {
           const account = ctx.account;
+          if (account.tokenStatus === "configured_unavailable") {
+            throw new Error(
+              `Discord bot token configured for account "${account.accountId}" is unavailable; resolve SecretRefs against the active runtime snapshot before using this account.`,
+            );
+          }
           const startupDelayMs = resolveDiscordStartupDelayMs(ctx.cfg, account.accountId);
           if (startupDelayMs > 0) {
             ctx.log?.info(

--- a/extensions/discord/src/shared.test.ts
+++ b/extensions/discord/src/shared.test.ts
@@ -63,7 +63,7 @@ describe("createDiscordPluginBase", () => {
     expect(plugin.config.isEnabled?.(workAccount, cfg)).toBe(true);
   });
 
-  it("describes unresolved SecretRef tokens without marking them startup-configured", () => {
+  it("describes unresolved SecretRef tokens as startup-configured so startup reports the resolver error", () => {
     const plugin = createDiscordPluginBase({ setup: {} as never });
     const cfg = {
       channels: {
@@ -79,8 +79,8 @@ describe("createDiscordPluginBase", () => {
     expect(account.token).toBe("");
     expect(account.tokenSource).toBe("config");
     expect(account.tokenStatus).toBe("configured_unavailable");
-    expect(plugin.config.isConfigured?.(account, cfg)).toBe(false);
-    expect(described?.configured).toBe(false);
+    expect(plugin.config.isConfigured?.(account, cfg)).toBe(true);
+    expect(described?.configured).toBe(true);
     expect(described?.tokenStatus).toBe("configured_unavailable");
   });
 });

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -15,7 +15,11 @@ import {
   resolveDiscordAccountDisabledReason,
   type ResolvedDiscordAccount,
 } from "./accounts.js";
-import { getChatChannelMeta, type ChannelPlugin } from "./channel-api.js";
+import {
+  getChatChannelMeta,
+  resolveConfiguredFromCredentialStatuses,
+  type ChannelPlugin,
+} from "./channel-api.js";
 import { DiscordChannelConfigSchema } from "./config-schema.js";
 import { normalizeCompatibilityConfig } from "./doctor-contract.js";
 import { DISCORD_LEGACY_CONFIG_RULES } from "./doctor-shared.js";
@@ -149,11 +153,13 @@ export function createDiscordPluginBase(params: {
         typeof env?.DISCORD_BOT_TOKEN === "string" && env.DISCORD_BOT_TOKEN.trim().length > 0,
       isEnabled: (account, cfg) => isDiscordAccountEnabledForRuntime(account, cfg),
       disabledReason: (account, cfg) => resolveDiscordAccountDisabledReason(account, cfg),
-      isConfigured: (account) => Boolean(account.token?.trim()),
+      isConfigured: (account) =>
+        resolveConfiguredFromCredentialStatuses(account) ?? Boolean(account.token?.trim()),
       describeAccount: (account) =>
         describeAccountSnapshot({
           account,
-          configured: Boolean(account.token?.trim()),
+          configured:
+            resolveConfiguredFromCredentialStatuses(account) ?? Boolean(account.token?.trim()),
           extra: {
             tokenSource: account.tokenSource,
             tokenStatus: account.tokenStatus,

--- a/src/secrets/runtime-discord-surface.test.ts
+++ b/src/secrets/runtime-discord-surface.test.ts
@@ -9,6 +9,67 @@ import {
 const { prepareSecretsRuntimeSnapshot } = setupSecretsRuntimeSnapshotTestHooks();
 
 describe("secrets runtime snapshot discord surface", () => {
+  it("resolves active Discord token refs for the default account", async () => {
+    const topLevelSnapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          discord: {
+            token: {
+              source: "env",
+              provider: "default",
+              id: "DISCORD_BOT_TOKEN",
+            },
+          },
+        },
+      }),
+      env: {
+        DISCORD_BOT_TOKEN: "base-token",
+      },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => loadAuthStoreWithProfiles({}),
+    });
+    expect(topLevelSnapshot.config.channels?.discord?.token).toBe("base-token");
+
+    const accountSnapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          discord: {
+            token: {
+              source: "env",
+              provider: "default",
+              id: "DISCORD_BOT_TOKEN",
+            },
+            accounts: {
+              default: {
+                enabled: true,
+                token: {
+                  source: "env",
+                  provider: "default",
+                  id: "DISCORD_DEFAULT_ACCOUNT_TOKEN",
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: {
+        DISCORD_BOT_TOKEN: "base-token",
+        DISCORD_DEFAULT_ACCOUNT_TOKEN: "default-account-token",
+      },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => loadAuthStoreWithProfiles({}),
+    });
+
+    expect(accountSnapshot.config.channels?.discord?.token).toEqual({
+      source: "env",
+      provider: "default",
+      id: "DISCORD_BOT_TOKEN",
+    });
+    expect(accountSnapshot.config.channels?.discord?.accounts?.default?.token).toBe(
+      "default-account-token",
+    );
+  });
+
   it("fails when non-default Discord account inherits an unresolved top-level token ref", async () => {
     await expect(
       prepareSecretsRuntimeSnapshot({


### PR DESCRIPTION
## Summary
- keep unresolved configured Discord token SecretRefs in the startup-configured state so gateway startup reports the resolver error instead of silently marking the account unconfigured
- fail before Discord provider/probe startup with an explicit message telling users to resolve SecretRefs against the active runtime snapshot
- add coverage proving active Discord token refs resolve through the secrets runtime snapshot for top-level and default-account token configs

Addresses the Discord token SecretRef diagnostics/runtime-snapshot portion of #81926.

## Real behavior proof

**Behavior or issue addressed:** A configured-but-unresolved Discord token SecretRef now reaches the gateway startup path and fails with an explicit SecretRef runtime-snapshot error before any Discord probe/provider starts, instead of being reported as merely unconfigured.

**Real environment tested:** WSL Ubuntu-24.04 worktree `/root/src/openclaw-branches/fix-discord-token-ref-diagnostics-81926`, branch commit `994a593`, using live `tsx` imports of the production Discord plugin and secrets runtime modules.

**Exact steps or command run after this patch:** Ran a live production-path script that resolves the Discord account, calls `discordPlugin.config.isConfigured`, invokes `discordPlugin.gateway.startAccount`, and prepares a secrets runtime snapshot with `DISCORD_BOT_TOKEN` in env.

```console
$ pnpm exec tsx --eval '...production-path script importing extensions/discord/src/channel.ts and src/secrets/runtime.ts...'
```

**Evidence after fix:** Copied live terminal output from the changed branch:

```console
tokenStatus=configured_unavailable
isConfigured=true
startupError=Discord bot token configured for account "default" is unavailable; resolve SecretRefs against the active runtime snapshot before using this account.
runtimeToken=runtime-discord-token
```

**Observed result after fix:** The unresolved SecretRef is now startup-configured (`isConfigured=true`) and throws the explicit runtime-snapshot error before startup proceeds; when the env ref is available to the secrets runtime, the same Discord token ref resolves to `runtime-discord-token`.

**What was not tested:** None

## Validation
- `pnpm exec vitest run extensions/discord/src/shared.test.ts extensions/discord/src/channel.test.ts extensions/discord/src/token.test.ts src/secrets/runtime-discord-surface.test.ts --config test/vitest/vitest.runtime-config.config.ts`
- `pnpm check:changed`