### PR TITLE
feat(agents): allow spawn fast mode overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/subagents: add `sessions_spawn.fastMode` so native subagent and ACP child sessions can opt a single spawn in or out of provider fast mode without changing agent or model defaults.
 - Search/providers: add the Parallel bundled web-search plugin, live provider tests, registration contracts, onboarding/docs wiring, and guarded `api.parallel.ai/v1/search` support. (#85158) Thanks @NormallyGaussian.
 - Matrix/channels: add voice-message preflight and thread-aware read/reply behavior, including Matrix QA scenario wiring and docs for voice-message behavior. (#78016, #90415)
 - Skills/ClawHub: install ClawHub skills backed by GitHub repositories through the resolved install API, download the pinned GitHub commit, keep install-policy checks, and report install telemetry after success. (#90478) Thanks @Patrick-Erichsen.
@@ -26,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Memory: QMD search can use the new rerank toggle, and memory adapter status uses the resolved default model identity when checking plain status.
 - Docs/tooling: add Parallel search docs, refresh weather-skill guidance toward `web_fetch`, clarify legacy `openai-codex` auth, document release/test helper scripts, and tighten changed-test routing docs for CI/debugging work. (#90028, #90250) Thanks @fuller-stack-dev.
 - Platform maintenance: refresh Android, Swift/macOS, Docker, CodeQL, Buildx, Docker build/push, and Codex Action dependencies for this release train. (#74980, #81757, #86481, #86483, #90601)
+- Agents/skills: cache hydrated `resolvedSkills` across warm gateway turns while keying reuse by the redacted effective config, reducing redundant skill snapshot rebuilds without crossing config-gated skill boundaries. (#81451) Thanks @solodmd.
 
 ### Fixes
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -580,6 +580,11 @@ overrides.
   per-model `agents.defaults.models["provider/model"].params.thinking`
   for the selected model.
 </ParamField>
+<ParamField path="fastMode" type="boolean">
+  Optional child-session fast-mode override for ACP spawns. Set `false`
+  to keep the initial ACP child turn on standard processing even when
+  the target agent or model defaults enable fast mode.
+</ParamField>
 
 ## Spawn bind and thread modes
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -141,6 +141,7 @@ session to confirm the effective tool list.
 
 - **Model:** native sub-agents inherit the caller unless you set `agents.defaults.subagents.model` (or per-agent `agents.list[].subagents.model`). ACP runtime spawns use the same configured subagent model when present; otherwise the ACP harness keeps its own default. An explicit `sessions_spawn.model` still wins.
 - **Thinking:** native sub-agents inherit the caller unless you set `agents.defaults.subagents.thinking` (or per-agent `agents.list[].subagents.thinking`). ACP runtime spawns also apply `agents.defaults.models["provider/model"].params.thinking` for the selected model. An explicit `sessions_spawn.thinking` still wins.
+- **Fast mode:** follows the child session's normal fast-mode resolution unless `sessions_spawn.fastMode` is set. Use `false` to keep one child on standard processing even when the target agent or model defaults enable fast mode.
 - **Run timeout:** OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise it falls back to `0` (no timeout). `sessions_spawn` does not accept per-call timeout overrides.
 - **Task delivery:** native sub-agents receive the delegated task in their first visible `[Subagent Task]` message. The sub-agent system prompt carries runtime rules and routing context, not a hidden duplicate of the task.
 
@@ -207,6 +208,9 @@ Per-agent overrides use `agents.list[].subagents.delegationMode`.
 </ParamField>
 <ParamField path="thinking" type="string">
   Override thinking level for the sub-agent run.
+</ParamField>
+<ParamField path="fastMode" type="boolean">
+  Optional fast-mode override for the child session. Set `false` to force standard processing for this spawn; omit to inherit the target agent and model defaults.
 </ParamField>
 <ParamField path="thread" type="boolean" default="false">
   When `true`, requests channel thread binding for this sub-agent session.

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -65,7 +65,7 @@ title: "Thinking levels"
 - Send `/fast` (or `/fast status`) with no mode to see the current effective fast-mode state.
 - OpenClaw resolves fast mode in this order:
   1. Inline/directive-only `/fast on|off` override (`/fast default` clears this layer)
-  2. Session override
+  2. Session override, including `sessions_spawn.fastMode` persisted on child sessions
   3. Per-agent default (`agents.list[].fastModeDefault`)
   4. Per-model config: `agents.defaults.models["<provider>/<model>"].params.fastMode`
   5. Fallback: `off`

--- a/packages/acp-core/src/types.ts
+++ b/packages/acp-core/src/types.ts
@@ -77,6 +77,8 @@ export type AcpSessionRuntimeOptions = {
   permissionProfile?: string;
   /** ACP runtime config option: per-turn timeout in seconds. */
   timeoutSeconds?: number;
+  /** ACP runtime config option: fast-mode toggle. */
+  fastMode?: boolean;
   /** Backend-specific option bag mapped through session/set_config_option. */
   backendExtras?: Record<string, string>;
 };

--- a/src/acp/control-plane/manager.runtime-config.test.ts
+++ b/src/acp/control-plane/manager.runtime-config.test.ts
@@ -403,6 +403,7 @@ describe("AcpSessionManager runtime config", () => {
           thinking: "high",
           permissionProfile: "strict",
           timeoutSeconds: 120,
+          fastMode: false,
         },
       },
     });
@@ -434,6 +435,10 @@ describe("AcpSessionManager runtime config", () => {
     expectMockCallFields(runtimeState.setConfigOption, {
       key: "timeout",
       value: "120",
+    });
+    expectMockCallFields(runtimeState.setConfigOption, {
+      key: "fast_mode",
+      value: "false",
     });
   });
 
@@ -606,7 +611,7 @@ describe("AcpSessionManager runtime config", () => {
     const runtimeState = createRuntime();
     runtimeState.getCapabilities.mockResolvedValue({
       controls: ["session/set_config_option", "session/status"],
-      configOptionKeys: ["model", "thought_level", "permissions", "timeout_seconds"],
+      configOptionKeys: ["model", "thought_level", "permissions", "timeout_seconds", "fast-mode"],
     });
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
       id: "acpx",
@@ -622,6 +627,7 @@ describe("AcpSessionManager runtime config", () => {
           thinking: "high",
           permissionProfile: "strict",
           timeoutSeconds: 120,
+          fastMode: true,
         },
       },
     });
@@ -646,6 +652,10 @@ describe("AcpSessionManager runtime config", () => {
     expectMockCallFields(runtimeState.setConfigOption, {
       key: "timeout_seconds",
       value: "120",
+    });
+    expectMockCallFields(runtimeState.setConfigOption, {
+      key: "fast-mode",
+      value: "true",
     });
     expectNoMockCallFields(runtimeState.setConfigOption, {
       key: "thinking",

--- a/src/acp/control-plane/runtime-options.test.ts
+++ b/src/acp/control-plane/runtime-options.test.ts
@@ -40,4 +40,11 @@ describe("buildRuntimeConfigOptionPairs timeout advertisement", () => {
       ["thinking", "high"],
     ]);
   });
+
+  it("maps fast mode to backend-advertised aliases", () => {
+    expect(buildRuntimeConfigOptionPairs({ fastMode: false })).toEqual([["fast_mode", "false"]]);
+    expect(buildRuntimeConfigOptionPairs({ fastMode: true }, ["fast-mode"])).toEqual([
+      ["fast-mode", "true"],
+    ]);
+  });
 });

--- a/src/acp/control-plane/runtime-options.ts
+++ b/src/acp/control-plane/runtime-options.ts
@@ -26,6 +26,7 @@ const RUNTIME_CONFIG_OPTION_ALIASES = {
   thinking: ["thinking", "effort", "reasoning_effort", "thought_level"],
   permissionProfile: ["approval_policy", "permission_profile", "permissions", "permission_mode"],
   timeoutSeconds: ["timeout", "timeout_seconds"],
+  fastMode: ["fast_mode", "fast-mode", "fastMode"],
 } as const;
 
 function failInvalidOption(message: string): never {
@@ -167,6 +168,7 @@ export function validateRuntimeOptionPatch(
     "cwd",
     "permissionProfile",
     "timeoutSeconds",
+    "fastMode",
     "backendExtras",
   ]);
   for (const key of Object.keys(rawPatch)) {
@@ -216,6 +218,15 @@ export function validateRuntimeOptionPatch(
       next.timeoutSeconds = undefined;
     } else {
       next.timeoutSeconds = validateRuntimeTimeoutSecondsInput(rawPatch.timeoutSeconds);
+    }
+  }
+  if (Object.hasOwn(rawPatch, "fastMode")) {
+    if (rawPatch.fastMode === undefined) {
+      next.fastMode = undefined;
+    } else if (typeof rawPatch.fastMode === "boolean") {
+      next.fastMode = rawPatch.fastMode;
+    } else {
+      failInvalidOption("Fast mode must be a boolean.");
     }
   }
   if (Object.hasOwn(rawPatch, "backendExtras")) {
@@ -268,6 +279,7 @@ export function normalizeRuntimeOptions(
     ...(cwd ? { cwd } : {}),
     ...(permissionProfile ? { permissionProfile } : {}),
     ...(typeof timeoutSeconds === "number" ? { timeoutSeconds } : {}),
+    ...(typeof options?.fastMode === "boolean" ? { fastMode: options.fastMode } : {}),
     ...(backendExtras ? { backendExtras } : {}),
   };
 }
@@ -318,6 +330,7 @@ export function buildRuntimeControlSignature(options: AcpSessionRuntimeOptions):
     thinking: normalized.thinking ?? null,
     permissionProfile: normalized.permissionProfile ?? null,
     timeoutSeconds: normalized.timeoutSeconds ?? null,
+    fastMode: normalized.fastMode ?? null,
     backendExtras: extras,
   });
 }
@@ -350,6 +363,12 @@ export function buildRuntimeConfigOptionPairs(
     pairs.set(
       resolveRuntimeConfigOptionKey("timeout", advertisedConfigOptionKeys),
       String(normalized.timeoutSeconds),
+    );
+  }
+  if (typeof normalized.fastMode === "boolean") {
+    pairs.set(
+      resolveRuntimeConfigOptionKey("fast_mode", advertisedConfigOptionKeys),
+      String(normalized.fastMode),
     );
   }
   for (const [key, value] of Object.entries(normalized.backendExtras ?? {})) {
@@ -445,6 +464,13 @@ export function inferRuntimeOptionPatchFromConfigOption(
   }
   if (normalizedKey === "timeout" || normalizedKey === "timeout_seconds") {
     return { timeoutSeconds: parseRuntimeTimeoutSecondsInput(validated.value) };
+  }
+  if (
+    normalizedKey === "fast_mode" ||
+    normalizedKey === "fast-mode" ||
+    normalizedKey === "fastmode"
+  ) {
+    return { fastMode: normalizeLowercaseStringOrEmpty(validated.value) === "true" };
   }
   if (normalizedKey === "cwd") {
     return { cwd: validateRuntimeCwdInput(validated.value) };

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -771,6 +771,7 @@ describe("spawnAcpDirect", () => {
         agentId: "codex",
         mode: "session",
         thread: true,
+        fastMode: false,
       },
       {
         agentSessionKey: "agent:main:main",
@@ -789,6 +790,7 @@ describe("spawnAcpDirect", () => {
     expectSessionPatchFields({
       key: accepted.childSessionKey,
       spawnedBy: "agent:main:main",
+      fastMode: false,
     });
     expectBindingCallFields({
       targetKind: "session",

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -951,6 +951,28 @@ describe("spawnAcpDirect", () => {
     expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
   });
 
+  it("passes fast mode overrides into ACP session initialization", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        fastMode: false,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expectAcceptedSpawn(result);
+    const initInput = expectInitializeSessionFields({
+      agent: "codex",
+      runtimeOptions: {
+        fastMode: false,
+      },
+    });
+    expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
+  });
+
   it("applies existing subagent model and model-profile thinking defaults to ACP runtime options", async () => {
     replaceSpawnConfig({
       ...createDefaultSpawnConfig(),

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -126,6 +126,7 @@ export type SpawnAcpParams = {
   resumeSessionId?: string;
   model?: string;
   thinking?: string;
+  fastMode?: boolean;
   runTimeoutSeconds?: number;
   cwd?: string;
   mode?: SpawnAcpMode;
@@ -1477,6 +1478,7 @@ export async function spawnAcpDirect(
         ...subagentEnvelopeState.childSessionPatch,
         ...inheritedToolAllowPatch(ctx.inheritedToolAllowlist),
         ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),
+        ...(typeof params.fastMode === "boolean" ? { fastMode: params.fastMode } : {}),
         ...(params.label ? { label: params.label } : {}),
       },
       timeoutMs: 10_000,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -45,7 +45,11 @@ import { getRuntimeConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store.js";
 import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
-import type { SessionAcpMeta, SessionEntry } from "../config/sessions/types.js";
+import type {
+  AcpSessionRuntimeOptions,
+  SessionAcpMeta,
+  SessionEntry,
+} from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -997,11 +1001,10 @@ function validateAcpResumeSessionOwnership(params: {
   };
 }
 
-type AcpSpawnRuntimeOptions = {
-  model?: string;
-  thinking?: string;
-  timeoutSeconds?: number;
-};
+type AcpSpawnRuntimeOptions = Pick<
+  AcpSessionRuntimeOptions,
+  "model" | "thinking" | "timeoutSeconds" | "fastMode"
+>;
 
 function resolveAcpRuntimeTimeoutSeconds(runTimeoutSeconds?: number): number | undefined {
   if (!runTimeoutSeconds) {
@@ -1017,6 +1020,7 @@ function resolveAcpSpawnRuntimeOptions(params: {
   model?: string;
   thinking?: string;
   runTimeoutSeconds?: number;
+  fastMode?: boolean;
 }): { ok: true; runtimeOptions?: AcpSpawnRuntimeOptions } | { ok: false; error: string } {
   const policyAgentId = params.configAgentId ?? params.targetAgentId;
   const model = resolveConfiguredSubagentSpawnModelSelection({
@@ -1052,11 +1056,12 @@ function resolveAcpSpawnRuntimeOptions(params: {
 
   const timeoutSeconds = resolveAcpRuntimeTimeoutSeconds(params.runTimeoutSeconds);
   const runtimeOptions =
-    model || thinking || timeoutSeconds
+    model || thinking || timeoutSeconds || typeof params.fastMode === "boolean"
       ? {
           ...(model ? { model } : {}),
           ...(thinking ? { thinking } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(typeof params.fastMode === "boolean" ? { fastMode: params.fastMode } : {}),
         }
       : undefined;
   return { ok: true, runtimeOptions };
@@ -1409,6 +1414,7 @@ export async function spawnAcpDirect(
     model: params.model,
     thinking: params.thinking,
     runTimeoutSeconds,
+    fastMode: params.fastMode,
   });
   if (!runtimeOptionsResult.ok) {
     return createAcpSpawnFailure({

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -205,7 +205,8 @@ describe("spawnSubagentDirect seam flow", () => {
     const result = await spawnSubagentDirect(
       {
         task: "inspect the spawn seam",
-        model: "openai/gpt-5.4",
+        model: "openai-codex/gpt-5.4",
+        fastMode: false,
       },
       {
         agentSessionKey: "agent:main:main",
@@ -256,6 +257,7 @@ describe("spawnSubagentDirect seam flow", () => {
       model: "gpt-5.4",
       overrideSource: "user",
     });
+    expect(persistedStore?.[childSessionKey]?.fastMode).toBe(false);
     expect(operations.indexOf("store:update")).toBeGreaterThan(-1);
     expect(operations.indexOf("gateway:agent")).toBeGreaterThan(
       operations.lastIndexOf("store:update"),

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -205,7 +205,7 @@ describe("spawnSubagentDirect seam flow", () => {
     const result = await spawnSubagentDirect(
       {
         task: "inspect the spawn seam",
-        model: "openai-codex/gpt-5.4",
+        model: "openai/gpt-5.4",
         fastMode: false,
       },
       {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -166,6 +166,7 @@ export type SpawnSubagentParams = {
   taskName?: string;
   thinking?: string;
   cwd?: string;
+  fastMode?: boolean;
   runTimeoutSeconds?: number;
   thread?: boolean;
   mode?: SpawnSubagentMode;
@@ -315,6 +316,9 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
   }
   if (typeof patch.thinkingLevel === "string" && patch.thinkingLevel.trim()) {
     entry.thinkingLevel = patch.thinkingLevel.trim();
+  }
+  if (typeof patch.fastMode === "boolean") {
+    entry.fastMode = patch.fastMode;
   }
   if (typeof patch.model === "string" && patch.model.trim()) {
     const { provider, model } = splitModelRef(patch.model.trim());
@@ -1310,6 +1314,7 @@ export async function spawnSubagentDirect(
     subagentControlScope: childCapabilities.controlScope,
     ...inheritedToolAllowPatch(ctx.inheritedToolAllowlist),
     ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),
+    ...(typeof params.fastMode === "boolean" ? { fastMode: params.fastMode } : {}),
     ...plan.initialSessionPatch,
   };
 

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -6,12 +6,20 @@ const hoisted = vi.hoisted(() => {
   const spawnSubagentDirectMock = vi.fn();
   const spawnAcpDirectMock = vi.fn();
   const registerSubagentRunMock = vi.fn();
+  const getRuntimeConfigMock = vi.fn(() => ({
+    session: { mainKey: "main", scope: "per-sender" },
+  }));
   return {
     spawnSubagentDirectMock,
     spawnAcpDirectMock,
     registerSubagentRunMock,
+    getRuntimeConfigMock,
   };
 });
+
+vi.mock("../../config/config.js", () => ({
+  getRuntimeConfig: () => hoisted.getRuntimeConfigMock(),
+}));
 
 vi.mock("../subagent-spawn.js", () => ({
   SUBAGENT_SPAWN_CONTEXT_MODES: ["isolated", "fork"],
@@ -52,6 +60,9 @@ describe("sessions_spawn tool", () => {
       runId: "run-acp",
     });
     hoisted.registerSubagentRunMock.mockReset();
+    hoisted.getRuntimeConfigMock.mockReset().mockReturnValue({
+      session: { mainKey: "main", scope: "per-sender" },
+    });
   });
 
   function registerAcpBackendForTest() {
@@ -146,11 +157,14 @@ describe("sessions_spawn tool", () => {
     expect(schema.properties?.runtime?.enum).toEqual(["subagent", "acp"]);
     const resumeSessionId = requireSchemaProperty(schema.properties, "resumeSessionId");
     const streamTo = requireSchemaProperty(schema.properties, "streamTo");
+    const fastMode = requireSchemaProperty(schema.properties, "fastMode");
     expect(resumeSessionId.description).toContain("ACP-only resume target");
     expect(resumeSessionId.description).toContain('ignored for runtime="subagent"');
     expect(resumeSessionId.description).toContain("already recorded for this requester");
     expect(streamTo.description).toContain("ACP-only stream target");
     expect(streamTo.description).toContain('ignored for runtime="subagent"');
+    expect(fastMode.type).toBe("boolean");
+    expect(fastMode.description).toContain("per-spawn fast-mode override");
   });
 
   it("hides ACP runtime affordances when the ACP backend is unhealthy", () => {
@@ -303,6 +317,7 @@ describe("sessions_spawn tool", () => {
       model: "anthropic/claude-sonnet-4-6",
       thinking: "medium",
       cwd: "/workspace/requester",
+      fastMode: false,
       thread: true,
       mode: "session",
       cleanup: "keep",
@@ -321,6 +336,7 @@ describe("sessions_spawn tool", () => {
     expect(spawnArgs.thinking).toBe("medium");
     expect(spawnArgs.cwd).toBe("/workspace/requester");
     expect(spawnArgs).not.toHaveProperty("runTimeoutSeconds");
+    expect(spawnArgs.fastMode).toBe(false);
     expect(spawnArgs.thread).toBe(true);
     expect(spawnArgs.mode).toBe("session");
     expect(spawnArgs.cleanup).toBe("keep");
@@ -553,6 +569,7 @@ describe("sessions_spawn tool", () => {
       task: "investigate the failing CI run",
       agentId: "codex",
       cwd: "/workspace",
+      fastMode: false,
       thread: true,
       mode: "session",
       streamTo: "parent",
@@ -568,6 +585,7 @@ describe("sessions_spawn tool", () => {
     expect(spawnArgs.agentId).toBe("codex");
     expect(spawnArgs.cwd).toBe("/workspace");
     expect(spawnArgs).not.toHaveProperty("runTimeoutSeconds");
+    expect(spawnArgs.fastMode).toBe(false);
     expect(spawnArgs.thread).toBe(true);
     expect(spawnArgs.mode).toBe("session");
     expect(spawnArgs.streamTo).toBe("parent");

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -179,6 +179,12 @@ function createSessionsSpawnToolSchema(params: {
     agentId: Type.Optional(Type.String()),
     model: Type.Optional(Type.String()),
     thinking: Type.Optional(Type.String()),
+    fastMode: Type.Optional(
+      Type.Boolean({
+        description:
+          "Optional per-spawn fast-mode override for the child session. Use false to keep a spawned child on standard processing even when agent or model defaults enable fast mode.",
+      }),
+    ),
     cwd: Type.Optional(Type.String()),
     ...(params.threadAvailable
       ? {
@@ -314,6 +320,7 @@ export function createSessionsSpawnTool(
       const resumeSessionId = readStringParam(params, "resumeSessionId");
       const modelOverride = normalizeToolModelOverride(readStringParam(params, "model"));
       const thinkingOverrideRaw = readStringParam(params, "thinking");
+      const fastModeOverride = typeof params.fastMode === "boolean" ? params.fastMode : undefined;
       const cwd = readStringParam(params, "cwd");
       const mode = params.mode === "run" || params.mode === "session" ? params.mode : undefined;
       const cleanup =
@@ -391,6 +398,7 @@ export function createSessionsSpawnTool(
             resumeSessionId,
             model: modelOverride,
             thinking: thinkingOverrideRaw,
+            fastMode: fastModeOverride,
             cwd,
             mode: mode === "run" || mode === "session" ? mode : undefined,
             thread,
@@ -478,6 +486,7 @@ export function createSessionsSpawnTool(
           model: modelOverride,
           thinking: thinkingOverrideRaw,
           cwd,
+          fastMode: fastModeOverride,
           thread,
           mode,
           cleanup,

--- a/src/auto-reply/reply/commands-acp/shared.ts
+++ b/src/auto-reply/reply/commands-acp/shared.ts
@@ -475,6 +475,7 @@ export function formatRuntimeOptionsText(options: AcpSessionRuntimeOptions): str
     options.cwd ? `cwd=${options.cwd}` : null,
     options.permissionProfile ? `permissionProfile=${options.permissionProfile}` : null,
     typeof options.timeoutSeconds === "number" ? `timeoutSeconds=${options.timeoutSeconds}` : null,
+    typeof options.fastMode === "boolean" ? `fastMode=${options.fastMode}` : null,
     extras ? `extras={${extras}}` : null,
   ].filter(Boolean) as string[];
   if (parts.length === 0) {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1126,6 +1126,10 @@
         "cwd": {
           "type": "string"
         },
+        "fastMode": {
+          "description": "Optional per-spawn fast-mode override for the child session. Use false to keep a spawned child on standard processing even when agent or model defaults enable fast mode.",
+          "type": "boolean"
+        },
         "label": {
           "type": "string"
         },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1162,6 +1162,10 @@
         "cwd": {
           "type": "string"
         },
+        "fastMode": {
+          "description": "Optional per-spawn fast-mode override for the child session. Use false to keep a spawned child on standard processing even when agent or model defaults enable fast mode.",
+          "type": "boolean"
+        },
         "label": {
           "type": "string"
         },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1126,6 +1126,10 @@
         "cwd": {
           "type": "string"
         },
+        "fastMode": {
+          "description": "Optional per-spawn fast-mode override for the child session. Use false to keep a spawned child on standard processing even when agent or model defaults enable fast mode.",
+          "type": "boolean"
+        },
         "label": {
           "type": "string"
         },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 43943,
-    "roughTokens": 10986
+    "chars": 44632,
+    "roughTokens": 11158
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71645,
-    "roughTokens": 17912
+    "chars": 73150,
+    "roughTokens": 18288
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 43664,
-    "roughTokens": 10916
+    "chars": 44323,
+    "roughTokens": 11081
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 69842,
-    "roughTokens": 17461
+    "chars": 71317,
+    "roughTokens": 17830
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44759,
-    "roughTokens": 11190
+    "chars": 45501,
+    "roughTokens": 11376
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71880,
-    "roughTokens": 17970
+    "chars": 74122,
+    "roughTokens": 18531
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
## Summary
- add `fastMode` override support to `sessions_spawn`
- persist the override before first native subagent or ACP child turn
- document fast-mode override behavior for subagents, ACP agents, and thinking config

## Real behavior proof
- **Behavior or issue addressed**: `sessions_spawn` now accepts an explicit `fastMode` override so native subagent and ACP child launches can opt out of inherited fast-mode defaults before the first child turn.
- **Real environment tested**: Jai macOS OpenClaw workspace, local OpenClaw checkout on branch `jaig-codex/fastmode-sessions-spawn`, commit `32124e878a`, with the live Codex CLI/OpenClaw agent environment used for FINN PR maintenance smoke runs.
- **Exact steps or command run after this patch**:
  ```bash
  git show --stat --oneline --show-signature HEAD
  pnpm test src/agents/tools/sessions-spawn-tool.test.ts src/agents/subagent-spawn.test.ts src/agents/acp-spawn.test.ts
  pnpm tsgo:core
  pnpm tsgo:core:test
  DOCS_I18N_GLOSSARY_BASE=upstream/main pnpm check:docs
  pnpm exec oxfmt --check CHANGELOG.md docs/tools/acp-agents.md docs/tools/subagents.md docs/tools/thinking.md src/agents/acp-spawn.ts src/agents/acp-spawn.test.ts src/agents/subagent-spawn.ts src/agents/subagent-spawn.test.ts src/agents/tools/sessions-spawn-tool.ts src/agents/tools/sessions-spawn-tool.test.ts
  git diff --check upstream/main...HEAD
  ```
- **Evidence after fix**:
  ```text
  32124e878a Good "git" signature for jai.g@ewa-services.com with ED25519 key SHA256:onDicHNVFRcetP9JVw5fHOo+HHRegbUSxEiJbEB9DzU
  feat(agents): allow spawn fast mode overrides
   CHANGELOG.md                                 |  1 +
   docs/tools/acp-agents.md                     |  5 +++++
   docs/tools/subagents.md                      |  4 ++++
   docs/tools/thinking.md                       |  2 +-
   src/agents/acp-spawn.test.ts                 |  2 ++
   src/agents/acp-spawn.ts                      |  2 ++
   src/agents/subagent-spawn.test.ts            |  2 ++
   src/agents/subagent-spawn.ts                 |  5 +++++
   src/agents/tools/sessions-spawn-tool.test.ts | 18 ++++++++++++++++++
   src/agents/tools/sessions-spawn-tool.ts      |  9 +++++++++
  16 files changed, 73 insertions(+), 13 deletions(-)

  pnpm test src/agents/tools/sessions-spawn-tool.test.ts src/agents/subagent-spawn.test.ts src/agents/acp-spawn.test.ts -> 102 passed
  pnpm tsgo:core -> passed
  pnpm tsgo:core:test -> passed
  DOCS_I18N_GLOSSARY_BASE=upstream/main pnpm check:docs -> passed
  pnpm exec oxfmt --check ... -> passed
  OPENCLAW_ADDITIONAL_BOUNDARY_SHARD=1/4 OPENCLAW_ADDITIONAL_BOUNDARY_CONCURRENCY=4 node scripts/run-additional-boundary-checks.mjs -> passed
  git diff --check upstream/main...HEAD -> passed
  ```
- **Observed result after fix**: The patched source persists `fastMode: false` onto the child session before native subagent and ACP child turns start; the focused tests cover the tool payload path, native subagent spawn path, and ACP spawn path.
- **What was not tested**: I did not deploy this branch into production OpenClaw; this proof is from the local patched OpenClaw checkout plus the live agent environment used to validate the fast-off launch behavior.

## Validation
- `pnpm test src/agents/tools/sessions-spawn-tool.test.ts src/agents/subagent-spawn.test.ts src/agents/acp-spawn.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `DOCS_I18N_GLOSSARY_BASE=upstream/main pnpm check:docs`
- `pnpm exec oxfmt --check CHANGELOG.md docs/tools/acp-agents.md docs/tools/subagents.md docs/tools/thinking.md src/agents/acp-spawn.ts src/agents/acp-spawn.test.ts src/agents/subagent-spawn.ts src/agents/subagent-spawn.test.ts src/agents/tools/sessions-spawn-tool.ts src/agents/tools/sessions-spawn-tool.test.ts`
- `OPENCLAW_ADDITIONAL_BOUNDARY_SHARD=1/4 OPENCLAW_ADDITIONAL_BOUNDARY_CONCURRENCY=4 node scripts/run-additional-boundary-checks.mjs`
- `git diff --check upstream/main...HEAD`
