### PR TITLE
[codex] Honor wildcard model runtime policy

### DIFF
--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -220,6 +220,18 @@ describe("runAgentHarnessAttempt", () => {
     expect(piRunAttempt).toHaveBeenCalledTimes(1);
   });
 
+  it("honors provider wildcard PI runtime policy for OpenAI agent model runs", async () => {
+    registerSuccessfulCodexHarness();
+
+    const result = await runAgentHarnessAttempt({
+      ...createAttemptParams(agentModelRuntimeConfig("openai/*", "pi")),
+      provider: "openai",
+      modelId: "gpt-5.4",
+    });
+    expect(result.sessionIdUsed).toBe("pi");
+    expect(piRunAttempt).toHaveBeenCalledTimes(1);
+  });
+
   it("annotates non-ok harness result classifications for outer model fallback", async () => {
     const classify = vi.fn<NonNullable<AgentHarness["classify"]>>(() => "empty" as const);
     registerAgentHarness(

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -79,4 +79,36 @@ describe("resolveModelRuntimePolicy", () => {
       source: "model",
     });
   });
+
+  it("prefers scoped agent provider wildcards over default exact model entries", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+          },
+        },
+        list: [
+          {
+            id: "research",
+            models: {
+              "openai/*": { agentRuntime: { id: "pi" } },
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        agentId: "research",
+        provider: "openai",
+        modelId: "gpt-5.5",
+      }),
+    ).toEqual({
+      policy: { id: "pi" },
+      source: "model",
+    });
+  });
 });

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveModelRuntimePolicy } from "./model-runtime-policy.js";
+
+describe("resolveModelRuntimePolicy", () => {
+  it("honors provider wildcard agent model runtime policy entries", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "vllm/*": { agentRuntime: { id: "pi" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "vllm",
+        modelId: "qwen-local",
+      }),
+    ).toEqual({
+      policy: { id: "pi" },
+      source: "model",
+    });
+  });
+
+  it("prefers exact model runtime policy entries over provider wildcards", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "vllm/*": { agentRuntime: { id: "pi" } },
+            "vllm/qwen-local": { agentRuntime: { id: "codex" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "vllm",
+        modelId: "qwen-local",
+      }),
+    ).toEqual({
+      policy: { id: "codex" },
+      source: "model",
+    });
+  });
+});

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -49,4 +49,34 @@ describe("resolveModelRuntimePolicy", () => {
       source: "model",
     });
   });
+
+  it("prefers exact provider model runtime policy over agent provider wildcards", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "vllm/*": { agentRuntime: { id: "pi" } },
+          },
+        },
+      },
+      models: {
+        providers: {
+          vllm: {
+            models: [{ id: "qwen-local", agentRuntime: { id: "codex" } }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "vllm",
+        modelId: "qwen-local",
+      }),
+    ).toEqual({
+      policy: { id: "codex" },
+      source: "model",
+    });
+  });
 });

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -132,33 +132,20 @@ function resolveAgentModelEntryRuntimePolicy(params: {
   modelId?: string;
   agentId?: string;
   sessionKey?: string;
+  models?: Record<string, AgentModelEntryConfig>;
   matchKind: "exact" | "provider-wildcard";
 }): ResolvedModelRuntimePolicy {
   const modelId = normalizeModelIdForProvider(params.provider, params.modelId);
   if (!params.config || !modelId) {
     return {};
   }
-  const { sessionAgentId } = resolveSessionAgentIds({
-    config: params.config,
-    agentId: params.agentId,
-    sessionKey: params.sessionKey,
+  const policy = findRuntimePolicyInModelMap(params.models, {
+    provider: params.provider,
+    modelId,
+    matchKind: params.matchKind,
   });
-  const agentEntry = listAgentEntries(params.config).find(
-    (entry) => normalizeAgentId(entry.id) === sessionAgentId,
-  );
-  const modelMaps: Array<Record<string, AgentModelEntryConfig> | undefined> = [
-    agentEntry?.models,
-    params.config.agents?.defaults?.models,
-  ];
-  for (const models of modelMaps) {
-    const policy = findRuntimePolicyInModelMap(models, {
-      provider: params.provider,
-      modelId,
-      matchKind: params.matchKind,
-    });
-    if (policy) {
-      return { policy, source: "model" };
-    }
+  if (policy) {
+    return { policy, source: "model" };
   }
   return {};
 }
@@ -184,12 +171,37 @@ export function resolveModelRuntimePolicy(params: {
   agentId?: string;
   sessionKey?: string;
 }): ResolvedModelRuntimePolicy {
-  const exactAgentModelPolicy = resolveAgentModelEntryRuntimePolicy({
+  const { sessionAgentId } = resolveSessionAgentIds({
+    config: params.config ?? {},
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
+  const agentEntry = params.config
+    ? listAgentEntries(params.config).find((entry) => normalizeAgentId(entry.id) === sessionAgentId)
+    : undefined;
+  const exactScopedAgentModelPolicy = resolveAgentModelEntryRuntimePolicy({
     ...params,
+    models: agentEntry?.models,
     matchKind: "exact",
   });
-  if (exactAgentModelPolicy.policy) {
-    return exactAgentModelPolicy;
+  if (exactScopedAgentModelPolicy.policy) {
+    return exactScopedAgentModelPolicy;
+  }
+  const wildcardScopedAgentModelPolicy = resolveAgentModelEntryRuntimePolicy({
+    ...params,
+    models: agentEntry?.models,
+    matchKind: "provider-wildcard",
+  });
+  if (wildcardScopedAgentModelPolicy.policy) {
+    return wildcardScopedAgentModelPolicy;
+  }
+  const exactDefaultAgentModelPolicy = resolveAgentModelEntryRuntimePolicy({
+    ...params,
+    models: params.config?.agents?.defaults?.models,
+    matchKind: "exact",
+  });
+  if (exactDefaultAgentModelPolicy.policy) {
+    return exactDefaultAgentModelPolicy;
   }
   const providerConfig = resolveProviderConfig(params.config, params.provider);
   const modelConfig = resolveModelConfig({
@@ -200,12 +212,13 @@ export function resolveModelRuntimePolicy(params: {
   if (hasRuntimePolicy(modelConfig?.agentRuntime)) {
     return { policy: modelConfig?.agentRuntime, source: "model" };
   }
-  const wildcardAgentModelPolicy = resolveAgentModelEntryRuntimePolicy({
+  const wildcardDefaultAgentModelPolicy = resolveAgentModelEntryRuntimePolicy({
     ...params,
+    models: params.config?.agents?.defaults?.models,
     matchKind: "provider-wildcard",
   });
-  if (wildcardAgentModelPolicy.policy) {
-    return wildcardAgentModelPolicy;
+  if (wildcardDefaultAgentModelPolicy.policy) {
+    return wildcardDefaultAgentModelPolicy;
   }
   if (hasRuntimePolicy(providerConfig?.agentRuntime)) {
     return { policy: providerConfig?.agentRuntime, source: "provider" };

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -13,6 +13,8 @@ export type ResolvedModelRuntimePolicy = {
   source?: ModelRuntimePolicySource;
 };
 
+type ModelEntryMatchKind = "none" | "exact" | "provider-wildcard";
+
 function hasRuntimePolicy(value: AgentRuntimePolicyConfig | undefined): boolean {
   return Boolean(value?.id?.trim());
 }
@@ -63,30 +65,68 @@ function modelEntryMatches(params: {
   provider: string | undefined;
   modelId: string;
 }): boolean {
+  return modelEntryMatchKind(params) === "exact";
+}
+
+function modelEntryMatchKind(params: {
+  entry: Pick<ModelDefinitionConfig, "id">;
+  provider: string | undefined;
+  modelId: string;
+}): ModelEntryMatchKind {
   const entryId = params.entry.id.trim();
   if (entryId === params.modelId) {
-    return true;
+    return "exact";
   }
   const slash = entryId.indexOf("/");
   if (slash <= 0) {
-    return false;
+    return "none";
   }
-  return (
-    normalizeProviderId(entryId.slice(0, slash)) === normalizeProviderId(params.provider ?? "") &&
-    entryId.slice(slash + 1).trim() === params.modelId
-  );
+  if (normalizeProviderId(entryId.slice(0, slash)) !== normalizeProviderId(params.provider ?? "")) {
+    return "none";
+  }
+  const entryModelId = entryId.slice(slash + 1).trim();
+  if (entryModelId === params.modelId) {
+    return "exact";
+  }
+  if (entryModelId === "*") {
+    return "provider-wildcard";
+  }
+  return "none";
 }
 
-function modelKeyMatches(params: {
+function modelKeyMatchKind(params: {
   key: string;
   provider: string | undefined;
   modelId: string;
-}): boolean {
-  return modelEntryMatches({
+}): ModelEntryMatchKind {
+  return modelEntryMatchKind({
     entry: { id: params.key },
     provider: params.provider,
     modelId: params.modelId,
   });
+}
+
+function findRuntimePolicyInModelMap(
+  models: Record<string, AgentModelEntryConfig> | undefined,
+  params: {
+    provider?: string;
+    modelId: string;
+  },
+): AgentRuntimePolicyConfig | undefined {
+  let wildcardPolicy: AgentRuntimePolicyConfig | undefined;
+  for (const [key, entry] of Object.entries(models ?? {})) {
+    if (!hasRuntimePolicy(entry?.agentRuntime)) {
+      continue;
+    }
+    const match = modelKeyMatchKind({ key, provider: params.provider, modelId: params.modelId });
+    if (match === "exact") {
+      return entry.agentRuntime;
+    }
+    if (match === "provider-wildcard" && !wildcardPolicy) {
+      wildcardPolicy = entry.agentRuntime;
+    }
+  }
+  return wildcardPolicy;
 }
 
 function resolveAgentModelEntryRuntimePolicy(params: {
@@ -113,13 +153,12 @@ function resolveAgentModelEntryRuntimePolicy(params: {
     params.config.agents?.defaults?.models,
   ];
   for (const models of modelMaps) {
-    for (const [key, entry] of Object.entries(models ?? {})) {
-      if (
-        modelKeyMatches({ key, provider: params.provider, modelId }) &&
-        hasRuntimePolicy(entry?.agentRuntime)
-      ) {
-        return { policy: entry.agentRuntime, source: "model" };
-      }
+    const policy = findRuntimePolicyInModelMap(models, {
+      provider: params.provider,
+      modelId,
+    });
+    if (policy) {
+      return { policy, source: "model" };
     }
   }
   return {};

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -111,22 +111,19 @@ function findRuntimePolicyInModelMap(
   params: {
     provider?: string;
     modelId: string;
+    matchKind: "exact" | "provider-wildcard";
   },
 ): AgentRuntimePolicyConfig | undefined {
-  let wildcardPolicy: AgentRuntimePolicyConfig | undefined;
   for (const [key, entry] of Object.entries(models ?? {})) {
     if (!hasRuntimePolicy(entry?.agentRuntime)) {
       continue;
     }
     const match = modelKeyMatchKind({ key, provider: params.provider, modelId: params.modelId });
-    if (match === "exact") {
+    if (match === params.matchKind) {
       return entry.agentRuntime;
     }
-    if (match === "provider-wildcard" && !wildcardPolicy) {
-      wildcardPolicy = entry.agentRuntime;
-    }
   }
-  return wildcardPolicy;
+  return undefined;
 }
 
 function resolveAgentModelEntryRuntimePolicy(params: {
@@ -135,6 +132,7 @@ function resolveAgentModelEntryRuntimePolicy(params: {
   modelId?: string;
   agentId?: string;
   sessionKey?: string;
+  matchKind: "exact" | "provider-wildcard";
 }): ResolvedModelRuntimePolicy {
   const modelId = normalizeModelIdForProvider(params.provider, params.modelId);
   if (!params.config || !modelId) {
@@ -156,6 +154,7 @@ function resolveAgentModelEntryRuntimePolicy(params: {
     const policy = findRuntimePolicyInModelMap(models, {
       provider: params.provider,
       modelId,
+      matchKind: params.matchKind,
     });
     if (policy) {
       return { policy, source: "model" };
@@ -185,9 +184,12 @@ export function resolveModelRuntimePolicy(params: {
   agentId?: string;
   sessionKey?: string;
 }): ResolvedModelRuntimePolicy {
-  const agentModelPolicy = resolveAgentModelEntryRuntimePolicy(params);
-  if (agentModelPolicy.policy) {
-    return agentModelPolicy;
+  const exactAgentModelPolicy = resolveAgentModelEntryRuntimePolicy({
+    ...params,
+    matchKind: "exact",
+  });
+  if (exactAgentModelPolicy.policy) {
+    return exactAgentModelPolicy;
   }
   const providerConfig = resolveProviderConfig(params.config, params.provider);
   const modelConfig = resolveModelConfig({
@@ -197,6 +199,13 @@ export function resolveModelRuntimePolicy(params: {
   });
   if (hasRuntimePolicy(modelConfig?.agentRuntime)) {
     return { policy: modelConfig?.agentRuntime, source: "model" };
+  }
+  const wildcardAgentModelPolicy = resolveAgentModelEntryRuntimePolicy({
+    ...params,
+    matchKind: "provider-wildcard",
+  });
+  if (wildcardAgentModelPolicy.policy) {
+    return wildcardAgentModelPolicy;
   }
   if (hasRuntimePolicy(providerConfig?.agentRuntime)) {
     return { policy: providerConfig?.agentRuntime, source: "provider" };


### PR DESCRIPTION
## Summary

- Problem: `agents.defaults.models["provider/*"].agentRuntime` was ignored during agent runtime/harness selection, even though `provider/*` already worked for model picker/list visibility.
- Why it matters: wildcard runtime policy looked valid in config but silently fell through to provider-level or implicit runtime behavior. OpenAI's implicit Codex harness default could mask the bug when users expected Codex anyway.
- What changed: model runtime policy now treats `provider/*` as a model-map runtime policy fallback after exact `provider/model` entries and before provider-level runtime policy.
- What did NOT change: OpenAI still defaults to the Codex harness unless an explicit provider/model or provider-wildcard runtime policy overrides it.

Closes #82243.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82243
- Related #79519
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: provider wildcard model entries should apply `agentRuntime` policy during actual agent runtime/harness selection, not only model picker/list visibility.
- Real environment tested: local OpenClaw source checkout on branch `models_debug`, with focused Vitest seam tests for runtime policy and harness selection.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs src/agents/model-runtime-policy.test.ts src/agents/harness/selection.test.ts`
  - `pnpm exec oxfmt --check --threads=1 src/agents/model-runtime-policy.ts src/agents/model-runtime-policy.test.ts src/agents/harness/selection.test.ts`
  - `git diff --check`
  - `bash /home/ubuntu/.codex/skills/codex-review/scripts/codex-review --mode local --full-access --output /tmp/openclaw-codex-review-models-debug.txt --parallel-tests "node scripts/run-vitest.mjs src/agents/model-runtime-policy.test.ts src/agents/harness/selection.test.ts"`
- Evidence after fix:

```text
Test Files  3 passed (3)
Tests  42 passed (42)
```

```text
Checking formatting...
All matched files use the correct format.
```

```text
codex-review exit: 0
tests exit: 0
codex-review clean: no accepted/actionable findings reported
```

- Observed result after fix: `resolveModelRuntimePolicy` returns the `agentRuntime` from matching `provider/*` model entries, exact model entries still override wildcard entries, and OpenAI's implicit Codex default can still be overridden by explicit wildcard runtime policy such as `openai/* -> pi`.
- What was not tested: live Discord interaction was not rerun because the affected bug is below the picker surface in runtime-policy resolution. Broad `pnpm check`/full suite was not run.
- Before evidence: the new regression test failed before the patch with `expected {} to deeply equal { policy: { id: 'pi' }, source: 'model' }`.

## Root Cause (if applicable)

- Root cause: #79519 added `provider/*` semantics to model visibility/listing helpers, but `src/agents/model-runtime-policy.ts` had a separate matcher that still required exact model-id equality for `agents.defaults.models` runtime policy entries.
- Missing detection / guardrail: no test covered `provider/*` entries carrying `agentRuntime` through the actual runtime-policy or harness-selection path.
- Contributing context: OpenAI's implicit Codex default masks the bug when `openai/*` is intended to select Codex, but explicit overrides and self-hosted provider runtimes still fall through.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/model-runtime-policy.test.ts`
  - `src/agents/harness/selection.test.ts`
- Scenario the test should lock in: exact `provider/model` runtime policy wins over `provider/*`; wildcard runtime policy applies when no exact model entry matches; OpenAI still defaults to Codex but explicit wildcard runtime policy can override that default.
- Why this is the smallest reliable guardrail: the unit test covers the policy resolver directly, and the harness test covers the actual runtime selection behavior that users observe.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Configs like this now work as intended for runtime selection:

```json
{
  "agents": {
    "defaults": {
      "models": {
        "vllm/*": { "agentRuntime": { "id": "pi" } }
      }
    }
  }
}
```

Exact entries still win:

```json
{
  "agents": {
    "defaults": {
      "models": {
        "vllm/*": { "agentRuntime": { "id": "pi" } },
        "vllm/qwen-local": { "agentRuntime": { "id": "codex" } }
      }
    }
  }
}
```

## Diagram (if applicable)

```text
Before:
agents.defaults.models["provider/*"].agentRuntime -> strict model-id comparison -> ignored

After:
exact provider/model match -> use exact runtime policy
else matching provider/* -> use wildcard runtime policy
else models.providers.<provider>.agentRuntime -> provider fallback
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local source checkout
- Model/provider: `vllm/qwen-local`, `openai/gpt-5.4`
- Integration/channel (if any): agent runtime policy and harness selection
- Relevant config (redacted):

```json
{
  "agents": {
    "defaults": {
      "models": {
        "vllm/*": { "agentRuntime": { "id": "pi" } }
      }
    }
  }
}
```

### Steps

1. Configure `agents.defaults.models` with a provider wildcard entry that includes `agentRuntime`.
2. Resolve runtime policy for a concrete model under that provider.
3. Run a harness-selection path where OpenAI's implicit Codex default would otherwise win.

### Expected

- Matching `provider/*` entries apply model-scoped runtime policy.
- Exact `provider/model` runtime policy overrides wildcard runtime policy.
- OpenAI still defaults to Codex unless explicit runtime policy overrides it.

### Actual

- Targeted tests now pass for all three cases.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification run:

```text
node scripts/run-vitest.mjs src/agents/model-runtime-policy.test.ts src/agents/harness/selection.test.ts
```

Result:

```text
Test Files  3 passed (3)
Tests  42 passed (42)
```

Additional checks:

```text
pnpm exec oxfmt --check --threads=1 src/agents/model-runtime-policy.ts src/agents/model-runtime-policy.test.ts src/agents/harness/selection.test.ts
git diff --check
```

Codex review helper:

```text
codex-review clean: no accepted/actionable findings reported
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `vllm/*` `agentRuntime` policy resolves for `vllm/qwen-local`.
  - Exact `vllm/qwen-local` policy wins over `vllm/*`.
  - `openai/*` policy can override OpenAI's implicit Codex default in the harness-selection path.
- Edge cases checked:
  - Provider-level runtime policy remains the fallback after model-map policy.
  - Existing exact matching behavior is preserved for provider model definitions.
- What you did **not** verify:
  - Live Discord UI round trip.
  - Broad full-suite or Testbox validation.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No GitHub bot review conversations exist yet on this PR. Local Codex review helper completed clean.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No new keys; existing `provider/*` model entries now apply their existing `agentRuntime` payload.
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: wildcard runtime policy could unexpectedly apply where a user only intended model visibility.
  - Mitigation: only entries with an explicit `agentRuntime.id` are considered by runtime policy, and exact entries still win.
- Risk: provider wildcard semantics diverge across model-map consumers.
  - Mitigation: this patch adds direct runtime-policy coverage plus harness-selection coverage for the user-observed path.

