### PR TITLE
fix(config): rotate clobber snapshots at cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Config/doctor: rotate capped `.clobbered.*` repair snapshots by artifact timestamp so repeated repairs keep the newest forensic copy instead of preserving only the first capped set. (#82012) Thanks @Kaspre.
 - Telegram: apply method-aware Bot API request timeouts to direct message/action clients so `openclaw message delete --channel telegram` no longer waits on grammY's 500-second default when the API request wedges. Fixes #81908. Thanks @DashLabsDev.
 - Cron: treat attempt dispatch and assembled context as execution-start milestones so isolated agent jobs that have reached backend dispatch are governed by their configured job timeout instead of the 60s pre-execution watchdog. Fixes #81368. (#81871) Thanks @alexph-dev.
 - Discord/channels: make `openclaw channels list --all` prefer reachable Gateway runtime account status and mark configured-but-unavailable credentials, avoiding false `not configured` output when Discord is running from service-only env. Fixes #79343. Thanks @EricY019.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -370,6 +370,7 @@ Look for:
 - `Config write rejected: ...`
 - A timestamped `openclaw.json.rejected.*` file beside the active config
 - A timestamped `openclaw.json.clobbered.*` file if `doctor --fix` repaired a broken direct edit
+- OpenClaw keeps the latest 32 `.clobbered.*` files for each config path and rotates older ones
 
 <AccordionGroup>
   <Accordion title="What happened">
@@ -378,6 +379,7 @@ Look for:
     - Hot reload skips invalid external edits and keeps the current runtime config active.
     - OpenClaw-owned writes reject invalid/destructive payloads before commit and save `.rejected.*`.
     - `openclaw doctor --fix` owns repair. It can remove non-JSON prefixes or restore the last-known-good copy while preserving the rejected payload as `.clobbered.*`.
+    - When many repairs happen for one config path, OpenClaw rotates older `.clobbered.*` files so the newest repaired payload is still available.
 
   </Accordion>
   <Accordion title="Inspect and repair">

--- a/src/config/io.clobber-snapshot.test.ts
+++ b/src/config/io.clobber-snapshot.test.ts
@@ -43,6 +43,38 @@ describe("config clobber snapshots", () => {
     );
   }
 
+  async function findClobberFileByContent(
+    configPath: string,
+    expectedContent: string,
+  ): Promise<string> {
+    const dir = path.dirname(configPath);
+    for (const entry of await listClobberFiles(configPath)) {
+      const candidatePath = path.join(dir, entry);
+      if ((await fsp.readFile(candidatePath, "utf-8")) === expectedContent) {
+        return candidatePath;
+      }
+    }
+    throw new Error(`Missing clobber snapshot with content ${expectedContent}`);
+  }
+
+  async function touchClobberFilesByContentOrder(configPath: string): Promise<void> {
+    const dir = path.dirname(configPath);
+    const filesWithContents = await Promise.all(
+      (await listClobberFiles(configPath)).map(async (entry) => ({
+        entry,
+        content: await fsp.readFile(path.join(dir, entry), "utf-8"),
+      })),
+    );
+    for (const file of filesWithContents) {
+      const match = /^polluted-(\d+)\n$/.exec(file.content);
+      if (!match) {
+        continue;
+      }
+      const touchedAt = new Date(`2026-05-03T00:00:${match[1].padStart(2, "0")}.000Z`);
+      await fsp.utimes(path.join(dir, file.entry), touchedAt, touchedAt);
+    }
+  }
+
   it("keeps concurrent async snapshots under the per-path cap by rotating oldest files", async () => {
     await withCase(async (configPath) => {
       const warn = vi.fn();
@@ -94,6 +126,77 @@ describe("config clobber snapshots", () => {
           typeof message === "string" && message.includes("Config clobber snapshot cap reached"),
       );
       expect(capWarnings).toHaveLength(1);
+    });
+  });
+
+  it("rotates async snapshots by artifact timestamp rather than mutable mtime", async () => {
+    await withCase(async (configPath) => {
+      const warn = vi.fn();
+
+      for (let index = 0; index < CONFIG_CLOBBER_SNAPSHOT_LIMIT; index++) {
+        await persistBoundedClobberedConfigSnapshot({
+          deps: { fs, logger: { warn } },
+          configPath,
+          raw: `polluted-${index}\n`,
+          observedAt: `2026-05-03T00:00:${String(index).padStart(2, "0")}.000Z`,
+        });
+      }
+
+      const oldestPath = await findClobberFileByContent(configPath, "polluted-0\n");
+      const future = new Date("2026-05-03T01:00:00.000Z");
+      await fsp.utimes(oldestPath, future, future);
+
+      await persistBoundedClobberedConfigSnapshot({
+        deps: { fs, logger: { warn } },
+        configPath,
+        raw: "polluted-latest\n",
+        observedAt: "2026-05-03T00:01:00.000Z",
+      });
+
+      const clobberFiles = await listClobberFiles(configPath);
+      expect(clobberFiles).toHaveLength(CONFIG_CLOBBER_SNAPSHOT_LIMIT);
+      const contents = await readClobberFileContents(configPath);
+      expect(contents).not.toContain("polluted-0\n");
+      expect(contents).toContain("polluted-latest\n");
+      expect(warn.mock.calls).toHaveLength(1);
+    });
+  });
+
+  it("keeps rotating same-timestamp async snapshots after the base artifact is reused", async () => {
+    await withCase(async (configPath) => {
+      const warn = vi.fn();
+      const observedAt = "2026-05-03T00:00:00.000Z";
+
+      for (let index = 0; index < CONFIG_CLOBBER_SNAPSHOT_LIMIT; index++) {
+        await persistBoundedClobberedConfigSnapshot({
+          deps: { fs, logger: { warn } },
+          configPath,
+          raw: `polluted-${index}\n`,
+          observedAt,
+        });
+      }
+      await touchClobberFilesByContentOrder(configPath);
+
+      for (
+        let index = CONFIG_CLOBBER_SNAPSHOT_LIMIT;
+        index < CONFIG_CLOBBER_SNAPSHOT_LIMIT + 3;
+        index++
+      ) {
+        await persistBoundedClobberedConfigSnapshot({
+          deps: { fs, logger: { warn } },
+          configPath,
+          raw: `polluted-${index}\n`,
+          observedAt,
+        });
+      }
+
+      const clobberFiles = await listClobberFiles(configPath);
+      expect(clobberFiles).toHaveLength(CONFIG_CLOBBER_SNAPSHOT_LIMIT);
+      const contents = await readClobberFileContents(configPath);
+      expect(contents).not.toContain("polluted-0\n");
+      expect(contents).not.toContain("polluted-1\n");
+      expect(contents).not.toContain("polluted-2\n");
+      expect(contents).toContain(`polluted-${CONFIG_CLOBBER_SNAPSHOT_LIMIT + 2}\n`);
     });
   });
 

--- a/src/config/io.clobber-snapshot.test.ts
+++ b/src/config/io.clobber-snapshot.test.ts
@@ -35,7 +35,15 @@ describe("config clobber snapshots", () => {
     return entries.filter((entry) => entry.startsWith(prefix));
   }
 
-  it("keeps concurrent async snapshots under the per-path cap", async () => {
+  async function readClobberFileContents(configPath: string): Promise<string[]> {
+    const dir = path.dirname(configPath);
+    const clobberFiles = await listClobberFiles(configPath);
+    return await Promise.all(
+      clobberFiles.map((entry) => fsp.readFile(path.join(dir, entry), "utf-8")),
+    );
+  }
+
+  it("keeps concurrent async snapshots under the per-path cap by rotating oldest files", async () => {
     await withCase(async (configPath) => {
       const warn = vi.fn();
       const observedAt = "2026-05-03T00:00:00.000Z";
@@ -61,7 +69,35 @@ describe("config clobber snapshots", () => {
     });
   });
 
-  it("keeps sync snapshots under the per-path cap and warns once", async () => {
+  it("rotates async snapshots so the latest clobbered config is preserved", async () => {
+    await withCase(async (configPath) => {
+      const warn = vi.fn();
+
+      for (let index = 0; index < CONFIG_CLOBBER_SNAPSHOT_LIMIT + 3; index++) {
+        await persistBoundedClobberedConfigSnapshot({
+          deps: { fs, logger: { warn } },
+          configPath,
+          raw: `polluted-${index}\n`,
+          observedAt: `2026-05-03T00:00:${String(index).padStart(2, "0")}.000Z`,
+        });
+      }
+
+      const clobberFiles = await listClobberFiles(configPath);
+      expect(clobberFiles).toHaveLength(CONFIG_CLOBBER_SNAPSHOT_LIMIT);
+      const contents = await readClobberFileContents(configPath);
+      expect(contents).not.toContain("polluted-0\n");
+      expect(contents).not.toContain("polluted-1\n");
+      expect(contents).not.toContain("polluted-2\n");
+      expect(contents).toContain(`polluted-${CONFIG_CLOBBER_SNAPSHOT_LIMIT + 2}\n`);
+      const capWarnings = warn.mock.calls.filter(
+        ([message]) =>
+          typeof message === "string" && message.includes("Config clobber snapshot cap reached"),
+      );
+      expect(capWarnings).toHaveLength(1);
+    });
+  });
+
+  it("rotates sync snapshots so the latest clobbered config is preserved", async () => {
     await withCase(async (configPath) => {
       const warn = vi.fn();
 
@@ -76,6 +112,11 @@ describe("config clobber snapshots", () => {
 
       const clobberFiles = await listClobberFiles(configPath);
       expect(clobberFiles).toHaveLength(CONFIG_CLOBBER_SNAPSHOT_LIMIT);
+      const contents = await readClobberFileContents(configPath);
+      expect(contents).not.toContain("polluted-0\n");
+      expect(contents).not.toContain("polluted-1\n");
+      expect(contents).not.toContain("polluted-2\n");
+      expect(contents).toContain(`polluted-${CONFIG_CLOBBER_SNAPSHOT_LIMIT + 2}\n`);
       const capWarnings = warn.mock.calls.filter(
         ([message]) =>
           typeof message === "string" && message.includes("Config clobber snapshot cap reached"),

--- a/src/config/io.clobber-snapshot.ts
+++ b/src/config/io.clobber-snapshot.ts
@@ -122,6 +122,7 @@ function acquireClobberLockSync(deps: ConfigClobberSnapshotDeps, lockPath: strin
 type ClobberedSiblingSnapshot = {
   name: string;
   path: string;
+  timestampKey: string;
   mtimeMs: number;
 };
 
@@ -129,7 +130,11 @@ function compareClobberedSiblings(
   left: ClobberedSiblingSnapshot,
   right: ClobberedSiblingSnapshot,
 ): number {
-  return left.mtimeMs - right.mtimeMs || left.name.localeCompare(right.name);
+  return (
+    left.timestampKey.localeCompare(right.timestampKey) ||
+    left.mtimeMs - right.mtimeMs ||
+    left.name.localeCompare(right.name)
+  );
 }
 
 async function listClobberedSiblings(
@@ -146,7 +151,12 @@ async function listClobberedSiblings(
       }
       const snapshotPath = path.join(dir, entry);
       const stat = await deps.fs.promises.stat(snapshotPath).catch(() => null);
-      snapshots.push({ name: entry, path: snapshotPath, mtimeMs: stat?.mtimeMs ?? 0 });
+      snapshots.push({
+        name: entry,
+        path: snapshotPath,
+        timestampKey: entry.slice(prefix.length).replace(/-\d{2}$/, ""),
+        mtimeMs: stat?.mtimeMs ?? 0,
+      });
     }
     return snapshots.toSorted(compareClobberedSiblings);
   } catch {
@@ -167,7 +177,12 @@ function listClobberedSiblingsSync(
       }
       const snapshotPath = path.join(dir, entry);
       const stat = deps.fs.statSync(snapshotPath, { throwIfNoEntry: false });
-      snapshots.push({ name: entry, path: snapshotPath, mtimeMs: stat?.mtimeMs ?? 0 });
+      snapshots.push({
+        name: entry,
+        path: snapshotPath,
+        timestampKey: entry.slice(prefix.length).replace(/-\d{2}$/, ""),
+        mtimeMs: stat?.mtimeMs ?? 0,
+      });
     }
     return snapshots.toSorted(compareClobberedSiblings);
   } catch {

--- a/src/config/io.clobber-snapshot.ts
+++ b/src/config/io.clobber-snapshot.ts
@@ -13,6 +13,7 @@ type ConfigClobberSnapshotFs = {
     readdir(path: string): Promise<string[]>;
     rmdir(path: string): Promise<unknown>;
     stat(path: string): Promise<{ mtimeMs?: number } | null>;
+    unlink(path: string): Promise<unknown>;
     writeFile(
       path: string,
       data: string,
@@ -23,6 +24,7 @@ type ConfigClobberSnapshotFs = {
   readdirSync(path: string): string[];
   rmdirSync(path: string): unknown;
   statSync(path: string, options?: { throwIfNoEntry?: boolean }): { mtimeMs?: number } | null;
+  unlinkSync(path: string): unknown;
   writeFileSync(
     path: string,
     data: string,
@@ -117,28 +119,59 @@ function acquireClobberLockSync(deps: ConfigClobberSnapshotDeps, lockPath: strin
   return false;
 }
 
-async function countClobberedSiblings(
+type ClobberedSiblingSnapshot = {
+  name: string;
+  path: string;
+  mtimeMs: number;
+};
+
+function compareClobberedSiblings(
+  left: ClobberedSiblingSnapshot,
+  right: ClobberedSiblingSnapshot,
+): number {
+  return left.mtimeMs - right.mtimeMs || left.name.localeCompare(right.name);
+}
+
+async function listClobberedSiblings(
   deps: ConfigClobberSnapshotDeps,
   dir: string,
   prefix: string,
-): Promise<number> {
+): Promise<ClobberedSiblingSnapshot[]> {
   try {
     const entries = await deps.fs.promises.readdir(dir);
-    return entries.filter((entry) => entry.startsWith(prefix)).length;
+    const snapshots: ClobberedSiblingSnapshot[] = [];
+    for (const entry of entries) {
+      if (!entry.startsWith(prefix)) {
+        continue;
+      }
+      const snapshotPath = path.join(dir, entry);
+      const stat = await deps.fs.promises.stat(snapshotPath).catch(() => null);
+      snapshots.push({ name: entry, path: snapshotPath, mtimeMs: stat?.mtimeMs ?? 0 });
+    }
+    return snapshots.toSorted(compareClobberedSiblings);
   } catch {
-    return 0;
+    return [];
   }
 }
 
-function countClobberedSiblingsSync(
+function listClobberedSiblingsSync(
   deps: ConfigClobberSnapshotDeps,
   dir: string,
   prefix: string,
-): number {
+): ClobberedSiblingSnapshot[] {
   try {
-    return deps.fs.readdirSync(dir).filter((entry) => entry.startsWith(prefix)).length;
+    const snapshots: ClobberedSiblingSnapshot[] = [];
+    for (const entry of deps.fs.readdirSync(dir)) {
+      if (!entry.startsWith(prefix)) {
+        continue;
+      }
+      const snapshotPath = path.join(dir, entry);
+      const stat = deps.fs.statSync(snapshotPath, { throwIfNoEntry: false });
+      snapshots.push({ name: entry, path: snapshotPath, mtimeMs: stat?.mtimeMs ?? 0 });
+    }
+    return snapshots.toSorted(compareClobberedSiblings);
   } catch {
-    return 0;
+    return [];
   }
 }
 
@@ -152,8 +185,42 @@ function warnClobberCapReached(
   }
   clobberCapWarnedPaths.add(configPath);
   deps.logger.warn(
-    `Config clobber snapshot cap reached for ${configPath}: ${existing} existing .clobbered.* files; skipping additional forensic snapshots.`,
+    `Config clobber snapshot cap reached for ${configPath}: ${existing} existing .clobbered.* files; rotating oldest snapshots to preserve the latest forensic copy.`,
   );
+}
+
+async function rotateOldestClobberedSiblings(
+  deps: ConfigClobberSnapshotDeps,
+  snapshots: ClobberedSiblingSnapshot[],
+): Promise<boolean> {
+  const deleteCount = Math.max(0, snapshots.length - CONFIG_CLOBBER_SNAPSHOT_LIMIT + 1);
+  for (const snapshot of snapshots.slice(0, deleteCount)) {
+    try {
+      await deps.fs.promises.unlink(snapshot.path);
+    } catch (error) {
+      if (!isFsErrorCode(error, "ENOENT")) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function rotateOldestClobberedSiblingsSync(
+  deps: ConfigClobberSnapshotDeps,
+  snapshots: ClobberedSiblingSnapshot[],
+): boolean {
+  const deleteCount = Math.max(0, snapshots.length - CONFIG_CLOBBER_SNAPSHOT_LIMIT + 1);
+  for (const snapshot of snapshots.slice(0, deleteCount)) {
+    try {
+      deps.fs.unlinkSync(snapshot.path);
+    } catch (error) {
+      if (!isFsErrorCode(error, "ENOENT")) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 function buildClobberedTargetPath(configPath: string, observedAt: string, attempt: number): string {
@@ -173,10 +240,13 @@ export async function persistBoundedClobberedConfigSnapshot(params: {
     return null;
   }
   try {
-    const existing = await countClobberedSiblings(params.deps, paths.dir, paths.prefix);
-    if (existing >= CONFIG_CLOBBER_SNAPSHOT_LIMIT) {
-      warnClobberCapReached(params.deps, params.configPath, existing);
-      return null;
+    const existing = await listClobberedSiblings(params.deps, paths.dir, paths.prefix);
+    if (existing.length >= CONFIG_CLOBBER_SNAPSHOT_LIMIT) {
+      warnClobberCapReached(params.deps, params.configPath, existing.length);
+      const rotated = await rotateOldestClobberedSiblings(params.deps, existing);
+      if (!rotated) {
+        return null;
+      }
     }
     for (let attempt = 0; attempt < CONFIG_CLOBBER_SNAPSHOT_LIMIT; attempt++) {
       const targetPath = buildClobberedTargetPath(params.configPath, params.observedAt, attempt);
@@ -210,10 +280,12 @@ export function persistBoundedClobberedConfigSnapshotSync(params: {
     return null;
   }
   try {
-    const existing = countClobberedSiblingsSync(params.deps, paths.dir, paths.prefix);
-    if (existing >= CONFIG_CLOBBER_SNAPSHOT_LIMIT) {
-      warnClobberCapReached(params.deps, params.configPath, existing);
-      return null;
+    const existing = listClobberedSiblingsSync(params.deps, paths.dir, paths.prefix);
+    if (existing.length >= CONFIG_CLOBBER_SNAPSHOT_LIMIT) {
+      warnClobberCapReached(params.deps, params.configPath, existing.length);
+      if (!rotateOldestClobberedSiblingsSync(params.deps, existing)) {
+        return null;
+      }
     }
     for (let attempt = 0; attempt < CONFIG_CLOBBER_SNAPSHOT_LIMIT; attempt++) {
       const targetPath = buildClobberedTargetPath(params.configPath, params.observedAt, attempt);

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -43,6 +43,7 @@ export type ObserveRecoveryDeps = {
       mkdir(path: string, options?: { recursive?: boolean; mode?: number }): Promise<unknown>;
       readdir(path: string): Promise<string[]>;
       rmdir(path: string): Promise<unknown>;
+      unlink(path: string): Promise<unknown>;
       appendFile(
         path: string,
         data: string,
@@ -73,6 +74,7 @@ export type ObserveRecoveryDeps = {
     mkdirSync(path: string, options?: { recursive?: boolean; mode?: number }): unknown;
     readdirSync(path: string): string[];
     rmdirSync(path: string): unknown;
+    unlinkSync(path: string): unknown;
     appendFileSync(
       path: string,
       data: string,

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -780,7 +780,7 @@ describe("config io write", () => {
     });
   });
 
-  it("caps repeated prefix-recovery clobber snapshots for doctor-style repair loops", async () => {
+  it("rotates repeated prefix-recovery clobber snapshots for doctor-style repair loops", async () => {
     await withSuiteHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");
       const cleanConfig = {
@@ -806,6 +806,13 @@ describe("config io write", () => {
       const entries = await fs.readdir(path.dirname(configPath));
       const clobbered = entries.filter((entry) => entry.includes(".clobbered."));
       expect(clobbered).toHaveLength(CONFIG_CLOBBER_SNAPSHOT_LIMIT);
+      const clobberedContents = await Promise.all(
+        clobbered.map((entry) => fs.readFile(path.join(path.dirname(configPath), entry), "utf-8")),
+      );
+      expect(clobberedContents).not.toContain(`Found and updated: False 0\n${cleanRaw}`);
+      expect(clobberedContents).toContain(
+        `Found and updated: False ${CONFIG_CLOBBER_SNAPSHOT_LIMIT + 3}\n${cleanRaw}`,
+      );
       const capWarnings = warn.mock.calls.filter(
         ([message]) =>
           typeof message === "string" && message.includes("Config clobber snapshot cap reached"),


### PR DESCRIPTION
## Problem

When OpenClaw repairs a broken config, it saves the broken version so operators can inspect what happened. On hosts with many past repairs, OpenClaw can hit the saved-copy limit for that config path. Before this PR, the next repair after that point kept going but did not save the broken version that operators would need for diagnosis.

That means the incident someone cares about most, usually the latest one, can be the one with no forensic copy.

## Change and value

This PR keeps the existing 32-file bound, but rotates older saved copies when the limit is reached. A new repair still leaves operators with the current broken payload to inspect, while the directory remains bounded.

The value is operational: capped hosts keep useful recent evidence instead of silently losing the newest repair artifact.

## Who is affected, and who is not

Affected:

- Operators using `openclaw doctor` or config recovery on hosts that have accumulated many `.clobbered.*` files.
- Maintainers investigating repeated config repair or auto-restore reports.
- Support workflows that ask users to inspect the latest saved broken config.

Not affected:

- Hosts that have not reached the per-config saved-copy limit.
- Normal config validation and write rejection behavior.
- The existing 32-file retention bound.
- `.rejected.*` files from OpenClaw-owned failed config writes.

## Why now

#80517 is still reproducible in the 2026.5.12 release line and on current `main`: once the saved-copy cap is reached, the latest repair can lose its diagnostic payload. This is a narrow follow-up to the earlier config-recovery work because it keeps the safety cap while preserving the newest event, which is usually the one an operator is trying to debug.

## Summary

- Rotate oldest `openclaw.json.clobbered.*` files when a config path is already at the snapshot cap.
- Preserve the newest broken config payload instead of returning `null` at the cap.
- Keep the cap warning, but update it to say OpenClaw is rotating older snapshots.
- Document that OpenClaw keeps the latest 32 `.clobbered.*` files for each config path.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #80517
- [x] This PR fixes a bug or regression

## Implementation

- Replaces the clobbered-sibling count helper with a sibling listing that records path and modification time.
- While holding the existing per-config clobber lock, deletes enough oldest siblings to make room for one new snapshot.
- Keeps async and sync snapshot paths aligned.
- Extends the recovery dependency type with `unlink` / `unlinkSync` because recovery paths pass the same filesystem dependency into the snapshot helper.

## Real behavior proof

- **Behavior or issue addressed:** At the clobber-snapshot cap, OpenClaw skipped the next forensic snapshot and returned no path. After this patch, the helper rotates the oldest saved copy and persists the latest broken payload while keeping the 32-file bound.
- **Real environment tested:** Local OpenClaw checkout on branch `fix/config-clobber-snapshot-rotate` at `8994964272`, Node 26.1.0, real Node filesystem calls, isolated temporary OpenClaw-style config directory. The proof imports the production `persistBoundedClobberedConfigSnapshot` helper from this PR head. Repo validation also ran remotely on Crabbox/GCP Spot in `us-east1-b` on an `e2-standard-8` VM from the same PR head.
- **Exact steps or command run after this patch:** `node --import tsx /tmp/openclaw-80517-proof.mjs`
- **Evidence after fix:** Copied live output from the proof driver, with the temporary root shortened:

  ```json
  {
    "limit": 32,
    "snapshotCount": 32,
    "resultBasename": "openclaw.json.clobbered.2026-05-15T00-00-00-000Z",
    "oldestPayloadStillPresent": false,
    "latestPayloadPresent": true,
    "warningCount": 1,
    "warning": "Config clobber snapshot cap reached for <tmp>/.openclaw/openclaw.json: 32 existing .clobbered.* files; rotating oldest snapshots to preserve the latest forensic copy."
  }
  ```

- **Observed result after fix:** With 32 existing saved copies, the next snapshot still left exactly 32 files, removed the oldest payload, preserved `latest-forensic-payload`, returned the new snapshot path, and emitted one rotation warning.
- **What was not tested:** I did not run a full `openclaw doctor --fix` CLI end-to-end smoke. The production helper proof exercises the retention behavior with real filesystem calls, and the remote Crabbox gate below ran the unfiltered affected config shard plus broader repo validation.

## Root Cause

- Root cause: The bounded clobber snapshot helper treated the retention limit as a hard stop. Once a config path had 32 saved copies, new recovery events returned `null` instead of making room for the current event.
- Missing detection / guardrail: Existing tests asserted that files stopped at the cap and that the cap warning appeared once, but did not assert that the newest repaired payload remained available.
- Contributing context: The retention cap protects hosts from unbounded snapshot growth, but the cap behavior did not preserve the most recent incident.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/config/io.clobber-snapshot.test.ts`
  - `src/config/io.write-config.test.ts`
  - `src/config/io.observe-recovery.test.ts`
- Scenario the test should lock in: when a config path is at or over the clobber-snapshot cap, a new snapshot rotates old files and preserves the latest payload.
- Why this is the smallest reliable guardrail: the shared helper owns the retention policy, while the write-config and observe-recovery tests prove the behavior through recovery callers.

## User-visible / Behavior Changes

OpenClaw still keeps at most 32 `.clobbered.*` files per config path, but capped hosts now keep the latest repaired payload by rotating older files.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Verification

- `node --import tsx /tmp/openclaw-80517-proof.mjs`
- Crabbox/GCP remote gate from PR head `8994964272`, Spot `e2-standard-8` in `us-east1-b`, lease `cbx_781cb7e93509`, exit `0`, total `6m43.603s`:
  - `pnpm install --frozen-lockfile`
  - `pnpm changed:lanes --json` selected `core`, `coreTests`, and `docs`
  - `pnpm exec oxfmt --check --threads=1 src/config/io.clobber-snapshot.ts src/config/io.clobber-snapshot.test.ts src/config/io.write-config.test.ts src/config/io.observe-recovery.ts docs/gateway/troubleshooting.md`
  - `node scripts/run-oxlint.mjs src/config/io.clobber-snapshot.ts src/config/io.clobber-snapshot.test.ts src/config/io.write-config.test.ts src/config/io.observe-recovery.ts`
  - `pnpm test src/config/io.clobber-snapshot.test.ts src/config/io.write-config.test.ts src/config/io.observe-recovery.test.ts` — 3 files passed, 48 tests passed
  - `pnpm check:docs`
  - `pnpm build`
  - `pnpm tsgo:core:test`
  - `pnpm check:changed`
- `timeout 90s pnpm test src/config/io.clobber-snapshot.test.ts src/config/io.write-config.test.ts src/config/io.observe-recovery.test.ts -t "config clobber snapshots|rotates repeated prefix-recovery|caps concurrent recovery"` — 3 files passed, 5 tests passed, 43 skipped
- `node scripts/run-oxlint.mjs src/config/io.clobber-snapshot.ts src/config/io.clobber-snapshot.test.ts src/config/io.write-config.test.ts src/config/io.observe-recovery.ts`
- `pnpm exec oxfmt --check --threads=1 src/config/io.clobber-snapshot.ts src/config/io.clobber-snapshot.test.ts src/config/io.write-config.test.ts src/config/io.observe-recovery.ts docs/gateway/troubleshooting.md`
- `git diff --check`
- `node scripts/check-docs-mdx.mjs docs/gateway/troubleshooting.md`
- `node scripts/docs-link-audit.mjs docs/gateway/troubleshooting.md`
- `pnpm changed:lanes --json` selected `core`, `coreTests`, and `docs`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations exist yet.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Rotating snapshots discards older forensic payloads.
  - Mitigation: This preserves the existing 32-file bound and favors the latest incident, which is usually the one operators are investigating. The docs now state that older `.clobbered.*` files rotate.

## AI Assistance

Prepared with Codex.
