### PR TITLE
Fix noninteractive Control UI auto-builds

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -364,6 +364,10 @@ run_pnpm() {
   "${PNPM_CMD[@]}" "$@"
 }
 
+run_pnpm_noninteractive() {
+  CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_pnpm --config.confirm-modules-purge=false "$@"
+}
+
 resolve_git_openclaw_ref() {
   local requested="${OPENCLAW_VERSION:-latest}"
   local resolved_version=""
@@ -739,9 +743,9 @@ install_openclaw_from_git() {
 
   local install_lockfile_flag
   install_lockfile_flag="$(git_install_lockfile_flag "$repo_dir" "$git_ref")"
-  CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"
+  run_pnpm_noninteractive -C "$repo_dir" install "$install_lockfile_flag"
 
-  if ! run_pnpm -C "$repo_dir" ui:build; then
+  if ! run_pnpm_noninteractive -C "$repo_dir" ui:build; then
     log "UI build failed; continuing (CLI may still work)"
   fi
   run_pnpm -C "$repo_dir" build

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -585,19 +585,24 @@ function Install-OpenClawFromGit {
     Remove-LegacySubmodule -RepoDir $RepoDir
 
     $prevPnpmScriptShell = $env:NPM_CONFIG_SCRIPT_SHELL
+    $prevCi = $env:CI
     $pnpmCommand = Get-PnpmCommandPath
     if (-not $pnpmCommand) {
         throw "pnpm not found after installation."
     }
     $env:NPM_CONFIG_SCRIPT_SHELL = "cmd.exe"
+    if (-not $env:CI) {
+        $env:CI = "true"
+    }
     try {
-        & $pnpmCommand -C $RepoDir install
-        if (-not (& $pnpmCommand -C $RepoDir ui:build)) {
+        & $pnpmCommand -C $RepoDir --config.confirm-modules-purge=false install
+        if (-not (& $pnpmCommand -C $RepoDir --config.confirm-modules-purge=false ui:build)) {
             Write-Host "[!] UI build failed; continuing (CLI may still work)" -ForegroundColor Yellow
         }
         & $pnpmCommand -C $RepoDir build
     } finally {
         $env:NPM_CONFIG_SCRIPT_SHELL = $prevPnpmScriptShell
+        $env:CI = $prevCi
     }
 
     $binDir = Join-Path $env:USERPROFILE ".local\\bin"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1910,6 +1910,10 @@ run_pnpm() {
     "${PNPM_CMD[@]}" "$@"
 }
 
+run_pnpm_noninteractive() {
+    CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_pnpm --config.confirm-modules-purge=false "$@"
+}
+
 resolve_git_openclaw_ref() {
     local requested="${OPENCLAW_VERSION:-latest}"
     local resolved_version=""
@@ -2384,9 +2388,9 @@ install_openclaw_from_git() {
 
     local install_lockfile_flag
     install_lockfile_flag="$(git_install_lockfile_flag "$repo_dir" "$git_ref")"
-    CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"
+    run_quiet_step "Installing dependencies" run_pnpm_noninteractive -C "$repo_dir" install "$install_lockfile_flag"
 
-    if ! run_quiet_step "Building UI" run_pnpm -C "$repo_dir" ui:build; then
+    if ! run_quiet_step "Building UI" run_pnpm_noninteractive -C "$repo_dir" ui:build; then
         ui_warn "UI build failed; continuing (CLI may still work)"
     fi
     run_quiet_step "Building OpenClaw" run_pnpm -C "$repo_dir" build

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -89,6 +89,15 @@ export function resolveSpawnCall(cmd, args, envOverride, params = {}) {
   };
 }
 
+export const AUTO_INSTALL_ARGS = ["install", "--config.confirm-modules-purge=false"];
+
+export function resolveAutoInstallEnv(baseEnv = process.env) {
+  return {
+    ...baseEnv,
+    CI: baseEnv.CI || "true",
+  };
+}
+
 function run(cmd, args) {
   const { command, args: spawnArgs, options } = resolveSpawnCall(cmd, args);
   let child;
@@ -186,9 +195,7 @@ export function main(argv = process.argv.slice(2)) {
   }
 
   if (!depsInstalled(action === "test" ? "test" : "build")) {
-    const installEnv = process.env;
-    const installArgs = ["install"];
-    runSync(runner.cmd, installArgs, installEnv);
+    runSync(runner.cmd, AUTO_INSTALL_ARGS, resolveAutoInstallEnv());
   }
 
   run(runner.cmd, ["run", script, ...rest]);

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -7,6 +7,7 @@ type FakeFsEntry = { kind: "file"; content: string } | { kind: "dir" };
 const state = vi.hoisted(() => ({
   entries: new Map<string, FakeFsEntry>(),
   realpaths: new Map<string, string>(),
+  runCommandWithTimeout: vi.fn(),
 }));
 
 const abs = (p: string) => path.resolve(p);
@@ -69,9 +70,14 @@ vi.mock("./openclaw-root.js", () => ({
   resolveOpenClawPackageRootSync: vi.fn(() => null),
 }));
 
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout: state.runCommandWithTimeout,
+}));
+
 let resolveControlUiRepoRoot: typeof import("./control-ui-assets.js").resolveControlUiRepoRoot;
 let resolveControlUiDistIndexPath: typeof import("./control-ui-assets.js").resolveControlUiDistIndexPath;
 let resolveControlUiDistIndexHealth: typeof import("./control-ui-assets.js").resolveControlUiDistIndexHealth;
+let ensureControlUiAssetsBuilt: typeof import("./control-ui-assets.js").ensureControlUiAssetsBuilt;
 let isPackageProvenControlUiRootSync: typeof import("./control-ui-assets.js").isPackageProvenControlUiRootSync;
 let resolveControlUiRootOverrideSync: typeof import("./control-ui-assets.js").resolveControlUiRootOverrideSync;
 let resolveControlUiRootSync: typeof import("./control-ui-assets.js").resolveControlUiRootSync;
@@ -83,6 +89,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
       resolveControlUiRepoRoot,
       resolveControlUiDistIndexPath,
       resolveControlUiDistIndexHealth,
+      ensureControlUiAssetsBuilt,
       isPackageProvenControlUiRootSync,
       resolveControlUiRootOverrideSync,
       resolveControlUiRootSync,
@@ -93,6 +100,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
   beforeEach(() => {
     state.entries.clear();
     state.realpaths.clear();
+    state.runCommandWithTimeout.mockReset();
     vi.clearAllMocks();
   });
 
@@ -246,6 +254,47 @@ describe("control UI assets helpers (fs-mocked)", () => {
         cwd: abs("fixtures/cwd"),
       }),
     ).toBe(true);
+  });
+
+  it("builds missing assets with CI enabled for noninteractive pnpm auto-install", async () => {
+    const root = abs("fixtures/auto-build");
+    const argv1 = path.join(root, "dist", "index.js");
+    const uiScript = path.join(root, "scripts", "ui.js");
+    const indexPath = path.join(root, "dist", "control-ui", "index.html");
+    const originalArgv = process.argv;
+    const originalCi = process.env.CI;
+
+    setFile(path.join(root, "package.json"), "{}\n");
+    setFile(path.join(root, "ui", "vite.config.ts"), "export {};\n");
+    setFile(uiScript, "export {};\n");
+    state.runCommandWithTimeout.mockImplementation(async () => {
+      setFile(indexPath, "<html></html>\n");
+      return { stdout: "", stderr: "", code: 0, signal: null, killed: false, termination: "exit" };
+    });
+
+    process.argv = [process.execPath, argv1];
+    delete process.env.CI;
+    try {
+      await expect(ensureControlUiAssetsBuilt()).resolves.toEqual({ ok: true, built: true });
+    } finally {
+      process.argv = originalArgv;
+      if (originalCi === undefined) {
+        delete process.env.CI;
+      } else {
+        process.env.CI = originalCi;
+      }
+    }
+
+    expect(state.runCommandWithTimeout).toHaveBeenCalledWith(
+      [process.execPath, uiScript, "build"],
+      {
+        cwd: root,
+        timeoutMs: 10 * 60_000,
+        env: {
+          CI: "true",
+        },
+      },
+    );
   });
 
   it("does not treat fallback roots as package-proven", () => {

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -330,6 +330,9 @@ export async function ensureControlUiAssetsBuilt(
   const build = await runCommandWithTimeout([process.execPath, uiScript, "build"], {
     cwd: repoRoot,
     timeoutMs: opts?.timeoutMs ?? 10 * 60_000,
+    env: {
+      CI: process.env.CI || "true",
+    },
   });
   if (build.code !== 0) {
     return {

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -81,8 +81,15 @@ describe("install-cli.sh", () => {
     expect(result.stdout).toContain("branch=--no-frozen-lockfile");
     expect(result.stdout).toContain("tag=--frozen-lockfile");
     expect(script).toContain(
-      'CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"',
+      'run_pnpm_noninteractive -C "$repo_dir" install "$install_lockfile_flag"',
     );
+  });
+
+  it("runs Control UI builds with noninteractive pnpm settings", () => {
+    expect(script).toContain(
+      'CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_pnpm --config.confirm-modules-purge=false "$@"',
+    );
+    expect(script).toContain('run_pnpm_noninteractive -C "$repo_dir" ui:build');
   });
 
   it("aligns pnpm to the checked-out repo packageManager before installing", () => {

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -104,6 +104,19 @@ describe("install.ps1 failure handling", () => {
     expect(mainBody).not.toContain("Remove-LegacySubmodule");
   });
 
+  it("runs git checkout dependency and UI builds with noninteractive pnpm settings", () => {
+    const gitInstallBody = extractFunctionBody(source, "Install-OpenClawFromGit");
+    expect(gitInstallBody).toContain("$prevCi = $env:CI");
+    expect(gitInstallBody).toContain('$env:CI = "true"');
+    expect(gitInstallBody).toContain(
+      "& $pnpmCommand -C $RepoDir --config.confirm-modules-purge=false install",
+    );
+    expect(gitInstallBody).toContain(
+      "& $pnpmCommand -C $RepoDir --config.confirm-modules-purge=false ui:build",
+    );
+    expect(gitInstallBody).toContain("$env:CI = $prevCi");
+  });
+
   runIfPowerShell("exits non-zero when run as a script file", () => {
     const tempDir = harness.createTempDir("openclaw-install-ps1-");
     const scriptPath = join(tempDir, "install.ps1");

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -415,7 +415,16 @@ describe("install.sh", () => {
     expect(result.stdout).toContain("branch=--no-frozen-lockfile");
     expect(result.stdout).toContain("tag=--frozen-lockfile");
     expect(script).toContain(
-      'CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"',
+      'run_quiet_step "Installing dependencies" run_pnpm_noninteractive -C "$repo_dir" install "$install_lockfile_flag"',
+    );
+  });
+
+  it("runs Control UI builds with noninteractive pnpm settings", () => {
+    expect(script).toContain(
+      'CI="${CI:-true}" SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" run_pnpm --config.confirm-modules-purge=false "$@"',
+    );
+    expect(script).toContain(
+      'run_quiet_step "Building UI" run_pnpm_noninteractive -C "$repo_dir" ui:build',
     );
   });
 

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { resolveSpawnCall, shouldUseCmdExeForCommand } from "../../scripts/ui.js";
+import {
+  AUTO_INSTALL_ARGS,
+  resolveAutoInstallEnv,
+  resolveSpawnCall,
+  shouldUseCmdExeForCommand,
+} from "../../scripts/ui.js";
 
 describe("scripts/ui windows spawn behavior", () => {
   it("wraps Windows command launchers with cmd.exe without enabling shell mode", () => {
@@ -86,6 +91,18 @@ describe("scripts/ui windows spawn behavior", () => {
         env: { PATH: "/bin" },
         shell: false,
       },
+    });
+  });
+
+  it("runs auto-install in noninteractive pnpm mode", () => {
+    expect(AUTO_INSTALL_ARGS).toEqual(["install", "--config.confirm-modules-purge=false"]);
+    expect(resolveAutoInstallEnv({ PATH: "/bin" })).toEqual({
+      PATH: "/bin",
+      CI: "true",
+    });
+    expect(resolveAutoInstallEnv({ PATH: "/bin", CI: "false" })).toEqual({
+      PATH: "/bin",
+      CI: "false",
     });
   });
 });


### PR DESCRIPTION
Summary:\n- Run git-install dependency and Control UI build steps with CI plus pnpm confirm-modules-purge disabled.\n- Make scripts/ui.js auto-install dependencies noninteractively so gateway Control UI repair cannot block without a TTY.\n- Pass CI through the gateway fallback Control UI asset builder.\n- Add focused coverage for shell, PowerShell, UI helper, and gateway fallback paths.\n\nVerification:\n- node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/install-cli.test.ts test/scripts/install-sh.test.ts test/scripts/install-ps1.test.ts\n- node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts test/scripts/ui.test.ts\n- node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/control-ui-assets.test.ts\n- bash -n scripts/install.sh scripts/install-cli.sh\n- git diff --check\n- pnpm tsgo:test:src