### PR TITLE
fix(memory): skip placeholder short-term promotions

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1166,14 +1166,6 @@ describe("short-term promotion", () => {
 
   it("does not record placeholder-only grounded candidates for promotion", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      await writeDailyMemoryNote(workspaceDir, "2026-04-18", [
-        "## Tagesnotizen",
-        "-",
-        "",
-        "## Entscheidungen",
-        "-",
-      ]);
-
       await recordGroundedShortTermCandidates({
         workspaceDir,
         query: "__dreaming_grounded_backfill__",
@@ -1192,20 +1184,28 @@ describe("short-term promotion", () => {
         nowMs: Date.parse("2026-04-18T10:00:00.000Z"),
       });
 
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-      });
-
-      expect(ranked).toStrictEqual([]);
+      await expectEnoent(fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8"));
     });
   });
 
-  it("does not rank or apply already stored placeholder snippets", async () => {
+  it("skips stored placeholders while allowing durable heading bullets", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      await writeDailyMemoryNote(workspaceDir, "2026-04-18", ["## Tagesnotizen", "-"]);
+      const entry = (snippet: string, line: number) => ({
+        key: snippet,
+        path: "memory/2026-04-18.md",
+        startLine: line,
+        endLine: line,
+        source: "memory",
+        snippet,
+        recallCount: 3,
+        totalScore: 2.8,
+        maxScore: 0.95,
+      });
+      await writeDailyMemoryNote(workspaceDir, "2026-04-18", [
+        "## Tagesnotizen",
+        "- ## Entscheidungen",
+        "- ## Decision: Move backups to S3",
+      ]);
       await fs.writeFile(
         resolveShortTermRecallStorePath(workspaceDir),
         JSON.stringify(
@@ -1213,24 +1213,8 @@ describe("short-term promotion", () => {
             version: 1,
             updatedAt: "2026-04-18T10:00:00.000Z",
             entries: {
-              placeholder: {
-                key: "placeholder",
-                path: "memory/2026-04-18.md",
-                startLine: 2,
-                endLine: 2,
-                source: "memory",
-                snippet: "- ## Entscheidungen",
-                recallCount: 3,
-                dailyCount: 0,
-                groundedCount: 0,
-                totalScore: 2.8,
-                maxScore: 0.95,
-                firstRecalledAt: "2026-04-18T10:00:00.000Z",
-                lastRecalledAt: "2026-04-18T10:00:00.000Z",
-                queryHashes: ["a", "b"],
-                recallDays: ["2026-04-18"],
-                conceptTags: [],
-              },
+              placeholder: entry("- ## Entscheidungen", 2),
+              durable: entry("- ## Decision: Move backups to S3", 3),
             },
           },
           null,
@@ -1245,50 +1229,21 @@ describe("short-term promotion", () => {
         minRecallCount: 0,
         minUniqueQueries: 0,
       });
-      expect(ranked).toStrictEqual([]);
+      expect(ranked).toHaveLength(1);
+      expect(ranked[0]?.snippet).toBe("- ## Decision: Move backups to S3");
 
       const applied = await applyShortTermPromotions({
         workspaceDir,
         minScore: 0,
         minRecallCount: 0,
         minUniqueQueries: 0,
-        candidates: [
-          {
-            key: "manual-placeholder",
-            path: "memory/2026-04-18.md",
-            startLine: 2,
-            endLine: 2,
-            source: "memory",
-            snippet: "- ## Entscheidungen",
-            recallCount: 3,
-            dailyCount: 0,
-            groundedCount: 0,
-            signalCount: 3,
-            avgScore: 0.92,
-            maxScore: 0.95,
-            uniqueQueries: 2,
-            firstRecalledAt: "2026-04-18T10:00:00.000Z",
-            lastRecalledAt: "2026-04-18T10:00:00.000Z",
-            ageDays: 0,
-            score: 0.9,
-            recallDays: ["2026-04-18"],
-            conceptTags: [],
-            components: {
-              frequency: 1,
-              relevance: 0.9,
-              diversity: 1,
-              recency: 1,
-              consolidation: 1,
-              conceptual: 0,
-            },
-          },
-        ],
+        candidates: ranked,
       });
 
-      expect(applied.applied).toBe(0);
-      await expect(
-        fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"),
-      ).rejects.toMatchObject({ code: "ENOENT" });
+      expect(applied.applied).toBe(1);
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).toContain("- ## Decision: Move backups to S3");
+      expect(memoryText).not.toContain("- ## Entscheidungen");
     });
   });
 

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1161,6 +1161,7 @@ describe("short-term promotion", () => {
     expect(testing.isUnpromotableShortTermSnippet("- Keep gateway restarts supervised.")).toBe(
       false,
     );
+    expect(testing.isUnpromotableShortTermSnippet("- ## Decision: Move backups to S3")).toBe(false);
   });
 
   it("does not record placeholder-only grounded candidates for promotion", async () => {

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1165,6 +1165,8 @@ describe("short-term promotion", () => {
     );
     expect(testing.isUnpromotableShortTermSnippet("## Decision: Move backups to S3")).toBe(false);
     expect(testing.isUnpromotableShortTermSnippet("- ## Decision: Move backups to S3")).toBe(false);
+    expect(testing.isUnpromotableShortTermSnippet("## Decision move backups to S3")).toBe(false);
+    expect(testing.isUnpromotableShortTermSnippet("- ## Decision move backups to S3")).toBe(false);
   });
 
   it("does not record placeholder-only grounded candidates for promotion", async () => {
@@ -1207,7 +1209,7 @@ describe("short-term promotion", () => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-18", [
         "## Tagesnotizen",
         "- ## Entscheidungen",
-        "- ## Decision: Move backups to S3",
+        "- ## Decision move backups to S3",
       ]);
       await fs.writeFile(
         resolveShortTermRecallStorePath(workspaceDir),
@@ -1217,7 +1219,7 @@ describe("short-term promotion", () => {
             updatedAt: "2026-04-18T10:00:00.000Z",
             entries: {
               placeholder: entry("- ## Entscheidungen", 2),
-              durable: entry("- ## Decision: Move backups to S3", 3),
+              durable: entry("- ## Decision move backups to S3", 3),
             },
           },
           null,
@@ -1233,7 +1235,7 @@ describe("short-term promotion", () => {
         minUniqueQueries: 0,
       });
       expect(ranked).toHaveLength(1);
-      expect(ranked[0]?.snippet).toBe("- ## Decision: Move backups to S3");
+      expect(ranked[0]?.snippet).toBe("- ## Decision move backups to S3");
 
       const applied = await applyShortTermPromotions({
         workspaceDir,
@@ -1245,7 +1247,7 @@ describe("short-term promotion", () => {
 
       expect(applied.applied).toBe(1);
       const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
-      expect(memoryText).toContain("- ## Decision: Move backups to S3");
+      expect(memoryText).toContain("- ## Decision move backups to S3");
       expect(memoryText).not.toContain("- ## Entscheidungen");
     });
   });

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1152,7 +1152,9 @@ describe("short-term promotion", () => {
       "|",
       "[]",
       "## Tagesnotizen\n-\n\n## Entscheidungen\n-",
+      "## Tagesnotizen\n## Entscheidungen",
       "## Tagesnotizen - ## Entscheidungen -",
+      "## Tagesnotizen ## Entscheidungen",
       "- ## Entscheidungen",
     ]) {
       expect(testing.isUnpromotableShortTermSnippet(snippet)).toBe(true);
@@ -1161,6 +1163,7 @@ describe("short-term promotion", () => {
     expect(testing.isUnpromotableShortTermSnippet("- Keep gateway restarts supervised.")).toBe(
       false,
     );
+    expect(testing.isUnpromotableShortTermSnippet("## Decision: Move backups to S3")).toBe(false);
     expect(testing.isUnpromotableShortTermSnippet("- ## Decision: Move backups to S3")).toBe(false);
   });
 

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1153,6 +1153,7 @@ describe("short-term promotion", () => {
       "[]",
       "## Tagesnotizen",
       "## Notes",
+      "## Notes:",
       "## Tagesnotizen\n-\n\n## Entscheidungen\n-",
       "## Tagesnotizen\n## Entscheidungen",
       "## Tagesnotizen - ## Entscheidungen -",
@@ -1172,6 +1173,7 @@ describe("short-term promotion", () => {
     expect(testing.isUnpromotableShortTermSnippet("- ## Decision move backups to S3")).toBe(false);
     expect(testing.isUnpromotableShortTermSnippet("## API keys rotated")).toBe(false);
     expect(testing.isUnpromotableShortTermSnippet("- ## VPN outage fix")).toBe(false);
+    expect(testing.isUnpromotableShortTermSnippet("## Notes: VPN outage fix")).toBe(false);
     expect(testing.isUnpromotableShortTermSnippet("## Prod outage")).toBe(false);
     expect(testing.isUnpromotableShortTermSnippet("## 修复备份轮换")).toBe(false);
   });

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1142,6 +1142,154 @@ describe("short-term promotion", () => {
     ).toBe(false);
   });
 
+  it("treats markdown skeleton snippets as unpromotable", () => {
+    for (const snippet of [
+      "-",
+      "* ",
+      "- -",
+      ">",
+      "```",
+      "|",
+      "[]",
+      "## Tagesnotizen\n-\n\n## Entscheidungen\n-",
+      "## Tagesnotizen - ## Entscheidungen -",
+    ]) {
+      expect(__testing.isUnpromotableShortTermSnippet(snippet)).toBe(true);
+    }
+
+    expect(__testing.isUnpromotableShortTermSnippet("- Keep gateway restarts supervised.")).toBe(
+      false,
+    );
+  });
+
+  it("does not record placeholder-only grounded candidates for promotion", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-18", [
+        "## Tagesnotizen",
+        "-",
+        "",
+        "## Entscheidungen",
+        "-",
+      ]);
+
+      await recordGroundedShortTermCandidates({
+        workspaceDir,
+        query: "__dreaming_grounded_backfill__",
+        items: [
+          {
+            path: "memory/2026-04-18.md",
+            startLine: 2,
+            endLine: 2,
+            snippet: "-",
+            score: 0.92,
+            query: "__dreaming_grounded_backfill__:placeholder",
+            signalCount: 3,
+            dayBucket: "2026-04-18",
+          },
+        ],
+        nowMs: Date.parse("2026-04-18T10:00:00.000Z"),
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(ranked).toStrictEqual([]);
+    });
+  });
+
+  it("does not rank or apply already stored placeholder snippets", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-18", ["## Tagesnotizen", "-"]);
+      await fs.writeFile(
+        resolveShortTermRecallStorePath(workspaceDir),
+        JSON.stringify(
+          {
+            version: 1,
+            updatedAt: "2026-04-18T10:00:00.000Z",
+            entries: {
+              placeholder: {
+                key: "placeholder",
+                path: "memory/2026-04-18.md",
+                startLine: 2,
+                endLine: 2,
+                source: "memory",
+                snippet: "-",
+                recallCount: 3,
+                dailyCount: 0,
+                groundedCount: 0,
+                totalScore: 2.8,
+                maxScore: 0.95,
+                firstRecalledAt: "2026-04-18T10:00:00.000Z",
+                lastRecalledAt: "2026-04-18T10:00:00.000Z",
+                queryHashes: ["a", "b"],
+                recallDays: ["2026-04-18"],
+                conceptTags: [],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      expect(ranked).toStrictEqual([]);
+
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        candidates: [
+          {
+            key: "manual-placeholder",
+            path: "memory/2026-04-18.md",
+            startLine: 2,
+            endLine: 2,
+            source: "memory",
+            snippet: "-",
+            recallCount: 3,
+            dailyCount: 0,
+            groundedCount: 0,
+            signalCount: 3,
+            avgScore: 0.92,
+            maxScore: 0.95,
+            uniqueQueries: 2,
+            firstRecalledAt: "2026-04-18T10:00:00.000Z",
+            lastRecalledAt: "2026-04-18T10:00:00.000Z",
+            ageDays: 0,
+            score: 0.9,
+            recallDays: ["2026-04-18"],
+            conceptTags: [],
+            components: {
+              frequency: 1,
+              relevance: 0.9,
+              diversity: 1,
+              recency: 1,
+              consolidation: 1,
+              conceptual: 0,
+            },
+          },
+        ],
+      });
+
+      expect(applied.applied).toBe(0);
+      await expect(
+        fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
   describe("lineRangeOverlapsDreamingFence", () => {
     it("returns true when the range falls inside a Light Sleep fence", () => {
       const lines = [

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1153,11 +1153,12 @@ describe("short-term promotion", () => {
       "[]",
       "## Tagesnotizen\n-\n\n## Entscheidungen\n-",
       "## Tagesnotizen - ## Entscheidungen -",
+      "- ## Entscheidungen",
     ]) {
-      expect(__testing.isUnpromotableShortTermSnippet(snippet)).toBe(true);
+      expect(testing.isUnpromotableShortTermSnippet(snippet)).toBe(true);
     }
 
-    expect(__testing.isUnpromotableShortTermSnippet("- Keep gateway restarts supervised.")).toBe(
+    expect(testing.isUnpromotableShortTermSnippet("- Keep gateway restarts supervised.")).toBe(
       false,
     );
   });
@@ -1217,7 +1218,7 @@ describe("short-term promotion", () => {
                 startLine: 2,
                 endLine: 2,
                 source: "memory",
-                snippet: "-",
+                snippet: "- ## Entscheidungen",
                 recallCount: 3,
                 dailyCount: 0,
                 groundedCount: 0,
@@ -1257,7 +1258,7 @@ describe("short-term promotion", () => {
             startLine: 2,
             endLine: 2,
             source: "memory",
-            snippet: "-",
+            snippet: "- ## Entscheidungen",
             recallCount: 3,
             dailyCount: 0,
             groundedCount: 0,

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1155,6 +1155,7 @@ describe("short-term promotion", () => {
       "## Tagesnotizen\n## Entscheidungen",
       "## Tagesnotizen - ## Entscheidungen -",
       "## Tagesnotizen ## Entscheidungen",
+      "## Tagesnotizen ## Entscheidungen ## Aufgaben",
       "- ## Entscheidungen",
     ]) {
       expect(testing.isUnpromotableShortTermSnippet(snippet)).toBe(true);
@@ -1167,6 +1168,8 @@ describe("short-term promotion", () => {
     expect(testing.isUnpromotableShortTermSnippet("- ## Decision: Move backups to S3")).toBe(false);
     expect(testing.isUnpromotableShortTermSnippet("## Decision move backups to S3")).toBe(false);
     expect(testing.isUnpromotableShortTermSnippet("- ## Decision move backups to S3")).toBe(false);
+    expect(testing.isUnpromotableShortTermSnippet("## API keys rotated")).toBe(false);
+    expect(testing.isUnpromotableShortTermSnippet("- ## VPN outage fix")).toBe(false);
   });
 
   it("does not record placeholder-only grounded candidates for promotion", async () => {
@@ -1209,7 +1212,7 @@ describe("short-term promotion", () => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-18", [
         "## Tagesnotizen",
         "- ## Entscheidungen",
-        "- ## Decision move backups to S3",
+        "- ## VPN outage fix",
       ]);
       await fs.writeFile(
         resolveShortTermRecallStorePath(workspaceDir),
@@ -1219,7 +1222,7 @@ describe("short-term promotion", () => {
             updatedAt: "2026-04-18T10:00:00.000Z",
             entries: {
               placeholder: entry("- ## Entscheidungen", 2),
-              durable: entry("- ## Decision move backups to S3", 3),
+              durable: entry("- ## VPN outage fix", 3),
             },
           },
           null,
@@ -1235,7 +1238,7 @@ describe("short-term promotion", () => {
         minUniqueQueries: 0,
       });
       expect(ranked).toHaveLength(1);
-      expect(ranked[0]?.snippet).toBe("- ## Decision move backups to S3");
+      expect(ranked[0]?.snippet).toBe("- ## VPN outage fix");
 
       const applied = await applyShortTermPromotions({
         workspaceDir,
@@ -1247,7 +1250,7 @@ describe("short-term promotion", () => {
 
       expect(applied.applied).toBe(1);
       const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
-      expect(memoryText).toContain("- ## Decision move backups to S3");
+      expect(memoryText).toContain("- ## VPN outage fix");
       expect(memoryText).not.toContain("- ## Entscheidungen");
     });
   });

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1151,6 +1151,8 @@ describe("short-term promotion", () => {
       "```",
       "|",
       "[]",
+      "## Tagesnotizen",
+      "## Notes",
       "## Tagesnotizen\n-\n\n## Entscheidungen\n-",
       "## Tagesnotizen\n## Entscheidungen",
       "## Tagesnotizen - ## Entscheidungen -",
@@ -1170,6 +1172,8 @@ describe("short-term promotion", () => {
     expect(testing.isUnpromotableShortTermSnippet("- ## Decision move backups to S3")).toBe(false);
     expect(testing.isUnpromotableShortTermSnippet("## API keys rotated")).toBe(false);
     expect(testing.isUnpromotableShortTermSnippet("- ## VPN outage fix")).toBe(false);
+    expect(testing.isUnpromotableShortTermSnippet("## Prod outage")).toBe(false);
+    expect(testing.isUnpromotableShortTermSnippet("## 修复备份轮换")).toBe(false);
   });
 
   it("does not record placeholder-only grounded candidates for promotion", async () => {
@@ -1212,7 +1216,7 @@ describe("short-term promotion", () => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-18", [
         "## Tagesnotizen",
         "- ## Entscheidungen",
-        "- ## VPN outage fix",
+        "- ## 修复备份轮换",
       ]);
       await fs.writeFile(
         resolveShortTermRecallStorePath(workspaceDir),
@@ -1222,7 +1226,7 @@ describe("short-term promotion", () => {
             updatedAt: "2026-04-18T10:00:00.000Z",
             entries: {
               placeholder: entry("- ## Entscheidungen", 2),
-              durable: entry("- ## VPN outage fix", 3),
+              durable: entry("- ## 修复备份轮换", 3),
             },
           },
           null,
@@ -1238,7 +1242,7 @@ describe("short-term promotion", () => {
         minUniqueQueries: 0,
       });
       expect(ranked).toHaveLength(1);
-      expect(ranked[0]?.snippet).toBe("- ## VPN outage fix");
+      expect(ranked[0]?.snippet).toBe("- ## 修复备份轮换");
 
       const applied = await applyShortTermPromotions({
         workspaceDir,
@@ -1250,7 +1254,7 @@ describe("short-term promotion", () => {
 
       expect(applied.applied).toBe(1);
       const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
-      expect(memoryText).toContain("- ## VPN outage fix");
+      expect(memoryText).toContain("- ## 修复备份轮换");
       expect(memoryText).not.toContain("- ## Entscheidungen");
     });
   });

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -336,7 +336,13 @@ function isMarkdownSkeletonSnippet(raw: string): boolean {
       continue;
     }
     if (/^#{1,6}\s+\S/.test(withoutLeadingMarkers)) {
-      if (/^#{1,6}\s+.+:\s*\S/.test(withoutLeadingMarkers)) {
+      const headingBody = withoutLeadingMarkers
+        .replace(/^#{1,6}\s+/, "")
+        .replace(/#{1,6}\s*/g, " ")
+        .trim();
+      const headingWords = headingBody.match(/[\p{L}\p{N}][\p{L}\p{N}'-]*/gu) ?? [];
+      // Short heading-only snippets are usually template scaffolding; longer headings carry memory text.
+      if (/:\s*\S/.test(headingBody) || headingWords.length >= 4) {
         return false;
       }
       hasPlaceholderLine = true;

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -334,7 +334,7 @@ const MARKDOWN_SKELETON_HEADING_BODIES = new Set([
 
 function normalizeMarkdownSkeletonHeadingBody(raw: string): string {
   return raw
-    .replace(/[-*+>`_[\](){}|~.,;!?]+/g, " ")
+    .replace(/[-*+>`_[\](){}|~.,;:!?]+/g, " ")
     .replace(/\s+/g, " ")
     .trim()
     .toLowerCase();

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -319,27 +319,6 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   return hasNarrativeLead && hasConfidence && hasEvidence && hasStatus && hasRecalls;
 }
 
-function stripMarkdownLeadingMarkers(raw: string): string {
-  return raw.replace(/^(?:[-*+>]\s*)+/, "").trim();
-}
-
-function markdownHeadingHasInlinePayload(raw: string): boolean {
-  const headingText = raw.replace(/^#{1,6}\s+/, "").trim();
-  return /:\s*\S/.test(headingText);
-}
-
-function isMarkdownMarkerOnlyLine(raw: string): boolean {
-  const line = raw.trim();
-  if (!line) {
-    return true;
-  }
-  const withoutLeadingMarkers = stripMarkdownLeadingMarkers(line);
-  if (!withoutLeadingMarkers) {
-    return true;
-  }
-  return !/[\p{L}\p{N}]/u.test(withoutLeadingMarkers);
-}
-
 function isMarkdownSkeletonSnippet(raw: string): boolean {
   const nonEmptyLines = raw
     .split(/\r?\n/)
@@ -351,13 +330,13 @@ function isMarkdownSkeletonSnippet(raw: string): boolean {
 
   let hasPlaceholderLine = false;
   for (const line of nonEmptyLines) {
-    if (isMarkdownMarkerOnlyLine(line)) {
+    const withoutLeadingMarkers = line.replace(/^(?:[-*+>]\s*)+/, "").trim();
+    if (!withoutLeadingMarkers || !/[\p{L}\p{N}]/u.test(withoutLeadingMarkers)) {
       hasPlaceholderLine = true;
       continue;
     }
-    const withoutLeadingMarkers = stripMarkdownLeadingMarkers(line);
     if (/^#{1,6}\s+\S/.test(withoutLeadingMarkers)) {
-      if (markdownHeadingHasInlinePayload(withoutLeadingMarkers)) {
+      if (/^#{1,6}\s+.+:\s*\S/.test(withoutLeadingMarkers)) {
         return false;
       }
       if (withoutLeadingMarkers !== line) {
@@ -379,9 +358,6 @@ function isUnpromotableShortTermSnippet(raw: string): boolean {
     return true;
   }
   if (isContaminatedDreamingSnippet(snippet)) {
-    return true;
-  }
-  if (isMarkdownMarkerOnlyLine(snippet)) {
     return true;
   }
   return isMarkdownSkeletonSnippet(raw);
@@ -1484,12 +1460,6 @@ function compareCandidateWindow(
   windowSnippet: string,
 ): { matched: boolean; quality: number } {
   if (!targetSnippet || !windowSnippet) {
-    return { matched: false, quality: 0 };
-  }
-  if (
-    isUnpromotableShortTermSnippet(targetSnippet) ||
-    isUnpromotableShortTermSnippet(windowSnippet)
-  ) {
     return { matched: false, quality: 0 };
   }
   if (windowSnippet === targetSnippet) {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -319,6 +319,27 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   return hasNarrativeLead && hasConfidence && hasEvidence && hasStatus && hasRecalls;
 }
 
+// Known empty daily-note section headings; arbitrary single headings should remain promotable.
+const MARKDOWN_SKELETON_HEADING_BODIES = new Set([
+  "aufgaben",
+  "daily notes",
+  "decisions",
+  "entscheidungen",
+  "notes",
+  "tasks",
+  "tagesnotizen",
+  "todo",
+  "todos",
+]);
+
+function normalizeMarkdownSkeletonHeadingBody(raw: string): string {
+  return raw
+    .replace(/[-*+>`_[\](){}|~.,;!?]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
 function isMarkdownSkeletonSnippet(raw: string): boolean {
   const nonEmptyLines = raw
     .split(/\r?\n/)
@@ -341,14 +362,11 @@ function isMarkdownSkeletonSnippet(raw: string): boolean {
         hasPlaceholderLine = true;
         continue;
       }
-      const headingWords =
-        headingBody.replace(/#{1,6}\s*/g, " ").match(/[\p{L}\p{N}][\p{L}\p{N}'-]*/gu) ?? [];
-      // Short single headings are usually template scaffolding; three or more words carry memory text.
-      if (/:\s*\S/.test(headingBody) || headingWords.length >= 3) {
-        return false;
+      if (MARKDOWN_SKELETON_HEADING_BODIES.has(normalizeMarkdownSkeletonHeadingBody(headingBody))) {
+        hasPlaceholderLine = true;
+        continue;
       }
-      hasPlaceholderLine = true;
-      continue;
+      return false;
     }
     return false;
   }

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -323,6 +323,11 @@ function stripMarkdownLeadingMarkers(raw: string): string {
   return raw.replace(/^(?:[-*+>]\s*)+/, "").trim();
 }
 
+function markdownHeadingHasInlinePayload(raw: string): boolean {
+  const headingText = raw.replace(/^#{1,6}\s+/, "").trim();
+  return /:\s*\S/.test(headingText);
+}
+
 function isMarkdownMarkerOnlyLine(raw: string): boolean {
   const line = raw.trim();
   if (!line) {
@@ -352,6 +357,9 @@ function isMarkdownSkeletonSnippet(raw: string): boolean {
     }
     const withoutLeadingMarkers = stripMarkdownLeadingMarkers(line);
     if (/^#{1,6}\s+\S/.test(withoutLeadingMarkers)) {
+      if (markdownHeadingHasInlinePayload(withoutLeadingMarkers)) {
+        return false;
+      }
       if (withoutLeadingMarkers !== line) {
         hasPlaceholderLine = true;
       }

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -336,13 +336,15 @@ function isMarkdownSkeletonSnippet(raw: string): boolean {
       continue;
     }
     if (/^#{1,6}\s+\S/.test(withoutLeadingMarkers)) {
-      const headingBody = withoutLeadingMarkers
-        .replace(/^#{1,6}\s+/, "")
-        .replace(/#{1,6}\s*/g, " ")
-        .trim();
-      const headingWords = headingBody.match(/[\p{L}\p{N}][\p{L}\p{N}'-]*/gu) ?? [];
-      // Short heading-only snippets are usually template scaffolding; longer headings carry memory text.
-      if (/:\s*\S/.test(headingBody) || headingWords.length >= 4) {
+      const headingBody = withoutLeadingMarkers.replace(/^#{1,6}\s+/, "").trim();
+      if (/(?:^|\s)#{1,6}\s+\S/.test(headingBody)) {
+        hasPlaceholderLine = true;
+        continue;
+      }
+      const headingWords =
+        headingBody.replace(/#{1,6}\s*/g, " ").match(/[\p{L}\p{N}][\p{L}\p{N}'-]*/gu) ?? [];
+      // Short single headings are usually template scaffolding; three or more words carry memory text.
+      if (/:\s*\S/.test(headingBody) || headingWords.length >= 3) {
         return false;
       }
       hasPlaceholderLine = true;

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -339,12 +339,7 @@ function isMarkdownSkeletonSnippet(raw: string): boolean {
       if (/^#{1,6}\s+.+:\s*\S/.test(withoutLeadingMarkers)) {
         return false;
       }
-      if (withoutLeadingMarkers !== line) {
-        hasPlaceholderLine = true;
-      }
-      if (/(?:^|\s)[-*+>]\s*$/.test(line)) {
-        hasPlaceholderLine = true;
-      }
+      hasPlaceholderLine = true;
       continue;
     }
     return false;

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -319,12 +319,16 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   return hasNarrativeLead && hasConfidence && hasEvidence && hasStatus && hasRecalls;
 }
 
+function stripMarkdownLeadingMarkers(raw: string): string {
+  return raw.replace(/^(?:[-*+>]\s*)+/, "").trim();
+}
+
 function isMarkdownMarkerOnlyLine(raw: string): boolean {
   const line = raw.trim();
   if (!line) {
     return true;
   }
-  const withoutLeadingMarkers = line.replace(/^(?:[-*+>]\s*)+/, "").trim();
+  const withoutLeadingMarkers = stripMarkdownLeadingMarkers(line);
   if (!withoutLeadingMarkers) {
     return true;
   }
@@ -346,7 +350,11 @@ function isMarkdownSkeletonSnippet(raw: string): boolean {
       hasPlaceholderLine = true;
       continue;
     }
-    if (/^#{1,6}\s+\S/.test(line)) {
+    const withoutLeadingMarkers = stripMarkdownLeadingMarkers(line);
+    if (/^#{1,6}\s+\S/.test(withoutLeadingMarkers)) {
+      if (withoutLeadingMarkers !== line) {
+        hasPlaceholderLine = true;
+      }
       if (/(?:^|\s)[-*+>]\s*$/.test(line)) {
         hasPlaceholderLine = true;
       }

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -319,6 +319,58 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   return hasNarrativeLead && hasConfidence && hasEvidence && hasStatus && hasRecalls;
 }
 
+function isMarkdownMarkerOnlyLine(raw: string): boolean {
+  const line = raw.trim();
+  if (!line) {
+    return true;
+  }
+  const withoutLeadingMarkers = line.replace(/^(?:[-*+>]\s*)+/, "").trim();
+  if (!withoutLeadingMarkers) {
+    return true;
+  }
+  return !/[\p{L}\p{N}]/u.test(withoutLeadingMarkers);
+}
+
+function isMarkdownSkeletonSnippet(raw: string): boolean {
+  const nonEmptyLines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (nonEmptyLines.length === 0) {
+    return true;
+  }
+
+  let hasPlaceholderLine = false;
+  for (const line of nonEmptyLines) {
+    if (isMarkdownMarkerOnlyLine(line)) {
+      hasPlaceholderLine = true;
+      continue;
+    }
+    if (/^#{1,6}\s+\S/.test(line)) {
+      if (/(?:^|\s)[-*+>]\s*$/.test(line)) {
+        hasPlaceholderLine = true;
+      }
+      continue;
+    }
+    return false;
+  }
+  return hasPlaceholderLine;
+}
+
+function isUnpromotableShortTermSnippet(raw: string): boolean {
+  const snippet = normalizeSnippet(raw);
+  if (!snippet) {
+    return true;
+  }
+  if (isContaminatedDreamingSnippet(snippet)) {
+    return true;
+  }
+  if (isMarkdownMarkerOnlyLine(snippet)) {
+    return true;
+  }
+  return isMarkdownSkeletonSnippet(raw);
+}
+
 function normalizeMemoryPath(rawPath: string): string {
   return rawPath.replaceAll("\\", "/").replace(/^\.\//, "");
 }
@@ -492,8 +544,9 @@ function normalizeStore(raw: unknown, nowIso: string): ShortTermRecallStore {
         typeof entry.claimHash === "string" && entry.claimHash.trim().length > 0
           ? entry.claimHash.trim()
           : undefined;
-      const snippet = typeof entry.snippet === "string" ? normalizeSnippet(entry.snippet) : "";
-      if (snippet && isContaminatedDreamingSnippet(snippet)) {
+      const snippetRaw = typeof entry.snippet === "string" ? entry.snippet : "";
+      const snippet = normalizeSnippet(snippetRaw);
+      if (isUnpromotableShortTermSnippet(snippetRaw)) {
         continue;
       }
       const queryHashes = Array.isArray(entry.queryHashes)
@@ -968,7 +1021,7 @@ export async function recordShortTermRecalls(params: {
     for (const result of relevant) {
       const normalizedPath = normalizeMemoryPath(result.path);
       const snippet = normalizeSnippet(result.snippet);
-      if (!snippet || isContaminatedDreamingSnippet(snippet)) {
+      if (isUnpromotableShortTermSnippet(result.snippet)) {
         continue;
       }
       const claimHash = snippet ? buildClaimHash(snippet) : undefined;
@@ -1075,8 +1128,7 @@ export async function recordGroundedShortTermCandidates(params: {
       const snippet = normalizeSnippet(item.snippet);
       const normalizedPath = normalizeMemoryPath(item.path);
       if (
-        !snippet ||
-        isContaminatedDreamingSnippet(snippet) ||
+        isUnpromotableShortTermSnippet(item.snippet) ||
         !normalizedPath ||
         !isShortTermMemoryPath(normalizedPath) ||
         !Number.isFinite(item.startLine) ||
@@ -1259,7 +1311,7 @@ export async function rankShortTermPromotionCandidates(
     if (!entry || entry.source !== "memory" || !isShortTermMemoryPath(entry.path)) {
       continue;
     }
-    if (isContaminatedDreamingSnippet(entry.snippet)) {
+    if (isUnpromotableShortTermSnippet(entry.snippet)) {
       continue;
     }
     if (!includePromoted && entry.promotedAt) {
@@ -1416,6 +1468,12 @@ function compareCandidateWindow(
   windowSnippet: string,
 ): { matched: boolean; quality: number } {
   if (!targetSnippet || !windowSnippet) {
+    return { matched: false, quality: 0 };
+  }
+  if (
+    isUnpromotableShortTermSnippet(targetSnippet) ||
+    isUnpromotableShortTermSnippet(windowSnippet)
+  ) {
     return { matched: false, quality: 0 };
   }
   if (windowSnippet === targetSnippet) {
@@ -1636,7 +1694,7 @@ export async function applyShortTermPromotions(
     const store = await readStore(workspaceDir, nowIso);
     const selected = options.candidates
       .filter((candidate) => {
-        if (isContaminatedDreamingSnippet(candidate.snippet)) {
+        if (isUnpromotableShortTermSnippet(candidate.snippet)) {
           return false;
         }
         if (candidate.promotedAt) {
@@ -1674,7 +1732,7 @@ export async function applyShortTermPromotions(
     const rehydratedSelected: PromotionCandidate[] = [];
     for (const candidate of selected) {
       const rehydrated = await rehydratePromotionCandidate(workspaceDir, candidate);
-      if (rehydrated && !isContaminatedDreamingSnippet(rehydrated.snippet)) {
+      if (rehydrated && !isUnpromotableShortTermSnippet(rehydrated.snippet)) {
         rehydratedSelected.push(rehydrated);
       }
     }
@@ -2067,6 +2125,7 @@ export const testing = {
   buildClaimHash,
   totalSignalCountForEntry,
   isContaminatedDreamingSnippet,
+  isUnpromotableShortTermSnippet,
   lineRangeOverlapsDreamingFence,
 };
 export { testing as __testing };


### PR DESCRIPTION
## Summary
- Add a shared short-term promotion guard for markdown placeholder/skeleton snippets.
- Apply it when loading the recall store, recording recall/grounded candidates, ranking, applying, and rehydrating promotion candidates.
- Add regression coverage for marker-only snippets, heading-only scaffolding, normalized marker-plus-heading placeholders, stale stored placeholders, trailing-colon scaffold headings, and inline heading bullets with durable payloads, including concise and localized heading text.

Fixes #80582.

## Verification
- `node scripts/run-vitest.mjs extensions/memory-core/src/short-term-promotion.test.ts -- --runInBand`
- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.test.ts -- --runInBand`
- `CI=true pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: Short-term promotion could treat markdown placeholders like `-`, plain heading-only scaffolding like `## Tagesnotizen ## Entscheidungen`, trailing-colon scaffold headings like `## Notes:`, and previously persisted normalized marker-plus-heading snippets like `- ## Entscheidungen` as durable memory candidates, allowing empty daily-note scaffolding to rank and eventually append to `MEMORY.md`. The guard also preserves list-wrapped heading content with durable body text, including localized non-colon headings such as `- ## 修复备份轮换`.

Real environment tested: Local filesystem-backed OpenClaw memory workspace on macOS, using PR head `519ee06236eca61c78764f59fa1837157efb37bf`. The standalone Node run created real temp files under `memory/`, wrote `memory/.dreams/short-term-recall.json`, called the production `rankShortTermPromotionCandidates` and `applyShortTermPromotions` functions from `extensions/memory-core/src/short-term-promotion.ts`, and checked the resulting `MEMORY.md` filesystem state.

Exact steps or command run after this patch: From the repo root, ran `node --import tsx -` with a standalone script that seeds temp workspaces with persisted short-term recall entries whose snippets are `## Tagesnotizen ## Entscheidungen`, `## Notes:`, `- ## Entscheidungen`, and `- ## 修复备份轮换`, then invokes production ranking and apply paths with thresholds set to zero.

Evidence after fix: Copied terminal output from that real temp-workspace run:

```console
$ node --import tsx -
{"name":"headingOnly","snippet":"## Tagesnotizen ## Entscheidungen","ranked":0,"applied":0,"memoryExists":false,"memoryIncludesSnippet":false}
{"name":"headingWithColon","snippet":"## Notes:","ranked":0,"applied":0,"memoryExists":false,"memoryIncludesSnippet":false}
{"name":"markerHeading","snippet":"- ## Entscheidungen","ranked":0,"applied":0,"memoryExists":false,"memoryIncludesSnippet":false}
{"name":"durableLocalized","snippet":"- ## 修复备份轮换","ranked":1,"applied":1,"memoryExists":true,"memoryIncludesSnippet":true}
```

Observed result after fix: Heading-only scaffolding, trailing-colon scaffold headings, and normalized marker-plus-heading placeholders ranked zero candidates, applied zero promotions, and did not create `MEMORY.md`. The durable localized non-colon inline heading bullet `- ## 修复备份轮换` ranked, applied once, created `MEMORY.md`, and appeared in the resulting memory file.

What was not tested: I did not run a full live dreaming cron cycle against a private real workspace; the user-reported failure shape is covered with filesystem-backed promotion fixtures and the standalone temp-workspace OpenClaw promotion run above rather than private memory contents.
