### PR TITLE
Keep Codex compaction on native threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex/Lossless: keep Codex explicit compaction on native app-server threads while allowing Lossless through the context-engine slot; `openclaw doctor --fix` now migrates legacy `compaction.provider: "lossless-claw"` config to `plugins.slots.contextEngine`.
 - Gateway/approvals: treat `turnSourceTo` as optional in `canBridgeNoDeviceChatApprovalFromBackend`, matching the existing optional handling of `turnSourceAccountId` and `turnSourceThreadId`. Channels without a recipient concept (webchat, control-ui) leave `turnSourceTo` null on both the approval snapshot and the replay params, so the prior required-string check rejected every backend replay with `APPROVAL_CLIENT_MISMATCH`. Cross-channel replay is still gated by the required `turnSourceChannel` and `sessionKey` checks. Fixes #82132. (#82136) Thanks @ottodeng.
 - Cron: load runtime plugins before isolated cron model and delivery resolution so external channels can be selected for scheduled runs. (#82111) Thanks @medns.
 - Twitch: keep gateway accounts running until shutdown instead of treating successful monitor startup as a clean channel exit, preventing immediate auto-restart loops. Fixes #60071. (#81853) Thanks @edenfunf.
@@ -87,6 +88,7 @@ Docs: https://docs.openclaw.ai
 - macOS/screen snapshots: reject malformed `screen.snapshot` params before capture, bound base64 results against the projected `node.invoke.result` frame, and preserve stable caller-facing errors for oversized payloads and capture failures. Fixes #68181. Thanks @shaun0927 and @BunsDev.
 - Config/doctor: rotate capped `.clobbered.*` repair snapshots by artifact timestamp so repeated repairs keep the newest forensic copy instead of preserving only the first capped set. (#82012) Thanks @Kaspre.
 - Telegram: initialize the bot before isolated polling drains spooled updates so default isolated polling no longer retries every update with `Bot not initialized` and stalls replies. Fixes #81973. (#81975) Thanks @neeravmakwana.
+- Codex app-server: keep Codex-runtime compaction on native Codex threads, warn when stale OpenClaw compaction summarizer overrides are ignored, and let doctor remove those unsupported overrides, avoiding public OpenAI Responses summarization with Codex OAuth tokens. Fixes #82008. (#82027) Thanks @pashpashpash.
 - Telegram: apply method-aware Bot API request timeouts to direct message/action clients so `openclaw message delete --channel telegram` no longer waits on grammY's 500-second default when the API request wedges. Fixes #81908. Thanks @DashLabsDev.
 - Cron: treat attempt dispatch and assembled context as execution-start milestones so isolated agent jobs that have reached backend dispatch are governed by their configured job timeout instead of the 60s pre-execution watchdog. Fixes #81368. (#81871) Thanks @alexph-dev.
 - Doctor/auth: warn about stale per-agent OAuth auth profile shadows and let `openclaw doctor --fix` remove the local shadow so agents inherit the fresher main-agent credential.

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -119,6 +119,18 @@ Use `openai/gpt-*` model refs for Codex-backed OpenAI agent turns. Prefer
 `openai-codex:*` auth profiles and `auth.order.openai-codex` remain valid, but
 do not write new `openai-codex/gpt-*` model refs.
 
+Do not set `compaction.model` or `compaction.provider` on Codex-backed agents.
+Codex owns compaction through its native app-server thread state, so OpenClaw
+ignores those local summarizer overrides at runtime and `openclaw doctor --fix`
+removes them when the agent uses Codex.
+
+Lossless remains supported as a context engine. Configure it through
+`plugins.slots.contextEngine: "lossless-claw"` and
+`plugins.entries.lossless-claw.config.summaryModel`, not through
+`agents.defaults.compaction.provider`. `openclaw doctor --fix` migrates the old
+`compaction.provider: "lossless-claw"` shape to the Lossless context-engine slot
+when Codex is the active runtime.
+
 ```json5
 {
   auth: {

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { HarnessContextEngine as ContextEngine } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  embeddedAgentLog,
+  type HarnessContextEngine as ContextEngine,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodexAppServerClientFactory } from "./client-factory.js";
 import type { CodexAppServerClient } from "./client.js";
@@ -157,6 +160,249 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(seenAuthProfileId).toBe("openai-codex:work");
   });
 
+  it("warns when stale OpenClaw compaction overrides are ignored", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const fake = createFakeCodexClient();
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+
+    const pendingResult = maybeCompactCodexAppServerSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile,
+      workspaceDir: tempDir,
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+    });
+    fake.emit({
+      method: "thread/compacted",
+      params: { threadId: "thread-1", turnId: "turn-1" },
+    });
+    await pendingResult;
+
+    expect(warn).toHaveBeenCalledWith(
+      "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
+      {
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        ignoredConfig: ["agents.defaults.compaction.model", "agents.defaults.compaction.provider"],
+      },
+    );
+    warn.mockRestore();
+  });
+
+  it("warns when active agent compaction overrides are ignored", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const fake = createFakeCodexClient();
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+
+    const pendingResult = maybeCompactCodexAppServerSession({
+      sessionId: "session-1",
+      sessionKey: "agent:nik:session-1",
+      sessionFile,
+      workspaceDir: tempDir,
+      config: {
+        agents: {
+          list: [
+            {
+              id: "nik",
+              compaction: {
+                model: "openai/gpt-5.4-mini",
+                provider: "openai",
+              },
+            },
+          ],
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+    });
+    fake.emit({
+      method: "thread/compacted",
+      params: { threadId: "thread-1", turnId: "turn-1" },
+    });
+    await pendingResult;
+
+    expect(warn).toHaveBeenCalledWith(
+      "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
+      {
+        sessionId: "session-1",
+        sessionKey: "agent:nik:session-1",
+        ignoredConfig: ["agents.list.nik.compaction.model", "agents.list.nik.compaction.provider"],
+      },
+    );
+    warn.mockRestore();
+  });
+
+  it("reports inherited compaction providers at the source path", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const fake = createFakeCodexClient();
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+
+    const pendingResult = maybeCompactCodexAppServerSession({
+      sessionId: "session-1",
+      sessionKey: "agent:nik:session-1",
+      sessionFile,
+      workspaceDir: tempDir,
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              provider: "custom-summary",
+            },
+          },
+          list: [
+            {
+              id: "nik",
+              compaction: {
+                model: "openai/gpt-5.4-mini",
+              },
+            },
+          ],
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+    });
+    fake.emit({
+      method: "thread/compacted",
+      params: { threadId: "thread-1", turnId: "turn-1" },
+    });
+    await pendingResult;
+
+    expect(warn).toHaveBeenCalledWith(
+      "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
+      {
+        sessionId: "session-1",
+        sessionKey: "agent:nik:session-1",
+        ignoredConfig: ["agents.defaults.compaction.provider", "agents.list.nik.compaction.model"],
+      },
+    );
+    warn.mockRestore();
+  });
+
+  it("does not warn for legacy Lossless config when the Lossless context engine slot is active", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const fake = createFakeCodexClient();
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+    const contextEngine: ContextEngine = {
+      info: { id: "lcm", name: "Lossless Context Manager", ownsCompaction: true },
+      assemble: vi.fn() as never,
+      ingest: vi.fn() as never,
+      compact: vi.fn() as never,
+    };
+
+    const pendingResult = maybeCompactCodexAppServerSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile,
+      workspaceDir: tempDir,
+      contextEngine,
+      config: {
+        plugins: {
+          slots: {
+            contextEngine: "lossless-claw",
+          },
+        },
+        agents: {
+          defaults: {
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "lossless-claw",
+            },
+          },
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+    });
+    fake.emit({
+      method: "thread/compacted",
+      params: { threadId: "thread-1", turnId: "turn-1" },
+    });
+    await pendingResult;
+
+    expect(warn).not.toHaveBeenCalledWith(
+      "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
+      expect.anything(),
+    );
+    warn.mockRestore();
+  });
+
+  it("does not warn for inherited legacy Lossless provider when the Lossless slot is active", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const fake = createFakeCodexClient();
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+    const contextEngine: ContextEngine = {
+      info: { id: "lcm", name: "Lossless Context Manager", ownsCompaction: true },
+      assemble: vi.fn() as never,
+      ingest: vi.fn() as never,
+      compact: vi.fn() as never,
+    };
+
+    const pendingResult = maybeCompactCodexAppServerSession({
+      sessionId: "session-1",
+      sessionKey: "agent:nik:session-1",
+      sessionFile,
+      workspaceDir: tempDir,
+      contextEngine,
+      config: {
+        plugins: {
+          slots: {
+            contextEngine: "lossless-claw",
+          },
+        },
+        agents: {
+          defaults: {
+            compaction: {
+              provider: "lossless-claw",
+            },
+          },
+          list: [
+            {
+              id: "nik",
+              compaction: {
+                model: "openai/gpt-5.4-mini",
+              },
+            },
+          ],
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+    });
+    fake.emit({
+      method: "thread/compacted",
+      params: { threadId: "thread-1", turnId: "turn-1" },
+    });
+    await pendingResult;
+
+    expect(warn).not.toHaveBeenCalledWith(
+      "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
+      expect.anything(),
+    );
+    warn.mockRestore();
+  });
+
   it("fails closed when the persisted binding auth profile disagrees with the runtime request", async () => {
     const fake = createFakeCodexClient();
     const factory = vi.fn(async () => fake.client);
@@ -184,11 +430,11 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(factory).not.toHaveBeenCalled();
   });
 
-  it("prefers owning context-engine compaction and records native status separately", async () => {
+  it("keeps context engines in maintenance mode after native compaction", async () => {
     const fake = createFakeCodexClient();
     setCodexAppServerClientFactoryForTest(async () => fake.client);
     const sessionFile = await writeTestBinding();
-    const compact = vi.fn(async (_params: unknown) => ({
+    const compact = vi.fn(async () => ({
       ok: true,
       compacted: true,
       result: {
@@ -235,35 +481,15 @@ describe("maybeCompactCodexAppServerSession", () => {
     const result = requireCompactResult(await pendingResult);
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
-    expect(result.result?.summary).toBe("engine summary");
-    expect(result.result?.firstKeptEntryId).toBe("entry-1");
-    expect(result.result?.tokensBefore).toBe(55);
+    expect(result.result?.summary).toBe("");
+    expect(result.result?.firstKeptEntryId).toBe("");
+    expect(result.result?.tokensBefore).toBe(123);
     const details = compactDetails(result);
-    expect(details.engine).toBe("lossless-claw");
-    const nativeDetails = details.codexNativeCompaction as
-      | {
-          ok?: boolean;
-          compacted?: boolean;
-          details?: { backend?: string; threadId?: string };
-        }
-      | undefined;
-    expect(nativeDetails?.ok).toBe(true);
-    expect(nativeDetails?.compacted).toBe(true);
-    expect(nativeDetails?.details?.backend).toBe("codex-app-server");
-    expect(nativeDetails?.details?.threadId).toBe("thread-1");
-    expect(compact).toHaveBeenCalledTimes(1);
-    const [compactCall] = compact.mock.calls[0] ?? [];
-    expect(compactCall).toStrictEqual({
-      sessionId: "session-1",
-      sessionKey: "agent:main:session-1",
-      sessionFile,
-      tokenBudget: 777,
-      currentTokenCount: 123,
-      compactionTarget: "threshold",
-      customInstructions: undefined,
-      force: true,
-      runtimeContext: { workspaceDir: tempDir, provider: "codex" },
-    });
+    expect(details.backend).toBe("codex-app-server");
+    expect(details.threadId).toBe("thread-1");
+    expect(details.signal).toBe("thread/compacted");
+    expect(details.turnId).toBe("turn-1");
+    expect(compact).not.toHaveBeenCalled();
     expect(maintain).toHaveBeenCalledTimes(1);
     const [maintainCall] = maintain.mock.calls[0] ?? [];
     const maintainParams = maintainCall as
@@ -281,23 +507,24 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(maintainParams?.runtimeContext?.provider).toBe("codex");
   });
 
-  it("still runs native compaction when context-engine maintenance fails", async () => {
+  it("returns native compaction success when context-engine maintenance fails", async () => {
     const fake = createFakeCodexClient();
     setCodexAppServerClientFactoryForTest(async () => fake.client);
     const sessionFile = await writeTestBinding();
+    const compact = vi.fn(async () => ({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "engine summary",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 55,
+      },
+    }));
     const contextEngine: ContextEngine = {
       info: { id: "lossless-claw", name: "Lossless Claw", ownsCompaction: true },
       assemble: vi.fn() as never,
       ingest: vi.fn() as never,
-      compact: vi.fn(async () => ({
-        ok: true,
-        compacted: true,
-        result: {
-          summary: "engine summary",
-          firstKeptEntryId: "entry-1",
-          tokensBefore: 55,
-        },
-      })),
+      compact,
       maintain: vi.fn(async () => {
         throw new Error("maintenance boom");
       }),
@@ -321,116 +548,33 @@ describe("maybeCompactCodexAppServerSession", () => {
     const result = requireCompactResult(await pendingResult);
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
-    const nativeDetails = compactDetails(result).codexNativeCompaction as
-      | { ok?: boolean; compacted?: boolean }
-      | undefined;
-    expect(nativeDetails?.ok).toBe(true);
-    expect(nativeDetails?.compacted).toBe(true);
-  });
-
-  it("records native compaction status when primary compaction has no result payload", async () => {
-    const fake = createFakeCodexClient();
-    setCodexAppServerClientFactoryForTest(async () => fake.client);
-    const sessionFile = await writeTestBinding();
-    const contextEngine: ContextEngine = {
-      info: { id: "lossless-claw", name: "Lossless Claw", ownsCompaction: true },
-      assemble: vi.fn() as never,
-      ingest: vi.fn() as never,
-      compact: vi.fn(async () => ({
-        ok: true,
-        compacted: false,
-        reason: "below threshold",
-      })),
-    };
-
-    const pendingResult = maybeCompactCodexAppServerSession({
-      sessionId: "session-1",
-      sessionKey: "agent:main:session-1",
-      sessionFile,
-      workspaceDir: tempDir,
-      contextEngine,
-      currentTokenCount: 222,
-    });
-    await vi.waitFor(() => {
-      expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
-    });
-    fake.emit({
-      method: "thread/compacted",
-      params: { threadId: "thread-1", turnId: "turn-1" },
-    });
-
-    const result = requireCompactResult(await pendingResult);
-    expect(result.ok).toBe(true);
-    expect(result.compacted).toBe(false);
-    expect(result.reason).toBe("below threshold");
-    expect(result.result?.tokensBefore).toBe(222);
-    const nativeDetails = compactDetails(result).codexNativeCompaction as
-      | { ok?: boolean; compacted?: boolean }
-      | undefined;
-    expect(nativeDetails?.ok).toBe(true);
-    expect(nativeDetails?.compacted).toBe(true);
-  });
-
-  it("reports context-engine compaction errors without skipping native compaction", async () => {
-    const fake = createFakeCodexClient();
-    setCodexAppServerClientFactoryForTest(async () => fake.client);
-    const sessionFile = await writeTestBinding();
-    const contextEngine: ContextEngine = {
-      info: { id: "lossless-claw", name: "Lossless Claw", ownsCompaction: true },
-      assemble: vi.fn() as never,
-      ingest: vi.fn() as never,
-      compact: vi.fn(async () => {
-        throw new Error("engine boom");
-      }),
-    };
-
-    const pendingResult = maybeCompactCodexAppServerSession({
-      sessionId: "session-1",
-      sessionKey: "agent:main:session-1",
-      sessionFile,
-      workspaceDir: tempDir,
-      contextEngine,
-      currentTokenCount: 222,
-    });
-    await vi.waitFor(() => {
-      expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
-    });
-    fake.emit({
-      method: "thread/compacted",
-      params: { threadId: "thread-1", turnId: "turn-1" },
-    });
-
-    const result = requireCompactResult(await pendingResult);
-    expect(result.ok).toBe(false);
-    expect(result.compacted).toBe(true);
-    expect(result.reason).toBe("context engine compaction failed: engine boom");
     const details = compactDetails(result);
-    const engineDetails = details.contextEngineCompaction as
-      | { ok?: boolean; reason?: string }
-      | undefined;
-    const nativeDetails = details.codexNativeCompaction as
-      | { ok?: boolean; compacted?: boolean }
-      | undefined;
-    expect(engineDetails?.ok).toBe(false);
-    expect(engineDetails?.reason).toBe("context engine compaction failed: engine boom");
-    expect(nativeDetails?.ok).toBe(true);
-    expect(nativeDetails?.compacted).toBe(true);
+    expect(details.backend).toBe("codex-app-server");
+    expect(details.threadId).toBe("thread-1");
+    expect(compact).not.toHaveBeenCalled();
   });
 
-  it("does not fail owning context-engine compaction when Codex native compaction cannot run", async () => {
+  it("does not fall back to context-engine compaction when native compaction cannot run", async () => {
+    const compact = vi.fn(async () => ({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "engine summary",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 8,
+      },
+    }));
+    const maintain = vi.fn(async () => ({
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+    }));
     const contextEngine: ContextEngine = {
       info: { id: "lossless-claw", name: "Lossless Claw", ownsCompaction: true },
       assemble: vi.fn() as never,
       ingest: vi.fn() as never,
-      compact: vi.fn(async () => ({
-        ok: true,
-        compacted: true,
-        result: {
-          summary: "engine summary",
-          firstKeptEntryId: "entry-1",
-          tokensBefore: 8,
-        },
-      })),
+      compact,
+      maintain,
     };
 
     const result = await maybeCompactCodexAppServerSession({
@@ -442,15 +586,42 @@ describe("maybeCompactCodexAppServerSession", () => {
     });
 
     const compactResult = requireCompactResult(result);
-    expect(compactResult.ok).toBe(true);
-    expect(compactResult.compacted).toBe(true);
-    expect(compactResult.result?.summary).toBe("engine summary");
-    const nativeDetails = compactDetails(compactResult).codexNativeCompaction as
-      | { ok?: boolean; compacted?: boolean; reason?: string }
-      | undefined;
-    expect(nativeDetails?.ok).toBe(false);
-    expect(nativeDetails?.compacted).toBe(false);
-    expect(nativeDetails?.reason).toBe("no codex app-server thread binding");
+    expect(compactResult.ok).toBe(false);
+    expect(compactResult.compacted).toBe(false);
+    expect(compactResult.reason).toBe("no codex app-server thread binding");
+    expect(compact).not.toHaveBeenCalled();
+    expect(maintain).not.toHaveBeenCalled();
+  });
+
+  it("does not run context-engine maintenance when native compaction is skipped", async () => {
+    const maintain = vi.fn(async () => ({
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+    }));
+    const contextEngine: ContextEngine = {
+      info: { id: "lossless-claw", name: "Lossless Claw", ownsCompaction: true },
+      assemble: vi.fn() as never,
+      ingest: vi.fn() as never,
+      compact: vi.fn(async () => ({
+        ok: true,
+        compacted: true,
+      })),
+      maintain,
+    };
+
+    const result = await maybeCompactCodexAppServerSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: path.join(tempDir, "missing-binding.jsonl"),
+      workspaceDir: tempDir,
+      contextEngine,
+    });
+
+    const compactResult = requireCompactResult(result);
+    expect(compactResult.ok).toBe(false);
+    expect(compactResult.compacted).toBe(false);
+    expect(maintain).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -2,6 +2,7 @@ import {
   embeddedAgentLog,
   formatErrorMessage,
   isActiveHarnessContextEngine,
+  resolveContextEngineOwnerPluginId,
   runHarnessContextEngineMaintenance,
   type CompactEmbeddedPiSessionParams,
   type EmbeddedPiCompactResult,
@@ -24,11 +25,9 @@ type CodexNativeCompactionWaiter = {
   startTimeout: () => void;
   cancel: () => void;
 };
-type ContextEngineCompactResult = Awaited<
-  ReturnType<NonNullable<CompactEmbeddedPiSessionParams["contextEngine"]>["compact"]>
->;
 
 const DEFAULT_CODEX_COMPACTION_WAIT_TIMEOUT_MS = 5 * 60 * 1000;
+const warnedIgnoredCompactionOverrides = new Set<string>();
 
 export async function maybeCompactCodexAppServerSession(
   params: CompactEmbeddedPiSessionParams,
@@ -37,70 +36,158 @@ export async function maybeCompactCodexAppServerSession(
   const activeContextEngine = isActiveHarnessContextEngine(params.contextEngine)
     ? params.contextEngine
     : undefined;
-  if (activeContextEngine?.info.ownsCompaction) {
-    let primary: ContextEngineCompactResult | undefined;
-    let primaryError: string | undefined;
+  warnIfIgnoringOpenClawCompactionOverrides(params);
+  const nativeResult = await compactCodexNativeThread(params, options);
+  if (activeContextEngine && nativeResult?.ok && nativeResult.compacted) {
     try {
-      primary = await activeContextEngine.compact({
+      await runHarnessContextEngineMaintenance({
+        contextEngine: activeContextEngine,
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
         sessionFile: params.sessionFile,
-        tokenBudget: params.contextTokenBudget,
-        currentTokenCount: params.currentTokenCount,
-        compactionTarget: params.trigger === "manual" ? "threshold" : "budget",
-        customInstructions: params.customInstructions,
-        force: params.trigger === "manual",
+        reason: "compaction",
         runtimeContext: params.contextEngineRuntimeContext,
+        config: params.config,
       });
     } catch (error) {
-      primaryError = formatErrorMessage(error);
-      embeddedAgentLog.warn(
-        "context engine compaction failed; attempting Codex native compaction",
-        {
-          sessionId: params.sessionId,
-          engineId: activeContextEngine.info.id,
-          error: primaryError,
-        },
-      );
-    }
-    if (primary?.ok && primary.compacted) {
-      try {
-        await runHarnessContextEngineMaintenance({
-          contextEngine: activeContextEngine,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          sessionFile: params.sessionFile,
-          reason: "compaction",
-          runtimeContext: params.contextEngineRuntimeContext,
-          config: params.config,
-        });
-      } catch (error) {
-        embeddedAgentLog.warn(
-          "context engine compaction maintenance failed; continuing Codex native compaction",
-          {
-            sessionId: params.sessionId,
-            engineId: activeContextEngine.info.id,
-            error: formatErrorMessage(error),
-          },
-        );
-      }
-    }
-    const nativeResult = await compactCodexNativeThread(params, options);
-    if (!primary) {
-      return buildContextEngineCompactionFailureResult({
-        primaryError,
-        nativeResult,
-        currentTokenCount: params.currentTokenCount,
+      embeddedAgentLog.warn("context engine compaction maintenance failed after Codex compaction", {
+        sessionId: params.sessionId,
+        engineId: activeContextEngine.info.id,
+        error: formatErrorMessage(error),
       });
     }
-    return {
-      ok: primary.ok,
-      compacted: primary.compacted,
-      reason: primary.reason,
-      result: buildContextEnginePrimaryResult(primary, nativeResult, params.currentTokenCount),
-    };
   }
-  return await compactCodexNativeThread(params, options);
+  return nativeResult;
+}
+
+function warnIfIgnoringOpenClawCompactionOverrides(params: CompactEmbeddedPiSessionParams): void {
+  const activeContextEngine = isActiveHarnessContextEngine(params.contextEngine)
+    ? params.contextEngine
+    : undefined;
+  const ignoredConfig = readIgnoredCompactionOverridePaths(params, activeContextEngine);
+  if (ignoredConfig.length === 0) {
+    return;
+  }
+  const warningKey = ignoredConfig.join("\0");
+  if (warnedIgnoredCompactionOverrides.has(warningKey)) {
+    return;
+  }
+  warnedIgnoredCompactionOverrides.add(warningKey);
+  embeddedAgentLog.warn(
+    "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
+    {
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      ignoredConfig,
+    },
+  );
+}
+
+function readIgnoredCompactionOverridePaths(
+  params: CompactEmbeddedPiSessionParams,
+  activeContextEngine?: CompactEmbeddedPiSessionParams["contextEngine"],
+): string[] {
+  const ignored = new Set<string>();
+  const configuredContextEngine = readStringPath(params.config, [
+    "plugins",
+    "slots",
+    "contextEngine",
+  ]);
+  const runtimeContextEnginePlugin =
+    typeof params.contextEngineRuntimeContext?.contextEnginePluginId === "string"
+      ? params.contextEngineRuntimeContext.contextEnginePluginId.trim()
+      : "";
+  const activeContextEnginePlugin = resolveContextEngineOwnerPluginId(activeContextEngine);
+  for (const entry of readCompactionOverrideEntries(params)) {
+    const localProvider =
+      typeof entry.record.provider === "string" ? entry.record.provider.trim() : "";
+    const inheritedProvider =
+      !localProvider && typeof entry.inheritedRecord?.provider === "string"
+        ? entry.inheritedRecord.provider.trim()
+        : "";
+    const provider = localProvider || inheritedProvider;
+    const providerPath = localProvider
+      ? `${entry.path}.compaction.provider`
+      : inheritedProvider && entry.inheritedPath
+        ? `${entry.inheritedPath}.compaction.provider`
+        : undefined;
+    const activeLosslessContextEngine =
+      provider.toLowerCase() === "lossless-claw" &&
+      (activeContextEnginePlugin === "lossless-claw" ||
+        runtimeContextEnginePlugin.toLowerCase() === "lossless-claw" ||
+        configuredContextEngine?.toLowerCase() === "lossless-claw");
+    if (activeLosslessContextEngine) {
+      continue;
+    }
+    if (typeof entry.record.model === "string" && entry.record.model.trim()) {
+      ignored.add(`${entry.path}.compaction.model`);
+    }
+    if (providerPath) {
+      ignored.add(providerPath);
+    }
+  }
+  return [...ignored];
+}
+
+function readCompactionOverrideEntries(params: CompactEmbeddedPiSessionParams): Array<{
+  path: string;
+  record: Record<string, unknown>;
+  inheritedRecord?: Record<string, unknown>;
+  inheritedPath?: string;
+}> {
+  const entries: Array<{
+    path: string;
+    record: Record<string, unknown>;
+    inheritedRecord?: Record<string, unknown>;
+    inheritedPath?: string;
+  }> = [];
+  const defaultCompaction = readRecord(readRecord(params.config?.agents)?.defaults)?.compaction;
+  const defaultRecord = readRecord(defaultCompaction);
+  if (defaultRecord) {
+    entries.push({ path: "agents.defaults", record: defaultRecord });
+  }
+  const agentId = readAgentIdFromSessionKey(params.sessionKey ?? params.sandboxSessionKey);
+  if (!agentId) {
+    return entries;
+  }
+  const agents = Array.isArray(params.config?.agents?.list) ? params.config.agents.list : [];
+  const activeAgent = agents.find((agent) => {
+    const id = typeof agent?.id === "string" ? agent.id.trim().toLowerCase() : "";
+    return id === agentId;
+  });
+  const agentCompaction = readRecord(activeAgent)?.compaction;
+  const agentRecord = readRecord(agentCompaction);
+  if (agentRecord) {
+    entries.push({
+      path: `agents.list.${agentId}`,
+      record: agentRecord,
+      inheritedRecord: defaultRecord,
+      inheritedPath: "agents.defaults",
+    });
+  }
+  return entries;
+}
+
+function readAgentIdFromSessionKey(sessionKey: string | undefined): string | undefined {
+  const parts = sessionKey?.trim().toLowerCase().split(":").filter(Boolean) ?? [];
+  if (parts.length < 3 || parts[0] !== "agent") {
+    return undefined;
+  }
+  return parts[1]?.trim() || undefined;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readStringPath(value: unknown, path: readonly string[]): string | undefined {
+  let current = value;
+  for (const segment of path) {
+    current = readRecord(current)?.[segment];
+  }
+  return typeof current === "string" && current.trim() ? current.trim() : undefined;
 }
 
 async function compactCodexNativeThread(
@@ -164,85 +251,11 @@ async function compactCodexNativeThread(
       tokensBefore: params.currentTokenCount ?? 0,
       details: {
         backend: "codex-app-server",
-        ownsCompaction: params.contextEngine?.info?.ownsCompaction === true,
         threadId: binding.threadId,
         signal: completion.signal,
         turnId: completion.turnId,
         itemId: completion.itemId,
       },
-    },
-  };
-}
-
-function mergeCompactionDetails(
-  primaryDetails: unknown,
-  nativeResult: EmbeddedPiCompactResult | undefined,
-  contextEngineCompaction?: { ok: false; reason?: string },
-): unknown {
-  const codexNativeCompaction = nativeResult
-    ? nativeResult.ok && nativeResult.compacted
-      ? { ok: true, compacted: true, details: nativeResult.result?.details }
-      : { ok: false, compacted: false, reason: nativeResult.reason }
-    : undefined;
-  const extraDetails = {
-    ...(codexNativeCompaction ? { codexNativeCompaction } : {}),
-    ...(contextEngineCompaction ? { contextEngineCompaction } : {}),
-  };
-  if (primaryDetails && typeof primaryDetails === "object" && !Array.isArray(primaryDetails)) {
-    return {
-      ...(primaryDetails as Record<string, unknown>),
-      ...extraDetails,
-    };
-  }
-  return Object.keys(extraDetails).length > 0 ? extraDetails : primaryDetails;
-}
-
-function buildContextEnginePrimaryResult(
-  primary: ContextEngineCompactResult,
-  nativeResult: EmbeddedPiCompactResult | undefined,
-  currentTokenCount: number | undefined,
-): NonNullable<EmbeddedPiCompactResult["result"]> | undefined {
-  if (primary.result) {
-    return {
-      summary: primary.result.summary ?? "",
-      firstKeptEntryId: primary.result.firstKeptEntryId ?? "",
-      tokensBefore: primary.result.tokensBefore,
-      tokensAfter: primary.result.tokensAfter,
-      details: mergeCompactionDetails(primary.result.details, nativeResult),
-    };
-  }
-  const details = mergeCompactionDetails(undefined, nativeResult);
-  return details
-    ? {
-        summary: "",
-        firstKeptEntryId: "",
-        tokensBefore: nativeResult?.result?.tokensBefore ?? currentTokenCount ?? 0,
-        details,
-      }
-    : undefined;
-}
-
-function buildContextEngineCompactionFailureResult(params: {
-  primaryError?: string;
-  nativeResult: EmbeddedPiCompactResult | undefined;
-  currentTokenCount?: number;
-}): EmbeddedPiCompactResult {
-  const reason = params.primaryError
-    ? `context engine compaction failed: ${params.primaryError}`
-    : "context engine compaction failed";
-  return {
-    ok: false,
-    compacted: params.nativeResult?.compacted ?? false,
-    reason,
-    result: {
-      summary: params.nativeResult?.result?.summary ?? "",
-      firstKeptEntryId: params.nativeResult?.result?.firstKeptEntryId ?? "",
-      tokensBefore: params.nativeResult?.result?.tokensBefore ?? params.currentTokenCount ?? 0,
-      tokensAfter: params.nativeResult?.result?.tokensAfter,
-      details: mergeCompactionDetails(params.nativeResult?.result?.details, params.nativeResult, {
-        ok: false,
-        reason,
-      }),
     },
   };
 }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -19,6 +19,7 @@ import {
   resolveAttemptSpawnWorkspaceDir,
   resolveAgentHarnessBeforePromptBuildResult,
   resolveModelAuthMode,
+  resolveContextEngineOwnerPluginId,
   resolveSandboxContext,
   resolveSessionAgentIds,
   resolveUserPath,
@@ -580,6 +581,7 @@ export async function runCodexAppServerAttempt(
     ...hookContextWindowFields,
   };
   if (activeContextEngine) {
+    const activeContextEnginePluginId = resolveContextEngineOwnerPluginId(activeContextEngine);
     await bootstrapHarnessContextEngine({
       hadSessionFile,
       contextEngine: activeContextEngine,
@@ -590,6 +592,8 @@ export async function runCodexAppServerAttempt(
         attempt: runtimeParams,
         workspaceDir: effectiveWorkspace,
         agentDir,
+        activeAgentId: sessionAgentId,
+        contextEnginePluginId: activeContextEnginePluginId,
         tokenBudget: params.contextTokenBudget,
       }),
       runMaintenance: runHarnessContextEngineMaintenance,
@@ -1775,6 +1779,7 @@ export async function runCodexAppServerAttempt(
       });
     }
     if (activeContextEngine) {
+      const activeContextEnginePluginId = resolveContextEngineOwnerPluginId(activeContextEngine);
       const finalMessages =
         (await readMirroredSessionHistoryMessages(params.sessionFile)) ??
         historyMessages.concat(result.messagesSnapshot);
@@ -1793,6 +1798,8 @@ export async function runCodexAppServerAttempt(
           attempt: runtimeParams,
           workspaceDir: effectiveWorkspace,
           agentDir,
+          activeAgentId: sessionAgentId,
+          contextEnginePluginId: activeContextEnginePluginId,
           tokenBudget: params.contextTokenBudget,
           lastCallUsage: result.attemptUsage,
           promptCache: result.promptCache,

--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -134,6 +134,1654 @@ describe("collectCodexRouteWarnings", () => {
     expect(warnings).toStrictEqual([]);
   });
 
+  it("warns when Codex runtime has OpenClaw compaction summarizer overrides", () => {
+    const warnings = collectCodexRouteWarnings({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(warnings).toStrictEqual([
+      [
+        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
+        "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
+        "- Run `openclaw doctor --fix`: it removes unsupported Codex compaction overrides.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("warns when implicit default OpenAI Codex runtime has compaction overrides", () => {
+    const warnings = collectCodexRouteWarnings({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(warnings).toStrictEqual([
+      [
+        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
+        "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
+        "- Run `openclaw doctor --fix`: it removes unsupported Codex compaction overrides.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("warns when the Codex app-server runtime alias has compaction overrides", () => {
+    const warnings = collectCodexRouteWarnings({
+      cfg: {
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex-app-server" },
+            model: "anthropic/claude-sonnet-4.6",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(warnings).toStrictEqual([
+      [
+        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
+        "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
+        "- Run `openclaw doctor --fix`: it removes unsupported Codex compaction overrides.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("repairs Codex-runtime compaction summarizer overrides by removing them", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+              keepRecentTokens: 10_000,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
+      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      keepRecentTokens: 10_000,
+    });
+  });
+
+  it("repairs compaction overrides for the implicit default OpenAI Codex runtime", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+              keepRecentTokens: 10_000,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
+      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      keepRecentTokens: 10_000,
+    });
+  });
+
+  it("repairs compaction overrides for the Codex app-server runtime alias", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex-app-server" },
+            model: "anthropic/claude-sonnet-4.6",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+              keepRecentTokens: 10_000,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
+      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      keepRecentTokens: 10_000,
+    });
+  });
+
+  it("repairs compaction overrides for model-scoped Codex app-server runtime aliases", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            models: {
+              "openai/gpt-5.5": {
+                agentRuntime: { id: "codex-app-server" },
+              },
+            },
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+              keepRecentTokens: 10_000,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
+      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      keepRecentTokens: 10_000,
+    });
+  });
+
+  it("migrates legacy Lossless compaction config to the context-engine slot", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai-codex/gpt-5.4-mini",
+              provider: "lossless-claw",
+              keepRecentTokens: 10_000,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.cfg.plugins?.slots?.contextEngine).toBe("lossless-claw");
+    expect(result.cfg.plugins?.entries?.["lossless-claw"]).toEqual({
+      enabled: true,
+      config: {
+        summaryModel: "openai/gpt-5.4-mini",
+      },
+      llm: {
+        allowModelOverride: true,
+        allowedModels: ["openai/gpt-5.4-mini"],
+      },
+    });
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      keepRecentTokens: 10_000,
+    });
+    expect(result.changes).toContain(
+      'Set plugins.slots.contextEngine to "lossless-claw" for legacy Lossless compaction config.',
+    );
+    expect(result.changes).toContain(
+      "Removed agents.defaults.compaction.provider; Lossless now runs through plugins.slots.contextEngine.",
+    );
+  });
+
+  it("does not migrate mixed Lossless provider-only and summary-model consumers", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              provider: "lossless-claw",
+            },
+          },
+          list: [
+            {
+              id: "fast",
+              model: "openai/gpt-5.5",
+              compaction: {
+                model: "openai/gpt-5.4-mini",
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins).toBeUndefined();
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      provider: "lossless-claw",
+    });
+    expect(result.cfg.agents?.list?.[0]?.compaction).toEqual({
+      model: "openai/gpt-5.4-mini",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+        "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.list.fast.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("preserves Codex runtime policy for migrated Lossless summary models", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://proxy.example.test/v1",
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openai-codex/gpt-5.5",
+            compaction: {
+              model: "openai-codex/gpt-5.4-mini",
+              provider: "lossless-claw",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      summaryModel: "openai/gpt-5.4-mini",
+    });
+    expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.4-mini"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(result.changes).toContain(
+      'Set agents.defaults.models.openai/gpt-5.4-mini.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
+    );
+  });
+
+  it("canonicalizes bare legacy Lossless summary models during migration", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "gpt-5.4-mini",
+              provider: "lossless-claw",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.["lossless-claw"]).toEqual({
+      enabled: true,
+      config: {
+        summaryModel: "openai/gpt-5.4-mini",
+      },
+      llm: {
+        allowModelOverride: true,
+        allowedModels: ["openai/gpt-5.4-mini"],
+      },
+    });
+    expect(result.cfg.agents?.defaults?.compaction).toBeUndefined();
+  });
+
+  it("canonicalizes a case-variant Lossless context-engine slot during migration", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          slots: {
+            contextEngine: "Lossless-Claw",
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai/gpt-5.4-mini",
+              provider: "lossless-claw",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.cfg.plugins?.slots?.contextEngine).toBe("lossless-claw");
+    expect(result.cfg.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      summaryModel: "openai/gpt-5.4-mini",
+    });
+    expect(result.cfg.agents?.defaults?.compaction).toBeUndefined();
+  });
+
+  it("does not grant Lossless model override policy without a migrated summary model", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              provider: "lossless-claw",
+              keepRecentTokens: 10_000,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.cfg.plugins?.slots?.contextEngine).toBe("lossless-claw");
+    expect(result.cfg.plugins?.entries?.["lossless-claw"]).toEqual({
+      enabled: true,
+      config: {},
+    });
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      keepRecentTokens: 10_000,
+    });
+  });
+
+  it("migrates numeric string agent ids before treating the path label as an index", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          list: [
+            {
+              id: "other",
+              model: "anthropic/claude-sonnet-4-6",
+            },
+            {
+              id: "0",
+              model: "openai/gpt-5.5",
+              compaction: {
+                model: "openai/gpt-5.4-mini",
+                provider: "lossless-claw",
+              },
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(
+      (result.cfg.agents?.list?.[0] as Record<string, unknown> | undefined)?.compaction,
+    ).toBeUndefined();
+    expect(
+      (result.cfg.agents?.list?.[1] as Record<string, unknown> | undefined)?.compaction,
+    ).toBeUndefined();
+    expect(result.cfg.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      summaryModel: "openai/gpt-5.4-mini",
+    });
+  });
+
+  it("does not collapse conflicting per-agent Lossless summary models", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          list: [
+            {
+              id: "fast",
+              model: "openai/gpt-5.5",
+              compaction: {
+                model: "openai/gpt-5.4-mini",
+                provider: "lossless-claw",
+              },
+            },
+            {
+              id: "deep",
+              model: "openai/gpt-5.5",
+              compaction: {
+                model: "openai/gpt-5.5",
+                provider: "lossless-claw",
+              },
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins).toBeUndefined();
+    expect(
+      (result.cfg.agents?.list?.[0] as Record<string, unknown> | undefined)?.compaction,
+    ).toEqual({
+      model: "openai/gpt-5.4-mini",
+      provider: "lossless-claw",
+    });
+    expect(
+      (result.cfg.agents?.list?.[1] as Record<string, unknown> | undefined)?.compaction,
+    ).toEqual({
+      model: "openai/gpt-5.5",
+      provider: "lossless-claw",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+        "- agents.list.fast.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.list.fast.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- agents.list.deep.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.list.deep.compaction.model: openai/gpt-5.5 should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("does not overwrite a non-Lossless context-engine slot", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          slots: {
+            contextEngine: "qmd",
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai-codex/gpt-5.4",
+              provider: "lossless-claw",
+              memoryFlush: {
+                model: "openai-codex/gpt-5.4-mini",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([
+      [
+        "Repaired Codex model routes:",
+        "- agents.defaults.compaction.model: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
+        "- agents.defaults.compaction.memoryFlush.model: openai-codex/gpt-5.4-mini -> openai/gpt-5.4-mini.",
+      ].join("\n"),
+      'Set agents.defaults.models.openai/gpt-5.4.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+      provider: "lossless-claw",
+      memoryFlush: {
+        model: "openai/gpt-5.4-mini",
+      },
+    });
+    expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+        "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("preserves local Lossless models when inherited provider migration is blocked", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          slots: {
+            contextEngine: "qmd",
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              provider: "lossless-claw",
+            },
+          },
+          list: [
+            {
+              id: "fast",
+              model: "openai/gpt-5.5",
+              agentRuntime: { id: "codex" },
+              compaction: {
+                model: "openai-codex/gpt-5.4-mini",
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([
+      [
+        "Repaired Codex model routes:",
+        "- agents.list.fast.compaction.model: openai-codex/gpt-5.4-mini -> openai/gpt-5.4-mini.",
+      ].join("\n"),
+      'Set agents.list.fast.models.openai/gpt-5.4-mini.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      provider: "lossless-claw",
+    });
+    expect(
+      (result.cfg.agents?.list?.[0] as Record<string, unknown> | undefined)?.compaction,
+    ).toEqual({
+      model: "openai/gpt-5.4-mini",
+    });
+    expect(result.cfg.agents?.list?.[0]?.agentRuntime).toEqual({ id: "codex" });
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai/gpt-5.4-mini"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+        "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.list.fast.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("preserves Codex runtime policy for each migrated per-agent Lossless model", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://proxy.example.test/v1",
+              agentRuntime: { id: "pi" },
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openai-codex/gpt-5.5",
+            compaction: {
+              model: "openai-codex/gpt-5.4-mini",
+              provider: "lossless-claw",
+            },
+          },
+          list: [
+            {
+              id: "fast",
+              model: "openai/gpt-5.5",
+              models: {
+                "openai/gpt-5.5": {
+                  agentRuntime: {
+                    id: "codex",
+                  },
+                },
+              },
+              compaction: {
+                model: "openai-codex/gpt-5.4-mini",
+              },
+            },
+            {
+              id: "deep",
+              model: "openai/gpt-5.5",
+              models: {
+                "openai/gpt-5.5": {
+                  agentRuntime: {
+                    id: "codex",
+                  },
+                },
+              },
+              compaction: {
+                model: "openai-codex/gpt-5.4-mini",
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.plugins?.slots?.contextEngine).toBe("lossless-claw");
+    expect(result.cfg.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      summaryModel: "openai/gpt-5.4-mini",
+    });
+    expect(result.cfg.agents?.defaults?.compaction).toBeUndefined();
+    expect(result.cfg.agents?.list?.[0]?.compaction).toBeUndefined();
+    expect(result.cfg.agents?.list?.[1]?.compaction).toBeUndefined();
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai/gpt-5.4-mini"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(result.cfg.agents?.list?.[1]?.models?.["openai/gpt-5.4-mini"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(result.changes).toContain(
+      'Set agents.list.fast.models.openai/gpt-5.4-mini.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
+    );
+    expect(result.changes).toContain(
+      'Set agents.list.deep.models.openai/gpt-5.4-mini.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
+    );
+  });
+
+  it("preserves Codex runtime policy for blocked Lossless summary rewrites", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://proxy.example.test/v1",
+            },
+          },
+        },
+        plugins: {
+          slots: {
+            contextEngine: "qmd",
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            models: {
+              "openai/gpt-5.5": {
+                agentRuntime: {
+                  id: "codex",
+                },
+              },
+            },
+            compaction: {
+              model: "openai-codex/gpt-5.4-mini",
+              provider: "lossless-claw",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([
+      [
+        "Repaired Codex model routes:",
+        "- agents.defaults.compaction.model: openai-codex/gpt-5.4-mini -> openai/gpt-5.4-mini.",
+      ].join("\n"),
+      'Set agents.defaults.models.openai/gpt-5.4-mini.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4-mini",
+      provider: "lossless-claw",
+    });
+    expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.4-mini"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+        "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("points inherited Lossless model warnings at defaults when migration is blocked", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          slots: {
+            contextEngine: "qmd",
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai/gpt-5.4-mini",
+            },
+          },
+          list: [
+            {
+              id: "fast",
+              model: "openai/gpt-5.5",
+              models: {
+                "openai/gpt-5.5": {
+                  agentRuntime: {
+                    id: "codex",
+                  },
+                },
+              },
+              compaction: {
+                provider: "lossless-claw",
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4-mini",
+    });
+    expect(
+      (result.cfg.agents?.list?.[0] as Record<string, unknown> | undefined)?.compaction,
+    ).toEqual({
+      provider: "lossless-claw",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+        "- agents.list.fast.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("canonicalizes inherited Lossless summary models when migration is blocked", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://proxy.example.test/v1",
+            },
+          },
+        },
+        plugins: {
+          slots: {
+            contextEngine: "qmd",
+          },
+        },
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+            compaction: {
+              model: "openai-codex/gpt-5.4-mini",
+            },
+          },
+          list: [
+            {
+              id: "fast",
+              model: "openai/gpt-5.5",
+              models: {
+                "openai/gpt-5.5": {
+                  agentRuntime: {
+                    id: "codex",
+                  },
+                },
+              },
+              compaction: {
+                provider: "lossless-claw",
+              },
+            },
+            {
+              id: "deep",
+              model: "openai/gpt-5.5",
+              models: {
+                "openai/gpt-5.5": {
+                  agentRuntime: {
+                    id: "codex",
+                  },
+                },
+              },
+              compaction: {
+                provider: "lossless-claw",
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([
+      [
+        "Repaired Codex model routes:",
+        "- agents.defaults.compaction.model: openai-codex/gpt-5.4-mini -> openai/gpt-5.4-mini.",
+      ].join("\n"),
+      'Set agents.list.fast.models.openai/gpt-5.4-mini.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
+      'Set agents.list.deep.models.openai/gpt-5.4-mini.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4-mini",
+    });
+    expect(result.cfg.agents?.list?.[0]?.compaction).toEqual({
+      provider: "lossless-claw",
+    });
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai/gpt-5.4-mini"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(result.cfg.agents?.list?.[1]?.compaction).toEqual({
+      provider: "lossless-claw",
+    });
+    expect(result.cfg.agents?.list?.[1]?.models?.["openai/gpt-5.4-mini"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+        "- agents.list.fast.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- agents.list.deep.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("does not migrate Lossless compaction for agents whose Codex runtime pin is being cleared", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+              agentRuntime: { id: "codex" },
+              compaction: {
+                model: "openai/gpt-5.4",
+                provider: "lossless-claw",
+              },
+            },
+          ],
+        },
+        hooks: {
+          gmail: {
+            model: "openai-codex/gpt-5.4",
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([
+      "Repaired Codex model routes:\n- hooks.gmail.model: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
+      "Removed agents.list.worker.agentRuntime; runtime is now provider/model scoped.",
+    ]);
+    expect(result.cfg.plugins).toBeUndefined();
+    expect(result.cfg.agents?.list?.[0]).toEqual({
+      id: "worker",
+      model: "anthropic/claude-sonnet-4-6",
+      compaction: {
+        model: "openai/gpt-5.4",
+        provider: "lossless-claw",
+      },
+    });
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it("preserves local compaction overrides for agents whose Codex runtime pin is being cleared", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+              agentRuntime: { id: "codex" },
+              compaction: {
+                model: "openai/gpt-5.4",
+                provider: "custom-summary",
+              },
+            },
+          ],
+        },
+        hooks: {
+          gmail: {
+            model: "openai-codex/gpt-5.4",
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([
+      "Repaired Codex model routes:\n- hooks.gmail.model: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
+      "Removed agents.list.worker.agentRuntime; runtime is now provider/model scoped.",
+    ]);
+    expect(result.cfg.agents?.list?.[0]).toEqual({
+      id: "worker",
+      model: "anthropic/claude-sonnet-4-6",
+      compaction: {
+        model: "openai/gpt-5.4",
+        provider: "custom-summary",
+      },
+    });
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it("does not warn about compaction overrides for runtime pins doctor will clear", () => {
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "worker",
+            model: "anthropic/claude-sonnet-4-6",
+            agentRuntime: { id: "codex" },
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+        ],
+      },
+      hooks: {
+        gmail: {
+          model: "openai-codex/gpt-5.4",
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(collectCodexRouteWarnings({ cfg })).toStrictEqual([
+      [
+        "- Legacy `openai-codex/*` model refs should be rewritten to `openai/*`.",
+        "- hooks.gmail.model: openai-codex/gpt-5.4 should become openai/gpt-5.4.",
+        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("does not migrate shared Lossless summary models inherited by non-Codex agents", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              model: "openai/gpt-5.4",
+            },
+          },
+          list: [
+            {
+              id: "codex",
+              model: "openai/gpt-5.5",
+              compaction: {
+                provider: "lossless-claw",
+              },
+            },
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins).toBeUndefined();
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+    });
+    expect(result.cfg.agents?.list?.[0]?.compaction).toEqual({
+      provider: "lossless-claw",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+        "- agents.list.codex.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("does not discard a legacy Lossless model that conflicts with an existing summary model", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              enabled: true,
+              config: {
+                summaryModel: "openai/gpt-5.5",
+              },
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "lossless-claw",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      summaryModel: "openai/gpt-5.5",
+    });
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+      provider: "lossless-claw",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+        "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("does not migrate shared Lossless defaults inherited by non-Codex agents", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "lossless-claw",
+            },
+          },
+          list: [
+            {
+              id: "codex",
+              model: "openai/gpt-5.5",
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins).toBeUndefined();
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+      provider: "lossless-claw",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+        "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("preserves shared Lossless summary models inherited by non-Codex agents with local providers", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "lossless-claw",
+            },
+          },
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+              compaction: {
+                provider: "custom-summary",
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins).toBeUndefined();
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+      provider: "lossless-claw",
+    });
+    expect((result.cfg.agents?.list?.[0] as Record<string, unknown>).compaction).toEqual({
+      provider: "custom-summary",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+        "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 should become plugins.entries.lossless-claw.config.summaryModel.",
+        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("keeps shared default compaction summarizer overrides for non-Codex agents", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+              keepRecentTokens: 10_000,
+            },
+          },
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+              models: {
+                "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "pi" } },
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+      provider: "custom-summary",
+      keepRecentTokens: 10_000,
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
+        "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
+        "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("warns when listed Codex agents inherit shared default compaction overrides", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+          list: [
+            {
+              id: "codex",
+              model: "openai/gpt-5.5",
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+      provider: "custom-summary",
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
+        "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
+        "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("removes shared default compaction fields that non-Codex agents override", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+              keepRecentTokens: 10_000,
+            },
+          },
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+              ...({
+                compaction: {
+                  model: "anthropic/claude-haiku-4-6",
+                },
+              } as Record<string, unknown>),
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([
+      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      provider: "custom-summary",
+      keepRecentTokens: 10_000,
+    });
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+        "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
+        "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("keeps shared default compaction overrides when repairing legacy runtime pins", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai-codex/gpt-5.5",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+              agentRuntime: { id: "codex" },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.defaults?.model).toBe("openai/gpt-5.5");
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+      provider: "custom-summary",
+    });
+    expect(result.cfg.agents?.list?.[0]?.agentRuntime).toBeUndefined();
+    expect(result.changes.join("\n")).not.toContain("Removed agents.defaults.compaction");
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
+        "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
+        "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("removes defaults when listed agents still have active Codex runtime pins", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+              agentRuntime: { id: "codex" },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
+      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toBeUndefined();
+    expect(result.cfg.agents?.list?.[0]?.agentRuntime).toEqual({ id: "codex" });
+  });
+
+  it("does not clear active runtime pins for compaction-only legacy refs", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai-codex/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+              agentRuntime: { id: "codex" },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([
+      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
+      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toBeUndefined();
+    expect(result.cfg.agents?.defaults?.models).toBeUndefined();
+    expect(result.cfg.agents?.list?.[0]?.agentRuntime).toEqual({ id: "codex" });
+  });
+
+  it("keeps active runtime pins when shared compaction-only refs are preserved", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai-codex/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+          list: [
+            {
+              id: "codex-worker",
+              model: "anthropic/claude-sonnet-4-6",
+              agentRuntime: { id: "codex" },
+            },
+            {
+              id: "pi-worker",
+              model: "anthropic/claude-sonnet-4-6",
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes.join("\n")).toContain(
+      "agents.defaults.compaction.model: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
+    );
+    expect(result.changes.join("\n")).not.toContain(
+      "Removed agents.list.codex-worker.agentRuntime",
+    );
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+      provider: "custom-summary",
+    });
+    expect(result.cfg.agents?.list?.[0]?.agentRuntime).toEqual({ id: "codex" });
+  });
+
+  it("does not ignore active runtime pins for unrepaired stale refs", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://proxy.example.test/v1",
+            models: [],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          agentRuntime: { id: "codex" },
+          compaction: {
+            model: "openai/gpt-5.4",
+            provider: "custom-summary",
+          },
+        },
+        list: [
+          {
+            id: "worker",
+            model: "anthropic/claude-sonnet-4-6",
+          },
+        ],
+      },
+      hooks: {
+        gmail: {
+          model: "openai-codex/gpt-5.4",
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(collectCodexRouteWarnings({ cfg })).toStrictEqual([
+      [
+        "- Legacy `openai-codex/*` model refs should be rewritten to `openai/*`.",
+        "- hooks.gmail.model: openai-codex/gpt-5.4 should become openai/gpt-5.4.",
+        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
+      ].join("\n"),
+      [
+        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
+        "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
+        "- Run `openclaw doctor --fix`: it removes unsupported Codex compaction overrides.",
+      ].join("\n"),
+    ]);
+
+    const result = maybeRepairCodexRoutes({
+      cfg,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([
+      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
+      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toBeUndefined();
+    expect(result.cfg.agents?.defaults?.agentRuntime).toEqual({ id: "codex" });
+    expect(result.cfg.hooks?.gmail?.model).toBe("openai-codex/gpt-5.4");
+  });
+
+  it("keeps default compaction overrides when route repair clears the default Codex pin", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+            agentRuntime: { id: "codex" },
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+        },
+        hooks: {
+          gmail: {
+            model: "openai-codex/gpt-5.4",
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Repaired Codex model routes:\n- hooks.gmail.model: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
+      "Removed agents.defaults.agentRuntime; runtime is now provider/model scoped.",
+    ]);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+      provider: "custom-summary",
+    });
+    expect(result.cfg.agents?.defaults?.agentRuntime).toBeUndefined();
+    expect(result.cfg.hooks?.gmail?.model).toBe("openai/gpt-5.4");
+  });
+
+  it("keeps doctor fix hint for agent-specific compaction overrides", () => {
+    const warnings = collectCodexRouteWarnings({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+          list: [
+            {
+              id: "codex",
+              model: "openai/gpt-5.5",
+              compaction: {
+                model: "openai/gpt-5.4",
+              },
+            },
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+            },
+          ],
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(warnings).toStrictEqual([
+      [
+        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+        "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
+        "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
+      ].join("\n"),
+      [
+        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+        "- agents.list.codex.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
+        "- Run `openclaw doctor --fix`: it removes unsupported Codex compaction overrides.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("canonicalizes kept shared default compaction model refs", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: {
+              model: "openai-codex/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+      provider: "custom-summary",
+    });
+    expect(result.cfg.agents?.defaults?.models).toBeUndefined();
+    expect(result.cfg.agents?.defaults?.agentRuntime).toBeUndefined();
+    expect(result.warnings).toStrictEqual([
+      [
+        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+        "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
+        "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
+        "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("does not broaden runtime policy from kept compaction-only refs", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              agentRuntime: { id: "pi" },
+              models: [],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex" },
+            model: "openai-codex/gpt-5.5",
+            heartbeat: {
+              model: "openai/gpt-5.4",
+            },
+            compaction: {
+              model: "openai-codex/gpt-5.4",
+              provider: "custom-summary",
+            },
+          },
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.defaults?.model).toBe("openai/gpt-5.5");
+    expect(result.cfg.agents?.defaults?.heartbeat?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      model: "openai/gpt-5.4",
+      provider: "custom-summary",
+    });
+    expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.4"]).toBeUndefined();
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("pi");
+  });
+
   it("repairs configured Codex model refs to canonical OpenAI refs with model-scoped Codex runtime", () => {
     const result = maybeRepairCodexRoutes({
       cfg: {
@@ -215,7 +1863,6 @@ describe("collectCodexRouteWarnings", () => {
         "- agents.defaults.heartbeat.model: openai-codex/gpt-5.4-mini -> openai/gpt-5.4-mini.",
         "- agents.defaults.subagents.model.primary: openai-codex/gpt-5.5 -> openai/gpt-5.5.",
         "- agents.defaults.subagents.model.fallbacks.0: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
-        "- agents.defaults.compaction.model: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
         "- agents.defaults.compaction.memoryFlush.model: openai-codex/gpt-5.4-mini -> openai/gpt-5.4-mini.",
         "- agents.defaults.models.openai-codex/gpt-5.5: openai-codex/gpt-5.5 -> openai/gpt-5.5.",
         "- agents.list.worker.model: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
@@ -231,6 +1878,7 @@ describe("collectCodexRouteWarnings", () => {
       'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
       "Removed agents.defaults.agentRuntime; runtime is now provider/model scoped.",
       "Removed agents.list.worker.agentRuntime; runtime is now provider/model scoped.",
+      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
     ]);
     expect(result.cfg.agents?.defaults?.model).toEqual({
       primary: "openai/gpt-5.5",
@@ -241,7 +1889,7 @@ describe("collectCodexRouteWarnings", () => {
       primary: "openai/gpt-5.5",
       fallbacks: ["openai/gpt-5.4"],
     });
-    expect(result.cfg.agents?.defaults?.compaction?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.defaults?.compaction?.model).toBeUndefined();
     expect(result.cfg.agents?.defaults?.compaction?.memoryFlush?.model).toBe("openai/gpt-5.4-mini");
     expect(result.cfg.agents?.defaults?.agentRuntime).toBeUndefined();
     expect(result.cfg.agents?.defaults?.models).toEqual({
@@ -262,6 +1910,44 @@ describe("collectCodexRouteWarnings", () => {
       fallbacks: ["openai/gpt-5.4-mini"],
     });
     expect(result.cfg.messages?.tts?.summaryModel).toBe("openai/gpt-5.4-mini");
+  });
+
+  it("keeps whole-agent runtime pins while repairing compaction-only model refs and overrides", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex" },
+            model: "anthropic/claude-sonnet-4.6",
+            compaction: {
+              model: "openai/gpt-5.4",
+              provider: "custom-summary",
+              memoryFlush: {
+                model: "openai-codex/gpt-5.4-mini",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      shouldRepair: true,
+      codexRuntimeReady: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      [
+        "Repaired Codex model routes:",
+        "- agents.defaults.compaction.memoryFlush.model: openai-codex/gpt-5.4-mini -> openai/gpt-5.4-mini.",
+      ].join("\n"),
+      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
+      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
+    ]);
+    expect(result.cfg.agents?.defaults?.agentRuntime).toEqual({ id: "codex" });
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({
+      memoryFlush: {
+        model: "openai/gpt-5.4-mini",
+      },
+    });
   });
 
   it("repairs legacy routes without requiring OAuth readiness", () => {

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../../agents/defaults.js";
 import { resolveModelRuntimePolicy } from "../../../agents/model-runtime-policy.js";
 import { openAIProviderUsesCodexRuntimeByDefault } from "../../../agents/openai-codex-routing.js";
+import { normalizeEmbeddedAgentRuntime } from "../../../agents/pi-embedded-runner/runtime.js";
 import { AGENT_MODEL_CONFIG_KEYS } from "../../../config/model-refs.js";
 import { loadSessionStore, updateSessionStore } from "../../../config/sessions/store.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "../../../config/sessions/targets.js";
@@ -14,8 +16,25 @@ type CodexRouteHit = {
   canonicalModel: string;
   runtime?: string;
 };
+type CompactionOverrideKey = "model" | "provider";
+type UnsupportedCodexCompactionOverride = {
+  path: string;
+  key: CompactionOverrideKey;
+  value: string;
+};
+type LegacyLosslessCompactionConfig = {
+  path: string;
+  compactionPath: string;
+  providerPath: string;
+  providerValue: string;
+  modelPath?: string;
+  modelValue?: string;
+};
+type SharedDefaultCompactionOverrideConsumers = Record<CompactionOverrideKey, boolean>;
 
 type MutableRecord = Record<string, unknown>;
+const COMPACTION_OVERRIDE_KEYS: readonly CompactionOverrideKey[] = ["model", "provider"];
+const LOSSLESS_CONTEXT_ENGINE_ID = "lossless-claw";
 type SessionRouteRepairResult = {
   changed: boolean;
   sessionKeys: string[];
@@ -25,6 +44,7 @@ type ConfigRouteRepairResult = {
   changes: CodexRouteHit[];
   runtimePinChanges: string[];
   runtimePolicyChanges: string[];
+  unsupportedCompactionChanges: string[];
 };
 type CodexSessionRouteRepairSummary = {
   scannedStores: number;
@@ -36,6 +56,11 @@ type CodexSessionRouteRepairSummary = {
 
 function normalizeString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim().toLowerCase() : undefined;
+}
+
+function normalizeRuntimeString(value: unknown): string | undefined {
+  const normalized = normalizeString(value);
+  return normalized ? normalizeEmbeddedAgentRuntime(normalized) : undefined;
 }
 
 function asMutableRecord(value: unknown): MutableRecord | undefined {
@@ -75,9 +100,9 @@ function resolveRuntime(params: {
   defaultsRuntime?: AgentRuntimePolicyConfig;
 }): string | undefined {
   return (
-    normalizeString(params.env?.OPENCLAW_AGENT_RUNTIME) ??
-    normalizeString(params.agentRuntime?.id) ??
-    normalizeString(params.defaultsRuntime?.id)
+    normalizeRuntimeString(params.env?.OPENCLAW_AGENT_RUNTIME) ??
+    normalizeRuntimeString(params.agentRuntime?.id) ??
+    normalizeRuntimeString(params.defaultsRuntime?.id)
   );
 }
 
@@ -158,6 +183,442 @@ function collectModelConfigSlot(params: {
     }
   }
   return rewrotePrimary;
+}
+
+function readModelConfigPrimaryRef(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value.trim() || undefined;
+  }
+  const record = asMutableRecord(value);
+  if (typeof record?.primary === "string") {
+    return record.primary.trim() || undefined;
+  }
+  return undefined;
+}
+
+function readAgentPrimaryModelRef(agent: unknown, fallback?: string): string | undefined {
+  const record = asMutableRecord(agent);
+  if (!record) {
+    return fallback;
+  }
+  return readModelConfigPrimaryRef(record.model) ?? fallback;
+}
+
+function concreteRuntimeId(runtime: string | undefined): string | undefined {
+  return runtime && runtime !== "auto" && runtime !== "default" ? runtime : undefined;
+}
+
+function modelRefUsesCodexRuntime(params: {
+  cfg: OpenClawConfig;
+  modelRef: string | undefined;
+  agentId?: string;
+}): boolean {
+  const effectiveModelRef = params.modelRef?.trim() || `${DEFAULT_PROVIDER}/${DEFAULT_MODEL}`;
+  const canonicalModel =
+    toCanonicalOpenAIModelRef(effectiveModelRef) ??
+    normalizeDefaultProviderModelRef(effectiveModelRef);
+  if (isOpenAICodexModelRef(effectiveModelRef)) {
+    return true;
+  }
+  return canonicalOpenAIModelUsesCodexRuntime({
+    cfg: params.cfg,
+    modelRef: canonicalModel,
+    agentId: params.agentId,
+  });
+}
+
+function normalizeDefaultProviderModelRef(modelRef: string): string {
+  return modelRef.includes("/") ? modelRef : `${DEFAULT_PROVIDER}/${modelRef}`;
+}
+
+function agentUsesCodexRuntimeForCompaction(params: {
+  cfg: OpenClawConfig;
+  agent: unknown;
+  agentId?: string;
+  currentRuntime?: string;
+  inheritedModelRef?: string;
+}): boolean {
+  const runtime = concreteRuntimeId(normalizeString(params.currentRuntime));
+  if (runtime) {
+    return runtime === "codex";
+  }
+  return modelRefUsesCodexRuntime({
+    cfg: params.cfg,
+    modelRef: readAgentPrimaryModelRef(params.agent, params.inheritedModelRef),
+    agentId: params.agentId,
+  });
+}
+
+function collectUnsupportedCodexCompactionOverridesForAgent(params: {
+  cfg: OpenClawConfig;
+  agent: unknown;
+  path: string;
+  agentId?: string;
+  currentRuntime?: string;
+  inheritedModelRef?: string;
+  inheritedCompaction?: unknown;
+  inheritedCompactionPath?: string;
+}): UnsupportedCodexCompactionOverride[] {
+  const agent = asMutableRecord(params.agent);
+  const compaction = asMutableRecord(agent?.compaction);
+  const inheritedCompaction = asMutableRecord(params.inheritedCompaction);
+  if (
+    !agentUsesCodexRuntimeForCompaction({
+      cfg: params.cfg,
+      agent,
+      agentId: params.agentId,
+      currentRuntime: params.currentRuntime,
+      inheritedModelRef: params.inheritedModelRef,
+    })
+  ) {
+    return [];
+  }
+  const providerValue = compaction?.provider ?? inheritedCompaction?.provider;
+  if (normalizeString(providerValue) === LOSSLESS_CONTEXT_ENGINE_ID) {
+    return [];
+  }
+  const candidates = COMPACTION_OVERRIDE_KEYS.map((key) => {
+    const localValue = compaction?.[key];
+    const hasLocalValue = typeof localValue === "string" && localValue.trim();
+    return {
+      key,
+      value: hasLocalValue ? localValue : inheritedCompaction?.[key],
+      path: hasLocalValue
+        ? `${params.path}.compaction.${key}`
+        : params.inheritedCompactionPath
+          ? `${params.inheritedCompactionPath}.${key}`
+          : `${params.path}.compaction.${key}`,
+    };
+  });
+  return candidates.flatMap(({ key, path, value }) =>
+    typeof value === "string" && value.trim() ? [{ path, key, value: value.trim() }] : [],
+  );
+}
+
+function collectLegacyLosslessCompactionForAgent(params: {
+  cfg: OpenClawConfig;
+  agent: unknown;
+  path: string;
+  agentId?: string;
+  currentRuntime?: string;
+  inheritedModelRef?: string;
+  inheritedCompaction?: unknown;
+  inheritedCompactionPath?: string;
+}): LegacyLosslessCompactionConfig[] {
+  const agent = asMutableRecord(params.agent);
+  const compaction = asMutableRecord(agent?.compaction);
+  const inheritedCompaction = asMutableRecord(params.inheritedCompaction);
+  if (
+    !agentUsesCodexRuntimeForCompaction({
+      cfg: params.cfg,
+      agent,
+      agentId: params.agentId,
+      currentRuntime: params.currentRuntime,
+      inheritedModelRef: params.inheritedModelRef,
+    })
+  ) {
+    return [];
+  }
+  const localProvider = compaction?.provider;
+  const hasLocalProvider = typeof localProvider === "string" && localProvider.trim();
+  const providerValue = hasLocalProvider ? localProvider : inheritedCompaction?.provider;
+  if (normalizeString(providerValue) !== LOSSLESS_CONTEXT_ENGINE_ID) {
+    return [];
+  }
+  const compactionPath = hasLocalProvider
+    ? `${params.path}.compaction`
+    : (params.inheritedCompactionPath ?? `${params.path}.compaction`);
+  const localModel = compaction?.model;
+  const hasLocalModel = typeof localModel === "string" && localModel.trim();
+  const inheritedModel = inheritedCompaction?.model;
+  const modelValue = hasLocalModel ? localModel : inheritedModel;
+  const modelCompactionPath = hasLocalModel
+    ? `${params.path}.compaction`
+    : (params.inheritedCompactionPath ?? compactionPath);
+  return [
+    {
+      path: params.path,
+      compactionPath,
+      providerPath: `${compactionPath}.provider`,
+      providerValue: String(providerValue).trim(),
+      ...(typeof modelValue === "string" && modelValue.trim()
+        ? {
+            modelPath: `${modelCompactionPath}.model`,
+            modelValue: modelValue.trim(),
+          }
+        : {}),
+    },
+  ];
+}
+
+function dedupeLegacyLosslessCompactionConfigs(
+  hits: LegacyLosslessCompactionConfig[],
+): LegacyLosslessCompactionConfig[] {
+  const seen = new Set<string>();
+  return hits.filter((hit) => {
+    const key = `${hit.compactionPath}\0${hit.providerValue}\0${hit.modelPath ?? ""}\0${
+      hit.modelValue ?? ""
+    }`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function collectLegacyLosslessCompactionConfigs(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  ignoreLegacyAgentRuntimePins?: boolean;
+}): LegacyLosslessCompactionConfig[] {
+  const defaults = params.cfg.agents?.defaults;
+  const defaultsRuntime = params.ignoreLegacyAgentRuntimePins ? undefined : defaults?.agentRuntime;
+  const defaultModelRef = readAgentPrimaryModelRef(defaults);
+  const defaultCompaction = asMutableRecord(defaults?.compaction);
+  const hits = collectLegacyLosslessCompactionForAgent({
+    cfg: params.cfg,
+    agent: defaults,
+    path: "agents.defaults",
+    currentRuntime: resolveRuntime({ env: params.env, defaultsRuntime }),
+  });
+  const agents = Array.isArray(params.cfg.agents?.list) ? params.cfg.agents.list : [];
+  for (const [index, agent] of agents.entries()) {
+    const agentRecord = asMutableRecord(agent);
+    if (!agentRecord) {
+      continue;
+    }
+    const id =
+      typeof agentRecord.id === "string" && agentRecord.id.trim()
+        ? agentRecord.id.trim()
+        : String(index);
+    hits.push(
+      ...collectLegacyLosslessCompactionForAgent({
+        cfg: params.cfg,
+        agent: agentRecord,
+        path: `agents.list.${id}`,
+        agentId: id,
+        currentRuntime: resolveRuntime({
+          env: params.env,
+          agentRuntime: params.ignoreLegacyAgentRuntimePins
+            ? undefined
+            : asAgentRuntimePolicyConfig(agentRecord.agentRuntime),
+          defaultsRuntime,
+        }),
+        inheritedModelRef: defaultModelRef,
+        inheritedCompaction: defaultCompaction,
+        inheritedCompactionPath: "agents.defaults.compaction",
+      }),
+    );
+  }
+  return dedupeLegacyLosslessCompactionConfigs(hits);
+}
+
+function dedupeUnsupportedCompactionOverrides(
+  hits: UnsupportedCodexCompactionOverride[],
+): UnsupportedCodexCompactionOverride[] {
+  const seen = new Set<string>();
+  return hits.filter((hit) => {
+    const key = `${hit.path}\0${hit.key}\0${hit.value}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function collectUnsupportedCodexCompactionOverrides(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  ignoreLegacyAgentRuntimePins?: boolean;
+}): UnsupportedCodexCompactionOverride[] {
+  const defaults = params.cfg.agents?.defaults;
+  const defaultsRuntime = params.ignoreLegacyAgentRuntimePins ? undefined : defaults?.agentRuntime;
+  const defaultModelRef = readAgentPrimaryModelRef(defaults);
+  const defaultCompaction = asMutableRecord(defaults?.compaction);
+  const hits = collectUnsupportedCodexCompactionOverridesForAgent({
+    cfg: params.cfg,
+    agent: defaults,
+    path: "agents.defaults",
+    currentRuntime: resolveRuntime({ env: params.env, defaultsRuntime }),
+  });
+  const agents = Array.isArray(params.cfg.agents?.list) ? params.cfg.agents.list : [];
+  for (const [index, agent] of agents.entries()) {
+    const agentRecord = asMutableRecord(agent);
+    if (!agentRecord) {
+      continue;
+    }
+    const id =
+      typeof agentRecord.id === "string" && agentRecord.id.trim()
+        ? agentRecord.id.trim()
+        : String(index);
+    hits.push(
+      ...collectUnsupportedCodexCompactionOverridesForAgent({
+        cfg: params.cfg,
+        agent: agentRecord,
+        path: `agents.list.${id}`,
+        agentId: id,
+        currentRuntime: resolveRuntime({
+          env: params.env,
+          agentRuntime: params.ignoreLegacyAgentRuntimePins
+            ? undefined
+            : asAgentRuntimePolicyConfig(agentRecord.agentRuntime),
+          defaultsRuntime,
+        }),
+        inheritedModelRef: defaultModelRef,
+        inheritedCompaction: defaultCompaction,
+        inheritedCompactionPath: "agents.defaults.compaction",
+      }),
+    );
+  }
+  return dedupeUnsupportedCompactionOverrides(hits);
+}
+
+function getSharedDefaultCompactionOverrideConsumers(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  ignoreLegacyAgentRuntimePins?: boolean;
+}): SharedDefaultCompactionOverrideConsumers {
+  const consumers: SharedDefaultCompactionOverrideConsumers = { model: false, provider: false };
+  const defaults = params.cfg.agents?.defaults;
+  const defaultCompaction = asMutableRecord(defaults?.compaction);
+  if (!defaultCompaction) {
+    return consumers;
+  }
+  const hasDefaultModel =
+    typeof defaultCompaction.model === "string" && defaultCompaction.model.trim();
+  const hasDefaultProvider =
+    typeof defaultCompaction.provider === "string" && defaultCompaction.provider.trim();
+  if (!hasDefaultModel && !hasDefaultProvider) {
+    return consumers;
+  }
+  const defaultsRuntime = defaults?.agentRuntime;
+  const inheritedModelRef = readAgentPrimaryModelRef(defaults);
+  const defaultUsesCodexCompaction = agentUsesCodexRuntimeForCompaction({
+    cfg: params.cfg,
+    agent: defaults,
+    currentRuntime: resolveRuntime({
+      env: params.env,
+      defaultsRuntime: params.ignoreLegacyAgentRuntimePins ? undefined : defaultsRuntime,
+    }),
+  });
+  if (!defaultUsesCodexCompaction) {
+    consumers.model ||= Boolean(hasDefaultModel);
+    consumers.provider ||= Boolean(hasDefaultProvider);
+    if ((!hasDefaultModel || consumers.model) && (!hasDefaultProvider || consumers.provider)) {
+      return consumers;
+    }
+  }
+  const agents = Array.isArray(params.cfg.agents?.list) ? params.cfg.agents.list : [];
+  if (agents.length === 0) {
+    return consumers;
+  }
+  for (const [index, agent] of agents.entries()) {
+    const agentRecord = asMutableRecord(agent);
+    if (!agentRecord) {
+      continue;
+    }
+    const compaction = asMutableRecord(agentRecord.compaction);
+    const inheritsDefaultModel =
+      Boolean(hasDefaultModel) &&
+      !(typeof compaction?.model === "string" && compaction.model.trim());
+    const inheritsDefaultProvider =
+      Boolean(hasDefaultProvider) &&
+      !(typeof compaction?.provider === "string" && compaction.provider.trim());
+    if (!inheritsDefaultModel && !inheritsDefaultProvider) {
+      continue;
+    }
+    const id =
+      typeof agentRecord.id === "string" && agentRecord.id.trim()
+        ? agentRecord.id.trim()
+        : String(index);
+    const usesCodexCompaction = agentUsesCodexRuntimeForCompaction({
+      cfg: params.cfg,
+      agent: agentRecord,
+      agentId: id,
+      currentRuntime: resolveRuntime({
+        env: params.env,
+        agentRuntime: params.ignoreLegacyAgentRuntimePins
+          ? undefined
+          : asAgentRuntimePolicyConfig(agentRecord.agentRuntime),
+        defaultsRuntime: params.ignoreLegacyAgentRuntimePins ? undefined : defaultsRuntime,
+      }),
+      inheritedModelRef,
+    });
+    if (!usesCodexCompaction) {
+      consumers.model ||= inheritsDefaultModel;
+      consumers.provider ||= inheritsDefaultProvider;
+      if ((!hasDefaultModel || consumers.model) && (!hasDefaultProvider || consumers.provider)) {
+        break;
+      }
+    }
+  }
+  return consumers;
+}
+
+function sharedDefaultLosslessCompactionHasNonCodexConsumer(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  ignoreLegacyAgentRuntimePins?: boolean;
+}): boolean {
+  const defaults = params.cfg.agents?.defaults;
+  const defaultCompaction = asMutableRecord(defaults?.compaction);
+  const hasDefaultLosslessProvider =
+    normalizeString(defaultCompaction?.provider) === LOSSLESS_CONTEXT_ENGINE_ID;
+  const hasDefaultModel =
+    typeof defaultCompaction?.model === "string" && defaultCompaction.model.trim();
+  if (!hasDefaultLosslessProvider && !hasDefaultModel) {
+    return false;
+  }
+  const defaultsRuntime = params.ignoreLegacyAgentRuntimePins ? undefined : defaults?.agentRuntime;
+  const defaultUsesCodexCompaction = agentUsesCodexRuntimeForCompaction({
+    cfg: params.cfg,
+    agent: defaults,
+    currentRuntime: resolveRuntime({ env: params.env, defaultsRuntime }),
+  });
+  if (!defaultUsesCodexCompaction) {
+    return true;
+  }
+  const inheritedModelRef = readAgentPrimaryModelRef(defaults);
+  const agents = Array.isArray(params.cfg.agents?.list) ? params.cfg.agents.list : [];
+  for (const [index, agent] of agents.entries()) {
+    const agentRecord = asMutableRecord(agent);
+    if (!agentRecord) {
+      continue;
+    }
+    const compaction = asMutableRecord(agentRecord.compaction);
+    const inheritsDefaultProvider =
+      hasDefaultLosslessProvider &&
+      !(typeof compaction?.provider === "string" && compaction.provider.trim());
+    const inheritsDefaultModel =
+      Boolean(hasDefaultModel) &&
+      !(typeof compaction?.model === "string" && compaction.model.trim());
+    if (!inheritsDefaultProvider && !inheritsDefaultModel) {
+      continue;
+    }
+    const id =
+      typeof agentRecord.id === "string" && agentRecord.id.trim()
+        ? agentRecord.id.trim()
+        : String(index);
+    const usesCodexCompaction = agentUsesCodexRuntimeForCompaction({
+      cfg: params.cfg,
+      agent: agentRecord,
+      agentId: id,
+      currentRuntime: resolveRuntime({
+        env: params.env,
+        agentRuntime: params.ignoreLegacyAgentRuntimePins
+          ? undefined
+          : asAgentRuntimePolicyConfig(agentRecord.agentRuntime),
+        defaultsRuntime,
+      }),
+      inheritedModelRef,
+    });
+    if (!usesCodexCompaction) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function collectModelsMapRefs(params: {
@@ -478,7 +939,7 @@ function resolveCurrentRuntimeIdForCanonicalModel(params: {
   if (!parsed) {
     return "auto";
   }
-  const configured = normalizeString(
+  const configured = normalizeRuntimeString(
     resolveModelRuntimePolicy({
       config: params.cfg,
       provider: parsed.provider,
@@ -562,8 +1023,15 @@ function rewriteAgentModelRefs(params: {
   path: string;
   agentId?: string;
   currentRuntime?: string;
+  inheritedModelRef?: string;
+  inheritedCompaction?: unknown;
+  inheritedCompactionPath?: string;
   rewriteModelsMap?: boolean;
+  preserveUnsupportedCompactionOverrides?: SharedDefaultCompactionOverrideConsumers;
+  preserveUnsupportedCompactionPaths?: ReadonlySet<string>;
+  rewrittenInheritedCompactionModels?: Map<string, string>;
   runtimePolicyChanges: string[];
+  unsupportedCompactionChanges: string[];
 }): void {
   if (!params.agent) {
     return;
@@ -620,14 +1088,90 @@ function rewriteAgentModelRefs(params: {
     path: `${params.path}.subagents.model`,
   });
   const compaction = asMutableRecord(agent.compaction);
-  rewriteStringModelSlotIfCanonicalCodexRuntime({
+  const inheritedCompaction = asMutableRecord(params.inheritedCompaction);
+  const usesCodexCompaction = agentUsesCodexRuntimeForCompaction({
     cfg: params.cfg,
+    agent,
     agentId: params.agentId,
-    hits: params.hits,
-    container: compaction,
-    key: "model",
-    path: `${params.path}.compaction.model`,
+    currentRuntime: params.currentRuntime,
+    inheritedModelRef: params.inheritedModelRef,
   });
+  if (usesCodexCompaction) {
+    const effectiveCompactionProvider = compaction?.provider ?? inheritedCompaction?.provider;
+    if (normalizeString(effectiveCompactionProvider) === LOSSLESS_CONTEXT_ENGINE_ID) {
+      const start = params.hits.length;
+      rewriteStringModelSlot({
+        hits: params.hits,
+        container: compaction,
+        key: "model",
+        path: `${params.path}.compaction.model`,
+      });
+      preserveCodexRuntimePolicyForNewHits(start);
+      const localModel = typeof compaction?.model === "string" ? compaction.model.trim() : "";
+      const inheritedModelPath = params.inheritedCompactionPath
+        ? `${params.inheritedCompactionPath}.model`
+        : undefined;
+      if (
+        !localModel &&
+        inheritedModelPath &&
+        params.preserveUnsupportedCompactionPaths?.has(inheritedModelPath)
+      ) {
+        const inheritedStart = params.hits.length;
+        rewriteStringModelSlot({
+          hits: params.hits,
+          container: inheritedCompaction,
+          key: "model",
+          path: inheritedModelPath,
+        });
+        const inheritedHit = params.hits[inheritedStart];
+        const inheritedCanonicalModel =
+          inheritedHit?.canonicalModel ??
+          params.rewrittenInheritedCompactionModels?.get(inheritedModelPath);
+        if (inheritedHit) {
+          params.rewrittenInheritedCompactionModels?.set(
+            inheritedModelPath,
+            inheritedHit.canonicalModel,
+          );
+          preserveCodexRuntimePolicyForNewHits(inheritedStart);
+        } else if (inheritedCanonicalModel) {
+          ensureCodexRuntimePolicy({
+            cfg: params.cfg,
+            agent,
+            agentPath: params.path,
+            modelRef: inheritedCanonicalModel,
+            isDefaults: params.path === "agents.defaults",
+            changes: params.runtimePolicyChanges,
+          });
+        }
+      }
+    } else {
+      removeUnsupportedCodexCompactionOverrides({
+        agent,
+        compaction,
+        path: params.path,
+        preserve: params.preserveUnsupportedCompactionOverrides,
+        preservePaths: params.preserveUnsupportedCompactionPaths,
+        changes: params.unsupportedCompactionChanges,
+      });
+      if (params.preserveUnsupportedCompactionOverrides?.model) {
+        rewriteStringModelSlot({
+          hits: params.hits,
+          container: compaction,
+          key: "model",
+          path: `${params.path}.compaction.model`,
+        });
+      }
+    }
+  } else {
+    rewriteStringModelSlotIfCanonicalCodexRuntime({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      hits: params.hits,
+      container: compaction,
+      key: "model",
+      path: `${params.path}.compaction.model`,
+    });
+  }
   rewriteStringModelSlotIfCanonicalCodexRuntime({
     cfg: params.cfg,
     agentId: params.agentId,
@@ -645,6 +1189,309 @@ function rewriteAgentModelRefs(params: {
     });
     preserveCodexRuntimePolicyForNewHits(start);
   }
+}
+
+function removeUnsupportedCodexCompactionOverrides(params: {
+  agent: MutableRecord;
+  compaction: MutableRecord | undefined;
+  path: string;
+  preserve?: Partial<Record<CompactionOverrideKey, boolean>>;
+  preservePaths?: ReadonlySet<string>;
+  changes: string[];
+}): void {
+  if (!params.compaction) {
+    return;
+  }
+  if (normalizeString(params.compaction.provider) === LOSSLESS_CONTEXT_ENGINE_ID) {
+    return;
+  }
+  for (const key of COMPACTION_OVERRIDE_KEYS) {
+    const path = `${params.path}.compaction.${key}`;
+    if (params.preservePaths?.has(path)) {
+      continue;
+    }
+    if (params.preserve?.[key]) {
+      continue;
+    }
+    const value = params.compaction[key];
+    if (typeof value !== "string" || !value.trim()) {
+      continue;
+    }
+    delete params.compaction[key];
+    params.changes.push(`Removed ${path}; Codex runtime uses native server-side compaction.`);
+  }
+  if (Object.keys(params.compaction).length === 0) {
+    delete params.agent.compaction;
+  }
+}
+
+function readMutablePath(root: MutableRecord, pathLabel: string): MutableRecord | undefined {
+  const parts = pathLabel.split(".");
+  let cursor: unknown = root;
+  for (const part of parts) {
+    const record = asMutableRecord(cursor);
+    if (!record) {
+      return undefined;
+    }
+    cursor = record[part];
+  }
+  return asMutableRecord(cursor);
+}
+
+function readCompactionOwnerForPath(
+  cfg: OpenClawConfig,
+  ownerPath: string,
+): MutableRecord | undefined {
+  if (ownerPath === "agents.defaults") {
+    return asMutableRecord(cfg.agents?.defaults);
+  }
+  const prefix = "agents.list.";
+  if (!ownerPath.startsWith(prefix)) {
+    return readMutablePath(cfg as MutableRecord, ownerPath);
+  }
+  const label = ownerPath.slice(prefix.length);
+  const agents = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
+  const agentWithId = agents.find((agent) => agent.id === label);
+  if (agentWithId) {
+    return asMutableRecord(agentWithId);
+  }
+  const index = Number(label);
+  const candidate = Number.isInteger(index) ? agents[index] : undefined;
+  if (candidate) {
+    return asMutableRecord(candidate);
+  }
+  return undefined;
+}
+
+function removeMigratedLosslessCompactionKey(params: {
+  cfg: OpenClawConfig;
+  path: string;
+  key: CompactionOverrideKey;
+  changes: string[];
+  changeMessage: string;
+}): void {
+  const ownerPath = readCompactionOwnerPathForKeyPath(params.path);
+  const owner = readCompactionOwnerForPath(params.cfg, ownerPath);
+  const compaction = asMutableRecord(owner?.compaction);
+  if (!owner || !compaction) {
+    return;
+  }
+  const value = compaction[params.key];
+  if (typeof value !== "string" || !value.trim()) {
+    return;
+  }
+  delete compaction[params.key];
+  params.changes.push(params.changeMessage);
+  if (Object.keys(compaction).length === 0) {
+    delete owner.compaction;
+  }
+}
+
+function readCompactionOwnerPathForKeyPath(path: string): string {
+  return path.replace(/\.(model|provider)$/, "").replace(/\.compaction$/, "");
+}
+
+function legacyLosslessSummaryModels(hits: readonly LegacyLosslessCompactionConfig[]): string[] {
+  const models = new Set<string>();
+  for (const hit of hits) {
+    if (!hit.modelValue) {
+      continue;
+    }
+    models.add(
+      toCanonicalOpenAIModelRef(hit.modelValue) ?? normalizeDefaultProviderModelRef(hit.modelValue),
+    );
+  }
+  return [...models];
+}
+
+function preserveMigratedLosslessCodexRuntimePolicy(params: {
+  cfg: OpenClawConfig;
+  hits: readonly LegacyLosslessCompactionConfig[];
+  summaryModel: string | undefined;
+  changes: string[];
+}): void {
+  if (!params.summaryModel) {
+    return;
+  }
+  const preservedOwners = new Set<string>();
+  for (const hit of params.hits) {
+    if (!hit.modelValue || !isOpenAICodexModelRef(hit.modelValue)) {
+      continue;
+    }
+    const canonicalModel = toCanonicalOpenAIModelRef(hit.modelValue);
+    if (canonicalModel !== params.summaryModel) {
+      continue;
+    }
+    const ownerPath = readCompactionOwnerPathForKeyPath(hit.modelPath ?? hit.providerPath);
+    if (preservedOwners.has(ownerPath)) {
+      continue;
+    }
+    const owner = readCompactionOwnerForPath(params.cfg, ownerPath);
+    if (!owner) {
+      continue;
+    }
+    preservedOwners.add(ownerPath);
+    ensureCodexRuntimePolicy({
+      cfg: params.cfg,
+      agent: owner,
+      agentPath: ownerPath,
+      modelRef: params.summaryModel,
+      isDefaults: ownerPath === "agents.defaults",
+      changes: params.changes,
+    });
+  }
+}
+
+function canAutoMigrateLegacyLosslessCompaction(params: {
+  hits: readonly LegacyLosslessCompactionConfig[];
+  contextEngine?: string;
+  summaryModel?: string;
+}): boolean {
+  if (params.contextEngine && params.contextEngine !== LOSSLESS_CONTEXT_ENGINE_ID) {
+    return false;
+  }
+  const models = legacyLosslessSummaryModels(params.hits);
+  const hasProviderOnlyConsumer = params.hits.some((hit) => !hit.modelValue);
+  if (hasProviderOnlyConsumer && (models.length > 0 || params.summaryModel)) {
+    return false;
+  }
+  if (models.length === 0) {
+    return true;
+  }
+  if (params.summaryModel) {
+    return models.every((model) => model === params.summaryModel);
+  }
+  return models.length === 1;
+}
+
+function readLosslessSummaryModel(plugins: MutableRecord | undefined): string | undefined {
+  const entries = asMutableRecord(plugins?.entries);
+  const entry = asMutableRecord(entries?.[LOSSLESS_CONTEXT_ENGINE_ID]);
+  const config = asMutableRecord(entry?.config);
+  return typeof config?.summaryModel === "string" && config.summaryModel.trim()
+    ? config.summaryModel.trim()
+    : undefined;
+}
+
+function ensureMutablePath(root: MutableRecord, path: readonly string[]): MutableRecord {
+  let cursor = root;
+  for (const part of path) {
+    const next = asMutableRecord(cursor[part]) ?? {};
+    if (cursor[part] !== next) {
+      cursor[part] = next;
+    }
+    cursor = next;
+  }
+  return cursor;
+}
+
+function ensureLosslessLlmPolicy(params: {
+  entry: MutableRecord;
+  summaryModel: string | undefined;
+  changes: string[];
+}): void {
+  if (!params.summaryModel) {
+    return;
+  }
+  const llm = ensureMutablePath(params.entry, ["llm"]);
+  if (llm.allowModelOverride !== true) {
+    llm.allowModelOverride = true;
+    params.changes.push(
+      `Set plugins.entries.${LOSSLESS_CONTEXT_ENGINE_ID}.llm.allowModelOverride to true for Lossless summary model overrides.`,
+    );
+  }
+  const allowedModels = Array.isArray(llm.allowedModels) ? [...llm.allowedModels] : [];
+  if (!allowedModels.includes(params.summaryModel)) {
+    allowedModels.push(params.summaryModel);
+    llm.allowedModels = allowedModels;
+    params.changes.push(
+      `Added ${params.summaryModel} to plugins.entries.${LOSSLESS_CONTEXT_ENGINE_ID}.llm.allowedModels.`,
+    );
+  }
+}
+
+function maybeMigrateLegacyLosslessCompactionConfig(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  ignoreLegacyAgentRuntimePins?: boolean;
+}): string[] {
+  const root = params.cfg as MutableRecord;
+  const hits = collectLegacyLosslessCompactionConfigs(params);
+  if (hits.length === 0) {
+    return [];
+  }
+  const existingPlugins = asMutableRecord(root.plugins);
+  const existingSlots = asMutableRecord(existingPlugins?.slots);
+  const configuredContextEngine =
+    typeof existingSlots?.contextEngine === "string" && existingSlots.contextEngine.trim()
+      ? existingSlots.contextEngine.trim()
+      : undefined;
+  const existingSummaryModel = readLosslessSummaryModel(existingPlugins);
+  const contextEngine = normalizeString(configuredContextEngine);
+  if (
+    sharedDefaultLosslessCompactionHasNonCodexConsumer(params) ||
+    !canAutoMigrateLegacyLosslessCompaction({
+      hits,
+      contextEngine,
+      summaryModel: existingSummaryModel,
+    })
+  ) {
+    return [];
+  }
+  const plugins = ensureMutablePath(root, ["plugins"]);
+  const slots = ensureMutablePath(plugins, ["slots"]);
+  const changes: string[] = [];
+  const entries = ensureMutablePath(plugins, ["entries"]);
+  const entry = asMutableRecord(entries[LOSSLESS_CONTEXT_ENGINE_ID]) ?? {};
+  if (entries[LOSSLESS_CONTEXT_ENGINE_ID] !== entry) {
+    entries[LOSSLESS_CONTEXT_ENGINE_ID] = entry;
+  }
+  const config = ensureMutablePath(entry, ["config"]);
+  if (slots.contextEngine !== LOSSLESS_CONTEXT_ENGINE_ID) {
+    slots.contextEngine = LOSSLESS_CONTEXT_ENGINE_ID;
+    changes.push(
+      `Set plugins.slots.contextEngine to "${LOSSLESS_CONTEXT_ENGINE_ID}" for legacy Lossless compaction config.`,
+    );
+  }
+  if (entry.enabled !== true) {
+    entry.enabled = true;
+    changes.push(`Enabled plugins.entries.${LOSSLESS_CONTEXT_ENGINE_ID}.`);
+  }
+  let summaryModel = existingSummaryModel;
+  const firstModel = legacyLosslessSummaryModels(hits)[0];
+  if (!summaryModel && firstModel) {
+    summaryModel = firstModel;
+    config.summaryModel = summaryModel;
+    changes.push(
+      `Moved ${hits.find((hit) => hit.modelValue)?.modelPath ?? "legacy compaction model"} to plugins.entries.${LOSSLESS_CONTEXT_ENGINE_ID}.config.summaryModel.`,
+    );
+  }
+  ensureLosslessLlmPolicy({ entry, summaryModel, changes });
+  preserveMigratedLosslessCodexRuntimePolicy({
+    cfg: params.cfg,
+    hits,
+    summaryModel,
+    changes,
+  });
+  for (const hit of hits) {
+    removeMigratedLosslessCompactionKey({
+      cfg: params.cfg,
+      path: hit.providerPath,
+      key: "provider",
+      changes,
+      changeMessage: `Removed ${hit.providerPath}; Lossless now runs through plugins.slots.contextEngine.`,
+    });
+    if (hit.modelPath) {
+      removeMigratedLosslessCompactionKey({
+        cfg: params.cfg,
+        path: hit.modelPath,
+        key: "model",
+        changes,
+        changeMessage: `Removed ${hit.modelPath} after migrating the Lossless summary model.`,
+      });
+    }
+  }
+  return changes;
 }
 
 function ensureCodexRuntimePolicy(params: {
@@ -698,7 +1545,7 @@ function canonicalOpenAIModelUsesCodexRuntime(params: {
   if (!parsed) {
     return false;
   }
-  const configured = normalizeString(
+  const configured = normalizeRuntimeString(
     resolveModelRuntimePolicy({
       config: params.cfg,
       provider: parsed.provider,
@@ -832,14 +1679,47 @@ function clearConfigLegacyAgentRuntimePolicies(cfg: OpenClawConfig): string[] {
   return changes;
 }
 
-function rewriteConfigModelRefs(params: {
+function isCompactionOnlyRouteHit(hit: CodexRouteHit): boolean {
+  return (
+    hit.path.startsWith("agents.") &&
+    (hit.path.endsWith(".compaction.model") || hit.path.endsWith(".compaction.memoryFlush.model"))
+  );
+}
+
+function rewriteConfigModelRefsWithCompactionPolicy(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  preserveSharedDefaultCompactionOverrides: SharedDefaultCompactionOverrideConsumers;
+  ignoreLegacyAgentRuntimePins?: boolean;
 }): ConfigRouteRepairResult {
   const nextConfig = structuredClone(params.cfg);
   const hits: CodexRouteHit[] = [];
   const runtimePolicyChanges: string[] = [];
-  const defaultsRuntime = nextConfig.agents?.defaults?.agentRuntime;
+  const unsupportedCompactionChanges: string[] = [];
+  const ignoreLegacyAgentRuntimePins =
+    params.ignoreLegacyAgentRuntimePins ??
+    configRepairWouldClearLegacyRuntimePins({
+      cfg: nextConfig,
+      env: params.env,
+    });
+  unsupportedCompactionChanges.push(
+    ...maybeMigrateLegacyLosslessCompactionConfig({
+      cfg: nextConfig,
+      env: params.env,
+      ignoreLegacyAgentRuntimePins,
+    }),
+  );
+  const preservedLegacyLosslessCompactionPaths = new Set(
+    collectLegacyLosslessCompactionConfigs({
+      cfg: nextConfig,
+      env: params.env,
+      ignoreLegacyAgentRuntimePins,
+    }).flatMap((hit) => (hit.modelPath ? [hit.providerPath, hit.modelPath] : [hit.providerPath])),
+  );
+  const defaultsRuntime = ignoreLegacyAgentRuntimePins
+    ? undefined
+    : nextConfig.agents?.defaults?.agentRuntime;
+  const rewrittenInheritedCompactionModels = new Map<string, string>();
   rewriteAgentModelRefs({
     cfg: nextConfig,
     hits,
@@ -847,8 +1727,13 @@ function rewriteConfigModelRefs(params: {
     path: "agents.defaults",
     currentRuntime: resolveRuntime({ env: params.env, defaultsRuntime }),
     rewriteModelsMap: true,
+    preserveUnsupportedCompactionOverrides: params.preserveSharedDefaultCompactionOverrides,
+    preserveUnsupportedCompactionPaths: preservedLegacyLosslessCompactionPaths,
+    rewrittenInheritedCompactionModels,
     runtimePolicyChanges,
+    unsupportedCompactionChanges,
   });
+  const inheritedModelRef = readAgentPrimaryModelRef(nextConfig.agents?.defaults);
   const agents = Array.isArray(nextConfig.agents?.list) ? nextConfig.agents.list : [];
   for (const [index, agent] of agents.entries()) {
     const agentRecord = asMutableRecord(agent);
@@ -867,10 +1752,18 @@ function rewriteConfigModelRefs(params: {
       agentId: id,
       currentRuntime: resolveRuntime({
         env: params.env,
-        agentRuntime: asAgentRuntimePolicyConfig(agentRecord.agentRuntime),
+        agentRuntime: ignoreLegacyAgentRuntimePins
+          ? undefined
+          : asAgentRuntimePolicyConfig(agentRecord.agentRuntime),
         defaultsRuntime,
       }),
+      inheritedModelRef,
+      inheritedCompaction: nextConfig.agents?.defaults?.compaction,
+      inheritedCompactionPath: "agents.defaults.compaction",
+      preserveUnsupportedCompactionPaths: preservedLegacyLosslessCompactionPaths,
+      rewrittenInheritedCompactionModels,
       runtimePolicyChanges,
+      unsupportedCompactionChanges,
     });
   }
   const channelsModelByChannel = asMutableRecord(nextConfig.channels?.modelByChannel);
@@ -928,21 +1821,97 @@ function rewriteConfigModelRefs(params: {
     key: "model",
     path: "channels.discord.voice.model",
   });
-  const runtimePinChanges =
-    hits.length > 0 ? clearConfigLegacyAgentRuntimePolicies(nextConfig) : [];
+  const shouldClearRuntimePins = hits.some((hit) => !isCompactionOnlyRouteHit(hit));
+  const runtimePinChanges = shouldClearRuntimePins
+    ? clearConfigLegacyAgentRuntimePolicies(nextConfig)
+    : [];
   return {
     cfg:
-      hits.length > 0 || runtimePolicyChanges.length > 0 || runtimePinChanges.length > 0
+      hits.length > 0 ||
+      runtimePolicyChanges.length > 0 ||
+      runtimePinChanges.length > 0 ||
+      unsupportedCompactionChanges.length > 0
         ? nextConfig
         : params.cfg,
     changes: hits,
     runtimePinChanges,
     runtimePolicyChanges,
+    unsupportedCompactionChanges,
   };
+}
+
+function configRepairWouldClearLegacyRuntimePins(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  const dryRun = rewriteConfigModelRefsWithCompactionPolicy({
+    cfg: params.cfg,
+    env: params.env,
+    preserveSharedDefaultCompactionOverrides: { model: true, provider: true },
+    ignoreLegacyAgentRuntimePins: false,
+  });
+  return dryRun.changes.some((hit) => !isCompactionOnlyRouteHit(hit));
+}
+
+function rewriteConfigModelRefs(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): ConfigRouteRepairResult {
+  const preserveSharedDefaultCompactionOverrides = getSharedDefaultCompactionOverrideConsumers({
+    cfg: params.cfg,
+    env: params.env,
+    ignoreLegacyAgentRuntimePins: configRepairWouldClearLegacyRuntimePins(params),
+  });
+  return rewriteConfigModelRefsWithCompactionPolicy({
+    cfg: params.cfg,
+    env: params.env,
+    preserveSharedDefaultCompactionOverrides,
+  });
 }
 
 function formatCodexRouteChange(hit: CodexRouteHit): string {
   return `${hit.path}: ${hit.model} -> ${hit.canonicalModel}.`;
+}
+
+function formatUnsupportedCompactionWarning(params: {
+  hits: UnsupportedCodexCompactionOverride[];
+  fixHint: string;
+}): string {
+  return [
+    "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+    ...params.hits.map(
+      (hit) => `- ${hit.path}: ${hit.value} is ignored while this agent uses Codex runtime.`,
+    ),
+    params.fixHint,
+  ].join("\n");
+}
+
+function formatLegacyLosslessCompactionWarning(params: {
+  hits: LegacyLosslessCompactionConfig[];
+  canAutoFix: boolean;
+}): string {
+  const configLines: string[] = [];
+  const providerPaths = new Set<string>();
+  for (const hit of params.hits) {
+    if (!providerPaths.has(hit.providerPath)) {
+      providerPaths.add(hit.providerPath);
+      configLines.push(
+        `- ${hit.providerPath}: ${hit.providerValue} should become plugins.slots.contextEngine: ${LOSSLESS_CONTEXT_ENGINE_ID}.`,
+      );
+    }
+    if (hit.modelPath && hit.modelValue) {
+      configLines.push(
+        `- ${hit.modelPath}: ${hit.modelValue} should become plugins.entries.${LOSSLESS_CONTEXT_ENGINE_ID}.config.summaryModel.`,
+      );
+    }
+  }
+  return [
+    "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+    ...configLines,
+    params.canAutoFix
+      ? "- Run `openclaw doctor --fix`: it migrates legacy Lossless compaction config to the Lossless context-engine slot."
+      : "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+  ].join("\n");
 }
 
 export function collectCodexRouteWarnings(params: {
@@ -950,21 +1919,90 @@ export function collectCodexRouteWarnings(params: {
   env?: NodeJS.ProcessEnv;
 }): string[] {
   const hits = collectConfigModelRefs(params.cfg, params.env);
-  if (hits.length === 0) {
-    return [];
+  const ignoreLegacyAgentRuntimePins = configRepairWouldClearLegacyRuntimePins(params);
+  const legacyLosslessCompactionConfigs = collectLegacyLosslessCompactionConfigs({
+    ...params,
+    ignoreLegacyAgentRuntimePins,
+  });
+  const legacyLosslessCompactionPaths = new Set(
+    legacyLosslessCompactionConfigs.flatMap((hit) =>
+      hit.modelPath ? [hit.providerPath, hit.modelPath] : [hit.providerPath],
+    ),
+  );
+  const unsupportedCompactionOverrides = collectUnsupportedCodexCompactionOverrides({
+    ...params,
+    ignoreLegacyAgentRuntimePins,
+  }).filter((hit) => !legacyLosslessCompactionPaths.has(hit.path));
+  const sharedDefaultCompactionConsumers = getSharedDefaultCompactionOverrideConsumers({
+    cfg: params.cfg,
+    env: params.env,
+    ignoreLegacyAgentRuntimePins: configRepairWouldClearLegacyRuntimePins(params),
+  });
+  const sharedLosslessDefaultHasNonCodexConsumer =
+    sharedDefaultLosslessCompactionHasNonCodexConsumer({
+      ...params,
+      ignoreLegacyAgentRuntimePins,
+    });
+  const warnings: string[] = [];
+  if (hits.length > 0) {
+    warnings.push(
+      [
+        "- Legacy `openai-codex/*` model refs should be rewritten to `openai/*`.",
+        ...hits.map(
+          (hit) =>
+            `- ${hit.path}: ${hit.model} should become ${hit.canonicalModel}${
+              hit.runtime ? `; current runtime is "${hit.runtime}"` : ""
+            }.`,
+        ),
+        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
+      ].join("\n"),
+    );
   }
-  return [
-    [
-      "- Legacy `openai-codex/*` model refs should be rewritten to `openai/*`.",
-      ...hits.map(
-        (hit) =>
-          `- ${hit.path}: ${hit.model} should become ${hit.canonicalModel}${
-            hit.runtime ? `; current runtime is "${hit.runtime}"` : ""
-          }.`,
-      ),
-      "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
-    ].join("\n"),
-  ];
+  if (legacyLosslessCompactionConfigs.length > 0) {
+    const plugins = asMutableRecord(params.cfg.plugins);
+    const contextEngine = normalizeString(asMutableRecord(plugins?.slots)?.contextEngine);
+    warnings.push(
+      formatLegacyLosslessCompactionWarning({
+        hits: legacyLosslessCompactionConfigs,
+        canAutoFix:
+          !sharedLosslessDefaultHasNonCodexConsumer &&
+          canAutoMigrateLegacyLosslessCompaction({
+            hits: legacyLosslessCompactionConfigs,
+            contextEngine,
+            summaryModel: readLosslessSummaryModel(plugins),
+          }),
+      }),
+    );
+  }
+  const preservedSharedDefaultHits = unsupportedCompactionOverrides.filter(
+    (hit) =>
+      hit.path.startsWith("agents.defaults.compaction.") &&
+      sharedDefaultCompactionConsumers[hit.key],
+  );
+  const fixableHits = unsupportedCompactionOverrides.filter(
+    (hit) =>
+      !hit.path.startsWith("agents.defaults.compaction.") ||
+      !sharedDefaultCompactionConsumers[hit.key],
+  );
+  if (preservedSharedDefaultHits.length > 0) {
+    warnings.push(
+      formatUnsupportedCompactionWarning({
+        hits: preservedSharedDefaultHits,
+        fixHint:
+          "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
+      }),
+    );
+  }
+  if (fixableHits.length > 0) {
+    warnings.push(
+      formatUnsupportedCompactionWarning({
+        hits: fixableHits,
+        fixHint:
+          "- Run `openclaw doctor --fix`: it removes unsupported Codex compaction overrides.",
+      }),
+    );
+  }
+  return warnings;
 }
 
 export function maybeRepairCodexRoutes(params: {
@@ -974,7 +2012,22 @@ export function maybeRepairCodexRoutes(params: {
   codexRuntimeReady?: boolean;
 }): { cfg: OpenClawConfig; warnings: string[]; changes: string[] } {
   const hits = collectConfigModelRefs(params.cfg, params.env);
-  if (hits.length === 0) {
+  const ignoreLegacyAgentRuntimePins = configRepairWouldClearLegacyRuntimePins(params);
+  const unsupportedCompactionOverrides = collectUnsupportedCodexCompactionOverrides({
+    cfg: params.cfg,
+    env: params.env,
+    ignoreLegacyAgentRuntimePins,
+  });
+  const legacyLosslessCompactionConfigs = collectLegacyLosslessCompactionConfigs({
+    cfg: params.cfg,
+    env: params.env,
+    ignoreLegacyAgentRuntimePins,
+  });
+  if (
+    hits.length === 0 &&
+    unsupportedCompactionOverrides.length === 0 &&
+    legacyLosslessCompactionConfigs.length === 0
+  ) {
     return { cfg: params.cfg, warnings: [], changes: [] };
   }
   if (!params.shouldRepair) {
@@ -1000,7 +2053,12 @@ export function maybeRepairCodexRoutes(params: {
   return {
     cfg: repaired.cfg,
     warnings,
-    changes: [...changes, ...repaired.runtimePolicyChanges, ...repaired.runtimePinChanges],
+    changes: [
+      ...changes,
+      ...repaired.runtimePolicyChanges,
+      ...repaired.runtimePinChanges,
+      ...repaired.unsupportedCompactionChanges,
+    ],
   };
 }
 

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -181,6 +181,7 @@ export {
   isActiveHarnessContextEngine,
   runHarnessContextEngineMaintenance,
 } from "../agents/harness/context-engine-lifecycle.js";
+export { resolveContextEngineOwnerPluginId } from "../context-engine/registry.js";
 export {
   runAgentHarnessAfterToolCallHook,
   runAgentHarnessBeforeMessageWriteHook,


### PR DESCRIPTION
## Summary
- Keep Codex app-server compaction on native Codex thread compaction; no context-engine summarizer fallback or primary path for Codex-runtime sessions.
- Preserve Lossless by treating it as a context engine through `plugins.slots.contextEngine`, with agent/plugin runtime context passed into its maintenance LLM policy.
- Add `openclaw doctor --fix` migration/warnings for stale Codex compaction overrides, legacy Lossless `compaction.provider`, and legacy `codex-app-server` runtime aliases.

## Verification
Behavior addressed: Fixes #82008 OAuth compaction auth mismatch. Codex OAuth compaction no longer calls the OpenClaw/Public OpenAI Responses summarizer path, while Lossless remains supported through the context-engine slot.

Real environment tested:
- Baseline reproduction on origin/main: `tbx_01krn641yf4ppdtbb0kappkjbx`, Actions https://github.com/openclaw/openclaw/actions/runs/25904490545 (failed as expected: contextEngine.compact called for Codex compaction and warning absent).
- PR Testbox: `tbx_01krnafa4hbkrdpz35b8f5sx6w`, Actions https://github.com/openclaw/openclaw/actions/runs/25907207989 (passed).
- Edge-case Testbox: `tbx_01krnf6zh784p07gzpejccwwn2`, Actions https://github.com/openclaw/openclaw/actions/runs/25910432813 (passed).
- Security fix Testbox: `tbx_01krng2knqeyv0nb9g0x5e01tr`, Actions https://github.com/openclaw/openclaw/actions/runs/25911067410 (passed).
- Sibling Codex checkout: `../codex` on `main` at `6a225e4005`, clean worktree.

Exact steps or command run after this patch:
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/commands/doctor/shared/codex-route-warnings.test.ts extensions/codex/src/app-server/compact.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts extensions/codex/src/app-server/compact.test.ts`
- `pnpm plugin-sdk:api:check`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode branch`
- `(cd ../codex/codex-rs && cargo test -p codex-app-server thread_compact_start_triggers_compaction_and_returns_empty_response)`

Evidence after fix:
- Focused tests passed: doctor 59; Codex app-server/context-engine 22.
- Additional review-run focused test passed: 72 tests across doctor + Codex compaction.
- Plugin SDK API baseline check passed.
- Codex review final run reported no accepted/actionable findings.
- Codex app-server source confirms `thread/compact/start` takes `threadId`, submits `Op::Compact`, returns `{}`, and emits `contextCompaction` item started/completed notifications; the targeted sibling Codex test passed.
- Testbox runs above show before failure and after passes.

Observed result after fix:
- Codex app-server compaction starts native thread compaction and never invokes `contextEngine.compact()` as fallback/primary summarizer.
- OpenClaw's Codex adapter waits for the Codex-native completion signals that the sibling Codex app-server contract documents and tests: `contextCompaction` item completion, with deprecated `thread/compacted` still tolerated.
- Stale OpenClaw compaction summarizer overrides warn at runtime and are removed by doctor when safe, including legacy `codex-app-server` runtime alias configs.
- Legacy Lossless config migrates to `plugins.slots.contextEngine = "lossless-claw"` with bounded `summaryModel` policy; unsafe mixed/conflicting configs stay intact with manual warnings.
- Migrated or blocked `openai-codex/*` Lossless summary models keep Codex runtime policy after canonicalizing to `openai/*`, including inherited default summary models and per-agent local compaction-only refs.
- Doctor keeps whole-agent runtime pins when only compaction-only refs are canonicalized and suppresses ignored-override warnings for pins it will clear during route repair.
- Runtime ignored-override warnings report inherited provider paths at their source path.
- Lossless active context engine does not produce ignored-override warnings, including inherited provider configs.

What was not tested:
- No live installed Lossless package against a real user install in this PR pass; covered by contract/unit tests, local project fixtures, Testbox lanes, and sibling Codex app-server contract verification.
