### PR TITLE
fix: restore voice media uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/protocol: lazy-compile protocol validators on first use instead of compiling every AJV schema during cold import, reducing startup CPU and RSS. (#82064) Thanks @samzong.
 - Discord: report unresolved configured bot-token SecretRefs during startup instead of treating the account as unconfigured. (#82009) Thanks @giodl73-repo.
 - Discord: pass an explicit Ogg muxer to ffmpeg when transcoding voice-message audio through staged temp files, restoring TTS voice-message delivery. Fixes #82074. Thanks @hwlbb.
+- Discord/Feishu: allow Discord voice uploads through RFC2544 fake-IP proxy DNS and pass Feishu's voice ffmpeg transcode through an explicit Ogg muxer. (#82088) Thanks @hwlbb and @6peng888.
 - CLI/config: preserve numeric-looking object keys such as Discord guild IDs during `config patch` recursive merges. (#81999) Thanks @giodl73-repo.
 - Gateway/OpenAI-compatible HTTP: forward `response_format` from `/v1/chat/completions` requests through agent stream params to upstream Chat Completions and Responses transports, restoring structured-output support. Fixes #82003. (#82004) Thanks @Lellansin.
 - Control UI/WebChat: let sidebar markdown code-block Copy buttons use the same delegated clipboard handler as chat messages. (#58709) Thanks @tikitoki.

--- a/extensions/discord/src/voice-message.test.ts
+++ b/extensions/discord/src/voice-message.test.ts
@@ -6,6 +6,19 @@ import type { VoiceMessageMetadata } from "./voice-message.js";
 
 const runFfprobeMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<string>>());
 const runFfmpegMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>());
+const fetchWithSsrFGuardMock = vi.hoisted(() =>
+  vi.fn(
+    async (params: {
+      url: string;
+      init?: RequestInit;
+      policy?: { allowRfc2544BenchmarkRange?: boolean; allowIpv6UniqueLocalRange?: boolean };
+      auditContext?: string;
+    }) => ({
+      response: await globalThis.fetch(params.url, params.init),
+      release: async () => {},
+    }),
+  ),
+);
 
 vi.mock("openclaw/plugin-sdk/temp-path", async () => {
   return {
@@ -31,10 +44,7 @@ vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
   return {
-    fetchWithSsrFGuard: async (params: { url: string; init?: RequestInit }) => ({
-      response: await globalThis.fetch(params.url, params.init),
-      release: async () => {},
-    }),
+    fetchWithSsrFGuard: fetchWithSsrFGuardMock,
   };
 });
 
@@ -196,6 +206,7 @@ describe("sendDiscordVoiceMessage", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    fetchWithSsrFGuardMock.mockClear();
   });
 
   function createRest(post = vi.fn(async () => ({ id: "msg-1", channel_id: "channel-1" }))) {
@@ -269,6 +280,35 @@ describe("sendDiscordVoiceMessage", () => {
 
     expect(uploadUrlRequests).toBe(2);
     expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(4);
+    expect(
+      fetchWithSsrFGuardMock.mock.calls.map(([params]) => ({
+        auditContext: params.auditContext,
+        allowRfc2544BenchmarkRange: params.policy?.allowRfc2544BenchmarkRange,
+        allowIpv6UniqueLocalRange: params.policy?.allowIpv6UniqueLocalRange,
+      })),
+    ).toEqual([
+      {
+        auditContext: "discord.voice.upload-url",
+        allowRfc2544BenchmarkRange: true,
+        allowIpv6UniqueLocalRange: true,
+      },
+      {
+        auditContext: "discord.voice.attachment-upload",
+        allowRfc2544BenchmarkRange: true,
+        allowIpv6UniqueLocalRange: true,
+      },
+      {
+        auditContext: "discord.voice.upload-url",
+        allowRfc2544BenchmarkRange: true,
+        allowIpv6UniqueLocalRange: true,
+      },
+      {
+        auditContext: "discord.voice.attachment-upload",
+        allowRfc2544BenchmarkRange: true,
+        allowIpv6UniqueLocalRange: true,
+      },
+    ]);
     expect(post).toHaveBeenCalledWith("/channels/channel-1/messages", {
       body: {
         flags: 8192,

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -23,7 +23,7 @@ import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS } from "openclaw/plugin-sdk/media-
 import { unlinkIfExists } from "openclaw/plugin-sdk/media-runtime";
 import type { RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { DiscordError, RateLimitError, type RequestClient } from "./internal/discord.js";
@@ -33,6 +33,10 @@ const DISCORD_VOICE_MESSAGE_FLAG = 1 << 13;
 const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
 const WAVEFORM_SAMPLES = 256;
 const DISCORD_OPUS_SAMPLE_RATE_HZ = 48_000;
+const DISCORD_VOICE_UPLOAD_SSRF_POLICY: SsrFPolicy = {
+  allowRfc2544BenchmarkRange: true,
+  allowIpv6UniqueLocalRange: true,
+};
 
 async function runFfmpegToOutput(params: {
   outputPath: string;
@@ -335,6 +339,7 @@ async function requestVoiceUploadUrl(params: {
   const { response: res, release } = await fetchWithSsrFGuard({
     url,
     init: uploadUrlInit,
+    policy: DISCORD_VOICE_UPLOAD_SSRF_POLICY,
     auditContext: "discord.voice.upload-url",
   });
   try {
@@ -360,6 +365,7 @@ async function uploadVoiceAttachment(params: {
       },
       body: new Uint8Array(params.audioBuffer),
     },
+    policy: DISCORD_VOICE_UPLOAD_SSRF_POLICY,
     auditContext: "discord.voice.attachment-upload",
   });
 

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -301,9 +301,10 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     const ffmpegArgs = mockCallArg<string[]>(runFfmpegMock, 0, 0);
-    for (const arg of ["-c:a", "libopus", "-ar", "48000", "-b:a", "64k"]) {
+    for (const arg of ["-c:a", "libopus", "-ar", "48000", "-b:a", "64k", "-f", "ogg"]) {
       expect(ffmpegArgs).toContain(arg);
     }
+    expect(ffmpegArgs.slice(-3, -1)).toEqual(["-f", "ogg"]);
     const fileData = callData<{ file?: Buffer; file_name?: string; file_type?: string }>(
       fileCreateMock,
     );

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -959,6 +959,8 @@ async function transcodeToFeishuVoiceOpus(params: {
             "libopus",
             "-b:a",
             FEISHU_VOICE_BITRATE,
+            "-f",
+            "ogg",
             outputPath,
           ]);
         },


### PR DESCRIPTION
## Summary
- Allows Discord voice upload URL and attachment uploads through fake-IP proxy DNS ranges needed by RFC2544 and IPv6 ULA proxy resolvers.
- Adds an explicit Ogg muxer to Feishu voice ffmpeg output so staged `.ogg.part` files are encoded with the intended container.
- Adds regression assertions for the Discord SSRF policy and Feishu ffmpeg args, with changelog credit for #82074/#82088.

## Verification
- `node scripts/run-vitest.mjs extensions/discord/src/voice-message.test.ts extensions/feishu/src/media.test.ts`
- `pnpm test extensions/discord/src/voice-message.test.ts extensions/feishu/src/media.test.ts -- --reporter=verbose`
- `pnpm check:changed` via Blacksmith Testbox `tbx_01krnje95vxdzxsnd64m8mkmh2`, run https://github.com/openclaw/openclaw/actions/runs/25912759788
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --full-access`

## Real behavior proof
Behavior addressed: Discord voice upload fetches now permit fake-IP proxy DNS ranges, and Feishu voice transcodes force the Ogg muxer even when writing to `.ogg.part` temp paths.
Real environment tested: local OpenClaw source checkout plus Blacksmith Testbox changed-check lane.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/discord/src/voice-message.test.ts extensions/feishu/src/media.test.ts`; `pnpm check:changed` on Testbox run https://github.com/openclaw/openclaw/actions/runs/25912759788.
Evidence after fix: Maintainer override applied via proof: override after code-path proof and focused/Testbox verification. Discord test asserts all upload URL and attachment upload calls pass `allowRfc2544BenchmarkRange: true` and `allowIpv6UniqueLocalRange: true`; Feishu test asserts ffmpeg receives `-f ogg` immediately before the temp output path.
Observed result after fix: focused Vitest passed 50 tests across the Discord and Feishu media files; changed check passed typecheck/lint/guards/import-cycle lanes.
What was not tested: no live Discord or Feishu media upload was run with real channel credentials.

Fixes #82074.
Refs #82088.
