### PR TITLE
fix: force ffmpeg muxers for staged audio outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Docs: https://docs.openclaw.ai
 - Discord: report unresolved configured bot-token SecretRefs during startup instead of treating the account as unconfigured. (#82009) Thanks @giodl73-repo.
 - Discord: pass an explicit Ogg muxer to ffmpeg when transcoding voice-message audio through staged temp files, restoring TTS voice-message delivery. Fixes #82074. Thanks @hwlbb.
 - Discord/Feishu: allow Discord voice uploads through RFC2544 fake-IP proxy DNS and pass Feishu's voice ffmpeg transcode through an explicit Ogg muxer. (#82088) Thanks @hwlbb and @6peng888.
-- Audio/STT: pass explicit WAV/Ogg muxers to ffmpeg for whisper-cli, Feishu, and WhatsApp staged temp outputs so `.part` filenames do not break transcription or voice-message delivery. Fixes #82094.
+- Audio/STT: pass explicit WAV/Ogg muxers to ffmpeg for whisper-cli and WhatsApp staged temp outputs so `.part` filenames do not break transcription or voice-message delivery. Fixes #82094.
 - CLI/config: preserve numeric-looking object keys such as Discord guild IDs during `config patch` recursive merges. (#81999) Thanks @giodl73-repo.
 - Gateway/OpenAI-compatible HTTP: forward `response_format` from `/v1/chat/completions` requests through agent stream params to upstream Chat Completions and Responses transports, restoring structured-output support. Fixes #82003. (#82004) Thanks @Lellansin.
 - Control UI/WebChat: let sidebar markdown code-block Copy buttons use the same delegated clipboard handler as chat messages. (#58709) Thanks @tikitoki.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 - Discord: report unresolved configured bot-token SecretRefs during startup instead of treating the account as unconfigured. (#82009) Thanks @giodl73-repo.
 - Discord: pass an explicit Ogg muxer to ffmpeg when transcoding voice-message audio through staged temp files, restoring TTS voice-message delivery. Fixes #82074. Thanks @hwlbb.
 - Discord/Feishu: allow Discord voice uploads through RFC2544 fake-IP proxy DNS and pass Feishu's voice ffmpeg transcode through an explicit Ogg muxer. (#82088) Thanks @hwlbb and @6peng888.
+- Audio/STT: pass explicit WAV/Ogg muxers to ffmpeg for whisper-cli, Feishu, and WhatsApp staged temp outputs so `.part` filenames do not break transcription or voice-message delivery. Fixes #82094.
 - CLI/config: preserve numeric-looking object keys such as Discord guild IDs during `config patch` recursive merges. (#81999) Thanks @giodl73-repo.
 - Gateway/OpenAI-compatible HTTP: forward `response_format` from `/v1/chat/completions` requests through agent stream params to upstream Chat Completions and Responses transports, restoring structured-output support. Fixes #82003. (#82004) Thanks @Lellansin.
 - Control UI/WebChat: let sidebar markdown code-block Copy buttons use the same delegated clipboard handler as chat messages. (#58709) Thanks @tikitoki.

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -778,6 +778,7 @@ describe("deliverWebReply", () => {
     expect(ffmpegArgList).toContain("48000");
     expect(ffmpegArgList).toContain("-b:a");
     expect(ffmpegArgList).toContain("64k");
+    expect(ffmpegArgList.slice(-3, -1)).toEqual(["-f", "ogg"]);
     const mediaPayload = requireRecord(
       mockCallArg(msg.sendMedia, 0, 0, "sendMedia"),
       "sendMedia payload",

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -214,6 +214,8 @@ async function transcodeToWhatsAppVoiceOpus(params: {
             "libopus",
             "-b:a",
             WHATSAPP_VOICE_BITRATE,
+            "-f",
+            "ogg",
             outputPath,
           ]);
         },

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -315,6 +315,8 @@ describe("web outbound", () => {
       "libopus",
       "-b:a",
       "64k",
+      "-f",
+      "ogg",
     ]);
     const outputPath = ffmpegArgs?.at(-1);
     expect(outputPath).toContain("/fs-safe-output-");

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -846,12 +846,21 @@ describe("applyMediaUnderstanding", () => {
 
     expect(ctx.Transcript).toBe("whisper cpp ogg ok");
     const ffmpegArgs = getRunFfmpegArgs();
-    expect(ffmpegArgs).toHaveLength(10);
+    expect(ffmpegArgs).toHaveLength(12);
     expect(ffmpegArgs.slice(0, 2)).toEqual(["-y", "-i"]);
     expect(String(ffmpegArgs[2]).endsWith("telegram-voice.ogg")).toBe(true);
-    expect(ffmpegArgs.slice(3, 9)).toEqual(["-ac", "1", "-ar", "16000", "-c:a", "pcm_s16le"]);
-    expect(String(ffmpegArgs[9])).toContain("telegram-voice.wav");
-    expect(String(ffmpegArgs[9]).endsWith(".part")).toBe(true);
+    expect(ffmpegArgs.slice(3, 11)).toEqual([
+      "-ac",
+      "1",
+      "-ar",
+      "16000",
+      "-c:a",
+      "pcm_s16le",
+      "-f",
+      "wav",
+    ]);
+    expect(String(ffmpegArgs[11])).toContain("telegram-voice.wav");
+    expect(String(ffmpegArgs[11]).endsWith(".part")).toBe(true);
 
     const [command, args, options] = getRunExecCall();
     expect(command).toBe("whisper-cli");

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -269,6 +269,8 @@ async function resolveCliMediaPath(params: {
         "16000",
         "-c:a",
         "pcm_s16le",
+        "-f",
+        "wav",
         outputPath,
       ]);
     },


### PR DESCRIPTION
## Summary

- Force the WAV muxer for whisper-cli STT pre-transcode writes that go through fs-safe staged `.part` output paths.
- Force the Ogg muxer for WhatsApp voice-note transcoding through the same staged output contract.
- Add focused regression assertions for the ffmpeg argument order and update the changelog.

Fixes #82094.

## Verification

- `pnpm test src/media-understanding/apply.test.ts extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/auto-reply/deliver-reply.test.ts -- --reporter=verbose`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review` -> clean, no accepted/actionable findings
- `pnpm check:changed` via Blacksmith Testbox `tbx_01krnkqr8zacqdn9yd0n7zg9g0`, run https://github.com/openclaw/openclaw/actions/runs/25913660872

## Real behavior proof

Behavior addressed: ffmpeg could not infer the intended output container when fs-safe handed it a staged output path ending in `.part`, breaking whisper-cli WAV pre-transcode and WhatsApp Ogg voice-note transcoding.
Real environment tested: local focused Vitest shards plus Blacksmith Testbox changed gate on this branch.
Exact steps or command run after this patch: `pnpm test src/media-understanding/apply.test.ts extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/auto-reply/deliver-reply.test.ts -- --reporter=verbose`; `pnpm check:changed`.
Evidence after fix: tests assert `-f wav` before the whisper-cli staged output path and `-f ogg` before the WhatsApp staged voice output path; Testbox run `tbx_01krnkqr8zacqdn9yd0n7zg9g0` exited 0.
Observed result after fix: focused tests passed and changed gate passed.
What was not tested: live WhatsApp delivery and live whisper-cli binary transcription were not run; the regression is covered at the ffmpeg invocation boundary that failed for staged `.part` paths.
