### PR TITLE
fix(slack): clarify mention prompt guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: limit canonical OpenAI Codex app-server attribution rewrites to local transcript and trajectory records, leaving runtime/tool routing on the selected OpenAI model metadata so OpenAI API-key backup profiles keep their billing path.
 - Android/chat: make bare and markdown URLs in chat messages tappable by preserving Compose URL annotations in rendered markdown. Fixes #82187. (#82392) Thanks @neeravmakwana.
 - Plugins/doctor: migrate legacy top-level plugin `tools` declarations into `contracts.tools`, so `openclaw doctor --fix` repairs local plugins for the manifest tool contract. (#81112) Thanks @100yenadmin.
+- Slack: guide agents to use stable `<@USER_ID>` mention tokens from context instead of plain `@name` text, so user mentions link and notify correctly. Fixes #82090. (#82152) Thanks @neeravmakwana.
 - Codex app-server: release raw assistant completions when `turn/completed` is missing while keeping commentary/status items as progress, preventing completed Codex runs from hanging until timeout. Fixes #82343. (#82403) Thanks @IWhatsskill.
 - Agents/sessions: remove the transient `*.bak-<pid>-<ts>` backup written by `repairSessionFileIfNeeded` once the atomic replace succeeds, so a stuck session with a persistently malformed JSONL line no longer accumulates one snapshot per repair invocation. Fixes #80960. (#80969) Thanks @100yenadmin. Co-authored by @tynamite.
 - CLI/status: show plain empty-state messages instead of empty Channels and Sessions tables when no channels or sessions exist.

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1044,6 +1044,9 @@ describe("slackPlugin agentPrompt", () => {
       "- Slack plain text sends: write standard Markdown; OpenClaw converts it to Slack mrkdwn, including `**bold**`, headings, lists, and `[label](url)` links.",
     );
     expect(hints).toContain(
+      "- When mentioning Slack users, use the stable `<@USER_ID>` token from Slack context instead of plain `@name` text so Slack notifies and links the user.",
+    );
+    expect(hints).toContain(
       "- Slack Block Kit or presentation text fields are sent as Slack mrkdwn directly; use `*bold*`, `_italic_`, `~strike~`, `<url|label>` links, and avoid Markdown headings or pipe tables there.",
     );
   });
@@ -1072,6 +1075,9 @@ describe("slackPlugin agentPrompt", () => {
     );
     expect(hints).toContain(
       "- Slack plain text sends: write standard Markdown; OpenClaw converts it to Slack mrkdwn, including `**bold**`, headings, lists, and `[label](url)` links.",
+    );
+    expect(hints).toContain(
+      "- When mentioning Slack users, use the stable `<@USER_ID>` token from Slack context instead of plain `@name` text so Slack notifies and links the user.",
     );
     expect(hints).toContain(
       "- Slack Block Kit or presentation text fields are sent as Slack mrkdwn directly; use `*bold*`, `_italic_`, `~strike~`, `<url|label>` links, and avoid Markdown headings or pipe tables there.",

--- a/extensions/slack/src/shared.ts
+++ b/extensions/slack/src/shared.ts
@@ -115,6 +115,7 @@ export function createSlackPluginBase(params: {
             ]
         ).concat([
           "- Slack plain text sends: write standard Markdown; OpenClaw converts it to Slack mrkdwn, including `**bold**`, headings, lists, and `[label](url)` links.",
+          "- When mentioning Slack users, use the stable `<@USER_ID>` token from Slack context instead of plain `@name` text so Slack notifies and links the user.",
           "- Slack Block Kit or presentation text fields are sent as Slack mrkdwn directly; use `*bold*`, `_italic_`, `~strike~`, `<url|label>` links, and avoid Markdown headings or pipe tables there.",
         ]),
     },


### PR DESCRIPTION
## Summary

- Problem: Slack replies could mention users as plain `@name` text, which Slack does not link or notify like `<@USER_ID>` tokens.
- Why it matters: Users referenced by the bot may miss notifications and the mention is not clickable.
- What changed: Slack message-tool hints now tell agents to use stable `<@USER_ID>` tokens from Slack context when mentioning users, and the Slack prompt tests assert that guidance in both interactive-reply modes.
- What did NOT change (scope boundary): No runtime auto-conversion, user lookup resolver, `link_names` parsing, or Slack notification enforcement was added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82090
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: Slack agent prompt guidance for user mentions now points agents at Slack's stable `<@USER_ID>` syntax instead of plain `@name` text.
- Real environment tested: Local OpenClaw source checkout on macOS 25.3.0 with Node 22 and the repo-pinned pnpm 11.1.0 via corepack.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/slack/src/channel.test.ts`
- Evidence after fix: The focused Slack channel test passed with `Test Files 1 passed (1)` and `Tests 41 passed (41)`.
- Observed result after fix: The Slack plugin prompt tests now require the mention-token guidance for both disabled and enabled interactive-reply configurations.
- What was not tested: A live Slack workspace round trip was not run because this PR changes prompt guidance only and does not alter Slack Web API payload generation.

## Root Cause (if applicable)

- Root cause: Slack outbound formatting preserves valid Slack angle tokens such as `<@USER_ID>`, but prompt guidance did not tell agents to prefer those stable context tokens when referring to Slack users.
- Missing detection / guardrail: Existing prompt tests covered Markdown and Block Kit hints, but not mention-token guidance.
- Contributing context (if known): Slack's ID-based mention syntax is the stable app-published format; broad automatic parsing can create unintended notifications.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/channel.test.ts`
- Scenario the test should lock in: Slack message-tool hints include user mention guidance in both interactive-reply prompt modes.
- Why this is the smallest reliable guardrail: The fix is prompt text only, so asserting the emitted prompt hints catches regressions directly.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Slack agents receive clearer channel guidance to use `<@USER_ID>` tokens when mentioning users from Slack context.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

Security/runtime controls unchanged: this PR does not enable automatic Slack parsing, does not set `link_names`, does not add user-directory lookups on send, and does not convert arbitrary `@name` text into notifications.

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: Local source checkout, Node 22, pnpm 11.1.0 via corepack
- Model/provider: N/A
- Integration/channel (if any): Slack plugin
- Relevant config (redacted): N/A

### Steps

1. Inspect Slack agent prompt hints.
2. Verify the prompt includes `<@USER_ID>` mention guidance.
3. Run the focused Slack prompt tests and changed-file checks.

### Expected

- Slack prompt hints tell agents to use stable Slack user mention tokens from context.

### Actual

- The new guidance is present and covered by `extensions/slack/src/channel.test.ts`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Exact tests/checks run:

- `git diff --check`
- `node scripts/run-vitest.mjs extensions/slack/src/channel.test.ts`
- `PATH="/tmp/openclaw-corepack-shims-82090:$PATH" CI=true pnpm check:changed`

## Human Verification (required)

- Verified scenarios: Prompt guidance appears in both disabled and enabled Slack interactive-reply hint modes; changed-file typecheck/lint/guards pass.
- Edge cases checked: Runtime mention parsing and Slack payload behavior remain unchanged.
- What you did **not** verify: Live Slack message delivery in a real workspace.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

AI-assisted: yes; I reviewed the final diff line by line before opening the PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Prompt-only guidance depends on the agent following context tokens and does not runtime-enforce mention conversion.
  - Mitigation: The PR keeps scope tight and explicitly leaves runtime resolver work as a follow-up to avoid unsafe broad `@name` notification parsing.

Out-of-scope follow-ups:

- Add a constrained Slack-local resolver for unambiguous known users, if maintainers want runtime conversion.
- Add live Slack workspace proof for any future runtime send-path change.

Made with [Cursor](https://cursor.com)