### PR TITLE
Recover stale blocked tool calls

### DIFF
--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -557,7 +557,55 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
-  it("does not abort embedded runs while a native tool call is active", async () => {
+  it("does not abort embedded runs while a native tool call is below the abort threshold", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+            stuckSessionAbortMs: 90_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticToolStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        toolName: "bash",
+        toolCallId: "cmd-1",
+      });
+
+      vi.advanceTimersByTime(61_000);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+    expectRecordFields(
+      requireRecord(
+        events.findLast((event) => event.type === "session.stalled"),
+        "stalled event",
+      ),
+      {
+        classification: "blocked_tool_call",
+        reason: "blocked_tool_call",
+        activeWorkKind: "tool_call",
+        activeToolName: "bash",
+        activeToolCallId: "cmd-1",
+      },
+    );
+  });
+
+  it("aborts stale blocked tool calls after the abort threshold", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const unsubscribe = onDiagnosticEvent((event) => {
@@ -589,7 +637,6 @@ describe("stuck session diagnostics threshold", () => {
       unsubscribe();
     }
 
-    expect(recoverStuckSession).not.toHaveBeenCalled();
     expectRecordFields(
       requireRecord(
         events.findLast((event) => event.type === "session.stalled"),
@@ -603,6 +650,14 @@ describe("stuck session diagnostics threshold", () => {
         activeToolCallId: "cmd-1",
       },
     );
+    expect(recoverStuckSession).toHaveBeenCalledWith({
+      sessionId: "s1",
+      sessionKey: "main",
+      ageMs: expect.any(Number),
+      queueDepth: 0,
+      allowActiveAbort: true,
+      stateGeneration: expect.any(Number),
+    });
   });
 
   it("uses diagnostics.stuckSessionAbortMs for stalled active-work recovery", () => {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -466,6 +466,19 @@ function isStalledEmbeddedRunRecoveryEligible(params: {
   );
 }
 
+function isBlockedToolCallRecoveryEligible(params: {
+  classification: SessionAttentionClassification | undefined;
+  ageMs: number;
+  stuckSessionAbortMs: number;
+}): boolean {
+  return (
+    params.classification?.eventType === "session.stalled" &&
+    params.classification.classification === "blocked_tool_call" &&
+    params.classification.activeWorkKind === "tool_call" &&
+    params.ageMs >= params.stuckSessionAbortMs
+  );
+}
+
 export function logWebhookReceived(params: {
   channel: string;
   updateType?: string;
@@ -766,6 +779,12 @@ export function logSessionAttention(
   });
   const recoveryEligible =
     classification.recoveryEligible ||
+    isBlockedToolCallRecoveryEligible({
+      classification,
+      ageMs: params.ageMs,
+      stuckSessionAbortMs:
+        params.abortThresholdMs ?? resolveStalledEmbeddedRunAbortMs(params.thresholdMs),
+    }) ||
     isStalledEmbeddedRunRecoveryEligible({
       classification,
       ageMs: params.ageMs,
@@ -1024,6 +1043,26 @@ export function startDiagnosticHeartbeat(
               sessionKey: state.sessionKey,
               ageMs,
               queueDepth: state.queueDepth,
+              stateGeneration: state.generation,
+            },
+          });
+        } else if (
+          classification &&
+          isBlockedToolCallRecoveryEligible({
+            classification,
+            ageMs,
+            stuckSessionAbortMs,
+          })
+        ) {
+          requestStuckSessionRecovery({
+            recover: opts?.recoverStuckSession ?? recoverStuckSession,
+            classification,
+            request: {
+              sessionId: state.sessionId,
+              sessionKey: state.sessionKey,
+              ageMs,
+              queueDepth: state.queueDepth,
+              allowActiveAbort: true,
               stateGeneration: state.generation,
             },
           });


### PR DESCRIPTION
## Summary
- recover stale `blocked_tool_call` sessions after `diagnostics.stuckSessionAbortMs`
- pass `allowActiveAbort=true` for that stale blocked-tool recovery path so the existing stuck-session recovery can clear the active embedded run/lane
- keep active native tool calls observe-only before the abort threshold

## Root Cause
A session could be classified as `blocked_tool_call` after a stale tool call, but recovery stayed observe-only. That left the session lane busy even though diagnostics had identified the stuck state, which can surface as channel clients continuing to show typing or queued replies never reaching the visible channel.

## Validation
- `CI=1 pnpm vitest run src/logging/diagnostic.test.ts src/logging/diagnostic-session-attention.test.ts`
- `CI=1 pnpm vitest run src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`

## Notes
- `pnpm check:test-types` was attempted in a fresh worktree, but failed on unrelated missing optional/native test deps (`sharp`, `esbuild`) in existing test files before this patch area.