### PR TITLE
fix(models): show effective OpenAI runtime in picker

### DIFF
--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -379,11 +379,35 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).not.toMatch(/^- google-gemini-cli \(/m);
   });
 
-  it("labels the default runtime choice as OpenClaw Pi", async () => {
+  it("labels the OpenAI default runtime choice as Codex", async () => {
     const data = await buildModelsProviderData({
       agents: {
         defaults: {
           model: { primary: "openai/gpt-5.5" },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(data.runtimeChoicesByProvider?.get("openai")?.[0]).toEqual({
+      id: "codex",
+      label: "OpenAI Codex",
+      description: "Use the OpenAI Codex runtime selected by the effective harness policy.",
+    });
+  });
+
+  it("keeps custom OpenAI-compatible provider runtime choices on OpenClaw Pi", async () => {
+    const data = await buildModelsProviderData({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "http://localhost:8080/v1",
+            models: [],
+          },
         },
       },
     } as OpenClawConfig);

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -3,6 +3,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
+import { resolveAgentHarnessPolicy } from "../../agents/harness/selection.js";
 import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
 import { resolveVisibleModelCatalog } from "../../agents/model-catalog-visibility.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
@@ -28,6 +29,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { resolveAgentRuntimeLabel } from "../../status/agent-runtime-label.js";
 import type { ReplyPayload } from "../types.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
@@ -77,6 +79,38 @@ function isModelsBrowseVisibleProvider(provider: string): boolean {
 
 function usesUnfilteredCatalogModels(provider: string): boolean {
   return isCliRuntimeProvider(provider);
+}
+
+function normalizeRuntimeChoiceId(runtime: string | undefined): string {
+  const normalized = normalizeLowercaseStringOrEmpty(runtime);
+  if (!normalized || normalized === "auto" || normalized === "default") {
+    return "pi";
+  }
+  return normalized;
+}
+
+function buildDefaultRuntimeChoice(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  provider: string;
+  modelId?: string;
+}): ModelsRuntimeChoice {
+  const harnessPolicy = resolveAgentHarnessPolicy({
+    provider: params.provider,
+    modelId: params.modelId,
+    config: params.cfg,
+    agentId: params.agentId,
+  });
+  const id = normalizeRuntimeChoiceId(harnessPolicy.runtime);
+  const label = resolveAgentRuntimeLabel({ config: params.cfg, resolvedHarness: id });
+  return {
+    id,
+    label,
+    description:
+      id === "pi"
+        ? "Use the built-in OpenClaw Pi runtime."
+        : `Use the ${label} runtime selected by the effective harness policy.`,
+  };
 }
 
 export async function buildModelsProviderData(
@@ -223,14 +257,23 @@ export async function buildModelsProviderData(
   for (const alias of listLegacyRuntimeModelProviderAliases()) {
     const provider = normalizeProviderId(alias.provider);
     const choices = runtimeChoicesByProvider.get(provider) ?? [
-      {
-        id: "pi",
-        label: "OpenClaw Pi Default",
-        description: "Use the built-in OpenClaw Pi runtime.",
-      },
+      buildDefaultRuntimeChoice({
+        cfg,
+        agentId,
+        provider,
+        modelId:
+          provider === normalizeProviderId(resolvedDefault.provider)
+            ? resolvedDefault.model
+            : undefined,
+      }),
     ];
+    const runtimeId = normalizeRuntimeChoiceId(alias.runtime);
+    if (choices.some((choice) => choice.id === runtimeId)) {
+      runtimeChoicesByProvider.set(provider, choices);
+      continue;
+    }
     choices.push({
-      id: alias.runtime,
+      id: runtimeId,
       label: alias.runtime,
       description: alias.cli
         ? `Run ${provider} models through ${alias.runtime}.`


### PR DESCRIPTION
## Summary
- derive `/models` runtime transparency from `resolveAgentHarnessPolicy` instead of hard-coding the first provider runtime choice to Pi
- show official OpenAI defaults as `OpenAI Codex` when execution policy resolves them to the Codex harness
- keep custom OpenAI-compatible endpoints on `OpenClaw Pi Default`

Closes #82269

## Validation
- `CI=1 node scripts/run-vitest.mjs src/auto-reply/reply/commands-models.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/commands-models.ts src/auto-reply/reply/commands-models.test.ts`
- `pnpm check:changed`

## Real behavior proof

- Behavior or issue addressed: Model-provider picker runtime transparency now matches the effective execution harness policy. Official OpenAI defaults such as `openai/gpt-5.5` report `OpenAI Codex`; custom OpenAI-compatible `baseUrl` configs remain on `OpenClaw Pi Default`.
- Real environment tested: WSL Ubuntu 24.04 OpenClaw checkout at `/root/src/openclaw-branches/base`, comparing `origin/main` plus only the regression spec against PR #82283 branch `fix-model-picker-runtime-82269`.
- Exact steps or command run after this patch: Applied only the regression test patch to `origin/main`; ran `CI=1 node scripts/run-vitest.mjs src/auto-reply/reply/commands-models.test.ts -t 'labels the OpenAI default runtime choice as Codex|keeps custom OpenAI-compatible provider runtime choices on OpenClaw Pi'`; switched to PR #82283; ran the same command; compared before/after logs and proof image.
- Evidence after fix: before/after image https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82283/model-picker-runtime-82283/20260515-190427-305645407/model-picker-runtime-before-after-proof.png; before log https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82283/model-picker-runtime-82283/20260515-190427-305645407/before-origin-main-with-regression-test.log; after log https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82283/model-picker-runtime-82283/20260515-190427-305645407/after-pr-82283.log; regression patch https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82283/model-picker-runtime-82283/20260515-190427-305645407/regression-test.patch.
- Observed result after fix: Before fails because `origin/main` returns `{ id: "pi", label: "OpenClaw Pi Default" }` for the OpenAI default runtime choice. After passes because PR #82283 returns `{ id: "codex", label: "OpenAI Codex" }` for official OpenAI defaults and preserves `OpenClaw Pi Default` for a custom OpenAI-compatible `baseUrl`.
- What was not tested: Full interactive channel picker rendering was not exercised; this proof targets the shared model-provider data builder used by the picker surfaces.

![Before/after proof](https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82283/model-picker-runtime-82283/20260515-190427-305645407/model-picker-runtime-before-after-proof.png)
