### PR TITLE
fix: strip adjacent function_response sanitizer leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Agents/auto-reply: honor `agents.defaults.silentReply` and per-surface group silent-reply policy when generic agent-run failure fallbacks decide whether to send visible fallback text. Fixes #82060. (#82086) Thanks @taozengabc.
 - Discord: render channel topic context as structured untrusted metadata in reply prompts and stop duplicating inbound message bodies or exposing raw `EXTERNAL_UNTRUSTED_CONTENT` envelopes. Fixes #82168. Thanks @ronan-dandelion-cult.
 - Codex app-server: arm the short idle watchdog as soon as Codex accepts a turn, so accepted turns with no current-turn progress release the OpenClaw session lane before the outer model timeout. Fixes #82129. Thanks @Francois3d.
+- Agents/replies: also strip `<function_response>` workflow output when it becomes visible after an adjacent stripped tool-call XML block, closing the remaining sanitizer leak from #47444.
 - Control UI/WebChat: focus the composer when users click the visible input chrome and restore larger, labeled desktop composer controls while preserving compact mobile taps. Fixes #45656. Thanks @BunsDev.
 - Discord: suppress generated link embeds on outbound messages by default so agent-sent URLs stay as plain links unless `channels.discord.suppressEmbeds` is disabled.
 - System events: keep owner downgrades in structured metadata while rendering queued prompt text as plain `System:` lines, preserving least-privilege wakeups without prompt-visible trust labels. (#82067)

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -346,6 +346,13 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("After");
   });
 
+  it("strips adjacent function response payloads that match explanation wording", () => {
+    const input =
+      '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response> response wrapper secret</function_response>\nAfter';
+
+    expect(sanitizeUserFacingText(input)).toBe("After");
+  });
+
   it("strips dangling same-line function response payloads with leading spaces", () => {
     const input =
       'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response> raw output';

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -293,6 +293,93 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("Before\n\nAfter");
   });
 
+  it("strips function response wrappers adjacent to stripped function calls", () => {
+    const input = [
+      '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response>',
+      'Searching for: "what skills matter most in the age of AI"',
+      "</function_response>",
+      "After",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("After");
+  });
+
+  it("strips function response wrappers adjacent to inline stripped function calls", () => {
+    const input = [
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>',
+      'Searching for: "what skills matter most in the age of AI"',
+      "</function_response>",
+      "After",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Checking. \nAfter");
+  });
+
+  it("strips compact function response wrappers after newline-separated function calls", () => {
+    const input = [
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls>',
+      "<function_response>ok</function_response>",
+      "After",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Checking. \n\nAfter");
+  });
+
+  it("strips compact dangling function response wrappers adjacent to function calls", () => {
+    const input =
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>raw output';
+
+    expect(sanitizeUserFacingText(input)).toBe("Checking. ");
+  });
+
+  it("strips same-line function response payloads with leading spaces", () => {
+    const input =
+      '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response> raw output</function_response>\nAfter';
+
+    expect(sanitizeUserFacingText(input)).toBe("After");
+  });
+
+  it("strips same-line function response payloads that start like prose", () => {
+    const input =
+      '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response> is enabled</function_response>\nAfter';
+
+    expect(sanitizeUserFacingText(input)).toBe("After");
+  });
+
+  it("strips dangling same-line function response payloads with leading spaces", () => {
+    const input =
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response> raw output';
+
+    expect(sanitizeUserFacingText(input)).toBe("Checking. ");
+  });
+
+  it("strips chained function response wrappers adjacent to stripped function calls", () => {
+    const input = [
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>',
+      "first result",
+      "</function_response><function_response>",
+      "second result",
+      "</function_response>",
+      "After",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Checking. \nAfter");
+  });
+
+  it("strips compact chained function response wrappers adjacent to stripped function calls", () => {
+    const input =
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>first</function_response><function_response>second</function_response>\nAfter';
+
+    expect(sanitizeUserFacingText(input)).toBe("Checking. \nAfter");
+  });
+
+  it("strips compact function response wrappers before same-line visible replies", () => {
+    const input =
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>raw</function_response> Done.';
+
+    expect(sanitizeUserFacingText(input)).toBe("Checking.  Done.");
+  });
+
   it("preserves literal tool-call tag examples in user-facing prose", () => {
     const input = "Use `<tool_call>` to describe the XML tag in docs.";
     expect(sanitizeUserFacingText(input)).toBe(input);

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -685,22 +685,25 @@ describe("stripToolCallXmlTags", () => {
     expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe("");
   });
 
-  it("preserves literal function_response prose after a stripped tool-call block", () => {
+  it("strips function_response-looking prose adjacent to a stripped tool-call block", () => {
     const input =
       '<tool_call>{"name":"exec"}</tool_call>\n\n<function_response> is the response wrapper.';
 
-    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe(
-      "\n\n<function_response> is the response wrapper.",
-    );
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe("\n\n");
   });
 
-  it("preserves literal closed function_response prose after a stripped tool-call block", () => {
+  it("strips closed function_response-looking prose adjacent to a stripped tool-call block", () => {
     const input =
       '<tool_call>{"name":"exec"}</tool_call>\n<function_response> is the response wrapper; close it with </function_response>.';
 
-    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe(
-      "\n<function_response> is the response wrapper; close it with </function_response>.",
-    );
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe("\n.");
+  });
+
+  it("strips adjacent function_response payloads that match explanation wording", () => {
+    const input =
+      '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response> response wrapper secret</function_response>\nAfter';
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe("\nAfter");
   });
 
   it("strips compact function_response wrappers while preserving same-line prose tails", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -151,6 +151,21 @@ describe("stripAssistantInternalScaffolding", () => {
       expectVisibleText("Before\n<function_response>\nraw command output\n", "Before\n");
     });
 
+    it("preserves inline multi-line function_response examples in prose", () => {
+      expectVisibleText(
+        [
+          "Before <function_response>",
+          'Searching for: "what skills matter most in the age of AI"',
+          "</function_response> After",
+        ].join("\n"),
+        [
+          "Before <function_response>",
+          'Searching for: "what skills matter most in the age of AI"',
+          "</function_response> After",
+        ].join("\n"),
+      );
+    });
+
     it("strips <tool_result> closed with mismatched </tool_call> and preserves trailing text", () => {
       expectVisibleText(
         'Prefix\n<tool_result> {"output": "data"} </tool_call>\nSuffix',
@@ -411,6 +426,13 @@ describe("stripAssistantInternalScaffolding", () => {
       );
     });
 
+    it("preserves inline closed function_response examples in prose", () => {
+      expectVisibleText(
+        "Use <function_response>ok</function_response> to describe the response wrapper.",
+        "Use <function_response>ok</function_response> to describe the response wrapper.",
+      );
+    });
+
     it("preserves line-leading function_response prose examples", () => {
       expectVisibleText(
         "<function_response> is the response wrapper.",
@@ -587,6 +609,139 @@ describe("stripToolCallXmlTags", () => {
     expect(stripToolCallXmlTags(input)).toBe(input);
     expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe(
       "prefix  suffix",
+    );
+  });
+
+  it("strips function_response adjacent to an opt-in stripped function_calls block", () => {
+    const input = [
+      '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response>',
+      'Searching for: "what skills matter most in the age of AI"',
+      "</function_response>",
+      "After",
+    ].join("\n");
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe("\nAfter");
+  });
+
+  it("strips function_response adjacent to an inline stripped function_calls block", () => {
+    const input = [
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>',
+      'Searching for: "what skills matter most in the age of AI"',
+      "</function_response>",
+      "After",
+    ].join("\n");
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe(
+      "Checking. \nAfter",
+    );
+  });
+
+  it("strips compact function_response after a newline-separated stripped function_calls block", () => {
+    const input = [
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls>',
+      "<function_response>ok</function_response>",
+      "After",
+    ].join("\n");
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe(
+      "Checking. \n\nAfter",
+    );
+  });
+
+  it("strips dangling function_response adjacent to a stripped function_calls block", () => {
+    const input = [
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>',
+      'Searching for: "what skills matter most in the age of AI"',
+    ].join("\n");
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe("Checking. ");
+  });
+
+  it("strips compact dangling function_response adjacent to a stripped function_calls block", () => {
+    const input =
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>raw output';
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe("Checking. ");
+  });
+
+  it("strips same-line function_response payloads with leading spaces", () => {
+    const input =
+      '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response> raw output</function_response>\nAfter';
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe("\nAfter");
+  });
+
+  it("strips same-line function_response payloads that start like prose", () => {
+    const input =
+      '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response> is enabled</function_response>\nAfter';
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe("\nAfter");
+  });
+
+  it("strips dangling same-line function_response payloads with leading spaces", () => {
+    const input =
+      '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response> raw output';
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe("");
+  });
+
+  it("preserves literal function_response prose after a stripped tool-call block", () => {
+    const input =
+      '<tool_call>{"name":"exec"}</tool_call>\n\n<function_response> is the response wrapper.';
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe(
+      "\n\n<function_response> is the response wrapper.",
+    );
+  });
+
+  it("preserves literal closed function_response prose after a stripped tool-call block", () => {
+    const input =
+      '<tool_call>{"name":"exec"}</tool_call>\n<function_response> is the response wrapper; close it with </function_response>.';
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe(
+      "\n<function_response> is the response wrapper; close it with </function_response>.",
+    );
+  });
+
+  it("strips compact function_response wrappers while preserving same-line prose tails", () => {
+    const input =
+      '<tool_call>{"name":"exec"}</tool_call>\n\n<function_response>ok</function_response> is the response wrapper.';
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe(
+      "\n\n is the response wrapper.",
+    );
+  });
+
+  it("strips chained function_response blocks adjacent to a stripped function_calls block", () => {
+    const input = [
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>',
+      "first result",
+      "</function_response><function_response>",
+      "second result",
+      "</function_response>",
+      "After",
+    ].join("\n");
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe(
+      "Checking. \nAfter",
+    );
+  });
+
+  it("strips compact chained function_response blocks adjacent to a stripped function_calls block", () => {
+    const input =
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>first</function_response><function_response>second</function_response>\nAfter';
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe(
+      "Checking. \nAfter",
+    );
+  });
+
+  it("strips compact function_response before same-line visible replies", () => {
+    const input =
+      'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>raw</function_response> Done.';
+
+    expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe(
+      "Checking.  Done.",
     );
   });
 });

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -204,21 +204,6 @@ function hasSameLineContentAfterOpeningTag(text: string, tag: ParsedToolCallTag)
   return after < text.length && text[after] !== "\n" && text[after] !== "\r";
 }
 
-function isLikelyFunctionResponseTagProse(
-  text: string,
-  tag: ParsedToolCallTag,
-  closeStart: number,
-): boolean {
-  if (text[tag.end] !== " " && text[tag.end] !== "\t") {
-    return false;
-  }
-  const body = text.slice(tag.end, closeStart === -1 ? text.length : closeStart);
-  if (body.includes("\n") || body.includes("\r")) {
-    return false;
-  }
-  return /\b(?:response wrapper|wrapper syntax|xml tag|tag syntax)\b/i.test(body);
-}
-
 function isVisibleLineStart(text: string): boolean {
   let idx = text.length - 1;
   while (idx >= 0 && (text[idx] === " " || text[idx] === "\t")) {
@@ -388,7 +373,6 @@ export function stripToolCallXmlTags(
           : -1;
       const shouldStripAdjacentResult =
         isAdjacentToStrippedToolCallBlock(text, idx, lastStrippedToolCallBlockEnd) &&
-        !isLikelyFunctionResponseTagProse(text, tag, functionResponseCloseStart) &&
         (isOpeningTagFollowedByLineBreak(text, tag) ||
           functionResponseCloseStart !== -1 ||
           hasSameLineContentAfterOpeningTag(text, tag));

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -188,6 +188,78 @@ function isStandaloneOpeningTagLine(
   return after >= text.length || text[after] === "\n" || text[after] === "\r";
 }
 
+function isOpeningTagFollowedByLineBreak(text: string, tag: ParsedToolCallTag): boolean {
+  let after = tag.end;
+  while (after < text.length && (text[after] === " " || text[after] === "\t")) {
+    after += 1;
+  }
+  return after >= text.length || text[after] === "\n" || text[after] === "\r";
+}
+
+function hasSameLineContentAfterOpeningTag(text: string, tag: ParsedToolCallTag): boolean {
+  let after = tag.end;
+  while (after < text.length && (text[after] === " " || text[after] === "\t")) {
+    after += 1;
+  }
+  return after < text.length && text[after] !== "\n" && text[after] !== "\r";
+}
+
+function isLikelyFunctionResponseTagProse(
+  text: string,
+  tag: ParsedToolCallTag,
+  closeStart: number,
+): boolean {
+  if (text[tag.end] !== " " && text[tag.end] !== "\t") {
+    return false;
+  }
+  const body = text.slice(tag.end, closeStart === -1 ? text.length : closeStart);
+  if (body.includes("\n") || body.includes("\r")) {
+    return false;
+  }
+  return /\b(?:response wrapper|wrapper syntax|xml tag|tag syntax)\b/i.test(body);
+}
+
+function isVisibleLineStart(text: string): boolean {
+  let idx = text.length - 1;
+  while (idx >= 0 && (text[idx] === " " || text[idx] === "\t")) {
+    idx -= 1;
+  }
+  return idx < 0 || text[idx] === "\n" || text[idx] === "\r";
+}
+
+function isAdjacentToStrippedToolCallBlock(
+  text: string,
+  tagStart: number,
+  lastStrippedBlockEnd: number | null,
+): boolean {
+  if (lastStrippedBlockEnd === null || lastStrippedBlockEnd > tagStart) {
+    return false;
+  }
+  for (let idx = lastStrippedBlockEnd; idx < tagStart; idx += 1) {
+    if (text[idx] !== " " && text[idx] !== "\t" && text[idx] !== "\n" && text[idx] !== "\r") {
+      return false;
+    }
+  }
+  return true;
+}
+
+function findMatchingToolCallCloseIndex(text: string, start: number, tagName: string): number {
+  for (let idx = start; idx < text.length; idx += 1) {
+    if (text[idx] !== "<") {
+      continue;
+    }
+    const tag = parseToolCallTagAt(text, idx);
+    if (!tag) {
+      continue;
+    }
+    if (tag.isClose && tag.tagName === tagName && !tag.isTruncated) {
+      return idx;
+    }
+    idx = Math.max(idx, tag.end - 1);
+  }
+  return -1;
+}
+
 function parseToolCallTagAt(text: string, start: number): ParsedToolCallTag | null {
   if (text[start] !== "<") {
     return null;
@@ -256,6 +328,7 @@ export function stripToolCallXmlTags(
   let toolCallBlockNeedsQuoteBalance = false;
   let toolCallBlockStart = 0;
   let toolCallBlockTagName: string | null = null;
+  let lastStrippedToolCallBlockEnd: number | null = null;
   const visibleTagBalance = new Map<string, number>();
 
   for (let idx = 0; idx < text.length; idx += 1) {
@@ -291,6 +364,7 @@ export function stripToolCallXmlTags(
         continue;
       }
       if (tag.isSelfClosing) {
+        lastStrippedToolCallBlockEnd = tag.end;
         lastIndex = tag.end;
         idx = Math.max(idx, tag.end - 1);
         continue;
@@ -308,8 +382,23 @@ export function stripToolCallXmlTags(
           : null;
       const shouldStripStandaloneFunction =
         tag.tagName !== "function" || isLikelyStandaloneFunctionToolCall(text, idx, tag);
+      const functionResponseCloseStart =
+        tag.tagName === "function_response"
+          ? findMatchingToolCallCloseIndex(text, tag.end, tag.tagName)
+          : -1;
+      const shouldStripAdjacentResult =
+        isAdjacentToStrippedToolCallBlock(text, idx, lastStrippedToolCallBlockEnd) &&
+        !isLikelyFunctionResponseTagProse(text, tag, functionResponseCloseStart) &&
+        (isOpeningTagFollowedByLineBreak(text, tag) ||
+          functionResponseCloseStart !== -1 ||
+          hasSameLineContentAfterOpeningTag(text, tag));
       const shouldStripStandaloneResult =
-        tag.tagName === "function_response" && isStandaloneOpeningTagLine(text, idx, tag);
+        tag.tagName === "function_response" &&
+        (isStandaloneOpeningTagLine(text, idx, tag) ||
+          shouldStripAdjacentResult ||
+          (functionResponseCloseStart !== -1 &&
+            isVisibleLineStart(result) &&
+            isOpeningTagFollowedByLineBreak(text, tag)));
       if (
         !tag.isClose &&
         ((payloadKind && shouldStripStandaloneFunction) || shouldStripStandaloneResult)
@@ -342,9 +431,13 @@ export function stripToolCallXmlTags(
       (!toolCallBlockNeedsQuoteBalance ||
         !endsInsideQuotedString(text, toolCallBlockContentStart, idx))
     ) {
+      const closedBlockTagName = toolCallBlockTagName;
       inToolCallBlock = false;
       toolCallBlockNeedsQuoteBalance = false;
       toolCallBlockTagName = null;
+      if (closedBlockTagName) {
+        lastStrippedToolCallBlockEnd = tag.end;
+      }
     }
 
     lastIndex = tag.end;


### PR DESCRIPTION
## Summary

Fixes the remaining user-visible sanitizer leak where a stripped XML tool-call block can expose an immediately adjacent `<function_response>` block.

Root cause: `stripToolCallXmlTags()` already removed high-confidence `<function_calls>` / `<tool_call>` scaffolding, but it did not carry forward the fact that the next tag is adjacent to just-stripped internal workflow XML. That meant `<function_response>` could be evaluated as ordinary text after the preceding block disappeared, especially for compact same-line forms, chained response blocks, and dangling response starts.

This patch tracks the end of the last stripped XML tool-call block and strips adjacent `<function_response>` blocks across whitespace. It covers:

- multiline adjacent responses after `<function_calls>`
- same-line compact responses
- leading-space same-line response payloads
- dangling adjacent responses
- chained adjacent response blocks
- same-line visible reply tails after a response block

It keeps the literal-prose side tight: inline examples still preserve ordinary `<function_response>` mentions, and a narrow tag-explanation exception preserves prose such as `<function_response> is the response wrapper` after a stripped example block. The exception no longer treats generic prose-looking payloads such as `is enabled` as prose, because adjacent workflow output must strip even when output text starts like a sentence.

Fixes #47444.

## Real behavior proof

Behavior addressed: adjacent `<function_response>` workflow output no longer survives after stripped XML tool-call scaffolding.

Real environment tested: local OpenClaw checkout on the patched branch, running the production `sanitizeUserFacingText()` path through `node --import tsx`.

Exact steps or command run after this patch: `node --import tsx - <<'EOF' ... sanitizeUserFacingText(...) ... EOF`

Evidence after fix: terminal output from the patched sanitizer probe:

```text
case=adjacent multiline response
"After"
case=leading-space prose-like payload
"After"
case=literal wrapper prose
"<function_response> is the response wrapper; close it with </function_response>."
```

Observed result after fix: adjacent multiline and leading-space prose-like `<function_response>` payloads are removed from user-facing output, while literal wrapper explanation prose remains visible.

What was not tested: no live provider workflow was run; this is a deterministic text sanitizer change exercised through the production sanitizer function.

## Verification

- `pnpm test src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts -- --reporter=verbose` (203 tests passed)
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local --full-access --output /tmp/codex-review-47444-r4.txt --parallel-tests "pnpm test src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts -- --reporter=dot"` (clean, no accepted/actionable findings)
- `pnpm check:changed` (Blacksmith Testbox `tbx_01krnwp12a74pe8pvayaprmy7z`, GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/25920010654, exit 0)
