### PR TITLE
[Fix] Avoid eager file-transfer policy loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: fall back to same-account Codex CLI OAuth tokens at runtime when the local OpenAI Codex refresh token is rejected, without overwriting the canonical OpenClaw auth profile. Fixes #82069. Thanks @aaajiao.
 - Control UI: rotate browser service-worker caches per build so updated Gateways are less likely to keep serving stale dashboard bundles that trigger protocol mismatch errors.
 - Gateway/protocol: lazy-compile protocol validators on first use instead of compiling every AJV schema during cold import, reducing startup CPU and RSS. (#82064) Thanks @samzong.
+- File transfer: lazy-load node.invoke policy enforcement so gateway startup only registers static command metadata until file-transfer commands run. (#82211) Thanks @samzong.
 - Discord: report unresolved configured bot-token SecretRefs during startup instead of treating the account as unconfigured. (#82009) Thanks @giodl73-repo.
 - Discord: pass an explicit Ogg muxer to ffmpeg when transcoding voice-message audio through staged temp files, restoring TTS voice-message delivery. Fixes #82074. Thanks @hwlbb.
 - Discord/Feishu: allow Discord voice uploads through RFC2544 fake-IP proxy DNS and pass Feishu's voice ffmpeg transcode through an explicit Ogg muxer. (#82088) Thanks @hwlbb and @6peng888.

--- a/extensions/file-transfer/index.test.ts
+++ b/extensions/file-transfer/index.test.ts
@@ -15,6 +15,7 @@ vi.mock("./src/tools/file-fetch-tool.js", rejectRuntimeImport("tools/file-fetch-
 vi.mock("./src/tools/dir-list-tool.js", rejectRuntimeImport("tools/dir-list-tool"));
 vi.mock("./src/tools/dir-fetch-tool.js", rejectRuntimeImport("tools/dir-fetch-tool"));
 vi.mock("./src/tools/file-write-tool.js", rejectRuntimeImport("tools/file-write-tool"));
+vi.mock("./src/shared/node-invoke-policy.js", rejectRuntimeImport("shared/node-invoke-policy"));
 
 afterAll(() => {
   vi.doUnmock("./src/node-host/file-fetch.js");
@@ -25,6 +26,7 @@ afterAll(() => {
   vi.doUnmock("./src/tools/dir-list-tool.js");
   vi.doUnmock("./src/tools/dir-fetch-tool.js");
   vi.doUnmock("./src/tools/file-write-tool.js");
+  vi.doUnmock("./src/shared/node-invoke-policy.js");
   vi.resetModules();
 });
 
@@ -45,11 +47,46 @@ describe("file-transfer plugin entry", () => {
       "file.write",
     ]);
     expect(registerNodeInvokePolicy).toHaveBeenCalledTimes(1);
+    expect(registerNodeInvokePolicy.mock.calls[0]?.[0].commands).toEqual([
+      "file.fetch",
+      "dir.list",
+      "dir.fetch",
+      "file.write",
+    ]);
     expect(registerTool.mock.calls.map(([tool]) => tool.name)).toEqual([
       "file_fetch",
       "dir_list",
       "dir_fetch",
       "file_write",
     ]);
+  });
+
+  it("fails closed if the lazy policy module cannot load", async () => {
+    const registerNodeInvokePolicy = vi.fn();
+    const registerTool = vi.fn();
+    const invokeNode = vi.fn();
+
+    pluginEntry.register({
+      registerNodeInvokePolicy,
+      registerTool,
+    } as never);
+
+    const policy = registerNodeInvokePolicy.mock.calls[0]?.[0];
+    await expect(
+      policy.handle({
+        nodeId: "node-1",
+        command: "file.fetch",
+        params: { path: "/tmp/a.txt" },
+        config: {},
+        pluginConfig: {},
+        client: null,
+        invokeNode,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: "PLUGIN_POLICY_UNAVAILABLE",
+      unavailable: true,
+    });
+    expect(invokeNode).not.toHaveBeenCalled();
   });
 });

--- a/extensions/file-transfer/index.ts
+++ b/extensions/file-transfer/index.ts
@@ -3,7 +3,7 @@ import {
   type AnyAgentTool,
   type OpenClawPluginNodeHostCommand,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { createFileTransferNodeInvokePolicy } from "./src/shared/node-invoke-policy.js";
+import { createLazyFileTransferNodeInvokePolicy } from "./src/shared/lazy-node-invoke-policy.js";
 import {
   DIR_FETCH_TOOL_DESCRIPTOR,
   DIR_LIST_TOOL_DESCRIPTOR,
@@ -91,7 +91,7 @@ export default definePluginEntry({
   description: "Fetch, list, and write files on paired nodes via dedicated node commands.",
   nodeHostCommands: fileTransferNodeHostCommands,
   register(api) {
-    api.registerNodeInvokePolicy(createFileTransferNodeInvokePolicy());
+    api.registerNodeInvokePolicy(createLazyFileTransferNodeInvokePolicy());
     api.registerTool(
       createLazyTool(FILE_FETCH_TOOL_DESCRIPTOR, async () => {
         const { createFileFetchTool } = await import("./src/tools/file-fetch-tool.js");

--- a/extensions/file-transfer/src/shared/lazy-node-invoke-policy.test.ts
+++ b/extensions/file-transfer/src/shared/lazy-node-invoke-policy.test.ts
@@ -1,0 +1,101 @@
+import type {
+  OpenClawPluginNodeInvokePolicy,
+  OpenClawPluginNodeInvokePolicyContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it, vi } from "vitest";
+import { createLazyFileTransferNodeInvokePolicy } from "./lazy-node-invoke-policy.js";
+
+function createPolicyContext(
+  overrides: Partial<OpenClawPluginNodeInvokePolicyContext> = {},
+): OpenClawPluginNodeInvokePolicyContext {
+  return {
+    nodeId: "node-1",
+    command: "file.fetch",
+    params: { path: "/tmp/a.txt" },
+    config: {} as never,
+    pluginConfig: {},
+    node: {
+      nodeId: "node-1",
+      displayName: "Test Node",
+      commands: ["file.fetch"],
+    },
+    client: null,
+    invokeNode: vi.fn<OpenClawPluginNodeInvokePolicyContext["invokeNode"]>(async () => ({
+      ok: true,
+      payload: { ok: true },
+      payloadJSON: null,
+    })),
+    ...overrides,
+  };
+}
+
+describe("lazy file-transfer node invoke policy", () => {
+  it("exposes command metadata without loading the delegate", () => {
+    const loadPolicy = vi.fn<() => Promise<OpenClawPluginNodeInvokePolicy>>();
+
+    const policy = createLazyFileTransferNodeInvokePolicy(loadPolicy);
+
+    expect(policy.commands).toEqual(["file.fetch", "dir.list", "dir.fetch", "file.write"]);
+    expect(loadPolicy).not.toHaveBeenCalled();
+  });
+
+  it("loads and caches the delegate on first handle", async () => {
+    const invokeNode = vi.fn<OpenClawPluginNodeInvokePolicyContext["invokeNode"]>(async () => ({
+      ok: true,
+      payload: { ok: true },
+      payloadJSON: null,
+    }));
+    const delegateHandle = vi.fn<OpenClawPluginNodeInvokePolicy["handle"]>(async (ctx) => {
+      await ctx.invokeNode();
+      return { ok: true, payload: { delegated: true } };
+    });
+    const loadPolicy = vi.fn<() => Promise<OpenClawPluginNodeInvokePolicy>>(async () => ({
+      commands: ["file.fetch"],
+      handle: delegateHandle,
+    }));
+    const policy = createLazyFileTransferNodeInvokePolicy(loadPolicy);
+
+    await expect(policy.handle(createPolicyContext({ invokeNode }))).resolves.toEqual({
+      ok: true,
+      payload: { delegated: true },
+    });
+    await expect(policy.handle(createPolicyContext({ invokeNode }))).resolves.toEqual({
+      ok: true,
+      payload: { delegated: true },
+    });
+
+    expect(loadPolicy).toHaveBeenCalledTimes(1);
+    expect(delegateHandle).toHaveBeenCalledTimes(2);
+    expect(invokeNode).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed when the delegate cannot load", async () => {
+    const invokeNode = vi.fn<OpenClawPluginNodeInvokePolicyContext["invokeNode"]>(async () => ({
+      ok: true,
+      payload: { ok: true },
+      payloadJSON: null,
+    }));
+    const policy = createLazyFileTransferNodeInvokePolicy(async () => {
+      throw new Error("load failed");
+    });
+
+    await expect(policy.handle(createPolicyContext({ invokeNode }))).resolves.toMatchObject({
+      ok: false,
+      code: "PLUGIN_POLICY_UNAVAILABLE",
+      unavailable: true,
+    });
+    expect(invokeNode).not.toHaveBeenCalled();
+  });
+
+  it("does not rewrite delegate failures as load failures", async () => {
+    const delegateError = new Error("delegate failed");
+    const policy = createLazyFileTransferNodeInvokePolicy(async () => ({
+      commands: ["file.fetch"],
+      handle: async () => {
+        throw delegateError;
+      },
+    }));
+
+    await expect(policy.handle(createPolicyContext())).rejects.toBe(delegateError);
+  });
+});

--- a/extensions/file-transfer/src/shared/lazy-node-invoke-policy.ts
+++ b/extensions/file-transfer/src/shared/lazy-node-invoke-policy.ts
@@ -1,0 +1,35 @@
+import type { OpenClawPluginNodeInvokePolicy } from "openclaw/plugin-sdk/plugin-entry";
+import { FILE_TRANSFER_NODE_INVOKE_COMMANDS } from "./node-invoke-policy-commands.js";
+
+type LoadFileTransferNodeInvokePolicy = () => Promise<OpenClawPluginNodeInvokePolicy>;
+
+const loadFileTransferNodeInvokePolicy: LoadFileTransferNodeInvokePolicy = async () => {
+  const { createFileTransferNodeInvokePolicy } = await import("./node-invoke-policy.js");
+  return createFileTransferNodeInvokePolicy();
+};
+
+export function createLazyFileTransferNodeInvokePolicy(
+  loadPolicy: LoadFileTransferNodeInvokePolicy = loadFileTransferNodeInvokePolicy,
+): OpenClawPluginNodeInvokePolicy {
+  let policyPromise: Promise<OpenClawPluginNodeInvokePolicy> | undefined;
+
+  return {
+    commands: [...FILE_TRANSFER_NODE_INVOKE_COMMANDS],
+    async handle(ctx) {
+      let policy: OpenClawPluginNodeInvokePolicy;
+      try {
+        policyPromise ??= loadPolicy();
+        policy = await policyPromise;
+      } catch (error) {
+        const message = error instanceof Error && error.message ? error.message : String(error);
+        return {
+          ok: false,
+          code: "PLUGIN_POLICY_UNAVAILABLE",
+          message: `file-transfer PLUGIN_POLICY_UNAVAILABLE: node.invoke policy unavailable: ${message}`,
+          unavailable: true,
+        };
+      }
+      return await policy.handle(ctx);
+    },
+  };
+}

--- a/extensions/file-transfer/src/shared/node-invoke-policy-commands.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy-commands.ts
@@ -1,0 +1,8 @@
+export const FILE_TRANSFER_NODE_INVOKE_COMMANDS = [
+  "file.fetch",
+  "dir.list",
+  "dir.fetch",
+  "file.write",
+] as const;
+
+export type FileTransferNodeInvokeCommand = (typeof FILE_TRANSFER_NODE_INVOKE_COMMANDS)[number];

--- a/extensions/file-transfer/src/shared/node-invoke-policy.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.ts
@@ -5,6 +5,10 @@ import type {
   OpenClawPluginNodeInvokePolicyResult,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { appendFileTransferAudit, type FileTransferAuditOp } from "./audit.js";
+import {
+  FILE_TRANSFER_NODE_INVOKE_COMMANDS,
+  type FileTransferNodeInvokeCommand,
+} from "./node-invoke-policy-commands.js";
 import { evaluateFilePolicy, persistAllowAlways, type FilePolicyKind } from "./policy.js";
 
 const FILE_FETCH_DEFAULT_MAX_BYTES = 8 * 1024 * 1024;
@@ -14,9 +18,7 @@ const DIR_FETCH_HARD_MAX_BYTES = 16 * 1024 * 1024;
 const DIR_FETCH_ARCHIVE_LIST_TIMEOUT_MS = 30_000;
 const DIR_FETCH_ARCHIVE_LIST_MAX_OUTPUT_BYTES = 32 * 1024 * 1024;
 
-type FileTransferCommand = "file.fetch" | "dir.list" | "dir.fetch" | "file.write";
-
-const COMMANDS: FileTransferCommand[] = ["file.fetch", "dir.list", "dir.fetch", "file.write"];
+type FileTransferCommand = FileTransferNodeInvokeCommand;
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -651,7 +653,7 @@ async function runDirFetchPreflight(input: {
 async function handleFileTransferInvoke(
   ctx: OpenClawPluginNodeInvokePolicyContext,
 ): Promise<OpenClawPluginNodeInvokePolicyResult> {
-  if (!COMMANDS.includes(ctx.command as FileTransferCommand)) {
+  if (!FILE_TRANSFER_NODE_INVOKE_COMMANDS.includes(ctx.command as FileTransferCommand)) {
     return { ok: false, code: "UNSUPPORTED_COMMAND", message: "unsupported file-transfer command" };
   }
   const command = ctx.command as FileTransferCommand;
@@ -837,7 +839,7 @@ async function handleFileTransferInvoke(
 
 export function createFileTransferNodeInvokePolicy(): OpenClawPluginNodeInvokePolicy {
   return {
-    commands: COMMANDS,
+    commands: [...FILE_TRANSFER_NODE_INVOKE_COMMANDS],
     handle: handleFileTransferInvoke,
   };
 }


### PR DESCRIPTION
## Summary

- Problem: the file-transfer plugin registered node.invoke policy metadata by eagerly importing the full policy implementation during gateway startup.
- Why it matters: that policy path pulls in heavier file-transfer policy/audit/runtime code even when startup only needs static command metadata.
- What changed: file-transfer now registers a lightweight lazy node.invoke policy wrapper with shared command metadata and imports the full policy only when a file-transfer node command is handled.
- What did NOT change (scope boundary): command names, file-transfer policy enforcement, node host command handlers, config, and plugin permissions stay unchanged.
- AI-assisted: yes; the diff was produced with Codex and verified with local commands below.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: gateway startup no longer eagerly loads the full file-transfer node.invoke policy implementation just to register static command metadata.
- Real environment tested: macOS 26.4.1 local source checkout, Node v24.14.0, pnpm 11.1.0, built `dist` from the patch and compared against an `upstream/main` baseline worktree.
- Exact steps or command run after this patch:
  - `pnpm build`
  - `node scripts/run-vitest.mjs extensions/file-transfer/index.test.ts extensions/file-transfer/src/shared/lazy-node-invoke-policy.test.ts extensions/file-transfer/src/shared/node-invoke-policy.test.ts src/gateway/node-invoke-plugin-policy.test.ts`
  - `pnpm changed:lanes --json`
  - `command codex review --base HEAD~1`
  - `node --import tsx scripts/bench-gateway-startup.ts --case default --runs 5 --warmup 1 --output .artifacts/file-transfer-policy-after-final-default.json`
  - `node --import tsx scripts/bench-gateway-startup.ts --case skipChannels --runs 9 --warmup 2 --output .artifacts/file-transfer-policy-after-final-skipChannels.json`
- Evidence after fix: default startup p50 `plugins.gateway-load.plugin.file-transfer.loadMs` changed from `27.7ms` to `10.7ms` (`-61.4%`); skipChannels changed from `26.9ms` to `10.0ms` (`-62.8%`). Built output keeps `dist/extensions/file-transfer/index.js` on the lazy path with `await import("../../node-invoke-policy-DmGhu8Ym.js")` instead of bundling the full policy into the entry chunk.
- Observed result after fix: default p50 `/healthz` changed from `2681.3ms` to `2525.0ms`, `/readyz` from `3097.4ms` to `2840.1ms`, and the `/healthz` to `/readyz` gap from `421.3ms` to `317.8ms`. skipChannels p50 `/readyz` changed from `2968.2ms` to `2778.6ms`, and the `/healthz` to `/readyz` gap from `344.8ms` to `267.9ms`.
- What was not tested: live file-transfer execution against a real paired node and the full `pnpm check` suite were not run locally; the changed-lane discovery stayed scoped to extensions and extension tests.
- Before evidence: baseline benchmark artifacts were generated from an `upstream/main` worktree with the same benchmark script and run counts before running the patched worktree benchmarks.

## Root Cause (if applicable)

- Root cause: `extensions/file-transfer/index.ts` imported `createFileTransferNodeInvokePolicy` directly, so plugin registration loaded the full node.invoke policy implementation during startup even though only the static command list was needed.
- Missing detection / guardrail: the existing plugin entry test covered lazy tool and node-host handler registration, but did not assert that node.invoke policy implementation stayed lazy.
- Contributing context (if known): file-transfer tools and node host commands were already lazy; the node.invoke policy registration was the remaining eager path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/file-transfer/index.test.ts` and `extensions/file-transfer/src/shared/lazy-node-invoke-policy.test.ts`.
- Scenario the test should lock in: descriptor registration exposes command metadata without importing `src/shared/node-invoke-policy.js`; first handle call loads and caches the delegate; load failures fail closed; delegate failures are not rewritten as load failures.
- Why this is the smallest reliable guardrail: the bug is import timing at the plugin entry seam, so a focused entry/lazy-wrapper test catches it without requiring a full gateway E2E run.
- Existing test that already covers this (if any): existing file-transfer policy tests still cover the real policy behavior after the delegate is loaded.
- If no new test is added, why not: N/A - new tests were added.

## User-visible / Behavior Changes

No command names, config keys, permissions, or file-transfer policy decisions change. Gateway startup avoids eager policy loading; if the lazy policy module cannot load, file-transfer node.invoke fails closed.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.4.1
- Runtime/container: Node v24.14.0, pnpm 11.1.0, local source checkout
- Model/provider: N/A
- Integration/channel (if any): file-transfer bundled plugin
- Relevant config (redacted): default gateway startup benchmark cases `default` and `skipChannels`

### Steps

1. Build the patched checkout with `pnpm build`.
2. Run focused file-transfer and gateway node.invoke policy tests with `node scripts/run-vitest.mjs extensions/file-transfer/index.test.ts extensions/file-transfer/src/shared/lazy-node-invoke-policy.test.ts extensions/file-transfer/src/shared/node-invoke-policy.test.ts src/gateway/node-invoke-plugin-policy.test.ts`.
3. Run gateway startup benchmarks for `default` and `skipChannels` and compare the p50 startup trace values against the `upstream/main` baseline artifacts.

### Expected

- File-transfer command metadata is available at plugin registration without loading the full node.invoke policy implementation.
- The full policy implementation loads only when a file-transfer node.invoke command is handled.
- Startup trace shows lower file-transfer plugin load time.

### Actual

- Focused tests passed: 6 files, 32 tests.
- `pnpm build` passed.
- Codex review reported no actionable correctness issues.
- default p50 file-transfer plugin load time changed from `27.7ms` to `10.7ms`; skipChannels changed from `26.9ms` to `10.0ms`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: static descriptor registration, lazy delegate load/cache behavior, fail-closed load failure behavior, delegate error propagation, built output lazy import split, startup benchmark p50 deltas.
- Edge cases checked: missing lazy delegate module does not invoke the node; delegate runtime failures are not rewritten as policy load failures.
- What you did **not** verify: live file-transfer against a paired node, full local `pnpm check`, and remote CI.

## Review Conversations

- [x] N/A - no bot review conversations were present or addressed in this PR.
- [x] N/A - no review conversations need maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the lazy wrapper could drift from the real policy command list.
  - Mitigation: both wrappers use the shared `FILE_TRANSFER_NODE_INVOKE_COMMANDS` constant and tests assert the exposed command metadata.
- Risk: lazy module load failure could otherwise bypass policy enforcement.
  - Mitigation: the wrapper fails closed with `PLUGIN_POLICY_UNAVAILABLE` and tests assert the node is not invoked on load failure.
