### PR TITLE
fix(agents): honor completions max token params

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3417,6 +3417,60 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("max_tokens");
   });
 
+  it("uses model params max_completion_tokens for OpenAI completions params when runtime maxTokens is omitted", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "kimi-k2.6",
+        name: "Kimi K2.6",
+        api: "openai-completions",
+        provider: "dashscope",
+        baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 262_144,
+        maxTokens: 32_000,
+        params: { max_completion_tokens: 64_000 },
+      } as Model<"openai-completions"> & { params: Record<string, unknown> },
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params.max_completion_tokens).toBe(64_000);
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
+  it("lets runtime maxTokens override model params max_completion_tokens for OpenAI completions", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "kimi-k2.6",
+        name: "Kimi K2.6",
+        api: "openai-completions",
+        provider: "dashscope",
+        baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 262_144,
+        maxTokens: 32_000,
+        params: { max_completion_tokens: 64_000 },
+      } as Model<"openai-completions"> & { params: Record<string, unknown> },
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      { maxTokens: 48_000 } as never,
+    );
+
+    expect(params.max_completion_tokens).toBe(48_000);
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
   it("uses model maxTokens with max_tokens completions compat when runtime maxTokens is omitted", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -72,6 +72,11 @@ const DEFAULT_AZURE_OPENAI_API_VERSION = "preview";
 const OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT = " ";
 const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validator";
 const AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS = 30_000;
+const OPENAI_COMPLETIONS_MAX_TOKENS_PARAM_KEYS = [
+  "maxTokens",
+  "max_completion_tokens",
+  "max_tokens",
+] as const;
 const log = createSubsystemLogger("openai-transport");
 
 type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };
@@ -2223,6 +2228,21 @@ function getCompat(model: OpenAIModeModel): {
   };
 }
 
+function resolveModelConfiguredMaxTokens(model: Model<"openai-completions">): number | undefined {
+  const rawParams = (model as { params?: unknown }).params;
+  if (!rawParams || typeof rawParams !== "object" || Array.isArray(rawParams)) {
+    return undefined;
+  }
+  const params = rawParams as Record<string, unknown>;
+  for (const key of OPENAI_COMPLETIONS_MAX_TOKENS_PARAM_KEYS) {
+    const value = params[key];
+    if (typeof value === "number") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 type OpenAIResponsesRequestParams = {
   model: string;
   input: ResponseInput;
@@ -2592,7 +2612,8 @@ export function buildOpenAICompletionsParams(
     params.prompt_cache_key = options.sessionId;
   }
   {
-    const effectiveMaxTokens = options?.maxTokens || model.maxTokens;
+    const effectiveMaxTokens =
+      options?.maxTokens ?? resolveModelConfiguredMaxTokens(model) ?? model.maxTokens;
     if (effectiveMaxTokens) {
       if (compat.maxTokensField === "max_tokens") {
         params.max_tokens = effectiveMaxTokens;

--- a/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
@@ -63,6 +63,36 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     expect(callOptions?.maxTokens).toBe(512);
   });
 
+  it("forwards max_completion_tokens from resolved params into the underlying streamFn options", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(agent, undefined, "dashscope", "kimi-k2.6", {
+      max_completion_tokens: 64_000,
+    });
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      { id: "kimi-k2.6", api: "openai-completions", provider: "dashscope" } as never,
+      { messages: [], tools: [] } as never,
+      undefined,
+    );
+
+    expect(underlying).toHaveBeenCalledTimes(1);
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as { maxTokens?: number } | undefined;
+    expect(callOptions?.maxTokens).toBe(64_000);
+  });
+
   it("lets runtime options override the wrapper sampling defaults", () => {
     const underlying = vi.fn(() => ({
       push: vi.fn(),

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -48,6 +48,7 @@ const providerRuntimeDeps = {
 
 let preparedExtraParamsCache = new WeakMap<OpenClawConfig, Map<string, Record<string, unknown>>>();
 const REQUEST_SCOPED_EXTRA_PARAM_KEYS = new Set(["response_format", "responseFormat"]);
+const MAX_TOKENS_EXTRA_PARAM_KEYS = ["maxTokens", "max_completion_tokens", "max_tokens"] as const;
 
 export const __testing = {
   setProviderRuntimeDepsForTest(
@@ -419,8 +420,9 @@ function createStreamFnWithExtraParams(
   if (typeof extraParams.topP === "number") {
     streamParams.topP = extraParams.topP;
   }
-  if (typeof extraParams.maxTokens === "number") {
-    streamParams.maxTokens = extraParams.maxTokens;
+  const maxTokens = resolveMaxTokensExtraParam([extraParams]);
+  if (typeof maxTokens === "number") {
+    streamParams.maxTokens = maxTokens;
   }
   const resolvedResponseFormat = resolveAliasedParamValue(
     [extraParams],
@@ -515,6 +517,13 @@ function resolveAliasedParamValueFromKeys(
     }
   }
   return seen ? resolved : undefined;
+}
+
+function resolveMaxTokensExtraParam(
+  sources: Array<Record<string, unknown> | undefined>,
+): number | undefined {
+  const value = resolveAliasedParamValueFromKeys(sources, MAX_TOKENS_EXTRA_PARAM_KEYS);
+  return typeof value === "number" ? value : undefined;
 }
 
 function applyCanonicalAliasedParamValue(params: {


### PR DESCRIPTION
## Summary
- Normalize `max_completion_tokens` / `max_tokens` resolved model params into embedded Pi stream `maxTokens` options.
- Let direct OpenAI-completions payload construction use resolved model `params` token caps when runtime `maxTokens` is omitted.
- Preserve precedence: runtime `maxTokens` still wins over configured model params, which win over catalog `model.maxTokens`.

Fixes #82230.

## Verification
- `node --check src/agents/openai-transport-stream.ts`
- `node --check src/agents/pi-embedded-runner/extra-params.ts`
- `git diff --check`

I could not run the targeted Vitest suite locally because this checkout declares `packageManager: pnpm@11.1.0`, and the available pnpm attempts to fetch `@pnpm/exe@11.1.0` from npm, which currently returns `No matching version found`. I also tried a fallback `npm install --package-lock=false --ignore-scripts`, but it hung without output and was stopped without leaving node_modules or a package-lock.
