### PR TITLE
[codex] Show effective model picker runtime

### DIFF
--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -393,6 +393,11 @@ describe("handleModelsCommand", () => {
       label: "OpenAI Codex",
       description: "Run openai models through the codex harness.",
     });
+    expect(data.runtimeChoicesByProvider?.get("openai")?.[1]).toEqual({
+      id: "pi",
+      label: "OpenClaw Pi Default",
+      description: "Use the built-in OpenClaw Pi runtime.",
+    });
   });
 
   it("keeps custom OpenAI-compatible providers on the Pi default runtime choice", async () => {
@@ -441,6 +446,11 @@ describe("handleModelsCommand", () => {
       id: "codex",
       label: "OpenAI Codex",
       description: "Run openai models through the codex harness.",
+    });
+    expect(data.runtimeChoicesByProvider?.get("openai")?.[1]).toEqual({
+      id: "pi",
+      label: "OpenClaw Pi Default",
+      description: "Use the built-in OpenClaw Pi runtime.",
     });
   });
 

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -454,6 +454,31 @@ describe("handleModelsCommand", () => {
     });
   });
 
+  it("does not use another provider's first model override as that provider's default runtime choice", async () => {
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { provider: "openai", id: "gpt-5.5", name: "GPT-5.5" },
+      { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
+      { provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet" },
+    ]);
+
+    const data = await buildModelsProviderData({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          models: {
+            "anthropic/claude-opus-4-5": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(data.runtimeChoicesByProvider?.get("anthropic")?.[0]).toEqual({
+      id: "pi",
+      label: "OpenClaw Pi Default",
+      description: "Use the built-in OpenClaw Pi runtime.",
+    });
+  });
+
   it("keeps the telegram provider picker browse-only", async () => {
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
       { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -379,8 +379,31 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).not.toMatch(/^- google-gemini-cli \(/m);
   });
 
-  it("labels the default runtime choice as OpenClaw Pi", async () => {
+  it("labels the OpenAI default runtime choice as Codex", async () => {
     const data = await buildModelsProviderData({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(data.runtimeChoicesByProvider?.get("openai")?.[0]).toEqual({
+      id: "codex",
+      label: "OpenAI Codex",
+      description: "Run openai models through the codex harness.",
+    });
+  });
+
+  it("keeps custom OpenAI-compatible providers on the Pi default runtime choice", async () => {
+    const data = await buildModelsProviderData({
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://openai-compatible.example.test/v1",
+          },
+        },
+      },
       agents: {
         defaults: {
           model: { primary: "openai/gpt-5.5" },
@@ -392,6 +415,32 @@ describe("handleModelsCommand", () => {
       id: "pi",
       label: "OpenClaw Pi Default",
       description: "Use the built-in OpenClaw Pi runtime.",
+    });
+  });
+
+  it("lets exact model runtime policy override provider runtime policy in picker choices", async () => {
+    const data = await buildModelsProviderData({
+      models: {
+        providers: {
+          openai: {
+            agentRuntime: { id: "pi" },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          models: {
+            "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+          },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(data.runtimeChoicesByProvider?.get("openai")?.[0]).toEqual({
+      id: "codex",
+      label: "OpenAI Codex",
+      description: "Run openai models through the codex harness.",
     });
   });
 

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -3,6 +3,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
+import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
 import { resolveVisibleModelCatalog } from "../../agents/model-catalog-visibility.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
@@ -36,6 +37,13 @@ const PAGE_SIZE_DEFAULT = 20;
 const PAGE_SIZE_MAX = 100;
 const MODELS_ADD_DEPRECATED_TEXT =
   "⚠️ /models add is deprecated. Use /models to browse providers and /model to switch models.";
+const RUNTIME_CHOICE_LABELS: Readonly<Record<string, string>> = {
+  pi: "OpenClaw Pi Default",
+  codex: "OpenAI Codex",
+  "codex-cli": "OpenAI Codex",
+  "claude-cli": "Claude CLI",
+  "google-gemini-cli": "Gemini CLI",
+};
 
 type ModelsCommandSessionEntry = Partial<
   Pick<SessionEntry, "authProfileOverride" | "modelProvider" | "model">
@@ -77,6 +85,70 @@ function isModelsBrowseVisibleProvider(provider: string): boolean {
 
 function usesUnfilteredCatalogModels(provider: string): boolean {
   return isCliRuntimeProvider(provider);
+}
+
+function normalizeRuntimeChoiceId(runtime: string | undefined): string {
+  const trimmed = runtime?.trim();
+  if (!trimmed || trimmed === "auto" || trimmed === "default") {
+    return "pi";
+  }
+  return normalizeLowercaseStringOrEmpty(trimmed) || "pi";
+}
+
+function runtimeChoiceFor(params: {
+  provider: string;
+  runtime: string;
+  cli?: boolean;
+}): ModelsRuntimeChoice {
+  if (params.runtime === "pi") {
+    return {
+      id: "pi",
+      label: "OpenClaw Pi Default",
+      description: "Use the built-in OpenClaw Pi runtime.",
+    };
+  }
+  return {
+    id: params.runtime,
+    label: RUNTIME_CHOICE_LABELS[params.runtime] ?? params.runtime,
+    description: params.cli
+      ? `Run ${params.provider} models through ${params.runtime}.`
+      : `Run ${params.provider} models through the ${params.runtime} harness.`,
+  };
+}
+
+function resolveProviderDefaultRuntimeChoice(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  resolvedDefault: { provider: string; model: string };
+  byProvider: ReadonlyMap<string, ReadonlySet<string>>;
+  agentId?: string;
+}): string {
+  const modelId =
+    params.resolvedDefault.provider === params.provider
+      ? params.resolvedDefault.model
+      : params.byProvider.get(params.provider)?.values().next().value;
+  if (!modelId) {
+    return "pi";
+  }
+  return normalizeRuntimeChoiceId(
+    resolveAgentHarnessPolicy({
+      config: params.cfg,
+      provider: params.provider,
+      modelId,
+      agentId: params.agentId,
+    }).runtime,
+  );
+}
+
+function addRuntimeChoice(
+  choices: ModelsRuntimeChoice[],
+  choice: ModelsRuntimeChoice,
+): ModelsRuntimeChoice[] {
+  if (choices.some((existing) => existing.id === choice.id)) {
+    return choices;
+  }
+  choices.push(choice);
+  return choices;
 }
 
 export async function buildModelsProviderData(
@@ -222,20 +294,29 @@ export async function buildModelsProviderData(
   const runtimeChoicesByProvider = new Map<string, ModelsRuntimeChoice[]>();
   for (const alias of listLegacyRuntimeModelProviderAliases()) {
     const provider = normalizeProviderId(alias.provider);
-    const choices = runtimeChoicesByProvider.get(provider) ?? [
-      {
-        id: "pi",
-        label: "OpenClaw Pi Default",
-        description: "Use the built-in OpenClaw Pi runtime.",
-      },
-    ];
-    choices.push({
-      id: alias.runtime,
-      label: alias.runtime,
-      description: alias.cli
-        ? `Run ${provider} models through ${alias.runtime}.`
-        : `Run ${provider} models through the ${alias.runtime} harness.`,
-    });
+    const choices =
+      runtimeChoicesByProvider.get(provider) ??
+      addRuntimeChoice(
+        [],
+        runtimeChoiceFor({
+          provider,
+          runtime: resolveProviderDefaultRuntimeChoice({
+            cfg,
+            provider,
+            resolvedDefault,
+            byProvider,
+            agentId,
+          }),
+        }),
+      );
+    addRuntimeChoice(
+      choices,
+      runtimeChoiceFor({
+        provider,
+        runtime: normalizeRuntimeChoiceId(alias.runtime),
+        cli: alias.cli,
+      }),
+    );
     runtimeChoicesByProvider.set(provider, choices);
   }
 

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -294,21 +294,23 @@ export async function buildModelsProviderData(
   const runtimeChoicesByProvider = new Map<string, ModelsRuntimeChoice[]>();
   for (const alias of listLegacyRuntimeModelProviderAliases()) {
     const provider = normalizeProviderId(alias.provider);
+    const defaultRuntime = resolveProviderDefaultRuntimeChoice({
+      cfg,
+      provider,
+      resolvedDefault,
+      byProvider,
+      agentId,
+    });
     const choices =
       runtimeChoicesByProvider.get(provider) ??
       addRuntimeChoice(
         [],
         runtimeChoiceFor({
           provider,
-          runtime: resolveProviderDefaultRuntimeChoice({
-            cfg,
-            provider,
-            resolvedDefault,
-            byProvider,
-            agentId,
-          }),
+          runtime: defaultRuntime,
         }),
       );
+    addRuntimeChoice(choices, runtimeChoiceFor({ provider, runtime: "pi" }));
     addRuntimeChoice(
       choices,
       runtimeChoiceFor({

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -120,16 +120,10 @@ function resolveProviderDefaultRuntimeChoice(params: {
   cfg: OpenClawConfig;
   provider: string;
   resolvedDefault: { provider: string; model: string };
-  byProvider: ReadonlyMap<string, ReadonlySet<string>>;
   agentId?: string;
 }): string {
   const modelId =
-    params.resolvedDefault.provider === params.provider
-      ? params.resolvedDefault.model
-      : params.byProvider.get(params.provider)?.values().next().value;
-  if (!modelId) {
-    return "pi";
-  }
+    params.resolvedDefault.provider === params.provider ? params.resolvedDefault.model : undefined;
   return normalizeRuntimeChoiceId(
     resolveAgentHarnessPolicy({
       config: params.cfg,
@@ -298,7 +292,6 @@ export async function buildModelsProviderData(
       cfg,
       provider,
       resolvedDefault,
-      byProvider,
       agentId,
     });
     const choices =


### PR DESCRIPTION
## Summary

- Problem: model picker runtime metadata put the static Pi choice first even when the effective OpenAI harness policy resolves to Codex.
- Why it matters: users could think a model switch would run through Pi when execution would actually use Codex.
- What changed: `buildModelsProviderData` now orders runtime choices from `resolveAgentHarnessPolicy`, labels known harnesses consistently, preserves Pi as an alternate runtime choice, and avoids using an arbitrary first model to decide non-default provider runtime ordering.
- What did NOT change: wildcard runtime matching/model expansion remains in the separate wildcard PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82269
- Related #82243
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: model picker/provider data runtime choices showed `OpenClaw Pi Default` first for official OpenAI even though execution resolves official OpenAI to the Codex harness by default.

Real environment tested: local OpenClaw source checkout on branch `models_runtime_transparency`; focused provider-data path used by `/models` and `/model` picker metadata; companion Crabbox/browser artifact from #82283 exercises the same `buildModelsProviderData` path visually.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/reply/commands-models.test.ts -t "runtime choice"`, `node_modules/.bin/oxfmt --check src/auto-reply/reply/commands-models.ts src/auto-reply/reply/commands-models.test.ts`, and `git diff --check -- src/auto-reply/reply/commands-models.ts src/auto-reply/reply/commands-models.test.ts`.

Evidence after fix: focused test output from this branch showed `Test Files 1 passed`, `Tests 3 passed | 18 skipped`; the asserted picker/provider-data results are official OpenAI first choice `codex`, Pi preserved as an alternate choice, custom OpenAI-compatible provider first choice Pi, exact model runtime override respected for the active default model, and non-default provider ordering not driven by a first model-specific override. Companion visual proof for the same picker/provider-data bug is attached at https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82283/model-picker-runtime-82283/20260515-190427-305645407/model-picker-runtime-before-after-proof.png.

Observed result after fix: `runtimeChoicesByProvider.get("openai")` now exposes the effective Codex runtime first for official OpenAI, while still keeping Pi available; non-default providers resolve their provider-wide policy instead of inheriting an arbitrary exact-model override from the first visible model.

What was not tested: live Discord slash-command end-to-end on this branch; full repository test suite.

Before evidence (optional but encouraged): user-provided Discord screenshot showed the picker defaulting to `OpenClaw Pi Default` for the OpenAI model flow; #82283's before/after artifact demonstrates the same incorrect first-choice behavior and the corrected picker result.

## Root Cause (if applicable)

- Root cause: picker metadata constructed runtime choices from legacy runtime aliases and a hard-coded Pi default instead of asking the same harness policy resolver used by runtime execution.
- Missing detection / guardrail: tests covered the static Pi label but not effective runtime policy for official OpenAI, custom OpenAI-compatible providers, exact model overrides, or non-default provider ordering.
- Contributing context: runtime transparency was added separately from the runtime policy path, so picker metadata drifted from execution behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/commands-models.test.ts`
- Scenario the test should lock in: OpenAI default runtime choice reflects Codex, Pi remains selectable, custom OpenAI-compatible providers stay Pi-first, exact model runtime policy wins for the active default, and non-default providers do not use a first model-specific override as provider-wide runtime ordering.
- Why this is the smallest reliable guardrail: `buildModelsProviderData` is the shared source for channel picker/provider data.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Model picker runtime metadata now shows the effective runtime first instead of always showing Pi first.

## Diagram (if applicable)

```text
Before:
[/models provider data] -> [hard-coded Pi first] -> [runtime metadata can disagree with execution]

After:
[/models provider data] -> [resolve harness policy] -> [effective runtime first, Pi preserved]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local OpenClaw source checkout
- Model/provider: `openai/gpt-5.5`, custom OpenAI-compatible provider, model-specific runtime override fixture
- Integration/channel (if any): shared model picker/provider data
- Relevant config (redacted): test fixtures cover official OpenAI, custom OpenAI `baseUrl`, and exact model runtime override config

### Steps

1. Build model provider data for default `openai/gpt-5.5`.
2. Inspect `runtimeChoicesByProvider.get("openai")`.
3. Repeat with custom OpenAI-compatible `baseUrl`, exact model runtime policy override, and a non-default provider whose first visible model has an exact runtime override.

### Expected

- Official OpenAI defaults show Codex first and keep Pi available.
- Custom OpenAI-compatible providers keep Pi first.
- Exact model runtime policy wins for the active default model.
- Non-default provider runtime choices do not inherit arbitrary first-model overrides.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused test suite for `/models` provider data, formatting, whitespace, and the review-requested non-default provider ordering regression.
- Edge cases checked: OpenAI implicit Codex default, custom OpenAI-compatible `baseUrl`, exact model runtime override, Pi preserved as an alternate choice, and non-default provider model override not leaking into provider-wide ordering.
- What you did **not** verify: live Discord slash command; full repository test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: callers that assumed Pi was always first will see Codex first for official OpenAI.
  - Mitigation: the new order reflects actual execution policy, and Pi remains present as an alternate choice.
- Risk: provider-level runtime choice could be skewed by a model-specific override.
  - Mitigation: non-default providers now resolve provider-wide policy without a model id; exact model policy still applies to the active default model.
