### PR TITLE
fix: strip delivery function response leaks

### DIFF
--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -623,6 +623,20 @@ describe("stripToolCallXmlTags", () => {
     expect(stripToolCallXmlTags(input, { stripFunctionCallsXmlPayloads: true })).toBe("\nAfter");
   });
 
+  it("strips plural function-call XML before function_response without stripping prose examples", () => {
+    const leak =
+      '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response>raw</function_response>\nAfter';
+    const prose =
+      'prefix <function_calls><invoke name="find">secret</invoke></function_calls> suffix';
+
+    expect(stripToolCallXmlTags(leak, { stripFunctionResponseAfterPluralToolCalls: true })).toBe(
+      "\nAfter",
+    );
+    expect(stripToolCallXmlTags(prose, { stripFunctionResponseAfterPluralToolCalls: true })).toBe(
+      prose,
+    );
+  });
+
   it("strips function_response adjacent to an inline stripped function_calls block", () => {
     const input = [
       'Checking. <function_calls><invoke name="exec">internal</invoke></function_calls><function_response>',
@@ -796,6 +810,13 @@ describe("sanitizeAssistantVisibleText", () => {
     ].join("\n");
 
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
+  it("preserves prose examples of plural function-call XML on the delivery path", () => {
+    const input =
+      'prefix <function_calls><invoke name="find">secret</invoke></function_calls> suffix';
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
   });
 
   it("strips relevant-memories blocks on the canonical user-visible path", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -787,6 +787,17 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
   });
 
+  it("strips adjacent plural function-call XML on the delivery path", () => {
+    const input = [
+      '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response>',
+      'Searching for: "what skills matter most in the age of AI"',
+      "</function_response>",
+      "Visible answer",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
   it("strips relevant-memories blocks on the canonical user-visible path", () => {
     const input = [
       "<relevant-memories>",

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -245,6 +245,25 @@ function findMatchingToolCallCloseIndex(text: string, start: number, tagName: st
   return -1;
 }
 
+function findAdjacentOpeningToolCallTag(
+  text: string,
+  start: number,
+  tagName: string,
+): ParsedToolCallTag | null {
+  let idx = start;
+  while (idx < text.length && /\s/.test(text[idx])) {
+    idx += 1;
+  }
+  if (text[idx] !== "<") {
+    return null;
+  }
+  const tag = parseToolCallTagAt(text, idx);
+  if (!tag || tag.isClose || tag.tagName !== tagName) {
+    return null;
+  }
+  return tag;
+}
+
 function parseToolCallTagAt(text: string, start: number): ParsedToolCallTag | null {
   if (text[start] !== "<") {
     return null;
@@ -299,7 +318,10 @@ function parseToolCallTagAt(text: string, start: number): ParsedToolCallTag | nu
 
 export function stripToolCallXmlTags(
   text: string,
-  options: { stripFunctionCallsXmlPayloads?: boolean } = {},
+  options: {
+    stripFunctionCallsXmlPayloads?: boolean;
+    stripFunctionResponseAfterPluralToolCalls?: boolean;
+  } = {},
 ): string {
   if (!text || !TOOL_CALL_QUICK_RE.test(text)) {
     return text;
@@ -355,11 +377,24 @@ export function stripToolCallXmlTags(
         continue;
       }
       const payloadStart = tag.isTruncated ? tag.contentStart : tag.end;
+      const isPluralToolCallWrapper =
+        tag.tagName === "function_calls" || tag.tagName === "tool_calls";
+      const matchingCloseStart = isPluralToolCallWrapper
+        ? findMatchingToolCallCloseIndex(text, tag.end, tag.tagName)
+        : -1;
+      const matchingCloseTag =
+        matchingCloseStart === -1 ? null : parseToolCallTagAt(text, matchingCloseStart);
+      const shouldStripPluralWrapperBeforeResponse =
+        options.stripFunctionResponseAfterPluralToolCalls === true &&
+        isPluralToolCallWrapper &&
+        matchingCloseTag !== null &&
+        findAdjacentOpeningToolCallTag(text, matchingCloseTag.end, "function_response") !== null;
       const shouldDetectXmlPayload =
         tag.tagName === "tool_call" ||
         tag.tagName === "function" ||
-        (options.stripFunctionCallsXmlPayloads === true &&
-          (tag.tagName === "function_calls" || tag.tagName === "tool_calls"));
+        ((options.stripFunctionCallsXmlPayloads === true ||
+          shouldStripPluralWrapperBeforeResponse) &&
+          isPluralToolCallWrapper);
       const payloadKind = shouldDetectXmlPayload
         ? detectToolCallPayloadKind(text, payloadStart)
         : TOOL_CALL_JSON_PAYLOAD_START_RE.test(text.slice(payloadStart))
@@ -732,6 +767,7 @@ type AssistantVisibleTextPipelineOptions = {
   preserveDowngradedToolText?: boolean;
   preserveMinimaxToolXml?: boolean;
   stripFunctionCallsXmlPayloads?: boolean;
+  stripFunctionResponseAfterPluralToolCalls?: boolean;
   reasoningMode: ReasoningTagMode;
   reasoningTrim: ReasoningTagTrim;
   stageOrder: "reasoning-first" | "reasoning-last";
@@ -743,7 +779,7 @@ const ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS: Record<
 > = {
   delivery: {
     finalTrim: "both",
-    stripFunctionCallsXmlPayloads: true,
+    stripFunctionResponseAfterPluralToolCalls: true,
     reasoningMode: "strict",
     reasoningTrim: "both",
     stageOrder: "reasoning-last",
@@ -795,6 +831,7 @@ function applyAssistantVisibleTextStagePipeline(
     cleaned = stripRelevantMemoriesTags(cleaned);
     cleaned = stripToolCallXmlTags(cleaned, {
       stripFunctionCallsXmlPayloads: options.stripFunctionCallsXmlPayloads,
+      stripFunctionResponseAfterPluralToolCalls: options.stripFunctionResponseAfterPluralToolCalls,
     });
     cleaned = stripLegacyBracketToolCallBlocks(cleaned);
     cleaned = stripPlainTextToolCallBlocks(cleaned);

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -743,6 +743,7 @@ const ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS: Record<
 > = {
   delivery: {
     finalTrim: "both",
+    stripFunctionCallsXmlPayloads: true,
     reasoningMode: "strict",
     reasoningTrim: "both",
     stageOrder: "reasoning-last",


### PR DESCRIPTION
Summary
- Extend the assistant-visible delivery sanitizer so adjacent plural `<function_calls>...</function_calls><function_response>...</function_response>` scaffolding is stripped before Discord/other delivery paths see it.
- Keep the broad plural XML stripping opt-in limited to existing internal/user-facing sanitizer callers, and preserve literal prose examples of `<function_calls>` on the delivery path.
- Add regression coverage for the adjacent response leak and the prose-preservation case.

Verification
- `pnpm test src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts -- --reporter=dot`
- `git diff --check HEAD~2..HEAD`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode branch --full-access --output /tmp/codex-review-82155-followup-2.txt --parallel-tests "pnpm test src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts -- --reporter=dot"`

## Real behavior proof
Behavior addressed: closes the remaining delivery-path sanitizer leak from #47444 after #82155 by stripping adjacent plural function-call/function-response XML before message delivery.
Real environment tested: local OpenClaw checkout on macOS, Node/tsx with repo dependencies, running the production `sanitizeAssistantVisibleText` export from `src/shared/text/assistant-visible-text.ts`.
Exact steps or command run after this patch: `node --import tsx --input-type=module` probe against `sanitizeAssistantVisibleText`, plus the focused `pnpm test` command above.
Evidence after fix: terminal output from the local Node/tsx probe:
```text
"Visible answer"
"prefix <function_calls><invoke name=\"find\">x</invoke></function_calls> suffix"
```
Observed result after fix: the adjacent `<function_response>` payload is removed from delivery text, and the non-adjacent prose example is emitted unchanged.
What was not tested: full suite and live provider delivery; CI will cover repository gates on the PR.

Refs #47444
Follow-up to #82155
