### PR TITLE
fix(codex): wait for migrated plugin inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ Docs: https://docs.openclaw.ai
 - Message tool: rename the Discord channel-create schema field exposed to models from `type` to `channelType`, avoiding NVIDIA NIM JSON Schema parser failures while still accepting legacy `type` tool calls. (#78920) Thanks @YashSaliya.
 - Feishu: send CardKit streaming cards as delivered deltas and retry failed updates, preventing duplicated or dropped streamed text. Fixes #82417. (#82419) Thanks @hclsys.
 - Gateway/Gmail: stop queued post-ready Gmail sidecars before hot reload and abort stale Tailscale setup, so cancelled watcher restarts cannot rewrite an old public hook target or report abort-killed commands as success. (#82395) Thanks @samzong.
+- Codex migration: wait for selected curated plugin entries before installing during migration so partial target plugin inventories no longer report source-installed plugins as missing. (#82160) Thanks @rubencu and @vincentkoc.
 
 ## 2026.5.14
 

--- a/extensions/codex/src/migration/apply.ts
+++ b/extensions/codex/src/migration/apply.ts
@@ -175,6 +175,7 @@ async function applyCodexPluginInstallItem(
           agentDir: resolveCodexMigrationTargets(ctx).agentDir,
           config: ctx.config,
           isolated: false,
+          waitForPluginName: policy.pluginName,
         }),
       appCache: defaultCodexAppInventoryCache,
       appCacheKey,
@@ -274,6 +275,7 @@ async function requestTargetCodexAppServerJson(params: {
   agentDir: string;
   config: MigrationProviderContext["config"];
   isolated?: boolean;
+  waitForPluginName?: string;
 }): Promise<unknown> {
   if (params.method !== "plugin/list") {
     return await requestCodexAppServerJson(params);
@@ -291,7 +293,7 @@ async function requestTargetCodexAppServerJson(params: {
       ...params,
       timeoutMs: remainingMs,
     });
-    if (hasOpenAiCuratedMarketplace(lastResponse)) {
+    if (hasRequestedOpenAiCuratedPlugin(lastResponse, params.waitForPluginName)) {
       return lastResponse;
     }
     if (Date.now() >= discoveryDeadline) {
@@ -307,18 +309,35 @@ async function requestTargetCodexAppServerJson(params: {
   return lastResponse;
 }
 
-function hasOpenAiCuratedMarketplace(response: unknown): boolean {
+function hasRequestedOpenAiCuratedPlugin(
+  response: unknown,
+  pluginName: string | undefined,
+): boolean {
   if (!response || typeof response !== "object" || !("marketplaces" in response)) {
     return false;
   }
   const marketplaces = (response as { marketplaces?: unknown }).marketplaces;
+  if (!Array.isArray(marketplaces)) {
+    return false;
+  }
+  const marketplace = marketplaces.find(
+    (entry) =>
+      entry &&
+      typeof entry === "object" &&
+      (entry as { name?: unknown }).name === CODEX_PLUGINS_MARKETPLACE_NAME,
+  );
+  if (!marketplace || typeof marketplace !== "object") {
+    return false;
+  }
+  if (!pluginName) {
+    return true;
+  }
+  const plugins = (marketplace as { plugins?: unknown }).plugins;
   return (
-    Array.isArray(marketplaces) &&
-    marketplaces.some(
-      (marketplace) =>
-        marketplace &&
-        typeof marketplace === "object" &&
-        (marketplace as { name?: unknown }).name === CODEX_PLUGINS_MARKETPLACE_NAME,
+    Array.isArray(plugins) &&
+    plugins.some(
+      (plugin) =>
+        plugin && typeof plugin === "object" && (plugin as { name?: unknown }).name === pluginName,
     )
   );
 }

--- a/extensions/codex/src/migration/apply.ts
+++ b/extensions/codex/src/migration/apply.ts
@@ -175,7 +175,7 @@ async function applyCodexPluginInstallItem(
           agentDir: resolveCodexMigrationTargets(ctx).agentDir,
           config: ctx.config,
           isolated: false,
-          waitForPluginName: policy.pluginName,
+          targetPluginName: policy.pluginName,
         }),
       appCache: defaultCodexAppInventoryCache,
       appCacheKey,
@@ -275,7 +275,7 @@ async function requestTargetCodexAppServerJson(params: {
   agentDir: string;
   config: MigrationProviderContext["config"];
   isolated?: boolean;
-  waitForPluginName?: string;
+  targetPluginName: string;
 }): Promise<unknown> {
   if (params.method !== "plugin/list") {
     return await requestCodexAppServerJson(params);
@@ -293,7 +293,7 @@ async function requestTargetCodexAppServerJson(params: {
       ...params,
       timeoutMs: remainingMs,
     });
-    if (hasRequestedOpenAiCuratedPlugin(lastResponse, params.waitForPluginName)) {
+    if (hasRequestedOpenAiCuratedPlugin(lastResponse, params.targetPluginName)) {
       return lastResponse;
     }
     if (Date.now() >= discoveryDeadline) {
@@ -309,10 +309,7 @@ async function requestTargetCodexAppServerJson(params: {
   return lastResponse;
 }
 
-function hasRequestedOpenAiCuratedPlugin(
-  response: unknown,
-  pluginName: string | undefined,
-): boolean {
+function hasRequestedOpenAiCuratedPlugin(response: unknown, pluginName: string): boolean {
   if (!response || typeof response !== "object" || !("marketplaces" in response)) {
     return false;
   }
@@ -328,9 +325,6 @@ function hasRequestedOpenAiCuratedPlugin(
   );
   if (!marketplace || typeof marketplace !== "object") {
     return false;
-  }
-  if (!pluginName) {
-    return true;
   }
   const plugins = (marketplace as { plugins?: unknown }).plugins;
   return (

--- a/extensions/codex/src/migration/apply.ts
+++ b/extensions/codex/src/migration/apply.ts
@@ -37,6 +37,7 @@ import {
   type CodexPluginActivationResult,
 } from "../app-server/plugin-activation.js";
 import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
+import { findOpenAiCuratedPluginSummary } from "../app-server/plugin-inventory.js";
 import type { v2 } from "../app-server/protocol.js";
 import { requestCodexAppServerJson } from "../app-server/request.js";
 import {
@@ -310,29 +311,18 @@ async function requestTargetCodexAppServerJson(params: {
 }
 
 function hasRequestedOpenAiCuratedPlugin(response: unknown, pluginName: string): boolean {
-  if (!response || typeof response !== "object" || !("marketplaces" in response)) {
+  if (!isCodexPluginListResponse(response)) {
     return false;
   }
-  const marketplaces = (response as { marketplaces?: unknown }).marketplaces;
-  if (!Array.isArray(marketplaces)) {
-    return false;
-  }
-  const marketplace = marketplaces.find(
-    (entry) =>
-      entry &&
-      typeof entry === "object" &&
-      (entry as { name?: unknown }).name === CODEX_PLUGINS_MARKETPLACE_NAME,
-  );
-  if (!marketplace || typeof marketplace !== "object") {
-    return false;
-  }
-  const plugins = (marketplace as { plugins?: unknown }).plugins;
+  return findOpenAiCuratedPluginSummary(response, pluginName) !== undefined;
+}
+
+function isCodexPluginListResponse(response: unknown): response is v2.PluginListResponse {
   return (
-    Array.isArray(plugins) &&
-    plugins.some(
-      (plugin) =>
-        plugin && typeof plugin === "object" && (plugin as { name?: unknown }).name === pluginName,
-    )
+    !!response &&
+    typeof response === "object" &&
+    "marketplaces" in response &&
+    Array.isArray((response as { marketplaces?: unknown }).marketplaces)
   );
 }
 

--- a/extensions/codex/src/migration/apply.ts
+++ b/extensions/codex/src/migration/apply.ts
@@ -37,7 +37,10 @@ import {
   type CodexPluginActivationResult,
 } from "../app-server/plugin-activation.js";
 import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.js";
-import { findOpenAiCuratedPluginSummary } from "../app-server/plugin-inventory.js";
+import {
+  findOpenAiCuratedPluginSummary,
+  type CodexPluginRuntimeRequest,
+} from "../app-server/plugin-inventory.js";
 import type { v2 } from "../app-server/protocol.js";
 import { requestCodexAppServerJson } from "../app-server/request.js";
 import {
@@ -164,20 +167,18 @@ async function applyCodexPluginInstallItem(
   try {
     const appCacheKey = await buildTargetCodexPluginAppCacheKey(ctx);
     const appServer = resolveTargetCodexAppServer(ctx);
+    const targets = resolveCodexMigrationTargets(ctx);
     const result = await ensureCodexPluginActivation({
       identity: policy,
       installEvenIfActive: true,
-      request: async (method, requestParams) =>
-        await requestTargetCodexAppServerJson({
-          method,
-          requestParams,
-          timeoutMs: 60_000,
-          startOptions: appServer.start,
-          agentDir: resolveCodexMigrationTargets(ctx).agentDir,
-          config: ctx.config,
-          isolated: false,
-          targetPluginName: policy.pluginName,
-        }),
+      request: createTargetCodexPluginActivationRequest({
+        policy,
+        timeoutMs: 60_000,
+        startOptions: appServer.start,
+        agentDir: targets.agentDir,
+        config: ctx.config,
+        isolated: false,
+      }),
       appCache: defaultCodexAppInventoryCache,
       appCacheKey,
     });
@@ -268,7 +269,7 @@ function resolveTargetCodexAppServer(ctx: MigrationProviderContext) {
   });
 }
 
-async function requestTargetCodexAppServerJson(params: {
+type TargetCodexAppServerRequestParams = {
   method: string;
   requestParams?: unknown;
   timeoutMs: number;
@@ -276,25 +277,48 @@ async function requestTargetCodexAppServerJson(params: {
   agentDir: string;
   config: MigrationProviderContext["config"];
   isolated?: boolean;
-  targetPluginName: string;
-}): Promise<unknown> {
-  if (params.method !== "plugin/list") {
-    return await requestCodexAppServerJson(params);
-  }
+};
 
+function createTargetCodexPluginActivationRequest(params: {
+  policy: ResolvedCodexPluginPolicy;
+  timeoutMs: number;
+  startOptions: ReturnType<typeof resolveTargetCodexAppServer>["start"];
+  agentDir: string;
+  config: MigrationProviderContext["config"];
+  isolated?: boolean;
+}): CodexPluginRuntimeRequest {
+  return async (method, requestParams) => {
+    const request: TargetCodexAppServerRequestParams = {
+      method,
+      requestParams,
+      timeoutMs: params.timeoutMs,
+      startOptions: params.startOptions,
+      agentDir: params.agentDir,
+      config: params.config,
+      isolated: params.isolated,
+    };
+    if (method !== "plugin/list") {
+      return await requestCodexAppServerJson(request);
+    }
+    return await requestTargetCodexPluginList(request, params.policy);
+  };
+}
+
+async function requestTargetCodexPluginList(
+  params: TargetCodexAppServerRequestParams,
+  policy: ResolvedCodexPluginPolicy,
+): Promise<unknown> {
   const deadline = Date.now() + params.timeoutMs;
   const discoveryTimeoutMs = targetCodexMarketplaceDiscoveryTimeoutMs();
   const discoveryDeadline = Math.min(deadline, Date.now() + discoveryTimeoutMs);
   let lastResponse: unknown;
-  let attempt = 0;
   do {
-    attempt += 1;
     const remainingMs = Math.max(1, discoveryDeadline - Date.now());
     lastResponse = await requestCodexAppServerJson({
       ...params,
       timeoutMs: remainingMs,
     });
-    if (hasRequestedOpenAiCuratedPlugin(lastResponse, params.targetPluginName)) {
+    if (hasRequestedOpenAiCuratedPlugin(lastResponse, policy.pluginName)) {
       return lastResponse;
     }
     if (Date.now() >= discoveryDeadline) {

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -973,6 +973,69 @@ describe("buildCodexMigrationProvider", () => {
     expect(configState.plugins?.entries?.codex?.config?.codexPlugins).not.toHaveProperty("*");
   });
 
+  it("waits for target curated plugin entries after the marketplace appears", async () => {
+    vi.stubEnv("OPENCLAW_CODEX_MIGRATION_PLUGIN_LIST_TIMEOUT_MS", "600");
+    const fixture = await createCodexFixture();
+    const configState: MigrationProviderContext["config"] = {
+      agents: { defaults: { workspace: fixture.workspaceDir } },
+    } as MigrationProviderContext["config"];
+    let targetPluginListCalls = 0;
+    let targetPluginListCallsAtInstall = 0;
+    appServerRequest.mockImplementation(
+      async ({ method, agentDir }: { method: string; agentDir?: string }) => {
+        const isTarget = typeof agentDir === "string";
+        if (method === "plugin/list" && !isTarget) {
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read" && !isTarget) {
+          return pluginRead("google-calendar");
+        }
+        if (method === "plugin/list" && isTarget) {
+          targetPluginListCalls += 1;
+          if (targetPluginListCalls === 1) {
+            return pluginList([]);
+          }
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/install") {
+          targetPluginListCallsAtInstall = targetPluginListCalls;
+          return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
+        }
+        if (method === "skills/list") {
+          return { data: [] } satisfies v2.SkillsListResponse;
+        }
+        if (method === "hooks/list") {
+          return { data: [] } satisfies v2.HooksListResponse;
+        }
+        if (method === "config/mcpServer/reload") {
+          return {};
+        }
+        if (method === "app/list") {
+          return appsList([]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    );
+    const provider = buildCodexMigrationProvider({
+      runtime: createConfigRuntime(configState),
+    });
+
+    const result = await provider.apply(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+        config: configState,
+      }),
+    );
+
+    expect(targetPluginListCallsAtInstall).toBe(2);
+    expectRecordFields(findItem(result.items, "plugin:google-calendar"), {
+      status: "migrated",
+      reason: "already active",
+    });
+  });
+
   it("leaves selected Codex plugins as warnings when target curated plugins never load", async () => {
     vi.stubEnv("OPENCLAW_CODEX_MIGRATION_PLUGIN_LIST_TIMEOUT_MS", "1");
     const fixture = await createCodexFixture();
@@ -989,11 +1052,7 @@ describe("buildCodexMigrationProvider", () => {
           return pluginRead("google-calendar");
         }
         if (method === "plugin/list" && isTarget) {
-          return {
-            marketplaces: [],
-            marketplaceLoadErrors: [],
-            featuredPluginIds: [],
-          } satisfies v2.PluginListResponse;
+          return pluginList([]);
         }
         if (method === "skills/list") {
           return { data: [] } satisfies v2.SkillsListResponse;

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -884,30 +884,21 @@ describe("buildCodexMigrationProvider", () => {
     const loadedTargetPlugin = pluginList([
       pluginSummary("google-calendar", { installed: true, enabled: true }),
     ]);
-    const script = scriptAppServerRequests([
-      {
-        target: "source",
-        method: "plugin/list",
-        response: pluginList([
-          pluginSummary("google-calendar", { installed: true, enabled: true }),
-        ]),
-      },
-      { target: "source", method: "plugin/read", response: pluginRead("google-calendar") },
-      { target: "target", method: "plugin/list", response: loadedTargetPlugin },
-      {
-        target: "target",
-        method: "plugin/install",
-        response: {
-          authPolicy: "ON_USE",
-          appsNeedingAuth: [],
-        } satisfies v2.PluginInstallResponse,
-      },
-      { target: "target", method: "plugin/list", response: loadedTargetPlugin },
-      { target: "target", method: "skills/list", response: { data: [] } },
-      { target: "target", method: "hooks/list", response: { data: [] } },
-      { target: "target", method: "config/mcpServer/reload", response: {} },
-      { target: "target", method: "app/list", response: appsList([]) },
-    ]);
+    appServerRequest
+      .mockResolvedValueOnce(
+        pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]),
+      )
+      .mockResolvedValueOnce(pluginRead("google-calendar"))
+      .mockResolvedValueOnce(loadedTargetPlugin)
+      .mockResolvedValueOnce({
+        authPolicy: "ON_USE",
+        appsNeedingAuth: [],
+      } satisfies v2.PluginInstallResponse)
+      .mockResolvedValueOnce(loadedTargetPlugin)
+      .mockResolvedValueOnce({ data: [] } satisfies v2.SkillsListResponse)
+      .mockResolvedValueOnce({ data: [] } satisfies v2.HooksListResponse)
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce(appsList([]));
     const provider = buildCodexMigrationProvider({
       runtime: createConfigRuntime(configState),
     });
@@ -922,10 +913,8 @@ describe("buildCodexMigrationProvider", () => {
       }),
     );
 
-    script.expectComplete();
-    const installCall = script.calls.find(
-      ({ target, method }) => target === "target" && method === "plugin/install",
-    );
+    expect(appServerRequest).toHaveBeenCalledTimes(9);
+    const installCall = mockCallArg(appServerRequest, 3) as Record<string, unknown>;
     expectRecordFields(installCall, {
       method: "plugin/install",
       requestParams: {
@@ -976,31 +965,22 @@ describe("buildCodexMigrationProvider", () => {
         enabled: true,
       }),
     ]);
-    const script = scriptAppServerRequests([
-      {
-        target: "source",
-        method: "plugin/list",
-        response: pluginList([
-          pluginSummary("google-calendar", { installed: true, enabled: true }),
-        ]),
-      },
-      { target: "source", method: "plugin/read", response: pluginRead("google-calendar") },
-      { target: "target", method: "plugin/list", response: pluginList([]) },
-      { target: "target", method: "plugin/list", response: loadedTargetPlugin },
-      {
-        target: "target",
-        method: "plugin/install",
-        response: {
-          authPolicy: "ON_USE",
-          appsNeedingAuth: [],
-        } satisfies v2.PluginInstallResponse,
-      },
-      { target: "target", method: "plugin/list", response: loadedTargetPlugin },
-      { target: "target", method: "skills/list", response: { data: [] } },
-      { target: "target", method: "hooks/list", response: { data: [] } },
-      { target: "target", method: "config/mcpServer/reload", response: {} },
-      { target: "target", method: "app/list", response: appsList([]) },
-    ]);
+    appServerRequest
+      .mockResolvedValueOnce(
+        pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]),
+      )
+      .mockResolvedValueOnce(pluginRead("google-calendar"))
+      .mockResolvedValueOnce(pluginList([]))
+      .mockResolvedValueOnce(loadedTargetPlugin)
+      .mockResolvedValueOnce({
+        authPolicy: "ON_USE",
+        appsNeedingAuth: [],
+      } satisfies v2.PluginInstallResponse)
+      .mockResolvedValueOnce(loadedTargetPlugin)
+      .mockResolvedValueOnce({ data: [] } satisfies v2.SkillsListResponse)
+      .mockResolvedValueOnce({ data: [] } satisfies v2.HooksListResponse)
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce(appsList([]));
     const provider = buildCodexMigrationProvider({
       runtime: createConfigRuntime(configState),
     });
@@ -1014,11 +994,12 @@ describe("buildCodexMigrationProvider", () => {
       }),
     );
 
-    script.expectComplete();
-    const targetPluginCalls = script.calls
-      .filter(({ target, method }) => target === "target" && method.startsWith("plugin/"))
-      .map(({ method }) => method);
-    expect(targetPluginCalls.slice(0, 3)).toEqual(["plugin/list", "plugin/list", "plugin/install"]);
+    expect(appServerRequest).toHaveBeenCalledTimes(10);
+    expect(
+      appServerRequest.mock.calls
+        .slice(2, 5)
+        .map(([request]) => (request as { method?: string }).method),
+    ).toEqual(["plugin/list", "plugin/list", "plugin/install"]);
     expectRecordFields(findItem(result.items, "plugin:google-calendar"), {
       status: "migrated",
       reason: "already active",
@@ -1701,52 +1682,6 @@ function createConfigRuntime(
       },
     },
   } as unknown as MigrationProviderContext["runtime"];
-}
-
-type AppServerRequestTarget = "source" | "target";
-
-type AppServerRequestStep = {
-  target: AppServerRequestTarget;
-  method: string;
-  response: unknown;
-};
-
-function scriptAppServerRequests(steps: AppServerRequestStep[]) {
-  const pending = [...steps];
-  const calls: Array<{
-    target: AppServerRequestTarget;
-    method: string;
-    requestParams?: unknown;
-  }> = [];
-  appServerRequest.mockImplementation(
-    async ({
-      method,
-      agentDir,
-      requestParams,
-    }: {
-      method: string;
-      agentDir?: string;
-      requestParams?: unknown;
-    }) => {
-      const actual = {
-        target: typeof agentDir === "string" ? "target" : "source",
-        method,
-      } satisfies Pick<AppServerRequestStep, "target" | "method">;
-      calls.push({ ...actual, ...(requestParams !== undefined ? { requestParams } : {}) });
-      const expected = pending.shift();
-      if (!expected) {
-        throw new Error(`unexpected request ${actual.target}:${actual.method}`);
-      }
-      expect(actual).toEqual({ target: expected.target, method: expected.method });
-      return expected.response;
-    },
-  );
-  return {
-    calls,
-    expectComplete() {
-      expect(pending).toEqual([]);
-    },
-  };
 }
 
 function pluginList(plugins: v2.PluginSummary[]): v2.PluginListResponse {

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -1061,7 +1061,7 @@ describe("buildCodexMigrationProvider", () => {
       kind: "plugin",
       action: "install",
       status: "warning",
-      reason: "marketplace_missing",
+      reason: "plugin_missing",
     });
     expect(result.warnings).toContain(
       "Some Codex plugins could not be migrated. Run `openclaw migrate codex` after onboarding.",

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -881,43 +881,33 @@ describe("buildCodexMigrationProvider", () => {
       },
       agents: { defaults: { workspace: fixture.workspaceDir } },
     } as MigrationProviderContext["config"];
-    let targetPluginListCalls = 0;
-    let targetPluginListCallsAtInstall = 0;
-    appServerRequest.mockImplementation(
-      async ({ method, agentDir }: { method: string; agentDir?: string }) => {
-        const isTarget = typeof agentDir === "string";
-        if (method === "plugin/list" && !isTarget) {
-          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
-        }
-        if (method === "plugin/list" && isTarget) {
-          targetPluginListCalls += 1;
-          if (targetPluginListCalls === 1) {
-            return { marketplaces: [], marketplaceLoadErrors: [], featuredPluginIds: [] };
-          }
-          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
-        }
-        if (method === "plugin/read") {
-          return pluginRead("google-calendar");
-        }
-        if (method === "plugin/install") {
-          targetPluginListCallsAtInstall = targetPluginListCalls;
-          return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
-        }
-        if (method === "skills/list") {
-          return { data: [] } satisfies v2.SkillsListResponse;
-        }
-        if (method === "hooks/list") {
-          return { data: [] } satisfies v2.HooksListResponse;
-        }
-        if (method === "config/mcpServer/reload") {
-          return {};
-        }
-        if (method === "app/list") {
-          return appsList([]);
-        }
-        throw new Error(`unexpected request ${method}`);
+    const loadedTargetPlugin = pluginList([
+      pluginSummary("google-calendar", { installed: true, enabled: true }),
+    ]);
+    const script = scriptAppServerRequests([
+      {
+        target: "source",
+        method: "plugin/list",
+        response: pluginList([
+          pluginSummary("google-calendar", { installed: true, enabled: true }),
+        ]),
       },
-    );
+      { target: "source", method: "plugin/read", response: pluginRead("google-calendar") },
+      { target: "target", method: "plugin/list", response: loadedTargetPlugin },
+      {
+        target: "target",
+        method: "plugin/install",
+        response: {
+          authPolicy: "ON_USE",
+          appsNeedingAuth: [],
+        } satisfies v2.PluginInstallResponse,
+      },
+      { target: "target", method: "plugin/list", response: loadedTargetPlugin },
+      { target: "target", method: "skills/list", response: { data: [] } },
+      { target: "target", method: "hooks/list", response: { data: [] } },
+      { target: "target", method: "config/mcpServer/reload", response: {} },
+      { target: "target", method: "app/list", response: appsList([]) },
+    ]);
     const provider = buildCodexMigrationProvider({
       runtime: createConfigRuntime(configState),
     });
@@ -932,10 +922,10 @@ describe("buildCodexMigrationProvider", () => {
       }),
     );
 
-    const installCall = appServerRequest.mock.calls.find(
-      ([arg]) => (arg as { method?: string }).method === "plugin/install",
-    )?.[0] as Record<string, unknown>;
-    expect(targetPluginListCallsAtInstall).toBe(2);
+    script.expectComplete();
+    const installCall = script.calls.find(
+      ({ target, method }) => target === "target" && method === "plugin/install",
+    );
     expectRecordFields(installCall, {
       method: "plugin/install",
       requestParams: {
@@ -979,49 +969,38 @@ describe("buildCodexMigrationProvider", () => {
     const configState: MigrationProviderContext["config"] = {
       agents: { defaults: { workspace: fixture.workspaceDir } },
     } as MigrationProviderContext["config"];
-    let targetPluginListCalls = 0;
-    let targetPluginListCallsAtInstall = 0;
-    appServerRequest.mockImplementation(
-      async ({ method, agentDir }: { method: string; agentDir?: string }) => {
-        const isTarget = typeof agentDir === "string";
-        if (method === "plugin/list" && !isTarget) {
-          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
-        }
-        if (method === "plugin/read" && !isTarget) {
-          return pluginRead("google-calendar");
-        }
-        if (method === "plugin/list" && isTarget) {
-          targetPluginListCalls += 1;
-          if (targetPluginListCalls === 1) {
-            return pluginList([]);
-          }
-          return pluginList([
-            pluginSummary("openai-curated/google-calendar", {
-              name: "Google Calendar",
-              installed: true,
-              enabled: true,
-            }),
-          ]);
-        }
-        if (method === "plugin/install") {
-          targetPluginListCallsAtInstall = targetPluginListCalls;
-          return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
-        }
-        if (method === "skills/list") {
-          return { data: [] } satisfies v2.SkillsListResponse;
-        }
-        if (method === "hooks/list") {
-          return { data: [] } satisfies v2.HooksListResponse;
-        }
-        if (method === "config/mcpServer/reload") {
-          return {};
-        }
-        if (method === "app/list") {
-          return appsList([]);
-        }
-        throw new Error(`unexpected request ${method}`);
+    const loadedTargetPlugin = pluginList([
+      pluginSummary("openai-curated/google-calendar", {
+        name: "Google Calendar",
+        installed: true,
+        enabled: true,
+      }),
+    ]);
+    const script = scriptAppServerRequests([
+      {
+        target: "source",
+        method: "plugin/list",
+        response: pluginList([
+          pluginSummary("google-calendar", { installed: true, enabled: true }),
+        ]),
       },
-    );
+      { target: "source", method: "plugin/read", response: pluginRead("google-calendar") },
+      { target: "target", method: "plugin/list", response: pluginList([]) },
+      { target: "target", method: "plugin/list", response: loadedTargetPlugin },
+      {
+        target: "target",
+        method: "plugin/install",
+        response: {
+          authPolicy: "ON_USE",
+          appsNeedingAuth: [],
+        } satisfies v2.PluginInstallResponse,
+      },
+      { target: "target", method: "plugin/list", response: loadedTargetPlugin },
+      { target: "target", method: "skills/list", response: { data: [] } },
+      { target: "target", method: "hooks/list", response: { data: [] } },
+      { target: "target", method: "config/mcpServer/reload", response: {} },
+      { target: "target", method: "app/list", response: appsList([]) },
+    ]);
     const provider = buildCodexMigrationProvider({
       runtime: createConfigRuntime(configState),
     });
@@ -1035,7 +1014,11 @@ describe("buildCodexMigrationProvider", () => {
       }),
     );
 
-    expect(targetPluginListCallsAtInstall).toBe(2);
+    script.expectComplete();
+    const targetPluginCalls = script.calls
+      .filter(({ target, method }) => target === "target" && method.startsWith("plugin/"))
+      .map(({ method }) => method);
+    expect(targetPluginCalls.slice(0, 3)).toEqual(["plugin/list", "plugin/list", "plugin/install"]);
     expectRecordFields(findItem(result.items, "plugin:google-calendar"), {
       status: "migrated",
       reason: "already active",
@@ -1718,6 +1701,52 @@ function createConfigRuntime(
       },
     },
   } as unknown as MigrationProviderContext["runtime"];
+}
+
+type AppServerRequestTarget = "source" | "target";
+
+type AppServerRequestStep = {
+  target: AppServerRequestTarget;
+  method: string;
+  response: unknown;
+};
+
+function scriptAppServerRequests(steps: AppServerRequestStep[]) {
+  const pending = [...steps];
+  const calls: Array<{
+    target: AppServerRequestTarget;
+    method: string;
+    requestParams?: unknown;
+  }> = [];
+  appServerRequest.mockImplementation(
+    async ({
+      method,
+      agentDir,
+      requestParams,
+    }: {
+      method: string;
+      agentDir?: string;
+      requestParams?: unknown;
+    }) => {
+      const actual = {
+        target: typeof agentDir === "string" ? "target" : "source",
+        method,
+      } satisfies Pick<AppServerRequestStep, "target" | "method">;
+      calls.push({ ...actual, ...(requestParams !== undefined ? { requestParams } : {}) });
+      const expected = pending.shift();
+      if (!expected) {
+        throw new Error(`unexpected request ${actual.target}:${actual.method}`);
+      }
+      expect(actual).toEqual({ target: expected.target, method: expected.method });
+      return expected.response;
+    },
+  );
+  return {
+    calls,
+    expectComplete() {
+      expect(pending).toEqual([]);
+    },
+  };
 }
 
 function pluginList(plugins: v2.PluginSummary[]): v2.PluginListResponse {

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -995,7 +995,13 @@ describe("buildCodexMigrationProvider", () => {
           if (targetPluginListCalls === 1) {
             return pluginList([]);
           }
-          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+          return pluginList([
+            pluginSummary("openai-curated/google-calendar", {
+              name: "Google Calendar",
+              installed: true,
+              enabled: true,
+            }),
+          ]);
         }
         if (method === "plugin/install") {
           targetPluginListCallsAtInstall = targetPluginListCalls;


### PR DESCRIPTION
## Summary

- Problem: Codex migration could stop target plugin discovery as soon as `openai-curated` appeared, even if the selected plugin entry had not loaded yet.
- Why it matters: a transient partial target `plugin/list` response could report a source-installed plugin such as GitHub as `plugin_missing`, skipping native Codex plugin config for that migration run.
- What changed: migration now waits for the selected curated plugin entry before attempting installation, using the same curated plugin id matching as the inventory resolver; tests now split ordinary install/config behavior from the marketplace-present/plugin-delayed regression with direct queued app-server responses.
- What did NOT change (scope boundary): no new config surface, no marketplace wildcard behavior, no changes to source plugin eligibility or app auth policy.

AI-assisted: yes, prepared with Codex and checked with local `codex review --base origin/main`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex migration planning and plugin activation path for a source-installed `openai-curated/github` plugin no longer depends on a partial target marketplace inventory being treated as final.
- Real environment tested: Local OpenClaw checkout at PR head `a88b254cb00a5f09c00e11c5cc8114d0d4e1806b`, Node 22.22.2, pnpm 11.1.0, local Codex/OpenClaw state with GitHub present in Codex curated plugin inventory.
- Exact steps or command run after this patch: `OPENCLAW_STATE_DIR="$tmp_root/state" OPENCLAW_CONFIG_PATH="$tmp_root/state/openclaw.json" OPENCLAW_TEST_FAST=1 timeout 360s node scripts/run-node.mjs migrate apply codex --from /home/rubencu/.codex --plugin github --overwrite --yes --no-backup --force --json` using a fresh temp `tmp_root` under `/tmp/openclaw-codex-apply-proof.*`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal capture excerpt (console output) from the command above: `exitStatus: 124` after the timeout wrapper ended a lingering app-server process, but the CLI emitted a complete migration result first: `summary.total: 4`, `summary.migrated: 4`, `summary.errors: 0`, `warnings: 0`; item `plugin:github` had `status: "migrated"`, `activationReason: "installed"`, `installAttempted: true`; item `config:codex-plugins` had `status: "migrated"`.
- Observed result after fix: The isolated real apply emitted a complete JSON result without `plugin_missing` or migration errors and migrated both the GitHub plugin install item and the Codex plugin config merge.
- What was not tested: A non-temp apply against personal OpenClaw state, to avoid writing normal local config during PR prep. The isolated apply wrote only to a fresh temp OpenClaw state/config path; the delayed target plugin entry path is covered by the focused migration provider test added in this PR.
- Before evidence (optional but encouraged): Reported failure showed `plugin:github` with `status: "error"`, `reason: "plugin_missing"`, and `config:codex-plugins` skipped as `no selected Codex plugins`.

## Root Cause (if applicable)

- Root cause: the target app-server polling helper returned as soon as the `openai-curated` marketplace existed, even when the selected plugin list entry was still absent.
- Missing detection / guardrail: tests covered marketplace-delayed and never-loaded cases, but not marketplace-present/plugin-delayed inventory.
- Contributing context (if known): target Codex app-server plugin inventory can be temporarily partial while marketplace discovery and plugin entries finish loading.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/migration/provider.test.ts`
- Scenario the test should lock in: target `plugin/list` first returns the curated marketplace with no selected plugin entry, then returns the selected plugin entry; migration must wait and install instead of reporting `plugin_missing`.
- Why this is the smallest reliable guardrail: the migration provider test owns the app-server request mock and can deterministically model the partial inventory response without mutating real config.
- Existing test that already covers this (if any): existing tests covered marketplace absent, plugin never loaded, and inventory timeout, but not plugin entry delay after marketplace appearance.
- If no new test is added, why not: N/A; a regression test is added.

## User-visible / Behavior Changes

Codex migrations are less likely to falsely skip source-installed curated plugins when the target app-server inventory is still loading. No new user-facing options or config keys.

## Diagram (if applicable)

```text
Before:
plugin/list -> openai-curated present, selected plugin absent -> plugin_missing

After:
plugin/list -> openai-curated present, selected plugin absent -> keep polling
plugin/list -> selected plugin present -> install/configure plugin
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22.22.2, pnpm 11.1.0
- Model/provider: local Codex review used `gpt-5.5`
- Integration/channel (if any): Codex migration provider / native Codex plugin inventory
- Relevant config (redacted): source Codex plugin inventory includes `openai-curated/github`; no secrets included

### Steps

1. Run focused provider test: `node scripts/run-vitest.mjs extensions/codex/src/migration/provider.test.ts`
2. Run local review: `codex review --base origin/main`
3. Run isolated real apply: `OPENCLAW_STATE_DIR="$tmp_root/state" OPENCLAW_CONFIG_PATH="$tmp_root/state/openclaw.json" OPENCLAW_TEST_FAST=1 timeout 360s node scripts/run-node.mjs migrate apply codex --from /home/rubencu/.codex --plugin github --overwrite --yes --no-backup --force --json`

### Expected

- Migration waits for the selected plugin entry before install.
- The delayed plugin test migrates instead of warning with `plugin_missing`.
- Isolated real apply migrates `plugin:github` and `config:codex-plugins` without errors.

### Actual

- Focused test passed: 27 tests.
- Full-permission local Codex review found no actionable correctness issue introduced by this diff.
- Isolated real apply emitted complete JSON before the timeout wrapper ended a lingering app-server process; parsed result reported `summary.migrated: 4`, `summary.errors: 0`, `warnings: 0`, and migrated `plugin:github` plus `config:codex-plugins`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: delayed target plugin inventory via focused migration provider test; ordinary install/config flow via a separate direct-response test; isolated real Codex migration apply for `github`; local Codex review against `origin/main` with full local diff access.
- Edge cases checked: selected plugin appears after marketplace; selected plugin never appears; target inventory timeout remains warning-only.
- What you did **not** verify: a mutating apply against normal personal OpenClaw state or app-backed auth reauthorization flows.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: migration may spend longer waiting when a target marketplace is visible but the selected plugin remains absent.
  - Mitigation: the existing discovery timeout still bounds polling, and the never-loaded plugin case remains a warning without writing config.




