### PR TITLE
fix: preserve media completion message-tool delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/media: preserve message-tool-only delivery for generated music and video completion handoffs, so group/channel completions do not finish without posting the generated attachment.
 - LINE: acknowledge signed webhook events before agent processing so slow model replies do not cause LINE `request_timeout` delivery failures. Fixes #65375. Thanks @myericho.
 - TTS: preserve channel-derived voice-note delivery for `/tts audio` replies even when the provider output is not natively voice-compatible. (#82174) Thanks @xuruiray.
 - Codex/Lossless: keep Codex explicit compaction on native app-server threads while allowing Lossless through the context-engine slot; `openclaw doctor --fix` now migrates legacy `compaction.provider: "lossless-claw"` config to `plugins.slots.contextEngine`.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -751,6 +751,7 @@ public struct AgentParams: Codable, Sendable {
     public let internalruntimehandoffid: String?
     public let internalevents: [[String: AnyCodable]]?
     public let inputprovenance: [String: AnyCodable]?
+    public let sourcereplydeliverymode: AnyCodable?
     public let voicewaketrigger: String?
     public let idempotencykey: String
     public let label: String?
@@ -788,6 +789,7 @@ public struct AgentParams: Codable, Sendable {
         internalruntimehandoffid: String?,
         internalevents: [[String: AnyCodable]]?,
         inputprovenance: [String: AnyCodable]?,
+        sourcereplydeliverymode: AnyCodable?,
         voicewaketrigger: String?,
         idempotencykey: String,
         label: String?)
@@ -824,6 +826,7 @@ public struct AgentParams: Codable, Sendable {
         self.internalruntimehandoffid = internalruntimehandoffid
         self.internalevents = internalevents
         self.inputprovenance = inputprovenance
+        self.sourcereplydeliverymode = sourcereplydeliverymode
         self.voicewaketrigger = voicewaketrigger
         self.idempotencykey = idempotencykey
         self.label = label
@@ -862,6 +865,7 @@ public struct AgentParams: Codable, Sendable {
         case internalruntimehandoffid = "internalRuntimeHandoffId"
         case internalevents = "internalEvents"
         case inputprovenance = "inputProvenance"
+        case sourcereplydeliverymode = "sourceReplyDeliveryMode"
         case voicewaketrigger = "voiceWakeTrigger"
         case idempotencykey = "idempotencyKey"
         case label

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -630,6 +630,7 @@ export function runAgentAttempt(params: {
     toolsAllow: params.opts.toolsAllow,
     internalEvents: params.opts.internalEvents,
     inputProvenance: params.opts.inputProvenance,
+    sourceReplyDeliveryMode: params.opts.sourceReplyDeliveryMode,
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -1,6 +1,7 @@
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import type { SpawnedRunMetadata } from "../../agents/spawned-context.js";
 import type { PromptMode } from "../../agents/system-prompt.types.js";
+import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.public.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
@@ -105,6 +106,8 @@ export type AgentCommandOpts = {
   bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   internalEvents?: AgentInternalEvent[];
   inputProvenance?: InputProvenance;
+  /** Visible source replies must be sent through the message tool when set. */
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   /** Per-call stream param overrides (best-effort). */
   streamParams?: AgentStreamParams;
   /** Explicit workspace directory override (for subagents to inherit parent workspace). */

--- a/src/agents/pi-embedded-runner/run-state.ts
+++ b/src/agents/pi-embedded-runner/run-state.ts
@@ -1,3 +1,4 @@
+import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import {
   getActiveReplyRunCount,
   listActiveReplyRunSessionIds,
@@ -11,11 +12,13 @@ export type EmbeddedPiQueueHandle = {
   isCompacting: () => boolean;
   cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;
   abort: () => void;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };
 
 export type EmbeddedPiQueueMessageOptions = {
   steeringMode?: "all";
   debounceMs?: number;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };
 
 export type ActiveEmbeddedRunSnapshot = {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2902,6 +2902,7 @@ export async function runEmbeddedAttempt(
         },
         isStreaming: () => activeSession.isStreaming,
         isCompacting: () => subscription.isCompacting(),
+        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
         cancel: () => {
           abortRun();
         },

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -73,16 +73,46 @@ describe("pi-embedded runner run registry", () => {
     const queueMessage = vi.fn(async () => {});
     setActiveEmbeddedRun("session-steer", {
       ...createRunHandle(),
+      sourceReplyDeliveryMode: "message_tool_only",
       queueMessage,
     });
 
     expect(
       queueEmbeddedPiMessageWithOutcome("session-steer", "continue", {
         steeringMode: "all",
+        sourceReplyDeliveryMode: "message_tool_only",
       }).queued,
     ).toBe(true);
 
-    expect(queueMessage).toHaveBeenCalledWith("continue", { steeringMode: "all" });
+    expect(queueMessage).toHaveBeenCalledWith("continue", {
+      steeringMode: "all",
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+  });
+
+  it("rejects message-tool-only steering for active runs created without that mode", () => {
+    const queueMessage = vi.fn(async () => {});
+    setActiveEmbeddedRun("session-automatic-source-reply", {
+      ...createRunHandle(),
+      queueMessage,
+    });
+
+    const outcome = queueEmbeddedPiMessageWithOutcome(
+      "session-automatic-source-reply",
+      "continue",
+      {
+        steeringMode: "all",
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    );
+
+    expect(outcome).toEqual({
+      queued: false,
+      sessionId: "session-automatic-source-reply",
+      reason: "source_reply_delivery_mode_mismatch",
+      gatewayHealth: "live",
+    });
+    expect(queueMessage).not.toHaveBeenCalled();
   });
 
   it("defaults active embedded steering to all pending messages", () => {

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -44,6 +44,7 @@ export type EmbeddedPiQueueFailureReason =
   | "no_active_run"
   | "not_streaming"
   | "compacting"
+  | "source_reply_delivery_mode_mismatch"
   | "runtime_rejected";
 
 export type EmbeddedPiQueueMessageOutcome =
@@ -140,7 +141,7 @@ export function queueEmbeddedPiMessageWithOutcome(
   text: string,
   options?: EmbeddedPiQueueMessageOptions,
 ): EmbeddedPiQueueMessageOutcome {
-  const prepared = prepareEmbeddedPiQueueMessage(sessionId, text);
+  const prepared = prepareEmbeddedPiQueueMessage(sessionId, text, options);
   if (prepared.kind === "complete") {
     return prepared.outcome;
   }
@@ -169,7 +170,7 @@ export async function queueEmbeddedPiMessageWithOutcomeAsync(
   text: string,
   options?: EmbeddedPiQueueMessageOptions,
 ): Promise<EmbeddedPiQueueMessageOutcome> {
-  const prepared = prepareEmbeddedPiQueueMessage(sessionId, text);
+  const prepared = prepareEmbeddedPiQueueMessage(sessionId, text, options);
   if (prepared.kind === "complete") {
     return prepared.outcome;
   }
@@ -192,6 +193,7 @@ export async function queueEmbeddedPiMessageWithOutcomeAsync(
 function prepareEmbeddedPiQueueMessage(
   sessionId: string,
   text: string,
+  options?: EmbeddedPiQueueMessageOptions,
 ): PreparedEmbeddedPiQueueMessage {
   const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
   if (!handle) {
@@ -218,6 +220,18 @@ function prepareEmbeddedPiQueueMessage(
   if (handle.isCompacting()) {
     diag.debug(`queue message failed: sessionId=${sessionId} reason=compacting`);
     return { kind: "complete", outcome: createQueueFailureOutcome(sessionId, "compacting") };
+  }
+  if (
+    options?.sourceReplyDeliveryMode === "message_tool_only" &&
+    handle.sourceReplyDeliveryMode !== "message_tool_only"
+  ) {
+    diag.debug(
+      `queue message failed: sessionId=${sessionId} reason=source_reply_delivery_mode_mismatch`,
+    );
+    return {
+      kind: "complete",
+      outcome: createQueueFailureOutcome(sessionId, "source_reply_delivery_mode_mismatch"),
+    };
   }
   return { kind: "embedded_run", handle };
 }

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1411,6 +1411,80 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       accountId: "acct-1",
       to: "channel:C123",
       threadId: undefined,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a forced message-tool handoff when the active requester run cannot accept one", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            accountId: "acct-1",
+            to: "channel:C123",
+            text: "The track is ready.",
+            mediaUrls: ["/tmp/generated-night-drive.mp3"],
+          },
+        ],
+      },
+    });
+    const queueEmbeddedPiMessageWithOutcome = vi.fn((sessionId: string) => ({
+      queued: false as const,
+      sessionId,
+      reason: "source_reply_delivery_mode_mismatch" as const,
+      gatewayHealth: "live" as const,
+    }));
+    const sendMessage = createSendMessageMock();
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      sessionId: "requester-session-channel",
+      isActive: true,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-channel-media-message-tool-active-mismatch",
+      sourceTool: "music_generate",
+      queueEmbeddedPiMessageWithOutcome,
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "music_generation",
+          childSessionKey: "music_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "music generation task",
+          taskLabel: "night-drive synthwave",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 track.\nMEDIA:/tmp/generated-night-drive.mp3",
+          mediaUrls: ["/tmp/generated-night-drive.mp3"],
+          replyInstruction:
+            "Tell the user the music is ready. If visible source delivery requires the message tool, send it there with the generated media attached.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledWith(
+      "requester-session-channel",
+      "child done",
+      expect.objectContaining({
+        steeringMode: "all",
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    );
+    expectGatewayAgentParams(callGateway, {
+      deliver: false,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      threadId: undefined,
+      sourceReplyDeliveryMode: "message_tool_only",
     });
     expect(sendMessage).not.toHaveBeenCalled();
   });
@@ -1478,6 +1552,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         accountId: "acct-1",
         to: origin.to,
         threadId: undefined,
+        sourceReplyDeliveryMode: "message_tool_only",
       });
       expect(sendMessage).not.toHaveBeenCalled();
     },

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -640,6 +640,9 @@ async function sendSubagentAnnounceDirectly(params: {
         directOrigin: effectiveDirectOrigin,
         requesterSessionOrigin,
       });
+    const completionSourceReplyDeliveryMode = requiresMessageToolDelivery
+      ? "message_tool_only"
+      : undefined;
     const shouldDeliverAgentFinal = deliveryTarget.deliver && !requiresMessageToolDelivery;
     const requesterActivity = resolveRequesterSessionActivity(canonicalRequesterSessionKey);
     const requesterQueueSettings = resolveQueueSettings({
@@ -658,6 +661,9 @@ async function sendSubagentAnnounceDirectly(params: {
         params.triggerMessage,
         {
           steeringMode: "all",
+          ...(completionSourceReplyDeliveryMode
+            ? { sourceReplyDeliveryMode: completionSourceReplyDeliveryMode }
+            : {}),
           ...(requesterQueueSettings.debounceMs !== undefined
             ? { debounceMs: requesterQueueSettings.debounceMs }
             : {}),
@@ -669,7 +675,9 @@ async function sendSubagentAnnounceDirectly(params: {
           path: "steered",
         };
       }
-      if (requesterActivity.isActive) {
+      const shouldFallbackToForcedAgentHandoff =
+        requiresMessageToolDelivery && wakeOutcome.reason === "source_reply_delivery_mode_mismatch";
+      if (requesterActivity.isActive && !shouldFallbackToForcedAgentHandoff) {
         // Active requester sessions should receive completion data through their
         // running agent turn. If wake fails, let the dispatch layer steer/retry;
         // do not bypass the requester agent with raw child output.
@@ -717,6 +725,9 @@ async function sendSubagentAnnounceDirectly(params: {
         sourceChannel: params.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
         sourceTool: params.sourceTool ?? "subagent_announce",
       },
+      ...(completionSourceReplyDeliveryMode
+        ? { sourceReplyDeliveryMode: completionSourceReplyDeliveryMode }
+        : {}),
       idempotencyKey: params.directIdempotencyKey,
     };
     let directAnnounceResponse: unknown;

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -179,6 +179,9 @@ export const AgentParamsSchema = Type.Object(
     internalRuntimeHandoffId: Type.Optional(NonEmptyString),
     internalEvents: Type.Optional(Type.Array(AgentInternalEventSchema)),
     inputProvenance: Type.Optional(InputProvenanceSchema),
+    sourceReplyDeliveryMode: Type.Optional(
+      Type.Union([Type.Literal("automatic"), Type.Literal("message_tool_only")]),
+    ),
     voiceWakeTrigger: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -599,6 +599,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       internalRuntimeHandoffId?: string;
       internalEvents?: AgentInternalEvent[];
       idempotencyKey: string;
+      sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
       timeout?: number;
       bestEffortDeliver?: boolean;
       cleanupBundleMcpOnRunEnd?: boolean;
@@ -1490,6 +1491,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             acpTurnSource: request.acpTurnSource,
             internalEvents: request.internalEvents,
             inputProvenance,
+            sourceReplyDeliveryMode: request.sourceReplyDeliveryMode,
             suppressPromptPersistence: shouldSuppressAgentPromptPersistence({
               inputProvenance,
               internalEvents: request.internalEvents,

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -221,6 +221,19 @@ describe("gateway server agent", () => {
     expect(call.to).toBeUndefined();
   });
 
+  test("agent forwards sourceReplyDeliveryMode to agentCommand", async () => {
+    const res = await rpcReq(ws, "agent", {
+      message: "hi",
+      sessionKey: "main",
+      sourceReplyDeliveryMode: "message_tool_only",
+      idempotencyKey: "idem-agent-source-reply-mode",
+    });
+    expect(res.ok).toBe(true);
+
+    const call = await waitForAgentCommandCall("idem-agent-source-reply-mode");
+    expect(call.sourceReplyDeliveryMode).toBe("message_tool_only");
+  });
+
   test("agent preserves spawnDepth on subagent sessions", async () => {
     await setTestSessionStore({
       entries: {


### PR DESCRIPTION
## Summary
- Force generated music/video completion handoffs that target group/channel chats into `message_tool_only` reply mode.
- Carry `sourceReplyDeliveryMode` through gateway `agent` RPC, `agentCommand`, and embedded active-run queue state so the completion agent has the `message` tool when it must attach media.
- Add regression coverage for generated-media group completions, active-run delivery-mode mismatch fallback, embedded queue mode checks, and gateway forwarding.

## Bug
A background music task could complete successfully and still never post the mp3 back to Discord. The live `#clawtributors` repro was message `1504845517404770374` at `2026-05-15T13:58:50Z`: the agent queued task `af2bccc3-8366-47da-8f8a-0965b5cc8da8`, generation finished at `14:00:27Z`, but the gateway logged `Media generation completion wake failed` and task delivery stayed unnotified.

An earlier run showed the other half of the bug: the completion did reach the channel session, but that turn only exposed `image_generate` and `music_generate`; the group prompt also told the agent not to use `message`. The agent therefore produced a text-only reply and never attached the generated mp3.

## Fix
Generated media completions already know when group/channel delivery must go through the message tool. This patch preserves that fact across both completion paths:
- requester wake gets `sourceReplyDeliveryMode: "message_tool_only"`
- active embedded runs record their source-reply mode and reject a forced message-tool wake if they were created without that mode
- rejected forced wakes fall back to a fresh requester-agent handoff that carries the same mode
- gateway `agent` accepts and forwards the mode into `agentCommand`
- existing embedded tool construction then forces the `message` tool and message-tool-only prompt guidance

## Verification
- `OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/runs.test.ts src/agents/subagent-announce-delivery.test.ts -t "message-tool|generated media group completions|steering options" --reporter dot`
- `OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs src/gateway/server.agent.gateway-server-agent-a.test.ts -t "sourceReplyDeliveryMode" --reporter dot`
- `node_modules/.bin/oxfmt --check src/agents/command/types.ts src/agents/pi-embedded-runner/run-state.ts src/agents/pi-embedded-runner/runs.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/subagent-announce-delivery.ts src/agents/pi-embedded-runner/runs.test.ts src/agents/subagent-announce-delivery.test.ts src/gateway/protocol/schema/agent.ts src/gateway/server-methods/agent.ts src/agents/command/attempt-execution.ts src/gateway/server.agent.gateway-server-agent-a.test.ts`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review`

## Real behavior proof
Behavior addressed: Discord group/channel generated music completions no longer lose the must-use-message-tool invariant when the completion is queued or falls back to a requester-agent run.

Real environment tested: Live `#clawtributors` logs/session/task DB were inspected for failed music task `af2bccc3-8366-47da-8f8a-0965b5cc8da8`; patch behavior was verified with focused local regression tests.

Exact steps or command run after this patch: focused Vitest shards for generated-media completion delivery, embedded queue delivery-mode handling, and gateway `sourceReplyDeliveryMode` forwarding; formatting and diff whitespace checks; Codex review clean.

Evidence after fix: tests assert generated-media group handoffs include `sourceReplyDeliveryMode: "message_tool_only"`, active embedded runs reject incompatible forced wakes instead of reporting success, fallback handoff carries the forced mode, and gateway forwards that field to `agentCommand`.

Observed result after fix: the handoff mode reaches the embedded runner path that already forces the `message` tool and suppresses automatic source replies for `message_tool_only` turns.

What was not tested: did not re-trigger a live Discord music generation after patch before PR; the earlier broad music helper legacy WhatsApp wrapper shard was not completed because it hung under the test wrapper.
