### PR TITLE
fix: strip attributed final tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/media: preserve message-tool-only delivery for generated music and video completion handoffs, so group/channel completions do not finish without posting the generated attachment.
+- Agents: strip Gemini/Gemma `<final>` tags with attributes or self-closing syntax from delivered replies, including strict final-tag streaming enforcement. Fixes #65867.
 - LINE: acknowledge signed webhook events before agent processing so slow model replies do not cause LINE `request_timeout` delivery failures. Fixes #65375. Thanks @myericho.
 - TTS: preserve channel-derived voice-note delivery for `/tts audio` replies even when the provider output is not natively voice-compatible. (#82174) Thanks @xuruiray.
 - Codex/Lossless: keep Codex explicit compaction on native app-server threads while allowing Lossless through the context-engine slot; `openclaw doctor --fix` now migrates legacy `compaction.provider: "lossless-claw"` config to `plugins.slots.contextEngine`.

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -20,6 +20,29 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  it("strips self-closing and attributed final tags", () => {
+    expect(sanitizeUserFacingText("<final/>Hello")).toBe("Hello");
+    expect(sanitizeUserFacingText("<final data-model='gemini'>Hello</final>")).toBe("Hello");
+    expect(sanitizeUserFacingText('<final reason="gemma">Hello</final>')).toBe("Hello");
+    expect(sanitizeUserFacingText("<final data-model=openrouter/google/gemini>Hello</final>")).toBe(
+      "Hello",
+    );
+  });
+
+  it("does not strip custom or malformed final-like tags", () => {
+    expect(sanitizeUserFacingText("<final-result>Hello</final-result>")).toBe(
+      "<final-result>Hello</final-result>",
+    );
+    expect(sanitizeUserFacingText('<final reason="a>b">Hello')).toBe('<final reason="a>b">Hello');
+    expect(sanitizeUserFacingText("<final / nottag>Hello")).toBe("<final / nottag>Hello");
+    expect(sanitizeUserFacingText(`<final ${" ".repeat(10_000)}`)).toBe(
+      `<final ${" ".repeat(10_000)}`,
+    );
+    expect(sanitizeUserFacingText(`<final ${" ".repeat(10_000)}= >Hello`)).toBe(
+      `<final ${" ".repeat(10_000)}= >Hello`,
+    );
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -18,6 +18,7 @@ import {
   stripMinimaxToolCallXml,
   stripToolCallXmlTags,
 } from "../../shared/text/assistant-visible-text.js";
+import { stripFinalTags } from "../../shared/text/final-tags.js";
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
 import { stableStringify } from "../stable-stringify.js";
@@ -46,7 +47,6 @@ const MODEL_CAPACITY_ERROR_USER_MESSAGE =
   "⚠️ Selected model is at capacity. Try a different model, or wait and retry.";
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
-const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
 const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE = /^[ \t]*\[tool calls omitted\][ \t]*$/i;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
@@ -336,7 +336,7 @@ function stripFinalTagsFromText(text: unknown): string {
   if (!normalized) {
     return normalized;
   }
-  return normalized.replace(FINAL_TAG_RE, "");
+  return stripFinalTags(normalized);
 }
 
 function stripToolCallsOmittedPlaceholderLines(text: string): string {

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
@@ -119,6 +119,144 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payloads.some((payload) => payload.replace)).toBe(false);
   });
 
+  it("strips self-closing and attributed final tags from streamed deltas", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({
+      emit,
+      delta: "<final data-model=openrouter/google/gemini>Visible<final/>",
+    });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    const streamedText = payloads.map((payload) => payload.delta).join("");
+    expect(streamedText).toBe("Visible");
+    expect(streamedText).not.toContain("<final");
+  });
+
+  it("strips attributed final tags split across streamed deltas", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    for (const delta of ["<final data-model='ge", "mini'>Visible</final>"]) {
+      emitAssistantTextDelta({ emit, delta });
+    }
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    const streamedText = payloads.map((payload) => payload.delta).join("");
+    expect(streamedText).toBe("Visible");
+    expect(streamedText).not.toContain("<final");
+  });
+
+  it("treats self-closing final tags as closers during enforced streaming", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onPartialReply = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onPartialReply,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({
+      emit,
+      delta: "<final data-model='gemma'>Visible<final data-model='x' />hidden",
+    });
+
+    const streamedText = onPartialReply.mock.calls
+      .map((call) => (call[0] as { delta?: unknown }).delta)
+      .filter((delta): delta is string => typeof delta === "string")
+      .join("");
+    expect(streamedText).toBe("Visible");
+  });
+
+  it("treats leading self-closing final tags as openers during enforced streaming", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onPartialReply = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onPartialReply,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({
+      emit,
+      delta: "<final data-model=openrouter/google/gemini/>Visible",
+    });
+
+    const streamedText = onPartialReply.mock.calls
+      .map((call) => (call[0] as { delta?: unknown }).delta)
+      .filter((delta): delta is string => typeof delta === "string")
+      .join("");
+    expect(streamedText).toBe("Visible");
+  });
+
+  it("preserves enforced final content when attributed final tags split across deltas", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onPartialReply = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onPartialReply,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    for (const delta of ["<final data-model=openrouter/google/ge", "mma>Visible</final>"]) {
+      emitAssistantTextDelta({ emit, delta });
+    }
+
+    const streamedText = onPartialReply.mock.calls
+      .map((call) => (call[0] as { delta?: unknown }).delta)
+      .filter((delta): delta is string => typeof delta === "string")
+      .join("");
+    expect(streamedText).toBe("Visible");
+  });
+
+  it("does not treat custom or malformed final-like tags as enforced final blocks", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onPartialReply = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onPartialReply,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "<final-result>hidden" });
+    emitAssistantTextDelta({ emit, delta: '<final reason="a>b">also hidden' });
+
+    expect(onPartialReply).not.toHaveBeenCalled();
+  });
+
   it("preserves final content when enforced final tags are split across streamed deltas", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -9,6 +9,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-spans.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { findFinalTagMatches } from "../shared/text/final-tags.js";
 import { hasOrphanReasoningCloseBoundary } from "../shared/text/reasoning-tags.js";
 import { mediaUrlsFromGeneratedAttachments } from "./generated-attachments.js";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
@@ -43,7 +44,6 @@ import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.t
 import { stripDowngradedToolCallText, THINKING_TAG_SCAN_RE } from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
-const FINAL_TAG_SCAN_RE = /<\s*(\/?)\s*final\s*>/gi;
 const STREAM_STRIPPED_BLOCK_TAG_NAMES = [
   "final",
   "think",
@@ -60,15 +60,17 @@ function isPotentialTrailingBlockTagFragment(fragment: string): boolean {
   if (!fragment.startsWith("<") || fragment.includes(">")) {
     return false;
   }
-  const normalized = fragment.toLowerCase().replace(/\s+/g, "");
-  if (!normalized.startsWith("<")) {
-    return false;
-  }
-  const candidate = normalized.slice(1).replace(/^\//, "");
-  if (!candidate) {
+  const body = fragment.toLowerCase().slice(1).trimStart().replace(/^\//, "").trimStart();
+  if (!body) {
     return true;
   }
-  return STREAM_STRIPPED_BLOCK_TAG_NAMES.some((name) => name.startsWith(candidate));
+  const namePart = body.split(/[\s/>]/, 1)[0] ?? "";
+  if (!namePart) {
+    return true;
+  }
+  return STREAM_STRIPPED_BLOCK_TAG_NAMES.some((name) => {
+    return name.startsWith(namePart) || namePart === name;
+  });
 }
 
 function splitTrailingBlockTagFragment(
@@ -636,34 +638,42 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     const finalCodeSpans = buildCodeSpanIndex(processed, inlineStateStart);
     if (!params.enforceFinalTag) {
       state.inlineCode = finalCodeSpans.inlineState;
-      FINAL_TAG_SCAN_RE.lastIndex = 0;
-      return stripTagsOutsideCodeSpans(processed, FINAL_TAG_SCAN_RE, finalCodeSpans.isInside);
+      return stripFinalTagsOutsideCodeSpans(processed, finalCodeSpans.isInside);
     }
 
     // If enforcement is enabled, only return text that appeared inside a <final> block.
     let result = "";
-    FINAL_TAG_SCAN_RE.lastIndex = 0;
     let lastFinalIndex = 0;
     let inFinal = state.final;
     let everInFinal = state.final;
 
-    for (const match of processed.matchAll(FINAL_TAG_SCAN_RE)) {
-      const idx = match.index ?? 0;
+    for (const match of findFinalTagMatches(processed)) {
+      const idx = match.index;
       if (finalCodeSpans.isInside(idx)) {
         continue;
       }
-      const isClose = match[1] === "/";
+      const isClose = match.isClose;
+      const isSelfClosing = match.isSelfClosing;
 
-      if (!inFinal && !isClose) {
+      if (isSelfClosing) {
+        if (inFinal) {
+          result += processed.slice(lastFinalIndex, idx);
+          inFinal = false;
+        } else {
+          inFinal = true;
+          everInFinal = true;
+        }
+        lastFinalIndex = idx + match.text.length;
+      } else if (!inFinal && !isClose) {
         // Found <final> start tag.
         inFinal = true;
         everInFinal = true;
-        lastFinalIndex = idx + match[0].length;
+        lastFinalIndex = idx + match.text.length;
       } else if (inFinal && isClose) {
         // Found </final> end tag.
         result += processed.slice(lastFinalIndex, idx);
         inFinal = false;
-        lastFinalIndex = idx + match[0].length;
+        lastFinalIndex = idx + match.text.length;
       }
     }
 
@@ -683,24 +693,19 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // missed (e.g. nested tags or hallucinations) to prevent leakage.
     const resultCodeSpans = buildCodeSpanIndex(result, inlineStateStart);
     state.inlineCode = resultCodeSpans.inlineState;
-    return stripTagsOutsideCodeSpans(result, FINAL_TAG_SCAN_RE, resultCodeSpans.isInside);
+    return stripFinalTagsOutsideCodeSpans(result, resultCodeSpans.isInside);
   };
 
-  const stripTagsOutsideCodeSpans = (
-    text: string,
-    pattern: RegExp,
-    isInside: (index: number) => boolean,
-  ) => {
+  const stripFinalTagsOutsideCodeSpans = (text: string, isInside: (index: number) => boolean) => {
     let output = "";
     let lastIndex = 0;
-    pattern.lastIndex = 0;
-    for (const match of text.matchAll(pattern)) {
-      const idx = match.index ?? 0;
+    for (const match of findFinalTagMatches(text)) {
+      const idx = match.index;
       if (isInside(idx)) {
         continue;
       }
       output += text.slice(lastIndex, idx);
-      lastIndex = idx + match[0].length;
+      lastIndex = idx + match.text.length;
     }
     output += text.slice(lastIndex);
     return output;

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -51,6 +51,7 @@ import { normalizeGoogleModelId } from "../plugin-sdk/google-model-id.js";
 import { resolveProviderThinkingProfile } from "../plugins/provider-runtime.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { stripAssistantInternalScaffolding } from "../shared/text/assistant-visible-text.js";
+import { containsFinalTag, stripFinalTags } from "../shared/text/final-tags.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
 import { renderCatNoncePngBase64 } from "./live-image-probe.js";
@@ -73,7 +74,6 @@ const THINKING_LEVEL = GATEWAY_LIVE_SMOKE ? "low" : "high";
 const ENABLE_EXTRA_TOOL_PROBES = !GATEWAY_LIVE_SMOKE;
 const ENABLE_EXTRA_IMAGE_PROBES = !GATEWAY_LIVE_SMOKE;
 const THINKING_TAG_RE = /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>/i;
-const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/i;
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
 const GATEWAY_LIVE_DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
 const GATEWAY_LIVE_UNBOUNDED_TIMEOUT_MS = 60 * 60 * 1000;
@@ -377,7 +377,7 @@ function assertNoReasoningTags(params: {
   if (!params.text) {
     return;
   }
-  if (THINKING_TAG_RE.test(params.text) || FINAL_TAG_RE.test(params.text)) {
+  if (THINKING_TAG_RE.test(params.text) || containsFinalTag(params.text)) {
     const snippet = params.text.length > 200 ? `${params.text.slice(0, 200)}…` : params.text;
     throw new Error(
       `[${params.label}] reasoning tag leak (${params.model} / ${params.phase}): ${snippet}`,
@@ -440,10 +440,10 @@ function maybeStripAssistantScaffoldingForLiveModel(text: string, modelKey?: str
 }
 
 function stripKnownLiveReasoningWrappers(text: string): string {
-  return text
+  const withoutThinking = text
     .replace(/<\s*think\b[^<>]*>[\s\S]*?<\s*\/\s*think\s*>/gi, "")
-    .replace(/^[\s\S]*?<\s*\/\s*think\s*>\s*/i, "")
-    .replace(/<\s*final\b[^<>]*>([\s\S]*?)<\s*\/\s*final\s*>/gi, "$1");
+    .replace(/^[\s\S]*?<\s*\/\s*think\s*>\s*/i, "");
+  return stripFinalTags(withoutThinking);
 }
 
 function shouldSkipExecReadNonceMissForLiveModel(modelKey?: string): boolean {
@@ -490,6 +490,12 @@ describe("maybeStripAssistantScaffoldingForLiveModel", () => {
     expect(
       maybeStripAssistantScaffoldingForLiveModel(
         "<final>Visible</final>",
+        "google/gemini-3-flash-preview",
+      ),
+    ).toBe("Visible");
+    expect(
+      maybeStripAssistantScaffoldingForLiveModel(
+        "<final data-model=openrouter/google/gemini/>Visible",
         "google/gemini-3-flash-preview",
       ),
     ).toBe("Visible");

--- a/src/shared/text/final-tags.ts
+++ b/src/shared/text/final-tags.ts
@@ -1,0 +1,143 @@
+export type FinalTagMatch = {
+  index: number;
+  text: string;
+  isClose: boolean;
+  isSelfClosing: boolean;
+};
+
+const FINAL_TAG_CANDIDATE_RE = /<[^<>]*>/g;
+
+function isWhitespace(char: string): boolean {
+  return /\s/.test(char);
+}
+
+function parseAttributeList(text: string): boolean {
+  let index = 0;
+  while (index < text.length) {
+    while (index < text.length && isWhitespace(text[index] ?? "")) {
+      index += 1;
+    }
+    if (index >= text.length) {
+      return true;
+    }
+
+    const nameStart = index;
+    while (index < text.length) {
+      const char = text[index] ?? "";
+      if (isWhitespace(char) || char === "=") {
+        break;
+      }
+      if (char === "/" || char === '"' || char === "'" || char === "<" || char === ">") {
+        return false;
+      }
+      index += 1;
+    }
+    if (index === nameStart) {
+      return false;
+    }
+
+    while (index < text.length && isWhitespace(text[index] ?? "")) {
+      index += 1;
+    }
+    if (text[index] !== "=") {
+      continue;
+    }
+    index += 1;
+    while (index < text.length && isWhitespace(text[index] ?? "")) {
+      index += 1;
+    }
+    if (index >= text.length) {
+      return false;
+    }
+
+    const quote = text[index];
+    if (quote === '"' || quote === "'") {
+      index += 1;
+      const end = text.indexOf(quote, index);
+      if (end === -1) {
+        return false;
+      }
+      index = end + 1;
+      continue;
+    }
+
+    const valueStart = index;
+    while (index < text.length && !isWhitespace(text[index] ?? "")) {
+      const char = text[index] ?? "";
+      if (char === '"' || char === "'" || char === "<" || char === ">") {
+        return false;
+      }
+      index += 1;
+    }
+    if (index === valueStart) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function parseFinalTag(text: string): Omit<FinalTagMatch, "index" | "text"> | null {
+  if (!text.startsWith("<") || !text.endsWith(">")) {
+    return null;
+  }
+
+  let body = text.slice(1, -1).trimStart();
+  let isClose = false;
+  if (body.startsWith("/")) {
+    isClose = true;
+    body = body.slice(1).trimStart();
+  }
+
+  if (!body.toLowerCase().startsWith("final")) {
+    return null;
+  }
+  const boundary = body[5] ?? "";
+  if (boundary && !isWhitespace(boundary) && boundary !== "/") {
+    return null;
+  }
+
+  let rest = body.slice(5);
+  if (isClose) {
+    return rest.trim().length === 0 ? { isClose: true, isSelfClosing: false } : null;
+  }
+
+  const trimmedRest = rest.trimEnd();
+  const isSelfClosing = trimmedRest.endsWith("/");
+  rest = isSelfClosing ? trimmedRest.slice(0, -1) : rest;
+  if (!parseAttributeList(rest)) {
+    return null;
+  }
+  return { isClose: false, isSelfClosing };
+}
+
+export function findFinalTagMatches(text: string): FinalTagMatch[] {
+  const matches: FinalTagMatch[] = [];
+  for (const match of text.matchAll(FINAL_TAG_CANDIDATE_RE)) {
+    const tagText = match[0];
+    const parsed = parseFinalTag(tagText);
+    if (!parsed) {
+      continue;
+    }
+    matches.push({
+      index: match.index ?? 0,
+      text: tagText,
+      ...parsed,
+    });
+  }
+  return matches;
+}
+
+export function containsFinalTag(text: string): boolean {
+  return findFinalTagMatches(text).length > 0;
+}
+
+export function stripFinalTags(text: string): string {
+  let output = "";
+  let lastIndex = 0;
+  for (const match of findFinalTagMatches(text)) {
+    output += text.slice(lastIndex, match.index);
+    lastIndex = match.index + match.text.length;
+  }
+  output += text.slice(lastIndex);
+  return output;
+}

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -190,6 +190,38 @@ describe("stripReasoningTagsFromText", () => {
         input: "A <FINAL data-x='1'>visible</Final> B",
         expected: "A visible B",
       },
+      {
+        input: "A <final/>visible <final data-model='gemini'>answer</final> B",
+        expected: "A visible answer B",
+      },
+      {
+        input: "A <final data-model=openrouter/google/gemini>answer</final> B",
+        expected: "A answer B",
+      },
+      {
+        input: "A <final-result>visible</final-result> B",
+        expected: "A <final-result>visible</final-result> B",
+      },
+      {
+        input: "  <final-result>visible</final-result>  ",
+        expected: "  <final-result>visible</final-result>  ",
+      },
+      {
+        input: 'A <final reason="a>b">visible B',
+        expected: 'A <final reason="a>b">visible B',
+      },
+      {
+        input: "A <final / nottag>visible B",
+        expected: "A <final / nottag>visible B",
+      },
+      {
+        input: `A <final ${" ".repeat(10_000)} B`,
+        expected: `A <final ${" ".repeat(10_000)} B`,
+      },
+      {
+        input: `A <final ${" ".repeat(10_000)}= > B`,
+        expected: `A <final ${" ".repeat(10_000)}= > B`,
+      },
     ] as const)("handles nested/final tag behavior: %j", (testCase) => {
       expectStrippedCase(testCase);
     });

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -1,9 +1,9 @@
 import { findCodeRegions, isInsideCode } from "./code-regions.js";
+import { findFinalTagMatches } from "./final-tags.js";
 export type ReasoningTagMode = "strict" | "preserve";
 export type ReasoningTagTrim = "none" | "start" | "both";
 
 const QUICK_TAG_RE = /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking|final)\b/i;
-const FINAL_TAG_RE = /<\s*\/?\s*final\b[^<>]*>/gi;
 const THINKING_TAG_RE =
   /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
 
@@ -42,15 +42,21 @@ export function stripReasoningTagsFromText(
   const trimMode = options?.trim ?? "both";
 
   let cleaned = text;
-  if (FINAL_TAG_RE.test(cleaned)) {
-    FINAL_TAG_RE.lastIndex = 0;
+  const matches = findFinalTagMatches(cleaned);
+  THINKING_TAG_RE.lastIndex = 0;
+  const hasThinkingTag = THINKING_TAG_RE.test(cleaned);
+  THINKING_TAG_RE.lastIndex = 0;
+  if (matches.length === 0 && !hasThinkingTag) {
+    return text;
+  }
+  if (matches.length > 0) {
     const finalMatches: Array<{ start: number; length: number; inCode: boolean }> = [];
     const preCodeRegions = findCodeRegions(cleaned);
-    for (const match of cleaned.matchAll(FINAL_TAG_RE)) {
-      const start = match.index ?? 0;
+    for (const match of matches) {
+      const start = match.index;
       finalMatches.push({
         start,
-        length: match[0].length,
+        length: match.text.length,
         inCode: isInsideCode(start, preCodeRegions),
       });
     }
@@ -61,8 +67,6 @@ export function stripReasoningTagsFromText(
         cleaned = cleaned.slice(0, m.start) + cleaned.slice(m.start + m.length);
       }
     }
-  } else {
-    FINAL_TAG_RE.lastIndex = 0;
   }
 
   const codeRegions = findCodeRegions(cleaned);


### PR DESCRIPTION
## Summary

- Add a shared `<final>` tag parser that recognizes attributed and self-closing Gemini/Gemma variants without matching malformed or custom final-like tags.
- Reuse it in user-facing sanitization, reasoning-wrapper stripping, and embedded Pi streaming final-tag enforcement.
- Add regression coverage for sanitizer, reasoning text cleanup, streaming chunk boundaries, strict final enforcement, and live-scaffolding helper behavior.

Fixes #65867.

## Verification

- `node scripts/run-vitest.mjs src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts src/shared/text/reasoning-tags.test.ts`
  - 4 files passed; 203 tests passed.
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts src/agents/pi-embedded-subscribe.ts src/gateway/gateway-models.profiles.live.test.ts src/shared/text/final-tags.ts src/shared/text/reasoning-tags.test.ts src/shared/text/reasoning-tags.ts`
  - All matched files use the correct format.
- `git diff --check`
  - Passed.
- `gemini gemma status`
  - Binary installed, `gemma3-1b-gpu-custom` downloaded, server running on port 9379, settings enabled, routing active.
- Fresh live proof script using exact 1Password `api_key` fields from `API Key - Google Gemini - Personal` and `API Key - OpenRouter - Personal`; secret values were not printed.

## Real behavior proof

Behavior addressed: Gemini/Gemma `<final>` tags with attributes or self-closing syntax leaked through delivered replies on current main because main only stripped bare `<final>` / `</final>` shapes.

Real environment tested: macOS local checkout; Google Gemini API `gemini-2.5-flash`; OpenRouter `google/gemini-2.5-flash`; local LiteRT Gemma `gemma3-1b-gpu-custom` on `127.0.0.1:9379`; fresh keys pulled from 1Password exact `api_key` fields.

Exact steps or command run after this patch: focused Vitest command above, formatting command above, `git diff --check`, `gemini gemma status`, plus a one-off Node live proof that requested literal final-tag fixtures from Google Gemini, OpenRouter Gemini, and local Gemma, then passed each raw output through `sanitizeUserFacingText` / `containsFinalTag`.

Evidence after fix:

```json
{"proof":"origin-main-pattern-check-on-live-shape","raw":"<final data-model=openrouter/google/gemini/>VISIBLE_SELF","originMainSanitizer":"<final data-model=openrouter/google/gemini/>VISIBLE_SELF","leaksOnMain":true}
{"label":"google-self-closing-attributed","attempt":1,"stopReason":"STOP","raw":"<final data-model=openrouter/google/gemini/>VISIBLE_SELF","sanitized":"VISIBLE_SELF","ok":true}
{"label":"google-attributed-open-close","attempt":1,"stopReason":"STOP","raw":"<final data-model=openrouter/google/gemini>VISIBLE_ATTR</final>","sanitized":"VISIBLE_ATTR","ok":true}
{"label":"openrouter-gemini-self-closing-attributed","attempt":1,"stopReason":"stop","raw":"<final data-model=openrouter/google/gemini/>VISIBLE_OR","sanitized":"VISIBLE_OR","ok":true}
{"label":"local-gemma-self-closing-attributed","attempt":2,"stopReason":"STOP","raw":"<final data-model=local/gemma/>VISIBLE_LOCAL\n","sanitized":"VISIBLE_LOCAL\n","ok":true}
```

Observed result after fix: all live raw outputs that contained attributed or self-closing `<final>` tags sanitized to visible text only, and `containsFinalTag` returned false for sanitized text.

What was not tested: full repo suite, broad Testbox/Crabbox lane, and every provider family; proof was focused on the implicated sanitizer/streaming surfaces plus real Google Gemini, OpenRouter Gemini, and local Gemma reproduction shapes.
