### PR TITLE
fix(feishu): MP3 to OGG conversion failure

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -959,6 +959,8 @@ async function transcodeToFeishuVoiceOpus(params: {
             "libopus",
             "-b:a",
             FEISHU_VOICE_BITRATE,
+            "-f",
+            "ogg",
             outputPath,
           ]);
         },


### PR DESCRIPTION
## Summary

- Problem: MP3 to OGG conversion failure.
- Why it matters: Due to the conversion failure, Feishu receives the audio as an MP3 file attachment instead of a playable voice message.
- What changed:Modified the FFmpeg command parameters to explicitly specify the output format as OGG.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Real behavior proof

Before the fix: The following error occurred, and the Feishu app received both the original text message and an MP3 file.
After the fix: No errors occur, and the Feishu app correctly receives a voice message.

<img width="1297" height="820" alt="image" src="https://github.com/user-attachments/assets/e15b26ec-cc4b-43a1-91fe-1a5d73b24b5c" />

```
6:55:31 [feishu] audioAsVoice transcode failed; sending voice-1778835330859---4e8625f7-e31a-46d5-8a86-d8b883fb4391.mp3 as a file attachment: Error: Command failed: /usr/bin/ffmpeg -hide_banner -loglevel error -y -i /tmp/openclaw/feishu-voice-b8133141-497c-413f-a58f-3267cd4cfa38-5e5KR7/input.mp3 -vn -sn -dn -t 1200 -ar 48000 -ac 1 -c:a libopus -b:a 64k /tmp/fs-safe-output-1001/fs-safe-output-HiiN2K/.fs-safe-output-6fc982ec-bee7-4658-8097-b7acd18aa377-voice.ogg.part
[NULL @ 0x559e2f0ce0] Unable to find a suitable output format for '/tmp/fs-safe-output-1001/fs-safe-output-HiiN2K/.fs-safe-output-6fc982ec-bee7-4658-8097-b7acd18aa377-voice.ogg.part'
/tmp/fs-safe-output-1001/fs-safe-output-HiiN2K/.fs-safe-output-6fc982ec-bee7-4658-8097-b7acd18aa377-voice.ogg.part: Invalid argument

    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at ChildProcess.exithandler (node:child_process:417:12)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5)
    at Process.callbackTrampoline (node:internal/async_hooks:130:17) {
  code: 1,
  killed: false,
  signal: null,
  cmd: '/usr/bin/ffmpeg -hide_banner -loglevel error -y -i /tmp/openclaw/feishu-voice-b8133141-497c-413f-a58f-3267cd4cfa38-5e5KR7/input.mp3 -vn -sn -dn -t 1200 -ar 48000 -ac 1 -c:a libopus -b:a 64k /tmp/fs-safe-output-1001/fs-safe-output-HiiN2K/.fs-safe-output-6fc982ec-bee7-4658-8097-b7acd18aa377-voice.ogg.part',
  stdout: '',
  stderr: "[NULL @ 0x559e2f0ce0] Unable to find a suitable output format for '/tmp/fs-safe-output-1001/fs-safe-output-HiiN2K/.fs-safe-output-6fc982ec-bee7-4658-8097-b7acd18aa377-voice.ogg.part'\n" +
    '/tmp/fs-safe-output-1001/fs-safe-output-HiiN2K/.fs-safe-output-6fc982ec-bee7-4658-8097-b7acd18aa377-voice.ogg.part: Invalid argument\n'
}
```

## Root Cause

FFmpeg was unable to automatically infer the output format based on the output filename .fs-safe-output-6fc982ec-bee7-4658-8097-b7acd18aa377-voice.ogg.part

## Behavior Changes

Added parameters to explicitly specify the format as OGG.

```
-f ogg
```