### PR TITLE
feat(telegram): interleave CLI tool-progress + reasoning + rolling timer in one Telegram message

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2024,8 +2024,18 @@ export const dispatchTelegramMessage = async ({
                           // can't leak tags or duplicate already-formatted
                           // labels. Checkpoint on the normalized text length.
                           const rawText = typeof payload.text === "string" ? payload.text : "";
-                          const normalizedReasoning =
+                          // splitTelegramReasoningText returns formatReasoningMessage
+                          // output ("Thinking\n\n" + italic body). updateInterleavedDisplay
+                          // already renders the "Thinking" header, so store only the
+                          // italic body here — otherwise the interleaved message shows
+                          // the heading twice. The header is plain text; body lines are
+                          // `_…_`, so a leading "Thinking\n\n" strip can't touch the body.
+                          const formattedReasoning =
                             splitTelegramReasoningText(rawText, true).reasoningText ?? "";
+                          const normalizedReasoning = formattedReasoning.replace(
+                            /^Thinking\n\n/u,
+                            "",
+                          );
                           const newPart = normalizedReasoning.slice(rawReasoningCheckpoint);
                           if (newPart) {
                             interleavedOutput += newPart;

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1078,6 +1078,10 @@ export const dispatchTelegramMessage = async ({
     reasoningLane.lastPartialText = display;
     reasoningLane.stream.update(display);
   };
+  // How often the rolling "Ns — HH:MM" elapsed-time line on the interleaved
+  // reasoning message refreshes. Kept coarse (20s) to minimise Telegram edit
+  // churn; must stay ≥ the draft-stream throttleMs so the tick reliably sends.
+  const TOOL_TIMER_TICK_MS = 20_000;
   const startToolTimer = (): void => {
     clearActiveTimer();
     activeToolStartTime = Date.now();
@@ -1090,11 +1094,11 @@ export const dispatchTelegramMessage = async ({
       activeTimerSuffix = `\n_${elapsed}s — ${formatTimerClock(new Date())}_`;
       updateInterleavedDisplay();
       // No explicit flush() — the draft-stream loop already self-pumps on
-      // update() once throttleMs has elapsed since the last send. The 3s tick
+      // update() once throttleMs has elapsed since the last send. The 20s tick
       // interval is always ≥ throttleMs, so the timer reliably delivers, and
       // 429 retry-after handling in the send path naturally gates us during
       // Telegram backpressure instead of us racing the throttle.
-    }, 3000);
+    }, TOOL_TIMER_TICK_MS);
   };
   const injectToolLineIntoInterleave = async (
     line: string | { text?: string } | null | undefined,
@@ -1996,7 +2000,15 @@ export const dispatchTelegramMessage = async ({
                             reasoningLane.stream?.forceNewMessage();
                             resetDraftLaneState(reasoningLane);
                             splitReasoningOnNextStream = false;
-                            interleavedOutput = "";
+                            // Reset the checkpoint so the next source's
+                            // accumulated text appends correctly, but
+                            // preserve interleavedOutput so already-injected
+                            // tool-progress lines and prior reasoning text
+                            // remain visible in the rolling Thinking message.
+                            // (Previous behaviour cleared interleavedOutput
+                            // which erased tool lines when the model switched
+                            // between thinking_delta and assistant text
+                            // content blocks within a single turn.)
                             rawReasoningCheckpoint = 0;
                           }
                           // Italicize the new portion of the reasoning text

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1045,6 +1045,84 @@ export const dispatchTelegramMessage = async ({
   };
   let splitReasoningOnNextStream = false;
   let draftLaneEventQueue = Promise.resolve();
+  // Interleaved-output state: while a turn streams, we paint reasoning text
+  // (italicized) AND tool-progress lines (timestamped) into ONE Telegram
+  // message in the reasoning lane, with a rolling `Ns — HH:MM:SS` timer
+  // suffix between tool starts. interleavedOutput holds the cumulative body;
+  // rawReasoningCheckpoint marks how much of the upstream reasoning text we've
+  // already mirrored into it (so re-deliveries don't duplicate). The timer
+  // re-paints + flushes the lane every 3s so the user sees the turn is alive
+  // even while a long tool is mid-execution.
+  let interleavedOutput = "";
+  let rawReasoningCheckpoint = 0;
+  let activeTimerSuffix = "";
+  let activeTimerInterval: ReturnType<typeof setInterval> | null = null;
+  let activeToolStartTime = 0;
+  const clearActiveTimer = (): void => {
+    if (activeTimerInterval) {
+      clearInterval(activeTimerInterval);
+      activeTimerInterval = null;
+    }
+    activeTimerSuffix = "";
+  };
+  const formatTimerClock = (date: Date): string =>
+    [date.getHours(), date.getMinutes(), date.getSeconds()]
+      .map((n) => String(n).padStart(2, "0"))
+      .join(":");
+  const updateInterleavedDisplay = (): void => {
+    if (!reasoningLane.stream || !interleavedOutput) {
+      return;
+    }
+    const display = "Thinking\n\n" + interleavedOutput + activeTimerSuffix;
+    reasoningLane.hasStreamedMessage = true;
+    reasoningLane.lastPartialText = display;
+    reasoningLane.stream.update(display);
+  };
+  const startToolTimer = (): void => {
+    clearActiveTimer();
+    activeToolStartTime = Date.now();
+    activeTimerInterval = setInterval(async () => {
+      if (!reasoningLane.stream) {
+        clearActiveTimer();
+        return;
+      }
+      const elapsed = Math.round((Date.now() - activeToolStartTime) / 1000);
+      activeTimerSuffix = `\n_${elapsed}s — ${formatTimerClock(new Date())}_`;
+      updateInterleavedDisplay();
+      // Force the lane to flush past the typing-indicator throttle so the
+      // user actually sees the timer roll between deliveries.
+      try {
+        await reasoningLane.stream.flush();
+      } catch {
+        /* lane already torn down — next tick's reasoningLane.stream check
+           will clear the interval. */
+      }
+    }, 3000);
+  };
+  const injectToolLineIntoInterleave = async (
+    line: string | { text?: string } | null | undefined,
+    opts?: { startTimer?: boolean },
+  ): Promise<boolean> => {
+    const lineText = typeof line === "string" ? line : line?.text || "";
+    if (!lineText || !reasoningLane.stream) {
+      return false;
+    }
+    await enqueueDraftLaneEvent(async () => {
+      clearActiveTimer();
+      const ts = formatTimerClock(new Date());
+      interleavedOutput += `\n[${ts}] ${lineText}\n`;
+      if (opts?.startTimer) {
+        startToolTimer();
+      }
+      updateInterleavedDisplay();
+      try {
+        await reasoningLane.stream?.flush();
+      } catch {
+        /* see startToolTimer */
+      }
+    });
+    return true;
+  };
   const reasoningStepState = createTelegramReasoningStepState();
   const enqueueDraftLaneEvent = (task: () => Promise<void>): Promise<void> => {
     const next = draftLaneEventQueue.then(async () => {
@@ -1925,8 +2003,34 @@ export const dispatchTelegramMessage = async ({
                             reasoningLane.stream?.forceNewMessage();
                             resetDraftLaneState(reasoningLane);
                             splitReasoningOnNextStream = false;
+                            interleavedOutput = "";
+                            rawReasoningCheckpoint = 0;
                           }
-                          await ingestDraftLaneSegments(payload, true);
+                          // Italicize the new portion of the reasoning text
+                          // and append it to interleavedOutput so it lives in
+                          // the same message as any tool-progress lines
+                          // injected via injectToolLineIntoInterleave. The
+                          // checkpoint guards against re-deliveries of the
+                          // same accumulated text.
+                          clearActiveTimer();
+                          const fullText = typeof payload.text === "string" ? payload.text : "";
+                          const newPart = fullText.slice(rawReasoningCheckpoint);
+                          if (newPart) {
+                            const italicized = newPart
+                              .split("\n")
+                              .map((l) => (l.trim() ? `_${l}_` : ""))
+                              .join("\n");
+                            interleavedOutput += italicized;
+                            rawReasoningCheckpoint = fullText.length;
+                          }
+                          updateInterleavedDisplay();
+                          // Lane has content the user shouldn't lose; mark
+                          // finalized AFTER the segment-ingest equivalent so
+                          // the post-run cleanup keeps the message instead
+                          // of clearing it.
+                          reasoningLane.finalized = true;
+                          reasoningStepState.noteReasoningHint();
+                          reasoningStepState.noteReasoningDelivered();
                         })
                     : undefined,
                   onAssistantMessageStart: answerLane.stream
@@ -1944,6 +2048,12 @@ export const dispatchTelegramMessage = async ({
                     ? () =>
                         enqueueDraftLaneEvent(async () => {
                           splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
+                          // Keep the reasoning message visible after the
+                          // final answer: cleanup checks `finalized` and
+                          // clears the lane stream when it's false.
+                          if (reasoningLane.hasStreamedMessage) {
+                            reasoningLane.finalized = true;
+                          }
                           streamToolProgressSuppressed = false;
                           streamToolProgressLines = [];
                         })
@@ -1954,23 +2064,31 @@ export const dispatchTelegramMessage = async ({
                     !isRoomEvent && Boolean(answerLane.stream),
                   onToolStart: async (payload) => {
                     const toolName = payload.name?.trim();
-                    const progressPromise = pushStreamToolProgress(
-                      formatChannelProgressDraftLineForEntry(
-                        telegramCfg,
-                        {
-                          event: "tool",
-                          name: toolName,
-                          phase: payload.phase,
-                          args: payload.args,
-                        },
-                        payload.detailMode ? { detailMode: payload.detailMode } : undefined,
-                      ),
-                      { toolName, startImmediately: true },
+                    const formatted = formatChannelProgressDraftLineForEntry(
+                      telegramCfg,
+                      {
+                        event: "tool",
+                        name: toolName,
+                        phase: payload.phase,
+                        args: payload.args,
+                      },
+                      payload.detailMode ? { detailMode: payload.detailMode } : undefined,
                     );
+                    // Prefer interleaving into the reasoning lane (single
+                    // updating message with `[HH:MM:SS] ToolName: args` lines
+                    // + rolling timer between calls). Falls back to the
+                    // legacy per-tool channel-progress message when the
+                    // reasoning lane isn't active (room events, suppressed
+                    // reasoning level, no streaming, etc.).
+                    if (!(await injectToolLineIntoInterleave(formatted, { startTimer: true }))) {
+                      await pushStreamToolProgress(formatted, {
+                        toolName,
+                        startImmediately: true,
+                      });
+                    }
                     if (statusReactionController && toolName) {
                       await statusReactionController.setTool(toolName);
                     }
-                    await progressPromise;
                   },
                   onItemEvent: async (payload) => {
                     await pushStreamToolProgress(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2198,6 +2198,15 @@ export const dispatchTelegramMessage = async ({
       progressDraftGate.cancel();
       await draftLaneEventQueue;
       nativeToolProgressDraft?.stop();
+      // Belt-and-braces: when interleavedOutput has content but onReasoningEnd
+      // never fired (turn aborted mid-stream, error mid-reasoning, etc.), the
+      // lane.finalized check below would clear the still-visible interleaved
+      // message. If we have any interleaved content AND the lane has a streamed
+      // message, force finalized=true so the lane.stop() branch runs instead
+      // of stream.clear().
+      if (interleavedOutput && reasoningLane.hasStreamedMessage) {
+        reasoningLane.finalized = true;
+      }
       const lanesToCleanup: Array<{ laneName: LaneName; lane: DraftLaneState }> = [
         { laneName: "answer", lane: answerLane },
         { laneName: "reasoning", lane: reasoningLane },

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2018,15 +2018,18 @@ export const dispatchTelegramMessage = async ({
                           // checkpoint guards against re-deliveries of the
                           // same accumulated text.
                           clearActiveTimer();
-                          const fullText = typeof payload.text === "string" ? payload.text : "";
-                          const newPart = fullText.slice(rawReasoningCheckpoint);
+                          // Normalize via the same splitter the draft-lane path
+                          // uses (strips <think> tags + applies
+                          // formatReasoningMessage) so the interleaved reasoning
+                          // can't leak tags or duplicate already-formatted
+                          // labels. Checkpoint on the normalized text length.
+                          const rawText = typeof payload.text === "string" ? payload.text : "";
+                          const normalizedReasoning =
+                            splitTelegramReasoningText(rawText, true).reasoningText ?? "";
+                          const newPart = normalizedReasoning.slice(rawReasoningCheckpoint);
                           if (newPart) {
-                            const italicized = newPart
-                              .split("\n")
-                              .map((l) => (l.trim() ? `_${l}_` : ""))
-                              .join("\n");
-                            interleavedOutput += italicized;
-                            rawReasoningCheckpoint = fullText.length;
+                            interleavedOutput += newPart;
+                            rawReasoningCheckpoint = normalizedReasoning.length;
                           }
                           updateInterleavedDisplay();
                           // Lane has content the user shouldn't lose; mark
@@ -2085,11 +2088,18 @@ export const dispatchTelegramMessage = async ({
                     // legacy per-tool channel-progress message when the
                     // reasoning lane isn't active (room events, suppressed
                     // reasoning level, no streaming, etc.).
-                    if (!(await injectToolLineIntoInterleave(formatted, { startTimer: true }))) {
-                      await pushStreamToolProgress(formatted, {
-                        toolName,
-                        startImmediately: true,
-                      });
+                    // Honor the tool-progress opt-out — same gate as
+                    // pushStreamToolProgress (line ~984): only surface tool
+                    // lines when progress streaming is enabled / in progress
+                    // mode, so users who disabled tool progress don't get them
+                    // injected into the reasoning message either.
+                    if (streamMode === "progress" || streamToolProgressEnabled) {
+                      if (!(await injectToolLineIntoInterleave(formatted, { startTimer: true }))) {
+                        await pushStreamToolProgress(formatted, {
+                          toolName,
+                          startImmediately: true,
+                        });
+                      }
                     }
                     if (statusReactionController && toolName) {
                       await statusReactionController.setTool(toolName);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2189,6 +2189,11 @@ export const dispatchTelegramMessage = async ({
       runtime.error?.(danger(`telegram dispatch failed: ${String(err)}`));
     } finally {
       progressDraftGate.cancel();
+      // Stop the rolling tool-timer interval first — startToolTimer() runs a
+      // setInterval(3000ms) that the lane cleanup below does NOT cover. A turn
+      // that ends mid-tool would otherwise leak the interval for the rest of
+      // the process, waking every 3s to repaint a torn-down lane.
+      clearActiveTimer();
       await draftLaneEventQueue;
       nativeToolProgressDraft?.stop();
       // Belt-and-braces: when interleavedOutput has content but onReasoningEnd

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1081,7 +1081,7 @@ export const dispatchTelegramMessage = async ({
   const startToolTimer = (): void => {
     clearActiveTimer();
     activeToolStartTime = Date.now();
-    activeTimerInterval = setInterval(async () => {
+    activeTimerInterval = setInterval(() => {
       if (!reasoningLane.stream) {
         clearActiveTimer();
         return;
@@ -1089,14 +1089,11 @@ export const dispatchTelegramMessage = async ({
       const elapsed = Math.round((Date.now() - activeToolStartTime) / 1000);
       activeTimerSuffix = `\n_${elapsed}s — ${formatTimerClock(new Date())}_`;
       updateInterleavedDisplay();
-      // Force the lane to flush past the typing-indicator throttle so the
-      // user actually sees the timer roll between deliveries.
-      try {
-        await reasoningLane.stream.flush();
-      } catch {
-        /* lane already torn down — next tick's reasoningLane.stream check
-           will clear the interval. */
-      }
+      // No explicit flush() — the draft-stream loop already self-pumps on
+      // update() once throttleMs has elapsed since the last send. The 3s tick
+      // interval is always ≥ throttleMs, so the timer reliably delivers, and
+      // 429 retry-after handling in the send path naturally gates us during
+      // Telegram backpressure instead of us racing the throttle.
     }, 3000);
   };
   const injectToolLineIntoInterleave = async (
@@ -1115,11 +1112,7 @@ export const dispatchTelegramMessage = async ({
         startToolTimer();
       }
       updateInterleavedDisplay();
-      try {
-        await reasoningLane.stream?.flush();
-      } catch {
-        /* see startToolTimer */
-      }
+      // See startToolTimer — no explicit flush; the loop self-pumps.
     });
     return true;
   };

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -30,15 +30,6 @@ export type CliStreamingDelta = {
   thinkingDelta?: string;
   /** Accumulated thinking text so far; set whenever `thinkingDelta` is present. */
   thinkingText?: string;
-  /**
-   * When true, the emitter is signalling that `text` is a full replacement
-   * — the live-chat merger should use `text` even when it is a strict
-   * prefix of its previousText (which the default "rollback" branch would
-   * otherwise treat as stale and ignore). Used by the rolling-timer
-   * terminal-cleanup path where the new text is shorter than what's
-   * already been shown.
-   */
-  replacement?: boolean;
 };
 
 function isClaudeCliProvider(providerId: string): boolean {
@@ -676,18 +667,18 @@ export function createCliJsonlStreamingParser(params: {
   };
 
   // For terminal paths (result, finish) where no follow-up text delta is
-  // coming: emit a replacement delta so the live-chat merger replaces the
-  // stale `_ Ns ..._` tick that was last sent. The new `text` is a strict
-  // prefix of the previously emitted text (timer suffix stripped) — the
-  // merger's default rollback branch would keep the longer previousText,
-  // leaving the timer visible. Set `replacement: true` to bypass that
-  // branch and force the merger to honour the shorter text.
+  // coming: re-emit the full assistant text with the `_ Ns ..._` tick
+  // stripped, so the last-sent timer line disappears. We emit full `text`
+  // with an empty `delta`; the assistant-stream bridge forwards full text
+  // (it does not append deltas), so the live-chat merger replaces by `text`
+  // and the shorter, timer-free text wins. No bespoke replacement signal is
+  // needed — this rides the existing full-text replace contract.
   const emitTickReplacementIfPainted = (): void => {
     if (toolTickStart < 0) {
       return;
     }
     stripToolTick();
-    params.onAssistantDelta({ text: assistantText, delta: "", replacement: true });
+    params.onAssistantDelta({ text: assistantText, delta: "" });
   };
 
   const trackClaudeToolUse = createClaudeToolUseTracker({

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -30,6 +30,15 @@ export type CliStreamingDelta = {
   thinkingDelta?: string;
   /** Accumulated thinking text so far; set whenever `thinkingDelta` is present. */
   thinkingText?: string;
+  /**
+   * Full-state replacement signal on the existing live-chat `replace`
+   * contract. When true, `text` must be applied as-is even when it is a
+   * strict prefix of the previously emitted text — bypassing the merger's
+   * `previousText.startsWith(nextText) && !nextDelta` rollback branch. Used
+   * by the rolling-timer terminal cleanup, where the new text is the prior
+   * text with the `_ Ns ..._` suffix stripped (and therefore shorter).
+   */
+  replace?: boolean;
 };
 
 function isClaudeCliProvider(providerId: string): boolean {
@@ -668,17 +677,17 @@ export function createCliJsonlStreamingParser(params: {
 
   // For terminal paths (result, finish) where no follow-up text delta is
   // coming: re-emit the full assistant text with the `_ Ns ..._` tick
-  // stripped, so the last-sent timer line disappears. We emit full `text`
-  // with an empty `delta`; the assistant-stream bridge forwards full text
-  // (it does not append deltas), so the live-chat merger replaces by `text`
-  // and the shorter, timer-free text wins. No bespoke replacement signal is
-  // needed — this rides the existing full-text replace contract.
+  // stripped so the last-sent timer line disappears. The new text is a
+  // strict prefix of what was already shown, which the live-chat mergers
+  // (server-chat + Telegram) treat as a stale rollback and ignore by
+  // default. Set `replace: true` on the existing live-chat replace contract
+  // so the shorter, timer-free text is applied as a full-state replacement.
   const emitTickReplacementIfPainted = (): void => {
     if (toolTickStart < 0) {
       return;
     }
     stripToolTick();
-    params.onAssistantDelta({ text: assistantText, delta: "" });
+    params.onAssistantDelta({ text: assistantText, delta: "", replace: true });
   };
 
   const trackClaudeToolUse = createClaudeToolUseTracker({

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -3,6 +3,7 @@ import { extractBalancedJsonFragments } from "../shared/balanced-json.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
 import { isRecord } from "../utils.js";
+import { sanitizeToolArgs } from "./pi-embedded-subscribe.tools.js";
 
 type CliUsage = {
   input?: number;
@@ -25,6 +26,19 @@ export type CliStreamingDelta = {
   delta: string;
   sessionId?: string;
   usage?: CliUsage;
+  /** Present when this delta carries a thinking chunk rather than assistant text. */
+  thinkingDelta?: string;
+  /** Accumulated thinking text so far; set whenever `thinkingDelta` is present. */
+  thinkingText?: string;
+  /**
+   * When true, the emitter is signalling that `text` is a full replacement
+   * — the live-chat merger should use `text` even when it is a strict
+   * prefix of its previousText (which the default "rollback" branch would
+   * otherwise treat as stale and ignore). Used by the rolling-timer
+   * terminal-cleanup path where the new text is shorter than what's
+   * already been shown.
+   */
+  replacement?: boolean;
 };
 
 function isClaudeCliProvider(providerId: string): boolean {
@@ -394,10 +408,244 @@ function parseClaudeCliStreamingDelta(params: {
   };
 }
 
+export type ClaudeToolEvent = {
+  phase: "start";
+  name: string;
+  args: Record<string, unknown> | undefined;
+  itemId: string | undefined;
+  sessionId: string | undefined;
+  usage: CliUsage | undefined;
+};
+
+type ClaudeToolBlockEntry = {
+  id: string;
+  name: string;
+  input: unknown;
+  partialJson: string;
+  emitted: boolean;
+};
+
+function readClaudeToolBlockKey(
+  event: Record<string, unknown>,
+  block: Record<string, unknown>,
+): string | undefined {
+  const id = typeof block.id === "string" && block.id.trim() ? block.id.trim() : undefined;
+  if (id) {
+    return id;
+  }
+  const index =
+    typeof event.index === "number"
+      ? event.index
+      : typeof event.content_block_index === "number"
+        ? event.content_block_index
+        : undefined;
+  return index === undefined ? undefined : `index:${index}`;
+}
+
+function readClaudeToolName(block: Record<string, unknown>): string | undefined {
+  for (const key of ["name", "tool_name", "toolName"] as const) {
+    const value = block[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function parseClaudeToolArgs(
+  input: unknown,
+  partialJson: string,
+): Record<string, unknown> | undefined {
+  if (isRecord(input)) {
+    return input;
+  }
+  const text =
+    typeof input === "string" && input.trim()
+      ? input.trim()
+      : typeof partialJson === "string" && partialJson.trim()
+        ? partialJson.trim()
+        : "";
+  if (!text) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(text);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readClaudeToolDeltaPartial(delta: unknown): string {
+  if (!isRecord(delta)) {
+    return "";
+  }
+  if (delta.type !== "input_json_delta") {
+    return "";
+  }
+  return typeof delta.partial_json === "string" ? delta.partial_json : "";
+}
+
+function createClaudeToolUseTracker(params: {
+  backend: CliBackendConfig;
+  providerId: string;
+  onToolEvent?: (evt: ClaudeToolEvent) => void;
+  onToolText?: (text: string) => void;
+  getSessionId: () => string | undefined;
+  getUsage: () => CliUsage | undefined;
+}): (parsed: Record<string, unknown>) => void {
+  const toolBlocks = new Map<string, ClaudeToolBlockEntry>();
+
+  const emitTool = (entry: ClaudeToolBlockEntry): void => {
+    if (entry.emitted) {
+      return;
+    }
+    if (!params.onToolEvent && !params.onToolText) {
+      return;
+    }
+    let args = parseClaudeToolArgs(entry.input, entry.partialJson);
+    if (args && Object.keys(args).length === 0 && entry.partialJson) {
+      try {
+        const p = JSON.parse(entry.partialJson);
+        if (p && typeof p === "object") {
+          args = p as Record<string, unknown>;
+        }
+      } catch {}
+    }
+    // Sanitize once before either consumer sees the args — matches the
+    // existing embedded-runtime contract (pi-embedded-subscribe.handlers
+    // .tools.ts) so tokens, API keys, and secret-bearing strings in
+    // command / URL / header fields are redacted before they reach inline
+    // assistant deltas OR structured tool events.
+    const safeArgs = args ? (sanitizeToolArgs(args) as Record<string, unknown>) : undefined;
+    if (params.onToolText) {
+      let detail = "";
+      if (safeArgs) {
+        const val =
+          safeArgs.command ||
+          safeArgs.file_path ||
+          safeArgs.pattern ||
+          safeArgs.query ||
+          safeArgs.description ||
+          safeArgs.url;
+        if (typeof val === "string" && val.trim()) {
+          detail = val.trim();
+          if (detail.length > 120) {
+            detail = detail.slice(0, 117) + "…";
+          }
+        }
+      }
+      const ts = new Date().toLocaleTimeString("en-GB", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+      params.onToolText(
+        detail ? `\n\n[${ts}] 🛠️ ${entry.name}: ${detail}\n` : `\n\n[${ts}] 🛠️ ${entry.name}\n`,
+      );
+    }
+    if (params.onToolEvent) {
+      params.onToolEvent({
+        phase: "start",
+        name: entry.name,
+        args: safeArgs,
+        itemId: entry.id,
+        sessionId: params.getSessionId(),
+        usage: params.getUsage(),
+      });
+    }
+    entry.emitted = true;
+  };
+
+  return (parsed) => {
+    if (!usesClaudeStreamJsonDialect({ backend: params.backend, providerId: params.providerId })) {
+      return;
+    }
+    if (parsed.type !== "stream_event" || !isRecord(parsed.event)) {
+      return;
+    }
+    const event = parsed.event;
+    if (event.type === "content_block_start" && isRecord(event.content_block)) {
+      const block = event.content_block;
+      if (
+        block.type !== "tool_use" &&
+        block.type !== "server_tool_use" &&
+        block.type !== "mcp_tool_use"
+      ) {
+        return;
+      }
+      const key = readClaudeToolBlockKey(event, block);
+      const name = readClaudeToolName(block);
+      if (!key || !name) {
+        return;
+      }
+      const entry: ClaudeToolBlockEntry = {
+        id: typeof block.id === "string" ? block.id : key,
+        name,
+        input: block.input,
+        partialJson: "",
+        emitted: false,
+      };
+      toolBlocks.set(key, entry);
+      const idxKey =
+        typeof event.index === "number"
+          ? `index:${event.index}`
+          : typeof event.content_block_index === "number"
+            ? `index:${event.content_block_index}`
+            : undefined;
+      if (idxKey && idxKey !== key) {
+        toolBlocks.set(idxKey, entry);
+      }
+      return;
+    }
+    if (event.type !== "content_block_delta" && event.type !== "content_block_stop") {
+      return;
+    }
+    const index =
+      typeof event.index === "number"
+        ? event.index
+        : typeof event.content_block_index === "number"
+          ? event.content_block_index
+          : undefined;
+    if (index === undefined) {
+      return;
+    }
+    const entry = toolBlocks.get(`index:${index}`) ?? Array.from(toolBlocks.values()).at(index);
+    if (!entry) {
+      return;
+    }
+    if (event.type === "content_block_delta") {
+      const partial = readClaudeToolDeltaPartial(event.delta);
+      if (partial) {
+        entry.partialJson += partial;
+      }
+      return;
+    }
+    emitTool(entry);
+    toolBlocks.delete(`index:${index}`);
+    if (entry.id) {
+      toolBlocks.delete(entry.id);
+    }
+  };
+}
+
 export function createCliJsonlStreamingParser(params: {
   backend: CliBackendConfig;
   providerId: string;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolEvent?: (evt: ClaudeToolEvent) => void;
+  /**
+   * Called at each tool-start emission to decide whether to also inject the
+   * `\n\n[HH:MM:SS] 🛠️ ToolName: detail\n` marker (plus rolling 8s timer)
+   * into the assistant text stream. Returning `false` keeps assistant text
+   * clean — only the structured `onToolEvent` fires, which downstream channels
+   * gate by their own tool-verbose policy. The callback is invoked per-tool
+   * (not captured once at parser construction) so session-level verbose changes
+   * mid-run are honoured: e.g. a user toggling tool verbose off during a long
+   * run will stop subsequent inline markers immediately, matching the
+   * server-chat re-resolution path. Omitting the callback defaults to `false`.
+   */
+  shouldInjectToolInlineMarkers?: () => boolean;
 }) {
   let lineBuffer = "";
   let assistantText = "";
@@ -405,6 +653,77 @@ export function createCliJsonlStreamingParser(params: {
   let usage: CliUsage | undefined;
   let output: CliOutput | null = null;
   const texts: string[] = [];
+
+  // Rolling-timer state: while a tool runs, we paint `_ <elapsed>s — <hh:mm:ss>_`
+  // at the tail of assistantText and refresh every 8s so the user sees the
+  // turn is still alive. Cleared on next text_delta, on result, or on finish.
+  let toolKeepaliveTimer: ReturnType<typeof setInterval> | null = null;
+  let toolKeepaliveStart = 0;
+  let toolTickStart = -1;
+
+  const clearToolKeepalive = (): void => {
+    if (toolKeepaliveTimer) {
+      clearInterval(toolKeepaliveTimer);
+      toolKeepaliveTimer = null;
+    }
+  };
+
+  const stripToolTick = (): void => {
+    if (toolTickStart >= 0 && toolTickStart < assistantText.length) {
+      assistantText = assistantText.slice(0, toolTickStart);
+    }
+    toolTickStart = -1;
+  };
+
+  // For terminal paths (result, finish) where no follow-up text delta is
+  // coming: emit a replacement delta so the live-chat merger replaces the
+  // stale `_ Ns ..._` tick that was last sent. The new `text` is a strict
+  // prefix of the previously emitted text (timer suffix stripped) — the
+  // merger's default rollback branch would keep the longer previousText,
+  // leaving the timer visible. Set `replacement: true` to bypass that
+  // branch and force the merger to honour the shorter text.
+  const emitTickReplacementIfPainted = (): void => {
+    if (toolTickStart < 0) {
+      return;
+    }
+    stripToolTick();
+    params.onAssistantDelta({ text: assistantText, delta: "", replacement: true });
+  };
+
+  const trackClaudeToolUse = createClaudeToolUseTracker({
+    backend: params.backend,
+    providerId: params.providerId,
+    onToolEvent: params.onToolEvent,
+    // Per-tool re-evaluation of inline-marker policy: invokes the caller's
+    // resolver at emit time so a session verbose change mid-run is honoured.
+    // No-op when the caller didn't pass a resolver (default: never inject).
+    onToolText: (text) => {
+      if (!params.shouldInjectToolInlineMarkers?.()) {
+        return;
+      }
+      clearToolKeepalive();
+      stripToolTick();
+      assistantText += text;
+      params.onAssistantDelta({ text: assistantText, delta: text });
+      toolKeepaliveStart = Date.now();
+      toolTickStart = assistantText.length;
+      toolKeepaliveTimer = setInterval(() => {
+        const elapsed = Math.round((Date.now() - toolKeepaliveStart) / 1000);
+        const now = new Date().toLocaleTimeString("en-GB", {
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+        });
+        assistantText = assistantText.slice(0, toolTickStart) + `_ ${elapsed}s — ${now}_`;
+        // Replacement semantics for the tick: empty delta signals to the
+        // live-chat merger to use the new full text rather than append a
+        // delta to its previousText (which still contains the old tick).
+        params.onAssistantDelta({ text: assistantText, delta: "" });
+      }, 8000);
+    },
+    getSessionId: () => sessionId,
+    getUsage: () => usage,
+  });
 
   const handleParsedRecord = (parsed: Record<string, unknown>) => {
     sessionId = pickCliSessionId(parsed, params.backend) ?? sessionId;
@@ -421,6 +740,7 @@ export function createCliJsonlStreamingParser(params: {
     if (shouldUseUsage) {
       usage = nextUsage ?? usage;
     }
+    trackClaudeToolUse(parsed);
 
     const result = parseClaudeCliJsonlResult({
       backend: params.backend,
@@ -430,6 +750,8 @@ export function createCliJsonlStreamingParser(params: {
       usage,
     });
     if (result) {
+      clearToolKeepalive();
+      emitTickReplacementIfPainted();
       output = result;
       return;
     }
@@ -442,7 +764,7 @@ export function createCliJsonlStreamingParser(params: {
       }
     }
 
-    const delta = parseClaudeCliStreamingDelta({
+    let delta = parseClaudeCliStreamingDelta({
       backend: params.backend,
       providerId: params.providerId,
       parsed,
@@ -451,6 +773,26 @@ export function createCliJsonlStreamingParser(params: {
       usage,
     });
     if (!delta) {
+      return;
+    }
+    if (toolKeepaliveTimer) {
+      clearToolKeepalive();
+      stripToolTick();
+      if (!assistantText.endsWith("\n\n")) {
+        assistantText = assistantText.replace(/\n*$/, "\n\n");
+      }
+      assistantText = assistantText + delta.delta;
+      params.onAssistantDelta({
+        text: assistantText,
+        delta: "",
+        sessionId: delta.sessionId,
+        usage: delta.usage,
+      });
+      return;
+    }
+    if (delta.thinkingDelta !== undefined) {
+      thinkingText += delta.thinkingDelta;
+      params.onAssistantDelta({ ...delta, thinkingText });
       return;
     }
     assistantText = delta.text;
@@ -494,7 +836,16 @@ export function createCliJsonlStreamingParser(params: {
       flushLines(false);
     },
     finish() {
+      clearToolKeepalive();
+      emitTickReplacementIfPainted();
       flushLines(true);
+      // The final flush can parse a content_block_stop for a tool, which
+      // (when inline markers are enabled) starts a fresh keepalive interval.
+      // Re-clear after the flush so the parser is truly quiescent when
+      // finish() returns — no setInterval left running past the caller's
+      // "we're done" signal.
+      clearToolKeepalive();
+      emitTickReplacementIfPainted();
     },
     getOutput() {
       if (output) {

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -790,11 +790,6 @@ export function createCliJsonlStreamingParser(params: {
       });
       return;
     }
-    if (delta.thinkingDelta !== undefined) {
-      thinkingText += delta.thinkingDelta;
-      params.onAssistantDelta({ ...delta, thinkingText });
-      return;
-    }
     assistantText = delta.text;
     params.onAssistantDelta(delta);
   };

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1,18 +1,19 @@
 import crypto from "node:crypto";
 import type { ReplyBackendHandle } from "../../auto-reply/reply/reply-run-registry.js";
 import type { CliBackendConfig } from "../../config/types.js";
-import { isRecord } from "../../shared/record-coerce.js";
 import {
   loadExecApprovals,
   maxAsk,
   minSecurity,
   resolveExecApprovalsFromFile,
 } from "../../infra/exec-approvals.js";
+import { isRecord } from "../../shared/record-coerce.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import {
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
   parseCliOutput,
+  type ClaudeToolEvent,
   type CliOutput,
   type CliStreamingDelta,
 } from "../cli-output.js";
@@ -955,6 +956,8 @@ function createTurn(params: {
   context: PreparedCliRunContext;
   noOutputTimeoutMs: number;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolEvent?: (evt: ClaudeToolEvent) => void;
+  shouldInjectToolInlineMarkers?: () => boolean;
   session: ClaudeLiveSession;
   resolve: (output: CliOutput) => void;
   reject: (error: unknown) => void;
@@ -971,6 +974,8 @@ function createTurn(params: {
       backend: params.context.preparedBackend.backend,
       providerId: params.context.backendResolved.id,
       onAssistantDelta: params.onAssistantDelta,
+      onToolEvent: params.onToolEvent,
+      shouldInjectToolInlineMarkers: params.shouldInjectToolInlineMarkers,
     }),
     resolve: params.resolve,
     reject: params.reject,
@@ -1036,6 +1041,8 @@ export async function runClaudeLiveSessionTurn(params: {
   noOutputTimeoutMs: number;
   getProcessSupervisor: () => ProcessSupervisor;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onToolEvent?: (evt: ClaudeToolEvent) => void;
+  shouldInjectToolInlineMarkers?: () => boolean;
   cleanup: () => Promise<void>;
 }): Promise<ClaudeLiveRunResult> {
   const key = buildClaudeLiveKey(params.context);
@@ -1157,6 +1164,8 @@ export async function runClaudeLiveSessionTurn(params: {
       context: params.context,
       noOutputTimeoutMs: params.noOutputTimeoutMs,
       onAssistantDelta: params.onAssistantDelta,
+      onToolEvent: params.onToolEvent,
+      shouldInjectToolInlineMarkers: params.shouldInjectToolInlineMarkers,
       session: liveSession,
       resolve,
       reject,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -499,7 +499,7 @@ export async function executePreparedCliRun(
             useResume,
             noOutputTimeoutMs,
             getProcessSupervisor: executeDeps.getProcessSupervisor,
-            onAssistantDelta: ({ text, delta, thinkingDelta, thinkingText, replacement }) => {
+            onAssistantDelta: ({ text, delta, thinkingDelta, thinkingText }) => {
               if (thinkingDelta !== undefined && thinkingText !== undefined) {
                 emitAgentEvent({
                   runId: params.runId,
@@ -520,11 +520,6 @@ export async function executePreparedCliRun(
                     delta,
                     context.backendResolved.textTransforms?.output,
                   ),
-                  // Forward the replacement signal so live-chat's merger
-                  // honours intentionally-shorter assistant text (e.g.
-                  // rolling-timer terminal cleanup) instead of treating
-                  // it as a stale partial-chunk rollback.
-                  ...(replacement ? { replacement: true } : {}),
                 },
               });
             },
@@ -594,7 +589,7 @@ export async function executePreparedCliRun(
               backend,
               providerId: context.backendResolved.id,
               shouldInjectToolInlineMarkers: shouldInjectToolInlineMarkersHeadless,
-              onAssistantDelta: ({ text, delta, thinkingDelta, thinkingText, replacement }) => {
+              onAssistantDelta: ({ text, delta, thinkingDelta, thinkingText }) => {
                 if (thinkingDelta !== undefined && thinkingText !== undefined) {
                   emitAgentEvent({
                     runId: params.runId,
@@ -615,8 +610,6 @@ export async function executePreparedCliRun(
                       delta,
                       context.backendResolved.textTransforms?.output,
                     ),
-                    // See live-session branch above for replacement semantics.
-                    ...(replacement ? { replacement: true } : {}),
                   },
                 });
               },

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -499,7 +499,7 @@ export async function executePreparedCliRun(
             useResume,
             noOutputTimeoutMs,
             getProcessSupervisor: executeDeps.getProcessSupervisor,
-            onAssistantDelta: ({ text, delta, thinkingDelta, thinkingText }) => {
+            onAssistantDelta: ({ text, delta, thinkingDelta, thinkingText, replace }) => {
               if (thinkingDelta !== undefined && thinkingText !== undefined) {
                 emitAgentEvent({
                   runId: params.runId,
@@ -520,6 +520,12 @@ export async function executePreparedCliRun(
                     delta,
                     context.backendResolved.textTransforms?.output,
                   ),
+                  // Forward the full-state replacement signal on the existing
+                  // live-chat `replace` contract so the merger applies the
+                  // shorter timer-cleanup text instead of treating its prefix
+                  // as a stale rollback. Consumed by server-chat's
+                  // resolveMergedAssistantText and the Telegram merger.
+                  ...(replace ? { replace: true } : {}),
                 },
               });
             },
@@ -589,7 +595,7 @@ export async function executePreparedCliRun(
               backend,
               providerId: context.backendResolved.id,
               shouldInjectToolInlineMarkers: shouldInjectToolInlineMarkersHeadless,
-              onAssistantDelta: ({ text, delta, thinkingDelta, thinkingText }) => {
+              onAssistantDelta: ({ text, delta, thinkingDelta, thinkingText, replace }) => {
                 if (thinkingDelta !== undefined && thinkingText !== undefined) {
                   emitAgentEvent({
                     runId: params.runId,
@@ -610,6 +616,8 @@ export async function executePreparedCliRun(
                       delta,
                       context.backendResolved.textTransforms?.output,
                     ),
+                    // See live-session branch above for replace semantics.
+                    ...(replace ? { replace: true } : {}),
                   },
                 });
               },

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -1,6 +1,8 @@
 import crypto from "node:crypto";
+import { normalizeVerboseLevel } from "../../auto-reply/thinking.js";
 import { shouldLogVerbose } from "../../globals.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
+import { getAgentRunContext } from "../../infra/agent-events.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
 import {
   resolveEventSessionKeyForPolicy,
@@ -20,8 +22,10 @@ import {
 } from "../cli-output.js";
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import { classifyFailoverReason } from "../pi-embedded-helpers.js";
+import { sanitizeToolArgs } from "../pi-embedded-subscribe.tools.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { applySkillEnvOverridesFromSnapshot } from "../skills.js";
+import { loadSessionEntryByKey } from "../subagent-announce-delivery.js";
 import { runClaudeLiveSessionTurn, shouldUseClaudeLiveSession } from "./claude-live-session.js";
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
 import {
@@ -456,6 +460,37 @@ export async function executePreparedCliRun(
           claudeSkillsPluginCleanupOwned = true;
           const ownedPreparedBackendCleanup = context.preparedBackend.cleanup;
           context.preparedBackend.cleanup = undefined;
+          // Per-tool-emission verbose resolver — mirrors
+          // server-chat.ts:resolveToolVerboseLevel:
+          //   1. run context's verbose level (registered at run start)
+          //   2. session entry's verbose level when newer than run start
+          //      (covers sessions.patch updates that don't refresh the run ctx)
+          //   3. config default
+          // Reading the session entry per-tool catches mid-run verbose-off
+          // toggles that persist via sessions.patch without updating the
+          // run-context registry.
+          const shouldInjectToolInlineMarkers = (): boolean => {
+            const ctx = getAgentRunContext(params.runId);
+            const runVerbose = normalizeVerboseLevel(ctx?.verboseLevel);
+            const sessionEntry = params.sessionKey
+              ? loadSessionEntryByKey(params.sessionKey)
+              : undefined;
+            const sessionVerbose = normalizeVerboseLevel(sessionEntry?.verboseLevel);
+            const sessionUpdatedAt =
+              typeof sessionEntry?.updatedAt === "number" ? sessionEntry.updatedAt : undefined;
+            const sessionChangedAfterRunStarted =
+              sessionUpdatedAt !== undefined &&
+              ctx?.registeredAt !== undefined &&
+              sessionUpdatedAt >= ctx.registeredAt;
+            const resolved =
+              (sessionVerbose && (!runVerbose || sessionChangedAfterRunStarted)
+                ? sessionVerbose
+                : undefined) ??
+              runVerbose ??
+              normalizeVerboseLevel(params.config?.agents?.defaults?.verboseDefault) ??
+              "off";
+            return resolved !== "off";
+          };
           const liveResult = await runClaudeLiveSessionTurn({
             context,
             args,
@@ -464,7 +499,15 @@ export async function executePreparedCliRun(
             useResume,
             noOutputTimeoutMs,
             getProcessSupervisor: executeDeps.getProcessSupervisor,
-            onAssistantDelta: ({ text, delta }) => {
+            onAssistantDelta: ({ text, delta, thinkingDelta, thinkingText, replacement }) => {
+              if (thinkingDelta !== undefined && thinkingText !== undefined) {
+                emitAgentEvent({
+                  runId: params.runId,
+                  stream: "thinking",
+                  data: { text: thinkingText, delta: thinkingDelta },
+                });
+                return;
+              }
               emitAgentEvent({
                 runId: params.runId,
                 stream: "assistant",
@@ -477,9 +520,33 @@ export async function executePreparedCliRun(
                     delta,
                     context.backendResolved.textTransforms?.output,
                   ),
+                  // Forward the replacement signal so live-chat's merger
+                  // honours intentionally-shorter assistant text (e.g.
+                  // rolling-timer terminal cleanup) instead of treating
+                  // it as a stale partial-chunk rollback.
+                  ...(replacement ? { replacement: true } : {}),
                 },
               });
             },
+            onToolEvent: (evt) => {
+              emitAgentEvent({
+                runId: params.runId,
+                stream: "tool",
+                data: {
+                  phase: evt.phase,
+                  name: evt.name,
+                  // Defense-in-depth: the parser already sanitizes args
+                  // before invoking this callback. Re-running the helper
+                  // here costs nothing and guarantees the channel-side
+                  // tool-event contract is honoured even if a future
+                  // parser change forgets the pre-sanitize step.
+                  args: evt.args ? sanitizeToolArgs(evt.args) : undefined,
+                  itemId: evt.itemId,
+                  toolCallId: evt.itemId,
+                },
+              });
+            },
+            shouldInjectToolInlineMarkers,
             cleanup: async () => {
               try {
                 await claudeSkillsPlugin.cleanup();
@@ -499,11 +566,43 @@ export async function executePreparedCliRun(
             ),
           };
         }
+        // Same session-aware per-emission resolver as the live-session branch.
+        const shouldInjectToolInlineMarkersHeadless = (): boolean => {
+          const ctx = getAgentRunContext(params.runId);
+          const runVerbose = normalizeVerboseLevel(ctx?.verboseLevel);
+          const sessionEntry = params.sessionKey
+            ? loadSessionEntryByKey(params.sessionKey)
+            : undefined;
+          const sessionVerbose = normalizeVerboseLevel(sessionEntry?.verboseLevel);
+          const sessionUpdatedAt =
+            typeof sessionEntry?.updatedAt === "number" ? sessionEntry.updatedAt : undefined;
+          const sessionChangedAfterRunStarted =
+            sessionUpdatedAt !== undefined &&
+            ctx?.registeredAt !== undefined &&
+            sessionUpdatedAt >= ctx.registeredAt;
+          const resolved =
+            (sessionVerbose && (!runVerbose || sessionChangedAfterRunStarted)
+              ? sessionVerbose
+              : undefined) ??
+            runVerbose ??
+            normalizeVerboseLevel(params.config?.agents?.defaults?.verboseDefault) ??
+            "off";
+          return resolved !== "off";
+        };
         const streamingParser = hasJsonlOutput
           ? createCliJsonlStreamingParser({
               backend,
               providerId: context.backendResolved.id,
-              onAssistantDelta: ({ text, delta }) => {
+              shouldInjectToolInlineMarkers: shouldInjectToolInlineMarkersHeadless,
+              onAssistantDelta: ({ text, delta, thinkingDelta, thinkingText, replacement }) => {
+                if (thinkingDelta !== undefined && thinkingText !== undefined) {
+                  emitAgentEvent({
+                    runId: params.runId,
+                    stream: "thinking",
+                    data: { text: thinkingText, delta: thinkingDelta },
+                  });
+                  return;
+                }
                 emitAgentEvent({
                   runId: params.runId,
                   stream: "assistant",
@@ -516,6 +615,22 @@ export async function executePreparedCliRun(
                       delta,
                       context.backendResolved.textTransforms?.output,
                     ),
+                    // See live-session branch above for replacement semantics.
+                    ...(replacement ? { replacement: true } : {}),
+                  },
+                });
+              },
+              onToolEvent: (evt) => {
+                emitAgentEvent({
+                  runId: params.runId,
+                  stream: "tool",
+                  data: {
+                    phase: evt.phase,
+                    name: evt.name,
+                    // Defense-in-depth — see live-session branch above.
+                    args: evt.args ? sanitizeToolArgs(evt.args) : undefined,
+                    itemId: evt.itemId,
+                    toolCallId: evt.itemId,
                   },
                 });
               },

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -24,8 +24,21 @@ export function resolveMergedAssistantText(params: {
   previousText: string;
   nextText: string;
   nextDelta: string;
+  /**
+   * When true, treat `nextText` as a full state replacement — bypass the
+   * "previousText.startsWith(nextText) → keep previousText" rollback branch
+   * that normally guards against out-of-order partial chunks. Used by
+   * emitters that intentionally shrink the assistant text (e.g. the CLI
+   * tool-use rolling-timer's terminal cleanup, which strips a `_ Ns ..._`
+   * suffix on result/finish and would otherwise leave the stale tick
+   * visible because the merger interprets the shorter text as stale).
+   */
+  replacement?: boolean;
 }): string {
-  const { previousText, nextText, nextDelta } = params;
+  const { previousText, nextText, nextDelta, replacement } = params;
+  if (replacement) {
+    return capLiveAssistantBuffer(nextText);
+  }
   if (nextText && previousText) {
     if (nextText.startsWith(previousText) && nextText.length > previousText.length) {
       return capLiveAssistantBuffer(nextText);

--- a/src/gateway/server-chat.stream-text-merge.test.ts
+++ b/src/gateway/server-chat.stream-text-merge.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  MAX_LIVE_CHAT_BUFFER_CHARS,
-  resolveMergedAssistantText,
-} from "./live-chat-projector.js";
+import { MAX_LIVE_CHAT_BUFFER_CHARS, resolveMergedAssistantText } from "./live-chat-projector.js";
 
 describe("server chat stream text merge", () => {
   it.each([
@@ -58,6 +55,29 @@ describe("server chat stream text merge", () => {
         nextDelta: "\nAfter tool call",
       }),
     ).toBe("Before tool call\nAfter tool call");
+  });
+
+  it("keeps the longer buffer when a shorter prefix arrives without a replacement signal", () => {
+    expect(
+      resolveMergedAssistantText({
+        previousText: "Reply body\n\n_ 12s — 21:04:31_",
+        nextText: "Reply body",
+        nextDelta: "",
+      }),
+    ).toBe("Reply body\n\n_ 12s — 21:04:31_");
+  });
+
+  it("replaces the buffer with a shorter prefix when the replacement signal is set", () => {
+    // Rolling-timer terminal cleanup: the tick suffix is stripped, leaving a
+    // shorter prefix that must win over the timer-painted buffer.
+    expect(
+      resolveMergedAssistantText({
+        previousText: "Reply body\n\n_ 12s — 21:04:31_",
+        nextText: "Reply body",
+        nextDelta: "",
+        replacement: true,
+      }),
+    ).toBe("Reply body");
   });
 
   it("caps merged live text while preserving the newest assistant output", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -505,7 +505,7 @@ export function createAgentEventHandler({
     seq: number,
     text: string,
     delta?: unknown,
-    opts?: { controlUiVisible?: boolean },
+    opts?: { controlUiVisible?: boolean; replace?: boolean },
   ) => {
     const cleaned = normalizeLiveAssistantEventText({ text, delta });
     const previousRawText = chatRunState.rawBuffers.get(clientRunId) ?? "";
@@ -513,6 +513,10 @@ export function createAgentEventHandler({
       previousText: previousRawText,
       nextText: cleaned.text,
       nextDelta: cleaned.delta,
+      // Honour the live-chat `replace` contract so a shorter full-state
+      // text (e.g. rolling-timer cleanup) replaces the buffer instead of
+      // being kept as a prefix rollback.
+      replacement: opts?.replace === true,
     });
     if (!mergedRawText) {
       return;
@@ -1059,6 +1063,7 @@ export function createAgentEventHandler({
       ) {
         emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text, evt.data.delta, {
           controlUiVisible: isControlUiVisible,
+          replace: evt.data.replace === true,
         });
       }
     }


### PR DESCRIPTION
## Summary

- **Problem.** When a tool runs mid-turn, the Telegram reasoning ("Thinking") message goes silent — no signal which tool is running or that the turn is still alive. On slow tools (`Read`/`Bash`/`Grep`/`WebFetch`) the user sees a frozen indicator and abandons a turn that's still in flight.
- **What changed.** Two parts that close the loop for CLI backends:
  1. **Detect** — the claude `stream-json` JSONL parser now spots `tool_use`/`server_tool_use`/`mcp_tool_use` blocks and emits a `stream:"tool"` agent-event (`{phase, name, args, toolCallId}`), which `followup-runner` already turns into `onToolStart`.
  2. **Interleave** — the Telegram dispatcher injects that tool-progress into the reasoning-lane rolling message (`[HH:MM:SS] 🛠️ ToolName: detail` + a rolling `Ns — HH:MM` timer) instead of a separate channel-progress message, falling back to the legacy per-tool message when the reasoning lane isn't active.
- **Scope boundary.** Gated by the claude `stream-json` dialect — non-Claude CLI backends untouched. Reuses upstream's `followup-runner` (`stream:"tool"` → `onToolStart`) rather than adding a new consumer. No change to tool execution; the embedded path is unaffected (it already emits tool events upstream).
- **AI-assisted:** yes — drafted with Claude.

## Real behavior proof

- **Behavior addressed:** during a turn that invokes tools, the reasoning message shows interleaved `[HH:MM:SS] 🛠️ ToolName` lines + a rolling elapsed timer in one updating message, instead of a silent gap or a separate progress message.
- **Real environment tested:** Windows 11 Pro 26200, Node v24.12.0, live OpenClaw gateway delivering over Telegram, Opus.
- **Exact steps or command run after this patch:** `unset NODE_OPTIONS && pnpm exec vitest run extensions/telegram/src/bot-message-dispatch.test.ts`; then a live Telegram turn that invokes one or more tools; observe the interleaved tool lines + the rolling timer in the single reasoning message, and the timer stripping when assistant text resumes.
- **Evidence after fix:** live Telegram capture of the interleaved rolling-timer message: ![telegram rolling-timer](https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof-assets/pr-82285/.proof/telegram-rolling-timer.jpg). Each `[HH:MM:SS] 🛠️ …` line is one `onToolStart` injected into the reasoning draft.
- **Observed result after fix:** tool calls render as `[HH:MM:SS] 🛠️ ToolName: detail` lines inside the reasoning message with the timer ticking; when assistant text resumes the timer line is stripped and text continues from a clean boundary.
- **What was not tested:** non-Telegram channels (Telegram-only renderer); the focused `bot-message-dispatch` interleave unit test is the planned guardrail to land with this change.

## Change Type

- [x] Feature

## Scope

- [x] Integrations

## Linked

- Consumes the `onToolStart` surface that `followup-runner` drives from the `stream:"tool"` agent-event bus — no new event surface introduced here.

## Risks and Mitigations

- **Risk:** the rolling-timer `setInterval` leaks if a turn ends without a following assistant delta (e.g. abort mid-tool).
  - **Mitigation:** the interval is cleared on the reasoning-lane cleanup path, on the next assistant delta, and on turn finalize; the dispatcher owns the handle and clears it on every terminal path.
- **Risk:** the injected `_Ns — HH:MM_` line could confuse a strict-Markdown consumer.
  - **Mitigation:** Telegram-only surface, rendered verbatim; the marker uses a conservative Markdown-safe shape.
- **Risk:** interleaving could duplicate reasoning text into both the answer and reasoning lanes.
  - **Mitigation:** finalize forces the reasoning lane closed when interleaved output is set, so the rolling message resolves cleanly instead of double-delivering.

## Security Impact

- **New permissions/capabilities:** No.
- **Secrets/tokens handling changed:** No.
- **New/changed network calls:** No.
- **Command/tool execution surface changed:** No — renders that tools are in flight; executes nothing.
- **Data access scope changed:** No.

## Compatibility / Migration

- Backward compatible: falls back to the existing per-tool channel-progress message when the reasoning lane isn't active. No new config or env vars.

