### PR TITLE
fix(exec): return approved WebChat gateway exec output inline

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -576,7 +576,7 @@ EOF`,
     expect(requireBuildFollowupTargetInput(0).sessionKey).toBe("agent:main:telegram:direct:123");
   });
 
-  it("formats diagnostics approvals as direct pasteable followups", async () => {
+  it("keeps webchat diagnostics approvals as direct pasteable followups", async () => {
     resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
     createExecApprovalDecisionStateMock.mockReturnValue({
       baseDecision: { timedOut: false },
@@ -624,13 +624,15 @@ EOF`,
       ].join("\n"),
     );
 
-    await runGatewayAllowlist({
+    const result = await runGatewayAllowlist({
       command: "openclaw gateway diagnostics export --json",
       trigger: "diagnostics",
       approvalFollowupMode: "direct",
       approvalFollowup,
+      turnSourceChannel: "webchat",
     });
 
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
     await vi.waitFor(() => {
       expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(1);
     });
@@ -651,6 +653,51 @@ EOF`,
     expect(approvalInput?.trigger).toBe("diagnostics");
     expect(approvalInput?.outcome?.status).toBe("completed");
     expect(approvalInput?.outcome?.exitCode).toBe(0);
+  });
+
+  it("waits inline for webchat approval so the exec tool can return real output to the model", async () => {
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "pwd && df -h",
+      turnSourceChannel: "webchat",
+    });
+
+    expect(result.pendingResult).toBeUndefined();
+    expect(result.deniedResult).toBeUndefined();
+    expect(result.allowWithoutEnforcedCommand).toBe(true);
+    expect(runExecProcessMock).not.toHaveBeenCalled();
+    expect(buildExecApprovalFollowupTargetMock).not.toHaveBeenCalled();
+    expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+  });
+
+  it("returns webchat approval denials as the foreground tool result", async () => {
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("deny");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: false,
+      deniedReason: "user-denied",
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "pwd && df -h",
+      turnSourceChannel: "webchat",
+    });
+
+    expect(result.pendingResult).toBeUndefined();
+    expect(result.deniedResult?.details.status).toBe("failed");
+    expect(result.deniedResult?.content[0]).toEqual(
+      expect.objectContaining({
+        text: "Exec denied (gateway id=req-1, user-denied): pwd && df -h",
+      }),
+    );
+    expect(runExecProcessMock).not.toHaveBeenCalled();
+    expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
   });
 
   it("denies timed-out inline-eval requests instead of auto-running them", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -16,6 +16,7 @@ import {
   requiresExecApproval,
 } from "../infra/exec-approvals.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
+import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../utils/message-channel.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
 import {
   buildExecApprovalRequesterContext,
@@ -86,6 +87,7 @@ export type ProcessGatewayAllowlistResult = {
   execCommandOverride?: string;
   allowWithoutEnforcedCommand?: boolean;
   pendingResult?: AgentToolResult<ExecToolDetails>;
+  deniedResult?: AgentToolResult<ExecToolDetails>;
 };
 
 function hasGatewayAllowlistMiss(params: {
@@ -346,6 +348,36 @@ function buildGatewayExecApprovalFollowupSummary(params: {
     : `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})`;
 }
 
+function shouldAwaitGatewayApprovalInline(params: {
+  turnSourceChannel?: string;
+  approvalFollowupMode?: "agent" | "direct";
+}): boolean {
+  if (params.approvalFollowupMode === "direct") {
+    return false;
+  }
+  return normalizeMessageChannel(params.turnSourceChannel) === INTERNAL_MESSAGE_CHANNEL;
+}
+
+function buildGatewayExecApprovalDeniedToolResult(params: {
+  approvalId: string;
+  deniedReason: string;
+  command: string;
+  cwd: string;
+}): AgentToolResult<ExecToolDetails> {
+  const text = `Exec denied (gateway id=${params.approvalId}, ${params.deniedReason}): ${params.command}`;
+  return {
+    content: [{ type: "text", text }],
+    details: {
+      status: "failed",
+      exitCode: null,
+      durationMs: 0,
+      aggregated: text,
+      timedOut: params.deniedReason.includes("timeout"),
+      cwd: params.cwd,
+    },
+  };
+}
+
 async function resolveGatewayExecApprovalFollowupText(params: {
   approvalFollowup?: ExecApprovalFollowupFactory;
   approvalId: string;
@@ -563,31 +595,14 @@ export async function processGatewayAllowlist(
       allowlistEval.segments[0]?.resolution ?? null,
       params.workdir,
     );
-    const effectiveTimeout =
-      typeof params.timeoutSec === "number" ? params.timeoutSec : params.defaultTimeoutSec;
-    const followupTarget = buildExecApprovalFollowupTarget({
-      approvalId,
-      sessionKey: params.notifySessionKey ?? params.sessionKey,
-      bashElevated: params.bashElevated,
-      turnSourceChannel: params.turnSourceChannel,
-      turnSourceTo: params.turnSourceTo,
-      turnSourceAccountId: params.turnSourceAccountId,
-      turnSourceThreadId: params.turnSourceThreadId,
-      direct: params.approvalFollowupMode === "direct",
-    });
-
-    void (async () => {
+    const resolveApprovalForExecution = async (onFailure: () => void) => {
       const decision = await resolveApprovalDecisionOrUndefined({
         approvalId,
         preResolvedDecision,
-        onFailure: () =>
-          void sendExecApprovalFollowupResult(
-            followupTarget,
-            `Exec denied (gateway id=${approvalId}, approval-request-failed): ${params.command}`,
-          ),
+        onFailure,
       });
       if (decision === undefined) {
-        return;
+        return { deniedReason: "approval-request-failed", requestFailed: true };
       }
 
       const {
@@ -646,10 +661,58 @@ export async function processGatewayAllowlist(
         deniedReason = deniedReason ?? "allowlist-miss";
       }
 
-      if (deniedReason) {
+      return { deniedReason, requestFailed: false };
+    };
+
+    if (unavailableReason === null && shouldAwaitGatewayApprovalInline(params)) {
+      const approvalDecision = await resolveApprovalForExecution(() => undefined);
+      if (approvalDecision.deniedReason) {
+        return {
+          deniedResult: buildGatewayExecApprovalDeniedToolResult({
+            approvalId,
+            deniedReason: approvalDecision.deniedReason,
+            command: params.command,
+            cwd: params.workdir,
+          }),
+        };
+      }
+
+      recordMatchedAllowlistUse(resolvedPath ?? undefined);
+      return {
+        execCommandOverride: enforcedCommand,
+        allowWithoutEnforcedCommand: enforcedCommand === undefined,
+      };
+    }
+
+    const effectiveTimeout =
+      typeof params.timeoutSec === "number" ? params.timeoutSec : params.defaultTimeoutSec;
+    const followupTarget = buildExecApprovalFollowupTarget({
+      approvalId,
+      sessionKey: params.notifySessionKey ?? params.sessionKey,
+      bashElevated: params.bashElevated,
+      turnSourceChannel: params.turnSourceChannel,
+      turnSourceTo: params.turnSourceTo,
+      turnSourceAccountId: params.turnSourceAccountId,
+      turnSourceThreadId: params.turnSourceThreadId,
+      direct: params.approvalFollowupMode === "direct",
+    });
+
+    void (async () => {
+      const approvalDecision = await resolveApprovalForExecution(
+        () =>
+          void sendExecApprovalFollowupResult(
+            followupTarget,
+            `Exec denied (gateway id=${approvalId}, approval-request-failed): ${params.command}`,
+          ),
+      );
+      if (approvalDecision.requestFailed) {
+        return;
+      }
+
+      if (approvalDecision.deniedReason) {
         await sendExecApprovalFollowupResult(
           followupTarget,
-          `Exec denied (gateway id=${approvalId}, ${deniedReason}): ${params.command}`,
+          `Exec denied (gateway id=${approvalId}, ${approvalDecision.deniedReason}): ${params.command}`,
         );
         return;
       }

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -1081,7 +1081,35 @@ describe("exec approvals", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("executes approved commands and emits a session-only followup in webchat-only mode", async () => {
+  it("waits for native webchat approval and returns approved gateway output as a foreground result", async () => {
+    const agentCalls: Array<Record<string, unknown>> = [];
+
+    mockAcceptedApprovalFlow({
+      onAgent: (params) => {
+        agentCalls.push(params);
+      },
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "always",
+      approvalRunningNoticeMs: 0,
+      sessionKey: "agent:main:main",
+      elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
+      messageProvider: "webchat",
+    });
+
+    const result = await tool.execute("call-gw-native-webchat", {
+      command: "printf webchat-ok",
+      workdir: process.cwd(),
+    });
+
+    expect(result.details.status).toBe("completed");
+    expect(getResultText(result)).toContain("webchat-ok");
+    expect(agentCalls).toHaveLength(0);
+  });
+
+  it("keeps approved internal commands asynchronous without a webchat turn source", async () => {
     const agentCalls: Array<Record<string, unknown>> = [];
 
     mockAcceptedApprovalFlow({

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1592,6 +1592,9 @@ export function createExecTool(
         if (gatewayResult.pendingResult) {
           return gatewayResult.pendingResult;
         }
+        if (gatewayResult.deniedResult) {
+          return gatewayResult.deniedResult;
+        }
         execCommandOverride = gatewayResult.execCommandOverride;
         if (gatewayResult.allowWithoutEnforcedCommand) {
           execCommandOverride = undefined;


### PR DESCRIPTION
## Summary

Return approved WebChat gateway exec output as the foreground `exec` tool result.

When an exec command originates from WebChat and the gateway can surface native approval, the exec tool now waits for that approval decision inline. If the user approves, the command continues through the normal foreground exec path and the model receives the real command output in the same tool call. If the user denies, the denial is returned as a failed foreground exec result.

Other channels keep the existing async approval follow-up behavior.

## Problem

The current WebChat gateway approval path can return `approval-pending` to the model before the command output is available. That works for asynchronous notification-style channels, but it is problematic for WebChat agent turns where the model is expected to inspect command output and continue the same response.

For example, if the user asks WebChat to run `whoami` and report the output, the original model turn should receive `openclaw` as the exec result after approval. Returning only `approval-pending` can cause the model to summarize incomplete state, retry commands, or expose internal approval text instead of reasoning over the real output.

## Approach

- Detect WebChat/internal message-channel exec turns in the gateway approval path.
- Await the gateway approval decision inline for that native WebChat path.
- On approval, continue through foreground exec so the actual command output becomes the tool result.
- On denial, return a foreground failed exec result.
- Preserve the async follow-up path for non-WebChat / non-inline approval cases.

## Related Work

This is related to, but separate from:

- #77672, which improves WebChat approval routing through the backend command path.
- #56581, which preserves WebChat async approval follow-up behavior.
- #78184, which cleans up approval-pending prompts.
- #58479, which tracks approval consumption problems.

This PR focuses specifically on foreground tool-result semantics for WebChat agent mode: after native approval, the model should receive the actual command output in the same exec tool call.

## Tests

All passed locally with Node 24:

```bash
node scripts/run-vitest.mjs \
  src/agents/bash-tools.exec-host-gateway.test.ts \
  src/agents/bash-tools.exec.approval-id.test.ts \
  src/auto-reply/reply/commands-diagnostics.test.ts

node scripts/test-projects.mjs \
  src/agents/bash-tools.exec-host-gateway.test.ts \
  src/agents/bash-tools.exec.approval-id.test.ts

pnpm tsgo:core:test

git diff --check
```

## Real behavior proof

- **Behavior or issue addressed**: WebChat exec approval should not leave the model with only an `approval-pending` result. After the user approves a native WebChat exec request, the same agent turn should receive the real command output and continue the response.
- **Real environment tested**: Downstream WebChat canary deployment using the OpenClaw patch this PR was ported from: `OpenClaw 2026.5.7 (eeef486)`, served through a WebChat UI against a gateway-hosted OpenClaw workspace.
- **Exact steps or command run after this patch**:
  1. Opened the WebChat canary environment.
  2. Sent: `Run this command and tell me the output: whoami`.
  3. Clicked the native WebChat approval button: `allow once`.
  4. Repeated with grouped read-only commands such as `pwd`, `df -h`, and `whoami` to verify the approved command output is delivered back into the same WebChat response.
- **Evidence after fix**: Copied live output from the WebChat canary after native approval:

  ```text
  User: Run this command and tell me the output: whoami
  Native approval: allow once
  Exec output observed by the response:
  openclaw
  ```

  Copied live output from grouped command validation:

  ```text
  User: Run these commands and summarize the output:
  pwd
  df -h
  whoami

  Native approval: allow once
  Response included copied command output ending with:
  /home/openclaw/.openclaw/workspace
  ... filesystem usage from df -h ...
  openclaw
  ```
- **Observed result after fix**: After approval, the WebChat response continued and summarized the actual command output instead of exposing `approval-pending`, retrying the exec command, or requiring a separate follow-up run.
- **What was not tested**: The canary validation covered WebChat/native approval behavior. Other channels were covered by existing and updated unit tests to ensure they keep the async follow-up path.
