### PR TITLE
fix(ui): align chat header controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Azure OpenAI Responses: default unset Azure OpenAI API versions to `preview` so `/openai/v1/responses` calls use Azure's current Responses API route. (#82026) Thanks @leoge007.
+- Control UI/WebChat: compact the desktop chat header controls into a single aligned row so the session, model, thinking, and action controls no longer waste vertical space. Thanks @BunsDev.
 - Agents: retry empty final turns for generic `anthropic-messages` providers instead of limiting non-visible recovery to Kimi, so custom/proxied Anthropic-compatible routes can recover with a visible answer. Addresses #46080. Thanks @wmgx, @w1tv, and @iFwu.
 - Control UI: rotate browser service-worker caches per build so updated Gateways are less likely to keep serving stale dashboard bundles that trigger protocol mismatch errors.
 - Discord: report unresolved configured bot-token SecretRefs during startup instead of treating the account as unconfigured. (#82009) Thanks @giodl73-repo.

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1158,8 +1158,9 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 12px;
+  gap: 8px;
   flex-wrap: wrap;
+  min-height: 36px;
 }
 
 .chat-controls__session {
@@ -1179,8 +1180,9 @@
     minmax(128px, 4fr);
   grid-template-areas: "agent session model thinking";
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   width: 100%;
+  min-height: 36px;
   min-width: 0;
 }
 
@@ -1251,51 +1253,46 @@
 
 /* Controls separator */
 .chat-controls__separator {
-  color: rgba(255, 255, 255, 0.4);
-  font-size: 18px;
-  margin: 0 8px;
+  align-self: center;
+  flex: 0 0 1px;
+  width: 1px;
+  height: 22px;
+  margin: 0 3px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--border-strong) 72%, transparent);
+  color: transparent;
+  font-size: 0;
   font-weight: 300;
 }
 
-:root[data-theme-mode="light"] .chat-controls__separator {
-  color: rgba(16, 24, 40, 0.3);
+.chat-controls .btn--icon {
+  width: 36px;
+  min-width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: var(--radius-lg);
 }
 
-.chat-controls__session select {
-  padding: 6px 10px;
-  font-size: 13px;
+:root[data-theme-mode="light"] .chat-controls__separator {
+  background: rgba(16, 24, 40, 0.18);
+}
+
+.chat-controls__session select,
+.chat-controls__agent select,
+.chat-controls__model select,
+.chat-controls__thinking-select select {
+  box-sizing: border-box;
+  height: 36px;
+  min-height: 36px;
+  padding: 0 34px 0 12px;
   width: 100%;
   max-width: none;
+  border-color: color-mix(in srgb, var(--input) 88%, transparent);
+  border-radius: var(--radius-lg);
+  background-color: color-mix(in srgb, var(--card) 92%, var(--bg-elevated) 8%);
+  font-size: 13px;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.chat-controls__agent select {
-  width: 100%;
-  max-width: none;
-}
-
-.chat-controls__model select {
-  width: 100%;
-  max-width: none;
-}
-
-.chat-controls__thinking-select select {
-  width: 100%;
-  max-width: none;
-}
-
-.chat-controls__autoscroll {
-  min-width: 112px;
-  max-width: 118px;
-}
-
-.chat-controls__autoscroll-select {
-  width: 100%;
-  height: 32px;
-  min-width: 0;
-  padding: 4px 26px 4px 8px;
-  font-size: 12px;
 }
 
 .chat-controls__thinking {

--- a/ui/src/styles/chat/layout.test.ts
+++ b/ui/src/styles/chat/layout.test.ts
@@ -46,4 +46,15 @@ describe("chat layout styles", () => {
     expect(css).toContain("@media (display-mode: standalone) and (max-width: 768px)");
     expect(css).toContain("margin-bottom: calc(14px + max(var(--safe-area-bottom), 34px));");
   });
+
+  it("keeps desktop chat header controls on a compact aligned rhythm", () => {
+    const css = readLayoutCss();
+
+    expect(css).toContain("min-height: 36px;");
+    expect(css).toContain("height: 36px;");
+    expect(css).toContain(".chat-controls .btn--icon {");
+    expect(css).toContain("width: 36px;");
+    expect(css).toContain(".chat-controls__separator {");
+    expect(css).toContain("height: 22px;");
+  });
 });

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -983,6 +983,7 @@
 .content--chat .content-header.content-header--chat-hidden {
   opacity: 0;
   transform: translateY(-10px);
+  min-height: 0;
   max-height: 0px;
   padding-top: 0;
   padding-bottom: 0;
@@ -1108,19 +1109,30 @@
   grid-template-columns: minmax(0, 1fr) max-content;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding-bottom: 0;
+  gap: 10px;
+  min-height: 44px;
+  padding: 4px 8px;
   overflow: visible;
-  max-height: 56px;
+  max-height: 44px;
 }
 
 .content--chat .content-header > div:first-child {
+  display: grid;
+  align-items: center;
+  position: relative;
   text-align: left;
   min-width: 0;
 }
 
+.shell--chat-focus .content--chat .content-header {
+  min-height: 0;
+}
+
 .content--chat .page-meta {
+  align-self: center;
   justify-content: flex-end;
+  height: 36px;
+  align-items: center;
   min-width: max-content;
   overflow: visible;
 }
@@ -1128,6 +1140,19 @@
 .content--chat .chat-controls {
   flex-shrink: 0;
   flex-wrap: nowrap;
+  gap: 6px;
+}
+
+.content--chat .content-header .chat-controls__session-notice {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  width: min(100%, 680px);
+  min-height: 0;
+  overflow: hidden;
+  pointer-events: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ===========================================

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -4,10 +4,11 @@
 
 @media (max-width: 1320px) {
   .content--chat .content-header {
-    align-items: stretch;
+    align-items: center;
     gap: 8px;
     row-gap: 0;
-    max-height: 56px;
+    min-height: 44px;
+    max-height: 44px;
     overflow: visible;
   }
 
@@ -16,6 +17,9 @@
   }
 
   .content--chat .page-meta {
+    align-self: center;
+    height: 36px;
+    align-items: center;
     min-width: 0;
     justify-content: flex-end;
     flex-wrap: nowrap;
@@ -505,28 +509,18 @@
   }
 
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__thinking {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    justify-content: flex-end;
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    align-items: center;
+    justify-content: stretch;
+    gap: 8px;
     width: 100%;
     padding: 0;
   }
 
-  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__autoscroll {
-    flex: 1 1 100%;
-    max-width: none;
-    min-width: 0;
-  }
-
-  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__autoscroll-select {
-    width: 100%;
-    height: 40px;
-  }
-
   .chat-mobile-controls-wrapper .chat-controls-dropdown .btn--icon {
-    width: 44px;
-    min-width: 44px;
+    width: 100%;
+    min-width: 0;
     height: 44px;
   }
 

--- a/ui/src/styles/layout.mobile.test.ts
+++ b/ui/src/styles/layout.mobile.test.ts
@@ -16,11 +16,28 @@ function readGroupedChatCss(): string {
 describe("chat header responsive mobile styles", () => {
   it("keeps the chat header and session controls from clipping on narrow widths", () => {
     const css = readMobileCss();
+    const layoutCss = readLayoutCss();
 
     expect(css).toContain("@media (max-width: 1320px)");
     expect(css).toContain(".content--chat .content-header");
+    expect(css).toContain("max-height: 44px;");
+    expect(layoutCss).toContain(".content--chat .content-header .chat-controls__session-notice");
+    expect(layoutCss).toContain("position: absolute;");
     expect(css).toContain(".chat-controls__session-row");
     expect(css).toContain(".chat-controls__thinking-select");
+  });
+
+  it("lays out mobile chat header action icons as an even full-width grid", () => {
+    const css = readMobileCss();
+
+    expect(css).toContain(
+      ".chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__thinking",
+    );
+    expect(css).toContain("grid-template-columns: repeat(5, minmax(0, 1fr));");
+    expect(css).toContain(
+      ".chat-mobile-controls-wrapper .chat-controls-dropdown .btn--icon {\n    width: 100%;",
+    );
+    expect(css).toContain("height: 44px;");
   });
 });
 

--- a/ui/src/ui/app-render.helpers.browser.test.ts
+++ b/ui/src/ui/app-render.helpers.browser.test.ts
@@ -100,11 +100,12 @@ describe("chat header controls (browser)", () => {
       container.querySelectorAll<HTMLButtonElement>(".chat-controls .btn--icon[data-tooltip]"),
     );
 
-    expect(buttons).toHaveLength(5);
+    expect(buttons).toHaveLength(6);
 
     const labels = buttons.map((button) => button.getAttribute("data-tooltip"));
     expect(labels).toEqual([
       t("chat.refreshTitle"),
+      `${t("chat.autoScrollMode")}: ${t("chat.autoScrollNearBottom")}`,
       t("chat.thinkingToggle"),
       t("chat.toolCallsToggle"),
       t("chat.focusToggle"),
@@ -162,7 +163,9 @@ describe("chat header controls (browser)", () => {
       container.querySelectorAll<HTMLButtonElement>(".chat-controls__thinking .btn--icon"),
     );
 
-    expect(buttons).toHaveLength(4);
+    expect(buttons).toHaveLength(5);
+    const autoScrollButton = requireButton(buttons.at(0), "auto-scroll mode");
+    expect(autoScrollButton.dataset.chatAutoScrollMode).toBe("near-bottom");
     const cronButton = requireButton(buttons.at(-1), "cron sessions");
     expect([...cronButton.classList]).toEqual(["btn", "btn--sm", "btn--icon", "active"]);
     expect(cronButton.getAttribute("aria-pressed")).toBe("true");
@@ -173,26 +176,29 @@ describe("chat header controls (browser)", () => {
     expect(state.sessionsHideCron).toBe(false);
   });
 
-  it("renders and applies the chat auto-scroll mode selector", async () => {
+  it("renders and applies the chat auto-scroll mode toggle", async () => {
     const applySettings = vi.fn();
     const state = createState({ applySettings });
     const container = document.createElement("div");
     render(renderChatControls(state), container);
     await Promise.resolve();
 
-    const select = requireElement(
-      container.querySelector<HTMLSelectElement>('[data-chat-auto-scroll-select="true"]'),
-      "auto-scroll select",
+    const toggle = requireButton(
+      container.querySelector<HTMLButtonElement>('[data-chat-auto-scroll-toggle="true"]'),
+      "auto-scroll toggle",
     );
-    expect(select.getAttribute("aria-label")).toBe(t("chat.autoScrollMode"));
-    expect(select.value).toBe("near-bottom");
+    expect(toggle.getAttribute("aria-label")).toBe(
+      `${t("chat.autoScrollMode")}: ${t("chat.autoScrollNearBottom")}`,
+    );
+    expect(toggle.getAttribute("data-tooltip")).toBe(toggle.getAttribute("aria-label"));
+    expect(toggle.dataset.chatAutoScrollMode).toBe("near-bottom");
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
 
-    select.value = "off";
-    select.dispatchEvent(new Event("change"));
+    toggle.click();
 
     expect(applySettings).toHaveBeenCalledWith({
       ...state.settings,
-      chatAutoScroll: "off",
+      chatAutoScroll: "always",
     });
   });
 
@@ -229,12 +235,16 @@ describe("chat header controls (browser)", () => {
     const selectDatasets = Array.from(container.querySelectorAll("select")).map(
       (select) => select.dataset,
     );
-    expect(selectDatasets).toHaveLength(5);
+    expect(selectDatasets).toHaveLength(4);
     expect(selectDatasets[0]?.chatAgentFilter).toBe("true");
     expect(selectDatasets[1]?.chatSessionSelect).toBe("true");
     expect(selectDatasets[2]?.chatModelSelect).toBe("true");
     expect(selectDatasets[3]?.chatThinkingSelect).toBe("true");
-    expect(selectDatasets[4]?.chatAutoScrollSelect).toBe("true");
+    const autoScrollToggle = requireButton(
+      container.querySelector<HTMLButtonElement>('[data-chat-auto-scroll-toggle="true"]'),
+      "auto-scroll toggle",
+    );
+    expect(autoScrollToggle.dataset.chatAutoScrollMode).toBe("near-bottom");
   });
 
   it("renders the mobile dropdown from state instead of mutating DOM classes", async () => {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -25,11 +25,7 @@ import {
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "./session-key.ts";
-import {
-  CHAT_AUTO_SCROLL_MODES,
-  normalizeChatAutoScrollMode,
-  type ChatAutoScrollMode,
-} from "./storage.ts";
+import { normalizeChatAutoScrollMode, type ChatAutoScrollMode } from "./storage.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "./string-coerce.ts";
 import type { ThemeMode } from "./theme.ts";
 import type { SessionsListResult } from "./types.ts";
@@ -276,37 +272,40 @@ function chatAutoScrollLabel(mode: ChatAutoScrollMode) {
   return t("chat.autoScrollNearBottom");
 }
 
-function renderChatAutoScrollSelect(state: AppViewState) {
+function nextChatAutoScrollMode(mode: ChatAutoScrollMode): ChatAutoScrollMode {
+  switch (mode) {
+    case "near-bottom":
+      return "always";
+    case "always":
+      return "off";
+    case "off":
+      return "near-bottom";
+  }
+  return "near-bottom";
+}
+
+function renderChatAutoScrollToggle(state: AppViewState) {
   const mode = normalizeChatAutoScrollMode(state.settings.chatAutoScroll);
-  const label = t("chat.autoScrollMode");
+  const label = `${t("chat.autoScrollMode")}: ${chatAutoScrollLabel(mode)}`;
+  const active = mode !== "off";
   return html`
-    <label class="field chat-controls__autoscroll" title=${label}>
-      <span class="agent-chat__sr-only">${label}</span>
-      <select
-        class="chat-controls__autoscroll-select"
-        data-chat-auto-scroll-select="true"
-        aria-label=${label}
-        title=${label}
-        .value=${mode}
-        @change=${(event: Event) => {
-          const nextMode = normalizeChatAutoScrollMode(
-            (event.currentTarget as HTMLSelectElement | null)?.value,
-          );
-          state.applySettings({
-            ...state.settings,
-            chatAutoScroll: nextMode,
-          });
-        }}
-      >
-        ${CHAT_AUTO_SCROLL_MODES.map(
-          (option) => html`
-            <option value=${option} ?selected=${option === mode}>
-              ${chatAutoScrollLabel(option)}
-            </option>
-          `,
-        )}
-      </select>
-    </label>
+    <button
+      class="btn btn--sm btn--icon ${active ? "active" : ""}"
+      data-chat-auto-scroll-toggle="true"
+      data-chat-auto-scroll-mode=${mode}
+      data-tooltip=${label}
+      aria-label=${label}
+      aria-pressed=${active}
+      title=${label}
+      @click=${() => {
+        state.applySettings({
+          ...state.settings,
+          chatAutoScroll: nextChatAutoScrollMode(mode),
+        });
+      }}
+    >
+      ${icons.scrollText}
+    </button>
   `;
 }
 
@@ -399,7 +398,7 @@ export function renderChatControls(state: AppViewState) {
         ${refreshIcon}
       </button>
       <span class="chat-controls__separator">|</span>
-      ${renderChatAutoScrollSelect(state)}
+      ${renderChatAutoScrollToggle(state)}
       <button
         class="btn btn--sm btn--icon ${showThinking ? "active" : ""}"
         ?disabled=${disableThinkingToggle}
@@ -564,7 +563,7 @@ export function renderChatMobileToggle(state: AppViewState) {
         <div class="chat-controls">
           ${renderChatSessionSelectBase(state, switchChatSession)}
           <div class="chat-controls__thinking">
-            ${renderChatAutoScrollSelect(state)}
+            ${renderChatAutoScrollToggle(state)}
             <button
               class="btn btn--sm btn--icon ${showThinking ? "active" : ""}"
               ?disabled=${disableThinkingToggle}


### PR DESCRIPTION
## Summary

- Problem: the WebChat header mixed 36px controls, a text auto-scroll select, and a visible separator in a row that could grow taller than necessary and align unevenly.
- Why it matters: the first chat viewport should stay compact, predictable, and scan-friendly on desktop and mobile.
- What changed: aligned desktop chat header controls to a 44px header / 36px control rhythm, replaced the auto-scroll select with an icon toggle + tooltip, and made mobile action icons a five-column full-width grid.
- What did NOT change (scope boundary): broader composer hit-target issues remain out of scope; issue #45656 appears related but is not closed by this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #45656
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: chat header control alignment, compact height, auto-scroll affordance, and mobile action icon distribution.
- Real environment tested: local OpenClaw Control UI against a loopback gateway on macOS.
- Exact steps or command run after this patch: opened `http://localhost:5173/chat?session=main` with a paired local gateway, checked desktop at `1200x760`, checked mobile at `390x844`, opened the mobile chat settings dropdown.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Playwright snapshot showed desktop `.content-header` at `902x44`, session/model controls at `36px` height, and action buttons all at `36x36` with the same y-position. Mobile dropdown snapshot showed the action grid at `346px` wide with five evenly spaced `62x44` icon buttons.
- Observed result after fix: desktop controls align on one row with a minimal 44px header; mobile action icons span the full dropdown row evenly.
- What was not tested: cross-browser visual rendering beyond Playwright's Chromium-backed browser session.
- Before evidence (optional but encouraged): original attached screenshot showed the text auto-scroll select and action buttons sitting on a taller, visually uneven row.

## Root Cause (if applicable)

- Root cause: the header allowed mixed intrinsic control heights and included a full text auto-scroll select in the compact action cluster.
- Missing detection / guardrail: CSS/style tests covered clipping but not exact desktop rhythm or mobile action-grid distribution.
- Contributing context (if known): the session notice participated in header layout space even when the row needed to stay compact.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/styles/chat/layout.test.ts`, `ui/src/styles/layout.mobile.test.ts`, `ui/src/ui/app-render.helpers.browser.test.ts`
- Scenario the test should lock in: desktop control height/width rhythm, auto-scroll icon toggle rendering, and mobile five-column action grid.
- Why this is the smallest reliable guardrail: these tests lock the rendered controls and CSS contracts without broad snapshot churn.
- Existing test that already covers this (if any): existing browser render tests covered chat controls but expected the old select.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- The chat auto-scroll control is now an icon button with a tooltip. It cycles `Near bottom -> Always -> Off -> Near bottom`.
- Desktop chat header controls use a compact, aligned row.
- Mobile chat settings action icons span the dropdown row evenly.

## Diagram (if applicable)

```text
Before:
[selects] [refresh] [Near bottom dropdown] [icons] -> mixed heights and wider text control

After:
[selects] [refresh] [scroll icon] [icons] -> 44px header / 36px controls
Mobile after:
[action icon][action icon][action icon][action icon][action icon] -> full-width grid
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): local Control UI + loopback gateway
- Relevant config (redacted): local paired gateway token redacted

### Steps

1. Start the Control UI dev server and a loopback gateway.
2. Open `/chat?session=main` on desktop and mobile viewport widths.
3. Inspect the chat header and mobile chat settings dropdown.

### Expected

- Desktop chat header keeps exact compact alignment across selects and icon buttons.
- Mobile chat settings action icons span the available row evenly.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: desktop header alignment and mobile dropdown grid with Playwright snapshots; auto-scroll toggle behavior through browser-rendered tests.
- Edge cases checked: `Off` remains an inactive `aria-pressed=false` state in the cycle tests; mobile row keeps fixed 44px icon height.
- What you did **not** verify: Safari/Firefox-specific rendering.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: icon-only auto-scroll control could be less obvious than text.
  - Mitigation: the button keeps mode-specific tooltip, aria-label, title, and pressed state.

## Verification

- `git diff --check`
- `pnpm changed:lanes --json`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md ui/src/ui/app-render.helpers.ts ui/src/ui/app-render.helpers.browser.test.ts ui/src/styles/layout.css ui/src/styles/layout.mobile.css ui/src/styles/chat/layout.css ui/src/styles/chat/layout.test.ts ui/src/styles/layout.mobile.test.ts`
- `pnpm lint:core`
- `pnpm test ui/src/styles/chat/layout.test.ts ui/src/styles/layout.mobile.test.ts ui/src/ui/app-render.helpers.browser.test.ts`
- `pnpm ui:build`
- Browser proof: Playwright snapshots at desktop `1200x760` and mobile `390x844`.
