### PR TITLE
fix: restore plugin-sdk/feishu compatibility facade

### DIFF
--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -59,10 +59,11 @@ map when they have tracked owner usage. They exist for bundled-plugin
 maintenance only and are not recommended import paths for new third-party
 plugins.
 
-`openclaw/plugin-sdk/discord` and `openclaw/plugin-sdk/telegram-account` are
-also kept as deprecated compatibility facades for tracked owner usage. Do not
-copy those import paths into new plugins; use injected runtime helpers and
-generic channel SDK subpaths instead.
+`openclaw/plugin-sdk/discord`, `openclaw/plugin-sdk/feishu`, and
+`openclaw/plugin-sdk/telegram-account` are also kept as deprecated
+compatibility facades for tracked owner usage. Do not copy those import paths
+into new plugins; use injected runtime helpers and generic channel SDK
+subpaths instead.
 </Warning>
 
 ## Subpath reference

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -56,7 +56,7 @@ but new plugin code should use focused, actively consumed SDK subpaths instead:
 `agent-config-primitives`, `channel-config-schema-legacy`,
 `channel-reply-pipeline`, `channel-runtime`, `channel-secret-runtime`,
 `command-auth`, `compat`, `config-runtime`, `config-schema`, `discord`,
-`group-access`, `infra-runtime`, `matrix`, `mattermost`,
+`feishu`, `group-access`, `infra-runtime`, `matrix`, `mattermost`,
 `media-generation-runtime-shared`, `memory-core-engine-runtime`,
 `memory-core-host-multimodal`, `memory-core-host-query`,
 `music-generation-core`, `self-hosted-provider-setup`, `telegram-account`,
@@ -134,6 +134,7 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/group-access` | Shared group-access decision helpers |
     | `plugin-sdk/direct-dm` | Shared direct-DM auth/guard helpers |
     | `plugin-sdk/discord` | Deprecated Discord compatibility facade for published `@openclaw/discord@2026.3.13` and tracked owner compatibility; new plugins should use generic channel SDK subpaths |
+    | `plugin-sdk/feishu` | Deprecated Feishu/Lark compatibility facade for older channel packages that still import pairing helpers; new plugins should use generic channel SDK subpaths |
     | `plugin-sdk/telegram-account` | Deprecated Telegram account-resolution compatibility facade for tracked owner compatibility; new plugins should use injected runtime helpers or generic channel SDK subpaths |
     | `plugin-sdk/zalouser` | Deprecated Zalo Personal compatibility facade for published Lark/Zalo packages that still import sender command authorization; new plugins should use `plugin-sdk/command-auth` |
     | `plugin-sdk/interactive-runtime` | Semantic message presentation, delivery, and legacy interactive reply helpers. See [Message Presentation](/plugins/message-presentation) |

--- a/package.json
+++ b/package.json
@@ -728,6 +728,10 @@
       "types": "./dist/plugin-sdk/discord.d.ts",
       "default": "./dist/plugin-sdk/discord.js"
     },
+    "./plugin-sdk/feishu": {
+      "types": "./dist/plugin-sdk/feishu.d.ts",
+      "default": "./dist/plugin-sdk/feishu.js"
+    },
     "./plugin-sdk/mattermost": {
       "types": "./dist/plugin-sdk/mattermost.d.ts",
       "default": "./dist/plugin-sdk/mattermost.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -157,6 +157,7 @@
   "direct-dm-access",
   "direct-dm-guard-policy",
   "discord",
+  "feishu",
   "mattermost",
   "matrix",
   "device-bootstrap",

--- a/src/plugin-sdk/entrypoints.ts
+++ b/src/plugin-sdk/entrypoints.ts
@@ -44,6 +44,7 @@ export const reservedBundledPluginSdkEntrypoints = [
 // until they move to generic, plugin-neutral contracts.
 export const supportedBundledFacadeSdkEntrypoints = [
   "discord",
+  "feishu",
   "lmstudio",
   "lmstudio-runtime",
   "matrix",

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -1,0 +1,18 @@
+/**
+ * @deprecated Compatibility facade for older Feishu/Lark channel packages that
+ * imported pairing helpers from `openclaw/plugin-sdk/feishu`.
+ * New plugins should use generic channel SDK subpaths instead.
+ */
+export type { ChannelPlugin } from "./channel-core.js";
+export type { OpenClawConfig } from "./config-types.js";
+export type { OpenClawPluginApi, PluginRuntime } from "./channel-plugin-common.js";
+
+export {
+  DEFAULT_ACCOUNT_ID,
+  buildChannelConfigSchema,
+  emptyPluginConfigSchema,
+  normalizeAccountId,
+  PAIRING_APPROVED_MESSAGE,
+} from "./channel-plugin-common.js";
+export { createScopedPairingAccess } from "./pairing-access.js";
+export { issuePairingChallenge } from "../pairing/pairing-challenge.js";

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -1375,6 +1375,14 @@ describe("plugin-sdk subpath exports", () => {
     }
   });
 
+  it("keeps the Feishu compatibility facade importable", async () => {
+    const feishuSdk = await importResolvedPluginSdkSubpath("openclaw/plugin-sdk/feishu");
+
+    expect(typeof feishuSdk.createScopedPairingAccess).toBe("function");
+    expect(typeof feishuSdk.issuePairingChallenge).toBe("function");
+    expect(feishuSdk.PAIRING_APPROVED_MESSAGE).toBeTruthy();
+  });
+
   it("keeps the Zalouser command-auth compatibility facade importable", async () => {
     const zalouserSdk = await importResolvedPluginSdkSubpath("openclaw/plugin-sdk/zalouser");
     const commandAuthSdk = await importResolvedPluginSdkSubpath("openclaw/plugin-sdk/command-auth");


### PR DESCRIPTION
## Background

Fixes a Feishu/Lark regression reported in #74138 where older channel packages still importing `openclaw/plugin-sdk/feishu` hit `TypeError: createScopedPairingAccess is not a function` after upgrading OpenClaw.

## Changes

- restore a thin deprecated `openclaw/plugin-sdk/feishu` compatibility facade for pairing helpers used by older Feishu/Lark packages
- wire the facade back into the plugin SDK export map and supported bundled-facade metadata
- document the restored compatibility subpath in the SDK docs
- add a contract test that keeps the Feishu facade importable with the expected pairing exports

## Verification

- `pnpm test src/plugins/contracts/plugin-sdk-subpaths.test.ts src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts`
- `pnpm build`
- `pnpm check:changed`

## Impact

- restores upgrade compatibility for older Feishu/Lark channel packages without changing the newer generic channel SDK path
- keeps the compatibility surface explicitly deprecated so new plugins still migrate to generic subpaths

Fixes #74138
