### PR TITLE
feat(media): allow text/html for host-local media file attachments

### DIFF
--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -106,10 +106,12 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   "text/csv",
   "text/markdown",
+  "text/html",
 ]);
-// file-type returns undefined (no magic bytes) for plain-text formats like CSV and
-// Markdown, so host-read needs an explicit "this really decodes as text" fallback.
-const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["text/csv", "text/markdown"]);
+// file-type returns undefined (no magic bytes) for plain-text formats like CSV,
+// Markdown, and HTML, so host-read needs an explicit "this really decodes as text"
+// fallback.
+const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["text/csv", "text/markdown", "text/html"]);
 const MB = 1024 * 1024;
 
 function getTextStats(text: string): { printableRatio: number } {
@@ -251,7 +253,7 @@ function assertHostReadMediaAllowed(params: {
     }
     throw new LocalMediaAccessError(
       "path-not-allowed",
-      "hostReadCapability permits only validated plain-text CSV/Markdown documents for local reads",
+      "hostReadCapability permits only validated plain-text CSV/Markdown/HTML documents for local reads",
     );
   }
   const sniffedKind = kindFromMime(params.sniffedContentType);
@@ -298,7 +300,7 @@ function assertHostReadMediaAllowed(params: {
   }
   throw new LocalMediaAccessError(
     "path-not-allowed",
-    `Host-local media sends only allow buffer-verified images, audio, video, PDF, and Office documents (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
+    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, CSV, Markdown, and HTML (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
   );
 }
 


### PR DESCRIPTION
## Summary

Add `text/html` to the host-local media attachment allowlist so HTML files can be sent as Discord (and other channel) attachments via `message(filePath=...)`.

## Problem

When sending a local `.html` file via `message` tool on Discord, OpenClaw rejects it:

```
Host-local media sends only allow buffer-verified images, audio, video, PDF, and Office documents (got text/html).
```

HTML files are commonly generated as reports, translations, curation digests, etc. and need to be shareable over Discord like any other document.

## Change

- Added `"text/html"` to `HOST_READ_ALLOWED_DOCUMENT_MIMES` — HTML passes the buffer-verified document-type check (sniffed as text/document)
- Added `"text/html"` to `HOST_READ_TEXT_PLAIN_ALIASES` — HTML content passes the validated plain-text readability test (file-type may not detect magic bytes for HTML, so it needs the explicit text-plain alias path)
- Updated the `hostReadCapability` error message to include HTML
- Updated the final fallback error message to list all allowed document types

## Verification

Patched locally against OpenClaw v2026.5.12 dist and verified HTML file sending works on Discord. The same change applied to source in this PR.

## Risk

Low. HTML files can contain scripts/links but Discord does not execute attached files; the same risk exists when users download any document. The `isValidatedHostReadText` check already ensures the buffer contains valid text content.