### PR TITLE
fix(ui): avoid inline webchat image previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram/active-memory: run blocking memory recall through the Telegram provider for direct-message turns even when the hook context carries the raw chat id, preventing embedded recall from launching against an invalid numeric channel. Fixes #82177. Thanks @cslash-zz.
+- Control UI/WebChat: keep optimistic image messages from embedding large inline `data:` previews and preserve image-only user turns in chat history, avoiding browser stack overflows when sending image attachments. Fixes #82182. Thanks @ExploreSheep.
 - Agents/media: preserve message-tool-only delivery for generated music and video completion handoffs, so group/channel completions do not finish without posting the generated attachment.
 - Agents: strip Gemini/Gemma `<final>` tags with attributes or self-closing syntax from delivered replies, including strict final-tag streaming enforcement. Fixes #65867.
 - macOS/update: disarm legacy `ai.openclaw.update.*` LaunchAgents when `openclaw update` starts from one, preventing KeepAlive relaunch loops that repeatedly restart the Gateway and replay update continuations. Fixes #82167.

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -509,6 +509,15 @@ function isEmptyTextOnlyContent(content: unknown): boolean {
   return sawText;
 }
 
+function hasTranscriptMediaPaths(message: Record<string, unknown>): boolean {
+  const mediaPaths = Array.isArray(message.MediaPaths)
+    ? message.MediaPaths
+    : typeof message.MediaPath === "string"
+      ? [message.MediaPath]
+      : [];
+  return mediaPaths.some((value) => typeof value === "string" && value.trim());
+}
+
 function extractProjectedText(content: unknown): string {
   if (typeof content === "string") {
     return content;
@@ -548,7 +557,11 @@ function shouldHideProjectedHistoryMessage(message: Record<string, unknown>): bo
   if (roleContent.role === "user" && isSubagentAnnounceInterSessionUserMessage(message)) {
     return true;
   }
-  if (roleContent.role === "user" && isEmptyTextOnlyContent(message.content ?? message.text)) {
+  if (
+    roleContent.role === "user" &&
+    isEmptyTextOnlyContent(message.content ?? message.text) &&
+    !hasTranscriptMediaPaths(message)
+  ) {
     return true;
   }
   if (roleContent.role === "assistant" && isEmptyTextOnlyContent(message.content ?? message.text)) {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -594,6 +594,28 @@ describe("projectRecentChatDisplayMessages", () => {
 
     expect(result).toEqual([{ role: "assistant", content: "older answer", timestamp: 2 }]);
   });
+
+  it("keeps media-only user messages while dropping empty text-only user messages", () => {
+    const mediaOnly = {
+      role: "user",
+      content: "",
+      MediaPath: "/tmp/openclaw/user-upload.png",
+      timestamp: 1,
+    };
+    const multiMediaOnly = {
+      role: "user",
+      content: "",
+      MediaPaths: ["/tmp/openclaw/first.png", "/tmp/openclaw/second.jpg"],
+      timestamp: 2,
+    };
+    const result = projectRecentChatDisplayMessages([
+      mediaOnly,
+      multiMediaOnly,
+      { role: "user", content: "", timestamp: 3 },
+    ]);
+
+    expect(result).toEqual([mediaOnly, multiMediaOnly]);
+  });
 });
 
 describe("resolveEffectiveChatHistoryMaxChars", () => {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -901,6 +901,29 @@ describe("loadChatHistory filtering", () => {
     expect(state.chatMessages).toEqual([messages[0], messages[2]]);
   });
 
+  it("keeps image-only user messages that carry transcript media paths", async () => {
+    const messages = [
+      { role: "user", content: "", MediaPath: "/tmp/openclaw/user-upload.png" },
+      {
+        role: "user",
+        content: "",
+        MediaPaths: ["/tmp/openclaw/first.png", "/tmp/openclaw/second.jpg"],
+      },
+      { role: "user", content: "" },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([messages[0], messages[1]]);
+  });
+
   it("keeps a user message even if it matches the synthetic repair text", async () => {
     const messages = [
       {
@@ -1073,6 +1096,76 @@ describe("sendChatMessage", () => {
         timestamp: expect.any(Number),
       },
     ]);
+  });
+
+  it("sends inline image payloads without copying data URLs into optimistic chat state", async () => {
+    const request = vi.fn().mockResolvedValue({ runId: "run-1", status: "started" });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+    const imageBase64 = "A".repeat(1024 * 1024);
+    const imageDataUrl = `data:image/png;base64,${imageBase64}`;
+
+    const result = await sendChatMessage(state, "", [
+      {
+        id: "att-image",
+        dataUrl: imageDataUrl,
+        mimeType: "image/png",
+        fileName: "photo.png",
+      },
+    ]);
+
+    expect(result).toMatch(UUID_V4_RE);
+    expect(request).toHaveBeenCalledTimes(1);
+    const [requestMethod, requestParams] = requireFirstRequestCall(request);
+    expect(requestMethod).toBe("chat.send");
+    const sendParams = requireRecord(requestParams);
+    expect(sendParams.message).toBe("");
+    expect(sendParams.attachments).toEqual([
+      {
+        type: "image",
+        mimeType: "image/png",
+        fileName: "photo.png",
+        content: imageBase64,
+      },
+    ]);
+    expect(state.chatMessages).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Attached image: photo.png" }],
+        timestamp: expect.any(Number),
+      },
+    ]);
+    expect(JSON.stringify(state.chatMessages)).not.toContain("data:image/png;base64");
+
+    const captionedRequest = vi.fn().mockResolvedValue({ runId: "run-2", status: "started" });
+    const captionedState = createState({
+      connected: true,
+      client: { request: captionedRequest } as unknown as ChatState["client"],
+    });
+
+    await expect(
+      sendChatMessage(captionedState, "describe", [
+        {
+          id: "att-captioned-image",
+          dataUrl: imageDataUrl,
+          mimeType: "image/png",
+          fileName: "photo.png",
+        },
+      ]),
+    ).resolves.toMatch(UUID_V4_RE);
+    expect(captionedState.chatMessages).toStrictEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "describe" },
+          { type: "text", text: "Attached image: photo.png" },
+        ],
+        timestamp: expect.any(Number),
+      },
+    ]);
+    expect(JSON.stringify(captionedState.chatMessages)).not.toContain("data:image/png;base64");
   });
 
   it("formats structured non-auth connect failures for chat send", async () => {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -118,6 +118,14 @@ function isEmptyUserTextOnlyMessage(message: unknown): boolean {
   if (normalizeLowercaseStringOrEmpty(entry.role) !== "user") {
     return false;
   }
+  const mediaPaths = Array.isArray(entry.MediaPaths)
+    ? entry.MediaPaths
+    : typeof entry.MediaPath === "string"
+      ? [entry.MediaPath]
+      : [];
+  if (mediaPaths.some((value) => typeof value === "string" && value.trim())) {
+    return false;
+  }
   if (!isTextOnlyContent(entry.content ?? entry.text)) {
     return false;
   }
@@ -375,6 +383,15 @@ function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string }
   return { mimeType: match[1], content: match[2] };
 }
 
+function isInlineDataUrl(value: string): boolean {
+  return /^\s*data:/iu.test(value);
+}
+
+function formatInlineImageAttachmentPlaceholder(attachment: ChatAttachment): string {
+  const label = attachment.fileName?.trim();
+  return label ? `Attached image: ${label}` : "Attached image";
+}
+
 function buildApiAttachments(attachments?: ChatAttachment[]) {
   const hasAttachments = attachments && attachments.length > 0;
   return hasAttachments
@@ -506,6 +523,10 @@ export async function sendChatMessage(
         continue;
       }
       if (att.mimeType.startsWith("image/")) {
+        if (isInlineDataUrl(previewUrl)) {
+          contentBlocks.push({ type: "text", text: formatInlineImageAttachmentPlaceholder(att) });
+          continue;
+        }
         contentBlocks.push({
           type: "image",
           url: previewUrl,


### PR DESCRIPTION
Summary
- Avoid copying inline image `data:` URLs into optimistic WebChat chat state; keep the attachment payload sent to `chat.send` unchanged.
- Preserve image-only user turns that carry transcript `MediaPath`/`MediaPaths` through backend projection and UI history filtering.
- Add regression coverage for large inline image sends and media-only chat history messages.

Fixes #82182.

Verification
- `node scripts/run-vitest.mjs ui/src/ui/controllers/chat.test.ts src/gateway/server-methods/server-methods.test.ts`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --parallel-tests "node scripts/run-vitest.mjs ui/src/ui/controllers/chat.test.ts src/gateway/server-methods/server-methods.test.ts"`
- `pnpm changed:lanes --json`
- `git diff --check`
- `pnpm check:changed` was started, delegated to Blacksmith Testbox run `tbx_01krp8pv1m5emndyhcy3m20jfg`, but stayed queued and was stopped before execution; no failing signal.

Behavior addressed: WebChat image sends no longer store large inline `data:` image previews in optimistic chat state, and image-only user turns survive chat history projection/filtering.
Real environment tested: Local source checkout on macOS with focused UI and gateway unit coverage plus codex-review.
Exact steps or command run after this patch: The focused Vitest command above sends a 1 MiB inline image payload through `sendChatMessage` and projects media-only history messages with `MediaPath`/`MediaPaths`.
Evidence after fix: The API still receives the base64 image attachment, optimistic chat state contains only an attachment placeholder, JSON state does not contain `data:image/png;base64`, and media-only user messages remain in projected/loaded history.
Observed result after fix: Focused tests passed, codex-review reported no accepted/actionable findings, changed-lane detection identified the expected core/docs surfaces, and diff whitespace check passed.
What was not tested: Manual browser image send was not run; broad `pnpm check:changed` could not start because the delegated Testbox runner stayed queued.
