### PR TITLE
fix(ui): repair chat composer usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/WebChat: focus the composer when users click the visible input chrome and restore larger, labeled desktop composer controls while preserving compact mobile taps. Fixes #45656. Thanks @BunsDev.
 - Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
 
 ## 2026.5.14

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -641,15 +641,16 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  gap: 6px;
+  min-width: 36px;
+  height: 36px;
   border-radius: var(--radius-sm);
   border: none;
   background: transparent;
   color: var(--muted);
   cursor: pointer;
   flex-shrink: 0;
-  padding: 0;
+  padding: 0 10px;
   transition: all var(--duration-fast) ease;
 }
 
@@ -662,6 +663,16 @@
   stroke-width: 1.5px;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
+
+.agent-chat__control-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.76rem;
+  font-weight: 500;
+  line-height: 1;
 }
 
 .agent-chat__input-btn:hover:not(:disabled),
@@ -800,8 +811,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  gap: 6px;
+  min-width: 40px;
+  height: 36px;
   border-radius: var(--radius-md);
   border: none;
   background: transparent;
@@ -811,7 +823,21 @@
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
-  padding: 0;
+  padding: 0 12px;
+}
+
+@media (max-width: 860px) {
+  .agent-chat__input-btn,
+  .agent-chat__toolbar .btn--ghost,
+  .chat-send-btn {
+    width: 36px;
+    min-width: 36px;
+    padding: 0;
+  }
+
+  .agent-chat__control-label {
+    display: none;
+  }
 }
 
 @media (max-width: 560px) {

--- a/ui/src/styles/chat/layout.test.ts
+++ b/ui/src/styles/chat/layout.test.ts
@@ -57,4 +57,14 @@ describe("chat layout styles", () => {
     expect(css).toContain(".chat-controls__separator {");
     expect(css).toContain("height: 22px;");
   });
+
+  it("keeps composer controls labeled and large enough without shrinking mobile taps", () => {
+    const css = readLayoutCss();
+
+    expect(css).toContain(".agent-chat__control-label");
+    expect(css).toContain("min-width: 36px;");
+    expect(css).toContain("height: 36px;");
+    expect(css).toContain("@media (max-width: 860px)");
+    expect(css).toContain("width: 44px;");
+  });
 });

--- a/ui/src/ui/chat/run-controls.test.ts
+++ b/ui/src/ui/chat/run-controls.test.ts
@@ -101,11 +101,13 @@ describe("chat run controls", () => {
 
     const newSessionButton = getButton(container, 'button[title="New session"]');
     expect(newSessionButton.title).toBe("New session");
+    expect(newSessionButton.textContent).toContain("New session");
     newSessionButton.click();
     expect(onNewSession).toHaveBeenCalledTimes(1);
 
     const sendButton = getButton(container, 'button[title="Send"]');
     expect(sendButton.title).toBe("Send");
+    expect(sendButton.textContent).toContain("Send");
     sendButton.click();
     expect(onStoreDraft).toHaveBeenCalledWith(" run this ");
     expect(onSend).toHaveBeenCalledTimes(1);
@@ -160,9 +162,15 @@ describe("chat run controls", () => {
     const container = document.createElement("div");
     render(renderChatRunControls(createProps({ hasMessages: true })), container);
 
-    getButton(container, `button[title="${t("chat.runControls.newSession")}"]`);
-    getButton(container, `button[title="${t("chat.runControls.export")}"]`);
-    getButton(container, `button[title="${t("chat.runControls.send")}"]`);
+    expect(
+      getButton(container, `button[title="${t("chat.runControls.newSession")}"]`).textContent,
+    ).toContain(t("chat.runControls.newSession"));
+    expect(
+      getButton(container, `button[title="${t("chat.runControls.export")}"]`).textContent,
+    ).toContain(t("chat.runControls.export"));
+    expect(
+      getButton(container, `button[title="${t("chat.runControls.send")}"]`).textContent,
+    ).toContain(t("chat.runControls.send"));
     expect(container.querySelector('button[title="New session"]')).toBeNull();
   });
 });

--- a/ui/src/ui/chat/run-controls.ts
+++ b/ui/src/ui/chat/run-controls.ts
@@ -29,6 +29,7 @@ export function renderChatRunControls(props: ChatRunControlsProps) {
               aria-label=${t("chat.runControls.newSession")}
             >
               ${icons.plus}
+              <span class="agent-chat__control-label">${t("chat.runControls.newSession")}</span>
             </button>
           `}
       <button
@@ -39,6 +40,7 @@ export function renderChatRunControls(props: ChatRunControlsProps) {
         ?disabled=${!props.hasMessages}
       >
         ${icons.download}
+        <span class="agent-chat__control-label">${t("chat.runControls.export")}</span>
       </button>
 
       ${props.canAbort
@@ -56,6 +58,7 @@ export function renderChatRunControls(props: ChatRunControlsProps) {
               aria-label=${t("chat.runControls.queueMessage")}
             >
               ${icons.send}
+              <span class="agent-chat__control-label">${t("chat.runControls.queue")}</span>
             </button>
             <button
               class="chat-send-btn chat-send-btn--stop"
@@ -64,6 +67,7 @@ export function renderChatRunControls(props: ChatRunControlsProps) {
               aria-label=${t("chat.runControls.stopGenerating")}
             >
               ${icons.stop}
+              <span class="agent-chat__control-label">${t("chat.runControls.stop")}</span>
             </button>
           `
         : html`
@@ -82,6 +86,9 @@ export function renderChatRunControls(props: ChatRunControlsProps) {
                 : t("chat.runControls.sendMessage")}
             >
               ${icons.send}
+              <span class="agent-chat__control-label"
+                >${props.isBusy ? t("chat.runControls.queue") : t("chat.runControls.send")}</span
+              >
             </button>
           `}
     </div>

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -613,7 +613,7 @@ describe("chat voice controls", () => {
       "localized Start Talk button",
     );
     expect(talkButton.getAttribute("title")).toBe(startTalkLabel);
-    expect(talkButton.textContent?.trim()).toBe("");
+    expect(talkButton.textContent?.trim()).toBe(startTalkLabel);
     expect(container.querySelector('[aria-label="Start Talk"]')).toBeNull();
     requireElement(
       container,
@@ -623,6 +623,40 @@ describe("chat voice controls", () => {
     expect(container.querySelector("textarea")?.getAttribute("placeholder")).toBe(
       t("chat.composer.placeholder", { name: "Val" }),
     );
+  });
+
+  it("focuses the composer from non-control input chrome", () => {
+    const container = renderChatView();
+    const toolbar = requireElement(container, ".agent-chat__toolbar", "composer toolbar");
+    const textarea = requireElement(
+      container,
+      ".agent-chat__composer-combobox > textarea",
+      "composer textarea",
+    ) as HTMLTextAreaElement;
+    const focusSpy = vi.spyOn(textarea, "focus");
+
+    toolbar.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it("keeps composer control clicks on the clicked control", () => {
+    const container = renderChatView();
+    const attachButton = requireElement(
+      container,
+      `[aria-label="${t("chat.composer.attachFile")}"]`,
+      "attach button",
+    );
+    const textarea = requireElement(
+      container,
+      ".agent-chat__composer-combobox > textarea",
+      "composer textarea",
+    ) as HTMLTextAreaElement;
+    const focusSpy = vi.spyOn(textarea, "focus");
+
+    attachButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(focusSpy).not.toHaveBeenCalled();
   });
 
   it("lets users dismiss Talk start errors", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -58,6 +58,19 @@ import { resolveLocalUserName } from "../user-identity.ts";
 import { renderMarkdownSidebar } from "./markdown-sidebar.ts";
 import "../components/resizable-divider.ts";
 
+const COMPOSER_CHROME_INTERACTIVE_SELECTOR = [
+  "a[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "summary",
+  "[contenteditable='true']",
+  "[role='button']",
+  "[role='listbox']",
+  "[role='option']",
+].join(",");
+
 export type ChatProps = {
   sessionKey: string;
   onSessionKeyChange: (next: string) => void;
@@ -322,6 +335,23 @@ export const cleanupChatModuleState = resetChatViewState;
 function adjustTextareaHeight(el: HTMLTextAreaElement) {
   el.style.height = "auto";
   el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+}
+
+function focusComposerFromChrome(event: MouseEvent, connected: boolean) {
+  if (!connected || event.defaultPrevented) {
+    return;
+  }
+  const target = event.target;
+  const currentTarget = event.currentTarget;
+  if (!(target instanceof Element) || !(currentTarget instanceof HTMLElement)) {
+    return;
+  }
+  if (target.closest(COMPOSER_CHROME_INTERACTIVE_SELECTOR)) {
+    return;
+  }
+  currentTarget
+    .querySelector<HTMLTextAreaElement>(".agent-chat__composer-combobox > textarea")
+    ?.focus({ preventScroll: true });
 }
 
 function restoreHistoryCaret(target: HTMLTextAreaElement, direction: "up" | "down") {
@@ -1359,7 +1389,10 @@ export function renderChat(props: ChatProps) {
         : nothing}
 
       <!-- Input bar -->
-      <div class="agent-chat__input">
+      <div
+        class="agent-chat__input"
+        @click=${(event: MouseEvent) => focusComposerFromChrome(event, props.connected)}
+      >
         ${renderSlashMenu(requestUpdate, props)} ${renderAttachmentPreview(props)}
 
         <input
@@ -1423,6 +1456,7 @@ export function renderChat(props: ChatProps) {
               ?disabled=${!props.connected}
             >
               ${icons.paperclip}
+              <span class="agent-chat__control-label">${t("chat.composer.attachFile")}</span>
             </button>
 
             ${props.onToggleRealtimeTalk
@@ -1441,6 +1475,11 @@ export function renderChat(props: ChatProps) {
                     ?disabled=${!props.connected}
                   >
                     ${props.realtimeTalkActive ? icons.volume2 : icons.radio}
+                    <span class="agent-chat__control-label"
+                      >${props.realtimeTalkActive
+                        ? t("chat.composer.stopTalk")
+                        : t("chat.composer.startTalk")}</span
+                    >
                   </button>
                   <button
                     class="agent-chat__input-btn ${props.realtimeTalkOptionsOpen


### PR DESCRIPTION
## Summary

- Fixes the still-open #45656 composer usability regression by focusing the textarea when users click non-control areas of the visible composer chrome, including the lower toolbar row.
- Restores visible desktop labels and larger 36px composer controls for Attach file, Start Talk, New session, Export, and Send/Queue/Stop while keeping compact 44px mobile tap targets.
- Adds focused regression coverage for wrapper click-to-focus, control-click exclusion, localized visible labels, and the CSS hit-target/label contract.

## Issue Review

- Target: #45656, reported by Henry Loenwind (@HenryLoenwind, account created 2012-02-29).
- Current state before this PR: open.
- Current-main proof: after #82077 landed, the issue remained open by design because that PR only aligned chat header controls. Current main still rendered `.agent-chat__input` as a bordered wrapper around a separate textarea and toolbar without wrapper-level focus delegation, so clicks on lower empty chrome did not focus the composer.
- Best fix judgment: a narrow composer repair is safer than reverting the full v2 layout. The patch fixes the dead click target and improves desktop button discoverability without changing gateway, session, model, or message-send contracts.

## Duplicate / Related Search

- `gitcrawl threads openclaw/openclaw --numbers 45656 --include-closed`: target is open in the local issue store.
- `gitcrawl neighbors openclaw/openclaw --number 45656 --limit 20`: found broader v2 UI neighbors such as #45649, #45654, #45688, #45703, #45711, #45752, and #45694, but these are related UI regressions, not the same composer click-target/button-label bug.
- Live GitHub exact symptom search for `upper half` found only #45656.
- Live PR search for `45656` found merged #82077, whose scope explicitly says broader composer hit-target issues remain out of scope and #45656 should stay open.
- `prtags` was installed and authenticated as BunsDev, but group search returned `request failed (502)`, so no duplicate group/annotation write was forced. Decision: `not_duplicate`, high confidence.

## Security Impact

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? No.
- Data access scope changed? No.
- Security review: the patch is limited to Lit event handling, button text, CSS, tests, and changelog. No `innerHTML`, `unsafeHTML`, `eval`, URL handling, auth, or RPC changes were introduced.

## Browser Proof

- Local Vite dev server: `pnpm ui:dev`.
- Full dashboard route loaded but required local gateway auth, so I used Playwright to render `renderChat()` in the same Vite module graph without printing any gateway token.
- Browser result: dispatching a click on `.agent-chat__toolbar` made `document.activeElement` the composer textarea.
- Browser result: desktop composer controls rendered at 36px height with visible labels: Attach file, Start Talk, New session, Export, Send. Talk options remains icon-only with `aria-label`/`title`.
- Browser console: 0 errors; only local dev/auth warnings.

## Verification

- `pnpm install` after the fresh worktree initially lacked `node_modules`; unintended `pnpm-lock.yaml` metadata churn was discarded before commit.
- `pnpm test ui/src/ui/views/chat.test.ts ui/src/ui/chat/run-controls.test.ts ui/src/styles/chat/layout.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md ui/src/ui/views/chat.ts ui/src/ui/views/chat.test.ts ui/src/ui/chat/run-controls.ts ui/src/ui/chat/run-controls.test.ts ui/src/styles/chat/layout.css ui/src/styles/chat/layout.test.ts`
- `git diff --check origin/main...HEAD`
- `pnpm changed:lanes --json`
- `pnpm lint:core`
- `pnpm ui:build` (passes; Vite reports the existing large-chunk warning)

Closes #45656.
