### PR TITLE
refactor: centralize live provider drift policy

### DIFF
--- a/src/agents/live-cache-regression-runner.test.ts
+++ b/src/agents/live-cache-regression-runner.test.ts
@@ -84,20 +84,6 @@ describe("live cache regression runner", () => {
     ).toBe(false);
   });
 
-  it("classifies Anthropic account drift as non-cache provider state", () => {
-    expect(
-      __testing.isAnthropicAccountDrift(
-        new Error("Your credit balance is too low to access the Anthropic API."),
-      ),
-    ).toBe(true);
-    expect(
-      __testing.isAnthropicAccountDrift(
-        '401 {"error":{"message":"The API key you provided is invalid."}}',
-      ),
-    ).toBe(true);
-    expect(__testing.isAnthropicAccountDrift("anthropic:image cacheRead=0 < min=4500")).toBe(false);
-  });
-
   it("retries a cache probe twice when provider text misses the sentinel", () => {
     expect(
       __testing.shouldRetryCacheProbeText({

--- a/src/agents/live-cache-regression-runner.ts
+++ b/src/agents/live-cache-regression-runner.ts
@@ -15,12 +15,10 @@ import {
   extractAssistantText,
   type LiveResolvedModel,
   logLiveCache,
-  resolveLiveDirectModel,
+  resolveLiveDirectModelPool,
+  withLiveDirectModelApiKey,
 } from "./live-cache-test-support.js";
-import {
-  isAuthErrorMessage,
-  isBillingErrorMessage,
-} from "./pi-embedded-helpers/failover-matches.js";
+import { shouldSkipLiveProviderDrift } from "./live-test-provider-drift.js";
 
 const OPENAI_TIMEOUT_MS = 120_000;
 const ANTHROPIC_TIMEOUT_MS = 120_000;
@@ -599,30 +597,29 @@ function appendBaselineFindings(target: BaselineFindings, source: BaselineFindin
   target.warnings.push(...source.warnings);
 }
 
-function isAnthropicAccountDrift(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return isBillingErrorMessage(message) || isAuthErrorMessage(message);
-}
-
 function isAnthropicEmptyCacheProbe(error: unknown): boolean {
   return error instanceof CacheProbeTextMismatchError && error.text.trim().length === 0;
 }
 
-function cloneFixtureWithKey(fixture: LiveResolvedModel, apiKey: string): LiveResolvedModel {
-  return { ...fixture, apiKey };
+function shouldSkipAnthropicCacheProviderDrift(error: unknown): boolean {
+  return Boolean(
+    shouldSkipLiveProviderDrift({
+      error,
+      allowAuth: true,
+      allowBilling: true,
+    }),
+  );
 }
 
 async function runAnthropicCacheLane(params: {
+  apiKeys: readonly string[];
   fixture: LiveResolvedModel;
   lane: CacheLane;
   pngBase64: string;
   runToken: string;
   warnings: string[];
 }): Promise<{ attempt?: Awaited<ReturnType<typeof runRepeatedLaneWithBaselineRetry>> }> {
-  const keys =
-    params.fixture.apiKeys && params.fixture.apiKeys.length > 0
-      ? params.fixture.apiKeys
-      : [params.fixture.apiKey];
+  const keys = params.apiKeys.length > 0 ? params.apiKeys : [params.fixture.apiKey];
   let lastError: unknown;
   for (const [index, apiKey] of keys.entries()) {
     try {
@@ -630,14 +627,14 @@ async function runAnthropicCacheLane(params: {
         attempt: await runRepeatedLaneWithBaselineRetry({
           lane: params.lane,
           providerTag: "anthropic",
-          fixture: cloneFixtureWithKey(params.fixture, apiKey),
+          fixture: withLiveDirectModelApiKey(params.fixture, apiKey),
           runToken: params.runToken,
           pngBase64: params.pngBase64,
         }),
       };
     } catch (error) {
       lastError = error;
-      if (isAnthropicAccountDrift(error) && index + 1 < keys.length) {
+      if (shouldSkipAnthropicCacheProviderDrift(error) && index + 1 < keys.length) {
         logLiveCache(`anthropic ${params.lane} account drift; retrying with next key`);
         continue;
       }
@@ -645,7 +642,7 @@ async function runAnthropicCacheLane(params: {
     }
   }
 
-  if (isAnthropicAccountDrift(lastError) || isAnthropicEmptyCacheProbe(lastError)) {
+  if (shouldSkipAnthropicCacheProviderDrift(lastError) || isAnthropicEmptyCacheProbe(lastError)) {
     const reason = isAnthropicEmptyCacheProbe(lastError) ? "empty response" : "account drift";
     const warning = `anthropic ${params.lane} skipped: ${reason}`;
     params.warnings.push(warning);
@@ -667,7 +664,7 @@ async function runAnthropicDisabledCacheLane(params: {
       sessionId: `live-cache-regression-${params.runToken}-anthropic-disabled`,
     });
   } catch (error) {
-    if (isAnthropicAccountDrift(error) || isAnthropicEmptyCacheProbe(error)) {
+    if (shouldSkipAnthropicCacheProviderDrift(error) || isAnthropicEmptyCacheProbe(error)) {
       const warning = "anthropic disabled skipped: account drift";
       params.warnings.push(warning);
       logLiveCache(warning);
@@ -680,7 +677,6 @@ async function runAnthropicDisabledCacheLane(params: {
 export const __testing = {
   assertAgainstBaseline,
   evaluateAgainstBaseline,
-  isAnthropicAccountDrift,
   resolveCacheProbeMaxTokens,
   shouldAcceptEmptyOpenAICacheProbe,
   shouldRetryCacheProbeText,
@@ -690,13 +686,13 @@ export const __testing = {
 export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResult> {
   const pngBase64 = (await fs.readFile(LIVE_TEST_PNG_URL)).toString("base64");
   const runToken = randomUUID().slice(0, 13);
-  const openai = await resolveLiveDirectModel({
+  const openai = await resolveLiveDirectModelPool({
     provider: "openai",
     api: "openai-responses",
     envVar: "OPENCLAW_LIVE_OPENAI_CACHE_MODEL",
     preferredModelIds: ["gpt-4.1", "gpt-5.2", "gpt-5.4-mini", "gpt-5.4", "gpt-5.5"],
   });
-  const anthropic = await resolveLiveDirectModel({
+  const anthropic = await resolveLiveDirectModelPool({
     provider: "anthropic",
     api: "anthropic-messages",
     envVar: "OPENCLAW_LIVE_ANTHROPIC_CACHE_MODEL",
@@ -714,7 +710,7 @@ export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResul
     const openaiAttempt = await runRepeatedLaneWithBaselineRetry({
       lane,
       providerTag: "openai",
-      fixture: openai,
+      fixture: openai.fixture,
       runToken,
       pngBase64,
     });
@@ -734,8 +730,9 @@ export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResul
     appendBaselineFindings({ regressions, warnings }, openaiAttempt.findings);
 
     const { attempt: anthropicAttempt } = await runAnthropicCacheLane({
+      apiKeys: anthropic.apiKeys,
       lane,
-      fixture: anthropic,
+      fixture: anthropic.fixture,
       runToken,
       pngBase64,
       warnings,
@@ -761,7 +758,7 @@ export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResul
   }
 
   const disabled = await runAnthropicDisabledCacheLane({
-    fixture: anthropic,
+    fixture: anthropic.fixture,
     runToken,
     warnings,
   });

--- a/src/agents/live-cache-test-support.ts
+++ b/src/agents/live-cache-test-support.ts
@@ -24,8 +24,12 @@ const DEFAULT_TIMEOUT_MS = 90_000;
 
 export type LiveResolvedModel = {
   apiKey: string;
-  apiKeys?: string[];
   model: Model<Api>;
+};
+
+export type LiveResolvedModelPool = {
+  apiKeys: string[];
+  fixture: LiveResolvedModel;
 };
 
 function toInt(value: string | undefined, fallback: number): number {
@@ -162,12 +166,12 @@ export function computeCacheHitRate(usage: {
   return cacheRead / totalPrompt;
 }
 
-export async function resolveLiveDirectModel(params: {
+export async function resolveLiveDirectModelPool(params: {
   provider: "anthropic" | "openai";
   api: "anthropic-messages" | "openai-responses";
   envVar: string;
   preferredModelIds: readonly string[];
-}): Promise<LiveResolvedModel> {
+}): Promise<LiveResolvedModelPool> {
   const liveKeys = collectProviderApiKeys(params.provider);
   const rawModel = process.env[params.envVar]?.trim();
   const parsed = rawModel ? parseModelRef(rawModel, params.provider) : null;
@@ -188,9 +192,11 @@ export async function resolveLiveDirectModel(params: {
     }
     logLiveCache(`resolved ${params.provider} model ${selectedModel.id} from live env key`);
     return {
-      model: selectedModel,
-      apiKey: liveKeys[0] ?? "",
       apiKeys: liveKeys,
+      fixture: {
+        model: selectedModel,
+        apiKey: liveKeys[0] ?? "",
+      },
     };
   }
 
@@ -237,8 +243,23 @@ export async function resolveLiveDirectModel(params: {
     `resolved ${params.provider} model ${resolvedModel.id} from configured auth storage`,
   );
   return {
-    model: resolvedModel,
-    apiKey,
     apiKeys: [apiKey],
+    fixture: {
+      model: resolvedModel,
+      apiKey,
+    },
   };
+}
+
+export async function resolveLiveDirectModel(
+  params: Parameters<typeof resolveLiveDirectModelPool>[0],
+): Promise<LiveResolvedModel> {
+  return (await resolveLiveDirectModelPool(params)).fixture;
+}
+
+export function withLiveDirectModelApiKey(
+  fixture: LiveResolvedModel,
+  apiKey: string,
+): LiveResolvedModel {
+  return { ...fixture, apiKey };
 }

--- a/src/agents/live-test-provider-drift.test.ts
+++ b/src/agents/live-test-provider-drift.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLiveAuthDrift,
+  isLiveBillingDrift,
+  isLiveProviderUnavailableDrift,
+  isLiveRateLimitDrift,
+  shouldSkipLiveProviderDrift,
+} from "./live-test-provider-drift.js";
+
+describe("live test provider drift", () => {
+  it("classifies provider account drift", () => {
+    expect(
+      isLiveBillingDrift(new Error("Your credit balance is too low to access the Anthropic API.")),
+    ).toBe(true);
+    expect(isLiveBillingDrift("billing has been disabled for this API key")).toBe(true);
+    expect(isLiveBillingDrift("insufficient credit")).toBe(true);
+    expect(
+      isLiveAuthDrift('401 {"error":{"message":"The API key you provided is invalid."}}'),
+    ).toBe(true);
+  });
+
+  it("classifies API-key rate-limit drift", () => {
+    expect(isLiveRateLimitDrift("resource exhausted")).toBe(true);
+  });
+
+  it("classifies transient provider availability drift", () => {
+    expect(
+      isLiveProviderUnavailableDrift(
+        "521 <!DOCTYPE html><html><head><title>Web server is down</title></head><body>Cloudflare</body></html>",
+      ),
+    ).toBe(true);
+    expect(
+      isLiveProviderUnavailableDrift(
+        "Error: <html><head><title>Service Unavailable</title></head><body>try again</body></html>",
+      ),
+    ).toBe(true);
+    expect(
+      isLiveProviderUnavailableDrift(
+        "Error: <html><head><title>500 Internal Server Error</title></head><body>try again</body></html>",
+      ),
+    ).toBe(true);
+    expect(
+      isLiveProviderUnavailableDrift("provider returned error: 502 Internal Server Error"),
+    ).toBe(true);
+    expect(
+      isLiveProviderUnavailableDrift(
+        "Service temporarily unavailable. The model is at capacity and currently cannot serve this request.",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns explicit skip labels only for enabled drift classes", () => {
+    expect(
+      shouldSkipLiveProviderDrift({
+        error: '401 {"error":{"message":"The API key you provided is invalid."}}',
+        allowAuth: true,
+      }),
+    ).toEqual({ reason: "auth", label: "auth drift" });
+    expect(
+      shouldSkipLiveProviderDrift({
+        error: '401 {"error":{"message":"The API key you provided is invalid."}}',
+        allowBilling: true,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/live-test-provider-drift.ts
+++ b/src/agents/live-test-provider-drift.ts
@@ -1,0 +1,108 @@
+import { isCloudflareOrHtmlErrorPage } from "../shared/assistant-error-format.js";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { isAnthropicBillingError, isApiKeyRateLimitError } from "./live-auth-keys.js";
+import { isModelNotFoundErrorMessage } from "./live-model-errors.js";
+import {
+  isAuthErrorMessage,
+  isBillingErrorMessage,
+  isRateLimitErrorMessage,
+  isTimeoutErrorMessage,
+} from "./pi-embedded-helpers/failover-matches.js";
+
+export type LiveProviderDriftReason =
+  | "auth"
+  | "billing"
+  | "model-not-found"
+  | "provider-unavailable"
+  | "rate-limit"
+  | "timeout";
+
+export type LiveProviderDriftDecision = {
+  label: string;
+  reason: LiveProviderDriftReason;
+};
+
+export type LiveProviderDriftOptions = {
+  allowAuth?: boolean;
+  allowBilling?: boolean;
+  allowModelNotFound?: boolean;
+  allowProviderUnavailable?: boolean;
+  allowRateLimit?: boolean;
+  allowTimeout?: boolean;
+  error: unknown;
+};
+
+export function liveProviderErrorText(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}
+
+export function isLiveAuthDrift(error: unknown): boolean {
+  return isAuthErrorMessage(liveProviderErrorText(error));
+}
+
+export function isLiveBillingDrift(error: unknown): boolean {
+  const raw = liveProviderErrorText(error);
+  return isBillingErrorMessage(raw) || isAnthropicBillingError(raw);
+}
+
+export function isLiveRateLimitDrift(error: unknown): boolean {
+  const raw = liveProviderErrorText(error);
+  return isRateLimitErrorMessage(raw) || isApiKeyRateLimitError(raw);
+}
+
+export function isLiveTimeoutDrift(error: unknown): boolean {
+  return isTimeoutErrorMessage(liveProviderErrorText(error));
+}
+
+export function isLiveModelNotFoundDrift(error: unknown): boolean {
+  return isModelNotFoundErrorMessage(liveProviderErrorText(error));
+}
+
+export function isLiveProviderUnavailableDrift(error: unknown): boolean {
+  const raw = liveProviderErrorText(error);
+  const htmlCandidate = raw.trim().replace(/^error:\s*/i, "");
+  const msg = normalizeLowercaseStringOrEmpty(raw);
+  return (
+    isRawHtmlProviderErrorPage(htmlCandidate) ||
+    isCloudflareOrHtmlErrorPage(raw) ||
+    isCloudflareOrHtmlErrorPage(htmlCandidate) ||
+    msg.includes("no allowed providers are available") ||
+    msg.includes("provider unavailable") ||
+    msg.includes("upstream provider unavailable") ||
+    msg.includes("upstream error from google") ||
+    msg.includes("temporarily rate-limited upstream") ||
+    (msg.includes("service temporarily unavailable") && msg.includes("capacity")) ||
+    msg.includes("unable to access non-serverless model") ||
+    msg.includes("create and start a new dedicated endpoint") ||
+    msg.includes("no available capacity was found for the model") ||
+    (msg.includes("502") && msg.includes("internal server error"))
+  );
+}
+
+function isRawHtmlProviderErrorPage(raw: string): boolean {
+  return /^(?:<!doctype\s+html\b|<html\b)/i.test(raw) && /<\/html>/i.test(raw);
+}
+
+export function shouldSkipLiveProviderDrift(
+  options: LiveProviderDriftOptions,
+): LiveProviderDriftDecision | undefined {
+  if (options.allowBilling && isLiveBillingDrift(options.error)) {
+    return { reason: "billing", label: "billing drift" };
+  }
+  if (options.allowAuth && isLiveAuthDrift(options.error)) {
+    return { reason: "auth", label: "auth drift" };
+  }
+  if (options.allowRateLimit && isLiveRateLimitDrift(options.error)) {
+    return { reason: "rate-limit", label: "rate limit" };
+  }
+  if (options.allowProviderUnavailable && isLiveProviderUnavailableDrift(options.error)) {
+    return { reason: "provider-unavailable", label: "provider unavailable" };
+  }
+  if (options.allowTimeout && isLiveTimeoutDrift(options.error)) {
+    return { reason: "timeout", label: "timeout" };
+  }
+  if (options.allowModelNotFound && isLiveModelNotFoundDrift(options.error)) {
+    return { reason: "model-not-found", label: "model not found" };
+  }
+  return undefined;
+}

--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -14,11 +14,7 @@ import { parseLiveCsvFilter } from "../media-generation/live-test-helpers.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { resolveDefaultAgentDir } from "./agent-scope.js";
 import { externalCliDiscoveryForProviders } from "./auth-profiles/external-cli-discovery.js";
-import {
-  collectAnthropicApiKeys,
-  isAnthropicBillingError,
-  isAnthropicRateLimitError,
-} from "./live-auth-keys.js";
+import { collectAnthropicApiKeys } from "./live-auth-keys.js";
 import { isModelNotFoundErrorMessage } from "./live-model-errors.js";
 import {
   isHighSignalLiveModelRef,
@@ -46,14 +42,15 @@ import {
 } from "./live-model-turn-probes.js";
 import { createLiveTargetMatcher } from "./live-target-matcher.js";
 import { isLiveProfileKeyModeEnabled, isLiveTestEnabled } from "./live-test-helpers.js";
+import {
+  isLiveBillingDrift,
+  isLiveRateLimitDrift,
+  shouldSkipLiveProviderDrift,
+} from "./live-test-provider-drift.js";
 import { getApiKeyForModel, requireApiKey } from "./model-auth.js";
 import { shouldSuppressBuiltInModel } from "./model-suppression.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
-import {
-  isCloudflareOrHtmlErrorPage,
-  isRateLimitErrorMessage,
-} from "./pi-embedded-helpers/errors.js";
-import { isAuthErrorMessage } from "./pi-embedded-helpers/failover-matches.js";
+import { isRateLimitErrorMessage } from "./pi-embedded-helpers/errors.js";
 import {
   discoverAuthStorage,
   discoverModels,
@@ -251,39 +248,6 @@ describe("isModelNotFoundErrorMessage", () => {
   });
 });
 
-describe("isProviderUnavailableErrorMessage", () => {
-  it("matches raw HTML provider error pages from transient upstreams", () => {
-    expect(
-      isProviderUnavailableErrorMessage(
-        "Error: <html><head><title>Service Unavailable</title></head><body>try again</body></html>",
-      ),
-    ).toBe(true);
-  });
-
-  it("matches status-prefixed Cloudflare HTML pages", () => {
-    expect(
-      isProviderUnavailableErrorMessage(
-        "521 <!DOCTYPE html><html><head><title>Web server is down</title></head><body>Cloudflare</body></html>",
-      ),
-    ).toBe(true);
-  });
-
-  it("matches transient upstream 502 errors", () => {
-    expect(isProviderUnavailableErrorMessage("502 internal server error")).toBe(true);
-    expect(
-      isProviderUnavailableErrorMessage("provider returned error: 502 Internal Server Error"),
-    ).toBe(true);
-  });
-
-  it("matches xAI temporary capacity errors", () => {
-    expect(
-      isProviderUnavailableErrorMessage(
-        "Service temporarily unavailable. The model is at capacity and currently cannot serve this request. Please try again later.",
-      ),
-    ).toBe(true);
-  });
-});
-
 function isChatGPTUsageLimitErrorMessage(raw: string): boolean {
   const msg = raw.toLowerCase();
   return msg.includes("hit your chatgpt usage limit") && msg.includes("try again in");
@@ -307,36 +271,6 @@ function isOpenAiCodexHtmlInterruption(raw: string): boolean {
     /^(?:<!doctype\s+html\b|<html\b)/i.test(trimmed) &&
     (/<meta\s+name=["']viewport["']/i.test(trimmed) || /<body\b/i.test(trimmed))
   );
-}
-
-function isModelTimeoutError(raw: string): boolean {
-  return /model call timed out after \d+ms/i.test(raw);
-}
-
-function isProviderUnavailableErrorMessage(raw: string): boolean {
-  const msg = raw.toLowerCase();
-  return (
-    isRawHtmlProviderErrorPage(raw) ||
-    isCloudflareOrHtmlErrorPage(raw) ||
-    msg.includes("no allowed providers are available") ||
-    msg.includes("provider unavailable") ||
-    msg.includes("upstream provider unavailable") ||
-    msg.includes("upstream error from google") ||
-    msg.includes("temporarily rate-limited upstream") ||
-    (msg.includes("service temporarily unavailable") && msg.includes("capacity")) ||
-    msg.includes("unable to access non-serverless model") ||
-    msg.includes("create and start a new dedicated endpoint") ||
-    msg.includes("no available capacity was found for the model") ||
-    (msg.includes("502") && msg.includes("internal server error"))
-  );
-}
-
-function isRawHtmlProviderErrorPage(raw: string): boolean {
-  const normalized = raw
-    .trim()
-    .replace(/^error:\s*/i, "")
-    .trim();
-  return /^(?:<!doctype\s+html\b|<html\b)/i.test(normalized) && /<\/html>/i.test(normalized);
 }
 
 function isOllamaUnavailableErrorMessage(raw: string): boolean {
@@ -393,14 +327,6 @@ describe("isUnsupportedPlanErrorMessage", () => {
     );
     expect(isUnsupportedPlanErrorMessage("your current token plan not support model")).toBe(true);
     expect(isUnsupportedPlanErrorMessage("model not found")).toBe(false);
-  });
-});
-
-describe("isAuthErrorMessage", () => {
-  it("matches provider API key drift", () => {
-    expect(
-      isAuthErrorMessage('401 {"error":{"message":"The API key you provided is invalid."}}'),
-    ).toBe(true);
   });
 });
 
@@ -1211,18 +1137,18 @@ describeLive("live models (profile keys)", () => {
             const message = String(err);
             if (
               model.provider === "anthropic" &&
-              isAnthropicRateLimitError(message) &&
+              isLiveRateLimitDrift(message) &&
               attempt + 1 < attemptMax
             ) {
               logProgress(`${progressLabel}: rate limit, retrying with next key`);
               continue;
             }
-            if (model.provider === "anthropic" && isAnthropicRateLimitError(message)) {
+            if (model.provider === "anthropic" && isLiveRateLimitDrift(message)) {
               skipped.push({ model: id, reason: message });
               logProgress(`${progressLabel}: skip (anthropic rate limit)`);
               break;
             }
-            if (model.provider === "anthropic" && isAnthropicBillingError(message)) {
+            if (model.provider === "anthropic" && isLiveBillingDrift(message)) {
               if (attempt + 1 < attemptMax) {
                 logProgress(`${progressLabel}: billing issue, retrying with next key`);
                 continue;
@@ -1313,19 +1239,16 @@ describeLive("live models (profile keys)", () => {
               logProgress(`${progressLabel}: skip (codex html interruption)`);
               break;
             }
-            if (allowNotFoundSkip && isModelTimeoutError(message)) {
+            const driftSkip = shouldSkipLiveProviderDrift({
+              error: message,
+              allowAuth: allowNotFoundSkip,
+              allowModelNotFound: false,
+              allowProviderUnavailable: allowNotFoundSkip,
+              allowTimeout: allowNotFoundSkip,
+            });
+            if (driftSkip) {
               skipped.push({ model: id, reason: message });
-              logProgress(`${progressLabel}: skip (timeout)`);
-              break;
-            }
-            if (allowNotFoundSkip && isProviderUnavailableErrorMessage(message)) {
-              skipped.push({ model: id, reason: message });
-              logProgress(`${progressLabel}: skip (provider unavailable)`);
-              break;
-            }
-            if (allowNotFoundSkip && isAuthErrorMessage(message)) {
-              skipped.push({ model: id, reason: message });
-              logProgress(`${progressLabel}: skip (auth drift)`);
+              logProgress(`${progressLabel}: skip (${driftSkip.label})`);
               break;
             }
             if (

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -5,11 +5,8 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveCliBackendConfig, resolveCliBackendLiveTest } from "../agents/cli-backends.js";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
+import { shouldSkipLiveProviderDrift } from "../agents/live-test-provider-drift.js";
 import { parseModelRef } from "../agents/model-selection.js";
-import {
-  isAuthErrorMessage,
-  isBillingErrorMessage,
-} from "../agents/pi-embedded-helpers/failover-matches.js";
 import { clearRuntimeConfigSnapshot, type OpenClawConfig } from "../config/config.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import {
@@ -126,11 +123,6 @@ function isProviderCapacityError(error: unknown): boolean {
   );
 }
 
-function isProviderAccountDriftError(error: unknown): boolean {
-  const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
-  return isBillingErrorMessage(message) || isAuthErrorMessage(message);
-}
-
 async function requestWithProviderCapacityRetry<T>(
   providerId: string,
   label: string,
@@ -142,7 +134,13 @@ async function requestWithProviderCapacityRetry<T>(
       return await request();
     } catch (error) {
       if (!isProviderCapacityError(error) || attempt >= maxAttempts) {
-        if (isProviderAccountDriftError(error)) {
+        if (
+          shouldSkipLiveProviderDrift({
+            error,
+            allowAuth: true,
+            allowBilling: true,
+          })
+        ) {
           console.warn(`SKIP: ${label} skipped because provider account/auth drift blocked it.`);
           return undefined;
         }

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -21,11 +21,7 @@ import {
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import {
-  collectAnthropicApiKeys,
-  isAnthropicBillingError,
-  isAnthropicRateLimitError,
-} from "../agents/live-auth-keys.js";
+import { collectAnthropicApiKeys } from "../agents/live-auth-keys.js";
 import { isModelNotFoundErrorMessage } from "../agents/live-model-errors.js";
 import {
   DEFAULT_HIGH_SIGNAL_LIVE_MODEL_LIMIT,
@@ -37,15 +33,15 @@ import {
 } from "../agents/live-model-filter.js";
 import { createLiveTargetMatcher } from "../agents/live-target-matcher.js";
 import { isLiveProfileKeyModeEnabled, isLiveTestEnabled } from "../agents/live-test-helpers.js";
+import {
+  isLiveBillingDrift,
+  isLiveRateLimitDrift,
+  shouldSkipLiveProviderDrift,
+} from "../agents/live-test-provider-drift.js";
 import { getApiKeyForModel, resolveEnvApiKey } from "../agents/model-auth.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
 import { shouldSuppressBuiltInModel } from "../agents/model-suppression.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
-import { isRateLimitErrorMessage } from "../agents/pi-embedded-helpers/errors.js";
-import {
-  isAuthErrorMessage,
-  isBillingErrorMessage,
-} from "../agents/pi-embedded-helpers/failover-matches.js";
 import { discoverAuthStorage, discoverModels } from "../agents/pi-model-discovery.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { clearRuntimeConfigSnapshot, getRuntimeConfig } from "../config/io.js";
@@ -854,20 +850,6 @@ function isChatGPTUsageLimitErrorMessage(raw: string): boolean {
   return msg.includes("hit your chatgpt usage limit") && msg.includes("try again in");
 }
 
-function isProviderUnavailableErrorMessage(raw: string): boolean {
-  const msg = raw.toLowerCase();
-  return (
-    msg.includes("no allowed providers are available") ||
-    msg.includes("provider unavailable") ||
-    msg.includes("upstream provider unavailable") ||
-    msg.includes("upstream error from google") ||
-    msg.includes("temporarily rate-limited upstream") ||
-    msg.includes("unable to access non-serverless model") ||
-    msg.includes("create and start a new dedicated endpoint") ||
-    msg.includes("no available capacity was found for the model")
-  );
-}
-
 function isOllamaUnavailableErrorMessage(raw: string): boolean {
   const msg = raw.toLowerCase();
   return (
@@ -918,14 +900,6 @@ function isPromptProbeMiss(error: string): boolean {
   const msg = error.toLowerCase();
   return msg.includes("not meaningful:") || msg.includes("missing required keywords:");
 }
-
-describe("isAuthErrorMessage", () => {
-  it("matches provider API key drift", () => {
-    expect(
-      isAuthErrorMessage('401 {"error":{"message":"The API key you provided is invalid."}}'),
-    ).toBe(true);
-  });
-});
 
 function shouldSkipToolNonceProbeMissForLiveModel(modelKey?: string): boolean {
   if (!modelKey) {
@@ -2415,18 +2389,18 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
           const message = String(err);
           if (
             model.provider === "anthropic" &&
-            isAnthropicRateLimitError(message) &&
+            isLiveRateLimitDrift(message) &&
             attempt + 1 < attemptMax
           ) {
             logProgress(`${progressLabel}: rate limit, retrying with next key`);
             continue;
           }
-          if (model.provider === "anthropic" && isAnthropicRateLimitError(message)) {
+          if (model.provider === "anthropic" && isLiveRateLimitDrift(message)) {
             skippedCount += 1;
             logProgress(`${progressLabel}: skip (anthropic rate limit)`);
             break;
           }
-          if (model.provider === "anthropic" && isAnthropicBillingError(message)) {
+          if (model.provider === "anthropic" && isLiveBillingDrift(message)) {
             if (attempt + 1 < attemptMax) {
               logProgress(`${progressLabel}: billing issue, retrying with next key`);
               continue;
@@ -2458,19 +2432,20 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
             logProgress(`${progressLabel}: skip (${model.provider} empty response)`);
             break;
           }
-          if (isGoogleishProvider(model.provider) && isRateLimitErrorMessage(message)) {
+          if (isGoogleishProvider(model.provider) && isLiveRateLimitDrift(message)) {
             skippedCount += 1;
             logProgress(`${progressLabel}: skip (google rate limit)`);
             break;
           }
-          if (isBillingErrorMessage(message)) {
+          const driftSkip = shouldSkipLiveProviderDrift({
+            error: message,
+            allowAuth: true,
+            allowBilling: true,
+            allowProviderUnavailable: true,
+          });
+          if (driftSkip) {
             skippedCount += 1;
-            logProgress(`${progressLabel}: skip (billing drift)`);
-            break;
-          }
-          if (isAuthErrorMessage(message)) {
-            skippedCount += 1;
-            logProgress(`${progressLabel}: skip (auth drift)`);
+            logProgress(`${progressLabel}: skip (${driftSkip.label})`);
             break;
           }
           if (
@@ -2478,15 +2453,10 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
               model.provider === "opencode" ||
               model.provider === "opencode-go" ||
               model.provider === "zai") &&
-            isRateLimitErrorMessage(message)
+            isLiveRateLimitDrift(message)
           ) {
             skippedCount += 1;
             logProgress(`${progressLabel}: skip (rate limit)`);
-            break;
-          }
-          if (isProviderUnavailableErrorMessage(message)) {
-            skippedCount += 1;
-            logProgress(`${progressLabel}: skip (provider unavailable)`);
             break;
           }
           if (isAudioOnlyModelErrorMessage(message)) {


### PR DESCRIPTION
## Summary
- centralize live-test provider drift classification for auth, billing, rate-limit, timeout, model-not-found, and transient provider-unavailable cases
- split cache live direct-model resolution into a stable single-fixture API plus an explicit key-pool API for Anthropic retry rotation
- update live model, gateway model, CLI backend, and cache regression lanes to use the shared drift policy while preserving existing skip/retry patterns

## Verification
- `node scripts/run-vitest.mjs src/agents/live-test-provider-drift.test.ts src/agents/live-cache-regression-runner.test.ts src/agents/live-auth-keys.test.ts src/agents/models.profiles.live.test.ts src/gateway/gateway-models.profiles.live.test.ts src/gateway/gateway-cli-backend.live.test.ts` passed: 4 files, 20 tests
- `pnpm check:changed` passed in Blacksmith Testbox: `tbx_01krn2akr0j4cf0awjwmxk835n`
- Codex review passed clean: no accepted/actionable findings

## Real behavior proof
Behavior addressed: refactor live provider drift skip/retry logic without changing accepted transient/account-state behavior
Real environment tested: local macOS checkout plus Blacksmith Testbox
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/live-test-provider-drift.test.ts src/agents/live-cache-regression-runner.test.ts src/agents/live-auth-keys.test.ts src/agents/models.profiles.live.test.ts src/gateway/gateway-models.profiles.live.test.ts src/gateway/gateway-cli-backend.live.test.ts`; `pnpm check:changed`; `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --parallel-tests "node scripts/run-vitest.mjs src/agents/live-test-provider-drift.test.ts src/agents/live-cache-regression-runner.test.ts src/agents/live-auth-keys.test.ts src/agents/models.profiles.live.test.ts src/gateway/gateway-models.profiles.live.test.ts src/gateway/gateway-cli-backend.live.test.ts"`
Evidence after fix: terminal capture from local focused suite showed 4 files and 20 tests passed; Blacksmith Testbox run `tbx_01krn2akr0j4cf0awjwmxk835n` exited 0; Codex review output reported no accepted/actionable findings
Observed result after fix: live-provider drift classification preserves raw HTML provider pages, Anthropic account/rate drift, and existing live skip labels while moving callers to the shared helper
What was not tested: full live provider sweep against external model APIs
