### PR TITLE
feat(telegram): bind spawned subagents to forum topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Telegram: expose `sessions_spawn(thread:true)` through explicit automatic-spawn capability and bind spawned subagents to child forum topics while keeping normal top-level bindings current.
 - Dependencies: route root ambient Node proxy agents through `@openclaw/proxyline` and drop root `proxy-agent`, `https-proxy-agent`, and `minimatch` dependencies.
 - Control UI/i18n: add a `pnpm ui:i18n:report` baseline report for hardcoded-copy focus areas and locale fallback metadata. (#81320) Thanks @samzong.
 - Maintainer tooling: add a repo-local `codex-review` skill for Codex closeout reviews, including local dirty-work and PR-branch review helpers that rerun until no accepted/actionable findings remain and avoid unsupported inline prompts with `--base`.

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -128,6 +128,18 @@ can also expose a top-level `session-key-api.ts` file with a matching
 `resolveSessionConversation(...)` export. Core uses that bootstrap-safe surface
 only when the runtime plugin registry is not available yet.
 
+If your channel supports explicit thread-bound session spawns, set
+`conversationBindings.supportsAutomaticThreadBindingSpawn` to `true`. This is
+separate from `conversationBindings.defaultTopLevelPlacement`: keep the default
+as `current` when commands such as `/focus` should bind the current
+conversation, and use the automatic-spawn flag only when `sessions_spawn` can
+request a new child thread explicitly. Use a per-kind object such as
+`{ subagent: true, acp: false }` when native subagent and ACP-backed session
+spawns have different support. Bundled plugins that need this decision before
+the channel registry boots can also expose a top-level `thread-binding-api.ts`
+file with `supportsAutomaticThreadBindingSpawn = true` or the same per-kind
+object.
+
 `messaging.resolveParentConversationCandidates(...)` remains available as a
 legacy compatibility fallback when a plugin only needs parent fallbacks on top
 of the generic/raw id. If both hooks exist, core uses

--- a/extensions/telegram/index.test.ts
+++ b/extensions/telegram/index.test.ts
@@ -1,5 +1,5 @@
 import { assertBundledChannelEntries } from "openclaw/plugin-sdk/channel-test-helpers";
-import { beforeEach, describe, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import entry from "./index.js";
 import setupEntry from "./setup-entry.js";
 
@@ -14,5 +14,19 @@ describe("telegram bundled entries", () => {
     expectedName: "Telegram",
     setupEntry,
     channelMessage: "declares the channel entry without importing the broad api barrel",
+  });
+
+  it("registers Telegram subagent lifecycle hooks in the full runtime", () => {
+    const on = vi.fn();
+    entry.register({
+      registrationMode: "tool-discovery",
+      on,
+    } as never);
+
+    expect(on.mock.calls.map((call) => call[0])).toEqual([
+      "subagent_spawning",
+      "subagent_ended",
+      "subagent_delivery_target",
+    ]);
   });
 });

--- a/extensions/telegram/index.ts
+++ b/extensions/telegram/index.ts
@@ -1,4 +1,5 @@
 import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+import { registerTelegramSubagentHooks } from "./subagent-hooks-api.js";
 
 export default defineBundledChannelEntry({
   id: "telegram",
@@ -20,5 +21,8 @@ export default defineBundledChannelEntry({
   accountInspect: {
     specifier: "./account-inspect-api.js",
     exportName: "inspectTelegramReadOnlyAccount",
+  },
+  registerFull(api) {
+    registerTelegramSubagentHooks(api);
   },
 });

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -633,6 +633,7 @@ export const telegramPlugin = createChatChannelPlugin({
     conversationBindings: {
       supportsCurrentConversationBinding: true,
       defaultTopLevelPlacement: "current",
+      supportsAutomaticThreadBindingSpawn: { subagent: true, acp: false },
       resolveConversationRef: ({
         accountId: _accountId,
         conversationId,

--- a/extensions/telegram/src/subagent-hooks.test.ts
+++ b/extensions/telegram/src/subagent-hooks.test.ts
@@ -1,0 +1,227 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-binding-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __testing, createTelegramThreadBindingManager } from "./thread-bindings.js";
+
+const createForumTopicTelegram = vi.hoisted(() => vi.fn());
+
+vi.mock("./send.js", () => ({
+  createForumTopicTelegram,
+}));
+
+import {
+  handleTelegramSubagentDeliveryTarget,
+  handleTelegramSubagentEnded,
+  handleTelegramSubagentSpawning,
+} from "./subagent-hooks.js";
+
+const TELEGRAM_HOOKS_CFG = {
+  channels: {
+    telegram: {
+      botToken: "test-token",
+    },
+  },
+} as OpenClawConfig;
+
+function createApi(config: OpenClawConfig = TELEGRAM_HOOKS_CFG): OpenClawPluginApi {
+  return {
+    config,
+  } as unknown as OpenClawPluginApi;
+}
+
+describe("telegram subagent hooks", () => {
+  beforeEach(async () => {
+    createForumTopicTelegram.mockReset().mockResolvedValue({
+      chatId: "-100200300",
+      topicId: 777,
+      name: "topic",
+    });
+    await __testing.resetTelegramThreadBindingsForTests();
+  });
+
+  afterEach(async () => {
+    await __testing.resetTelegramThreadBindingsForTests();
+  });
+
+  it("binds a thread-requested Telegram subagent to a new child forum topic", async () => {
+    createTelegramThreadBindingManager({
+      cfg: TELEGRAM_HOOKS_CFG,
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+    });
+
+    const result = await handleTelegramSubagentSpawning(createApi(), {
+      threadRequested: true,
+      requester: {
+        channel: "telegram",
+        accountId: "default",
+        to: "telegram:-100200300:topic:55",
+        threadId: 55,
+      },
+      childSessionKey: "agent:main:subagent:child-telegram",
+      agentId: "reviewer",
+      label: "Review PR #123 with a deliberately long label ".repeat(4),
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin: {
+        channel: "telegram",
+        accountId: "default",
+        to: "-100200300",
+        threadId: "777",
+      },
+    });
+    expect(createForumTopicTelegram).toHaveBeenCalledTimes(1);
+    const [target, topicName] = createForumTopicTelegram.mock.calls[0] ?? [];
+    expect(target).toBe("-100200300");
+    expect(String(topicName)).toMatch(/^🤖 Review PR #123/);
+    expect(String(topicName).length).toBeLessThanOrEqual(100);
+
+    const bindings = getSessionBindingService().listBySession("agent:main:subagent:child-telegram");
+    expect(bindings).toHaveLength(1);
+    expect(bindings[0]?.conversation.conversationId).toBe("-100200300:topic:777");
+  });
+
+  it("returns policy errors before binding", async () => {
+    const result = await handleTelegramSubagentSpawning(
+      createApi({
+        channels: {
+          telegram: {
+            botToken: "test-token",
+            threadBindings: {
+              spawnSessions: false,
+            },
+          },
+        },
+      } as OpenClawConfig),
+      {
+        threadRequested: true,
+        requester: {
+          channel: "telegram",
+          accountId: "default",
+          to: "-100200300",
+        },
+        childSessionKey: "agent:main:subagent:child-telegram",
+        agentId: "reviewer",
+      },
+    );
+
+    expect(result).toEqual({
+      status: "error",
+      error:
+        "Thread-bound session spawns are disabled for telegram (set channels.telegram.threadBindings.spawnSessions=true to enable).",
+    });
+    expect(createForumTopicTelegram).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-group requester targets with a Telegram-specific error", async () => {
+    createTelegramThreadBindingManager({
+      cfg: TELEGRAM_HOOKS_CFG,
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+    });
+
+    const result = await handleTelegramSubagentSpawning(createApi(), {
+      threadRequested: true,
+      requester: {
+        channel: "telegram",
+        accountId: "default",
+        to: "12345",
+      },
+      childSessionKey: "agent:main:subagent:child-telegram",
+      agentId: "reviewer",
+    });
+
+    expect(result).toEqual({
+      status: "error",
+      error:
+        "Telegram thread-bound subagent sessions require a group or supergroup chat target that can host forum topics.",
+    });
+    expect(createForumTopicTelegram).not.toHaveBeenCalled();
+  });
+
+  it("routes completion delivery to the single bound Telegram topic", async () => {
+    createTelegramThreadBindingManager({
+      cfg: TELEGRAM_HOOKS_CFG,
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+    });
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:main:subagent:child-telegram",
+      targetKind: "subagent",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "-100200300:topic:777",
+      },
+      placement: "current",
+    });
+
+    const result = handleTelegramSubagentDeliveryTarget({
+      expectsCompletionMessage: true,
+      childSessionKey: "agent:main:subagent:child-telegram",
+      requesterOrigin: {
+        channel: "telegram",
+        accountId: "default",
+        to: "telegram:-100200300",
+      },
+    });
+
+    expect(result).toEqual({
+      origin: {
+        channel: "telegram",
+        accountId: "default",
+        to: "-100200300",
+        threadId: "777",
+      },
+    });
+  });
+
+  it("cleans up only Telegram subagent bindings when a subagent ends", async () => {
+    createTelegramThreadBindingManager({
+      cfg: TELEGRAM_HOOKS_CFG,
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+    });
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:main:subagent:child-telegram",
+      targetKind: "subagent",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "-100200300:topic:777",
+      },
+      placement: "current",
+    });
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:main:acp:child-telegram",
+      targetKind: "session",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "-100200300:topic:888",
+      },
+      placement: "current",
+    });
+
+    await handleTelegramSubagentEnded({
+      targetSessionKey: "agent:main:subagent:child-telegram",
+      targetKind: "subagent",
+      reason: "complete",
+    });
+
+    expect(
+      getSessionBindingService().listBySession("agent:main:subagent:child-telegram"),
+    ).toHaveLength(0);
+    expect(getSessionBindingService().listBySession("agent:main:acp:child-telegram")).toHaveLength(
+      1,
+    );
+  });
+});

--- a/extensions/telegram/src/subagent-hooks.ts
+++ b/extensions/telegram/src/subagent-hooks.ts
@@ -1,0 +1,312 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
+import {
+  getSessionBindingService,
+  type SessionBindingRecord,
+} from "openclaw/plugin-sdk/conversation-binding-runtime";
+import {
+  formatThreadBindingDisabledError,
+  formatThreadBindingSpawnDisabledError,
+  resolveThreadBindingSpawnPolicy,
+  resolveThreadBindingThreadName,
+} from "openclaw/plugin-sdk/conversation-runtime";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+  normalizeOptionalStringifiedId,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveTelegramAccount } from "./accounts.js";
+import { parseTelegramTarget } from "./targets.js";
+import { parseTelegramTopicConversation } from "./topic-conversation.js";
+
+type TelegramSubagentSpawningEvent = {
+  threadRequested?: boolean;
+  requester?: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+  };
+  childSessionKey: string;
+  agentId: string;
+  label?: string;
+};
+
+type TelegramSubagentEndedEvent = {
+  targetSessionKey: string;
+  targetKind?: string;
+  accountId?: string;
+  reason?: string;
+};
+
+type TelegramSubagentDeliveryTargetEvent = {
+  expectsCompletionMessage?: boolean;
+  childSessionKey: string;
+  requesterOrigin?: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+  };
+};
+
+type TelegramDeliveryOrigin = {
+  channel: "telegram";
+  accountId: string;
+  to: string;
+  threadId: string;
+};
+
+type TelegramSubagentSpawningResult =
+  | {
+      status: "ok";
+      threadBindingReady?: boolean;
+      deliveryOrigin?: TelegramDeliveryOrigin;
+    }
+  | { status: "error"; error: string }
+  | undefined;
+
+type TelegramSubagentDeliveryTargetResult =
+  | {
+      origin: TelegramDeliveryOrigin;
+    }
+  | undefined;
+
+const TELEGRAM_FORUM_TOPIC_REQUIRED_ERROR =
+  "Telegram thread-bound subagent sessions require a group or supergroup chat target that can host forum topics.";
+
+function summarizeError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (typeof err === "string") {
+    return err;
+  }
+  return "error";
+}
+
+function resolveRequesterForumChatId(requester?: {
+  to?: string;
+}): { chatId: string } | { error: string } {
+  const rawTo = normalizeOptionalString(requester?.to);
+  if (!rawTo) {
+    return {
+      error:
+        "Cannot create Telegram thread binding: no chat target in spawn request (requester.to must be a Telegram group or supergroup chat ID).",
+    };
+  }
+  const target = parseTelegramTarget(rawTo);
+  const chatId = normalizeOptionalString(target.chatId) ?? "";
+  if (target.chatType !== "group" || !chatId.startsWith("-")) {
+    return { error: TELEGRAM_FORUM_TOPIC_REQUIRED_ERROR };
+  }
+  return { chatId };
+}
+
+function resolveTelegramBindingDeliveryOrigin(
+  binding: SessionBindingRecord,
+  fallbackAccountId: string,
+): TelegramDeliveryOrigin | null {
+  const parsed = parseTelegramTopicConversation({
+    conversationId: binding.conversation.conversationId,
+    parentConversationId: binding.conversation.parentConversationId,
+  });
+  if (!parsed) {
+    return null;
+  }
+  return {
+    channel: "telegram",
+    accountId: normalizeOptionalString(binding.conversation.accountId) || fallbackAccountId,
+    to: parsed.chatId,
+    threadId: parsed.topicId,
+  };
+}
+
+function isTelegramSubagentBinding(binding: SessionBindingRecord): boolean {
+  return binding.conversation.channel === "telegram" && binding.targetKind === "subagent";
+}
+
+export async function handleTelegramSubagentSpawning(
+  api: OpenClawPluginApi,
+  event: TelegramSubagentSpawningEvent,
+): Promise<TelegramSubagentSpawningResult> {
+  if (!event.threadRequested) {
+    return undefined;
+  }
+  const channel = normalizeOptionalLowercaseString(event.requester?.channel);
+  if (channel !== "telegram") {
+    return undefined;
+  }
+
+  const account = resolveTelegramAccount({
+    cfg: api.config,
+    accountId: event.requester?.accountId,
+  });
+  const policy = resolveThreadBindingSpawnPolicy({
+    cfg: api.config,
+    channel: "telegram",
+    accountId: account.accountId,
+    kind: "subagent",
+  });
+  if (!policy.enabled) {
+    return {
+      status: "error",
+      error: formatThreadBindingDisabledError({
+        channel: policy.channel,
+        accountId: policy.accountId,
+        kind: "subagent",
+      }),
+    };
+  }
+  if (!policy.spawnEnabled) {
+    return {
+      status: "error",
+      error: formatThreadBindingSpawnDisabledError({
+        channel: policy.channel,
+        accountId: policy.accountId,
+        kind: "subagent",
+      }),
+    };
+  }
+
+  const forumTarget = resolveRequesterForumChatId(event.requester);
+  if ("error" in forumTarget) {
+    return { status: "error", error: forumTarget.error };
+  }
+
+  const bindingService = getSessionBindingService();
+  const capabilities = bindingService.getCapabilities({
+    channel: "telegram",
+    accountId: account.accountId,
+  });
+  if (!capabilities.adapterAvailable || !capabilities.bindSupported) {
+    return {
+      status: "error",
+      error: `No Telegram session binding adapter available for account "${account.accountId}". Is the Telegram channel running?`,
+    };
+  }
+  if (!capabilities.placements.includes("child")) {
+    return {
+      status: "error",
+      error: `Telegram session binding adapter for account "${account.accountId}" does not support child forum topic bindings.`,
+    };
+  }
+
+  try {
+    const binding = await bindingService.bind({
+      targetSessionKey: event.childSessionKey,
+      targetKind: "subagent",
+      conversation: {
+        channel: "telegram",
+        accountId: account.accountId,
+        conversationId: forumTarget.chatId,
+      },
+      placement: "child",
+      metadata: {
+        agentId: normalizeOptionalString(event.agentId) || undefined,
+        label: normalizeOptionalString(event.label) || undefined,
+        threadName: resolveThreadBindingThreadName({
+          agentId: event.agentId,
+          label: event.label,
+        }),
+        boundBy: "system",
+      },
+    });
+    const deliveryOrigin = resolveTelegramBindingDeliveryOrigin(binding, account.accountId);
+    if (!deliveryOrigin) {
+      return {
+        status: "error",
+        error: "Telegram thread bind failed: adapter returned a non-topic binding.",
+      };
+    }
+    return {
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin,
+    };
+  } catch (err) {
+    return {
+      status: "error",
+      error: `Telegram thread bind failed: ${summarizeError(err)}`,
+    };
+  }
+}
+
+export async function handleTelegramSubagentEnded(
+  event: TelegramSubagentEndedEvent,
+): Promise<void> {
+  if (normalizeOptionalLowercaseString(event.targetKind) !== "subagent") {
+    return;
+  }
+  const requesterAccountId = normalizeOptionalString(event.accountId);
+  const bindingService = getSessionBindingService();
+  const bindings = bindingService
+    .listBySession(event.targetSessionKey)
+    .filter(
+      (entry) =>
+        isTelegramSubagentBinding(entry) &&
+        (!requesterAccountId || entry.conversation.accountId === requesterAccountId),
+    );
+  const reason = normalizeOptionalString(event.reason) || "subagent-ended";
+  for (const binding of bindings) {
+    await bindingService.unbind({ bindingId: binding.bindingId, reason });
+  }
+}
+
+export function handleTelegramSubagentDeliveryTarget(
+  event: TelegramSubagentDeliveryTargetEvent,
+): TelegramSubagentDeliveryTargetResult {
+  if (!event.expectsCompletionMessage) {
+    return undefined;
+  }
+  const requesterChannel = normalizeOptionalLowercaseString(event.requesterOrigin?.channel);
+  if (requesterChannel !== "telegram") {
+    return undefined;
+  }
+
+  const requesterAccountId = normalizeOptionalString(event.requesterOrigin?.accountId);
+  const requesterThreadId = normalizeOptionalStringifiedId(event.requesterOrigin?.threadId);
+  const requesterTo = normalizeOptionalString(event.requesterOrigin?.to);
+  const requesterChatId = requesterTo ? parseTelegramTarget(requesterTo).chatId.trim() : "";
+  const bindings = getSessionBindingService()
+    .listBySession(event.childSessionKey)
+    .filter(
+      (entry) =>
+        isTelegramSubagentBinding(entry) &&
+        (!requesterAccountId || entry.conversation.accountId === requesterAccountId),
+    );
+  if (bindings.length === 0) {
+    return undefined;
+  }
+
+  let binding: SessionBindingRecord | undefined;
+  if (requesterThreadId || requesterChatId) {
+    binding = bindings.find((entry) => {
+      const origin = resolveTelegramBindingDeliveryOrigin(
+        entry,
+        requesterAccountId || entry.conversation.accountId,
+      );
+      if (!origin) {
+        return false;
+      }
+      if (requesterThreadId && origin.threadId !== requesterThreadId) {
+        return false;
+      }
+      if (requesterChatId && origin.to !== requesterChatId) {
+        return false;
+      }
+      return true;
+    });
+  }
+  if (!binding && bindings.length === 1) {
+    binding = bindings[0];
+  }
+  if (!binding) {
+    return undefined;
+  }
+
+  const origin = resolveTelegramBindingDeliveryOrigin(
+    binding,
+    requesterAccountId || binding.conversation.accountId,
+  );
+  return origin ? { origin } : undefined;
+}

--- a/extensions/telegram/subagent-hooks-api.ts
+++ b/extensions/telegram/subagent-hooks-api.ts
@@ -1,0 +1,25 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
+
+type TelegramSubagentHooksModule = typeof import("./src/subagent-hooks.js");
+
+let telegramSubagentHooksPromise: Promise<TelegramSubagentHooksModule> | null = null;
+
+function loadTelegramSubagentHooksModule() {
+  telegramSubagentHooksPromise ??= import("./src/subagent-hooks.js");
+  return telegramSubagentHooksPromise;
+}
+
+export function registerTelegramSubagentHooks(api: OpenClawPluginApi): void {
+  api.on("subagent_spawning", async (event) => {
+    const { handleTelegramSubagentSpawning } = await loadTelegramSubagentHooksModule();
+    return await handleTelegramSubagentSpawning(api, event);
+  });
+  api.on("subagent_ended", async (event) => {
+    const { handleTelegramSubagentEnded } = await loadTelegramSubagentHooksModule();
+    await handleTelegramSubagentEnded(event);
+  });
+  api.on("subagent_delivery_target", async (event) => {
+    const { handleTelegramSubagentDeliveryTarget } = await loadTelegramSubagentHooksModule();
+    return handleTelegramSubagentDeliveryTarget(event);
+  });
+}

--- a/extensions/telegram/thread-binding-api.ts
+++ b/extensions/telegram/thread-binding-api.ts
@@ -1,0 +1,1 @@
+export const supportsAutomaticThreadBindingSpawn = { subagent: true, acp: false } as const;

--- a/src/agents/runtime-capabilities.test.ts
+++ b/src/agents/runtime-capabilities.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { collectRuntimeChannelCapabilities } from "./runtime-capabilities.js";
 
 describe("collectRuntimeChannelCapabilities", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
   it("adds thread-bound spawn capabilities when the channel account allows unified spawns", () => {
     const capabilities = collectRuntimeChannelCapabilities({
       channel: "discord",
@@ -18,6 +24,40 @@ describe("collectRuntimeChannelCapabilities", () => {
     });
 
     expect(capabilities).toEqual(["threadbound-subagent-spawn", "threadbound-acp-spawn"]);
+  });
+
+  it("keeps per-kind automatic spawn support separate", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),
+            conversationBindings: {
+              defaultTopLevelPlacement: "current",
+              supportsAutomaticThreadBindingSpawn: { subagent: true, acp: false },
+            },
+          },
+        },
+      ]),
+    );
+
+    const capabilities = collectRuntimeChannelCapabilities({
+      channel: "telegram",
+      accountId: "default",
+      cfg: {
+        channels: {
+          telegram: {
+            threadBindings: {
+              spawnSessions: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(capabilities).toEqual(["threadbound-subagent-spawn"]);
   });
 
   it("omits thread-bound spawn capabilities when unified spawns are disabled", () => {

--- a/src/agents/runtime-capabilities.ts
+++ b/src/agents/runtime-capabilities.ts
@@ -40,11 +40,14 @@ export function collectRuntimeChannelCapabilities(params: {
     return undefined;
   }
   const threadSpawnCapabilities: string[] = [];
-  if (params.cfg && supportsAutomaticThreadBindingSpawn(params.channel)) {
+  if (params.cfg) {
     for (const [kind, capability] of [
       ["subagent", THREAD_BOUND_SUBAGENT_SPAWN_CAPABILITY],
       ["acp", THREAD_BOUND_ACP_SPAWN_CAPABILITY],
     ] as const) {
+      if (!supportsAutomaticThreadBindingSpawn(params.channel, kind)) {
+        continue;
+      }
       const policy = resolveThreadBindingSpawnPolicy({
         cfg: params.cfg,
         channel: params.channel,

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -436,6 +436,60 @@ describe("resolveSubagentCompletionOrigin", () => {
   });
 });
 
+describe("deliverSubagentAnnouncement thread-bound subagent completion delivery", () => {
+  it("delivers nested completion turns to the requester subagent's bound thread", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [{ text: "PR topic digest" }],
+        deliveryStatus: { requested: true, attempted: true, status: "sent", succeeded: true },
+      },
+    });
+    const requesterThreadOrigin = {
+      channel: "telegram",
+      to: "-1001234567890",
+      accountId: "default",
+      threadId: "1176",
+    } as const;
+    __testing.setDepsForTest({
+      callGateway,
+      getRequesterSessionActivity: () => ({
+        sessionId: "requester-subagent-session",
+        isActive: false,
+      }),
+      getRuntimeConfig: () => ({}) as never,
+    });
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:subagent:topic-parent",
+      targetRequesterSessionKey: "agent:main:subagent:topic-parent",
+      triggerMessage: "child done",
+      steerMessage: "child done",
+      requesterOrigin: { channel: "webchat", to: "internal:parent" },
+      requesterSessionOrigin: requesterThreadOrigin,
+      completionDirectOrigin: requesterThreadOrigin,
+      directOrigin: { channel: "webchat", to: "internal:parent" },
+      requesterIsSubagent: true,
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+      directIdempotencyKey: "announce-thread-bound-subagent-completion",
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expectGatewayAgentParams(callGateway, {
+      sessionKey: "agent:main:subagent:topic-parent",
+      deliver: true,
+      bestEffortDeliver: true,
+      channel: "telegram",
+      accountId: "default",
+      to: "-1001234567890",
+      threadId: "1176",
+    });
+  });
+});
+
 describe("deliverSubagentAnnouncement active requester steering", () => {
   async function deliverSteeredAnnouncement(params: {
     mode?: "followup" | "collect" | "interrupt";

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -8,6 +8,7 @@ import { isCronSessionKey } from "../sessions/session-key-utils.js";
 import { isNonTerminalAgentRunStatus } from "../shared/agent-run-status.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import {
+  deliveryContextFromSession,
   mergeDeliveryContext,
   normalizeDeliveryContext,
   resolveConversationDeliveryTarget,
@@ -525,6 +526,31 @@ function stripNonDeliverableChannelForCompletionOrigin(
   return normalizeDeliveryContext(rest);
 }
 
+function isDeliverableThreadOrigin(context?: DeliveryContext): context is DeliveryContext & {
+  channel: string;
+  to: string;
+  threadId: string | number;
+} {
+  const normalized = normalizeDeliveryContext(context);
+  if (!normalized?.channel || !normalized.to || normalized.threadId == null) {
+    return false;
+  }
+  const channel = normalizeMessageChannel(normalized.channel);
+  return Boolean(channel && isDeliverableMessageChannel(channel));
+}
+
+function resolveThreadBoundSubagentCompletionOrigin(
+  ...candidates: Array<DeliveryContext | undefined>
+): DeliveryContext | undefined {
+  for (const candidate of candidates) {
+    const normalized = normalizeDeliveryContext(candidate);
+    if (isDeliverableThreadOrigin(normalized)) {
+      return normalized;
+    }
+  }
+  return undefined;
+}
+
 async function sendSubagentAnnounceDirectly(params: {
   requesterSessionKey: string;
   targetRequesterSessionKey: string;
@@ -575,14 +601,24 @@ async function sendSubagentAnnounceDirectly(params: {
       ? effectiveDirectOrigin
       : requesterSessionOrigin;
     const requesterEntry = loadRequesterSessionEntry(params.targetRequesterSessionKey).entry;
-    const deliveryTarget = !params.requesterIsSubagent
-      ? resolveExternalBestEffortDeliveryTarget({
-          channel: effectiveDirectOrigin?.channel,
-          to: effectiveDirectOrigin?.to,
-          accountId: effectiveDirectOrigin?.accountId,
-          threadId: effectiveDirectOrigin?.threadId,
-        })
-      : { deliver: false };
+    const storedRequesterOrigin = deliveryContextFromSession(requesterEntry);
+    const threadBoundSubagentOrigin = params.requesterIsSubagent
+      ? resolveThreadBoundSubagentCompletionOrigin(
+          effectiveDirectOrigin,
+          requesterSessionOrigin,
+          storedRequesterOrigin,
+        )
+      : undefined;
+    const deliveryOrigin = threadBoundSubagentOrigin ?? effectiveDirectOrigin;
+    const deliveryTarget =
+      !params.requesterIsSubagent || threadBoundSubagentOrigin
+        ? resolveExternalBestEffortDeliveryTarget({
+            channel: deliveryOrigin?.channel,
+            to: deliveryOrigin?.to,
+            accountId: deliveryOrigin?.accountId,
+            threadId: deliveryOrigin?.threadId,
+          })
+        : { deliver: false };
     const normalizedSessionOnlyOriginChannel = !params.requesterIsSubagent
       ? normalizeMessageChannel(sessionOnlyOrigin?.channel)
       : undefined;

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -1,4 +1,9 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 
 const hoisted = vi.hoisted(() => {
   const spawnSubagentDirectMock = vi.fn();
@@ -38,6 +43,7 @@ describe("sessions_spawn tool", () => {
   });
 
   beforeEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
     acpRuntimeRegistry.__testing.resetAcpRuntimeBackendsForTests();
     hoisted.spawnSubagentDirectMock.mockReset().mockResolvedValue({
       status: "accepted",
@@ -66,6 +72,24 @@ describe("sessions_spawn tool", () => {
         close: vi.fn(async () => {}),
       },
     });
+  }
+
+  function registerTelegramAutomaticSubagentSpawnChannelForTest() {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),
+            conversationBindings: {
+              defaultTopLevelPlacement: "current",
+              supportsAutomaticThreadBindingSpawn: { subagent: true, acp: false },
+            },
+          },
+        },
+      ]),
+    );
   }
 
   function requireSchemaProperty(
@@ -269,6 +293,68 @@ describe("sessions_spawn tool", () => {
     expect(thread.type).toBe("boolean");
     expect(schema.properties?.mode?.enum).toEqual(["run", "session"]);
     expect(tool.description).toContain("thread-bound");
+  });
+
+  it("shows thread-bound spawn fields for Telegram without changing top-level placement", () => {
+    registerTelegramAutomaticSubagentSpawnChannelForTest();
+    const tool = createSessionsSpawnTool({
+      agentChannel: "telegram",
+      agentAccountId: "default",
+      config: {
+        channels: {
+          telegram: {
+            threadBindings: {
+              spawnSessions: true,
+            },
+          },
+        },
+      },
+    });
+    const schema = tool.parameters as {
+      properties?: Record<
+        string,
+        { description?: string; enum?: string[]; type?: string } | undefined
+      >;
+    };
+
+    const thread = requireSchemaProperty(schema.properties, "thread");
+    expect(thread.type).toBe("boolean");
+    expect(schema.properties?.mode?.enum).toEqual(["run", "session"]);
+    expect(tool.description).toContain("thread-bound");
+  });
+
+  it("rejects Telegram ACP thread spawns when only subagent child topics are supported", async () => {
+    registerTelegramAutomaticSubagentSpawnChannelForTest();
+    registerAcpBackendForTest();
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "telegram",
+      agentAccountId: "default",
+      agentTo: "-100200300",
+      config: {
+        channels: {
+          telegram: {
+            threadBindings: {
+              spawnSessions: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = await tool.execute("call-telegram-acp-thread", {
+      runtime: "acp",
+      task: "investigate",
+      agentId: "codex",
+      thread: true,
+      mode: "session",
+    });
+
+    expectDetailFields(result.details, { status: "error", role: "codex" });
+    const details = requireRecord(result.details, "result details");
+    expect(details.error).toContain('thread=true is unavailable for runtime="acp"');
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
   it("uses subagent runtime by default", async () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -134,10 +134,13 @@ function resolveSessionsSpawnThreadAvailability(opts?: {
 }): SessionsSpawnThreadAvailability {
   const channel = opts?.agentChannel;
   const cfg = opts?.config;
-  if (!channel || !cfg || !supportsAutomaticThreadBindingSpawn(channel)) {
+  if (!channel || !cfg) {
     return { subagent: false, acp: false };
   }
   const resolve = (kind: "subagent" | "acp") => {
+    if (!supportsAutomaticThreadBindingSpawn(channel, kind)) {
+      return false;
+    }
     const policy = resolveThreadBindingSpawnPolicy({
       cfg,
       channel,
@@ -358,6 +361,13 @@ export function createSessionsSpawnTool(
           ? Math.max(0, Math.floor(timeoutSecondsCandidate))
           : undefined;
       const thread = params.thread === true;
+      if (thread && opts?.agentChannel && opts.config && !threadAvailability[runtime]) {
+        return jsonResult({
+          status: "error",
+          error: `thread=true is unavailable for runtime="${runtime}" in the current ${opts.agentChannel} channel/account.`,
+          ...roleContext,
+        });
+      }
       const attachments = Array.isArray(params.attachments)
         ? (params.attachments as Array<{
             name: string;

--- a/src/auto-reply/reply/commands-acp/shared.ts
+++ b/src/auto-reply/reply/commands-acp/shared.ts
@@ -174,7 +174,7 @@ function normalizeAcpOptionToken(raw: string): string {
 
 function resolveDefaultSpawnThreadMode(params: HandleCommandsParams): AcpSpawnThreadMode {
   const channel = resolveAcpCommandChannel(params);
-  if (!supportsAutomaticThreadBindingSpawn(channel)) {
+  if (!supportsAutomaticThreadBindingSpawn(channel, "acp")) {
     return "off";
   }
   const currentThreadId = resolveAcpCommandThreadId(params);

--- a/src/channels/plugins/thread-binding-api.test.ts
+++ b/src/channels/plugins/thread-binding-api.test.ts
@@ -12,9 +12,22 @@ const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => ({
           }),
         };
       }
+      if (dirName === "telegram" && artifactBasename === "thread-binding-api.js") {
+        return {
+          defaultTopLevelPlacement: "current",
+          supportsAutomaticThreadBindingSpawn: { subagent: true, acp: false },
+        };
+      }
+      if (dirName === "child-disabled" && artifactBasename === "thread-binding-api.js") {
+        return {
+          defaultTopLevelPlacement: "child",
+          supportsAutomaticThreadBindingSpawn: false,
+        };
+      }
       if (dirName === "invalid" && artifactBasename === "thread-binding-api.js") {
         return {
           defaultTopLevelPlacement: "floating",
+          supportsAutomaticThreadBindingSpawn: "yes",
         };
       }
       if (dirName === "empty" && artifactBasename === "thread-binding-api.js") {
@@ -35,6 +48,7 @@ vi.mock("../../plugins/public-surface-loader.js", () => ({
 }));
 
 import {
+  resolveBundledChannelThreadBindingAutomaticSpawnSupport,
   resolveBundledChannelThreadBindingDefaultPlacement,
   resolveBundledChannelThreadBindingInboundConversation,
 } from "./thread-binding-api.js";
@@ -50,6 +64,16 @@ describe("bundled channel thread binding fast path", () => {
       dirName: "matrix",
       artifactBasename: "thread-binding-api.js",
     });
+  });
+
+  it("loads explicit automatic spawn support from the narrow thread binding artifact", () => {
+    expect(resolveBundledChannelThreadBindingDefaultPlacement("telegram")).toBe("current");
+    expect(resolveBundledChannelThreadBindingAutomaticSpawnSupport("telegram")).toBe(true);
+    expect(resolveBundledChannelThreadBindingAutomaticSpawnSupport("telegram", "subagent")).toBe(
+      true,
+    );
+    expect(resolveBundledChannelThreadBindingAutomaticSpawnSupport("telegram", "acp")).toBe(false);
+    expect(resolveBundledChannelThreadBindingAutomaticSpawnSupport("child-disabled")).toBe(false);
   });
 
   it("loads inbound conversation resolution from the narrow artifact", () => {
@@ -77,8 +101,9 @@ describe("bundled channel thread binding fast path", () => {
     ).toBeUndefined();
   });
 
-  it("ignores invalid placement values", () => {
+  it("ignores invalid placement and automatic spawn support values", () => {
     expect(resolveBundledChannelThreadBindingDefaultPlacement("invalid")).toBeUndefined();
+    expect(resolveBundledChannelThreadBindingAutomaticSpawnSupport("invalid")).toBeUndefined();
   });
 
   it("distinguishes a present artifact without an inbound resolver from a missing artifact", () => {

--- a/src/channels/plugins/thread-binding-api.ts
+++ b/src/channels/plugins/thread-binding-api.ts
@@ -2,6 +2,7 @@ import { loadBundledPluginPublicArtifactModuleSync } from "../../plugins/public-
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 
 type ThreadBindingPlacement = "current" | "child";
+type ThreadBindingAutomaticSpawnKind = "subagent" | "acp";
 
 type ThreadBindingInboundConversationParams = {
   from?: string;
@@ -18,6 +19,7 @@ type ThreadBindingConversationRef = {
 
 type ThreadBindingApi = {
   defaultTopLevelPlacement?: unknown;
+  supportsAutomaticThreadBindingSpawn?: unknown;
   resolveInboundConversation?: (
     params: ThreadBindingInboundConversationParams,
   ) => ThreadBindingConversationRef | null;
@@ -46,11 +48,48 @@ function normalizeThreadBindingPlacement(value: unknown): ThreadBindingPlacement
   return normalized === "current" || normalized === "child" ? normalized : undefined;
 }
 
+function normalizeBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function normalizeThreadBindingAutomaticSpawnSupport(
+  value: unknown,
+  kind?: ThreadBindingAutomaticSpawnKind,
+): boolean | undefined {
+  const booleanValue = normalizeBoolean(value);
+  if (booleanValue !== undefined) {
+    return booleanValue;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const support = value as Record<ThreadBindingAutomaticSpawnKind, unknown>;
+  if (kind) {
+    return normalizeBoolean(support[kind]) ?? false;
+  }
+  const subagent = normalizeBoolean(support.subagent);
+  const acp = normalizeBoolean(support.acp);
+  if (subagent === undefined && acp === undefined) {
+    return undefined;
+  }
+  return subagent === true || acp === true;
+}
+
 export function resolveBundledChannelThreadBindingDefaultPlacement(
   channelId: string,
 ): ThreadBindingPlacement | undefined {
   return normalizeThreadBindingPlacement(
     loadBundledChannelThreadBindingApi(channelId)?.defaultTopLevelPlacement,
+  );
+}
+
+export function resolveBundledChannelThreadBindingAutomaticSpawnSupport(
+  channelId: string,
+  kind?: ThreadBindingAutomaticSpawnKind,
+): boolean | undefined {
+  return normalizeThreadBindingAutomaticSpawnSupport(
+    loadBundledChannelThreadBindingApi(channelId)?.supportsAutomaticThreadBindingSpawn,
+    kind,
   );
 }
 

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -764,6 +764,15 @@ export type ChannelConfiguredBindingProvider = {
   ) => ChannelConfiguredBindingConversationRef | null;
 };
 
+export type ThreadBindingAutomaticSpawnKind = "subagent" | "acp";
+
+export type ThreadBindingAutomaticSpawnSupport =
+  | boolean
+  | {
+      subagent?: boolean;
+      acp?: boolean;
+    };
+
 export type ChannelConversationBindingSupport = {
   supportsCurrentConversationBinding?: boolean;
   /**
@@ -774,6 +783,13 @@ export type ChannelConversationBindingSupport = {
    * - `child`: create a child thread/conversation first
    */
   defaultTopLevelPlacement?: "current" | "child";
+  /**
+   * Whether explicit thread-bound session spawns can create or bind a child
+   * conversation even when normal top-level binding should remain `current`.
+   * Use a per-kind object when support differs between native subagents and
+   * ACP-backed sessions.
+   */
+  supportsAutomaticThreadBindingSpawn?: ThreadBindingAutomaticSpawnSupport;
   resolveConversationRef?: (params: {
     accountId?: string | null;
     conversationId: string;

--- a/src/channels/thread-bindings-policy.test.ts
+++ b/src/channels/thread-bindings-policy.test.ts
@@ -28,6 +28,34 @@ describe("thread binding spawn policy helpers", () => {
             conversationBindings: { defaultTopLevelPlacement: "current" },
           },
         },
+        {
+          pluginId: "current-spawn-chat",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "current-spawn-chat",
+              label: "Current spawn chat",
+            }),
+            conversationBindings: {
+              defaultTopLevelPlacement: "current",
+              supportsAutomaticThreadBindingSpawn: { subagent: true, acp: false },
+            },
+          },
+        },
+        {
+          pluginId: "child-disabled-chat",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "child-disabled-chat",
+              label: "Child disabled chat",
+            }),
+            conversationBindings: {
+              defaultTopLevelPlacement: "child",
+              supportsAutomaticThreadBindingSpawn: false,
+            },
+          },
+        },
       ]),
     );
   });
@@ -36,6 +64,17 @@ describe("thread binding spawn policy helpers", () => {
     expect(supportsAutomaticThreadBindingSpawn("child-chat")).toBe(true);
     expect(supportsAutomaticThreadBindingSpawn("current-chat")).toBe(false);
     expect(supportsAutomaticThreadBindingSpawn("unknown-chat")).toBe(false);
+  });
+
+  it("lets explicit automatic spawn support differ from top-level placement", () => {
+    expect(supportsAutomaticThreadBindingSpawn("current-spawn-chat")).toBe(true);
+    expect(supportsAutomaticThreadBindingSpawn("current-spawn-chat", "subagent")).toBe(true);
+    expect(supportsAutomaticThreadBindingSpawn("current-spawn-chat", "acp")).toBe(false);
+    expect(supportsAutomaticThreadBindingSpawn("child-disabled-chat")).toBe(false);
+    expect(requiresNativeThreadContextForThreadHere("current-spawn-chat")).toBe(false);
+    expect(resolveThreadBindingPlacementForCurrentContext({ channel: "current-spawn-chat" })).toBe(
+      "current",
+    );
   });
 
   it("allows thread-here on threadless conversation channels without a native thread id", () => {

--- a/src/channels/thread-bindings-policy.ts
+++ b/src/channels/thread-bindings-policy.ts
@@ -6,7 +6,10 @@ import {
   type ThreadBindingLifecycleRecord,
 } from "../shared/thread-binding-lifecycle.js";
 import { getLoadedChannelPlugin } from "./plugins/index.js";
-import { resolveBundledChannelThreadBindingDefaultPlacement } from "./plugins/thread-binding-api.js";
+import {
+  resolveBundledChannelThreadBindingAutomaticSpawnSupport,
+  resolveBundledChannelThreadBindingDefaultPlacement,
+} from "./plugins/thread-binding-api.js";
 
 export {
   resolveThreadBindingLifecycle,
@@ -47,7 +50,14 @@ function normalizeChannelId(value: string | undefined | null): string {
   return normalizeLowercaseStringOrEmpty(value);
 }
 
-export function supportsAutomaticThreadBindingSpawn(channel: string): boolean {
+export function supportsAutomaticThreadBindingSpawn(
+  channel: string,
+  kind?: ThreadBindingSpawnKind,
+): boolean {
+  const explicitSupport = resolveAutomaticThreadBindingSpawnSupport(channel, kind);
+  if (explicitSupport !== undefined) {
+    return explicitSupport;
+  }
   return resolveDefaultTopLevelPlacement(channel) === "child";
 }
 
@@ -75,6 +85,47 @@ function resolveDefaultTopLevelPlacement(channel: string): "current" | "child" {
     resolveBundledChannelThreadBindingDefaultPlacement(normalized) ??
     "current"
   );
+}
+
+function resolveAutomaticThreadBindingSpawnSupport(
+  channel: string,
+  kind?: ThreadBindingSpawnKind,
+): boolean | undefined {
+  const normalized = normalizeChannelId(channel);
+  if (!normalized) {
+    return undefined;
+  }
+  const loadedSupport = normalizeAutomaticSpawnSupport(
+    getLoadedChannelPlugin(normalized)?.conversationBindings?.supportsAutomaticThreadBindingSpawn,
+    kind,
+  );
+  if (loadedSupport !== undefined) {
+    return loadedSupport;
+  }
+  return resolveBundledChannelThreadBindingAutomaticSpawnSupport(normalized, kind);
+}
+
+function normalizeAutomaticSpawnSupport(
+  value: unknown,
+  kind?: ThreadBindingSpawnKind,
+): boolean | undefined {
+  const booleanValue = normalizeBoolean(value);
+  if (booleanValue !== undefined) {
+    return booleanValue;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const support = value as Record<ThreadBindingSpawnKind, unknown>;
+  if (kind) {
+    return normalizeBoolean(support[kind]) ?? false;
+  }
+  const subagent = normalizeBoolean(support.subagent);
+  const acp = normalizeBoolean(support.acp);
+  if (subagent === undefined && acp === undefined) {
+    return undefined;
+  }
+  return subagent === true || acp === true;
 }
 
 function normalizeBoolean(value: unknown): boolean | undefined {

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -177,6 +177,12 @@ export function createCronPromptExecutor(params: {
           }) ?? providerOverride;
         const bootstrapPromptWarningSignature =
           bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
+        registerAgentRunContext(params.cronSession.sessionEntry.sessionId, {
+          sessionKey: params.runSessionKey,
+          verboseLevel: params.resolvedVerboseLevel,
+          isControlUiVisible: false,
+        });
+
         if (isCliProvider(executionProvider, params.cfgWithAgentDefaults)) {
           const cliSessionId = params.cronSession.isNewSession
             ? undefined

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -178,7 +178,7 @@ export function createCronPromptExecutor(params: {
         const bootstrapPromptWarningSignature =
           bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
         registerAgentRunContext(params.cronSession.sessionEntry.sessionId, {
-          sessionKey: params.runSessionKey,
+          sessionKey: params.agentSessionKey,
           verboseLevel: params.resolvedVerboseLevel,
           isControlUiVisible: false,
         });

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -4,7 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
-import { createPersistCronSessionEntry, type MutableCronSession } from "./run-session-state.js";
+import {
+  applyCronDeliveryRouteToSessionEntry,
+  createPersistCronSessionEntry,
+  type MutableCronSession,
+} from "./run-session-state.js";
 
 function makeSessionEntry(overrides?: Partial<SessionEntry>): SessionEntry {
   return {
@@ -25,6 +29,35 @@ function makeCronSession(entry = makeSessionEntry()): MutableCronSession {
     previousSessionId: undefined,
   } as MutableCronSession;
 }
+
+describe("applyCronDeliveryRouteToSessionEntry", () => {
+  it("stores explicit Telegram thread delivery on cron session entries for live channel mirroring", () => {
+    const entry = makeSessionEntry();
+
+    applyCronDeliveryRouteToSessionEntry({
+      entry,
+      resolvedDelivery: {
+        ok: true,
+        channel: "telegram",
+        to: "-100",
+        accountId: "default",
+        threadId: 1189,
+      },
+    });
+
+    expect(entry.channel).toBe("telegram");
+    expect(entry.lastChannel).toBe("telegram");
+    expect(entry.lastTo).toBe("-100");
+    expect(entry.lastAccountId).toBe("default");
+    expect(entry.lastThreadId).toBe("1189");
+    expect(entry.deliveryContext).toEqual({
+      channel: "telegram",
+      to: "-100",
+      accountId: "default",
+      threadId: "1189",
+    });
+  });
+});
 
 describe("createPersistCronSessionEntry", () => {
   it("persists isolated cron state only under the stable cron session key", async () => {

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -3,6 +3,7 @@ import type { LiveSessionModelSelection } from "../../agents/live-model-switch.j
 import type { SkillSnapshot } from "../../agents/skills.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { isCronSessionKey } from "../../sessions/session-key-utils.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import type { resolveCronSession } from "./session.js";
 
 type MutableSessionStore = Record<string, SessionEntry>;
@@ -20,6 +21,53 @@ type UpdateSessionStore = (
 ) => Promise<void>;
 
 export type PersistCronSessionEntry = () => Promise<void>;
+
+export function applyCronDeliveryRouteToSessionEntry(params: {
+  entry: MutableCronSessionEntry;
+  resolvedDelivery:
+    | {
+        ok: true;
+        channel: string;
+        to?: string;
+        accountId?: string;
+        threadId?: string | number;
+      }
+    | { ok: false };
+}) {
+  if (!params.resolvedDelivery.ok) {
+    return;
+  }
+  const channel = normalizeOptionalString(params.resolvedDelivery.channel);
+  const to = normalizeOptionalString(params.resolvedDelivery.to);
+  if (!channel || !to) {
+    return;
+  }
+  const accountId = normalizeOptionalString(params.resolvedDelivery.accountId);
+  const threadId =
+    params.resolvedDelivery.threadId === undefined || params.resolvedDelivery.threadId === null
+      ? undefined
+      : normalizeOptionalString(String(params.resolvedDelivery.threadId));
+
+  params.entry.channel = channel;
+  params.entry.lastChannel = channel;
+  params.entry.lastTo = to;
+  if (accountId) {
+    params.entry.lastAccountId = accountId;
+  } else {
+    delete params.entry.lastAccountId;
+  }
+  if (threadId) {
+    params.entry.lastThreadId = threadId;
+  } else {
+    delete params.entry.lastThreadId;
+  }
+  params.entry.deliveryContext = {
+    channel,
+    to,
+    ...(accountId ? { accountId } : {}),
+    ...(threadId ? { threadId } : {}),
+  };
+}
 
 function cronTranscriptExists(entry: SessionEntry): boolean {
   const sessionFile = entry.sessionFile?.trim();

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -37,6 +37,7 @@ import {
 import { resolveCronModelSelection } from "./model-selection.js";
 import { buildCronAgentDefaultsConfig } from "./run-config.js";
 import {
+  applyCronDeliveryRouteToSessionEntry,
   createPersistCronSessionEntry,
   markCronSessionPreRun,
   persistCronSkillsSnapshotIfChanged,
@@ -744,6 +745,10 @@ async function prepareCronRunContext(params: {
   });
 
   markCronSessionPreRun({ entry: cronSession.sessionEntry, provider, model });
+  applyCronDeliveryRouteToSessionEntry({
+    entry: cronSession.sessionEntry,
+    resolvedDelivery,
+  });
   try {
     await persistSessionEntry();
   } catch (err) {

--- a/src/gateway/agent-event-channel-mirror.test.ts
+++ b/src/gateway/agent-event-channel-mirror.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
-import type { AgentEventPayload } from "../infra/agent-events.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  registerAgentRunContext,
+  resetAgentRunContextForTest,
+  type AgentEventPayload,
+} from "../infra/agent-events.js";
 import { createAgentEventChannelMirror } from "./agent-event-channel-mirror.js";
 
 function event(overrides: Partial<AgentEventPayload>): AgentEventPayload {
@@ -41,6 +45,9 @@ function createHarness() {
 }
 
 describe("agent event channel mirror", () => {
+  afterEach(() => {
+    resetAgentRunContextForTest();
+  });
   it("mirrors thread-bound subagent progress, tool, command output, and thinking events to the Telegram topic", async () => {
     const { mirror, sendDurableMessageBatch } = createHarness();
 
@@ -105,6 +112,29 @@ describe("agent event channel mirror", () => {
     );
 
     expect(sendDurableMessageBatch).not.toHaveBeenCalled();
+  });
+
+  it("resolves hidden cron run session keys from agent run context", async () => {
+    const { mirror, sendDurableMessageBatch } = createHarness();
+    registerAgentRunContext("run-hidden-cron", {
+      sessionKey: "agent:main:cron:job-1:run:run-hidden-cron",
+      isControlUiVisible: false,
+    });
+
+    await mirror(
+      event({
+        runId: "run-hidden-cron",
+        sessionKey: undefined,
+        data: { text: "hidden cron progress", delta: "hidden cron progress" },
+      }),
+    );
+
+    expect(sendDurableMessageBatch).toHaveBeenCalledTimes(1);
+    expect(sendDurableMessageBatch.mock.calls[0]?.[0]).toMatchObject({
+      channel: "telegram",
+      threadId: "1189",
+      payloads: [{ text: "💬 hidden cron progress" }],
+    });
   });
 
   it("mirrors any session with an explicit Telegram thread route, including cron proof sessions", async () => {

--- a/src/gateway/agent-event-channel-mirror.test.ts
+++ b/src/gateway/agent-event-channel-mirror.test.ts
@@ -124,6 +124,34 @@ describe("agent event channel mirror", () => {
     expect(editedTexts).toContain("checking blockers");
   });
 
+  it("shares one progress preview across multiple sessions bound to the same Telegram topic", async () => {
+    const { mirror, sendProgressPreview, editProgressPreview } = createHarness();
+
+    await mirror(
+      event({
+        sessionKey: "agent:main:subagent:parent",
+        data: { text: "parent progress", delta: "parent progress" },
+      }),
+    );
+    await mirror(
+      event({
+        seq: 2,
+        runId: "child-run",
+        sessionKey: "agent:security:subagent:child",
+        data: { text: "child progress", delta: "child progress" },
+      }),
+    );
+
+    expect(sendProgressPreview).toHaveBeenCalledTimes(1);
+    expect(editProgressPreview).toHaveBeenCalledTimes(1);
+    expect(editProgressPreview.mock.calls[0]?.[0]).toMatchObject({
+      messageId: "preview-1",
+      to: "-100",
+      threadId: "1189",
+      text: expect.stringContaining("child progress"),
+    });
+  });
+
   it("skips final-answer assistant text because normal agent delivery already sends it", async () => {
     const { mirror, sendProgressPreview } = createHarness();
 

--- a/src/gateway/agent-event-channel-mirror.test.ts
+++ b/src/gateway/agent-event-channel-mirror.test.ts
@@ -107,9 +107,28 @@ describe("agent event channel mirror", () => {
     expect(sendDurableMessageBatch).not.toHaveBeenCalled();
   });
 
-  it("does not mirror non-thread or non-subagent sessions", async () => {
+  it("mirrors any session with an explicit Telegram thread route, including cron proof sessions", async () => {
+    const { mirror, sendDurableMessageBatch } = createHarness();
+
+    await mirror(
+      event({
+        sessionKey: "agent:main:cron:job-1:run:run-1",
+        data: { text: "cron threaded progress", delta: "cron threaded progress" },
+      }),
+    );
+
+    expect(sendDurableMessageBatch).toHaveBeenCalledTimes(1);
+    expect(sendDurableMessageBatch.mock.calls[0]?.[0]).toMatchObject({
+      channel: "telegram",
+      to: "-100",
+      threadId: "1189",
+      payloads: [{ text: "💬 cron threaded progress" }],
+    });
+  });
+
+  it("does not mirror sessions without a Telegram thread route", async () => {
     const { sendDurableMessageBatch, loadSessionEntry } = createHarness();
-    loadSessionEntry.mockReturnValueOnce({
+    loadSessionEntry.mockReturnValue({
       cfg: { channels: {} },
       entry: {
         sessionId: "session-1",
@@ -123,9 +142,11 @@ describe("agent event channel mirror", () => {
     });
 
     await mirror(
-      event({ sessionKey: "agent:main:explicit:abc", data: { text: "hello", delta: "hello" } }),
+      event({
+        sessionKey: "agent:main:explicit:abc",
+        data: { text: "no thread", delta: "no thread" },
+      }),
     );
-    await mirror(event({ seq: 2, data: { text: "no thread", delta: "no thread" } }));
 
     expect(sendDurableMessageBatch).not.toHaveBeenCalled();
   });

--- a/src/gateway/agent-event-channel-mirror.test.ts
+++ b/src/gateway/agent-event-channel-mirror.test.ts
@@ -18,16 +18,26 @@ function event(overrides: Partial<AgentEventPayload>): AgentEventPayload {
   } as AgentEventPayload;
 }
 
-function createHarness() {
+function createHarness(options?: { telegramConfig?: Record<string, unknown> }) {
   const sendDurableMessageBatch = vi.fn().mockResolvedValue({
     status: "sent",
     results: [{ channel: "telegram", messageId: "tg-1", chatId: "-100" }],
     receipt: { id: "receipt-1" },
   });
+  const sendProgressPreview = vi.fn().mockResolvedValue({ messageId: "preview-1" });
+  const editProgressPreview = vi.fn().mockResolvedValue(undefined);
+  const deleteProgressPreview = vi.fn().mockResolvedValue(undefined);
   const loadSessionEntry = vi.fn().mockReturnValue({
-    cfg: { channels: {} },
+    cfg: {
+      channels: {
+        telegram: options?.telegramConfig ?? {
+          streaming: { mode: "progress", progress: { label: false, maxLines: 8 } },
+        },
+      },
+    },
     entry: {
       sessionId: "session-1",
+      agentId: "main",
       deliveryContext: {
         channel: "telegram",
         to: "-100",
@@ -39,17 +49,29 @@ function createHarness() {
   const mirror = createAgentEventChannelMirror({
     sendDurableMessageBatch,
     loadSessionEntry,
+    sendProgressPreview,
+    editProgressPreview,
+    deleteProgressPreview,
     delayMs: 0,
-  });
-  return { mirror, sendDurableMessageBatch, loadSessionEntry };
+  } as any);
+  return {
+    mirror,
+    sendDurableMessageBatch,
+    sendProgressPreview,
+    editProgressPreview,
+    deleteProgressPreview,
+    loadSessionEntry,
+  };
 }
 
 describe("agent event channel mirror", () => {
   afterEach(() => {
     resetAgentRunContextForTest();
   });
-  it("mirrors thread-bound subagent progress, tool, command output, and thinking events to the Telegram topic", async () => {
-    const { mirror, sendDurableMessageBatch } = createHarness();
+
+  it("updates one thread progress preview instead of appending durable messages for each mirrored event", async () => {
+    const { mirror, sendDurableMessageBatch, sendProgressPreview, editProgressPreview } =
+      createHarness();
 
     await mirror(
       event({
@@ -61,14 +83,21 @@ describe("agent event channel mirror", () => {
       event({
         seq: 2,
         stream: "item",
-        data: { phase: "start", kind: "tool", title: "exec cargo fmt" },
+        data: { itemId: "tool-1", phase: "start", kind: "tool", title: "exec cargo fmt" },
       }),
     );
     await mirror(
       event({
         seq: 3,
         stream: "command_output",
-        data: { phase: "end", title: "exec cargo fmt", output: "fmt passed" },
+        data: {
+          itemId: "tool-1-output",
+          phase: "end",
+          title: "exec cargo fmt",
+          name: "exec",
+          output: "fmt passed",
+          exitCode: 0,
+        },
       }),
     );
     await mirror(
@@ -79,27 +108,24 @@ describe("agent event channel mirror", () => {
       }),
     );
 
-    expect(sendDurableMessageBatch).toHaveBeenCalledTimes(4);
-    for (const call of sendDurableMessageBatch.mock.calls) {
-      expect(call[0]).toMatchObject({
-        channel: "telegram",
-        to: "-100",
-        accountId: "default",
-        threadId: "1189",
-        bestEffort: true,
-      });
-    }
-    const sentText = sendDurableMessageBatch.mock.calls
-      .map((call) => call[0].payloads?.[0]?.text)
-      .join("\n---\n");
-    expect(sentText).toContain("Step 1: inspect");
-    expect(sentText).toContain("exec cargo fmt");
-    expect(sentText).toContain("fmt passed");
-    expect(sentText).toContain("checking blockers");
+    expect(sendDurableMessageBatch).not.toHaveBeenCalled();
+    expect(sendProgressPreview).toHaveBeenCalledTimes(1);
+    expect(sendProgressPreview.mock.calls[0]?.[0]).toMatchObject({
+      cfg: { channels: { telegram: expect.any(Object) } },
+      to: "-100",
+      accountId: "default",
+      threadId: "1189",
+      text: expect.stringContaining("Step 1: inspect"),
+    });
+    expect(editProgressPreview).toHaveBeenCalledTimes(3);
+    const editedTexts = editProgressPreview.mock.calls.map((call) => call[0].text).join("\n---\n");
+    expect(editedTexts).toContain("exec cargo fmt");
+    expect(editedTexts).toContain("completed");
+    expect(editedTexts).toContain("checking blockers");
   });
 
   it("skips final-answer assistant text because normal agent delivery already sends it", async () => {
-    const { mirror, sendDurableMessageBatch } = createHarness();
+    const { mirror, sendProgressPreview } = createHarness();
 
     await mirror(
       event({
@@ -111,11 +137,11 @@ describe("agent event channel mirror", () => {
       }),
     );
 
-    expect(sendDurableMessageBatch).not.toHaveBeenCalled();
+    expect(sendProgressPreview).not.toHaveBeenCalled();
   });
 
   it("resolves hidden cron run session keys from agent run context", async () => {
-    const { mirror, sendDurableMessageBatch } = createHarness();
+    const { mirror, sendProgressPreview } = createHarness();
     registerAgentRunContext("run-hidden-cron", {
       sessionKey: "agent:main:cron:job-1:run:run-hidden-cron",
       isControlUiVisible: false,
@@ -129,16 +155,15 @@ describe("agent event channel mirror", () => {
       }),
     );
 
-    expect(sendDurableMessageBatch).toHaveBeenCalledTimes(1);
-    expect(sendDurableMessageBatch.mock.calls[0]?.[0]).toMatchObject({
-      channel: "telegram",
+    expect(sendProgressPreview).toHaveBeenCalledTimes(1);
+    expect(sendProgressPreview.mock.calls[0]?.[0]).toMatchObject({
       threadId: "1189",
-      payloads: [{ text: "💬 hidden cron progress" }],
+      text: "💬 hidden cron progress",
     });
   });
 
   it("mirrors any session with an explicit Telegram thread route, including cron proof sessions", async () => {
-    const { mirror, sendDurableMessageBatch } = createHarness();
+    const { mirror, sendProgressPreview } = createHarness();
 
     await mirror(
       event({
@@ -147,17 +172,48 @@ describe("agent event channel mirror", () => {
       }),
     );
 
-    expect(sendDurableMessageBatch).toHaveBeenCalledTimes(1);
-    expect(sendDurableMessageBatch.mock.calls[0]?.[0]).toMatchObject({
-      channel: "telegram",
+    expect(sendProgressPreview).toHaveBeenCalledTimes(1);
+    expect(sendProgressPreview.mock.calls[0]?.[0]).toMatchObject({
       to: "-100",
       threadId: "1189",
-      payloads: [{ text: "💬 cron threaded progress" }],
+      text: "💬 cron threaded progress",
     });
   });
 
+  it("bounds progress preview lines and deletes the preview when the run ends", async () => {
+    const { mirror, sendProgressPreview, editProgressPreview, deleteProgressPreview } =
+      createHarness({
+        telegramConfig: {
+          streaming: { mode: "progress", progress: { label: false, maxLines: 3 } },
+        },
+      });
+
+    await mirror(event({ data: { text: "first", delta: "first" } }));
+    await mirror(event({ seq: 2, stream: "thinking", data: { text: "second", delta: "second" } }));
+    await mirror(event({ seq: 3, stream: "assistant", data: { text: "third", delta: "third" } }));
+    await mirror(event({ seq: 4, stream: "assistant", data: { text: "fourth", delta: "fourth" } }));
+
+    const latestPreviewText = editProgressPreview.mock.calls.at(-1)?.[0].text;
+    expect(latestPreviewText).not.toContain("first");
+    expect(latestPreviewText).toContain("second");
+    expect(latestPreviewText).toContain("third");
+    expect(latestPreviewText).toContain("fourth");
+
+    await mirror(event({ seq: 5, stream: "lifecycle", data: { phase: "end" } }));
+    expect(deleteProgressPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "-100",
+        threadId: "1189",
+        messageId: "preview-1",
+      }),
+    );
+
+    await mirror(event({ seq: 6, runId: "run-2", data: { text: "new run", delta: "new run" } }));
+    expect(sendProgressPreview).toHaveBeenCalledTimes(2);
+  });
+
   it("does not mirror sessions without a Telegram thread route", async () => {
-    const { sendDurableMessageBatch, loadSessionEntry } = createHarness();
+    const { sendProgressPreview, sendDurableMessageBatch, loadSessionEntry } = createHarness();
     loadSessionEntry.mockReturnValue({
       cfg: { channels: {} },
       entry: {
@@ -168,8 +224,9 @@ describe("agent event channel mirror", () => {
     const mirror = createAgentEventChannelMirror({
       sendDurableMessageBatch,
       loadSessionEntry,
+      sendProgressPreview,
       delayMs: 0,
-    });
+    } as any);
 
     await mirror(
       event({
@@ -178,6 +235,7 @@ describe("agent event channel mirror", () => {
       }),
     );
 
+    expect(sendProgressPreview).not.toHaveBeenCalled();
     expect(sendDurableMessageBatch).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/agent-event-channel-mirror.test.ts
+++ b/src/gateway/agent-event-channel-mirror.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentEventPayload } from "../infra/agent-events.js";
+import { createAgentEventChannelMirror } from "./agent-event-channel-mirror.js";
+
+function event(overrides: Partial<AgentEventPayload>): AgentEventPayload {
+  return {
+    runId: "run-1",
+    seq: 1,
+    stream: "assistant",
+    ts: 1_000,
+    sessionKey: "agent:main:subagent:child-1",
+    data: {},
+    ...overrides,
+  } as AgentEventPayload;
+}
+
+function createHarness() {
+  const sendDurableMessageBatch = vi.fn().mockResolvedValue({
+    status: "sent",
+    results: [{ channel: "telegram", messageId: "tg-1", chatId: "-100" }],
+    receipt: { id: "receipt-1" },
+  });
+  const loadSessionEntry = vi.fn().mockReturnValue({
+    cfg: { channels: {} },
+    entry: {
+      sessionId: "session-1",
+      deliveryContext: {
+        channel: "telegram",
+        to: "-100",
+        accountId: "default",
+        threadId: "1189",
+      },
+    },
+  });
+  const mirror = createAgentEventChannelMirror({
+    sendDurableMessageBatch,
+    loadSessionEntry,
+    delayMs: 0,
+  });
+  return { mirror, sendDurableMessageBatch, loadSessionEntry };
+}
+
+describe("agent event channel mirror", () => {
+  it("mirrors thread-bound subagent progress, tool, command output, and thinking events to the Telegram topic", async () => {
+    const { mirror, sendDurableMessageBatch } = createHarness();
+
+    await mirror(
+      event({
+        stream: "assistant",
+        data: { text: "Step 1: inspect", delta: "Step 1: inspect", phase: "commentary" },
+      }),
+    );
+    await mirror(
+      event({
+        seq: 2,
+        stream: "item",
+        data: { phase: "start", kind: "tool", title: "exec cargo fmt" },
+      }),
+    );
+    await mirror(
+      event({
+        seq: 3,
+        stream: "command_output",
+        data: { phase: "end", title: "exec cargo fmt", output: "fmt passed" },
+      }),
+    );
+    await mirror(
+      event({
+        seq: 4,
+        stream: "thinking",
+        data: { text: "checking blockers", delta: "checking blockers" },
+      }),
+    );
+
+    expect(sendDurableMessageBatch).toHaveBeenCalledTimes(4);
+    for (const call of sendDurableMessageBatch.mock.calls) {
+      expect(call[0]).toMatchObject({
+        channel: "telegram",
+        to: "-100",
+        accountId: "default",
+        threadId: "1189",
+        bestEffort: true,
+      });
+    }
+    const sentText = sendDurableMessageBatch.mock.calls
+      .map((call) => call[0].payloads?.[0]?.text)
+      .join("\n---\n");
+    expect(sentText).toContain("Step 1: inspect");
+    expect(sentText).toContain("exec cargo fmt");
+    expect(sentText).toContain("fmt passed");
+    expect(sentText).toContain("checking blockers");
+  });
+
+  it("skips final-answer assistant text because normal agent delivery already sends it", async () => {
+    const { mirror, sendDurableMessageBatch } = createHarness();
+
+    await mirror(
+      event({
+        data: {
+          text: "Final review summary",
+          delta: "Final review summary",
+          phase: "final_answer",
+        },
+      }),
+    );
+
+    expect(sendDurableMessageBatch).not.toHaveBeenCalled();
+  });
+
+  it("does not mirror non-thread or non-subagent sessions", async () => {
+    const { sendDurableMessageBatch, loadSessionEntry } = createHarness();
+    loadSessionEntry.mockReturnValueOnce({
+      cfg: { channels: {} },
+      entry: {
+        sessionId: "session-1",
+        deliveryContext: { channel: "telegram", to: "-100", accountId: "default" },
+      },
+    });
+    const mirror = createAgentEventChannelMirror({
+      sendDurableMessageBatch,
+      loadSessionEntry,
+      delayMs: 0,
+    });
+
+    await mirror(
+      event({ sessionKey: "agent:main:explicit:abc", data: { text: "hello", delta: "hello" } }),
+    );
+    await mirror(event({ seq: 2, data: { text: "no thread", delta: "no thread" } }));
+
+    expect(sendDurableMessageBatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/agent-event-channel-mirror.test.ts
+++ b/src/gateway/agent-event-channel-mirror.test.ts
@@ -208,6 +208,59 @@ describe("agent event channel mirror", () => {
     });
   });
 
+  it("replaces repeated tool progress lines with the latest current tool", async () => {
+    const { mirror, editProgressPreview } = createHarness({
+      telegramConfig: { streaming: { mode: "progress", progress: { label: false, maxLines: 8 } } },
+    });
+
+    await mirror(
+      event({
+        stream: "item",
+        data: {
+          itemId: "read-1",
+          phase: "end",
+          kind: "tool",
+          name: "read",
+          title: "Read",
+          progressText: "first 120 lines of memory/gotchas.md",
+        },
+      }),
+    );
+    await mirror(
+      event({
+        seq: 2,
+        stream: "item",
+        data: {
+          itemId: "read-2",
+          phase: "end",
+          kind: "tool",
+          name: "read",
+          title: "Read",
+          progressText: "first 120 lines of memory/designs.md",
+        },
+      }),
+    );
+    await mirror(
+      event({
+        seq: 3,
+        stream: "item",
+        data: {
+          itemId: "read-3",
+          phase: "end",
+          kind: "tool",
+          name: "read",
+          title: "Read",
+          progressText: "first 120 lines of memory/anti-patterns.md",
+        },
+      }),
+    );
+
+    const latestPreviewText = editProgressPreview.mock.calls.at(-1)?.[0].text;
+    expect(latestPreviewText).not.toContain("gotchas");
+    expect(latestPreviewText).not.toContain("designs");
+    expect(latestPreviewText).toContain("anti-patterns");
+  });
+
   it("bounds progress preview lines and deletes the preview when the run ends", async () => {
     const { mirror, sendProgressPreview, editProgressPreview, deleteProgressPreview } =
       createHarness({

--- a/src/gateway/agent-event-channel-mirror.ts
+++ b/src/gateway/agent-event-channel-mirror.ts
@@ -1,9 +1,18 @@
-import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import { sendDurableMessageBatch as defaultSendDurableMessageBatch } from "../channels/message/runtime.js";
 import type { DurableMessageBatchSendResult } from "../channels/message/send.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
 import { getAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  buildChannelProgressDraftLineForEntry,
+  formatChannelProgressDraftText,
+  mergeChannelProgressDraftLine,
+  resolveChannelPreviewStreamMode,
+  resolveChannelProgressDraftMaxLines,
+  resolveChannelStreamingPreviewToolProgress,
+  type ChannelProgressDraftLine,
+} from "../plugin-sdk/channel-streaming.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { loadSessionEntry as defaultLoadSessionEntry } from "./session-utils.js";
 
@@ -17,16 +26,49 @@ type SendDurableMessageBatch = (
   params: Parameters<typeof defaultSendDurableMessageBatch>[0],
 ) => Promise<DurableMessageBatchSendResult> | DurableMessageBatchSendResult;
 
+type ProgressPreviewParams = {
+  cfg: OpenClawConfig;
+  to: string;
+  accountId?: string;
+  threadId: string | number;
+  text: string;
+  sessionKey: string;
+};
+
+type SendProgressPreview = (
+  params: ProgressPreviewParams,
+) => Promise<{ messageId: string }> | { messageId: string };
+
+type EditProgressPreview = (
+  params: ProgressPreviewParams & { messageId: string },
+) => Promise<void> | void;
+
+type DeleteProgressPreview = (
+  params: Omit<ProgressPreviewParams, "text"> & { messageId: string },
+) => Promise<void> | void;
+
 type AgentEventChannelMirrorDeps = {
   loadSessionEntry?: (sessionKey: string) => LoadedSessionEntry;
   sendDurableMessageBatch?: SendDurableMessageBatch;
+  sendProgressPreview?: SendProgressPreview;
+  editProgressPreview?: EditProgressPreview;
+  deleteProgressPreview?: DeleteProgressPreview;
   delayMs?: number;
+};
+
+type ProgressPreviewLine = string | ChannelProgressDraftLine;
+
+type ProgressPreviewState = {
+  lines: ProgressPreviewLine[];
+  messageId?: string;
+  lastText?: string;
 };
 
 type MirrorState = {
   assistantTextByRun: Map<string, string>;
   thinkingTextByRun: Map<string, string>;
   queuesBySession: Map<string, Promise<void>>;
+  previewsBySession: Map<string, ProgressPreviewState>;
   seenEvents: Set<string>;
 };
 
@@ -36,6 +78,15 @@ type DeliveryRoute = {
   accountId?: string;
   threadId: string | number;
 };
+
+type TelegramRuntimeApi = typeof import("../../extensions/telegram/runtime-api.js");
+
+let telegramRuntimeApiPromise: Promise<TelegramRuntimeApi> | undefined;
+
+async function loadTelegramRuntimeApi(): Promise<TelegramRuntimeApi> {
+  telegramRuntimeApiPromise ??= import("../../extensions/telegram/runtime-api.js");
+  return await telegramRuntimeApiPromise;
+}
 
 function eventKey(evt: AgentEventPayload): string {
   return `${evt.runId}:${evt.seq}:${evt.stream}`;
@@ -79,6 +130,43 @@ function resolveTelegramThreadRoute(loaded: LoadedSessionEntry | undefined): Del
   };
 }
 
+function resolveTelegramStreamingEntry(
+  cfg: OpenClawConfig,
+  accountId: string | undefined,
+): Record<string, unknown> | null {
+  const telegram = cfg.channels?.telegram;
+  if (!telegram || typeof telegram !== "object") {
+    return null;
+  }
+  const base = telegram as Record<string, unknown>;
+  const accounts = base.accounts;
+  const account =
+    accountId && accountId !== "default" && accounts && typeof accounts === "object"
+      ? (accounts as Record<string, unknown>)[accountId]
+      : undefined;
+  if (account && typeof account === "object" && !Array.isArray(account)) {
+    const accountRecord = account as Record<string, unknown>;
+    return {
+      ...base,
+      ...accountRecord,
+      streaming: accountRecord.streaming ?? base.streaming,
+    };
+  }
+  return base;
+}
+
+function shouldMirrorTelegramProgress(loaded: LoadedSessionEntry, route: DeliveryRoute): boolean {
+  const entry = resolveTelegramStreamingEntry(loaded.cfg, route.accountId);
+  if (!entry) {
+    return false;
+  }
+  const mode = resolveChannelPreviewStreamMode(entry, "partial");
+  if (mode === "off" || mode === "block") {
+    return false;
+  }
+  return resolveChannelStreamingPreviewToolProgress(entry, true);
+}
+
 function trimForProgressMessage(text: string): string {
   const trimmed = text.trim();
   if (trimmed.length <= MAX_INLINE_OUTPUT_CHARS) {
@@ -115,10 +203,21 @@ function textFromData(
   return text;
 }
 
-export function formatAgentEventForChannelMirror(
+function lineWithId<TLine extends ChannelProgressDraftLine | undefined>(
+  line: TLine,
+  id: string | undefined,
+): TLine {
+  if (!line || !id) {
+    return line;
+  }
+  return { ...line, id } as TLine;
+}
+
+function formatAgentEventForChannelMirrorLine(
   evt: AgentEventPayload,
   state: Pick<MirrorState, "assistantTextByRun" | "thinkingTextByRun">,
-): string | undefined {
+  entry: Record<string, unknown> | null,
+): ProgressPreviewLine | undefined {
   const data = evt.data ?? {};
   if (evt.stream === "assistant") {
     if (data.phase === "final_answer") {
@@ -137,43 +236,81 @@ export function formatAgentEventForChannelMirror(
     if (data.suppressChannelProgress === true) {
       return undefined;
     }
-    const phase = normalizeOptionalString(data.phase) ?? "update";
-    const title =
-      normalizeOptionalString(data.title) ?? normalizeOptionalString(data.name) ?? "agent item";
-    const status = normalizeOptionalString(data.status);
-    const summary =
-      normalizeOptionalString(data.summary) ?? normalizeOptionalString(data.progressText);
-    const prefix = phase === "start" ? "▶️" : phase === "end" ? "✅" : "🔄";
-    const statusPart = status ? ` (${status})` : "";
-    const summaryPart = summary ? `\n${trimForProgressMessage(summary)}` : "";
-    return `${prefix} ${title}${statusPart}${summaryPart}`;
+    return buildChannelProgressDraftLineForEntry(entry, {
+      event: "item",
+      itemId: normalizeOptionalString(data.itemId),
+      itemKind: normalizeOptionalString(data.kind),
+      title: normalizeOptionalString(data.title),
+      name: normalizeOptionalString(data.name),
+      phase: normalizeOptionalString(data.phase),
+      status: normalizeOptionalString(data.status),
+      summary: normalizeOptionalString(data.summary),
+      progressText: normalizeOptionalString(data.progressText),
+      meta: normalizeOptionalString(data.meta),
+    });
   }
 
   if (evt.stream === "command_output") {
-    const phase = normalizeOptionalString(data.phase) ?? "output";
-    const title =
-      normalizeOptionalString(data.title) ?? normalizeOptionalString(data.name) ?? "command output";
-    const output = normalizeOptionalString(data.output);
-    const exitCode = typeof data.exitCode === "number" ? data.exitCode : undefined;
-    const exitPart = exitCode === undefined ? "" : ` exit=${exitCode}`;
-    if (!output && phase !== "end") {
-      return undefined;
-    }
-    const outputPart = output ? `\n\`\`\`\n${trimForProgressMessage(output)}\n\`\`\`` : "";
-    return `📟 ${title} [${phase}${exitPart}]${outputPart}`;
+    const id = normalizeOptionalString(data.itemId) ?? normalizeOptionalString(data.toolCallId);
+    return lineWithId(
+      buildChannelProgressDraftLineForEntry(entry, {
+        event: "command-output",
+        phase: normalizeOptionalString(data.phase),
+        title: normalizeOptionalString(data.title),
+        name: normalizeOptionalString(data.name),
+        status: normalizeOptionalString(data.status),
+        exitCode: typeof data.exitCode === "number" ? data.exitCode : null,
+      }),
+      id,
+    );
   }
 
   if (evt.stream === "approval") {
-    const title = normalizeOptionalString(data.title) ?? "approval";
-    const status =
-      normalizeOptionalString(data.status) ?? normalizeOptionalString(data.phase) ?? "requested";
-    return `🛂 ${title} (${status})`;
+    const id = normalizeOptionalString(data.approvalId) ?? normalizeOptionalString(data.toolCallId);
+    return lineWithId(
+      buildChannelProgressDraftLineForEntry(entry, {
+        event: "approval",
+        phase: normalizeOptionalString(data.phase),
+        title: normalizeOptionalString(data.title),
+        command: normalizeOptionalString(data.command),
+        reason: normalizeOptionalString(data.reason),
+        message: normalizeOptionalString(data.message),
+      }),
+      id,
+    );
   }
 
   if (evt.stream === "plan") {
-    const title = normalizeOptionalString(data.title) ?? "plan update";
-    const explanation = normalizeOptionalString(data.explanation);
-    return `📝 ${title}${explanation ? `\n${trimForProgressMessage(explanation)}` : ""}`;
+    return buildChannelProgressDraftLineForEntry(entry, {
+      event: "plan",
+      phase: normalizeOptionalString(data.phase),
+      title: normalizeOptionalString(data.title),
+      explanation: normalizeOptionalString(data.explanation),
+      steps: Array.isArray(data.steps)
+        ? data.steps.filter((step): step is string => typeof step === "string")
+        : undefined,
+    });
+  }
+
+  if (evt.stream === "patch") {
+    const id = normalizeOptionalString(data.itemId) ?? normalizeOptionalString(data.toolCallId);
+    const stringArray = (value: unknown): string[] | undefined =>
+      Array.isArray(value)
+        ? value.filter((entry): entry is string => typeof entry === "string")
+        : undefined;
+    return lineWithId(
+      buildChannelProgressDraftLineForEntry(entry, {
+        event: "patch",
+        phase: normalizeOptionalString(data.phase),
+        title: normalizeOptionalString(data.title),
+        name: normalizeOptionalString(data.name),
+        added: stringArray(data.added),
+        modified: stringArray(data.modified),
+        deleted: stringArray(data.deleted),
+        summary: normalizeOptionalString(data.summary),
+      }),
+      id,
+    );
   }
 
   if (evt.stream === "error") {
@@ -195,6 +332,29 @@ export function formatAgentEventForChannelMirror(
   }
 
   return undefined;
+}
+
+export function formatAgentEventForChannelMirror(
+  evt: AgentEventPayload,
+  state: Pick<MirrorState, "assistantTextByRun" | "thinkingTextByRun">,
+): string | undefined {
+  const line = formatAgentEventForChannelMirrorLine(evt, state, null);
+  if (!line) {
+    return undefined;
+  }
+  return typeof line === "string" ? line : line.text;
+}
+
+function isTerminalMirrorEvent(evt: AgentEventPayload): boolean {
+  const data = evt.data ?? {};
+  if (evt.stream === "assistant" && data.phase === "final_answer") {
+    return true;
+  }
+  if (evt.stream === "lifecycle") {
+    const phase = normalizeOptionalString(data.phase);
+    return phase === "end" || phase === "error";
+  }
+  return false;
 }
 
 function enqueueSessionSend(
@@ -226,15 +386,80 @@ function enqueueSessionSend(
   return next;
 }
 
+function resolveMessageIdFromDurableSend(
+  result: DurableMessageBatchSendResult,
+): string | undefined {
+  if ("receipt" in result) {
+    const receiptId =
+      result.receipt.primaryPlatformMessageId ?? result.receipt.platformMessageIds[0];
+    if (receiptId) {
+      return String(receiptId);
+    }
+  }
+  if ("results" in result) {
+    const resultId = result.results.find((entry) => entry.messageId)?.messageId;
+    if (resultId) {
+      return String(resultId);
+    }
+  }
+  return undefined;
+}
+
+function defaultSendProgressPreview(
+  sendDurableMessageBatch: SendDurableMessageBatch,
+): SendProgressPreview {
+  return async (params) => {
+    const result = await sendDurableMessageBatch({
+      cfg: params.cfg,
+      channel: "telegram",
+      to: params.to,
+      ...(params.accountId ? { accountId: params.accountId } : {}),
+      threadId: params.threadId,
+      payloads: [{ text: params.text }],
+      bestEffort: true,
+      session: {
+        key: params.sessionKey,
+      },
+    });
+    const messageId = resolveMessageIdFromDurableSend(result);
+    if (!messageId) {
+      throw new Error("Telegram progress preview send returned no message id");
+    }
+    return { messageId };
+  };
+}
+
+const defaultEditProgressPreview: EditProgressPreview = async (params) => {
+  const { editMessageTelegram } = await loadTelegramRuntimeApi();
+  await editMessageTelegram(params.to, params.messageId, params.text, {
+    cfg: params.cfg,
+    ...(params.accountId ? { accountId: params.accountId } : {}),
+    linkPreview: false,
+  });
+};
+
+const defaultDeleteProgressPreview: DeleteProgressPreview = async (params) => {
+  const { deleteMessageTelegram } = await loadTelegramRuntimeApi();
+  await deleteMessageTelegram(params.to, params.messageId, {
+    cfg: params.cfg,
+    ...(params.accountId ? { accountId: params.accountId } : {}),
+  });
+};
+
 export function createAgentEventChannelMirror(deps: AgentEventChannelMirrorDeps = {}) {
   const state: MirrorState = {
     assistantTextByRun: new Map(),
     thinkingTextByRun: new Map(),
     queuesBySession: new Map(),
+    previewsBySession: new Map(),
     seenEvents: new Set(),
   };
   const loadSessionEntry = deps.loadSessionEntry ?? defaultLoadSessionEntry;
   const sendDurableMessageBatch = deps.sendDurableMessageBatch ?? defaultSendDurableMessageBatch;
+  const sendProgressPreview =
+    deps.sendProgressPreview ?? defaultSendProgressPreview(sendDurableMessageBatch);
+  const editProgressPreview = deps.editProgressPreview ?? defaultEditProgressPreview;
+  const deleteProgressPreview = deps.deleteProgressPreview ?? defaultDeleteProgressPreview;
   const delayMs = deps.delayMs ?? DEFAULT_DELAY_MS;
 
   return async (evt: AgentEventPayload): Promise<void> => {
@@ -248,31 +473,82 @@ export function createAgentEventChannelMirror(deps: AgentEventChannelMirrorDeps 
     if (!rememberSeenEvent(state, key)) {
       return;
     }
-    const text = formatAgentEventForChannelMirror(evt, state);
-    if (!text) {
-      return;
-    }
+
     const loaded = loadSessionEntry(sessionKey);
     const route = resolveTelegramThreadRoute(loaded);
     if (!route) {
       return;
     }
-    const payloads: ReplyPayload[] = [{ text }];
+
+    if (isTerminalMirrorEvent(evt)) {
+      const preview = state.previewsBySession.get(sessionKey);
+      if (!preview) {
+        return;
+      }
+      await enqueueSessionSend(state, sessionKey, delayMs, async () => {
+        state.previewsBySession.delete(sessionKey);
+        const messageId = preview.messageId;
+        preview.messageId = undefined;
+        preview.lines = [];
+        preview.lastText = undefined;
+        if (!messageId) {
+          return;
+        }
+        await deleteProgressPreview({
+          cfg: loaded.cfg,
+          to: route.to,
+          ...(route.accountId ? { accountId: route.accountId } : {}),
+          threadId: route.threadId,
+          messageId,
+          sessionKey,
+        });
+      });
+      return;
+    }
+
+    if (!shouldMirrorTelegramProgress(loaded, route)) {
+      return;
+    }
+
+    const entry = resolveTelegramStreamingEntry(loaded.cfg, route.accountId);
+    const line = formatAgentEventForChannelMirrorLine(evt, state, entry);
+    if (!line) {
+      return;
+    }
+
+    let preview = state.previewsBySession.get(sessionKey);
+    if (!preview) {
+      preview = { lines: [] };
+      state.previewsBySession.set(sessionKey, preview);
+    }
+    const maxLines = resolveChannelProgressDraftMaxLines(entry, 8);
+    preview.lines = mergeChannelProgressDraftLine(preview.lines, line, { maxLines });
+    const text = formatChannelProgressDraftText({
+      entry,
+      lines: preview.lines,
+      seed: sessionKey,
+    });
+    if (!text.trim() || text === preview.lastText) {
+      return;
+    }
+
     await enqueueSessionSend(state, sessionKey, delayMs, async () => {
-      await sendDurableMessageBatch({
+      const params = {
         cfg: loaded.cfg,
-        channel: route.channel,
         to: route.to,
         ...(route.accountId ? { accountId: route.accountId } : {}),
         threadId: route.threadId,
-        payloads,
-        bestEffort: true,
-        session: {
-          key: sessionKey,
-          agentId: loaded.entry?.agentId,
-          sessionId: loaded.entry?.sessionId,
-        },
-      });
+        text,
+        sessionKey,
+      } satisfies ProgressPreviewParams;
+      if (!preview.messageId) {
+        const sent = await sendProgressPreview(params);
+        preview.messageId = sent.messageId;
+        preview.lastText = text;
+        return;
+      }
+      await editProgressPreview({ ...params, messageId: preview.messageId });
+      preview.lastText = text;
     });
   };
 }

--- a/src/gateway/agent-event-channel-mirror.ts
+++ b/src/gateway/agent-event-channel-mirror.ts
@@ -208,6 +208,8 @@ function textFromData(
   return text;
 }
 
+const CURRENT_TOOL_PROGRESS_LINE_ID = "current-tool";
+
 function lineWithId<TLine extends ChannelProgressDraftLine | undefined>(
   line: TLine,
   id: string | undefined,
@@ -241,22 +243,23 @@ function formatAgentEventForChannelMirrorLine(
     if (data.suppressChannelProgress === true) {
       return undefined;
     }
-    return buildChannelProgressDraftLineForEntry(entry, {
-      event: "item",
-      itemId: normalizeOptionalString(data.itemId),
-      itemKind: normalizeOptionalString(data.kind),
-      title: normalizeOptionalString(data.title),
-      name: normalizeOptionalString(data.name),
-      phase: normalizeOptionalString(data.phase),
-      status: normalizeOptionalString(data.status),
-      summary: normalizeOptionalString(data.summary),
-      progressText: normalizeOptionalString(data.progressText),
-      meta: normalizeOptionalString(data.meta),
-    });
+    return lineWithId(
+      buildChannelProgressDraftLineForEntry(entry, {
+        event: "item",
+        itemKind: normalizeOptionalString(data.kind),
+        title: normalizeOptionalString(data.title),
+        name: normalizeOptionalString(data.name),
+        phase: normalizeOptionalString(data.phase),
+        status: normalizeOptionalString(data.status),
+        summary: normalizeOptionalString(data.summary),
+        progressText: normalizeOptionalString(data.progressText),
+        meta: normalizeOptionalString(data.meta),
+      }),
+      CURRENT_TOOL_PROGRESS_LINE_ID,
+    );
   }
 
   if (evt.stream === "command_output") {
-    const id = normalizeOptionalString(data.itemId) ?? normalizeOptionalString(data.toolCallId);
     return lineWithId(
       buildChannelProgressDraftLineForEntry(entry, {
         event: "command-output",
@@ -266,12 +269,11 @@ function formatAgentEventForChannelMirrorLine(
         status: normalizeOptionalString(data.status),
         exitCode: typeof data.exitCode === "number" ? data.exitCode : null,
       }),
-      id,
+      CURRENT_TOOL_PROGRESS_LINE_ID,
     );
   }
 
   if (evt.stream === "approval") {
-    const id = normalizeOptionalString(data.approvalId) ?? normalizeOptionalString(data.toolCallId);
     return lineWithId(
       buildChannelProgressDraftLineForEntry(entry, {
         event: "approval",
@@ -281,7 +283,7 @@ function formatAgentEventForChannelMirrorLine(
         reason: normalizeOptionalString(data.reason),
         message: normalizeOptionalString(data.message),
       }),
-      id,
+      CURRENT_TOOL_PROGRESS_LINE_ID,
     );
   }
 
@@ -298,7 +300,6 @@ function formatAgentEventForChannelMirrorLine(
   }
 
   if (evt.stream === "patch") {
-    const id = normalizeOptionalString(data.itemId) ?? normalizeOptionalString(data.toolCallId);
     const stringArray = (value: unknown): string[] | undefined =>
       Array.isArray(value)
         ? value.filter((entry): entry is string => typeof entry === "string")
@@ -314,7 +315,7 @@ function formatAgentEventForChannelMirrorLine(
         deleted: stringArray(data.deleted),
         summary: normalizeOptionalString(data.summary),
       }),
-      id,
+      CURRENT_TOOL_PROGRESS_LINE_ID,
     );
   }
 

--- a/src/gateway/agent-event-channel-mirror.ts
+++ b/src/gateway/agent-event-channel-mirror.ts
@@ -1,0 +1,283 @@
+import type { ReplyPayload } from "../auto-reply/reply-payload.js";
+import { sendDurableMessageBatch as defaultSendDurableMessageBatch } from "../channels/message/runtime.js";
+import type { DurableMessageBatchSendResult } from "../channels/message/send.js";
+import type { AgentEventPayload } from "../infra/agent-events.js";
+import { onAgentEvent } from "../infra/agent-events.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { loadSessionEntry as defaultLoadSessionEntry } from "./session-utils.js";
+
+const log = createSubsystemLogger("gateway/agent-event-channel-mirror");
+const DEFAULT_DELAY_MS = 250;
+const MAX_INLINE_OUTPUT_CHARS = 12_000;
+const MAX_SEEN_EVENTS = 10_000;
+
+type LoadedSessionEntry = ReturnType<typeof defaultLoadSessionEntry>;
+type SendDurableMessageBatch = (
+  params: Parameters<typeof defaultSendDurableMessageBatch>[0],
+) => Promise<DurableMessageBatchSendResult> | DurableMessageBatchSendResult;
+
+type AgentEventChannelMirrorDeps = {
+  loadSessionEntry?: (sessionKey: string) => LoadedSessionEntry;
+  sendDurableMessageBatch?: SendDurableMessageBatch;
+  delayMs?: number;
+};
+
+type MirrorState = {
+  assistantTextByRun: Map<string, string>;
+  thinkingTextByRun: Map<string, string>;
+  queuesBySession: Map<string, Promise<void>>;
+  seenEvents: Set<string>;
+};
+
+type DeliveryRoute = {
+  channel: "telegram";
+  to: string;
+  accountId?: string;
+  threadId: string | number;
+};
+
+function eventKey(evt: AgentEventPayload): string {
+  return `${evt.runId}:${evt.seq}:${evt.stream}`;
+}
+
+function rememberSeenEvent(state: MirrorState, key: string): boolean {
+  if (state.seenEvents.has(key)) {
+    return false;
+  }
+  state.seenEvents.add(key);
+  if (state.seenEvents.size > MAX_SEEN_EVENTS) {
+    const first = state.seenEvents.values().next().value;
+    if (typeof first === "string") {
+      state.seenEvents.delete(first);
+    }
+  }
+  return true;
+}
+
+function isThreadBoundSubagentSession(sessionKey: string | undefined): sessionKey is string {
+  return Boolean(sessionKey && sessionKey.includes(":subagent:"));
+}
+
+function resolveTelegramThreadRoute(loaded: LoadedSessionEntry | undefined): DeliveryRoute | null {
+  const ctx = loaded?.entry?.deliveryContext;
+  if (!ctx || ctx.channel !== "telegram") {
+    return null;
+  }
+  const to = normalizeOptionalString(ctx.to);
+  const threadId =
+    typeof ctx.threadId === "string" || typeof ctx.threadId === "number" ? ctx.threadId : undefined;
+  if (!to || threadId === undefined || threadId === null || String(threadId).trim() === "") {
+    return null;
+  }
+  const accountId = normalizeOptionalString(ctx.accountId);
+  return {
+    channel: "telegram",
+    to,
+    ...(accountId ? { accountId } : {}),
+    threadId,
+  };
+}
+
+function trimForProgressMessage(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= MAX_INLINE_OUTPUT_CHARS) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, MAX_INLINE_OUTPUT_CHARS)}\n…[truncated ${trimmed.length - MAX_INLINE_OUTPUT_CHARS} chars in Telegram mirror; full output remains in the session transcript]`;
+}
+
+function textFromData(
+  data: Record<string, unknown>,
+  stateMap: Map<string, string>,
+  runId: string,
+): string {
+  const explicitDelta = normalizeOptionalString(data.delta);
+  if (explicitDelta) {
+    const currentText = normalizeOptionalString(data.text);
+    if (currentText) {
+      stateMap.set(runId, currentText);
+    }
+    return explicitDelta;
+  }
+  const text = normalizeOptionalString(data.text);
+  if (!text) {
+    return "";
+  }
+  const previous = stateMap.get(runId) ?? "";
+  stateMap.set(runId, text);
+  if (previous && text.startsWith(previous)) {
+    return text.slice(previous.length);
+  }
+  if (previous === text) {
+    return "";
+  }
+  return text;
+}
+
+export function formatAgentEventForChannelMirror(
+  evt: AgentEventPayload,
+  state: Pick<MirrorState, "assistantTextByRun" | "thinkingTextByRun">,
+): string | undefined {
+  const data = evt.data ?? {};
+  if (evt.stream === "assistant") {
+    if (data.phase === "final_answer") {
+      return undefined;
+    }
+    const text = textFromData(data, state.assistantTextByRun, evt.runId);
+    return text.trim() ? `💬 ${trimForProgressMessage(text)}` : undefined;
+  }
+
+  if (evt.stream === "thinking") {
+    const text = textFromData(data, state.thinkingTextByRun, evt.runId);
+    return text.trim() ? `🧠 ${trimForProgressMessage(text)}` : undefined;
+  }
+
+  if (evt.stream === "item") {
+    if (data.suppressChannelProgress === true) {
+      return undefined;
+    }
+    const phase = normalizeOptionalString(data.phase) ?? "update";
+    const title =
+      normalizeOptionalString(data.title) ?? normalizeOptionalString(data.name) ?? "agent item";
+    const status = normalizeOptionalString(data.status);
+    const summary =
+      normalizeOptionalString(data.summary) ?? normalizeOptionalString(data.progressText);
+    const prefix = phase === "start" ? "▶️" : phase === "end" ? "✅" : "🔄";
+    const statusPart = status ? ` (${status})` : "";
+    const summaryPart = summary ? `\n${trimForProgressMessage(summary)}` : "";
+    return `${prefix} ${title}${statusPart}${summaryPart}`;
+  }
+
+  if (evt.stream === "command_output") {
+    const phase = normalizeOptionalString(data.phase) ?? "output";
+    const title =
+      normalizeOptionalString(data.title) ?? normalizeOptionalString(data.name) ?? "command output";
+    const output = normalizeOptionalString(data.output);
+    const exitCode = typeof data.exitCode === "number" ? data.exitCode : undefined;
+    const exitPart = exitCode === undefined ? "" : ` exit=${exitCode}`;
+    if (!output && phase !== "end") {
+      return undefined;
+    }
+    const outputPart = output ? `\n\`\`\`\n${trimForProgressMessage(output)}\n\`\`\`` : "";
+    return `📟 ${title} [${phase}${exitPart}]${outputPart}`;
+  }
+
+  if (evt.stream === "approval") {
+    const title = normalizeOptionalString(data.title) ?? "approval";
+    const status =
+      normalizeOptionalString(data.status) ?? normalizeOptionalString(data.phase) ?? "requested";
+    return `🛂 ${title} (${status})`;
+  }
+
+  if (evt.stream === "plan") {
+    const title = normalizeOptionalString(data.title) ?? "plan update";
+    const explanation = normalizeOptionalString(data.explanation);
+    return `📝 ${title}${explanation ? `\n${trimForProgressMessage(explanation)}` : ""}`;
+  }
+
+  if (evt.stream === "error") {
+    const reason =
+      normalizeOptionalString(data.reason) ?? normalizeOptionalString(data.error) ?? "agent error";
+    return `⚠️ ${trimForProgressMessage(reason)}`;
+  }
+
+  if (evt.stream === "lifecycle") {
+    const phase = normalizeOptionalString(data.phase);
+    if (phase === "start") {
+      return "▶️ Agent run started";
+    }
+    if (phase === "error") {
+      const error = normalizeOptionalString(data.error) ?? "agent run failed";
+      return `❌ Agent run failed\n${trimForProgressMessage(error)}`;
+    }
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function enqueueSessionSend(
+  state: MirrorState,
+  sessionKey: string,
+  delayMs: number,
+  task: () => Promise<void>,
+): Promise<void> {
+  const previous = state.queuesBySession.get(sessionKey) ?? Promise.resolve();
+  const next = previous
+    .catch(() => undefined)
+    .then(task)
+    .then(async () => {
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    })
+    .catch((err) => {
+      log.warn(
+        `agent event channel mirror send failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  state.queuesBySession.set(sessionKey, next);
+  void next.finally(() => {
+    if (state.queuesBySession.get(sessionKey) === next) {
+      state.queuesBySession.delete(sessionKey);
+    }
+  });
+  return next;
+}
+
+export function createAgentEventChannelMirror(deps: AgentEventChannelMirrorDeps = {}) {
+  const state: MirrorState = {
+    assistantTextByRun: new Map(),
+    thinkingTextByRun: new Map(),
+    queuesBySession: new Map(),
+    seenEvents: new Set(),
+  };
+  const loadSessionEntry = deps.loadSessionEntry ?? defaultLoadSessionEntry;
+  const sendDurableMessageBatch = deps.sendDurableMessageBatch ?? defaultSendDurableMessageBatch;
+  const delayMs = deps.delayMs ?? DEFAULT_DELAY_MS;
+
+  return async (evt: AgentEventPayload): Promise<void> => {
+    const sessionKey = normalizeOptionalString(evt.sessionKey);
+    if (!isThreadBoundSubagentSession(sessionKey)) {
+      return;
+    }
+    const key = eventKey(evt);
+    if (!rememberSeenEvent(state, key)) {
+      return;
+    }
+    const text = formatAgentEventForChannelMirror(evt, state);
+    if (!text) {
+      return;
+    }
+    const loaded = loadSessionEntry(sessionKey);
+    const route = resolveTelegramThreadRoute(loaded);
+    if (!route) {
+      return;
+    }
+    const payloads: ReplyPayload[] = [{ text }];
+    await enqueueSessionSend(state, sessionKey, delayMs, async () => {
+      await sendDurableMessageBatch({
+        cfg: loaded.cfg,
+        channel: route.channel,
+        to: route.to,
+        ...(route.accountId ? { accountId: route.accountId } : {}),
+        threadId: route.threadId,
+        payloads,
+        bestEffort: true,
+        session: {
+          key: sessionKey,
+          agentId: loaded.entry?.agentId,
+          sessionId: loaded.entry?.sessionId,
+        },
+      });
+    });
+  };
+}
+
+export function startAgentEventChannelMirror(deps: AgentEventChannelMirrorDeps = {}): () => void {
+  const mirror = createAgentEventChannelMirror(deps);
+  return onAgentEvent((evt) => {
+    void mirror(evt);
+  });
+}

--- a/src/gateway/agent-event-channel-mirror.ts
+++ b/src/gateway/agent-event-channel-mirror.ts
@@ -55,8 +55,8 @@ function rememberSeenEvent(state: MirrorState, key: string): boolean {
   return true;
 }
 
-function isThreadBoundSubagentSession(sessionKey: string | undefined): sessionKey is string {
-  return Boolean(sessionKey && sessionKey.includes(":subagent:"));
+function hasSessionKey(sessionKey: string | undefined): sessionKey is string {
+  return Boolean(sessionKey);
 }
 
 function resolveTelegramThreadRoute(loaded: LoadedSessionEntry | undefined): DeliveryRoute | null {
@@ -239,7 +239,7 @@ export function createAgentEventChannelMirror(deps: AgentEventChannelMirrorDeps 
 
   return async (evt: AgentEventPayload): Promise<void> => {
     const sessionKey = normalizeOptionalString(evt.sessionKey);
-    if (!isThreadBoundSubagentSession(sessionKey)) {
+    if (!hasSessionKey(sessionKey)) {
       return;
     }
     const key = eventKey(evt);

--- a/src/gateway/agent-event-channel-mirror.ts
+++ b/src/gateway/agent-event-channel-mirror.ts
@@ -60,6 +60,7 @@ type ProgressPreviewLine = string | ChannelProgressDraftLine;
 
 type ProgressPreviewState = {
   lines: ProgressPreviewLine[];
+  activeSessionKeys: Set<string>;
   messageId?: string;
   lastText?: string;
 };
@@ -68,7 +69,7 @@ type MirrorState = {
   assistantTextByRun: Map<string, string>;
   thinkingTextByRun: Map<string, string>;
   queuesBySession: Map<string, Promise<void>>;
-  previewsBySession: Map<string, ProgressPreviewState>;
+  previewsByRoute: Map<string, ProgressPreviewState>;
   seenEvents: Set<string>;
 };
 
@@ -108,6 +109,10 @@ function rememberSeenEvent(state: MirrorState, key: string): boolean {
 
 function hasSessionKey(sessionKey: string | undefined): sessionKey is string {
   return Boolean(sessionKey);
+}
+
+function routeKey(route: DeliveryRoute): string {
+  return `telegram:${route.accountId ?? "default"}:${route.to}:topic:${String(route.threadId)}`;
 }
 
 function resolveTelegramThreadRoute(loaded: LoadedSessionEntry | undefined): DeliveryRoute | null {
@@ -451,7 +456,7 @@ export function createAgentEventChannelMirror(deps: AgentEventChannelMirrorDeps 
     assistantTextByRun: new Map(),
     thinkingTextByRun: new Map(),
     queuesBySession: new Map(),
-    previewsBySession: new Map(),
+    previewsByRoute: new Map(),
     seenEvents: new Set(),
   };
   const loadSessionEntry = deps.loadSessionEntry ?? defaultLoadSessionEntry;
@@ -480,13 +485,19 @@ export function createAgentEventChannelMirror(deps: AgentEventChannelMirrorDeps 
       return;
     }
 
+    const previewKey = routeKey(route);
+
     if (isTerminalMirrorEvent(evt)) {
-      const preview = state.previewsBySession.get(sessionKey);
+      const preview = state.previewsByRoute.get(previewKey);
       if (!preview) {
         return;
       }
-      await enqueueSessionSend(state, sessionKey, delayMs, async () => {
-        state.previewsBySession.delete(sessionKey);
+      preview.activeSessionKeys.delete(sessionKey);
+      if (preview.activeSessionKeys.size > 0) {
+        return;
+      }
+      await enqueueSessionSend(state, previewKey, delayMs, async () => {
+        state.previewsByRoute.delete(previewKey);
         const messageId = preview.messageId;
         preview.messageId = undefined;
         preview.lines = [];
@@ -516,11 +527,12 @@ export function createAgentEventChannelMirror(deps: AgentEventChannelMirrorDeps 
       return;
     }
 
-    let preview = state.previewsBySession.get(sessionKey);
+    let preview = state.previewsByRoute.get(previewKey);
     if (!preview) {
-      preview = { lines: [] };
-      state.previewsBySession.set(sessionKey, preview);
+      preview = { activeSessionKeys: new Set(), lines: [] };
+      state.previewsByRoute.set(previewKey, preview);
     }
+    preview.activeSessionKeys.add(sessionKey);
     const maxLines = resolveChannelProgressDraftMaxLines(entry, 8);
     preview.lines = mergeChannelProgressDraftLine(preview.lines, line, { maxLines });
     const text = formatChannelProgressDraftText({
@@ -532,7 +544,7 @@ export function createAgentEventChannelMirror(deps: AgentEventChannelMirrorDeps 
       return;
     }
 
-    await enqueueSessionSend(state, sessionKey, delayMs, async () => {
+    await enqueueSessionSend(state, previewKey, delayMs, async () => {
       const params = {
         cfg: loaded.cfg,
         to: route.to,

--- a/src/gateway/agent-event-channel-mirror.ts
+++ b/src/gateway/agent-event-channel-mirror.ts
@@ -2,7 +2,7 @@ import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import { sendDurableMessageBatch as defaultSendDurableMessageBatch } from "../channels/message/runtime.js";
 import type { DurableMessageBatchSendResult } from "../channels/message/send.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
-import { onAgentEvent } from "../infra/agent-events.js";
+import { getAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { loadSessionEntry as defaultLoadSessionEntry } from "./session-utils.js";
@@ -238,7 +238,9 @@ export function createAgentEventChannelMirror(deps: AgentEventChannelMirrorDeps 
   const delayMs = deps.delayMs ?? DEFAULT_DELAY_MS;
 
   return async (evt: AgentEventPayload): Promise<void> => {
-    const sessionKey = normalizeOptionalString(evt.sessionKey);
+    const sessionKey =
+      normalizeOptionalString(evt.sessionKey) ??
+      normalizeOptionalString(getAgentRunContext(evt.runId)?.sessionKey);
     if (!hasSessionKey(sessionKey)) {
       return;
     }

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -2,6 +2,7 @@ import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import { startAgentEventChannelMirror } from "./agent-event-channel-mirror.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import type {
   ChatRunState,
@@ -85,6 +86,7 @@ export function startGatewayEventSubscriptions(params: {
   const agentUnsub = onAgentEvent((evt) => {
     void getAgentEventHandler().then((handler) => handler(evt));
   });
+  const agentChannelMirrorUnsub = startAgentEventChannelMirror();
 
   const heartbeatUnsub = onHeartbeatEvent((evt) => {
     params.broadcast("heartbeat", evt, { dropIfSlow: true });
@@ -100,6 +102,7 @@ export function startGatewayEventSubscriptions(params: {
 
   return {
     agentUnsub,
+    agentChannelMirrorUnsub,
     heartbeatUnsub,
     transcriptUnsub,
     lifecycleUnsub,

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -19,6 +19,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_FILES = [
   "extensions/memory-core/src/dreaming.ts",
   "extensions/memory-lancedb/index.ts",
   "extensions/skill-workshop/index.ts",
+  "extensions/telegram/subagent-hooks-api.ts",
   "extensions/thread-ownership/index.ts",
 ] as const;
 const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
@@ -44,6 +45,11 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/memory-core/src/dreaming.ts": ["before_agent_reply", "gateway_start", "gateway_stop"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/skill-workshop/index.ts": ["agent_end", "before_prompt_build"],
+  "extensions/telegram/subagent-hooks-api.ts": [
+    "subagent_delivery_target",
+    "subagent_ended",
+    "subagent_spawning",
+  ],
   "extensions/thread-ownership/index.ts": ["message_received", "message_sending"],
 } as const satisfies Record<
   (typeof BUNDLED_TYPED_HOOK_REGISTRATION_FILES)[number],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -957,7 +957,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Spawn a clean isolated session by default with the native subagent runtime. `mode=\"run\"` is one-shot background work. Subagents inherit the parent workspace directory automatically. Native subagents receive the delegated task in their first visible `[Subagent Task]` message. For native subagents only, set `context=\"fork\"` when the child needs the current transcript context; otherwise omit it or use `context=\"isolated\"`. Use this when the work should happen in a fresh child session instead of the current one.",
+    "description": "Spawn a clean isolated session by default with the native subagent runtime. `mode=\"run\"` is one-shot and `mode=\"session\"` is persistent and thread-bound. Subagents inherit the parent workspace directory automatically. Native subagents receive the delegated task in their first visible `[Subagent Task]` message. For native subagents only, set `context=\"fork\"` when the child needs the current transcript context; otherwise omit it or use `context=\"isolated\"`. Use this when the work should happen in a fresh child session instead of the current one.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -1014,7 +1014,7 @@
           "type": "boolean"
         },
         "mode": {
-          "enum": ["run"],
+          "enum": ["run", "session"],
           "type": "string"
         },
         "model": {
@@ -1041,6 +1041,10 @@
         },
         "thinking": {
           "type": "string"
+        },
+        "thread": {
+          "description": "Bind the spawned session to a new chat thread when the current channel/account supports thread-bound session spawns. `thread=true` defaults mode to \"session\".",
+          "type": "boolean"
         },
         "timeoutSeconds": {
           "minimum": 0,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -921,7 +921,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Spawn a clean isolated session by default with the native subagent runtime. `mode=\"run\"` is one-shot background work. Subagents inherit the parent workspace directory automatically. Native subagents receive the delegated task in their first visible `[Subagent Task]` message. For native subagents only, set `context=\"fork\"` when the child needs the current transcript context; otherwise omit it or use `context=\"isolated\"`. Use this when the work should happen in a fresh child session instead of the current one.",
+    "description": "Spawn a clean isolated session by default with the native subagent runtime. `mode=\"run\"` is one-shot and `mode=\"session\"` is persistent and thread-bound. Subagents inherit the parent workspace directory automatically. Native subagents receive the delegated task in their first visible `[Subagent Task]` message. For native subagents only, set `context=\"fork\"` when the child needs the current transcript context; otherwise omit it or use `context=\"isolated\"`. Use this when the work should happen in a fresh child session instead of the current one.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -978,7 +978,7 @@
           "type": "boolean"
         },
         "mode": {
-          "enum": ["run"],
+          "enum": ["run", "session"],
           "type": "string"
         },
         "model": {
@@ -1005,6 +1005,10 @@
         },
         "thinking": {
           "type": "string"
+        },
+        "thread": {
+          "description": "Bind the spawned session to a new chat thread when the current channel/account supports thread-bound session spawns. `thread=true` defaults mode to \"session\".",
+          "type": "boolean"
         },
         "timeoutSeconds": {
           "minimum": 0,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -217,8 +217,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 42879,
-    "roughTokens": 10720
+    "chars": 43188,
+    "roughTokens": 10797
   },
   "openClawDeveloperInstructions": {
     "chars": 4412,
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6748
   },
   "totalWithDynamicToolsJson": {
-    "chars": 69873,
-    "roughTokens": 17469
+    "chars": 70182,
+    "roughTokens": 17546
   },
   "userInputText": {
     "chars": 370,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -218,8 +218,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 44057,
-    "roughTokens": 11015
+    "chars": 44366,
+    "roughTokens": 11092
   },
   "openClawDeveloperInstructions": {
     "chars": 4412,
@@ -230,8 +230,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7155
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72678,
-    "roughTokens": 18170
+    "chars": 72987,
+    "roughTokens": 18247
   },
   "userInputText": {
     "chars": 608,


### PR DESCRIPTION
## Summary

- Adds an explicit `supportsAutomaticThreadBindingSpawn` channel capability so automatic thread-bound session spawn support is not overloaded onto `defaultTopLevelPlacement`.
- Wires Telegram `subagent_spawning`, `subagent_delivery_target`, and `subagent_ended` hooks so `sessions_spawn(thread:true)` for subagents can create and bind a child forum topic while keeping Telegram's normal top-level binding placement as `current`.
- Makes the spawn capability per-kind (`subagent` vs `acp`) so Telegram advertises subagent forum-topic spawn support without incorrectly exposing ACP child-topic spawn.
- Documents the new capability seam and adds Telegram/core regression coverage for schema exposure, runtime capabilities, hook registration, binding, completion routing, cleanup, and boundary invariants.

## Context

Telegram already had forum-topic primitives and session binding infrastructure, but it lacked the subagent lifecycle hook wiring and an explicit capability to say: "explicit subagent thread spawns can create child topics, while ordinary top-level binding should stay in the current conversation." Discord and Matrix naturally expose automatic thread spawns through `defaultTopLevelPlacement: "child"`; Feishu keeps `current` placement and does not advertise child-thread session spawn. Telegram now follows the narrower model: keep normal Telegram `/focus` and top-level binding behavior current, while allowing explicit `sessions_spawn(thread:true)` for subagents to create a child forum topic when the Telegram adapter can do so.

## Real behavior proof

- Behavior or issue addressed: Telegram `sessions_spawn(thread:true, mode:"session")` from a channel-bound CodeClaw triage session creates and binds a real Telegram forum topic for the spawned subagent session, so follow-up work routes to that topic instead of becoming invisible or falling back to the parent topic.
- Real environment tested: Live `codeclaw-triage` Docker container after installing a custom OpenClaw package built from combined proof branch `codeclaw-proof-82023-82275` (https://github.com/efpiva/openclaw/tree/codeclaw-proof-82023-82275) at `OpenClaw 2026.5.17 (db1c53a)`. The container was connected to the real CodeClaw Telegram forum supergroup and used the real CodeClaw triage cron job.
- Exact steps or command run after this patch:

  ```bash
  docker exec --user codeclaw codeclaw-triage     HOME=/home/codeclaw openclaw cron run cc373f35-b483-4c7f-9253-2f6c9c94a595       --wait --wait-timeout 15m --timeout 30000
  ```

- Evidence after fix:

  The triage transcript for run `1d6d77dd-c23b-4b02-9831-e990fb11a7fc` shows the initial PR action for private CodeClaw PR #1223 was spawned with `thread:true` and `mode:"session"`:

  ```json
  {
    "type": "toolCall",
    "name": "sessions_spawn",
    "arguments": {
      "agentId": "main",
      "label": "codeclaw-pr:external:microsoft.ghe.com:bic/lobster:1223",
      "mode": "session",
      "context": "isolated",
      "thread": true
    }
  }
  ```

  The tool result accepted the spawn and returned a thread-bound child session:

  ```json
  {
    "toolName": "sessions_spawn",
    "isError": false,
    "details": {
      "status": "accepted",
      "childSessionKey": "agent:main:subagent:c89515e3-1a1e-4465-8fe9-8b25e85c7819",
      "runId": "23538111-3540-4645-a66b-cc0568f96de0",
      "mode": "session",
      "note": "thread-bound session stays active after this task; continue in-thread for follow-ups.",
      "modelApplied": true
    }
  }
  ```

  Live Telegram/OpenClaw logs show the forum topic was created and bound to that child session. The Telegram supergroup id is redacted, but the topic id and session key are unchanged:

  ```text
  2026-05-17T15:07:57.282-07:00 telegram: bound conversation <telegram-supergroup-id>:topic:1167 -> agent:main:subagent:c89515e3-1a1e-4465-8fe9-8b25e85c7819 (idle=24h maxAge=disabled)
  2026-05-17T15:07:57.406-07:00 [telegram] update: {"message":{"message_id":1167,"chat":{"title":"CodeClaw Activity","is_forum":true,"type":"supergroup"},"message_thread_id":1167,"forum_topic_created":{"name":"🤖 codeclaw-pr:external:microsoft.ghe.com:bic/lobster:1223"},"is_topic_message":true}}
  2026-05-17T15:07:57.923-07:00 [agent/embedded] embedded run start: runId=23538111-3540-4645-a66b-cc0568f96de0 sessionId=ada5b4d0-65b5-48ff-8c81-76c2ab477ab8 provider=github-copilot model=gpt-5.5 thinking=medium messageChannel=telegram
  2026-05-17T15:07:58.444-07:00 [agent/embedded] [context-diag] pre-prompt: sessionKey=agent:main:subagent:c89515e3-1a1e-4465-8fe9-8b25e85c7819 ... sessionFile=/home/codeclaw/.openclaw/agents/main/sessions/ada5b4d0-65b5-48ff-8c81-76c2ab477ab8-topic-1167.jsonl
  ```

  The persisted Telegram binding file contains the same mapping:

  ```json
  {
    "conversationId": "<telegram-supergroup-id>:topic:1167",
    "targetKind": "subagent",
    "targetSessionKey": "agent:main:subagent:c89515e3-1a1e-4465-8fe9-8b25e85c7819",
    "agentId": "main",
    "label": "codeclaw-pr:external:microsoft.ghe.com:bic/lobster:1223",
    "metadata": {
      "threadName": "🤖 codeclaw-pr:external:microsoft.ghe.com:bic/lobster:1223"
    }
  }
  ```

  The CodeClaw poller state also persisted the spawned native session key for that PR:

  ```json
  {
    "source": "pr_reviews",
    "id": "microsoft.ghe.com|bic/lobster#1223",
    "lastKind": "initial",
    "nativeSessionKey": "agent:main:subagent:c89515e3-1a1e-4465-8fe9-8b25e85c7819"
  }
  ```

- Observed result after fix: The live Telegram Bot API created forum topic `1167`, OpenClaw bound it to the spawned `main` subagent session, the child session ran with `messageChannel=telegram`, and all child/specialist session transcript files for the spawned review used the `topic-1167` suffix. CodeClaw recorded `nativeSessionKey` for future follow-ups.
- What was not tested: Telegram permission-denied and non-forum failure paths in the live container; those remain covered by local mocked tests. The live proof used one real forum supergroup and one real CodeClaw triage run.

## Supplemental validation


Behavior addressed: Telegram subagent `sessions_spawn(thread:true)` now has an explicit per-kind automatic-spawn capability and lifecycle hooks that bind spawned subagents to child forum topics without enabling Telegram ACP child-topic spawns.

Real environment tested: Local OpenClaw source checkout with mocked Telegram forum topic creation and session binding adapters; no live Telegram Bot API/forum supergroup was used.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs \
  extensions/telegram/src/subagent-hooks.test.ts \
  extensions/telegram/index.test.ts \
  extensions/telegram/src/thread-bindings.test.ts \
  src/channels/plugins/thread-binding-api.test.ts \
  src/channels/thread-bindings-policy.test.ts \
  src/agents/runtime-capabilities.test.ts \
  src/agents/tools/sessions-spawn-tool.test.ts \
  src/agents/acp-spawn.test.ts \
  src/plugins/contracts/boundary-invariants.test.ts
pnpm docs:check-mdx docs/plugins/sdk-channel-plugins.md
git diff --check
pnpm build
codex review --uncommitted
```

Evidence after fix: Targeted Vitest proof passed with 12 files and 245 tests; docs MDX check passed; whitespace check passed; `pnpm build` completed including plugin SDK export verification; final Codex CLI review reported no actionable correctness issues.

Observed result after fix: Telegram advertises `thread` for subagent session spawn through the new explicit per-kind capability, returns a routable Telegram delivery origin for created forum topics, routes completion to the bound topic, cleans up Telegram subagent bindings, and does not advertise/recommend ACP thread-bound spawns when ACP support is disabled for Telegram.

What was not tested: Live Telegram Bot API behavior in a real forum supergroup with `can_manage_topics`; non-forum group and permission failure behavior were covered only through local unit paths/mocked failures.

