### PR TITLE
fix: restore Discord voice Ogg transcoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - Control UI: rotate browser service-worker caches per build so updated Gateways are less likely to keep serving stale dashboard bundles that trigger protocol mismatch errors.
 - Gateway/protocol: lazy-compile protocol validators on first use instead of compiling every AJV schema during cold import, reducing startup CPU and RSS. (#82064) Thanks @samzong.
 - Discord: report unresolved configured bot-token SecretRefs during startup instead of treating the account as unconfigured. (#82009) Thanks @giodl73-repo.
+- Discord: pass an explicit Ogg muxer to ffmpeg when transcoding voice-message audio through staged temp files, restoring TTS voice-message delivery. Fixes #82074. Thanks @hwlbb.
 - CLI/config: preserve numeric-looking object keys such as Discord guild IDs during `config patch` recursive merges. (#81999) Thanks @giodl73-repo.
 - Gateway/OpenAI-compatible HTTP: forward `response_format` from `/v1/chat/completions` requests through agent stream params to upstream Chat Completions and Responses transports, restoring structured-output support. Fixes #82003. (#82004) Thanks @Lellansin.
 - Control UI/WebChat: let sidebar markdown code-block Copy buttons use the same delegated clipboard handler as chat messages. (#58709) Thanks @tikitoki.

--- a/extensions/discord/src/voice-message.test.ts
+++ b/extensions/discord/src/voice-message.test.ts
@@ -136,6 +136,8 @@ describe("ensureOggOpus", () => {
       "libopus",
       "-b:a",
       "64k",
+      "-f",
+      "ogg",
     ]);
     const ffmpegOutputPath = ffmpegArgs.at(-1);
     expectStagedFfmpegOutput(ffmpegOutputPath, result.path);
@@ -173,6 +175,8 @@ describe("ensureOggOpus", () => {
       "libopus",
       "-b:a",
       "64k",
+      "-f",
+      "ogg",
     ]);
     const ffmpegOutputPath = ffmpegArgs.at(-1);
     expectStagedFfmpegOutput(ffmpegOutputPath, result.path);

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -250,6 +250,8 @@ export async function ensureOggOpus(filePath: string): Promise<{ path: string; c
       "libopus",
       "-b:a",
       "64k",
+      "-f",
+      "ogg",
       tempPath,
     ],
   });


### PR DESCRIPTION
Summary
- Fix Discord voice-message transcoding by passing ffmpeg an explicit Ogg muxer before the staged temp output path.
- Extend exact-args coverage for both Ogg re-encode and non-Ogg input conversion.
- Add changelog credit for #82074.

Fixes #82074.

Verification
- codex review --base origin/main: clean, no accepted/actionable findings
- pnpm test extensions/discord/src/voice-message.test.ts: 6 passed
- pnpm check:changed: passed on Blacksmith Testbox tbx_01krnfgn255w9abgtf65af47gh

## Real behavior proof

Behavior addressed: Discord TTS voice-message delivery failed when ffmpeg received a staged .ogg.part output path and could not infer the Ogg muxer.
Real environment tested: Local OpenClaw checkout on macOS with real ffmpeg/ffprobe, exercising extensions/discord/src/voice-message.ts ensureOggOpus after this patch.
Exact steps or command run after this patch: Generated a short MP3 with ffmpeg, called ensureOggOpus through node --import tsx, then ffprobed the returned staged Ogg output.
Evidence after fix: Terminal output from the post-patch run:

```text
input=/tmp/openclaw-discord-voice-proof-OpofUx/input.mp3
output=/tmp/openclaw/voice-a424b8c7-4128-487e-b789-e49a0668bb6e.ogg
cleanup=true
bytes=2732
codec=opus
sample_rate=48000
format=ogg
duration=0.256500
```

Observed result after fix: The real Discord conversion helper returned a non-empty Ogg container with Opus audio at 48 kHz even though the write path used a staged temp file.
What was not tested: Live Discord upload/send with real bot credentials; covered here by the implicated conversion path plus existing mocked Discord upload/send tests.
