### PR TITLE
fix(failover): preserve rate_limit profile failure reason over timeout precedence (#81902)

### DIFF
--- a/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
@@ -100,6 +100,48 @@ describe("handleAssistantFailover", () => {
       expect(events).toEqual(["advance", "mark-start", "mark-finish"]);
     });
 
+    it("preserves rate_limit profile failure reason when racing the idle-timeout watchdog (#81902)", async () => {
+      const maybeMarkAuthProfileFailure = vi.fn(async () => {});
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          assistantProfileFailureReason: "rate_limit",
+          timedOut: true,
+          lastProfileId: "google:p1",
+          billingFailure: false,
+          rateLimitFailure: true,
+          maybeMarkAuthProfileFailure,
+          advanceAuthProfile: vi.fn(async () => true),
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      await vi.waitFor(() => expect(maybeMarkAuthProfileFailure).toHaveBeenCalledTimes(1));
+      expect(maybeMarkAuthProfileFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ profileId: "google:p1", reason: "rate_limit" }),
+      );
+    });
+
+    it("still skips cooldown marking when only timedOut is set without a concrete reason", async () => {
+      const maybeMarkAuthProfileFailure = vi.fn(async () => {});
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "timeout" },
+          failoverReason: "timeout",
+          timedOut: true,
+          assistantProfileFailureReason: null,
+          lastProfileId: "anthropic:p1",
+          billingFailure: false,
+          maybeMarkAuthProfileFailure,
+          advanceAuthProfile: vi.fn(async () => true),
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      expect(maybeMarkAuthProfileFailure).not.toHaveBeenCalled();
+    });
+
     it("does not log profile-specific warnings without a failed profile id", async () => {
       const warn = vi.fn();
       const outcome = await handleAssistantFailover(

--- a/src/agents/pi-embedded-runner/run/assistant-failover.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.ts
@@ -99,7 +99,18 @@ export async function handleAssistantFailover(params: {
   if (decision.action === "rotate_profile") {
     const failedProfileId = params.lastProfileId;
     const timeoutFailure = params.timedOut || params.idleTimedOut;
-    const failureReason = timeoutFailure ? "timeout" : params.assistantProfileFailureReason;
+    // Preserve a concrete classified profile failure reason (e.g. rate_limit)
+    // over generic timeout when both signals are present, so a 429 racing the
+    // idle-timeout watchdog still drives auth-profile cooldown via
+    // markAuthProfileFailure. Pure-timeout attempts continue to skip cooldown
+    // marking via the failureReason === "timeout" early return below (#81902).
+    const concreteProfileFailureReason: AuthProfileFailureReason | null =
+      params.assistantProfileFailureReason && params.assistantProfileFailureReason !== "timeout"
+        ? params.assistantProfileFailureReason
+        : null;
+    const failureReason: AuthProfileFailureReason | null =
+      concreteProfileFailureReason ??
+      (timeoutFailure ? "timeout" : params.assistantProfileFailureReason);
     const markFailedProfile = async () => {
       if (!failedProfileId || !failureReason || failureReason === "timeout") {
         return;


### PR DESCRIPTION
## Summary

- Fixes #81902. In `handleAssistantFailover`'s `rotate_profile` branch (`src/agents/pi-embedded-runner/run/assistant-failover.ts:101`), `failureReason` was set to `"timeout"` whenever `timedOut || idleTimedOut` was true, even when the caller had already classified the attempt's `assistantProfileFailureReason` as `"rate_limit"`. `markFailedProfile` then short-circuits on `failureReason === "timeout"`, so a 429 racing the idle-timeout watchdog never reached `markAuthProfileFailure` and the affected auth profile stayed eligible for round-robin instead of entering cooldown — matching the reporter's repeated-Google-profile symptom in `embedded_run_failover_decision` logs.
- Per the clawsweeper review: preserve a concrete classified profile failure reason over generic timeout when both signals are present, while keeping pure-timeout attempts out of auth-profile cooldown. Pure-timeout attempts continue to fall through the `failureReason === "timeout"` early return.

## Real behavior proof

Behavior addressed: When both `timedOut: true` and `assistantProfileFailureReason: "rate_limit"` are present, the rotate-profile branch now invokes `maybeMarkAuthProfileFailure` with `reason: "rate_limit"` instead of skipping cooldown marking. Pure-timeout attempts (`timedOut: true`, `assistantProfileFailureReason: null`) still skip cooldown marking, preserving the documented "pure timeouts should not blacklist profiles" contract.

Real environment tested: Real `darwin/arm64` `node v22` driver running the exact `failureReason` computation from `assistant-failover.ts:99` verbatim (pre-patch and patched), driven against three production-shape inputs: Google 429 racing idle-timeout (reporter symptom), pure idle-timeout, pure rate-limit. Stdout shows the side-by-side decision table including whether `markFailedProfile` would call `maybeMarkAuthProfileFailure`. Focused regression coverage in `src/agents/pi-embedded-runner/run/assistant-failover.test.ts` exercises the same cases through the real `handleAssistantFailover` export.

Exact steps or command run after this patch:
```
$ node /tmp/openclaw-failover-real-proof.mjs
```

Evidence after fix:
```
$ node /tmp/openclaw-failover-real-proof.mjs
case | timedOut | profileFailureReason | pre.failureReason | pre.markCalled | post.failureReason | post.markCalled
Google 429 racing idle-timeout (reporter symptom) | true | rate_limit | timeout | false | rate_limit | true
Pure idle-timeout (no upstream classification) | true | null | timeout | false | timeout | false
Pure rate-limit (no timeout) | false | rate_limit | rate_limit | true | rate_limit | true
```

Observed result after fix: For the reporter's case (`timedOut: true` + `assistantProfileFailureReason: "rate_limit"`) the patched computation returns `failureReason: "rate_limit"` and `markFailedProfile` calls `maybeMarkAuthProfileFailure` (was: `failureReason: "timeout"` + skipped). The pure idle-timeout case still resolves to `"timeout"` and skips cooldown marking — the existing pure-timeout contract is preserved. The pre-existing rate-limit-without-timeout case is unaffected.

What was not tested: Live Google-quota exhaustion run against a real OAuth-backed profile pool — the bug is in the failover decision boundary itself, fully exercised by the driver above against the real computation. Happy to provide live proof if maintainers can wire up a quota-exhausted Google profile in Crabbox/Testbox; the source-level coverage matches the `AGENTS.md` maintainer-skip clause.
