### PR TITLE
refactor: record dropped channel history in turn kernel

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -8,13 +8,10 @@ import {
 import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
 import { shouldHandleTextCommands } from "openclaw/plugin-sdk/command-surface";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
+import { recordDroppedChannelTurnHistory } from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import { logDebug } from "openclaw/plugin-sdk/logging-core";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
-import {
-  type HistoryEntry,
-  type HistoryMediaEntry,
-  recordPendingHistoryEntryWithMedia,
-} from "openclaw/plugin-sdk/reply-history";
+import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { getChildLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { resolveDefaultDiscordAccountId } from "../accounts.js";
@@ -110,7 +107,14 @@ function isDiscordImageAttachmentCandidate(attachment: {
 async function resolveDiscordHistoryMediaForPendingRecord(params: {
   preflight: DiscordMessagePreflightParams;
   message: DiscordMessagePreflightContext["message"];
-}): Promise<HistoryMediaEntry[]> {
+}): Promise<
+  Array<{
+    path: string;
+    contentType?: string;
+    kind: "image";
+    messageId: string;
+  }>
+> {
   const imageAttachments = (params.message.attachments ?? [])
     .filter(isDiscordImageAttachmentCandidate)
     .slice(0, DISCORD_HISTORY_MEDIA_MAX_ATTACHMENTS);
@@ -172,19 +176,39 @@ async function recordDiscordPendingHistoryEntry(params: {
   if (params.preflight.historyLimit <= 0) {
     return;
   }
-  await recordPendingHistoryEntryWithMedia({
-    historyMap: params.preflight.guildHistories,
-    historyKey: params.historyKey,
-    limit: params.preflight.historyLimit,
-    entry: params.entry ?? null,
-    mediaLimit: DISCORD_HISTORY_MEDIA_MAX_ATTACHMENTS,
-    messageId: params.message.id,
-    shouldRecord: () => !isPreflightAborted(params.preflight.abortSignal),
-    media: () =>
-      resolveDiscordHistoryMediaForPendingRecord({
-        preflight: params.preflight,
-        message: params.message,
-      }),
+  await recordDroppedChannelTurnHistory({
+    input: {
+      id: params.message.id,
+      timestamp: params.entry?.timestamp,
+      rawText: params.entry?.body ?? "",
+      textForAgent: params.entry?.body,
+      raw: params.message,
+    },
+    admission: { kind: "drop", reason: "discord-preflight", recordHistory: true },
+    preflight: {
+      message: params.entry
+        ? {
+            rawBody: params.entry.body,
+            body: params.entry.body,
+            bodyForAgent: params.entry.body,
+            senderLabel: params.entry.sender,
+            envelopeFrom: params.entry.sender,
+          }
+        : undefined,
+      history: {
+        key: params.historyKey,
+        historyMap: params.preflight.guildHistories,
+        limit: params.preflight.historyLimit,
+        recordOnDrop: true,
+        mediaLimit: DISCORD_HISTORY_MEDIA_MAX_ATTACHMENTS,
+        shouldRecord: () => !isPreflightAborted(params.preflight.abortSignal),
+      },
+      media: () =>
+        resolveDiscordHistoryMediaForPendingRecord({
+          preflight: params.preflight,
+          message: params.message,
+        }),
+    },
   });
 }
 

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -16,13 +16,12 @@ import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
 import { shouldHandleTextCommands } from "openclaw/plugin-sdk/command-surface";
 import { ensureConfiguredBindingRouteReady } from "openclaw/plugin-sdk/conversation-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { recordDroppedChannelTurnHistory } from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import {
   buildInboundHistoryFromMap,
   buildPendingHistoryContextFromMap,
-  type HistoryMediaEntry,
-  recordPendingHistoryEntryWithMedia,
   recordPendingHistoryEntryIfEnabled,
 } from "openclaw/plugin-sdk/reply-history";
 import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
@@ -169,7 +168,14 @@ async function resolveSlackHistoryMediaForPendingRecord(params: {
   isThreadReply: boolean;
   threadStarter: SlackThreadStarter | null;
   isBotMessage: boolean;
-}): Promise<HistoryMediaEntry[]> {
+}): Promise<
+  Array<{
+    path: string;
+    contentType?: string;
+    kind: "image";
+    messageId?: string;
+  }>
+> {
   const mediaMessage = buildSlackHistoryMediaCandidateMessage(params.message);
   if (!mediaMessage) {
     return [];
@@ -813,28 +819,43 @@ export async function prepareSlackMessage(params: {
             client: ctx.app.client,
           })
         : null;
-    await recordPendingHistoryEntryWithMedia({
-      historyMap: ctx.channelHistories,
-      historyKey,
-      limit: ctx.historyLimit,
-      entry: pendingBody
-        ? {
-            sender: await resolveSenderName(),
-            body: pendingBody,
-            timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
-            messageId: message.ts,
-          }
-        : null,
-      mediaLimit: SLACK_HISTORY_MEDIA_MAX_ATTACHMENTS,
-      messageId: message.ts,
-      media: () =>
-        resolveSlackHistoryMediaForPendingRecord({
-          ctx,
-          message,
-          isThreadReply,
-          threadStarter: skippedThreadStarter,
-          isBotMessage,
-        }),
+    const timestamp = message.ts ? Math.round(Number(message.ts) * 1000) : undefined;
+    const senderName = pendingBody ? await resolveSenderName() : undefined;
+    await recordDroppedChannelTurnHistory({
+      input: {
+        id: message.ts ?? `${message.channel}:${Date.now()}`,
+        timestamp,
+        rawText: pendingBody,
+        textForAgent: pendingBody,
+        raw: message,
+      },
+      admission: { kind: "drop", reason: "slack-no-mention", recordHistory: true },
+      preflight: {
+        message: pendingBody
+          ? {
+              rawBody: pendingBody,
+              body: pendingBody,
+              bodyForAgent: pendingBody,
+              senderLabel: senderName,
+              envelopeFrom: senderName,
+            }
+          : undefined,
+        history: {
+          key: historyKey,
+          historyMap: ctx.channelHistories,
+          limit: ctx.historyLimit,
+          recordOnDrop: true,
+          mediaLimit: SLACK_HISTORY_MEDIA_MAX_ATTACHMENTS,
+        },
+        media: () =>
+          resolveSlackHistoryMediaForPendingRecord({
+            ctx,
+            message,
+            isThreadReply,
+            threadStarter: skippedThreadStarter,
+            isBotMessage,
+          }),
+      },
     });
     return null;
   }

--- a/src/channels/turn/kernel.test.ts
+++ b/src/channels/turn/kernel.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import type { HistoryEntry } from "../../auto-reply/reply/history.types.js";
 import type { DispatchReplyWithBufferedBlockDispatcher } from "../../auto-reply/reply/provider-dispatcher.types.js";
 import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -822,6 +823,60 @@ describe("channel turn kernel", () => {
     });
     expect(result.dispatched).toBe(false);
     expect(resolveTurn).not.toHaveBeenCalled();
+  });
+
+  it("records preflight drop history through the turn kernel", async () => {
+    const historyMap = new Map<string, HistoryEntry[]>();
+    const resolveTurn = vi.fn();
+
+    const result = await runChannelTurn({
+      channel: "test",
+      raw: {},
+      adapter: {
+        ingest: () => ({
+          id: "msg-1",
+          timestamp: 1_700_000_000_000,
+          rawText: "<media:image>",
+        }),
+        preflight: () => ({
+          admission: { kind: "drop", reason: "missing-mention", recordHistory: true },
+          message: {
+            bodyForAgent: "<media:image>",
+            senderLabel: "Alice",
+          },
+          history: {
+            key: "room-1",
+            historyMap,
+            limit: 5,
+            mediaLimit: 2,
+          },
+          media: async () => [
+            { path: "/tmp/a.png", contentType: "image/png", kind: "image" },
+            { path: "https://example.com/b.png", contentType: "image/png", kind: "image" },
+          ],
+        }),
+        resolveTurn,
+      },
+    });
+
+    expect(result.admission).toEqual({
+      kind: "drop",
+      reason: "missing-mention",
+      recordHistory: true,
+    });
+    expect(result.dispatched).toBe(false);
+    expect(resolveTurn).not.toHaveBeenCalled();
+    expect(historyMap.get("room-1")).toEqual([
+      {
+        sender: "Alice",
+        body: "<media:image>",
+        timestamp: 1_700_000_000_000,
+        messageId: "msg-1",
+        media: [
+          { path: "/tmp/a.png", contentType: "image/png", kind: "image", messageId: "msg-1" },
+        ],
+      },
+    ]);
   });
 
   it("drops repeated bot-pair turns in the core turn kernel before record and dispatch", async () => {

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -1,5 +1,9 @@
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
-import { clearHistoryEntriesIfEnabled } from "../../auto-reply/reply/history.js";
+import {
+  clearHistoryEntriesIfEnabled,
+  recordPendingHistoryEntryWithMedia,
+} from "../../auto-reply/reply/history.js";
+import type { HistoryMediaEntry } from "../../auto-reply/reply/history.types.js";
 import { createChannelReplyPipeline } from "../message/reply-pipeline.js";
 import type { CreateChannelReplyPipelineParams } from "../message/reply-pipeline.js";
 import { recordChannelBotPairLoopAndCheckSuppression } from "./bot-loop-protection.js";
@@ -38,6 +42,8 @@ import type {
   ChannelTurnResolved,
   ChannelTurnResult,
   DispatchedChannelTurnResult,
+  InboundMediaFacts,
+  NormalizedTurnInput,
   PreparedChannelTurn,
   PreflightFacts,
   RunChannelTurnParams,
@@ -61,6 +67,7 @@ export type {
   ChannelTurnAdapter,
   ChannelTurnAdmission,
   ChannelTurnDeliveryAdapter,
+  ChannelTurnDroppedHistoryOptions,
   ChannelTurnHistoryFinalizeOptions,
   ChannelTurnDispatcherOptions,
   ChannelTurnLogEvent,
@@ -149,6 +156,85 @@ function clearPendingHistoryAfterTurn(params?: ChannelTurnHistoryFinalizeOptions
     historyMap: params.historyMap,
     historyKey: params.historyKey,
     limit: params.limit,
+  });
+}
+
+function historyMediaFromInboundFacts(
+  media: readonly InboundMediaFacts[] | readonly HistoryMediaEntry[] | null | undefined,
+  messageId: string,
+): HistoryMediaEntry[] {
+  if (!Array.isArray(media)) {
+    return [];
+  }
+  return media.map((entry) => ({
+    path: entry.path,
+    url: entry.url,
+    contentType: entry.contentType,
+    kind: entry.kind,
+    messageId: entry.messageId ?? messageId,
+  }));
+}
+
+function resolveDroppedHistorySender(input: NormalizedTurnInput, preflight: PreflightFacts) {
+  return (
+    preflight.message?.senderLabel ??
+    preflight.message?.envelopeFrom ??
+    (typeof input.raw === "object" &&
+    input.raw &&
+    "sender" in input.raw &&
+    typeof (input.raw as { sender?: unknown }).sender === "string"
+      ? (input.raw as { sender: string }).sender
+      : undefined) ??
+    "unknown"
+  );
+}
+
+function resolveDroppedHistoryBody(input: NormalizedTurnInput, preflight: PreflightFacts) {
+  return (
+    preflight.message?.bodyForAgent ??
+    preflight.message?.body ??
+    preflight.message?.rawBody ??
+    input.textForAgent ??
+    input.rawText
+  );
+}
+
+export async function recordDroppedChannelTurnHistory(params: {
+  input: NormalizedTurnInput;
+  preflight: PreflightFacts;
+  admission?: ChannelTurnAdmission;
+}): Promise<void> {
+  const admission = params.admission ?? params.preflight.admission;
+  if (admission?.kind !== "drop") {
+    return;
+  }
+  const history = params.preflight.history;
+  if (!history || history.limit <= 0 || !(history.recordOnDrop || admission.recordHistory)) {
+    return;
+  }
+  const body = resolveDroppedHistoryBody(params.input, params.preflight);
+  const entry =
+    body.trim().length > 0
+      ? {
+          sender: resolveDroppedHistorySender(params.input, params.preflight),
+          body,
+          timestamp: params.input.timestamp,
+          messageId: params.input.id,
+        }
+      : null;
+  const media = params.preflight.media;
+  await recordPendingHistoryEntryWithMedia({
+    historyMap: history.historyMap,
+    historyKey: history.key,
+    limit: history.limit,
+    entry,
+    mediaLimit: history.mediaLimit,
+    messageId: params.input.id,
+    shouldRecord: history.shouldRecord,
+    media:
+      typeof media === "function"
+        ? async () => historyMediaFromInboundFacts(await media(), params.input.id)
+        : historyMediaFromInboundFacts(media, params.input.id),
   });
 }
 
@@ -522,6 +608,11 @@ export async function runChannelTurn<
     preflightAdmission.kind !== "dispatch" &&
     preflightAdmission.kind !== "observeOnly"
   ) {
+    await recordDroppedChannelTurnHistory({
+      input,
+      preflight,
+      admission: preflightAdmission,
+    });
     emit({
       ...params,
       event: {

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -3,7 +3,7 @@ import type { GetReplyOptions } from "../../auto-reply/get-reply-options.types.j
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { DispatchFromConfigResult } from "../../auto-reply/reply/dispatch-from-config.types.js";
 import type { GetReplyFromConfig } from "../../auto-reply/reply/get-reply.types.js";
-import type { HistoryEntry } from "../../auto-reply/reply/history.types.js";
+import type { HistoryEntry, HistoryMediaEntry } from "../../auto-reply/reply/history.types.js";
 import type { DispatchReplyWithBufferedBlockDispatcher } from "../../auto-reply/reply/provider-dispatcher.types.js";
 import type { ReplyDispatcherWithTypingOptions } from "../../auto-reply/reply/reply-dispatcher.js";
 import type { ReplyDispatchKind } from "../../auto-reply/reply/reply-dispatcher.types.js";
@@ -228,14 +228,22 @@ export type InboundMediaFacts = {
   contentType?: string;
   kind?: "image" | "video" | "audio" | "document" | "unknown";
   transcribed?: boolean;
+  messageId?: string;
 };
+
+type MaybePromise<T> = T | Promise<T>;
 
 export type PreflightFacts = {
   admission?: ChannelTurnAdmission;
   command?: CommandFacts;
   message?: Partial<MessageFacts>;
-  media?: InboundMediaFacts[];
+  media?:
+    | readonly InboundMediaFacts[]
+    | (() => MaybePromise<
+        readonly InboundMediaFacts[] | readonly HistoryMediaEntry[] | null | undefined
+      >);
   supplemental?: SupplementalContextFacts;
+  history?: ChannelTurnDroppedHistoryOptions;
 };
 
 export type ChannelDeliveryInfo = {
@@ -306,6 +314,15 @@ export type ChannelTurnHistoryFinalizeOptions = {
   historyKey?: string;
   historyMap?: Map<string, HistoryEntry[]>;
   limit?: number;
+};
+
+export type ChannelTurnDroppedHistoryOptions = {
+  key: string;
+  limit: number;
+  historyMap: Map<string, HistoryEntry[]>;
+  recordOnDrop?: boolean;
+  mediaLimit?: number;
+  shouldRecord?: () => boolean;
 };
 
 export type ChannelTurnDispatcherOptions = Omit<

--- a/src/plugin-sdk/inbound-reply-dispatch.ts
+++ b/src/plugin-sdk/inbound-reply-dispatch.ts
@@ -13,6 +13,7 @@ import {
   deliverInboundReplyWithMessageSendContext,
   isDurableInboundReplyDeliveryHandled,
   resolveChannelTurnDispatchCounts,
+  recordDroppedChannelTurnHistory,
   runChannelTurn,
   runPreparedChannelTurn,
   throwIfDurableInboundReplyDeliveryFailed,
@@ -23,7 +24,10 @@ import type {
   DurableInboundReplyDeliveryOptions,
 } from "../channels/turn/kernel.js";
 import type { PreparedChannelTurn, RunChannelTurnParams } from "../channels/turn/types.js";
-export type { ChannelTurnRecordOptions } from "../channels/turn/types.js";
+export type {
+  ChannelTurnDroppedHistoryOptions,
+  ChannelTurnRecordOptions,
+} from "../channels/turn/types.js";
 export type { DurableInboundReplyDeliveryParams } from "../channels/turn/kernel.js";
 export type { ChannelBotLoopProtectionFacts } from "../channels/turn/kernel.js";
 export { recordChannelBotPairLoopAndCheckSuppression } from "../channels/turn/kernel.js";
@@ -83,6 +87,7 @@ export {
   hasVisibleChannelTurnDispatch as hasVisibleInboundReplyDispatch,
   deliverInboundReplyWithMessageSendContext as deliverDurableInboundReplyPayload,
   deliverInboundReplyWithMessageSendContext,
+  recordDroppedChannelTurnHistory,
   resolveChannelTurnDispatchCounts as resolveInboundReplyDispatchCounts,
 };
 


### PR DESCRIPTION
Summary
- Move dropped-turn pending history recording into the generic channel turn kernel.
- Add preflight history/media facts so adapters can describe recordable channel turns without owning the recording policy.
- Route Discord and Slack no-mention history recording through the kernel helper while preserving their provider-specific media resolution.

Verification
- node scripts/run-vitest.mjs src/channels/turn/kernel.test.ts src/auto-reply/reply/history.test.ts extensions/discord/src/monitor/message-handler.preflight.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts
- node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false
- node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental false
- OPENCLAW_TESTBOX_REMOTE_RUN=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm check:changed
- /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local

## Real behavior proof
Behavior addressed: dropped/no-mention message history recording is now driven by the core channel turn kernel instead of each message plugin calling the history recorder directly.
Real environment tested: local OpenClaw source checkout on macOS plus Testbox remote changed gate for the branch head.
Exact steps or command run after this patch: `OPENCLAW_TESTBOX_REMOTE_RUN=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm check:changed` after focused local kernel, Discord, Slack, core tsgo, and extension tsgo proof.
Evidence after fix: terminal output from the real source checkout and Testbox changed gate:
```text
OPENCLAW_TESTBOX_REMOTE_RUN=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm check:changed
changed gate completed for branch codex/channel-turn-kernel-history-recording at 41e0053cce407b7bb7655052da526e7b606ac7fd
remote Testbox run completed without failures
```
Observed result after fix: copied live output showed the changed gate completed successfully on the branch head; Discord and Slack skipped inbound messages still flow into history recording, while the record-on-drop decision now runs through the shared turn kernel.
What was not tested: live Discord or Slack webhook traffic; this PR is the core refactor on top of the already landed image-history behavior PR.
