### PR TITLE
refactor: centralize channel history window

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-228e53a4748d3e797b54fba1ac9069ef65b459ece5807e100e01f14c872e0610  plugin-sdk-api-baseline.json
-e675bb9b25b849f6a54eca75fcd343efc1258cb1f5e33cf3ec0a00aa7eaf4f05  plugin-sdk-api-baseline.jsonl
+6baa084622419b66219a494865773fa1f5000d392558d8150afa247ce20fb66d  plugin-sdk-api-baseline.json
+bb414f636e114ecc41ab3184da768d712f53b24f4f2b65de679affcdb7e0efce  plugin-sdk-api-baseline.jsonl

--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -6,10 +6,7 @@ import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/conversation-runtime";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
-import {
-  buildInboundHistoryFromMap,
-  buildPendingHistoryContextFromMap,
-} from "openclaw/plugin-sdk/reply-history";
+import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import { buildAgentSessionKey, resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { evaluateSupplementalContextVisibility } from "openclaw/plugin-sdk/security-runtime";
@@ -154,6 +151,7 @@ export async function buildDiscordMessageProcessContext(params: {
     storePath,
     sessionKey: route.sessionKey,
   });
+  const channelHistory = createChannelHistoryWindow({ historyMap: guildHistories });
   let combinedBody = formatInboundEnvelope({
     channel: "Discord",
     from: fromLabel,
@@ -167,8 +165,7 @@ export async function buildDiscordMessageProcessContext(params: {
   const shouldIncludeChannelHistory =
     !isDirectMessage && !(isGuildMessage && channelConfig?.autoThread && !threadChannel);
   if (shouldIncludeChannelHistory) {
-    combinedBody = buildPendingHistoryContextFromMap({
-      historyMap: guildHistories,
+    combinedBody = channelHistory.buildPendingContext({
       historyKey: messageChannelId,
       limit: historyLimit,
       currentMessage: combinedBody,
@@ -316,8 +313,7 @@ export async function buildDiscordMessageProcessContext(params: {
   }
   const lastRouteTo = dmConversationTarget ?? effectiveTo;
   const inboundHistory = shouldIncludeChannelHistory
-    ? buildInboundHistoryFromMap({
-        historyMap: guildHistories,
+    ? channelHistory.buildInboundHistory({
         historyKey: messageChannelId,
         limit: historyLimit,
       })

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -525,6 +525,9 @@ vi.mock("openclaw/plugin-sdk/outbound-runtime", () => ({
 
 vi.mock("openclaw/plugin-sdk/reply-history", () => ({
   clearHistoryEntriesIfEnabled: () => {},
+  createChannelHistoryWindow: () => ({
+    clear: () => {},
+  }),
 }));
 
 vi.mock("openclaw/plugin-sdk/reply-payload", () => ({

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -38,7 +38,7 @@ import {
 } from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import { resolveAgentOutboundIdentity } from "openclaw/plugin-sdk/outbound-runtime";
 import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-runtime";
-import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-history";
+import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
@@ -1391,12 +1391,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       agentId: route.agentId,
     });
   }
+  const channelHistory = createChannelHistoryWindow({ historyMap: ctx.channelHistories });
 
   if (!anyReplyDelivered) {
     await draftStream?.clear();
     if (prepared.isRoomish && prepared.requireMention) {
-      clearHistoryEntriesIfEnabled({
-        historyMap: ctx.channelHistories,
+      channelHistory.clear({
         historyKey: prepared.historyKey,
         limit: ctx.historyLimit,
       });
@@ -1438,8 +1438,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   }
 
   if (prepared.isRoomish && prepared.requireMention) {
-    clearHistoryEntriesIfEnabled({
-      historyMap: ctx.channelHistories,
+    channelHistory.clear({
       historyKey: prepared.historyKey,
       limit: ctx.historyLimit,
     });

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -19,11 +19,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { recordDroppedChannelTurnHistory } from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
-import {
-  buildInboundHistoryFromMap,
-  buildPendingHistoryContextFromMap,
-  recordPendingHistoryEntryIfEnabled,
-} from "openclaw/plugin-sdk/reply-history";
+import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -974,6 +970,7 @@ export async function prepareSlackMessage(params: {
     storePath,
     sessionKey,
   });
+  const channelHistory = createChannelHistoryWindow({ historyMap: ctx.channelHistories });
   const dmHistoryLimit = isDirectMessage
     ? resolveSlackDmHistoryLimit({
         account,
@@ -1007,8 +1004,7 @@ export async function prepareSlackMessage(params: {
     combinedBody = `${dmHistoryContext.body}\n\n${combinedBody}`;
   }
   if (isRoomish && ctx.historyLimit > 0) {
-    combinedBody = buildPendingHistoryContextFromMap({
-      historyMap: ctx.channelHistories,
+    combinedBody = channelHistory.buildPendingContext({
       historyKey,
       limit: ctx.historyLimit,
       currentMessage: combinedBody,
@@ -1064,8 +1060,7 @@ export async function prepareSlackMessage(params: {
 
   const inboundHistory =
     isRoomish && ctx.historyLimit > 0
-      ? buildInboundHistoryFromMap({
-          historyMap: ctx.channelHistories,
+      ? channelHistory.buildInboundHistory({
           historyKey,
           limit: ctx.historyLimit,
         })
@@ -1132,8 +1127,7 @@ export async function prepareSlackMessage(params: {
   }) satisfies FinalizedMsgContext;
 
   if (isRoomish && !shouldRequireMention) {
-    recordPendingHistoryEntryIfEnabled({
-      historyMap: ctx.channelHistories,
+    channelHistory.record({
       historyKey,
       limit: ctx.historyLimit,
       entry: {

--- a/extensions/zalouser/src/monitor.group-gating.test.ts
+++ b/extensions/zalouser/src/monitor.group-gating.test.ts
@@ -944,6 +944,7 @@ describe("zalouser monitor group mention gating", () => {
         sender: "Alice",
         body: "first unmentioned line",
         timestamp: 1700000000000,
+        messageId: "history-1",
       },
     ]);
     expect(firstDispatch?.ctx?.Body ?? "").toContain("first unmentioned line");

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -10,12 +10,9 @@ import { KeyedAsyncQueue } from "openclaw/plugin-sdk/core";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
-  buildInboundHistoryFromMap,
   DEFAULT_GROUP_HISTORY_LIMIT,
   type HistoryEntry,
-  buildPendingHistoryContextFromMap,
-  clearHistoryEntriesIfEnabled,
-  recordPendingHistoryEntryIfEnabled,
+  createChannelHistoryWindow,
 } from "openclaw/plugin-sdk/reply-history";
 import {
   deliverTextOrMediaReply,
@@ -489,6 +486,9 @@ async function processMessage(
     },
   });
   const historyKey = isGroup ? route.sessionKey : undefined;
+  const channelHistory = createChannelHistoryWindow({
+    historyMap: historyState.groupHistories,
+  });
 
   const requireMention = isGroup
     ? resolveGroupRequireMention({
@@ -538,8 +538,7 @@ async function processMessage(
     return;
   }
   if (isGroup && mentionDecision.shouldSkip) {
-    recordPendingHistoryEntryIfEnabled({
-      historyMap: historyState.groupHistories,
+    channelHistory.record({
       historyKey: historyKey ?? "",
       limit: historyState.historyLimit,
       entry:
@@ -587,8 +586,7 @@ async function processMessage(
   });
   const combinedBody =
     isGroup && historyKey
-      ? buildPendingHistoryContextFromMap({
-          historyMap: historyState.groupHistories,
+      ? channelHistory.buildPendingContext({
           historyKey,
           limit: historyState.historyLimit,
           currentMessage: body,
@@ -606,8 +604,7 @@ async function processMessage(
       : body;
   const inboundHistory =
     isGroup && historyKey && historyState.historyLimit > 0
-      ? buildInboundHistoryFromMap({
-          historyMap: historyState.groupHistories,
+      ? channelHistory.buildInboundHistory({
           historyKey,
           limit: historyState.historyLimit,
         })
@@ -750,8 +747,7 @@ async function processMessage(
     },
   });
   if (isGroup && historyKey) {
-    clearHistoryEntriesIfEnabled({
-      historyMap: historyState.groupHistories,
+    channelHistory.clear({
       historyKey,
       limit: historyState.historyLimit,
     });

--- a/src/channels/turn/history-window.test.ts
+++ b/src/channels/turn/history-window.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { HistoryEntry } from "../../auto-reply/reply/history.types.js";
+import { createChannelHistoryWindow } from "./history-window.js";
+
+describe("createChannelHistoryWindow", () => {
+  it("records, formats, exposes, and clears a channel history window", async () => {
+    const historyMap = new Map<string, HistoryEntry[]>();
+    const history = createChannelHistoryWindow({ historyMap });
+
+    history.record({
+      historyKey: "room-1",
+      limit: 3,
+      entry: {
+        sender: "Alice",
+        body: "first",
+        timestamp: 1,
+        messageId: "m1",
+      },
+    });
+    await history.recordWithMedia({
+      historyKey: "room-1",
+      limit: 3,
+      messageId: "m2",
+      entry: {
+        sender: "Bob",
+        body: "<media:image>",
+        timestamp: 2,
+        messageId: "m2",
+      },
+      media: [
+        { path: "/tmp/image.png", contentType: "image/png", kind: "image" },
+        { path: "https://example.com/skip.png", contentType: "image/png", kind: "image" },
+      ],
+    });
+
+    expect(
+      history.buildPendingContext({
+        historyKey: "room-1",
+        limit: 3,
+        currentMessage: "now",
+        formatEntry: (entry) => `${entry.sender}: ${entry.body}`,
+      }),
+    ).toContain("Alice: first\nBob: <media:image>");
+    expect(history.buildInboundHistory({ historyKey: "room-1", limit: 3 })).toEqual([
+      {
+        sender: "Alice",
+        body: "first",
+        timestamp: 1,
+        messageId: "m1",
+      },
+      {
+        sender: "Bob",
+        body: "<media:image>",
+        timestamp: 2,
+        messageId: "m2",
+        media: [
+          { path: "/tmp/image.png", contentType: "image/png", kind: "image", messageId: "m2" },
+        ],
+      },
+    ]);
+
+    history.clear({ historyKey: "room-1", limit: 3 });
+    expect(history.buildInboundHistory({ historyKey: "room-1", limit: 3 })).toEqual([]);
+  });
+});

--- a/src/channels/turn/history-window.ts
+++ b/src/channels/turn/history-window.ts
@@ -1,0 +1,89 @@
+import {
+  buildInboundHistoryFromMap,
+  buildPendingHistoryContextFromMap,
+  clearHistoryEntriesIfEnabled,
+  recordPendingHistoryEntryIfEnabled,
+  recordPendingHistoryEntryWithMedia,
+} from "../../auto-reply/reply/history.js";
+import type { HistoryEntry, HistoryMediaEntry } from "../../auto-reply/reply/history.types.js";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export type ChannelHistoryWindow = {
+  record: (params: {
+    historyKey: string;
+    entry?: HistoryEntry | null;
+    limit: number;
+  }) => HistoryEntry[];
+  recordWithMedia: (params: {
+    historyKey: string;
+    entry?: HistoryEntry | null;
+    limit: number;
+    media?:
+      | readonly HistoryMediaEntry[]
+      | null
+      | (() => MaybePromise<readonly HistoryMediaEntry[] | null | undefined>);
+    mediaLimit?: number;
+    messageId?: string;
+    shouldRecord?: () => boolean;
+  }) => Promise<HistoryEntry[]>;
+  buildPendingContext: (params: {
+    historyKey: string;
+    limit: number;
+    currentMessage: string;
+    formatEntry: (entry: HistoryEntry) => string;
+    lineBreak?: string;
+  }) => string;
+  buildInboundHistory: (params: {
+    historyKey: string;
+    limit: number;
+  }) => HistoryEntry[] | undefined;
+  clear: (params: { historyKey: string; limit: number }) => void;
+};
+
+export function createChannelHistoryWindow(params: {
+  historyMap: Map<string, HistoryEntry[]>;
+}): ChannelHistoryWindow {
+  const { historyMap } = params;
+  return {
+    record: (recordParams) =>
+      recordPendingHistoryEntryIfEnabled({
+        historyMap,
+        historyKey: recordParams.historyKey,
+        limit: recordParams.limit,
+        entry: recordParams.entry,
+      }),
+    recordWithMedia: (recordParams) =>
+      recordPendingHistoryEntryWithMedia({
+        historyMap,
+        historyKey: recordParams.historyKey,
+        limit: recordParams.limit,
+        entry: recordParams.entry,
+        media: recordParams.media,
+        mediaLimit: recordParams.mediaLimit,
+        messageId: recordParams.messageId,
+        shouldRecord: recordParams.shouldRecord,
+      }),
+    buildPendingContext: (contextParams) =>
+      buildPendingHistoryContextFromMap({
+        historyMap,
+        historyKey: contextParams.historyKey,
+        limit: contextParams.limit,
+        currentMessage: contextParams.currentMessage,
+        formatEntry: contextParams.formatEntry,
+        lineBreak: contextParams.lineBreak,
+      }),
+    buildInboundHistory: (historyParams) =>
+      buildInboundHistoryFromMap({
+        historyMap,
+        historyKey: historyParams.historyKey,
+        limit: historyParams.limit,
+      }),
+    clear: (clearParams) =>
+      clearHistoryEntriesIfEnabled({
+        historyMap,
+        historyKey: clearParams.historyKey,
+        limit: clearParams.limit,
+      }),
+  };
+}

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -20,6 +20,8 @@ export {
   listTrackedChannelBotPairsForTests,
   recordChannelBotPairLoopAndCheckSuppression,
 } from "./bot-loop-protection.js";
+export { createChannelHistoryWindow } from "./history-window.js";
+export type { ChannelHistoryWindow } from "./history-window.js";
 export type { ChannelBotLoopProtectionFacts } from "./bot-loop-protection.js";
 export {
   deliverDurableInboundReplyPayload,

--- a/src/plugin-sdk/reply-history.ts
+++ b/src/plugin-sdk/reply-history.ts
@@ -1,6 +1,10 @@
 /** Shared reply-history helpers for plugins that keep short per-thread context windows. */
 export type { HistoryEntry, HistoryMediaEntry } from "../auto-reply/reply/history.types.js";
 export {
+  createChannelHistoryWindow,
+  type ChannelHistoryWindow,
+} from "../channels/turn/history-window.js";
+export {
   DEFAULT_GROUP_HISTORY_LIMIT,
   HISTORY_CONTEXT_MARKER,
   buildHistoryContext,


### PR DESCRIPTION
## Summary

- add a core `ChannelHistoryWindow` facade over the short reply-history map
- export the facade through `openclaw/plugin-sdk/reply-history`
- migrate Discord, Slack, and Zalo call sites away from direct low-level history-map helpers
- keep platform-specific text formatting callbacks unchanged
- add focused facade coverage and refresh the Plugin SDK API baseline

## Verification

- `node scripts/run-vitest.mjs src/channels/turn/history-window.test.ts src/channels/turn/kernel.test.ts src/auto-reply/reply/history.test.ts extensions/discord/src/monitor/message-handler.preflight.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/zalouser/src/monitor.group-gating.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental false`
- `pnpm plugin-sdk:api:check`
- `OPENCLAW_TESTBOX_REMOTE_RUN=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm check:changed`
- Codex review: clean

## Real behavior proof

Behavior addressed: short channel history recording, pending context formatting, structured inbound history, media-history normalization, and post-reply clearing now go through one core facade instead of per-plugin direct helper calls.

Real environment tested: local OpenClaw checkout on Node 22 toolchain plus Testbox-backed changed gate.

Exact steps or command run after this patch: focused Vitest command above, core/extensions tsgo commands above, Plugin SDK API check above, `OPENCLAW_TESTBOX_REMOTE_RUN=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm check:changed`, Codex review, and the direct runtime import below.

Evidence after fix: terminal output from a direct Node/tsx import of the new core facade in this checkout:

```text
$ pnpm exec tsx -e 'import { createChannelHistoryWindow } from "./src/channels/turn/history-window.ts"; const map = new Map(); const h = createChannelHistoryWindow({ historyMap: map }); h.record({ historyKey: "demo", limit: 2, entry: { sender: "Alice", body: "image posted", timestamp: 1, messageId: "m1" } }); console.log(JSON.stringify(h.buildInboundHistory({ historyKey: "demo", limit: 2 }))); h.clear({ historyKey: "demo", limit: 2 }); console.log(JSON.stringify(h.buildInboundHistory({ historyKey: "demo", limit: 2 })));'
[{"sender":"Alice","body":"image posted","timestamp":1,"messageId":"m1"}]
[]
```

Observed result after fix: the facade records a message, exposes the same structured inbound history entry including `messageId`, and clears the window back to empty. Discord, Slack, and Zalo preserve existing formatting callbacks while using this shared path.

What was not tested: live Discord, Slack, or Zalo message delivery; this PR is a behavior-preserving refactor covered by focused tests, changed gates, and direct runtime import proof.
