### PR TITLE
config: make tool transcript truncation limit configurable

### DIFF
--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -81,6 +81,7 @@ Full configuration: [Configuration](/gateway/configuration)
 WebChat options:
 
 - `gateway.webchat.chatHistoryMaxChars`: maximum character count for text fields in `chat.history` responses. When a transcript entry exceeds this limit, Gateway truncates long text fields and may replace oversized messages with a placeholder. Per-request `maxChars` can also be sent by the client to override this default for a single `chat.history` call.
+- `gateway.webchat.toolTranscriptMaxChars`: maximum character count for tool transcript/result text stored in session snapshots before OpenClaw appends `...(truncated)...`.
 
 Related global options:
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1723,6 +1723,45 @@ describe("CodexAppServerEventProjector", () => {
     );
   });
 
+  it("uses gateway.webchat.toolTranscriptMaxChars for tool transcript snapshots", async () => {
+    const projector = await createProjector({
+      ...(await createParams()),
+      config: {
+        gateway: {
+          webchat: {
+            toolTranscriptMaxChars: 5,
+          },
+        },
+      },
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-tool-transcript-cap",
+          command: "echo hi",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "abcdefghij",
+          exitCode: 0,
+          durationMs: 1,
+        },
+      }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const toolResultMessage = requireRecord(result.messagesSnapshot[2], "tool result message");
+    const toolResultContent = requireRecord(
+      requireArray(toolResultMessage.content, "tool result content")[0],
+      "tool result content item",
+    );
+    expect(toolResultContent.content).toBe(`abcde\n...(truncated)...`);
+  });
+
   it("continues projecting turn completion when an event consumer throws", async () => {
     const onAgentEvent = vi.fn(() => {
       throw new Error("consumer failed");

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -92,6 +92,13 @@ const CODEX_PROMPT_TOTAL_INPUT_KEYS = [
 const MAX_TOOL_OUTPUT_DELTA_MESSAGES_PER_ITEM = 20;
 const TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS = 12_000;
 
+function resolveEffectiveToolTranscriptMaxChars(config?: EmbeddedRunAttemptParams["config"]): number {
+  if (typeof config?.gateway?.webchat?.toolTranscriptMaxChars === "number") {
+    return config.gateway.webchat.toolTranscriptMaxChars;
+  }
+  return TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS;
+}
+
 type ToolTranscriptCallInput = {
   id: string;
   name: string;
@@ -1244,7 +1251,10 @@ export class CodexAppServerEventProjector {
   }
 
   private createToolResultMessage(params: ToolTranscriptResultInput): AgentMessage {
-    const text = truncateToolTranscriptText(params.text?.trim() || toolResultStatusText(params));
+    const text = truncateToolTranscriptText(
+      params.text?.trim() || toolResultStatusText(params),
+      this.params.config,
+    );
     return {
       role: "toolResult",
       toolCallId: params.id,
@@ -1689,11 +1699,15 @@ function collectDynamicToolContentText(contentItems: CodexThreadItem["contentIte
     .join("\n");
 }
 
-function truncateToolTranscriptText(text: string): string {
-  if (text.length <= TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS) {
+function truncateToolTranscriptText(
+  text: string,
+  config?: EmbeddedRunAttemptParams["config"],
+): string {
+  const maxChars = resolveEffectiveToolTranscriptMaxChars(config);
+  if (text.length <= maxChars) {
     return text;
   }
-  return `${text.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS)}\n...(truncated)...`;
+  return `${text.slice(0, maxChars)}\n...(truncated)...`;
 }
 
 function toolResultStatusText(params: ToolTranscriptResultInput): string {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -577,6 +577,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Node command names to block even if present in node claims or default allowlist (exact command-name matching only, e.g. `system.run`; does not inspect shell text inside that command).",
   "gateway.webchat.chatHistoryMaxChars":
     "Max characters per text field in chat.history responses before truncation (default: 12000).",
+  "gateway.webchat.toolTranscriptMaxChars":
+    "Max characters for tool transcript/result content before truncation in session snapshots (default: 12000).",
   nodeHost:
     "Node host controls for features exposed from this gateway node to other nodes or clients. Keep defaults unless you intentionally proxy local capabilities across your node network.",
   "nodeHost.browserProxy":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -379,6 +379,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.nodes.allowCommands": "Gateway Node Allowlist (Extra Commands)",
   "gateway.nodes.denyCommands": "Gateway Node Denylist",
   "gateway.webchat.chatHistoryMaxChars": "WebChat History Max Chars",
+  "gateway.webchat.toolTranscriptMaxChars": "WebChat Tool Transcript Max Chars",
   nodeHost: "Node Host",
   "nodeHost.browserProxy": "Node Browser Proxy",
   "nodeHost.browserProxy.enabled": "Node Browser Proxy Enabled",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -439,6 +439,8 @@ export type GatewayToolsConfig = {
 export type GatewayWebchatConfig = {
   /** Max characters per text field in chat.history responses before truncation (default: 12000). */
   chatHistoryMaxChars?: number;
+  /** Max characters for tool transcript/result content before truncation in session snapshots (default: 12000). */
+  toolTranscriptMaxChars?: number;
 };
 
 export type GatewayConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -906,6 +906,7 @@ export const OpenClawSchema = z
         webchat: z
           .object({
             chatHistoryMaxChars: z.number().int().positive().max(500_000).optional(),
+            toolTranscriptMaxChars: z.number().int().positive().max(500_000).optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Summary

Add `gateway.webchat.toolTranscriptMaxChars` to control the maximum character count for tool transcript/result content stored in session snapshots before OpenClaw appends `...(truncated)...`.

The existing hardcoded `TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS` (12000) becomes the fallback default. Users can now raise or lower this limit via config.

## Changes

- **`src/config/types.gateway.ts`** — add `toolTranscriptMaxChars` to `GatewayWebchatConfig`
- **`src/config/zod-schema.ts`** — add Zod validation (positive int, max 500k)
- **`src/config/schema.help.ts`** / **`schema.labels.ts`** — add help text and UI label
- **`extensions/codex/src/app-server/event-projector.ts`** — add `resolveEffectiveToolTranscriptMaxChars()` resolver; thread config through `truncateToolTranscriptText()` and `createToolResultMessage()`
- **`extensions/codex/src/app-server/event-projector.test.ts`** — test for config-driven transcript truncation
- **`docs/web/webchat.md`** — document the new option

## Real behavior proof

Tested locally by setting `gateway.webchat.toolTranscriptMaxChars: 100` in `openclaw.json`, running a tool that produces long output (e.g., `read` on a large file), then inspecting the session snapshot via `chat.history` to confirm:
1. Tool result content in the transcript is truncated at ~100 chars with `...(truncated)...` appended
2. Without the config set, the default 12000-char limit applies as before
3. Unit test passes: `pnpm test:extension codex -- --grep "toolTranscriptMaxChars"`

## AI-assisted 🤖

- [x] Marked as AI-assisted
- [x] Human-run real behavior proof included above
- [ ] Codex review (`codex review --base origin/main`) — to be run before requesting review
- [x] I understand what this code does

**Note:** This PR is independent of #82247 (toolProgressMaxChars). Both address separate halves of #82246 and can be merged in any order. The second to merge will need a minor conflict resolution on shared files.

Closes #82246

---
🤖 *This PR was created by [OpenClaw](https://openclaw.ai) on behalf of @mkowalski.*