### PR TITLE
[codex] Apply OpenAI completions model params in embedded runs

### DIFF
--- a/src/agents/openai-completions-model-params.test.ts
+++ b/src/agents/openai-completions-model-params.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { applyOpenAICompletionsModelParams } from "./openai-completions-model-params.js";
+
+describe("applyOpenAICompletionsModelParams", () => {
+  it("applies raw OpenAI completions model params and normalizes max token aliases", () => {
+    const payload: Record<string, unknown> = {
+      max_tokens: 32_000,
+    };
+
+    applyOpenAICompletionsModelParams(payload, {
+      params: {
+        max_completion_tokens: 64_000,
+        temperature: 0.2,
+      },
+    });
+
+    expect(payload).toMatchObject({
+      max_completion_tokens: 64_000,
+      temperature: 0.2,
+    });
+    expect(payload).not.toHaveProperty("max_tokens");
+  });
+
+  it("does not forward reserved, prototype-polluting, or OpenClaw control params", () => {
+    const payload: Record<string, unknown> = {};
+
+    applyOpenAICompletionsModelParams(payload, {
+      params: {
+        __proto__: { polluted: true },
+        constructor: "bad",
+        model: "bad",
+        messages: [],
+        prototype: "bad",
+        stream: false,
+        stream_options: {},
+        extra_body: { thinking: { type: "enabled" } },
+        extraBody: { store: false },
+        fastMode: true,
+        fast_mode: true,
+        chat_template_kwargs: { enable_thinking: false },
+        chatTemplateKwargs: { enable_thinking: false },
+        reasoning_effort: "high",
+        reasoningEffort: "high",
+        service_tier: "flex",
+        serviceTier: "flex",
+        transport: "websocket",
+        openaiWsWarmup: true,
+        cachedContent: "cached",
+        responseCache: true,
+        text_verbosity: "low",
+        top_p: 0.9,
+      },
+    });
+
+    expect(payload).toEqual({ top_p: 0.9 });
+    expect(Object.getPrototypeOf(payload)).toBe(Object.prototype);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});

--- a/src/agents/openai-completions-model-params.ts
+++ b/src/agents/openai-completions-model-params.ts
@@ -1,0 +1,59 @@
+const RESERVED_OPENAI_COMPLETIONS_MODEL_PARAM_KEYS = new Set([
+  "__proto__",
+  "constructor",
+  "model",
+  "messages",
+  "prototype",
+  "stream",
+  "stream_options",
+  "cacheRetention",
+  "cachedContent",
+  "cached_content",
+  "chatTemplateKwargs",
+  "chat_template_kwargs",
+  "extraBody",
+  "extra_body",
+  "fastMode",
+  "fast_mode",
+  "openaiWsWarmup",
+  "reasoningEffort",
+  "reasoning_effort",
+  "responseCache",
+  "responseCacheClear",
+  "responseCacheTtl",
+  "responseCacheTtlSeconds",
+  "response_cache",
+  "response_cache_clear",
+  "response_cache_ttl",
+  "response_cache_ttl_seconds",
+  "textVerbosity",
+  "text_verbosity",
+  "serviceTier",
+  "service_tier",
+  "transport",
+]);
+
+export type OpenAICompletionsModelParamsInput = {
+  params?: Record<string, unknown> | null;
+};
+
+export function applyOpenAICompletionsModelParams(
+  payload: Record<string, unknown>,
+  model: OpenAICompletionsModelParamsInput | undefined,
+): void {
+  const modelParams = model?.params;
+  if (!modelParams || typeof modelParams !== "object") {
+    return;
+  }
+  for (const [key, value] of Object.entries(modelParams)) {
+    if (value === undefined || RESERVED_OPENAI_COMPLETIONS_MODEL_PARAM_KEYS.has(key)) {
+      continue;
+    }
+    if (key === "max_completion_tokens") {
+      delete payload.max_tokens;
+    } else if (key === "max_tokens") {
+      delete payload.max_completion_tokens;
+    }
+    payload[key] = value;
+  }
+}

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2629,6 +2629,37 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("max_tokens");
   });
 
+  it("lets model params override embedded OpenAI completions maxTokens defaults", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "kimi-k2.6",
+        name: "Kimi K2.6",
+        api: "openai-completions",
+        provider: "DashScope",
+        baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 262_144,
+        maxTokens: 262_144,
+        params: {
+          max_completion_tokens: 64_000,
+        },
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        maxTokens: 32_000,
+        reasoningEffort: "high",
+      } as never,
+    );
+
+    expect(params.max_completion_tokens).toBe(64_000);
+  });
+
   it("uses model maxTokens with max_tokens completions compat when runtime maxTokens is omitted", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -28,6 +28,7 @@ import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.typ
 import { resolveProviderTransportTurnStateWithPlugin } from "../plugins/provider-runtime.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
 import { detectOpenAICompletionsCompat } from "./openai-completions-compat.js";
+import { applyOpenAICompletionsModelParams } from "./openai-completions-model-params.js";
 import { flattenCompletionMessagesToStringContent } from "./openai-completions-string-content.js";
 import { resolveOpenAIReasoningEffortMap } from "./openai-reasoning-compat.js";
 import {
@@ -102,6 +103,7 @@ type OpenAIModeCompatInput = Omit<ModelCompatConfig, "thinkingFormat"> & {
 
 type OpenAIModeModel = Omit<Model<Api>, "compat"> & {
   compat?: OpenAIModeCompatInput | null;
+  params?: Record<string, unknown> | null;
 };
 
 type MutableAssistantOutput = {
@@ -1924,6 +1926,7 @@ export function buildOpenAICompletionsParams(
   } else if (hasToolHistory(context.messages)) {
     params.tools = [];
   }
+  applyOpenAICompletionsModelParams(params, model);
   const completionsReasoningEffort = resolveOpenAICompletionsReasoningEffort(options);
   const resolvedCompletionsReasoningEffort = completionsReasoningEffort
     ? resolveOpenAIReasoningEffortForModel({

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -526,6 +526,7 @@ describe("applyExtraParamsToAgent", () => {
     extraParamsOverride?: Record<string, unknown>;
     payload?: Record<string, unknown>;
     thinkingLevel?: Parameters<typeof applyExtraParamsToAgent>[5];
+    runtimeModel?: Parameters<typeof applyExtraParamsToAgent>[8];
   }) {
     const payload = params.payload ?? { store: false };
     const baseStreamFn: StreamFn = (model, _context, options) => {
@@ -540,6 +541,9 @@ describe("applyExtraParamsToAgent", () => {
       params.applyModelId,
       params.extraParamsOverride,
       params.thinkingLevel,
+      undefined,
+      undefined,
+      params.runtimeModel,
     );
     const context: Context = { messages: [] };
     void agent.streamFn?.(params.model, context, params.options ?? {});
@@ -699,6 +703,32 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("reasoning");
     expect(payload).not.toHaveProperty("reasoningEffort");
     expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("applies OpenAI completions model params after embedded maxTokens defaults", () => {
+    const model = {
+      api: "openai-completions",
+      provider: "DashScope",
+      id: "kimi-k2.6",
+      params: {
+        max_completion_tokens: 64_000,
+        extra_body: { thinking: { type: "enabled" } },
+        transport: "websocket",
+      },
+    } as unknown as Model<"openai-completions">;
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "DashScope",
+      applyModelId: "kimi-k2.6",
+      model,
+      runtimeModel: model,
+      payload: {
+        max_completion_tokens: 32_000,
+      },
+    });
+
+    expect(payload.max_completion_tokens).toBe(64_000);
+    expect(payload).not.toHaveProperty("extra_body");
+    expect(payload).not.toHaveProperty("transport");
   });
 
   it("strips disabled reasoning payloads for native OpenAI responses models that do not support none", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -11,6 +11,7 @@ import {
 } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { legacyModelKey, modelKey } from "../model-selection-normalize.js";
+import { applyOpenAICompletionsModelParams } from "../openai-completions-model-params.js";
 import { supportsGptParallelToolCallsPayload } from "../provider-api-families.js";
 import { resolveProviderRequestPolicyConfig } from "../provider-request-config.js";
 import { createGoogleThinkingPayloadWrapper } from "./google-stream-wrappers.js";
@@ -641,6 +642,23 @@ function createOpenAICompletionsExtraBodyWrapper(
   };
 }
 
+function createOpenAICompletionsModelParamsWrapper(
+  baseStreamFn: StreamFn | undefined,
+  configured: Record<string, unknown> | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (model.api !== "openai-completions") {
+      return underlying(model, context, options);
+    }
+    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
+      applyOpenAICompletionsModelParams(payloadObj, {
+        params: configured ?? (model as { params?: Record<string, unknown> | null }).params,
+      });
+    });
+  };
+}
+
 type ApplyExtraParamsContext = {
   agent: { streamFn?: StreamFn };
   cfg: OpenClawConfig | undefined;
@@ -687,6 +705,10 @@ function applyPostPluginStreamWrappers(
 ): void {
   ctx.agent.streamFn = createOpenRouterSystemCacheWrapper(ctx.agent.streamFn);
   ctx.agent.streamFn = createOpenAIStringContentWrapper(ctx.agent.streamFn);
+  ctx.agent.streamFn = createOpenAICompletionsModelParamsWrapper(
+    ctx.agent.streamFn,
+    ctx.model?.params,
+  );
 
   if (!ctx.providerWrapperHandled) {
     // Guard Google-family payloads against invalid negative thinking budgets


### PR DESCRIPTION
## Summary

- Problem: embedded Pi agent runs can ignore resolved OpenAI-compatible model `params`, leaving upstream defaults such as `max_completion_tokens: 32000` in the final payload.
- Why it matters: DashScope Kimi K2.6 with high thinking can require a reasoning budget above 32000, making the provider request invalid even though the resolved model config has `params.max_completion_tokens: 64000`.
- What changed: added a shared OpenAI-completions model-param payload helper and applied it in both direct OpenAI-completions transport and embedded Pi stream payload patching.
- What did NOT change (scope boundary): no QQBot-specific behavior, no provider-specific special case, no QQBot-specific behavior and no provider-specific special case.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82230
- Related #37804
- Related #55760
- Related #57860
- Related #73607
- Related #30398
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count.

- Behavior or issue addressed: DashScope Kimi K2.6 requests from OpenClaw should use resolved model params so the final OpenAI-completions payload can raise `max_completion_tokens` above the embedded default.
- Real environment tested: Windows source checkout, OpenClaw 2026.5.6, local gateway from `D:\desktop\openclaw`, config at `C:\Users\two-one\.openclaw\openclaw.json`.
- Exact steps or command run after this patch:

```powershell
pnpm openclaw infer model run --gateway --model DashScope/kimi-k2.6 --prompt "Reply with exactly: openclaw-k2-reviewed-fix-ok" --json
```

- Evidence after fix (copied live output):

```json
{
  "ok": true,
  "capability": "model.run",
  "transport": "gateway",
  "provider": "DashScope",
  "model": "kimi-k2.6",
  "attempts": [],
  "outputs": [
    {
      "text": "openclaw-k2-reviewed-fix-ok",
      "mediaUrl": null
    }
  ]
}
```

- Observed result after fix: live gateway call completed successfully with the expected K2.6 output.
- What was not tested: a live Tencent QQ network message was not sent from the PR branch. A local mock QQ inbound -> outbound dispatch -> embedded payload path was tested outside this PR diff.
- Before evidence (optional but encouraged): original failure path produced an invalid request where high-thinking reasoning budget exceeded embedded `max_completion_tokens: 32000` despite resolved K2.6 config having `params.max_completion_tokens: 64000`.

## Root Cause (if applicable)

- Root cause: direct model calls and embedded Pi agent runs used different payload construction paths. Resolved model params existed, but embedded Pi payloads did not reliably apply them after upstream defaults were created.
- Missing detection / guardrail: no regression coverage for resolved model params flowing through embedded OpenAI-completions payload construction.
- Contributing context (if known): QQBot exposed the issue because it routes messages through embedded Pi agent dispatch; the bug is in OpenClaw's integration layer, not QQBot routing.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openai-completions-model-params.test.ts`, `src/agents/pi-embedded-runner-extraparams.test.ts`, and `src/agents/openai-transport-stream.test.ts`.
- Scenario the test should lock in: a resolved OpenAI-completions model with `params.max_completion_tokens` overrides embedded/default `max_completion_tokens`, while OpenClaw control keys and prototype-pollution keys do not leak to the provider payload.
- Why this is the smallest reliable guardrail: the bug sits at model-param-to-payload normalization and embedded stream payload patching, so focused payload tests catch it without requiring real QQ network traffic.
- Existing test that already covers this (if any): none known before this local validation.
- If no new test is added, why not: N/A; this PR now includes focused regression tests. A heavier mock QQ inbound test was kept out of the PR to avoid broadening the diff, but was run locally.

## User-visible / Behavior Changes

DashScope K2.6 and other OpenAI-compatible completions models can now have resolved model params applied consistently in embedded Pi agent runs. This should prevent high-thinking runs from failing due to stale embedded defaults such as `max_completion_tokens: 32000`.

## Diagram (if applicable)

```text
Before:
[QQ/gateway embedded agent] -> [Pi stream default payload: max_completion_tokens=32000] -> [provider rejects high-thinking budget]

After:
[QQ/gateway embedded agent] -> [Pi stream payload] -> [OpenClaw applies resolved OpenAI-completions model params] -> [provider receives valid cap]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

The shared helper also filters prototype-pollution keys (`__proto__`, `constructor`, `prototype`) and OpenClaw internal control keys before applying model params to a provider payload.

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local source checkout, pnpm, gateway running from source
- Model/provider: `DashScope/kimi-k2.6`
- Integration/channel (if any): gateway; QQBot was the original trigger path
- Relevant config (redacted): resolved model has `api: "openai-completions"` and `params.max_completion_tokens: 64000`

### Steps

1. Configure DashScope Kimi K2.6 with `params.max_completion_tokens: 64000`.
2. Run a gateway model call against `DashScope/kimi-k2.6`.
3. Verify the request completes instead of failing due to the embedded 32000 completion-token cap.

### Expected

- K2.6 request succeeds with the resolved model params applied.

### Actual

- After this patch, the gateway smoke call returned the expected text exactly.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Copied live output is included in the Real behavior proof section above.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - live gateway call to `DashScope/kimi-k2.6` returned `openclaw-k2-reviewed-fix-ok`
  - direct OpenAI-completions payload smoke script kept `max_completion_tokens: 64000` and did not leak OpenClaw control keys
  - local mock QQ inbound -> outbound dispatch -> embedded payload path kept the resolved K2.6 token cap
  - local and committed helper regression checked max-token aliasing, control-key filtering, and prototype-pollution keys
- Edge cases checked:
  - `max_tokens` and `max_completion_tokens` are normalized so only the explicitly configured alias remains
  - OpenClaw control params such as `extra_body`, `transport`, `chat_template_kwargs`, `reasoning_effort`, `serviceTier`, and `fastMode` are not forwarded as raw provider payload fields
  - prototype-pollution keys are ignored
- What you did **not** verify:
  - full `pnpm check`; `pnpm exec tsc --noEmit --pretty false` hit Node/V8 heap OOM around 4GB in this local environment
  - live Tencent QQ network message on this PR branch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No GitHub bot review conversations existed at PR creation time. A local Codex subagent review was run twice; blocker/major findings were addressed before opening the PR. Focused regression tests are included in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: model `params` may include OpenClaw control keys that are not valid provider payload keys.
  - Mitigation: the helper filters known internal/reserved/control keys before mutating OpenAI-completions payloads.
- Risk: token aliases could conflict if both `max_tokens` and `max_completion_tokens` are present.
  - Mitigation: applying either alias removes the other from the final payload.
- Risk: a provider-specific raw payload key may be unintentionally filtered if it shares a name with an OpenClaw control key.
  - Mitigation: this PR keeps the generic `params` path conservative; provider-specific raw bodies should use explicit wrapper mechanisms such as `extra_body` rather than accidental top-level passthrough.

