### PR TITLE
Refactor command turns into channel facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Channels/SDK: add normalized command turn facts to channel turn construction and expose command-turn helpers for plugin inbound contexts.
 - Agents/config: support per-agent bootstrap profile overrides for `contextInjection`, `bootstrapMaxChars`, and `bootstrapTotalMaxChars`, inheriting from `agents.defaults` when omitted. Fixes #69966. Thanks @BunsDev.
 - Dependencies: route root ambient Node proxy agents through `@openclaw/proxyline` and drop root `proxy-agent`, `https-proxy-agent`, and `minimatch` dependencies.
 - Canvas: lazy-load HTTP host, hosted media resolver, CLI implementation, and tool runtime modules so Gateway startup only pays Canvas implementation cost on first use. (#82001) Thanks @samzong.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-bac467c6f33077fcb78a4655866451a8c2c25fd9c2dbe95b40acdaa7bcb0a210  plugin-sdk-api-baseline.json
-efc57691a67157e9fa1fbc43fd7270f29cf2adb25680a3ab1583815b6d04d63b  plugin-sdk-api-baseline.jsonl
+228e53a4748d3e797b54fba1ac9069ef65b459ece5807e100e01f14c872e0610  plugin-sdk-api-baseline.json
+e675bb9b25b849f6a54eca75fcd343efc1258cb1f5e33cf3ec0a00aa7eaf4f05  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-9a5b14ebb8d1443ebf4620a811e7de0099a71f7891de8a6a5330fd12b3417d70  plugin-sdk-api-baseline.json
-d28f0cba321bf267bfb10e4ee4d4639655dc92899b9f889b8b552397a7f01a1d  plugin-sdk-api-baseline.jsonl
+bac467c6f33077fcb78a4655866451a8c2c25fd9c2dbe95b40acdaa7bcb0a210  plugin-sdk-api-baseline.json
+efc57691a67157e9fa1fbc43fd7270f29cf2adb25680a3ab1583815b6d04d63b  plugin-sdk-api-baseline.jsonl

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -466,18 +466,16 @@ export async function buildTelegramInboundContextPayload(params: {
         authorizers: [],
       },
     },
-    commandTurn:
+    command:
       commandSource === "native"
         ? {
             kind: "native",
-            source: "native",
             authorized: commandAuthorized,
             body: commandBody,
           }
         : commandSource === "text"
           ? {
               kind: "text-slash",
-              source: "text",
               authorized: commandAuthorized,
               body: commandBody,
             }

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -17,6 +17,7 @@ import {
   isInternalMessageChannel,
   normalizeMessageChannel,
 } from "../utils/message-channel.js";
+import { isNativeCommandTurn, resolveCommandTurnContext } from "./command-turn-context.js";
 import type { MsgContext } from "./templating.js";
 
 export type CommandAuthorization = {
@@ -711,7 +712,7 @@ export function resolveCommandAuthorization(params: {
         ? senderIsOwner
         : senderIsOwnerByScope || Boolean(matchedCommandOwner);
   const nativeCommandAuthorized =
-    commandAuthorized && ctx.CommandSource === "native" && !requireOwner;
+    commandAuthorized && isNativeCommandTurn(resolveCommandTurnContext(ctx)) && !requireOwner;
   const isAuthorizedSender = resolveCommandSenderAuthorization({
     commandAuthorized,
     enforceOwnerForCommands: enforceOwner,

--- a/src/auto-reply/command-turn-context.test.ts
+++ b/src/auto-reply/command-turn-context.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { isExplicitCommandTurn, resolveCommandTurnContext } from "./command-turn-context.js";
+import {
+  createCommandTurnContext,
+  isAuthorizedTextSlashCommandTurn,
+  isExplicitCommandTurn,
+  isNativeCommandTurn,
+  resolveCommandTurnContext,
+  resolveCommandTurnTargetSessionKey,
+} from "./command-turn-context.js";
 
 describe("resolveCommandTurnContext", () => {
   it("derives native command turns from legacy context fields", () => {
@@ -85,5 +92,33 @@ describe("resolveCommandTurnContext", () => {
       source: "text",
       authorized: true,
     });
+  });
+
+  it("exposes native/text helper predicates and target session resolution", () => {
+    const nativeTurn = createCommandTurnContext("native", {
+      authorized: true,
+      body: "/stop",
+    });
+    const textTurn = createCommandTurnContext("text", {
+      authorized: true,
+      body: "/status",
+    });
+
+    expect(isNativeCommandTurn(nativeTurn)).toBe(true);
+    expect(isAuthorizedTextSlashCommandTurn(textTurn)).toBe(true);
+    expect(
+      resolveCommandTurnTargetSessionKey({
+        CommandTurn: nativeTurn,
+        CommandTargetSessionKey: " target-session ",
+      }),
+    ).toBe("target-session");
+    expect(
+      resolveCommandTurnTargetSessionKey({
+        CommandSource: "native",
+        CommandAuthorized: true,
+        CommandTargetSessionKey: " legacy-target ",
+      }),
+    ).toBe("legacy-target");
+    expect(isExplicitCommandTurn(undefined)).toBe(false);
   });
 });

--- a/src/auto-reply/command-turn-context.ts
+++ b/src/auto-reply/command-turn-context.ts
@@ -64,7 +64,7 @@ function parseCommandName(body: string | undefined): string | undefined {
   return normalizeOptionalString(name);
 }
 
-function commandTurnKindToSource(kind: CommandTurnKind): CommandTurnSource {
+export function commandTurnKindToSource(kind: CommandTurnKind): CommandTurnSource {
   if (kind === "native") {
     return "native";
   }
@@ -82,7 +82,7 @@ function normalizeCommandTurnSource(value: unknown): CommandTurnSource | undefin
   return value === "native" || value === "text" || value === "message" ? value : undefined;
 }
 
-function sourceToCommandTurnKind(source: CommandTurnSource): CommandTurnKind {
+export function commandTurnSourceToKind(source: CommandTurnSource): CommandTurnKind {
   if (source === "native") {
     return "native";
   }
@@ -92,7 +92,7 @@ function sourceToCommandTurnKind(source: CommandTurnSource): CommandTurnKind {
   return "normal";
 }
 
-function buildCommandTurnContext(
+export function createCommandTurnContext(
   source: CommandTurnSource,
   input: {
     authorized: boolean;
@@ -138,7 +138,7 @@ function normalizeExplicitCommandTurn(
   const kind = normalizeCommandTurnKind(record.kind);
   const source =
     normalizeCommandTurnSource(record.source) ?? (kind ? commandTurnKindToSource(kind) : undefined);
-  const resolvedKind = kind ?? (source ? sourceToCommandTurnKind(source) : undefined);
+  const resolvedKind = kind ?? (source ? commandTurnSourceToKind(source) : undefined);
   if (kind && source && commandTurnKindToSource(kind) !== source) {
     return undefined;
   }
@@ -146,7 +146,7 @@ function normalizeExplicitCommandTurn(
     return undefined;
   }
   const body = normalizeOptionalString(record.body) ?? resolveCommandBody(input);
-  return buildCommandTurnContext(source, {
+  return createCommandTurnContext(source, {
     authorized:
       resolvedKind === "normal"
         ? false
@@ -170,16 +170,50 @@ export function resolveCommandTurnContext(input: CommandTurnContextInput): Comma
         ? "text"
         : "message";
   const body = resolveCommandBody(input);
-  const kind = sourceToCommandTurnKind(source);
-  return buildCommandTurnContext(source, {
+  const kind = commandTurnSourceToKind(source);
+  return createCommandTurnContext(source, {
     authorized: kind === "normal" ? false : input.CommandAuthorized === true,
     commandName: parseCommandName(body),
     body,
   });
 }
 
-export function isExplicitCommandTurn(commandTurn: CommandTurnContext): boolean {
+export function isNativeCommandTurn(commandTurn: CommandTurnContext | undefined): boolean {
+  return commandTurn?.kind === "native";
+}
+
+export function isTextSlashCommandTurn(commandTurn: CommandTurnContext | undefined): boolean {
+  return commandTurn?.kind === "text-slash";
+}
+
+export function isAuthorizedTextSlashCommandTurn(
+  commandTurn: CommandTurnContext | undefined,
+): boolean {
+  return commandTurn?.kind === "text-slash" && commandTurn.authorized;
+}
+
+export function isExplicitCommandTurn(commandTurn: CommandTurnContext | undefined): boolean {
   return (
-    commandTurn.kind === "native" || (commandTurn.kind === "text-slash" && commandTurn.authorized)
+    commandTurn?.kind === "native" || (commandTurn?.kind === "text-slash" && commandTurn.authorized)
   );
+}
+
+export function resolveCommandTurnTargetSessionKey(input: {
+  CommandTurn?: CommandTurnContext;
+  CommandSource?: unknown;
+  CommandAuthorized?: unknown;
+  CommandBody?: unknown;
+  BodyForCommands?: unknown;
+  RawBody?: unknown;
+  Body?: unknown;
+  CommandTargetSessionKey?: unknown;
+}): string | undefined {
+  if (
+    !isNativeCommandTurn(resolveCommandTurnContext(input)) ||
+    typeof input.CommandTargetSessionKey !== "string"
+  ) {
+    return undefined;
+  }
+  const trimmed = input.CommandTargetSessionKey.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -10,7 +10,10 @@ import {
 } from "../infra/diagnostics-timeline.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { SilentReplyConversationType } from "../shared/silent-reply-policy.js";
-import { resolveCommandTurnContext } from "./command-turn-context.js";
+import {
+  resolveCommandTurnContext,
+  resolveCommandTurnTargetSessionKey,
+} from "./command-turn-context.js";
 import { withReplyDispatcher } from "./dispatch-dispatcher.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.types.js";
@@ -118,15 +121,11 @@ function resolveDispatcherSilentReplyContext(
   cfg: OpenClawConfig,
 ) {
   const finalized = finalizeInboundContext(ctx);
-  const policySessionKey =
-    finalized.CommandSource === "native"
-      ? (finalized.CommandTargetSessionKey ?? finalized.SessionKey)
-      : finalized.SessionKey;
+  const commandTargetSessionKey = resolveCommandTurnTargetSessionKey(finalized);
+  const policySessionKey = commandTargetSessionKey ?? finalized.SessionKey;
   const chatType = normalizeChatType(finalized.ChatType);
   const conversationType: SilentReplyConversationType | undefined =
-    finalized.CommandSource === "native" &&
-    finalized.CommandTargetSessionKey &&
-    finalized.CommandTargetSessionKey !== finalized.SessionKey
+    commandTargetSessionKey && commandTargetSessionKey !== finalized.SessionKey
       ? undefined
       : chatType === "direct"
         ? "direct"

--- a/src/auto-reply/reply/command-gates.ts
+++ b/src/auto-reply/reply/command-gates.ts
@@ -1,6 +1,7 @@
 import { isCommandFlagEnabled, type CommandFlagKey } from "../../config/commands.flags.js";
 import { logVerbose } from "../../globals.js";
 import { redactIdentifier } from "../../logging/redact-identifier.js";
+import { isNativeCommandTurn, resolveCommandTurnContext } from "../command-turn-context.js";
 import type { ReplyPayload } from "../types.js";
 import type { CommandHandlerResult, HandleCommandsParams } from "./commands-types.js";
 
@@ -21,7 +22,7 @@ export function rejectUnauthorizedCommand(
   logVerbose(
     `Ignoring ${commandLabel} from unauthorized sender: ${redactIdentifier(params.command.senderId)}`,
   );
-  if (params.ctx.CommandSource === "native") {
+  if (isNativeCommandTurn(resolveCommandTurnContext(params.ctx))) {
     return buildNativeCommandGateReply("You are not authorized to use this command.");
   }
   return { shouldContinue: false };
@@ -37,7 +38,7 @@ export function rejectNonOwnerCommand(
   logVerbose(
     `Ignoring ${commandLabel} from non-owner sender: ${redactIdentifier(params.command.senderId)}`,
   );
-  if (params.ctx.CommandSource === "native") {
+  if (isNativeCommandTurn(resolveCommandTurnContext(params.ctx))) {
     return buildNativeCommandGateReply("You are not authorized to use this command.");
   }
   return { shouldContinue: false };

--- a/src/auto-reply/reply/commands-steer.ts
+++ b/src/auto-reply/reply/commands-steer.ts
@@ -5,6 +5,7 @@ import {
 import type { SessionEntry } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import { isNativeCommandTurn, resolveCommandTurnContext } from "../command-turn-context.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
 import {
   formatEmbeddedPiQueueFailureSummary,
@@ -31,10 +32,9 @@ function parseSteerMessage(raw: string): string | null {
 function resolveSteerTargetSessionKey(params: HandleCommandsParams): string | undefined {
   const commandTarget = normalizeOptionalString(params.ctx.CommandTargetSessionKey);
   const commandSession = normalizeOptionalString(params.sessionKey);
-  const raw =
-    params.ctx.CommandSource === "native"
-      ? commandTarget || commandSession
-      : commandSession || commandTarget;
+  const raw = isNativeCommandTurn(resolveCommandTurnContext(params.ctx))
+    ? commandTarget || commandSession
+    : commandSession || commandTarget;
   if (!raw) {
     return undefined;
   }

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -17,6 +17,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../../../shared/string-coerce.js";
+import { isNativeCommandTurn, resolveCommandTurnContext } from "../../command-turn-context.js";
 import { resolveCommandSurfaceChannel, resolveChannelAccountId } from "../channel-context.js";
 import { extractMessageText, type ChatMessage } from "../commands-subagents-text.js";
 import type { CommandHandler, CommandHandlerResult } from "../commands-types.js";
@@ -131,7 +132,7 @@ export function resolveRequesterSessionKey(
   const commandTarget = normalizeOptionalString(params.ctx.CommandTargetSessionKey);
   const commandSession = normalizeOptionalString(params.sessionKey);
   const shouldPreferCommandTarget =
-    opts?.preferCommandTarget ?? params.ctx.CommandSource === "native";
+    opts?.preferCommandTarget ?? isNativeCommandTurn(resolveCommandTurnContext(params.ctx));
   const raw = shouldPreferCommandTarget
     ? commandTarget || commandSession
     : commandSession || commandTarget;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -79,6 +79,11 @@ import {
   shouldAttemptTtsPayload,
 } from "../../tts/tts-config.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
+import {
+  isNativeCommandTurn,
+  resolveCommandTurnContext,
+  resolveCommandTurnTargetSessionKey,
+} from "../command-turn-context.js";
 import type { BlockReplyContext } from "../get-reply-options.types.js";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
 import type { FinalizedMsgContext } from "../templating.js";
@@ -198,11 +203,8 @@ const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
 const resolveRoutedPolicyConversationType = (
   ctx: FinalizedMsgContext,
 ): "direct" | "group" | undefined => {
-  if (
-    ctx.CommandSource === "native" &&
-    ctx.CommandTargetSessionKey &&
-    ctx.CommandTargetSessionKey !== ctx.SessionKey
-  ) {
+  const commandTargetSessionKey = resolveCommandTurnTargetSessionKey(ctx);
+  if (commandTargetSessionKey && commandTargetSessionKey !== ctx.SessionKey) {
     return undefined;
   }
   const chatType = normalizeChatType(ctx.ChatType);
@@ -223,10 +225,7 @@ const resolveSessionStoreLookup = (
   storePath?: string;
   entry?: SessionEntry;
 } => {
-  const targetSessionKey =
-    ctx.CommandSource === "native"
-      ? normalizeOptionalString(ctx.CommandTargetSessionKey)
-      : undefined;
+  const targetSessionKey = resolveCommandTurnTargetSessionKey(ctx);
   const sessionKey = normalizeOptionalString(targetSessionKey ?? ctx.SessionKey);
   if (!sessionKey) {
     return {};
@@ -308,7 +307,7 @@ const resolveHarnessSourceVisibleRepliesDefault = (params: {
   sessionAgentId: string;
   sessionKey?: string;
 }): "automatic" | "message_tool" | undefined => {
-  if (params.ctx.CommandSource === "native") {
+  if (isNativeCommandTurn(resolveCommandTurnContext(params.ctx))) {
     return undefined;
   }
   try {
@@ -610,10 +609,7 @@ export async function dispatchReplyFromConfig(
       channel: routeReplyChannel,
       to: routeReplyTo,
       sessionKey: ctx.SessionKey,
-      policySessionKey:
-        ctx.CommandSource === "native"
-          ? (ctx.CommandTargetSessionKey ?? ctx.SessionKey)
-          : ctx.SessionKey,
+      policySessionKey: resolveCommandTurnTargetSessionKey(ctx) ?? ctx.SessionKey,
       policyConversationType: resolveRoutedPolicyConversationType(ctx),
       accountId: replyRoute.accountId,
       requesterSenderId: ctx.SenderId,

--- a/src/auto-reply/reply/get-reply-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-fast-path.ts
@@ -11,6 +11,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
 import { normalizeCommandBody } from "../commands-registry.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import { parseSoftResetCommand } from "./commands-reset-mode.js";
@@ -38,8 +39,7 @@ function resolveFastSessionKey(params: {
   mainKey?: string;
 }): string {
   const { ctx } = params;
-  const nativeCommandTarget =
-    ctx.CommandSource === "native" ? normalizeOptionalString(ctx.CommandTargetSessionKey) : "";
+  const nativeCommandTarget = resolveCommandTurnTargetSessionKey(ctx) ?? "";
   if (nativeCommandTarget) {
     return nativeCommandTarget;
   }

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -6,6 +6,7 @@ import {
 import type { OpenClawConfig } from "../../config/config.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import { isNativeCommandTurn, resolveCommandTurnContext } from "../command-turn-context.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
@@ -32,7 +33,7 @@ function loadStatusCommandRuntime() {
 }
 
 function resolveNativeSlashCommandName(ctx: MsgContext): string | undefined {
-  if (ctx.CommandSource !== "native") {
+  if (!isNativeCommandTurn(resolveCommandTurnContext(ctx))) {
     return undefined;
   }
   const commandText = stripStructuralPrefixes(

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -31,6 +31,7 @@ import type { SilentReplyConversationType } from "../../shared/silent-reply-poli
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { hasControlCommand } from "../command-detection.js";
+import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
 import { resolveEnvelopeFormatOptions } from "../envelope.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import {
@@ -81,15 +82,15 @@ type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
 
 export function resolvePromptSilentReplyConversationType(params: {
-  ctx: Pick<MsgContext, "ChatType" | "CommandSource" | "CommandTargetSessionKey" | "SessionKey">;
+  ctx: Pick<
+    MsgContext,
+    "ChatType" | "CommandSource" | "CommandTargetSessionKey" | "CommandTurn" | "SessionKey"
+  >;
   inboundSessionKey?: string;
 }): SilentReplyConversationType | undefined {
   const sourceSessionKey = params.inboundSessionKey ?? params.ctx.SessionKey;
-  if (
-    params.ctx.CommandSource === "native" &&
-    params.ctx.CommandTargetSessionKey &&
-    params.ctx.CommandTargetSessionKey !== sourceSessionKey
-  ) {
+  const commandTargetSessionKey = resolveCommandTurnTargetSessionKey(params.ctx);
+  if (commandTargetSessionKey && commandTargetSessionKey !== sourceSessionKey) {
     return undefined;
   }
   const chatType = normalizeChatType(params.ctx.ChatType);

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -19,6 +19,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
+import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../heartbeat.js";
 import type { ReplyPayload } from "../reply-payload.js";
@@ -218,10 +219,7 @@ export async function getReplyFromConfig(
     isFastTestEnv,
   });
   const finalized = finalizeInboundContext(ctx);
-  const targetSessionKey =
-    finalized.CommandSource === "native"
-      ? normalizeOptionalString(finalized.CommandTargetSessionKey)
-      : undefined;
+  const targetSessionKey = resolveCommandTurnTargetSessionKey(finalized);
   const agentSessionKey = targetSessionKey || finalized.SessionKey;
   const traceAttributes = {
     surface: normalizeOptionalString(finalized.Surface ?? finalized.Provider) ?? "unknown",

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -7,6 +7,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
 import type { MsgContext } from "../templating.js";
 
 const DEFAULT_INBOUND_DEDUPE_TTL_MS = 20 * 60_000;
@@ -39,11 +40,7 @@ const resolveInboundPeerId = (ctx: MsgContext) =>
 
 function resolveInboundDedupeSessionScope(ctx: MsgContext): string {
   const sessionKey =
-    (ctx.CommandSource === "native"
-      ? normalizeOptionalString(ctx.CommandTargetSessionKey)
-      : undefined) ||
-    normalizeOptionalString(ctx.SessionKey) ||
-    "";
+    resolveCommandTurnTargetSessionKey(ctx) || normalizeOptionalString(ctx.SessionKey) || "";
   if (!sessionKey) {
     return "";
   }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -52,6 +52,7 @@ import {
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.shared.js";
+import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
 import { normalizeCommandBody } from "../commands-registry.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import { resolveEffectiveResetTargetSessionKey } from "./acp-reset-target.js";
@@ -248,10 +249,7 @@ export async function initSessionState(params: {
     : resolveSessionConversationBindingContext(cfg, ctx);
   // Native slash commands (Telegram/Discord/Slack) are delivered on a separate
   // "slash session" key, but should mutate the target chat session.
-  const commandTargetSessionKey =
-    ctx.CommandSource === "native"
-      ? normalizeOptionalString(ctx.CommandTargetSessionKey)
-      : undefined;
+  const commandTargetSessionKey = resolveCommandTurnTargetSessionKey(ctx);
   // Native slash/menu commands can arrive on a transport-specific "slash session"
   // while explicitly targeting an existing chat session. Honor that explicit target
   // before any binding lookup so command-side mutations land on the intended session.

--- a/src/channels/turn/context.test.ts
+++ b/src/channels/turn/context.test.ts
@@ -226,6 +226,72 @@ describe("buildChannelTurnContext", () => {
     expect(ctx.CommandAuthorized).toBe(true);
   });
 
+  it("derives command turns from normalized command facts", () => {
+    const ctx = buildChannelTurnContext(
+      createBaseContextParams({
+        message: {
+          rawBody: "/status",
+          commandBody: "/status",
+          envelopeFrom: "User One",
+        },
+        command: {
+          kind: "text-slash",
+          name: "status",
+        },
+        access: {
+          commands: {
+            authorized: true,
+            allowTextCommands: true,
+            useAccessGroups: true,
+            authorizers: [],
+          },
+        },
+      }),
+    );
+
+    expect(ctx.CommandTurn).toEqual({
+      kind: "text-slash",
+      source: "text",
+      authorized: true,
+      commandName: "status",
+      body: "/status",
+    });
+    expect(ctx.CommandSource).toBe("text");
+    expect(ctx.CommandAuthorized).toBe(true);
+  });
+
+  it("keeps explicit command turns ahead of normalized command facts", () => {
+    const ctx = buildChannelTurnContext(
+      createBaseContextParams({
+        message: {
+          rawBody: "/status",
+          commandBody: "/status",
+          envelopeFrom: "User One",
+        },
+        command: {
+          kind: "native",
+          authorized: true,
+        },
+        commandTurn: {
+          kind: "normal",
+          source: "message",
+          authorized: false,
+          body: "hello",
+        },
+      }),
+    );
+
+    expect(ctx.CommandTurn).toEqual({
+      kind: "normal",
+      source: "message",
+      authorized: false,
+      commandName: undefined,
+      body: "hello",
+    });
+    expect(ctx.CommandSource).toBeUndefined();
+    expect(ctx.CommandAuthorized).toBe(false);
+  });
+
   it("filters supplemental context with channel visibility policy", () => {
     const ctx = buildChannelTurnContext(
       createBaseContextParams({

--- a/src/channels/turn/context.ts
+++ b/src/channels/turn/context.ts
@@ -1,10 +1,15 @@
-import type { CommandTurnContext } from "../../auto-reply/command-turn-context.js";
+import {
+  commandTurnKindToSource,
+  createCommandTurnContext,
+  type CommandTurnContext,
+} from "../../auto-reply/command-turn-context.js";
 import { finalizeInboundContext } from "../../auto-reply/reply/inbound-context.js";
 import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
 import type { ContextVisibilityMode } from "../../config/types.base.js";
 import { shouldIncludeSupplementalContext } from "../../security/context-visibility.js";
 import type {
   AccessFacts,
+  CommandFacts,
   ConversationFacts,
   InboundMediaFacts,
   MessageFacts,
@@ -29,6 +34,7 @@ export type BuildChannelTurnContextParams = {
   reply: ReplyPlanFacts;
   message: MessageFacts;
   access?: AccessFacts;
+  command?: CommandFacts;
   commandTurn?: CommandTurnContext;
   media?: InboundMediaFacts[];
   supplemental?: SupplementalContextFacts;
@@ -124,6 +130,30 @@ function resolveAccessFactsCommandAuthorized(access: AccessFacts | undefined): b
     : commands?.authorizers?.some((entry) => entry.allowed);
 }
 
+function resolveChannelTurnCommandContext(params: {
+  command?: CommandFacts;
+  commandTurn?: CommandTurnContext;
+  message: MessageFacts;
+  access?: AccessFacts;
+}): CommandTurnContext | undefined {
+  if (params.commandTurn) {
+    return params.commandTurn;
+  }
+  const command = params.command;
+  if (!command) {
+    return undefined;
+  }
+  const body = command.body ?? params.message.commandBody ?? params.message.rawBody;
+  return createCommandTurnContext(commandTurnKindToSource(command.kind), {
+    authorized:
+      command.kind === "normal"
+        ? false
+        : (command.authorized ?? resolveAccessFactsCommandAuthorized(params.access) === true),
+    commandName: command.name,
+    body,
+  });
+}
+
 export function buildChannelTurnContext(
   params: BuildChannelTurnContextParams,
 ): BuiltChannelTurnContext {
@@ -133,6 +163,12 @@ export function buildChannelTurnContext(
     contextVisibility: params.contextVisibility,
   });
   const body = params.message.body ?? params.message.rawBody;
+  const commandTurn = resolveChannelTurnCommandContext({
+    command: params.command,
+    commandTurn: params.commandTurn,
+    message: params.message,
+    access: params.access,
+  });
 
   return finalizeInboundContext({
     Body: body,
@@ -184,7 +220,7 @@ export function buildChannelTurnContext(
     Surface: params.surface ?? params.provider ?? params.channel,
     WasMentioned: params.access?.mentions?.wasMentioned,
     CommandAuthorized: resolveAccessFactsCommandAuthorized(params.access) === true,
-    CommandTurn: params.commandTurn,
+    CommandTurn: commandTurn,
     MessageThreadId: params.reply.messageThreadId ?? params.conversation.threadId,
     NativeChannelId: params.reply.nativeChannelId ?? params.conversation.nativeChannelId,
     OriginatingChannel: params.channel,

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -1,3 +1,4 @@
+import type { CommandTurnKind } from "../../auto-reply/command-turn-context.js";
 import type { GetReplyOptions } from "../../auto-reply/get-reply-options.types.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { DispatchFromConfigResult } from "../../auto-reply/reply/dispatch-from-config.types.js";
@@ -184,6 +185,13 @@ export type MessageFacts = {
   inboundHistory?: Array<{ sender: string; body: string; timestamp?: number }>;
 };
 
+export type CommandFacts = {
+  kind: CommandTurnKind;
+  body?: string;
+  name?: string;
+  authorized?: boolean;
+};
+
 export type SupplementalContextFacts = {
   quote?: {
     id?: string;
@@ -224,6 +232,7 @@ export type InboundMediaFacts = {
 
 export type PreflightFacts = {
   admission?: ChannelTurnAdmission;
+  command?: CommandFacts;
   message?: Partial<MessageFacts>;
   media?: InboundMediaFacts[];
   supplemental?: SupplementalContextFacts;

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -519,6 +519,8 @@ describe("stuck session diagnostics threshold", () => {
   it("aborts and drains embedded runs after an extended no-progress stall", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
+    const stuckSessionWarnMs = 30_000;
+    const stuckSessionAbortMs = resolveStuckSessionAbortMs(undefined, stuckSessionWarnMs);
     const unsubscribe = onDiagnosticEvent((event) => {
       events.push(event);
     });
@@ -527,7 +529,7 @@ describe("stuck session diagnostics threshold", () => {
         {
           diagnostics: {
             enabled: true,
-            stuckSessionWarnMs: 30_000,
+            stuckSessionWarnMs,
           },
         },
         { recoverStuckSession },
@@ -535,10 +537,10 @@ describe("stuck session diagnostics threshold", () => {
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
 
-      vi.advanceTimersByTime(9 * 60_000);
+      vi.advanceTimersByTime(stuckSessionAbortMs - 30_000);
       expect(recoverStuckSession).not.toHaveBeenCalled();
 
-      vi.advanceTimersByTime(2 * 60_000);
+      vi.advanceTimersByTime(30_000);
     } finally {
       unsubscribe();
     }

--- a/src/plugin-sdk/channel-inbound.ts
+++ b/src/plugin-sdk/channel-inbound.ts
@@ -58,5 +58,13 @@ export type {
   BuildChannelTurnContextParams,
   BuiltChannelTurnContext,
 } from "../channels/turn/context.js";
+export type { CommandFacts } from "../channels/turn/types.js";
+export {
+  createCommandTurnContext,
+  isAuthorizedTextSlashCommandTurn,
+  isExplicitCommandTurn,
+  isNativeCommandTurn,
+  isTextSlashCommandTurn,
+} from "../auto-reply/command-turn-context.js";
 export type { CommandTurnContext } from "../auto-reply/command-turn-context.js";
 export { mergeInboundPathRoots } from "../media/inbound-path-policy.js";

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -631,6 +631,43 @@
         "asVoice": {
           "type": "boolean"
         },
+        "attachments": {
+          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "items": {
+            "properties": {
+              "filePath": {
+                "type": "string"
+              },
+              "fileUrl": {
+                "type": "string"
+              },
+              "media": {
+                "type": "string"
+              },
+              "mediaUrl": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "type": {
+                "enum": ["image", "audio", "video", "file"],
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
         "bestEffort": {
           "type": "boolean"
         },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -631,6 +631,43 @@
         "asVoice": {
           "type": "boolean"
         },
+        "attachments": {
+          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "items": {
+            "properties": {
+              "filePath": {
+                "type": "string"
+              },
+              "fileUrl": {
+                "type": "string"
+              },
+              "media": {
+                "type": "string"
+              },
+              "mediaUrl": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "type": {
+                "enum": ["image", "audio", "video", "file"],
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
         "bestEffort": {
           "type": "boolean"
         },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -631,6 +631,43 @@
         "asVoice": {
           "type": "boolean"
         },
+        "attachments": {
+          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "items": {
+            "properties": {
+              "filePath": {
+                "type": "string"
+              },
+              "fileUrl": {
+                "type": "string"
+              },
+              "media": {
+                "type": "string"
+              },
+              "mediaUrl": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "type": {
+                "enum": ["image", "audio", "video", "file"],
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
         "bestEffort": {
           "type": "boolean"
         },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -217,8 +217,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 43188,
-    "roughTokens": 10797
+    "chars": 44328,
+    "roughTokens": 11082
   },
   "openClawDeveloperInstructions": {
     "chars": 5436,
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7129
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71706,
-    "roughTokens": 17927
+    "chars": 72846,
+    "roughTokens": 18212
   },
   "userInputText": {
     "chars": 870,
@@ -607,6 +607,43 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
         },
         "asVoice": {
           "type": "boolean"
+        },
+        "attachments": {
+          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "items": {
+            "properties": {
+              "filePath": {
+                "type": "string"
+              },
+              "fileUrl": {
+                "type": "string"
+              },
+              "media": {
+                "type": "string"
+              },
+              "mediaUrl": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "type": {
+                "enum": ["image", "audio", "video", "file"],
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
         },
         "bestEffort": {
           "type": "boolean"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -217,8 +217,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 42879,
-    "roughTokens": 10720
+    "chars": 44019,
+    "roughTokens": 11005
   },
   "openClawDeveloperInstructions": {
     "chars": 4412,
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6748
   },
   "totalWithDynamicToolsJson": {
-    "chars": 69873,
-    "roughTokens": 17469
+    "chars": 71013,
+    "roughTokens": 17754
   },
   "userInputText": {
     "chars": 370,
@@ -584,6 +584,43 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
         },
         "asVoice": {
           "type": "boolean"
+        },
+        "attachments": {
+          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "items": {
+            "properties": {
+              "filePath": {
+                "type": "string"
+              },
+              "fileUrl": {
+                "type": "string"
+              },
+              "media": {
+                "type": "string"
+              },
+              "mediaUrl": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "type": {
+                "enum": ["image", "audio", "video", "file"],
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
         },
         "bestEffort": {
           "type": "boolean"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -218,8 +218,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 44057,
-    "roughTokens": 11015
+    "chars": 45197,
+    "roughTokens": 11300
   },
   "openClawDeveloperInstructions": {
     "chars": 4412,
@@ -230,8 +230,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7155
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72678,
-    "roughTokens": 18170
+    "chars": 73818,
+    "roughTokens": 18455
   },
   "userInputText": {
     "chars": 608,
@@ -601,6 +601,43 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
         },
         "asVoice": {
           "type": "boolean"
+        },
+        "attachments": {
+          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "items": {
+            "properties": {
+              "filePath": {
+                "type": "string"
+              },
+              "fileUrl": {
+                "type": "string"
+              },
+              "media": {
+                "type": "string"
+              },
+              "mediaUrl": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "type": {
+                "enum": ["image", "audio", "video", "file"],
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
         },
         "bestEffort": {
           "type": "boolean"


### PR DESCRIPTION
## Summary

- Add normalized command facts to channel turn construction and derive canonical command turns in buildChannelTurnContext.
- Migrate core native-command routing, session, gates, and delivery decisions to command-turn helpers while preserving legacy fallback fields.
- Move Telegram message context production onto command facts; update SDK exports, API baseline, prompt snapshots, tests, and changelog.
- Refresh a stale diagnostic recovery test expectation exposed by latest main so it follows the configured abort threshold.

## Verification

- pnpm test src/auto-reply/command-turn-context.test.ts src/channels/turn/context.test.ts src/auto-reply/reply/source-reply-delivery-mode.test.ts -- --reporter=verbose
- pnpm test src/logging/diagnostic.test.ts -- --reporter=verbose
- pnpm prompt:snapshots:check
- pnpm plugin-sdk:api:check
- git diff --check origin/main...HEAD
- pnpm test:changed
  - earlier local env-sensitive failure only: src/flows/search-setup.test.ts saw exported XAI_API_KEY
- env -u XAI_API_KEY pnpm test src/flows/search-setup.test.ts -- --reporter=verbose
- pnpm check:changed
  - Testbox run: 25909629476
- pnpm build
- /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local
  - clean: no accepted/actionable findings reported

## Real behavior proof

Behavior addressed: Core command-target, session, gate, and visible-reply decisions now resolve from canonical command turns; channel turn construction derives canonical command turns from normalized command facts with legacy fallback preserved.

Real environment tested: Local OpenClaw source checkout plus Blacksmith Testbox changed-check run.

Exact steps or command run after this patch: Focused Vitest command-turn/channel-turn/source-delivery tests; diagnostic regression test; prompt snapshot check; SDK API check; changed tests with exact env-sensitive rerun; Testbox changed check; production build; diff whitespace check; Codex review local mode.

Evidence after fix: Focused command tests passed 33 tests; diagnostic test passed 38 tests; prompt snapshots are current; SDK API baseline check passed; env-unset search setup rerun passed 7 tests; Testbox run 25909629476 exited 0; build exited 0; codex-review found no actionable correctness issues.

Observed result after fix: Text and native command metadata flows through the normalized turn model, and native-only decisions use explicit command-turn helpers instead of rediscovering raw legacy source strings.

What was not tested: Live WhatsApp or Telegram device roundtrip was not run for this refactor-only pass; maintainer proof override is applied for this normalized internal turn-model refactor.
