### PR TITLE
fix(codex): use stable hooks feature flag

### DIFF
--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -13,7 +13,7 @@ describe("Codex native hook relay config", () => {
     });
 
     expect(config).toEqual({
-      "features.codex_hooks": true,
+      "features.hooks": true,
       "hooks.PreToolUse": [
         {
           matcher: null,
@@ -87,7 +87,7 @@ describe("Codex native hook relay config", () => {
         events: ["permission_request"],
       }),
     ).toEqual({
-      "features.codex_hooks": true,
+      "features.hooks": true,
       "hooks.PermissionRequest": [
         {
           matcher: null,
@@ -118,7 +118,7 @@ describe("Codex native hook relay config", () => {
 
   it("builds deterministic clearing config when the relay is disabled", () => {
     expect(buildCodexNativeHookRelayDisabledConfig()).toEqual({
-      "features.codex_hooks": false,
+      "features.hooks": false,
       "hooks.PreToolUse": [],
       "hooks.PostToolUse": [],
       "hooks.PermissionRequest": [],

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -27,7 +27,7 @@ export function buildCodexNativeHookRelayConfig(params: {
 }): JsonObject {
   const events = params.events?.length ? params.events : CODEX_NATIVE_HOOK_RELAY_EVENTS;
   const config: JsonObject = {
-    "features.codex_hooks": true,
+    "features.hooks": true,
   };
   for (const event of events) {
     const codexEvent = CODEX_HOOK_EVENT_BY_NATIVE_EVENT[event];
@@ -51,7 +51,7 @@ export function buildCodexNativeHookRelayConfig(params: {
 
 export function buildCodexNativeHookRelayDisabledConfig(): JsonObject {
   return {
-    "features.codex_hooks": false,
+    "features.hooks": false,
     "hooks.PreToolUse": [],
     "hooks.PostToolUse": [],
     "hooks.PermissionRequest": [],

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -624,11 +624,11 @@ describe("Codex plugin thread config", () => {
   it("merges app config with native hook config", () => {
     expect(
       mergeCodexThreadConfigs(
-        { "features.codex_hooks": true, hooks: { PreToolUse: [] } },
+        { "features.hooks": true, hooks: { PreToolUse: [] } },
         { apps: { _default: { enabled: false } } },
       ),
     ).toEqual({
-      "features.codex_hooks": true,
+      "features.hooks": true,
       hooks: { PreToolUse: [] },
       apps: { _default: { enabled: false } },
     });

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2797,7 +2797,7 @@ describe("runCodexAppServerAttempt", () => {
     const startRequest = harness.requests.find((request) => request.method === "thread/start");
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
-    expect(startConfig?.["features.codex_hooks"]).toBe(true);
+    expect(startConfig?.["features.hooks"]).toBe(true);
     const preToolUseHooks = startConfig?.["hooks.PreToolUse"] as
       | Array<{ hooks?: Array<{ command?: string; timeout?: number; type?: string }> }>
       | undefined;
@@ -2885,7 +2885,7 @@ describe("runCodexAppServerAttempt", () => {
     const startRequest = harness.requests.find((request) => request.method === "thread/start");
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
-    expect(startConfig?.["features.codex_hooks"]).toBe(true);
+    expect(startConfig?.["features.hooks"]).toBe(true);
     expect(Array.isArray(startConfig?.["hooks.PreToolUse"])).toBe(true);
     expect(Array.isArray(startConfig?.["hooks.PostToolUse"])).toBe(true);
     expect(Array.isArray(startConfig?.["hooks.Stop"])).toBe(true);
@@ -2921,7 +2921,7 @@ describe("runCodexAppServerAttempt", () => {
     const startRequest = harness.requests.find((request) => request.method === "thread/start");
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
-    expect(startConfig?.["features.codex_hooks"]).toBe(true);
+    expect(startConfig?.["features.hooks"]).toBe(true);
     expect(Array.isArray(startConfig?.["hooks.PermissionRequest"])).toBe(true);
     const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
     expect(
@@ -3061,7 +3061,7 @@ describe("runCodexAppServerAttempt", () => {
     const startRequest = harness.requests.find((request) => request.method === "thread/start");
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
-    expect(startConfig?.["features.codex_hooks"]).toBe(false);
+    expect(startConfig?.["features.hooks"]).toBe(false);
     expect(startConfig?.["hooks.PreToolUse"]).toEqual([]);
     expect(startConfig?.["hooks.PostToolUse"]).toEqual([]);
     expect(startConfig?.["hooks.PermissionRequest"]).toEqual([]);
@@ -5145,7 +5145,7 @@ describe("runCodexAppServerAttempt", () => {
       throw new Error(`unexpected method: ${method}`);
     });
     const config = {
-      "features.codex_hooks": true,
+      "features.hooks": true,
       "hooks.PreToolUse": [],
     };
     const expectedConfig = {
@@ -5204,7 +5204,7 @@ describe("runCodexAppServerAttempt", () => {
       cwd: workspaceDir,
       dynamicTools: [],
       appServer,
-      config: { "features.codex_hooks": true, hooks: { PreToolUse: [] } },
+      config: { "features.hooks": true, hooks: { PreToolUse: [] } },
       pluginThreadConfig: {
         enabled: true,
         inputFingerprint: "plugin-apps-input-1",
@@ -5217,7 +5217,7 @@ describe("runCodexAppServerAttempt", () => {
     const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
     expect(requestCalls.map(([method]) => method)).toEqual(["thread/start"]);
     expect(requestCalls[0]?.[1].config).toEqual({
-      "features.codex_hooks": true,
+      "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": true,
       hooks: { PreToolUse: [] },
@@ -5257,7 +5257,7 @@ describe("runCodexAppServerAttempt", () => {
       cwd: workspaceDir,
       dynamicTools: [],
       appServer,
-      config: { "features.codex_hooks": true },
+      config: { "features.hooks": true },
       pluginThreadConfig: {
         enabled: true,
         inputFingerprint: "plugin-apps-input-1",
@@ -5270,7 +5270,7 @@ describe("runCodexAppServerAttempt", () => {
       cwd: workspaceDir,
       dynamicTools: [],
       appServer,
-      config: { "features.codex_hooks": true },
+      config: { "features.hooks": true },
       pluginThreadConfig: {
         enabled: true,
         inputFingerprint: "plugin-apps-input-1",
@@ -5284,13 +5284,13 @@ describe("runCodexAppServerAttempt", () => {
     const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
     expect(requestCalls.map(([method]) => method)).toEqual(["thread/start", "thread/resume"]);
     expect(requestCalls[0]?.[1].config).toEqual({
-      "features.codex_hooks": true,
+      "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": true,
       ...createPluginAppConfigPatch(),
     });
     expect(requestCalls[1]?.[1].config).toEqual({
-      "features.codex_hooks": true,
+      "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": true,
     });
@@ -5750,7 +5750,7 @@ describe("runCodexAppServerAttempt", () => {
     const resumeRequest = requests.find((request) => request.method === "thread/resume");
     const resumeRequestParams = resumeRequest?.params as Record<string, unknown> | undefined;
     const resumeConfig = resumeRequestParams?.config as Record<string, unknown> | undefined;
-    expect(resumeConfig?.["features.codex_hooks"]).toBe(true);
+    expect(resumeConfig?.["features.hooks"]).toBe(true);
     expect(resumeConfig?.["features.code_mode"]).toBe(true);
     expect(resumeConfig?.["features.code_mode_only"]).toBe(true);
     expect(resumeRequestParams?.developerInstructions).toContain(CODEX_GPT5_BEHAVIOR_CONTRACT);

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -61,13 +61,13 @@ describe("Codex app-server native code mode config", () => {
       appServer: createAppServerOptions() as never,
       developerInstructions: "test instructions",
       config: {
-        "features.codex_hooks": true,
+        "features.hooks": true,
         apps: { _default: { enabled: false } },
       },
     });
 
     expect(request.config).toEqual({
-      "features.codex_hooks": true,
+      "features.hooks": true,
       apps: { _default: { enabled: false } },
       "features.code_mode": true,
       "features.code_mode_only": true,
@@ -101,14 +101,14 @@ describe("Codex app-server native code mode config", () => {
         developerInstructions: "test instructions",
         config: {
           project_doc_max_bytes: 64_000,
-          "features.codex_hooks": true,
+          "features.hooks": true,
         },
       },
     );
 
     expect(request.config).toEqual({
       project_doc_max_bytes: 0,
-      "features.codex_hooks": true,
+      "features.hooks": true,
       "features.code_mode": true,
       "features.code_mode_only": true,
     });


### PR DESCRIPTION
## Summary

OpenClaw's Codex app-server native hook relay now emits the stable `features.hooks` flag instead of the deprecated `features.codex_hooks` flag. This keeps the generated per-thread config aligned with current Codex CLI behavior and removes the confusing Settings warning when the user's own `config.toml` is clean.

## Verification

- `codex --version && codex features list`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/native-hook-relay.test.ts extensions/codex/src/app-server/plugin-thread-config.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `git diff --check`
- `rg -n "features\\.codex_hooks|codex_hooks" extensions/codex src packages docs test -g '!node_modules'`

## Real Behavior Proof

Behavior addressed: OpenClaw-generated Codex app-server thread config no longer injects the deprecated `features.codex_hooks` key for native hook relay setup or clearing.

Real environment tested: Local OpenClaw source checkout on macOS with `codex-cli 0.129.0`; `codex features list` reports `hooks stable true` and does not list `codex_hooks`.

Exact steps or command run after this patch: Ran the focused Codex extension Vitest command above against the four affected app-server test files.

Evidence after fix: `buildCodexNativeHookRelayConfig()` and `buildCodexNativeHookRelayDisabledConfig()` now emit `features.hooks`; the app-server tests assert the new key through native relay, thread lifecycle, plugin config merging, start, and resume paths.

Observed result after fix: 4 test files passed with 159 tests passed.

What was not tested: Did not rebuild and install the npm package or manually reopen the Codex desktop Settings screen from an installed OpenClaw package.
