### PR TITLE
fix(agents): honor subagent cron fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Release tooling: align the published launcher Node floor, `npm start`, package script checks, sharded lint locking, Vitest root project coverage, and plugin-SDK declaration build cache metadata so release/package validation does not silently skip or ship stale surfaces.
+- Agents/subagents: honor `subagents.model.fallbacks` for isolated cron embedded runs, so subagent model timeouts can fall back through the configured child-agent chain. Fixes #74985. Thanks @chrisgwynne.
 - Codex app-server/MCP: scope user MCP servers to specific OpenClaw agent ids through an optional `mcp.servers.<name>.codex.agents` list and accept `codex.defaultToolsApprovalMode` (`auto`/`prompt`/`approve`) for native Codex approval defaults; OpenClaw strips the `codex` block before handing `mcp_servers` config to Codex. (#82180) Thanks @sercada.
 - Agents/OpenAI Responses: clamp `input_tokens - cached_tokens` at zero and reconstruct `totalTokens` from input + output + cached components so Responses-API streams report consistent usage when providers under-report `input_tokens` relative to `cached_tokens`.
 - Plugins: reject malformed `package.json` `openclaw.extensions` metadata during install, discovery, and post-update payload smoke instead of silently dropping invalid entries.

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -16,6 +16,7 @@ import {
   resolveAgentModelFallbacksOverride,
   resolveAgentModelPrimary,
   resolveRunModelFallbacksOverride,
+  resolveSubagentModelConfigSelection,
   resolveSubagentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
   resolveAgentIdByWorkspacePath,
@@ -548,6 +549,16 @@ describe("resolveAgentConfig", () => {
             },
           },
           {
+            id: "metadata-only-subagent",
+            model: {
+              primary: "anthropic/claude-sonnet-4-6",
+              fallbacks: ["google/gemini-3-pro"],
+            },
+            subagents: {
+              model: { timeoutMs: 1_000 },
+            },
+          },
+          {
             id: "default-subagent",
           },
           {
@@ -567,11 +578,65 @@ describe("resolveAgentConfig", () => {
     expect(resolveSubagentModelFallbacksOverride(cfg, "agent-model")).toEqual([
       "google/gemini-3-pro",
     ]);
+    expect(resolveSubagentModelFallbacksOverride(cfg, "metadata-only-subagent")).toEqual([
+      "google/gemini-3-pro",
+    ]);
     expect(resolveSubagentModelFallbacksOverride(cfg, "default-subagent")).toEqual([
       "openai-codex/gpt-5.4",
       "zai/glm-5",
     ]);
     expect(resolveSubagentModelFallbacksOverride(cfg, "strict")).toStrictEqual([]);
+  });
+
+  it("resolves the subagent model config selected for isolated runs", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          subagents: { model: "openai/gpt-5.4" },
+        },
+        list: [
+          {
+            id: "agent-model",
+            model: {
+              primary: "anthropic/claude-sonnet-4-6",
+              fallbacks: ["google/gemini-3-pro"],
+            },
+          },
+          {
+            id: "subagent-model",
+            model: "anthropic/claude-sonnet-4-6",
+            subagents: {
+              model: {
+                primary: "kimi/kimi-code",
+                fallbacks: ["openai-codex/gpt-5.4"],
+              },
+            },
+          },
+          {
+            id: "metadata-only-subagent",
+            model: "anthropic/claude-sonnet-4-6",
+            subagents: {
+              model: { timeoutMs: 1_000 },
+            },
+          },
+        ],
+      },
+    };
+
+    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "agent-model" })).toEqual({
+      primary: "anthropic/claude-sonnet-4-6",
+      fallbacks: ["google/gemini-3-pro"],
+    });
+    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "subagent-model" })).toEqual({
+      primary: "kimi/kimi-code",
+      fallbacks: ["openai-codex/gpt-5.4"],
+    });
+    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "metadata-only-subagent" })).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
+    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "default-subagent" })).toBe(
+      "openai/gpt-5.4",
+    );
   });
 
   it("should return agent-specific sandbox config", () => {

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -16,6 +16,7 @@ import {
   resolveAgentModelFallbacksOverride,
   resolveAgentModelPrimary,
   resolveRunModelFallbacksOverride,
+  resolveSubagentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
   resolveAgentIdByWorkspacePath,
   resolveAgentIdsByWorkspacePath,
@@ -512,6 +513,65 @@ describe("resolveAgentConfig", () => {
         sessionKey: "agent:main:session",
       }),
     ).toBe(false);
+  });
+
+  it("resolves subagent model fallbacks from the selected subagent model source", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["openai/gpt-5.4"],
+          },
+          subagents: {
+            model: {
+              primary: "kimi/kimi-code",
+              fallbacks: ["openai-codex/gpt-5.4", "zai/glm-5"],
+            },
+          },
+        },
+        list: [
+          {
+            id: "research",
+            subagents: {
+              model: {
+                primary: "kimi/kimi-code",
+                fallbacks: ["openai-codex/gpt-5.4", "zai/glm-5"],
+              },
+            },
+          },
+          {
+            id: "agent-model",
+            model: {
+              primary: "anthropic/claude-sonnet-4-6",
+              fallbacks: ["google/gemini-3-pro"],
+            },
+          },
+          {
+            id: "default-subagent",
+          },
+          {
+            id: "strict",
+            subagents: {
+              model: "kimi/kimi-code",
+            },
+          },
+        ],
+      },
+    };
+
+    expect(resolveSubagentModelFallbacksOverride(cfg, "research")).toEqual([
+      "openai-codex/gpt-5.4",
+      "zai/glm-5",
+    ]);
+    expect(resolveSubagentModelFallbacksOverride(cfg, "agent-model")).toEqual([
+      "google/gemini-3-pro",
+    ]);
+    expect(resolveSubagentModelFallbacksOverride(cfg, "default-subagent")).toEqual([
+      "openai-codex/gpt-5.4",
+      "zai/glm-5",
+    ]);
+    expect(resolveSubagentModelFallbacksOverride(cfg, "strict")).toStrictEqual([]);
   });
 
   it("should return agent-specific sandbox config", () => {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -172,16 +172,48 @@ function resolveSelectedModelFallbacksOverride(
   return Array.isArray(raw.fallbacks) ? raw.fallbacks : undefined;
 }
 
+export function resolveSubagentModelConfigSelection(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
+}): AgentModelConfig | undefined {
+  return resolveSubagentModelConfigValue({
+    ...params,
+    select: (raw) => (resolvePrimaryStringValue(raw) ? raw : undefined),
+  });
+}
+
+function resolveSubagentModelConfigValue<T>(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
+  select: (raw: AgentModelConfig | undefined) => T | undefined;
+}): T | undefined {
+  const agentConfig =
+    params.agentConfigOverride ??
+    (params.agentId ? resolveAgentConfig(params.cfg, params.agentId) : undefined);
+  for (const raw of [
+    agentConfig?.subagents?.model,
+    agentConfig?.model,
+    params.cfg.agents?.defaults?.subagents?.model,
+  ]) {
+    const selected = params.select(raw);
+    if (selected !== undefined) {
+      return selected;
+    }
+  }
+  return undefined;
+}
+
 export function resolveSubagentModelFallbacksOverride(
   cfg: OpenClawConfig,
   agentId: string,
 ): string[] | undefined {
-  const agentConfig = resolveAgentConfig(cfg, agentId);
-  return (
-    resolveSelectedModelFallbacksOverride(agentConfig?.subagents?.model) ??
-    resolveAgentModelFallbacksOverride(cfg, agentId) ??
-    resolveSelectedModelFallbacksOverride(cfg.agents?.defaults?.subagents?.model)
-  );
+  return resolveSubagentModelConfigValue({
+    cfg,
+    agentId,
+    select: resolveSelectedModelFallbacksOverride,
+  });
 }
 
 export function resolveFallbackAgentId(params: {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -153,7 +153,12 @@ export function resolveAgentModelFallbacksOverride(
   cfg: OpenClawConfig,
   agentId: string,
 ): string[] | undefined {
-  const raw = resolveAgentConfig(cfg, agentId)?.model;
+  return resolveSelectedModelFallbacksOverride(resolveAgentConfig(cfg, agentId)?.model);
+}
+
+function resolveSelectedModelFallbacksOverride(
+  raw: AgentModelConfig | undefined,
+): string[] | undefined {
   if (!raw) {
     return undefined;
   }
@@ -165,6 +170,18 @@ export function resolveAgentModelFallbacksOverride(
     return Object.hasOwn(raw, "primary") && resolvePrimaryStringValue(raw) ? [] : undefined;
   }
   return Array.isArray(raw.fallbacks) ? raw.fallbacks : undefined;
+}
+
+export function resolveSubagentModelFallbacksOverride(
+  cfg: OpenClawConfig,
+  agentId: string,
+): string[] | undefined {
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  return (
+    resolveSelectedModelFallbacksOverride(agentConfig?.subagents?.model) ??
+    resolveAgentModelFallbacksOverride(cfg, agentId) ??
+    resolveSelectedModelFallbacksOverride(cfg.agents?.defaults?.subagents?.model)
+  );
 }
 
 export function resolveFallbackAgentId(params: {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -479,11 +479,14 @@ export async function runEmbeddedPiAgent(
       const agentDir =
         params.agentDir ?? resolveAgentDir(params.config ?? {}, workspaceResolution.agentId);
       const normalizedSessionKey = params.sessionKey?.trim();
-      const fallbackConfigured = hasConfiguredModelFallbacks({
-        cfg: params.config,
-        agentId: params.agentId,
-        sessionKey: normalizedSessionKey,
-      });
+      const fallbackConfigured =
+        params.modelFallbacksOverride !== undefined
+          ? params.modelFallbacksOverride.length > 0
+          : hasConfiguredModelFallbacks({
+              cfg: params.config,
+              agentId: params.agentId,
+              sessionKey: normalizedSessionKey,
+            });
       const resolvedSessionKey = normalizedSessionKey;
       const hookRunner = getGlobalHookRunner();
       const hookCtx = {

--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -39,6 +39,24 @@ vi.mock("./isolated-agent/run-model-selection.runtime.js", () => ({
   resolveAllowedModelRef: resolveAllowedModelRefMock,
   resolveConfiguredModelRef: resolveConfiguredModelRefMock,
   resolveHooksGmailModel: resolveHooksGmailModelMock,
+  resolveSubagentModelConfigSelection: ({
+    cfg,
+    agentConfigOverride,
+  }: {
+    cfg?: { agents?: { defaults?: { subagents?: { model?: unknown } } } };
+    agentConfigOverride?: { model?: unknown; subagents?: { model?: unknown } };
+  }) => {
+    for (const raw of [
+      agentConfigOverride?.subagents?.model,
+      agentConfigOverride?.model,
+      cfg?.agents?.defaults?.subagents?.model,
+    ]) {
+      if (normalizeModelSelectionMock(raw)) {
+        return raw;
+      }
+    }
+    return undefined;
+  },
 }));
 
 import { resolveCronModelSelection } from "./isolated-agent/model-selection.js";
@@ -612,6 +630,26 @@ describe("cron model formatting and precedence edge cases", () => {
           },
         },
         { provider: "google", model: "gemini-2.5-flash" },
+      );
+    });
+
+    it("falls through metadata-only subagents.model to the agent model", async () => {
+      await expectSelectedModel(
+        {
+          cfg: {
+            agents: {
+              defaults: {
+                model: "anthropic/claude-sonnet-4-6",
+                subagents: { model: "ollama/llama3.2:3b" },
+              },
+            },
+          },
+          agentConfigOverride: {
+            model: { primary: "anthropic/claude-opus-4-6" },
+            subagents: { model: { timeoutMs: 1_000 } },
+          },
+        },
+        { provider: "anthropic", model: "claude-opus-4-6" },
       );
     });
 

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -1,3 +1,4 @@
+import type { AgentConfig } from "../../config/types.agents.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
 import {
@@ -9,6 +10,7 @@ import {
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
+  resolveSubagentModelConfigSelection,
 } from "./run-model-selection.runtime.js";
 
 type CronSessionModelOverrides = {
@@ -19,12 +21,7 @@ type CronSessionModelOverrides = {
 export type ResolveCronModelSelectionParams = {
   cfg: OpenClawConfig;
   cfgWithAgentDefaults: OpenClawConfig;
-  agentConfigOverride?: {
-    model?: unknown;
-    subagents?: {
-      model?: unknown;
-    };
-  };
+  agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
   sessionEntry: CronSessionModelOverrides;
   payload: CronJob["payload"];
   isGmailHook: boolean;
@@ -82,10 +79,13 @@ export async function resolveCronModelSelection(
     return catalog;
   };
 
-  const subagentModelRaw =
-    normalizeModelSelection(params.agentConfigOverride?.subagents?.model) ??
-    normalizeModelSelection(params.agentConfigOverride?.model) ??
-    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model);
+  const subagentModelRaw = normalizeModelSelection(
+    resolveSubagentModelConfigSelection({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      agentConfigOverride: params.agentConfigOverride,
+    }),
+  );
   if (subagentModelRaw) {
     const resolvedSubagent = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,

--- a/src/cron/isolated-agent/run-execution.runtime.ts
+++ b/src/cron/isolated-agent/run-execution.runtime.ts
@@ -1,4 +1,7 @@
-export { resolveEffectiveModelFallbacks } from "../../agents/agent-scope.js";
+export {
+  resolveEffectiveModelFallbacks,
+  resolveSubagentModelFallbacksOverride,
+} from "../../agents/agent-scope.js";
 export { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 export { resolveCronAgentLane } from "../../agents/lanes.js";
 export { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -246,6 +246,7 @@ export function createCronPromptExecutor(params: {
           lane: resolveCronAgentLane(params.lane),
           provider: providerOverride,
           model: modelOverride,
+          modelFallbacksOverride: cronFallbacksOverride,
           authProfileId: params.liveSelection.authProfileId,
           authProfileIdSource: params.liveSelection.authProfileId
             ? params.liveSelection.authProfileIdSource

--- a/src/cron/isolated-agent/run-fallback-policy.test.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.test.ts
@@ -71,6 +71,88 @@ describe("resolveCronFallbacksOverride", () => {
     ).toStrictEqual([]);
   });
 
+  it("uses configured subagent model fallbacks for isolated agent turns", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-opus-4-6",
+                fallbacks: ["openai/gpt-5.4"],
+              },
+              subagents: {
+                model: {
+                  primary: "kimi/kimi-code",
+                  fallbacks: ["openai-codex/gpt-5.4", "zai/glm-5"],
+                },
+              },
+            },
+          },
+        },
+        agentId: "main",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toEqual(["openai-codex/gpt-5.4", "zai/glm-5"]);
+  });
+
+  it("treats string subagent model selection as strict when no fallbacks are configured", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-opus-4-6",
+                fallbacks: ["openai/gpt-5.4"],
+              },
+              subagents: {
+                model: "kimi/kimi-code",
+              },
+            },
+          },
+        },
+        agentId: "main",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps payload model overrides on the configured model fallback policy", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-opus-4-6",
+                fallbacks: ["openai/gpt-5.4"],
+              },
+              subagents: {
+                model: {
+                  primary: "kimi/kimi-code",
+                  fallbacks: ["openai-codex/gpt-5.4", "zai/glm-5"],
+                },
+              },
+            },
+          },
+        },
+        agentId: "main",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+          model: "google/gemini-3-pro",
+        }),
+      }),
+    ).toEqual(["openai/gpt-5.4"]);
+  });
+
   it("leaves the default model path to the fallback runner when no payload model is set", () => {
     expect(
       resolveCronFallbacksOverride({

--- a/src/cron/isolated-agent/run-fallback-policy.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
-import { resolveEffectiveModelFallbacks } from "./run-execution.runtime.js";
+import {
+  resolveEffectiveModelFallbacks,
+  resolveSubagentModelFallbacksOverride,
+} from "./run-execution.runtime.js";
 
 export function resolveCronFallbacksOverride(params: {
   cfg: OpenClawConfig;
@@ -13,6 +16,9 @@ export function resolveCronFallbacksOverride(params: {
     typeof payload?.model === "string" && payload.model.trim().length > 0;
   return (
     payloadFallbacks ??
+    (!hasCronPayloadModelOverride
+      ? resolveSubagentModelFallbacksOverride(params.cfg, params.agentId)
+      : undefined) ??
     resolveEffectiveModelFallbacks({
       cfg: params.cfg,
       agentId: params.agentId,

--- a/src/cron/isolated-agent/run-model-selection.runtime.ts
+++ b/src/cron/isolated-agent/run-model-selection.runtime.ts
@@ -1,4 +1,5 @@
 export { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
+export { resolveSubagentModelConfigSelection } from "../../agents/agent-scope.js";
 export { loadModelCatalog } from "../../agents/model-catalog.js";
 export {
   getModelRefStatus,

--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -9,7 +9,9 @@ import {
   loadRunCronIsolatedAgentTurn,
   resolveConfiguredModelRefMock,
   resolveAgentModelFallbacksOverrideMock,
+  resolveSubagentModelFallbacksOverrideMock,
   runCliAgentMock,
+  runEmbeddedPiAgentMock,
   runWithModelFallbackMock,
 } from "./run.test-harness.js";
 
@@ -29,6 +31,20 @@ function requireModelFallbackRequest(): {
     | undefined;
   if (!request) {
     throw new Error("Expected model fallback request");
+  }
+  return request;
+}
+
+function requireEmbeddedRunRequest(): {
+  modelFallbacksOverride?: string[];
+} {
+  const request = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as
+    | {
+        modelFallbacksOverride?: string[];
+      }
+    | undefined;
+  if (!request) {
+    throw new Error("Expected embedded run request");
   }
   return request;
 }
@@ -123,5 +139,29 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
       ["claude-cli", "claude-opus-4-6"],
       ["claude-cli", "claude-sonnet-4-6"],
     ]);
+  });
+
+  it("passes resolved subagent fallbacks into the embedded runner", async () => {
+    const subagentFallbacks = ["openai-codex/gpt-5.4", "zai/glm-5"];
+    resolveSubagentModelFallbacksOverrideMock.mockReturnValue(subagentFallbacks);
+    runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
+      const result = await run(provider, model);
+      return { result, provider, model, attempts: [] };
+    });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          payload: {
+            kind: "agentTurn",
+            message: "test",
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(requireModelFallbackRequest().fallbacksOverride).toEqual(subagentFallbacks);
+    expect(requireEmbeddedRunRequest().modelFallbacksOverride).toEqual(subagentFallbacks);
   });
 });

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -164,6 +164,24 @@ vi.mock("./run-model-selection.runtime.js", () => ({
   resolveAllowedModelRef: resolveAllowedModelRefMock,
   resolveConfiguredModelRef: resolveConfiguredModelRefMock,
   resolveHooksGmailModel: resolveHooksGmailModelMock,
+  resolveSubagentModelConfigSelection: ({
+    cfg,
+    agentConfigOverride,
+  }: {
+    cfg?: { agents?: { defaults?: { subagents?: { model?: unknown } } } };
+    agentConfigOverride?: { model?: unknown; subagents?: { model?: unknown } };
+  }) => {
+    for (const raw of [
+      agentConfigOverride?.subagents?.model,
+      agentConfigOverride?.model,
+      cfg?.agents?.defaults?.subagents?.model,
+    ]) {
+      if (normalizeModelSelectionForTest(raw)) {
+        return raw;
+      }
+    }
+    return undefined;
+  },
 }));
 
 vi.mock("./run-execution.runtime.js", () => ({

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -41,6 +41,7 @@ function normalizeModelSelectionForTest(value: unknown): string | undefined {
 export const buildWorkspaceSkillSnapshotMock = createMock();
 export const resolveAgentConfigMock = createMock();
 export const resolveEffectiveModelFallbacksMock = createMock();
+export const resolveSubagentModelFallbacksOverrideMock = createMock();
 export const resolveAgentModelFallbacksOverrideMock = createMock();
 export const resolveAgentSkillsFilterMock = createMock();
 export const getModelRefStatusMock = createMock();
@@ -167,6 +168,7 @@ vi.mock("./run-model-selection.runtime.js", () => ({
 
 vi.mock("./run-execution.runtime.js", () => ({
   resolveEffectiveModelFallbacks: resolveEffectiveModelFallbacksMock,
+  resolveSubagentModelFallbacksOverride: resolveSubagentModelFallbacksOverrideMock,
   resolveBootstrapWarningSignaturesSeen: resolveBootstrapWarningSignaturesSeenMock,
   getCliSessionId: getCliSessionIdMock,
   runCliAgent: runCliAgentMock,
@@ -317,6 +319,8 @@ function resetRunConfigMocks(): void {
       return agentFallbacksOverride ?? defaultFallbacks;
     },
   );
+  resolveSubagentModelFallbacksOverrideMock.mockReset();
+  resolveSubagentModelFallbacksOverrideMock.mockReturnValue(undefined);
   resolveAgentModelFallbacksOverrideMock.mockReturnValue(undefined);
   resolveAgentSkillsFilterMock.mockReturnValue(undefined);
   resolveConfiguredModelRefMock.mockReturnValue({ provider: "openai", model: "gpt-5.4" });


### PR DESCRIPTION
Summary
- Fix isolated cron subagent fallback resolution so subagents.model.fallbacks drives both the outer model fallback runner and the embedded runner fallback flag.
- Preserve payload fallback precedence, keep payload model overrides on their configured default model policy, and keep string subagent models strict.
- Share cron subagent model-config selection between primary model resolution and fallback resolution, including metadata-only model config fallthrough coverage.
- Add regression coverage and changelog entry for #74985.

## Real behavior proof
Behavior addressed: #74985 isolated cron embedded runs with subagents.model.fallbacks now pass the fallback chain into model fallback execution and embedded failover state.
Real environment tested: local checkout, importing the real OpenClaw cron fallback resolver through the TS runtime loader.
Exact steps or command run after this patch: node --import tsx with a cron isolated agentTurn fixture that configures agents.defaults.subagents.model.fallbacks, then the same fixture with payload.model override; node scripts/run-vitest.mjs src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/model-selection.test.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/agents/agent-scope.test.ts src/agents/pi-embedded-runner/run/failover-policy.test.ts; pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/agent-scope.ts src/agents/agent-scope.test.ts src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/model-selection.ts src/cron/isolated-agent/run-model-selection.runtime.ts src/cron/isolated-agent/run.test-harness.ts src/cron/isolated-agent/run-fallback-policy.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/cron/isolated-agent/run-executor.ts src/agents/pi-embedded-runner/run.ts; git diff --check; codex-review --full-access.
Evidence after fix: Terminal output from the runtime resolver probe:
```json
{
  "isolated": [
    "openai-codex/gpt-5.4",
    "zai/glm-5"
  ],
  "payloadOverride": [
    "openai/gpt-5.4"
  ]
}
```
Focused Vitest also passed 6 files / 134 tests after rebase onto origin/main; oxfmt passed; git diff --check passed; codex-review clean after accepted fixups.
Observed result after fix: isolated cron agent turns resolve to the configured subagent fallback chain, payload model overrides use the configured default model fallback policy instead of subagent fallbacks, embedded runs receive modelFallbacksOverride, and metadata-only subagents.model falls through to the next selected model config.
What was not tested: live Kimi/provider timeout E2E.
