### PR TITLE
fix(agents): fallback gateway context for embedded --local runs (#82140)

### DIFF
--- a/src/agents/embedded-gateway-context.test.ts
+++ b/src/agents/embedded-gateway-context.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearFallbackGatewayContext,
+  dispatchGatewayMethodInProcessRaw,
+} from "../gateway/server-plugins.js";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  buildEmbeddedGatewayContext,
+  withEmbeddedGatewayContext,
+} from "./embedded-gateway-context.js";
+
+function fakeRuntime(): RuntimeEnv {
+  return {
+    log: () => {},
+    error: () => {},
+    debug: () => {},
+    warn: () => {},
+    exit: () => {},
+    info: () => {},
+  } as unknown as RuntimeEnv;
+}
+
+describe("buildEmbeddedGatewayContext", () => {
+  it("returns an object with all required state Maps initialized empty", () => {
+    const ctx = buildEmbeddedGatewayContext({ runtime: fakeRuntime() });
+    expect(ctx.agentRunSeq).toBeInstanceOf(Map);
+    expect(ctx.chatAbortControllers).toBeInstanceOf(Map);
+    expect(ctx.chatAbortedRuns).toBeInstanceOf(Map);
+    expect(ctx.chatRunBuffers).toBeInstanceOf(Map);
+    expect(ctx.dedupe).toBeInstanceOf(Map);
+    expect(ctx.bufferedAgentEvents).toBeInstanceOf(Map);
+    expect(ctx.wizardSessions).toBeInstanceOf(Map);
+    expect(ctx.agentRunSeq.size).toBe(0);
+    expect(ctx.dedupe.size).toBe(0);
+  });
+
+  it("getRuntimeConfig is wired to the real config getter", () => {
+    const ctx = buildEmbeddedGatewayContext({ runtime: fakeRuntime() });
+    const cfg = ctx.getRuntimeConfig();
+    expect(cfg).toBeTypeOf("object");
+  });
+
+  it("broadcast / nodeSendToSession / connId hooks are callable no-ops", () => {
+    const ctx = buildEmbeddedGatewayContext({ runtime: fakeRuntime() });
+    expect(() => ctx.broadcast({} as never)).not.toThrow();
+    expect(() => ctx.nodeSendToSession("k", "e", {})).not.toThrow();
+    expect(() => ctx.broadcastToConnIds(new Set(), {} as never)).not.toThrow();
+    expect(ctx.getSessionEventSubscriberConnIds().size).toBe(0);
+    expect(ctx.hasConnectedTalkNode()).toBe(false);
+  });
+
+  it("logGateway routes through subsystem logger (no throw)", () => {
+    const ctx = buildEmbeddedGatewayContext({ runtime: fakeRuntime() });
+    expect(() => ctx.logGateway.info("test")).not.toThrow();
+    expect(() => ctx.logGateway.warn("test")).not.toThrow();
+    expect(() => ctx.logGateway.error("test")).not.toThrow();
+  });
+
+  it("threads provided deps through (used by server-methods/agent.ts agentCommandFromIngress)", () => {
+    const fakeDeps = { __marker: "embedded-deps-fixture" } as unknown as Parameters<
+      typeof buildEmbeddedGatewayContext
+    >[0]["deps"];
+    const ctx = buildEmbeddedGatewayContext({ runtime: fakeRuntime(), deps: fakeDeps });
+    expect(ctx.deps).toBe(fakeDeps);
+  });
+
+  it("returns an empty deps stub when none is provided (caller responsibility)", () => {
+    const ctx = buildEmbeddedGatewayContext({ runtime: fakeRuntime() });
+    expect(ctx.deps).toBeDefined();
+  });
+});
+
+describe("regression #82140 -- raw dispatch error shape", () => {
+  afterEach(() => {
+    clearFallbackGatewayContext();
+  });
+
+  it("dispatchGatewayMethodInProcessRaw error message is byte-identical to the issue stderr", async () => {
+    // The issue reporter quoted this exact string in their stderr; this test
+    // locks the format so future refactors do not regress the diagnostic.
+    clearFallbackGatewayContext();
+    let actualMessage: string | undefined;
+    try {
+      await dispatchGatewayMethodInProcessRaw("agent", { message: "hi" });
+    } catch (err) {
+      actualMessage = err instanceof Error ? err.message : String(err);
+    }
+    expect(actualMessage).toBe(
+      "In-process gateway dispatch requires a gateway request scope (method: agent). No scope set and no fallback context available.",
+    );
+  });
+});
+
+describe("withEmbeddedGatewayContext", () => {
+  afterEach(() => {
+    clearFallbackGatewayContext();
+  });
+
+  it("installs fallback gateway context for the duration of `work`", async () => {
+    clearFallbackGatewayContext();
+    let dispatchErrorDuringWork: unknown;
+    await withEmbeddedGatewayContext({ runtime: fakeRuntime() }, async () => {
+      try {
+        await dispatchGatewayMethodInProcessRaw("nodes.list", {});
+      } catch (err) {
+        dispatchErrorDuringWork = err;
+      }
+    });
+    // Whatever happened inside `work`, it MUST NOT be the scope-check throw.
+    if (dispatchErrorDuringWork instanceof Error) {
+      expect(dispatchErrorDuringWork.message).not.toMatch(
+        /No scope set and no fallback context available\./,
+      );
+    }
+  });
+
+  it("cleans up fallback context after `work` resolves", async () => {
+    clearFallbackGatewayContext();
+    await withEmbeddedGatewayContext({ runtime: fakeRuntime() }, async () => {
+      // no-op work
+    });
+    // After cleanup, dispatch should throw the scope error again.
+    await expect(dispatchGatewayMethodInProcessRaw("nodes.list", {})).rejects.toThrowError(
+      /No scope set and no fallback context available\./,
+    );
+  });
+
+  it("cleans up fallback context after `work` throws", async () => {
+    clearFallbackGatewayContext();
+    const sentinel = new Error("synthetic failure inside work");
+    await expect(
+      withEmbeddedGatewayContext({ runtime: fakeRuntime() }, async () => {
+        throw sentinel;
+      }),
+    ).rejects.toThrowError(sentinel);
+    // Cleanup must still have run.
+    await expect(dispatchGatewayMethodInProcessRaw("nodes.list", {})).rejects.toThrowError(
+      /No scope set and no fallback context available\./,
+    );
+  });
+
+  it("returns the value resolved by `work`", async () => {
+    clearFallbackGatewayContext();
+    const result = await withEmbeddedGatewayContext({ runtime: fakeRuntime() }, async () => 42);
+    expect(result).toBe(42);
+  });
+});

--- a/src/agents/embedded-gateway-context.ts
+++ b/src/agents/embedded-gateway-context.ts
@@ -1,0 +1,151 @@
+// Minimal GatewayRequestContext for embedded local agent runs (e.g.
+// `openclaw agent --local`, gateway-timeout fallback, gateway-transport
+// fallback). Installed as the fallback gateway context for the duration of
+// the embedded run so that in-process gateway dispatch -- routed there by
+// #81383 (subagent announce handoff) and similar handoffs -- has a context
+// to read.
+//
+// Fixes #82140: regression where `--local` runs would fail subagent
+// completion announce with "In-process gateway dispatch requires a gateway
+// request scope (method: agent). No scope set and no fallback context
+// available."
+//
+// Design notes:
+//   - Embedded mode has no connected gateway clients, so broadcast / node-
+//     subscribe / connId-tracking functions are no-ops.
+//   - Mutable Maps are fresh per run (no cross-run sharing -- embedded runs
+//     do not have concurrent peers in the same process scope).
+//   - getRuntimeConfig is wired to the real config getter so dispatched
+//     methods see the running config.
+//   - SubsystemLogger and logHealth route through the embedded run's runtime
+//     logger so messages still surface, just without WS broadcast.
+
+import type { CliDeps } from "../cli/deps.types.js";
+import { getRuntimeConfig } from "../config/config.js";
+import type { GatewayRequestContext } from "../gateway/server-methods/types.js";
+import { setFallbackGatewayContext } from "../gateway/server-plugins.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+/**
+ * Build a minimal GatewayRequestContext suitable for embedded agent runs.
+ *
+ * The returned context satisfies the type-check on
+ * `dispatchGatewayMethodInProcessRaw` and provides functional state Maps
+ * plus no-op broadcast hooks. Fields that only matter when a real gateway
+ * server is running (subscriber tracking, voice-wake broadcasts, channel
+ * lifecycle, wizard runner) are stubbed as no-ops or harmless defaults.
+ *
+ * `deps` should be threaded through from the CLI command. The agent method
+ * handler reads `context.deps` when dispatching follow-up agent runs (see
+ * `server-methods/agent.ts: agentCommandFromIngress(..., params.context.deps)`).
+ *
+ * The following fields are intentionally undefined / empty for embedded mode
+ * and should never be accessed by code paths that fire during embedded
+ * runs: `cron`, `cronStorePath`, `nodeRegistry`. Subagent announce delivery
+ * (the primary path #82140 covers) does not touch them.
+ */
+export function buildEmbeddedGatewayContext(params: {
+  runtime: RuntimeEnv;
+  deps?: CliDeps;
+}): GatewayRequestContext {
+  const logSubsystem = createSubsystemLogger("agent/embedded");
+  const noop = () => {};
+  const noopAsync = async () => {};
+  const emptyReadonlySet: ReadonlySet<string> = new Set();
+
+  return {
+    deps: params.deps ?? ({} as unknown as GatewayRequestContext["deps"]),
+    cron: undefined as unknown as GatewayRequestContext["cron"],
+    cronStorePath: "",
+    getRuntimeConfig,
+    loadGatewayModelCatalog: async () => [],
+    getHealthCache: () => null,
+    refreshHealthSnapshot: async () =>
+      ({}) as unknown as Awaited<ReturnType<GatewayRequestContext["refreshHealthSnapshot"]>>,
+    logHealth: { error: (message: string) => logSubsystem.error(message) },
+    logGateway: logSubsystem,
+    incrementPresenceVersion: () => 0,
+    getHealthVersion: () => 0,
+    broadcast: noop as unknown as GatewayRequestContext["broadcast"],
+    broadcastToConnIds: noop as unknown as GatewayRequestContext["broadcastToConnIds"],
+    nodeSendToSession: noop,
+    nodeSendToAllSubscribed: noop,
+    nodeSubscribe: noop,
+    nodeUnsubscribe: noop,
+    nodeUnsubscribeAll: noop,
+    hasConnectedTalkNode: () => false,
+    nodeRegistry: {} as unknown as GatewayRequestContext["nodeRegistry"],
+    agentRunSeq: new Map(),
+    chatAbortControllers: new Map(),
+    chatAbortedRuns: new Map(),
+    chatRunBuffers: new Map(),
+    chatDeltaSentAt: new Map(),
+    chatDeltaLastBroadcastLen: new Map(),
+    chatDeltaLastBroadcastText: new Map(),
+    agentDeltaSentAt: new Map(),
+    bufferedAgentEvents: new Map(),
+    addChatRun: noop,
+    removeChatRun: () => undefined,
+    subscribeSessionEvents: noop,
+    unsubscribeSessionEvents: noop,
+    subscribeSessionMessageEvents: noop,
+    unsubscribeSessionMessageEvents: noop,
+    unsubscribeAllSessionEvents: noop,
+    getSessionEventSubscriberConnIds: () => emptyReadonlySet,
+    registerToolEventRecipient: noop,
+    dedupe: new Map(),
+    wizardSessions: new Map(),
+    findRunningWizard: () => null,
+    purgeWizardSession: noop,
+    getRuntimeSnapshot: () =>
+      ({}) as unknown as ReturnType<GatewayRequestContext["getRuntimeSnapshot"]>,
+    startChannel: noopAsync,
+    stopChannel: noopAsync,
+    markChannelLoggedOut: noop,
+    wizardRunner: noopAsync,
+    broadcastVoiceWakeChanged: noop,
+    broadcastVoiceWakeRoutingChanged: noop,
+  };
+}
+
+/**
+ * Run `work` with an embedded gateway context installed as the fallback.
+ * Cleans up the fallback after `work` resolves (success or failure).
+ *
+ * Useful for tests and scoped scenarios where the context must not outlive
+ * the wrapped work. Not appropriate for CLI entry points: subagent
+ * completion announce can fire AFTER the parent's `agentCommand` returns
+ * from a `sessions_yield` turn, by which time the cleanup would have run.
+ * Use `ensureEmbeddedGatewayContextInstalledForProcess` for CLI entry.
+ */
+export async function withEmbeddedGatewayContext<T>(
+  params: { runtime: RuntimeEnv; deps?: CliDeps },
+  work: () => Promise<T>,
+): Promise<T> {
+  const cleanup = setFallbackGatewayContext(buildEmbeddedGatewayContext(params));
+  try {
+    return await work();
+  } finally {
+    cleanup();
+  }
+}
+
+/**
+ * Install the embedded gateway context as a process-scoped fallback.
+ *
+ * Designed for CLI entry points where the process exits when the command
+ * completes -- no cleanup necessary. This is the production wiring used
+ * by `agentCliCommand` to ensure subagent completion announce delivery
+ * has a context even when it fires asynchronously AFTER the parent's
+ * `agentCommand` returns from a `sessions_yield` turn.
+ *
+ * Returns the cleanup function from `setFallbackGatewayContext` for tests
+ * that need to revert state between cases. CLI callers can discard it.
+ */
+export function ensureEmbeddedGatewayContextInstalledForProcess(params: {
+  runtime: RuntimeEnv;
+  deps?: CliDeps;
+}): () => void {
+  return setFallbackGatewayContext(buildEmbeddedGatewayContext(params));
+}

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -20,6 +20,7 @@ const isGatewayTransportError = vi.hoisted(() =>
   }),
 );
 const agentCommand = vi.hoisted(() => vi.fn());
+const ensureEmbeddedGatewayContextInstalledForProcess = vi.hoisted(() => vi.fn(() => () => {}));
 
 const runtime: RuntimeEnv = {
   log: vi.fn(),
@@ -145,6 +146,9 @@ vi.mock("../gateway/call.js", () => ({
   randomIdempotencyKey: () => "idem-1",
 }));
 vi.mock("./agent.js", () => ({ agentCommand }));
+vi.mock("../agents/embedded-gateway-context.js", () => ({
+  ensureEmbeddedGatewayContextInstalledForProcess,
+}));
 
 let originalForceConsoleToStderr = false;
 
@@ -502,6 +506,41 @@ describe("agentCliCommand", () => {
       expect(localOpts.cleanupCliLiveSessionOnRunEnd).toBe(true);
       expect(localOpts).not.toHaveProperty("resultMetaOverrides");
       expect(runtime.log).toHaveBeenCalledWith("local");
+    });
+  });
+
+  it("installs embedded gateway context before --local agent runs (#82140 regression)", async () => {
+    // #82140: subagent completion announce dispatch happens asynchronously after
+    // agentCommand returns from sessions_yield; the embedded context must be
+    // installed BEFORE agentCommand so the async dispatch finds it.
+    await withTempStore(async () => {
+      mockLocalAgentReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555", local: true }, runtime);
+
+      expect(ensureEmbeddedGatewayContextInstalledForProcess).toHaveBeenCalledTimes(1);
+      // Lock the install ordering: install must happen before agentCommand so the
+      // fallback context is live when async subagent announces fire.
+      const installOrder =
+        ensureEmbeddedGatewayContextInstalledForProcess.mock.invocationCallOrder[0];
+      const agentOrder = agentCommand.mock.invocationCallOrder[0];
+      expect(installOrder).toBeLessThan(agentOrder);
+    });
+  });
+
+  it("installs embedded gateway context before gateway-error embedded fallback (#82140)", async () => {
+    // Same regression coverage for the gateway-transport-error fallback path.
+    await withTempStore(async () => {
+      callGateway.mockRejectedValue(createGatewayClosedError());
+      mockLocalAgentReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+
+      expect(ensureEmbeddedGatewayContextInstalledForProcess).toHaveBeenCalledTimes(1);
+      const installOrder =
+        ensureEmbeddedGatewayContextInstalledForProcess.mock.invocationCallOrder[0];
+      const agentOrder = agentCommand.mock.invocationCallOrder[0];
+      expect(installOrder).toBeLessThan(agentOrder);
     });
   });
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { listAgentIds } from "../agents/agent-scope.js";
+import { ensureEmbeddedGatewayContextInstalledForProcess } from "../agents/embedded-gateway-context.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { withProgress } from "../cli/progress.js";
@@ -248,6 +249,17 @@ async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: RuntimeEnv) {
 
 export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, deps?: CliDeps) {
   protectJsonStdout(opts);
+  // Install a process-scoped fallback gateway context BEFORE any embedded
+  // agent path runs. Without this, in-process gateway dispatch -- routed
+  // there by #81383 (subagent announce handoff) -- throws "In-process
+  // gateway dispatch requires a gateway request scope..." (see #82140).
+  //
+  // Process-scoped (not try/finally wrapped) because subagent completion
+  // announce can fire ASYNCHRONOUSLY after the parent's `agentCommand`
+  // returns from a `sessions_yield` turn. A scoped wrapper would clean up
+  // before the announce dispatch runs. The CLI process exits when this
+  // function returns, so explicit cleanup is unnecessary.
+  ensureEmbeddedGatewayContextInstalledForProcess({ runtime, deps });
   const localOpts = {
     ...opts,
     agentId: opts.agent,


### PR DESCRIPTION
## Summary

- Problem: `openclaw agent --local` fails subagent completion announce with `In-process gateway dispatch requires a gateway request scope (method: agent). No scope set and no fallback context available.` after a `sessions_yield` turn (regression from #81383).
- Why it matters: subagent flows in embedded local runs are completely broken; the parent never receives the child's final reply and silently hangs from the operator's perspective.
- What changed: install a process-scoped fallback `GatewayRequestContext` at the top of `agentCliCommand` so async announce delivery has a context to read, even after `agentCommand` returns from a `sessions_yield` turn.
- What did NOT change (scope boundary): no changes to `dispatchGatewayMethodInProcessRaw`, no changes to subagent-announce-delivery, no changes to `agentCommand`. Gateway-mode (`--local` not set) is byte-identical to before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82140
- Regression from #81383 (subagent announce handoff moved to in-process dispatch)
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw agent --local --message "Begin"` with an agent whose `AGENTS.md` instructs `sessions_spawn` + `sessions_yield`. Reporter saw `Subagent completion direct announce failed for run <id>: In-process gateway dispatch requires a gateway request scope (method: agent). No scope set and no fallback context available.` Same throw reproduced locally.
- Real environment tested: Windows 11, Node v22.16.0, OpenClaw 2026.5.14 source (commit `2ac011b`) via `npx tsx src/entry.ts`, OpenRouter `anthropic/claude-haiku-4-5`, local gateway running on `127.0.0.1:18789`.
- Exact steps or command run after this patch:
  ```
  rm -rf ~/.openclaw/agents/subagent-repro/sessions/*
  OPENCLAW_CONFIG_PATH=~/.openclaw-linetest/openclaw.json \
    npx tsx src/entry.ts agent --agent subagent-repro --local --message "Begin"
  ```
  (with the same `subagent-repro` workspace `AGENTS.md`: "When user sends 'Begin', IMMEDIATELY call sessions_spawn with prompt 'Reply pong and stop.', then sessions_yield. When you receive pong back, respond with exactly OK and stop.")
- Evidence after fix (terminal capture):
  ```
  [agent/embedded] [trace:embedded-run] startup stages: runId=2e854bea-... totalMs=34809
  [agent/embedded] [trace:embedded-run] core-plugin-tool stages: ... totalMs=3884
  [agent/embedded] [trace:embedded-run] prep stages: ... totalMs=10692
  Now waiting for the subagent to complete.
  OK
  ```
  Parent received `pong` and replied `OK`. Process exited with code 0.
- Observed result after fix: full subagent round-trip works; no scope-check throw fires anywhere; parent's final assistant message is `OK` as the agent prompt requires.
- What was not tested: gateway-timeout fallback and gateway-error fallback paths were not driven live (no way to deterministically force those errors against a working gateway). The same install fires at the same point for those paths; same fix applies.
- Before evidence:
  ```
  Now I'll wait for the subagent to complete:
  Subagent completion direct announce failed for run 6da63921-e15f-4c57-89af-9c6f42b125f5:
    In-process gateway dispatch requires a gateway request scope (method: agent).
    No scope set and no fallback context available.
  ```

## Root Cause (if applicable)

- Root cause: #81383 (merged 2026-05-13) routed subagent completion announce delivery from loopback `callGateway` to `dispatchGatewayMethodInProcessRaw`. That path requires either a plugin runtime gateway request scope (set by plugin HTTP routes) or a fallback gateway context (installed at gateway server startup via `setFallbackGatewayContextResolver` at `src/gateway/server.impl.ts:1310`). Neither is installed in the CLI process that runs `openclaw agent --local`, so the throw at `src/gateway/server-plugins.ts:336` fires when any subagent completes and tries to deliver its announce.
- Missing detection / guardrail: the new in-process dispatch was added without a regression test covering `--local` mode, and no startup assertion checks that some kind of context is available before the embedded agent path is entered.
- Contributing context (if known): an earlier draft of this PR wrapped each `agentCommand` call with `withEmbeddedGatewayContext` (try/finally cleanup). Live reproduction caught that the cleanup fires when `agentCommand` returns from the `sessions_yield` turn, BEFORE the async subagent completion announce. Process-scoped install (no cleanup) is the correct lifetime.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/embedded-gateway-context.test.ts`
- Scenario the test should lock in:
  1. `dispatchGatewayMethodInProcessRaw("agent", ...)` with no scope and no fallback throws the exact issue-text diagnostic (byte-match regression for #82140).
  2. `buildEmbeddedGatewayContext({ runtime, deps })` threads `deps` through (used downstream by `agentCommandFromIngress(..., context.deps)`).
  3. `withEmbeddedGatewayContext` installs + cleans up on success and on thrown error.
- Why this is the smallest reliable guardrail: the bug is at a single dispatcher boundary (`server-plugins.ts:336`). A unit test directly exercises that throw shape; the wrapper tests prove the cleanup contract; the byte-match assertion locks the diagnostic format so future refactors do not silently rewrite the message.
- Existing test that already covers this (if any): none. `src/gateway/server-plugins.test.ts` exercises `setFallbackGatewayContext` lifecycle but does not cover the embedded-mode use case introduced by #81383.

## User-visible / Behavior Changes

- `openclaw agent --local` (and the gateway-timeout / gateway-error fallback paths) no longer throw on subagent completion announce. Subagent round-trip completes normally.
- No new config keys, no new flags, no changes to existing defaults.

## Diagram (if applicable)

```text
Before:
  agentCliCommand
    └─ agentCommand (--local path)
        └─ parent emits sessions_yield, agentCommand returns
            └─ (async) subagent completes
                └─ announce delivery -> dispatchGatewayMethodInProcessRaw
                    └─ getFallbackGatewayContext() === undefined
                        └─ THROW

After:
  agentCliCommand
    ├─ ensureEmbeddedGatewayContextInstalledForProcess  <-- new
    └─ agentCommand (--local path)
        └─ parent emits sessions_yield, agentCommand returns
            └─ (async) subagent completes
                └─ announce delivery -> dispatchGatewayMethodInProcessRaw
                    └─ getFallbackGatewayContext() returns embedded context
                        └─ proceeds to handleGatewayRequest -> parent resumes with "pong"
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (the embedded context exposes the SAME runtime config and deps as the CLI process already has; broadcast / node-subscribe / connId hooks are no-ops because there are no connected gateway clients in `--local` mode)
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node v22.16.0, pnpm 11.1.0, `npx tsx src/entry.ts` (bypasses build chain)
- Model/provider: openrouter / `anthropic/claude-haiku-4-5`
- Integration/channel (if any): none required for repro; gateway listening on `127.0.0.1:18789` (started via `openclaw gateway run` in a second shell)
- Relevant config (redacted): `models.providers.openrouter.{baseUrl,apiKey,models}` + `agents.defaults.model.primary: "openrouter/anthropic/claude-haiku-4-5"` + one workspace `AGENTS.md` instructing `sessions_spawn` + `sessions_yield`

### Steps

1. Start gateway: `OPENCLAW_CONFIG_PATH=<...> npx tsx src/entry.ts gateway run`
2. Register agent: `openclaw agents add subagent-repro --workspace /c/tmp/repro-82140 --non-interactive`
3. Run: `openclaw agent --agent subagent-repro --local --message "Begin"`

### Expected

- Parent receives the subagent's `pong` and replies `OK`. Process exits 0.

### Actual

- Before this PR: parent emits `Now I'll wait for the subagent to complete:` then stderr fires `Subagent completion direct announce failed for run <id>: In-process gateway dispatch requires a gateway request scope...`. Parent never receives `pong`.
- After this PR: parent emits `Now waiting for the subagent to complete.` then `OK`. Process exits 0.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```
$ pnpm exec vitest run src/agents/embedded-gateway-context.test.ts

 Test Files  1 passed (1)
      Tests  11 passed (11)

$ pnpm exec vitest run \
    src/agents/embedded-gateway-context.test.ts \
    src/agents/subagent-announce-delivery.test.ts \
    src/agents/subagent-announce.test.ts \
    src/gateway/server-plugins.test.ts

 Test Files  6 passed (6)
      Tests  152 passed (152)
```

## Human Verification (required)

- Verified scenarios:
  - Live reproduction of the issue stderr (before fix, after format check).
  - Live success run with this fix applied, same agent workspace, same model, same gateway: parent receives `pong`, replies `OK`, exits 0.
  - 11 focused unit tests across builder + wrapper + byte-match regression.
  - 152 tests total across the new test file plus all adjacent subagent / dispatch / server-plugins tests (no regression).
  - `pnpm exec oxlint` clean (0 warnings, 0 errors).
  - `pnpm exec oxfmt --check` clean.
- Edge cases checked:
  - `deps` undefined: builder returns an empty deps stub; documented as caller responsibility.
  - Wrapper cleanup on thrown error: covered by `cleans up fallback context after work throws`.
  - Re-entrant install: `setFallbackGatewayContext` cleanup uses reference-equality so stale cleanups are no-ops.
  - Reference-only fields the announce path does not touch (`cron`, `cronStorePath`, `nodeRegistry`) are explicitly documented as intentionally stubbed; if any future code path accesses them in embedded mode this becomes a separate bug.
- What you did **not** verify:
  - The gateway-timeout fallback and generic gateway-error fallback paths (`agent-via-gateway.ts:271` / `:297`) were not exercised live -- they share the same install call site so the same fix applies, but a deterministic trigger requires forcing gateway transport errors against an otherwise-working gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: `N/A`

## Risks and Mitigations

- Risk: the stubbed fields (`cron`, `cronStorePath`, `nodeRegistry`) are reached by a code path that fires during embedded runs.
  - Mitigation: subagent announce delivery (the path this PR covers) does not access them. If a future change routes additional surfaces through in-process dispatch in embedded mode, this becomes a separate, easy-to-locate bug (the cast lies are explicit in the source). The module doc names these fields and the contract.
- Risk: gateway and embedded run share the same process and the gateway has installed a real fallback context resolver, then a CLI invocation calls `setFallbackGatewayContext` and overwrites it.
  - Mitigation: in supported CLI deployments the gateway runs in a separate process. If a future deployment colocates them, the cleanup contract on `setFallbackGatewayContext` (`server-plugins.ts:54-62`) is reference-equality and will not clear the gateway's resolver. The current CLI invocation lives until process exit, so no ordering ambiguity exists today.
