### PR TITLE
fix(slack): default unfurl_links to false for outbound messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - Control UI/WebChat: focus the composer when users click the visible input chrome and restore larger, labeled desktop composer controls while preserving compact mobile taps. Fixes #45656. Thanks @BunsDev.
 - System events: keep owner downgrades in structured metadata while rendering queued prompt text as plain `System:` lines, preserving least-privilege wakeups without prompt-visible trust labels. (#82067)
+- Slack: default outbound bot link unfurls off so agent-sent URLs no longer expand into inline previews unless `channels.slack.unfurlLinks` is enabled. (#82123) Thanks @kibi-bsp.
 - Providers/Xiaomi: preserve MiMo `reasoning_content` on multi-turn tool-call replay, including custom Xiaomi-compatible proxy routes, so follow-up turns no longer fail with `400 Param Incorrect`. Fixes #81419. (#81589) Thanks @lovelefeng-glitch and @jimdawdy-hub.
 - Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1261,7 +1261,7 @@ Primary reference: [Configuration reference - Slack](/gateway/config-channels#sl
 - channel access: `groupPolicy`, `channels.*`, `channels.*.users`, `channels.*.requireMention`
 - threading/history: `replyToMode`, `replyToModeByChatType`, `thread.*`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
 - delivery: `textChunkLimit`, `chunkMode`, `mediaMaxMb`, `streaming`, `streaming.nativeTransport`, `streaming.preview.toolProgress`
-- unfurls: `unfurlLinks` (default: `false`), `unfurlMedia` for `chat.postMessage` link/media preview control
+- unfurls: `unfurlLinks` (default: `false`), `unfurlMedia` for `chat.postMessage` link/media preview control; set `unfurlLinks: true` to opt back into link previews
 - ops/features: `configWrites`, `commands.native`, `slashCommand.*`, `actions.*`, `userToken`, `userTokenReadOnly`
 
 </Accordion>

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1261,7 +1261,7 @@ Primary reference: [Configuration reference - Slack](/gateway/config-channels#sl
 - channel access: `groupPolicy`, `channels.*`, `channels.*.users`, `channels.*.requireMention`
 - threading/history: `replyToMode`, `replyToModeByChatType`, `thread.*`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
 - delivery: `textChunkLimit`, `chunkMode`, `mediaMaxMb`, `streaming`, `streaming.nativeTransport`, `streaming.preview.toolProgress`
-- unfurls: `unfurlLinks`, `unfurlMedia` for `chat.postMessage` link/media preview control
+- unfurls: `unfurlLinks` (default: `false`), `unfurlMedia` for `chat.postMessage` link/media preview control
 - ops/features: `configWrites`, `commands.native`, `slashCommand.*`, `actions.*`, `userToken`, `userTokenReadOnly`
 
 </Accordion>

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -487,7 +487,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - `configWrites: false` blocks Slack-initiated config writes.
 - Optional `channels.slack.defaultAccount` overrides default account selection when it matches a configured account id.
 - `channels.slack.streaming.mode` is the canonical Slack stream mode key. `channels.slack.streaming.nativeTransport` controls Slack's native streaming transport. Legacy `streamMode`, boolean `streaming`, and `nativeStreaming` values remain runtime aliases; run `openclaw doctor --fix` to rewrite persisted config.
-- `unfurlLinks` and `unfurlMedia` pass Slack's `chat.postMessage` link and media unfurl booleans through for bot replies. Omit them to keep Slack's default behavior; set them at `channels.slack.accounts.<accountId>` to override the top-level default for one account.
+- `unfurlLinks` and `unfurlMedia` pass Slack's `chat.postMessage` link and media unfurl booleans through for bot replies. `unfurlLinks` defaults to `false` so outbound bot links do not expand inline unless enabled; `unfurlMedia` is omitted unless configured. Set either value at `channels.slack.accounts.<accountId>` to override the top-level value for one account.
 - Use `user:<id>` (DM) or `channel:<id>` for delivery targets.
 
 **Reaction notification modes:** `off`, `own` (default), `all`, `allowlist` (from `reactionAllowlist`).

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -128,7 +128,10 @@ function hasCustomIdentity(identity?: SlackSendIdentity): boolean {
 
 function buildSlackUnfurlPayload(options?: SlackUnfurlOptions) {
   return {
-    ...(typeof options?.unfurlLinks === "boolean" ? { unfurl_links: options.unfurlLinks } : {}),
+    // Default unfurl_links to false so bot messages don't expand inline
+    // link previews (Slack message links, URLs, etc.) unless the operator
+    // explicitly opts in via `channels.slack.unfurlLinks: true`.
+    unfurl_links: options?.unfurlLinks ?? false,
     ...(typeof options?.unfurlMedia === "boolean" ? { unfurl_media: options.unfurlMedia } : {}),
   };
 }

--- a/extensions/slack/src/send.unfurl.test.ts
+++ b/extensions/slack/src/send.unfurl.test.ts
@@ -47,7 +47,7 @@ function requireLastPostMessagePayload(client: SlackUnfurlTestClient) {
 }
 
 describe("sendMessageSlack unfurl controls", () => {
-  it("omits Slack unfurl flags when config is unset", async () => {
+  it("defaults unfurl_links to false when config is unset", async () => {
     const client = createSlackSendTestClient();
 
     await sendMessageSlack("channel:C123", "https://example.com", {
@@ -58,7 +58,7 @@ describe("sendMessageSlack unfurl controls", () => {
 
     expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
     const payload = requirePostMessagePayload(client);
-    expect("unfurl_links" in payload).toBe(false);
+    expect(payload.unfurl_links).toBe(false);
     expect("unfurl_media" in payload).toBe(false);
   });
 

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -173,7 +173,7 @@ export type SlackAccountConfig = {
   /** Per-DM config overrides keyed by user ID. */
   dms?: Record<string, DmConfig>;
   textChunkLimit?: number;
-  /** Pass through Slack chat.postMessage link unfurl control. Omitted by default. */
+  /** Pass through Slack chat.postMessage link unfurl control. Default: false. */
   unfurlLinks?: boolean;
   /** Pass through Slack chat.postMessage media unfurl control. Omitted by default. */
   unfurlMedia?: boolean;


### PR DESCRIPTION
## Summary

Defaults `unfurl_links` to `false` for all outbound Slack messages, suppressing the inline link preview cards that Slack auto-generates when a message contains URLs or Slack message links.

## Problem

When OpenClaw posts messages containing links (e.g. Slack message links in a weekly recap, GitHub URLs, etc.), Slack expands them into rich inline preview cards by default. These previews are noisy and can dominate the conversation view — especially in channels like `#ai-tools` where messages frequently contain links.

The existing `channels.slack.unfurlLinks` config option allows disabling this, but when left unset the Slack API defaults to `true`, meaning previews are on unless every operator remembers to explicitly disable them.

## Solution

Default `unfurl_links` to `false` in `buildSlackUnfurlPayload()` so bot messages are clean by default. Operators who want link previews can still enable them with:

```yaml
channels:
  slack:
    unfurlLinks: true
```

`unfurlMedia` behavior is unchanged (only sent when explicitly configured).

## Changes

- `extensions/slack/src/send.ts` — default `unfurl_links` to `false` via nullish coalescing
- `extensions/slack/src/send.unfurl.test.ts` — update test to expect the new default
- `docs/channels/slack.md` — document the default