### PR TITLE
docs: add configuration internals guide and improve validation diagnostics

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1145,8 +1145,8 @@
                       "concepts/memory",
                       "concepts/memory-builtin",
                       "concepts/memory-qmd",
-                      "concepts/memory-search",
                       "concepts/memory-honcho",
+                      "concepts/memory-search",
                       "concepts/active-memory",
                       "concepts/commitments",
                       "concepts/dreaming"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1145,8 +1145,8 @@
                       "concepts/memory",
                       "concepts/memory-builtin",
                       "concepts/memory-qmd",
-                      "concepts/memory-honcho",
                       "concepts/memory-search",
+                      "concepts/memory-honcho",
                       "concepts/active-memory",
                       "concepts/commitments",
                       "concepts/dreaming"
@@ -1478,6 +1478,7 @@
                     "pages": [
                       "gateway/configuration",
                       "gateway/configuration-reference",
+                      "gateway/configuration-internals",
                       "gateway/config-agents",
                       "gateway/config-channels",
                       "gateway/config-tools",

--- a/docs/gateway/configuration-internals.md
+++ b/docs/gateway/configuration-internals.md
@@ -1,0 +1,246 @@
+---
+summary: "Where every OpenClaw setting lives on disk, who validates it, and how it is recovered when a write goes wrong"
+read_when:
+  - Investigating why a settings change broke gateway startup or hot reload
+  - Mapping which file or schema owns a given config surface
+  - Looking up the backup, recovery, and doctor behavior for openclaw.json
+  - Wiring a third-party plugin into the config schema and recovery flow
+title: "Configuration internals"
+sidebarTitle: "Internals"
+---
+
+This page maps the storage and lifecycle of OpenClaw configuration: where every
+surface lives on disk, which schema validates it, when it is loaded, how hot
+reload swaps it, and what happens when a write fails validation. Use the
+[Configuration overview](/gateway/configuration) for task-oriented guidance and
+the [Configuration reference](/gateway/configuration-reference) for the full
+field map. This page is the one to open when something already went wrong.
+
+## Files on disk
+
+OpenClaw owns a small set of files under `~/.openclaw/` (override the root
+with `OPENCLAW_STATE_DIR`). All paths shown are defaults; the canonical config
+path can be overridden with `OPENCLAW_CONFIG_PATH`.
+
+| Path | Purpose | Writer |
+|---|---|---|
+| `~/.openclaw/openclaw.json` | Canonical configuration. JSON5 with comments and trailing commas. | `src/config/io.ts` via `src/config/mutate.ts` |
+| `~/.openclaw/openclaw.json.bak` | Most recent successful copy. Used by the last known good recovery path. | `src/config/backup-rotation.ts` |
+| `~/.openclaw/openclaw.json.bak.1` to `.bak.4` | Older backups in a 5 slot ring. | `src/config/backup-rotation.ts` |
+| `~/.openclaw/openclaw.json.pre-update` | One time snapshot captured before a major update. Write once, never rotated. | `src/config/backup-rotation.ts` |
+| `~/.openclaw/.config-health.json` | Last load result, fingerprint, degraded flag, recovery hints. | `src/config/io.ts` |
+| `~/.openclaw/.oauth` | OAuth tokens for connected services. | `src/config/paths.ts` |
+| `~/.openclaw/plugin-installs.json` | Installed plugin records. | `src/plugins/installed-plugin-index-records.js` |
+| `~/.openclaw/<agent-id>/` | Per agent workspace, transcripts, session state. | `src/agents/agent-scope-config.ts` |
+| `./.env` or `~/.openclaw/.env` | Dotenv overrides loaded into `process.env`. | `src/infra/dotenv.js` |
+
+The active config file must be a regular file. Symlinks at the config path are
+not supported because the atomic write replaces the path target instead of
+following the link. If you keep the file outside the default state directory,
+point `OPENCLAW_CONFIG_PATH` at the real file, not at a symlink to it.
+
+## Settings categories
+
+Every category below is a top level key under `openclaw.json` unless noted.
+The schema column points at the Zod module that owns validation; the
+documentation column points at the user facing page.
+
+| Key | Owns | Schema | Documentation |
+|---|---|---|---|
+| `agents` | Agent identities, defaults, per agent overrides | `src/config/zod-schema.agents.ts` | [config-agents](/gateway/config-agents) |
+| `channels` | Per channel auth, allowlists, group policy, presence | `src/config/zod-schema.providers.ts` | [config-channels](/gateway/config-channels) |
+| `models` and `agents.defaults.models` | Model catalog and allowlist | `src/config/zod-schema.providers-core.ts` | [Models](/concepts/models) |
+| `tools` and `plugins.entries.<id>.config` | Tool and skill plugin configuration | Plugin contributed via `src/plugin-sdk/plugin-config-runtime.ts` | [config-tools](/gateway/config-tools) |
+| `plugins` | Plugin allow and deny lists, per plugin enable and hooks | `src/config/zod-schema.ts` | [Plugin reference](/plugins/reference) |
+| `gateway` | Port, auth mode, control UI, reload mode, Tailscale, remote | `src/config/zod-schema.ts` | [Configuration overview](/gateway/configuration) |
+| `hooks` | Internal hooks, Gmail hooks, channel mappings | `src/config/zod-schema.hooks.ts` | [Hooks](/automation/hooks) |
+| `session` | Commands, messages, send policy | `src/config/zod-schema.session.ts` | [Configuration reference](/gateway/configuration-reference#session) |
+| `approvals` | Tool approval policy | `src/config/zod-schema.approvals.ts` | [Configuration reference](/gateway/configuration-reference#approvals) |
+| `memory` | Memory backend, QMD configuration | `src/config/zod-schema.ts` (`MemoryQmdSchema`) | [memory-config](/reference/memory-config) |
+| `logging` and `diagnostics` | Levels, OTEL, cache trace | `src/config/zod-schema.ts` | [Configuration reference](/gateway/configuration-reference#logging) |
+| `proxy` | Outbound proxy | `src/config/zod-schema.proxy.ts` | [Configuration reference](/gateway/configuration-reference#proxy) |
+| `env` | Inline environment variables and shell env policy | `src/config/zod-schema.ts` | [Configuration reference](/gateway/configuration-reference#env) |
+
+Per agent and per project state lives outside `openclaw.json`:
+
+- Per agent: `~/.openclaw/<agent-id>/`, owned by `src/agents/agent-scope-config.ts`.
+- Per project: managed by the `@earendil-works/pi-coding-agent` settings manager via `src/agents/pi-project-settings.ts`. Project settings travel with the project, not with `openclaw.json`.
+
+## Validation surfaces
+
+The master schema is `OpenClawSchema` exported from `src/config/zod-schema.ts`.
+It composes the sub schemas listed in the table above. The top level entry
+point for validating an in memory config object is
+`validateConfigObjectWithPlugins` in `src/config/validation.ts`.
+
+Validation runs in three places:
+
+1. After read, before any in process consumer sees the parsed object.
+2. After every transform, before writing the new copy to disk.
+3. At hot reload time, on the candidate config, before swapping the runtime snapshot.
+
+Validation is strict. Unknown keys, malformed types, and out of range values
+are rejected. The only root level exception is `$schema` (string), which lets
+editors attach JSON Schema metadata. See the [Strict validation](/gateway/configuration#strict-validation)
+section of the overview for the user facing contract.
+
+Generated metadata for bundled channel plugins lives at
+`src/config/bundled-channel-config-metadata.generated.ts`. It is produced by
+`scripts/generate-bundled-channel-config-metadata.ts` and validated at build
+time. Hand edits to the generated file are overwritten on next generation.
+
+## Read and write lifecycle
+
+A normal write from any callsite goes through
+`transformConfigFileWithRetry` in `src/config/mutate.ts`. The steps are:
+
+1. Acquire a file lock with a 30 second stale timeout. Concurrent writers are queued.
+2. Read the current file plus its fingerprint via `resolveConfigSnapshotHash`.
+3. Call the user supplied transform on the parsed object.
+4. Validate the transformed object with `validateConfigObjectWithPlugins`. If validation fails, the write aborts and the lock is released without touching disk.
+5. Run backup rotation through `maintainConfigBackups`: shift `.bak.1..4`, copy the current file into `.bak`, harden permissions to `0o600`, prune orphan `.bak.*` files.
+6. Atomic write through `replaceFileAtomic`: write to a temp sibling, then rename over the target.
+7. Update `.config-health.json` with the new fingerprint and recovery hints.
+8. Notify in process listeners via `notifyRuntimeConfigWriteListeners`.
+
+The lock plus the base hash check protect against lost updates when two writers
+race. A write whose base hash no longer matches the on disk file is rejected
+with `ConfigMutationConflictError`; the caller retries with fresh state.
+
+Direct file writes that bypass `transformConfigFileWithRetry` are not
+supported. Plugin authors should write through the SDK helpers, not through
+`fs.writeFile`.
+
+## Hot reload
+
+Hot reload is configured via `gateway.reload`:
+
+| Mode | Behavior |
+|---|---|
+| `off` | The gateway ignores config file changes. Requires manual restart. |
+| `restart` | The gateway process bounces on any change. Cleanest but interrupts active conversations. |
+| `hot` | The gateway mutates channel and plugin state in place. Fastest but the most fragile mode. |
+| `hybrid` (default) | Hot mutate for cheap surfaces, restart for surfaces that cannot be safely mutated live. |
+
+Hot reload runs through `src/gateway/config-reload.ts` and reads its settings
+from `src/gateway/config-reload-settings.ts`. The debounce window
+(`gateway.reload.debounceMs`) coalesces editor save bursts and rapid CLI runs.
+
+A reload that fails validation does not bring the runtime down: the gateway
+keeps serving on the last accepted config and logs the validation error. The
+file on disk is left as is; the user must fix it before the next reload will
+succeed.
+
+## Backups and recovery
+
+OpenClaw maintains a 5 slot backup ring plus a one time `.pre-update`
+snapshot. The mechanics live in `src/config/backup-rotation.ts`.
+
+- `rotateConfigBackups` shifts every backup down one slot before each successful write.
+- `hardenBackupPermissions` chmods every backup to `0o600` (POSIX only; the call is a no op on Windows).
+- `cleanOrphanBackups` deletes `.bak.<n>` files outside the managed slots so a stray copy does not confuse recovery.
+- `createPreUpdateConfigSnapshot` is called once per major update with the `wx` open flag, so an existing snapshot is never overwritten.
+
+Recovery from a bad config lives in `src/config/io.observe-recovery.ts`. Two
+helpers matter:
+
+- `recoverConfigFromLastKnownGood`: copies `.bak` over `openclaw.json` and re-validates the result. Used by `openclaw doctor --fix`.
+- `promoteConfigSnapshotToLastKnownGood`: marks the current snapshot as the new `.bak`. Skipped when the candidate contains redacted secret placeholders such as `***`, so a secret scrub never poisons the recovery anchor.
+
+The decision of whether to attempt recovery is made by `src/config/recovery-policy.ts`:
+
+- `shouldAttemptLastKnownGoodRecovery` answers yes only when the failure is non plugin local. Plugin local issues (a missing plugin entry, a renamed plugin key) are recoverable by re enabling the plugin or running its install repair, not by rolling back the whole file.
+- `isPluginLocalInvalidConfigSnapshot` is the predicate that lets the gateway keep running on a plugin scoped problem without escalating to a full file swap.
+
+A startup failure today is reported, but the rollback is not automatic. Run
+`openclaw doctor --fix` (or `--yes`) to apply the rollback once you have
+inspected the error. This is the behavior contract documented in the
+[Configuration overview](/gateway/configuration#strict-validation).
+
+## Doctor coverage
+
+`openclaw doctor` and `openclaw doctor --fix` live in `src/commands/doctor.ts`
+and `src/commands/doctor/`. For settings, doctor today handles:
+
+- Detecting and reporting validation failures with the schema diagnostic.
+- Applying legacy migration rules from `src/commands/doctor/shared/legacy-config-rules.js` (re exported through `src/config/legacy.rules.ts`).
+- Repairing plugin local invalid snapshots without touching the whole file (`src/commands/doctor/repair-sequencing.ts`).
+- Restoring `.bak` on operator confirmation when the failure is non plugin local.
+
+Doctor does not auto repair:
+
+- Unknown top level keys. They are reported, not stripped.
+- Malformed provider or channel credentials. The auth subsystem owns those flows.
+- Circularly referenced includes. The include resolver bails out and reports the cycle.
+
+## Environment variables
+
+The full list lives in `.env.example` at the repo root. The most common
+categories are:
+
+- **State and paths**: `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, `OPENCLAW_HOME`, `OPENCLAW_AUTH_PROFILE_SECRET_DIR`, `OPENCLAW_INCLUDE_ROOTS`.
+- **Gateway auth**: `OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_GATEWAY_PASSWORD`.
+- **Shell env loading**: `OPENCLAW_LOAD_SHELL_ENV`, `OPENCLAW_SHELL_ENV_TIMEOUT_MS`.
+- **Provider API keys**: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, plus numbered and comma separated variants for rotation pools.
+- **Channel credentials**: `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `MATTERMOST_BOT_TOKEN`, and similar per channel tokens.
+- **Tool keys**: `BRAVE_API_KEY`, `PERPLEXITY_API_KEY`, `FIRECRAWL_API_KEY`, `ELEVENLABS_API_KEY`, `INWORLD_API_KEY`, `DEEPGRAM_API_KEY`.
+
+Precedence at load time is: `process.env`, then `./.env`, then
+`~/.openclaw/.env`, then the `env.vars` block in `openclaw.json`. Earlier wins
+over later. The list of declared vars and their parsers lives in
+`src/config/config-env-vars.ts`.
+
+## Plugin and channel config
+
+Plugins declare a config schema in their manifest (`configSchema`). The
+runtime merges the user value from
+`config.plugins.entries.<pluginId>.config` over the plugin defaults and
+validates the result before handing it to the plugin. The integration code is
+in `src/plugin-sdk/plugin-config-runtime.ts`.
+
+A plugin entry has three subkeys:
+
+- `enabled` (boolean, optional): off switch without removing the entry.
+- `config` (object): plugin specific settings validated by the plugin schema.
+- `hooks` (object, optional): event handlers mapped through `src/config/zod-schema.hooks.ts`.
+
+Per channel config lives under `config.channels.<type>`. Each channel ships
+its own zod sub schema, and the bundled set is generated into
+`src/config/bundled-channel-config-metadata.generated.ts`. Third party
+channels register at runtime through the plugin manifest registry and are
+merged into the live schema when the gateway loads.
+
+## When things go wrong
+
+A decision tree for the most common failure modes:
+
+1. **Gateway refuses to start.** Run `openclaw doctor`. If the failure is plugin local, disable the plugin in `config.plugins.entries.<id>.enabled` or run the plugin install repair. If non plugin local, run `openclaw doctor --fix` to restore the last known good copy from `.bak`. Inspect the failed file under `~/.openclaw/openclaw.json` after the restore to learn what change broke it.
+
+2. **Hot reload silently does nothing.** Check the gateway logs. A reload that fails validation logs the error and keeps the previous runtime snapshot. Fix the file and save again to retrigger the watcher.
+
+3. **An AI agent wrote an unknown key.** The validation diagnostic lists the offending path. Use `openclaw config schema` or the `config.schema.lookup` RPC to confirm the supported keys. Either rename to the correct key or remove the entry. The strict policy is documented and is not user disableable.
+
+4. **A backup is missing or stale.** Backups rotate on every successful write. If `.bak` is older than expected, recent writes failed validation and never advanced the ring. Look at `.config-health.json` for the last successful fingerprint.
+
+5. **A secret leaked into a backup.** Backups are chmod 0o600 by default. If the on disk permissions look wrong, run `openclaw doctor --fix`, which calls `hardenBackupPermissions`. Snapshots that contain redacted placeholders (`***`) are never promoted to last known good, so a scrub never poisons recovery.
+
+## Known limitations
+
+These are documented gaps that operators should know about until they are
+closed. They are tracked in repo issues; check the changelog for status.
+
+- Auto rollback to last known good is not applied on startup or hot reload today. Recovery is manual through `openclaw doctor --fix`.
+- `replaceFileAtomic` relies on POSIX rename atomicity. Network mounts (NFS, some Docker volume drivers) do not guarantee it; a crash mid rename can leave a partial file. Keep config on a local filesystem.
+- Env var substitution resolves after schema validation. A reference to a missing variable like `${MISSING_VAR}` survives validation as a literal string and surfaces only at use time.
+- The runtime snapshot setter does not re validate the candidate. Callers must ensure the object already passed `validateConfigObjectWithPlugins`.
+
+## Related pages
+
+- [Configuration overview](/gateway/configuration)
+- [Configuration reference](/gateway/configuration-reference)
+- [Configuration examples](/gateway/configuration-examples)
+- [config-agents](/gateway/config-agents)
+- [config-channels](/gateway/config-channels)
+- [config-tools](/gateway/config-tools)
+- [Config CLI](/cli/config)
+- [Doctor CLI](/cli/doctor)

--- a/src/config/did-you-mean.test.ts
+++ b/src/config/did-you-mean.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  editDistance,
+  getKnownKeysAtSchemaPath,
+  suggestClosestKey,
+} from "./did-you-mean.js";
+
+describe("editDistance", () => {
+  it("returns 0 for identical strings", () => {
+    expect(editDistance("foo", "foo")).toBe(0);
+  });
+  it("counts insertions, deletions, and substitutions", () => {
+    expect(editDistance("", "abc")).toBe(3);
+    expect(editDistance("abc", "")).toBe(3);
+    expect(editDistance("kitten", "sitting")).toBe(3);
+    expect(editDistance("port", "Port")).toBe(1);
+  });
+});
+
+describe("suggestClosestKey", () => {
+  const keys = ["model", "modelRef", "primary", "fallbacks", "tools"];
+
+  it("suggests a close match within the threshold", () => {
+    expect(suggestClosestKey("modle", keys)).toBe("model");
+    expect(suggestClosestKey("primery", keys)).toBe("primary");
+  });
+
+  it("returns null when the unknown key is far from any candidate", () => {
+    expect(suggestClosestKey("nope", keys)).toBeNull();
+    expect(suggestClosestKey("xyzzy", keys, { maxDistance: 2 })).toBeNull();
+  });
+
+  it("ignores exact matches so the suggestion never names the unknown key itself", () => {
+    // With threshold 2 the only candidate within reach of "model" is itself,
+    // which we skip, so no suggestion fires.
+    expect(suggestClosestKey("model", keys)).toBeNull();
+    // Loosening the threshold lets nearby candidates surface again.
+    expect(suggestClosestKey("model", keys, { maxDistance: 4 })).toBe("modelRef");
+    expect(suggestClosestKey("model", keys, { maxDistance: 4 })).not.toBe("model");
+  });
+
+  it("is case insensitive but returns the canonical cased candidate", () => {
+    expect(suggestClosestKey("MODEL", ["model"])).toBe("model");
+    expect(suggestClosestKey("Port", ["port"])).toBe("port");
+  });
+
+  it("returns null for empty inputs", () => {
+    expect(suggestClosestKey("", keys)).toBeNull();
+    expect(suggestClosestKey("foo", [])).toBeNull();
+  });
+
+  it("ties break on lexicographic order so the suggestion is stable", () => {
+    expect(suggestClosestKey("aa", ["ab", "ba"])).toBe("ab");
+  });
+});
+
+describe("getKnownKeysAtSchemaPath", () => {
+  const root = {
+    type: "object",
+    properties: {
+      gateway: {
+        type: "object",
+        properties: {
+          port: { type: "number" },
+          mode: { type: "string" },
+          reload: {
+            type: "object",
+            properties: {
+              mode: { type: "string" },
+              debounceMs: { type: "number" },
+            },
+          },
+        },
+      },
+      channels: {
+        type: "object",
+        additionalProperties: {
+          type: "object",
+          properties: {
+            enabled: { type: "boolean" },
+            botToken: { type: "string" },
+          },
+        },
+      },
+    },
+  };
+
+  it("returns the root keys for an empty path", () => {
+    expect([...getKnownKeysAtSchemaPath(root, [])]).toEqual(["gateway", "channels"]);
+  });
+
+  it("descends through nested object paths", () => {
+    expect([...getKnownKeysAtSchemaPath(root, ["gateway"])]).toEqual(["port", "mode", "reload"]);
+    expect([...getKnownKeysAtSchemaPath(root, ["gateway", "reload"])]).toEqual([
+      "mode",
+      "debounceMs",
+    ]);
+  });
+
+  it("falls through additionalProperties when a key is not in properties", () => {
+    expect([...getKnownKeysAtSchemaPath(root, ["channels", "telegram"])]).toEqual([
+      "enabled",
+      "botToken",
+    ]);
+  });
+
+  it("returns an empty list when the path does not resolve", () => {
+    expect([...getKnownKeysAtSchemaPath(root, ["nonexistent"])]).toEqual([]);
+    expect([...getKnownKeysAtSchemaPath(root, ["gateway", "port"])]).toEqual([]);
+  });
+});

--- a/src/config/did-you-mean.ts
+++ b/src/config/did-you-mean.ts
@@ -1,0 +1,146 @@
+// Diagnostic helpers that suggest the closest valid key when a config write
+// names a key that does not exist in the schema. Kept small and dependency
+// free so the cost on every validation failure stays negligible.
+
+export function editDistance(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  if (!a) {
+    return b.length;
+  }
+  if (!b) {
+    return a.length;
+  }
+
+  const dp: number[] = Array.from({ length: b.length + 1 }, (_, j) => j);
+
+  for (let i = 1; i <= a.length; i++) {
+    let prev = dp[0];
+    dp[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const temp = dp[j];
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[j] = Math.min(dp[j] + 1, dp[j - 1] + 1, prev + cost);
+      prev = temp;
+    }
+  }
+
+  return dp[b.length];
+}
+
+export function suggestClosestKey(
+  unknownKey: string,
+  candidates: readonly string[],
+  options?: { maxDistance?: number },
+): string | null {
+  const threshold = options?.maxDistance ?? 2;
+  if (!unknownKey || candidates.length === 0) {
+    return null;
+  }
+
+  let best: { key: string; d: number } | null = null;
+  const unknownLower = unknownKey.toLowerCase();
+
+  for (const candidate of candidates) {
+    if (candidate === unknownKey) {
+      continue;
+    }
+    // Case-insensitive distance keeps the suggestion useful when the user
+    // typed a wrong case (port vs Port). Tie break on the original cased
+    // candidate so the suggestion stays canonical.
+    const d = editDistance(unknownLower, candidate.toLowerCase());
+    if (d > threshold) {
+      continue;
+    }
+    if (!best || d < best.d || (d === best.d && candidate < best.key)) {
+      best = { key: candidate, d };
+    }
+  }
+
+  return best ? best.key : null;
+}
+
+type JsonSchemaNode = {
+  properties?: Record<string, JsonSchemaNode>;
+  items?: JsonSchemaNode | JsonSchemaNode[];
+  additionalProperties?: JsonSchemaNode | boolean;
+  oneOf?: JsonSchemaNode[];
+  anyOf?: JsonSchemaNode[];
+  allOf?: JsonSchemaNode[];
+  $ref?: string;
+};
+
+function isNumericSegment(segment: string | number): boolean {
+  if (typeof segment === "number") {
+    return true;
+  }
+  return /^\d+$/.test(segment);
+}
+
+function resolveDollarRef(root: JsonSchemaNode, node: JsonSchemaNode): JsonSchemaNode {
+  let current = node;
+  // Local refs only (`#/definitions/...` or `#/$defs/...`).
+  const seen = new Set<string>();
+  while (typeof current.$ref === "string" && current.$ref.startsWith("#/")) {
+    if (seen.has(current.$ref)) {
+      return current;
+    }
+    seen.add(current.$ref);
+    const pathParts = current.$ref.slice(2).split("/");
+    let target: unknown = root;
+    for (const part of pathParts) {
+      if (!target || typeof target !== "object") {
+        return current;
+      }
+      target = (target as Record<string, unknown>)[part];
+    }
+    if (!target || typeof target !== "object") {
+      return current;
+    }
+    current = target as JsonSchemaNode;
+  }
+  return current;
+}
+
+function descendIntoSegment(
+  root: JsonSchemaNode,
+  node: JsonSchemaNode,
+  segment: string | number,
+): JsonSchemaNode | null {
+  const resolved = resolveDollarRef(root, node);
+  if (isNumericSegment(segment)) {
+    if (Array.isArray(resolved.items)) {
+      return resolved.items[0] ?? null;
+    }
+    return resolved.items ?? null;
+  }
+  const properties = resolved.properties;
+  const key = String(segment);
+  if (properties && key in properties) {
+    return properties[key] ?? null;
+  }
+  if (typeof resolved.additionalProperties === "object" && resolved.additionalProperties !== null) {
+    return resolved.additionalProperties;
+  }
+  return null;
+}
+
+export function getKnownKeysAtSchemaPath(
+  schemaRoot: JsonSchemaNode,
+  pathSegments: readonly (string | number)[],
+): readonly string[] {
+  let node: JsonSchemaNode | null = schemaRoot;
+  for (const segment of pathSegments) {
+    if (!node) {
+      return [];
+    }
+    node = descendIntoSegment(schemaRoot, node, segment);
+  }
+  if (!node) {
+    return [];
+  }
+  const resolved = resolveDollarRef(schemaRoot, node);
+  const properties = resolved.properties;
+  return properties ? Object.keys(properties) : [];
+}

--- a/src/config/io.did-you-mean.test.ts
+++ b/src/config/io.did-you-mean.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { createConfigIO, resetConfigRuntimeState } from "./io.js";
+
+describe("config validation surfaces did-you-mean hints", () => {
+  const suiteRootTracker = createSuiteTempRootTracker({
+    prefix: "openclaw-did-you-mean-",
+  });
+  const silentLogger = { warn: () => {}, error: () => {} };
+
+  beforeAll(async () => {
+    await suiteRootTracker.setup();
+  });
+
+  afterAll(async () => {
+    await suiteRootTracker.cleanup();
+  });
+
+  afterEach(() => {
+    resetConfigRuntimeState();
+  });
+
+  it("suggests gateway.port when the user writes a typo for the port key", async () => {
+    const home = await suiteRootTracker.make("typo-port");
+    const io = createConfigIO({
+      env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+      homedir: () => home,
+      logger: silentLogger,
+    });
+
+    // "porrt" is one transposition away from "port".
+    await expect(
+      io.writeConfigFile({ gateway: { mode: "local", porrt: 18789 } as never }),
+    ).rejects.toThrow(/did you mean.*"port"/);
+  });
+
+  it("does not append a did-you-mean clause when the unknown key is too far from any valid key", async () => {
+    const home = await suiteRootTracker.make("typo-far");
+    const io = createConfigIO({
+      env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+      homedir: () => home,
+      logger: silentLogger,
+    });
+
+    let captured: Error | null = null;
+    try {
+      await io.writeConfigFile({
+        gateway: { mode: "local", absolutelyNotAKey: 18789 } as never,
+      });
+    } catch (err) {
+      captured = err as Error;
+    }
+
+    expect(captured, "expected writeConfigFile to throw a validation error").toBeTruthy();
+    expect(captured?.message).not.toContain("did you mean");
+  });
+});

--- a/src/config/io.fsync-on-write.test.ts
+++ b/src/config/io.fsync-on-write.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+
+// Spy on replaceFileAtomic so we can verify that fsync flags are forwarded.
+// We delegate to the real implementation so the test still exercises the
+// actual write path and resulting file.
+const replaceFileAtomicSpy = vi.hoisted(() =>
+  vi.fn<
+    [import("../infra/replace-file.js").ReplaceFileAtomicOptions],
+    ReturnType<typeof import("../infra/replace-file.js").replaceFileAtomic>
+  >(),
+);
+const replaceFileAtomicSyncSpy = vi.hoisted(() =>
+  vi.fn<
+    [import("../infra/replace-file.js").ReplaceFileAtomicSyncOptions],
+    ReturnType<typeof import("../infra/replace-file.js").replaceFileAtomicSync>
+  >(),
+);
+
+vi.mock("../infra/replace-file.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/replace-file.js")>();
+  return {
+    ...actual,
+    replaceFileAtomic: (options: import("../infra/replace-file.js").ReplaceFileAtomicOptions) => {
+      replaceFileAtomicSpy(options);
+      return actual.replaceFileAtomic(options);
+    },
+    replaceFileAtomicSync: (
+      options: import("../infra/replace-file.js").ReplaceFileAtomicSyncOptions,
+    ) => {
+      replaceFileAtomicSyncSpy(options);
+      return actual.replaceFileAtomicSync(options);
+    },
+  };
+});
+
+// Imported after the mock is registered so the module picks up the wrapped
+// helpers from the mock above.
+const { createConfigIO, resetConfigRuntimeState } = await import("./io.js");
+
+describe("config writers enable fsync", () => {
+  const suiteRootTracker = createSuiteTempRootTracker({
+    prefix: "openclaw-config-fsync-",
+  });
+  const silentLogger = { warn: () => {}, error: () => {} };
+
+  beforeAll(async () => {
+    await suiteRootTracker.setup();
+  });
+
+  afterAll(async () => {
+    await suiteRootTracker.cleanup();
+  });
+
+  afterEach(() => {
+    resetConfigRuntimeState();
+    replaceFileAtomicSpy.mockClear();
+    replaceFileAtomicSyncSpy.mockClear();
+  });
+
+  it("writeConfigFile forwards syncTempFile and syncParentDir to replaceFileAtomic", async () => {
+    const home = await suiteRootTracker.make("write-config");
+    const io = createConfigIO({
+      env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+      homedir: () => home,
+      logger: silentLogger,
+    });
+
+    await io.writeConfigFile({ gateway: { mode: "local", port: 18789 } });
+
+    // Find the call that targeted the main config file. Other write paths
+    // (health state, plugin install index) may also call replaceFileAtomic
+    // and are not in scope for this assertion.
+    const configCall = replaceFileAtomicSpy.mock.calls.find(([options]) =>
+      options.filePath.endsWith(path.join(".openclaw", "openclaw.json")),
+    );
+
+    expect(
+      configCall,
+      "expected replaceFileAtomic to be invoked for openclaw.json",
+    ).toBeDefined();
+    expect(configCall?.[0].syncTempFile).toBe(true);
+    expect(configCall?.[0].syncParentDir).toBe(true);
+
+    // Sanity check: the file actually landed on disk.
+    const written = await fs.readFile(
+      path.join(home, ".openclaw", "openclaw.json"),
+      "utf-8",
+    );
+    expect(written).toContain('"port"');
+  });
+});

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1327,6 +1327,10 @@ export function createConfigIO(
       mode: 0o600,
       tempPrefix: path.basename(configPath),
       copyFallbackOnPermissionError: true,
+      // fsync the temp file and parent directory so a crash mid write or a
+      // power loss on a network volume cannot leave a partial config file.
+      syncTempFile: true,
+      syncParentDir: true,
       fileSystem: deps.fs,
     });
   }
@@ -2235,6 +2239,10 @@ export function createConfigIO(
         mode: 0o600,
         tempPrefix: path.basename(configPath),
         copyFallbackOnPermissionError: true,
+        // fsync the temp file and parent directory so a crash mid write or a
+        // power loss on a network volume cannot leave a partial config file.
+        syncTempFile: true,
+        syncParentDir: true,
         fileSystem: deps.fs,
         beforeRename: async () => {
           if (deps.fs.existsSync(configPath)) {

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -221,6 +221,10 @@ async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<vo
     dirMode: 0o700,
     mode: 0o600,
     tempPrefix: path.basename(filePath),
+    // fsync the temp file and parent directory so a crash mid write or a
+    // power loss on a network volume cannot leave a partial config file.
+    syncTempFile: true,
+    syncParentDir: true,
     beforeRename: async () => {
       await fs.access(filePath).then(
         async () => await maintainConfigBackups(filePath, fs),

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -37,6 +37,7 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { isRecord, resolveUserPath } from "../utils.js";
 import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-dirs.js";
 import { appendAllowedValuesHint, summarizeAllowedValues } from "./allowed-values.js";
+import { getKnownKeysAtSchemaPath, suggestClosestKey } from "./did-you-mean.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
 import { collectChannelSchemaMetadata } from "./channel-config-metadata.js";
 import { materializeRuntimeConfig } from "./materialize.js";
@@ -513,10 +514,56 @@ export function collectUnsupportedSecretRefPolicyIssues(raw: unknown): ConfigVal
   return collectUnsupportedMutableSecretRefIssues(raw);
 }
 
+let cachedSchemaRootForDidYouMean: Record<string, unknown> | null = null;
+function getSchemaRootForDidYouMean(): Record<string, unknown> {
+  if (!cachedSchemaRootForDidYouMean) {
+    cachedSchemaRootForDidYouMean = OpenClawSchema.toJSONSchema({
+      target: "draft-07",
+      unrepresentable: "any",
+    }) as Record<string, unknown>;
+  }
+  return cachedSchemaRootForDidYouMean;
+}
+
+function appendDidYouMeanHint(issue: unknown, message: string): string {
+  const record = toIssueRecord(issue);
+  if (!record || record.code !== "unrecognized_keys") {
+    return message;
+  }
+  const offendingKeys = [...message.matchAll(/"([^"]+)"/g)]
+    .map((match) => match[1])
+    .filter((key): key is string => Boolean(key));
+  if (offendingKeys.length === 0) {
+    return message;
+  }
+  const segments = toConfigPathSegments(record.path);
+  let candidates: readonly string[];
+  try {
+    candidates = getKnownKeysAtSchemaPath(getSchemaRootForDidYouMean(), segments);
+  } catch {
+    return message;
+  }
+  if (candidates.length === 0) {
+    return message;
+  }
+  const suggestions: string[] = [];
+  for (const offending of offendingKeys) {
+    const closest = suggestClosestKey(offending, candidates);
+    if (closest) {
+      suggestions.push(`"${offending}" -> "${closest}"`);
+    }
+  }
+  if (suggestions.length === 0) {
+    return message;
+  }
+  return `${message} (did you mean: ${suggestions.join(", ")})`;
+}
+
 function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
   const record = toIssueRecord(issue);
   const path = formatConfigPath(toConfigPathSegments(record?.path));
-  const message = typeof record?.message === "string" ? record.message : "Invalid input";
+  const rawMessage = typeof record?.message === "string" ? record.message : "Invalid input";
+  const message = appendDidYouMeanHint(issue, rawMessage);
 
   const allowedValuesSummary = summarizeAllowedValues(collectAllowedValuesFromUnknownIssue(issue));
 


### PR DESCRIPTION
## Summary

- **Problem:** Operators lack documentation on where config lives on disk, how validation works, backup/recovery mechanics, and what to do when things go wrong. Validation errors for typos in config keys are unhelpful.
- **Why it matters:** Configuration is critical infrastructure; operators need to understand the lifecycle, recovery paths, and troubleshooting steps. Better error messages reduce support burden.
- **What changed:** Added comprehensive `configuration-internals.md` documentation, implemented "did you mean" suggestions for unknown config keys, and hardened atomic writes with fsync flags.
- **What did NOT change:** No changes to config schema, runtime behavior, or hot reload mechanics. Recovery policy remains manual (via `openclaw doctor --fix`).

## Change Type

- [x] Docs
- [x] Feature (validation diagnostics)
- [x] Security hardening (fsync on writes)

## Scope

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Related to configuration reliability and operator experience

## Real behavior proof

**Validation diagnostics:**
- Unknown key `porrt` (typo for `port`) now surfaces: `"porrt" (did you mean: "port")`
- Unknown key `absolutelyNotAKey` (too far from any valid key) surfaces without suggestion
- Tests verify both cases: `src/config/io.did-you-mean.test.ts`

**Fsync hardening:**
- Config writes now call `fsync()` on temp file and parent directory before rename
- Prevents partial config files on crash or power loss on network volumes
- Test verifies flags are forwarded: `src/config/io.fsync-on-write.test.ts`

**Documentation:**
- New `docs/gateway/configuration-internals.md` (246 lines) covers:
  - File layout and ownership (`openclaw.json`, backups, health state)
  - Settings categories and schema ownership
  - Validation surfaces and lifecycle
  - Read/write flow with locking and atomic semantics
  - Hot reload modes and behavior
  - Backup rotation and recovery mechanics
  - Doctor coverage and repair sequencing
  - Environment variable precedence
  - Plugin and channel config integration
  - Troubleshooting decision tree
  - Known limitations
- Added to docs nav in `docs/docs.json`

## Root Cause

N/A (feature and documentation addition)

## Regression Test Plan

- Unit tests for edit distance and key suggestion: `src/config/did-you-mean.test.ts` (12 cases)
- Integration test for validation error messages: `src/config/io.did-you-mean.test.ts` (2 cases)
- Integration test for fsync flags: `src/config/io.fsync-on-write.test.ts` (1 case)
- Existing validation tests continue to pass (`src/config/io.write-config.test.ts`, `src/config/mutate.test.ts`)

## User-visible / Behavior Changes

**Validation error messages now include suggestions:**
```
Unrecognized key "porrt" (did you mean: "porrt" -> "port")
```

**Config writes are now more durable:**
- Temp file and parent directory are fsynced before atomic rename
- Reduces risk of partial config on network volumes or power loss

## Diagram

```text
Before:
[user typo: "porrt"] -> [validation error: "Unrecognized key porrt"]

After:
[user typo: "porrt"] -> [validation error: "Unrecognized key porrt (did you mean: port)"]

Before:
[write temp file] -> [rename] -> [crash] -> [partial file possible]

After:
[write temp file] -> [fsync temp + parent] -> [rename] -> [crash] -> [complete or nothing]
```

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

Fsync hardening is a defensive measure; no new attack surface.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## SQLite for settings: reasoning and decision

This branch was sized to two small fixes plus the reference doc. A larger
follow up about safe mode boot, bundled recipes, and an architecture rule
against direct `fs.writeFile` against the config path is queued.

The initial discussion considered SQLite as either the canonical store for
`openclaw.json` or as a preset catalog of known good values. Both options
were evaluated and rejected for this branch. Recording the reasoning here so
the decision is reviewable.

### Case for SQLite

- Queryable knowledge base for valid models, channel auth shapes, and
  similar.
- Versioned migrations via familiar SQL patterns.
- Indexed Levenshtein for did-you-mean across thousands of keys.
- Transactions for multi key recipe application.
- Operator friendly inspection with `sqlite3 ... ".tables"`.
- Concurrent readers across gateway, Control UI, and CLI without
  contention.

### Case against SQLite (decisive)

- The "correct values" we would ship are static data versioned with the
  code. SQLite earns its weight when data mutates in production and needs
  range queries. Recipes do neither and behave like constants, so JSON in
  source is a better fit.
- Native dependency cost. `better-sqlite3` requires `node-gyp`, breaks
  cross platform Docker and `nix-openclaw` builds, and forces a separate
  abstraction over Bun's `bun:sqlite`. The root `AGENTS.md` requires Node
  and Bun paths to keep working. Node 22's stable `node:sqlite` sidesteps
  the install pain but is sync only and Bun does not expose it; an
  abstraction layer is not worth it for this dataset.
- Loss of git as audit trail. JSON recipes in repo are diff readable and
  code reviewed. A SQLite seed needs a separate review process or a
  migration files system that re-implements PR review.
- Doubles the source of truth. The Zod schema already carries titles,
  descriptions, enums, and bounds. `openclaw config schema` emits the full
  JSON Schema and `config.schema.lookup` returns path scoped drill down.
  Adding SQLite means every schema change must be replicated.
- Performance is not the bottleneck. With roughly 50 recipes and 500
  schema keys, in memory lookup beats a SQLite query for both Levenshtein
  and exact matches. SQLite wins only when data does not fit in RAM or
  when query latency dominates total time.
- The actual operator pain that this work addresses is not lookup speed or
  queryability. It is "gateway will not start" (queued for the safe mode
  boot follow up), "AI wrote an unknown key" (fixed by did-you-mean in
  this PR against the existing in memory schema), and "where do I look
  this up" (fixed by the new Configuration internals reference page in
  this PR).

### Hybrid considered

JSON recipes in repo plus a SQLite cache generated at build time or first
run for faster lookup. Considered and rejected. The cache introduces
SQLite at runtime, which means the full native dependency cost is paid
anyway, while the lookup speed gain is theoretical for this dataset. The
cache also has to be invalidated on version bump, adding bug surface.

### Where SQLite does fit

Out of scope for this branch, but a candidate for a future opt in plugin:

- Append heavy audit log of config mutations queried by time range.
  SQLite is the right tool. JSON is impossible for temporal range queries.
- Session and transcript store. Currently flat files. Natural SQLite
  candidate, but owned by the agent runtime work, not this branch.

### Decision

Ship JSON recipes (in a follow up) plus did-you-mean over the in memory
schema. Keep `openclaw.json` as the canonical settings store. Treat
SQLite as an optional plugin that adds an audit log of config mutations,
behind its own feature flag, only after explicit maintainer alignment.

https://claude.ai/code/session_012JKfpZdT1t4jsv7M54WdfM