### PR TITLE
feat(plugins): add @iflow-ai/iflow-plugin to external plugin catalog

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -62,6 +62,22 @@ file messages via any DingTalk client.
 openclaw plugins install @largezhou/ddingtalk
 ```
 
+### iFlow Search
+
+Chinese-first web search, image search, and clean-content web fetch via the
+[iFlow Open Platform](https://platform.iflow.cn/). Exposes
+`iflow_web_search`, `iflow_image_search`, and `iflow_web_fetch` as agent
+tools, and registers as a `web_search` provider (best-effort) so the managed
+`web_search` tool can be routed through iFlow with one config line.
+
+- **npm:** `@iflow-ai/iflow-plugin`
+- **repo:** [github.com/zhengyanglsun/openclaw-iflow-plugin](https://github.com/zhengyanglsun/openclaw-iflow-plugin)
+- **provider id:** `iflow`
+
+```bash
+openclaw plugins install @iflow-ai/iflow-plugin
+```
+
 ### Lossless Claw (LCM)
 
 Lossless Context Management plugin for OpenClaw. DAG-based conversation

--- a/docs/tools/iflow-search.md
+++ b/docs/tools/iflow-search.md
@@ -1,0 +1,141 @@
+---
+summary: "iFlow Search API setup for web_search, image search, and web fetch"
+read_when:
+  - You want to use iFlow Search (心流搜索) for web_search
+  - You need IFLOW_API_KEY or Chinese-first search results
+title: "iFlow search"
+---
+
+OpenClaw supports iFlow Search (心流搜索) as a `web_search` provider, plus
+two extra agent tools for image search and clean web-page extraction. iFlow's
+results are Chinese-first but cover the global web.
+
+## Get an API key
+
+1. Create an account at the [iFlow Open Platform](https://platform.iflow.cn).
+2. Generate an API key in the dashboard.
+3. Store the key in config or set `IFLOW_API_KEY` in the Gateway environment.
+
+## Config example
+
+```json5
+{
+  plugins: {
+    entries: {
+      iflow: {
+        enabled: true,
+        config: {
+          webSearch: {
+            apiKey: "IFLOW_API_KEY_HERE",
+            baseUrl: "https://platform.iflow.cn", // optional override
+            timeoutSeconds: 30,                   // optional, default 30
+            cacheTtlMinutes: 15,                  // optional, default 15; set 0 to disable
+          },
+        },
+      },
+    },
+  },
+  tools: {
+    web: {
+      search: {
+        provider: "iflow",
+      },
+    },
+  },
+}
+```
+
+Provider-specific iFlow settings live under
+`plugins.entries.iflow.config.webSearch.*`. The plugin also reads
+`IFLOW_API_KEY` from the Gateway environment as a fallback when the
+config-level key is absent.
+
+## Install
+
+The plugin is published on npm as
+[`@iflow-ai/iflow-plugin`](https://www.npmjs.com/package/@iflow-ai/iflow-plugin).
+After choosing iFlow in `openclaw onboard` or `openclaw configure --section web`,
+OpenClaw installs it on demand. To install manually:
+
+```bash
+openclaw plugins install @iflow-ai/iflow-plugin
+openclaw gateway restart
+openclaw plugins inspect iflow
+```
+
+## Tools
+
+The plugin exposes three explicit tools alongside the managed `web_search`
+provider routing. Tool names use the `iflow_` prefix for namespace clarity.
+
+### `iflow_web_search`
+
+<ParamField path="query" type="string" required>
+Search query. Forwarded to iFlow as `keywords`.
+</ParamField>
+
+<ParamField path="count" type="number" default="10">
+Number of results to return (1–10). Forwarded to iFlow as `num`.
+</ParamField>
+
+Returns `{ query, provider:"iflow", count, tookMs, results: [{ title, url, snippet, position, date }] }`.
+
+### `iflow_image_search`
+
+<ParamField path="query" type="string" required>
+Image search query. Forwarded to iFlow as `keywords`.
+</ParamField>
+
+<ParamField path="count" type="number" default="10">
+Number of images to return (1–20). Forwarded to iFlow as `num`.
+</ParamField>
+
+Returns `{ query, provider:"iflow", count, tookMs, images: [{ url, title, sourceUrl }] }`.
+
+### `iflow_web_fetch`
+
+<ParamField path="url" type="string" required>
+HTTP(S) URL to fetch.
+</ParamField>
+
+Returns `{ title, url, content, fromCache, provider:"iflow", tookMs }`.
+
+**Example:**
+
+```javascript
+// Web search
+await web_search({ query: "Java Spring Boot 教程" });
+
+// Image search (via the explicit tool)
+await iflow_image_search({ query: "小猫", count: 5 });
+
+// Clean-content fetch
+await iflow_web_fetch({ url: "https://example.com/article" });
+```
+
+## Notes
+
+- Results are cached in-memory for 15 minutes by default (configurable via
+  `cacheTtlMinutes`; set `0` to disable). The cache key includes the iFlow
+  base URL, so proxy-specific responses do not collide.
+- The plugin also registers `iflow` as a `web_search` provider via
+  `api.registerWebSearchProvider` when the runtime exposes that API; if the
+  runtime does not, the three explicit tools above still work.
+- Error codes: `missing_api_key`, `missing_param`, `invalid_param`,
+  `network_timeout`, `network_error`, `api_error`, `api_business_error`.
+
+## Attribution headers
+
+The iFlow plugin sends non-sensitive attribution headers so iFlow can identify requests coming from the OpenClaw plugin integration. No API key, user query, URL, search keywords, or user content is added to these headers.
+
+```http
+IFlow-Source: openclaw
+IFlow-Integration: @iflow-ai/iflow-plugin
+IFlow-Integration-Version: <plugin version>
+```
+
+## Related
+
+- [Web Search overview](/tools/web) -- all providers and auto-detection
+- [iFlow plugin on GitHub](https://github.com/zhengyanglsun/openclaw-iflow-plugin)
+- [iFlow Open Platform](https://platform.iflow.cn/)

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -75,6 +75,9 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
   <Card title="Grok" icon="zap" href="/tools/grok-search">
     AI-synthesized answers with citations via xAI web grounding.
   </Card>
+  <Card title="iFlow Search" icon="globe" href="/tools/iflow-search">
+    Chinese-first structured results plus image search and clean-content web fetch via the iFlow Open Platform.
+  </Card>
   <Card title="Kimi" icon="moon" href="/tools/kimi-search">
     AI-synthesized answers with citations via Moonshot web search; ungrounded chat fallbacks fail explicitly.
   </Card>
@@ -105,6 +108,7 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 | [Firecrawl](/tools/firecrawl)             | Structured snippets                                            | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                                                                     |
 | [Gemini](/tools/gemini-search)            | AI-synthesized + citations                                     | --                                               | `GEMINI_API_KEY`                                                                        |
 | [Grok](/tools/grok-search)                | AI-synthesized + citations                                     | --                                               | `XAI_API_KEY`                                                                           |
+| [iFlow Search](/tools/iflow-search)       | Structured snippets (Chinese-first)                            | Via `iflow_image_search` and `iflow_web_fetch`   | `IFLOW_API_KEY`                                                                         |
 | [Kimi](/tools/kimi-search)                | AI-synthesized + citations; fails on ungrounded chat fallbacks | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`                                                     |
 | [MiniMax Search](/tools/minimax-search)   | Structured snippets                                            | Region (`global` / `cn`)                         | `MINIMAX_CODE_PLAN_KEY` / `MINIMAX_CODING_API_KEY` / `MINIMAX_OAUTH_TOKEN`              |
 | [Ollama Web Search](/tools/ollama-search) | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -26,7 +26,7 @@
           }
         ],
         "install": {
-          "npmSpec": "@iflow-ai/iflow-plugin",
+          "npmSpec": "@iflow-ai/iflow-plugin@0.1.3",
           "defaultChoice": "npm",
           "minHostVersion": ">=2026.5.7"
         }

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -14,7 +14,7 @@
           {
             "id": "iflow",
             "label": "iFlow Search",
-            "hint": "Chinese-first web search via iFlow Open Platform.",
+            "hint": "Connect Your AI Agent to the Real World",
             "onboardingScopes": ["text-inference"],
             "credentialLabel": "iFlow API key",
             "envVars": ["IFLOW_API_KEY"],

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -1,6 +1,38 @@
 {
   "entries": [
     {
+      "name": "@iflow-ai/iflow-plugin",
+      "description": "iFlow Search (心流搜索) — Chinese-first web search, image search, and web content fetch.",
+      "source": "external",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "iflow",
+          "label": "iFlow Search"
+        },
+        "webSearchProviders": [
+          {
+            "id": "iflow",
+            "label": "iFlow Search",
+            "hint": "Chinese-first web search via iFlow Open Platform.",
+            "onboardingScopes": ["text-inference"],
+            "credentialLabel": "iFlow API key",
+            "envVars": ["IFLOW_API_KEY"],
+            "placeholder": "sk-...",
+            "signupUrl": "https://platform.iflow.cn",
+            "docsUrl": "https://docs.openclaw.ai/tools/iflow-search",
+            "credentialPath": "plugins.entries.iflow.config.webSearch.apiKey",
+            "autoDetectOrder": 80
+          }
+        ],
+        "install": {
+          "npmSpec": "@iflow-ai/iflow-plugin",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.5.7"
+        }
+      }
+    },
+    {
       "name": "@openclaw/acpx",
       "description": "OpenClaw ACP runtime backend",
       "source": "official",


### PR DESCRIPTION
## Summary

Adds `@iflow-ai/iflow-plugin` to the official external plugin catalog so OpenClaw's onboard / configure
search-provider picker can discover and install iFlow Search alongside Brave, Tavily, Exa, etc.

- New `webSearchProviders[iflow]` entry with credential path `plugins.entries.iflow.config.webSearch.apiKey`, env
  var `IFLOW_API_KEY`, autoDetectOrder 80
- `install.npmSpec` is pinned to `@iflow-ai/iflow-plugin@0.1.3` — see "Why pin" below
- Hint copy uses the iFlow product tagline

## Why pin the npm spec to an exact version

The catalog originally used unpinned `"npmSpec": "@iflow-ai/iflow-plugin"`, which resolves to npm `latest` (=
0.1.3). However, beta-channel hosts (any version matching the `-beta` tag, e.g. `2026.5.x-beta.N`) hit
`resolveNpmInstallSpecsForUpdateChannel` and the spec gets rewritten to `@beta`. The `@beta` dist-tag on this
package still points to 0.1.2, which has an async fire-and-forget provider registration bug (fixed in 0.1.3).
Pinning the catalog to an exact version bypasses the channel rewrite and ensures beta-host onboards install the
working version. Future bumps will be one-line catalog updates.

## Plugin source

- npm: https://www.npmjs.com/package/@iflow-ai/iflow-plugin
- GitHub: https://github.com/zhengyanglsun/openclaw-iflow-plugin
- License: MIT
- Plugin registers `iflow` as a web_search provider and three explicit tools: `iflow_web_search`,
  `iflow_image_search`, `iflow_web_fetch`. Skill at `skills/iflow-search/SKILL.md` describes routing.

## Test plan

- [x] `onboard` on a fresh profile shows `iFlow Search (Connect Your AI Agent to the Real World)` in the
  Search provider picker
- [x] Selecting iFlow Search auto-installs `@iflow-ai/iflow-plugin@0.1.3` (verified on host
  `2026.5.12-beta.1`)
- [x] `configure --section web` produces an equivalent profile config
- [x] `infer web search --query ... --json` returns `provider: "iflow"` with real iFlow API results
- [x] All four config keys written correctly: `tools.web.search.provider="iflow"`,
  `tools.web.search.enabled=true`, `plugins.entries.iflow.enabled=true`,
  `plugins.entries.iflow.config.webSearch.apiKey` populated; no top-level `tools.web.search.apiKey` residue

🤖 Generated with [Claude Code](https://claude.com/claude-code)