### PR TITLE
fix(slack): remove truncated message preview from inbound system events

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -160,7 +160,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     const prepared = await prepareWithDefaultCtx(createSlackMessage({}));
 
     assertPrepared(prepared);
-    expect(enqueueSystemEventMock).toHaveBeenCalledWith("Slack DM from Alice: hi", {
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith("Slack DM from Alice", {
       sessionKey: prepared.ctxPayload.SessionKey,
       contextKey: "slack:message:D123:1.000",
       trusted: false,

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -805,7 +805,7 @@ export async function prepareSlackMessage(params: {
       ? `slack:channel:${message.channel}`
       : `slack:group:${message.channel}`;
 
-  enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+  enqueueSystemEvent(inboundLabel, {
     sessionKey,
     contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
     trusted: false,


### PR DESCRIPTION
## Summary

Removes the truncated 160-char message preview from Slack inbound system event headers.

## Problem

System events include a truncated preview of the message body:

```
System: [2026-05-15 11:05:16 UTC] Slack DM from cnor: Kibi, can you put up a pr to remove message previews in ai - tools?
```

This causes the model to sometimes reference the truncated header instead of the full message body, leading to confused responses about cut-off text when the full message is delivered correctly in the user turn.

## Solution

System events now contain only the notification label:

```
System: [2026-05-15 11:05:16 UTC] Slack DM from cnor
```

The preview is retained for verbose debug logging and the prepared message return type for internal use.

## Changes

- `extensions/slack/src/monitor/message-handler/prepare.ts` — remove preview from system event string
- `extensions/slack/src/monitor/message-handler/prepare.test.ts` — update test expectation

Closes #67503