### PR TITLE
fix(auto-reply): failure-fallback respects silentReply policy in groups/channels

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.silent-reply-policy.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.silent-reply-policy.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests that the failure-fallback path honors the agents.defaults.silentReply
+ * policy set by the operator (issue #82060).
+ *
+ * Previously, resolveExternalRunFailureTextForConversation() hardcoded
+ * SILENT_REPLY_TOKEN for any non-direct context regardless of the configured
+ * silentReply policy. Now it delegates to resolveSilentReplyPolicy(), so
+ * operators can opt groups/channels into receiving failure copy by setting
+ * `agents.defaults.silentReply.group: "disallow"`.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { TemplateContext } from "../templating.js";
+import { SILENT_REPLY_TOKEN } from "../tokens.js";
+import { buildKnownAgentRunFailureReplyPayload } from "./agent-runner-execution.js";
+
+function makeGroupCtx(overrides?: Partial<TemplateContext>): TemplateContext {
+  return {
+    SessionKey: "telegram:group:12345",
+    ChatType: "group",
+    Surface: "telegram",
+    Provider: "telegram",
+    ...overrides,
+  } as unknown as TemplateContext;
+}
+
+function makeDirectCtx(overrides?: Partial<TemplateContext>): TemplateContext {
+  return {
+    SessionKey: "telegram:direct:67890",
+    ChatType: "direct",
+    Surface: "telegram",
+    Provider: "telegram",
+    ...overrides,
+  } as unknown as TemplateContext;
+}
+
+const RATE_LIMIT_ERR = Object.assign(new Error("Too Many Requests - rate limit exceeded"), {
+  status: 429,
+});
+
+describe("buildKnownAgentRunFailureReplyPayload — silentReply policy", () => {
+  it("silences failure copy in group context by default (group policy: allow)", () => {
+    const payload = buildKnownAgentRunFailureReplyPayload({
+      err: RATE_LIMIT_ERR,
+      sessionCtx: makeGroupCtx(),
+      resolvedVerboseLevel: undefined,
+      cfg: {
+        // Default: agents.defaults.silentReply not set → group defaults to "allow"
+      },
+    });
+    expect(payload?.text).toBe(SILENT_REPLY_TOKEN);
+  });
+
+  it("delivers failure copy in group context when silentReply.group is 'disallow'", () => {
+    const payload = buildKnownAgentRunFailureReplyPayload({
+      err: RATE_LIMIT_ERR,
+      sessionCtx: makeGroupCtx(),
+      resolvedVerboseLevel: undefined,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: { group: "disallow" },
+          },
+        },
+      },
+    });
+    expect(payload?.text).not.toBe(SILENT_REPLY_TOKEN);
+    expect(payload?.text).toBeTruthy();
+  });
+
+  it("delivers failure copy in direct context regardless of group policy", () => {
+    // Direct context: policy defaults to "disallow", so text should be returned.
+    const payload = buildKnownAgentRunFailureReplyPayload({
+      err: RATE_LIMIT_ERR,
+      sessionCtx: makeDirectCtx(),
+      resolvedVerboseLevel: undefined,
+      cfg: {},
+    });
+    expect(payload?.text).not.toBe(SILENT_REPLY_TOKEN);
+    expect(payload?.text).toBeTruthy();
+  });
+
+  it("silences failure copy in direct context when silentReply.direct is 'allow'", () => {
+    const payload = buildKnownAgentRunFailureReplyPayload({
+      err: RATE_LIMIT_ERR,
+      sessionCtx: makeDirectCtx(),
+      resolvedVerboseLevel: undefined,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: { direct: "allow" },
+          },
+        },
+      },
+    });
+    expect(payload?.text).toBe(SILENT_REPLY_TOKEN);
+  });
+
+  it("falls back to silencing when cfg is undefined (safe default)", () => {
+    // Without cfg, resolveSilentReplyPolicy uses DEFAULT_SILENT_REPLY_POLICY
+    // where group defaults to "allow", so group contexts should still be silenced.
+    const payload = buildKnownAgentRunFailureReplyPayload({
+      err: RATE_LIMIT_ERR,
+      sessionCtx: makeGroupCtx(),
+      resolvedVerboseLevel: undefined,
+    });
+    expect(payload?.text).toBe(SILENT_REPLY_TOKEN);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -39,6 +39,8 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { resolveSilentReplyPolicy } from "../../config/silent-reply.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, onAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -474,11 +476,25 @@ function resolveExternalRunFailureTextForConversation(params: {
   text: string;
   sessionCtx: TemplateContext;
   isGenericRunnerFailure: boolean;
+  cfg?: OpenClawConfig;
 }): string {
   if (!isNonDirectConversationContext(params.sessionCtx)) {
     return params.text;
   }
   if (!params.isGenericRunnerFailure && !params.text.includes(AGENT_FAILED_BEFORE_REPLY_TEXT)) {
+    return params.text;
+  }
+  // Consult the silentReply policy rather than hardcoding silent for all
+  // non-direct contexts. When an operator sets silentReply.group="disallow"
+  // the failure-fallback copy should be delivered, matching route-reply.ts.
+  const silentPolicy = resolveSilentReplyPolicy({
+    cfg: params.cfg,
+    sessionKey: params.sessionCtx.SessionKey,
+    surface: normalizeLowercaseStringOrEmpty(
+      params.sessionCtx.Surface ?? params.sessionCtx.Provider,
+    ),
+  });
+  if (silentPolicy !== "allow") {
     return params.text;
   }
   return SILENT_REPLY_TOKEN;
@@ -589,6 +605,7 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
   err: unknown;
   sessionCtx: TemplateContext;
   resolvedVerboseLevel: VerboseLevel | undefined;
+  cfg?: OpenClawConfig;
 }): ReplyPayload | undefined {
   const message = formatErrorMessage(params.err);
   const isFallbackSummary = isFallbackSummaryError(params.err);
@@ -601,6 +618,7 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
         text: BILLING_ERROR_USER_MESSAGE,
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: false,
+        cfg: params.cfg,
       }),
     });
   }
@@ -620,6 +638,7 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
         text: buildRateLimitCooldownMessage(params.err),
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: false,
+        cfg: params.cfg,
       }),
     });
   }
@@ -630,6 +649,7 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
         text: rateLimitOrOverloadedCopy,
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: false,
+        cfg: params.cfg,
       }),
     });
   }
@@ -645,6 +665,7 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
       text: externalRunFailureReply.text,
       sessionCtx: params.sessionCtx,
       isGenericRunnerFailure: false,
+      cfg: params.cfg,
     }),
   });
 }
@@ -2112,6 +2133,7 @@ export async function runAgentTurnWithFallback(params: {
                 text: switchErrorText,
                 sessionCtx: params.sessionCtx,
                 isGenericRunnerFailure: !shouldSurfaceToControlUi,
+                cfg: params.followupRun.run.config,
               }),
             }),
           };
@@ -2318,6 +2340,7 @@ export async function runAgentTurnWithFallback(params: {
         text: fallbackText,
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
+        cfg: params.followupRun.run.config,
       });
 
       params.replyOperation?.fail("run_failed", err);

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2161,6 +2161,7 @@ export async function runReplyAgent(params: {
       err: error,
       sessionCtx,
       resolvedVerboseLevel,
+      cfg,
     });
     if (knownFailurePayload) {
       replyOperation.fail("run_failed", error);


### PR DESCRIPTION
## Problem

Closes #82060.

`resolveExternalRunFailureTextForConversation()` in `agent-runner-execution.ts` hardcoded `SILENT_REPLY_TOKEN` for every non-direct conversation context (group/channel) when a runner failure occurred. It never consulted the `agents.defaults.silentReply` / `surfaces.<id>.silentReply` policy, making those knobs inert for the failure-fallback path.

As reported: an operator setting `silentReply.group: "disallow"` to opt their group into seeing failure copy got silence anyway.

## Root cause

Two code paths decide silent vs. delivered for failed runs:

1. **`route-reply.ts:127`** — already calls `resolveSilentReplyPolicy({...})` ✅
2. **`agent-runner-execution.ts` (failure path)** — hardcoded `SILENT_REPLY_TOKEN` based only on `isNonDirectConversationContext()` ❌

## Fix

Replace the hardcoded `return SILENT_REPLY_TOKEN` with a call to the same `resolveSilentReplyPolicy()` helper that `route-reply.ts` uses:

- When policy resolves to `"allow"` → `SILENT_REPLY_TOKEN` (unchanged default behavior)
- When policy resolves to `"disallow"` → return the failure text (new: respects operator override)

The function receives an optional `cfg` param, threaded through `buildKnownAgentRunFailureReplyPayload` and the two inline call sites in `runAgentTurnWithFallback`. Existing callers without `cfg` fall back to the default policy (group=allow), preserving backward compatibility.

## Tests

Added `agent-runner-execution.silent-reply-policy.test.ts` with five cases:
- Group context, default cfg → silenced (preserves existing behavior)
- Group context, `silentReply.group: "disallow"` → failure copy delivered ✅ (new)
- Direct context, default cfg → delivered (was already correct)
- Direct context, `silentReply.direct: "allow"` → silenced (policy respected)
- No cfg → silenced (safe fallback)

## Behavior change summary

| Config | Before | After |
|---|---|---|
| Default (no override) | Silent in groups | **Silent in groups** (unchanged) |
| `silentReply.group: "disallow"` | Silent (bug) | **Failure copy delivered** (fixed) |
| `silentReply.direct: "allow"` | Delivered (direct always unaffected) | **Silent** (now consistent) |