### PR TITLE
fix: skip timeout-triggered compaction when run was aborted by user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/compaction: skip timeout-triggered compaction when the run was aborted by the user (Stop button). Previously, user-initiated aborts would still fire timeout compaction if context usage exceeded 65%, causing unnecessary compaction at an inappropriate time. Uses `externalAbort` (set only for user-initiated stops) rather than `aborted` (also set for internal timeouts) to correctly distinguish user aborts from provider timeouts.
 - Feishu: return bound subagent delivery origins from session thread setup so Feishu subagent completions route back to the same DM or topic. (#83190) Thanks @100menotu001.
 - CLI/update: tailor post-update Gateway recovery hints by platform, showing systemd, LaunchAgent, Scheduled Task, or generic service-manager guidance instead of macOS-only recovery text. (#83096) Thanks @rubencu.
 - Plugins: apply a default 15-second timeout to legacy `before_agent_start` hooks so hung plugin handlers no longer block agent startup. Fixes #48534. (#83136) Thanks @therahul-yo.

--- a/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
@@ -371,6 +371,7 @@ describe("timeout-triggered compaction", () => {
       makeAttemptResult({
         timedOut: true,
         aborted: true,
+        externalAbort: false,
         lastAssistant: {
           usage: { input: 180000 },
         } as never,
@@ -390,6 +391,26 @@ describe("timeout-triggered compaction", () => {
     expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.meta.error).toBeUndefined();
+  });
+
+  it("does not attempt compaction when user aborted (externalAbort=true)", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        timedOut: true,
+        aborted: true,
+        externalAbort: true,
+        lastAssistant: {
+          usage: { input: 180000 },
+        } as never,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    // User-initiated abort should skip timeout compaction entirely
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("timed out");
   });
 
   it("does not attempt compaction when timedOutDuringCompaction is true", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1688,7 +1688,7 @@ export async function runEmbeddedPiAgent(
           // ── Timeout-triggered compaction ──────────────────────────────────
           // When the LLM times out with high context usage, compact before
           // retrying to break the death spiral of repeated timeouts.
-          if (timedOut && !timedOutDuringCompaction && !timedOutDuringToolExecution) {
+          if (timedOut && !timedOutDuringCompaction && !timedOutDuringToolExecution && !externalAbort) {
             // Only consider prompt-side tokens here. API totals include output
             // tokens, which can make a long generation look like high context
             // pressure even when the prompt itself was small.
@@ -2639,7 +2639,7 @@ export async function runEmbeddedPiAgent(
             sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
           });
           const timedOutDuringPrompt =
-            timedOut && !timedOutDuringCompaction && !timedOutDuringToolExecution;
+            timedOut && !timedOutDuringCompaction && !timedOutDuringToolExecution && !externalAbort;
           const hasPartialAssistantTextAfterPromptTimeout =
             timedOutDuringPrompt &&
             (attempt.assistantTexts ?? []).some((text) => text.trim().length > 0) &&


### PR DESCRIPTION
## Summary

- Problem: When a user presses the Stop button to abort a run, the timeout-triggered compaction still fires if context usage exceeds 65%. This causes unnecessary compaction at an inappropriate time.
- Why it matters: User-initiated aborts should not trigger compaction. The user explicitly chose to stop, so compacting and retrying is wrong behavior.
- What changed: Added `!externalAbort` guard to both timeout-triggered compaction check and `timedOutDuringPrompt` evaluation in `runEmbeddedPiAgent`. `externalAbort` is set only for user-initiated stops (not internal timeouts), correctly distinguishing user aborts from provider timeouts.
- What did NOT change: Timeout-triggered compaction still works normally for actual provider timeouts. Only user-initiated aborts are excluded.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: Pressing Stop during a long LLM response with high context usage triggers timeout compaction instead of cleanly aborting.
- Real environment tested: OpenClaw gateway with high-context sessions, user-initiated abort via Stop button.
- Exact steps: Start a session that builds high context (>65%), press Stop button during LLM response timeout.
- Evidence after fix: Compaction is skipped when `externalAbort=true`. Error payload returned without compaction.
- Observed result after fix: Clean abort without unnecessary compaction.
- What was not tested: Internal provider timeout paths (unchanged, covered by existing tests).
- Unit test added: `run.timeout-triggered-compaction.test.ts` — "does not attempt compaction when user aborted (externalAbort=true)"

## Root Cause

- Root cause: The timeout-triggered compaction guard checked `timedOut`, `timedOutDuringCompaction`, and `timedOutDuringToolExecution` but did not check `externalAbort`. User-initiated aborts set both `aborted` and `externalAbort`, but the compaction code only looked at timeout-related flags.
- Missing detection: No test covered the `externalAbort=true` + `timedOut=true` combination for compaction.
- Contributing context: `externalAbort` was introduced to distinguish user stops from internal timeouts, but the compaction path was not updated.

## Regression Test Plan

- [x] Unit test
- Target test: `run.timeout-triggered-compaction.test.ts` — "does not attempt compaction when user aborted (externalAbort=true)"
- Scenario: `timedOut=true`, `aborted=true`, `externalAbort=true` → compaction should NOT fire.
- Why this is the smallest reliable guardrail: Direct unit test of the exact guard condition.

## User-visible / Behavior Changes

- Pressing Stop during a timeout with high context no longer triggers compaction. The run aborts cleanly.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: A legitimate timeout during user abort might not get compacted on retry.
  - Mitigation: User abort means no retry. The run ends. Compaction is unnecessary.