### PR TITLE
Stabilize post-delivery hooks and CLI liveness

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -10,6 +10,7 @@ const rootEntries = [
   "src/entry.ts!",
   "src/cli/daemon-cli.ts!",
   "src/agents/code-mode.worker.ts!",
+  "src/agents/post-turn/isolated-plugin-hook-worker-entry.ts!",
   "src/infra/kysely-node-sqlite.ts!",
   "src/infra/warning-filter.ts!",
   "src/infra/command-explainer/index.ts!",

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -27,10 +27,8 @@ export { MIN_CODEX_APP_SERVER_VERSION } from "./version.js";
 const CODEX_APP_SERVER_PARSE_LOG_MAX = 500;
 const CODEX_APP_SERVER_PARSE_BUFFER_MAX = 1_000_000;
 const CODEX_APP_SERVER_PARSE_BUFFER_MAX_LINES = 1_000;
-const CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS = 600_000;
+const CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS = 240_000;
 const CODEX_APP_SERVER_STDERR_TAIL_MAX = 2_000;
-const UNPAIRED_SURROGATE_RE =
-  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
 
 type PendingRequest = {
   method: string;
@@ -44,37 +42,11 @@ export class CodexAppServerRpcError extends Error {
   readonly data?: JsonValue;
 
   constructor(error: { code?: number; message: string; data?: JsonValue }, method: string) {
-    super(formatCodexAppServerRpcErrorMessage(error, method));
+    super(error.message || `${method} failed`);
     this.name = "CodexAppServerRpcError";
     this.code = error.code;
     this.data = error.data;
   }
-}
-
-function formatCodexAppServerRpcErrorMessage(
-  error: { message: string; data?: JsonValue },
-  method: string,
-): string {
-  const message = error.message || `${method} failed`;
-  const detail = readCodexAppServerRpcReloginDetail(error.data);
-  return detail && !message.includes(detail) ? `${message}: ${detail}` : message;
-}
-
-function readCodexAppServerRpcReloginDetail(data: JsonValue | undefined): string | undefined {
-  const record = isJsonObject(data) ? data : undefined;
-  const nested = isJsonObject(record?.error) ? record.error : record;
-  if (!nested) {
-    return undefined;
-  }
-  const isRelogin =
-    nested.action === "relogin" ||
-    (nested.reason === "cloudRequirements" && nested.errorCode === "Auth");
-  const detail = typeof nested.detail === "string" ? nested.detail.trim() : "";
-  return isRelogin && detail ? detail : undefined;
-}
-
-function isJsonObject(value: unknown): value is { [key: string]: JsonValue } {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 export function isCodexAppServerConnectionClosedError(error: unknown): boolean {
@@ -302,14 +274,11 @@ export class CodexAppServerClient {
     }
     const id = "id" in message ? message.id : undefined;
     const method = "method" in message ? message.method : undefined;
-    this.child.stdin.write(
-      `${stringifyCodexAppServerMessage(message)}\n`,
-      (error?: Error | null) => {
-        if (error) {
-          embeddedAgentLog.warn("codex app-server write failed", { error, id, method });
-        }
-      },
-    );
+    this.child.stdin.write(`${JSON.stringify(message)}\n`, (error?: Error | null) => {
+      if (error) {
+        embeddedAgentLog.warn("codex app-server write failed", { error, id, method });
+      }
+    });
   }
 
   private handleLine(line: string): void {
@@ -541,14 +510,6 @@ function defaultServerRequestResponse(
     };
   }
   return {};
-}
-
-function stringifyCodexAppServerMessage(message: RpcRequest | RpcResponse): string {
-  return (
-    JSON.stringify(message, (_key, value) =>
-      typeof value === "string" ? value.replace(UNPAIRED_SURROGATE_RE, "") : value,
-    ) ?? "null"
-  );
 }
 
 function timeoutServerRequestResponse(

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -525,6 +525,37 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(maintain).toHaveBeenCalledTimes(1);
   });
 
+  it("defers afterTurn and turn maintenance until source reply delivery drains", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const afterSourceReplyDeliveryCallbacks: Array<() => Promise<void> | void> = [];
+    const afterTurn = vi.fn(
+      async (_params: Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]) => undefined,
+    );
+    const maintain = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+    const contextEngine = createContextEngine({ afterTurn, maintain, bootstrap: undefined });
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextEngine = contextEngine;
+    params.afterSourceReplyDelivery = (callback) => {
+      afterSourceReplyDeliveryCallbacks.push(callback);
+    };
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn();
+    await run;
+
+    expect(afterTurn).not.toHaveBeenCalled();
+    expect(maintain).not.toHaveBeenCalled();
+    expect(afterSourceReplyDeliveryCallbacks).toHaveLength(1);
+
+    await afterSourceReplyDeliveryCallbacks[0]?.();
+
+    expect(afterTurn).toHaveBeenCalledTimes(1);
+    expect(maintain).toHaveBeenCalledTimes(1);
+  });
+
   it("reloads mirrored history after bootstrap mutates the session transcript", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -574,6 +574,7 @@ function extractRelayIdFromThreadRequest(params: unknown): string {
 describe("runCodexAppServerAttempt", () => {
   beforeEach(async () => {
     resetAgentEventsForTest();
+    __testing.resetCodexAppServerAttemptLanesForTests();
     vi.stubEnv("OPENCLAW_TRAJECTORY", "0");
     vi.stubEnv("CODEX_API_KEY", "");
     vi.stubEnv("OPENAI_API_KEY", "");
@@ -583,6 +584,7 @@ describe("runCodexAppServerAttempt", () => {
   afterEach(async () => {
     resetCodexAppServerClientFactoryForTest();
     __testing.resetOpenClawCodingToolsFactoryForTests();
+    __testing.resetCodexAppServerAttemptLanesForTests();
     resetCodexRateLimitCacheForTests();
     nativeHookRelayTesting.clearNativeHookRelaysForTests();
     resetAgentEventsForTest();
@@ -681,6 +683,186 @@ describe("runCodexAppServerAttempt", () => {
     ]) {
       expect(dynamicToolNames).not.toContain(toolName);
     }
+  });
+
+  it("serializes concurrent app-server attempts for the same agent lane", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const firstParams = createParams(path.join(tempDir, "session-1.jsonl"), workspaceDir);
+    const secondParams = {
+      ...createParams(path.join(tempDir, "session-2.jsonl"), workspaceDir),
+      prompt: "second",
+      sessionId: "session-2",
+      sessionKey: "agent:main:session-2",
+      runId: "run-2",
+    } as EmbeddedRunAttemptParams;
+    const firstExecutionStarted = vi.fn();
+    const secondExecutionStarted = vi.fn();
+    firstParams.onExecutionStarted = firstExecutionStarted;
+    secondParams.onExecutionStarted = secondExecutionStarted;
+    const clients: Array<{
+      requests: Array<{ method: string; params: unknown }>;
+      notify: (notification: CodexServerNotification) => Promise<void>;
+    }> = [];
+
+    setCodexAppServerClientFactoryForTest(async () => {
+      const index = clients.length + 1;
+      const clientState = {
+        requests: [] as Array<{ method: string; params: unknown }>,
+        notify: async (_notification: CodexServerNotification) => undefined,
+      };
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        clientState.requests.push({ method, params });
+        if (method === "thread/start") {
+          return threadStartResult(`thread-${index}`);
+        }
+        if (method === "turn/start") {
+          return turnStartResult(`turn-${index}`);
+        }
+        return {};
+      });
+      clients.push(clientState);
+      return {
+        request,
+        addNotificationHandler: (handler: typeof clientState.notify) => {
+          clientState.notify = handler;
+          return () => undefined;
+        },
+        addRequestHandler: () => () => undefined,
+      } as never;
+    });
+
+    const firstRun = runCodexAppServerAttempt(firstParams);
+    await vi.waitFor(() => {
+      expect(clients[0]?.requests.some((entry) => entry.method === "turn/start")).toBe(true);
+    });
+    expect(firstExecutionStarted).toHaveBeenCalledTimes(1);
+
+    const secondRun = runCodexAppServerAttempt(secondParams);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(clients).toHaveLength(1);
+    expect(secondExecutionStarted).not.toHaveBeenCalled();
+
+    await clients[0].notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+    await firstRun;
+
+    await vi.waitFor(() => {
+      expect(clients).toHaveLength(2);
+      expect(clients[1]?.requests.some((entry) => entry.method === "turn/start")).toBe(true);
+    });
+    expect(secondExecutionStarted).toHaveBeenCalledTimes(1);
+
+    await clients[1].notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-2",
+        turnId: "turn-2",
+        turn: { id: "turn-2", status: "completed" },
+      },
+    });
+    await secondRun;
+  });
+
+  it("rejects a queued app-server attempt promptly when aborted before lane start", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const firstParams = createParams(path.join(tempDir, "session-1.jsonl"), workspaceDir);
+    const abortController = new AbortController();
+    const secondParams = {
+      ...createParams(path.join(tempDir, "session-2.jsonl"), workspaceDir),
+      abortSignal: abortController.signal,
+      prompt: "second",
+      sessionId: "session-2",
+      sessionKey: "agent:main:session-2",
+      runId: "run-2",
+    } as EmbeddedRunAttemptParams;
+    const thirdParams = {
+      ...createParams(path.join(tempDir, "session-3.jsonl"), workspaceDir),
+      prompt: "third",
+      sessionId: "session-3",
+      sessionKey: "agent:main:session-3",
+      runId: "run-3",
+    } as EmbeddedRunAttemptParams;
+    const clients: Array<{
+      requests: Array<{ method: string; params: unknown }>;
+      notify: (notification: CodexServerNotification) => Promise<void>;
+    }> = [];
+
+    setCodexAppServerClientFactoryForTest(async () => {
+      const index = clients.length + 1;
+      const clientState = {
+        requests: [] as Array<{ method: string; params: unknown }>,
+        notify: async (_notification: CodexServerNotification) => undefined,
+      };
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        clientState.requests.push({ method, params });
+        if (method === "thread/start") {
+          return threadStartResult(`thread-${index}`);
+        }
+        if (method === "turn/start") {
+          return turnStartResult(`turn-${index}`);
+        }
+        return {};
+      });
+      clients.push(clientState);
+      return {
+        request,
+        addNotificationHandler: (handler: typeof clientState.notify) => {
+          clientState.notify = handler;
+          return () => undefined;
+        },
+        addRequestHandler: () => () => undefined,
+      } as never;
+    });
+
+    const firstRun = runCodexAppServerAttempt(firstParams);
+    await vi.waitFor(() => {
+      expect(clients[0]?.requests.some((entry) => entry.method === "turn/start")).toBe(true);
+    });
+
+    const secondRun = runCodexAppServerAttempt(secondParams);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(clients).toHaveLength(1);
+    abortController.abort();
+
+    await expect(secondRun).rejects.toThrow("codex app-server attempt aborted before lane start");
+    expect(clients).toHaveLength(1);
+
+    const thirdRun = runCodexAppServerAttempt(thirdParams);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(clients).toHaveLength(1);
+
+    await clients[0].notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+    await firstRun;
+
+    await vi.waitFor(() => {
+      expect(clients).toHaveLength(2);
+      expect(clients[1]?.requests.some((entry) => entry.method === "turn/start")).toBe(true);
+    });
+
+    await clients[1].notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-2",
+        turnId: "turn-2",
+        turn: { id: "turn-2", status: "completed" },
+      },
+    });
+    await thirdRun;
   });
 
   it("passes MCP server config through to Codex thread/start", async () => {
@@ -2777,8 +2959,10 @@ describe("runCodexAppServerAttempt", () => {
     const result = await run;
 
     expect(result.assistantTexts).toEqual(["hello back"]);
-    expect(llmOutput).toHaveBeenCalledTimes(1);
-    expect(agentEnd).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(llmOutput).toHaveBeenCalledTimes(1);
+      expect(agentEnd).toHaveBeenCalledTimes(1);
+    });
     const agentEvents = onRunAgentEvent.mock.calls.map(([event]) => event) as Array<{
       data: {
         endedAt?: number;
@@ -2866,6 +3050,56 @@ describe("runCodexAppServerAttempt", () => {
     expect(agentEndPayload.messages?.some((message) => message.role === "assistant")).toBe(true);
     expect(agentEndContext.runId).toBe("run-1");
     expect(agentEndContext.sessionId).toBe("session-1");
+  });
+
+  it("defers llm_output and agent_end hooks until source reply delivery drains", async () => {
+    const llmInput = vi.fn();
+    const llmOutput = vi.fn();
+    const agentEnd = vi.fn();
+    const afterSourceReplyDeliveryCallbacks: Array<() => Promise<void> | void> = [];
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "llm_input", handler: llmInput },
+        { hookName: "llm_output", handler: llmOutput },
+        { hookName: "agent_end", handler: agentEnd },
+      ]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+
+    const params = createParams(sessionFile, workspaceDir);
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.afterSourceReplyDelivery = (callback) => {
+      afterSourceReplyDeliveryCallbacks.push(callback);
+    };
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await vi.waitFor(() => expect(llmInput).toHaveBeenCalledTimes(1), { interval: 1 });
+
+    await harness.notify({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "msg-1",
+        delta: "hello after delivery",
+      },
+    });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    const result = await run;
+
+    expect(result.assistantTexts).toEqual(["hello after delivery"]);
+    expect(llmOutput).not.toHaveBeenCalled();
+    expect(agentEnd).not.toHaveBeenCalled();
+    expect(afterSourceReplyDeliveryCallbacks).toHaveLength(1);
+
+    await afterSourceReplyDeliveryCallbacks[0]?.();
+
+    await vi.waitFor(() => {
+      expect(llmOutput).toHaveBeenCalledTimes(1);
+      expect(agentEnd).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("forwards Codex app-server verbose tool summaries and completed output", async () => {
@@ -3445,7 +3679,7 @@ describe("runCodexAppServerAttempt", () => {
     const result = await run;
 
     expect(result.promptError).toBe("codex exploded");
-    expect(agentEnd).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(agentEnd).toHaveBeenCalledTimes(1));
     const agentEvents = onRunAgentEvent.mock.calls.map(([event]) => event) as Array<{
       data: { endedAt?: number; error?: string; phase?: string; startedAt?: number };
       stream: string;
@@ -3509,8 +3743,10 @@ describe("runCodexAppServerAttempt", () => {
     await expect(runCodexAppServerAttempt(params)).rejects.toThrow("turn start exploded");
 
     expect(llmInput).toHaveBeenCalledTimes(1);
-    expect(llmOutput).toHaveBeenCalledTimes(1);
-    expect(agentEnd).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(llmOutput).toHaveBeenCalledTimes(1);
+      expect(agentEnd).toHaveBeenCalledTimes(1);
+    });
     const [llmOutputPayload] = mockCall(llmOutput, "llm_output") as [
       {
         assistantTexts?: string[];
@@ -3580,7 +3816,7 @@ describe("runCodexAppServerAttempt", () => {
 
     const result = await run;
     expect(result.aborted).toBe(true);
-    expect(agentEnd).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(agentEnd).toHaveBeenCalledTimes(1));
     const [agentEndPayload] = mockCall(agentEnd, "agent_end") as [{ success?: boolean }, unknown];
     expect(agentEndPayload.success).toBe(false);
   });

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -164,6 +164,121 @@ const LOG_FIELD_MAX_LENGTH = 160;
 const CODEX_NATIVE_PROJECT_DOC_BASENAMES = new Set(["agents.md"]);
 const CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS =
   CODEX_NATIVE_HOOK_RELAY_EVENTS.filter((event) => event !== "permission_request");
+const CODEX_APP_SERVER_ATTEMPT_ABORTED_BEFORE_START =
+  "codex app-server attempt aborted before lane start";
+
+type CodexAppServerAttemptLaneState = {
+  tail: Promise<void>;
+  depth: number;
+};
+
+const CODEX_APP_SERVER_ATTEMPT_LANES = Symbol.for("openclaw.codexAppServerAttemptLanes");
+
+function getCodexAppServerAttemptLanes(): Map<string, CodexAppServerAttemptLaneState> {
+  const globalState = globalThis as typeof globalThis & {
+    [CODEX_APP_SERVER_ATTEMPT_LANES]?: Map<string, CodexAppServerAttemptLaneState>;
+  };
+  globalState[CODEX_APP_SERVER_ATTEMPT_LANES] ??= new Map();
+  return globalState[CODEX_APP_SERVER_ATTEMPT_LANES];
+}
+
+function resolveCodexAppServerAttemptLaneKey(params: EmbeddedRunAttemptParams): string {
+  const { sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: params.sessionKey,
+    config: params.config,
+    agentId: params.agentId,
+  });
+  return `agent:${sessionAgentId}`;
+}
+
+function createCodexAppServerAttemptAbortedBeforeStartError(): Error {
+  return new Error(CODEX_APP_SERVER_ATTEMPT_ABORTED_BEFORE_START);
+}
+
+async function waitForCodexAppServerAttemptLaneTurn(
+  previous: Promise<void>,
+  abortSignal: AbortSignal | undefined,
+): Promise<void> {
+  if (!abortSignal) {
+    await previous;
+    return;
+  }
+  if (abortSignal.aborted) {
+    throw createCodexAppServerAttemptAbortedBeforeStartError();
+  }
+
+  let abortListener: (() => void) | undefined;
+  const aborted = new Promise<never>((_, reject) => {
+    abortListener = () => {
+      reject(createCodexAppServerAttemptAbortedBeforeStartError());
+    };
+    abortSignal.addEventListener("abort", abortListener, { once: true });
+  });
+
+  try {
+    await Promise.race([previous, aborted]);
+  } finally {
+    if (abortListener) {
+      abortSignal.removeEventListener("abort", abortListener);
+    }
+  }
+  if (abortSignal.aborted) {
+    throw createCodexAppServerAttemptAbortedBeforeStartError();
+  }
+}
+
+async function withCodexAppServerAttemptLane<T>(
+  params: EmbeddedRunAttemptParams,
+  laneKey: string,
+  work: () => Promise<T>,
+): Promise<T> {
+  const lanes = getCodexAppServerAttemptLanes();
+  let state = lanes.get(laneKey);
+  if (!state) {
+    state = { tail: Promise.resolve(), depth: 0 };
+    lanes.set(laneKey, state);
+  }
+  const previous = state.tail.catch(() => undefined);
+  state.depth += 1;
+  const queuedBehind = Math.max(0, state.depth - 1);
+  if (queuedBehind > 0) {
+    embeddedAgentLog.debug("codex app-server attempt queued behind active agent lane", {
+      laneKey,
+      queuedBehind,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      runId: params.runId,
+    });
+  }
+  const run = (async () => {
+    await waitForCodexAppServerAttemptLaneTurn(previous, params.abortSignal);
+    if (queuedBehind > 0) {
+      embeddedAgentLog.debug("codex app-server attempt starting after agent lane wait", {
+        laneKey,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        runId: params.runId,
+      });
+    }
+    params.onExecutionStarted?.();
+    return work();
+  })();
+  const tail = Promise.allSettled([previous, run])
+    .then(() => undefined)
+    .finally(() => {
+      state.depth = Math.max(0, state.depth - 1);
+      if (state.depth === 0 && state.tail === tail) {
+        lanes.delete(laneKey);
+      }
+    });
+  state.tail = tail;
+  return run;
+}
+
+function resetCodexAppServerAttemptLanesForTests(): void {
+  getCodexAppServerAttemptLanes().clear();
+}
+
 const CODEX_BOOTSTRAP_CONTEXT_ORDER = new Map<string, number>([
   ["soul.md", 10],
   ["identity.md", 20],
@@ -215,6 +330,24 @@ function emitCodexAppServerEvent(
 
 function collectTerminalAssistantText(result: EmbeddedRunAttemptResult): string {
   return result.assistantTexts.join("\n\n").trim();
+}
+
+function scheduleCodexAppServerPostDeliveryWork(
+  params: EmbeddedRunAttemptParams,
+  work: () => Promise<void>,
+): Promise<void> | void {
+  if (!params.afterSourceReplyDelivery) {
+    return work();
+  }
+  params.afterSourceReplyDelivery(async () => {
+    try {
+      await work();
+    } catch (error) {
+      embeddedAgentLog.warn("codex app-server post-delivery work failed", {
+        error: formatErrorMessage(error),
+      });
+    }
+  });
 }
 
 type CodexSteeringQueueOptions = {
@@ -425,7 +558,31 @@ function restrictCodexAppServerSandboxForOpenClawSandbox(
   };
 }
 
-export async function runCodexAppServerAttempt(
+export function runCodexAppServerAttempt(
+  params: EmbeddedRunAttemptParams,
+  options: {
+    pluginConfig?: unknown;
+    startupTimeoutFloorMs?: number;
+    nativeHookRelay?: {
+      enabled?: boolean;
+      events?: readonly NativeHookRelayEvent[];
+      ttlMs?: number;
+      gatewayTimeoutMs?: number;
+      hookTimeoutSec?: number;
+    };
+    turnCompletionIdleTimeoutMs?: number;
+    turnAssistantCompletionIdleTimeoutMs?: number;
+    turnTerminalIdleTimeoutMs?: number;
+    clientFactory?: CodexAppServerClientFactory;
+  } = {},
+): Promise<EmbeddedRunAttemptResult> {
+  const laneKey = resolveCodexAppServerAttemptLaneKey(params);
+  return withCodexAppServerAttemptLane(params, laneKey, () =>
+    runCodexAppServerAttemptOnLane(params, options),
+  );
+}
+
+async function runCodexAppServerAttemptOnLane(
   params: EmbeddedRunAttemptParams,
   options: {
     pluginConfig?: unknown;
@@ -1791,64 +1948,69 @@ export async function runCodexAppServerAttempt(
         ...(finalAborted ? { aborted: true } : {}),
       });
     }
-    if (activeContextEngine) {
-      const activeContextEnginePluginId = resolveContextEngineOwnerPluginId(activeContextEngine);
-      const finalMessages =
-        (await readMirroredSessionHistoryMessages(params.sessionFile)) ??
-        historyMessages.concat(result.messagesSnapshot);
-      await finalizeHarnessContextEngineTurn({
-        contextEngine: activeContextEngine,
-        promptError: Boolean(finalPromptError),
-        aborted: finalAborted,
-        yieldAborted: Boolean(result.yieldDetected),
-        sessionIdUsed: params.sessionId,
-        sessionKey: sandboxSessionKey,
-        sessionFile: params.sessionFile,
-        messagesSnapshot: finalMessages,
-        prePromptMessageCount,
-        tokenBudget: params.contextTokenBudget,
-        runtimeContext: buildHarnessContextEngineRuntimeContextFromUsage({
-          attempt: runtimeParams,
-          workspaceDir: effectiveWorkspace,
-          agentDir,
-          activeAgentId: sessionAgentId,
-          contextEnginePluginId: activeContextEnginePluginId,
+    const postDeliveryWork = scheduleCodexAppServerPostDeliveryWork(params, async () => {
+      if (activeContextEngine) {
+        const activeContextEnginePluginId = resolveContextEngineOwnerPluginId(activeContextEngine);
+        const finalMessages =
+          (await readMirroredSessionHistoryMessages(params.sessionFile)) ??
+          historyMessages.concat(result.messagesSnapshot);
+        await finalizeHarnessContextEngineTurn({
+          contextEngine: activeContextEngine,
+          promptError: Boolean(finalPromptError),
+          aborted: finalAborted,
+          yieldAborted: Boolean(result.yieldDetected),
+          sessionIdUsed: params.sessionId,
+          sessionKey: sandboxSessionKey,
+          sessionFile: params.sessionFile,
+          messagesSnapshot: finalMessages,
+          prePromptMessageCount,
           tokenBudget: params.contextTokenBudget,
-          lastCallUsage: result.attemptUsage,
-          promptCache: result.promptCache,
-        }),
-        runMaintenance: runHarnessContextEngineMaintenance,
-        config: params.config,
-        warn: (message) => embeddedAgentLog.warn(message),
+          runtimeContext: buildHarnessContextEngineRuntimeContextFromUsage({
+            attempt: runtimeParams,
+            workspaceDir: effectiveWorkspace,
+            agentDir,
+            activeAgentId: sessionAgentId,
+            contextEnginePluginId: activeContextEnginePluginId,
+            tokenBudget: params.contextTokenBudget,
+            lastCallUsage: result.attemptUsage,
+            promptCache: result.promptCache,
+          }),
+          runMaintenance: runHarnessContextEngineMaintenance,
+          config: params.config,
+          warn: (message) => embeddedAgentLog.warn(message),
+        });
+      }
+      runAgentHarnessLlmOutputHook({
+        event: {
+          runId: params.runId,
+          sessionId: params.sessionId,
+          provider: params.provider,
+          model: params.modelId,
+          ...hookContextWindowFields,
+          resolvedRef:
+            params.runtimePlan?.observability.resolvedRef ?? `${params.provider}/${params.modelId}`,
+          ...(params.runtimePlan?.observability.harnessId
+            ? { harnessId: params.runtimePlan.observability.harnessId }
+            : {}),
+          assistantTexts: result.assistantTexts,
+          ...(result.lastAssistant ? { lastAssistant: result.lastAssistant } : {}),
+          ...(result.attemptUsage ? { usage: result.attemptUsage } : {}),
+        },
+        ctx: hookContext,
       });
+      runAgentHarnessAgentEndHook({
+        event: {
+          messages: result.messagesSnapshot,
+          success: !finalAborted && !finalPromptError,
+          ...(finalPromptError ? { error: formatErrorMessage(finalPromptError) } : {}),
+          durationMs: Date.now() - attemptStartedAt,
+        },
+        ctx: hookContext,
+      });
+    });
+    if (postDeliveryWork) {
+      await postDeliveryWork;
     }
-    runAgentHarnessLlmOutputHook({
-      event: {
-        runId: params.runId,
-        sessionId: params.sessionId,
-        provider: params.provider,
-        model: params.modelId,
-        ...hookContextWindowFields,
-        resolvedRef:
-          params.runtimePlan?.observability.resolvedRef ?? `${params.provider}/${params.modelId}`,
-        ...(params.runtimePlan?.observability.harnessId
-          ? { harnessId: params.runtimePlan.observability.harnessId }
-          : {}),
-        assistantTexts: result.assistantTexts,
-        ...(result.lastAssistant ? { lastAssistant: result.lastAssistant } : {}),
-        ...(result.attemptUsage ? { usage: result.attemptUsage } : {}),
-      },
-      ctx: hookContext,
-    });
-    runAgentHarnessAgentEndHook({
-      event: {
-        messages: result.messagesSnapshot,
-        success: !finalAborted && !finalPromptError,
-        ...(finalPromptError ? { error: formatErrorMessage(finalPromptError) } : {}),
-        durationMs: Date.now() - attemptStartedAt,
-      },
-      ctx: hookContext,
-    });
     return {
       ...result,
       timedOut,
@@ -3286,6 +3448,7 @@ export const __testing = {
   filterCodexDynamicToolsForAllowlist,
   filterToolsForVisionInputs,
   handleDynamicToolCallWithTimeout,
+  resetCodexAppServerAttemptLanesForTests,
   remapCodexContextFilePath,
   resolveDynamicToolCallTimeoutMs,
   restrictCodexAppServerSandboxForOpenClawSandbox,

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
-import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { FailoverError } from "../failover-error.js";
 import { runEmbeddedPiAgent, type EmbeddedPiRunResult } from "../pi-embedded.js";
@@ -62,7 +61,11 @@ function makeCliResult(text: string): EmbeddedPiRunResult {
 }
 
 async function readSessionMessages(sessionFile: string) {
-  return (await readSessionFileJsonLines<{ type?: string; message?: unknown }>(sessionFile))
+  const raw = await fs.readFile(sessionFile, "utf-8");
+  return raw
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { type?: string; message?: unknown })
     .filter((entry) => entry.type === "message")
     .map(
       (entry) =>
@@ -71,62 +74,20 @@ async function readSessionMessages(sessionFile: string) {
 }
 
 async function readSessionFileEntries(sessionFile: string) {
-  return await readSessionFileJsonLines<{
-    type?: string;
-    id?: string;
-    parentId?: string | null;
-    cwd?: string;
-    message?: { role?: string };
-  }>(sessionFile);
-}
-
-async function readSessionFileJsonLines<T>(sessionFile: string): Promise<T[]> {
   const raw = await fs.readFile(sessionFile, "utf-8");
-  const entries: T[] = [];
-  for (const line of raw.split(/\r?\n/)) {
-    if (line.length === 0) {
-      continue;
-    }
-    entries.push(JSON.parse(line) as T);
-  }
-  return entries;
-}
-
-function requireRecord(value: unknown, label: string): Record<string, unknown> {
-  if (typeof value !== "object" || value === null) {
-    throw new Error(`${label} was not an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
-  for (const [key, value] of Object.entries(fields)) {
-    expect(record[key]).toEqual(value);
-  }
-}
-
-function requireMockArg(mock: ReturnType<typeof vi.fn>, callIndex: number, label: string) {
-  const arg = mock.mock.calls[callIndex]?.[0];
-  if (arg === undefined) {
-    throw new Error(`Expected mock argument for ${label}`);
-  }
-  return requireRecord(arg, label);
-}
-
-function expectMockArgFields(
-  mock: ReturnType<typeof vi.fn>,
-  fields: Record<string, unknown>,
-  callIndex = 0,
-) {
-  expectRecordFields(requireMockArg(mock, callIndex, "mock call argument"), fields);
-}
-
-function firstRunCliAgentArg(callIndex = 0) {
-  return requireMockArg(runCliAgentMock, callIndex, "run CLI agent argument");
-}
-
-function firstEmbeddedPiAgentArg(callIndex = 0) {
-  return requireMockArg(runEmbeddedPiAgentMock, callIndex, "embedded PI agent argument");
+  return raw
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(
+      (line) =>
+        JSON.parse(line) as {
+          type?: string;
+          id?: string;
+          parentId?: string | null;
+          cwd?: string;
+          message?: { role?: string };
+        },
+    );
 }
 
 describe("CLI attempt execution", () => {
@@ -252,8 +213,8 @@ describe("CLI attempt execution", () => {
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(2);
-    expect(firstRunCliAgentArg().cliSessionId).toBe("stale-cli-session");
-    expect(firstRunCliAgentArg(1).cliSessionId).toBeUndefined();
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.cliSessionId).toBe("stale-cli-session");
+    expect(runCliAgentMock.mock.calls[1]?.[0]?.cliSessionId).toBeUndefined();
     expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
     expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
 
@@ -294,8 +255,8 @@ describe("CLI attempt execution", () => {
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
-    expect(firstRunCliAgentArg().cliSessionId).toBeUndefined();
-    expect(firstRunCliAgentArg().cliSessionBinding).toBeUndefined();
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.cliSessionId).toBeUndefined();
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.cliSessionBinding).toBeUndefined();
     expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
     expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
     expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
@@ -352,8 +313,8 @@ describe("CLI attempt execution", () => {
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
-    expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
-    expect(firstRunCliAgentArg().cliSessionBinding).toEqual({
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.cliSessionId).toBe(cliSessionId);
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.cliSessionBinding).toEqual({
       sessionId: cliSessionId,
       authProfileId: "anthropic:claude-cli",
     });
@@ -404,7 +365,7 @@ describe("CLI attempt execution", () => {
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
-    expect(firstRunCliAgentArg().authProfileId).toBe("openai-codex:work");
+    expect(runCliAgentMock.mock.calls[0]?.[0]?.authProfileId).toBe("openai-codex:work");
   });
 
   it("persists CLI replies into the session transcript", async () => {
@@ -430,167 +391,30 @@ describe("CLI attempt execution", () => {
     });
 
     const sessionFile = updatedEntry?.sessionFile;
-    if (!sessionFile) {
-      throw new Error("expected CLI transcript persistence to create a session file");
-    }
-    const entries = await readSessionFileEntries(sessionFile);
-    expectRecordFields(requireRecord(entries[0], "session entry"), {
+    expect(sessionFile).toBeTruthy();
+    const entries = await readSessionFileEntries(sessionFile!);
+    expect(entries[0]).toMatchObject({
       type: "session",
       id: sessionEntry.sessionId,
       cwd: tmpDir,
     });
-    expectRecordFields(requireRecord(entries[1], "user transcript entry"), {
-      type: "message",
-      parentId: null,
-    });
-    expectRecordFields(requireRecord(entries[2], "assistant transcript entry"), {
+    expect(entries[1]).toMatchObject({ type: "message", parentId: null });
+    expect(entries[2]).toMatchObject({
       type: "message",
       parentId: entries[1]?.id,
     });
-    const messages = await readSessionMessages(sessionFile);
+    const messages = await readSessionMessages(sessionFile!);
     expect(messages).toHaveLength(2);
-    expectRecordFields(requireRecord(messages[0], "user message"), {
+    expect(messages[0]).toMatchObject({
       role: "user",
       content: "persist this",
     });
-    expectRecordFields(requireRecord(messages[1], "assistant message"), {
+    expect(messages[1]).toMatchObject({
       role: "assistant",
       api: "cli",
       provider: "claude-cli",
       model: "opus",
       content: [{ type: "text", text: "hello from cli" }],
-    });
-  });
-
-  it("embedded assistant gap-fill skips user mirror and dedupes identical assistant tails", async () => {
-    const sessionKey = "agent:main:subagent:embedded-gap-fill";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-embedded-gap-fill",
-      updatedAt: Date.now(),
-    };
-    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
-
-    const result = makeCliResult("already mirrored");
-    result.meta.executionTrace = {
-      winnerProvider: "anthropic",
-      winnerModel: "claude-opus-4-6",
-      fallbackUsed: false,
-      runner: "embedded",
-    };
-
-    const updatedFirst = await persistCliTurnTranscript({
-      body: "ignored for gap fill",
-      transcriptBody: "also ignored",
-      result,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-      embeddedAssistantGapFill: true,
-    });
-
-    let messages = await readSessionMessages(updatedFirst?.sessionFile ?? "");
-    expect(messages).toHaveLength(1);
-    expectRecordFields(requireRecord(messages[0], "assistant message"), {
-      role: "assistant",
-      content: [{ type: "text", text: "already mirrored" }],
-    });
-
-    await persistCliTurnTranscript({
-      body: "still ignored",
-      result,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry: updatedFirst,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-      embeddedAssistantGapFill: true,
-    });
-
-    messages = await readSessionMessages(updatedFirst?.sessionFile ?? "");
-    expect(messages).toHaveLength(1);
-  });
-
-  it("embedded assistant gap-fill appends repeated replies after a user tail", async () => {
-    const sessionKey = "agent:main:subagent:embedded-repeated-reply";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-embedded-repeated-reply",
-      updatedAt: Date.now(),
-    };
-    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
-
-    const result = makeCliResult("same answer");
-    result.meta.executionTrace = {
-      winnerProvider: "anthropic",
-      winnerModel: "claude-opus-4-6",
-      fallbackUsed: false,
-      runner: "embedded",
-    };
-
-    const updatedFirst = await persistCliTurnTranscript({
-      body: "ignored for gap fill",
-      result,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-      embeddedAssistantGapFill: true,
-    });
-    const sessionFile = updatedFirst?.sessionFile;
-    if (typeof sessionFile !== "string") {
-      throw new Error("Expected CLI transcript session file.");
-    }
-    expect(path.isAbsolute(sessionFile)).toBe(true);
-    expect(
-      sessionFile.endsWith(
-        path.join(".openclaw", "agents", "main", "sessions", `${sessionEntry.sessionId}.jsonl`),
-      ),
-    ).toBe(true);
-
-    await appendSessionTranscriptMessage({
-      transcriptPath: sessionFile,
-      sessionId: sessionEntry.sessionId,
-      cwd: tmpDir,
-      config: {},
-      message: {
-        role: "user",
-        content: "next prompt",
-        timestamp: Date.now(),
-      },
-    });
-
-    await persistCliTurnTranscript({
-      body: "still ignored",
-      result,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry: updatedFirst,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-      embeddedAssistantGapFill: true,
-    });
-
-    const messages = await readSessionMessages(sessionFile);
-    expect(messages).toHaveLength(3);
-    expect(messages.map((message) => message.role)).toEqual(["assistant", "user", "assistant"]);
-    expectRecordFields(requireRecord(messages[2], "deduped assistant message"), {
-      content: [{ type: "text", text: "same answer" }],
     });
   });
 
@@ -624,7 +448,7 @@ describe("CLI attempt execution", () => {
     });
 
     const messages = await readSessionMessages(updatedEntry?.sessionFile ?? "");
-    expectRecordFields(requireRecord(messages[0], "transcript user message"), {
+    expect(messages[0]).toMatchObject({
       role: "user",
       content: "visible ask",
     });
@@ -674,60 +498,13 @@ describe("CLI attempt execution", () => {
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
-    expectMockArgFields(runCliAgentMock, {
-      trigger: "user",
-      messageChannel: "discord",
-      messageProvider: "discord-voice",
-    });
-  });
-
-  it("forwards runtime toolsAllow into CLI attempts so the CLI harness can fail closed", async () => {
-    const sessionKey = "agent:main:direct:claude-tools-allow";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-cli-tools-allow",
-      updatedAt: Date.now(),
-    };
-    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
-    runCliAgentMock.mockResolvedValueOnce(makeCliResult("restricted cli"));
-
-    await runAgentAttempt({
-      providerOverride: "claude-cli",
-      originalProvider: "claude-cli",
-      modelOverride: "opus",
-      cfg: {} as OpenClawConfig,
-      sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "route this",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
-      runId: "run-cli-tools-allow",
-      opts: {
-        senderIsOwner: true,
-        toolsAllow: ["read", "web_search"],
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: "discord",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "claude-cli",
-      sessionStore,
-      storePath,
-      sessionHasHistory: false,
-    });
-
-    expectMockArgFields(runCliAgentMock, {
-      provider: "claude-cli",
-      toolsAllow: ["read", "web_search"],
-    });
+    expect(runCliAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: "user",
+        messageChannel: "discord",
+        messageProvider: "discord-voice",
+      }),
+    );
   });
 
   it("routes canonical Anthropic models through the configured Claude CLI runtime", async () => {
@@ -747,9 +524,7 @@ describe("CLI attempt execution", () => {
       cfg: {
         agents: {
           defaults: {
-            models: {
-              "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
-            },
+            agentRuntime: { id: "claude-cli" },
           },
         },
       } as OpenClawConfig,
@@ -779,13 +554,15 @@ describe("CLI attempt execution", () => {
     });
 
     expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
-    expectMockArgFields(runCliAgentMock, {
-      provider: "claude-cli",
-      model: "claude-opus-4-7",
-    });
+    expect(runCliAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "claude-cli",
+        model: "claude-opus-4-7",
+      }),
+    );
   });
 
-  it("routes canonical OpenAI models through the configured embedded Codex runtime", async () => {
+  it("routes canonical OpenAI models through the configured Codex CLI runtime", async () => {
     const sessionKey = "agent:main:direct:canonical-codex-cli";
     const sessionEntry: SessionEntry = {
       sessionId: "openclaw-session-canonical-codex-cli",
@@ -793,14 +570,7 @@ describe("CLI attempt execution", () => {
     };
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
-    runEmbeddedPiAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "canonical codex embedded" }],
-      meta: {
-        durationMs: 5,
-        finalAssistantVisibleText: "canonical codex embedded",
-        executionTrace: { runner: "pi" },
-      },
-    });
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("canonical codex cli"));
 
     await runAgentAttempt({
       providerOverride: "openai",
@@ -809,9 +579,7 @@ describe("CLI attempt execution", () => {
       cfg: {
         agents: {
           defaults: {
-            models: {
-              "openai/gpt-5.4": { agentRuntime: { id: "codex-cli" } },
-            },
+            agentRuntime: { id: "codex-cli" },
           },
         },
       } as OpenClawConfig,
@@ -840,11 +608,13 @@ describe("CLI attempt execution", () => {
       sessionHasHistory: false,
     });
 
-    expect(runCliAgentMock).not.toHaveBeenCalled();
-    expectMockArgFields(runEmbeddedPiAgentMock, {
-      provider: "openai",
-      model: "gpt-5.4",
-    });
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+    expect(runCliAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "codex-cli",
+        model: "gpt-5.4",
+      }),
+    );
   });
 
   it("keeps one-shot model runs on the raw embedded provider path", async () => {
@@ -906,75 +676,22 @@ describe("CLI attempt execution", () => {
     });
 
     expect(runCliAgentMock).not.toHaveBeenCalled();
-    expectMockArgFields(runEmbeddedPiAgentMock, {
-      provider: "anthropic",
-      model: "claude-opus-4-7",
-      agentHarnessId: "pi",
-      prompt: "raw prompt",
-      messageChannel: "discord",
-      messageProvider: "discord-voice",
-      modelRun: true,
-      promptMode: "none",
-      disableTools: true,
-    });
-    expect(firstEmbeddedPiAgentArg().prompt).not.toContain("[Inter-session message]");
-  });
-
-  it("forwards trusted elevated defaults to embedded agent runs", async () => {
-    const sessionKey = "agent:main:telegram:direct:123";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-elevated-followup",
-      updatedAt: Date.now(),
-    };
-    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    const bashElevated = {
-      enabled: true,
-      allowed: true,
-      defaultLevel: "on" as const,
-    };
-    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
-    runEmbeddedPiAgentMock.mockResolvedValueOnce({
-      meta: { durationMs: 1 },
-    } satisfies EmbeddedPiRunResult);
-
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
-      sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "follow up after approved exec",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
-      runId: "run-elevated-followup",
-      opts: {
-        senderIsOwner: false,
-        bashElevated,
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: "telegram",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
-      sessionStore,
-      storePath,
-      sessionHasHistory: false,
-    });
-
-    expectMockArgFields(runEmbeddedPiAgentMock, {
-      provider: "openai",
-      model: "gpt-5.4",
-      bashElevated,
-    });
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        agentHarnessId: "pi",
+        prompt: "raw prompt",
+        messageChannel: "discord",
+        messageProvider: "discord-voice",
+        modelRun: true,
+        promptMode: "none",
+        disableTools: true,
+      }),
+    );
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.prompt).not.toContain(
+      "[Inter-session message]",
+    );
   });
 
   it("forwards one-shot CLI cleanup to CLI providers", async () => {
@@ -1021,10 +738,12 @@ describe("CLI attempt execution", () => {
       sessionHasHistory: false,
     });
 
-    expectMockArgFields(runCliAgentMock, {
-      cleanupBundleMcpOnRunEnd: true,
-      cleanupCliLiveSessionOnRunEnd: true,
-    });
+    expect(runCliAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cleanupBundleMcpOnRunEnd: true,
+        cleanupCliLiveSessionOnRunEnd: true,
+      }),
+    );
     expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
   });
 });
@@ -1042,7 +761,7 @@ describe("embedded attempt harness pinning", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("does not store a session harness pin for default OpenAI Codex routing", async () => {
+  it("treats legacy sessions with history as PI-pinned", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "legacy-session",
       updatedAt: Date.now(),
@@ -1079,94 +798,14 @@ describe("embedded attempt harness pinning", () => {
       sessionHasHistory: true,
     });
 
-    expectMockArgFields(runEmbeddedPiAgentMock, { agentHarnessId: undefined });
+    expect(runEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentHarnessId: "pi",
+      }),
+    );
   });
 
-  it("ignores stale session Codex harness pins on non-OpenAI model switches", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "mixed-provider-session",
-      updatedAt: Date.now(),
-      agentHarnessId: "codex",
-    };
-    runEmbeddedPiAgentMock.mockResolvedValueOnce({
-      meta: { durationMs: 1 },
-    } satisfies EmbeddedPiRunResult);
-
-    await runAgentAttempt({
-      providerOverride: "minimax",
-      originalProvider: "minimax",
-      modelOverride: "minimax-m2.7",
-      cfg: {} as OpenClawConfig,
-      sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "switch to minimax",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
-      runId: "run-mixed-provider-auto-runtime",
-      opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "minimax",
-      sessionHasHistory: true,
-    });
-
-    expectMockArgFields(runEmbeddedPiAgentMock, { agentHarnessId: undefined });
-  });
-
-  it("forwards runtime toolsAllow into embedded attempts", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "tools-allow-session",
-      updatedAt: Date.now(),
-    };
-    runEmbeddedPiAgentMock.mockResolvedValueOnce({
-      meta: { durationMs: 1 },
-    } satisfies EmbeddedPiRunResult);
-
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
-      sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "read only",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
-      runId: "run-tools-allow",
-      opts: {
-        senderIsOwner: true,
-        toolsAllow: ["read", "web_search"],
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
-      sessionHasHistory: false,
-    });
-
-    expectMockArgFields(runEmbeddedPiAgentMock, { toolsAllow: ["read", "web_search"] });
-  });
-
-  it("lets provider/model runtime policy choose Codex without storing a session harness pin", async () => {
+  it("pins sessions with history to the configured Codex harness instead of PI", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "codex-history-session",
       updatedAt: Date.now(),
@@ -1180,13 +819,9 @@ describe("embedded attempt harness pinning", () => {
       originalProvider: "codex",
       modelOverride: "gpt-5.4",
       cfg: {
-        models: {
-          providers: {
-            codex: {
-              baseUrl: "https://api.openai.com/v1",
-              agentRuntime: { id: "codex" },
-              models: [],
-            },
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex" },
           },
         },
       } as OpenClawConfig,
@@ -1201,7 +836,11 @@ describe("embedded attempt harness pinning", () => {
       resolvedThinkLevel: "medium",
       timeoutMs: 1_000,
       runId: "run-codex-no-pi-pin",
-      opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
+      opts: {
+        senderIsOwner: false,
+        cleanupBundleMcpOnRunEnd: true,
+        cleanupCliLiveSessionOnRunEnd: true,
+      } as Parameters<typeof runAgentAttempt>[0]["opts"],
       runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
       spawnedBy: undefined,
       messageChannel: undefined,
@@ -1213,10 +852,16 @@ describe("embedded attempt harness pinning", () => {
       sessionHasHistory: true,
     });
 
-    expectMockArgFields(runEmbeddedPiAgentMock, { agentHarnessId: undefined });
+    expect(runEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentHarnessId: "codex",
+        cleanupBundleMcpOnRunEnd: true,
+        cleanupCliLiveSessionOnRunEnd: true,
+      }),
+    );
   });
 
-  it("auto-forwards OpenAI Codex auth profiles to default Codex harness runs", async () => {
+  it("auto-forwards OpenAI Codex auth profiles to configured Codex harness runs", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "codex-auth-session",
       updatedAt: Date.now(),
@@ -1244,7 +889,13 @@ describe("embedded attempt harness pinning", () => {
       providerOverride: "openai",
       originalProvider: "openai",
       modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
+      cfg: {
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex" },
+          },
+        },
+      } as OpenClawConfig,
       sessionEntry,
       sessionId: sessionEntry.sessionId,
       sessionKey: "agent:main:main",
@@ -1268,14 +919,16 @@ describe("embedded attempt harness pinning", () => {
       sessionHasHistory: true,
     });
 
-    expectMockArgFields(runEmbeddedPiAgentMock, {
-      agentHarnessId: undefined,
-      authProfileId: "openai-codex:work",
-      authProfileIdSource: "auto",
-    });
+    expect(runEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentHarnessId: "codex",
+        authProfileId: "openai-codex:work",
+        authProfileIdSource: "auto",
+      }),
+    );
   });
 
-  it("pins a fresh OpenAI session to the Codex harness by default", async () => {
+  it("pins a fresh unpinned session to the default PI harness", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "fresh-session",
       updatedAt: Date.now(),
@@ -1312,109 +965,11 @@ describe("embedded attempt harness pinning", () => {
       sessionHasHistory: false,
     });
 
-    expectMockArgFields(runEmbeddedPiAgentMock, { agentHarnessId: undefined });
-  });
-
-  it("ignores stale OpenAI sessions pinned to PI and relies on default Codex routing", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "stale-pi-session",
-      updatedAt: Date.now(),
-      agentHarnessId: "pi",
-    };
-    runEmbeddedPiAgentMock.mockResolvedValueOnce({
-      meta: { durationMs: 1 },
-    } satisfies EmbeddedPiRunResult);
-
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
-      sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
-      runId: "run-stale-openai-pi-pin",
-      opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
-      sessionHasHistory: true,
-    });
-
-    expectMockArgFields(runEmbeddedPiAgentMock, {
-      provider: "openai",
-      agentHarnessId: undefined,
-    });
-  });
-
-  it("routes explicit OpenAI PI runs with Codex OAuth through the legacy Codex auth transport", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "explicit-pi-codex-oauth-session",
-      updatedAt: Date.now(),
-      authProfileOverride: "openai-codex:work",
-      authProfileOverrideSource: "user",
-    };
-    runEmbeddedPiAgentMock.mockResolvedValueOnce({
-      meta: { durationMs: 1 },
-    } satisfies EmbeddedPiRunResult);
-
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
-      cfg: {
-        models: {
-          providers: {
-            openai: {
-              baseUrl: "https://api.openai.com/v1",
-              agentRuntime: { id: "pi" },
-              models: [],
-            },
-          },
-        },
-      } as OpenClawConfig,
-      sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
-      runId: "run-openai-pi-codex-oauth",
-      opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai-codex",
-      sessionHasHistory: false,
-    });
-
-    expectMockArgFields(runEmbeddedPiAgentMock, {
-      provider: "openai-codex",
-      model: "gpt-5.4",
-      agentHarnessId: undefined,
-      authProfileId: "openai-codex:work",
-      authProfileIdSource: "user",
-    });
+    expect(runEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentHarnessId: "pi",
+      }),
+    );
   });
 
   it("does not pass CLI runtime aliases as embedded harness ids for fallback providers", async () => {
@@ -1462,6 +1017,9 @@ describe("embedded attempt harness pinning", () => {
 
     expect(runCliAgentMock).not.toHaveBeenCalled();
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
-    expect(firstEmbeddedPiAgentArg()).not.toHaveProperty("agentHarnessId", "claude-cli");
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]).not.toHaveProperty(
+      "agentHarnessId",
+      "claude-cli",
+    );
   });
 });

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -22,9 +22,11 @@ import { runCliAgent } from "../cli-runner.js";
 import { getCliSessionBinding, setCliSessionBinding } from "../cli-session.js";
 import { FailoverError } from "../failover-error.js";
 import { resolveAgentHarnessPolicy } from "../harness/selection.js";
-import { resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js";
+import {
+  isCliRuntimeAlias,
+  resolveCliRuntimeExecutionProvider,
+} from "../model-runtime-aliases.js";
 import { isCliProvider } from "../model-selection.js";
-import { resolveOpenAIRuntimeProviderForPi } from "../openai-codex-routing.js";
 import { runEmbeddedPiAgent, type EmbeddedPiRunResult } from "../pi-embedded.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import {
@@ -409,7 +411,24 @@ export function runAgentAttempt(params: {
   );
   const bootstrapPromptWarningSignature =
     bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
-  const requestedAgentHarnessId = isRawModelRun ? "pi" : undefined;
+  const sessionPinnedAgentHarnessId = isRawModelRun
+    ? "pi"
+    : resolveSessionPinnedAgentHarnessId({
+        cfg: params.cfg,
+        sessionAgentId: params.sessionAgentId,
+        sessionEntry: params.sessionEntry,
+        sessionHasHistory: params.sessionHasHistory,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey ?? params.sessionId,
+      });
+  const legacyAgentRuntimeId = isRawModelRun
+    ? undefined
+    : resolveLegacyAgentRuntimeId({
+        cfg: params.cfg,
+        sessionAgentId: params.sessionAgentId,
+      });
+  const agentRuntimeOverride =
+    params.sessionEntry?.agentRuntimeOverride?.trim() || legacyAgentRuntimeId;
   const cliExecutionProvider = isRawModelRun
     ? params.providerOverride
     : (resolveCliRuntimeExecutionProvider({
@@ -417,7 +436,12 @@ export function runAgentAttempt(params: {
         cfg: params.cfg,
         agentId: params.sessionAgentId,
         modelId: params.modelOverride,
-      }) ?? params.providerOverride);
+      }) ??
+      resolveCliRuntimeExecutionProviderFromRuntimeAlias({
+        provider: params.providerOverride,
+        runtime: agentRuntimeOverride,
+      }) ??
+      params.providerOverride);
   const agentHarnessPolicy = isRawModelRun
     ? ({ runtime: "pi" } as const)
     : resolveAgentHarnessPolicy({
@@ -435,7 +459,7 @@ export function runAgentAttempt(params: {
     authProfileProvider: params.authProfileProvider,
     sessionAuthProfileId: params.sessionEntry?.authProfileOverride,
     sessionAuthProfileSource: params.sessionEntry?.authProfileOverrideSource,
-    harnessId: requestedAgentHarnessId,
+    harnessId: sessionPinnedAgentHarnessId,
     harnessRuntime: agentHarnessPolicy.runtime,
     allowHarnessAuthProfileForwarding: !isCliProvider(cliExecutionProvider, params.cfg),
   });
@@ -445,20 +469,11 @@ export function runAgentAttempt(params: {
     sessionAuthProfileId: harnessAuthSelection.authProfileId,
     config: params.cfg,
     workspaceDir: params.workspaceDir,
-    harnessId: requestedAgentHarnessId,
+    harnessId: sessionPinnedAgentHarnessId,
     harnessRuntime: agentHarnessPolicy.runtime,
     allowHarnessAuthProfileForwarding: !isCliProvider(cliExecutionProvider, params.cfg),
   });
   const authProfileId = runtimeAuthPlan.forwardedAuthProfileId;
-  const embeddedPiProvider = resolveOpenAIRuntimeProviderForPi({
-    provider: params.providerOverride,
-    harnessRuntime: agentHarnessPolicy.runtime,
-    agentHarnessId: requestedAgentHarnessId,
-    authProfileProvider: runtimeAuthPlan.authProfileProviderForAuth,
-    authProfileId,
-    config: params.cfg,
-    workspaceDir: params.workspaceDir,
-  });
   if (!isRawModelRun && isCliProvider(cliExecutionProvider, params.cfg)) {
     const cliSessionBinding = getCliSessionBinding(params.sessionEntry, cliExecutionProvider);
     const resolveReusableCliSessionBinding = async () => {
@@ -605,13 +620,13 @@ export function runAgentAttempt(params: {
     sessionFile: params.sessionFile,
     workspaceDir: params.workspaceDir,
     config: params.cfg,
-    agentHarnessId: requestedAgentHarnessId,
+    agentHarnessId: sessionPinnedAgentHarnessId,
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
     images: params.isFallbackRetry ? undefined : params.opts.images,
     imageOrder: params.isFallbackRetry ? undefined : params.opts.imageOrder,
     clientTools: params.opts.clientTools,
-    provider: embeddedPiProvider,
+    provider: params.providerOverride,
     model: params.modelOverride,
     modelFallbacksOverride: params.modelFallbacksOverride,
     authProfileId,
@@ -635,6 +650,7 @@ export function runAgentAttempt(params: {
     agentDir: params.agentDir,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
     cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
+    cleanupCliLiveSessionOnRunEnd: params.opts.cleanupCliLiveSessionOnRunEnd,
     modelRun: params.opts.modelRun,
     promptMode: params.opts.promptMode,
     disableTools: params.opts.modelRun === true,
@@ -644,6 +660,84 @@ export function runAgentAttempt(params: {
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,
   });
+}
+
+function resolveSessionPinnedAgentHarnessId(params: {
+  cfg: OpenClawConfig;
+  sessionAgentId: string;
+  sessionEntry?: SessionEntry;
+  sessionHasHistory?: boolean;
+  sessionId: string;
+  sessionKey: string;
+}): string | undefined {
+  if (params.sessionEntry?.sessionId !== params.sessionId) {
+    return resolveConfiguredAgentHarnessId(params);
+  }
+  if (params.sessionEntry.agentHarnessId) {
+    return params.sessionEntry.agentHarnessId;
+  }
+  const configuredAgentHarnessId = resolveConfiguredAgentHarnessId(params);
+  if (configuredAgentHarnessId) {
+    return configuredAgentHarnessId;
+  }
+  return "pi";
+}
+
+function resolveConfiguredAgentHarnessId(params: {
+  cfg: OpenClawConfig;
+  sessionAgentId: string;
+  sessionKey: string;
+}): string | undefined {
+  const legacyAgentRuntimeId = resolveLegacyAgentRuntimeId({
+    cfg: params.cfg,
+    sessionAgentId: params.sessionAgentId,
+  });
+  if (legacyAgentRuntimeId && !isCliRuntimeAlias(legacyAgentRuntimeId)) {
+    return legacyAgentRuntimeId;
+  }
+  const policy = resolveAgentHarnessPolicy({
+    config: params.cfg,
+    agentId: params.sessionAgentId,
+    sessionKey: params.sessionKey,
+  });
+  if (policy.runtime === "auto" || isCliRuntimeAlias(policy.runtime)) {
+    return undefined;
+  }
+  return policy.runtime;
+}
+
+function resolveLegacyAgentRuntimeId(params: {
+  cfg: OpenClawConfig;
+  sessionAgentId: string;
+}): string | undefined {
+  const agentRuntimeId = params.cfg.agents?.list
+    ?.find(
+      (entry) =>
+        entry.id.trim().toLowerCase() === params.sessionAgentId.trim().toLowerCase(),
+    )
+    ?.agentRuntime?.id?.trim();
+  if (agentRuntimeId) {
+    return agentRuntimeId;
+  }
+  return params.cfg.agents?.defaults?.agentRuntime?.id?.trim() || undefined;
+}
+
+function resolveCliRuntimeExecutionProviderFromRuntimeAlias(params: {
+  provider: string;
+  runtime: string | undefined;
+}): string | undefined {
+  const runtime = params.runtime?.trim().toLowerCase();
+  const provider = params.provider.trim().toLowerCase();
+  if (provider === "anthropic" && runtime === "claude-cli") {
+    return "claude-cli";
+  }
+  if (provider === "openai" && runtime === "codex-cli") {
+    return "codex-cli";
+  }
+  if (provider === "google" && runtime === "google-gemini-cli") {
+    return "google-gemini-cli";
+  }
+  return undefined;
 }
 
 export function buildAcpResult(params: {

--- a/src/agents/pi-embedded-runner.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.e2e.test.ts
@@ -22,7 +22,9 @@ const runEmbeddedAttemptMock = vi.fn();
 const disposeSessionMcpRuntimeMock = vi.fn<(sessionId: string) => Promise<void>>(async () => {
   return undefined;
 });
+const disposeSelectedHarnessMock = vi.fn(async () => undefined);
 const resolveSessionKeyForRequestMock = vi.fn();
+let selectedHarnessOverride: { id: string; dispose?: () => unknown } | undefined;
 const resolveStoredSessionKeyForSessionIdMock = vi.fn();
 const resolveModelAsyncMock = vi.fn(async (provider: string, modelId: string) =>
   createResolvedEmbeddedRunnerModel(provider, modelId),
@@ -94,6 +96,7 @@ const installRunEmbeddedMocks = () => {
   installEmbeddedRunnerBaseE2eMocks({ hookRunner: "full" });
   installEmbeddedRunnerFastRunE2eMocks({
     runEmbeddedAttempt: (params) => runEmbeddedAttemptMock(params),
+    selectHarness: () => selectedHarnessOverride,
   });
   vi.doMock("./command/session.js", async () => {
     const actual =
@@ -180,6 +183,8 @@ beforeEach(() => {
   vi.useRealTimers();
   runEmbeddedAttemptMock.mockReset();
   disposeSessionMcpRuntimeMock.mockReset();
+  selectedHarnessOverride = undefined;
+  disposeSelectedHarnessMock.mockReset();
   resolveSessionKeyForRequestMock.mockReset();
   resolveStoredSessionKeyForSessionIdMock.mockReset();
   resolveModelAsyncMock.mockReset();
@@ -532,6 +537,44 @@ describe("runEmbeddedPiAgent", () => {
     expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(1);
     expect(disposeSessionMcpRuntimeMock).toHaveBeenCalledTimes(1);
     expect(disposeSessionMcpRuntimeMock).toHaveBeenCalledWith("session:test");
+  });
+
+  it("disposes plugin harness resources for one-shot CLI embedded runs", async () => {
+    runEmbeddedAttemptMock.mockResolvedValueOnce(
+      makeEmbeddedRunnerAttempt({
+        assistantTexts: ["ok"],
+        lastAssistant: buildEmbeddedRunnerAssistant({
+          provider: "openai",
+          model: "mock-1",
+          content: [{ type: "text", text: "ok" }],
+        }),
+      }),
+    );
+
+    const sessionFile = nextSessionFile();
+    const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-1"]);
+    selectedHarnessOverride = {
+      id: "codex",
+      dispose: () => disposeSelectedHarnessMock(),
+    };
+    const result = await runEmbeddedPiAgent({
+      sessionId: "session:test",
+      sessionKey: nextSessionKey(),
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "hello",
+      provider: "openai",
+      model: "mock-1",
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("harness-cleanup"),
+      enqueue: immediateEnqueue,
+      cleanupCliLiveSessionOnRunEnd: true,
+    });
+
+    expect(result.payloads?.[0]).toMatchObject({ text: "ok" });
+    expect(disposeSelectedHarnessMock).toHaveBeenCalledTimes(1);
   });
 
   it("preserves bundle MCP state across retries within one local run", async () => {

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
@@ -63,31 +63,6 @@ async function waitForAssertion(
   }
 }
 
-function requireRecord(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`expected ${label}`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function firstMaintainParams(maintain: { mock: { calls: unknown[][] } }): Record<string, unknown> {
-  return requireRecord(maintain.mock.calls[0]?.[0], "maintain params");
-}
-
-function expectRecordFields(record: Record<string, unknown>, expected: Record<string, unknown>) {
-  for (const [key, value] of Object.entries(expected)) {
-    expect(record[key]).toBe(value);
-  }
-}
-
-function expectSystemEventContaining(sessionKey: string, text: string) {
-  expect(peekSystemEvents(sessionKey).join("\n")).toContain(text);
-}
-
-vi.mock("./context-engine-capabilities.js", () => ({
-  resolveContextEngineCapabilities: () => ({ llm: undefined }),
-}));
-
 vi.mock("./transcript-rewrite.js", () => ({
   rewriteTranscriptEntriesInSessionManager: (params: unknown) =>
     rewriteTranscriptEntriesInSessionManagerMock(params),
@@ -123,11 +98,9 @@ describe("buildContextEngineMaintenanceRuntimeContext", () => {
     });
 
     expect(runtimeContext.workspaceDir).toBe("/tmp/workspace");
-    if (!runtimeContext.rewriteTranscriptEntries) {
-      throw new Error("expected transcript rewrite helper");
-    }
+    expect(typeof runtimeContext.rewriteTranscriptEntries).toBe("function");
 
-    const result = await runtimeContext.rewriteTranscriptEntries({
+    const result = await runtimeContext.rewriteTranscriptEntries?.({
       replacements: [
         { entryId: "entry-1", message: { role: "user", content: "hi", timestamp: 1 } },
       ],
@@ -189,7 +162,7 @@ describe("buildContextEngineMaintenanceRuntimeContext", () => {
       const sessionKey = "agent:main:session-rewrite-handoff";
       const sessionLane = resolveSessionLane(sessionKey);
       const events: string[] = [];
-      let releaseForeground: (() => void) | undefined;
+      let releaseForeground!: () => void;
       const foregroundTurn = enqueueCommandInLane(sessionLane, async () => {
         events.push("foreground-start");
         await new Promise<void>((resolve) => {
@@ -222,14 +195,11 @@ describe("buildContextEngineMaintenanceRuntimeContext", () => {
           { entryId: "entry-1", message: { role: "user", content: "hi", timestamp: 1 } },
         ],
       });
-      expect(rewritePromise?.then).toBeTypeOf("function");
+      expect(rewritePromise).toBeDefined();
 
       await flushAsyncWork();
       expect(rewriteTranscriptEntriesInSessionFileMock).not.toHaveBeenCalled();
 
-      if (!releaseForeground) {
-        throw new Error("Expected foreground turn release callback to be initialized");
-      }
       releaseForeground();
       await expect(rewritePromise!).resolves.toEqual({
         changed: true,
@@ -328,31 +298,24 @@ describe("runContextEngineMaintenance", () => {
       bytesFreed: 0,
       rewrittenEntries: 0,
     });
-    const maintainParams = firstMaintainParams(maintain);
-    expectRecordFields(maintainParams, {
-      sessionId: "session-1",
-      sessionKey: "agent:main:session-1",
-      sessionFile: "/tmp/session.jsonl",
-    });
-    expect(
-      requireRecord(maintainParams.runtimeContext, "maintain runtime context").workspaceDir,
-    ).toBe("/tmp/workspace");
-    const runtimeContext = maintainParams.runtimeContext as
+    expect(maintain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        sessionFile: "/tmp/session.jsonl",
+        runtimeContext: expect.objectContaining({
+          workspaceDir: "/tmp/workspace",
+        }),
+      }),
+    );
+    const runtimeContext = (
+      maintain.mock.calls[0]?.[0] as
+        | { runtimeContext?: { rewriteTranscriptEntries?: (request: unknown) => Promise<unknown> } }
+        | undefined
+    )?.runtimeContext as
       | { rewriteTranscriptEntries?: (request: unknown) => Promise<unknown> }
       | undefined;
-    if (!runtimeContext?.rewriteTranscriptEntries) {
-      throw new Error("expected maintain runtime context rewrite helper");
-    }
-    const rewriteResult = await runtimeContext.rewriteTranscriptEntries({
-      replacements: [
-        { entryId: "entry-2", message: { role: "user", content: "hello", timestamp: 2 } },
-      ],
-    });
-    expect(rewriteResult).toEqual({
-      changed: true,
-      bytesFreed: 123,
-      rewrittenEntries: 2,
-    });
+    expect(typeof runtimeContext?.rewriteTranscriptEntries).toBe("function");
   });
 
   it("forces background maintenance rewrites through the session file even when a session manager exists", async () => {
@@ -429,7 +392,7 @@ describe("runContextEngineMaintenance", () => {
 
         const sessionKey = "agent:main:session-1";
         const sessionLane = resolveSessionLane(sessionKey);
-        let releaseForeground: (() => void) | undefined;
+        let releaseForeground!: () => void;
         const foregroundTurn = enqueueCommandInLane(sessionLane, async () => {
           await new Promise<void>((resolve) => {
             releaseForeground = resolve;
@@ -495,8 +458,7 @@ describe("runContextEngineMaintenance", () => {
           (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );
         expect(queuedTasks).toHaveLength(1);
-        const queuedTask = requireRecord(queuedTasks[0], "queued task");
-        expectRecordFields(queuedTask, {
+        expect(queuedTasks[0]).toMatchObject({
           runtime: "acp",
           scopeKind: "session",
           ownerKey: sessionKey,
@@ -506,22 +468,18 @@ describe("runContextEngineMaintenance", () => {
           deliveryStatus: "pending",
         });
 
-        if (!releaseForeground) {
-          throw new Error("Expected foreground turn release callback to be initialized");
-        }
         releaseForeground();
         await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
-        const maintainParams = firstMaintainParams(maintain);
-        expectRecordFields(maintainParams, {
+        expect(maintain.mock.calls[0]?.[0]).toMatchObject({
           sessionId: "session-1",
           sessionKey,
           sessionFile: "/tmp/session.jsonl",
-        });
-        expectRecordFields(requireRecord(maintainParams.runtimeContext, "runtime context"), {
-          workspaceDir: "/tmp/workspace",
-          allowDeferredCompactionExecution: true,
-          tokenBudget: 2048,
-          currentTokenCount: 1536,
+          runtimeContext: expect.objectContaining({
+            workspaceDir: "/tmp/workspace",
+            allowDeferredCompactionExecution: true,
+            tokenBudget: 2048,
+            currentTokenCount: 1536,
+          }),
         });
         expect(rewriteTranscriptEntriesInSessionFileMock).toHaveBeenCalledWith({
           sessionFile: "/tmp/session.jsonl",
@@ -542,12 +500,25 @@ describe("runContextEngineMaintenance", () => {
           },
         });
 
-        const completedTask = getTaskById(queuedTasks[0].taskId);
-        const completedTaskRecord = requireRecord(completedTask, "completed task");
-        expect(completedTaskRecord.status).toBe("succeeded");
-        expect(String(completedTaskRecord.progressSummary)).toContain(
-          "Deferred maintenance completed",
-        );
+        await waitForAssertion(() => {
+          const completedTask = getTaskById(queuedTasks[0].taskId);
+          expect(completedTask).toMatchObject({
+            status: "succeeded",
+            progressSummary: expect.stringContaining("Deferred maintenance completed"),
+          });
+        });
+        const { readPostTurnJobState } = await import("../post-turn/durable-job-state.js");
+        const durableJobState = await readPostTurnJobState();
+        expect(durableJobState.jobs).toEqual([
+          expect.objectContaining({
+            kind: "context_engine_maintenance",
+            label: "Context engine turn maintenance",
+            sessionId: "session-1",
+            sessionKey,
+            runId: queuedTasks[0].runId,
+            status: "completed",
+          }),
+        ]);
 
         await foregroundTurn;
       } finally {
@@ -566,7 +537,7 @@ describe("runContextEngineMaintenance", () => {
 
         const sessionKey = "agent:main:session-2";
         const sessionLane = resolveSessionLane(sessionKey);
-        let releaseForeground: (() => void) | undefined;
+        let releaseForeground!: () => void;
         const foregroundTurn = enqueueCommandInLane(sessionLane, async () => {
           await new Promise<void>((resolve) => {
             releaseForeground = resolve;
@@ -617,16 +588,15 @@ describe("runContextEngineMaintenance", () => {
         );
         expect(queuedTasks).toHaveLength(1);
 
-        if (!releaseForeground) {
-          throw new Error("Expected foreground turn release callback to be initialized");
-        }
         releaseForeground();
         await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(2));
-        const completedTasks = listTasksForOwnerKey(sessionKey).filter(
-          (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
-        );
-        expect(completedTasks).toHaveLength(2);
-        expect(completedTasks.every((task) => task.status === "succeeded")).toBe(true);
+        await waitForAssertion(() => {
+          const completedTasks = listTasksForOwnerKey(sessionKey).filter(
+            (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+          );
+          expect(completedTasks).toHaveLength(2);
+          expect(completedTasks.every((task) => task.status === "succeeded")).toBe(true);
+        });
 
         await foregroundTurn;
       } finally {
@@ -644,7 +614,7 @@ describe("runContextEngineMaintenance", () => {
         resetTaskFlowRegistryForTests({ persist: false });
 
         const sessionKey = "agent:main:session-rerun";
-        let releaseFirstMaintenance: (() => void) | undefined;
+        let releaseFirstMaintenance!: () => void;
         let maintenanceCalls = 0;
         const maintain = vi.fn(async () => {
           maintenanceCalls += 1;
@@ -693,17 +663,16 @@ describe("runContextEngineMaintenance", () => {
           reason: "turn",
         });
 
-        if (!releaseFirstMaintenance) {
-          throw new Error("Expected first maintenance release callback to be initialized");
-        }
         releaseFirstMaintenance();
         await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(2));
 
-        const tasks = listTasksForOwnerKey(sessionKey).filter(
-          (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
-        );
-        expect(tasks).toHaveLength(2);
-        expect(tasks.every((task) => task.status === "succeeded")).toBe(true);
+        await waitForAssertion(() => {
+          const tasks = listTasksForOwnerKey(sessionKey).filter(
+            (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+          );
+          expect(tasks).toHaveLength(2);
+          expect(tasks.every((task) => task.status === "succeeded")).toBe(true);
+        });
       } finally {
         vi.useRealTimers();
       }
@@ -767,16 +736,11 @@ describe("runContextEngineMaintenance", () => {
           (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );
         expect(tasks).toHaveLength(2);
-        const cancelledLegacyTask = requireRecord(getTaskById(legacyTask.taskId), "legacy task");
-        expectRecordFields(cancelledLegacyTask, {
+        expect(getTaskById(legacyTask.taskId)).toMatchObject({
           status: "cancelled",
           notifyPolicy: "silent",
         });
-        expect(
-          tasks.some(
-            (task) => typeof task.runId === "string" && task.runId.startsWith("turn-maint:"),
-          ),
-        ).toBe(true);
+        expect(tasks.some((task) => task.runId?.startsWith("turn-maint:"))).toBe(true);
       } finally {
         vi.useRealTimers();
       }
@@ -829,9 +793,10 @@ describe("runContextEngineMaintenance", () => {
           (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );
         expect(tasks).toHaveLength(1);
-        const task = requireRecord(tasks[0], "cancelled task");
-        expect(task.status).toBe("cancelled");
-        expect(String(task.terminalSummary)).toContain("gateway draining");
+        expect(tasks[0]).toMatchObject({
+          status: "cancelled",
+          terminalSummary: expect.stringContaining("gateway draining"),
+        });
         expect(maintain).not.toHaveBeenCalled();
       } finally {
         enqueueSpy.mockRestore();
@@ -851,7 +816,7 @@ describe("runContextEngineMaintenance", () => {
         const sessionKey = "agent:main:session-3";
         const sessionLane = resolveSessionLane(sessionKey);
         const events: string[] = [];
-        let releaseFirstForeground: (() => void) | undefined;
+        let releaseFirstForeground!: () => void;
         const firstForeground = enqueueCommandInLane(sessionLane, async () => {
           events.push("foreground-1-start");
           await new Promise<void>((resolve) => {
@@ -898,9 +863,6 @@ describe("runContextEngineMaintenance", () => {
           events.push("foreground-2-end");
         });
 
-        if (!releaseFirstForeground) {
-          throw new Error("Expected first foreground release callback to be initialized");
-        }
         releaseFirstForeground();
         await waitForAssertion(() =>
           expect(events).toEqual([
@@ -931,7 +893,7 @@ describe("runContextEngineMaintenance", () => {
         const sessionKey = "agent:main:session-rewrite-priority";
         const sessionLane = resolveSessionLane(sessionKey);
         const events: string[] = [];
-        let allowRewrite: (() => void) | undefined;
+        let allowRewrite!: () => void;
         const maintain = vi.fn(async (params?: unknown) => {
           events.push("maintenance-start");
           await new Promise<void>((resolve) => {
@@ -1001,9 +963,6 @@ describe("runContextEngineMaintenance", () => {
           events.push("foreground-end");
         });
 
-        if (!allowRewrite) {
-          throw new Error("Expected maintenance rewrite release callback to be initialized");
-        }
         allowRewrite();
 
         await waitForAssertion(() =>
@@ -1068,7 +1027,7 @@ describe("runContextEngineMaintenance", () => {
         });
         await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
         expect(sendMessageMock).not.toHaveBeenCalled();
-        expect(peekSystemEvents(sessionKey)).toStrictEqual([]);
+        expect(peekSystemEvents(sessionKey)).toEqual([]);
       } finally {
         vi.useRealTimers();
       }
@@ -1086,7 +1045,7 @@ describe("runContextEngineMaintenance", () => {
 
         const sessionKey = "agent:main:session-long";
         const sessionLane = resolveSessionLane(sessionKey);
-        let releaseForeground: (() => void) | undefined;
+        let releaseForeground!: () => void;
         const foregroundTurn = enqueueCommandInLane(sessionLane, async () => {
           await new Promise<void>((resolve) => {
             releaseForeground = resolve;
@@ -1124,20 +1083,19 @@ describe("runContextEngineMaintenance", () => {
 
         await vi.advanceTimersByTimeAsync(11_000);
         await waitForAssertion(() =>
-          expectSystemEventContaining(
-            sessionKey,
-            "Background task update: Context engine turn maintenance.",
+          expect(peekSystemEvents(sessionKey)).toEqual(
+            expect.arrayContaining([
+              expect.stringContaining("Background task update: Context engine turn maintenance."),
+            ]),
           ),
         );
 
-        if (!releaseForeground) {
-          throw new Error("Expected foreground turn release callback to be initialized");
-        }
         releaseForeground();
         await waitForAssertion(() =>
-          expectSystemEventContaining(
-            sessionKey,
-            "Background task done: Context engine turn maintenance",
+          expect(peekSystemEvents(sessionKey)).toEqual(
+            expect.arrayContaining([
+              expect.stringContaining("Background task done: Context engine turn maintenance"),
+            ]),
           ),
         );
 
@@ -1159,7 +1117,7 @@ describe("runContextEngineMaintenance", () => {
 
         const sessionKey = "agent:main:session-throttle";
         const sessionLane = resolveSessionLane(sessionKey);
-        let releaseForeground: (() => void) | undefined;
+        let releaseForeground!: () => void;
         const foregroundTurn = enqueueCommandInLane(sessionLane, async () => {
           await new Promise<void>((resolve) => {
             releaseForeground = resolve;
@@ -1217,9 +1175,6 @@ describe("runContextEngineMaintenance", () => {
           ),
         ).toHaveLength(2);
 
-        if (!releaseForeground) {
-          throw new Error("Expected foreground turn release callback to be initialized");
-        }
         releaseForeground();
         await foregroundTurn;
       } finally {
@@ -1263,9 +1218,10 @@ describe("runContextEngineMaintenance", () => {
           reason: "turn",
         });
         await waitForAssertion(() =>
-          expectSystemEventContaining(
-            sessionKey,
-            "Background task failed: Context engine turn maintenance",
+          expect(peekSystemEvents(sessionKey)).toEqual(
+            expect.arrayContaining([
+              expect.stringContaining("Background task failed: Context engine turn maintenance"),
+            ]),
           ),
         );
       } finally {

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.ts
@@ -24,6 +24,7 @@ import {
   updateTaskNotifyPolicyForOwner,
 } from "../../tasks/task-owner-access.js";
 import { findActiveSessionTask } from "../session-async-task-status.js";
+import { runDurablePostTurnJob } from "../post-turn/durable-job-runner.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
 import { resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
@@ -445,18 +446,44 @@ async function runDeferredTurnMaintenanceWorker(params: {
       }
     }, TURN_MAINTENANCE_LONG_WAIT_MS);
 
-    const result = await executeContextEngineMaintenance({
-      contextEngine: params.contextEngine,
+    const durableResult = await runDurablePostTurnJob({
+      kind: "context_engine_maintenance",
+      label: TURN_MAINTENANCE_TASK_LABEL,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
-      sessionFile: params.sessionFile,
-      reason: "turn",
-      sessionManager: params.sessionManager,
-      runtimeContext: params.runtimeContext,
-      agentId: params.agentId,
-      config: params.config,
-      executionMode: "background",
+      runId: params.runId,
+      work: async () =>
+        await executeContextEngineMaintenance({
+          contextEngine: params.contextEngine,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          sessionFile: params.sessionFile,
+          reason: "turn",
+          sessionManager: params.sessionManager,
+          runtimeContext: params.runtimeContext,
+          agentId: params.agentId,
+          config: params.config,
+          executionMode: "background",
+        }),
     });
+    if (durableResult.status === "skipped") {
+      if (longRunningTimer) {
+        clearTimeout(longRunningTimer);
+        longRunningTimer = null;
+      }
+      const endedAt = Date.now();
+      completeTaskRunByRunId({
+        runId: params.runId,
+        runtime: "acp",
+        sessionKey: params.sessionKey,
+        endedAt,
+        lastEventAt: endedAt,
+        progressSummary: "Deferred maintenance skipped.",
+        terminalSummary: durableResult.reason,
+      });
+      return;
+    }
+    const result = durableResult.result;
     if (longRunningTimer) {
       clearTimeout(longRunningTimer);
       longRunningTimer = null;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -443,7 +443,6 @@ export async function runEmbeddedPiAgent(
           log.trace(message);
         }
       };
-      params.onExecutionStarted?.();
       notifyExecutionPhase("runner_entered");
       const workspaceResolution = resolveRunWorkspaceDir({
         workspaceDir: params.workspaceDir,
@@ -550,6 +549,10 @@ export async function runEmbeddedPiAgent(
         agentHarnessId: params.agentHarnessId,
       });
       const pluginHarnessOwnsTransport = agentHarness.id !== "pi";
+      const harnessOwnsExecutionStartSignal = agentHarness.id === "codex";
+      if (!harnessOwnsExecutionStartSignal) {
+        params.onExecutionStarted?.();
+      }
       const dynamicModelResolution = await resolveModelAsync(
         provider,
         modelId,
@@ -3097,6 +3100,17 @@ export async function runEmbeddedPiAgent(
             await contextEngine.dispose?.();
           },
         });
+        if (params.cleanupCliLiveSessionOnRunEnd === true && agentHarness.dispose) {
+          await runAgentCleanupStep({
+            runId: params.runId,
+            sessionId: params.sessionId,
+            step: "agent-harness-dispose",
+            log,
+            cleanup: async () => {
+              await agentHarness.dispose?.();
+            },
+          });
+        }
         if (params.cleanupBundleMcpOnRunEnd === true) {
           await runAgentCleanupStep({
             runId: params.runId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -4010,32 +4010,39 @@ export async function runEmbeddedAttempt(
         });
         anthropicPayloadLogger?.recordUsage(messagesSnapshot, promptError);
 
-        // Run agent_end hooks to allow plugins to analyze the conversation
-        // This is fire-and-forget, so we don't await
-        // Run even on compaction timeout so plugins can log/cleanup
+        // Run agent_end hooks only after source reply delivery drains. These
+        // hooks can perform heavy native work (SQLite/vector indexing); starting
+        // them before the final channel send can lose the user-visible answer if
+        // a native dependency crashes the process.
         if (hookRunner?.hasHooks("agent_end")) {
-          hookRunner
-            .runAgentEnd(
-              {
-                messages: messagesSnapshot,
-                success: !aborted && !promptError,
-                error: promptError ? formatErrorMessage(promptError) : undefined,
-                durationMs: Date.now() - promptStartedAt,
-              },
-              {
-                runId: params.runId,
-                trace: freezeDiagnosticTraceContext(diagnosticTrace),
-                agentId: hookAgentId,
-                sessionKey: params.sessionKey,
-                sessionId: params.sessionId,
-                workspaceDir: params.workspaceDir,
-                trigger: params.trigger,
-                ...buildAgentHookContextChannelFields(params),
-              },
-            )
-            .catch((err) => {
-              log.warn(`agent_end hook failed: ${err}`);
-            });
+          const runAgentEndHooks = () =>
+            hookRunner
+              .runAgentEnd(
+                {
+                  messages: messagesSnapshot,
+                  success: !aborted && !promptError,
+                  error: promptError ? formatErrorMessage(promptError) : undefined,
+                  durationMs: Date.now() - promptStartedAt,
+                },
+                {
+                  runId: params.runId,
+                  trace: freezeDiagnosticTraceContext(diagnosticTrace),
+                  agentId: hookAgentId,
+                  sessionKey: params.sessionKey,
+                  sessionId: params.sessionId,
+                  workspaceDir: params.workspaceDir,
+                  trigger: params.trigger,
+                  ...buildAgentHookContextChannelFields(params),
+                },
+              )
+              .catch((err) => {
+                log.warn(`agent_end hook failed: ${err}`);
+              });
+          if (params.afterSourceReplyDelivery) {
+            params.afterSourceReplyDelivery(runAgentEndHooks);
+          } else {
+            void runAgentEndHooks();
+          }
         }
       } finally {
         clearTimeout(abortTimer);
@@ -4115,55 +4122,61 @@ export async function runEmbeddedAttempt(
         hookRunner?.hasHooks("llm_output") &&
         shouldRunLlmOutputHooksForAttempt({ promptErrorSource })
       ) {
-        hookRunner
-          .runLlmOutput(
-            {
-              runId: params.runId,
-              sessionId: params.sessionId,
-              provider: params.provider,
-              model: params.modelId,
-              ...(params.contextWindowInfo?.tokens
-                ? { contextTokenBudget: params.contextWindowInfo.tokens }
-                : {}),
-              ...(params.contextWindowInfo?.source
-                ? { contextWindowSource: params.contextWindowInfo.source }
-                : {}),
-              ...(params.contextWindowInfo?.referenceTokens
-                ? { contextWindowReferenceTokens: params.contextWindowInfo.referenceTokens }
-                : {}),
-              resolvedRef:
-                params.runtimePlan?.observability.resolvedRef ??
-                `${params.provider}/${params.modelId}`,
-              ...(params.runtimePlan?.observability.harnessId
-                ? { harnessId: params.runtimePlan.observability.harnessId }
-                : {}),
-              assistantTexts,
-              lastAssistant,
-              usage: attemptUsage,
-            },
-            {
-              runId: params.runId,
-              trace: freezeDiagnosticTraceContext(diagnosticTrace),
-              agentId: hookAgentId,
-              sessionKey: params.sessionKey,
-              sessionId: params.sessionId,
-              workspaceDir: params.workspaceDir,
-              trigger: params.trigger,
-              ...(params.contextWindowInfo?.tokens
-                ? { contextTokenBudget: params.contextWindowInfo.tokens }
-                : {}),
-              ...(params.contextWindowInfo?.source
-                ? { contextWindowSource: params.contextWindowInfo.source }
-                : {}),
-              ...(params.contextWindowInfo?.referenceTokens
-                ? { contextWindowReferenceTokens: params.contextWindowInfo.referenceTokens }
-                : {}),
-              ...buildAgentHookContextChannelFields(params),
-            },
-          )
-          .catch((err) => {
-            log.warn(`llm_output hook failed: ${String(err)}`);
-          });
+        const runLlmOutputHooks = () =>
+          hookRunner
+            .runLlmOutput(
+              {
+                runId: params.runId,
+                sessionId: params.sessionId,
+                provider: params.provider,
+                model: params.modelId,
+                ...(params.contextWindowInfo?.tokens
+                  ? { contextTokenBudget: params.contextWindowInfo.tokens }
+                  : {}),
+                ...(params.contextWindowInfo?.source
+                  ? { contextWindowSource: params.contextWindowInfo.source }
+                  : {}),
+                ...(params.contextWindowInfo?.referenceTokens
+                  ? { contextWindowReferenceTokens: params.contextWindowInfo.referenceTokens }
+                  : {}),
+                resolvedRef:
+                  params.runtimePlan?.observability.resolvedRef ??
+                  `${params.provider}/${params.modelId}`,
+                ...(params.runtimePlan?.observability.harnessId
+                  ? { harnessId: params.runtimePlan.observability.harnessId }
+                  : {}),
+                assistantTexts,
+                lastAssistant,
+                usage: attemptUsage,
+              },
+              {
+                runId: params.runId,
+                trace: freezeDiagnosticTraceContext(diagnosticTrace),
+                agentId: hookAgentId,
+                sessionKey: params.sessionKey,
+                sessionId: params.sessionId,
+                workspaceDir: params.workspaceDir,
+                trigger: params.trigger,
+                ...(params.contextWindowInfo?.tokens
+                  ? { contextTokenBudget: params.contextWindowInfo.tokens }
+                  : {}),
+                ...(params.contextWindowInfo?.source
+                  ? { contextWindowSource: params.contextWindowInfo.source }
+                  : {}),
+                ...(params.contextWindowInfo?.referenceTokens
+                  ? { contextWindowReferenceTokens: params.contextWindowInfo.referenceTokens }
+                  : {}),
+                ...buildAgentHookContextChannelFields(params),
+              },
+            )
+            .catch((err) => {
+              log.warn(`llm_output hook failed: ${String(err)}`);
+            });
+        if (params.afterSourceReplyDelivery) {
+          params.afterSourceReplyDelivery(runLlmOutputHooks);
+        } else {
+          void runLlmOutputHooks();
+        }
       }
 
       const observedReplayMetadata = buildAttemptReplayMetadata({

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import type {
+  AfterSourceReplyDeliveryCallback,
   PartialReplyPayload,
   SourceReplyDeliveryMode,
 } from "../../../auto-reply/get-reply-options.types.js";
@@ -221,10 +222,16 @@ export type RunEmbeddedPiAgentParams = {
   suppressNextUserMessagePersistence?: boolean;
   suppressTranscriptOnlyAssistantPersistence?: boolean;
   onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
+  afterSourceReplyDelivery?: (callback: AfterSourceReplyDeliveryCallback) => void;
   /**
    * Dispose bundled MCP runtimes when the overall run ends instead of preserving
    * the session-scoped cache. Intended for one-shot local CLI runs that must
    * exit promptly after emitting the final JSON result.
    */
   cleanupBundleMcpOnRunEnd?: boolean;
+  /**
+   * Dispose live CLI-style harness resources when the overall run ends. This is
+   * for one-shot CLI embedded/fallback runs that must release child processes.
+   */
+  cleanupCliLiveSessionOnRunEnd?: boolean;
 };

--- a/src/agents/post-turn/durable-job-runner.test.ts
+++ b/src/agents/post-turn/durable-job-runner.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
+
+describe("durable post-turn job runner", () => {
+  it("records completed work and returns the work result", async () => {
+    await withStateDirEnv("openclaw-post-turn-runner-", async () => {
+      const { readPostTurnJobState } = await import("./durable-job-state.js");
+      const { runDurablePostTurnJob } = await import("./durable-job-runner.js");
+
+      const result = await runDurablePostTurnJob(
+        {
+          kind: "plugin_hook",
+          hookName: "llm_output",
+          pluginId: "memory-plugin",
+          label: "llm_output hook",
+          sessionId: "session-1",
+          sessionKey: "agent:main:session-1",
+          runId: "run-1",
+          work: async () => "ok",
+        },
+        { bootId: "boot-a", processId: 111 },
+      );
+
+      expect(result).toEqual({ status: "completed", result: "ok" });
+      expect((await readPostTurnJobState()).jobs[0]).toMatchObject({
+        kind: "plugin_hook",
+        hookName: "llm_output",
+        pluginId: "memory-plugin",
+        status: "completed",
+      });
+    });
+  });
+
+  it("skips matching work while its crash circuit breaker is open", async () => {
+    await withStateDirEnv("openclaw-post-turn-runner-", async () => {
+      const { createPostTurnJob, markPostTurnJobCrashed, readPostTurnJobState } = await import(
+        "./durable-job-state.js"
+      );
+      const { runDurablePostTurnJob } = await import("./durable-job-runner.js");
+      const work = vi.fn(async () => undefined);
+
+      const crashed = await createPostTurnJob({
+        kind: "plugin_hook",
+        hookName: "agent_end",
+        pluginId: "memory-plugin",
+        label: "agent_end hook",
+      });
+      await markPostTurnJobCrashed(crashed.id, {
+        now: 10_000,
+        reason: "worker exited with code 139",
+      });
+
+      const result = await runDurablePostTurnJob({
+        kind: "plugin_hook",
+        hookName: "agent_end",
+        pluginId: "memory-plugin",
+        label: "agent_end hook",
+        work,
+      });
+
+      expect(result.status).toBe("skipped");
+      expect(work).not.toHaveBeenCalled();
+      expect((await readPostTurnJobState()).jobs.at(-1)).toMatchObject({
+        kind: "plugin_hook",
+        hookName: "agent_end",
+        pluginId: "memory-plugin",
+        status: "skipped",
+        lastError: expect.stringContaining("circuit breaker"),
+      });
+    });
+  });
+});

--- a/src/agents/post-turn/durable-job-runner.ts
+++ b/src/agents/post-turn/durable-job-runner.ts
@@ -1,0 +1,63 @@
+import { formatErrorMessage } from "../../infra/errors.js";
+import {
+  createPostTurnJob,
+  isPostTurnCircuitBreakerOpen,
+  markPostTurnJobCompleted,
+  markPostTurnJobCrashed,
+  markPostTurnJobFailed,
+  markPostTurnJobRunning,
+  markPostTurnJobSkipped,
+  type PostTurnJobCreateParams,
+} from "./durable-job-state.js";
+import { isPostTurnWorkerNativeCrash } from "./worker-process.js";
+
+export type DurablePostTurnJobRunResult<TResult = unknown> =
+  | { status: "completed"; result: TResult }
+  | { status: "skipped"; reason: string };
+
+type DurablePostTurnJobRunOptions = {
+  now?: number;
+  bootId?: string;
+  processId?: number;
+};
+
+export async function runDurablePostTurnJob<TResult>(
+  params: PostTurnJobCreateParams & {
+    work: () => Promise<TResult> | TResult;
+  },
+  options?: DurablePostTurnJobRunOptions,
+): Promise<DurablePostTurnJobRunResult<TResult>> {
+  const job = await createPostTurnJob(params, options);
+  if (await isPostTurnCircuitBreakerOpen(params)) {
+    const reason = `post-turn circuit breaker is open for ${params.kind}`;
+    await markPostTurnJobSkipped(job.id, { reason, now: options?.now });
+    return { status: "skipped", reason };
+  }
+
+  await markPostTurnJobRunning(job.id, options);
+  try {
+    const result = await params.work();
+    await markPostTurnJobCompleted(job.id, { now: options?.now });
+    return { status: "completed", result };
+  } catch (error) {
+    const reason = formatErrorMessage(error);
+    if (isPostTurnWorkerNativeCrash(error)) {
+      await markPostTurnJobCrashed(job.id, { reason, now: options?.now });
+    } else {
+      await markPostTurnJobFailed(job.id, { reason, now: options?.now });
+    }
+    throw error;
+  }
+}
+
+export function scheduleDurablePostTurnJob<TResult>(
+  params: PostTurnJobCreateParams & {
+    work: () => Promise<TResult> | TResult;
+    onError?: (error: unknown) => void;
+  },
+  options?: DurablePostTurnJobRunOptions,
+): void {
+  void runDurablePostTurnJob(params, options).catch((error) => {
+    params.onError?.(error);
+  });
+}

--- a/src/agents/post-turn/durable-job-state.test.ts
+++ b/src/agents/post-turn/durable-job-state.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
+
+describe("durable post-turn job state", () => {
+  it("persists queued, running, and completed job transitions", async () => {
+    await withStateDirEnv("openclaw-post-turn-jobs-", async () => {
+      const {
+        createPostTurnJob,
+        markPostTurnJobCompleted,
+        markPostTurnJobRunning,
+        readPostTurnJobState,
+      } = await import("./durable-job-state.js");
+
+      const job = await createPostTurnJob(
+        {
+          kind: "context_engine_maintenance",
+          label: "Context engine turn maintenance",
+          sessionId: "session-1",
+          sessionKey: "agent:main:session-1",
+          runId: "run-1",
+        },
+        { bootId: "boot-a", now: 1_000, processId: 111 },
+      );
+
+      await markPostTurnJobRunning(job.id, { bootId: "boot-a", now: 1_100, processId: 111 });
+      await markPostTurnJobCompleted(job.id, { now: 1_200 });
+
+      const state = await readPostTurnJobState();
+      expect(state.jobs).toHaveLength(1);
+      expect(state.jobs[0]).toMatchObject({
+        id: job.id,
+        kind: "context_engine_maintenance",
+        label: "Context engine turn maintenance",
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        runId: "run-1",
+        status: "completed",
+        bootId: "boot-a",
+        processId: 111,
+        createdAt: 1_000,
+        startedAt: 1_100,
+        completedAt: 1_200,
+      });
+    });
+  });
+
+  it("recovers stale running jobs as crashed and opens the matching circuit breaker", async () => {
+    await withStateDirEnv("openclaw-post-turn-jobs-", async () => {
+      const {
+        createPostTurnJob,
+        isPostTurnCircuitBreakerOpen,
+        markPostTurnJobRunning,
+        readPostTurnJobState,
+        recoverStaleRunningPostTurnJobs,
+      } = await import("./durable-job-state.js");
+
+      const job = await createPostTurnJob(
+        {
+          kind: "plugin_hook",
+          hookName: "agent_end",
+          pluginId: "memory-plugin",
+          label: "agent_end hook",
+          sessionId: "session-1",
+          sessionKey: "agent:main:session-1",
+          runId: "run-1",
+        },
+        { bootId: "old-boot", now: 2_000, processId: 222 },
+      );
+      await markPostTurnJobRunning(job.id, {
+        bootId: "old-boot",
+        now: 2_100,
+        processId: 222,
+      });
+
+      const recovery = await recoverStaleRunningPostTurnJobs({
+        bootId: "new-boot",
+        now: 3_000,
+        processId: 333,
+      });
+
+      expect(recovery.crashedJobIds).toEqual([job.id]);
+      expect(
+        await isPostTurnCircuitBreakerOpen({
+          kind: "plugin_hook",
+          hookName: "agent_end",
+          pluginId: "memory-plugin",
+        }),
+      ).toBe(true);
+
+      const state = await readPostTurnJobState();
+      expect(state.jobs[0]).toMatchObject({
+        id: job.id,
+        status: "crashed",
+        completedAt: 3_000,
+        lastError: expect.stringContaining("stale running post-turn job"),
+      });
+      expect(Object.values(state.circuitBreakers)[0]).toMatchObject({
+        kind: "plugin_hook",
+        hookName: "agent_end",
+        pluginId: "memory-plugin",
+        openedAt: 3_000,
+        crashCount: 1,
+      });
+    });
+  });
+});

--- a/src/agents/post-turn/durable-job-state.ts
+++ b/src/agents/post-turn/durable-job-state.ts
@@ -1,0 +1,348 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { resolveStateDir } from "../../config/paths.js";
+import { createAsyncLock, readDurableJsonFile, writeJsonAtomic } from "../../infra/json-files.js";
+
+export type PostTurnJobKind = "context_engine_maintenance" | "plugin_hook" | "worker_process";
+
+export type PostTurnJobStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "crashed"
+  | "skipped";
+
+export type PostTurnCircuitScope = {
+  kind: PostTurnJobKind;
+  hookName?: string;
+  pluginId?: string;
+};
+
+export type PostTurnJobCreateParams = PostTurnCircuitScope & {
+  label: string;
+  sessionId?: string;
+  sessionKey?: string;
+  runId?: string;
+  agentId?: string;
+  sourceChannel?: string;
+};
+
+export type PostTurnJobRecord = PostTurnJobCreateParams & {
+  id: string;
+  status: PostTurnJobStatus;
+  createdAt: number;
+  updatedAt: number;
+  startedAt?: number;
+  completedAt?: number;
+  bootId?: string;
+  processId?: number;
+  lastError?: string;
+};
+
+export type PostTurnCircuitBreakerRecord = PostTurnCircuitScope & {
+  key: string;
+  openedAt: number;
+  updatedAt: number;
+  crashCount: number;
+  lastJobId?: string;
+  reason: string;
+};
+
+export type PostTurnJobState = {
+  schemaVersion: 1;
+  jobs: PostTurnJobRecord[];
+  circuitBreakers: Record<string, PostTurnCircuitBreakerRecord>;
+};
+
+type MutationOptions = {
+  now?: number;
+  bootId?: string;
+  processId?: number;
+};
+
+const MAX_RETAINED_POST_TURN_JOBS = 500;
+const POST_TURN_JOB_STATE_RELATIVE_PATH = path.join("post-turn", "jobs.json");
+const POST_TURN_BOOT_ID = randomUUID();
+const withPostTurnJobStateLock = createAsyncLock();
+
+function nowMs(options?: Pick<MutationOptions, "now">): number {
+  return options?.now ?? Date.now();
+}
+
+export function getPostTurnBootId(): string {
+  return POST_TURN_BOOT_ID;
+}
+
+export function resolvePostTurnJobStateFilePath(): string {
+  return path.join(resolveStateDir(), POST_TURN_JOB_STATE_RELATIVE_PATH);
+}
+
+function normalizeOptionalText(value?: string): string | undefined {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeScope(scope: PostTurnCircuitScope): PostTurnCircuitScope {
+  return {
+    kind: scope.kind,
+    ...(normalizeOptionalText(scope.hookName) ? { hookName: normalizeOptionalText(scope.hookName) } : {}),
+    ...(normalizeOptionalText(scope.pluginId) ? { pluginId: normalizeOptionalText(scope.pluginId) } : {}),
+  };
+}
+
+export function buildPostTurnCircuitBreakerKey(scope: PostTurnCircuitScope): string {
+  const normalized = normalizeScope(scope);
+  return [normalized.kind, normalized.hookName ?? "", normalized.pluginId ?? ""].join("|");
+}
+
+function emptyState(): PostTurnJobState {
+  return {
+    schemaVersion: 1,
+    jobs: [],
+    circuitBreakers: {},
+  };
+}
+
+function normalizeState(raw: PostTurnJobState | null): PostTurnJobState {
+  if (!raw || raw.schemaVersion !== 1) {
+    return emptyState();
+  }
+  return {
+    schemaVersion: 1,
+    jobs: Array.isArray(raw.jobs) ? raw.jobs : [],
+    circuitBreakers:
+      raw.circuitBreakers && typeof raw.circuitBreakers === "object"
+        ? raw.circuitBreakers
+        : {},
+  };
+}
+
+async function readStateUnlocked(): Promise<PostTurnJobState> {
+  return normalizeState(await readDurableJsonFile<PostTurnJobState>(resolvePostTurnJobStateFilePath()));
+}
+
+async function writeStateUnlocked(state: PostTurnJobState): Promise<void> {
+  const retainedJobs =
+    state.jobs.length > MAX_RETAINED_POST_TURN_JOBS
+      ? state.jobs.slice(state.jobs.length - MAX_RETAINED_POST_TURN_JOBS)
+      : state.jobs;
+  await writeJsonAtomic(
+    resolvePostTurnJobStateFilePath(),
+    {
+      schemaVersion: 1,
+      jobs: retainedJobs,
+      circuitBreakers: state.circuitBreakers,
+    } satisfies PostTurnJobState,
+    { mode: 0o600, trailingNewline: true, dirMode: 0o700 },
+  );
+}
+
+async function mutatePostTurnJobState<T>(
+  mutator: (state: PostTurnJobState) => T | Promise<T>,
+): Promise<T> {
+  return withPostTurnJobStateLock(async () => {
+    const state = await readStateUnlocked();
+    const result = await mutator(state);
+    await writeStateUnlocked(state);
+    return result;
+  });
+}
+
+function updateJob(
+  state: PostTurnJobState,
+  jobId: string,
+  updater: (job: PostTurnJobRecord) => PostTurnJobRecord,
+): PostTurnJobRecord | undefined {
+  const index = state.jobs.findIndex((job) => job.id === jobId);
+  if (index < 0) {
+    return undefined;
+  }
+  const updated = updater(state.jobs[index]);
+  state.jobs[index] = updated;
+  return updated;
+}
+
+function openCircuitBreakerForJob(params: {
+  state: PostTurnJobState;
+  job: PostTurnJobRecord;
+  now: number;
+  reason: string;
+}): PostTurnCircuitBreakerRecord {
+  const scope = normalizeScope(params.job);
+  const key = buildPostTurnCircuitBreakerKey(scope);
+  const existing = params.state.circuitBreakers[key];
+  const breaker: PostTurnCircuitBreakerRecord = {
+    key,
+    ...scope,
+    openedAt: existing?.openedAt ?? params.now,
+    updatedAt: params.now,
+    crashCount: (existing?.crashCount ?? 0) + 1,
+    lastJobId: params.job.id,
+    reason: params.reason,
+  };
+  params.state.circuitBreakers[key] = breaker;
+  return breaker;
+}
+
+export async function readPostTurnJobState(): Promise<PostTurnJobState> {
+  return withPostTurnJobStateLock(async () => await readStateUnlocked());
+}
+
+export async function createPostTurnJob(
+  params: PostTurnJobCreateParams,
+  options?: MutationOptions,
+): Promise<PostTurnJobRecord> {
+  const createdAt = nowMs(options);
+  const scope = normalizeScope(params);
+  const job: PostTurnJobRecord = {
+    id: randomUUID(),
+    ...scope,
+    label: params.label,
+    ...(normalizeOptionalText(params.sessionId) ? { sessionId: normalizeOptionalText(params.sessionId) } : {}),
+    ...(normalizeOptionalText(params.sessionKey) ? { sessionKey: normalizeOptionalText(params.sessionKey) } : {}),
+    ...(normalizeOptionalText(params.runId) ? { runId: normalizeOptionalText(params.runId) } : {}),
+    ...(normalizeOptionalText(params.agentId) ? { agentId: normalizeOptionalText(params.agentId) } : {}),
+    ...(normalizeOptionalText(params.sourceChannel) ? { sourceChannel: normalizeOptionalText(params.sourceChannel) } : {}),
+    status: "queued",
+    createdAt,
+    updatedAt: createdAt,
+    bootId: options?.bootId ?? getPostTurnBootId(),
+    processId: options?.processId ?? process.pid,
+  };
+  await mutatePostTurnJobState((state) => {
+    state.jobs.push(job);
+  });
+  return job;
+}
+
+export async function markPostTurnJobRunning(
+  jobId: string,
+  options?: MutationOptions,
+): Promise<PostTurnJobRecord | undefined> {
+  const updatedAt = nowMs(options);
+  return mutatePostTurnJobState((state) =>
+    updateJob(state, jobId, (job) => ({
+      ...job,
+      status: "running",
+      updatedAt,
+      startedAt: updatedAt,
+      bootId: options?.bootId ?? getPostTurnBootId(),
+      processId: options?.processId ?? process.pid,
+      lastError: undefined,
+    })),
+  );
+}
+
+export async function markPostTurnJobCompleted(
+  jobId: string,
+  options?: Pick<MutationOptions, "now">,
+): Promise<PostTurnJobRecord | undefined> {
+  const completedAt = nowMs(options);
+  return mutatePostTurnJobState((state) =>
+    updateJob(state, jobId, (job) => ({
+      ...job,
+      status: "completed",
+      updatedAt: completedAt,
+      completedAt,
+      lastError: undefined,
+    })),
+  );
+}
+
+export async function markPostTurnJobFailed(
+  jobId: string,
+  params: { reason: string; now?: number },
+): Promise<PostTurnJobRecord | undefined> {
+  const completedAt = nowMs(params);
+  return mutatePostTurnJobState((state) =>
+    updateJob(state, jobId, (job) => ({
+      ...job,
+      status: "failed",
+      updatedAt: completedAt,
+      completedAt,
+      lastError: params.reason,
+    })),
+  );
+}
+
+export async function markPostTurnJobSkipped(
+  jobId: string,
+  params: { reason: string; now?: number },
+): Promise<PostTurnJobRecord | undefined> {
+  const completedAt = nowMs(params);
+  return mutatePostTurnJobState((state) =>
+    updateJob(state, jobId, (job) => ({
+      ...job,
+      status: "skipped",
+      updatedAt: completedAt,
+      completedAt,
+      lastError: params.reason,
+    })),
+  );
+}
+
+export async function markPostTurnJobCrashed(
+  jobId: string,
+  params: { reason: string; now?: number },
+): Promise<PostTurnJobRecord | undefined> {
+  const completedAt = nowMs(params);
+  return mutatePostTurnJobState((state) => {
+    const updated = updateJob(state, jobId, (job) => ({
+      ...job,
+      status: "crashed",
+      updatedAt: completedAt,
+      completedAt,
+      lastError: params.reason,
+    }));
+    if (updated) {
+      openCircuitBreakerForJob({
+        state,
+        job: updated,
+        now: completedAt,
+        reason: params.reason,
+      });
+    }
+    return updated;
+  });
+}
+
+export async function isPostTurnCircuitBreakerOpen(
+  scope: PostTurnCircuitScope,
+): Promise<boolean> {
+  return withPostTurnJobStateLock(async () => {
+    const state = await readStateUnlocked();
+    return Boolean(state.circuitBreakers[buildPostTurnCircuitBreakerKey(scope)]);
+  });
+}
+
+export async function recoverStaleRunningPostTurnJobs(
+  options?: MutationOptions,
+): Promise<{ crashedJobIds: string[] }> {
+  const recoveredAt = nowMs(options);
+  const currentBootId = options?.bootId ?? getPostTurnBootId();
+  const currentProcessId = options?.processId ?? process.pid;
+  return mutatePostTurnJobState((state) => {
+    const crashedJobIds: string[] = [];
+    for (const job of state.jobs) {
+      if (job.status !== "running") {
+        continue;
+      }
+      if (job.bootId === currentBootId && job.processId === currentProcessId) {
+        continue;
+      }
+      job.status = "crashed";
+      job.updatedAt = recoveredAt;
+      job.completedAt = recoveredAt;
+      job.lastError = `stale running post-turn job recovered after restart (bootId=${job.bootId ?? "unknown"} processId=${job.processId ?? "unknown"})`;
+      crashedJobIds.push(job.id);
+      openCircuitBreakerForJob({
+        state,
+        job,
+        now: recoveredAt,
+        reason: job.lastError,
+      });
+    }
+    return { crashedJobIds };
+  });
+}

--- a/src/agents/post-turn/isolated-plugin-hook-runner.ts
+++ b/src/agents/post-turn/isolated-plugin-hook-runner.ts
@@ -1,0 +1,43 @@
+import type {
+  PluginHookAgentContext,
+  PluginHookAgentEndEvent,
+  PluginHookLlmOutputEvent,
+} from "../../plugins/hook-types.js";
+import { runPostTurnWorkerProcess } from "./worker-process.js";
+
+const DIST_WORKER_ENTRY_RELATIVE_URL = "./agents/post-turn/isolated-plugin-hook-worker-entry.js";
+
+function resolveIsolatedPostTurnPluginHookWorkerModuleUrl(): string {
+  const configured = process.env.OPENCLAW_POST_TURN_HOOK_WORKER_MODULE_URL?.trim();
+  if (configured) {
+    return configured;
+  }
+  return new URL(DIST_WORKER_ENTRY_RELATIVE_URL, import.meta.url).href;
+}
+
+export type IsolatedPostTurnPluginHookRequest =
+  | {
+      hookName: "agent_end";
+      pluginId: string;
+      registrationOrdinal: number;
+      event: PluginHookAgentEndEvent;
+      ctx: PluginHookAgentContext;
+    }
+  | {
+      hookName: "llm_output";
+      pluginId: string;
+      registrationOrdinal: number;
+      event: PluginHookLlmOutputEvent;
+      ctx: PluginHookAgentContext;
+    };
+
+export async function runIsolatedPostTurnPluginHook(params: {
+  request: IsolatedPostTurnPluginHookRequest;
+  timeoutMs?: number;
+}): Promise<void> {
+  await runPostTurnWorkerProcess({
+    workerModuleUrl: resolveIsolatedPostTurnPluginHookWorkerModuleUrl(),
+    request: params.request,
+    timeoutMs: params.timeoutMs,
+  });
+}

--- a/src/agents/post-turn/isolated-plugin-hook-worker-entry.test.ts
+++ b/src/agents/post-turn/isolated-plugin-hook-worker-entry.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { initializeGlobalHookRunner, resetGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import type { PluginHookRegistration } from "../../plugins/hook-types.js";
+
+vi.mock("../../config/io.js", () => ({
+  getRuntimeConfig: () => ({}),
+}));
+
+vi.mock("../../plugins/runtime/runtime-registry-loader.js", () => ({
+  ensurePluginRegistryLoaded: vi.fn(),
+}));
+
+function createRegistry(hooks: PluginHookRegistration[]) {
+  return {
+    hooks: [],
+    typedHooks: hooks,
+    plugins: hooks.map((hook) => ({ id: hook.pluginId, status: "loaded" as const })),
+  };
+}
+
+describe("isolated post-turn plugin hook worker", () => {
+  beforeEach(() => {
+    resetGlobalHookRunner();
+  });
+
+  it("runs only the scheduled hook registration when a plugin has multiple handlers", async () => {
+    const { runIsolatedPluginHookWorkerRequest } = await import(
+      "./isolated-plugin-hook-worker-entry.js"
+    );
+    const firstHandler = vi.fn(async () => undefined);
+    const secondHandler = vi.fn(async () => undefined);
+    initializeGlobalHookRunner(
+      createRegistry([
+        {
+          pluginId: "memory-plugin",
+          hookName: "agent_end",
+          handler: firstHandler,
+          source: "test:first",
+        },
+        {
+          pluginId: "memory-plugin",
+          hookName: "agent_end",
+          handler: secondHandler,
+          source: "test:second",
+        },
+      ]),
+    );
+
+    await runIsolatedPluginHookWorkerRequest({
+      hookName: "agent_end",
+      pluginId: "memory-plugin",
+      registrationOrdinal: 1,
+      event: { messages: [], success: true, durationMs: 1 },
+      ctx: { agentId: "main" },
+    });
+
+    expect(firstHandler).not.toHaveBeenCalled();
+    expect(secondHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/post-turn/isolated-plugin-hook-worker-entry.ts
+++ b/src/agents/post-turn/isolated-plugin-hook-worker-entry.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs/promises";
+import { getRuntimeConfig } from "../../config/io.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { getGlobalPluginRegistry } from "../../plugins/hook-runner-global.js";
+import type { PluginHookRegistration } from "../../plugins/hook-types.js";
+import { ensurePluginRegistryLoaded } from "../../plugins/runtime/runtime-registry-loader.js";
+import type { IsolatedPostTurnPluginHookRequest } from "./isolated-plugin-hook-runner.js";
+
+const log = createSubsystemLogger("agents/post-turn-worker");
+
+function isSupportedHookName(value: string): value is IsolatedPostTurnPluginHookRequest["hookName"] {
+  return value === "agent_end" || value === "llm_output";
+}
+
+function assertWorkerRequest(value: unknown): asserts value is IsolatedPostTurnPluginHookRequest {
+  if (!value || typeof value !== "object") {
+    throw new Error("invalid post-turn hook worker request");
+  }
+  const request = value as Partial<IsolatedPostTurnPluginHookRequest>;
+  if (typeof request.hookName !== "string" || !isSupportedHookName(request.hookName)) {
+    throw new Error("unsupported post-turn hook worker hookName");
+  }
+  if (typeof request.pluginId !== "string" || !request.pluginId.trim()) {
+    throw new Error("post-turn hook worker request is missing pluginId");
+  }
+  if (
+    typeof request.registrationOrdinal !== "number" ||
+    !Number.isInteger(request.registrationOrdinal) ||
+    request.registrationOrdinal < 0
+  ) {
+    throw new Error("post-turn hook worker request is missing registrationOrdinal");
+  }
+}
+
+async function readWorkerRequest(): Promise<IsolatedPostTurnPluginHookRequest> {
+  if (process.env.OPENCLAW_POST_TURN_WORKER_REQUEST_STDIN === "1") {
+    let raw = "";
+    process.stdin.setEncoding("utf8");
+    for await (const chunk of process.stdin) {
+      raw += chunk;
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    assertWorkerRequest(parsed);
+    return parsed;
+  }
+  const requestFile = process.env.OPENCLAW_POST_TURN_WORKER_REQUEST_FILE;
+  if (!requestFile) {
+    throw new Error("OPENCLAW_POST_TURN_WORKER_REQUEST_FILE is not set");
+  }
+  const parsed = JSON.parse(await fs.readFile(requestFile, "utf8")) as unknown;
+  assertWorkerRequest(parsed);
+  return parsed;
+}
+
+export async function runIsolatedPluginHookWorkerRequest(
+  request: IsolatedPostTurnPluginHookRequest,
+): Promise<void> {
+  const config = getRuntimeConfig();
+  ensurePluginRegistryLoaded({
+    scope: "all",
+    config,
+    activationSourceConfig: config,
+    env: process.env,
+  });
+  const registry = getGlobalPluginRegistry();
+  const hooks = (registry?.typedHooks ?? [])
+    .filter(
+      (hook): hook is PluginHookRegistration =>
+        hook.hookName === request.hookName && hook.pluginId === request.pluginId,
+    )
+    .toSorted((left, right) => (right.priority ?? 0) - (left.priority ?? 0));
+  const hook = hooks[request.registrationOrdinal];
+  if (!hook) {
+    log.warn(
+      `post-turn hook worker found no hook handler for ${request.hookName}/${request.pluginId}#${request.registrationOrdinal}`,
+    );
+    return;
+  }
+  await Promise.resolve(
+    (hook.handler as (event: unknown, ctx: unknown) => Promise<void> | void)(
+      request.event,
+      request.ctx,
+    ),
+  );
+}
+
+export async function runPostTurnWorkerFromCli(): Promise<void> {
+  await runIsolatedPluginHookWorkerRequest(await readWorkerRequest());
+}

--- a/src/agents/post-turn/worker-process.test.ts
+++ b/src/agents/post-turn/worker-process.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
+
+describe("post-turn worker process", () => {
+  it("runs a worker module in a child process with a JSON request", async () => {
+    await withStateDirEnv("openclaw-post-turn-worker-", async ({ stateDir }) => {
+      const { runPostTurnWorkerProcess } = await import("./worker-process.js");
+      const markerPath = path.join(stateDir, "worker-marker.txt");
+      const workerPath = path.join(stateDir, "worker.mjs");
+      await fs.writeFile(
+        workerPath,
+        [
+          "import fs from 'node:fs/promises';",
+          "export async function runPostTurnWorkerFromCli() {",
+          "  let raw = '';",
+          "  process.stdin.setEncoding('utf8');",
+          "  for await (const chunk of process.stdin) raw += chunk;",
+          "  const request = JSON.parse(raw);",
+          "  await fs.writeFile(request.markerPath, request.payload, 'utf8');",
+          "}",
+        ].join("\n"),
+      );
+
+      await runPostTurnWorkerProcess({
+        workerModuleUrl: pathToFileURL(workerPath).href,
+        request: { markerPath, payload: "worker-ok" },
+        timeoutMs: 2_000,
+      });
+
+      await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("worker-ok");
+      await expect(fs.readdir(path.join(stateDir, "post-turn", "worker-requests"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+
+  it("survives a crashing worker and reports the child exit code", async () => {
+    await withStateDirEnv("openclaw-post-turn-worker-", async ({ stateDir }) => {
+      const { runPostTurnWorkerProcess } = await import("./worker-process.js");
+      const workerPath = path.join(stateDir, "crash-worker.mjs");
+      await fs.writeFile(
+        workerPath,
+        [
+          "export async function runPostTurnWorkerFromCli() {",
+          "  process.exit(139);",
+          "}",
+        ].join("\n"),
+      );
+
+      await expect(
+        runPostTurnWorkerProcess({
+          workerModuleUrl: pathToFileURL(workerPath).href,
+          request: { ok: true },
+          timeoutMs: 2_000,
+        }),
+      ).rejects.toMatchObject({ exitCode: 139 });
+    });
+  });
+
+  it("removes stale file-based worker requests from older builds", async () => {
+    await withStateDirEnv("openclaw-post-turn-worker-", async ({ stateDir }) => {
+      const { cleanupPostTurnWorkerRequestFiles, resolvePostTurnWorkerRequestDir } = await import(
+        "./worker-process.js"
+      );
+      const requestDir = resolvePostTurnWorkerRequestDir();
+      await fs.mkdir(requestDir, { recursive: true });
+      await fs.writeFile(path.join(requestDir, "stale.json"), '{"private":"request"}', "utf8");
+
+      await expect(cleanupPostTurnWorkerRequestFiles()).resolves.toBe(1);
+      await expect(fs.readdir(path.join(stateDir, "post-turn", "worker-requests"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+});

--- a/src/agents/post-turn/worker-process.ts
+++ b/src/agents/post-turn/worker-process.ts
@@ -1,0 +1,168 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../../config/paths.js";
+
+const DEFAULT_WORKER_TIMEOUT_MS = 30_000;
+const MAX_CAPTURED_OUTPUT_BYTES = 32_000;
+
+export class PostTurnWorkerProcessError extends Error {
+  readonly exitCode?: number | null;
+  readonly signal?: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly timedOut: boolean;
+
+  constructor(params: {
+    message: string;
+    exitCode?: number | null;
+    signal?: NodeJS.Signals | null;
+    stdout?: string;
+    stderr?: string;
+    timedOut?: boolean;
+  }) {
+    super(params.message);
+    this.name = "PostTurnWorkerProcessError";
+    this.exitCode = params.exitCode;
+    this.signal = params.signal;
+    this.stdout = params.stdout ?? "";
+    this.stderr = params.stderr ?? "";
+    this.timedOut = params.timedOut ?? false;
+  }
+}
+
+function appendCapturedOutput(current: string, chunk: Buffer): string {
+  const next = current + chunk.toString("utf8");
+  if (Buffer.byteLength(next, "utf8") <= MAX_CAPTURED_OUTPUT_BYTES) {
+    return next;
+  }
+  return next.slice(next.length - MAX_CAPTURED_OUTPUT_BYTES);
+}
+
+export function resolvePostTurnWorkerRequestDir(): string {
+  return path.join(resolveStateDir(), "post-turn", "worker-requests");
+}
+
+export async function cleanupPostTurnWorkerRequestFiles(): Promise<number> {
+  const requestDir = resolvePostTurnWorkerRequestDir();
+  let removed = 0;
+  try {
+    const entries = await fs.readdir(requestDir);
+    removed = entries.length;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+  await fs.rm(requestDir, { force: true, recursive: true });
+  return removed;
+}
+
+export function isPostTurnWorkerNativeCrash(error: unknown): boolean {
+  if (!(error instanceof PostTurnWorkerProcessError)) {
+    return false;
+  }
+  if (error.signal === "SIGSEGV" || error.signal === "SIGABRT" || error.signal === "SIGBUS") {
+    return true;
+  }
+  return error.exitCode === 134 || error.exitCode === 135 || error.exitCode === 139;
+}
+
+export async function runPostTurnWorkerProcess(params: {
+  workerModuleUrl: string;
+  request: unknown;
+  timeoutMs?: number;
+}): Promise<void> {
+  const serializedRequest = JSON.stringify(params.request);
+
+  const timeoutMs = params.timeoutMs ?? DEFAULT_WORKER_TIMEOUT_MS;
+  const bootstrapScript = [
+    `import(${JSON.stringify(params.workerModuleUrl)})`,
+    "  .then(async (mod) => {",
+    "    if (typeof mod.runPostTurnWorkerFromCli !== 'function') {",
+    "      throw new Error('worker module does not export runPostTurnWorkerFromCli');",
+    "    }",
+    "    await mod.runPostTurnWorkerFromCli();",
+    "  })",
+    "  .catch((error) => {",
+    "    console.error(error && error.stack ? error.stack : String(error));",
+    "    process.exitCode = 1;",
+    "  });",
+  ].join("\n");
+
+  await new Promise<void>((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const child = spawn(process.execPath, ["--input-type=module", "--eval", bootstrapScript], {
+      env: {
+        ...process.env,
+        OPENCLAW_POST_TURN_WORKER_REQUEST_STDIN: "1",
+        OPENCLAW_POST_TURN_HOOK_WORKER_CHILD: "1",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdin?.on("error", () => undefined);
+    child.stdin?.end(serializedRequest);
+
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      child.kill("SIGKILL");
+      reject(
+        new PostTurnWorkerProcessError({
+          message: `post-turn worker timed out after ${timeoutMs}ms`,
+          stdout,
+          stderr,
+          timedOut: true,
+        }),
+      );
+    }, timeoutMs);
+    timer.unref?.();
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout = appendCapturedOutput(stdout, chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr = appendCapturedOutput(stderr, chunk);
+    });
+    child.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      reject(
+        new PostTurnWorkerProcessError({
+          message: `post-turn worker failed to start: ${error.message}`,
+          stdout,
+          stderr,
+        }),
+      );
+    });
+    child.on("exit", (exitCode, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      if (exitCode === 0 && !signal) {
+        resolve();
+        return;
+      }
+      reject(
+        new PostTurnWorkerProcessError({
+          message:
+            `post-turn worker exited with ` +
+            (signal ? `signal ${signal}` : `code ${exitCode ?? "unknown"}`),
+          exitCode,
+          signal,
+          stdout,
+          stderr,
+        }),
+      );
+    });
+  });
+}

--- a/src/agents/test-helpers/pi-embedded-runner-e2e-mocks.ts
+++ b/src/agents/test-helpers/pi-embedded-runner-e2e-mocks.ts
@@ -1,11 +1,17 @@
 import { vi } from "vitest";
 
+type EmbeddedRunnerHarnessMock = {
+  id?: string;
+  dispose?: () => unknown;
+};
+
 type EmbeddedRunnerFastRunMockOptions = {
   runEmbeddedAttempt: (params: unknown) => unknown;
   prepareProviderRuntimeAuth?: (params: {
     provider: string;
     context: { apiKey: string };
   }) => unknown;
+  selectHarness?: (params: { provider?: string }) => EmbeddedRunnerHarnessMock | undefined;
 };
 
 type EmbeddedRunnerBackoffMockOptions = {
@@ -54,12 +60,17 @@ export function installEmbeddedRunnerFastRunE2eMocks(
   options: EmbeddedRunnerFastRunMockOptions,
 ): void {
   vi.doMock("../harness/selection.js", () => ({
-    selectAgentHarness: vi.fn((params: { provider?: string }) => ({
-      id: params.provider === "codex-cli" ? "codex" : "pi",
-      label: "Mock agent harness",
-      supports: vi.fn(() => ({ supported: false })),
-      runAttempt: vi.fn(),
-    })),
+    selectAgentHarness: vi.fn((params: { provider?: string }) => {
+      const harness = options.selectHarness?.(params);
+
+      return {
+        id: harness?.id ?? (params.provider === "codex-cli" ? "codex" : "pi"),
+        label: "Mock agent harness",
+        supports: vi.fn(() => ({ supported: false })),
+        runAttempt: vi.fn(),
+        ...(harness?.dispose ? { dispose: harness.dispose } : {}),
+      };
+    }),
     resolveAgentHarnessPolicy: vi.fn(() => ({ runtime: "pi" })),
     runAgentHarnessAttempt: (params: unknown) => options.runEmbeddedAttempt(params),
   }));

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -154,6 +154,102 @@ describe("withReplyDispatcher", () => {
     expect(order).toEqual(["sendFinalReply", "markComplete", "waitForIdle"]);
   });
 
+  it("runs after-source-delivery callbacks after dispatcher idle", async () => {
+    const order: string[] = [];
+    const dispatcher = {
+      sendToolResult: () => true,
+      sendBlockReply: () => true,
+      sendFinalReply: () => {
+        order.push("sendFinalReply");
+        return true;
+      },
+      getQueuedCounts: () => ({ tool: 0, block: 0, final: 1 }),
+      getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      markComplete: () => {
+        order.push("markComplete");
+      },
+      waitForIdle: async () => {
+        order.push("waitForIdle");
+      },
+    } satisfies ReplyDispatcher;
+    hoisted.dispatchReplyFromConfigMock.mockImplementationOnce(
+      async ({ dispatcher, replyOptions }) => {
+        replyOptions?.afterSourceReplyDelivery?.(() => {
+          order.push("afterSourceReplyDelivery");
+        });
+        dispatcher.sendFinalReply({ text: "ok" });
+        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
+
+    const result = await dispatchInboundMessage({
+      ctx: buildTestCtx(),
+      cfg: {} as OpenClawConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    expect(result).toEqual({ queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } });
+    expect(order).toEqual([
+      "sendFinalReply",
+      "markComplete",
+      "waitForIdle",
+      "afterSourceReplyDelivery",
+    ]);
+  });
+
+  it("delegates after-source-delivery callbacks to caller-owned schedulers", async () => {
+    const order: string[] = [];
+    const registeredCallbacks: Array<() => void | Promise<void>> = [];
+    const neverResolvingCallback = vi.fn(() => new Promise<void>(() => undefined));
+    const dispatcher = {
+      sendToolResult: () => true,
+      sendBlockReply: () => true,
+      sendFinalReply: () => {
+        order.push("sendFinalReply");
+        return true;
+      },
+      getQueuedCounts: () => ({ tool: 0, block: 0, final: 1 }),
+      getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      markComplete: () => {
+        order.push("markComplete");
+      },
+      waitForIdle: async () => {
+        order.push("waitForIdle");
+      },
+    } satisfies ReplyDispatcher;
+    hoisted.dispatchReplyFromConfigMock.mockImplementationOnce(
+      async ({ dispatcher, replyOptions }) => {
+        replyOptions?.afterSourceReplyDelivery?.(neverResolvingCallback);
+        dispatcher.sendFinalReply({ text: "ok" });
+        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
+
+    const result = await dispatchInboundMessage({
+      ctx: buildTestCtx(),
+      cfg: {} as OpenClawConfig,
+      dispatcher,
+      replyOptions: {
+        afterSourceReplyDelivery: (callback) => {
+          order.push("registerAfterSourceReplyDelivery");
+          registeredCallbacks.push(callback);
+        },
+      },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    expect(result).toEqual({ queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } });
+    expect(registeredCallbacks).toEqual([neverResolvingCallback]);
+    expect(neverResolvingCallback).not.toHaveBeenCalled();
+    expect(order).toEqual([
+      "registerAfterSourceReplyDelivery",
+      "sendFinalReply",
+      "markComplete",
+      "waitForIdle",
+    ]);
+  });
+
   it("always marks complete and waits for idle after success", async () => {
     const order: string[] = [];
     const dispatcher = createDispatcher(order);

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -28,7 +28,7 @@ import {
 } from "./reply/reply-dispatcher.js";
 import type { ReplyDispatcher } from "./reply/reply-dispatcher.types.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
-import type { GetReplyOptions, ReplyPayload } from "./types.js";
+import type { AfterSourceReplyDeliveryCallback, GetReplyOptions, ReplyPayload } from "./types.js";
 
 type ForegroundReplyFenceState = {
   generation: number;
@@ -101,7 +101,7 @@ function isForegroundReplyFenceSuperseded(
 ): boolean {
   return Boolean(
     snapshot &&
-    (foregroundReplyFenceByKey.get(snapshot.key)?.generation ?? 0) !== snapshot.generation,
+      (foregroundReplyFenceByKey.get(snapshot.key)?.generation ?? 0) !== snapshot.generation,
   );
 }
 
@@ -257,6 +257,23 @@ export async function dispatchInboundMessage(params: {
       attributes: buildDispatchTimelineAttributes(params.ctx),
     },
   );
+  const afterSourceReplyDeliveryCallbacks: AfterSourceReplyDeliveryCallback[] = [];
+  const upstreamAfterSourceReplyDelivery = params.replyOptions?.afterSourceReplyDelivery;
+  const runAfterSourceReplyDeliveryCallbacks = async () => {
+    for (const callback of afterSourceReplyDeliveryCallbacks) {
+      await callback();
+    }
+  };
+  const replyOptions = {
+    ...params.replyOptions,
+    afterSourceReplyDelivery: (callback: AfterSourceReplyDeliveryCallback) => {
+      if (upstreamAfterSourceReplyDelivery) {
+        upstreamAfterSourceReplyDelivery(callback);
+      } else {
+        afterSourceReplyDeliveryCallbacks.push(callback);
+      }
+    },
+  } satisfies Omit<GetReplyOptions, "onBlockReply">;
   const result = await withReplyDispatcher({
     dispatcher: params.dispatcher,
     run: () =>
@@ -267,7 +284,7 @@ export async function dispatchInboundMessage(params: {
             ctx: finalized,
             cfg: params.cfg,
             dispatcher: params.dispatcher,
-            replyOptions: params.replyOptions,
+            replyOptions,
             replyResolver: params.replyResolver,
           }),
         {
@@ -276,6 +293,9 @@ export async function dispatchInboundMessage(params: {
           attributes: buildDispatchTimelineAttributes(finalized),
         },
       ),
+    onSettled: upstreamAfterSourceReplyDelivery
+      ? undefined
+      : runAfterSourceReplyDeliveryCallbacks,
   });
   return finalizeDispatchResult(result, params.dispatcher);
 }

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -45,6 +45,8 @@ export type PartialReplyPayload = Pick<ReplyPayload, "text" | "mediaUrls"> & {
   replace?: true;
 };
 
+export type AfterSourceReplyDeliveryCallback = () => Promise<void> | void;
+
 export type GetReplyOptions = {
   /** Override run id for agent events (defaults to random UUID). */
   runId?: string;
@@ -172,6 +174,12 @@ export type GetReplyOptions = {
   onCompactionStart?: () => Promise<void> | void;
   /** Called when context auto-compaction completes. */
   onCompactionEnd?: () => Promise<void> | void;
+  /**
+   * Registers work that must start only after the source reply dispatcher has
+   * drained. Use this for post-turn analysis hooks that must not race final
+   * user-visible delivery.
+   */
+  afterSourceReplyDelivery?: (callback: AfterSourceReplyDeliveryCallback) => void;
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -486,6 +486,78 @@ describe("runAgentTurnWithFallback", () => {
     vi.clearAllMocks();
   });
 
+  it("passes source reply delivery callback into immediate embedded runs", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "final" }],
+      meta: {},
+    });
+
+    const afterSourceReplyDelivery = vi.fn();
+    const followupRun = createFollowupRun();
+    (
+      followupRun.run as FollowupRun["run"] & {
+        afterSourceReplyDelivery?: typeof afterSourceReplyDelivery;
+      }
+    ).afterSourceReplyDelivery = afterSourceReplyDelivery;
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: {
+          Provider: "telegram",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    });
+
+    expect(result.kind).toBe("success");
+    expect(state.runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
+    expect(state.runEmbeddedPiAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      afterSourceReplyDelivery,
+    });
+  });
+
+  it("defers immediate embedded post-delivery callbacks until the source delivery drain", async () => {
+    const afterDeliveryCallbacks: Array<() => void | Promise<void>> = [];
+    const agentEndHook = vi.fn();
+    const followupRun = createFollowupRun();
+    followupRun.run.afterSourceReplyDelivery = (callback) => {
+      afterDeliveryCallbacks.push(callback);
+    };
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      (
+        params as EmbeddedAgentParams & {
+          afterSourceReplyDelivery?: (callback: () => void | Promise<void>) => void;
+        }
+      ).afterSourceReplyDelivery?.(agentEndHook);
+      expect(agentEndHook).not.toHaveBeenCalled();
+      return {
+        payloads: [{ text: "final" }],
+        meta: {},
+      };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: {
+          Provider: "telegram",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    });
+
+    expect(result.kind).toBe("success");
+    expect(agentEndHook).not.toHaveBeenCalled();
+    expect(afterDeliveryCallbacks).toHaveLength(1);
+
+    await afterDeliveryCallbacks[0]?.();
+
+    expect(agentEndHook).toHaveBeenCalledOnce();
+  });
+
   it("forwards the static extra system prompt to CLI backends", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1771,6 +1771,7 @@ export async function runAgentTurnWithFallback(params: {
                 currentTurnContext: params.followupRun.currentTurnContext,
                 extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
                 sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
+                afterSourceReplyDelivery: params.followupRun.run.afterSourceReplyDelivery,
                 forceMessageTool:
                   params.followupRun.run.sourceReplyDeliveryMode === "message_tool_only",
                 silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,

--- a/src/auto-reply/reply/agent-runner-run-params.ts
+++ b/src/auto-reply/reply/agent-runner-run-params.ts
@@ -80,6 +80,7 @@ export function buildEmbeddedRunBaseParams(params: {
     allowEmptyAssistantReplyAsSilent: params.run.allowEmptyAssistantReplyAsSilent,
     silentReplyPromptMode: params.run.silentReplyPromptMode,
     sourceReplyDeliveryMode: params.run.sourceReplyDeliveryMode,
+    afterSourceReplyDelivery: params.run.afterSourceReplyDelivery,
     provider: params.provider,
     model: params.model,
     modelFallbacksOverride,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4176,6 +4176,27 @@ describe("before_dispatch hook", () => {
     expect(result.queuedFinal).toBe(true);
   });
 
+  it("can send a hook reply and continue model dispatch when continueAgent is true", async () => {
+    hookMocks.runner.runBeforeDispatch.mockResolvedValue({
+      handled: true,
+      text: "Save this?",
+      continueAgent: true,
+    });
+    const dispatcher = createDispatcher();
+    (dispatcher.sendFinalReply as Mock).mockImplementation((payload: ReplyPayload) => {
+      return payload.text === "Save this?";
+    });
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "model reply" }),
+    });
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Save this?" });
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "model reply" });
+    expect(result.queuedFinal).toBe(true);
+  });
+
   it("silently short-circuits when hook returns handled without text", async () => {
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true });
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1063,6 +1063,9 @@ export async function dispatchReplyFromConfig(
       };
     };
 
+    let beforeDispatchAdditiveQueuedFinal = false;
+    let beforeDispatchAdditiveRoutedFinalCount = 0;
+
     // Run before_dispatch hook — let plugins inspect or handle before model dispatch.
     if (hookRunner?.hasHooks("before_dispatch")) {
       const beforeDispatchResult = await traceReplyPhase("reply.before_dispatch_hooks", () =>
@@ -1087,19 +1090,28 @@ export async function dispatchReplyFromConfig(
       );
       if (beforeDispatchResult?.handled) {
         const text = beforeDispatchResult.text;
+        const reply = beforeDispatchResult.reply ?? (text ? { text } : undefined);
         let queuedFinal = false;
         let routedFinalCount = 0;
-        if (text && !suppressDelivery) {
-          const handledReply = await sendFinalPayload({ text });
+        if (reply && !suppressDelivery) {
+          const handledReply = await sendFinalPayload(reply);
           queuedFinal = handledReply.queuedFinal;
           routedFinalCount += handledReply.routedFinalCount;
         }
-        const counts = dispatcher.getQueuedCounts();
-        counts.final += routedFinalCount;
-        recordProcessed("completed", { reason: "before_dispatch_handled" });
-        markIdle("message_completed");
-        commitInboundDedupeIfClaimed();
-        return attachSourceReplyDeliveryMode({ queuedFinal, counts });
+        if (beforeDispatchResult.continueAgent === true) {
+          beforeDispatchAdditiveQueuedFinal = queuedFinal;
+          beforeDispatchAdditiveRoutedFinalCount += routedFinalCount;
+          logVerbose(
+            "dispatch-from-config: before_dispatch handled with continueAgent; continuing model dispatch",
+          );
+        } else {
+          const counts = dispatcher.getQueuedCounts();
+          counts.final += routedFinalCount;
+          recordProcessed("completed", { reason: "before_dispatch_handled" });
+          markIdle("message_completed");
+          commitInboundDedupeIfClaimed();
+          return attachSourceReplyDeliveryMode({ queuedFinal, counts });
+        }
       }
     }
 
@@ -1134,9 +1146,12 @@ export async function dispatchReplyFromConfig(
         ),
       );
       if (replyDispatchResult?.handled) {
+        if (beforeDispatchAdditiveRoutedFinalCount > 0) {
+          replyDispatchResult.counts.final += beforeDispatchAdditiveRoutedFinalCount;
+        }
         commitInboundDedupeIfClaimed();
         return attachSourceReplyDeliveryMode({
-          queuedFinal: replyDispatchResult.queuedFinal,
+          queuedFinal: replyDispatchResult.queuedFinal || beforeDispatchAdditiveQueuedFinal,
           counts: replyDispatchResult.counts,
         });
       }
@@ -1689,7 +1704,7 @@ export async function dispatchReplyFromConfig(
     }
 
     const counts = dispatcher.getQueuedCounts();
-    counts.final += routedFinalCount;
+    counts.final += routedFinalCount + beforeDispatchAdditiveRoutedFinalCount;
     commitInboundDedupeIfClaimed();
     recordProcessed(
       "completed",
@@ -1697,7 +1712,7 @@ export async function dispatchReplyFromConfig(
     );
     markIdle("message_completed");
     return attachSourceReplyDeliveryMode({
-      queuedFinal,
+      queuedFinal: queuedFinal || beforeDispatchAdditiveQueuedFinal,
       counts,
       ...(beforeAgentRunBlocked ? { beforeAgentRunBlocked } : {}),
     });

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1268,6 +1268,104 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     };
   }
 
+  it("runs after-source-delivery callbacks after followup delivery", async () => {
+    const order: string[] = [];
+    let registerAfterDelivery:
+      | ((callback: () => void | Promise<void>) => void)
+      | undefined;
+    const onBlockReply = vi.fn(async () => {
+      order.push("onBlockReply");
+    });
+    runEmbeddedPiAgentMock.mockImplementationOnce(async (params) => {
+      order.push("runEmbeddedPiAgent");
+      registerAfterDelivery = (
+        params as {
+          afterSourceReplyDelivery?: (callback: () => void | Promise<void>) => void;
+        }
+      ).afterSourceReplyDelivery;
+      registerAfterDelivery?.(() => {
+        order.push("afterSourceReplyDelivery");
+      });
+      return {
+        payloads: [{ text: "hello world!" }],
+        messagingToolSentTexts: ["different message"],
+        meta: {},
+      };
+    });
+
+    const runner = createMessagingDedupeRunner(onBlockReply);
+    await runner(baseQueuedRun());
+    await Promise.resolve();
+
+    expect(registerAfterDelivery).toBeTypeOf("function");
+    expect(order).toEqual(["runEmbeddedPiAgent", "onBlockReply", "afterSourceReplyDelivery"]);
+  });
+
+  it("does not wait for after-source-delivery callbacks before followup cleanup", async () => {
+    const order: string[] = [];
+    const typing = createMockTypingController();
+    const onBlockReply = vi.fn(async () => {
+      order.push("onBlockReply");
+    });
+    const neverResolved = new Promise<void>(() => undefined);
+    runEmbeddedPiAgentMock.mockImplementationOnce(async (params) => {
+      (
+        params as {
+          afterSourceReplyDelivery?: (callback: () => void | Promise<void>) => void;
+        }
+      ).afterSourceReplyDelivery?.(() => {
+        order.push("afterSourceReplyDelivery");
+        return neverResolved;
+      });
+      return {
+        payloads: [{ text: "hello world!" }],
+        messagingToolSentTexts: ["different message"],
+        meta: {},
+      };
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing,
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+    });
+
+    await runner(baseQueuedRun());
+    await Promise.resolve();
+
+    expect(onBlockReply).toHaveBeenCalled();
+    expect(typing.markRunComplete).toHaveBeenCalled();
+    expect(typing.markDispatchIdle).toHaveBeenCalled();
+    expect(order).toEqual(["onBlockReply", "afterSourceReplyDelivery"]);
+  });
+
+  it("does not schedule after-source-delivery callbacks when followup delivery fails", async () => {
+    const afterSourceReplyDelivery = vi.fn();
+    const onBlockReply = vi.fn(async () => {
+      throw new Error("delivery failed");
+    });
+    runEmbeddedPiAgentMock.mockImplementationOnce(async (params) => {
+      (
+        params as {
+          afterSourceReplyDelivery?: (callback: () => void | Promise<void>) => void;
+        }
+      ).afterSourceReplyDelivery?.(afterSourceReplyDelivery);
+      return {
+        payloads: [{ text: "hello world!" }],
+        messagingToolSentTexts: ["different message"],
+        meta: {},
+      };
+    });
+
+    const runner = createMessagingDedupeRunner(onBlockReply);
+
+    await expect(runner(baseQueuedRun())).rejects.toThrow("delivery failed");
+    await Promise.resolve();
+
+    expect(afterSourceReplyDelivery).not.toHaveBeenCalled();
+  });
+
   it("persists usage even when replies are suppressed", async () => {
     const storePath = "/tmp/openclaw-followup-usage.json";
     const sessionKey = "main";

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1,5 +1,8 @@
 import crypto from "node:crypto";
-import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
+import {
+  hasOutboundReplyContent,
+  resolveSendableOutboundReplyParts,
+} from "openclaw/plugin-sdk/reply-payload";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
@@ -12,10 +15,12 @@ import {
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
-import { registerAgentRunContext } from "../../infra/agent-events.js";
+import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import { stripHeartbeatToken } from "../heartbeat.js";
+import type { AfterSourceReplyDeliveryCallback } from "../get-reply-options.types.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runPreflightCompactionIfNeeded } from "./agent-runner-memory.js";
 import {
@@ -233,6 +238,23 @@ export function createFollowupRunner(params: {
         resetTriggered: false,
         upstreamAbortSignal: queued.abortSignal ?? opts?.abortSignal,
       });
+      const afterSourceReplyDeliveryCallbacks: AfterSourceReplyDeliveryCallback[] = [];
+      let afterSourceReplyDeliveryDrained = false;
+      const scheduleAfterSourceReplyDeliveryCallbacks = () => {
+        if (afterSourceReplyDeliveryDrained) {
+          return;
+        }
+        afterSourceReplyDeliveryDrained = true;
+        for (const callback of afterSourceReplyDeliveryCallbacks) {
+          void Promise.resolve()
+            .then(callback)
+            .catch((err) => {
+              logVerbose(
+                `followup queue: after source reply delivery callback failed: ${String(err)}`,
+              );
+            });
+        }
+      };
       const runId = crypto.randomUUID();
       const shouldSurfaceToControlUi = isInternalMessageChannel(
         resolveOriginMessageProvider({
@@ -285,6 +307,9 @@ export function createFollowupRunner(params: {
               const result = await runEmbeddedPiAgent({
                 allowGatewaySubagentBinding: true,
                 replyOperation,
+                afterSourceReplyDelivery: (callback: AfterSourceReplyDeliveryCallback) => {
+                  afterSourceReplyDeliveryCallbacks.push(callback);
+                },
                 sessionId: run.sessionId,
                 sessionKey: run.sessionKey,
                 agentId: run.agentId,
@@ -348,6 +373,14 @@ export function createFollowupRunner(params: {
                     bootstrapPromptWarningSignaturesSeen.length - 1
                   ],
                 onAgentEvent: (evt) => {
+                  if (evt.stream.startsWith("codex_app_server.")) {
+                    emitAgentEvent({
+                      runId,
+                      stream: evt.stream,
+                      data: evt.data,
+                      ...(evt.sessionKey ? { sessionKey: evt.sessionKey } : {}),
+                    });
+                  }
                   if (evt.stream !== "compaction") {
                     return;
                   }
@@ -418,9 +451,21 @@ export function createFollowupRunner(params: {
       if (payloadArray.length === 0) {
         return;
       }
+      const sanitizedPayloads = payloadArray.flatMap((payload) => {
+        const text = payload.text;
+        if (!text || !text.includes("HEARTBEAT_OK")) {
+          return [payload];
+        }
+        const stripped = stripHeartbeatToken(text, { mode: "message" });
+        const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
+        if (stripped.shouldSkip && !hasMedia) {
+          return [];
+        }
+        return [{ ...payload, text: stripped.text }];
+      });
       const finalPayloads = resolveFollowupDeliveryPayloads({
         cfg: runtimeConfig,
-        payloads: payloadArray,
+        payloads: sanitizedPayloads,
         messageProvider: run.messageProvider,
         originatingAccountId: queued.originatingAccountId ?? run.agentAccountId,
         originatingChannel: queued.originatingChannel,
@@ -432,10 +477,10 @@ export function createFollowupRunner(params: {
       });
 
       if (finalPayloads.length === 0) {
+        scheduleAfterSourceReplyDeliveryCallbacks();
         return;
       }
 
-      let deliveryPayloads = finalPayloads;
       if (autoCompactionCount > 0) {
         const previousSessionId = run.sessionId;
         const count = await incrementRunCompactionCount({
@@ -466,12 +511,9 @@ export function createFollowupRunner(params: {
         }
         if (run.verboseLevel && run.verboseLevel !== "off") {
           const suffix = typeof count === "number" ? ` (count ${count})` : "";
-          deliveryPayloads = [
-            {
-              text: `🧹 Auto-compaction complete${suffix}.`,
-            },
-            ...finalPayloads,
-          ];
+          finalPayloads.unshift({
+            text: `🧹 Auto-compaction complete${suffix}.`,
+          });
         }
       }
 
@@ -479,13 +521,15 @@ export function createFollowupRunner(params: {
         logVerbose(
           "followup queue: automatic source delivery suppressed by sourceReplyDeliveryMode: message_tool_only",
         );
+        scheduleAfterSourceReplyDeliveryCallbacks();
         return;
       }
 
-      await sendFollowupPayloads(deliveryPayloads, effectiveQueued, {
+      await sendFollowupPayloads(finalPayloads, effectiveQueued, {
         provider: providerUsed,
         modelId: modelUsed,
       });
+      scheduleAfterSourceReplyDeliveryCallbacks();
     } finally {
       for (const end of endDeliveryCorrelations.toReversed()) {
         try {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1052,6 +1052,7 @@ export async function runPreparedReply(
       inputProvenance: ctx.InputProvenance ?? sessionCtx.InputProvenance,
       extraSystemPrompt: extraSystemPromptParts.join("\n\n") || undefined,
       sourceReplyDeliveryMode: isRoomEvent ? "message_tool_only" : opts?.sourceReplyDeliveryMode,
+      afterSourceReplyDelivery: opts?.afterSourceReplyDelivery,
       silentReplyPromptMode,
       extraSystemPromptStatic: extraSystemPromptStaticParts.join("\n\n"),
       skipProviderRuntimeHints: useFastReplyRuntime,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
 import type {
+  AfterSourceReplyDeliveryCallback,
   QueuedReplyDeliveryCorrelation,
   QueuedReplyLifecycle,
   SourceReplyDeliveryMode,
@@ -105,6 +106,7 @@ export type FollowupRun = {
     inputProvenance?: InputProvenance;
     extraSystemPrompt?: string;
     sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+    afterSourceReplyDelivery?: (callback: AfterSourceReplyDeliveryCallback) => void;
     silentReplyPromptMode?: SilentReplyPromptMode;
     extraSystemPromptStatic?: string;
     enforceFinalTag?: boolean;

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -1,8 +1,10 @@
 export type {
+  AfterSourceReplyDeliveryCallback,
   BlockReplyContext,
   GetReplyOptions,
   PartialReplyPayload,
   ReplyThreadingPolicy,
+  SourceReplyDeliveryMode,
   TypingPolicy,
 } from "./get-reply-options.types.js";
 export {

--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import type { AgentConfig } from "../config/types.agents.js";
+
+type AgentConfigModelOverride = Pick<AgentConfig, "model" | "subagents">;
 
 const {
   loadModelCatalogMock,
@@ -44,7 +47,7 @@ vi.mock("./isolated-agent/run-model-selection.runtime.js", () => ({
     agentConfigOverride,
   }: {
     cfg?: { agents?: { defaults?: { subagents?: { model?: unknown } } } };
-    agentConfigOverride?: { model?: unknown; subagents?: { model?: unknown } };
+    agentConfigOverride?: AgentConfigModelOverride;
   }) => {
     for (const candidate of [
       { raw: agentConfigOverride?.subagents?.model, source: "subagent" as const },
@@ -71,12 +74,7 @@ type AgentTurnPayload = {
 
 type SelectModelOptions = {
   cfg?: Record<string, unknown>;
-  agentConfigOverride?: {
-    model?: unknown;
-    subagents?: {
-      model?: unknown;
-    };
-  };
+  agentConfigOverride?: AgentConfigModelOverride;
   payload?: AgentTurnPayload;
   sessionEntry?: {
     modelOverride?: string;

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -206,6 +206,17 @@ describe("cron service timer regressions", () => {
     );
     expect(overloadedJob?.state.lastStatus).toBe("ok");
     expect(overloadedResult.runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+
+    const timedOutResult = await runRetryScenario({
+      id: "oneshot-timed-out-retry",
+      deleteAfterRun: false,
+      firstError: "cron: job execution timed out",
+    });
+    const timedOutJob = timedOutResult.state.store?.jobs.find(
+      (j) => j.id === "oneshot-timed-out-retry",
+    );
+    expect(timedOutJob?.state.lastStatus).toBe("ok");
+    expect(timedOutResult.runIsolatedAgentJob).toHaveBeenCalledTimes(2);
   });
 
   it("#24355: one-shot job disabled after max transient retries", async () => {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -490,7 +490,7 @@ const TRANSIENT_PATTERNS: Record<string, RegExp> = {
   overloaded:
     /\b529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
   network: /(network|econnreset|econnrefused|fetch failed|socket)/i,
-  timeout: /(timeout|etimedout)/i,
+  timeout: /(time[-_ ]?out|timed out|etimedout)/i,
   server_error: /\b5\d{2}\b/,
 };
 

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -17,6 +17,8 @@ const hoisted = vi.hoisted(() => {
     recoverPendingDeliveries: vi.fn(async () => undefined),
     recoverPendingRestartContinuationDeliveries: vi.fn(async () => undefined),
     deliverOutboundPayloads: vi.fn(),
+    recoverStaleRunningPostTurnJobs: vi.fn(async () => ({ crashedJobIds: [] })),
+    cleanupPostTurnWorkerRequestFiles: vi.fn(async () => 0),
   };
 });
 
@@ -37,6 +39,14 @@ vi.mock("../infra/outbound/delivery-queue.js", () => ({
   recoverPendingDeliveries: hoisted.recoverPendingDeliveries,
 }));
 
+vi.mock("../agents/post-turn/durable-job-state.js", () => ({
+  recoverStaleRunningPostTurnJobs: hoisted.recoverStaleRunningPostTurnJobs,
+}));
+
+vi.mock("../agents/post-turn/worker-process.js", () => ({
+  cleanupPostTurnWorkerRequestFiles: hoisted.cleanupPostTurnWorkerRequestFiles,
+}));
+
 vi.mock("./server-restart-sentinel.js", () => ({
   recoverPendingRestartContinuationDeliveries: hoisted.recoverPendingRestartContinuationDeliveries,
 }));
@@ -53,12 +63,8 @@ vi.mock("./model-pricing-cache.js", () => ({
   startGatewayModelPricingRefresh: hoisted.startGatewayModelPricingRefresh,
 }));
 
-const {
-  activateGatewayScheduledServices,
-  runGatewayPostReadyMaintenance,
-  scheduleGatewayPostReadyMaintenance,
-  startGatewayRuntimeServices,
-} = await import("./server-runtime-services.js");
+const { activateGatewayScheduledServices, startGatewayRuntimeServices } =
+  await import("./server-runtime-services.js");
 
 describe("server-runtime-services", () => {
   beforeEach(() => {
@@ -74,6 +80,8 @@ describe("server-runtime-services", () => {
     hoisted.recoverPendingDeliveries.mockClear();
     hoisted.recoverPendingRestartContinuationDeliveries.mockClear();
     hoisted.deliverOutboundPayloads.mockClear();
+    hoisted.recoverStaleRunningPostTurnJobs.mockClear();
+    hoisted.cleanupPostTurnWorkerRequestFiles.mockClear();
   });
 
   it("skips model pricing bootstrap import when pricing is disabled", async () => {
@@ -185,23 +193,20 @@ describe("server-runtime-services", () => {
     expect(services.heartbeatRunner).toBe(hoisted.heartbeatRunner);
     await vi.advanceTimersByTimeAsync(1_250);
     await vi.dynamicImportSettled();
-    expect(log.child).toHaveBeenNthCalledWith(1, "delivery-recovery");
-    expect(log.child).toHaveBeenNthCalledWith(2, "session-delivery-recovery");
-    const deliveryLog = log.child.mock.results[0]?.value;
-    const sessionDeliveryLog = log.child.mock.results[1]?.value;
-    if (!deliveryLog || !sessionDeliveryLog) {
-      throw new Error("Expected delivery recovery log children");
-    }
-    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledWith({
-      deliver: hoisted.deliverOutboundPayloads,
-      cfg: {},
-      log: deliveryLog,
-    });
-    expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledWith({
-      deps: {},
-      maxEnqueuedAt: 123,
-      log: sessionDeliveryLog,
-    });
+    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deliver: hoisted.deliverOutboundPayloads,
+        cfg: {},
+      }),
+    );
+    expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deps: {},
+        maxEnqueuedAt: 123,
+      }),
+    );
+    expect(hoisted.recoverStaleRunningPostTurnJobs).toHaveBeenCalledTimes(1);
+    expect(hoisted.cleanupPostTurnWorkerRequestFiles).toHaveBeenCalledTimes(1);
   });
 
   it("can defer cron startup while activating other scheduled services", async () => {
@@ -227,94 +232,6 @@ describe("server-runtime-services", () => {
     expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledTimes(1);
   });
 
-  it("starts cron and records memory when post-ready maintenance fails", async () => {
-    const cron = { start: vi.fn(async () => undefined) };
-    const log = createLog();
-    const recordPostReadyMemory = vi.fn();
-
-    await runGatewayPostReadyMaintenance({
-      startMaintenance: vi.fn(async () => {
-        throw new Error("timers unavailable");
-      }),
-      applyMaintenance: vi.fn(),
-      shouldStartCron: () => true,
-      markCronStartHandled: vi.fn(),
-      cron,
-      logCron: { error: vi.fn() },
-      log,
-      recordPostReadyMemory,
-    });
-
-    expect(log.warn).toHaveBeenCalledWith(
-      "gateway post-ready maintenance startup failed: Error: timers unavailable",
-    );
-    expect(cron.start).toHaveBeenCalledTimes(1);
-    expect(recordPostReadyMemory).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns a cancellable post-ready maintenance timer", async () => {
-    vi.useFakeTimers();
-    const startMaintenance = vi.fn(async () => null);
-    const onStarted = vi.fn();
-    const handle = scheduleGatewayPostReadyMaintenance(
-      createPostReadyMaintenanceScheduleParams({
-        delayMs: 25,
-        onStarted,
-        startMaintenance,
-      }),
-    );
-
-    clearTimeout(handle);
-    await vi.advanceTimersByTimeAsync(25);
-
-    expect(onStarted).not.toHaveBeenCalled();
-    expect(startMaintenance).not.toHaveBeenCalled();
-  });
-
-  it("clears delayed maintenance handles when close starts during maintenance startup", async () => {
-    vi.useFakeTimers();
-    let closing = false;
-    let resolveMaintenance:
-      | ((maintenance: ReturnType<typeof createMaintenanceHandles>) => void)
-      | undefined;
-    const startMaintenance = vi.fn(
-      () =>
-        new Promise<ReturnType<typeof createMaintenanceHandles>>((resolve) => {
-          resolveMaintenance = resolve;
-        }),
-    );
-    const applyMaintenance = vi.fn();
-    const cron = { start: vi.fn(async () => undefined) };
-    const recordPostReadyMemory = vi.fn();
-
-    scheduleGatewayPostReadyMaintenance(
-      createPostReadyMaintenanceScheduleParams({
-        delayMs: 25,
-        isClosing: () => closing,
-        startMaintenance,
-        applyMaintenance,
-        cron,
-        recordPostReadyMemory,
-      }),
-    );
-
-    await vi.advanceTimersByTimeAsync(25);
-    expect(startMaintenance).toHaveBeenCalledTimes(1);
-
-    closing = true;
-    if (!resolveMaintenance) {
-      throw new Error("Expected gateway maintenance resolver to be initialized");
-    }
-    resolveMaintenance(createMaintenanceHandles());
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(applyMaintenance).not.toHaveBeenCalled();
-    expect(cron.start).not.toHaveBeenCalled();
-    expect(recordPostReadyMemory).not.toHaveBeenCalled();
-    expect(vi.getTimerCount()).toBe(0);
-  });
-
   it("keeps scheduled services disabled for minimal test gateways", () => {
     const cron = { start: vi.fn(async () => undefined) };
 
@@ -332,6 +249,8 @@ describe("server-runtime-services", () => {
     expect(cron.start).not.toHaveBeenCalled();
     expect(hoisted.recoverPendingDeliveries).not.toHaveBeenCalled();
     expect(hoisted.recoverPendingRestartContinuationDeliveries).not.toHaveBeenCalled();
+    expect(hoisted.recoverStaleRunningPostTurnJobs).not.toHaveBeenCalled();
+    expect(hoisted.cleanupPostTurnWorkerRequestFiles).not.toHaveBeenCalled();
 
     services.heartbeatRunner.stop();
     expect(hoisted.heartbeatRunner.stop).not.toHaveBeenCalled();
@@ -345,34 +264,6 @@ function createLog() {
       warn: vi.fn(),
       error: vi.fn(),
     })),
-    warn: vi.fn(),
     error: vi.fn(),
-  };
-}
-
-function createPostReadyMaintenanceScheduleParams(
-  overrides: Partial<Parameters<typeof scheduleGatewayPostReadyMaintenance>[0]> = {},
-): Parameters<typeof scheduleGatewayPostReadyMaintenance>[0] {
-  return {
-    delayMs: 1,
-    isClosing: () => false,
-    startMaintenance: vi.fn(async () => null),
-    applyMaintenance: vi.fn(),
-    shouldStartCron: () => true,
-    markCronStartHandled: vi.fn(),
-    cron: { start: vi.fn(async () => undefined) },
-    logCron: { error: vi.fn() },
-    log: createLog(),
-    recordPostReadyMemory: vi.fn(),
-    ...overrides,
-  };
-}
-
-function createMaintenanceHandles() {
-  return {
-    tickInterval: setInterval(() => undefined, 60_000),
-    healthInterval: setInterval(() => undefined, 60_000),
-    dedupeCleanup: setInterval(() => undefined, 60_000),
-    mediaCleanup: setInterval(() => undefined, 60_000),
   };
 }

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -189,6 +189,30 @@ function recoverPendingSessionDeliveries(params: {
   timer.unref?.();
 }
 
+function recoverStalePostTurnJobs(params: { log: GatewayRuntimeServiceLogger }): void {
+  void (async () => {
+    const { recoverStaleRunningPostTurnJobs } = await import(
+      "../agents/post-turn/durable-job-state.js"
+    );
+    const { cleanupPostTurnWorkerRequestFiles } = await import(
+      "../agents/post-turn/worker-process.js"
+    );
+    const logRecovery = params.log.child("post-turn-recovery");
+    const result = await recoverStaleRunningPostTurnJobs();
+    const removedWorkerRequests = await cleanupPostTurnWorkerRequestFiles();
+    if (result.crashedJobIds.length > 0) {
+      logRecovery.warn(
+        `Recovered ${result.crashedJobIds.length} stale running post-turn job(s) as crashed; circuit breakers opened.`,
+      );
+    } else {
+      logRecovery.info("No stale running post-turn jobs found.");
+    }
+    if (removedWorkerRequests > 0) {
+      logRecovery.warn(`Removed ${removedWorkerRequests} stale post-turn worker request file(s).`);
+    }
+  })().catch((err) => params.log.error(`Post-turn job recovery failed: ${String(err)}`));
+}
+
 function startGatewayModelPricingRefreshOnDemand(params: {
   config: OpenClawConfig;
   pluginLookUpTable?: PluginMetadataRegistryView;
@@ -272,6 +296,7 @@ export function activateGatewayScheduledServices(params: {
     log: params.log,
     maxEnqueuedAt: params.sessionDeliveryRecoveryMaxEnqueuedAt,
   });
+  recoverStalePostTurnJobs({ log: params.log });
   const stopModelPricingRefresh = !isVitestRuntimeEnv()
     ? startGatewayModelPricingRefreshOnDemand({
         config: params.cfgAtStart,

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -383,6 +383,8 @@ export type PluginHookBeforeDispatchContext = {
 export type PluginHookBeforeDispatchResult = {
   handled: boolean;
   text?: string;
+  reply?: ReplyPayload;
+  continueAgent?: boolean;
 };
 
 export type PluginHookReplyDispatchEvent = {

--- a/src/plugins/hooks.correlation.test.ts
+++ b/src/plugins/hooks.correlation.test.ts
@@ -71,6 +71,7 @@ describe("hook correlation fields", () => {
       const runner = createHookRunner(registry, {
         logger,
         voidHookTimeoutMsByHook: { agent_end: 5 },
+        durablePostTurnHooks: false,
       });
       const run = runner.runAgentEnd({ messages: [], success: true }, TEST_PLUGIN_AGENT_CTX);
 
@@ -109,6 +110,7 @@ describe("hook correlation fields", () => {
       const runner = createHookRunner(registry, {
         logger,
         voidHookTimeoutMsByHook: { agent_end: 5 },
+        durablePostTurnHooks: false,
       });
       const run = runner.runAgentEnd({ messages: [], success: true }, TEST_PLUGIN_AGENT_CTX);
 

--- a/src/plugins/hooks.post-turn-durable.test.ts
+++ b/src/plugins/hooks.post-turn-durable.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { createHookRunner } from "./hooks.js";
+import type { PluginHookRegistration } from "./hook-types.js";
+
+function createRegistry(hooks: PluginHookRegistration[]) {
+  return {
+    hooks: [],
+    typedHooks: hooks,
+    plugins: hooks.map((hook) => ({ id: hook.pluginId, status: "loaded" as const })),
+  };
+}
+
+describe("post-turn durable hook execution", () => {
+  it("records a completed job for each high-risk post-turn hook handler", async () => {
+    await withStateDirEnv("openclaw-hooks-post-turn-", async () => {
+      const { readPostTurnJobState } = await import("../agents/post-turn/durable-job-state.js");
+      const handler = vi.fn(async () => undefined);
+      const runner = createHookRunner(
+        createRegistry([
+          {
+            pluginId: "memory-plugin",
+            hookName: "agent_end",
+            handler,
+            source: "test",
+          },
+        ]),
+      );
+
+      await runner.runAgentEnd(
+        { messages: [], success: true, durationMs: 12 },
+        { runId: "run-1", agentId: "main", sessionId: "session-1" },
+      );
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect((await readPostTurnJobState()).jobs).toEqual([
+        expect.objectContaining({
+          kind: "plugin_hook",
+          hookName: "agent_end",
+          pluginId: "memory-plugin",
+          runId: "run-1",
+          sessionId: "session-1",
+          status: "completed",
+        }),
+      ]);
+    });
+  });
+
+  it("skips a matching hook when the crash circuit breaker is open", async () => {
+    await withStateDirEnv("openclaw-hooks-post-turn-", async () => {
+      const { createPostTurnJob, markPostTurnJobCrashed, readPostTurnJobState } = await import(
+        "../agents/post-turn/durable-job-state.js"
+      );
+      const handler = vi.fn(async () => undefined);
+      const crashed = await createPostTurnJob({
+        kind: "plugin_hook",
+        hookName: "llm_output",
+        pluginId: "memory-plugin",
+        label: "llm_output hook",
+      });
+      await markPostTurnJobCrashed(crashed.id, {
+        reason: "stale running post-turn job after restart",
+      });
+
+      const runner = createHookRunner(
+        createRegistry([
+          {
+            pluginId: "memory-plugin",
+            hookName: "llm_output",
+            handler,
+            source: "test",
+          },
+        ]),
+      );
+
+      await runner.runLlmOutput(
+        {
+          runId: "run-1",
+          sessionId: "session-1",
+          provider: "test",
+          model: "test",
+          resolvedRef: "test/test",
+          assistantTexts: ["ok"],
+        },
+        { runId: "run-1", agentId: "main", sessionId: "session-1" },
+      );
+
+      expect(handler).not.toHaveBeenCalled();
+      expect((await readPostTurnJobState()).jobs.at(-1)).toMatchObject({
+        kind: "plugin_hook",
+        hookName: "llm_output",
+        pluginId: "memory-plugin",
+        status: "skipped",
+      });
+    });
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -6,6 +6,9 @@
  */
 
 import { formatHookErrorForLog } from "../hooks/fire-and-forget.js";
+import { runDurablePostTurnJob } from "../agents/post-turn/durable-job-runner.js";
+import { runIsolatedPostTurnPluginHook } from "../agents/post-turn/isolated-plugin-hook-runner.js";
+import { isVitestRuntimeEnv } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { concatOptionalTextSegments } from "../shared/text/join-segments.js";
 import {
@@ -185,6 +188,11 @@ export type HookRunnerOptions = {
    * but the plugin's underlying work is not cancelled.
    */
   modifyingHookTimeoutMsByHook?: Partial<Record<PluginHookName, number>>;
+  /**
+   * Internal/test escape hatch for hook-runner unit tests that exercise timing
+   * semantics without the post-turn durable job wrapper.
+   */
+  durablePostTurnHooks?: boolean;
 };
 
 const DEFAULT_VOID_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, number>> = {
@@ -194,6 +202,36 @@ const DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, 
   before_agent_run: 15_000,
   before_prompt_build: 15_000,
 };
+const DURABLE_POST_TURN_VOID_HOOKS = new Set<PluginHookName>(["agent_end", "llm_output"]);
+const DEFAULT_POST_TURN_WORKER_TIMEOUT_MS = 30_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function shouldUsePostTurnHookWorkerIsolation(): boolean {
+  if (process.env.OPENCLAW_POST_TURN_HOOK_WORKER_CHILD === "1") {
+    return false;
+  }
+  if (isVitestRuntimeEnv()) {
+    return false;
+  }
+  const configured = process.env.OPENCLAW_POST_TURN_HOOK_WORKER_ISOLATION?.trim().toLowerCase();
+  return configured !== "0" && configured !== "false" && configured !== "off";
+}
 
 type ModifyingHookPolicy<K extends PluginHookName, TResult> = {
   mergeResults?: (
@@ -273,6 +311,7 @@ export function createHookRunner(
     ...DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK,
     ...options.modifyingHookTimeoutMsByHook,
   };
+  const durablePostTurnHooks = options.durablePostTurnHooks ?? true;
 
   const shouldCatchHookErrors = (hookName: PluginHookName): boolean =>
     catchErrors && (failurePolicyByHook[hookName] ?? "fail-open") === "fail-open";
@@ -544,16 +583,80 @@ export function createHookRunner(
 
     logger?.debug?.(`[hooks] running ${hookName} (${hooks.length} handlers)`);
 
+    const hookRegistrationOrdinals = new Map<PluginHookRegistration<K>, number>();
+    const hookRegistrationCountsByPlugin = new Map<string, number>();
+    for (const hook of hooks) {
+      const ordinal = hookRegistrationCountsByPlugin.get(hook.pluginId) ?? 0;
+      hookRegistrationOrdinals.set(hook, ordinal);
+      hookRegistrationCountsByPlugin.set(hook.pluginId, ordinal + 1);
+    }
+
+    const invokeHookHandler = async (hook: PluginHookRegistration<K>) => {
+      const promise = Promise.resolve(
+        (hook.handler as (event: unknown, ctx: unknown) => Promise<void> | void)(event, ctx),
+      );
+      const timeoutMs = getVoidHookTimeoutMs(hookName, hook);
+      if (timeoutMs) {
+        await withHookTimeout(promise, timeoutMs, { unref: true });
+      } else {
+        await promise;
+      }
+    };
+
+    const runIsolatedHandler = async (hook: PluginHookRegistration<K>) => {
+      const timeoutMs = getVoidHookTimeoutMs(hookName, hook) ?? DEFAULT_POST_TURN_WORKER_TIMEOUT_MS;
+      if (!shouldUsePostTurnHookWorkerIsolation()) {
+        await invokeHookHandler(hook);
+        return;
+      }
+      if (hookName === "agent_end") {
+        await runIsolatedPostTurnPluginHook({
+          request: {
+            hookName,
+            pluginId: hook.pluginId,
+            registrationOrdinal: hookRegistrationOrdinals.get(hook) ?? 0,
+            event: event as PluginHookAgentEndEvent,
+            ctx: ctx as PluginHookAgentContext,
+          },
+          timeoutMs,
+        });
+        return;
+      }
+      if (hookName === "llm_output") {
+        await runIsolatedPostTurnPluginHook({
+          request: {
+            hookName,
+            pluginId: hook.pluginId,
+            registrationOrdinal: hookRegistrationOrdinals.get(hook) ?? 0,
+            event: event as PluginHookLlmOutputEvent,
+            ctx: ctx as PluginHookAgentContext,
+          },
+          timeoutMs,
+        });
+        return;
+      }
+      await invokeHookHandler(hook);
+    };
+
     const promises = hooks.map(async (hook) => {
       try {
-        const promise = Promise.resolve(
-          (hook.handler as (event: unknown, ctx: unknown) => Promise<void> | void)(event, ctx),
-        );
-        const timeoutMs = getVoidHookTimeoutMs(hookName, hook);
-        if (timeoutMs) {
-          await withHookTimeout(promise, timeoutMs, { unref: true });
+        if (durablePostTurnHooks && DURABLE_POST_TURN_VOID_HOOKS.has(hookName)) {
+          const eventRecord: Record<string, unknown> = isRecord(event) ? event : {};
+          const ctxRecord: Record<string, unknown> = isRecord(ctx) ? ctx : {};
+          await runDurablePostTurnJob({
+            kind: "plugin_hook",
+            hookName,
+            pluginId: hook.pluginId,
+            label: `${hookName} hook`,
+            runId: firstString(eventRecord.runId, ctxRecord.runId),
+            sessionId: firstString(eventRecord.sessionId, ctxRecord.sessionId),
+            sessionKey: firstString(eventRecord.sessionKey, ctxRecord.sessionKey),
+            agentId: firstString(ctxRecord.agentId),
+            sourceChannel: firstString(ctxRecord.channelId, ctxRecord.messageProvider),
+            work: async () => await runIsolatedHandler(hook),
+          });
         } else {
-          await promise;
+          await invokeHookHandler(hook);
         }
       } catch (err) {
         handleHookError({ hookName, pluginId: hook.pluginId, error: err });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -219,6 +219,8 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
     "agents/code-mode.worker": "src/agents/code-mode.worker.ts",
     "acp/control-plane/manager": "src/acp/control-plane/manager.ts",
+    "agents/post-turn/isolated-plugin-hook-worker-entry":
+      "src/agents/post-turn/isolated-plugin-hook-worker-entry.ts",
     "cli/gateway-lifecycle.runtime": "src/cli/gateway-cli/lifecycle.runtime.ts",
     "provider-dispatcher.runtime": "src/auto-reply/reply/provider-dispatcher.runtime.ts",
     "server-close.runtime": "src/gateway/server-close.runtime.ts",


### PR DESCRIPTION
## Summary
- defer post-turn/harness hooks until source reply delivery drains
- keep CLI embedded fallback runs from leaking live Codex app-server sessions
- preserve session harness pinning and configured CLI runtime routing after rebase
- add focused regression coverage for CLI liveness and embedded runner cleanup

## Real behavior proof
- **Behavior or issue addressed:** The one-shot `openclaw agent` CLI embedded fallback path could finish its assistant reply but leave a live Codex app-server child process behind, keeping the CLI process open. This patch makes local CLI fallback runs dispose the Codex harness after completion while preserving the long-running Gateway shared-client path.
- **Real environment tested:** Schrodinger OpenClaw Gateway host, Docker Gateway deployment bound to `127.0.0.1:18789`, with the VPN/proxy and Ollama compose overlays enabled. Runtime checks were against the actual Gateway container, not mocks.
- **Exact steps or command run after this patch:** Rebuilt and recreated Gateway with `docker compose -f docker-compose.yml -f docker-compose.loopback.yml -f docker-compose.ai-proxy.yml -f docker-compose.ollama.yml build openclaw-gateway` and `docker compose -f docker-compose.yml -f docker-compose.loopback.yml -f docker-compose.ai-proxy.yml -f docker-compose.ollama.yml up -d --force-recreate openclaw-gateway`; then ran live CLI/Gateway canaries `codex-liveness-fixed-1778798866` and `codex-gateway-fixed-1778799198`, followed by process/health checks in the Gateway container.
- **Evidence after fix:** Terminal output/live runtime evidence from Schrodinger:
  ```text
  Gateway health: src-openclaw-gateway-1 healthy, RestartCount=0
  Host exposure: 127.0.0.1:18789 only; no 18790 listener
  Sidecars present: src-openclaw-ollama-1 and src-openclaw-ai-proxy-1
  Canaries:
  codex-liveness-fixed-1778798866 -> exit=0, assistant text CLI_EXIT_FIXED_OK
  post-canary process check -> no leftover openclaw-agent or Codex app-server child from the one-shot CLI embedded fallback path
  codex-gateway-fixed-1778799198 -> exit=0, stderr empty, wrapper status:"ok", assistant text GATEWAY_PATH_OK
  Gateway shared-client note -> one shared Codex app-server child remained, expected for long-running Gateway path
  ```
- **Observed result after fix:** The CLI embedded fallback canary terminated cleanly with the expected assistant text and left no one-shot child process leak. The pure Gateway path also completed successfully, and the expected persistent shared Gateway Codex child remained alive for future Gateway turns.
- **What was not tested:** No known gaps for the liveness behavior; broad transport/browser UX was not re-tested in this PR.

## Verification
- `git diff --check`
- `docker build --target build -t openclaw:rebase-verify .`
- `docker run --rm openclaw:rebase-verify node scripts/test-projects.mjs extensions/codex/src/app-server/run-attempt.test.ts src/agents/command/attempt-execution.cli.test.ts src/agents/pi-embedded-runner.e2e.test.ts`