### PR TITLE
fix(gateway/approvals): treat turnSourceTo as optional in chat approval bridge (#82132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/approvals: treat `turnSourceTo` as optional in `canBridgeNoDeviceChatApprovalFromBackend`, matching the existing optional handling of `turnSourceAccountId` and `turnSourceThreadId`. Channels without a recipient concept (webchat, control-ui) leave `turnSourceTo` null on both the approval snapshot and the replay params, so the prior required-string check rejected every backend replay with `APPROVAL_CLIENT_MISMATCH`. Cross-channel replay is still gated by the required `turnSourceChannel` and `sessionKey` checks. Fixes #82132. (#82136) Thanks @ottodeng.
 - Cron: load runtime plugins before isolated cron model and delivery resolution so external channels can be selected for scheduled runs. (#82111) Thanks @medns.
 - Twitch: keep gateway accounts running until shutdown instead of treating successful monitor startup as a clean channel exit, preventing immediate auto-restart loops. Fixes #60071. (#81853) Thanks @edenfunf.
 - Agents/auto-reply: honor `agents.defaults.silentReply` and per-surface group silent-reply policy when generic agent-run failure fallbacks decide whether to send visible fallback text. Fixes #82060. (#82086) Thanks @taozengabc.

--- a/src/gateway/node-invoke-system-run-approval.test.ts
+++ b/src/gateway/node-invoke-system-run-approval.test.ts
@@ -689,6 +689,52 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
     expectAllowOnceForwardingResult(result);
   });
 
+  test("accepts trusted backend webchat replay when turnSourceTo is null on both sides (regression #82132)", () => {
+    const sessionKey = "agent:main:main";
+    const record = makeChatRecord({
+      sessionKey,
+      turnSourceChannel: "webchat",
+      turnSourceTo: null,
+      turnSourceAccountId: null,
+      turnSourceThreadId: null,
+      systemRunPlan: {
+        argv: ["echo", "SAFE"],
+        cwd: null,
+        commandText: "echo SAFE",
+        agentId: "main",
+        sessionKey,
+      },
+      systemRunBinding: buildSystemRunApprovalBinding({
+        argv: ["echo", "SAFE"],
+        cwd: null,
+        agentId: "main",
+        sessionKey,
+      }).binding,
+    });
+
+    const result = sanitizeSystemRunParamsForForwarding({
+      rawParams: {
+        command: ["echo", "SAFE"],
+        rawCommand: "echo SAFE",
+        agentId: "main",
+        sessionKey,
+        turnSourceChannel: "webchat",
+        turnSourceTo: null,
+        turnSourceAccountId: null,
+        turnSourceThreadId: null,
+        runId: "approval-1",
+        approved: true,
+        approvalDecision: "allow-once",
+      },
+      nodeId: "node-1",
+      client: trustedBackendClient,
+      execApprovalManager: manager(record),
+      nowMs: now,
+    });
+
+    expectAllowOnceForwardingResult(result);
+  });
+
   test("rejects trusted backend chat replay when session binding changes", () => {
     const result = sanitizeSystemRunParamsForForwarding({
       rawParams: {

--- a/src/gateway/node-invoke-system-run-approval.ts
+++ b/src/gateway/node-invoke-system-run-approval.ts
@@ -158,7 +158,13 @@ function canBridgeNoDeviceChatApprovalFromBackend(params: {
       actual: params.rawParams.turnSourceChannel,
       lowercase: true,
     }) &&
-    matchesRequiredString({
+    // turnSourceTo is channel-specific: required for messaging channels with a
+    // recipient (e.g. telegram chat id), null for channels without a "to"
+    // concept (webchat, control-ui). matchesRequiredString returns false on
+    // null expected, which broke webchat node exec approval replay. Treat it
+    // as optional so null-on-both-sides matches; required fields below
+    // (turnSourceChannel, sessionKey) still gate cross-channel replays.
+    matchesOptionalString({
       expected: request.turnSourceTo,
       actual: params.rawParams.turnSourceTo,
     }) &&


### PR DESCRIPTION
## Problem

After approving a node exec request from WebChat, the backend `gateway-client` replay was rejected with `INVALID_REQUEST` / `APPROVAL_CLIENT_MISMATCH`. The approval got consumed but the `node.invoke` was discarded, so no node command could be run from WebChat. Reported in #82132 with full debug trace and root cause.

## Root cause

`canBridgeNoDeviceChatApprovalFromBackend()` in `src/gateway/node-invoke-system-run-approval.ts:140` checks every chat-source field that must match between the approval snapshot and the replay params. Three of them (`turnSourceAccountId`, `turnSourceThreadId`, `agentId`) already use `matchesOptionalString` because the value is channel-specific and may be `null` on both sides. `turnSourceTo` was missed when PR #78728 introduced the helper and got `matchesRequiredString` instead.

`matchesRequiredString` returns `false` when `expected` is `null`. WebChat (and other channels without a recipient concept) has no `to` value, so `request.turnSourceTo` is always `null` on both the snapshot and the replay → bridge function returns `false` → guard at `:331` raises `APPROVAL_CLIENT_MISMATCH`.

## Fix

`src/gateway/node-invoke-system-run-approval.ts:161` — swap `matchesRequiredString` to `matchesOptionalString` for `turnSourceTo`, mirroring the existing handling of the other channel-specific fields below it. Required-channel and required-`sessionKey` checks above still gate cross-channel replays.

## Real behavior proof

Stash-toggle was not viable because the function is private; I built a self-contained `scripts/repro-82132.mjs` probe (not committed) that embeds both classifier implementations inline and runs the snapshot from the issue's debug trace through each, plus two neighboring cases:

```
=== Issue #82132 — canBridgeNoDeviceChatApprovalFromBackend ===

Scenario 1: webchat approval, webchat replay, turnSourceTo=null on both sides
  PRE-fix (matchesRequiredString):  false  ← bug: rejects valid webchat replay → APPROVAL_CLIENT_MISMATCH
  POST-fix (matchesOptionalString): true  ← correct

Scenario 2: telegram approval, telegram replay, turnSourceTo="telegram:12345"
  PRE-fix:  true  ← already working, must not regress
  POST-fix: true  ← unchanged

Scenario 3: cross-channel mismatch (webchat approval, telegram replay)
  PRE-fix:  false  ← rejected (channel guard fires first)
  POST-fix: false  ← still rejected; required turnSourceChannel guards cross-channel replay
```

The smoking-gun row is scenario 1: identical input, classifier flips from `false` → `true` solely because of this one-line change. Scenario 2 confirms populated-`turnSourceTo` channels (telegram, wecom) are unaffected. Scenario 3 confirms cross-channel attack still rejected by the required `turnSourceChannel` check above this line.

Vitest regression coverage:

```
$ node scripts/run-vitest.mjs src/gateway/node-invoke-system-run-approval.test.ts
 ✓  gateway-core    src/gateway/node-invoke-system-run-approval.test.ts (27 tests) 100ms
 ✓  gateway-server  src/gateway/node-invoke-system-run-approval.test.ts (27 tests) 94ms
 ✓  gateway-client  src/gateway/node-invoke-system-run-approval.test.ts (27 tests) 93ms

 Test Files  3 passed (3)
      Tests  81 passed (81)
```

Added test: `accepts trusted backend webchat replay when turnSourceTo is null on both sides (regression #82132)` — asserts an `allow-once` outcome with `turnSourceTo: null` on both the snapshot and the replay params. Pre-fix this test fails; post-fix it passes alongside the existing 26 cases (incl. telegram + wecom replay, cross-session rejection, session-binding rejection).

## Files

- `src/gateway/node-invoke-system-run-approval.ts` — one-line behavior change + comment explaining why `turnSourceTo` is optional
- `src/gateway/node-invoke-system-run-approval.test.ts` — regression test
- `CHANGELOG.md` — entry under `## Unreleased ### Fixes`

Closes #82132.