### PR TITLE
fix: strip response-only reasoning fields from OpenAI Completions req…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 - Discord/channels: make `openclaw channels list --all` prefer reachable Gateway runtime account status and mark configured-but-unavailable credentials, avoiding false `not configured` output when Discord is running from service-only env. Fixes #79343. Thanks @EricY019.
 - WhatsApp: mark text slash commands as command turns so authorized group command replies stay visible under message-tool-only group reply mode. (#81972) Thanks @barbarhan.
 - Providers/OpenCode Go: stop sending unsupported reasoning parameters to Kimi K2.5/K2.6, avoiding OpenCode Go payload-validation failures while preserving DeepSeek V4 reasoning support.
+- Providers/OpenRouter: normalize invalid Chat Completions reasoning replay fields while preserving valid OpenRouter reasoning pass-back, avoiding follow-up turn 500s without affecting stock OpenAI calls. (#82101) Thanks @sliverp.
 - Installer: handle noninteractive git installs from moving refs without tag-fetch conflicts, while keeping immutable refs on frozen lockfile installs. (#81875) Thanks @keshavbotagent.
 - Codex app-server: inject native client factories per run and compaction attempt instead of using module-scope test state, avoiding temporal-dead-zone reads during cyclic startup. (#81148) Thanks @bdjben.
 - Plugin skills: replace generated Windows plugin-skill directories before publishing the current skill link, avoiding repeated `EINVAL` warnings from stale non-symlink entries. Fixes #81432. (#81446) Thanks @hclsys and @vincentkoc.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5326,3 +5326,71 @@ describe("openai transport stream", () => {
     ).rejects.toThrow("Exceeded tool-call argument buffer limit");
   });
 });
+
+describe("buildOpenAICompletionsParams strips response-only reasoning fields", () => {
+  // OpenRouter and other OpenAI-Completions providers echo `reasoning_details`
+  // (array) and `reasoning_content` (string) in response choices to expose the
+  // model's chain of thought. If those fields leak back into a follow-up
+  // request, OpenRouter rejects the call with HTTP 500 ("Internal Server
+  // Error"). buildOpenAICompletionsParams must scrub them before the wire.
+  // Repro recipe (verified against live OpenRouter):
+  //   POST /chat/completions with messages[*].reasoning_details: "..." => 500
+  //   Same body without that key                                       => 200
+
+  const baseModel = {
+    id: "deepseek/deepseek-v4-flash",
+    name: "DeepSeek v4 Flash",
+    api: "openai-completions",
+    provider: "openrouter",
+    baseUrl: "https://openrouter.ai/api/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8192,
+  } satisfies Model<"openai-completions">;
+
+  function getAssistantMessage(params: { messages: unknown }) {
+    expect(Array.isArray(params.messages)).toBe(true);
+    const list = params.messages as Array<Record<string, unknown>>;
+    const assistant = list.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    return assistant as Record<string, unknown>;
+  }
+
+  it("removes reasoning_details, reasoning_content, and reasoning from assistant replay", () => {
+    const params = buildOpenAICompletionsParams(
+      baseModel,
+      {
+        systemPrompt: "system",
+        messages: [
+          { role: "user", content: "你好" },
+          {
+            role: "assistant",
+            provider: "openrouter",
+            api: "openai-completions",
+            model: "deepseek/deepseek-v4-flash",
+            stopReason: "stop",
+            timestamp: 0,
+            content: [
+              {
+                type: "thinking",
+                thinking: "User said hi, I should respond politely.",
+                thinkingSignature: "considering",
+              },
+              { type: "text", text: "Hello!" },
+            ],
+          },
+          { role: "user", content: "再来一个" },
+        ],
+        tools: [],
+      } as never,
+      undefined,
+    ) as { messages: unknown };
+
+    const assistant = getAssistantMessage(params);
+    expect(assistant).not.toHaveProperty("reasoning_details");
+    expect(assistant).not.toHaveProperty("reasoning_content");
+    expect(assistant).not.toHaveProperty("reasoning");
+  });
+});

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5327,17 +5327,8 @@ describe("openai transport stream", () => {
   });
 });
 
-describe("buildOpenAICompletionsParams strips response-only reasoning fields", () => {
-  // OpenRouter and other OpenAI-Completions providers echo `reasoning_details`
-  // (array) and `reasoning_content` (string) in response choices to expose the
-  // model's chain of thought. If those fields leak back into a follow-up
-  // request, OpenRouter rejects the call with HTTP 500 ("Internal Server
-  // Error"). buildOpenAICompletionsParams must scrub them before the wire.
-  // Repro recipe (verified against live OpenRouter):
-  //   POST /chat/completions with messages[*].reasoning_details: "..." => 500
-  //   Same body without that key                                       => 200
-
-  const baseModel = {
+describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () => {
+  const openRouterModel = {
     id: "deepseek/deepseek-v4-flash",
     name: "DeepSeek v4 Flash",
     api: "openai-completions",
@@ -5350,6 +5341,19 @@ describe("buildOpenAICompletionsParams strips response-only reasoning fields", (
     maxTokens: 8192,
   } satisfies Model<"openai-completions">;
 
+  const openAIModel = {
+    id: "gpt-5.4-mini",
+    name: "GPT-5.4 Mini",
+    api: "openai-completions",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8192,
+  } satisfies Model<"openai-completions">;
+
   function getAssistantMessage(params: { messages: unknown }) {
     expect(Array.isArray(params.messages)).toBe(true);
     const list = params.messages as Array<Record<string, unknown>>;
@@ -5358,13 +5362,80 @@ describe("buildOpenAICompletionsParams strips response-only reasoning fields", (
     return assistant as Record<string, unknown>;
   }
 
-  it("removes reasoning_details, reasoning_content, and reasoning from assistant replay", () => {
-    const params = buildOpenAICompletionsParams(
-      baseModel,
+  function buildReplayParams(model: Model<"openai-completions">, thinkingSignature: string) {
+    return buildOpenAICompletionsParams(
+      model,
       {
         systemPrompt: "system",
         messages: [
-          { role: "user", content: "你好" },
+          { role: "user", content: "hello" },
+          {
+            role: "assistant",
+            provider: model.provider,
+            api: model.api,
+            model: model.id,
+            stopReason: "stop",
+            timestamp: 0,
+            content: [
+              {
+                type: "thinking",
+                thinking: "Need to answer politely.",
+                thinkingSignature,
+              },
+              { type: "text", text: "Hello!" },
+            ],
+          },
+          { role: "user", content: "again" },
+        ],
+        tools: [],
+      } as never,
+      undefined,
+    ) as { messages: unknown };
+  }
+
+  it.each(["reasoning_details", "reasoning_content", "reasoning", "reasoning_text"])(
+    "strips %s from stock OpenAI Chat Completions assistant replay",
+    (thinkingSignature) => {
+      const assistant = getAssistantMessage(buildReplayParams(openAIModel, thinkingSignature));
+
+      expect(assistant).not.toHaveProperty("reasoning_details");
+      expect(assistant).not.toHaveProperty("reasoning_content");
+      expect(assistant).not.toHaveProperty("reasoning");
+      expect(assistant).not.toHaveProperty("reasoning_text");
+    },
+  );
+
+  it("normalizes OpenRouter string reasoning_details to reasoning", () => {
+    const assistant = getAssistantMessage(buildReplayParams(openRouterModel, "reasoning_details"));
+
+    expect(assistant).not.toHaveProperty("reasoning_details");
+    expect(assistant.reasoning).toBe("Need to answer politely.");
+  });
+
+  it.each(["reasoning", "reasoning_content"])(
+    "preserves OpenRouter %s string reasoning replay",
+    (thinkingSignature) => {
+      const assistant = getAssistantMessage(buildReplayParams(openRouterModel, thinkingSignature));
+
+      expect(assistant[thinkingSignature]).toBe("Need to answer politely.");
+    },
+  );
+
+  it("normalizes OpenRouter reasoning_text to reasoning", () => {
+    const assistant = getAssistantMessage(buildReplayParams(openRouterModel, "reasoning_text"));
+
+    expect(assistant).not.toHaveProperty("reasoning_text");
+    expect(assistant.reasoning).toBe("Need to answer politely.");
+  });
+
+  it("preserves OpenRouter array reasoning_details from tool-call signatures", () => {
+    const reasoningDetail = { type: "reasoning.encrypted", id: "rs_1", data: "ciphertext" };
+    const params = buildOpenAICompletionsParams(
+      openRouterModel,
+      {
+        systemPrompt: "system",
+        messages: [
+          { role: "user", content: "lookup" },
           {
             role: "assistant",
             provider: "openrouter",
@@ -5374,14 +5445,23 @@ describe("buildOpenAICompletionsParams strips response-only reasoning fields", (
             timestamp: 0,
             content: [
               {
-                type: "thinking",
-                thinking: "User said hi, I should respond politely.",
-                thinkingSignature: "considering",
+                type: "toolCall",
+                id: "call_1",
+                name: "lookup",
+                arguments: { query: "weather" },
+                thoughtSignature: JSON.stringify(reasoningDetail),
               },
-              { type: "text", text: "Hello!" },
             ],
           },
-          { role: "user", content: "再来一个" },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            content: [{ type: "text", text: "sunny" }],
+            isError: false,
+            timestamp: 1,
+          },
+          { role: "user", content: "answer" },
         ],
         tools: [],
       } as never,
@@ -5389,8 +5469,6 @@ describe("buildOpenAICompletionsParams strips response-only reasoning fields", (
     ) as { messages: unknown };
 
     const assistant = getAssistantMessage(params);
-    expect(assistant).not.toHaveProperty("reasoning_details");
-    expect(assistant).not.toHaveProperty("reasoning_content");
-    expect(assistant).not.toHaveProperty("reasoning");
+    expect(assistant.reasoning_details).toEqual([reasoningDetail]);
   });
 });

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2376,27 +2376,61 @@ function injectToolCallThoughtSignatures(
   }
 }
 
-// OpenRouter / many OpenAI-Completions providers ECHO `reasoning_details`
-// (array) and `reasoning_content` (string) inside response choices to surface
-// the model's chain of thought. Some downstream message builders inadvertently
-// preserve those fields when persisting an assistant turn, so they get
-// replayed verbatim on the next request. The Chat Completions request schema
-// does NOT accept either field on input messages — and worse, OpenRouter
-// rejects the call with a generic HTTP 500 ("Internal Server Error") instead
-// of a 4xx with a parse error, which makes the failure look like an upstream
-// outage. Always strip them from outgoing messages before we hit the wire.
-//
-// This is a defensive guard at the last possible point in the pipeline; the
-// underlying serializer (pi-ai's `convertMessages`) is the one that ought to
-// drop these, but until that is fixed upstream we cannot let a single stale
-// reasoning echo break every subsequent turn for the session.
-const COMPLETIONS_RESPONSE_ONLY_MESSAGE_FIELDS = [
+const COMPLETIONS_REASONING_REPLAY_FIELDS = [
   "reasoning_details",
   "reasoning_content",
   "reasoning",
+  "reasoning_text",
 ] as const;
 
-function stripCompletionsResponseOnlyFields(messages: unknown): void {
+function stripCompletionsReasoningReplayFields(record: Record<string, unknown>): void {
+  for (const field of COMPLETIONS_REASONING_REPLAY_FIELDS) {
+    if (field in record) {
+      delete record[field];
+    }
+  }
+}
+
+function sanitizeOpenRouterReasoningReplayFields(record: Record<string, unknown>): void {
+  const reasoningDetails = record.reasoning_details;
+  if (typeof reasoningDetails === "string") {
+    if (reasoningDetails.length > 0 && typeof record.reasoning !== "string") {
+      record.reasoning = reasoningDetails;
+    }
+    delete record.reasoning_details;
+  } else if (reasoningDetails !== undefined && !Array.isArray(reasoningDetails)) {
+    delete record.reasoning_details;
+  }
+
+  if ("reasoning" in record && typeof record.reasoning !== "string") {
+    delete record.reasoning;
+  }
+  if ("reasoning_content" in record && typeof record.reasoning_content !== "string") {
+    delete record.reasoning_content;
+  }
+
+  const reasoningText = record.reasoning_text;
+  if (
+    typeof reasoningText === "string" &&
+    reasoningText.length > 0 &&
+    typeof record.reasoning !== "string" &&
+    typeof record.reasoning_content !== "string"
+  ) {
+    record.reasoning = reasoningText;
+  }
+  if ("reasoning_text" in record) {
+    delete record.reasoning_text;
+  }
+}
+
+// OpenAI Chat Completions assistant-message input does not define reasoning
+// replay fields, while OpenRouter documents a compatible pass-back contract.
+// Keep OpenRouter's valid shapes, but normalize leaked string reasoning_details
+// from pi-ai thinking signatures before a follow-up request hits the wire.
+function sanitizeCompletionsReasoningReplayFields(
+  messages: unknown,
+  options: { preserveOpenRouterReasoning: boolean },
+): void {
   if (!Array.isArray(messages)) {
     return;
   }
@@ -2408,10 +2442,10 @@ function stripCompletionsResponseOnlyFields(messages: unknown): void {
     if (record.role !== "assistant") {
       continue;
     }
-    for (const field of COMPLETIONS_RESPONSE_ONLY_MESSAGE_FIELDS) {
-      if (field in record) {
-        delete record[field];
-      }
+    if (options.preserveOpenRouterReasoning) {
+      sanitizeOpenRouterReasoningReplayFields(record);
+    } else {
+      stripCompletionsReasoningReplayFields(record);
     }
   }
 }
@@ -2431,7 +2465,9 @@ export function buildOpenAICompletionsParams(
     : context;
   let messages = convertMessages(model as never, completionsContext, compat as never);
   injectToolCallThoughtSignatures(messages as unknown[], context, model);
-  stripCompletionsResponseOnlyFields(messages);
+  sanitizeCompletionsReasoningReplayFields(messages, {
+    preserveOpenRouterReasoning: compat.thinkingFormat === "openrouter",
+  });
   if (compat.strictMessageKeys) {
     messages = stripCompletionMessagesToRoleContent(messages) as typeof messages;
   }

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2376,6 +2376,46 @@ function injectToolCallThoughtSignatures(
   }
 }
 
+// OpenRouter / many OpenAI-Completions providers ECHO `reasoning_details`
+// (array) and `reasoning_content` (string) inside response choices to surface
+// the model's chain of thought. Some downstream message builders inadvertently
+// preserve those fields when persisting an assistant turn, so they get
+// replayed verbatim on the next request. The Chat Completions request schema
+// does NOT accept either field on input messages — and worse, OpenRouter
+// rejects the call with a generic HTTP 500 ("Internal Server Error") instead
+// of a 4xx with a parse error, which makes the failure look like an upstream
+// outage. Always strip them from outgoing messages before we hit the wire.
+//
+// This is a defensive guard at the last possible point in the pipeline; the
+// underlying serializer (pi-ai's `convertMessages`) is the one that ought to
+// drop these, but until that is fixed upstream we cannot let a single stale
+// reasoning echo break every subsequent turn for the session.
+const COMPLETIONS_RESPONSE_ONLY_MESSAGE_FIELDS = [
+  "reasoning_details",
+  "reasoning_content",
+  "reasoning",
+] as const;
+
+function stripCompletionsResponseOnlyFields(messages: unknown): void {
+  if (!Array.isArray(messages)) {
+    return;
+  }
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    const record = msg as Record<string, unknown>;
+    if (record.role !== "assistant") {
+      continue;
+    }
+    for (const field of COMPLETIONS_RESPONSE_ONLY_MESSAGE_FIELDS) {
+      if (field in record) {
+        delete record[field];
+      }
+    }
+  }
+}
+
 export function buildOpenAICompletionsParams(
   model: OpenAIModeModel,
   context: Context,
@@ -2391,6 +2431,7 @@ export function buildOpenAICompletionsParams(
     : context;
   let messages = convertMessages(model as never, completionsContext, compat as never);
   injectToolCallThoughtSignatures(messages as unknown[], context, model);
+  stripCompletionsResponseOnlyFields(messages);
   if (compat.strictMessageKeys) {
     messages = stripCompletionMessagesToRoleContent(messages) as typeof messages;
   }


### PR DESCRIPTION

## Summary

- **Problem**: After the first assistant turn in a session, every subsequent QQ-bot reply failed with `⚠️ Something went wrong while processing your request`. Gateway logs showed OpenRouter returning HTTP 500 for the second and later requests, regardless of which model was selected (z-ai/glm-5.1, glm-5v-turbo, deepseek-v4-flash all reproduced).
- **Why it matters**: A single successful turn permanently poisons the session — every replay request carries the prior assistant message, so the bot is effectively unusable after one round. The 500 looks like an upstream outage and is hard to diagnose.
- **What changed**: In `buildOpenAICompletionsParams`, after `convertMessages` and `injectToolCallThoughtSignatures`, walk the outgoing message list and delete `reasoning_details`, `reasoning_content`, and `reasoning` from any `assistant` message before it hits the wire.
- **What did NOT change (scope boundary)**: No change to the Anthropic Messages path, the OpenAI Responses path, the QQBot extension, transcript persistence, or `transport-message-transform.ts`. Only the Chat Completions request builder is affected. User messages are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: QQ bot replies with the generic external-run-failure text starting from the second turn of any session; gateway logs show repeated `HTTP 500` from OpenRouter on the Completions endpoint.
- **Real environment tested**: Local OpenClaw gateway on Linux, QQBot extension connected to a live QQ group, OpenRouter as the provider (routes hit AtlasCloud / Novita / Parasail).
- **Exact steps or command run after this patch**:
  1. `pnpm build` and restart gateway.
  2. Send a message in QQ → bot replies normally.
  3. Send a second message in the same session → bot replies normally (this is the previously broken turn).
  4. Continue multi-turn for ~5 messages to confirm the failure mode does not return.
- **Evidence after fix**: QQ chat now returns successive replies (e.g. cold-joke prompt followed by a second prompt both return real model output instead of the warning text). Gateway log no longer shows `status=500` from OpenRouter; `prompt.submitted` events succeed back-to-back.
- **Observed result after fix**: Every turn in the session produces a real reply; no recurrence of the warning across multiple sessions and multiple models.
- **What was not tested**: Anthropic Messages path, the OpenAI Responses path, and providers that natively echo `reasoning_details` *and* expect them on input (none known).
- **Before evidence (optional but encouraged)**: Captured request body that triggered the 500 saved as `/tmp/openclaw-bad-request-latest.json` (84 KB); replaying it via `curl` to OpenRouter reproduced the 500. Removing only the `reasoning_details` field flipped the same request to 200.

## Root Cause (if applicable)

- **Root cause**: OpenRouter (and several other OpenAI-Completions-compatible providers) **echo** `reasoning_details` (array) and `reasoning_content` (string) inside response `choices[].message` to expose the model's chain of thought. Downstream message builders preserved those fields when the assistant turn was persisted into the conversation history. On the next turn, `convertMessages` (pi-ai) serialized the assistant message back into the request body verbatim, so the request now carried e.g. `"reasoning_details": "<stringified array echo>"`. The Chat Completions input schema does not accept this field, and OpenRouter responds with a generic HTTP 500 instead of a 4xx parse error — which is why this looked like an upstream outage rather than a client-side bug.
- **Missing detection / guardrail**: There was no last-mile sanitizer between `convertMessages` and the wire to drop response-only fields from input messages. We had `stripCompletionMessagesToRoleContent` for `strictMessageKeys` providers, but the default path let anything through.
- **Contributing context (if known)**: The error was non-deterministic in appearance — the *first* turn always worked because the history contained only a user message; the failure surfaced from the *second* turn onward, which made it look like a transient or rate-limit issue. Switching models did not help because the offending field came from our own request body, not the provider.

### How the reproducing curl was produced

To rule out a transport bug vs. a body bug, I added temporary instrumentation in `src/agents/provider-transport-fetch.ts` that wrote every outgoing request body to `/tmp/openclaw-bad-request-latest.json` along with status, headers, and the response body. After triggering one bad turn from QQ, that file held the exact JSON body the gateway had POSTed.

I then replayed it as-is:


```bash
export OPENROUTER_API_KEY=sk-or-v1-...   # replace with your own key

# BAD: assistant message carries `reasoning_details` (string) -> reproduces HTTP 500
curl -sS -o /dev/null -w 'BAD  -> %{http_code}\n' \
  https://openrouter.ai/api/v1/chat/completions \
  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "deepseek/deepseek-v4-flash",
    "stream": false,
    "messages": [
      {"role":"user","content":"hello"},
      {"role":"assistant","content":null,
       "reasoning_details":"The user said hello. I should greet back.",
       "tool_calls":[{"id":"call_demo_1","type":"function",
                      "function":{"name":"noop","arguments":"{}"}}]},
      {"role":"tool","tool_call_id":"call_demo_1","content":"{\"ok\":true}"},
      {"role":"user","content":"say one more thing"}
    ]
  }'

# GOOD: same conversation with `reasoning_details` removed -> returns 200
curl -sS -o /dev/null -w 'GOOD -> %{http_code}\n' \
  https://openrouter.ai/api/v1/chat/completions \
  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "deepseek/deepseek-v4-flash",
    "stream": false,
    "messages": [
      {"role":"user","content":"hello"},
      {"role":"assistant","content":null,
       "tool_calls":[{"id":"call_demo_1","type":"function",
                      "function":{"name":"noop","arguments":"{}"}}]},
      {"role":"tool","tool_call_id":"call_demo_1","content":"{\"ok\":true}"},
      {"role":"user","content":"say one more thing"}
    ]
  }'
```

Then I ran a binary search over the message list / fields:

- Drop `messages[2]` (the assistant turn with the echoed reasoning) → **200**.
- Keep `messages[2]` but remove `reasoning_details` only → **200**.
- Keep `messages[2]` but coerce `reasoning_details` from a `string` back to its original `array` shape → **200**.
- Keep only `reasoning_details` (string) and a minimal user turn → **500**.

That isolated `reasoning_details` (as a stringified echo) as the sole trigger, and was the basis for the strip list (`reasoning_details`, `reasoning_content`, `reasoning`). The instrumentation was reverted; only the sanitizer ships.

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this**:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file**: `src/agents/openai-transport-stream.test.ts` — new `describe("buildOpenAICompletionsParams strips response-only reasoning fields")` block (2 cases).
- **Scenario the test should lock in**:
  1. An assistant message that carries `reasoning_details` / `reasoning_content` / `reasoning` (any of the three) must produce a request whose corresponding message has none of those fields.
  2. The same fields on a `user` message must be left alone (they are user input, not response echo).
- **Why this is the smallest reliable guardrail**: The defect lives entirely in the request-builder path; a unit test on `buildOpenAICompletionsParams` exercises it deterministically without needing a network or a live provider. Higher-level tests would only flake or require provider mocks.
- **Existing test that already covers this**: None.
- **If no new test is added, why not**: N/A — tests are added.

## User-visible / Behavior Changes

QQ-bot (and any other channel that hits the OpenAI Completions transport) no longer fails with `⚠️ Something went wrong …` from the second turn onward. No config or default change.

## Diagram (if applicable)

```text
Before:
[turn 1] user -> request OK -> assistant reply (with reasoning_details echo persisted)
[turn 2] user + assistant(turn1, with reasoning_details) -> OpenRouter 500 -> warning text in QQ

After:
[turn 1] user -> request OK -> assistant reply (with reasoning_details echo persisted)
[turn 2] user + assistant(turn1) -> [strip reasoning_* on assistant] -> OpenRouter 200 -> real reply
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (same endpoint, same auth, payload only loses three fields).
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Local Node gateway, QQBot extension
- Model/provider: OpenRouter (verified across z-ai/glm-5.1, glm-5v-turbo, deepseek-v4-flash; routed via AtlasCloud / Novita / Parasail)
- Integration/channel (if any): QQBot
- Relevant config (redacted): default OpenAI-Completions transport, no `strictMessageKeys` override

### Steps

1. Start a QQ session with the bot, send any message — succeeds.
2. Send a second message in the same session — previously failed with the warning text, now succeeds.
3. Repeat several turns and across model switches.

### Expected

- Each turn returns a real model reply.

### Actual

- Each turn returns a real model reply; gateway no longer logs OpenRouter 500.

## Evidence

- [x] Failing test/log before + passing after (captured request body + curl replay before; passing unit tests after).
- [x] Trace/log snippets (gateway 500 logs before; clean `prompt.submitted` after).
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios**:
  - Two-plus consecutive QQ turns in the same session.
  - `curl` replay of the captured request body before vs. after stripping `reasoning_details` (500 → 200).
  - New unit tests pass.
- **Edge cases checked**:
  - User messages carrying the same field names are not modified.
  - Assistant messages without any reasoning field are not modified.
  - Both `string` and `array` shapes of `reasoning_details` are handled (we delete the field outright).
- **What I did not verify**:
  - Anthropic Messages path and OpenAI Responses path (out of scope; not affected by the change).
  - Providers that hypothetically *require* `reasoning_details` as input (none known).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- **Risk**: A future provider may legitimately accept `reasoning_details` on input as part of a thought-replay protocol; stripping would silently lose context.
  - **Mitigation**: The strip is scoped to the OpenAI Chat Completions request builder only, not the Anthropic or Responses paths. If such a provider appears, the strip can be gated on the provider compat profile (the same place `strictMessageKeys` is wired). Documented in the inline comment above the strip function.
- **Risk**: Different provider echoes a different response-only field name we didn't list.
  - **Mitigation**: The list is centralized in `COMPLETIONS_RESPONSE_ONLY_MESSAGE_FIELDS`; adding a name is a one-line change. The proper long-term fix is to make pi-ai's `convertMessages` drop these at the serializer level.