### PR TITLE
fix(auto-reply): honor silentReply policy on group failure-fallback path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/auto-reply: honor `agents.defaults.silentReply` and per-surface group silent-reply policy when generic agent-run failure fallbacks decide whether to send visible fallback text. Fixes #82060. (#82086) Thanks @taozengabc.
 - Control UI/WebChat: focus the composer when users click the visible input chrome and restore larger, labeled desktop composer controls while preserving compact mobile taps. Fixes #45656. Thanks @BunsDev.
 - System events: keep owner downgrades in structured metadata while rendering queued prompt text as plain `System:` lines, preserving least-privilege wakeups without prompt-visible trust labels. (#82067)
 - Providers/Xiaomi: preserve MiMo `reasoning_content` on multi-turn tool-call replay, including custom Xiaomi-compatible proxy routes, so follow-up turns no longer fail with `400 Param Incorrect`. Fixes #81419. (#81589) Thanks @lovelefeng-glitch and @jimdawdy-hub.

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -3151,6 +3151,46 @@ describe("runAgentTurnWithFallback", () => {
     },
   );
 
+  it("surfaces raw runner failure copy when per-surface silentReply.group is set to disallow", async () => {
+    state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error("openai-codex/gpt-5.5 ended with an incomplete terminal response"),
+    );
+
+    const followupRun = createFollowupRun();
+    followupRun.run.config = {
+      agents: {
+        defaults: {
+          silentReply: { group: "allow" },
+        },
+      },
+      surfaces: {
+        discord: {
+          silentReply: { group: "disallow" },
+        },
+      },
+    };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: {
+          Provider: "discord",
+          Surface: "discord",
+          ChatType: "group",
+          GroupSubject: "agent group",
+          GroupChannel: "#general",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
+    }
+  });
+
   it.each(["group", "channel"] as const)(
     "keeps default silent behavior in Discord %s chats when silentReply policy is unset",
     async (chatType) => {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -3112,6 +3112,80 @@ describe("runAgentTurnWithFallback", () => {
     },
   );
 
+  it.each(["group", "channel"] as const)(
+    "surfaces raw runner failure copy in Discord %s chats when silentReply.group is set to disallow",
+    async (chatType) => {
+      state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+        new Error("openai-codex/gpt-5.5 ended with an incomplete terminal response"),
+      );
+
+      const followupRun = createFollowupRun();
+      followupRun.run.config = {
+        agents: {
+          defaults: {
+            silentReply: { group: "disallow" },
+          },
+        },
+      };
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback(
+        createMinimalRunAgentTurnParams({
+          followupRun,
+          sessionCtx: {
+            Provider: "discord",
+            Surface: "discord",
+            ChatType: chatType,
+            GroupSubject: "agent group",
+            GroupChannel: "#general",
+            MessageSid: "msg",
+          } as unknown as TemplateContext,
+        }),
+      );
+
+      expect(result.kind).toBe("final");
+      if (result.kind === "final") {
+        expect(result.payload.text).not.toBe(SILENT_REPLY_TOKEN);
+        expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
+      }
+    },
+  );
+
+  it.each(["group", "channel"] as const)(
+    "keeps default silent behavior in Discord %s chats when silentReply policy is unset",
+    async (chatType) => {
+      // Sanity check: explicit `{}` config (no silentReply) must still resolve
+      // to the documented default `group: "allow"` and produce a silent payload
+      // — the new policy hookup must not regress the default behavior.
+      state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+        new Error("openai-codex/gpt-5.5 ended with an incomplete terminal response"),
+      );
+
+      const followupRun = createFollowupRun();
+      followupRun.run.config = {};
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback(
+        createMinimalRunAgentTurnParams({
+          followupRun,
+          sessionCtx: {
+            Provider: "discord",
+            Surface: "discord",
+            ChatType: chatType,
+            GroupSubject: "agent group",
+            GroupChannel: "#general",
+            MessageSid: "msg",
+          } as unknown as TemplateContext,
+        }),
+      );
+
+      expect(result.kind).toBe("final");
+      if (result.kind === "final") {
+        expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
+      }
+    },
+  );
+
   it("uses compact generic copy for raw runner failures in normal Discord direct chats", async () => {
     state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
       new Error("openai-codex/gpt-5.5 ended with an incomplete terminal response"),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -484,18 +484,12 @@ function resolveExternalRunFailureTextForConversation(params: {
   if (!params.isGenericRunnerFailure && !params.text.includes(AGENT_FAILED_BEFORE_REPLY_TEXT)) {
     return params.text;
   }
-  // Honor the documented `agents.defaults.silentReply` /
-  // `surfaces.<id>.silentReply` policy here so failure-fallback respects the
-  // same operator-visible knob that `route-reply.ts` already uses for
-  // `NO_REPLY`-style silent payloads. Defaults preserve the existing
-  // "groups/channels stay quiet on generic runner failure" behavior; opting
-  // into `silentReply.group: "disallow"` (or the per-surface override) lets
-  // the operator surface the failure copy in the chat instead.
-  // See docs/concepts/messages.md ("Silent replies") for the policy contract.
+  // Match normal reply routing: default group/channel failures stay silent,
+  // while explicit default or per-surface policy can surface the failure copy.
   const silentPolicy = resolveSilentReplyPolicy({
     cfg: params.cfg,
     sessionKey: params.sessionCtx.SessionKey,
-    surface: params.sessionCtx.Surface,
+    surface: params.sessionCtx.Surface ?? params.sessionCtx.Provider,
     conversationType: "group",
   });
   if (silentPolicy === "disallow") {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -39,6 +39,8 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { resolveSilentReplyPolicy } from "../../config/silent-reply.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, onAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -474,11 +476,29 @@ function resolveExternalRunFailureTextForConversation(params: {
   text: string;
   sessionCtx: TemplateContext;
   isGenericRunnerFailure: boolean;
+  cfg?: OpenClawConfig;
 }): string {
   if (!isNonDirectConversationContext(params.sessionCtx)) {
     return params.text;
   }
   if (!params.isGenericRunnerFailure && !params.text.includes(AGENT_FAILED_BEFORE_REPLY_TEXT)) {
+    return params.text;
+  }
+  // Honor the documented `agents.defaults.silentReply` /
+  // `surfaces.<id>.silentReply` policy here so failure-fallback respects the
+  // same operator-visible knob that `route-reply.ts` already uses for
+  // `NO_REPLY`-style silent payloads. Defaults preserve the existing
+  // "groups/channels stay quiet on generic runner failure" behavior; opting
+  // into `silentReply.group: "disallow"` (or the per-surface override) lets
+  // the operator surface the failure copy in the chat instead.
+  // See docs/concepts/messages.md ("Silent replies") for the policy contract.
+  const silentPolicy = resolveSilentReplyPolicy({
+    cfg: params.cfg,
+    sessionKey: params.sessionCtx.SessionKey,
+    surface: params.sessionCtx.Surface,
+    conversationType: "group",
+  });
+  if (silentPolicy === "disallow") {
     return params.text;
   }
   return SILENT_REPLY_TOKEN;
@@ -589,6 +609,7 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
   err: unknown;
   sessionCtx: TemplateContext;
   resolvedVerboseLevel: VerboseLevel | undefined;
+  cfg?: OpenClawConfig;
 }): ReplyPayload | undefined {
   const message = formatErrorMessage(params.err);
   const isFallbackSummary = isFallbackSummaryError(params.err);
@@ -601,6 +622,7 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
         text: BILLING_ERROR_USER_MESSAGE,
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: false,
+        cfg: params.cfg,
       }),
     });
   }
@@ -620,6 +642,7 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
         text: buildRateLimitCooldownMessage(params.err),
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: false,
+        cfg: params.cfg,
       }),
     });
   }
@@ -630,6 +653,7 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
         text: rateLimitOrOverloadedCopy,
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: false,
+        cfg: params.cfg,
       }),
     });
   }
@@ -645,6 +669,7 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
       text: externalRunFailureReply.text,
       sessionCtx: params.sessionCtx,
       isGenericRunnerFailure: false,
+      cfg: params.cfg,
     }),
   });
 }
@@ -2112,6 +2137,7 @@ export async function runAgentTurnWithFallback(params: {
                 text: switchErrorText,
                 sessionCtx: params.sessionCtx,
                 isGenericRunnerFailure: !shouldSurfaceToControlUi,
+                cfg: params.followupRun.run.config,
               }),
             }),
           };
@@ -2318,6 +2344,7 @@ export async function runAgentTurnWithFallback(params: {
         text: fallbackText,
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
+        cfg: params.followupRun.run.config,
       });
 
       params.replyOperation?.fail("run_failed", err);

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2161,6 +2161,7 @@ export async function runReplyAgent(params: {
       err: error,
       sessionCtx,
       resolvedVerboseLevel,
+      cfg,
     });
     if (knownFailurePayload) {
       replyOperation.fail("run_failed", error);


### PR DESCRIPTION
## Summary

- **Problem:** When an LLM run fails in a group/channel (LLM timeout, provider error, etc.), `resolveExternalRunFailureTextForConversation` hard-codes `SILENT_REPLY_TOKEN` for any non-direct conversation, regardless of `agents.defaults.silentReply` / `surfaces.<id>.silentReply`. Operators who explicitly configure `silentReply.group: "disallow"` to surface failures still see nothing in the chat.
- **Why it matters:** This is internally inconsistent with the rest of the reply pipeline: `src/auto-reply/reply/route-reply.ts:127` already routes `NO_REPLY`-style payloads through `resolveSilentReplyPolicy()`. The failure-fallback path bypassed the same knob, so groups that opt-in to visible failure copy still go silent — operators have no way to detect runtime failures in groups without scraping `gateway.log`.
- **What changed:** Threaded `cfg?: OpenClawConfig` through `buildKnownAgentRunFailureReplyPayload` → `resolveExternalRunFailureTextForConversation`, and called the existing `resolveSilentReplyPolicy({cfg, sessionKey, surface, conversationType: "group"})` helper before returning `SILENT_REPLY_TOKEN`. When policy resolves to `"disallow"`, the failure copy is returned instead of the silent sentinel.
- **What did NOT change (scope boundary):**
  - `DEFAULT_SILENT_REPLY_POLICY` is unchanged (`{ direct: "disallow", group: "allow", internal: "allow" }`), so out-of-the-box behavior — groups stay silent on generic runner failures — is preserved.
  - No new config keys, no new defaults, no new public APIs. Bug fix only.
  - `route-reply.ts` and `resolveSilentReplyPolicy` are not modified.
  - Direct-chat behavior is untouched (the silent branch was already group-only via `isNonDirectConversationContext`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #82060
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Failure-fallback path in groups/channels ignored `agents.defaults.silentReply` policy. Originally observed on a Feishu group (3 LLM-timeout failures in a row, all silently swallowed; only `gateway.log` showed the model fallback exhaustion). See #82060 for the redacted real-env logs of the original silent failures.
- **Real environment tested:** Not yet tested in a live channel runtime against the patched build. Coverage in this PR is mock unit tests against the actual code paths (see Tests). I deliberately scoped the proof package to internal-inconsistency + unit tests because:
  1. The pre-fix silent behavior is already documented with redacted real-env evidence in #82060 (Feishu group, 3 consecutive timeouts, no chat output).
  2. The fix reuses `resolveSilentReplyPolicy()` — the exact helper that `route-reply.ts:127` already calls — so the only new behavior is "this code path now consults the same policy the sibling path already consults".
  3. Default policy is unchanged; the only operator-visible change is that `silentReply.group: "disallow"` now does what it documents.
- **Exact steps or command run after this patch:**
  ```
  pnpm test src/auto-reply/reply/agent-runner-execution.test.ts
  pnpm test src/auto-reply/reply/route-reply.test.ts \
            src/auto-reply/reply/groups.test.ts \
            src/config/silent-reply.test.ts \
            src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
  pnpm tsgo:core
  pnpm exec oxfmt --check src/auto-reply/reply/agent-runner-execution.ts \
            src/auto-reply/reply/agent-runner-execution.test.ts \
            src/auto-reply/reply/agent-runner.ts
  pnpm check:import-cycles
  ```
- **Evidence after fix:**
  ```
  src/auto-reply/reply/agent-runner-execution.test.ts (80 tests) ✓
  src/auto-reply/reply/route-reply.test.ts            (26 tests) ✓
  src/config/silent-reply.test.ts                     ( 4 tests) ✓
  src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts (46 tests) ✓
  pnpm tsgo:core                                                ✓ EXIT=0
  pnpm exec oxfmt --check                                       ✓ All matched files use the correct format.
  pnpm check:import-cycles                                      ✓ 0 runtime value cycle(s).
  ```
  4 new unit tests added, behaviorally bracket the change matrix:
  - default `config: {}` + group/channel → still `SILENT_REPLY_TOKEN` (regression guard for default behavior)
  - `silentReply.group: "disallow"` + group/channel → returns visible failure copy (the new opt-in path)
- **Observed result after fix:** Default behavior preserved; `silentReply.group: "disallow"` now surfaces the failure copy in groups/channels.
- **What was not tested:**
  - End-to-end against a real channel runtime with the patched build deployed (Feishu/Discord/Telegram/Slack).
  - Per-surface override (`channels.feishu.silentReply.group: "disallow"`) — only tested via `agents.defaults.silentReply` because `resolveSilentReplyPolicy()` already handles surface-override resolution and is covered by `src/config/silent-reply.test.ts`.
  - Embedded-runner code path was patched (the inline `resolveExternalRunFailureTextForConversation` calls in `runAgentTurnWithFallback`) but only covered by the same mock unit-test harness, not by a runner-specific e2e.
- **Before evidence (optional but encouraged):** See #82060 for the original redacted Feishu group silent-failure logs.

## Root Cause (if applicable)

- **Root cause:** `resolveExternalRunFailureTextForConversation` short-circuits to `SILENT_REPLY_TOKEN` purely on `isNonDirectConversationContext(sessionCtx)`. The function predates `resolveSilentReplyPolicy()` (introduced in `src/config/silent-reply.ts` and adopted by `route-reply.ts`), and was never retrofitted to consult the same policy. The contract documented in `docs/concepts/messages.md:184-202` ("Silent replies … policy: `agents.defaults.silentReply` / `surfaces.<id>.silentReply`") therefore does not apply on the failure-fallback path — internally inconsistent with the rest of the reply pipeline.
- **Missing detection / guardrail:** No unit test asserted that the failure-fallback path honors `silentReply.group: "disallow"`. Existing tests only locked in the default-silent behavior (`"keeps raw runner failure boilerplate out of Discord %s chats"`).
- **Contributing context (if known):** `resolveSilentReplyPolicy()` was added later for the success path; the failure path was overlooked.

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/auto-reply/reply/agent-runner-execution.test.ts`
- **Scenario the test should lock in:** With `agents.defaults.silentReply.group: "disallow"` set on `followupRun.run.config`, a runner failure in a `group`/`channel` chat must produce visible failure copy, **not** `SILENT_REPLY_TOKEN`. Conversely, default config (no `silentReply` set) must still produce `SILENT_REPLY_TOKEN` in groups/channels (regression guard).
- **Why this is the smallest reliable guardrail:** The bug is purely in the policy-evaluation branch of one function; mocking the runner result and asserting the returned `payload.text` is the narrowest layer that exercises the exact buggy line.
- **Existing test that already covers this (if any):** None. The closest existing test (`"keeps raw runner failure boilerplate out of Discord %s chats"`) only covered the default-silent direction and is now joined by the opt-in counterpart.
- **If no new test is added, why not:** N/A — 4 new tests added.

## User-visible / Behavior Changes

- **Default behavior:** Unchanged. Groups/channels remain silent on generic runner failures.
- **Opt-in:** `agents.defaults.silentReply.group: "disallow"` (or per-surface `surfaces.<id>.silentReply.group: "disallow"`) now causes runner-failure copy to be sent to the chat instead of being silently dropped — matching the documented `silentReply` contract that already applies on the success path via `route-reply.ts`.

## Diagram (if applicable)

```text
Before (failure-fallback path):
  group/channel runner failure
    → resolveExternalRunFailureTextForConversation
        → isNonDirectConversationContext == true
            → return SILENT_REPLY_TOKEN   (always; ignores silentReply policy)

After:
  group/channel runner failure
    → resolveExternalRunFailureTextForConversation(cfg, ...)
        → isNonDirectConversationContext == true
            → resolveSilentReplyPolicy({cfg, sessionKey, surface, conversationType: "group"})
                → "disallow" → return failure copy text
                → "allow"    → return SILENT_REPLY_TOKEN   (default; unchanged)
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

No security impact. The change is a control-flow branch on an already-resolved policy value; failure copy that this PR can newly surface is the same copy `buildExternalRunFailureReply` already constructs and `route-reply.ts` already routes through `resolveSilentReplyPolicy` on the success path.

## Repro + Verification

### Environment

- OS: macOS 25.3.0 (arm64)
- Runtime/container: Node 25.8.0
- Model/provider: N/A for the test harness (mocked runner). Originating real-env observation: `litellm/bedrock-claude-opus-4-7` → fallback `litellm/bedrock-claude-sonnet-4-6`, both timing out at 120s on the LiteLLM HTTP layer.
- Integration/channel (if any): Original real-env observation on Feishu group (see #82060). Patch verified via mock unit tests in this PR.
- Relevant config (redacted):
  ```jsonc
  {
    "agents": {
      "defaults": {
        "silentReply": { "group": "disallow" }
      }
    }
  }
  ```

### Steps

1. Configure `agents.defaults.silentReply.group: "disallow"`.
2. Cause a runner failure in a group/channel (e.g. provider HTTP timeout exceeding `models.providers.<id>.timeoutSeconds`).
3. Observe the chat.

### Expected

- After patch: failure copy is delivered to the group (`"⚠️ ..."` or rate-limit / billing copy as resolved by existing branches).

### Actual

- Before patch: nothing reaches the group; only `gateway.log` shows the failure.
- After patch (verified via unit tests): failure copy is returned to the delivery layer; `payload.text !== SILENT_REPLY_TOKEN`.

## Evidence

- [x] Failing test/log before + passing after (4 new unit tests bracket the change; full output above)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:**
  - 4/4 new unit tests pass; `agent-runner-execution.test.ts` total 80/80 pass.
  - Adjacent suites green: `route-reply.test.ts` 26/26, `silent-reply.test.ts` 4/4, `agent-runner.runreplyagent.e2e.test.ts` 46/46.
  - `pnpm tsgo:core` clean (full core typecheck, EXIT=0).
  - `pnpm exec oxfmt --check` clean on the 3 modified files.
  - `pnpm check:import-cycles` reports 0 runtime value cycles.
- **Edge cases checked:**
  - Empty config (`config: {}`) → still defaults to `group: "allow"` → still silent (regression guard).
  - Both `ChatType: "group"` and `ChatType: "channel"` covered (parametrized via `it.each(["group", "channel"] as const)`).
  - `cfg` parameter is optional; missing `cfg` falls through to `resolveSilentReplyPolicy`'s documented defaults — confirmed by an existing pre-fix test that does not pass `cfg` and still asserts `SILENT_REPLY_TOKEN`.
- **What you did not verify:**
  - End-to-end against a real channel runtime with the patched build deployed.
  - Per-surface override (`surfaces.<id>.silentReply.group`) — relies on `resolveSilentReplyPolicy`'s existing surface-resolution coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** (default policy unchanged)
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- **Risk:** A user already setting `silentReply.group: "disallow"` will now start seeing runner-failure copy in groups where previously they saw nothing.
  - **Mitigation:** This is the documented intent of `silentReply.group: "disallow"`. Users who want the previous "silent on failure" behavior should leave the default `group: "allow"` (or omit the setting entirely). The PR title and changelog (added by maintainer at land time) make this opt-in change explicit.
- **Risk:** `cfg` is optional on `resolveExternalRunFailureTextForConversation` and `buildKnownAgentRunFailureReplyPayload`, so any caller that doesn't pass it falls through to the policy default.
  - **Mitigation:** All known call sites in this repo are updated to pass `cfg` (`agent-runner.ts:2161` from `followupRun.run.config`; both inline call sites in `runAgentTurnWithFallback` from `params.followupRun.run.config`). The optional signature is purely a backward-compat hedge for any out-of-tree callers.
