### PR TITLE
fix: require web search query schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ Docs: https://docs.openclaw.ai
 - Memory host SDK: report malformed remote JSON with caller-scoped errors for POST and batch file upload responses instead of leaking raw parser failures.
 - Media providers: report malformed operation-poll and audio-transcription JSON with provider-owned errors instead of leaking raw parser failures.
 - MiniMax, Gemini, Kimi, and Ollama web search: report malformed API JSON with provider-owned errors instead of leaking raw parser failures.
+- Web search: mark the managed `web_search` `query` argument as required in the advertised tool schema, so schema-following local models stop emitting `queries` payloads that fail at execution. Fixes #82097. Thanks @SpidFightFR.
 - Twilio voice-call: report malformed successful API JSON responses with provider-owned errors instead of leaking raw parser failures.
 - Voice-call provider APIs: report malformed successful guarded JSON responses with provider-prefixed errors instead of leaking raw parser failures.
 - Realtime transcription: report malformed provider websocket JSON frames with owned parser errors instead of leaking raw `SyntaxError` objects.

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -10,6 +10,13 @@ import { mergeScopedSearchConfig } from "./web-search-provider-config.js";
 import { createWebSearchTool } from "./web-search.js";
 
 describe("web_search tool schema", () => {
+  it("marks query as required for model tool-call schemas", () => {
+    const tool = createWebSearchTool();
+    const parameters = tool?.parameters as { required?: unknown } | undefined;
+
+    expect(parameters?.required).toEqual(["query"]);
+  });
+
   it("advertises the shared runtime count limit", () => {
     const tool = createWebSearchTool();
     const parameters = tool?.parameters as

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -8,6 +8,7 @@ import { resolveWebSearchToolRuntimeContext } from "./web-tool-runtime-context.j
 
 const WebSearchSchema = {
   type: "object",
+  required: ["query"],
   properties: {
     query: { type: "string", description: "Search query string." },
     count: {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1174,6 +1174,7 @@
           "type": "string"
         }
       },
+      "required": ["query"],
       "type": "object"
     },
     "name": "web_search",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1206,6 +1206,7 @@
           "type": "string"
         }
       },
+      "required": ["query"],
       "type": "object"
     },
     "name": "web_search",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1170,6 +1170,7 @@
           "type": "string"
         }
       },
+      "required": ["query"],
       "type": "object"
     },
     "name": "web_search",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -217,8 +217,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 44328,
-    "roughTokens": 11082
+    "chars": 44373,
+    "roughTokens": 11094
   },
   "openClawDeveloperInstructions": {
     "chars": 5436,
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7129
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72846,
-    "roughTokens": 18212
+    "chars": 72891,
+    "roughTokens": 18223
   },
   "userInputText": {
     "chars": 870,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -217,8 +217,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 44019,
-    "roughTokens": 11005
+    "chars": 44064,
+    "roughTokens": 11016
   },
   "openClawDeveloperInstructions": {
     "chars": 4412,
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6748
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71013,
-    "roughTokens": 17754
+    "chars": 71058,
+    "roughTokens": 17765
   },
   "userInputText": {
     "chars": 370,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -218,8 +218,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 45197,
-    "roughTokens": 11300
+    "chars": 45242,
+    "roughTokens": 11311
   },
   "openClawDeveloperInstructions": {
     "chars": 4412,
@@ -230,8 +230,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7155
   },
   "totalWithDynamicToolsJson": {
-    "chars": 73818,
-    "roughTokens": 18455
+    "chars": 73863,
+    "roughTokens": 18466
   },
   "userInputText": {
     "chars": 608,


### PR DESCRIPTION
## Summary

- Mark the managed `web_search` `query` parameter as required in the advertised JSON schema.
- Regenerate dynamic-tool prompt snapshots so serialized tool catalogs include the required field.
- Add a focused regression test for the schema contract.

Fixes #82097.

## Verification

- `node scripts/run-vitest.mjs src/agents/tools/web-search.test.ts`
- `node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts -t "adds direct type hints to native Ollama tool schemas before sending them"`
- `node scripts/run-vitest.mjs src/agents/tools/web-search.signal.test.ts src/agents/tools/web-search.late-bind.test.ts`
- `node scripts/run-vitest.mjs test/scripts/prompt-snapshots.test.ts -t "matches the committed Codex prompt snapshot artifacts" --hookTimeout=300000`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --full-access`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode branch --full-access`

## Real behavior proof

Behavior addressed: Managed `web_search` now advertises the same required `query` contract that provider execution already enforces, reducing malformed `queries` calls from schema-following local models.
Real environment tested: Local OpenClaw CLI from this branch (`OpenClaw 2026.5.14 (f94a10e)`) with the keyless DuckDuckGo web-search provider.
Exact steps or command run after this patch: `pnpm openclaw infer web search --provider duckduckgo --query "OpenClaw docs web_search schema" --limit 1 --json`
Evidence after fix: The real CLI web-search command accepted the `--query` value, executed through OpenClaw's local `web.search` capability, and returned a wrapped result from `docs.openclaw.ai/tools/web`.
Observed result after fix: The command exited 0 and printed `"ok": true`, `"capability": "web.search"`, `"transport": "local"`, `"provider": "duckduckgo"`, and `"query": "OpenClaw docs web_search schema"`.
What was not tested: No live Ollama/gemma4 model invocation was run; the PR includes schema-contract, transport serialization, and real OpenClaw CLI web-search proof.

```json
{
  "ok": true,
  "capability": "web.search",
  "transport": "local",
  "provider": "duckduckgo",
  "resultQuery": "OpenClaw docs web_search schema",
  "resultUrl": "https://docs.openclaw.ai/tools/web",
  "resultSiteName": "docs.openclaw.ai"
}
```
