### PR TITLE
[AI] fix: force WAV format in ffmpeg audio transcode for fs-safe temp paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Media/audio: force WAV muxing when `whisper-cli` transcodes through fs-safe staged temp paths, restoring STT for non-WAV voice messages. Fixes #82094. (#82110) Thanks @civiltox.
 - Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
 
 ## 2026.5.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Media/audio: force WAV muxing when `whisper-cli` transcodes through fs-safe staged temp paths, restoring STT for non-WAV voice messages. Fixes #82094. (#82110) Thanks @civiltox.
 - Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
 
 ## 2026.5.14
@@ -64,7 +63,7 @@ Docs: https://docs.openclaw.ai
 - Discord: report unresolved configured bot-token SecretRefs during startup instead of treating the account as unconfigured. (#82009) Thanks @giodl73-repo.
 - Discord: pass an explicit Ogg muxer to ffmpeg when transcoding voice-message audio through staged temp files, restoring TTS voice-message delivery. Fixes #82074. Thanks @hwlbb.
 - Discord/Feishu: allow Discord voice uploads through RFC2544 fake-IP proxy DNS and pass Feishu's voice ffmpeg transcode through an explicit Ogg muxer. (#82088) Thanks @hwlbb and @6peng888.
-- Audio/STT: pass explicit WAV/Ogg muxers to ffmpeg for whisper-cli and WhatsApp staged temp outputs so `.part` filenames do not break transcription or voice-message delivery. Fixes #82094.
+- Audio/STT: pass explicit WAV/Ogg muxers to ffmpeg for whisper-cli and WhatsApp staged temp outputs so `.part` filenames do not break transcription or voice-message delivery. Fixes #82094. (#82110) Thanks @civiltox.
 - CLI/config: preserve numeric-looking object keys such as Discord guild IDs during `config patch` recursive merges. (#81999) Thanks @giodl73-repo.
 - Gateway/OpenAI-compatible HTTP: forward `response_format` from `/v1/chat/completions` requests through agent stream params to upstream Chat Completions and Responses transports, restoring structured-output support. Fixes #82003. (#82004) Thanks @Lellansin.
 - Control UI/WebChat: let sidebar markdown code-block Copy buttons use the same delegated clipboard handler as chat messages. (#58709) Thanks @tikitoki.


### PR DESCRIPTION
## Summary

Fixes the STT audio transcription regression introduced in v2026.5.12. Voice messages fail with `audio: failed (0/1) reason=Command failed` because ffmpeg receives a `.wav.part` temp path and cannot guess the output format from the extension.

## Root Cause

`writeExternalFileWithinRoot` from `@openclaw/fs-safe` writes to a `.wav.part` temp path before renaming to the final `.wav`. ffmpeg infers output format from the file extension; `.wav.part` is not recognized as WAV, so it produces no output.

## Fix

Added `-f wav` before the output path so ffmpeg knows the format explicitly, regardless of the temp filename extension.

## Real behavior proof

- Behavior addressed: STT audio transcription via `whisper-cli` fails for Telegram voice messages after the v2026.5.12 fs-safe transcode change because ffmpeg receives a `.wav.part` temp output path without an explicit WAV muxer.
- Real environment tested: Live Debian 13 OpenClaw 2026.5.12 setup with Telegram DM voice messages, `whisper-cli`, and ffmpeg.
- Exact steps or command run after this patch: Applied the patch, restarted the gateway at 19:56, sent the same Telegram voice-message flow at 19:59, and inspected OpenClaw runtime logs plus temp media directory cleanup.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Before fix, voice message at 19:54 was received, but audio transcoding failed in both preflight and main pass:

```
[2026-05-15T19:54:09.428+10:00] Inbound message telegram:id -> @clawbot (direct, audio/ogg, 13 chars)
[2026-05-15T19:54:09.424+10:00] audio: failed (0/1) reason=Command failed
[2026-05-15T19:54:09.521+10:00] audio: failed (0/1) reason=Command failed
```

`ls -la /tmp/openclaw/openclaw-media-cli-7NNikc/` showed an empty directory, so ffmpeg never wrote output.

After fix, same setup, patch applied at 19:56, voice message at 19:59:

```
[2026-05-15T19:59:23.742+10:00] Inbound message telegram:id -> @clawbot (direct, audio/ogg, 13 chars)
```

No `audio: failed` entries occurred after restart. Temp directories cleaned up normally, and Telegram machine-generated transcript came through, confirming the full pipeline worked.

- Observed result after fix: Non-WAV Telegram voice audio transcoded through the fs-safe temp path and produced a transcript without `audio: failed` log entries.
- What was not tested: Broad cross-provider audio transcription matrix; this proof targets the reported `whisper-cli`/Telegram non-WAV regression path.

## Unit tests

Updated focused test expectations: ffmpeg args length 10 to 12 and assert `-f wav` at positions 9-10.

## AI-Assisted

- [x] Mark as AI-assisted in the PR title or description
- [x] Include human-run real behavior proof from my own setup (see above)
- [x] Confirm I understand what the code does
- [x] Resolve or reply to bot review conversations after addressing them

Closes #82094
