### PR TITLE
fix(agents): strip truncation sentinel lines from user-facing text

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -445,9 +445,14 @@ describe("sanitizeUserFacingText", () => {
         "Text\n\u2026(truncated TOOLS.md: kept 200+100 chars of 5000)\u2026\nMore",
       ),
     ).toBe("Text\nMore");
+    expect(sanitizeUserFacingText("Data\n[\u2026truncated 200+100/5000]\nRest")).toBe("Data\nRest");
+    // Bootstrap read-file sentinel
     expect(
-      sanitizeUserFacingText("Data\n[\u2026truncated 200+100/5000]\nRest"),
-    ).toBe("Data\nRest");
+      sanitizeUserFacingText("Before\n[...truncated, read AGENTS.md for full content...]\nAfter"),
+    ).toBe("Before\nAfter");
+    expect(sanitizeUserFacingText("[...truncated, read src/foo/bar.ts for full content...]")).toBe(
+      "",
+    );
   });
 
   it("preserves normal prose ellipses and bracketed text", () => {

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -432,6 +432,30 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("strips truncation sentinel lines from user-facing text", () => {
+    expect(sanitizeUserFacingText("...(truncated)...")).toBe("");
+    expect(sanitizeUserFacingText("  ...(truncated)...\t")).toBe("");
+    expect(sanitizeUserFacingText("Hello\n...(truncated)...\nWorld")).toBe("Hello\nWorld");
+    expect(sanitizeUserFacingText("Hello\n\u2026(truncated)\u2026\nWorld")).toBe("Hello\nWorld");
+    expect(sanitizeUserFacingText("Result\n[... 5000 more characters truncated]\nEnd")).toBe(
+      "Result\nEnd",
+    );
+    expect(
+      sanitizeUserFacingText(
+        "Text\n\u2026(truncated TOOLS.md: kept 200+100 chars of 5000)\u2026\nMore",
+      ),
+    ).toBe("Text\nMore");
+    expect(
+      sanitizeUserFacingText("Data\n[\u2026truncated 200+100/5000]\nRest"),
+    ).toBe("Data\nRest");
+  });
+
+  it("preserves normal prose ellipses and bracketed text", () => {
+    expect(sanitizeUserFacingText("Wait... let me think")).toBe("Wait... let me think");
+    expect(sanitizeUserFacingText("See [the docs] for more")).toBe("See [the docs] for more");
+    expect(sanitizeUserFacingText("I truncated the list")).toBe("I truncated the list");
+  });
+
   it("strips marked internal runtime context blocks but keeps real reply text", () => {
     const input = [
       INTERNAL_RUNTIME_CONTEXT_BEGIN,

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -53,7 +53,7 @@ const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE = /^[ \t]*\[tool calls omitted\][ \
 // truncation, and session-history truncation.  They are internal scaffolding and
 // must not leak into user-visible final replies.
 const TRUNCATION_SENTINEL_LINE_RE =
-  /^[ \t]*(?:\.\.\.\(truncated\)\.\.\.|…\(truncated(?:\s[^)]*)?\)…|\[\.\.\.,?\s*\d+\s+more\s+characters?\s+truncated\]|\[…truncated\s[^\]]*\])[ \t]*$/i;
+  /^[ \t]*(?:\.\.\.\(truncated\)\.\.\.|…\(truncated(?:\s[^)]*)?\)…|\[\.\.\.,?\s*\d+\s+more\s+characters?\s+truncated\]|\[…truncated\s[^\]]*\]|\[\.\.\.truncated,\sread\s\S+\sfor\sfull\scontent\.\.\.\])[ \t]*$/i;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -49,6 +49,11 @@ const MODEL_CAPACITY_ERROR_USER_MESSAGE =
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE = /^[ \t]*\[tool calls omitted\][ \t]*$/i;
+// Truncation sentinels injected by tool-transcript truncation, bootstrap file
+// truncation, and session-history truncation.  They are internal scaffolding and
+// must not leak into user-visible final replies.
+const TRUNCATION_SENTINEL_LINE_RE =
+  /^[ \t]*(?:\.\.\.\(truncated\)\.\.\.|…\(truncated(?:\s[^)]*)?\)…|\[\.\.\.,?\s*\d+\s+more\s+characters?\s+truncated\]|\[…truncated\s[^\]]*\])[ \t]*$/i;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
@@ -340,6 +345,22 @@ function stripFinalTagsFromText(text: unknown): string {
   return stripFinalTags(normalized);
 }
 
+function stripStandaloneLinesByPattern(text: string, pattern: RegExp): string {
+  let result = "";
+  let start = 0;
+  while (start < text.length) {
+    const newlineIndex = text.indexOf("\n", start);
+    const end = newlineIndex === -1 ? text.length : newlineIndex + 1;
+    const chunk = text.slice(start, end);
+    const line = chunk.endsWith("\n") ? chunk.slice(0, -1).replace(/\r$/, "") : chunk;
+    if (!pattern.test(line)) {
+      result += chunk;
+    }
+    start = end;
+  }
+  return result;
+}
+
 function stripToolCallsOmittedPlaceholderLines(text: string): string {
   let result = "";
   let start = 0;
@@ -413,7 +434,11 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   // Replay repair may synthesize this placeholder to keep provider transcripts valid.
   // It is internal scaffolding, so drop standalone placeholder lines before delivery
   // while preserving ordinary inline mentions a user may be discussing.
-  const withoutPlaceholder = stripToolCallsOmittedPlaceholderLines(withoutToolCallXml);
+  const withoutTruncationSentinels = stripStandaloneLinesByPattern(
+    withoutToolCallXml,
+    TRUNCATION_SENTINEL_LINE_RE,
+  );
+  const withoutPlaceholder = stripToolCallsOmittedPlaceholderLines(withoutTruncationSentinels);
   const withoutToolCallBlocks = stripPlainTextToolCallBlocks(
     stripLegacyBracketToolCallBlocks(withoutPlaceholder),
   );


### PR DESCRIPTION
## Summary

- **Problem:** `sanitizeUserFacingText()` strips several internal placeholders (`<final>` tags, tool-call XML, `[tool calls omitted]`) but truncation sentinels like `...(truncated)...` and `[...truncated, read <file> for full content...]` can leak through to the final assistant reply.
- **Why it matters:** Exposes internal implementation details to end users, degrades reply quality, and can pollute downstream reasoning if later turns treat those markers as normal text.
- **What changed:** Added `TRUNCATION_SENTINEL_LINE_RE` regex and a `stripStandaloneLinesByPattern()` helper that removes truncation sentinel lines during the sanitization pipeline, before user-facing delivery.
- **What did NOT change (scope boundary):** The existing `stripToolCallsOmittedPlaceholderLines()` function and all other sanitization logic remain untouched. Only standalone truncation sentinel lines are stripped — normal prose ellipses and bracketed text are preserved.

## Change Type (select all)

- [x] Bug fix

## Sentinel patterns matched

| Pattern | Source |
|---------|--------|
| `...(truncated)...` | `truncateToolTranscriptText()` in tool transcript generation |
| `…(truncated)…` | `sessions-history-tool.ts` session history truncation |
| `…(truncated <file>: kept N+N chars of N)…` | `bootstrap.ts` file truncation |
| `[... N more characters truncated]` | Various UI/log truncation paths |
| `[…truncated N+N/N]` | Bootstrap compact truncation marker |
| `[...truncated, read <file> for full content...]` | `bootstrap.ts` read-file sentinel |

## Real behavior proof

**Behavior or issue addressed**: Truncation sentinels (including bootstrap read-file markers) leaking into user-visible final assistant replies.

**Real environment tested**: Node.js v24.14.1 on Linux 6.17.0-22-generic (x64), running the patched `TRUNCATION_SENTINEL_LINE_RE` from this branch against all producer patterns including the bootstrap read-file sentinel identified by @clawsweeper.

**Exact steps or command run after this patch**:

```bash
cd ~/repos/forks/openclaw && git checkout fix/strip-truncation-sentinels && node -e "
const re = /^[ \t]*(?:\\.\\.\\.\\(truncated\\)\\.\\.\\.|\u2026\\(truncated(?:\\s[^)]*)?\\)\u2026|\\[\\.\\.\\.,?\\s*\\d+\\s+more\\s+characters?\\s+truncated\\]|\\[\u2026truncated\\s[^\\]]*\\]|\\[\\.\\.\\.truncated,\\sread\\s\\S+\\sfor\\sfull\\scontent\\.\\.\\.\\])[ \t]*$/i;

// All producer patterns:
const tests = [
  ['...(truncated)...', true],
  ['\u2026(truncated TOOLS.md: kept 200+100 chars of 5000)\u2026', true],
  ['[... 42 more characters truncated]', true],
  ['[\u2026truncated 200+100/5000]', true],
  ['[...truncated, read AGENTS.md for full content...]', true],
  ['[...truncated, read src/foo/bar.ts for full content...]', true],
  // Prose preservation:
  ['Wait... let me think', false],
  ['See [the docs] for more', false],
];
let pass = 0;
for (const [input, expected] of tests) {
  const result = re.test(input);
  console.log(result === expected ? '\u2713' : '\u2717', JSON.stringify(input), '->', result ? 'stripped' : 'preserved');
  if (result === expected) pass++;
}
console.log(pass + '/' + tests.length + ' pass');
"
```

**Evidence after fix**:

```
✓ "...(truncated)..." -> stripped
✓ "…(truncated TOOLS.md: kept 200+100 chars of 5000)…" -> stripped
✓ "[... 42 more characters truncated]" -> stripped
✓ "[…truncated 200+100/5000]" -> stripped
✓ "[...truncated, read AGENTS.md for full content...]" -> stripped
✓ "[...truncated, read src/foo/bar.ts for full content...]" -> stripped
✓ "Wait... let me think" -> preserved
✓ "See [the docs] for more" -> preserved
8/8 pass
```

**Observed result after fix**: All 6 producer sentinel patterns stripped correctly (including the bootstrap read-file marker missed in the initial revision). Normal prose with ellipses and brackets preserved. Vitest suite exits 0.

**What was not tested**: End-to-end delivery path with a live OpenClaw instance (tested regex + helper in isolation against all known producer patterns from `bootstrap.ts`, `context-truncation-notice.ts`, and `sessions-history-tool.ts`).

**Before evidence**: Without this patch, `sanitizeUserFacingText("[...truncated, read AGENTS.md for full content...]")` returns the input unchanged — the internal marker leaks to the user.

## Root Cause (if applicable)

- Root cause: `sanitizeUserFacingText()` had no stripping logic for truncation sentinels. These markers are emitted by `bootstrap.ts`, `truncateToolTranscriptText()`, and `sessions-history-tool.ts` as internal scaffolding but were passed through to final delivery.
- Missing detection / guardrail: No regex filter for standalone truncation marker lines in the sanitizer pipeline.
- Contributing context: The sanitizer already strips `[tool calls omitted]` lines via a similar standalone-line pattern; truncation sentinels were simply not covered.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- Scenario the test should lock in: Each producer's sentinel format is stripped as a standalone line; prose ellipses and bracketed text are preserved.
- Why this is the smallest reliable guardrail: Regex-level unit tests cover all known producer formats without requiring full pipeline integration.
- Existing test that already covers this: None before this PR.

## User-visible / Behavior Changes

Internal truncation markers (`...(truncated)...`, `[...truncated, read X for full content...]`, etc.) no longer appear in assistant replies delivered to users.

## Diagram (if applicable)

N/A

Closes #82121
