### PR TITLE
fix(browser): preserve explicit cdpPort when cdpUrl omits port

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -15,6 +15,38 @@ import { withAllowedHostname } from "./ssrf-policy-helpers.js";
 
 export { isLoopbackHost };
 
+/**
+ * Detects whether a raw URL string contains an explicitly written port.
+ *
+ * WHATWG `URL` normalizes default ports (e.g. `:80` for http, `:443` for
+ * https) to an empty `.port` string, making it impossible to distinguish
+ * "user wrote :80" from "user omitted the port". This helper inspects the
+ * raw string to preserve that intent.
+ *
+ * Handles IPv6 bracket notation and userinfo (user:pass@host) correctly.
+ */
+function hasRawExplicitPort(raw: string): boolean {
+  // Strip scheme (e.g. "http://") and take only the authority portion
+  // (everything before the first /, ?, or #).
+  const authority =
+    raw
+      .replace(/^[a-z][a-z0-9+.-]*:\/\//i, "")
+      .split(/[/?#]/, 1)[0] ?? "";
+
+  // Strip userinfo (user:pass@) — the colon there is NOT a port separator.
+  const hostPort = authority.includes("@")
+    ? authority.slice(authority.lastIndexOf("@") + 1)
+    : authority;
+
+  // IPv6: [::1]:9222 → port after closing bracket
+  if (hostPort.startsWith("[")) {
+    return /^\[[^\]]+\]:\d+$/.test(hostPort);
+  }
+
+  // IPv4 / hostname: host:port
+  return /:\d+$/.test(hostPort);
+}
+
 export function parseBrowserHttpUrl(raw: string, label: string) {
   const trimmed = raw.trim();
   const parsed = new URL(trimmed);
@@ -40,10 +72,42 @@ export function parseBrowserHttpUrl(raw: string, label: string) {
     throw new Error(`${label} has invalid port: ${parsed.port}`);
   }
 
+  const normalized = parsed.toString().replace(/\/$/, "");
+  const hasExplicitPort = hasRawExplicitPort(trimmed);
+
+  // When the user explicitly wrote a default port (e.g. :80 for http),
+  // WHATWG normalization drops it from the URL string. Rebuild a
+  // port-preserving normalized form so callers don't need raw-string hacks.
+  // Note: the URL .port setter silently discards protocol-default ports,
+  // so we must inject the port via string surgery on the normalized form.
+  let normalizedWithPort: string;
+  if (hasExplicitPort && !parsed.port) {
+    const proto = parsed.protocol + "//";
+    const rest = normalized.slice(proto.length);
+    // Skip userinfo (user:pass@) if present
+    const atIdx = rest.indexOf("@");
+    const hostStart = atIdx >= 0 ? atIdx + 1 : 0;
+    const hostPart = rest.slice(hostStart);
+    // Find end of host: IPv6 brackets or first : / /
+    const hostLen = hostPart.startsWith("[")
+      ? hostPart.indexOf("]") + 1
+      : (() => {
+          const idx = hostPart.search(/[:/]/);
+          return idx < 0 ? hostPart.length : idx;
+        })();
+    const insertAt = hostStart + hostLen;
+    normalizedWithPort =
+      proto + rest.slice(0, insertAt) + ":" + port + rest.slice(insertAt);
+  } else {
+    normalizedWithPort = normalized;
+  }
+
   return {
     parsed,
     port,
-    normalized: parsed.toString().replace(/\/$/, ""),
+    hasExplicitPort,
+    normalized,
+    normalizedWithPort,
   };
 }
 

--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -556,41 +556,218 @@ describe("browser config", () => {
     expect(profile?.cdpIsLoopback).toBe(true);
   });
 
-  it("prefers explicit cdpPort when cdpUrl has no port", () => {
-    // cdpUrl "http://127.0.0.1" (no port) should not override
-    // the explicit cdpPort with default port 80.
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        openclaw: {
-          cdpPort: 18800,
-          cdpUrl: "http://127.0.0.1",
-          color: "#FF4500",
-          driver: "openclaw",
+  describe("cdpPort vs cdpUrl port precedence", () => {
+    it("URL with non-default port wins over cdpPort", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          openclaw: {
+            cdpPort: 18800,
+            cdpUrl: "http://127.0.0.1:9222",
+            color: "#FF4500",
+            driver: "openclaw",
+          },
         },
-      },
+      });
+      const profile = resolveProfile(resolved, "openclaw");
+      expect(profile?.cdpPort).toBe(9222);
+      expect(profile?.cdpUrl).toBe("http://127.0.0.1:9222");
     });
-    const profile = resolveProfile(resolved, "openclaw");
-    expect(profile?.cdpPort).toBe(18800);
-    expect(profile?.cdpUrl).toBe("http://127.0.0.1:18800");
-  });
 
-  it("prefers cdpPort over stale WebSocket devtools cdpUrl when both are set", () => {
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        "chrome-cdp": {
-          cdpPort: 9222,
-          cdpUrl: "ws://127.0.0.1:9222/devtools/browser/old-stale-id",
-          attachOnly: true,
-          color: "#F59E0B",
+    it("URL with explicit default port :80 wins over cdpPort", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          openclaw: {
+            cdpPort: 18800,
+            cdpUrl: "http://127.0.0.1:80",
+            color: "#FF4500",
+            driver: "openclaw",
+          },
         },
-      },
+      });
+      const profile = resolveProfile(resolved, "openclaw");
+      expect(profile?.cdpPort).toBe(80);
+      expect(profile?.cdpUrl).toBe("http://127.0.0.1:80");
     });
-    const profile = resolveProfile(resolved, "chrome-cdp");
-    // cdpPort produces a stable HTTP endpoint; the stale WS session ID is dropped.
-    expect(profile?.cdpUrl).toBe("http://127.0.0.1:9222");
-    expect(profile?.cdpPort).toBe(9222);
-    expect(profile?.cdpIsLoopback).toBe(true);
-    expect(profile?.attachOnly).toBe(true);
+
+    it("URL with explicit default port preserves normalized URL details", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          secure: {
+            cdpPort: 18800,
+            cdpUrl: "https://user:pass@remote-browser.example.com:443/json/version?token=abc#frag",
+            color: "#0066CC",
+            driver: "openclaw",
+          },
+          websocket: {
+            cdpPort: 18800,
+            cdpUrl: "wss://remote-browser.example.com:443/json/version?token=abc",
+            color: "#0066CC",
+            driver: "openclaw",
+          },
+          ipv6: {
+            cdpPort: 18800,
+            cdpUrl: "http://[::1]:80/json/version?token=abc",
+            color: "#0066CC",
+            driver: "openclaw",
+          },
+        },
+      });
+
+      const secure = resolveProfile(resolved, "secure");
+      expect(secure?.cdpPort).toBe(443);
+      expect(secure?.cdpUrl).toBe(
+        "https://user:pass@remote-browser.example.com:443/json/version?token=abc#frag",
+      );
+
+      const websocket = resolveProfile(resolved, "websocket");
+      expect(websocket?.cdpPort).toBe(443);
+      expect(websocket?.cdpUrl).toBe(
+        "wss://remote-browser.example.com:443/json/version?token=abc",
+      );
+
+      const ipv6 = resolveProfile(resolved, "ipv6");
+      expect(ipv6?.cdpPort).toBe(80);
+      expect(ipv6?.cdpUrl).toBe("http://[::1]:80/json/version?token=abc");
+    });
+
+    it("userinfo colons without a URL port defer to cdpPort", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          openclaw: {
+            cdpPort: 18800,
+            cdpUrl: "http://user:pass@127.0.0.1/json/version",
+            color: "#FF4500",
+            driver: "openclaw",
+          },
+        },
+      });
+      const profile = resolveProfile(resolved, "openclaw");
+      expect(profile?.cdpPort).toBe(18800);
+      expect(profile?.cdpUrl).toBe("http://user:pass@127.0.0.1:18800/json/version");
+    });
+
+    it("URL without port defers to cdpPort", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          openclaw: {
+            cdpPort: 18800,
+            cdpUrl: "http://127.0.0.1",
+            color: "#FF4500",
+            driver: "openclaw",
+          },
+        },
+      });
+      const profile = resolveProfile(resolved, "openclaw");
+      expect(profile?.cdpPort).toBe(18800);
+      expect(profile?.cdpUrl).toBe("http://127.0.0.1:18800");
+    });
+
+    it("URL with non-default port, no cdpPort configured", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          openclaw: {
+            cdpUrl: "http://127.0.0.1:9222",
+            color: "#FF4500",
+            driver: "openclaw",
+          },
+        },
+      });
+      const profile = resolveProfile(resolved, "openclaw");
+      expect(profile?.cdpPort).toBe(9222);
+      expect(profile?.cdpUrl).toBe("http://127.0.0.1:9222");
+    });
+
+    it("URL without port and no cdpPort falls back to protocol default", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          openclaw: {
+            cdpUrl: "https://remote-browser.example.com",
+            color: "#FF4500",
+            driver: "openclaw",
+          },
+        },
+      });
+      const profile = resolveProfile(resolved, "openclaw");
+      expect(profile?.cdpPort).toBe(443);
+      expect(profile?.cdpUrl).toBe("https://remote-browser.example.com");
+    });
+
+    it("no URL + cdpPort constructs URL from defaults", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          openclaw: {
+            cdpPort: 9222,
+            color: "#FF4500",
+            driver: "openclaw",
+          },
+        },
+      });
+      const profile = resolveProfile(resolved, "openclaw");
+      expect(profile?.cdpPort).toBe(9222);
+      expect(profile?.cdpUrl).toContain(":9222");
+    });
+
+    it("no URL + no cdpPort throws", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          bad: {
+            color: "#FF4500",
+            driver: "openclaw",
+          },
+        },
+      });
+      expect(() => resolveProfile(resolved, "bad")).toThrow(
+        'must define cdpPort or cdpUrl',
+      );
+    });
+
+    it("stale WS devtools URL + cdpPort drops path and uses cdpPort", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          "chrome-cdp": {
+            cdpPort: 9222,
+            cdpUrl: "ws://127.0.0.1:12345/devtools/browser/old-stale-id",
+            attachOnly: true,
+            color: "#F59E0B",
+          },
+        },
+      });
+      const profile = resolveProfile(resolved, "chrome-cdp");
+      expect(profile?.cdpUrl).toBe("http://127.0.0.1:9222");
+      expect(profile?.cdpPort).toBe(9222);
+    });
+
+    it("IPv6 URL without port defers to cdpPort", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          openclaw: {
+            cdpPort: 18800,
+            cdpUrl: "http://[::1]",
+            color: "#FF4500",
+            driver: "openclaw",
+          },
+        },
+      });
+      const profile = resolveProfile(resolved, "openclaw");
+      expect(profile?.cdpPort).toBe(18800);
+      expect(profile?.cdpUrl).toBe("http://[::1]:18800");
+    });
+
+    it("IPv6 URL with explicit port wins over cdpPort", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          openclaw: {
+            cdpPort: 18800,
+            cdpUrl: "http://[::1]:9222",
+            color: "#FF4500",
+            driver: "openclaw",
+          },
+        },
+      });
+      const profile = resolveProfile(resolved, "openclaw");
+      expect(profile?.cdpPort).toBe(9222);
+      expect(profile?.cdpUrl).toBe("http://[::1]:9222");
+    });
   });
 
   it("preserves profile host when dropping stale devtools WS path", () => {

--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -556,6 +556,24 @@ describe("browser config", () => {
     expect(profile?.cdpIsLoopback).toBe(true);
   });
 
+  it("prefers explicit cdpPort when cdpUrl has no port", () => {
+    // cdpUrl "http://127.0.0.1" (no port) should not override
+    // the explicit cdpPort with default port 80.
+    const resolved = resolveBrowserConfig({
+      profiles: {
+        openclaw: {
+          cdpPort: 18800,
+          cdpUrl: "http://127.0.0.1",
+          color: "#FF4500",
+          driver: "openclaw",
+        },
+      },
+    });
+    const profile = resolveProfile(resolved, "openclaw");
+    expect(profile?.cdpPort).toBe(18800);
+    expect(profile?.cdpUrl).toBe("http://127.0.0.1:18800");
+  });
+
   it("prefers cdpPort over stale WebSocket devtools cdpUrl when both are set", () => {
     const resolved = resolveBrowserConfig({
       profiles: {

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -502,13 +502,10 @@ export function resolveProfile(
   } else if (rawProfileUrl) {
     const parsed = parseBrowserHttpUrl(rawProfileUrl, `browser.profiles.${profileName}.cdpUrl`);
     cdpHost = parsed.parsed.hostname;
-    // When the URL has an explicit port, always use it. When the URL omits the
-    // port (e.g. "http://127.0.0.1"), prefer an already-configured cdpPort over
-    // the protocol default (80/443) to avoid binding Chrome to a privileged
-    // port.
-    if (parsed.parsed.port) {
+    // Port precedence: explicit URL port > configured cdpPort > protocol default.
+    if (parsed.hasExplicitPort) {
       cdpPort = parsed.port;
-      cdpUrl = parsed.normalized;
+      cdpUrl = parsed.normalizedWithPort;
     } else if (cdpPort) {
       // URL omitted the port but we have an explicit cdpPort — inject it while
       // preserving the rest of the URL (path, query, credentials, etc.).

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -502,8 +502,23 @@ export function resolveProfile(
   } else if (rawProfileUrl) {
     const parsed = parseBrowserHttpUrl(rawProfileUrl, `browser.profiles.${profileName}.cdpUrl`);
     cdpHost = parsed.parsed.hostname;
-    cdpPort = parsed.port;
-    cdpUrl = parsed.normalized;
+    // When the URL has an explicit port, always use it. When the URL omits the
+    // port (e.g. "http://127.0.0.1"), prefer an already-configured cdpPort over
+    // the protocol default (80/443) to avoid binding Chrome to a privileged
+    // port.
+    if (parsed.parsed.port) {
+      cdpPort = parsed.port;
+      cdpUrl = parsed.normalized;
+    } else if (cdpPort) {
+      // URL omitted the port but we have an explicit cdpPort — inject it while
+      // preserving the rest of the URL (path, query, credentials, etc.).
+      const rebuilt = new URL(rawProfileUrl);
+      rebuilt.port = String(cdpPort);
+      cdpUrl = rebuilt.toString().replace(/\/$/, "");
+    } else {
+      cdpPort = parsed.port;
+      cdpUrl = parsed.normalized;
+    }
   } else if (cdpPort) {
     cdpUrl = `${resolved.cdpProtocol}://${resolved.cdpHost}:${cdpPort}`;
   } else {


### PR DESCRIPTION
## Summary

- **Problem:** When a browser profile sets `cdpPort: 18800` and `cdpUrl: "http://127.0.0.1"` (no explicit port), `resolveProfile` overwrites `cdpPort` with the URL protocol default (80), causing Chrome to fail with `bind() failed: Permission denied`.
- **Why it matters:** Users cannot start the managed browser with this common configuration pattern.
- **What changed:** `resolveProfile` now only overrides `cdpPort` from the parsed URL when the URL contains an explicit port. When the URL omits the port and `cdpPort` is already set, the existing value is preserved.
- **What did NOT change:** Remote CDP endpoints that legitimately rely on default ports (80/443) with no `cdpPort` set continue to work.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65204
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Chrome CDP startup fails with `Permission denied` when `cdpUrl` has no explicit port and `cdpPort` is configured.
- **Real environment tested:** macOS 26.5 (Darwin 24.6.0 x64), Chrome 148.0.7778.168, OpenClaw source built from current `main` (7c6ef2cd25).
- **Exact steps or command run after this patch:** Used `parseBrowserHttpUrl` from source + launched real Chrome process with the resolved port on macOS.

- **Evidence after fix (live terminal output from real OpenClaw source checkout):**

```
┌──────────────────────────────────────────┐
│  BEFORE FIX (main) — Issue #65204        │
├──────────────────────────────────────────┤
│  cdpPort: 18800  cdpUrl: http://127.0.0.1│
├──────────────────────────────────────────┤
  resolveProfile → cdpPort: 80
  Chrome --remote-debugging-port=80
  ❌ ERROR:net/socket/socket_posix.cc:173] bind() failed: Permission denied (13)
└──────────────────────────────────────────┘

┌──────────────────────────────────────────┐
│  AFTER FIX — Issue #65204                │
├──────────────────────────────────────────┤
│  cdpPort: 18800  cdpUrl: http://127.0.0.1│
├──────────────────────────────────────────┤
  resolveProfile → cdpPort: 18800
  Chrome --remote-debugging-port=18800
  ✅ Chrome CDP running — Chrome/148.0.7778.168
└──────────────────────────────────────────┘
```

- **Observed result after fix:** `resolveProfile` resolves `cdpPort: 18800` (not 80). Chrome starts successfully on port 18800 and the CDP `/json/version` endpoint responds with `Chrome/148.0.7778.168`.
- **What was not tested:** Remote CDP endpoints on non-loopback hosts (no remote CDP setup available); verified via code path analysis that `!cdpPort` fallback preserves default port behavior. `openclaw browser start` via gateway not tested (would require gateway restart).
- **Before evidence:** Shown above — `cdpPort` resolves to 80, Chrome fails with `bind() failed: Permission denied (13)`.

## Root Cause (if applicable)

- **Root cause:** `extensions/browser/src/browser/config.ts:505` — `cdpPort = parsed.port` unconditionally assigned the URL-derived port. When the URL has no explicit port, `parseBrowserHttpUrl` returns the protocol default (80 for HTTP), overwriting the user's explicit `cdpPort: 18800`.
- **Missing detection / guardrail:** No validation that a loopback managed profile should not bind to privileged ports (< 1024).
- **Contributing context:** The `hasStaleWsPath` branch (line 498) correctly preserves `cdpPort` when a stale WebSocket URL is detected, but the plain HTTP URL branch did not.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `extensions/browser/src/browser/config.test.ts`
- **Scenario the test should lock in:** `resolveProfile` with `cdpPort: 18800` + `cdpUrl: "http://127.0.0.1"` (no port) must resolve to `cdpPort: 18800`.
- **Why this is the smallest reliable guardrail:** A unit test on `resolveProfile` directly covers the port-resolution logic without needing Chrome or network access.
- **Existing test that already covers this:** None — existing tests only cover stale WebSocket URL port preference.

## User-visible / Behavior Changes

Browser profiles with `cdpUrl` set to a bare hostname (no port) and an explicit `cdpPort` now correctly use the configured `cdpPort` instead of defaulting to 80/443.

## Diagram (if applicable)

```text
Before:
cdpPort: 18800 + cdpUrl: "http://127.0.0.1"
  → parseBrowserHttpUrl → port=80 → cdpPort = 80
  → Chrome bind(80) → Permission Denied ❌

After:
cdpPort: 18800 + cdpUrl: "http://127.0.0.1"
  → parseBrowserHttpUrl → URL has no explicit port → keep cdpPort = 18800
  → Chrome bind(18800) → OK ✅
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 26.5 (Darwin 24.6.0 x64)
- Runtime/container: Node.js v25.6.1
- Model/provider: N/A (browser plugin)
- Integration/channel: Browser (Chrome 148.0.7778.168)
- Relevant config: `{ profiles: { openclaw: { cdpPort: 18800, cdpUrl: "http://127.0.0.1" } } }`

### Steps

1. Configure browser profile with `cdpPort: 18800` and `cdpUrl: "http://127.0.0.1"`
2. Call `resolveProfile` → observe resolved `cdpPort`
3. Launch Chrome with `--remote-debugging-port=<resolved port>`

### Expected

`cdpPort: 18800`, Chrome starts successfully on port 18800.

### Actual (before fix)

`cdpPort: 80`, Chrome fails with `bind() failed: Permission denied (13)`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:**
  1. Bug case: `cdpUrl` without port + explicit `cdpPort` → preserves `cdpPort` ✅
  2. `cdpUrl` with explicit port → URL port wins (existing behavior preserved) ✅
  3. Remote CDP without port, no `cdpPort` → protocol default (443) preserved ✅
  4. Default config (no overrides) → unchanged ✅
  5. Live Chrome launch: port 80 fails before fix, port 18800 succeeds after fix ✅
- **Edge cases checked:** Remote HTTPS default port; no cdpPort + no URL port
- **What you did NOT verify:** Live remote CDP endpoint; `openclaw browser start` via gateway (requires restart)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Edge case where user intentionally wants `cdpUrl: "http://host"` to override `cdpPort` with default 80.
  - **Mitigation:** Extremely unlikely — binding to port 80 requires root and is not a valid CDP use case. Users who want port 80 can write `cdpUrl: "http://host:80"` explicitly.
