### PR TITLE
fix(opencode-go): drop reasoning in passthrough replay

### DIFF
--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -248,6 +248,7 @@ describe("buildProviderReplayFamilyHooks", () => {
           allowBase64Only: true,
           includeCamelCase: true,
         },
+        dropReasoningFromHistory: true,
       },
     );
 

--- a/src/plugin-sdk/provider-model-shared.ts
+++ b/src/plugin-sdk/provider-model-shared.ts
@@ -221,8 +221,8 @@ export function buildProviderReplayFamilyHooks(
       };
     case "passthrough-gemini":
       return {
-        buildReplayPolicy: ({ modelId }: ProviderReplayPolicyContext) =>
-          buildPassthroughGeminiSanitizingReplayPolicy(modelId),
+        buildReplayPolicy: ({ modelApi, modelId }: ProviderReplayPolicyContext) =>
+          buildPassthroughGeminiSanitizingReplayPolicy(modelId, { modelApi }),
       };
     case "hybrid-anthropic-openai":
       return {

--- a/src/plugin-sdk/test-helpers/provider-replay-policy.ts
+++ b/src/plugin-sdk/test-helpers/provider-replay-policy.ts
@@ -18,6 +18,7 @@ export async function expectPassthroughReplayPolicy(params: {
     applyAssistantFirstOrderingFix: false,
     validateGeminiTurns: false,
     validateAnthropicTurns: false,
+    dropReasoningFromHistory: true,
   });
 
   if (params.sanitizeThoughtSignatures) {

--- a/src/plugins/provider-replay-helpers.test.ts
+++ b/src/plugins/provider-replay-helpers.test.ts
@@ -220,6 +220,19 @@ describe("provider replay helpers", () => {
     ).not.toHaveProperty("sanitizeThoughtSignatures");
   });
 
+  it("drops historical reasoning for passthrough OpenAI-compatible completions replay", () => {
+    expect(
+      buildPassthroughGeminiSanitizingReplayPolicy("kimi-k2.6", {
+        modelApi: "openai-completions",
+      }),
+    ).toHaveProperty("dropReasoningFromHistory", true);
+    expect(
+      buildPassthroughGeminiSanitizingReplayPolicy("gemini-2.5-pro", {
+        modelApi: "google-generative-ai",
+      }),
+    ).not.toHaveProperty("dropReasoningFromHistory");
+  });
+
   it("sanitizes Gemini replay ordering with a bootstrap turn", () => {
     const customEntries: Array<{ customType: string; data: unknown }> = [];
 

--- a/src/plugins/provider-replay-helpers.ts
+++ b/src/plugins/provider-replay-helpers.ts
@@ -191,12 +191,14 @@ export function buildGoogleGeminiReplayPolicy(): ProviderReplayPolicy {
 /** @deprecated Google provider replay helper; prefer provider-local replay hooks. */
 export function buildPassthroughGeminiSanitizingReplayPolicy(
   modelId?: string,
+  options: { modelApi?: string | null } = {},
 ): ProviderReplayPolicy {
   const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
   return {
     applyAssistantFirstOrderingFix: false,
     validateGeminiTurns: false,
     validateAnthropicTurns: false,
+    ...(options.modelApi === "openai-completions" ? { dropReasoningFromHistory: true } : {}),
     ...(normalizedModelId.includes("gemini")
       ? {
           sanitizeThoughtSignatures: {


### PR DESCRIPTION
## Summary
- pass `modelApi` into the passthrough-Gemini replay-family helper
- drop historical assistant reasoning for passthrough `openai-completions` replay, matching strict OpenAI-compatible fallback behavior
- extend the shared provider replay contract tests so opencode-go-style passthrough providers keep stripping replayed reasoning

Fixes #81988

## Pre-implement audit
- Existing-helper check: reused existing `dropReasoningFromHistory` replay-policy flag; no new sanitizer/predicate introduced.
- Shared-helper caller check: `buildPassthroughGeminiSanitizingReplayPolicy` is used through `PASSTHROUGH_GEMINI_REPLAY_HOOKS`; checked opencode-go plus shared provider-family tests and tightened the shared test helper.
- Broader-fix rival scan: no open PR linked to #81988 at implementation time; adjacent issues are different replay-field directions.

## Real behavior proof
- **Behavior or issue addressed:** plugin-owned passthrough OpenAI-compatible completions models, including `opencode-go/kimi-k2.6`, could replay historical assistant reasoning back to providers that reject `messages[].reasoning`.
- **Real environment tested:** local OpenClaw source checkout on Linux, branch `fix/opencode-go-passthrough-reasoning-replay-81988`, Node/Vitest repo test runner, no live opencode-go credentials.
- **Exact steps or command run after this patch:**
  ```bash
  node scripts/run-vitest.mjs src/plugins/provider-replay-helpers.test.ts src/plugin-sdk/provider-model-shared.test.ts extensions/opencode-go/index.test.ts src/agents/transcript-policy.test.ts
  node scripts/run-vitest.mjs extensions/opencode/index.test.ts extensions/openrouter/index.test.ts extensions/kilocode/index.test.ts
  pnpm exec oxfmt --check src/plugins/provider-replay-helpers.ts src/plugin-sdk/provider-model-shared.ts src/plugins/provider-replay-helpers.test.ts src/plugin-sdk/provider-model-shared.test.ts src/plugin-sdk/test-helpers/provider-replay-policy.ts
  git diff --check
  pnpm test:changed --changed origin/main
  ```
- **Evidence:** copied terminal output from the local OpenClaw checkout after this patch:
  ```text
  Test Files  4 passed (4)
  Tests  89 passed (89)

  All matched files use the correct format.

  [test] passed 2 Vitest shards in 4.63s
  ```
- **Observed result after fix:** focused replay/opencode/transcript suite passed 4 files / 89 tests; passthrough-provider contract suite passed; changed-project tests passed 2 Vitest shards. The shared `expectPassthroughReplayPolicy` helper now asserts `dropReasoningFromHistory: true` for provider-owned passthrough `openai-completions` replay.
- **What was not tested:** no live opencode-go credentialed provider call was run; coverage is source-level replay policy and provider contract regression coverage.

## Risk
- Low blast radius: affects provider-owned passthrough replay policy only when `modelApi === "openai-completions"`.
- Gemini signature sanitation remains unchanged for Gemini model IDs.