### PR TITLE
feat(agents): add config toggle for the GPT-5 chatty-reply brevity guard

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -140,7 +140,11 @@ vi.mock("./agent-runner-utils.js", () => ({
   buildEmbeddedRunExecutionParams: (params: {
     provider: string;
     model: string;
-    run: { provider?: string; authProfileId?: string; authProfileIdSource?: "auto" | "user" };
+    run: {
+      provider?: string;
+      authProfileId?: string;
+      authProfileIdSource?: "auto" | "user";
+    };
   }) => ({
     embeddedContext: {},
     senderContext: {},
@@ -179,7 +183,13 @@ async function getApplyFallbackCandidateSelectionToEntry() {
 type FallbackRunnerParams = {
   run: (provider: string, model: string) => Promise<unknown>;
   classifyResult?: (params: {
-    result: { payloads?: Array<{ text?: string; isError?: boolean; isReasoning?: boolean }> };
+    result: {
+      payloads?: Array<{
+        text?: string;
+        isError?: boolean;
+        isReasoning?: boolean;
+      }>;
+    };
     provider: string;
     model: string;
     attempt: number;
@@ -699,7 +709,10 @@ describe("runAgentTurnWithFallback", () => {
       realAgentEvents.emitAgentEvent({
         runId: params.runId,
         stream: "assistant",
-        data: { text: "secret heartbeat output", delta: "secret heartbeat output" },
+        data: {
+          text: "secret heartbeat output",
+          delta: "secret heartbeat output",
+        },
       });
       realAgentEvents.emitAgentEvent({
         runId: params.runId,
@@ -721,7 +734,10 @@ describe("runAgentTurnWithFallback", () => {
     await runAgentTurnWithFallback({
       commandBody: "hi",
       followupRun,
-      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
       opts: { onPartialReply },
       typingSignals: createMockTypingSignaler(),
       blockReplyPipeline: null,
@@ -819,12 +835,18 @@ describe("runAgentTurnWithFallback", () => {
       realAgentEvents.emitAgentEvent({
         runId: params.runId,
         stream: "assistant",
-        data: { text: "heartbeat scratch text", delta: "heartbeat scratch text" },
+        data: {
+          text: "heartbeat scratch text",
+          delta: "heartbeat scratch text",
+        },
       });
       realAgentEvents.emitAgentEvent({
         runId: params.runId,
         stream: "assistant",
-        data: { text: "NO_REPLY do not preview reasoning", delta: " do not preview reasoning" },
+        data: {
+          text: "NO_REPLY do not preview reasoning",
+          delta: " do not preview reasoning",
+        },
       });
       return { payloads: [{ text: "final" }], meta: {} };
     });
@@ -841,7 +863,10 @@ describe("runAgentTurnWithFallback", () => {
     await runAgentTurnWithFallback({
       commandBody: "hi",
       followupRun,
-      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
       opts: { onReasoningStream },
       typingSignals: createMockTypingSignaler(),
       blockReplyPipeline: null,
@@ -894,7 +919,10 @@ describe("runAgentTurnWithFallback", () => {
     await runAgentTurnWithFallback({
       commandBody: "hi",
       followupRun,
-      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
       opts: { onReasoningStream },
       typingSignals: createMockTypingSignaler(),
       blockReplyPipeline: null,
@@ -931,11 +959,17 @@ describe("runAgentTurnWithFallback", () => {
       realAgentEvents.emitAgentEvent({
         runId: "api-run",
         stream: "assistant",
-        data: { text: "assistant text from API run", delta: "assistant text from API run" },
+        data: {
+          text: "assistant text from API run",
+          delta: "assistant text from API run",
+        },
       });
       await params.onAgentEvent?.({
         stream: "assistant",
-        data: { text: "assistant text from API run", delta: "assistant text from API run" },
+        data: {
+          text: "assistant text from API run",
+          delta: "assistant text from API run",
+        },
       });
       return { payloads: [{ text: "final" }], meta: {} };
     });
@@ -951,7 +985,10 @@ describe("runAgentTurnWithFallback", () => {
     await runAgentTurnWithFallback({
       commandBody: "hi",
       followupRun,
-      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
       opts: { onReasoningStream },
       typingSignals: createMockTypingSignaler(),
       blockReplyPipeline: null,
@@ -1224,7 +1261,11 @@ describe("runAgentTurnWithFallback", () => {
     });
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
       const first = (await params.run("openai-codex", "gpt-5.4")) as {
-        payloads?: Array<{ text?: string; isError?: boolean; isReasoning?: boolean }>;
+        payloads?: Array<{
+          text?: string;
+          isError?: boolean;
+          isReasoning?: boolean;
+        }>;
       };
       const classification = await params.classifyResult?.({
         result: first,
@@ -1304,7 +1345,11 @@ describe("runAgentTurnWithFallback", () => {
     });
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
       const result = (await params.run("openai-codex", "gpt-5.4")) as {
-        payloads?: Array<{ text?: string; isError?: boolean; isReasoning?: boolean }>;
+        payloads?: Array<{
+          text?: string;
+          isError?: boolean;
+          isReasoning?: boolean;
+        }>;
       };
       expect(
         await params.classifyResult?.({
@@ -1417,7 +1462,10 @@ describe("runAgentTurnWithFallback", () => {
       compactionCount: 0,
     };
     const activeSessionStore = { main: sessionEntry };
-    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
       const failedResult = await params.run("openai-codex", "gpt-5.4");
       expect(sessionEntry.providerOverride).toBe("openai-codex");
@@ -1457,7 +1505,9 @@ describe("runAgentTurnWithFallback", () => {
   it("strips a glued leading NO_REPLY token from streamed tool results", async () => {
     const onToolResult = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
-      await params.onToolResult?.({ text: "NO_REPLYThe user is saying hello" });
+      await params.onToolResult?.({
+        text: "NO_REPLYThe user is saying hello",
+      });
       return { payloads: [{ text: "final" }], meta: {} };
     });
 
@@ -1494,7 +1544,9 @@ describe("runAgentTurnWithFallback", () => {
 
     expect(result.kind).toBe("success");
     expect(typingSignals.signalTextDelta).toHaveBeenCalledWith("The user is saying hello");
-    expect(onToolResult).toHaveBeenCalledWith({ text: "The user is saying hello" });
+    expect(onToolResult).toHaveBeenCalledWith({
+      text: "The user is saying hello",
+    });
   });
 
   it("continues delivering later streamed tool results after an earlier delivery failure", async () => {
@@ -1883,8 +1935,17 @@ describe("runAgentTurnWithFallback", () => {
         data: { phase: "start", startedAt: 1_000 },
       });
       return {
-        payloads: [{ text: "Request timed out before a response was generated.", isError: true }],
-        meta: { aborted: true, livenessState: "blocked", replayInvalid: true },
+        payloads: [
+          {
+            text: "Request timed out before a response was generated.",
+            isError: true,
+          },
+        ],
+        meta: {
+          aborted: true,
+          livenessState: "blocked",
+          replayInvalid: true,
+        },
       };
     });
 
@@ -2040,6 +2101,60 @@ describe("runAgentTurnWithFallback", () => {
       expect(result.runResult.payloads?.[0]?.text).toBe(
         "I updated the prompt overlay and tightened the runtime guard. I also added the ack-turn fast path so short approvals skip the recap. The reply-side brevity cap now trims long prose-heavy GPT confirmations...",
       );
+    }
+  });
+
+  it("preserves chatty GPT ack-turn replies when gptChatBrevityGuardEnabled is false", async () => {
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("openai", "gpt-5.4"),
+      provider: "openai",
+      model: "gpt-5.4",
+      attempts: [],
+    }));
+    const fullReply = [
+      "I updated the prompt overlay and tightened the runtime guard.",
+      "I also added the ack-turn fast path so short approvals skip the recap.",
+      "The reply-side brevity cap now trims long prose-heavy GPT confirmations.",
+      "I updated tests for the overlay, retry guard, and reply normalization.",
+      "Everything is wired together and ready for verification.",
+    ].join(" ");
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
+      payloads: [{ text: fullReply }],
+      meta: {},
+    }));
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "openai";
+    followupRun.run.model = "gpt-5.4";
+    const result = await runAgentTurnWithFallback({
+      commandBody: "ok do it",
+      followupRun,
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+      gptChatBrevityGuardEnabled: false,
+    });
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads?.[0]?.text).toBe(fullReply);
     }
   });
 
@@ -2228,7 +2343,10 @@ describe("runAgentTurnWithFallback", () => {
   it("keeps compaction start notices silent by default", async () => {
     const onBlockReply = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
-      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      await params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "start" },
+      });
       return { payloads: [{ text: "final" }], meta: {} };
     });
 
@@ -2266,7 +2384,10 @@ describe("runAgentTurnWithFallback", () => {
     const onCompactionStart = vi.fn();
     const onCompactionEnd = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
-      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      await params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "start" },
+      });
       await params.onAgentEvent?.({
         stream: "compaction",
         data: { phase: "end", completed: true },
@@ -2312,7 +2433,10 @@ describe("runAgentTurnWithFallback", () => {
   it("emits a compaction start notice when notifyUser is enabled", async () => {
     const onBlockReply = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
-      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      await params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "start" },
+      });
       return { payloads: [{ text: "final" }], meta: {} };
     });
 
@@ -2365,7 +2489,10 @@ describe("runAgentTurnWithFallback", () => {
   it("emits a compaction completion notice when notifyUser is enabled", async () => {
     const onBlockReply = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
-      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      await params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "start" },
+      });
       await params.onAgentEvent?.({
         stream: "compaction",
         data: { phase: "end", completed: true },
@@ -2494,7 +2621,10 @@ describe("runAgentTurnWithFallback", () => {
     const onBlockReply = vi.fn();
     const onCompactionEnd = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
-      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      await params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "start" },
+      });
       await params.onAgentEvent?.({
         stream: "compaction",
         data: { phase: "end", completed: true },
@@ -2552,7 +2682,10 @@ describe("runAgentTurnWithFallback", () => {
   it("emits an incomplete compaction notice when compaction ends without completing", async () => {
     const onBlockReply = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
-      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      await params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "start" },
+      });
       await params.onAgentEvent?.({
         stream: "compaction",
         data: { phase: "end", completed: false },
@@ -2616,8 +2749,18 @@ describe("runAgentTurnWithFallback", () => {
         {
           name: "FallbackSummaryError",
           attempts: [
-            { provider: "anthropic", model: "claude", error: "429", reason: "rate_limit" },
-            { provider: "openai", model: "gpt-5.4", error: "402", reason: "billing" },
+            {
+              provider: "anthropic",
+              model: "claude",
+              error: "429",
+              reason: "rate_limit",
+            },
+            {
+              provider: "openai",
+              model: "gpt-5.4",
+              error: "402",
+              reason: "billing",
+            },
           ],
           soonestCooldownExpiry: Date.now() + 60_000,
         },

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -277,7 +277,10 @@ export function applyFallbackCandidateSelectionToEntry(params: {
     return { updated: false };
   }
   const scopedAuthProfile = resolveRunAuthProfile(params.run, params.provider);
-  const origin = resolveFallbackSelectionOrigin({ entry: params.entry, run: params.run });
+  const origin = resolveFallbackSelectionOrigin({
+    entry: params.entry,
+    run: params.run,
+  });
   const nextState = buildFallbackSelectionState({
     provider: params.provider,
     model: params.model,
@@ -400,7 +403,9 @@ function extractCodexUsageLimitMessage(text: string): string | undefined {
   if (markerIndex === undefined) {
     return undefined;
   }
-  const message = sanitizeUserFacingText(text.slice(markerIndex), { errorContext: true })
+  const message = sanitizeUserFacingText(text.slice(markerIndex), {
+    errorContext: true,
+  })
     .split(/\r?\n/u)
     .map((line) => line.trim())
     .filter(Boolean)
@@ -916,8 +921,12 @@ function applyOpenAIGptChatReplyGuard(params: {
   commandBody: string;
   isHeartbeat: boolean;
   payloads?: ReplyPayload[];
+  // When explicitly false, the guard is disabled and reply text is passed through unchanged.
+  // Default behavior (undefined or true) preserves the existing brevity capping.
+  enabled?: boolean;
 }): void {
   if (
+    params.enabled === false ||
     params.isHeartbeat ||
     !shouldApplyOpenAIGptChatGuard({
       provider: params.provider,
@@ -1127,6 +1136,9 @@ export async function runAgentTurnWithFallback(params: {
   resolvedVerboseLevel: VerboseLevel;
   toolProgressDetail?: "explain" | "raw";
   replyMediaContext?: ReplyMediaContext;
+  // When explicitly false, disables the OpenAI GPT-5 chatty-reply brevity guard for this turn.
+  // Default (undefined or true) preserves the existing behavior of trimming verbose chat replies.
+  gptChatBrevityGuardEnabled?: boolean;
 }): Promise<AgentRunLoopResult> {
   const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
   let didLogHeartbeatStrip = false;
@@ -1567,7 +1579,9 @@ export async function runAgentTurnWithFallback(params: {
                 drain: async (): Promise<void> => undefined,
               };
               const assistantBridge = createAssistantTextBridge(async (text) => {
-                const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
+                const textForTyping = await handlePartialForTyping({
+                  text,
+                } as ReplyPayload);
                 if (textForTyping === undefined || !params.opts?.onPartialReply) {
                   return;
                 }
@@ -2415,6 +2429,7 @@ export async function runAgentTurnWithFallback(params: {
       commandBody: params.commandBody,
       isHeartbeat: params.isHeartbeat,
       payloads: runResult.payloads,
+      enabled: params.gptChatBrevityGuardEnabled,
     });
   }
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -161,7 +161,10 @@ function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
 }
 
 function hasSuccessfulSideEffectDelivery(params: {
-  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
+  blockReplyPipeline: {
+    didStream: () => boolean;
+    isAborted: () => boolean;
+  } | null;
   directlySentBlockKeys?: Set<string>;
   messagingToolSentTexts?: string[];
   messagingToolSentMediaUrls?: string[];
@@ -189,7 +192,11 @@ function resolveConfiguredFallbackModel(params: {
     const originProvider = normalizeOptionalString(entry.modelOverrideFallbackOriginProvider);
     const originModel = normalizeOptionalString(entry.modelOverrideFallbackOriginModel);
     if (originProvider && originModel) {
-      return { provider: originProvider, model: originModel, persistedAutoFallback: true };
+      return {
+        provider: originProvider,
+        model: originModel,
+        persistedAutoFallback: true,
+      };
     }
   }
   return {
@@ -547,7 +554,10 @@ function derivePromptSegments(prompt: string | undefined): TracePromptSegmentVie
   if (userChars > 0) {
     addChars("user_message", userChars);
   }
-  const result = Array.from(segments.entries()).map(([key, chars]) => ({ key, chars }));
+  const result = Array.from(segments.entries()).map(([key, chars]) => ({
+    key,
+    chars,
+  }));
   return result.length > 0 ? result : undefined;
 }
 
@@ -979,7 +989,9 @@ function enqueueCommitmentExtractionForTurn(params: {
     userText,
     assistantText,
     ...(params.sessionCtx.MessageSidFull || params.sessionCtx.MessageSid
-      ? { sourceMessageId: params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid }
+      ? {
+          sourceMessageId: params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid,
+        }
       : {}),
     sourceRunId: params.runId,
   });
@@ -1466,6 +1478,7 @@ export async function runReplyAgent(params: {
         resolvedVerboseLevel,
         toolProgressDetail,
         replyMediaContext,
+        gptChatBrevityGuardEnabled: cfg.agents?.defaults?.gptChatBrevityGuard?.enabled,
       }),
     );
 
@@ -1815,7 +1828,9 @@ export async function runReplyAgent(params: {
     const verboseNotices: ReplyPayload[] = [];
 
     if (verboseEnabled && activeIsNewSession) {
-      verboseNotices.push({ text: `🧭 New session: ${followupRun.run.sessionId}` });
+      verboseNotices.push({
+        text: `🧭 New session: ${followupRun.run.sessionId}`,
+      });
     }
 
     if (fallbackTransition.fallbackTransitioned) {
@@ -1990,7 +2005,9 @@ export async function runReplyAgent(params: {
         ? { sessionCompactions: activeSessionEntry.compactionCount }
         : {}),
       ...(typeof runResult.meta?.contextManagement?.lastTurnCompactions === "number"
-        ? { lastTurnCompactions: runResult.meta.contextManagement.lastTurnCompactions }
+        ? {
+            lastTurnCompactions: runResult.meta.contextManagement.lastTurnCompactions,
+          }
         : typeof runResult.meta?.agentMeta?.compactionCount === "number"
           ? { lastTurnCompactions: runResult.meta.agentMeta.compactionCount }
           : {}),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -291,6 +291,15 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    gptChatBrevityGuard: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional()
+      .describe(
+        "Toggle for the chatty-reply guard that truncates verbose GPT-5 chat replies after acknowledgement-style prompts. Default true (current behavior). Set enabled=false to disable when you prefer unconstrained reply length.",
+      ),
     sandbox: AgentSandboxSchema,
   })
   .strict()


### PR DESCRIPTION
## Summary

Add an opt-out toggle (`agents.defaults.gptChatBrevityGuard.enabled`) for `applyOpenAIGptChatReplyGuard` so operators on long-form GPT-5 workloads can keep verbose replies intact when they need to.

- New schema field on `AgentDefaultsSchema`: `gptChatBrevityGuard.enabled` (boolean, optional, default-on).
- Thread the resolved value from `agent-runner.ts` through `runAgentTurnWithFallback` into `applyOpenAIGptChatReplyGuard`; explicit `false` short-circuits the guard before any sentence/char trimming.
- Regression test asserting that when the toggle is `false`, an ack-turn GPT-5 reply with five sentences is preserved verbatim (no `...` truncation).

Default behavior is unchanged when the field is omitted, so existing deployments keep the current brevity capping.

## Why

The current guard unconditionally trims GPT-5 replies after acknowledgement-style prompts (`"ok"`, `"proceed"`, …), capping at 420 chars / 3 sentences and appending `"..."`. On a multi-agent orchestrator running review/status/plan workflows, this clips substantive replies mid-thought with no per-deployment escape hatch. Users either swap the primary model off GPT-5 (losing reasoning quality) or rephrase every approval to bypass the ack-turn detector.

This PR keeps the safer GPT-5 default and lets operators opt out per-deployment when they need full replies.

## Tests

```
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts
```

Result: 1 test file, **82 / 82 tests passed** in 9.3s. The two adjacent existing tests (`trims chatty GPT ack-turn final prose` and `does not trim GPT replies when the user asked for depth`) continue to pass — the toggle only short-circuits when explicitly `false`.

## Real behavior proof

**Behavior addressed**: On `openclaw 2026.5.12`, an operator replying to `"proceed"` on Telegram had its substantive GPT-5 reply (5 short sentences) trimmed to 3 sentences with a trailing `"..."` appended by `applyOpenAIGptChatReplyGuard`. There was no config path to disable this for the affected deployment.

**Real environment tested**: macOS 25.3.0 / Node 22.22.2 worktree off `origin/main` (`111a17b6e8`). Targeted Vitest via `scripts/run-vitest.mjs` after `corepack pnpm install`.

**Exact steps or command run after this patch**:
```
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts
corepack pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-runner-execution.ts \
  src/auto-reply/reply/agent-runner-execution.test.ts \
  src/auto-reply/reply/agent-runner.ts \
  src/config/zod-schema.agent-defaults.ts
```

**Evidence after fix**: All 82 tests pass; the new test `preserves chatty GPT ack-turn replies when gptChatBrevityGuardEnabled is false` verifies the toggle short-circuits the guard and the full 5-sentence reply text reaches `runResult.payloads[0].text` unmodified.

**Observed result after fix**: With `gptChatBrevityGuardEnabled: false`, the full reply is preserved (no `...`, no sentence cap). With the toggle omitted or `true`, the existing trim still fires — matched by the unchanged sibling test.

**What was not tested**: End-to-end live Telegram round-trip on the affected installation; the proof is unit-level. Maintainer can confirm via the runtime path that the new field reaches the call site as expected via `cfg.agents?.defaults?.gptChatBrevityGuard?.enabled`.
