### PR TITLE
fix(auto-reply): preserve session model display for heartbeat usage

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1608,6 +1608,7 @@ export async function runReplyAgent(params: {
       lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
       promptTokens,
       usageIsContextSnapshot: usedCliProvider ? true : undefined,
+      isHeartbeat,
       modelUsed,
       providerUsed,
       contextTokensUsed,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -405,6 +405,7 @@ export function createFollowupRunner(params: {
           usage,
           lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
           promptTokens,
+          isHeartbeat: opts?.isHeartbeat === true,
           modelUsed,
           providerUsed,
           contextTokensUsed,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -85,6 +85,7 @@ export async function persistSessionUsageUpdate(params: {
   contextTokensUsed?: number;
   promptTokens?: number;
   usageIsContextSnapshot?: boolean;
+  isHeartbeat?: boolean;
   systemPromptReport?: SessionSystemPromptReport;
   cliSessionId?: string;
   cliSessionBinding?: import("../../config/sessions.js").CliSessionBinding;
@@ -134,8 +135,11 @@ export async function persistSessionUsageUpdate(params: {
             modelUsed: params.modelUsed ?? entry.model,
           });
           const patch: Partial<SessionEntry> = {
-            modelProvider: params.providerUsed ?? entry.modelProvider,
-            model: params.modelUsed ?? entry.model,
+            modelProvider:
+              params.isHeartbeat === true
+                ? entry.modelProvider
+                : (params.providerUsed ?? entry.modelProvider),
+            model: params.isHeartbeat === true ? entry.model : (params.modelUsed ?? entry.model),
             contextTokens: resolvedContextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),
@@ -180,8 +184,11 @@ export async function persistSessionUsageUpdate(params: {
         sessionKey,
         update: async (entry) => {
           const patch: Partial<SessionEntry> = {
-            modelProvider: params.providerUsed ?? entry.modelProvider,
-            model: params.modelUsed ?? entry.model,
+            modelProvider:
+              params.isHeartbeat === true
+                ? entry.modelProvider
+                : (params.providerUsed ?? entry.modelProvider),
+            model: params.isHeartbeat === true ? entry.model : (params.modelUsed ?? entry.model),
             contextTokens: params.contextTokensUsed ?? entry.contextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3284,6 +3284,40 @@ describe("persistSessionUsageUpdate", () => {
     expect(stored2[sessionKey].estimatedCostUsd).toBeCloseTo(0.007725, 8);
   });
 
+  it("preserves the displayed session model when heartbeat usage uses a heartbeat model", async () => {
+    const storePath = await createStorePath("openclaw-usage-heartbeat-model-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        modelProvider: "openai-codex",
+        model: "gpt-5.4",
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      isHeartbeat: true,
+      usage: { input: 1_200, output: 100, cacheRead: 300, cacheWrite: 10 },
+      lastCallUsage: { input: 900, output: 80, cacheRead: 200, cacheWrite: 5 },
+      providerUsed: "openai-codex",
+      modelUsed: "gpt-5.1-codex-mini",
+      contextTokensUsed: 128_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].modelProvider).toBe("openai-codex");
+    expect(stored[sessionKey].model).toBe("gpt-5.4");
+    expect(stored[sessionKey].inputTokens).toBe(1_200);
+    expect(stored[sessionKey].outputTokens).toBe(100);
+    expect(stored[sessionKey].cacheRead).toBe(200);
+    expect(stored[sessionKey].totalTokens).toBe(1_105);
+  });
+
   it("persists zero estimatedCostUsd for free priced models", async () => {
     const storePath = await createStorePath("openclaw-usage-free-cost-");
     const sessionKey = "main";


### PR DESCRIPTION
## Summary

- preserve the stored session `model` / `modelProvider` display fields when a heartbeat run persists usage for a different heartbeat model
- keep heartbeat usage, cache counters, context totals, cost snapshots, system prompt reports, and CLI binding persistence intact
- thread the existing heartbeat run flag into the shared usage persistence path

Fixes #62954.

## Tests

- `CI=1 node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts src/auto-reply/reply/followup-runner.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/session-usage.ts src/auto-reply/reply/session-run-accounting.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/session.test.ts src/auto-reply/reply/followup-runner.test.ts`
- `pnpm check:changed`

## Real behavior proof

Behavior or issue addressed: heartbeat turns using `agents.defaults.heartbeat.model` could overwrite a session's persisted display `model` / `modelProvider`, making UI/history show the heartbeat model until the next user turn.

Real environment tested: local OpenClaw checkout on Ubuntu 24.04 under WSL, exercising the real session usage persistence path used after agent runs.

Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts src/auto-reply/reply/followup-runner.test.ts`.

Evidence after fix: before/after proof bundle published via Crabbox artifacts:

![heartbeat-session-model-display-before-after-proof.png](https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82267/heartbeat-session-model-display-82267/20260515-183602-989336935/heartbeat-session-model-display-before-after-proof.png)

- Before log: https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82267/heartbeat-session-model-display-82267/20260515-183602-989336935/before-origin-main-with-regression-test.log
- After log: https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82267/heartbeat-session-model-display-82267/20260515-183602-989336935/after-pr-82267.log

Observed result after fix: `origin/main` plus only the new regression spec fails because heartbeat usage overwrites the stored display model; this PR branch passes the same focused shard and preserves `model` / `modelProvider` while usage/cache/token fields update.

What was not tested: a live heartbeat tick in the control UI; this PR validates the source-level persistence path that caused the stale UI model.
