### PR TITLE
refactor: centralize channel turn media facts

### DIFF
--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -2,6 +2,7 @@ import {
   buildChannelTurnContext,
   formatInboundEnvelope,
   resolveEnvelopeFormatOptions,
+  toInboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context-visibility-runtime";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/conversation-runtime";
@@ -397,11 +398,9 @@ export async function buildDiscordMessageProcessContext(params: {
       authorized: commandAuthorized,
       body: preflightAudioTranscript ?? baseText,
     },
-    media: mediaListForContext.map((media, index) => ({
-      path: media.path,
-      contentType: media.contentType,
-      transcribed: index === preflightAudioIndex,
-    })),
+    media: toInboundMediaFacts(mediaListForContext, {
+      transcribed: (_media, index) => index === preflightAudioIndex,
+    }),
     supplemental: {
       quote: filteredReplyContext
         ? {

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -4,6 +4,7 @@ import {
   buildMentionRegexes,
   logInboundDrop,
   resolveInboundMentionDecision,
+  toInboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
 import { shouldHandleTextCommands } from "openclaw/plugin-sdk/command-surface";
@@ -107,14 +108,7 @@ function isDiscordImageAttachmentCandidate(attachment: {
 async function resolveDiscordHistoryMediaForPendingRecord(params: {
   preflight: DiscordMessagePreflightParams;
   message: DiscordMessagePreflightContext["message"];
-}): Promise<
-  Array<{
-    path: string;
-    contentType?: string;
-    kind: "image";
-    messageId: string;
-  }>
-> {
+}) {
   const imageAttachments = (params.message.attachments ?? [])
     .filter(isDiscordImageAttachmentCandidate)
     .slice(0, DISCORD_HISTORY_MEDIA_MAX_ATTACHMENTS);
@@ -159,12 +153,7 @@ async function resolveDiscordHistoryMediaForPendingRecord(params: {
       abortSignal: params.preflight.abortSignal,
     },
   );
-  return mediaList.map((media) => ({
-    path: media.path,
-    contentType: media.contentType,
-    kind: "image" as const,
-    messageId: params.message.id,
-  }));
+  return toInboundMediaFacts(mediaList, { kind: "image", messageId: params.message.id });
 }
 
 async function recordDiscordPendingHistoryEntry(params: {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -11,6 +11,7 @@ import {
   logInboundDrop,
   matchesMentionWithExplicit,
   resolveEnvelopeFormatOptions,
+  toInboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveChannelMessageSourceReplyDeliveryMode } from "openclaw/plugin-sdk/channel-message";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
@@ -164,14 +165,7 @@ async function resolveSlackHistoryMediaForPendingRecord(params: {
   isThreadReply: boolean;
   threadStarter: SlackThreadStarter | null;
   isBotMessage: boolean;
-}): Promise<
-  Array<{
-    path: string;
-    contentType?: string;
-    kind: "image";
-    messageId?: string;
-  }>
-> {
+}) {
   const mediaMessage = buildSlackHistoryMediaCandidateMessage(params.message);
   if (!mediaMessage) {
     return [];
@@ -187,12 +181,10 @@ async function resolveSlackHistoryMediaForPendingRecord(params: {
     mediaReadIdleTimeoutMs: SLACK_HISTORY_MEDIA_IDLE_TIMEOUT_MS,
     mediaTotalTimeoutMs: SLACK_HISTORY_MEDIA_TOTAL_TIMEOUT_MS,
   });
-  return (content?.effectiveDirectMedia ?? []).map((media) => ({
-    path: media.path,
-    contentType: media.contentType,
-    kind: "image" as const,
+  return toInboundMediaFacts(content?.effectiveDirectMedia, {
+    kind: "image",
     messageId: params.message.ts,
-  }));
+  });
 }
 
 type SlackConversationContext = {
@@ -1129,10 +1121,7 @@ export async function prepareSlackMessage(params: {
         authorizers: [],
       },
     },
-    media: effectiveMedia?.map((media) => ({
-      path: media.path,
-      contentType: media.contentType,
-    })),
+    media: toInboundMediaFacts(effectiveMedia),
     supplemental: {
       thread: {
         // Only include thread starter body for NEW sessions (existing sessions already have it in their transcript)

--- a/src/channels/turn/context.test.ts
+++ b/src/channels/turn/context.test.ts
@@ -150,7 +150,7 @@ describe("buildChannelTurnContext", () => {
       MediaPath: "/tmp/image.png",
       MediaUrl: "/tmp/image.png",
       MediaType: "image/png",
-      MediaPaths: ["/tmp/image.png"],
+      MediaPaths: ["/tmp/image.png", ""],
       MediaUrls: ["/tmp/image.png", "https://example.test/audio.mp3"],
       MediaTypes: ["image/png", "audio/mpeg"],
       MediaTranscribedIndexes: [1],

--- a/src/channels/turn/context.ts
+++ b/src/channels/turn/context.ts
@@ -7,6 +7,7 @@ import { finalizeInboundContext } from "../../auto-reply/reply/inbound-context.j
 import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
 import type { ContextVisibilityMode } from "../../config/types.base.js";
 import { shouldIncludeSupplementalContext } from "../../security/context-visibility.js";
+import { buildChannelTurnMediaPayload } from "./media.js";
 import type {
   AccessFacts,
   CommandFacts,
@@ -54,18 +55,6 @@ export type BuiltChannelTurnContext = FinalizedMsgContext & {
   SessionKey: string;
   To: string;
 };
-
-function compactStrings(values: Array<string | undefined>): string[] | undefined {
-  const compacted = values.filter((value): value is string => Boolean(value));
-  return compacted.length > 0 ? compacted : undefined;
-}
-
-function mediaTranscribedIndexes(media: InboundMediaFacts[]): number[] | undefined {
-  const indexes = media
-    .map((item, index) => (item.transcribed ? index : undefined))
-    .filter((index): index is number => index !== undefined);
-  return indexes.length > 0 ? indexes : undefined;
-}
 
 function keepSupplementalContext(params: {
   mode?: ContextVisibilityMode;
@@ -158,6 +147,7 @@ export function buildChannelTurnContext(
   params: BuildChannelTurnContextParams,
 ): BuiltChannelTurnContext {
   const media = params.media ?? [];
+  const mediaPayload = buildChannelTurnMediaPayload(media);
   const supplemental = filterChannelTurnSupplementalContext({
     supplemental: params.supplemental,
     contextVisibility: params.contextVisibility,
@@ -197,13 +187,7 @@ export function buildChannelTurnContext(
     ThreadStarterBody: supplemental?.thread?.starterBody,
     ThreadHistoryBody: supplemental?.thread?.historyBody,
     ThreadLabel: supplemental?.thread?.label,
-    MediaPath: media[0]?.path,
-    MediaUrl: media[0]?.url ?? media[0]?.path,
-    MediaType: media[0]?.contentType ?? media[0]?.kind,
-    MediaPaths: compactStrings(media.map((item) => item.path)),
-    MediaUrls: compactStrings(media.map((item) => item.url ?? item.path)),
-    MediaTypes: compactStrings(media.map((item) => item.contentType ?? item.kind)),
-    MediaTranscribedIndexes: mediaTranscribedIndexes(media),
+    ...mediaPayload,
     ChatType: params.conversation.kind,
     ConversationLabel: params.conversation.label,
     GroupSubject: params.conversation.kind !== "direct" ? params.conversation.label : undefined,

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -3,7 +3,6 @@ import {
   clearHistoryEntriesIfEnabled,
   recordPendingHistoryEntryWithMedia,
 } from "../../auto-reply/reply/history.js";
-import type { HistoryMediaEntry } from "../../auto-reply/reply/history.types.js";
 import { createChannelReplyPipeline } from "../message/reply-pipeline.js";
 import type { CreateChannelReplyPipelineParams } from "../message/reply-pipeline.js";
 import { recordChannelBotPairLoopAndCheckSuppression } from "./bot-loop-protection.js";
@@ -13,6 +12,7 @@ import {
   isDurableInboundReplyDeliveryHandled,
   throwIfDurableInboundReplyDeliveryFailed,
 } from "./durable-delivery.js";
+import { toHistoryMediaEntries } from "./media.js";
 export { buildChannelTurnContext, filterChannelTurnSupplementalContext } from "./context.js";
 export type { BuildChannelTurnContextParams } from "./context.js";
 export {
@@ -44,7 +44,6 @@ import type {
   ChannelTurnResolved,
   ChannelTurnResult,
   DispatchedChannelTurnResult,
-  InboundMediaFacts,
   NormalizedTurnInput,
   PreparedChannelTurn,
   PreflightFacts,
@@ -79,7 +78,6 @@ export type {
   ChannelTurnResult,
   DispatchedChannelTurnResult,
   ConversationFacts,
-  InboundMediaFacts,
   MessageFacts,
   NormalizedTurnInput,
   PreflightFacts,
@@ -91,6 +89,7 @@ export type {
   SenderFacts,
   SupplementalContextFacts,
 } from "./types.js";
+export type { InboundMediaFacts } from "./types.js";
 
 const DEFAULT_EVENT_CLASS: ChannelEventClass = {
   kind: "message",
@@ -161,22 +160,6 @@ function clearPendingHistoryAfterTurn(params?: ChannelTurnHistoryFinalizeOptions
   });
 }
 
-function historyMediaFromInboundFacts(
-  media: readonly InboundMediaFacts[] | readonly HistoryMediaEntry[] | null | undefined,
-  messageId: string,
-): HistoryMediaEntry[] {
-  if (!Array.isArray(media)) {
-    return [];
-  }
-  return media.map((entry) => ({
-    path: entry.path,
-    url: entry.url,
-    contentType: entry.contentType,
-    kind: entry.kind,
-    messageId: entry.messageId ?? messageId,
-  }));
-}
-
 function resolveDroppedHistorySender(input: NormalizedTurnInput, preflight: PreflightFacts) {
   return (
     preflight.message?.senderLabel ??
@@ -235,8 +218,8 @@ export async function recordDroppedChannelTurnHistory(params: {
     shouldRecord: history.shouldRecord,
     media:
       typeof media === "function"
-        ? async () => historyMediaFromInboundFacts(await media(), params.input.id)
-        : historyMediaFromInboundFacts(media, params.input.id),
+        ? async () => toHistoryMediaEntries(await media(), { messageId: params.input.id })
+        : toHistoryMediaEntries(media, { messageId: params.input.id }),
   });
 }
 

--- a/src/channels/turn/media.test.ts
+++ b/src/channels/turn/media.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAttachments } from "../../media-understanding/attachments.normalize.js";
+import {
+  buildChannelTurnMediaPayload,
+  toHistoryMediaEntries,
+  toInboundMediaFacts,
+} from "./media.js";
+
+describe("channel turn media facts", () => {
+  it("normalizes provider media into inbound media facts", () => {
+    expect(
+      toInboundMediaFacts(
+        [
+          {
+            path: " /tmp/image.png ",
+            contentType: " image/png ",
+            messageId: " ",
+          },
+          {
+            url: "https://example.test/audio.mp3",
+            contentType: "audio/mpeg",
+            kind: "audio",
+          },
+        ],
+        {
+          kind: "image",
+          messageId: "msg-1",
+          transcribed: (_media, index) => index === 1,
+        },
+      ),
+    ).toEqual([
+      {
+        path: "/tmp/image.png",
+        url: undefined,
+        contentType: "image/png",
+        kind: "image",
+        transcribed: false,
+        messageId: "msg-1",
+      },
+      {
+        path: undefined,
+        url: "https://example.test/audio.mp3",
+        contentType: "audio/mpeg",
+        kind: "audio",
+        transcribed: true,
+        messageId: "msg-1",
+      },
+    ]);
+  });
+
+  it("builds legacy media payload fields from inbound media facts", () => {
+    expect(
+      buildChannelTurnMediaPayload([
+        { path: "/tmp/image.png", contentType: "image/png", kind: "image" },
+        {
+          url: "https://example.test/audio.mp3",
+          contentType: "audio/mpeg",
+          kind: "audio",
+          transcribed: true,
+        },
+      ]),
+    ).toEqual({
+      MediaPath: "/tmp/image.png",
+      MediaUrl: "/tmp/image.png",
+      MediaType: "image/png",
+      MediaPaths: ["/tmp/image.png", ""],
+      MediaUrls: ["/tmp/image.png", "https://example.test/audio.mp3"],
+      MediaTypes: ["image/png", "audio/mpeg"],
+      MediaTranscribedIndexes: [1],
+    });
+  });
+
+  it("keeps legacy media arrays index-aligned for mixed path and URL media", () => {
+    const payload = buildChannelTurnMediaPayload([
+      { path: "/tmp/image.png", contentType: "image/png", kind: "image" },
+      { url: "https://example.test/remote.png", contentType: "image/png", kind: "image" },
+    ]);
+
+    expect(payload.MediaPaths).toEqual(["/tmp/image.png", ""]);
+    expect(payload.MediaUrls).toEqual(["/tmp/image.png", "https://example.test/remote.png"]);
+    expect(payload.MediaTypes).toEqual(["image/png", "image/png"]);
+    expect(normalizeAttachments(payload)).toMatchObject([
+      { path: "/tmp/image.png", url: "/tmp/image.png", mime: "image/png" },
+      { path: undefined, url: "https://example.test/remote.png", mime: "image/png" },
+    ]);
+  });
+
+  it("maps inbound media facts into history media entries", () => {
+    expect(
+      toHistoryMediaEntries([{ path: "/tmp/image.png", contentType: "image/png" }], {
+        kind: "image",
+        messageId: "msg-1",
+      }),
+    ).toEqual([
+      {
+        path: "/tmp/image.png",
+        url: undefined,
+        contentType: "image/png",
+        kind: "image",
+        messageId: "msg-1",
+      },
+    ]);
+  });
+});

--- a/src/channels/turn/media.ts
+++ b/src/channels/turn/media.ts
@@ -1,0 +1,96 @@
+import type { HistoryMediaEntry } from "../../auto-reply/reply/history.types.js";
+import type { InboundMediaFacts } from "./types.js";
+
+export type ChannelTurnMediaInput = {
+  path?: string | null;
+  url?: string | null;
+  contentType?: string | null;
+  kind?: InboundMediaFacts["kind"] | null;
+  transcribed?: boolean | null;
+  messageId?: string | null;
+};
+
+export type ChannelTurnMediaPayload = {
+  MediaPath?: string;
+  MediaUrl?: string;
+  MediaType?: string;
+  MediaPaths?: string[];
+  MediaUrls?: string[];
+  MediaTypes?: string[];
+  MediaTranscribedIndexes?: number[];
+};
+
+function alignedStrings(values: Array<string | undefined>): string[] | undefined {
+  if (!values.some(Boolean)) {
+    return undefined;
+  }
+  return values.map((value) => value ?? "");
+}
+
+function normalizeString(value: string | null | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function normalizeKind(value: InboundMediaFacts["kind"] | null | undefined) {
+  return value ?? undefined;
+}
+
+function mediaType(media: InboundMediaFacts): string | undefined {
+  return media.contentType ?? media.kind;
+}
+
+export function toInboundMediaFacts(
+  media: readonly ChannelTurnMediaInput[] | null | undefined,
+  defaults: {
+    kind?: InboundMediaFacts["kind"];
+    messageId?: string;
+    transcribed?: (media: ChannelTurnMediaInput, index: number) => boolean;
+  } = {},
+): InboundMediaFacts[] {
+  if (!Array.isArray(media)) {
+    return [];
+  }
+  return media.map((entry, index) => ({
+    path: normalizeString(entry.path),
+    url: normalizeString(entry.url),
+    contentType: normalizeString(entry.contentType),
+    kind: normalizeKind(entry.kind) ?? defaults.kind,
+    transcribed: entry.transcribed === true || defaults.transcribed?.(entry, index) === true,
+    messageId: normalizeString(entry.messageId) ?? defaults.messageId,
+  }));
+}
+
+export function toHistoryMediaEntries(
+  media: readonly ChannelTurnMediaInput[] | null | undefined,
+  defaults: {
+    kind?: InboundMediaFacts["kind"];
+    messageId?: string;
+  } = {},
+): HistoryMediaEntry[] {
+  return toInboundMediaFacts(media, defaults).map((entry) => ({
+    path: entry.path,
+    url: entry.url,
+    contentType: entry.contentType,
+    kind: entry.kind,
+    messageId: entry.messageId,
+  }));
+}
+
+export function buildChannelTurnMediaPayload(
+  media: readonly InboundMediaFacts[] | null | undefined,
+): ChannelTurnMediaPayload {
+  const entries = Array.isArray(media) ? media : [];
+  const transcribedIndexes = entries
+    .map((item, index) => (item.transcribed ? index : undefined))
+    .filter((index): index is number => index !== undefined);
+  return {
+    MediaPath: entries[0]?.path,
+    MediaUrl: entries[0]?.url ?? entries[0]?.path,
+    MediaType: entries[0] ? mediaType(entries[0]) : undefined,
+    MediaPaths: alignedStrings(entries.map((item) => item.path)),
+    MediaUrls: alignedStrings(entries.map((item) => item.url ?? item.path)),
+    MediaTypes: alignedStrings(entries.map(mediaType)),
+    MediaTranscribedIndexes: transcribedIndexes.length > 0 ? transcribedIndexes : undefined,
+  };
+}

--- a/src/plugin-sdk/channel-inbound.ts
+++ b/src/plugin-sdk/channel-inbound.ts
@@ -58,7 +58,13 @@ export type {
   BuildChannelTurnContextParams,
   BuiltChannelTurnContext,
 } from "../channels/turn/context.js";
-export type { CommandFacts } from "../channels/turn/types.js";
+export {
+  buildChannelTurnMediaPayload,
+  toHistoryMediaEntries,
+  toInboundMediaFacts,
+} from "../channels/turn/media.js";
+export type { ChannelTurnMediaInput, ChannelTurnMediaPayload } from "../channels/turn/media.js";
+export type { CommandFacts, InboundMediaFacts } from "../channels/turn/types.js";
 export {
   createCommandTurnContext,
   isAuthorizedTextSlashCommandTurn,


### PR DESCRIPTION
## Summary

- add a core channel-turn media helper for inbound media facts, history media entries, and legacy `MediaPath`/`MediaPaths` payload fields
- route Discord and Slack current/history media through `toInboundMediaFacts` instead of adapter-local object maps
- preserve mixed local-path plus URL-only media by keeping legacy media arrays index-aligned for downstream attachment normalization

## Verification

- `node scripts/run-vitest.mjs src/channels/turn/media.test.ts src/channels/turn/context.test.ts src/channels/turn/kernel.test.ts extensions/discord/src/monitor/message-handler.preflight.test.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental false`
- `pnpm plugin-sdk:api:check`
- `node scripts/run-oxlint.mjs src/channels/turn/media.ts src/channels/turn/media.test.ts src/channels/turn/context.ts src/channels/turn/context.test.ts src/channels/turn/kernel.ts src/plugin-sdk/channel-inbound.ts extensions/discord/src/monitor/message-handler.context.ts extensions/discord/src/monitor/message-handler.preflight.ts extensions/slack/src/monitor/message-handler/prepare.ts`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode auto`

## Real behavior proof

Behavior addressed: channel adapters now pass generic inbound media facts while core owns context/history media shaping for the model turn.
Real environment tested: local OpenClaw checkout on branch `refactor/channel-turn-media-facts` at `cbe74306da`.
Exact steps or command run after this patch: focused Vitest for turn media/context/kernel plus Discord/Slack media paths; core and extensions tsgo; plugin SDK API check; targeted oxlint; Codex review.
Evidence after fix: focused Vitest passed 6 files / 211 tests; core and extensions tsgo exited 0; plugin SDK API hash check exited 0; targeted oxlint found 0 warnings and 0 errors; Codex review reported no accepted/actionable findings.
Observed result after fix: Discord and Slack retain current/history media behavior through the shared core helper, and mixed path/URL media stays visible to attachment normalization instead of losing URL-only entries.
What was not tested: full `pnpm check:changed` did not complete because latest main currently fails unrelated core lint in `src/commands/doctor-cron.ts` (`Array#sort()` should be `toSorted()`).
