### PR TITLE
fix(tts): preserve command voice delivery decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - LINE: acknowledge signed webhook events before agent processing so slow model replies do not cause LINE `request_timeout` delivery failures. Fixes #65375. Thanks @myericho.
+- TTS: preserve channel-derived voice-note delivery for `/tts audio` replies even when the provider output is not natively voice-compatible. (#82174) Thanks @xuruiray.
 - Codex/Lossless: keep Codex explicit compaction on native app-server threads while allowing Lossless through the context-engine slot; `openclaw doctor --fix` now migrates legacy `compaction.provider: "lossless-claw"` config to `plugins.slots.contextEngine`.
 - Cron/doctor: report scheduled jobs with explicit `payload.model` overrides, including provider namespace counts and default-model mismatches, so stale cron model pins are visible during auth or billing investigations. Fixes #82151. Thanks @mgonto.
 - Gateway/approvals: treat `turnSourceTo` as optional in `canBridgeNoDeviceChatApprovalFromBackend`, matching the existing optional handling of `turnSourceAccountId` and `turnSourceThreadId`. Channels without a recipient concept (webchat, control-ui) leave `turnSourceTo` null on both the approval snapshot and the replay params, so the prior required-string check rejected every backend replay with `APPROVAL_CLIENT_MISMATCH`. Cross-channel replay is still gated by the required `turnSourceChannel` and `sessionKey` checks. Fixes #82132. (#82136) Thanks @ottodeng.

--- a/src/auto-reply/reply/commands-tts.test.ts
+++ b/src/auto-reply/reply/commands-tts.test.ts
@@ -214,6 +214,22 @@ describe("handleTtsCommands status fallback reporting", () => {
     );
   });
 
+  it("uses the channel-derived audioAsVoice decision for /tts audio", async () => {
+    ttsMocks.textToSpeech.mockResolvedValue({
+      success: true,
+      audioPath: "/tmp/channel-voice.ogg",
+      provider: PRIMARY_TTS_PROVIDER,
+      voiceCompatible: false,
+      audioAsVoice: true,
+    });
+
+    const result = await handleTtsCommands(buildTtsParams("/tts audio hello channel"), true);
+    const reply = expectReply(result);
+
+    expect(reply.mediaUrl).toBe("/tmp/channel-voice.ogg");
+    expect(reply.audioAsVoice).toBe(true);
+  });
+
   it("treats bare /tts as status", async () => {
     const result = await handleTtsCommands(
       buildTtsParams("/tts", {

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -150,7 +150,7 @@ async function buildTtsAudioReply(params: {
       provider: result.provider,
       reply: {
         mediaUrl: result.audioPath,
-        audioAsVoice: result.voiceCompatible === true,
+        audioAsVoice: result.audioAsVoice === true || result.voiceCompatible === true,
         trustedLocalMedia: true,
         spokenText: params.text,
       },


### PR DESCRIPTION
## Summary
- Honor `textToSpeech().audioAsVoice` when `/tts audio` builds its media reply.
- Keep the existing `voiceCompatible` fallback so provider-level voice compatibility still works.
- Add a focused regression where channel capability inference chooses voice delivery even when the provider result itself is not voice-compatible.

## Verification
- `pnpm install`
- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-tts.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: `/tts audio` now preserves the channel-derived voice-delivery decision returned by `textToSpeech()` by honoring `audioAsVoice` before falling back to `voiceCompatible`.
Real environment tested: Local OpenClaw checkout on macOS using the repository Node runner against the TTS command surface.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/reply/commands-tts.test.ts`.
Evidence after fix: Terminal output from the local run:
```text
$ node scripts/run-vitest.mjs src/auto-reply/reply/commands-tts.test.ts
✓ src/auto-reply/reply/commands-tts.test.ts (11 tests)
Test Files  1 passed (1)
Tests  11 passed (11)
```
Observed result after fix: The command completed successfully and the regression covered `audioAsVoice: true` with `voiceCompatible: false`, so the reply path keeps `reply.audioAsVoice === true`.
What was not tested: Live channel delivery with a credentialed TTS provider.
