### PR TITLE
fix(agents): honor OpenAI completions token aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 - Hooks: raise bounded gateway lifecycle hook wait budgets to 5 seconds for shutdown and 10 seconds for pre-restart, giving short restart notification handlers time to finish before shutdown continues. (#82273) Thanks @bryanbaer.
 - Plugin releases: require external package compatibility metadata in the npm plugin publish plan, matching the ClawHub package contract before packages ship.
+- Agents/OpenAI-compatible: honor per-model `max_completion_tokens`/`max_tokens` params in embedded OpenAI-completions runs so high-token Kimi-style routes keep their configured completion cap. Fixes #82230. Thanks @albert-zen.
 - Telegram/active-memory: run blocking memory recall through the Telegram provider for direct-message turns even when the hook context carries the raw chat id, preventing embedded recall from launching against an invalid numeric channel. Fixes #82177. Thanks @cslash-zz.
 - Control UI/WebChat: keep optimistic image messages from embedding large inline `data:` previews and preserve image-only user turns in chat history, avoiding browser stack overflows when sending image attachments. Fixes #82182. Thanks @ExploreSheep.
 - Agents/media: preserve message-tool-only delivery for generated music and video completion handoffs, so group/channel completions do not finish without posting the generated attachment.

--- a/src/agents/model-max-tokens-params.ts
+++ b/src/agents/model-max-tokens-params.ts
@@ -1,0 +1,40 @@
+const MAX_TOKENS_PARAM_KEYS = ["maxTokens", "max_completion_tokens", "max_tokens"] as const;
+
+export function resolveNonNegativeMaxTokensParam(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+export function resolveMaxTokensParam(
+  params: Record<string, unknown> | undefined,
+): number | undefined {
+  if (!params) {
+    return undefined;
+  }
+  for (const key of MAX_TOKENS_PARAM_KEYS) {
+    const resolved = resolveNonNegativeMaxTokensParam(params[key]);
+    if (resolved !== undefined) {
+      return resolved;
+    }
+  }
+  return undefined;
+}
+
+export function canonicalizeMaxTokensParam(params: {
+  merged: Record<string, unknown>;
+  sources: Array<Record<string, unknown> | undefined>;
+}): void {
+  let resolved: number | undefined;
+  for (const source of params.sources) {
+    const sourceValue = resolveMaxTokensParam(source);
+    if (sourceValue !== undefined) {
+      resolved = sourceValue;
+    }
+  }
+  if (resolved === undefined) {
+    return;
+  }
+  for (const key of MAX_TOKENS_PARAM_KEYS) {
+    delete params.merged[key];
+  }
+  params.merged.maxTokens = resolved;
+}

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3444,6 +3444,93 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("max_tokens");
   });
 
+  it("uses model params max_completion_tokens for OpenAI completions before model maxTokens", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "kimi-k2.6",
+        name: "Kimi K2.6",
+        api: "openai-completions",
+        provider: "dashscope",
+        baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 262_144,
+        maxTokens: 32_000,
+        params: {
+          max_completion_tokens: 64_000,
+        },
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params.max_completion_tokens).toBe(64_000);
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
+  it("keeps runtime maxTokens ahead of model params max_completion_tokens for OpenAI completions", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "kimi-k2.6",
+        name: "Kimi K2.6",
+        api: "openai-completions",
+        provider: "dashscope",
+        baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 262_144,
+        maxTokens: 32_000,
+        params: {
+          max_completion_tokens: 64_000,
+        },
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      { maxTokens: 16_000 } as never,
+    );
+
+    expect(params.max_completion_tokens).toBe(16_000);
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
+  it("keeps zero runtime maxTokens falling back to model params for OpenAI completions", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "kimi-k2.6",
+        name: "Kimi K2.6",
+        api: "openai-completions",
+        provider: "dashscope",
+        baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 262_144,
+        maxTokens: 32_000,
+        params: {
+          max_completion_tokens: 64_000,
+        },
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      { maxTokens: 0 } as never,
+    );
+
+    expect(params.max_completion_tokens).toBe(64_000);
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
   it("uses model maxTokens with max_tokens completions compat when runtime maxTokens is omitted", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -30,6 +30,7 @@ import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.typ
 import { resolveProviderTransportTurnStateWithPlugin } from "../plugins/provider-runtime.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
 import { createDeepSeekTextFilter } from "./deepseek-text-filter.js";
+import { resolveMaxTokensParam } from "./model-max-tokens-params.js";
 import {
   emitModelTransportDebug,
   resolveModelPayloadDebugMode,
@@ -2252,6 +2253,16 @@ function resolveOpenAICompletionsReasoningEffort(options: OpenAICompletionsOptio
   return options?.reasoningEffort ?? options?.reasoning ?? "high";
 }
 
+function resolveOpenAICompletionsMaxTokens(
+  model: OpenAIModeModel,
+  options: OpenAICompletionsOptions | undefined,
+): number | undefined {
+  const paramsMaxTokens = resolveMaxTokensParam(
+    (model as { params?: Record<string, unknown> }).params,
+  );
+  return (options?.maxTokens || undefined) ?? (paramsMaxTokens || undefined) ?? model.maxTokens;
+}
+
 function isQwenOpenAICompletionsThinkingFormat(format: string): boolean {
   return format === "qwen" || format === "qwen-chat-template";
 }
@@ -2594,7 +2605,7 @@ export function buildOpenAICompletionsParams(
     params.prompt_cache_key = options.sessionId;
   }
   {
-    const effectiveMaxTokens = options?.maxTokens || model.maxTokens;
+    const effectiveMaxTokens = resolveOpenAICompletionsMaxTokens(model, options);
     if (effectiveMaxTokens) {
       if (compat.maxTokensField === "max_tokens") {
         params.max_tokens = effectiveMaxTokens;

--- a/src/agents/pi-embedded-runner-extraparams.live.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.live.test.ts
@@ -14,7 +14,7 @@ const describeLive = LIVE && OPENAI_KEY ? describe : describe.skip;
 const describeAnthropicLive = ANTHROPIC_LIVE && ANTHROPIC_KEY ? describe : describe.skip;
 
 describeLive("pi embedded extra params (live)", () => {
-  it("applies config maxTokens to openai streamFn", async () => {
+  it("applies config max_completion_tokens alias to openai streamFn", async () => {
     const model = getModel("openai", "gpt-5.4") as unknown as Model<"openai-completions">;
 
     const cfg: OpenClawConfig = {
@@ -24,7 +24,7 @@ describeLive("pi embedded extra params (live)", () => {
             "openai/gpt-5.4": {
               // OpenAI Responses enforces a minimum max_output_tokens of 16.
               params: {
-                maxTokens: 16,
+                max_completion_tokens: 16,
               },
             },
           },
@@ -61,7 +61,7 @@ describeLive("pi embedded extra params (live)", () => {
 
     expect(stopReason).toBeTypeOf("string");
     expect(outputTokens).toBeTypeOf("number");
-    // Should respect maxTokens from config (16) — allow a small buffer for provider rounding.
+    // Should respect max_completion_tokens from config (16) — allow a small buffer for provider rounding.
     expect(outputTokens ?? 0).toBeLessThanOrEqual(20);
   }, 30_000);
 

--- a/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
@@ -4,6 +4,7 @@ import { createPiAiStreamSimpleMock } from "../../../test/helpers/agents/pi-ai-s
 import {
   __testing as extraParamsTesting,
   applyExtraParamsToAgent,
+  resolveExtraParams,
   resolvePreparedExtraParams,
 } from "./extra-params.js";
 
@@ -61,6 +62,100 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     expect(callOptions?.temperature).toBe(0.4);
     expect(callOptions?.topP).toBe(0.7);
     expect(callOptions?.maxTokens).toBe(512);
+  });
+
+  it("forwards OpenAI completions token aliases into the underlying streamFn options", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(agent, undefined, "dashscope", "kimi-k2.6", {
+      max_completion_tokens: 64_000,
+    });
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      { id: "kimi-k2.6", api: "openai-completions", provider: "dashscope" } as never,
+      { messages: [], tools: [] } as never,
+      undefined,
+    );
+
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as { maxTokens?: number } | undefined;
+    expect(callOptions?.maxTokens).toBe(64_000);
+  });
+
+  it("keeps runtime maxTokens ahead of OpenAI completions token alias defaults", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(agent, undefined, "dashscope", "kimi-k2.6", {
+      max_completion_tokens: 64_000,
+    });
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      { id: "kimi-k2.6", api: "openai-completions", provider: "dashscope" } as never,
+      { messages: [], tools: [] } as never,
+      { maxTokens: 32_000 } as never,
+    );
+
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as { maxTokens?: number } | undefined;
+    expect(callOptions?.maxTokens).toBe(32_000);
+  });
+
+  it("canonicalizes token aliases with config precedence before preparing stream params", () => {
+    const resolved = resolveExtraParams({
+      cfg: {
+        agents: {
+          defaults: {
+            params: {
+              maxTokens: 32_000,
+            },
+            models: {
+              "dashscope/kimi-k2.6": {
+                params: {
+                  max_completion_tokens: 64_000,
+                },
+              },
+            },
+          },
+          list: [
+            {
+              id: "bot",
+              params: {
+                max_tokens: 48_000,
+              },
+            },
+          ],
+        },
+      } as never,
+      provider: "dashscope",
+      modelId: "kimi-k2.6",
+      agentId: "bot",
+    });
+
+    expect(resolved?.maxTokens).toBe(48_000);
+    expect(resolved).not.toHaveProperty("max_completion_tokens");
+    expect(resolved).not.toHaveProperty("max_tokens");
   });
 
   it("lets runtime options override the wrapper sampling defaults", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -15,6 +15,7 @@ import {
   wrapProviderStreamFn as wrapProviderStreamFnRuntime,
 } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { canonicalizeMaxTokensParam, resolveMaxTokensParam } from "../model-max-tokens-params.js";
 import { legacyModelKey, modelKey } from "../model-selection-normalize.js";
 import { supportsGptParallelToolCallsPayload } from "../provider-api-families.js";
 import { resolveProviderRequestPolicyConfig } from "../provider-request-config.js";
@@ -125,6 +126,10 @@ export function resolveExtraParams(params: {
     merged.response_format = resolvedResponseFormat;
     delete merged.responseFormat;
   }
+  canonicalizeMaxTokensParam({
+    merged,
+    sources: [defaultParams, globalParams, agentParams],
+  });
 
   const resolvedCachedContent = resolveAliasedParamValue(
     [defaultParams, globalParams, agentParams],
@@ -251,6 +256,10 @@ export function resolvePreparedExtraParams(params: {
     ...sanitizeExtraParamsRecord(resolvedExtraParams),
     ...override,
   };
+  canonicalizeMaxTokensParam({
+    merged,
+    sources: [resolvedExtraParams, override],
+  });
   const resolvedCachedContent = resolveAliasedParamValue(
     [resolvedExtraParams, override],
     "cached_content",
@@ -305,6 +314,10 @@ export function resolvePreparedExtraParams(params: {
     },
   })?.patch;
   const result = transportPatch ? { ...prepared, ...transportPatch } : prepared;
+  canonicalizeMaxTokensParam({
+    merged: result,
+    sources: [prepared, transportPatch ?? undefined],
+  });
   if (cacheKey) {
     let bucket = preparedExtraParamsCache.get(cfg!);
     if (!bucket) {
@@ -419,8 +432,9 @@ function createStreamFnWithExtraParams(
   if (typeof extraParams.topP === "number") {
     streamParams.topP = extraParams.topP;
   }
-  if (typeof extraParams.maxTokens === "number") {
-    streamParams.maxTokens = extraParams.maxTokens;
+  const maxTokens = resolveMaxTokensParam(extraParams);
+  if (maxTokens !== undefined) {
+    streamParams.maxTokens = maxTokens;
   }
   const resolvedResponseFormat = resolveAliasedParamValue(
     [extraParams],


### PR DESCRIPTION
## Summary

- canonicalize `maxTokens`, `max_completion_tokens`, and `max_tokens` from agent/model params before embedded Pi stream wrapping
- make OpenAI-completions payload building read per-model params before falling back to catalog `maxTokens`
- add regression coverage for alias precedence, runtime override precedence, and zero fallback behavior
- update the OpenAI live extra-params test to exercise `max_completion_tokens`

## Real behavior proof

Behavior addressed: embedded OpenAI-compatible runs now honor per-model `max_completion_tokens`/`max_tokens` params instead of dropping back to the lower catalog `maxTokens` value.
Real environment tested: local macOS checkout plus real OpenAI API using `openai/gpt-5.4` through `applyExtraParamsToAgent` and `streamSimple`.
Exact steps or command run after this patch: `OPENCLAW_LIVE_TEST=1 OPENAI_LIVE_TEST=1 node --import tsx --input-type=module` with config `params.max_completion_tokens: 16`; separate payload probe used a DashScope/Kimi-shaped OpenAI-completions model with `params.max_completion_tokens: 64000`.
Evidence after fix: copied terminal output from the local run:

```text
smoke ok
live ok stop=stop outputTokens=0
```

Observed result after fix: the DashScope/Kimi-shaped payload carried `max_completion_tokens: 64000`, the embedded wrapper passed `options.maxTokens: 64000`, and the real OpenAI embedded run completed under the configured 16-token cap.
What was not tested: real DashScope/Kimi request, because `DASHSCOPE_API_KEY`, `QWEN_API_KEY`, and `MODELSTUDIO_API_KEY` were not exported locally.

## Verification

- `git diff --check`
- `env -u OPENCLAW_TESTBOX pnpm check:changed`
- `$codex-review` local review: clean after the zero-fallback fix
- direct payload/wrapper smoke with `node --import tsx --input-type=module`: `smoke ok`
- live embedded OpenAI smoke with `OPENCLAW_LIVE_TEST=1 OPENAI_LIVE_TEST=1 node --import tsx --input-type=module`: `live ok stop=stop outputTokens=0`

Fixes #82230.
