### PR TITLE
fix(discord): harden read message results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Plugin releases: require external package compatibility metadata in the npm plugin publish plan, matching the ClawHub package contract before packages ship.
 - Agents/OpenAI-compatible: honor per-model `max_completion_tokens`/`max_tokens` params in embedded OpenAI-completions runs so high-token Kimi-style routes keep their configured completion cap. Fixes #82230. Thanks @albert-zen.
 - Agents/local: install a local gateway request scope around trusted `openclaw agent --local` runs, so subagent completion announces can use in-process gateway dispatch without crashing. Fixes #82140. Thanks @Kushmaro.
+- Discord: validate message-read results before normalizing channel history and report unexpected payloads with a Discord boundary error instead of `map is not a function`. Fixes #82252. Thanks @jessewunderlich.
 - Telegram/active-memory: run blocking memory recall through the Telegram provider for direct-message turns even when the hook context carries the raw chat id, preventing embedded recall from launching against an invalid numeric channel. Fixes #82177. Thanks @cslash-zz.
 - Control UI/WebChat: keep optimistic image messages from embedding large inline `data:` previews and preserve image-only user turns in chat history, avoiding browser stack overflows when sending image attachments. Fixes #82182. Thanks @ExploreSheep.
 - Agents/media: preserve message-tool-only delivery for generated music and video completion handoffs, so group/channel completions do not finish without posting the generated attachment.

--- a/extensions/discord/src/actions/runtime.messaging.messages.ts
+++ b/extensions/discord/src/actions/runtime.messaging.messages.ts
@@ -24,6 +24,29 @@ function parseDiscordMessageLink(link: string) {
   };
 }
 
+function describeDiscordMessageListResult(value: unknown): string {
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (value && typeof value === "object") {
+    const keys = Object.keys(value).toSorted();
+    return keys.length ? `object with keys ${keys.join(", ")}` : "object";
+  }
+  return typeof value;
+}
+
+function assertDiscordMessageListResult(value: unknown): Array<unknown> {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  throw new Error(
+    `Discord message read returned ${describeDiscordMessageListResult(value)} instead of an array.`,
+  );
+}
+
 export async function handleDiscordMessageManagementAction(ctx: DiscordMessagingActionContext) {
   switch (ctx.action) {
     case "permissions": {
@@ -80,10 +103,8 @@ export async function handleDiscordMessageManagementAction(ctx: DiscordMessaging
         after: readStringParam(ctx.params, "after"),
         around: readStringParam(ctx.params, "around"),
       };
-      const messages = await discordMessagingActionRuntime.readMessagesDiscord(
-        channelId,
-        query,
-        ctx.withOpts(),
+      const messages = assertDiscordMessageListResult(
+        await discordMessagingActionRuntime.readMessagesDiscord(channelId, query, ctx.withOpts()),
       );
       return jsonResult({
         ok: true,

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -389,6 +389,14 @@ describe("handleDiscordMessagingAction", () => {
     expect(payload.messages[0].timestampUtc).toBe(new Date(expectedMs).toISOString());
   });
 
+  it("rejects unexpected readMessages payloads with a boundary error", async () => {
+    readMessagesDiscord.mockResolvedValueOnce({ ok: true } as never);
+
+    await expect(
+      handleMessagingAction("readMessages", { channelId: "C1" }, enableAllActions),
+    ).rejects.toThrow("Discord message read returned object with keys ok instead of an array.");
+  });
+
   it("threads provided cfg into readMessages calls", async () => {
     const cfg = {
       channels: {


### PR DESCRIPTION
Summary:
- Harden Discord `message read` results before normalizing channel history.
- Preserve the Discord `APIMessage[]` contract and return a Discord-specific boundary error if runtime data is not an array.
- Add regression coverage and changelog entry for #82252.

Verification:
- `git diff --check`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=240000 node scripts/run-vitest.mjs extensions/discord/src/actions/runtime.test.ts` (55 passed)
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local --full-access --output /tmp/codex-review-82252.txt` (clean before the spec-alignment follow-up)
- `env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_REMOTE_RUN pnpm check:changed` reached extension typecheck, then failed on current-main Telegram `extensions/telegram/src/polling-session.ts:220` from 7270bb95b7, outside this PR diff.

## Real Behavior Proof

Behavior addressed: Discord `message action=read` could fail with `TypeError: (intermediate value).map is not a function` if the runtime result reaching the read path was not the `APIMessage[]` array promised by the Discord REST contract.
Real environment tested: local OpenClaw checkout on macOS with the Discord runtime path. No live Discord credentials were available for a real channel read.
Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=240000 node scripts/run-vitest.mjs extensions/discord/src/actions/runtime.test.ts`.
Evidence after fix: terminal output from the local OpenClaw runtime regression run:

```text
Test Files  1 passed (1)
Tests  55 passed (55)
```

Observed result after fix: the runtime test covers the unexpected-object shape before the read path maps messages; unexpected read payloads now produce `Discord message read returned ... instead of an array.` instead of an unowned `.map` TypeError. Normal array payloads still normalize timestamps as before.
What was not tested: live `openclaw message read --channel discord --target channel:<id> --limit 3 --json`; maintainer `proof: override` is appropriate here because this is narrow boundary hardening with no live Discord credentials in this session.

Fixes #82252

<!-- proof override label applied after PR creation -->
