### PR TITLE
docs: document channel turn guardrails

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-d9bc6e6c97408d5811ba8e811a259864d5786ec9f8306c2d74d8c3fc144bb477  plugin-sdk-api-baseline.json
-299c40530cd524c20e74ae149a1267d3cb08f21812dcec2564264f979b369484  plugin-sdk-api-baseline.jsonl
+01967db7ff4d52e187f557a21f6433f7640542b96872eee9d4e97c72e7a4e30c  plugin-sdk-api-baseline.json
+c88fe1415b3fde1ba1ede62222022768695054c2ad5c97a5975dbe28cd03df75  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-channel-turn.md
+++ b/docs/plugins/sdk-channel-turn.md
@@ -315,6 +315,148 @@ Supplemental context covers quote, forwarded, and thread-bootstrap context. The 
 
 Media is fact-shaped. Platform download, auth, SSRF policy, CDN rules, and decryption stay channel-local. The kernel maps facts into `MediaPath`, `MediaUrl`, `MediaType`, `MediaPaths`, `MediaUrls`, `MediaTypes`, and `MediaTranscribedIndexes`.
 
+Use `toInboundMediaFacts(...)` from `openclaw/plugin-sdk/channel-inbound` when
+your channel has a resolved media list and only needs to attach generic facts:
+
+```typescript
+media: toInboundMediaFacts(resolvedMedia, {
+  kind: "image",
+  messageId: input.id,
+});
+```
+
+If media mixes local files and URL-only entries, keep the list as media facts.
+Core preserves array indexes when it writes legacy context fields so downstream
+media understanding, transcription markers, and prompt notes continue to refer
+to the same attachment.
+
+For skipped group messages that should be available to a later mention, pass
+media facts through the turn `preflight.media` field. The kernel converts those
+facts into bounded history media entries before recording:
+
+```typescript
+preflight(input) {
+  return {
+    admission: { kind: "drop", reason: "missing_mention", recordHistory: true },
+    media: () => toInboundMediaFacts(resolveLocalImages(input), {
+      kind: "image",
+      messageId: input.id,
+    }),
+    history: {
+      key: historyKey,
+      limit: historyLimit,
+      mediaLimit: 4,
+      shouldRecord: () => stillCurrent(input),
+    },
+  };
+}
+```
+
+History media is intentionally conservative: image-only today, local readable
+paths only, bounded by the configured media limit, and still tied to the
+channel history key. Authenticated provider URLs should be downloaded by the
+plugin before they become model-visible media.
+
+## History windows
+
+Message-turn code should use `createChannelHistoryWindow(...)` instead of
+calling low-level `reply-history` map helpers directly. The window facade keeps
+text context, structured `InboundHistory`, history-media normalization, and
+clearing behind one core-owned API while still letting the channel choose how a
+history line is rendered.
+
+```typescript
+const history = createChannelHistoryWindow({ historyMap: groupHistories });
+
+await history.recordWithMedia({
+  historyKey,
+  limit: historyLimit,
+  entry,
+  media: () =>
+    toInboundMediaFacts(resolvedImages, {
+      kind: "image",
+      messageId: entry.messageId,
+    }),
+});
+
+const combinedBody = history.buildPendingContext({
+  historyKey,
+  limit: historyLimit,
+  currentMessage,
+  formatEntry: (entry) => `${entry.sender}: ${entry.body}`,
+});
+```
+
+The older `buildPendingHistoryContextFromMap`,
+`buildInboundHistoryFromMap`, `recordPendingHistoryEntry*`, and
+`clearHistoryEntriesIfEnabled` exports remain for compatibility with plugins
+that have not migrated yet. New channel work should use the window or the turn
+kernel record/finalize options.
+
+## Common message patterns
+
+Text-only group with mention required:
+
+```typescript
+preflight(input) {
+  const decision = resolveInboundMentionDecision({ facts, policy });
+  if (decision.shouldSkip) {
+    return {
+      admission: { kind: "drop", reason: "missing_mention", recordHistory: true },
+      history: { key: historyKey, limit: historyLimit },
+    };
+  }
+  return { access: { mentions: decision } };
+}
+```
+
+Image-only message followed by a later mention:
+
+```typescript
+preflight(input) {
+  if (!wasMentioned && resolvedImages.length > 0) {
+    return {
+      admission: { kind: "drop", reason: "missing_mention", recordHistory: true },
+      media: () => toInboundMediaFacts(resolvedImages, {
+        kind: "image",
+        messageId: input.id,
+      }),
+      history: { key: historyKey, limit: historyLimit, mediaLimit: 4 },
+    };
+  }
+  return {};
+}
+```
+
+Explicit reply-to-image:
+
+```typescript
+resolveTurn(input, _eventClass, preflight) {
+  return {
+    ...assembled,
+    media: toInboundMediaFacts([...currentMedia, ...referencedReplyMedia]),
+    supplemental: {
+      quote: preflight.supplemental?.quote,
+    },
+  };
+}
+```
+
+Direct message with history:
+
+```typescript
+resolveTurn(input) {
+  return {
+    ...assembled,
+    history: undefined,
+    message: {
+      rawBody: input.rawText,
+      bodyForAgent: input.textForAgent,
+    },
+  };
+}
+```
+
 ## Adapter contract
 
 For full `run`, the adapter shape is:

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -244,7 +244,7 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/approval-runtime` | Exec/plugin approval helpers, approval-capability builders, auth/profile helpers, native routing/runtime helpers, and structured approval display path formatting |
     | `plugin-sdk/reply-runtime` | Shared inbound/reply runtime helpers, chunking, dispatch, heartbeat, reply planner |
     | `plugin-sdk/reply-dispatch-runtime` | Narrow reply dispatch/finalize and conversation-label helpers |
-    | `plugin-sdk/reply-history` | Shared short-window reply-history helpers and markers such as `buildHistoryContext`, `HISTORY_CONTEXT_MARKER`, `recordPendingHistoryEntry`, and `clearHistoryEntriesIfEnabled` |
+    | `plugin-sdk/reply-history` | Shared short-window reply-history compatibility helpers. New message-turn code should use `createChannelHistoryWindow` rather than the lower-level map helpers |
     | `plugin-sdk/reply-reference` | `createReplyReferencePlanner` |
     | `plugin-sdk/reply-chunking` | Narrow text/markdown chunking helpers |
     | `plugin-sdk/session-store-runtime` | Session store path, session-key, updated-at, and store mutation helpers |

--- a/src/channels/turn/message-turn-guardrails.test.ts
+++ b/src/channels/turn/message-turn-guardrails.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+const migratedMessageTurnFiles = [
+  "extensions/discord/src/monitor/message-handler.context.ts",
+  "extensions/discord/src/monitor/message-handler.preflight.ts",
+  "extensions/slack/src/monitor/message-handler/prepare.ts",
+  "extensions/zalouser/src/monitor.ts",
+];
+
+const historyWindowFiles = [
+  "extensions/discord/src/monitor/message-handler.context.ts",
+  "extensions/slack/src/monitor/message-handler/prepare.ts",
+  "extensions/zalouser/src/monitor.ts",
+];
+
+const lowLevelHistoryHelpers = [
+  "buildInboundHistoryFromMap",
+  "buildPendingHistoryContextFromMap",
+  "clearHistoryEntriesIfEnabled",
+  "recordPendingHistoryEntry",
+  "recordPendingHistoryEntryIfEnabled",
+  "recordPendingHistoryEntryWithMedia",
+];
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+describe("message turn migration guardrails", () => {
+  it("keeps migrated message paths off low-level reply-history helpers", () => {
+    for (const file of migratedMessageTurnFiles) {
+      const source = readRepoFile(file);
+      for (const helper of lowLevelHistoryHelpers) {
+        expect(source, `${file} should use the channel history window, not ${helper}`).not.toMatch(
+          new RegExp(`\\b${helper}\\b`),
+        );
+      }
+    }
+  });
+
+  it("keeps migrated history users on the channel history window facade", () => {
+    for (const file of historyWindowFiles) {
+      expect(readRepoFile(file), `${file} should keep using createChannelHistoryWindow`).toContain(
+        "createChannelHistoryWindow",
+      );
+    }
+  });
+});

--- a/src/plugin-sdk/reply-history.ts
+++ b/src/plugin-sdk/reply-history.ts
@@ -1,4 +1,9 @@
-/** Shared reply-history helpers for plugins that keep short per-thread context windows. */
+/**
+ * Shared reply-history helpers for plugins that keep short per-thread context windows.
+ *
+ * Prefer `createChannelHistoryWindow` for message-turn code. The lower-level map helpers remain
+ * exported for older plugins and adapter bridges that have not migrated to the channel turn kernel.
+ */
 export type { HistoryEntry, HistoryMediaEntry } from "../auto-reply/reply/history.types.js";
 export {
   createChannelHistoryWindow,


### PR DESCRIPTION
## Summary

- add a core guardrail test so migrated Discord, Slack, and Zalo message-turn paths keep using the channel history window instead of low-level reply-history map helpers
- document `toInboundMediaFacts`, recent/skipped-message media handoff, and `createChannelHistoryWindow` in the channel turn SDK guide
- mark low-level `reply-history` exports as compatibility helpers and refresh the Plugin SDK API hash after source-link line drift

## Verification

- `node scripts/run-vitest.mjs src/channels/turn/message-turn-guardrails.test.ts src/channels/turn/history-window.test.ts src/channels/turn/media.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false`
- `pnpm plugin-sdk:api:check`
- `node scripts/run-oxlint.mjs src/channels/turn/message-turn-guardrails.test.ts src/plugin-sdk/reply-history.ts`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode auto`

## Real behavior proof

Behavior addressed: migrated message-turn paths are guarded against reintroducing adapter-local low-level history handling, and SDK docs now describe the core-owned media/history handoff.
Real environment tested: local OpenClaw checkout on branch `refactor/message-sdk-guardrails` at `577f0e06ad`.
Exact steps or command run after this patch: focused Vitest for guardrails/history/media; core tsgo; Plugin SDK API check; targeted oxlint; diff whitespace check; Codex review.
Evidence after fix: focused Vitest passed 3 files / 7 tests; core tsgo exited 0; Plugin SDK API check exited 0; targeted oxlint found 0 warnings and 0 errors; `git diff --check` exited 0; Codex review reported no accepted/actionable findings.
Observed result after fix: Discord, Slack, and Zalo migrated message-turn files cannot silently call raw `reply-history` map helpers again without a failing test.
What was not tested: no live channel runtime; this PR is docs plus guardrail coverage only.
