### PR TITLE
fix(discord): clear failed preview drafts

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -203,28 +203,35 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
   },
   createReplyDispatcherWithTyping: (opts: {
     deliver: (payload: unknown, info: { kind: string }) => Promise<void> | void;
+    onError?: (err: unknown, info: { kind: string }) => void;
     onReplyStart?: () => Promise<void> | void;
-  }) => ({
-    dispatcher: {
-      sendToolResult: vi.fn(() => true),
-      sendBlockReply: vi.fn((payload: unknown) => {
-        void opts.deliver(payload, { kind: "block" });
-        return true;
-      }),
-      sendFinalReply: vi.fn((payload: unknown) => {
-        void opts.deliver(payload, { kind: "final" });
-        return true;
-      }),
-      waitForIdle: vi.fn(async () => {}),
-      getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
-      markComplete: vi.fn(),
-    },
-    replyOptions: {
-      onReplyStart: opts.onReplyStart,
-    },
-    markDispatchIdle: vi.fn(),
-    markRunComplete: vi.fn(),
-  }),
+  }) => {
+    const pendingDeliveries: Promise<void>[] = [];
+    const enqueueDelivery = (payload: unknown, info: { kind: string }) => {
+      const delivery = Promise.resolve()
+        .then(() => opts.deliver(payload, info))
+        .catch((err: unknown) => opts.onError?.(err, info));
+      pendingDeliveries.push(delivery);
+      return true;
+    };
+    return {
+      dispatcher: {
+        sendToolResult: vi.fn(() => true),
+        sendBlockReply: vi.fn((payload: unknown) => enqueueDelivery(payload, { kind: "block" })),
+        sendFinalReply: vi.fn((payload: unknown) => enqueueDelivery(payload, { kind: "final" })),
+        waitForIdle: vi.fn(async () => {
+          await Promise.all(pendingDeliveries);
+        }),
+        getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+        markComplete: vi.fn(),
+      },
+      replyOptions: {
+        onReplyStart: opts.onReplyStart,
+      },
+      markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
+    };
+  },
 }));
 
 vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
@@ -1471,6 +1478,31 @@ describe("processDiscordMessage draft streaming", () => {
 
     expect(editMessageDiscord).not.toHaveBeenCalled();
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears partial preview drafts when fallback final delivery fails", async () => {
+    const draftStream = createMockDraftStreamForTest();
+    deliverDiscordReply.mockRejectedValueOnce(new Error("durable send failed"));
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onPartialReply?.({ text: "Partial answer..." });
+      await params?.dispatcher.sendFinalReply({ text: "Hello\nWorld" });
+      return {
+        queuedFinal: true,
+        counts: { final: 1, tool: 0, block: 0 },
+        failedCounts: { final: 1 },
+      };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 1 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(draftStream.messageId()).toBeUndefined();
   });
 
   it("uses root discord maxLinesPerMessage for preview finalization when runtime config omits it", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -462,7 +462,6 @@ export async function processDiscordMessage(
           isFinal &&
           (!draftPreview.isProgressMode || draftPreview.hasProgressDraftStarted)
         ) {
-          draftPreview.markFinalDeliveryHandled();
           const reply = resolveSendableOutboundReplyParts(payload);
           const hasMedia = reply.hasMedia;
           const finalText = payload.text;
@@ -546,6 +545,7 @@ export async function processDiscordMessage(
             },
           });
           if (result.kind !== "normal-skipped") {
+            draftPreview.markFinalDeliveryHandled();
             return;
           }
         }

--- a/src/channels/message/lifecycle.test.ts
+++ b/src/channels/message/lifecycle.test.ts
@@ -140,6 +140,62 @@ describe("message lifecycle primitives", () => {
     expect(liveState.canFinalizeInPlace).toBe(false);
   });
 
+  it("clears live preview fallback drafts when normal delivery fails", async () => {
+    const discardPending = vi.fn(async () => undefined);
+    const clear = vi.fn(async () => undefined);
+    const deliveryError = new Error("send failed");
+
+    await expect(
+      deliverFinalizableLivePreview({
+        kind: "final",
+        payload: { text: "with media" },
+        draft: {
+          flush: vi.fn(async () => undefined),
+          id: () => "preview-failed-fallback",
+          discardPending,
+          clear,
+        },
+        buildFinalEdit: () => undefined,
+        editFinal: vi.fn(async () => undefined),
+        deliverNormally: vi.fn(async () => {
+          throw deliveryError;
+        }),
+      }),
+    ).rejects.toThrow(deliveryError);
+
+    expect(discardPending).toHaveBeenCalledTimes(1);
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves live preview fallback delivery errors when draft cleanup also fails", async () => {
+    const discardPending = vi.fn(async () => undefined);
+    const deliveryError = new Error("send failed");
+    const clear = vi.fn(async () => {
+      throw new Error("clear failed");
+    });
+
+    await expect(
+      deliverFinalizableLivePreview({
+        kind: "final",
+        payload: { text: "with media" },
+        draft: {
+          flush: vi.fn(async () => undefined),
+          id: () => "preview-failed-cleanup",
+          discardPending,
+          clear,
+        },
+        buildFinalEdit: () => undefined,
+        editFinal: vi.fn(async () => undefined),
+        deliverNormally: vi.fn(async () => {
+          throw deliveryError;
+        }),
+      }),
+    ).rejects.toBe(deliveryError);
+
+    expect(discardPending).toHaveBeenCalledTimes(1);
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
   it("delivers through finalizable live preview adapters", async () => {
     const editFinal = vi.fn(async () => undefined);
     const adapter = defineFinalizableLivePreviewAdapter({

--- a/src/channels/message/live.ts
+++ b/src/channels/message/live.ts
@@ -191,16 +191,28 @@ export async function deliverFinalizableLivePreview<TPayload, TId, TEdit>(params
   liveState = markLiveMessageCancelled(liveState);
 
   let delivered = false;
+  let deliveryFailed = false;
+  let deliveryError: unknown;
   try {
     const result = await params.deliverNormally(params.payload);
     delivered = result !== false;
     if (delivered) {
       await params.onNormalDelivered?.();
     }
-  } finally {
-    if (delivered) {
-      await params.draft.clear();
+  } catch (err) {
+    deliveryFailed = true;
+    deliveryError = err;
+  }
+
+  try {
+    await params.draft.clear();
+  } catch (err) {
+    if (!deliveryFailed) {
+      throw err;
     }
+  }
+  if (deliveryFailed) {
+    throw deliveryError;
   }
 
   return { kind: delivered ? "normal-delivered" : "normal-skipped", liveState };


### PR DESCRIPTION
## Summary

Fix Discord partial preview finalization so a streamed partial draft is not treated as handled before a final visible reply has actually been produced.

- mark Discord draft final delivery handled only after preview finalization/fallback delivery returns a non-skipped result
- clear live-preview fallback drafts after normal delivery is attempted, including failed fallback delivery
- preserve the original fallback delivery error when draft cleanup also fails
- add regressions for Discord partial-mode fallback failure and shared live-preview cleanup

Fixes #82035.

## Verification

- `node --import tsx - <<'NODE' ...` standalone runtime probe for fallback delivery error preservation
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.test.ts`
- `node scripts/run-vitest.mjs src/channels/message/lifecycle.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.process.test.ts src/channels/message/live.ts src/channels/message/lifecycle.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: Discord partial streaming could leave a partial live draft visible as the apparent final reply when final preview/fallback delivery did not complete cleanly.

Real environment tested: Local Linux source checkout of `openclaw/openclaw` on branch `fix-discord-partial-draft-final`, Node 22.22.2, pnpm 11.1.0 via Corepack.

Exact steps or command run after this patch:
- Ran this standalone runtime probe against the patched `deliverFinalizableLivePreview()` implementation:

```bash
node --import tsx - <<'NODE'
import { deliverFinalizableLivePreview } from "./src/channels/message/live.ts";

const deliveryError = new Error("durable send failed");
let clearCount = 0;

try {
  await deliverFinalizableLivePreview({
    kind: "final",
    payload: { text: "final text" },
    draft: {
      flush: async () => {},
      id: () => "preview-live-probe",
      discardPending: async () => {},
      clear: async () => {
        clearCount += 1;
        throw new Error("draft clear failed");
      },
    },
    buildFinalEdit: () => undefined,
    editFinal: async () => {},
    deliverNormally: async () => {
      throw deliveryError;
    },
  });
} catch (err) {
  console.log("rejectedSameDeliveryError=" + String(err === deliveryError));
  console.log("rejectedMessage=" + (err instanceof Error ? err.message : String(err)));
  console.log("clearCount=" + clearCount);
}
NODE
```

- Also ran the targeted regression/format checks listed in Verification.

Evidence after fix: Terminal output from the standalone runtime probe:

```text
rejectedSameDeliveryError=true
rejectedMessage=durable send failed
clearCount=1
```

Observed result after fix: The patched finalizer still attempts to clear the stale preview draft, and if cleanup fails while delivery is already failing, the original delivery error remains the rejected error instead of being masked by the cleanup error. The targeted Discord regression also covers a partial preview draft followed by fallback final delivery failure; cleanup clears the draft instead of leaving the stale partial preview visible.

What was not tested: No live Discord end-to-end reproduction was run. The bug is covered with source-level regressions and the standalone runtime probe against the draft preview/final delivery path identified in #82035.

