### PR TITLE
config: make tool progress truncation limit configurable

### DIFF
--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -81,6 +81,7 @@ Full configuration: [Configuration](/gateway/configuration)
 WebChat options:
 
 - `gateway.webchat.chatHistoryMaxChars`: maximum character count for text fields in `chat.history` responses. When a transcript entry exceeds this limit, Gateway truncates long text fields and may replace oversized messages with a placeholder. Per-request `maxChars` can also be sent by the client to override this default for a single `chat.history` call.
+- `gateway.webchat.toolProgressMaxChars`: maximum character count for live tool/progress output before OpenClaw appends `...(truncated)...` to streamed tool output.
 
 Related global options:
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1723,6 +1723,31 @@ describe("CodexAppServerEventProjector", () => {
     );
   });
 
+  it("uses gateway.webchat.toolProgressMaxChars for streamed tool output", async () => {
+    const onToolResult = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      config: {
+        gateway: {
+          webchat: {
+            toolProgressMaxChars: 5,
+          },
+        },
+      },
+      onToolResult,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-tool-progress-cap",
+        delta: "abcdefghij",
+      }),
+    );
+
+    const toolResult = mockCallArg(onToolResult, 0, 0, "onToolResult") as { text?: string };
+    expect(toolResult.text).toContain(`abcde\n...(truncated)...`);
+  });
+
   it("continues projecting turn completion when an event consumer throws", async () => {
     const onAgentEvent = vi.fn(() => {
       throw new Error("consumer failed");

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -8,6 +8,7 @@ import {
   formatToolProgressOutput,
   inferToolMetaFromArgs,
   normalizeUsage,
+  resolveEffectiveToolProgressMaxChars,
   runAgentHarnessAfterCompactionHook,
   runAgentHarnessAfterToolCallHook,
   runAgentHarnessBeforeCompactionHook,
@@ -666,14 +667,15 @@ export class CodexAppServerEventProjector {
     if (state.truncated) {
       return;
     }
-    const remainingChars = Math.max(0, TOOL_PROGRESS_OUTPUT_MAX_CHARS - state.chars);
+    const maxProgressChars = resolveEffectiveToolProgressMaxChars(this.params.config);
+    const remainingChars = Math.max(0, maxProgressChars - state.chars);
     const remainingMessages = Math.max(0, MAX_TOOL_OUTPUT_DELTA_MESSAGES_PER_ITEM - state.messages);
     if (remainingChars === 0 || remainingMessages === 0) {
       state.truncated = true;
       this.toolResultOutputDeltaState.set(itemId, state);
       this.emitToolResultMessage({
         itemId,
-        text: formatToolOutput(toolName, undefined, "(output truncated)"),
+        text: formatToolOutput(toolName, undefined, "(output truncated)", this.params.config),
       });
       return;
     }
@@ -682,7 +684,7 @@ export class CodexAppServerEventProjector {
     state.messages += 1;
     const reachedLimit =
       delta.length > remainingChars ||
-      state.chars >= TOOL_PROGRESS_OUTPUT_MAX_CHARS ||
+      state.chars >= maxProgressChars ||
       state.messages >= MAX_TOOL_OUTPUT_DELTA_MESSAGES_PER_ITEM;
     if (reachedLimit) {
       state.truncated = true;
@@ -695,6 +697,7 @@ export class CodexAppServerEventProjector {
         toolName,
         undefined,
         reachedLimit ? `${chunk}\n...(truncated)...` : chunk,
+        this.params.config,
       ),
     });
   }
@@ -996,7 +999,7 @@ export class CodexAppServerEventProjector {
     }
     this.emitToolResultMessage({
       itemId,
-      text: formatToolOutput(toolName, itemMeta(item, this.toolProgressDetailMode()), output),
+      text: formatToolOutput(toolName, itemMeta(item, this.toolProgressDetailMode()), output, this.params.config),
       finalOutput: true,
     });
   }
@@ -1715,8 +1718,13 @@ function formatToolSummary(toolName: string, meta?: string): string {
   });
 }
 
-function formatToolOutput(toolName: string, meta: string | undefined, output: string): string {
-  const formattedOutput = formatToolProgressOutput(output);
+function formatToolOutput(
+  toolName: string,
+  meta: string | undefined,
+  output: string,
+  config?: EmbeddedRunAttemptParams["config"],
+): string {
+  const formattedOutput = formatToolProgressOutput(output, { cfg: config });
   if (!formattedOutput) {
     return formatToolSummary(toolName, meta);
   }

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -577,6 +577,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Node command names to block even if present in node claims or default allowlist (exact command-name matching only, e.g. `system.run`; does not inspect shell text inside that command).",
   "gateway.webchat.chatHistoryMaxChars":
     "Max characters per text field in chat.history responses before truncation (default: 12000).",
+  "gateway.webchat.toolProgressMaxChars":
+    "Max characters for tool progress output before truncation in live tool/progress UI updates (default: 8000).",
   nodeHost:
     "Node host controls for features exposed from this gateway node to other nodes or clients. Keep defaults unless you intentionally proxy local capabilities across your node network.",
   "nodeHost.browserProxy":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -379,6 +379,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.nodes.allowCommands": "Gateway Node Allowlist (Extra Commands)",
   "gateway.nodes.denyCommands": "Gateway Node Denylist",
   "gateway.webchat.chatHistoryMaxChars": "WebChat History Max Chars",
+  "gateway.webchat.toolProgressMaxChars": "WebChat Tool Progress Max Chars",
   nodeHost: "Node Host",
   "nodeHost.browserProxy": "Node Browser Proxy",
   "nodeHost.browserProxy.enabled": "Node Browser Proxy Enabled",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -439,6 +439,8 @@ export type GatewayToolsConfig = {
 export type GatewayWebchatConfig = {
   /** Max characters per text field in chat.history responses before truncation (default: 12000). */
   chatHistoryMaxChars?: number;
+  /** Max characters for tool progress output before truncation in live tool/progress UI updates (default: 8000). */
+  toolProgressMaxChars?: number;
 };
 
 export type GatewayConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -906,6 +906,7 @@ export const OpenClawSchema = z
         webchat: z
           .object({
             chatHistoryMaxChars: z.number().int().positive().max(500_000).optional(),
+            toolProgressMaxChars: z.number().int().positive().max(500_000).optional(),
           })
           .strict()
           .optional(),

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -17,9 +17,23 @@ import {
 } from "../agents/pi-embedded-runner/runs.js";
 import { formatToolDetail, resolveToolDisplay } from "../agents/tool-display.js";
 import { redactToolDetail } from "../logging/redact.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { truncateUtf16Safe } from "../utils.js";
 
 export const TOOL_PROGRESS_OUTPUT_MAX_CHARS = 8_000;
+
+export function resolveEffectiveToolProgressMaxChars(
+  cfg?: OpenClawConfig,
+  maxChars?: number,
+): number {
+  if (typeof maxChars === "number") {
+    return maxChars;
+  }
+  if (typeof cfg?.gateway?.webchat?.toolProgressMaxChars === "number") {
+    return cfg.gateway.webchat.toolProgressMaxChars;
+  }
+  return TOOL_PROGRESS_OUTPUT_MAX_CHARS;
+}
 
 export type { AgentMessage } from "@earendil-works/pi-agent-core";
 export type {
@@ -217,14 +231,14 @@ export function inferToolMetaFromArgs(
  */
 export function formatToolProgressOutput(
   output: string,
-  options?: { maxChars?: number },
+  options?: { maxChars?: number; cfg?: OpenClawConfig },
 ): string | undefined {
   const trimmed = output.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
   if (!trimmed) {
     return undefined;
   }
   const redacted = redactToolDetail(trimmed);
-  const maxChars = options?.maxChars ?? TOOL_PROGRESS_OUTPUT_MAX_CHARS;
+  const maxChars = resolveEffectiveToolProgressMaxChars(options?.cfg, options?.maxChars);
   if (redacted.length <= maxChars) {
     return redacted;
   }


### PR DESCRIPTION
## Summary

Add `gateway.webchat.toolProgressMaxChars` to control the maximum character count for live tool/progress output before OpenClaw appends `...(truncated)...` to streamed tool output.

The existing hardcoded `TOOL_PROGRESS_OUTPUT_MAX_CHARS` (8000) becomes the fallback default. Users can now raise or lower this limit via config.

## Changes

- **`src/config/types.gateway.ts`** — add `toolProgressMaxChars` to `GatewayWebchatConfig`
- **`src/config/zod-schema.ts`** — add Zod validation (positive int, max 500k)
- **`src/config/schema.help.ts`** / **`schema.labels.ts`** — add help text and UI label
- **`src/plugin-sdk/agent-harness-runtime.ts`** — add `resolveEffectiveToolProgressMaxChars()` resolver; thread config through `formatToolProgressOutput()`
- **`extensions/codex/src/app-server/event-projector.ts`** — use resolver for progress delta truncation; pass config through `formatToolOutput()`
- **`extensions/codex/src/app-server/event-projector.test.ts`** — test for config-driven progress truncation
- **`docs/web/webchat.md`** — document the new option

## Real behavior proof

Tested locally by setting `gateway.webchat.toolProgressMaxChars: 100` in `openclaw.json`, running a tool that produces verbose output (e.g., `exec ls -la /`), and confirming that:
1. Live streamed progress is truncated at ~100 chars with `...(truncated)...` appended
2. Without the config set, the default 8000-char limit applies as before
3. Unit test passes: `pnpm test:extension codex -- --grep "toolProgressMaxChars"`

## AI-assisted 🤖

- [x] Marked as AI-assisted
- [x] Human-run real behavior proof included above
- [ ] Codex review (`codex review --base origin/main`) — to be run before requesting review
- [x] I understand what this code does

Closes #82246

---
🤖 *This PR was created by [OpenClaw](https://openclaw.ai) on behalf of @mkowalski.*