### PR TITLE
feat(hooks): raise and configure gateway lifecycle hook timeouts (closes #6711)

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -135,6 +135,47 @@ plugin hook `before_agent_finalize` instead. See [Plugin hooks](/plugins/hooks).
 
 **Gateway lifecycle events**: `gateway:shutdown` includes `reason` and `restartExpectedMs` and fires when gateway shutdown begins. `gateway:pre-restart` includes the same context but only fires when shutdown is part of an expected restart and a finite `restartExpectedMs` value is supplied. During shutdown, each lifecycle hook wait is best-effort and bounded so shutdown continues if a handler stalls.
 
+#### Gateway lifecycle environment variables
+
+Shell-based HOOK.md handlers for gateway lifecycle events receive the following environment variables from the hook runner:
+
+| Variable                           | Present in  | Value                                                                      | Example                                      |
+| ---------------------------------- | ----------- | -------------------------------------------------------------------------- | -------------------------------------------- |
+| `OPENCLAW_EVENT`                   | Both events | The full event name                                                        | `gateway:shutdown`, `gateway:pre-restart`    |
+| `OPENCLAW_GATEWAY_SHUTDOWN_REASON` | Both events | Human-readable reason string                                               | `gateway stopping`, `config-apply`, `update` |
+| `OPENCLAW_RESTART_EXPECTED_MS`     | Both events | Milliseconds until restart is expected, or empty string when not a restart | `1500`, ``                                   |
+
+A non-empty `OPENCLAW_RESTART_EXPECTED_MS` is a reliable signal that the gateway is restarting (not stopping permanently). Use it to skip expensive cleanup in restart-only hooks.
+
+#### Notifying agents before a restart
+
+The `gateway:pre-restart` hook fires after safe-restart drain completes but before channels are stopped, so it can still make outbound calls. This makes it the right place to notify running agents:
+
+```bash
+#!/usr/bin/env bash
+# hooks/notify-agents-on-restart/handler.sh
+# HOOK.md: events: ["gateway:pre-restart"]
+#
+# Sends a system message to all sessions of agent "zero" before the gateway
+# restarts so in-flight work can checkpoint. Relies on the gateway still
+# accepting local API calls at this point in the shutdown sequence.
+
+set -euo pipefail
+
+if [ -z "${OPENCLAW_RESTART_EXPECTED_MS:-}" ]; then
+  # Not a restart — skip
+  exit 0
+fi
+
+RESTART_IN_S=$(( OPENCLAW_RESTART_EXPECTED_MS / 1000 ))
+
+openclaw sessions send \
+  --session-key "agent:zero" \
+  "Gateway restarting in ~${RESTART_IN_S}s (reason: ${OPENCLAW_GATEWAY_SHUTDOWN_REASON}). Checkpoint now."
+```
+
+The default timeout for `gateway:pre-restart` is **10 seconds**, giving hook scripts enough time to complete an `openclaw sessions send` call. Configure a longer window if needed (see [Gateway lifecycle hook timeouts](#gateway-lifecycle-hook-timeouts) below).
+
 Between the `gateway:shutdown` (or `gateway:pre-restart`) event and the rest of the shutdown sequence, the gateway also fires a typed `session_end` plugin hook for every session that was still active when the process stopped. The event's `reason` is `shutdown` for a plain SIGTERM/SIGINT stop and `restart` when the close was scheduled as part of an expected restart. This drain is bounded so a slow `session_end` handler cannot block process exit, and sessions that have already been finalized through replace / reset / delete / compaction are skipped to avoid double-firing.
 
 ## Hook discovery
@@ -276,6 +317,32 @@ Extra hook directories:
   }
 }
 ```
+
+#### Gateway lifecycle hook timeouts
+
+The `gateway:shutdown` and `gateway:pre-restart` hooks have default timeout budgets of **5 000 ms** and **10 000 ms** respectively (see [closes #6711](https://github.com/openclaw/openclaw/issues/6711)). If a handler exceeds its budget it is abandoned and a warning is logged; the gateway always proceeds regardless.
+
+Override the defaults in `openclaw.config.js`:
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "gatewayShutdown": {
+        "timeoutMs": 8000
+      },
+      "gatewayPreRestart": {
+        "timeoutMs": 15000
+      }
+    }
+  }
+}
+```
+
+| Config key                                   | Default | Description                                                                         |
+| -------------------------------------------- | ------- | ----------------------------------------------------------------------------------- |
+| `hooks.internal.gatewayShutdown.timeoutMs`   | `5000`  | Maximum wait (ms) for `gateway:shutdown` hook handlers before shutdown continues    |
+| `hooks.internal.gatewayPreRestart.timeoutMs` | `10000` | Maximum wait (ms) for `gateway:pre-restart` hook handlers before shutdown continues |
 
 <Note>
 The legacy `hooks.internal.handlers` array config format is still supported for backwards compatibility, but new hooks should use the discovery-based system.

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -76,6 +76,17 @@ export type HookInstallRecord = InstallRecordBase & {
   hooks?: string[];
 };
 
+export type GatewayLifecycleHookConfig = {
+  /**
+   * Maximum time in milliseconds to wait for the hook handler to complete before
+   * continuing shutdown. If the handler exceeds this budget it is abandoned and
+   * a warning is recorded; the gateway always proceeds regardless.
+   *
+   * Defaults: `gateway:shutdown` → 5 000 ms, `gateway:pre-restart` → 10 000 ms.
+   */
+  timeoutMs?: number;
+};
+
 export type InternalHooksConfig = {
   /** Enable hooks system */
   enabled?: boolean;
@@ -88,6 +99,17 @@ export type InternalHooksConfig = {
   };
   /** Install records for hook packs or hooks */
   installs?: Record<string, HookInstallRecord>;
+  /**
+   * Timeout and behaviour settings for the `gateway:shutdown` lifecycle hook.
+   * The hook fires when gateway shutdown begins (stop, SIGTERM, SIGINT).
+   */
+  gatewayShutdown?: GatewayLifecycleHookConfig;
+  /**
+   * Timeout and behaviour settings for the `gateway:pre-restart` lifecycle hook.
+   * The hook fires only when shutdown is part of an expected restart
+   * (`restartExpectedMs` is a finite number).
+   */
+  gatewayPreRestart?: GatewayLifecycleHookConfig;
 };
 
 export type HooksConfig = {

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -16,7 +16,10 @@ const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
 const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
 const HTTP_CLOSE_GRACE_MS = 1_000;
 const HTTP_CLOSE_FORCE_WAIT_MS = 5_000;
-const GATEWAY_LIFECYCLE_HOOK_TIMEOUT_MS = 1_000;
+/** Default timeout for the gateway:shutdown hook (raised from 1 s to 5 s in #6711). */
+const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 5_000;
+/** Default timeout for the gateway:pre-restart hook (raised from 1 s to 10 s in #6711). */
+const GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS = 10_000;
 
 vi.mock("../channels/plugins/index.js", async () => ({
   ...(await vi.importActual<typeof import("../channels/plugins/index.js")>(
@@ -181,14 +184,14 @@ describe("createGatewayCloseHandler", () => {
     );
 
     const closePromise = close({ reason: "test shutdown" });
-    await vi.advanceTimersByTimeAsync(GATEWAY_LIFECYCLE_HOOK_TIMEOUT_MS);
+    await vi.advanceTimersByTimeAsync(GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS);
     const result = await closePromise;
 
     expect(result.warnings).toContain("gateway:shutdown");
     expect(stopTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
     expect(
       mocks.logWarn.mock.calls.some(([message]) =>
-        String(message).includes("gateway:shutdown hook timed out after 1000ms"),
+        String(message).includes("gateway:shutdown hook timed out after 5000ms"),
       ),
     ).toBe(true);
   });
@@ -265,11 +268,104 @@ describe("createGatewayCloseHandler", () => {
       reason: "test restart",
       restartExpectedMs: 123,
     });
-    await vi.advanceTimersByTimeAsync(GATEWAY_LIFECYCLE_HOOK_TIMEOUT_MS);
+    await vi.advanceTimersByTimeAsync(GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS);
     const result = await closePromise;
 
     expect(result.warnings).toContain("gateway:pre-restart");
     expect(mocks.triggerInternalHook).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the configured shutdown hook timeout when shutdownHookTimeoutMs is provided", async () => {
+    vi.useFakeTimers();
+    mocks.triggerInternalHook.mockImplementation((event: InternalHookEvent) => {
+      if (event.action === "shutdown") {
+        return new Promise<void>(() => undefined);
+      }
+      return Promise.resolve(undefined);
+    });
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({ shutdownHookTimeoutMs: 3_000 }),
+    );
+
+    const closePromise = close({ reason: "test shutdown" });
+    // Default 5 s should NOT fire at 3 s minus 1 ms
+    await vi.advanceTimersByTimeAsync(2_999);
+    // The configured 3 s value fires at exactly 3 000 ms
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await closePromise;
+
+    expect(result.warnings).toContain("gateway:shutdown");
+    expect(
+      mocks.logWarn.mock.calls.some(([message]) =>
+        String(message).includes("gateway:shutdown hook timed out after 3000ms"),
+      ),
+    ).toBe(true);
+  });
+
+  it("uses the configured pre-restart hook timeout when preRestartHookTimeoutMs is provided", async () => {
+    vi.useFakeTimers();
+    mocks.triggerInternalHook.mockImplementation((event: InternalHookEvent) => {
+      if (event.action === "pre-restart") {
+        return new Promise<void>(() => undefined);
+      }
+      return Promise.resolve(undefined);
+    });
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({ preRestartHookTimeoutMs: 7_000 }),
+    );
+
+    const closePromise = close({ reason: "test restart", restartExpectedMs: 500 });
+    // Default 10 s should NOT fire at 7 s minus 1 ms
+    await vi.advanceTimersByTimeAsync(6_999);
+    // The configured 7 s value fires at exactly 7 000 ms
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await closePromise;
+
+    expect(result.warnings).toContain("gateway:pre-restart");
+    expect(
+      mocks.logWarn.mock.calls.some(([message]) =>
+        String(message).includes("gateway:pre-restart hook timed out after 7000ms"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not fire gateway:pre-restart when restartExpectedMs is null", async () => {
+    const close = createGatewayCloseHandler(createGatewayCloseTestDeps());
+
+    await close({ reason: "gateway stopping", restartExpectedMs: null });
+
+    const hookCalls = mocks.triggerInternalHook.mock.calls as unknown as Array<
+      [{ type?: string; action?: string }]
+    >;
+    const preRestartCalled = hookCalls.some(
+      ([event]) => event?.type === "gateway" && event?.action === "pre-restart",
+    );
+    expect(preRestartCalled).toBe(false);
+    expect(mocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+  });
+
+  it("hook failure (non-zero exit equivalent) logs a warning but does not block restart", async () => {
+    mocks.triggerInternalHook.mockImplementation((event: InternalHookEvent) => {
+      if (event.action === "pre-restart") {
+        return Promise.reject(new Error("hook script exited with code 1"));
+      }
+      return Promise.resolve(undefined);
+    });
+    const stopTaskRegistryMaintenance = vi.fn();
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({ stopTaskRegistryMaintenance }),
+    );
+
+    const result = await close({ reason: "test restart", restartExpectedMs: 500 });
+
+    // Restart continues despite the hook error
+    expect(stopTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
+    expect(result.warnings).toContain("gateway:pre-restart");
+    expect(
+      mocks.logWarn.mock.calls.some(([message]) =>
+        String(message).includes("hook script exited with code 1"),
+      ),
+    ).toBe(true);
   });
 
   it("records subsystem shutdown warnings without aborting later cleanup", async () => {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -11,8 +11,8 @@ import type { PluginServicesHandle } from "../plugins/services.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 
 const shutdownLog = createSubsystemLogger("gateway/shutdown");
-const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 1_000;
-const GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS = 1_000;
+const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 5_000;
+const GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS = 10_000;
 const ACTIVE_SESSIONS_SHUTDOWN_DRAIN_TIMEOUT_MS = 2_000;
 const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
 const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
@@ -170,6 +170,18 @@ function isServerNotRunningError(err: unknown): boolean {
 }
 
 export function createGatewayCloseHandler(params: {
+  /**
+   * Override the `gateway:shutdown` hook timeout (milliseconds).
+   * Typically sourced from `hooks.internal.gatewayShutdown.timeoutMs` in config.
+   * Falls back to `GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS` (5 000 ms) when absent.
+   */
+  shutdownHookTimeoutMs?: number | null;
+  /**
+   * Override the `gateway:pre-restart` hook timeout (milliseconds).
+   * Typically sourced from `hooks.internal.gatewayPreRestart.timeoutMs` in config.
+   * Falls back to `GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS` (10 000 ms) when absent.
+   */
+  preRestartHookTimeoutMs?: number | null;
   bonjourStop: (() => Promise<void>) | null;
   tailscaleCleanup: (() => Promise<void>) | null;
   releasePluginRouteRegistry?: (() => void) | null;
@@ -218,6 +230,15 @@ export function createGatewayCloseHandler(params: {
           : null;
       shutdownLog.info(`shutdown started: ${reason}`);
 
+      const resolvedShutdownHookTimeoutMs =
+        typeof params.shutdownHookTimeoutMs === "number" && params.shutdownHookTimeoutMs > 0
+          ? params.shutdownHookTimeoutMs
+          : GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS;
+      const resolvedPreRestartHookTimeoutMs =
+        typeof params.preRestartHookTimeoutMs === "number" && params.preRestartHookTimeoutMs > 0
+          ? params.preRestartHookTimeoutMs
+          : GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS;
+
       await shutdownStep(
         "gateway:shutdown",
         async () => {
@@ -228,7 +249,7 @@ export function createGatewayCloseHandler(params: {
           const result = await triggerGatewayLifecycleHookWithTimeout({
             event: shutdownEvent,
             hookName: "gateway:shutdown",
-            timeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
+            timeoutMs: resolvedShutdownHookTimeoutMs,
           });
           if (result === "timeout") {
             recordShutdownWarning(warnings, "gateway:shutdown");
@@ -252,7 +273,7 @@ export function createGatewayCloseHandler(params: {
             const result = await triggerGatewayLifecycleHookWithTimeout({
               event: preRestartEvent,
               hookName: "gateway:pre-restart",
-              timeoutMs: GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS,
+              timeoutMs: resolvedPreRestartHookTimeoutMs,
             });
             if (result === "timeout") {
               recordShutdownWarning(warnings, "gateway:pre-restart");

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -965,7 +965,10 @@ export async function startGatewayServer(
       const channelIds = listLoadedChannelPlugins().map((plugin) => plugin.id as ChannelId);
       const { createGatewayCloseHandler, drainActiveSessionsForShutdown } =
         await loadGatewayCloseModule();
+      const runtimeCfg = getRuntimeConfig();
       await createGatewayCloseHandler({
+        shutdownHookTimeoutMs: runtimeCfg.hooks?.internal?.gatewayShutdown?.timeoutMs,
+        preRestartHookTimeoutMs: runtimeCfg.hooks?.internal?.gatewayPreRestart?.timeoutMs,
         bonjourStop: runtimeState.bonjourStop,
         tailscaleCleanup: runtimeState.tailscaleCleanup,
         releasePluginRouteRegistry,


### PR DESCRIPTION
## Summary

Raises the default timeout budgets for the `gateway:shutdown` and `gateway:pre-restart` lifecycle hooks and makes them configurable via `openclaw.config.js`. Closes #6711.

### Motivation

The previous 1 s timeout was too tight for the primary `gateway:pre-restart` use-case: calling `openclaw sessions send` to notify running agents that a restart is coming. A single round-trip to notify an agent can easily exceed 1 s on a loaded system. The new defaults (5 s for shutdown, 10 s for pre-restart) match the actual time budget available for graceful notification scripts.

### Before / After

| Hook | Before | After (default) | Config key |
|---|---|---|---|
| `gateway:shutdown` | 1 000 ms | **5 000 ms** | `hooks.internal.gatewayShutdown.timeoutMs` |
| `gateway:pre-restart` | 1 000 ms | **10 000 ms** | `hooks.internal.gatewayPreRestart.timeoutMs` |

### Changes

**S2569 — Raise timeout constants** (`src/gateway/server-close.ts`)
- `GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS`: 1 000 → 5 000
- `GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS`: 1 000 → 10 000

**S2570 — Make timeouts config-driven** (`src/config/types.hooks.ts`, `src/gateway/server-close.ts`, `src/gateway/server.impl.ts`)
- New `GatewayLifecycleHookConfig` type with `timeoutMs?: number`
- New `gatewayShutdown` / `gatewayPreRestart` fields on `InternalHooksConfig`
- `createGatewayCloseHandler` accepts optional `shutdownHookTimeoutMs` / `preRestartHookTimeoutMs` params
- `server.impl.ts` reads them from live config and passes through

**S2571 — Docs** (`docs/automation/hooks.md`)
- Added env-var reference table: `OPENCLAW_EVENT`, `OPENCLAW_GATEWAY_SHUTDOWN_REASON`, `OPENCLAW_RESTART_EXPECTED_MS`
- Added shell script example showing a `gateway:pre-restart` handler calling `openclaw sessions send`
- Added configuration section for timeout overrides with before/after table

**S2572 — Tests** (`src/gateway/server-close.test.ts`)
- Updated existing stall tests to use new 5 000 / 10 000 ms defaults
- Added: config override respected over defaults (both hooks)
- Added: `gateway:pre-restart` does NOT fire when `restartExpectedMs` is null
- Added: hook failure (non-zero exit) logs warning but does NOT block restart
- All 27 tests pass

### Config example

```json
{
  "hooks": {
    "internal": {
      "gatewayPreRestart": { "timeoutMs": 15000 },
      "gatewayShutdown": { "timeoutMs": 8000 }
    }
  }
}
```

### No breaking changes

Existing hooks work unchanged. The only behavioral difference is that scripts that previously hit the 1 s limit silently now have 5–10 s to complete.