### PR TITLE
[codex] Honor configured max token aliases

### DIFF
--- a/src/agents/max-tokens-params.ts
+++ b/src/agents/max-tokens-params.ts
@@ -1,3 +1,5 @@
+// Normalize config aliases to the internal output-token budget. Transports still
+// choose the provider-specific wire field name.
 export const MAX_TOKENS_PARAM_KEYS = ["maxTokens", "max_completion_tokens", "max_tokens"] as const;
 
 type MaxTokensParamResolution = {

--- a/src/agents/max-tokens-params.ts
+++ b/src/agents/max-tokens-params.ts
@@ -1,0 +1,48 @@
+export const MAX_TOKENS_PARAM_KEYS = ["maxTokens", "max_completion_tokens", "max_tokens"] as const;
+
+type MaxTokensParamResolution = {
+  seen: boolean;
+  value: unknown;
+};
+
+function resolveMaxTokensParamValue(
+  sources: Array<Record<string, unknown> | undefined>,
+): MaxTokensParamResolution {
+  let resolved: MaxTokensParamResolution = { seen: false, value: undefined };
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+    for (const key of MAX_TOKENS_PARAM_KEYS) {
+      if (!Object.hasOwn(source, key)) {
+        continue;
+      }
+      resolved = { seen: true, value: source[key] };
+      break;
+    }
+  }
+  return resolved;
+}
+
+export function resolveMaxTokensParam(
+  sources: Array<Record<string, unknown> | undefined>,
+): number | undefined {
+  const resolved = resolveMaxTokensParamValue(sources);
+  return typeof resolved.value === "number" ? resolved.value : undefined;
+}
+
+export function canonicalizeMaxTokensParam(params: {
+  merged: Record<string, unknown>;
+  sources: Array<Record<string, unknown> | undefined>;
+}): void {
+  const resolved = resolveMaxTokensParamValue(params.sources);
+  if (!resolved.seen) {
+    return;
+  }
+  for (const key of MAX_TOKENS_PARAM_KEYS) {
+    delete params.merged[key];
+  }
+  if (typeof resolved.value === "number") {
+    params.merged.maxTokens = resolved.value;
+  }
+}

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3417,6 +3417,66 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("max_tokens");
   });
 
+  it("uses model params max_completion_tokens for OpenAI completions when runtime maxTokens is omitted", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+        params: {
+          max_completion_tokens: 64_000,
+        },
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params.max_completion_tokens).toBe(64_000);
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
+  it("keeps runtime maxTokens ahead of model params max_completion_tokens", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+        params: {
+          max_completion_tokens: 64_000,
+        },
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        maxTokens: 2048,
+      } as never,
+    );
+
+    expect(params.max_completion_tokens).toBe(2048);
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
   it("uses model maxTokens with max_tokens completions compat when runtime maxTokens is omitted", () => {
     const params = buildOpenAICompletionsParams(
       {
@@ -3439,6 +3499,34 @@ describe("openai transport stream", () => {
     );
 
     expect(params.max_tokens).toBe(65_536);
+    expect(params).not.toHaveProperty("max_completion_tokens");
+  });
+
+  it("uses model param aliases with max_tokens completions compat", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "zai-org/GLM-4.7-TEE",
+        name: "GLM 4.7 TEE",
+        api: "openai-completions",
+        provider: "chutes",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+        params: {
+          max_completion_tokens: 64_000,
+        },
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params.max_tokens).toBe(64_000);
     expect(params).not.toHaveProperty("max_completion_tokens");
   });
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3477,6 +3477,66 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("max_tokens");
   });
 
+  it("preserves runtime maxTokens: 0 for OpenAI completions", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+        params: {
+          max_completion_tokens: 64_000,
+        },
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        maxTokens: 0,
+      } as never,
+    );
+
+    expect(params.max_completion_tokens).toBe(0);
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
+  it("preserves model params max_completion_tokens: 0 for OpenAI completions", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+        params: {
+          max_completion_tokens: 0,
+        },
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params.max_completion_tokens).toBe(0);
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
   it("uses model maxTokens with max_tokens completions compat when runtime maxTokens is omitted", () => {
     const params = buildOpenAICompletionsParams(
       {
@@ -3527,6 +3587,34 @@ describe("openai transport stream", () => {
     );
 
     expect(params.max_tokens).toBe(64_000);
+    expect(params).not.toHaveProperty("max_completion_tokens");
+  });
+
+  it("preserves model params max_tokens: 0 with max_tokens completions compat", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "zai-org/GLM-4.7-TEE",
+        name: "GLM 4.7 TEE",
+        api: "openai-completions",
+        provider: "chutes",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+        params: {
+          max_tokens: 0,
+        },
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params.max_tokens).toBe(0);
     expect(params).not.toHaveProperty("max_completion_tokens");
   });
 

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -30,6 +30,7 @@ import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.typ
 import { resolveProviderTransportTurnStateWithPlugin } from "../plugins/provider-runtime.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
 import { createDeepSeekTextFilter } from "./deepseek-text-filter.js";
+import { resolveMaxTokensParam } from "./max-tokens-params.js";
 import {
   emitModelTransportDebug,
   resolveModelPayloadDebugMode,
@@ -120,6 +121,7 @@ type OpenAIModeCompatInput = Omit<ModelCompatConfig, "thinkingFormat"> & {
 
 type OpenAIModeModel = Omit<Model<Api>, "compat"> & {
   compat?: OpenAIModeCompatInput | null;
+  params?: Record<string, unknown> | null;
 };
 
 type MutableAssistantOutput = {
@@ -2592,7 +2594,8 @@ export function buildOpenAICompletionsParams(
     params.prompt_cache_key = options.sessionId;
   }
   {
-    const effectiveMaxTokens = options?.maxTokens || model.maxTokens;
+    const effectiveMaxTokens =
+      options?.maxTokens || resolveMaxTokensParam([model.params ?? undefined]) || model.maxTokens;
     if (effectiveMaxTokens) {
       if (compat.maxTokensField === "max_tokens") {
         params.max_tokens = effectiveMaxTokens;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2595,8 +2595,8 @@ export function buildOpenAICompletionsParams(
   }
   {
     const effectiveMaxTokens =
-      options?.maxTokens || resolveMaxTokensParam([model.params ?? undefined]) || model.maxTokens;
-    if (effectiveMaxTokens) {
+      options?.maxTokens ?? resolveMaxTokensParam([model.params ?? undefined]) ?? model.maxTokens;
+    if (effectiveMaxTokens !== undefined) {
       if (compat.maxTokensField === "max_tokens") {
         params.max_tokens = effectiveMaxTokens;
       } else {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2045,6 +2045,26 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls[0]?.maxTokens).toBe(0);
   });
 
+  it("maps configured max_completion_tokens into shared stream maxTokens", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = buildModelConfig("dashscope/kimi-k2.6", {
+      max_completion_tokens: 64_000,
+    });
+
+    applyExtraParamsToAgent(agent, cfg, "dashscope", "kimi-k2.6");
+
+    const model = {
+      api: "openai-completions",
+      provider: "dashscope",
+      id: "kimi-k2.6",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.maxTokens).toBe(64_000);
+  });
+
   it("defaults Codex transport to auto (WebSocket-first)", () => {
     const { calls, agent } = createOptionsCaptureAgent();
 

--- a/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
@@ -63,6 +63,35 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     expect(callOptions?.maxTokens).toBe(512);
   });
 
+  it("forwards max_completion_tokens aliases into the underlying streamFn options", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5.4", {
+      max_completion_tokens: 64_000,
+    });
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      { id: "gpt-5.4", api: "openai-completions", provider: "openai" } as never,
+      { messages: [], tools: [] } as never,
+      undefined,
+    );
+
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as { maxTokens?: number } | undefined;
+    expect(callOptions?.maxTokens).toBe(64_000);
+  });
+
   it("lets runtime options override the wrapper sampling defaults", () => {
     const underlying = vi.fn(() => ({
       push: vi.fn(),
@@ -73,7 +102,11 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     })) as unknown as StreamFn;
     const agent: { streamFn?: StreamFn } = { streamFn: underlying };
 
-    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5.4", { temperature: 0.4, topP: 0.7 });
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5.4", {
+      temperature: 0.4,
+      topP: 0.7,
+      max_completion_tokens: 64_000,
+    });
 
     if (!agent.streamFn) {
       throw new Error("expected extra params to wrap streamFn");
@@ -82,13 +115,14 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     void agent.streamFn(
       { id: "gpt-5.4", api: "openai-completions", provider: "openai" } as never,
       { messages: [], tools: [] } as never,
-      { topP: 0.9 } as never,
+      { topP: 0.9, maxTokens: 128 } as never,
     );
 
     const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
-      .calls[0]?.[2] as { temperature?: number; topP?: number } | undefined;
+      .calls[0]?.[2] as { temperature?: number; topP?: number; maxTokens?: number } | undefined;
     expect(callOptions?.temperature).toBe(0.4);
     expect(callOptions?.topP).toBe(0.9);
+    expect(callOptions?.maxTokens).toBe(128);
   });
 
   it("forwards response_format aliases into the underlying streamFn options", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -15,6 +15,7 @@ import {
   wrapProviderStreamFn as wrapProviderStreamFnRuntime,
 } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { canonicalizeMaxTokensParam, resolveMaxTokensParam } from "../max-tokens-params.js";
 import { legacyModelKey, modelKey } from "../model-selection-normalize.js";
 import { supportsGptParallelToolCallsPayload } from "../provider-api-families.js";
 import { resolveProviderRequestPolicyConfig } from "../provider-request-config.js";
@@ -135,6 +136,10 @@ export function resolveExtraParams(params: {
     merged.cachedContent = resolvedCachedContent;
     delete merged.cached_content;
   }
+  canonicalizeMaxTokensParam({
+    merged,
+    sources: [defaultParams, globalParams, agentParams],
+  });
   if (params.provider === "openrouter") {
     canonicalizeOpenRouterResponseCacheParams(merged, [defaultParams, globalParams, agentParams]);
   }
@@ -260,6 +265,10 @@ export function resolvePreparedExtraParams(params: {
     merged.cachedContent = resolvedCachedContent;
     delete merged.cached_content;
   }
+  canonicalizeMaxTokensParam({
+    merged,
+    sources: [resolvedExtraParams, override],
+  });
   if (params.provider === "openrouter") {
     canonicalizeOpenRouterResponseCacheParams(merged, [resolvedExtraParams, override]);
   }
@@ -419,8 +428,9 @@ function createStreamFnWithExtraParams(
   if (typeof extraParams.topP === "number") {
     streamParams.topP = extraParams.topP;
   }
-  if (typeof extraParams.maxTokens === "number") {
-    streamParams.maxTokens = extraParams.maxTokens;
+  const resolvedMaxTokens = resolveMaxTokensParam([extraParams]);
+  if (resolvedMaxTokens !== undefined) {
+    streamParams.maxTokens = resolvedMaxTokens;
   }
   const resolvedResponseFormat = resolveAliasedParamValue(
     [extraParams],


### PR DESCRIPTION
## Summary

- Fixes #82230.
- Normalize configured `maxTokens`, `max_completion_tokens`, and `max_tokens` aliases into the shared embedded stream `maxTokens` option.
- Let OpenAI-completions payload construction read model `params` token caps before falling back to catalog `model.maxTokens`, while still honoring the provider's configured `maxTokensField`.
- Add regression coverage for embedded extra params, request override precedence, and completions `max_tokens`/`max_completion_tokens` payload selection.

## Verification

- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/extra-params.sampling.test.ts`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner-extraparams.test.ts`
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts`
- `pnpm tsgo:core:test`
- `git diff --check`

## Real behavior proof

Behavior addressed: Embedded Pi/OpenAI-compatible runs now carry configured model params such as `max_completion_tokens: 64000` through to `SimpleStreamOptions.maxTokens`, and direct OpenAI-completions payload construction uses model `params` token caps instead of falling back to catalog defaults.

Real environment tested: Local OpenClaw checkout with production agent/transport modules loaded through Node/tsx against a DashScope-compatible `openai-completions` model configuration. The probe exercised `applyExtraParamsToAgent()` and `buildOpenAICompletionsParams()` directly from `src/agents` and printed the resulting runtime stream option and request payload fields.

Exact steps or command run after this patch: Ran this local production-code probe from the repository root after the patch:

```sh
node --import tsx <<'PROBE'
import { applyExtraParamsToAgent } from './src/agents/pi-embedded-runner/extra-params.ts';
import { buildOpenAICompletionsParams } from './src/agents/openai-transport-stream.ts';

const streamCalls = [];
const agent = {
  streamFn: (_model, _context, options) => {
    streamCalls.push(options);
    return {};
  },
};

const cfg = {
  agents: {
    defaults: {
      models: {
        'dashscope/kimi-k2.6': {
          params: { max_completion_tokens: 64000 },
        },
      },
    },
  },
};

applyExtraParamsToAgent(agent, cfg, 'dashscope', 'kimi-k2.6');
agent.streamFn(
  { id: 'kimi-k2.6', api: 'openai-completions', provider: 'dashscope' },
  { messages: [], tools: [] },
  {},
);

const payload = buildOpenAICompletionsParams(
  {
    id: 'kimi-k2.6',
    name: 'Kimi K2.6',
    api: 'openai-completions',
    provider: 'dashscope',
    baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
    reasoning: true,
    input: ['text'],
    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
    contextWindow: 200000,
    maxTokens: 32000,
    params: { max_completion_tokens: 64000 },
  },
  { systemPrompt: 'system', messages: [], tools: [] },
  undefined,
);

console.log(JSON.stringify({
  embeddedStreamMaxTokens: streamCalls[0]?.maxTokens,
  completionsPayloadMaxCompletionTokens: payload.max_completion_tokens,
  completionsPayloadMaxTokens: payload.max_tokens ?? null,
}, null, 2));
PROBE
```

Evidence after fix: The production-code probe printed this output:

```json
{
  "embeddedStreamMaxTokens": 64000,
  "completionsPayloadMaxCompletionTokens": 64000,
  "completionsPayloadMaxTokens": null
}
```

Observed result after fix: The embedded stream wrapper resolved the configured `max_completion_tokens` alias to `maxTokens: 64000`, and the OpenAI-completions payload emitted `max_completion_tokens: 64000` instead of the catalog fallback `32000`. The targeted Vitest files, `pnpm tsgo:core:test`, and `git diff --check` also passed.

What was not tested: A live QQBot/DashScope request with real credentials was not run; the local proof stops before making an external network request.
