### PR TITLE
fix: deliver generated media as structured attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/WebChat: compact the desktop chat header controls into a single aligned row so the session, model, thinking, and action controls no longer waste vertical space. Thanks @BunsDev.
 - Agents: retry empty final turns for generic `anthropic-messages` providers instead of limiting non-visible recovery to Kimi, so custom/proxied Anthropic-compatible routes can recover with a visible answer. Addresses #46080. Thanks @wmgx, @w1tv, and @iFwu.
 - Agents/replies: strip workflow `<function_response>` scaffolding from user-visible sanitizer paths so raw tool output does not leak into chat history, transcript mirrors, or channel replies. Fixes #47444. Thanks @5toCode.
+- Agents/media: deliver generated image, music, and video results through structured attachments, keep message-tool-only Codex completions on the message tool, and fail completion handoff when expected media is not actually sent.
 - Control UI: rotate browser service-worker caches per build so updated Gateways are less likely to keep serving stale dashboard bundles that trigger protocol mismatch errors.
 - Discord: report unresolved configured bot-token SecretRefs during startup instead of treating the account as unconfigured. (#82009) Thanks @giodl73-repo.
 - CLI/config: preserve numeric-looking object keys such as Discord guild IDs during `config patch` recursive merges. (#81999) Thanks @giodl73-repo.

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -320,6 +320,45 @@ describe("createCodexDynamicToolBridge", () => {
     ]);
   });
 
+  it("records message tool media attachment aliases as delivery evidence", async () => {
+    const toolResult = {
+      content: [{ type: "text", text: "Sent." }],
+      details: { messageId: "message-1" },
+    } satisfies AgentToolResult<unknown>;
+    const tool = createTool({
+      name: "message",
+      execute: vi.fn(async () => toolResult),
+    });
+    const bridge = createCodexDynamicToolBridge({
+      tools: [tool],
+      signal: new AbortController().signal,
+    });
+
+    const result = await handleMessageToolCall(bridge, {
+      action: "send",
+      text: "song attached",
+      media: "/tmp/generated-song.mp3",
+      attachments: [{ filePath: "/tmp/generated-cover.png" }],
+    });
+
+    expect(result).toEqual(expectInputText("Sent."));
+    expect(bridge.telemetry.didSendViaMessagingTool).toBe(true);
+    expect(bridge.telemetry.messagingToolSentMediaUrls).toEqual([
+      "/tmp/generated-song.mp3",
+      "/tmp/generated-cover.png",
+    ]);
+    expect(bridge.telemetry.messagingToolSentTargets).toEqual([
+      {
+        tool: "message",
+        provider: "message",
+        to: undefined,
+        threadId: undefined,
+        text: "song attached",
+        mediaUrls: ["/tmp/generated-song.mp3", "/tmp/generated-cover.png"],
+      },
+    ]);
+  });
+
   it("records internal UI source replies separately from outbound messaging evidence", async () => {
     const toolResult = textToolResult("Sent to current chat.", {
       status: "ok",

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -417,11 +417,32 @@ function readFirstString(record: Record<string, unknown>, keys: string[]): strin
 
 function collectMediaUrls(record: Record<string, unknown>): string[] {
   const urls: string[] = [];
-  for (const key of ["mediaUrl", "media_url", "imageUrl", "image_url"]) {
-    const value = record[key];
+  const pushMediaUrl = (value: unknown) => {
     if (typeof value === "string" && value.trim()) {
       urls.push(value.trim());
     }
+  };
+  const pushAttachment = (value: unknown) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return;
+    }
+    const attachment = value as Record<string, unknown>;
+    for (const key of ["media", "mediaUrl", "path", "filePath", "fileUrl"]) {
+      pushMediaUrl(attachment[key]);
+    }
+  };
+  for (const key of [
+    "media",
+    "mediaUrl",
+    "media_url",
+    "path",
+    "filePath",
+    "fileUrl",
+    "imageUrl",
+    "image_url",
+  ]) {
+    const value = record[key];
+    pushMediaUrl(value);
   }
   for (const key of ["mediaUrls", "media_urls", "imageUrls", "image_urls"]) {
     const value = record[key];
@@ -429,9 +450,13 @@ function collectMediaUrls(record: Record<string, unknown>): string[] {
       continue;
     }
     for (const entry of value) {
-      if (typeof entry === "string" && entry.trim()) {
-        urls.push(entry.trim());
-      }
+      pushMediaUrl(entry);
+    }
+  }
+  const attachments = record.attachments;
+  if (Array.isArray(attachments)) {
+    for (const attachment of attachments) {
+      pushAttachment(attachment);
     }
   }
   return urls;

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -427,7 +427,7 @@ function collectMediaUrls(record: Record<string, unknown>): string[] {
       return;
     }
     const attachment = value as Record<string, unknown>;
-    for (const key of ["media", "mediaUrl", "path", "filePath", "fileUrl"]) {
+    for (const key of ["media", "mediaUrl", "path", "filePath", "fileUrl", "url"]) {
       pushMediaUrl(attachment[key]);
     }
   };

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -918,6 +918,37 @@ describe("runCodexAppServerAttempt", () => {
     expect(dynamicToolNames).toContain("music_generate");
   });
 
+  it("keeps forced message dynamic tool when toolsAllow is empty", async () => {
+    __testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("message"),
+      createRuntimeDynamicTool("music_generate"),
+    ]);
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.sourceReplyDeliveryMode = "message_tool_only";
+    params.toolsAllow = [];
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await harness.waitForMethod("turn/start", 120_000);
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const startRequest = harness.requests.find((entry) => entry.method === "thread/start");
+    const dynamicToolNames =
+      (
+        startRequest?.params as { dynamicTools?: Array<{ name?: string }> } | undefined
+      )?.dynamicTools?.map((tool) => tool.name) ?? [];
+
+    expect(dynamicToolNames).toEqual(["message"]);
+  });
+
   it("starts Codex threads with searchable OpenClaw dynamic tools by default", async () => {
     __testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("message"),

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -886,6 +886,38 @@ describe("runCodexAppServerAttempt", () => {
     expect(__testing.shouldForceMessageTool(params)).toBe(false);
   });
 
+  it("keeps forced message dynamic tool when toolsAllow omits it", async () => {
+    __testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("message"),
+      createRuntimeDynamicTool("music_generate"),
+    ]);
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.sourceReplyDeliveryMode = "message_tool_only";
+    params.toolsAllow = ["music_generate"];
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await harness.waitForMethod("turn/start", 120_000);
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const startRequest = harness.requests.find((entry) => entry.method === "thread/start");
+    const dynamicToolNames =
+      (
+        startRequest?.params as { dynamicTools?: Array<{ name?: string }> } | undefined
+      )?.dynamicTools?.map((tool) => tool.name) ?? [];
+
+    expect(dynamicToolNames).toContain("message");
+    expect(dynamicToolNames).toContain("music_generate");
+  });
+
   it("starts Codex threads with searchable OpenClaw dynamic tools by default", async () => {
     __testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("message"),

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2344,8 +2344,11 @@ function includeForcedMessageToolAllow(
   if (!shouldForceMessageTool(params)) {
     return toolsAllow;
   }
-  if (!toolsAllow?.length) {
+  if (toolsAllow === undefined) {
     return toolsAllow;
+  }
+  if (toolsAllow.length === 0) {
+    return ["message"];
   }
   const normalized = new Set(toolsAllow.map((name) => normalizeCodexDynamicToolName(name)));
   return normalized.has("message") ? toolsAllow : [...toolsAllow, "message"];

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2322,7 +2322,8 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelHasVision,
     hasInboundImages: (params.images?.length ?? 0) > 0,
   });
-  const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, params.toolsAllow);
+  const toolsAllow = includeForcedMessageToolAllow(params.toolsAllow, params);
+  const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   return normalizeAgentRuntimeTools({
     runtimePlan: params.runtimePlan,
     tools: filteredTools,
@@ -2334,6 +2335,20 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelApi: params.model.api,
     model: params.model,
   });
+}
+
+function includeForcedMessageToolAllow(
+  toolsAllow: string[] | undefined,
+  params: EmbeddedRunAttemptParams,
+): string[] | undefined {
+  if (!shouldForceMessageTool(params)) {
+    return toolsAllow;
+  }
+  if (!toolsAllow?.length) {
+    return toolsAllow;
+  }
+  const normalized = new Set(toolsAllow.map((name) => normalizeCodexDynamicToolName(name)));
+  return normalized.has("message") ? toolsAllow : [...toolsAllow, "message"];
 }
 
 function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(

--- a/src/agents/generated-attachments.ts
+++ b/src/agents/generated-attachments.ts
@@ -1,0 +1,81 @@
+import { basenameFromAnyPath } from "../media/file-name.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+export type AgentGeneratedAttachment = {
+  type?: "image" | "audio" | "video" | "file";
+  path?: string;
+  url?: string;
+  mediaUrl?: string;
+  filePath?: string;
+  mimeType?: string;
+  name?: string;
+};
+
+export function generatedAttachmentReference(
+  attachment: AgentGeneratedAttachment,
+): string | undefined {
+  return normalizeOptionalString(
+    attachment.path ?? attachment.url ?? attachment.mediaUrl ?? attachment.filePath,
+  );
+}
+
+export function mediaUrlsFromGeneratedAttachments(
+  attachments: readonly AgentGeneratedAttachment[] | undefined,
+): string[] {
+  if (!attachments?.length) {
+    return [];
+  }
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  for (const attachment of attachments) {
+    const url = generatedAttachmentReference(attachment);
+    if (!url || seen.has(url)) {
+      continue;
+    }
+    seen.add(url);
+    urls.push(url);
+  }
+  return urls;
+}
+
+export function nameFromGeneratedAttachment(
+  attachment: AgentGeneratedAttachment,
+): string | undefined {
+  return (
+    normalizeOptionalString(attachment.name) ??
+    basenameFromAnyPath(generatedAttachmentReference(attachment) ?? "")
+  );
+}
+
+export function formatGeneratedAttachmentLines(
+  attachments: readonly AgentGeneratedAttachment[] | undefined,
+): string[] {
+  if (!attachments?.length) {
+    return [];
+  }
+  const lines = ["Attachments:"];
+  for (const [index, attachment] of attachments.entries()) {
+    const parts = [`${index + 1}.`];
+    const type = normalizeOptionalString(attachment.type);
+    const name = nameFromGeneratedAttachment(attachment);
+    const mimeType = normalizeOptionalString(attachment.mimeType);
+    const path = normalizeOptionalString(attachment.path ?? attachment.filePath);
+    const url = normalizeOptionalString(attachment.url ?? attachment.mediaUrl);
+    if (type) {
+      parts.push(`type=${type}`);
+    }
+    if (name) {
+      parts.push(`name=${JSON.stringify(name)}`);
+    }
+    if (mimeType) {
+      parts.push(`mimeType=${mimeType}`);
+    }
+    if (path) {
+      parts.push(`path=${JSON.stringify(path)}`);
+    } else if (url) {
+      parts.push(`url=${JSON.stringify(url)}`);
+    }
+    lines.push(parts.join(" "));
+  }
+  return lines;
+}

--- a/src/agents/generated-attachments.ts
+++ b/src/agents/generated-attachments.ts
@@ -73,7 +73,7 @@ export function formatGeneratedAttachmentLines(
     if (path) {
       parts.push(`path=${JSON.stringify(path)}`);
     } else if (url) {
-      parts.push(`url=${JSON.stringify(url)}`);
+      parts.push(`mediaUrl=${JSON.stringify(url)}`);
     }
     lines.push(parts.join(" "));
   }

--- a/src/agents/internal-events.ts
+++ b/src/agents/internal-events.ts
@@ -1,4 +1,8 @@
 import {
+  formatGeneratedAttachmentLines,
+  type AgentGeneratedAttachment,
+} from "./generated-attachments.js";
+import {
   AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION,
   type AgentInternalEventSource,
   type AgentInternalEventStatus,
@@ -20,6 +24,7 @@ type AgentTaskCompletionInternalEvent = {
   status: AgentInternalEventStatus;
   statusLabel: string;
   result: string;
+  attachments?: AgentGeneratedAttachment[];
   mediaUrls?: string[];
   statsLine?: string;
   replyInstruction: string;
@@ -57,6 +62,7 @@ function formatTaskCompletionEvent(event: AgentTaskCompletionInternalEvent): str
   const taskLabel = sanitizeSingleLineField(event.taskLabel, "unnamed task");
   const statusLabel = sanitizeSingleLineField(event.statusLabel, event.status);
   const result = formatChildResultDataBlock(event.result);
+  const attachmentLines = formatGeneratedAttachmentLines(event.attachments);
   const lines = [
     "[Internal task completion event]",
     `source: ${event.source}`,
@@ -68,6 +74,9 @@ function formatTaskCompletionEvent(event: AgentTaskCompletionInternalEvent): str
     "",
     result,
   ];
+  if (attachmentLines.length > 0) {
+    lines.push("", ...attachmentLines);
+  }
   if (event.statsLine?.trim()) {
     lines.push("", sanitizeMultilineField(event.statsLine, ""));
   }
@@ -82,6 +91,7 @@ function formatTaskCompletionEventForPlainPrompt(event: AgentTaskCompletionInter
   const taskLabel = sanitizeSingleLineField(event.taskLabel, "unnamed task");
   const statusLabel = sanitizeSingleLineField(event.statusLabel, event.status);
   const result = formatChildResultDataBlock(event.result);
+  const attachmentLines = formatGeneratedAttachmentLines(event.attachments);
   const lines = [
     "A background task completed. Use this result to reply to the user in your normal assistant voice.",
     "",
@@ -94,6 +104,9 @@ function formatTaskCompletionEventForPlainPrompt(event: AgentTaskCompletionInter
     "",
     result,
   ];
+  if (attachmentLines.length > 0) {
+    lines.push("", ...attachmentLines);
+  }
   if (event.statsLine?.trim()) {
     lines.push("", sanitizeMultilineField(event.statsLine, ""));
   }

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -322,8 +322,7 @@ export function createOpenClawTools(
   });
   options?.recordToolPrepStage?.("openclaw-tools:nodes-tool");
   const embedded = isEmbeddedMode();
-  const includeMessageTool =
-    Boolean(messageTool) && (!embedded || options?.sourceReplyDeliveryMode === "message_tool_only");
+  const includeMessageTool = !embedded || options?.sourceReplyDeliveryMode === "message_tool_only";
   const effectiveCallGateway = embedded
     ? createEmbeddedCallGateway()
     : openClawToolsDeps.callGateway;
@@ -358,7 +357,7 @@ export function createOpenClawTools(
               : {}),
           }),
         ]),
-    ...(includeMessageTool ? [messageTool] : []),
+    ...(messageTool && includeMessageTool ? [messageTool] : []),
     ...collectPresentOpenClawTools([heartbeatTool]),
     createTtsTool({
       agentChannel: options?.agentChannel,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -322,6 +322,8 @@ export function createOpenClawTools(
   });
   options?.recordToolPrepStage?.("openclaw-tools:nodes-tool");
   const embedded = isEmbeddedMode();
+  const includeMessageTool =
+    Boolean(messageTool) && (!embedded || options?.sourceReplyDeliveryMode === "message_tool_only");
   const effectiveCallGateway = embedded
     ? createEmbeddedCallGateway()
     : openClawToolsDeps.callGateway;
@@ -356,7 +358,7 @@ export function createOpenClawTools(
               : {}),
           }),
         ]),
-    ...(!embedded && messageTool ? [messageTool] : []),
+    ...(includeMessageTool ? [messageTool] : []),
     ...collectPresentOpenClawTools([heartbeatTool]),
     createTtsTool({
       agentChannel: options?.agentChannel,

--- a/src/agents/openclaw-tools.update-plan.test.ts
+++ b/src/agents/openclaw-tools.update-plan.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import { isUpdatePlanToolEnabledForOpenClawTools } from "./openclaw-tools.registration.js";
 import { isToolWrappedWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
@@ -44,6 +45,10 @@ function openAiGpt5Params(
 }
 
 describe("openclaw-tools update_plan gating", () => {
+  afterEach(() => {
+    setEmbeddedMode(false);
+  });
+
   it("keeps update_plan disabled by default", () => {
     expectUpdatePlanEnabled({ config: {} as OpenClawConfig }, false);
   });
@@ -82,6 +87,17 @@ describe("openclaw-tools update_plan gating", () => {
     expect(
       isToolWrappedWithBeforeToolCallHook(expectToolNamed(unwrappedTools, "sessions_list")),
     ).toBe(false);
+  });
+
+  it("keeps message tool in embedded message-tool-only completions", () => {
+    setEmbeddedMode(true);
+    const tools = createOpenClawTools({
+      config: {} as OpenClawConfig,
+      disablePluginTools: true,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    expect(toolNames(tools)).toContain("message");
   });
 
   it("registers update_plan when explicitly enabled", () => {

--- a/src/agents/pi-embedded-runner/delivery-evidence.ts
+++ b/src/agents/pi-embedded-runner/delivery-evidence.ts
@@ -39,6 +39,71 @@ function hasNonEmptyStringArray(value: unknown): boolean {
   return Array.isArray(value) && value.some(hasNonEmptyString);
 }
 
+function collectStringValues(value: unknown, output: Set<string>) {
+  if (typeof value === "string" && value.trim()) {
+    output.add(value.trim());
+    return;
+  }
+  if (!Array.isArray(value)) {
+    return;
+  }
+  for (const entry of value) {
+    if (typeof entry === "string" && entry.trim()) {
+      output.add(entry.trim());
+    }
+  }
+}
+
+function collectMediaUrlsFromRecord(record: Record<string, unknown>, output: Set<string>) {
+  collectStringValues(record.mediaUrl, output);
+  collectStringValues(record.mediaUrls, output);
+  collectStringValues(record.path, output);
+  collectStringValues(record.url, output);
+  collectStringValues(record.filePath, output);
+  const attachments = record.attachments;
+  if (Array.isArray(attachments)) {
+    for (const attachment of attachments) {
+      if (attachment && typeof attachment === "object" && !Array.isArray(attachment)) {
+        collectMediaUrlsFromRecord(attachment as Record<string, unknown>, output);
+      }
+    }
+  }
+}
+
+export function collectDeliveredMediaUrls(result: AgentDeliveryEvidence): string[] {
+  const urls = new Set<string>();
+  if (Array.isArray(result.payloads)) {
+    for (const payload of result.payloads) {
+      if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+        collectMediaUrlsFromRecord(payload as Record<string, unknown>, urls);
+      }
+    }
+  }
+  collectStringValues(result.messagingToolSentMediaUrls, urls);
+  if (Array.isArray(result.messagingToolSentTargets)) {
+    for (const target of result.messagingToolSentTargets) {
+      if (target && typeof target === "object" && !Array.isArray(target)) {
+        collectMediaUrlsFromRecord(target as Record<string, unknown>, urls);
+      }
+    }
+  }
+  return Array.from(urls);
+}
+
+export function hasDeliveredExpectedMedia(
+  result: AgentDeliveryEvidence,
+  expectedMediaUrls: readonly string[],
+): boolean {
+  const expected = Array.from(
+    new Set(expectedMediaUrls.map((url) => url.trim()).filter((url) => url.length > 0)),
+  );
+  if (expected.length === 0) {
+    return true;
+  }
+  const delivered = new Set(collectDeliveredMediaUrls(result));
+  return expected.every((url) => delivered.has(url));
+}
+
 function hasPositiveNumber(value: unknown): boolean {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }

--- a/src/agents/pi-embedded-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-tool-construction-plan.test.ts
@@ -59,6 +59,18 @@ describe("applyEmbeddedAttemptToolsAllow", () => {
     ]);
   });
 
+  it("materializes forced message tool through empty runtime allowlists", () => {
+    const tools = [{ name: "music_generate" }, { name: "message" }];
+    const toolsAllow = mergeForcedEmbeddedAttemptToolsAllow([], {
+      forceMessageTool: true,
+    });
+
+    expect(toolsAllow).toEqual(["message"]);
+    expect(applyEmbeddedAttemptToolsAllow(tools, toolsAllow).map((tool) => tool.name)).toEqual([
+      "message",
+    ]);
+  });
+
   it("normalizes explicit toolsAllow entries before filtering", () => {
     const tools = [{ name: "cron" }, { name: "read" }, { name: "message" }];
 
@@ -153,6 +165,24 @@ describe("resolveEmbeddedAttemptToolConstructionPlan", () => {
         includePluginTools: false,
       },
     });
+  });
+
+  it("constructs message tool for forced message delivery on explicit no-tools runs", () => {
+    expectConstructionPlan(
+      resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: [], forceMessageTool: true }),
+      {
+        constructTools: true,
+        includeCoreTools: true,
+        runtimeToolAllowlist: ["message"],
+        coding: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: false,
+          includeOpenClawTools: true,
+          includePluginTools: false,
+        },
+      },
+    );
   });
 
   it("materializes only plugin candidates for plugin-only allowlists", () => {

--- a/src/agents/pi-embedded-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-tool-construction-plan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   applyEmbeddedAttemptToolsAllow,
+  mergeForcedEmbeddedAttemptToolsAllow,
   resolveEmbeddedAttemptToolConstructionPlan,
   shouldBuildCoreCodingToolsForAllowlist,
   shouldCreateBundleLspRuntimeForAttempt,
@@ -43,6 +44,19 @@ describe("applyEmbeddedAttemptToolsAllow", () => {
     expect(
       applyEmbeddedAttemptToolsAllow(tools, ["exec", "read"]).map((tool) => tool.name),
     ).toEqual(["exec", "read"]);
+  });
+
+  it("keeps forced message tool through explicit runtime allowlists", () => {
+    const tools = [{ name: "music_generate" }, { name: "message" }];
+    const toolsAllow = mergeForcedEmbeddedAttemptToolsAllow(["music_generate"], {
+      forceMessageTool: true,
+    });
+
+    expect(toolsAllow).toEqual(["music_generate", "message"]);
+    expect(applyEmbeddedAttemptToolsAllow(tools, toolsAllow).map((tool) => tool.name)).toEqual([
+      "music_generate",
+      "message",
+    ]);
   });
 
   it("normalizes explicit toolsAllow entries before filtering", () => {
@@ -153,6 +167,27 @@ describe("resolveEmbeddedAttemptToolConstructionPlan", () => {
           includeShellTools: false,
           includeChannelTools: true,
           includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      },
+    );
+  });
+
+  it("materializes OpenClaw tools when a plugin-only allowlist forces message", () => {
+    expectConstructionPlan(
+      resolveEmbeddedAttemptToolConstructionPlan({
+        toolsAllow: ["memory_search"],
+        forceMessageTool: true,
+      }),
+      {
+        constructTools: true,
+        includeCoreTools: true,
+        runtimeToolAllowlist: ["memory_search", "message"],
+        coding: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: true,
+          includeOpenClawTools: true,
           includePluginTools: true,
         },
       },

--- a/src/agents/pi-embedded-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-tool-construction-plan.ts
@@ -113,8 +113,15 @@ export function mergeForcedEmbeddedAttemptToolsAllow(
   toolsAllow: string[] | undefined,
   params: { forceMessageTool?: boolean },
 ): string[] | undefined {
-  if (!params.forceMessageTool || !toolsAllow?.length || hasWildcardToolAllowlist(toolsAllow)) {
+  if (
+    !params.forceMessageTool ||
+    toolsAllow === undefined ||
+    hasWildcardToolAllowlist(toolsAllow)
+  ) {
     return toolsAllow;
+  }
+  if (toolsAllow.length === 0) {
+    return ["message"];
   }
   const normalized = new Set(toolsAllow.map((entry) => normalizeToolName(entry)));
   return normalized.has("message") ? toolsAllow : [...toolsAllow, "message"];

--- a/src/agents/pi-embedded-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-tool-construction-plan.ts
@@ -109,6 +109,17 @@ export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
   return tools.filter((tool) => isToolAllowedByPolicyName(tool.name, policy));
 }
 
+export function mergeForcedEmbeddedAttemptToolsAllow(
+  toolsAllow: string[] | undefined,
+  params: { forceMessageTool?: boolean },
+): string[] | undefined {
+  if (!params.forceMessageTool || !toolsAllow?.length || hasWildcardToolAllowlist(toolsAllow)) {
+    return toolsAllow;
+  }
+  const normalized = new Set(toolsAllow.map((entry) => normalizeToolName(entry)));
+  return normalized.has("message") ? toolsAllow : [...toolsAllow, "message"];
+}
+
 function resolveCodingToolConstructionPlanForAllowlist(
   toolsAllow?: string[],
 ): OpenClawCodingToolConstructionPlan {
@@ -148,6 +159,7 @@ export function resolveEmbeddedAttemptToolConstructionPlan(params: {
   disableTools?: boolean;
   isRawModelRun?: boolean;
   toolsAllow?: string[];
+  forceMessageTool?: boolean;
 }): {
   constructTools: boolean;
   includeCoreTools: boolean;
@@ -161,9 +173,10 @@ export function resolveEmbeddedAttemptToolConstructionPlan(params: {
       codingToolConstructionPlan: cloneCodingToolConstructionPlan(NO_CODING_TOOL_CONSTRUCTION_PLAN),
     };
   }
-  const codingToolConstructionPlan = resolveCodingToolConstructionPlanForAllowlist(
-    params.toolsAllow,
-  );
+  const toolsAllow = mergeForcedEmbeddedAttemptToolsAllow(params.toolsAllow, {
+    forceMessageTool: params.forceMessageTool,
+  });
+  const codingToolConstructionPlan = resolveCodingToolConstructionPlanForAllowlist(toolsAllow);
   const includeCoreTools =
     codingToolConstructionPlan.includeBaseCodingTools ||
     codingToolConstructionPlan.includeShellTools ||
@@ -176,7 +189,7 @@ export function resolveEmbeddedAttemptToolConstructionPlan(params: {
   return {
     constructTools,
     includeCoreTools,
-    ...(params.toolsAllow ? { runtimeToolAllowlist: params.toolsAllow } : {}),
+    ...(toolsAllow ? { runtimeToolAllowlist: toolsAllow } : {}),
     codingToolConstructionPlan,
   };
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -270,6 +270,7 @@ import { abortable as abortableWithSignal } from "./abortable.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 import {
   applyEmbeddedAttemptToolsAllow,
+  mergeForcedEmbeddedAttemptToolsAllow,
   resolveEmbeddedAttemptToolConstructionPlan,
   shouldCreateBundleLspRuntimeForAttempt,
   shouldCreateBundleMcpRuntimeForAttempt,
@@ -989,10 +990,18 @@ export async function runEmbeddedAttempt(
       });
     };
     const corePluginToolStages = createEmbeddedRunStageTracker();
+    const toolsAllowWithForcedRuntimeTools = mergeForcedEmbeddedAttemptToolsAllow(
+      params.toolsAllow,
+      {
+        forceMessageTool:
+          params.forceMessageTool === true ||
+          params.sourceReplyDeliveryMode === "message_tool_only",
+      },
+    );
     const toolConstructionPlan = resolveEmbeddedAttemptToolConstructionPlan({
       disableTools: params.disableTools,
       isRawModelRun,
-      toolsAllow: params.toolsAllow,
+      toolsAllow: toolsAllowWithForcedRuntimeTools,
     });
     const toolsEnabled = supportsModelTools(params.model);
     const codeModeConfig = resolveCodeModeConfig(params.config);
@@ -1010,9 +1019,14 @@ export async function runEmbeddedAttempt(
       !codeModeControlsEnabledForRun &&
       resolveToolSearchConfig(params.config).enabled;
     const effectiveToolsAllow =
-      toolSearchControlsEnabledForRun && params.toolsAllow
-        ? [...new Set([...params.toolsAllow, ...TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES])]
-        : params.toolsAllow;
+      toolSearchControlsEnabledForRun && toolsAllowWithForcedRuntimeTools
+        ? [
+            ...new Set([
+              ...toolsAllowWithForcedRuntimeTools,
+              ...TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES,
+            ]),
+          ]
+        : toolsAllowWithForcedRuntimeTools;
     const shouldConstructTools =
       toolConstructionPlan.constructTools ||
       toolSearchControlsEnabledForRun ||

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1187,6 +1187,43 @@ describe("messaging tool media URL tracking", () => {
     expect(ctx.state.pendingMessagingMediaUrls.has("tool-upload-file")).toBe(false);
   });
 
+  it("commits message attachment aliases as delivery evidence", async () => {
+    const { ctx } = createTestContext();
+
+    const startEvt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-attachment-aliases",
+      args: {
+        action: "send",
+        to: "channel:123",
+        content: "track ready",
+        media: "/tmp/generated-song.mp3",
+        attachments: [{ filePath: "/tmp/generated-cover.png" }],
+      },
+    };
+    await handleToolExecutionStart(ctx, startEvt);
+
+    const endEvt: ToolExecutionEndEvent = {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-attachment-aliases",
+      isError: false,
+      result: { ok: true },
+    };
+    await handleToolExecutionEnd(ctx, endEvt);
+
+    expect(ctx.state.messagingToolSentMediaUrls).toEqual([
+      "/tmp/generated-song.mp3",
+      "/tmp/generated-cover.png",
+    ]);
+    expectRecordFields(requireSingleMessagingTarget(ctx), "messaging target", {
+      to: "channel:123",
+      text: "track ready",
+      mediaUrls: ["/tmp/generated-song.mp3", "/tmp/generated-cover.png"],
+    });
+  });
+
   it("commits sendAttachment args as message delivery evidence", async () => {
     const { ctx } = createTestContext();
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -351,6 +351,7 @@ function collectMessagingMediaUrlsFromRecord(record: Record<string, unknown>): s
     pushUniqueMediaUrl(urls, seen, attachment.path);
     pushUniqueMediaUrl(urls, seen, attachment.filePath);
     pushUniqueMediaUrl(urls, seen, attachment.fileUrl);
+    pushUniqueMediaUrl(urls, seen, attachment.url);
   };
 
   pushUniqueMediaUrl(urls, seen, record.media);

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -341,16 +341,34 @@ function pushUniqueMediaUrl(urls: string[], seen: Set<string>, value: unknown): 
 function collectMessagingMediaUrlsFromRecord(record: Record<string, unknown>): string[] {
   const urls: string[] = [];
   const seen = new Set<string>();
+  const pushAttachment = (value: unknown) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return;
+    }
+    const attachment = value as Record<string, unknown>;
+    pushUniqueMediaUrl(urls, seen, attachment.media);
+    pushUniqueMediaUrl(urls, seen, attachment.mediaUrl);
+    pushUniqueMediaUrl(urls, seen, attachment.path);
+    pushUniqueMediaUrl(urls, seen, attachment.filePath);
+    pushUniqueMediaUrl(urls, seen, attachment.fileUrl);
+  };
 
   pushUniqueMediaUrl(urls, seen, record.media);
   pushUniqueMediaUrl(urls, seen, record.mediaUrl);
   pushUniqueMediaUrl(urls, seen, record.path);
   pushUniqueMediaUrl(urls, seen, record.filePath);
+  pushUniqueMediaUrl(urls, seen, record.fileUrl);
 
   const mediaUrls = record.mediaUrls;
   if (Array.isArray(mediaUrls)) {
     for (const mediaUrl of mediaUrls) {
       pushUniqueMediaUrl(urls, seen, mediaUrl);
+    }
+  }
+  const attachments = record.attachments;
+  if (Array.isArray(attachments)) {
+    for (const attachment of attachments) {
+      pushAttachment(attachment);
     }
   }
 

--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -39,12 +39,19 @@ describe("extractToolResultMediaPaths", () => {
             attachments: [
               { type: "audio", path: "/tmp/song.mp3", mimeType: "audio/mpeg" },
               { type: "image", url: "https://example.test/cover.png" },
+              { type: "file", media: "/tmp/stems.zip" },
+              { type: "file", fileUrl: "https://example.test/stems.zip" },
             ],
           },
         },
       }),
     ).toEqual({
-      mediaUrls: ["/tmp/song.mp3", "https://example.test/cover.png"],
+      mediaUrls: [
+        "/tmp/song.mp3",
+        "https://example.test/cover.png",
+        "/tmp/stems.zip",
+        "https://example.test/stems.zip",
+      ],
     });
   });
 

--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -31,6 +31,23 @@ describe("extractToolResultMediaPaths", () => {
     });
   });
 
+  it("extracts structured details.media attachments", () => {
+    expect(
+      extractToolResultMediaArtifact({
+        details: {
+          media: {
+            attachments: [
+              { type: "audio", path: "/tmp/song.mp3", mimeType: "audio/mpeg" },
+              { type: "image", url: "https://example.test/cover.png" },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      mediaUrls: ["/tmp/song.mp3", "https://example.test/cover.png"],
+    });
+  });
+
   it("returns empty array when content has no text or image blocks", () => {
     expect(extractToolResultMediaPaths({ content: [{ type: "other" }] })).toStrictEqual([]);
   });

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -379,10 +379,12 @@ function collectStructuredMediaUrls(media: Record<string, unknown>): string[] {
       return;
     }
     const attachment = value as Record<string, unknown>;
+    pushString(attachment.media);
     pushString(attachment.path);
     pushString(attachment.url);
     pushString(attachment.mediaUrl);
     pushString(attachment.filePath);
+    pushString(attachment.fileUrl);
   };
   if (typeof media.mediaUrl === "string" && media.mediaUrl.trim()) {
     urls.push(media.mediaUrl.trim());

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -365,16 +365,37 @@ function readToolResultDetailsMedia(
 
 function collectStructuredMediaUrls(media: Record<string, unknown>): string[] {
   const urls: string[] = [];
+  const pushString = (value: unknown) => {
+    if (typeof value !== "string") {
+      return;
+    }
+    const normalized = value.trim();
+    if (normalized) {
+      urls.push(normalized);
+    }
+  };
+  const pushAttachment = (value: unknown) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return;
+    }
+    const attachment = value as Record<string, unknown>;
+    pushString(attachment.path);
+    pushString(attachment.url);
+    pushString(attachment.mediaUrl);
+    pushString(attachment.filePath);
+  };
   if (typeof media.mediaUrl === "string" && media.mediaUrl.trim()) {
     urls.push(media.mediaUrl.trim());
   }
   if (Array.isArray(media.mediaUrls)) {
-    urls.push(
-      ...media.mediaUrls
-        .filter((value): value is string => typeof value === "string")
-        .map((value) => value.trim())
-        .filter(Boolean),
-    );
+    for (const value of media.mediaUrls) {
+      pushString(value);
+    }
+  }
+  if (Array.isArray(media.attachments)) {
+    for (const attachment of media.attachments) {
+      pushAttachment(attachment);
+    }
   }
   return Array.from(new Set(urls));
 }

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -10,6 +10,7 @@ import type { InlineCodeState } from "../markdown/code-spans.js";
 import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-spans.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { hasOrphanReasoningCloseBoundary } from "../shared/text/reasoning-tags.js";
+import { mediaUrlsFromGeneratedAttachments } from "./generated-attachments.js";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import {
   isMessagingToolDuplicateNormalized,
@@ -97,10 +98,11 @@ function collectPendingMediaFromInternalEvents(
   const pending: string[] = [];
   const seen = new Set<string>();
   for (const event of events) {
-    if (!Array.isArray(event.mediaUrls)) {
-      continue;
-    }
-    for (const mediaUrl of event.mediaUrls) {
+    const mediaUrls = [
+      ...(Array.isArray(event.mediaUrls) ? event.mediaUrls : []),
+      ...mediaUrlsFromGeneratedAttachments(event.attachments),
+    ];
+    for (const mediaUrl of mediaUrls) {
       const normalized = normalizeOptionalString(mediaUrl) ?? "";
       if (!normalized || seen.has(normalized)) {
         continue;

--- a/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
@@ -930,6 +930,15 @@ describe("createOpenClawCodingTools", () => {
     expect(toolNameList(cronTools)).toContain("message");
   });
 
+  it("keeps message available for message-tool-only source replies under the coding profile", () => {
+    const tools = createOpenClawCodingTools({
+      config: { tools: { profile: "coding" } },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    expect(toolNameList(tools)).toContain("message");
+  });
+
   it("keeps heartbeat response available for heartbeat runs under the coding profile", () => {
     const codingTools = createOpenClawCodingTools({
       config: { tools: { profile: "coding" } },

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -523,7 +523,9 @@ export function createOpenClawCodingTools(options?: {
     policy: TPolicy | undefined,
   ) => mergeAlsoAllowPolicy(policy, toolSearchControlAllowlist);
   const runtimeProfileAlsoAllow = [
-    ...(options?.forceMessageTool ? ["message"] : []),
+    ...(options?.forceMessageTool || options?.sourceReplyDeliveryMode === "message_tool_only"
+      ? ["message"]
+      : []),
     ...(forceHeartbeatTool ? [HEARTBEAT_RESPONSE_TOOL_NAME] : []),
     ...toolSearchControlAllowlist,
   ];

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1316,6 +1316,53 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("reports generated media completions when the announce agent replies text-only", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [
+          {
+            text: "The track is ready.",
+          },
+        ],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      sourceTool: "music_generate",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "music_generation",
+          childSessionKey: "music_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "music generation task",
+          taskLabel: "night-drive synthwave",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 track.",
+          attachments: [
+            {
+              type: "audio",
+              path: "/tmp/generated-night-drive.mp3",
+              mimeType: "audio/mpeg",
+              name: "generated-night-drive.mp3",
+            },
+          ],
+          replyInstruction: "Deliver the generated music.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: false,
+      path: "direct",
+      error: "completion agent did not deliver generated media",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("reports generated media group completions that miss required message-tool delivery", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -19,10 +19,12 @@ import {
   isInternalMessageChannel,
   normalizeMessageChannel,
 } from "../utils/message-channel.js";
+import { mediaUrlsFromGeneratedAttachments } from "./generated-attachments.js";
 import type { AgentInternalEvent } from "./internal-events.js";
 import {
   getAgentCommandDeliveryFailure,
   getGatewayAgentResult,
+  hasDeliveredExpectedMedia,
   hasMessagingToolDeliveryEvidence,
   hasVisibleAgentPayload,
 } from "./pi-embedded-runner/delivery-evidence.js";
@@ -497,6 +499,39 @@ function hasGatewayAgentMessagingToolDelivery(response: unknown): boolean {
   return Boolean(result && hasMessagingToolDeliveryEvidence(result));
 }
 
+function collectExpectedMediaFromInternalEvents(
+  events: AgentInternalEvent[] | undefined,
+): string[] {
+  if (!events?.length) {
+    return [];
+  }
+  const mediaUrls: string[] = [];
+  const seen = new Set<string>();
+  for (const event of events) {
+    const values = [
+      ...(Array.isArray(event.mediaUrls) ? event.mediaUrls : []),
+      ...mediaUrlsFromGeneratedAttachments(event.attachments),
+    ];
+    for (const value of values) {
+      const normalized = typeof value === "string" ? value.trim() : "";
+      if (!normalized || seen.has(normalized)) {
+        continue;
+      }
+      seen.add(normalized);
+      mediaUrls.push(normalized);
+    }
+  }
+  return mediaUrls;
+}
+
+function hasGatewayAgentDeliveredExpectedMedia(
+  response: unknown,
+  expectedMediaUrls: readonly string[],
+): boolean {
+  const result = getGatewayAgentResult(response);
+  return Boolean(result && hasDeliveredExpectedMedia(result, expectedMediaUrls));
+}
+
 function getGatewayAgentCommandDeliveryFailure(response: unknown): string | undefined {
   const result = getGatewayAgentResult(response);
   return result ? getAgentCommandDeliveryFailure(result) : undefined;
@@ -724,6 +759,18 @@ async function sendSubagentAnnounceDirectly(params: {
         delivered: false,
         path: "direct",
         error: "completion agent did not deliver through the message tool",
+      };
+    }
+    const expectedMediaUrls = collectExpectedMediaFromInternalEvents(params.internalEvents);
+    if (
+      agentMediatedCompletion &&
+      expectedMediaUrls.length > 0 &&
+      !hasGatewayAgentDeliveredExpectedMedia(directAnnounceResponse, expectedMediaUrls)
+    ) {
+      return {
+        delivered: false,
+        path: "direct",
+        error: "completion agent did not deliver generated media",
       };
     }
     const directDeliveryFailure = shouldDeliverAgentFinal

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -909,6 +909,8 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("private by default for this source channel");
     expect(prompt).toContain("use `message(action=send)` for visible channel output");
+    expect(prompt).toContain("Attach media with message-tool attachment fields");
+    expect(prompt).not.toContain("Attach media: `MEDIA:<path-or-url>`");
     expect(prompt).toContain("The target defaults to the current source channel");
     expect(prompt).toContain("final answers are private in this mode");
     expect(prompt).not.toContain("## Silent Replies");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -389,9 +389,22 @@ function buildTimeSection(params: { userTimezone?: string }) {
   return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
 }
 
-function buildAssistantOutputDirectivesSection(isMinimal: boolean) {
-  if (isMinimal) {
+function buildAssistantOutputDirectivesSection(params: {
+  isMinimal: boolean;
+  sourceMessageToolOnly: boolean;
+}) {
+  if (params.isMinimal) {
     return [];
+  }
+  if (params.sourceMessageToolOnly) {
+    return [
+      "## Assistant Output Directives",
+      "- Visible source-channel output is delivered through `message(action=send)`.",
+      "- Attach media with message-tool attachment fields such as `media`, `path`, or `filePath`; do not use legacy `MEDIA:` directives for source-channel delivery.",
+      "- Voice-note audio hint: use message-tool `asVoice` when sending audio as a voice note.",
+      "- Native quote/reply: use message-tool `replyTo` when an explicit reply target is needed.",
+      "",
+    ];
   }
   return [
     "## Assistant Output Directives",
@@ -403,7 +416,11 @@ function buildAssistantOutputDirectivesSection(isMinimal: boolean) {
   ];
 }
 
-function buildWebchatCanvasSection(params: { isMinimal: boolean; runtimeChannel?: string }) {
+function buildWebchatCanvasSection(params: {
+  isMinimal: boolean;
+  runtimeChannel?: string;
+  sourceMessageToolOnly: boolean;
+}) {
   if (params.isMinimal || params.runtimeChannel !== "webchat") {
     return [];
   }
@@ -411,7 +428,9 @@ function buildWebchatCanvasSection(params: { isMinimal: boolean; runtimeChannel?
     "## Control UI Embed",
     "Use `[embed ...]` only in Control UI/webchat sessions for inline rich rendering inside the assistant bubble.",
     "- Do not use `[embed ...]` for non-web channels.",
-    "- `[embed ...]` is separate from `MEDIA:`. Use `MEDIA:` for attachments; use `[embed ...]` for web-only rich rendering.",
+    params.sourceMessageToolOnly
+      ? "- `[embed ...]` is separate from message-tool attachments; use message-tool attachment fields for files and `[embed ...]` for web-only rich rendering."
+      : "- `[embed ...]` is separate from `MEDIA:`. Use `MEDIA:` for attachments; use `[embed ...]` for web-only rich rendering.",
     '- Use self-closing form for hosted embed documents: `[embed ref="cv_123" title="Status" height="320" /]`.',
     '- You may also use an explicit hosted URL: `[embed url="/__openclaw__/canvas/documents/cv_123/index.html" title="Status" height="320" /]`.',
     '- Never use local filesystem paths or `file://...` URLs in `[embed ...]`. Hosted embeds must point at `/__openclaw__/canvas/...` URLs or use `ref="..."`.',
@@ -1166,7 +1185,7 @@ export function buildAgentSystemPrompt(params: {
       "## Workspace Files (injected)",
       "These user-editable files are loaded by OpenClaw and included below in Project Context.",
       "",
-      ...buildAssistantOutputDirectivesSection(isMinimal),
+      ...buildAssistantOutputDirectivesSection({ isMinimal, sourceMessageToolOnly }),
     ];
 
     if (reasoningHint) {
@@ -1218,6 +1237,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildWebchatCanvasSection({
       isMinimal,
       runtimeChannel,
+      sourceMessageToolOnly,
     }),
     ...buildMessagingSection({
       isMinimal,

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -653,8 +653,9 @@ describe("createImageGenerateTool", () => {
     expect(details.paths).toEqual(["/tmp/generated-1.png", "/tmp/generated-2.png"]);
     expect(details.filename).toBe("cats/output.png");
     expect(details.revisedPrompts).toEqual(["A more cinematic cat"]);
-    expect(text).toContain("MEDIA:/tmp/generated-1.png");
-    expect(text).toContain("MEDIA:/tmp/generated-2.png");
+    expect(text).toContain('path="/tmp/generated-1.png"');
+    expect(text).toContain('path="/tmp/generated-2.png"');
+    expect(text).not.toMatch(/^MEDIA:/m);
   });
 
   it("uses configured timeoutMs for image generation and lets calls override it", async () => {
@@ -869,7 +870,7 @@ describe("createImageGenerateTool", () => {
     const text = resultText(result);
 
     expect(text).toContain(
-      "MEDIA:/home/openclaw/.openclaw/media/tool-image-generation/kodo_sawaki_zazen---3337a0ed-898a-4572-8950-0d288719f4f8.jpg",
+      'path="/home/openclaw/.openclaw/media/tool-image-generation/kodo_sawaki_zazen---3337a0ed-898a-4572-8950-0d288719f4f8.jpg"',
     );
     const details = resultDetails(result);
     const media = requireRecord(details.media, "media details");
@@ -1336,7 +1337,7 @@ describe("createImageGenerateTool", () => {
       "Generated 1 image with openai\\nMEDIA:/tmp/provider.png/gpt-image-1\\nMEDIA:/etc/model.png.",
     );
     expect(text).toContain("size=1024x1024\\nMEDIA:/etc/passwd\\t\\u2028\\u0000");
-    expect(parsed.mediaUrls).toEqual(["/tmp/generated.png"]);
+    expect(parsed.mediaUrls).toBeUndefined();
     const details = resultDetails(result);
     expect(details.provider).toBe("openai\nMEDIA:/tmp/provider.png");
     expect(details.model).toBe("gpt-image-1\nMEDIA:/etc/model.png");

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -33,6 +33,7 @@ import { saveMediaBuffer } from "../../media/store.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
+import { formatGeneratedAttachmentLines } from "../generated-attachments.js";
 import { optionalStringEnum } from "../schema/string-enum.js";
 import { ToolInputError, readNumberParam, readStringParam } from "./common.js";
 import { decodeDataUrl } from "./image-tool.helpers.js";
@@ -652,7 +653,7 @@ export function createImageGenerateTool(options?: {
     label: "Image Generation",
     name: "image_generate",
     description:
-      'Generate new images or edit reference images with the configured or inferred image-generation model. For transparent backgrounds, use outputFormat="png" or "webp" and background="transparent"; OpenAI also accepts openai.background and OpenClaw routes the default OpenAI image model to gpt-image-1.5 for that mode. Set agents.defaults.imageGenerationModel.primary to pick a provider/model. Providers declare their own auth/readiness; use action="list" to inspect registered providers, models, readiness, and auth hints. Generated images are delivered automatically from the tool result as MEDIA paths.',
+      'Generate new images or edit reference images with the configured or inferred image-generation model. For transparent backgrounds, use outputFormat="png" or "webp" and background="transparent"; OpenAI also accepts openai.background and OpenClaw routes the default OpenAI image model to gpt-image-1.5 for that mode. Set agents.defaults.imageGenerationModel.primary to pick a provider/model. Providers declare their own auth/readiness; use action="list" to inspect registered providers, models, readiness, and auth hints. Generated images are delivered automatically from structured tool-result attachments.',
     parameters: ImageGenerateToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -791,12 +792,16 @@ export function createImageGenerateTool(options?: {
       const revisedPrompts = result.images
         .map((image) => image.revisedPrompt?.trim())
         .filter((entry): entry is string => Boolean(entry));
+      const attachments = savedImages.map((image) => ({
+        type: "image" as const,
+        path: image.path,
+        mimeType: image.contentType,
+        name: image.id,
+      }));
       const lines = [
         `Generated ${savedImages.length} image${savedImages.length === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
         ...(warning ? [`Warning: ${warning}`] : []),
-        // Show the actual saved paths so the model does not invent a bogus
-        // local path when it references the generated image in a follow-up reply.
-        ...savedImages.map((image) => `MEDIA:${image.path}`),
+        ...formatGeneratedAttachmentLines(attachments),
       ];
 
       return {
@@ -807,7 +812,9 @@ export function createImageGenerateTool(options?: {
           count: savedImages.length,
           media: {
             mediaUrls: savedImages.map((image) => image.path),
+            attachments,
           },
+          attachments,
           paths: savedImages.map((image) => image.path),
           ...buildMediaReferenceDetails({
             entries: loadedReferenceImages,

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -13,6 +13,10 @@ import {
 } from "../../tasks/detached-task-runtime.js";
 import type { DeliveryContext } from "../../utils/delivery-context.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
+import {
+  mediaUrlsFromGeneratedAttachments,
+  type AgentGeneratedAttachment,
+} from "../generated-attachments.js";
 import { formatAgentInternalEventsForPrompt, type AgentInternalEvent } from "../internal-events.js";
 import { deliverSubagentAnnouncement } from "../subagent-announce-delivery.js";
 
@@ -59,6 +63,7 @@ type WakeMediaGenerationTaskCompletionParams = {
   status: "ok" | "error";
   statusLabel: string;
   result: string;
+  attachments?: AgentGeneratedAttachment[];
   mediaUrls?: string[];
   statsLine?: string;
 };
@@ -231,12 +236,12 @@ function buildMediaGenerationReplyInstruction(params: {
       return [
         `The ${params.completionLabel} is ready for the original channel/group chat.`,
         "This route requires message-tool delivery: the user will NOT see your normal assistant final reply.",
-        'Call the message tool with action="send" to the original/current chat, put a short caption in the message, and attach the generated media paths from the result.',
+        'Call the message tool with action="send" to the original/current chat, put a short caption in the message, and attach every structured attachment from the internal event.',
         `After the message tool succeeds, reply only ${SILENT_REPLY_TOKEN}.`,
-        "Do not put MEDIA: lines only in your final answer; that final answer is private in this chat.",
+        "Do not rely on text-only output; the media must be sent as message-tool attachments.",
       ].join(" ");
     }
-    return `Tell the user the ${params.completionLabel} is ready. If visible source delivery requires the message tool, send it there with the generated media attached.`;
+    return `Tell the user the ${params.completionLabel} is ready and include every structured attachment. If visible source delivery requires the message tool, send it there with those attachments.`;
   }
   return [
     `${params.completionLabel[0]?.toUpperCase() ?? "T"}${params.completionLabel.slice(1)} generation task failed.`,
@@ -251,6 +256,7 @@ async function wakeMediaGenerationTaskCompletion(params: {
   status: "ok" | "error";
   statusLabel: string;
   result: string;
+  attachments?: AgentGeneratedAttachment[];
   mediaUrls?: string[];
   statsLine?: string;
   eventSource: AgentInternalEvent["source"];
@@ -262,6 +268,12 @@ async function wakeMediaGenerationTaskCompletion(params: {
     return;
   }
   const announceId = `${params.toolName}:${params.handle.taskId}:${params.status}`;
+  const mediaUrls = Array.from(
+    new Set([
+      ...(params.mediaUrls ?? []),
+      ...mediaUrlsFromGeneratedAttachments(params.attachments),
+    ]),
+  );
   const internalEvents: AgentInternalEvent[] = [
     {
       type: "task_completion",
@@ -273,7 +285,8 @@ async function wakeMediaGenerationTaskCompletion(params: {
       status: params.status,
       statusLabel: params.statusLabel,
       result: params.result,
-      ...(params.mediaUrls?.length ? { mediaUrls: params.mediaUrls } : {}),
+      ...(params.attachments?.length ? { attachments: params.attachments } : {}),
+      ...(mediaUrls.length ? { mediaUrls } : {}),
       ...(params.statsLine?.trim() ? { statsLine: params.statsLine } : {}),
       replyInstruction: buildMediaGenerationReplyInstruction({
         status: params.status,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -188,6 +188,25 @@ function buildSendSchema(options: { includePresentation: boolean; includeDeliver
     caption: Type.Optional(Type.String()),
     path: Type.Optional(Type.String()),
     filePath: Type.Optional(Type.String()),
+    attachments: Type.Optional(
+      Type.Array(
+        Type.Object({
+          type: Type.Optional(stringEnum(["image", "audio", "video", "file"])),
+          media: Type.Optional(Type.String()),
+          mediaUrl: Type.Optional(Type.String()),
+          path: Type.Optional(Type.String()),
+          filePath: Type.Optional(Type.String()),
+          fileUrl: Type.Optional(Type.String()),
+          url: Type.Optional(Type.String()),
+          name: Type.Optional(Type.String()),
+          mimeType: Type.Optional(Type.String()),
+        }),
+        {
+          description:
+            "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+        },
+      ),
+    ),
     replyTo: Type.Optional(Type.String()),
     threadId: Type.Optional(Type.String()),
     asVoice: Type.Optional(Type.Boolean()),

--- a/src/agents/tools/music-generate-background.test.ts
+++ b/src/agents/tools/music-generate-background.test.ts
@@ -136,7 +136,7 @@ describe("music generate background helpers", () => {
     });
 
     expectReplyInstructionContains("the user will NOT see your normal assistant final reply");
-    expectReplyInstructionContains("Do not put MEDIA: lines only in your final answer");
+    expectReplyInstructionContains("the media must be sent as message-tool attachments");
   });
 
   it.each(["agent:main:discord:guild-123:channel-456", "agent:main:whatsapp:123@g.us"])(
@@ -162,7 +162,7 @@ describe("music generate background helpers", () => {
       });
 
       expectReplyInstructionContains("the user will NOT see your normal assistant final reply");
-      expectReplyInstructionContains("Do not put MEDIA: lines only in your final answer");
+      expectReplyInstructionContains("the media must be sent as message-tool attachments");
     },
   );
 

--- a/src/agents/tools/music-generate-background.ts
+++ b/src/agents/tools/music-generate-background.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { AgentGeneratedAttachment } from "../generated-attachments.js";
 import { MUSIC_GENERATION_TASK_KIND } from "../music-generation-task-status.js";
 import {
   createMediaGenerationTaskLifecycle,
@@ -41,6 +42,7 @@ export async function wakeMusicGenerationTaskCompletion(params: {
   status: "ok" | "error";
   statusLabel: string;
   result: string;
+  attachments?: AgentGeneratedAttachment[];
   mediaUrls?: string[];
   statsLine?: string;
 }) {

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -354,7 +354,8 @@ describe("createMusicGenerateTool", () => {
     );
     expect(text).toContain("Generated 1 track with google/lyria-3-clip-preview.");
     expect(text).toContain("Lyrics returned.");
-    expect(text).toContain("MEDIA:/tmp/generated-night-drive.mp3");
+    expect(text).toContain('path="/tmp/generated-night-drive.mp3"');
+    expect(text).not.toContain("MEDIA:");
     const details = detailsOf(result);
     expect(details.provider).toBe("google");
     expect(details.model).toBe("lyria-3-clip-preview");
@@ -363,6 +364,14 @@ describe("createMusicGenerateTool", () => {
     expect(details.lyrics).toEqual(["wake the city up"]);
     expect((details.media as { mediaUrls?: unknown }).mediaUrls).toEqual([
       "/tmp/generated-night-drive.mp3",
+    ]);
+    expect((details.media as { attachments?: unknown }).attachments).toEqual([
+      {
+        type: "audio",
+        path: "/tmp/generated-night-drive.mp3",
+        mimeType: "audio/mpeg",
+        name: "night-drive.mp3",
+      },
     ]);
     expect(details.paths).toEqual(["/tmp/generated-night-drive.mp3"]);
     expect(details.metadata).toEqual({ taskId: "music-task-1" });
@@ -570,7 +579,16 @@ describe("createMusicGenerateTool", () => {
     const wake = wakeCompletionCall();
     expect((wake.handle as { taskId?: unknown }).taskId).toBe("task-123");
     expect(wake.status).toBe("ok");
-    expect(wake.result).toContain("MEDIA:/tmp/generated-night-drive.mp3");
+    expect(wake.result).toContain('path="/tmp/generated-night-drive.mp3"');
+    expect(wake.result).not.toContain("MEDIA:");
+    expect(wake.attachments).toEqual([
+      {
+        type: "audio",
+        path: "/tmp/generated-night-drive.mp3",
+        mimeType: "audio/mpeg",
+        name: "night-drive.mp3",
+      },
+    ]);
   });
 
   it("lists provider capabilities", async () => {

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -27,6 +27,10 @@ import { resolveUserPath } from "../../utils.js";
 import type { DeliveryContext } from "../../utils/delivery-context.js";
 import { buildTimeoutAbortSignal } from "../../utils/fetch-timeout.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
+import {
+  formatGeneratedAttachmentLines,
+  type AgentGeneratedAttachment,
+} from "../generated-attachments.js";
 import { ToolInputError, readNumberParam, readStringParam } from "./common.js";
 import { decodeDataUrl } from "./image-tool.helpers.js";
 import { withMediaGenerationTaskKeepalive } from "./media-generate-background-shared.js";
@@ -401,6 +405,7 @@ type ExecutedMusicGeneration = {
   provider: string;
   model: string;
   savedPaths: string[];
+  attachments: AgentGeneratedAttachment[];
   contentText: string;
   details: Record<string, unknown>;
   wakeResult: string;
@@ -482,6 +487,12 @@ async function executeMusicGenerationJob(params: {
     ignoredOverrides.length > 0
       ? `Ignored unsupported overrides for ${result.provider}/${result.model}: ${ignoredOverrides.map((entry) => `${entry.key}=${String(entry.value)}`).join(", ")}.`
       : undefined;
+  const attachments: AgentGeneratedAttachment[] = savedTracks.map((track, index) => ({
+    type: "audio",
+    path: track.path,
+    mimeType: track.contentType,
+    name: result.tracks[index]?.fileName,
+  }));
   const lines = [
     `Generated ${savedTracks.length} track${savedTracks.length === 1 ? "" : "s"} with ${result.provider}/${result.model}.`,
     ...(warning ? [`Warning: ${warning}`] : []),
@@ -496,12 +507,13 @@ async function executeMusicGenerationJob(params: {
       ? `Duration normalized: requested ${requestedDurationSeconds}s; used ${appliedDurationSeconds}s.`
       : null,
     ...(result.lyrics?.length ? ["Lyrics returned.", ...result.lyrics] : []),
-    ...savedTracks.map((track) => `MEDIA:${track.path}`),
+    ...formatGeneratedAttachmentLines(attachments),
   ].filter((entry): entry is string => Boolean(entry));
   return {
     provider: result.provider,
     model: result.model,
     savedPaths: savedTracks.map((track) => track.path),
+    attachments,
     contentText: lines.join("\n"),
     wakeResult: lines.join("\n"),
     details: {
@@ -510,7 +522,9 @@ async function executeMusicGenerationJob(params: {
       count: savedTracks.length,
       media: {
         mediaUrls: savedTracks.map((track) => track.path),
+        attachments,
       },
+      attachments,
       paths: savedTracks.map((track) => track.path),
       ...buildTaskRunDetails(params.taskHandle),
       ...(!ignoredOverrideKeys.has("lyrics") && params.lyrics
@@ -719,7 +733,7 @@ export function createMusicGenerateTool(options?: {
                 status: "ok",
                 statusLabel: "completed successfully",
                 result: executed.wakeResult,
-                mediaUrls: executed.savedPaths,
+                attachments: executed.attachments,
               });
             } catch (error) {
               log.warn("Music generation completion wake failed after successful generation", {

--- a/src/agents/tools/video-generate-background.ts
+++ b/src/agents/tools/video-generate-background.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { AgentGeneratedAttachment } from "../generated-attachments.js";
 import { VIDEO_GENERATION_TASK_KIND } from "../video-generation-task-status.js";
 import {
   createMediaGenerationTaskLifecycle,
@@ -41,6 +42,7 @@ export async function wakeVideoGenerationTaskCompletion(params: {
   status: "ok" | "error";
   statusLabel: string;
   result: string;
+  attachments?: AgentGeneratedAttachment[];
   mediaUrls?: string[];
   statsLine?: string;
 }) {

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -501,7 +501,7 @@ describe("createVideoGenerateTool", () => {
 
     expect(saveSpy).not.toHaveBeenCalled();
     expect(text).toContain("Generated 1 video with vydra/veo3.");
-    expect(text).toContain('url="https://example.com/generated-lobster.mp4"');
+    expect(text).toContain('mediaUrl="https://example.com/generated-lobster.mp4"');
     expect(text).not.toContain("MEDIA:");
     const details = resultDetails(result);
     expect(details.provider).toBe("vydra");
@@ -552,7 +552,7 @@ describe("createVideoGenerateTool", () => {
     const text = (result.content?.[0] as { text: string } | undefined)?.text ?? "";
 
     expect(text).toContain("Generated 1 video with fal/fal-ai/minimax/video-01-live.");
-    expect(text).toContain('url="https://fal.run/files/generated-lobster.mp4"');
+    expect(text).toContain('mediaUrl="https://fal.run/files/generated-lobster.mp4"');
     expect(text).not.toContain("MEDIA:");
     const details = resultDetails(result);
     expect(details.provider).toBe("fal");
@@ -658,7 +658,7 @@ describe("createVideoGenerateTool", () => {
         name: "lobster.mp4",
       },
     ]);
-    expect(wake.result).toContain('url="https://example.com/generated-lobster.mp4"');
+    expect(wake.result).toContain('mediaUrl="https://example.com/generated-lobster.mp4"');
     expect(wake.result).not.toContain("MEDIA:");
   });
 

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -359,13 +359,22 @@ describe("createVideoGenerateTool", () => {
       "lobster.mp4",
     );
     expect(text).toContain("Generated 1 video with qwen/wan2.6-t2v.");
-    expect(text).toContain("MEDIA:/tmp/generated-lobster.mp4");
+    expect(text).toContain('path="/tmp/generated-lobster.mp4"');
+    expect(text).not.toContain("MEDIA:");
     const details = resultDetails(result);
     expect(details.provider).toBe("qwen");
     expect(details.model).toBe("wan2.6-t2v");
     expect(details.count).toBe(1);
     expect((details.media as { mediaUrls?: string[] }).mediaUrls).toEqual([
       "/tmp/generated-lobster.mp4",
+    ]);
+    expect((details.media as { attachments?: unknown }).attachments).toEqual([
+      {
+        type: "video",
+        path: "/tmp/generated-lobster.mp4",
+        mimeType: "video/mp4",
+        name: "generated-lobster.mp4",
+      },
     ]);
     expect(details.paths).toEqual(["/tmp/generated-lobster.mp4"]);
     expect(details.metadata).toEqual({ taskId: "task-1" });
@@ -492,7 +501,8 @@ describe("createVideoGenerateTool", () => {
 
     expect(saveSpy).not.toHaveBeenCalled();
     expect(text).toContain("Generated 1 video with vydra/veo3.");
-    expect(text).toContain("MEDIA:https://example.com/generated-lobster.mp4");
+    expect(text).toContain('url="https://example.com/generated-lobster.mp4"');
+    expect(text).not.toContain("MEDIA:");
     const details = resultDetails(result);
     expect(details.provider).toBe("vydra");
     expect(details.model).toBe("veo3");
@@ -542,7 +552,8 @@ describe("createVideoGenerateTool", () => {
     const text = (result.content?.[0] as { text: string } | undefined)?.text ?? "";
 
     expect(text).toContain("Generated 1 video with fal/fal-ai/minimax/video-01-live.");
-    expect(text).toContain("MEDIA:https://fal.run/files/generated-lobster.mp4");
+    expect(text).toContain('url="https://fal.run/files/generated-lobster.mp4"');
+    expect(text).not.toContain("MEDIA:");
     const details = resultDetails(result);
     expect(details.provider).toBe("fal");
     expect(details.model).toBe("fal-ai/minimax/video-01-live");
@@ -634,13 +645,21 @@ describe("createVideoGenerateTool", () => {
     const wake = firstMockCallArg(wakeSpy) as {
       handle: { taskId?: string };
       status: string;
-      mediaUrls: string[];
+      attachments: unknown[];
       result: string;
     };
     expect(wake.handle.taskId).toBe("task-123");
     expect(wake.status).toBe("ok");
-    expect(wake.mediaUrls).toEqual(["https://example.com/generated-lobster.mp4"]);
-    expect(wake.result).toContain("MEDIA:https://example.com/generated-lobster.mp4");
+    expect(wake.attachments).toEqual([
+      {
+        type: "video",
+        url: "https://example.com/generated-lobster.mp4",
+        mimeType: "video/mp4",
+        name: "lobster.mp4",
+      },
+    ]);
+    expect(wake.result).toContain('url="https://example.com/generated-lobster.mp4"');
+    expect(wake.result).not.toContain("MEDIA:");
   });
 
   it("surfaces provider generation failures inline when there is no detached session", async () => {

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -30,6 +30,10 @@ import type {
   VideoGenerationSourceAsset,
 } from "../../video-generation/types.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
+import {
+  formatGeneratedAttachmentLines,
+  type AgentGeneratedAttachment,
+} from "../generated-attachments.js";
 import { ToolInputError, readNumberParam, readStringParam } from "./common.js";
 import { decodeDataUrl } from "./image-tool.helpers.js";
 import { withMediaGenerationTaskKeepalive } from "./media-generate-background-shared.js";
@@ -540,6 +544,7 @@ type ExecutedVideoGeneration = {
   urlOnlyUrls: string[];
   /** Total generated video count, including url-only assets. */
   count: number;
+  attachments: AgentGeneratedAttachment[];
   contentText: string;
   details: Record<string, unknown>;
   wakeResult: string;
@@ -697,6 +702,20 @@ async function executeVideoGenerationJob(params: {
     ...savedVideos.map((video) => video.path),
     ...urlOnlyVideos.map((video) => video.url),
   ];
+  const attachments: AgentGeneratedAttachment[] = [
+    ...savedVideos.map((video) => ({
+      type: "video" as const,
+      path: video.path,
+      mimeType: video.contentType,
+      name: video.id,
+    })),
+    ...urlOnlyVideos.map((video) => ({
+      type: "video" as const,
+      url: video.url,
+      mimeType: video.mimeType,
+      name: video.fileName,
+    })),
+  ];
   const lines = [
     `Generated ${totalCount} video${totalCount === 1 ? "" : "s"} with ${result.provider}/${result.model}.`,
     ...(warning ? [`Warning: ${warning}`] : []),
@@ -705,8 +724,7 @@ async function executeVideoGenerationJob(params: {
     requestedDurationSeconds !== normalizedDurationSeconds
       ? `Duration normalized: requested ${requestedDurationSeconds}s; used ${normalizedDurationSeconds}s.`
       : null,
-    ...savedVideos.map((video) => `MEDIA:${video.path}`),
-    ...urlOnlyVideos.map((video) => `MEDIA:${video.url}`),
+    ...formatGeneratedAttachmentLines(attachments),
   ].filter((entry): entry is string => Boolean(entry));
 
   return {
@@ -715,6 +733,7 @@ async function executeVideoGenerationJob(params: {
     savedPaths: savedVideos.map((video) => video.path),
     urlOnlyUrls: urlOnlyVideos.map((video) => video.url),
     count: totalCount,
+    attachments,
     contentText: lines.join("\n"),
     wakeResult: lines.join("\n"),
     details: {
@@ -723,7 +742,9 @@ async function executeVideoGenerationJob(params: {
       count: totalCount,
       media: {
         mediaUrls: allMediaUrls,
+        attachments,
       },
+      attachments,
       paths: allMediaUrls,
       ...buildTaskRunDetails(params.taskHandle),
       ...buildMediaReferenceDetails({
@@ -1027,7 +1048,7 @@ export function createVideoGenerateTool(options?: {
                 status: "ok",
                 statusLabel: "completed successfully",
                 result: executed.wakeResult,
-                mediaUrls: [...executed.savedPaths, ...executed.urlOnlyUrls],
+                attachments: executed.attachments,
               });
             } catch (error) {
               log.warn("Video generation completion wake failed after successful generation", {

--- a/src/infra/outbound/message-action-param-keys.ts
+++ b/src/infra/outbound/message-action-param-keys.ts
@@ -3,6 +3,7 @@ import { normalizeOptionalString } from "../../shared/string-coerce.js";
 const STANDARD_MESSAGE_ACTION_PARAM_KEYS = new Set([
   "accountId",
   "asDocument",
+  "attachments",
   "base64",
   "bestEffort",
   "caption",

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -298,6 +298,41 @@ describe("runMessageAction media behavior", () => {
     expect(sendArgs.asVoice).toBe(true);
   });
 
+  it("sends structured attachments as media urls", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: workspacePlugin,
+        },
+      ]),
+    );
+
+    await withSandbox(async (sandboxDir) => {
+      const result = await runDrySend({
+        cfg: workspaceConfig,
+        actionParams: {
+          channel: "workspace",
+          target: "12345678",
+          message: "track ready",
+          attachments: [{ path: "./song.mp3" }, { filePath: "/workspace/cover.png" }],
+        },
+        sandboxRoot: sandboxDir,
+      });
+
+      expect(result.kind).toBe("send");
+      if (result.kind !== "send") {
+        throw new Error("expected send result");
+      }
+      expect(result.sendResult?.mediaUrl).toBe(path.join(sandboxDir, "song.mp3"));
+      expect(result.sendResult?.mediaUrls).toEqual([
+        path.join(sandboxDir, "song.mp3"),
+        path.join(sandboxDir, "cover.png"),
+      ]);
+    });
+  });
+
   describe("sendAttachment hydration", () => {
     const cfg = {
       channels: {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -468,6 +468,35 @@ type SendPayloadParts = {
   silent?: boolean;
 };
 
+function collectMessageAttachmentMediaHints(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const mediaUrls: string[] = [];
+  const seen = new Set<string>();
+  const pushMedia = (entry: unknown) => {
+    const normalized = normalizeOptionalString(entry);
+    if (!normalized || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    mediaUrls.push(normalized);
+  };
+  for (const attachment of value) {
+    if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
+      continue;
+    }
+    const record = attachment as Record<string, unknown>;
+    pushMedia(record.media);
+    pushMedia(record.mediaUrl);
+    pushMedia(record.path);
+    pushMedia(record.filePath);
+    pushMedia(record.fileUrl);
+    pushMedia(record.url);
+  }
+  return mediaUrls;
+}
+
 function hasExplicitRouteParam(params: Record<string, unknown>): boolean {
   for (const key of ["channel", "target", "to", "channelId"]) {
     if (normalizeOptionalString(params[key])) {
@@ -692,12 +721,14 @@ async function buildSendPayloadParts(params: {
     readStringParam(actionParams, "path", { trim: false }) ??
     readStringParam(actionParams, "filePath", { trim: false }) ??
     readStringParam(actionParams, "fileUrl", { trim: false });
+  const attachmentMediaHints = collectMessageAttachmentMediaHints(actionParams.attachments);
+  const hasMediaHint = Boolean(mediaHint) || attachmentMediaHints.length > 0;
   const hasPresentation = hasMessagePresentationBlocks(actionParams.presentation);
   const hasInteractive = hasInteractiveReplyBlocks(actionParams.interactive);
   const caption = readStringParam(actionParams, "caption", { allowEmpty: true }) ?? "";
   let message =
     readStringParam(actionParams, "message", {
-      required: !mediaHint && !hasPresentation && !hasInteractive,
+      required: !hasMediaHint && !hasPresentation && !hasInteractive,
       allowEmpty: true,
     }) ?? "";
   if (message.includes("\\n")) {
@@ -719,6 +750,9 @@ async function buildSendPayloadParts(params: {
     mergedMediaUrls.push(trimmed);
   };
   pushMedia(mediaHint);
+  for (const attachmentMediaHint of attachmentMediaHints) {
+    pushMedia(attachmentMediaHint);
+  }
   for (const url of parsed.mediaUrls ?? []) {
     pushMedia(url);
   }


### PR DESCRIPTION
Summary
- Deliver generated image/music/video outputs as structured attachments instead of legacy `MEDIA:` text.
- Keep `message` available for message-tool-only Codex completions across allowlists, tool profiles, and replay/tool construction.
- Add delivery evidence checks so generated-media completion handoff fails when expected media was not actually sent.
- Teach the message tool/send path to accept structured `attachments` and align telemetry aliases with real delivery.

Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt-tool-construction-plan.test.ts extensions/codex/src/app-server/run-attempt.test.ts src/agents/pi-embedded-subscribe.tools.media.test.ts src/infra/outbound/message-action-runner.media.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.media.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/subagent-announce-delivery.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/openclaw-tools.update-plan.test.ts src/agents/pi-tools.create-openclaw-coding-tools.test.ts src/agents/pi-embedded-runner/run/attempt-tool-construction-plan.test.ts`
- `git diff --check`
- `codex review --base origin/main` (clean after fixups)

Behavior addressed: generated media completion handoffs now carry message-tool-compatible structured attachments and require actual media delivery.
Real environment tested: local focused Vitest suites plus Codex autoreview.
Exact steps or command run after this patch: focused commands listed above.
Evidence after fix: tests cover generated attachment extraction, message-tool alias telemetry, real send-path `attachments`, forced message through explicit allowlists including empty allowlists, and completion delivery failure on text-only media replies.
Observed result after fix: Codex autoreview reported no blocking correctness issues.
What was not tested: live Hetzner/Discord/ClawSweeper end-to-end media post.
