### PR TITLE
fix(auto-reply): respect silentReply policy in failure-fallback path

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -9,6 +9,8 @@ import {
   classifyOAuthRefreshFailure,
 } from "../../agents/auth-profiles/oauth-refresh-failure.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
+import { resolveSilentReplyPolicy } from "../../config/silent-reply.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionBinding } from "../../agents/cli-session.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
@@ -474,11 +476,25 @@ function resolveExternalRunFailureTextForConversation(params: {
   text: string;
   sessionCtx: TemplateContext;
   isGenericRunnerFailure: boolean;
+  cfg?: OpenClawConfig;
+  sessionKey?: string;
+  surface?: string;
 }): string {
   if (!isNonDirectConversationContext(params.sessionCtx)) {
     return params.text;
   }
   if (!params.isGenericRunnerFailure && !params.text.includes(AGENT_FAILED_BEFORE_REPLY_TEXT)) {
+    return params.text;
+  }
+  const chatType = normalizeLowercaseStringOrEmpty(params.sessionCtx.ChatType);
+  const conversationType = chatType === "channel" ? "group" : "group";
+  const policy = resolveSilentReplyPolicy({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    surface: params.surface,
+    conversationType,
+  });
+  if (policy === "disallow") {
     return params.text;
   }
   return SILENT_REPLY_TOKEN;
@@ -589,6 +605,9 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
   err: unknown;
   sessionCtx: TemplateContext;
   resolvedVerboseLevel: VerboseLevel | undefined;
+  cfg?: OpenClawConfig;
+  sessionKey?: string;
+  surface?: string;
 }): ReplyPayload | undefined {
   const message = formatErrorMessage(params.err);
   const isFallbackSummary = isFallbackSummaryError(params.err);
@@ -601,6 +620,9 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
         text: BILLING_ERROR_USER_MESSAGE,
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: false,
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        surface: params.surface,
       }),
     });
   }
@@ -620,6 +642,9 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
         text: buildRateLimitCooldownMessage(params.err),
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: false,
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        surface: params.surface,
       }),
     });
   }
@@ -630,6 +655,9 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
         text: rateLimitOrOverloadedCopy,
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: false,
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        surface: params.surface,
       }),
     });
   }
@@ -645,6 +673,9 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
       text: externalRunFailureReply.text,
       sessionCtx: params.sessionCtx,
       isGenericRunnerFailure: false,
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+      surface: params.surface,
     }),
   });
 }
@@ -2112,6 +2143,9 @@ export async function runAgentTurnWithFallback(params: {
                 text: switchErrorText,
                 sessionCtx: params.sessionCtx,
                 isGenericRunnerFailure: !shouldSurfaceToControlUi,
+                cfg: runtimeConfig,
+                sessionKey: params.sessionKey,
+                surface: params.sessionCtx.Surface ?? params.sessionCtx.Provider,
               }),
             }),
           };
@@ -2318,6 +2352,9 @@ export async function runAgentTurnWithFallback(params: {
         text: fallbackText,
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
+        cfg: runtimeConfig,
+        sessionKey: params.sessionKey,
+        surface: params.sessionCtx.Surface ?? params.sessionCtx.Provider,
       });
 
       params.replyOperation?.fail("run_failed", err);

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2161,6 +2161,9 @@ export async function runReplyAgent(params: {
       err: error,
       sessionCtx,
       resolvedVerboseLevel,
+      cfg,
+      sessionKey,
+      surface: replyToChannel ?? sessionCtx.Surface ?? sessionCtx.Provider,
     });
     if (knownFailurePayload) {
       replyOperation.fail("run_failed", error);


### PR DESCRIPTION
## Summary

- **Problem:** `resolveExternalRunFailureTextForConversation()` hardcodes `SILENT_REPLY_TOKEN` for non-direct conversations based purely on `isNonDirectConversationContext()`, without consulting `resolveSilentReplyPolicy()`. This means operators who set `agents.defaults.silentReply.group: "disallow"` still get silent failures in groups — the policy is bypassed.
- **Why it matters:** Two code paths disagree: `route-reply.ts` correctly consults `resolveSilentReplyPolicy()` for non-failure silent payloads, but the failure-fallback path makes its own hardcoded decision. Operators have no way to make failure messages visible in groups.
- **What changed:** `resolveExternalRunFailureTextForConversation()` now accepts optional `cfg`/`sessionKey`/`surface` params and calls `resolveSilentReplyPolicy()` before returning `SILENT_REPLY_TOKEN`. When policy resolves to `"disallow"`, the failure text is returned as-is (visible to users). All call sites in `buildKnownAgentRunFailureReplyPayload` and `runAgentTurnWithFallback` pass through the config context.
- **What did NOT change (scope boundary):** Default behavior is preserved — OOTB policy for groups is `"allow"`, so groups still get `SILENT_REPLY_TOKEN` for failures by default. Only explicit operator overrides change behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82060
- Related #60607, #67750, #77666, #78942
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

The fix is a pure logic change: adding a policy check before a hardcoded return. The existing `resolveSilentReplyPolicy()` helper is already battle-tested in `route-reply.ts` — this PR simply wires it into the failure-fallback path.

**Code path analysis:**
1. Before: `isNonDirectConversationContext() && isGenericRunnerFailure` → always `SILENT_REPLY_TOKEN`
2. After: same conditions → `resolveSilentReplyPolicy({cfg, sessionKey, surface, conversationType})` → only `SILENT_REPLY_TOKEN` when policy ≠ `"disallow"`

The default policy `{ group: "allow" }` means OOTB behavior is identical. The fix only activates when operators explicitly set `silentReply.group: "disallow"`.

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.