### PR TITLE
feat(codex): add portable Codex command pickers

### DIFF
--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { resolveAgentDir, resolveSessionAgentIds } from "openclaw/plugin-sdk/agent-runtime";
+import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -240,12 +241,144 @@ export function resetCodexDiagnosticsFeedbackStateForTests(): void {
   pendingCodexDiagnosticsConfirmationTokensByScope.clear();
 }
 
+type CodexPickerButton = { label: string; command: string };
+
+function buildPickerPresentation(title: string, prompt: string, buttons: CodexPickerButton[]) {
+  return {
+    title,
+    blocks: [
+      { type: "text", text: prompt },
+      {
+        type: "buttons",
+        buttons: buttons.map((button) => ({
+          label: button.label,
+          value: button.command,
+        })),
+      },
+    ],
+  } satisfies MessagePresentation;
+}
+
+/**
+ * No-arg `/codex` picker. Core owns the native command tree; channels render
+ * the portable buttons as inline controls when their transport can.
+ */
+function buildCodexSubcommandPickerReply(): PluginCommandResult {
+  const verbs: CodexPickerButton[] = [
+    { label: "plugins", command: "/codex plugins menu" },
+    { label: "permissions", command: "/codex permissions menu" },
+    { label: "fast", command: "/codex fast menu" },
+    { label: "computer-use", command: "/codex computer-use menu" },
+    { label: "account", command: "/codex account" },
+    { label: "help", command: "/codex help" },
+  ];
+
+  const fallbackTextLines = [
+    "Codex commands. Pick a category or type:",
+    "",
+    ...verbs.map((v, i) => `  ${i + 1}. ${v.command}`),
+    "",
+    "Tap 'help' (or type /codex help) for the full list of typeable verbs",
+    "including threads, mcp, binding, detach, skills, resume, bind, steer,",
+    "model, diagnostics, compact, review, computer-use.",
+    "",
+    "Top-level shortcuts cover everyday operations: /status, /fast, /help, /stop, /models.",
+  ];
+
+  return {
+    text: fallbackTextLines.join("\n"),
+    presentation: buildPickerPresentation("Codex commands", "Pick a Codex subcommand:", verbs),
+  };
+}
+
+/** Sub-picker for `/codex fast menu` (on / off / status). */
+function buildCodexFastMenuReply(): PluginCommandResult {
+  const modes = ["on", "off", "status"] as const;
+  const buttons: CodexPickerButton[] = [
+    ...modes.map((mode) => ({ label: mode, command: `/codex fast ${mode}` })),
+    { label: "back", command: "/codex" },
+  ];
+  const fallbackTextLines = [
+    "Codex fast mode. Pick one or type /codex fast <mode>:",
+    "",
+    ...modes.map((m, i) => `  ${i + 1}. /codex fast ${m}`),
+    "",
+    "Type '/codex' to go back to the main menu.",
+  ];
+  return {
+    text: fallbackTextLines.join("\n"),
+    presentation: buildPickerPresentation("Codex fast mode", "Pick a Codex fast mode:", buttons),
+  };
+}
+
+/** Sub-picker for `/codex permissions menu` (default / yolo / status). */
+function buildCodexPermissionsMenuReply(): PluginCommandResult {
+  const modes = ["default", "yolo", "status"] as const;
+  const buttons: CodexPickerButton[] = [
+    ...modes.map((mode) => ({ label: mode, command: `/codex permissions ${mode}` })),
+    { label: "back", command: "/codex" },
+  ];
+  const fallbackTextLines = [
+    "Codex permissions. Pick one or type /codex permissions <mode>:",
+    "",
+    ...modes.map((m, i) => `  ${i + 1}. /codex permissions ${m}`),
+    "",
+    "Type '/codex' to go back to the main menu.",
+  ];
+  return {
+    text: fallbackTextLines.join("\n"),
+    presentation: buildPickerPresentation(
+      "Codex permissions",
+      "Pick a Codex permissions mode:",
+      buttons,
+    ),
+  };
+}
+
+/** Sub-picker for `/codex computer-use menu` (status / install). */
+function buildCodexComputerUseMenuReply(): PluginCommandResult {
+  const actions = ["status", "install"] as const;
+  const buttons: CodexPickerButton[] = [
+    ...actions.map((action) => ({
+      label: action,
+      command: `/codex computer-use ${action}`,
+    })),
+    { label: "back", command: "/codex" },
+  ];
+  const fallbackTextLines = [
+    "Codex computer-use. Pick one or type /codex computer-use <action>:",
+    "",
+    ...actions.map((a, i) => `  ${i + 1}. /codex computer-use ${a}`),
+    "",
+    "Flag-driven invocations (--source, --marketplace-path, --marketplace) are not in the picker. Type '/codex computer-use' or read '/codex help' for the full surface.",
+    "",
+    "Type '/codex' to go back to the main menu.",
+  ];
+  return {
+    text: fallbackTextLines.join("\n"),
+    presentation: buildPickerPresentation(
+      "Codex computer-use",
+      "Pick a Codex computer-use action:",
+      buttons,
+    ),
+  };
+}
+
+/** Returns true when the rest-args are exactly `["menu"]` (case-insensitive). */
+function isMenuVerb(rest: readonly string[]): boolean {
+  return rest.length === 1 && (rest[0] ?? "").trim().toLowerCase() === "menu";
+}
+
 export async function handleCodexSubcommand(
   ctx: PluginCommandContext,
   options: { pluginConfig?: unknown; deps?: Partial<CodexCommandDeps> },
 ): Promise<PluginCommandResult> {
   const deps: CodexCommandDeps = { ...defaultCodexCommandDeps, ...options.deps };
-  const [subcommand = "status", ...rest] = splitArgs(ctx.args);
+  const args = splitArgs(ctx.args);
+  if (args.length === 0) {
+    return buildCodexSubcommandPickerReply();
+  }
+  const [subcommand = "status", ...rest] = args;
   const normalized = subcommand.toLowerCase();
   if (normalized === "help") {
     return { text: buildHelp() };
@@ -321,9 +454,15 @@ export async function handleCodexSubcommand(
     return { text: await setConversationModel(deps, ctx, options.pluginConfig, rest) };
   }
   if (normalized === "fast") {
+    if (isMenuVerb(rest)) {
+      return buildCodexFastMenuReply();
+    }
     return { text: await setConversationFastMode(deps, ctx, options.pluginConfig, rest) };
   }
   if (normalized === "permissions") {
+    if (isMenuVerb(rest)) {
+      return buildCodexPermissionsMenuReply();
+    }
     return { text: await setConversationPermissions(deps, ctx, options.pluginConfig, rest) };
   }
   if (normalized === "compact") {
@@ -360,6 +499,9 @@ export async function handleCodexSubcommand(
     );
   }
   if (normalized === "computer-use" || normalized === "computeruse") {
+    if (isMenuVerb(rest)) {
+      return buildCodexComputerUseMenuReply();
+    }
     return {
       text: await handleComputerUseCommand(deps, options.pluginConfig, rest),
     };

--- a/extensions/codex/src/command-plugins-management.test.ts
+++ b/extensions/codex/src/command-plugins-management.test.ts
@@ -1,4 +1,4 @@
-import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
 import { describe, expect, it } from "vitest";
 import {
   handleCodexPluginsSubcommand,
@@ -40,6 +40,14 @@ const fakeCtx: PluginCommandContext = {
   getCurrentConversationBinding: async () => null,
 };
 
+function buttonValues(result: PluginCommandResult): string[] {
+  const block = result.presentation?.blocks.find((candidate) => candidate.type === "buttons");
+  if (!block || block.type !== "buttons") {
+    throw new Error("expected button presentation");
+  }
+  return block.buttons.map((button) => button.value ?? "");
+}
+
 describe("Codex /codex plugins subcommand", () => {
   it("lists a configured plugin with its enabled marker and explains the underlying file", async () => {
     const io = inMemoryIO({
@@ -70,6 +78,50 @@ describe("Codex /codex plugins subcommand", () => {
     const result = await handleCodexPluginsSubcommand(fakeCtx, ["list"], io);
     expect(result.text).toContain("OFF  google-calendar");
     expect(result.text).toContain("Global codexPlugins.enabled is off");
+  });
+
+  it("renders the plugins menu as portable slash-command buttons", async () => {
+    const io = inMemoryIO();
+
+    const result = await handleCodexPluginsSubcommand(fakeCtx, ["menu"], io);
+
+    expect(result.text).toContain("/codex plugins list");
+    expect(buttonValues(result)).toEqual([
+      "/codex plugins list",
+      "/codex plugins enable",
+      "/codex plugins disable",
+      "/codex plugins help",
+      "/codex",
+    ]);
+  });
+
+  it("renders enable and disable target pickers from effective plugin state", async () => {
+    const io = inMemoryIO({
+      "google-calendar": {
+        enabled: false,
+        marketplaceName: "openai-curated",
+        pluginName: "google-calendar",
+      },
+      notion: {
+        enabled: true,
+        marketplaceName: "openai-curated",
+        pluginName: "notion",
+      },
+    });
+
+    const enableResult = await handleCodexPluginsSubcommand(fakeCtx, ["enable"], io);
+    expect(enableResult.text).toContain("/codex plugins enable google-calendar");
+    expect(buttonValues(enableResult)).toEqual([
+      "/codex plugins enable google-calendar",
+      "/codex plugins menu",
+    ]);
+
+    const disableResult = await handleCodexPluginsSubcommand(fakeCtx, ["disable"], io);
+    expect(disableResult.text).toContain("/codex plugins disable notion");
+    expect(buttonValues(disableResult)).toEqual([
+      "/codex plugins disable notion",
+      "/codex plugins menu",
+    ]);
   });
 
   it("enables and disables a configured plugin and reflects the change in subsequent reads", async () => {
@@ -149,18 +201,13 @@ describe("Codex /codex plugins subcommand", () => {
     expect(result.text).not.toContain("@ops");
   });
 
-  it("returns usage when list, enable, or disable receives the wrong arity", async () => {
+  it("returns usage when list, menu, enable, or disable receives the wrong arity", async () => {
     const io = inMemoryIO();
     const listResult = await handleCodexPluginsSubcommand(fakeCtx, ["list", "chrome"], io);
     expect(listResult.text).toContain("Usage: /codex plugins list");
 
-    const result = await handleCodexPluginsSubcommand(fakeCtx, ["disable"], io);
-    expect(result.text).toContain("Usage: /codex plugins disable <name>");
-    expect(result.presentation).toBeUndefined();
-
-    const enableResult = await handleCodexPluginsSubcommand(fakeCtx, ["enable"], io);
-    expect(enableResult.text).toContain("Usage: /codex plugins enable <name>");
-    expect(enableResult.presentation).toBeUndefined();
+    const menuResult = await handleCodexPluginsSubcommand(fakeCtx, ["menu", "extra"], io);
+    expect(menuResult.text).toContain("Usage: /codex plugins menu");
 
     const extraResult = await handleCodexPluginsSubcommand(
       fakeCtx,

--- a/extensions/codex/src/command-plugins-management.ts
+++ b/extensions/codex/src/command-plugins-management.ts
@@ -1,3 +1,4 @@
+import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
 import { formatCodexDisplayText } from "./command-formatters.js";
 
@@ -33,6 +34,24 @@ export type CodexPluginsConfigBlock = {
 const POLICY_REFRESH_HINT =
   "New Codex conversations pick this up automatically. Use /new or /reset to refresh the current one.";
 
+type CodexPickerButton = { label: string; command: string };
+
+function buildPickerPresentation(title: string, prompt: string, buttons: CodexPickerButton[]) {
+  return {
+    title,
+    blocks: [
+      { type: "text", text: prompt },
+      {
+        type: "buttons",
+        buttons: buttons.map((button) => ({
+          label: button.label,
+          value: button.command,
+        })),
+      },
+    ],
+  } satisfies MessagePresentation;
+}
+
 export async function handleCodexPluginsSubcommand(
   ctx: PluginCommandContext,
   rest: string[],
@@ -40,6 +59,20 @@ export async function handleCodexPluginsSubcommand(
 ): Promise<PluginCommandResult> {
   const [verb = "list", ...args] = rest;
   const normalized = verb.toLowerCase();
+
+  if (normalized === "menu") {
+    if (args.length > 0) {
+      return { text: "Usage: /codex plugins menu" };
+    }
+    return buildPluginsMenuReply();
+  }
+
+  if (normalized === "help") {
+    if (args.length > 0) {
+      return { text: "Usage: /codex plugins help" };
+    }
+    return { text: buildPluginsHelp() };
+  }
 
   if (normalized === "list") {
     if (args.length > 0) {
@@ -53,6 +86,10 @@ export async function handleCodexPluginsSubcommand(
 
   const target = args[0];
   if (normalized === "enable" || normalized === "disable") {
+    if (args.length === 0) {
+      const current = await io.readConfig();
+      return buildPluginNamePickerReply(normalized, current);
+    }
     if (!target || args.length > 1) {
       return { text: `Usage: /codex plugins ${normalized} <name>` };
     }
@@ -82,6 +119,98 @@ export async function handleCodexPluginsSubcommand(
 
   return {
     text: `Unknown /codex plugins subcommand: ${formatCodexDisplayText(verb)}\n\n${buildPluginsHelp()}`,
+  };
+}
+
+function buildPluginsMenuReply(): PluginCommandResult {
+  const buttons: CodexPickerButton[] = [
+    { label: "list", command: "/codex plugins list" },
+    { label: "enable", command: "/codex plugins enable" },
+    { label: "disable", command: "/codex plugins disable" },
+    { label: "help", command: "/codex plugins help" },
+    { label: "back", command: "/codex" },
+  ];
+  const text = [
+    "Codex sub-plugins. Pick a sub-action or type:",
+    "",
+    "  1. /codex plugins list",
+    "  2. /codex plugins enable",
+    "  3. /codex plugins disable",
+    "  4. /codex plugins help",
+    "",
+    "Type '/codex' to go back to the main menu.",
+  ].join("\n");
+  return {
+    text,
+    presentation: buildPickerPresentation(
+      "Codex sub-plugins",
+      "Pick a Codex sub-plugin action:",
+      buttons,
+    ),
+  };
+}
+
+function buildPluginNamePickerReply(
+  verb: "enable" | "disable",
+  current: CodexPluginsConfigBlock,
+): PluginCommandResult {
+  const globalEnabled = current.enabled === true;
+  const entries = Object.entries(current.plugins ?? {}).toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  const eligible = entries.filter(([, entry]) => {
+    const effectivelyEnabled = globalEnabled && entry.enabled !== false;
+    return verb === "disable" ? effectivelyEnabled : !effectivelyEnabled;
+  });
+
+  if (eligible.length === 0) {
+    const action = verb === "enable" ? "disabled" : "enabled";
+    return {
+      text: [
+        `No configured ${action} Codex sub-plugins found.`,
+        "",
+        "Type '/codex plugins list' to inspect configured sub-plugins.",
+        "Type '/codex plugins menu' to go back to the plugins menu.",
+      ].join("\n"),
+      presentation: buildPickerPresentation(
+        "Codex sub-plugins",
+        "Pick another Codex sub-plugin action:",
+        [
+          { label: "list", command: "/codex plugins list" },
+          { label: "back", command: "/codex plugins menu" },
+        ],
+      ),
+    };
+  }
+
+  const buttons: CodexPickerButton[] = [
+    ...eligible.map(([key]) => ({
+      label: formatCodexDisplayText(key),
+      command: `/codex plugins ${verb} ${key}`,
+    })),
+    { label: "back", command: "/codex plugins menu" },
+  ];
+  const text = [
+    `Codex sub-plugins to ${verb}. Pick one or type:`,
+    "",
+    ...eligible.map(([key], index) => `  ${index + 1}. /codex plugins ${verb} ${key}`),
+    "",
+    ...(verb === "enable" && !globalEnabled
+      ? [
+          "Global codexPlugins.enabled is off; enabling one configured sub-plugin turns it on.",
+          "",
+        ]
+      : []),
+    "Type '/codex plugins menu' to go back to the plugins menu.",
+  ].join("\n");
+
+  return {
+    text,
+    presentation: buildPickerPresentation(
+      "Codex sub-plugins",
+      `Pick a Codex sub-plugin to ${verb}:`,
+      buttons,
+    ),
   };
 }
 

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -151,6 +151,14 @@ function expectResultTextContains(result: PluginCommandResult, expected: string)
   expect(requireResultText(result)).toContain(expected);
 }
 
+function buttonValues(result: PluginCommandResult): string[] {
+  const block = result.presentation?.blocks.find((candidate) => candidate.type === "buttons");
+  if (!block || block.type !== "buttons") {
+    throw new Error("expected button presentation");
+  }
+  return block.buttons.map((button) => button.value ?? "");
+}
+
 function installAuthProfileStore(store: AuthProfileStore, config: PluginCommandContext["config"]) {
   replaceRuntimeAuthProfileStoreSnapshots([
     {
@@ -265,6 +273,31 @@ describe("codex command", () => {
 
     expect(result.text).toContain("Codex command failed: &lt;\uff20U123&gt; loader failed");
     expect(result.text).not.toContain("<@U123>");
+  });
+
+  it("renders the top-level Codex menu as portable native slash commands", async () => {
+    const result = await handleCodexCommand(createContext(""));
+
+    expectResultTextContains(result, "/codex plugins menu");
+    expect(buttonValues(result)).toEqual([
+      "/codex plugins menu",
+      "/codex permissions menu",
+      "/codex fast menu",
+      "/codex computer-use menu",
+      "/codex account",
+      "/codex help",
+    ]);
+  });
+
+  it("routes /codex plugins menu to the Codex-owned plugin picker", async () => {
+    const codexPluginsManagementIo = inMemoryCodexPluginsIO();
+
+    const result = await handleCodexCommand(createContext("plugins menu"), {
+      deps: createDeps({ codexPluginsManagementIo }),
+    });
+
+    expectResultTextContains(result, "/codex plugins enable");
+    expect(buttonValues(result)).toContain("/codex plugins list");
   });
 
   it("lists Codex sub-plugins through the /codex plugins command surface", async () => {

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2052,7 +2052,9 @@ export const registerTelegramHandlers = ({
       const chatId = callbackMessage.chat.id;
       const isGroup =
         callbackMessage.chat.type === "group" || callbackMessage.chat.type === "supergroup";
-      const approvalCallback = parseExecApprovalCommandText(data);
+      const nativeCallbackCommand = parseTelegramNativeCommandCallbackData(data);
+      const callbackCommandText = nativeCallbackCommand ?? data;
+      const approvalCallback = parseExecApprovalCommandText(callbackCommandText);
       const isApprovalCallback = approvalCallback !== null;
       const inlineButtonsScope = resolveTelegramInlineButtonsScope({
         cfg,
@@ -2620,11 +2622,10 @@ export const registerTelegramHandlers = ({
         return;
       }
 
-      const nativeCallbackCommand = parseTelegramNativeCommandCallbackData(data);
       const syntheticMessage = buildSyntheticTextMessage({
         base: withResolvedTelegramForumFlag(callbackMessage, isForum),
         from: callback.from,
-        text: nativeCallbackCommand ?? data,
+        text: callbackCommandText,
       });
       const syntheticCtx = buildSyntheticContext(ctx, syntheticMessage);
       await processMessageWithReplyChain({

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -100,11 +100,15 @@ import {
 import { resolveTelegramGroupPromptSettings } from "./group-config-helpers.js";
 import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
+import { buildTelegramNativeCommandCallbackData } from "./native-command-callback-data.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 import { getTopicName, resolveTopicNameCacheScope } from "./topic-name-cache.js";
+export {
+  buildTelegramNativeCommandCallbackData,
+  parseTelegramNativeCommandCallbackData,
+} from "./native-command-callback-data.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
-const TELEGRAM_NATIVE_COMMAND_CALLBACK_PREFIX = "tgcmd:";
 
 type TelegramNativeCommandContext = Context & { match?: string };
 type TelegramChunkMode = ReturnType<
@@ -442,22 +446,6 @@ export type RegisterTelegramHandlerParams = {
   ) => Promise<boolean>;
   logger: ReturnType<typeof getChildLogger>;
 };
-
-export function buildTelegramNativeCommandCallbackData(commandText: string): string {
-  return `${TELEGRAM_NATIVE_COMMAND_CALLBACK_PREFIX}${commandText}`;
-}
-
-export function parseTelegramNativeCommandCallbackData(data?: string | null): string | null {
-  if (!data) {
-    return null;
-  }
-  const trimmed = data.trim();
-  if (!trimmed.startsWith(TELEGRAM_NATIVE_COMMAND_CALLBACK_PREFIX)) {
-    return null;
-  }
-  const commandText = trimmed.slice(TELEGRAM_NATIVE_COMMAND_CALLBACK_PREFIX.length).trim();
-  return commandText.startsWith("/") ? commandText : null;
-}
 
 export function resolveTelegramNativeCommandDisableBlockStreaming(
   telegramCfg: TelegramAccountConfig,

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -636,7 +636,7 @@ describe("createTelegramBot", () => {
     await callbackHandler({
       callbackQuery: {
         id: "cbq-approve-capability-free",
-        data: "/approve 138e9b8c allow-once",
+        data: "tgcmd:/approve 138e9b8c allow-once",
         from: { id: 9, first_name: "Ada", username: "ada_bot" },
         message: {
           chat: { id: 1234, type: "private" },

--- a/extensions/telegram/src/button-types.test.ts
+++ b/extensions/telegram/src/button-types.test.ts
@@ -41,7 +41,7 @@ describe("buildTelegramPresentationButtons", () => {
       [
         {
           text: "Approve",
-          callback_data: "/approve req-1 allow-once",
+          callback_data: "tgcmd:/approve req-1 allow-once",
           style: "success",
         },
       ],
@@ -65,7 +65,7 @@ describe("buildTelegramPresentationButtons", () => {
       [
         {
           text: "Keep",
-          callback_data: "/codex plugins menu",
+          callback_data: "tgcmd:/codex plugins menu",
           style: undefined,
         },
       ],

--- a/extensions/telegram/src/button-types.test.ts
+++ b/extensions/telegram/src/button-types.test.ts
@@ -47,4 +47,28 @@ describe("buildTelegramPresentationButtons", () => {
       ],
     ]);
   });
+
+  it("drops presentation buttons whose callback payload exceeds Telegram limits", () => {
+    expect(
+      buildTelegramPresentationButtons({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              { label: "Keep", value: "/codex plugins menu" },
+              { label: "Drop", value: `/codex plugins enable ${"x".repeat(80)}` },
+            ],
+          },
+        ],
+      }),
+    ).toEqual([
+      [
+        {
+          text: "Keep",
+          callback_data: "/codex plugins menu",
+          style: undefined,
+        },
+      ],
+    ]);
+  });
 });

--- a/extensions/telegram/src/button-types.test.ts
+++ b/extensions/telegram/src/button-types.test.ts
@@ -41,7 +41,7 @@ describe("buildTelegramPresentationButtons", () => {
       [
         {
           text: "Approve",
-          callback_data: "tgcmd:/approve req-1 allow-once",
+          callback_data: "/approve req-1 allow-once",
           style: "success",
         },
       ],
@@ -66,6 +66,28 @@ describe("buildTelegramPresentationButtons", () => {
         {
           text: "Keep",
           callback_data: "tgcmd:/codex plugins menu",
+          style: undefined,
+        },
+      ],
+    ]);
+  });
+
+  it("keeps shortened plugin approval callbacks on the approval bypass path", () => {
+    const approvalId = `plugin:${"a".repeat(36)}`;
+    expect(
+      buildTelegramPresentationButtons({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Allow", value: `/approve ${approvalId} allow-always` }],
+          },
+        ],
+      }),
+    ).toEqual([
+      [
+        {
+          text: "Allow",
+          callback_data: `/approve ${approvalId} always`,
           style: undefined,
         },
       ],

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -1,3 +1,4 @@
+import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { reduceInteractiveReply } from "openclaw/plugin-sdk/interactive-runtime";
 import {
   isMessagePresentationInteractiveBlock,
@@ -41,9 +42,7 @@ function toTelegramInlineButton(
       style,
     };
   }
-  const callbackData = button.value
-    ? sanitizeTelegramCallbackData(toTelegramCallbackData(button.value))
-    : undefined;
+  const callbackData = button.value ? toTelegramCallbackData(button.value) : undefined;
   if (callbackData) {
     return {
       text: button.label,
@@ -61,9 +60,19 @@ function toTelegramInlineButton(
   return undefined;
 }
 
-function toTelegramCallbackData(value: string): string {
-  const commandText = value.trim();
-  return commandText.startsWith("/") ? buildTelegramNativeCommandCallbackData(commandText) : value;
+function toTelegramCallbackData(value: string): string | undefined {
+  const sanitizedValue = sanitizeTelegramCallbackData(value);
+  if (!sanitizedValue) {
+    return undefined;
+  }
+  if (parseExecApprovalCommandText(sanitizedValue)) {
+    return sanitizedValue;
+  }
+  const commandText = sanitizedValue.trim();
+  const callbackData = commandText.startsWith("/")
+    ? buildTelegramNativeCommandCallbackData(commandText)
+    : sanitizedValue;
+  return sanitizeTelegramCallbackData(callbackData);
 }
 
 function chunkInteractiveButtons(

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -8,6 +8,7 @@ import {
   type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { sanitizeTelegramCallbackData } from "./approval-callback-data.js";
+import { buildTelegramNativeCommandCallbackData } from "./native-command-callback-data.js";
 
 export type TelegramButtonStyle = "danger" | "success" | "primary";
 
@@ -40,7 +41,9 @@ function toTelegramInlineButton(
       style,
     };
   }
-  const callbackData = button.value ? sanitizeTelegramCallbackData(button.value) : undefined;
+  const callbackData = button.value
+    ? sanitizeTelegramCallbackData(toTelegramCallbackData(button.value))
+    : undefined;
   if (callbackData) {
     return {
       text: button.label,
@@ -56,6 +59,11 @@ function toTelegramInlineButton(
     };
   }
   return undefined;
+}
+
+function toTelegramCallbackData(value: string): string {
+  const commandText = value.trim();
+  return commandText.startsWith("/") ? buildTelegramNativeCommandCallbackData(commandText) : value;
 }
 
 function chunkInteractiveButtons(

--- a/extensions/telegram/src/command-ui.ts
+++ b/extensions/telegram/src/command-ui.ts
@@ -5,6 +5,7 @@ import {
   buildProviderKeyboard,
   type ProviderInfo,
 } from "./model-buttons.js";
+import { buildTelegramNativeCommandCallbackData } from "./native-command-callback-data.js";
 
 export function buildCommandsPaginationKeyboard(
   currentPage: number,
@@ -94,7 +95,7 @@ export function buildTelegramModelsAddProviderChannelData(params: {
   const buttons = params.providers.map((provider) => [
     {
       text: provider.id,
-      callback_data: `/models add ${provider.id}`,
+      callback_data: buildTelegramNativeCommandCallbackData(`/models add ${provider.id}`),
     },
   ]);
   return {

--- a/extensions/telegram/src/native-command-callback-data.ts
+++ b/extensions/telegram/src/native-command-callback-data.ts
@@ -1,0 +1,17 @@
+const TELEGRAM_NATIVE_COMMAND_CALLBACK_PREFIX = "tgcmd:";
+
+export function buildTelegramNativeCommandCallbackData(commandText: string): string {
+  return `${TELEGRAM_NATIVE_COMMAND_CALLBACK_PREFIX}${commandText}`;
+}
+
+export function parseTelegramNativeCommandCallbackData(data?: string | null): string | null {
+  if (!data) {
+    return null;
+  }
+  const trimmed = data.trim();
+  if (!trimmed.startsWith(TELEGRAM_NATIVE_COMMAND_CALLBACK_PREFIX)) {
+    return null;
+  }
+  const commandText = trimmed.slice(TELEGRAM_NATIVE_COMMAND_CALLBACK_PREFIX.length).trim();
+  return commandText.startsWith("/") ? commandText : null;
+}

--- a/extensions/telegram/src/shared.test.ts
+++ b/extensions/telegram/src/shared.test.ts
@@ -56,8 +56,8 @@ describe("createTelegramPluginBase config duplicate token guard", () => {
     expect(channelData).toEqual({
       telegram: {
         buttons: [
-          [{ text: "ollama", callback_data: "/models add ollama" }],
-          [{ text: "lmstudio", callback_data: "/models add lmstudio" }],
+          [{ text: "ollama", callback_data: "tgcmd:/models add ollama" }],
+          [{ text: "lmstudio", callback_data: "tgcmd:/models add lmstudio" }],
         ],
       },
     });

--- a/src/agents/embedded-agent-runner.sanitize-session-history.test-harness.ts
+++ b/src/agents/embedded-agent-runner.sanitize-session-history.test-harness.ts
@@ -1,22 +1,10 @@
 import { expect, vi } from "vitest";
-import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import type { AgentMessage } from "./runtime/index.js";
 import type { SessionManager } from "./sessions/index.js";
-import type { TranscriptPolicy } from "./transcript-policy.js";
 
 type SessionEntry = { type: string; customType: string; data: unknown };
-export type SanitizeSessionHistoryFn = (params: {
-  messages: AgentMessage[];
-  modelApi: string;
-  provider: string;
-  allowedToolNames?: Iterable<string>;
-  sessionManager: SessionManager;
-  sessionId: string;
-  modelId?: string;
-  model?: ProviderRuntimeModel;
-  policy?: TranscriptPolicy;
-  preserveLatestAssistantThinking?: boolean;
-}) => Promise<AgentMessage[]>;
+export type SanitizeSessionHistoryFn =
+  typeof import("./embedded-agent-runner/replay-history.js").sanitizeSessionHistory;
 type SanitizeSessionHistoryMockedHelpers = typeof import("./embedded-agent-helpers.js");
 export type SanitizeSessionHistoryHarness = {
   sanitizeSessionHistory: SanitizeSessionHistoryFn;

--- a/src/media-understanding/apply.echo-transcript.test.ts
+++ b/src/media-understanding/apply.echo-transcript.test.ts
@@ -175,7 +175,6 @@ describe("applyMediaUnderstanding – echo transcript", () => {
         (err as { code?: string; provider?: string }).provider = provider;
         throw err;
       },
-      isProviderAuthError: vi.fn(() => false),
       resolveAwsSdkEnvVarName: vi.fn(() => undefined),
       resolveEnvApiKey: vi.fn(() => null),
       resolveModelAuthMode: vi.fn(() => "api-key"),

--- a/src/media-understanding/apply.echo-transcript.test.ts
+++ b/src/media-understanding/apply.echo-transcript.test.ts
@@ -160,13 +160,20 @@ describe("applyMediaUnderstanding – echo transcript", () => {
     vi.doMock("../agents/model-auth.js", () => ({
       resolveApiKeyForProvider: resolveApiKeyForProviderMock,
       hasAvailableAuthForProvider: hasAvailableAuthForProviderMock,
+      isProviderAuthError: (err: unknown, code?: string) =>
+        err instanceof Error &&
+        "code" in err &&
+        (code === undefined || (err as { code?: unknown }).code === code),
       requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
         if (auth?.apiKey) {
           return auth.apiKey;
         }
-        throw new Error(
+        const err = new Error(
           `No API key resolved for provider "${provider}" (auth mode: ${auth?.mode}).`,
         );
+        (err as { code?: string; provider?: string }).code = "missing-api-key";
+        (err as { code?: string; provider?: string }).provider = provider;
+        throw err;
       },
       isProviderAuthError: vi.fn(() => false),
       resolveAwsSdkEnvVarName: vi.fn(() => undefined),

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -286,7 +286,6 @@ describe("applyMediaUnderstanding", () => {
         (err as { code?: string; provider?: string }).provider = provider;
         throw err;
       },
-      isProviderAuthError: vi.fn(() => false),
     }));
     vi.doMock("../media/fetch.js", () => ({
       readRemoteMediaBuffer: readRemoteMediaBufferMock,

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -271,13 +271,20 @@ describe("applyMediaUnderstanding", () => {
     vi.doMock("../agents/model-auth.js", () => ({
       resolveApiKeyForProvider: resolveApiKeyForProviderMock,
       hasAvailableAuthForProvider: hasAvailableAuthForProviderMock,
+      isProviderAuthError: (err: unknown, code?: string) =>
+        err instanceof Error &&
+        "code" in err &&
+        (code === undefined || (err as { code?: unknown }).code === code),
       requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
         if (auth?.apiKey) {
           return auth.apiKey;
         }
-        throw new Error(
+        const err = new Error(
           `No API key resolved for provider "${provider}" (auth mode: ${auth?.mode}).`,
         );
+        (err as { code?: string; provider?: string }).code = "missing-api-key";
+        (err as { code?: string; provider?: string }).provider = provider;
+        throw err;
       },
       isProviderAuthError: vi.fn(() => false),
     }));

--- a/src/media-understanding/runner.test-mocks.ts
+++ b/src/media-understanding/runner.test-mocks.ts
@@ -19,12 +19,21 @@ export function createAvailableModelAuthMockModule() {
       source: "test",
       mode: "api-key",
     })),
-    requireApiKey: vi.fn((auth: { apiKey?: string }) => auth.apiKey ?? "test-key"),
     ProviderAuthError,
     isProviderAuthError: vi.fn(
       (err: unknown, code?: "missing-api-key" | "missing-provider-auth") =>
         err instanceof ProviderAuthError && (!code || err.code === code),
     ),
+    requireApiKey: vi.fn((auth: { apiKey?: string }, provider: string) => {
+      if (auth.apiKey) {
+        return auth.apiKey;
+      }
+      throw new ProviderAuthError(
+        "missing-api-key",
+        provider,
+        `No API key resolved for provider "${provider}".`,
+      );
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary

- Moves `/codex` picker ownership into the Codex plugin: core/native command handling returns portable `MessagePresentation` buttons for Codex submenus, plugin management, fast mode, permissions, and computer-use.
- Keeps Telegram generic: it renders portable slash-command buttons as Telegram native command callbacks when possible, while preserving approval callback shortening and the approval-specific bypass path.
- Removes the Telegram-specific Codex picker callback surface and covers the picker/plugin state behavior with focused Codex and Telegram coverage.

## Verification

- `node scripts/run-vitest.mjs extensions/codex/src/command-plugins-management.test.ts extensions/codex/src/commands.test.ts extensions/telegram/src/button-types.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts extensions/telegram/src/button-types.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/shared.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.media-understanding.config.ts --reporter=verbose`
- `pnpm check:test-types`
- `pnpm tsgo:prod`
- `pnpm lint --threads=8`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: `/codex` no-arg and submenu pickers now expose native slash-command actions as portable presentation buttons, and Telegram maps those slash buttons into native callback routing without Codex-specific Telegram callback ids.

Real environment tested: Local OpenClaw checkout on the rebased PR head, loading the real Telegram extension button mapper through the repo runtime (`node --import tsx`).

Exact steps or command run after this patch: Ran this command after the final Telegram native callback and approval preservation fixes:

```bash
node --import tsx --input-type=module <<'NODE'
import { buildTelegramPresentationButtons } from './extensions/telegram/src/button-types.ts';

const pluginApprovalId = `plugin:${'a'.repeat(36)}`;
const buttons = buildTelegramPresentationButtons({
  blocks: [
    { type: 'text', text: 'Pick an action' },
    {
      type: 'buttons',
      buttons: [
        { label: 'plugins', value: '/codex plugins menu' },
        { label: 'allow plugin', value: `/approve ${pluginApprovalId} allow-always` },
      ],
    },
  ],
});
console.log(JSON.stringify(buttons, null, 2));
NODE
```

Evidence after fix: Terminal output from the real mapper:

```json
[
  [
    {
      "text": "plugins",
      "callback_data": "tgcmd:/codex plugins menu"
    },
    {
      "text": "allow plugin",
      "callback_data": "/approve plugin:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa always"
    }
  ]
]
```

Observed result after fix: The portable Codex slash command is emitted as a Telegram native callback, while the long plugin approval action stays on the raw approval callback path and is shortened to fit Telegram callback data.

What was not tested: No live Telegram bot roundtrip was run.
