### PR TITLE
fix: add Copilot IDE headers to resolved models

### DIFF
--- a/src/agents/copilot-dynamic-headers.ts
+++ b/src/agents/copilot-dynamic-headers.ts
@@ -1,7 +1,30 @@
 import type { Context } from "@earendil-works/pi-ai";
-import { COPILOT_INTEGRATION_ID, buildCopilotIdeHeaders } from "../plugin-sdk/provider-auth.js";
 
-export { COPILOT_INTEGRATION_ID, buildCopilotIdeHeaders } from "../plugin-sdk/provider-auth.js";
+/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
+export const COPILOT_EDITOR_VERSION = "vscode/1.107.0";
+/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
+export const COPILOT_USER_AGENT = "GitHubCopilotChat/0.35.0";
+/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
+export const COPILOT_EDITOR_PLUGIN_VERSION = "copilot-chat/0.35.0";
+/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
+export const COPILOT_GITHUB_API_VERSION = "2025-04-01";
+/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
+export const COPILOT_INTEGRATION_ID = "vscode-chat";
+
+/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
+export function buildCopilotIdeHeaders(
+  params: {
+    includeApiVersion?: boolean;
+  } = {},
+): Record<string, string> {
+  return {
+    "Accept-Encoding": "identity",
+    "Editor-Version": COPILOT_EDITOR_VERSION,
+    "Editor-Plugin-Version": COPILOT_EDITOR_PLUGIN_VERSION,
+    "User-Agent": COPILOT_USER_AGENT,
+    ...(params.includeApiVersion ? { "X-Github-Api-Version": COPILOT_GITHUB_API_VERSION } : {}),
+  };
+}
 
 function inferCopilotInitiator(messages: Context["messages"]): "agent" | "user" {
   const last = messages[messages.length - 1];

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -147,7 +147,7 @@ vi.mock("./openrouter-model-capabilities.js", () => ({
 }));
 
 import type { OpenClawConfig } from "../../config/config.js";
-import { buildCopilotIdeHeaders, COPILOT_INTEGRATION_ID } from "../../plugin-sdk/provider-auth.js";
+import { COPILOT_INTEGRATION_ID, buildCopilotIdeHeaders } from "../copilot-dynamic-headers.js";
 import { getModelProviderLocalService } from "../provider-local-service.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
 import { buildForwardCompatTemplate } from "./model.forward-compat.test-support.js";

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -147,6 +147,7 @@ vi.mock("./openrouter-model-capabilities.js", () => ({
 }));
 
 import type { OpenClawConfig } from "../../config/config.js";
+import { buildCopilotIdeHeaders, COPILOT_INTEGRATION_ID } from "../../plugin-sdk/provider-auth.js";
 import { getModelProviderLocalService } from "../provider-local-service.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
 import { buildForwardCompatTemplate } from "./model.forward-compat.test-support.js";
@@ -894,6 +895,40 @@ describe("resolveModel", () => {
       id: "grok-4.1-fast",
       api: "openai-responses",
       baseUrl: "https://api.x.ai/v1",
+    });
+  });
+
+  it("adds GitHub Copilot IDE headers to dynamic resolved model headers for Pi-native compaction", () => {
+    const result = resolveModelForTest("github-copilot", "gpt-5.5", "/tmp/agent");
+    const model = expectResolvedModel(result) as unknown as { headers?: Record<string, string> };
+
+    expect(model.headers).toEqual({
+      ...buildCopilotIdeHeaders(),
+      "Copilot-Integration-Id": COPILOT_INTEGRATION_ID,
+      "Openai-Organization": "github-copilot",
+    });
+  });
+
+  it("adds GitHub Copilot IDE headers to configured resolved model headers for Pi-native compaction", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "github-copilot": {
+            baseUrl: "https://api.githubcopilot.com",
+            api: "openai-responses",
+            models: [makeModel("gpt-5.5")],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("github-copilot", "gpt-5.5", "/tmp/agent", cfg);
+    const model = expectResolvedModel(result) as unknown as { headers?: Record<string, string> };
+
+    expect(model.headers).toEqual({
+      ...buildCopilotIdeHeaders(),
+      "Copilot-Integration-Id": COPILOT_INTEGRATION_ID,
+      "Openai-Organization": "github-copilot",
     });
   });
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -545,11 +545,22 @@ function applyConfiguredProviderOverrides(params: {
       readModelParams(discoveredModel.params),
       defaultModelParams,
     );
+    const discoveredHeaders = sanitizeModelHeaders(discoveredModel.headers, {
+      stripSecretRefMarkers: true,
+    });
+    const requestConfig = resolveProviderRequestConfig({
+      provider: params.provider,
+      api: discoveredModel.api,
+      baseUrl: discoveredModel.baseUrl,
+      discoveredHeaders,
+      capability: "llm",
+      transport: "stream",
+    });
     return {
       ...discoveredModel,
       ...(resolvedParams ? { params: resolvedParams } : {}),
       // Discovered models originate from models.json and may contain persistence markers.
-      headers: sanitizeModelHeaders(discoveredModel.headers, { stripSecretRefMarkers: true }),
+      headers: requestConfig.headers,
     };
   }
   const configuredModel =
@@ -572,6 +583,18 @@ function applyConfiguredProviderOverrides(params: {
     stripSecretRefMarkers: true,
   });
   const providerParams = readModelParams(providerConfig.params);
+  const passthroughRequestConfig = resolveProviderRequestConfig({
+    provider: params.provider,
+    api: discoveredModel.api,
+    baseUrl: discoveredModel.baseUrl,
+    discoveredHeaders,
+    providerHeaders,
+    modelHeaders: configuredHeaders,
+    authHeader: providerConfig.authHeader,
+    request: providerRequest,
+    capability: "llm",
+    transport: "stream",
+  });
   if (
     !configuredModel &&
     !providerConfig.baseUrl &&
@@ -593,7 +616,7 @@ function applyConfiguredProviderOverrides(params: {
       ...discoveredModel,
       ...(resolvedParams ? { params: resolvedParams } : {}),
       ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
-      headers: discoveredHeaders,
+      headers: passthroughRequestConfig.headers,
     };
   }
   const resolvedParams = mergeModelParams(

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -6,8 +6,8 @@ import type {
 } from "../config/types.provider-request.js";
 import { assertSecretInputResolved } from "../config/types.secrets.js";
 import type { PinnedDispatcherPolicy } from "../infra/net/ssrf.js";
-import { COPILOT_INTEGRATION_ID, buildCopilotIdeHeaders } from "../plugin-sdk/provider-auth.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { COPILOT_INTEGRATION_ID, buildCopilotIdeHeaders } from "./copilot-dynamic-headers.js";
 import type {
   ProviderRequestCapabilities,
   ProviderRequestCapability,

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -6,6 +6,7 @@ import type {
 } from "../config/types.provider-request.js";
 import { assertSecretInputResolved } from "../config/types.secrets.js";
 import type { PinnedDispatcherPolicy } from "../infra/net/ssrf.js";
+import { COPILOT_INTEGRATION_ID, buildCopilotIdeHeaders } from "../plugin-sdk/provider-auth.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import type {
   ProviderRequestCapabilities,
@@ -395,6 +396,19 @@ export function normalizeBaseUrl(
   return raw.replace(/\/+$/, "");
 }
 
+function resolveProviderDefaultRequestHeaders(
+  provider: string | undefined,
+): Record<string, string> | undefined {
+  if (normalizeLowercaseStringOrEmpty(provider) !== "github-copilot") {
+    return undefined;
+  }
+  return {
+    ...buildCopilotIdeHeaders(),
+    "Copilot-Integration-Id": COPILOT_INTEGRATION_ID,
+    "Openai-Organization": "github-copilot",
+  };
+}
+
 function mergeProviderRequestHeaders(
   ...headerSets: Array<Record<string, string> | undefined>
 ): Record<string, string> | undefined {
@@ -643,6 +657,7 @@ export function resolveProviderRequestPolicyConfig(
   });
   const extraHeaders = applyResolvedAuthHeader(
     mergeProviderRequestHeaders(
+      resolveProviderDefaultRequestHeaders(params.provider),
       params.discoveredHeaders,
       params.providerHeaders,
       params.modelHeaders,

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -7,7 +7,6 @@ import { resolveAuthProfileOrder } from "../agents/auth-profiles/order.js";
 import { listProfilesForProvider } from "../agents/auth-profiles/profiles.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";
 import {
-  COPILOT_GITHUB_API_VERSION,
   COPILOT_INTEGRATION_ID,
   buildCopilotIdeHeaders,
 } from "../agents/copilot-dynamic-headers.js";

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -6,6 +6,11 @@ import { resolveApiKeyForProfile } from "../agents/auth-profiles/oauth.js";
 import { resolveAuthProfileOrder } from "../agents/auth-profiles/order.js";
 import { listProfilesForProvider } from "../agents/auth-profiles/profiles.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";
+import {
+  COPILOT_GITHUB_API_VERSION,
+  COPILOT_INTEGRATION_ID,
+  buildCopilotIdeHeaders,
+} from "../agents/copilot-dynamic-headers.js";
 import { resolveEnvApiKey } from "../agents/model-auth-env.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -94,19 +99,17 @@ export {
   DEFAULT_OAUTH_REFRESH_MARGIN_MS,
   hasUsableOAuthCredential,
 } from "../agents/auth-profiles/credential-state.js";
+export {
+  COPILOT_EDITOR_PLUGIN_VERSION,
+  COPILOT_EDITOR_VERSION,
+  COPILOT_GITHUB_API_VERSION,
+  COPILOT_INTEGRATION_ID,
+  COPILOT_USER_AGENT,
+  buildCopilotIdeHeaders,
+} from "../agents/copilot-dynamic-headers.js";
 
 const COPILOT_TOKEN_URL = "https://api.github.com/copilot_internal/v2/token";
 
-/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
-export const COPILOT_EDITOR_VERSION = "vscode/1.107.0";
-/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
-export const COPILOT_USER_AGENT = "GitHubCopilotChat/0.35.0";
-/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
-export const COPILOT_EDITOR_PLUGIN_VERSION = "copilot-chat/0.35.0";
-/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
-export const COPILOT_GITHUB_API_VERSION = "2025-04-01";
-/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
-export const COPILOT_INTEGRATION_ID = "vscode-chat";
 /** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
 export const DEFAULT_COPILOT_API_BASE_URL = "https://api.individual.githubcopilot.com";
 
@@ -117,21 +120,6 @@ export type CachedCopilotToken = {
   updatedAt: number;
   integrationId?: string;
 };
-
-/** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */
-export function buildCopilotIdeHeaders(
-  params: {
-    includeApiVersion?: boolean;
-  } = {},
-): Record<string, string> {
-  return {
-    "Accept-Encoding": "identity",
-    "Editor-Version": COPILOT_EDITOR_VERSION,
-    "Editor-Plugin-Version": COPILOT_EDITOR_PLUGIN_VERSION,
-    "User-Agent": COPILOT_USER_AGENT,
-    ...(params.includeApiVersion ? { "X-Github-Api-Version": COPILOT_GITHUB_API_VERSION } : {}),
-  };
-}
 
 function resolveCopilotTokenCachePath(env: NodeJS.ProcessEnv = process.env) {
   return path.join(resolveStateDir(env), "credentials", "github-copilot.token.json");


### PR DESCRIPTION
## Summary

Fixes GitHub Copilot Pi-native/default compaction requests by ensuring resolved GitHub Copilot models carry the required Copilot IDE headers into the lower-level Pi summarization path.

The default Pi compaction path calls `session.compact()` / Pi `generateSummary()` directly and does not go through OpenClaw's normal GitHub Copilot stream wrapper. Without these headers, Copilot can reject compaction summarization with:

```text
400 bad request: missing Editor-Version header for IDE auth
```

## Changes

- Add GitHub Copilot default request headers in `src/agents/provider-request-config.ts`:
  - `Editor-Version`
  - `Editor-Plugin-Version`
  - `User-Agent`
  - `Copilot-Integration-Id`
  - `Openai-Organization`
- Merge these defaults before discovered/provider/model/request headers so explicit config can still override them.
- Thread `resolveProviderRequestConfig()` through resolved model paths in `src/agents/pi-embedded-runner/model.ts`, including discovered/dynamic models without explicit provider config.
- Add regression tests for both dynamic and configured `github-copilot/gpt-5.5` resolved model headers.

## Reproduction / diagnostic evidence captured

Captured from local `codeclaw-triage` logs before this fix:

```text
2026-05-15T09:22:17.295-07:00 [agent/embedded] [compaction-diag] start runId=7d62f863-752b-4974-8dc6-0db0d8308a45 sessionKey=agent:main:subagent:4dc753b0-294a-423c-88e1-cb44b960eaef diagId=ovf-mp74l0tc-0_sa6Q trigger=overflow provider=github-copilot/gpt-5.5 attempt=1 maxAttempts=3 pre.messages=59 pre.historyTextChars=234876 pre.toolResultChars=233408 pre.estTokens=62724
2026-05-15T09:22:17.484-07:00 [agent/embedded] [compaction-diag] end runId=7d62f863-752b-4974-8dc6-0db0d8308a45 sessionKey=agent:main:subagent:4dc753b0-294a-423c-88e1-cb44b960eaef diagId=ovf-mp74l0tc-0_sa6Q trigger=overflow provider=github-copilot/gpt-5.5 attempt=1 maxAttempts=3 outcome=failed reason=provider_error_4xx durationMs=6423
2026-05-15T09:22:17.486-07:00 [agent/embedded] auto-compaction failed for github-copilot/gpt-5.5: Turn prefix summarization failed: 400 bad request: missing Editor-Version header for IDE auth
```

Also captured same-symptom later failure:

```text
2026-05-15T09:34:39.787-07:00 [agent/embedded] [compaction-diag] end runId=bd303136-0717-491f-8b7b-8683355b8686 sessionKey=agent:main:subagent:4dc753b0-294a-423c-88e1-cb44b960eaef diagId=ovf-mp750yhe-wHl9qw trigger=overflow provider=github-copilot/gpt-5.5 attempt=1 maxAttempts=3 outcome=failed reason=provider_error_4xx durationMs=5267
2026-05-15T09:34:39.789-07:00 [agent/embedded] auto-compaction failed for github-copilot/gpt-5.5: Summarization failed: 400 bad request: missing Editor-Version header for IDE auth
```

Local RED regression before implementation:

```text
FAIL |agents| src/agents/pi-embedded-runner/model.test.ts > resolveModel > adds GitHub Copilot IDE headers to dynamic resolved model headers for Pi-native compaction
AssertionError: expected undefined to deeply equal { ... }
```

## Evidence that the fix works locally

A local post-fix Pi-native compaction/header smoke test using `@earendil-works/pi-coding-agent` `generateSummary()` observed the expected outgoing headers. The test server would have returned the same `missing Editor-Version header for IDE auth` error if `Editor-Version` were absent.

```json
{
  "result": "",
  "requestCount": 1,
  "url": "/v1/responses",
  "observedHeaders": {
    "editor-version": "vscode/1.107.0",
    "editor-plugin-version": "copilot-chat/0.35.0",
    "user-agent": "GitHubCopilotChat/0.35.0",
    "copilot-integration-id": "vscode-chat",
    "openai-organization": "github-copilot",
    "authorization": "<redacted>"
  }
}
```

## Real behavior proof

- Behavior or issue addressed: GitHub Copilot Pi-native/default compaction requests now carry Copilot IDE headers, so compaction no longer fails with `400 bad request: missing Editor-Version header for IDE auth`.
- Real environment tested: Live `codeclaw-triage` Docker container after installing a custom OpenClaw package built from combined proof branch `codeclaw-proof-82023-82275` (https://github.com/efpiva/openclaw/tree/codeclaw-proof-82023-82275) at `OpenClaw 2026.5.17 (db1c53a)`. The proof used the running Gateway in that container and the real GitHub Copilot provider.
- Exact steps or command run after this patch:

  ```bash
  docker exec --user codeclaw codeclaw-triage     HOME=/home/codeclaw openclaw agent       --agent main       --model github-copilot/gpt-5.4       --session-id codeclaw-proof-82275-gpt54-20260517T220327Z       --json --timeout 600       --message '<proof seed with repeated real conversation text>'

  docker exec --user codeclaw codeclaw-triage     HOME=/home/codeclaw openclaw gateway call sessions.compact       --json --timeout 900000       --params '{"key":"agent:main:explicit:codeclaw-proof-82275-gpt54-20260517t220327z"}'
  ```

- Evidence after fix:

  The live `sessions.compact` call returned `ok: true` and `compacted: true`:

  ```json
  {
    "ok": true,
    "key": "agent:main:explicit:codeclaw-proof-82275-gpt54-20260517t220327z",
    "compacted": true,
    "result": {
      "tokensBefore": 28655,
      "tokensAfter": 15696,
      "firstKeptEntryId": "2ddaf766"
    }
  }
  ```

  The live Gateway logs show the compaction ran against GitHub Copilot and finished as compacted:

  ```text
  2026-05-17T15:03:30.171-07:00 [agent/embedded] embedded run start: runId=4b8123ef-a8c6-475c-bff2-355414ed75da sessionId=codeclaw-proof-82275-gpt54-20260517T220327Z provider=github-copilot model=gpt-5.4 thinking=medium messageChannel=webchat
  2026-05-17T15:03:43.161-07:00 [agent/embedded] [compaction-diag] start runId=codeclaw-proof-82275-gpt54-20260517T220327Z sessionKey=agent:main:explicit:codeclaw-proof-82275-gpt54-20260517t220327z diagId=cmp-mpabnuo1-LTDAVg trigger=manual provider=github-copilot/gpt-5.4 attempt=1 maxAttempts=1 pre.messages=2 pre.historyTextChars=62180 pre.toolResultChars=0 pre.estTokens=15545
  2026-05-17T15:03:46.476-07:00 [agent/embedded] [compaction-diag] end runId=codeclaw-proof-82275-gpt54-20260517T220327Z sessionKey=agent:main:explicit:codeclaw-proof-82275-gpt54-20260517t220327z diagId=cmp-mpabnuo1-LTDAVg trigger=manual provider=github-copilot/gpt-5.4 attempt=1 maxAttempts=1 outcome=compacted reason=none durationMs=2803 retrying=false post.messages=3 post.historyTextChars=62180 post.toolResultChars=0 post.estTokens=15696 delta.messages=1 delta.historyTextChars=0 delta.toolResultChars=0 delta.estTokens=151
  ```

  A grep over the proof window found no `missing Editor-Version` failures:

  ```text
  missing Editor-Version count in proof window: 0
  ```

- Observed result after fix: A live CodeClaw/OpenClaw session using GitHub Copilot compacted successfully through the Gateway. The compaction result reduced the effective token count from `28655` to `15696`, and the previous `missing Editor-Version header for IDE auth` failure did not occur.
- What was not tested: I did not wait for a naturally occurring overflow-triggered CodeClaw compaction. The live proof explicitly invoked `sessions.compact` on a real Gateway session in the deployed CodeClaw container; this exercises the same Pi-native GitHub Copilot summarization/header path that previously emitted the `missing Editor-Version` error.

## Validation

- `pnpm exec vitest run src/agents/pi-embedded-runner/model.test.ts --config test/vitest/vitest.agents.config.ts`
  - `Test Files 1 passed (1)`
  - `Tests 84 passed (84)`
- `pnpm test:changed`
  - passed 2 Vitest shards
- `pnpm tsgo:core`
- `pnpm build`
- `pnpm format:check -- src/agents/provider-request-config.ts src/agents/pi-embedded-runner/model.ts src/agents/pi-embedded-runner/model.test.ts`
- `codex review --commit HEAD -c 'sandbox_mode="danger-full-access"'`
  - Result: no actionable correctness issues found.

