### PR TITLE
fix(active-memory): use memory_recall default for memory-lancedb-pro slot

### DIFF
--- a/docs/concepts/active-memory.md
+++ b/docs/concepts/active-memory.md
@@ -338,9 +338,9 @@ By default that is:
 - `memory_search`
 - `memory_get`
 
-When `plugins.slots.memory` is `memory-lancedb`, the default is `memory_recall`
-instead. Set `config.toolsAllow` when another memory provider exposes a
-different recall tool contract.
+When `plugins.slots.memory` is `memory-lancedb` or `memory-lancedb-pro`, the
+default is `memory_recall` instead. Set `config.toolsAllow` when another memory
+provider exposes a different recall tool contract.
 
 If the connection is weak, it should return `NONE`.
 
@@ -470,9 +470,9 @@ field for older configs. It no longer changes runtime behavior.
 
 By default Active Memory lets the blocking recall sub-agent call
 `memory_search` and `memory_get`. That matches the built-in `memory-core`
-contract. When `plugins.slots.memory` selects `memory-lancedb` and
-`config.toolsAllow` is unset, Active Memory keeps the existing LanceDB behavior
-and uses `memory_recall` instead.
+contract. When `plugins.slots.memory` selects `memory-lancedb` or
+`memory-lancedb-pro` and `config.toolsAllow` is unset, Active Memory keeps the
+LanceDB behavior and uses `memory_recall` instead.
 
 If you use another memory plugin, set `config.toolsAllow` to the exact tool
 names that plugin registers. Active Memory lists those tools in the recall
@@ -484,9 +484,9 @@ entries, and core agent tools such as `read`, `exec`, `message`, and
 `web_search` are ignored before the hidden memory sub-agent starts.
 
 Default-behavior note: Active Memory no longer includes `memory_recall` in the
-memory-core default allowlist. Existing `memory-lancedb` setups keep working
-when `plugins.slots.memory` is set to `memory-lancedb`. Explicit `toolsAllow`
-always overrides the automatic default.
+memory-core default allowlist. Existing `memory-lancedb` and `memory-lancedb-pro`
+setups keep working when `plugins.slots.memory` is set to either slot id.
+Explicit `toolsAllow` always overrides the automatic default.
 
 ### Built-in memory-core
 
@@ -669,26 +669,26 @@ plugins.entries.active-memory
 
 The most important fields are:
 
-| Key                          | Type                                                                                                 | Meaning                                                                                                                                                                                                                                                  |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enabled`                    | `boolean`                                                                                            | Enables the plugin itself                                                                                                                                                                                                                                |
-| `config.agents`              | `string[]`                                                                                           | Agent ids that may use active memory                                                                                                                                                                                                                     |
-| `config.model`               | `string`                                                                                             | Optional blocking memory sub-agent model ref; when unset, active memory uses the current session model                                                                                                                                                   |
-| `config.allowedChatTypes`    | `("direct" \| "group" \| "channel")[]`                                                               | Session types that may run Active Memory; defaults to direct-message style sessions                                                                                                                                                                      |
-| `config.allowedChatIds`      | `string[]`                                                                                           | Optional per-conversation allowlist applied after `allowedChatTypes`; non-empty lists fail closed                                                                                                                                                        |
-| `config.deniedChatIds`       | `string[]`                                                                                           | Optional per-conversation denylist that overrides allowed session types and allowed ids                                                                                                                                                                  |
-| `config.queryMode`           | `"message" \| "recent" \| "full"`                                                                    | Controls how much conversation the blocking memory sub-agent sees                                                                                                                                                                                        |
-| `config.promptStyle`         | `"balanced" \| "strict" \| "contextual" \| "recall-heavy" \| "precision-heavy" \| "preference-only"` | Controls how eager or strict the blocking memory sub-agent is when deciding whether to return memory                                                                                                                                                     |
-| `config.toolsAllow`          | `string[]`                                                                                           | Concrete memory tool names the blocking memory sub-agent may call; defaults to `["memory_search", "memory_get"]`, or `["memory_recall"]` when `plugins.slots.memory` is `memory-lancedb`; wildcards, `group:*` entries, and core agent tools are ignored |
-| `config.thinking`            | `"off" \| "minimal" \| "low" \| "medium" \| "high" \| "xhigh" \| "adaptive" \| "max"`                | Advanced thinking override for the blocking memory sub-agent; default `off` for speed                                                                                                                                                                    |
-| `config.promptOverride`      | `string`                                                                                             | Advanced full prompt replacement; not recommended for normal use                                                                                                                                                                                         |
-| `config.promptAppend`        | `string`                                                                                             | Advanced extra instructions appended to the default or overridden prompt                                                                                                                                                                                 |
-| `config.timeoutMs`           | `number`                                                                                             | Hard timeout for the blocking memory sub-agent, capped at 120000 ms                                                                                                                                                                                      |
-| `config.setupGraceTimeoutMs` | `number`                                                                                             | Advanced extra setup budget before the recall timeout expires; defaults to 0 and is capped at 30000 ms. See [Cold-start grace](#cold-start-grace) for v2026.4.x upgrade guidance                                                                         |
-| `config.maxSummaryChars`     | `number`                                                                                             | Maximum total characters allowed in the active-memory summary                                                                                                                                                                                            |
-| `config.logging`             | `boolean`                                                                                            | Emits active memory logs while tuning                                                                                                                                                                                                                    |
-| `config.persistTranscripts`  | `boolean`                                                                                            | Keeps blocking memory sub-agent transcripts on disk instead of deleting temp files                                                                                                                                                                       |
-| `config.transcriptDir`       | `string`                                                                                             | Relative blocking memory sub-agent transcript directory under the agent sessions folder                                                                                                                                                                  |
+| Key                          | Type                                                                                                 | Meaning                                                                                                                                                                                                                                                                          |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                    | `boolean`                                                                                            | Enables the plugin itself                                                                                                                                                                                                                                                        |
+| `config.agents`              | `string[]`                                                                                           | Agent ids that may use active memory                                                                                                                                                                                                                                             |
+| `config.model`               | `string`                                                                                             | Optional blocking memory sub-agent model ref; when unset, active memory uses the current session model                                                                                                                                                                           |
+| `config.allowedChatTypes`    | `("direct" \| "group" \| "channel")[]`                                                               | Session types that may run Active Memory; defaults to direct-message style sessions                                                                                                                                                                                              |
+| `config.allowedChatIds`      | `string[]`                                                                                           | Optional per-conversation allowlist applied after `allowedChatTypes`; non-empty lists fail closed                                                                                                                                                                                |
+| `config.deniedChatIds`       | `string[]`                                                                                           | Optional per-conversation denylist that overrides allowed session types and allowed ids                                                                                                                                                                                          |
+| `config.queryMode`           | `"message" \| "recent" \| "full"`                                                                    | Controls how much conversation the blocking memory sub-agent sees                                                                                                                                                                                                                |
+| `config.promptStyle`         | `"balanced" \| "strict" \| "contextual" \| "recall-heavy" \| "precision-heavy" \| "preference-only"` | Controls how eager or strict the blocking memory sub-agent is when deciding whether to return memory                                                                                                                                                                             |
+| `config.toolsAllow`          | `string[]`                                                                                           | Concrete memory tool names the blocking memory sub-agent may call; defaults to `["memory_search", "memory_get"]`, or `["memory_recall"]` when `plugins.slots.memory` is `memory-lancedb` or `memory-lancedb-pro`; wildcards, `group:*` entries, and core agent tools are ignored |
+| `config.thinking`            | `"off" \| "minimal" \| "low" \| "medium" \| "high" \| "xhigh" \| "adaptive" \| "max"`                | Advanced thinking override for the blocking memory sub-agent; default `off` for speed                                                                                                                                                                                            |
+| `config.promptOverride`      | `string`                                                                                             | Advanced full prompt replacement; not recommended for normal use                                                                                                                                                                                                                 |
+| `config.promptAppend`        | `string`                                                                                             | Advanced extra instructions appended to the default or overridden prompt                                                                                                                                                                                                         |
+| `config.timeoutMs`           | `number`                                                                                             | Hard timeout for the blocking memory sub-agent, capped at 120000 ms                                                                                                                                                                                                              |
+| `config.setupGraceTimeoutMs` | `number`                                                                                             | Advanced extra setup budget before the recall timeout expires; defaults to 0 and is capped at 30000 ms. See [Cold-start grace](#cold-start-grace) for v2026.4.x upgrade guidance                                                                                                 |
+| `config.maxSummaryChars`     | `number`                                                                                             | Maximum total characters allowed in the active-memory summary                                                                                                                                                                                                                    |
+| `config.logging`             | `boolean`                                                                                            | Emits active memory logs while tuning                                                                                                                                                                                                                                            |
+| `config.persistTranscripts`  | `boolean`                                                                                            | Keeps blocking memory sub-agent transcripts on disk instead of deleting temp files                                                                                                                                                                                               |
+| `config.transcriptDir`       | `string`                                                                                             | Relative blocking memory sub-agent transcript directory under the agent sessions folder                                                                                                                                                                                          |
 
 Useful tuning fields:
 
@@ -805,7 +805,7 @@ If active memory is too slow:
 Active Memory rides on the configured memory plugin's recall pipeline, so most
 recall surprises are embedding-provider problems, not Active Memory bugs. The
 default `memory-core` path uses `memory_search` and `memory_get`; the
-`memory-lancedb` slot uses `memory_recall`. If you use another memory plugin,
+`memory-lancedb` and `memory-lancedb-pro` slots use `memory_recall`. If you use another memory plugin,
 confirm `config.toolsAllow` names the tools that plugin actually registers.
 
 <AccordionGroup>

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -1459,6 +1459,27 @@ describe("active-memory plugin", () => {
     expect(runParams.prompt).toContain("Configured memory tools: memory_recall.");
   });
 
+  it("uses memory_recall by default when the memory slot selects memory-lancedb-pro", async () => {
+    setMemorySlot("memory-lancedb-pro");
+
+    await hooks.before_prompt_build(
+      {
+        prompt: "What did we decide about active memory?",
+        messages: [],
+      },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    const runParams = lastEmbeddedRunParams();
+    expect(runParams.toolsAllow).toEqual(["memory_recall"]);
+    expect(runParams.prompt).toContain("Configured memory tools: memory_recall.");
+  });
+
   it("keeps explicit custom memory tools authoritative when the memory slot selects LanceDB", async () => {
     setMemorySlot("memory-lancedb");
     api.pluginConfig = {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -44,6 +44,10 @@ const DEFAULT_CIRCUIT_BREAKER_MAX_TIMEOUTS = 3;
 const DEFAULT_CIRCUIT_BREAKER_COOLDOWN_MS = 60_000;
 const DEFAULT_ACTIVE_MEMORY_TOOLS_ALLOW = ["memory_search", "memory_get"] as const;
 const LANCEDB_ACTIVE_MEMORY_TOOLS_ALLOW = ["memory_recall"] as const;
+// Slot ids whose memory plugin exposes the LanceDB recall contract
+// (memory_recall) rather than the OpenAI-memories defaults
+// (memory_search/memory_get). Keep in sync with new LanceDB-family plugins.
+const LANCEDB_MEMORY_SLOTS = new Set(["memory-lancedb", "memory-lancedb-pro"]);
 const MAX_ACTIVE_MEMORY_TOOLS_ALLOW = 32;
 const ACTIVE_MEMORY_RESERVED_TOOLS_ALLOW = new Set([
   "*",
@@ -467,7 +471,8 @@ function isReservedActiveMemoryToolsAllowEntry(value: string): boolean {
 }
 
 function resolveDefaultToolsAllow(cfg: OpenClawConfig | undefined): string[] {
-  return cfg?.plugins?.slots?.memory === "memory-lancedb"
+  const slot = cfg?.plugins?.slots?.memory;
+  return typeof slot === "string" && LANCEDB_MEMORY_SLOTS.has(slot)
     ? [...LANCEDB_ACTIVE_MEMORY_TOOLS_ALLOW]
     : [...DEFAULT_ACTIVE_MEMORY_TOOLS_ALLOW];
 }

--- a/extensions/active-memory/openclaw.plugin.json
+++ b/extensions/active-memory/openclaw.plugin.json
@@ -139,7 +139,7 @@
     },
     "toolsAllow": {
       "label": "Allowed Memory Tools",
-      "help": "Advanced: tool names the blocking memory sub-agent may use. Defaults to memory_search and memory_get, or memory_recall when plugins.slots.memory selects memory-lancedb; configure this for other non-core memory providers. Wildcards, group entries, and core agent tools are ignored."
+      "help": "Advanced: tool names the blocking memory sub-agent may use. Defaults to memory_search and memory_get, or memory_recall when plugins.slots.memory selects memory-lancedb or memory-lancedb-pro; configure this for other non-core memory providers. Wildcards, group entries, and core agent tools are ignored."
     },
     "thinking": {
       "label": "Thinking Override",


### PR DESCRIPTION
## Summary

- Closes #82265
- `resolveDefaultToolsAllow` matched only the exact slot id `"memory-lancedb"`, so deployments using `memory-lancedb-pro` (or any other LanceDB-family slot id) fell through to the openai-memories defaults `memory_search`/`memory_get` — neither of which those plugins register.
- Replace the bare equality check with a small allowlist (`LANCEDB_MEMORY_SLOTS`) covering both `memory-lancedb` and `memory-lancedb-pro`.
- Update the public default-tool surfaces (`docs/concepts/active-memory.md` defaults section, Memory tools section, config reference row, Common Issues note; plus the `extensions/active-memory/openclaw.plugin.json` `toolsAllow` config help) so they match the new runtime behavior.
- Failure mode previously was silent: `active-memory: done status=unavailable summaryChars=0` every turn, no pre-injected memories, no user-visible error.

A capability-driven default (inspect registered memory tools from the slot owner rather than hardcoding slot ids) would be cleaner but is a bigger change — flagged as a follow-up in the issue.

## Real behavior proof

**Behavior or issue addressed:** Active Memory's embedded recall sub-agent fails every turn with `No callable tools remain after resolving explicit tool allowlist (runtime toolsAllow: memory_search, memory_get); no registered tools matched.` when `plugins.slots.memory` is `memory-lancedb-pro`. The plugin registers `memory_recall` (not `memory_search`/`memory_get`). Failure is silent at the channel level — `status=unavailable summaryChars=0` and the main reply continues without recall.

**Real environment tested:** OpenClaw gateway `v2026.5.12` (`ghcr.io/openclaw/openclaw:2026.5.12-py3-local`) running in Docker on Linux x86_64. Memory slot plugin `memory-lancedb-pro@1.0.22`. Model: `litellm/qwen3.6-35b` via local LiteLLM. Telegram direct channel. `active-memory` config block as quoted in #82265.

**Exact steps or command run after this patch:**

1. Apply the patch's slot-id allowlist to the deployed `extensions/active-memory/index.js` (equivalent of the two-line change in this PR; verified by editing the in-container file).
2. `docker compose down && docker compose up -d` (bounce gateway to load the patched extension).
3. `until docker compose ps openclaw-gateway | grep -q healthy; do sleep 3; done`
4. Send any normal direct-chat message to the Telegram bot to trigger Active Memory.
5. `docker compose logs --since 10m openclaw-gateway 2>&1 | grep -E "active-memory|memory_recall|No callable tools"`

**Evidence after fix:** Redacted gateway logs from step 5 below.

Before this patch, every direct-chat turn produced:

```
[tools] No callable tools remain after resolving explicit tool allowlist
  (runtime toolsAllow: memory_search, memory_get); no registered tools matched.
embedded run failover decision: stage=prompt decision=surface_error
  rawError=No callable tools remain after resolving explicit tool allowlist
  (runtime toolsAllow: memory_search, memory_get)...
lane task error: lane=session:agent:<redacted>:active-memory:adee418ad176
  durationMs=3614
  error="Error: No callable tools remain after resolving explicit tool allowlist..."
active-memory: ... done status=unavailable elapsedMs=3647 summaryChars=0
```

After the patch (same config, plugin, gateway version):

```
active-memory: agent=<redacted> session=agent:<redacted>:active-memory
  activeProvider=litellm activeModel=qwen3.6-35b
  start timeoutMs=15000 queryChars=23 searchQueryChars=23
embedded run start: runId=active-memory-mp79th5t-f3ac71f0
embedded run prompt start: ...api=openai-completions
embedded run agent end: runId=active-memory-mp79th5t-f3ac71f0 isError=false
active-memory: ... done status=no_relevant_memory elapsedMs=2523 summaryChars=0
```

**Observed result after fix:** No `No callable tools` error in the post-patch logs. The embedded sub-agent runs cleanly through prompt → agent → done in ~2.5 s and exits with the normal `no_relevant_memory` status (test message had no related memories — expected and benign). Reproduced on every subsequent turn over the same session. `lane task error` lines for the `active-memory` lane are gone.

**What was not tested:** I did not exercise the `memory-lancedb` (bundled, non-Pro) regression path on the same deployment — the existing repo test for that slot remains green and I'm relying on it. I also did not test a third-party LanceDB-family plugin with a different slot id; users on other slot ids still need `config.toolsAllow` explicitly per the updated docs.

## Test plan

- [x] Added `it("uses memory_recall by default when the memory slot selects memory-lancedb-pro", ...)` to `extensions/active-memory/index.test.ts`, mirroring the existing `memory-lancedb` test.
- [x] `npx vitest run extensions/active-memory/index.test.ts` — 126/126 pass on the updated branch.
- [x] Real-deployment before/after captured above.
