### PR TITLE
refactor: centralize inbound history shaping

### DIFF
--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -6,7 +6,10 @@ import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/conversation-runtime";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
-import { buildPendingHistoryContextFromMap } from "openclaw/plugin-sdk/reply-history";
+import {
+  buildInboundHistoryFromMap,
+  buildPendingHistoryContextFromMap,
+} from "openclaw/plugin-sdk/reply-history";
 import { buildAgentSessionKey, resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { evaluateSupplementalContextVisibility } from "openclaw/plugin-sdk/security-runtime";
@@ -287,14 +290,13 @@ export async function buildDiscordMessageProcessContext(params: {
     return null;
   }
   const lastRouteTo = dmConversationTarget ?? effectiveTo;
-  const inboundHistory =
-    shouldIncludeChannelHistory && historyLimit > 0
-      ? (guildHistories.get(messageChannelId) ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
-      : undefined;
+  const inboundHistory = shouldIncludeChannelHistory
+    ? buildInboundHistoryFromMap({
+        historyMap: guildHistories,
+        historyKey: messageChannelId,
+        limit: historyLimit,
+      })
+    : undefined;
   const originatingTo = autoThreadContext?.OriginatingTo ?? dmConversationTarget ?? replyTarget;
   const effectiveSessionKey =
     boundSessionKey ?? autoThreadContext?.SessionKey ?? threadKeys.sessionKey;

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveAgentOutboundIdentity } from "openclaw/plugin-sdk/outbound-runtime";
 import {
+  buildInboundHistoryFromMap,
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
   DEFAULT_GROUP_HISTORY_LIMIT,
@@ -1076,11 +1077,11 @@ export async function handleFeishuMessage(params: {
 
     const inboundHistory =
       isGroup && historyKey && historyLimit > 0 && chatHistories
-        ? (chatHistories.get(historyKey) ?? []).map((entry) => ({
-            sender: entry.sender,
-            body: entry.body,
-            timestamp: entry.timestamp,
-          }))
+        ? buildInboundHistoryFromMap({
+            historyMap: chatHistories,
+            historyKey,
+            limit: historyLimit,
+          })
         : undefined;
 
     const threadContextBySessionKey = new Map<

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -21,6 +21,7 @@ import { hasControlCommand } from "openclaw/plugin-sdk/command-auth-native";
 import type { DmPolicy, GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context-visibility-runtime";
 import {
+  buildInboundHistoryFromMap,
   buildPendingHistoryContextFromMap,
   recordPendingHistoryEntryIfEnabled,
   type HistoryEntry,
@@ -989,11 +990,11 @@ export function buildIMessageInboundContext(params: {
   const imessageTo = (decision.isGroup ? chatTarget : undefined) || `imessage:${decision.sender}`;
   const inboundHistory =
     decision.isGroup && decision.historyKey && params.historyLimit > 0
-      ? (params.groupHistories.get(decision.historyKey) ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
+      ? buildInboundHistoryFromMap({
+          historyMap: params.groupHistories,
+          historyKey: decision.historyKey,
+          limit: params.historyLimit,
+        })
       : undefined;
 
   const ctxPayload = finalizeInboundContext({

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -54,6 +54,20 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 }));
 vi.mock("openclaw/plugin-sdk/reply-history", () => ({
   DEFAULT_GROUP_HISTORY_LIMIT: 20,
+  buildInboundHistoryFromMap: ({
+    historyMap,
+    historyKey,
+    limit,
+  }: {
+    historyMap: Map<string, HistoryEntry[]>;
+    historyKey: string;
+    limit: number;
+  }) => {
+    if (limit <= 0) {
+      return undefined;
+    }
+    return (historyMap.get(historyKey) ?? []).slice(-limit);
+  },
   clearHistoryEntriesIfEnabled: ({
     historyMap,
     historyKey,

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -14,7 +14,7 @@ import {
   resolveRuntimeConversationBindingRoute,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
-import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
+import { buildInboundHistoryFromMap, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -469,11 +469,11 @@ export async function buildLineMessageContext(params: BuildLineMessageContextPar
   const historyKey = isGroup ? peerId : undefined;
   const inboundHistory =
     historyKey && groupHistories && (historyLimit ?? 0) > 0
-      ? (groupHistories.get(historyKey) ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
+      ? buildInboundHistoryFromMap({
+          historyMap: groupHistories,
+          historyKey,
+          limit: historyLimit ?? 0,
+        })
       : undefined;
 
   const finalized = await finalizeLineInboundContext({

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -24,6 +24,7 @@ import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-na
 import { hasFinalInboundReplyDispatch } from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import type { ChannelBotLoopProtectionFacts } from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-runtime";
+import { buildInboundHistoryFromEntries } from "openclaw/plugin-sdk/reply-history";
 import type { GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import {
@@ -1137,7 +1138,12 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                 messageId,
               })
             : undefined;
-        const inboundHistory = preparedTrigger?.history;
+        const inboundHistory = preparedTrigger
+          ? buildInboundHistoryFromEntries({
+              entries: preparedTrigger.history,
+              limit: historyLimit,
+            })
+          : undefined;
         const triggerSnapshot = preparedTrigger;
 
         return {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -88,6 +88,7 @@ import type {
 import {
   buildAgentMediaPayload,
   buildModelsProviderData,
+  buildInboundHistoryFromMap,
   buildPendingHistoryContextFromMap,
   createChannelPairingController,
   createChannelMessageReplyPipeline,
@@ -1529,11 +1530,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         const commandBody = rawText.trim();
         const inboundHistory =
           historyKey && historyLimit > 0
-            ? (channelHistories.get(historyKey) ?? []).map((entry) => ({
-                sender: entry.sender,
-                body: entry.body,
-                timestamp: entry.timestamp,
-              }))
+            ? buildInboundHistoryFromMap({
+                historyMap: channelHistories,
+                historyKey,
+                limit: historyLimit,
+              })
             : undefined;
         const ctxPayload = core.channel.reply.finalizeInboundContext({
           Body: combinedBody,

--- a/extensions/mattermost/src/mattermost/runtime-api.ts
+++ b/extensions/mattermost/src/mattermost/runtime-api.ts
@@ -30,6 +30,7 @@ export { resolveChannelMediaMaxBytes } from "openclaw/plugin-sdk/media-runtime";
 export { loadOutboundMediaFromUrl } from "openclaw/plugin-sdk/outbound-media";
 export {
   DEFAULT_GROUP_HISTORY_LIMIT,
+  buildInboundHistoryFromMap,
   buildPendingHistoryContextFromMap,
   recordPendingHistoryEntryIfEnabled,
 } from "openclaw/plugin-sdk/reply-history";

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -15,6 +15,7 @@ import {
   resolveInboundReplyDispatchCounts,
 } from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import {
+  buildInboundHistoryFromMap,
   buildPendingHistoryContextFromMap,
   DEFAULT_GROUP_HISTORY_LIMIT,
   recordPendingHistoryEntryIfEnabled,
@@ -729,11 +730,11 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
 
     const inboundHistory =
       isRoomish && historyKey && historyLimit > 0
-        ? (conversationHistories.get(historyKey) ?? []).map((entry) => ({
-            sender: entry.sender,
-            body: entry.body,
-            timestamp: entry.timestamp,
-          }))
+        ? buildInboundHistoryFromMap({
+            historyMap: conversationHistories,
+            historyKey,
+            limit: historyLimit,
+          })
         : undefined;
     const commandBody = text.trim();
     const quoteSenderAllowed =

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -27,6 +27,7 @@ import {
 import { runInboundReplyTurn } from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import { kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import {
+  buildInboundHistoryFromMap,
   buildPendingHistoryContextFromMap,
   recordPendingHistoryEntryIfEnabled,
 } from "openclaw/plugin-sdk/reply-history";
@@ -186,11 +187,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const signalTo = normalizeSignalMessagingTarget(signalToRaw) ?? signalToRaw;
     const inboundHistory =
       entry.isGroup && historyKey && deps.historyLimit > 0
-        ? (deps.groupHistories.get(historyKey) ?? []).map((historyEntry) => ({
-            sender: historyEntry.sender,
-            body: historyEntry.body,
-            timestamp: historyEntry.timestamp,
-          }))
+        ? buildInboundHistoryFromMap({
+            historyMap: deps.groupHistories,
+            historyKey,
+            limit: deps.historyLimit,
+          })
         : undefined;
     const ctxPayload = finalizeInboundContext({
       Body: combinedBody,

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -18,6 +18,7 @@ import { ensureConfiguredBindingRouteReady } from "openclaw/plugin-sdk/conversat
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import {
+  buildInboundHistoryFromMap,
   buildPendingHistoryContextFromMap,
   recordPendingHistoryEntryIfEnabled,
 } from "openclaw/plugin-sdk/reply-history";
@@ -920,11 +921,11 @@ export async function prepareSlackMessage(params: {
 
   const inboundHistory =
     isRoomish && ctx.historyLimit > 0
-      ? (ctx.channelHistories.get(historyKey) ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
+      ? buildInboundHistoryFromMap({
+          historyMap: ctx.channelHistories,
+          historyKey,
+          limit: ctx.historyLimit,
+        })
       : dmHistoryContext.inboundHistory;
   const commandBody = textForCommandDetection.trim();
 

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -15,6 +15,7 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context-visibility-runtime";
 import {
+  buildInboundHistoryFromMap,
   buildPendingHistoryContextFromMap,
   type HistoryEntry,
 } from "openclaw/plugin-sdk/reply-history";
@@ -400,11 +401,11 @@ export async function buildTelegramInboundContextPayload(params: {
   });
   const inboundHistory =
     isGroup && historyKey && historyLimit > 0
-      ? (groupHistories.get(historyKey) ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
+      ? buildInboundHistoryFromMap({
+          historyMap: groupHistories,
+          historyKey,
+          limit: historyLimit,
+        })
       : undefined;
   const currentMediaForContext = stickerCacheHit ? [] : allMedia;
   const contextMedia = [...currentMediaForContext, ...replyMedia];

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -5,6 +5,7 @@ import {
 import type { CommandTurnContext } from "openclaw/plugin-sdk/channel-inbound";
 import { deliverInboundReplyWithMessageSendContext } from "openclaw/plugin-sdk/channel-message";
 import { hasVisibleInboundReplyDispatch } from "openclaw/plugin-sdk/inbound-reply-dispatch";
+import { buildInboundHistoryFromEntries } from "openclaw/plugin-sdk/reply-history";
 import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import {
   type DeliverableWhatsAppOutboundPayload,
@@ -243,11 +244,15 @@ export function buildWhatsAppInboundContext(params: {
 }) {
   const inboundHistory =
     params.msg.chatType === "group"
-      ? (params.groupHistory ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
+      ? buildInboundHistoryFromEntries({
+          entries: (params.groupHistory ?? []).map((entry) => ({
+            sender: entry.sender,
+            body: entry.body,
+            timestamp: entry.timestamp,
+            messageId: entry.id,
+          })),
+          limit: params.groupHistory?.length ?? 1,
+        })
       : undefined;
 
   const result = finalizeInboundContext({

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -10,6 +10,7 @@ import { KeyedAsyncQueue } from "openclaw/plugin-sdk/core";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
+  buildInboundHistoryFromMap,
   DEFAULT_GROUP_HISTORY_LIMIT,
   type HistoryEntry,
   buildPendingHistoryContextFromMap,
@@ -605,11 +606,11 @@ async function processMessage(
       : body;
   const inboundHistory =
     isGroup && historyKey && historyState.historyLimit > 0
-      ? (historyState.groupHistories.get(historyKey) ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
+      ? buildInboundHistoryFromMap({
+          historyMap: historyState.groupHistories,
+          historyKey,
+          limit: historyState.historyLimit,
+        })
       : undefined;
 
   const normalizedTo = isGroup ? `zalouser:group:${chatId}` : `zalouser:${chatId}`;

--- a/src/auto-reply/reply/history.ts
+++ b/src/auto-reply/reply/history.ts
@@ -1,3 +1,4 @@
+import type { HistoryEntry } from "./history.types.js";
 import { CURRENT_MESSAGE_MARKER } from "./mentions.js";
 
 export const HISTORY_CONTEXT_MARKER = "[Chat messages since your last reply - for context]";
@@ -27,12 +28,7 @@ export function evictOldHistoryKeys<T>(
   }
 }
 
-export type HistoryEntry = {
-  sender: string;
-  body: string;
-  timestamp?: number;
-  messageId?: string;
-};
+export type { HistoryEntry, HistoryMediaEntry } from "./history.types.js";
 
 export function buildHistoryContext(params: {
   historyText: string;
@@ -122,6 +118,43 @@ export function buildPendingHistoryContextFromMap(params: {
     formatEntry: params.formatEntry,
     lineBreak: params.lineBreak,
     excludeLast: false,
+  });
+}
+
+export function buildInboundHistoryFromMap<T extends HistoryEntry>(params: {
+  historyMap: Map<string, T[]>;
+  historyKey: string;
+  limit: number;
+}): HistoryEntry[] | undefined {
+  return buildInboundHistoryFromEntries({
+    entries: params.historyMap.get(params.historyKey) ?? [],
+    limit: params.limit,
+  });
+}
+
+export function buildInboundHistoryFromEntries(params: {
+  entries: readonly HistoryEntry[];
+  limit: number;
+}): HistoryEntry[] | undefined {
+  if (params.limit <= 0) {
+    return undefined;
+  }
+  if (params.entries.length === 0) {
+    return [];
+  }
+  return params.entries.slice(-params.limit).map((entry) => {
+    const historyEntry: HistoryEntry = {
+      sender: entry.sender,
+      body: entry.body,
+      timestamp: entry.timestamp,
+    };
+    if (entry.messageId) {
+      historyEntry.messageId = entry.messageId;
+    }
+    if (entry.media && entry.media.length > 0) {
+      historyEntry.media = entry.media;
+    }
+    return historyEntry;
   });
 }
 

--- a/src/auto-reply/reply/history.types.ts
+++ b/src/auto-reply/reply/history.types.ts
@@ -1,0 +1,15 @@
+export type HistoryEntry = {
+  sender: string;
+  body: string;
+  timestamp?: number;
+  messageId?: string;
+  media?: HistoryMediaEntry[];
+};
+
+export type HistoryMediaEntry = {
+  path?: string;
+  url?: string;
+  contentType?: string;
+  kind?: "image" | "video" | "audio" | "document" | "unknown";
+  messageId?: string;
+};

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -962,4 +962,51 @@ describe("buildInboundUserContextPrefix", () => {
     expect(history[0]?.["body"]).toBe("body-5");
     expect(history.at(-1)?.["body"]).toBe("body-24");
   });
+
+  it("includes inbound history media metadata without leaking paths or URLs", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      InboundHistory: [
+        {
+          sender: "Alice",
+          body: "<media:image> (1 image)",
+          timestamp: 1_736_380_700_000,
+          messageId: "m-1",
+          media: [
+            {
+              path: "/tmp/openclaw-secret-image.png",
+              url: "https://cdn.example.test/private-token",
+              contentType: "image/png",
+              kind: "image",
+              messageId: "m-1",
+            },
+          ],
+        },
+      ],
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["history_media_count"]).toBe(1);
+
+    const history = parseHistoryPayload(text);
+    expect(history).toEqual([
+      {
+        sender: "Alice",
+        timestamp_ms: 1_736_380_700_000,
+        message_id: "m-1",
+        body: "<media:image> (1 image)",
+        media: [
+          {
+            kind: "image",
+            content_type: "image/png",
+            message_id: "m-1",
+            has_local_path: true,
+            has_url: true,
+          },
+        ],
+      },
+    ]);
+    expect(text).not.toContain("/tmp/openclaw-secret-image.png");
+    expect(text).not.toContain("private-token");
+  });
 });

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -250,6 +250,25 @@ function buildLocationContextPayload(ctx: TemplateContext): Record<string, unkno
   return Object.values(payload).some((value) => value !== undefined) ? payload : undefined;
 }
 
+function buildInboundHistoryMediaPromptPayload(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((entry) => {
+    if (!isRecord(entry)) {
+      return [];
+    }
+    const payload = {
+      kind: normalizePromptMetadataString(entry["kind"]),
+      content_type: normalizePromptMetadataString(entry["contentType"]),
+      message_id: normalizePromptMetadataString(entry["messageId"]),
+      has_local_path: normalizePromptMetadataString(entry["path"]) ? true : undefined,
+      has_url: normalizePromptMetadataString(entry["url"]) ? true : undefined,
+    };
+    return Object.values(payload).some((field) => field !== undefined) ? [payload] : [];
+  });
+}
+
 function buildReplyChainPayload(ctx: TemplateContext): Array<Record<string, unknown>> {
   if (!Array.isArray(ctx.ReplyChain)) {
     return [];
@@ -437,6 +456,10 @@ export function buildInboundUserContextPrefix(
   const timestampStr = formatConversationTimestamp(ctx.Timestamp, envelope);
   const inboundHistory = Array.isArray(ctx.InboundHistory) ? ctx.InboundHistory : [];
   const boundedHistory = inboundHistory.slice(-MAX_UNTRUSTED_HISTORY_ENTRIES);
+  const historyMediaCount = boundedHistory.reduce(
+    (count, entry) => count + buildInboundHistoryMediaPromptPayload(entry.media).length,
+    0,
+  );
   const replyChainPayload = buildReplyChainPayload(ctx);
   const structuredContext = Array.isArray(ctx.UntrustedStructuredContext)
     ? ctx.UntrustedStructuredContext
@@ -489,6 +512,7 @@ export function buildInboundUserContextPrefix(
     has_forwarded_context: normalizePromptMetadataString(ctx.ForwardedFrom) ? true : undefined,
     has_thread_starter: sanitizePromptBody(ctx.ThreadStarterBody) ? true : undefined,
     history_count: boundedHistory.length > 0 ? boundedHistory.length : undefined,
+    history_media_count: historyMediaCount > 0 ? historyMediaCount : undefined,
     history_truncated: inboundHistory.length > MAX_UNTRUSTED_HISTORY_ENTRIES ? true : undefined,
   };
   if (Object.values(conversationInfo).some((v) => v !== undefined)) {
@@ -585,11 +609,16 @@ export function buildInboundUserContextPrefix(
     blocks.push(
       formatUntrustedJsonBlock(
         "Chat history since last reply (untrusted, for context):",
-        boundedHistory.map((entry) => ({
-          sender: sanitizePromptBody(entry.sender),
-          timestamp_ms: entry.timestamp,
-          body: sanitizePromptBody(entry.body),
-        })),
+        boundedHistory.map((entry) => {
+          const media = buildInboundHistoryMediaPromptPayload(entry.media);
+          return {
+            sender: sanitizePromptBody(entry.sender),
+            timestamp_ms: entry.timestamp,
+            message_id: normalizePromptMetadataString(entry.messageId),
+            body: sanitizePromptBody(entry.body),
+            media: media.length > 0 ? media : undefined,
+          };
+        }),
       ),
     );
   }

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -8,6 +8,8 @@ import {
   buildHistoryContext,
   buildHistoryContextFromEntries,
   buildHistoryContextFromMap,
+  buildInboundHistoryFromEntries,
+  buildInboundHistoryFromMap,
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
   HISTORY_CONTEXT_MARKER,
@@ -177,6 +179,58 @@ describe("history helpers", () => {
     expect(result).toContain("B: two");
     expect(result).toContain(CURRENT_MESSAGE_MARKER);
     expect(result).toContain("current");
+  });
+
+  it("builds structured inbound history with media metadata", () => {
+    const historyMap = new Map([
+      [
+        "group",
+        [
+          {
+            sender: "Older",
+            body: "zero",
+            timestamp: 0,
+          },
+          {
+            sender: "A",
+            body: "one",
+            timestamp: 1,
+            messageId: "m1",
+            media: [
+              {
+                path: "/tmp/image.png",
+                contentType: "image/png",
+                kind: "image" as const,
+              },
+            ],
+          },
+        ],
+      ],
+    ]);
+
+    expect(buildInboundHistoryFromMap({ historyMap, historyKey: "group", limit: 1 })).toEqual([
+      {
+        sender: "A",
+        body: "one",
+        timestamp: 1,
+        messageId: "m1",
+        media: [{ path: "/tmp/image.png", contentType: "image/png", kind: "image" }],
+      },
+    ]);
+    expect(
+      buildInboundHistoryFromMap({ historyMap, historyKey: "group", limit: 0 }),
+    ).toBeUndefined();
+    expect(
+      buildInboundHistoryFromEntries({ entries: historyMap.get("group") ?? [], limit: 1 }),
+    ).toEqual([
+      {
+        sender: "A",
+        body: "one",
+        timestamp: 1,
+        messageId: "m1",
+        media: [{ path: "/tmp/image.png", contentType: "image/png", kind: "image" }],
+      },
+    ]);
   });
 
   it("records pending entries only when enabled", () => {

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -5,6 +5,7 @@ import type {
 import type { InputProvenance } from "../sessions/input-provenance.js";
 import type { CommandTurnContext } from "./command-turn-context.js";
 import type { CommandArgs } from "./commands-args.types.js";
+import type { HistoryEntry } from "./reply/history.types.js";
 import type { ReplyThreadingPolicy } from "./types.js";
 
 /** Valid message channels for routing. */
@@ -48,11 +49,7 @@ export type MsgContext = {
    * Recent chat history for context (untrusted user content). Prefer passing this
    * as structured context blocks in the user prompt rather than rendering plaintext envelopes.
    */
-  InboundHistory?: Array<{
-    sender: string;
-    body: string;
-    timestamp?: number;
-  }>;
+  InboundHistory?: HistoryEntry[];
   /**
    * @deprecated Use CommandBody.
    *

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -3,7 +3,7 @@ import type { GetReplyOptions } from "../../auto-reply/get-reply-options.types.j
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { DispatchFromConfigResult } from "../../auto-reply/reply/dispatch-from-config.types.js";
 import type { GetReplyFromConfig } from "../../auto-reply/reply/get-reply.types.js";
-import type { HistoryEntry } from "../../auto-reply/reply/history.js";
+import type { HistoryEntry } from "../../auto-reply/reply/history.types.js";
 import type { DispatchReplyWithBufferedBlockDispatcher } from "../../auto-reply/reply/provider-dispatcher.types.js";
 import type { ReplyDispatcherWithTypingOptions } from "../../auto-reply/reply/reply-dispatcher.js";
 import type { ReplyDispatchKind } from "../../auto-reply/reply/reply-dispatcher.types.js";
@@ -182,7 +182,7 @@ export type MessageFacts = {
   envelopeFrom: string;
   senderLabel?: string;
   preview?: string;
-  inboundHistory?: Array<{ sender: string; body: string; timestamp?: number }>;
+  inboundHistory?: HistoryEntry[];
 };
 
 export type CommandFacts = {

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -148,7 +148,7 @@ export type {
 } from "../plugins/types.js";
 export type { OpenClawConfig } from "../config/config.js";
 export type { OutboundIdentity } from "../infra/outbound/identity.js";
-export type { HistoryEntry } from "../auto-reply/reply/history.js";
+export type { HistoryEntry } from "../auto-reply/reply/history.types.js";
 export type { ReplyPayload } from "./reply-payload.js";
 export type { AllowlistMatch } from "../channels/allowlist-match.js";
 export type {

--- a/src/plugin-sdk/reply-history.ts
+++ b/src/plugin-sdk/reply-history.ts
@@ -1,11 +1,13 @@
 /** Shared reply-history helpers for plugins that keep short per-thread context windows. */
-export type { HistoryEntry } from "../auto-reply/reply/history.js";
+export type { HistoryEntry, HistoryMediaEntry } from "../auto-reply/reply/history.types.js";
 export {
   DEFAULT_GROUP_HISTORY_LIMIT,
   HISTORY_CONTEXT_MARKER,
   buildHistoryContext,
   buildHistoryContextFromEntries,
   buildHistoryContextFromMap,
+  buildInboundHistoryFromEntries,
+  buildInboundHistoryFromMap,
   buildPendingHistoryContextFromMap,
   clearHistoryEntries,
   clearHistoryEntriesIfEnabled,

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -547,6 +547,8 @@ describe("plugin-sdk subpath exports", () => {
     ]);
     expectSourceMentions("reply-chunking", ["chunkText", "chunkTextWithMode"]);
     expectSourceMentions("reply-history", [
+      "buildInboundHistoryFromEntries",
+      "buildInboundHistoryFromMap",
       "buildPendingHistoryContextFromMap",
       "clearHistoryEntriesIfEnabled",
       "recordPendingHistoryEntryIfEnabled",


### PR DESCRIPTION
## Summary
- Adds core `HistoryEntry` / `HistoryMediaEntry` types plus shared inbound-history builders.
- Routes Discord, Slack, Telegram, Feishu, Mattermost, Matrix, MSTeams, Signal, iMessage, LINE, WhatsApp, and Zalo Personal through the core builders instead of local text-only shaping.
- Teaches core inbound prompt rendering to include bounded media metadata from history without exposing local paths or remote URLs.

## Why
Message platforms should not each decide how prior messages are represented to the model. This moves the shared history shape and context rendering into core so providers can expose capabilities and core can decide how to serve them.

## Real behavior proof
Behavior addressed: Channel adapters now pass recent inbound history through a common core `HistoryEntry` shape, including media metadata when providers supply it.
Real environment tested: Local focused Vitest, import-cycle checks, oxlint, Codex review, Blacksmith/Testbox changed gate, and GitHub CI on head `00f0518e93`.
Exact steps or command run after this patch:
- `pnpm test src/auto-reply/reply/reply-state.test.ts src/auto-reply/reply/inbound-meta.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/telegram/src/bot-message-context.body.test.ts -- --reporter=verbose`
- `pnpm test extensions/slack/src/monitor/message-handler/prepare.test.ts -- --reporter=verbose --testTimeout=180000`
- `pnpm test extensions/line/src/bot-handlers.test.ts -- --reporter=verbose`
- `node --import tsx scripts/check-madge-import-cycles.ts && node --import tsx scripts/check-import-cycles.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/history.ts src/auto-reply/reply/history.types.ts src/auto-reply/reply/inbound-meta.ts src/auto-reply/templating.ts src/channels/turn/types.ts src/plugin-sdk/core.ts src/plugin-sdk/reply-history.ts extensions/line/src/bot-handlers.test.ts`
- `git diff --check`
- `codex review --commit 013850d85e` found the missing Line partial mock export; fixed in `00f0518e93`
- `codex review --commit 00f0518e93`
- `pnpm check:changed` on Blacksmith Testbox: `tbx_01krn74fzhht4hz0f2pm08w6dp`
Evidence after fix: Focused tests cover core history shaping, safe prompt metadata, plugin SDK exports, Discord process behavior, Telegram body behavior, Slack prepare behavior, and the Line partial mock import path.
Observed result after fix: Focused tests passed; import-cycle checks passed; oxlint passed; Codex review clean after the Line mock fix; Testbox changed gate passed; GitHub checks are green on head `00f0518e93`.
What was not tested: Live channel roundtrip; behavior PR is stacked separately.
