### PR TITLE
Refactor shared channel status read model

### DIFF
--- a/src/channels/status/read-model.test.ts
+++ b/src/channels/status/read-model.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  findRuntimeChannelAccount,
+  getRuntimeChannelAccounts,
+  hasRuntimeCredentialAvailable,
+  markConfiguredUnavailableCredentialStatusesAvailable,
+  normalizeRuntimeChannelAccountSnapshots,
+  resolveChannelAccountStatusRows,
+} from "./read-model.js";
+
+describe("channel status read model", () => {
+  it("normalizes gateway channel account snapshots by channel", () => {
+    const accounts = normalizeRuntimeChannelAccountSnapshots({
+      channelAccounts: {
+        discord: [
+          { accountId: "default", configured: true },
+          { name: "missing-account-id", configured: true },
+        ],
+        slack: { accountId: "default" },
+      },
+    });
+
+    expect(accounts.get("discord")).toStrictEqual([{ accountId: "default", configured: true }]);
+    expect(accounts.has("slack")).toBe(false);
+  });
+
+  it("merges runtime-only accounts and prefers gateway snapshots", async () => {
+    const rows = await resolveChannelAccountStatusRows({
+      localAccountIds: ["default"],
+      runtimeAccounts: [
+        { accountId: "default", configured: true, tokenSource: "env" },
+        { accountId: "ops", configured: true, tokenSource: "env" },
+      ],
+      resolveLocalSnapshot: async (accountId) => ({
+        accountId,
+        configured: false,
+        tokenSource: "none",
+      }),
+    });
+
+    expect(rows).toStrictEqual([
+      {
+        accountId: "default",
+        source: "gateway",
+        snapshot: { accountId: "default", configured: true, tokenSource: "env" },
+      },
+      {
+        accountId: "ops",
+        source: "gateway",
+        snapshot: { accountId: "ops", configured: true, tokenSource: "env" },
+      },
+    ]);
+  });
+
+  it("finds legacy live accounts by id/name fallback for status summaries", () => {
+    const liveAccounts = getRuntimeChannelAccounts({
+      payload: {
+        channelAccounts: {
+          discord: [{ name: "default", running: true }],
+        },
+      },
+      channelId: "discord",
+    });
+
+    expect(findRuntimeChannelAccount({ liveAccounts, accountId: "default" })).toStrictEqual({
+      name: "default",
+      running: true,
+    });
+    expect(hasRuntimeCredentialAvailable({ liveAccounts, accountId: "default" })).toBe(true);
+  });
+
+  it("does not treat unavailable runtime credentials as available", () => {
+    const liveAccounts = [
+      { accountId: "default", running: true, tokenStatus: "configured_unavailable" },
+    ];
+
+    expect(hasRuntimeCredentialAvailable({ liveAccounts, accountId: "default" })).toBe(false);
+  });
+
+  it("marks configured-unavailable credential statuses available for runtime-backed summaries", () => {
+    expect(
+      markConfiguredUnavailableCredentialStatusesAvailable({
+        tokenStatus: "configured_unavailable",
+        userTokenStatus: "configured_unavailable",
+        appTokenStatus: "missing",
+      }),
+    ).toStrictEqual({
+      tokenStatus: "available",
+      userTokenStatus: "available",
+      appTokenStatus: "missing",
+    });
+  });
+});

--- a/src/channels/status/read-model.ts
+++ b/src/channels/status/read-model.ts
@@ -1,0 +1,136 @@
+import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
+import { asRecord } from "../../shared/record-coerce.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import { hasConfiguredUnavailableCredentialStatus } from "../account-snapshot-fields.js";
+import type { ChannelAccountSnapshot } from "../plugins/types.public.js";
+
+export type RuntimeChannelStatusPayload = {
+  channelAccounts?: unknown;
+};
+
+export type RuntimeChannelAccount = Record<string, unknown>;
+
+const CREDENTIAL_STATUS_KEYS = [
+  "tokenStatus",
+  "botTokenStatus",
+  "appTokenStatus",
+  "signingSecretStatus",
+  "userTokenStatus",
+] as const;
+
+function readRuntimeAccountsByChannel(payload: unknown): Record<string, unknown> {
+  return asRecord(asRecord(payload).channelAccounts);
+}
+
+export function getRuntimeChannelAccounts(params: {
+  payload: unknown;
+  channelId: string;
+}): RuntimeChannelAccount[] {
+  const raw = readRuntimeAccountsByChannel(params.payload)[params.channelId];
+  return Array.isArray(raw) ? raw.map(asRecord) : [];
+}
+
+export function normalizeRuntimeChannelAccountSnapshots(
+  payload: unknown,
+): Map<string, ChannelAccountSnapshot[]> {
+  const out = new Map<string, ChannelAccountSnapshot[]>();
+  for (const [channelId, accounts] of Object.entries(readRuntimeAccountsByChannel(payload))) {
+    if (!Array.isArray(accounts)) {
+      continue;
+    }
+    const normalized = accounts.filter(
+      (account): account is ChannelAccountSnapshot =>
+        Boolean(account) &&
+        typeof account === "object" &&
+        typeof (account as { accountId?: unknown }).accountId === "string",
+    );
+    if (normalized.length > 0) {
+      out.set(channelId, normalized);
+    }
+  }
+  return out;
+}
+
+export function resolveRuntimeChannelAccountId(account: RuntimeChannelAccount): string {
+  return (
+    normalizeOptionalString(account.accountId) ??
+    normalizeOptionalString(account.id) ??
+    normalizeOptionalString(account.name) ??
+    DEFAULT_ACCOUNT_ID
+  );
+}
+
+export function findRuntimeChannelAccount(params: {
+  liveAccounts: RuntimeChannelAccount[];
+  accountId: string;
+}): RuntimeChannelAccount | null {
+  return (
+    params.liveAccounts.find(
+      (account) => resolveRuntimeChannelAccountId(account) === params.accountId,
+    ) ??
+    (params.accountId === DEFAULT_ACCOUNT_ID && params.liveAccounts.length === 1
+      ? (params.liveAccounts[0] ?? null)
+      : null)
+  );
+}
+
+export function hasRuntimeCredentialAvailable(params: {
+  liveAccounts: RuntimeChannelAccount[];
+  accountId: string;
+}): boolean {
+  const account = findRuntimeChannelAccount(params);
+  if (!account) {
+    return false;
+  }
+  if (hasConfiguredUnavailableCredentialStatus(account)) {
+    return false;
+  }
+  return account.running === true || account.connected === true;
+}
+
+export function markConfiguredUnavailableCredentialStatusesAvailable(
+  account: unknown,
+): Record<string, unknown> {
+  const record = { ...asRecord(account) };
+  for (const key of CREDENTIAL_STATUS_KEYS) {
+    if (record[key] === "configured_unavailable") {
+      record[key] = "available";
+    }
+  }
+  return record;
+}
+
+export async function resolveChannelAccountStatusRows(params: {
+  localAccountIds: string[];
+  runtimeAccounts: ChannelAccountSnapshot[];
+  resolveLocalSnapshot: (accountId: string) => Promise<ChannelAccountSnapshot>;
+}): Promise<
+  Array<{
+    accountId: string;
+    snapshot: ChannelAccountSnapshot;
+    source: "gateway" | "config";
+  }>
+> {
+  const mergedAccountIds = [
+    ...new Set([
+      ...params.localAccountIds,
+      ...params.runtimeAccounts.map((account) => account.accountId),
+    ]),
+  ];
+  const rows: Array<{
+    accountId: string;
+    snapshot: ChannelAccountSnapshot;
+    source: "gateway" | "config";
+  }> = [];
+  for (const accountId of mergedAccountIds) {
+    const runtimeSnapshot = params.runtimeAccounts.find(
+      (account) => account.accountId === accountId,
+    );
+    rows.push({
+      accountId,
+      snapshot: runtimeSnapshot ?? (await params.resolveLocalSnapshot(accountId)),
+      source: runtimeSnapshot ? "gateway" : "config",
+    });
+  }
+  return rows;
+}

--- a/src/commands/channels/list.ts
+++ b/src/commands/channels/list.ts
@@ -5,6 +5,11 @@ import { listReadOnlyChannelPluginsForConfig } from "../../channels/plugins/read
 import { buildChannelAccountSnapshot } from "../../channels/plugins/status.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
+import {
+  normalizeRuntimeChannelAccountSnapshots,
+  resolveChannelAccountStatusRows,
+  type RuntimeChannelStatusPayload,
+} from "../../channels/status/read-model.js";
 import { callGateway } from "../../gateway/call.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
@@ -18,42 +23,13 @@ export type ChannelsListOptions = {
   all?: boolean;
 };
 
-type RuntimeChannelStatus = {
-  channelAccounts?: Record<string, unknown>;
-};
-
-function normalizeRuntimeAccounts(
-  payload: RuntimeChannelStatus | null,
-): Map<string, ChannelAccountSnapshot[]> {
-  const out = new Map<string, ChannelAccountSnapshot[]>();
-  const rawAccounts = payload?.channelAccounts;
-  if (!rawAccounts || typeof rawAccounts !== "object") {
-    return out;
-  }
-  for (const [channelId, accounts] of Object.entries(rawAccounts)) {
-    if (!Array.isArray(accounts)) {
-      continue;
-    }
-    const normalized = accounts.filter(
-      (account): account is ChannelAccountSnapshot =>
-        Boolean(account) &&
-        typeof account === "object" &&
-        typeof (account as { accountId?: unknown }).accountId === "string",
-    );
-    if (normalized.length > 0) {
-      out.set(channelId, normalized);
-    }
-  }
-  return out;
-}
-
-async function readGatewayChannelStatus(): Promise<RuntimeChannelStatus | null> {
+async function readGatewayChannelStatus(): Promise<RuntimeChannelStatusPayload | null> {
   try {
     return (await callGateway({
       method: "channels.status",
       params: { probe: false, timeoutMs: 5_000 },
       timeoutMs: 5_000,
-    })) as RuntimeChannelStatus;
+    })) as RuntimeChannelStatusPayload;
   } catch {
     return null;
   }
@@ -180,7 +156,7 @@ export async function channelsListCommand(
   const runtimeAccountsByChannel =
     opts.json === true
       ? new Map<string, ChannelAccountSnapshot[]>()
-      : normalizeRuntimeAccounts(await readGatewayChannelStatus());
+      : normalizeRuntimeChannelAccountSnapshots(await readGatewayChannelStatus());
   const installedByChannelId = new Map<string, boolean>();
   for (const entry of catalogEntries) {
     installedByChannelId.set(
@@ -211,16 +187,16 @@ export async function channelsListCommand(
     if (accountIds && accountIds.length > 0) {
       renderedChannelIds.add(plugin.id);
       const runtimeAccounts = runtimeAccountsByChannel.get(plugin.id) ?? [];
-      const mergedAccountIds = [
-        ...new Set([...accountIds, ...runtimeAccounts.map((account) => account.accountId)]),
-      ];
-      for (const accountId of mergedAccountIds) {
-        const runtimeSnapshot = runtimeAccounts.find((account) => account.accountId === accountId);
-        const snapshot =
-          runtimeSnapshot ?? (await buildChannelAccountSnapshot({ plugin, cfg, accountId }));
+      const rows = await resolveChannelAccountStatusRows({
+        localAccountIds: accountIds,
+        runtimeAccounts,
+        resolveLocalSnapshot: (accountId) =>
+          buildChannelAccountSnapshot({ plugin, cfg, accountId }),
+      });
+      for (const row of rows) {
         accountLines.push({
           plugin,
-          snapshot,
+          snapshot: row.snapshot,
           installed: isInstalled(plugin.id),
         });
       }

--- a/src/commands/status-all/channels.ts
+++ b/src/commands/status-all/channels.ts
@@ -13,6 +13,11 @@ import type {
   ChannelId,
   ChannelPlugin,
 } from "../../channels/plugins/types.public.js";
+import {
+  getRuntimeChannelAccounts,
+  hasRuntimeCredentialAvailable,
+  markConfiguredUnavailableCredentialStatusesAvailable,
+} from "../../channels/status/read-model.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { listExplicitConfiguredChannelIdsForConfig } from "../../plugins/channel-plugin-ids.js";
 import { resolveMissingOfficialExternalChannelPluginRepairHint } from "../../plugins/official-external-plugin-repair-hints.js";
@@ -43,63 +48,6 @@ type ResolvedChannelAccountRowParams = {
   sourceConfig: OpenClawConfig;
   accountId: string;
 };
-
-function getLiveChannelAccounts(params: {
-  liveChannelStatus: unknown;
-  channelId: string;
-}): Array<Record<string, unknown>> {
-  const payload = asRecord(params.liveChannelStatus);
-  const accountsByChannel = asRecord(payload.channelAccounts);
-  const raw = accountsByChannel[params.channelId];
-  return Array.isArray(raw) ? raw.map(asRecord) : [];
-}
-
-function getLiveAccountId(account: Record<string, unknown>): string {
-  return (
-    normalizeOptionalString(account.accountId) ??
-    normalizeOptionalString(account.id) ??
-    normalizeOptionalString(account.name) ??
-    "default"
-  );
-}
-
-function findLiveChannelAccount(params: {
-  liveAccounts: Array<Record<string, unknown>>;
-  accountId: string;
-}): Record<string, unknown> | null {
-  return (
-    params.liveAccounts.find((account) => getLiveAccountId(account) === params.accountId) ??
-    (params.accountId === "default" && params.liveAccounts.length === 1
-      ? (params.liveAccounts[0] ?? null)
-      : null)
-  );
-}
-
-function hasLiveCredentialAvailable(params: {
-  liveAccounts: Array<Record<string, unknown>>;
-  accountId: string;
-}): boolean {
-  const account = findLiveChannelAccount(params);
-  if (!account) {
-    return false;
-  }
-  if (hasConfiguredUnavailableCredentialStatus(account)) {
-    return false;
-  }
-  return account.running === true || account.connected === true;
-}
-
-function markConfiguredUnavailableCredentialStatusesAvailable(
-  account: unknown,
-): Record<string, unknown> {
-  const record = { ...asRecord(account) };
-  for (const key of ["tokenStatus", "botTokenStatus", "appTokenStatus", "signingSecretStatus"]) {
-    if (record[key] === "configured_unavailable") {
-      record[key] = "available";
-    }
-  }
-  return record;
-}
 
 function existsSyncMaybe(p: string | undefined): boolean | null {
   const path = normalizeOptionalString(p) ?? "";
@@ -298,8 +246,8 @@ export async function buildChannelsTable(
         }),
       );
     }
-    const liveAccounts = getLiveChannelAccounts({
-      liveChannelStatus: opts?.liveChannelStatus,
+    const liveAccounts = getRuntimeChannelAccounts({
+      payload: opts?.liveChannelStatus,
       channelId: plugin.id,
     });
 
@@ -309,11 +257,11 @@ export async function buildChannelsTable(
     const unavailableConfiguredAccounts = enabledAccounts.filter(
       (a) =>
         hasConfiguredUnavailableCredentialStatus(a.account) &&
-        !hasLiveCredentialAvailable({ liveAccounts, accountId: a.accountId }),
+        !hasRuntimeCredentialAvailable({ liveAccounts, accountId: a.accountId }),
     );
     const accountsForTokenSummary = accounts.map((entry) =>
       hasConfiguredUnavailableCredentialStatus(entry.account) &&
-      hasLiveCredentialAvailable({ liveAccounts, accountId: entry.accountId })
+      hasRuntimeCredentialAvailable({ liveAccounts, accountId: entry.accountId })
         ? {
             ...entry,
             account: markConfiguredUnavailableCredentialStatusesAvailable(entry.account),
@@ -462,7 +410,7 @@ export async function buildChannelsTable(
         title: `${label} accounts`,
         columns: ["Account", "Status", "Notes"],
         rows: configuredAccounts.map((entry) => {
-          const liveCredentialAvailable = hasLiveCredentialAvailable({
+          const liveCredentialAvailable = hasRuntimeCredentialAvailable({
             liveAccounts,
             accountId: entry.accountId,
           });


### PR DESCRIPTION
Summary:
- Extract shared channel status read-model helpers for Gateway channel account snapshots and credential availability.
- Migrate `channels list` and `status --all` to the shared runtime/local account merge helpers.
- Add focused read-model coverage for Gateway snapshot normalization, runtime-only accounts, and configured-unavailable credential handling.

Verification:
- `node scripts/run-vitest.mjs src/channels/status/read-model.test.ts src/commands/channels.list.test.ts src/commands/status-all/channels.test.ts`
- `pnpm test:changed`
- `git diff --check`
- `pnpm check:changed` via Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/25901927483
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --full-access`

## Real behavior proof

Behavior addressed: Shared the live Gateway/local-config channel status read model used by `channels list` and `status --all`, preserving the Discord SecretRef/runtime status behavior fixed for #79343 while reducing duplicated merge logic.
Real environment tested: Local OpenClaw CLI from this branch, run against an isolated temporary config file and state directory on macOS.
Exact steps or command run after this patch: `OPENCLAW_CONFIG_PATH=$tmpdir/openclaw.json OPENCLAW_STATE_DIR=$tmpdir/state pnpm openclaw channels list --all`
Evidence after fix: Terminal output from the real CLI run included:

```text
Chat channels:
- Discord: installed, not configured, disabled
- QQ Bot: installed, not configured, disabled
- Telegram: installed, not configured, disabled
- WhatsApp: not installed, not configured, disabled
```

Observed result after fix: The command rendered the channel inventory from the shared read model without crashing; configured-unavailable/local fallback logic remains covered by focused command regressions, and the isolated CLI run confirmed the human-facing list path still produces channel rows after the extraction.
What was not tested: No live Discord credential repro in this refactor PR; the runtime Discord behavior was covered by the already-landed issue fix and mocked command/read-model regressions here.
