### PR TITLE
Fix Telegram stop lane and gateway session aborts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/media: prevent image filenames from overriding generic non-image byte sniffing, so zip/octet-stream payloads mislabeled as images are offloaded or rejected before they become inline image attachments.
 - Plugins/web search: downgrade stale optional provider installs to warnings so Gateway and doctor repair paths keep running after startup provider selection. Refs #82313. Thanks @crackmac.
+- Telegram/Gateway: route targeted Telegram `/stop@bot` messages onto the control lane without cached bot metadata and match gateway stop requests across raw/canonical session aliases. (#82298) Thanks @VACInc.
 - MS Teams/media: sniff inline `data:image/*` attachment bytes before staging them, skipping payloads that are not actually images.
 - Update: let package-swap `doctor --fix` persist core config repairs while plugin schemas are still converging, preventing update failures on externalized channel configs.
 - Agents/subagents: warn and continue completion announce cleanup when lifecycle cleanup fails, preventing ended subagent runs from becoming silent ghosts. Fixes #82306. Thanks @SebTardif.

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -756,6 +756,9 @@ describe("TelegramPollingSession", () => {
       if (update.update_id === 43) {
         events.push("status");
       }
+      if (update.update_id === 44) {
+        events.push("stop");
+      }
     });
     const bot = {
       api: {
@@ -771,7 +774,12 @@ describe("TelegramPollingSession", () => {
       spoolDir: tempDir,
       update: {
         update_id: 42,
-        message: { text: "summarize this", chat: { id: -100, type: "supergroup" } },
+        message: {
+          text: "summarize this",
+          chat: { id: -100, type: "supergroup", is_forum: true },
+          is_topic_message: true,
+          message_thread_id: 5907,
+        },
       },
     });
     let stopWorker: (() => void) | undefined;
@@ -805,11 +813,28 @@ describe("TelegramPollingSession", () => {
         spoolDir: tempDir,
         update: {
           update_id: 43,
-          message: { text: "/status", chat: { id: -100, type: "supergroup" } },
+          message: {
+            text: "/status",
+            chat: { id: -100, type: "supergroup", is_forum: true },
+            is_topic_message: true,
+            message_thread_id: 5907,
+          },
+        },
+      });
+      await writeTelegramSpooledUpdate({
+        spoolDir: tempDir,
+        update: {
+          update_id: 44,
+          message: {
+            text: "/stop@vacs_tars_bot",
+            chat: { id: -100, type: "supergroup", is_forum: true },
+            is_topic_message: true,
+            message_thread_id: 5907,
+          },
         },
       });
 
-      await vi.waitFor(() => expect(events).toEqual(["regular:start", "status"]));
+      await vi.waitFor(() => expect(events).toEqual(["regular:start", "status", "stop"]));
       expect(
         (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map((update) => update.updateId),
       ).toEqual([42]);

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -79,6 +79,17 @@ describe("getTelegramSequentialKey", () => {
       "telegram:123:control",
     ],
     [
+      {
+        message: mockMessage({
+          chat: mockChat({ id: -100, type: "supergroup", is_forum: true }),
+          is_topic_message: true,
+          message_thread_id: 5907,
+          text: "/stop@vacs_tars_bot",
+        }),
+      },
+      "telegram:-100:control",
+    ],
+    [
       { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/status" }) },
       "telegram:123:control",
     ],

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -90,6 +90,30 @@ describe("getTelegramSequentialKey", () => {
       "telegram:-100:control",
     ],
     [
+      {
+        me: { username: "openclaw_bot" },
+        message: mockMessage({
+          chat: mockChat({ id: -100, type: "supergroup", is_forum: true }),
+          is_topic_message: true,
+          message_thread_id: 5907,
+          text: "/stop@some_other_bot",
+        }),
+      },
+      "telegram:-100:topic:5907",
+    ],
+    [
+      {
+        me: { username: "openclaw_bot" },
+        message: mockMessage({
+          chat: mockChat({ id: -100, type: "supergroup", is_forum: true }),
+          is_topic_message: true,
+          message_thread_id: 5907,
+          text: "/stop@openclaw_bot!",
+        }),
+      },
+      "telegram:-100:control",
+    ],
+    [
       { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/status" }) },
       "telegram:123:control",
     ],

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -91,7 +91,7 @@ describe("getTelegramSequentialKey", () => {
     ],
     [
       {
-        me: { username: "openclaw_bot" },
+        me: { username: "openclaw_bot" } as never,
         message: mockMessage({
           chat: mockChat({ id: -100, type: "supergroup", is_forum: true }),
           is_topic_message: true,
@@ -103,7 +103,7 @@ describe("getTelegramSequentialKey", () => {
     ],
     [
       {
-        me: { username: "openclaw_bot" },
+        me: { username: "openclaw_bot" } as never,
         message: mockMessage({
           chat: mockChat({ id: -100, type: "supergroup", is_forum: true }),
           is_topic_message: true,

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -49,6 +49,16 @@ function resolveStatusCommandControlLane(params: {
   return command?.category === "status" && command.key !== "export-session";
 }
 
+function isTelegramTargetedStopCommand(rawText?: string): boolean {
+  const trimmed = rawText?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  // Isolated ingress may not have getMe() metadata yet. A targeted Telegram
+  // /stop@bot command still needs the control lane so it can cancel a busy turn.
+  return /^\/stop@[A-Za-z0-9_]+(?:$|\s|[.!?…,，。;；:：'"’”)\]}])/iu.test(trimmed);
+}
+
 export function isTelegramControlLaneText(params: {
   rawText?: string;
   botUsername?: string;
@@ -59,6 +69,9 @@ export function isTelegramControlLaneText(params: {
       params.botUsername ? { botUsername: params.botUsername } : undefined,
     )
   ) {
+    return true;
+  }
+  if (isTelegramTargetedStopCommand(params.rawText)) {
     return true;
   }
   return resolveStatusCommandControlLane(params);

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -49,14 +49,22 @@ function resolveStatusCommandControlLane(params: {
   return command?.category === "status" && command.key !== "export-session";
 }
 
-function isTelegramTargetedStopCommand(rawText?: string): boolean {
+function isTelegramTargetedStopCommand(rawText?: string, botUsername?: string): boolean {
   const trimmed = rawText?.trim();
   if (!trimmed) {
     return false;
   }
   // Isolated ingress may not have getMe() metadata yet. A targeted Telegram
   // /stop@bot command still needs the control lane so it can cancel a busy turn.
-  return /^\/stop@[A-Za-z0-9_]+(?:$|\s|[.!?…,，。;；:：'"’”)\]}])/iu.test(trimmed);
+  const match = trimmed.match(/^\/stop@([A-Za-z0-9_]+)(?:$|\s|[.!?…,，。;；:：'"’”)\]}])/iu);
+  if (!match) {
+    return false;
+  }
+  const normalizedBotUsername = botUsername?.trim().toLowerCase();
+  if (!normalizedBotUsername) {
+    return true;
+  }
+  return match[1]?.toLowerCase() === normalizedBotUsername;
 }
 
 export function isTelegramControlLaneText(params: {
@@ -71,7 +79,7 @@ export function isTelegramControlLaneText(params: {
   ) {
     return true;
   }
-  if (isTelegramTargetedStopCommand(params.rawText)) {
+  if (isTelegramTargetedStopCommand(params.rawText, params.botUsername)) {
     return true;
   }
   return resolveStatusCommandControlLane(params);

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -299,6 +299,41 @@ describe("chat abort transcript persistence", () => {
     });
   });
 
+  it("plain stop aborts runs tracked under the canonical session key", async () => {
+    const { sessionId } = await createTranscriptFixture("openclaw-chat-stop-canonical-");
+    const respond = vi.fn();
+    const active = createActiveRun("main", { sessionId });
+    const context = createChatAbortContext({
+      chatAbortControllers: new Map([["run-stop-canonical", active]]),
+      removeChatRun: vi.fn().mockReturnValue({
+        sessionKey: "main",
+        clientRunId: "run-stop-canonical",
+      }),
+      dedupe: {
+        get: vi.fn(),
+      },
+    });
+
+    await chatHandlers["chat.send"]({
+      params: {
+        sessionKey: "alias-main",
+        message: "stop",
+        idempotencyKey: "idem-stop-canonical",
+      },
+      respond,
+      context: context as never,
+      req: {} as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    const [ok, payload] = requireLastRespondCall(respond);
+    expect(ok).toBe(true);
+    expectAbortPayload(payload, { runIds: ["run-stop-canonical"] });
+    expect(active.controller.signal.aborted).toBe(true);
+    expect(context.chatAbortControllers.has("run-stop-canonical")).toBe(false);
+  });
+
   it("skips run-scoped transcript persistence when partial text is blank", async () => {
     const { transcriptPath, sessionId } = await createTranscriptFixture(
       "openclaw-chat-abort-run-blank-",

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -16,6 +16,7 @@ type TranscriptLine = {
 const sessionEntryState = vi.hoisted(() => ({
   transcriptPath: "",
   sessionId: "",
+  hasEntry: true,
 }));
 
 vi.mock("../session-utils.js", async () => {
@@ -26,10 +27,12 @@ vi.mock("../session-utils.js", async () => {
     loadSessionEntry: () => ({
       cfg: {},
       storePath: path.join(path.dirname(sessionEntryState.transcriptPath), "sessions.json"),
-      entry: {
-        sessionId: sessionEntryState.sessionId,
-        sessionFile: sessionEntryState.transcriptPath,
-      },
+      entry: sessionEntryState.hasEntry
+        ? {
+            sessionId: sessionEntryState.sessionId,
+            sessionFile: sessionEntryState.transcriptPath,
+          }
+        : undefined,
       canonicalKey: "main",
     }),
   };
@@ -142,9 +145,10 @@ function expectPersistedAbortMessage(
   expect(abort.runId).toBe(expected.runId);
 }
 
-function setMockSessionEntry(transcriptPath: string, sessionId: string) {
+function setMockSessionEntry(transcriptPath: string, sessionId: string, hasEntry = true) {
   sessionEntryState.transcriptPath = transcriptPath;
   sessionEntryState.sessionId = sessionId;
+  sessionEntryState.hasEntry = hasEntry;
 }
 
 async function createTranscriptFixture(prefix: string) {
@@ -154,6 +158,14 @@ async function createTranscriptFixture(prefix: string) {
   await writeTranscriptHeader(transcriptPath, sessionId);
   setMockSessionEntry(transcriptPath, sessionId);
   return { transcriptPath, sessionId };
+}
+
+async function createMissingEntryFixture(prefix: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const transcriptPath = path.join(dir, "missing.jsonl");
+  const sessionId = "client-supplied-session";
+  setMockSessionEntry(transcriptPath, sessionId, false);
+  return { sessionId };
 }
 
 afterEach(() => {
@@ -332,6 +344,73 @@ describe("chat abort transcript persistence", () => {
     expectAbortPayload(payload, { runIds: ["run-stop-canonical"] });
     expect(active.controller.signal.aborted).toBe(true);
     expect(context.chatAbortControllers.has("run-stop-canonical")).toBe(false);
+  });
+
+  it("plain stop aborts raw-alias runs for the same backing session", async () => {
+    const { sessionId } = await createTranscriptFixture("openclaw-chat-stop-raw-alias-");
+    const respond = vi.fn();
+    const active = createActiveRun("alias-main", { sessionId });
+    const context = createChatAbortContext({
+      chatAbortControllers: new Map([["run-stop-raw-alias", active]]),
+      removeChatRun: vi.fn().mockReturnValue({
+        sessionKey: "alias-main",
+        clientRunId: "run-stop-raw-alias",
+      }),
+      dedupe: {
+        get: vi.fn(),
+      },
+    });
+
+    await chatHandlers["chat.send"]({
+      params: {
+        sessionKey: "main",
+        message: "stop",
+        idempotencyKey: "idem-stop-raw-alias",
+      },
+      respond,
+      context: context as never,
+      req: {} as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    const [ok, payload] = requireLastRespondCall(respond);
+    expect(ok).toBe(true);
+    expectAbortPayload(payload, { runIds: ["run-stop-raw-alias"] });
+    expect(active.controller.signal.aborted).toBe(true);
+    expect(context.chatAbortControllers.has("run-stop-raw-alias")).toBe(false);
+  });
+
+  it("does not match stop targets by client-supplied session id without a stored entry", async () => {
+    const { sessionId } = await createMissingEntryFixture("openclaw-chat-stop-client-session-");
+    const respond = vi.fn();
+    const active = createActiveRun("third-session", { sessionId });
+    const context = createChatAbortContext({
+      chatAbortControllers: new Map([["run-stop-client-session", active]]),
+      dedupe: {
+        get: vi.fn(),
+      },
+    });
+
+    await chatHandlers["chat.send"]({
+      params: {
+        sessionKey: "other-session",
+        sessionId,
+        message: "stop",
+        idempotencyKey: "idem-stop-client-session",
+      },
+      respond,
+      context: context as never,
+      req: {} as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    const [ok, payload] = requireLastRespondCall(respond);
+    expect(ok).toBe(true);
+    expect(expectRecord(payload, "abort payload").aborted).toBe(false);
+    expect(active.controller.signal.aborted).toBe(false);
+    expect(context.chatAbortControllers.has("run-stop-client-session")).toBe(true);
   });
 
   it("skips run-scoped transcript persistence when partial text is blank", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1582,25 +1582,30 @@ function canRequesterAbortChatRun(
   return false;
 }
 
-function resolveAuthorizedRunIdsForSession(params: {
+function resolveAuthorizedRunsForSessionKeys(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
-  sessionKey: string;
+  sessionKeys: Iterable<string>;
   requester: ChatAbortRequester;
 }) {
-  const authorizedRunIds: string[] = [];
+  const sessionKeys = new Set(
+    Array.from(params.sessionKeys, (sessionKey) => normalizeOptionalText(sessionKey)).filter(
+      (sessionKey): sessionKey is string => Boolean(sessionKey),
+    ),
+  );
+  const authorizedRuns: Array<{ runId: string; sessionKey: string }> = [];
   let matchedSessionRuns = 0;
   for (const [runId, active] of params.chatAbortControllers) {
-    if (active.sessionKey !== params.sessionKey) {
+    if (!sessionKeys.has(active.sessionKey)) {
       continue;
     }
     matchedSessionRuns += 1;
     if (canRequesterAbortChatRun(active, params.requester)) {
-      authorizedRunIds.push(runId);
+      authorizedRuns.push({ runId, sessionKey: active.sessionKey });
     }
   }
   return {
     matchedSessionRuns,
-    authorizedRunIds,
+    authorizedRuns,
   };
 }
 
@@ -1608,23 +1613,25 @@ async function abortChatRunsForSessionKeyWithPartials(params: {
   context: GatewayRequestContext;
   ops: ChatAbortOps;
   sessionKey: string;
+  sessionKeyAliases?: string[];
+  persistSessionKey?: string;
   abortOrigin: AbortOrigin;
   stopReason?: string;
   requester: ChatAbortRequester;
 }): Promise<{ aborted: boolean; runIds: string[]; unauthorized: boolean }> {
-  const { matchedSessionRuns, authorizedRunIds } = resolveAuthorizedRunIdsForSession({
+  const { matchedSessionRuns, authorizedRuns } = resolveAuthorizedRunsForSessionKeys({
     chatAbortControllers: params.context.chatAbortControllers,
-    sessionKey: params.sessionKey,
+    sessionKeys: [params.sessionKey, ...(params.sessionKeyAliases ?? [])],
     requester: params.requester,
   });
-  if (authorizedRunIds.length === 0) {
+  if (authorizedRuns.length === 0) {
     return {
       aborted: false,
       runIds: [],
       unauthorized: matchedSessionRuns > 0,
     };
   }
-  const authorizedRunIdSet = new Set(authorizedRunIds);
+  const authorizedRunIdSet = new Set(authorizedRuns.map((run) => run.runId));
   const snapshots = collectSessionAbortPartials({
     chatAbortControllers: params.context.chatAbortControllers,
     chatRunBuffers: params.context.chatRunBuffers,
@@ -1632,10 +1639,10 @@ async function abortChatRunsForSessionKeyWithPartials(params: {
     abortOrigin: params.abortOrigin,
   });
   const runIds: string[] = [];
-  for (const runId of authorizedRunIds) {
+  for (const { runId, sessionKey } of authorizedRuns) {
     const res = abortChatRunById(params.ops, {
       runId,
-      sessionKey: params.sessionKey,
+      sessionKey,
       stopReason: params.stopReason,
     });
     if (res.aborted) {
@@ -1646,7 +1653,7 @@ async function abortChatRunsForSessionKeyWithPartials(params: {
   if (res.aborted) {
     await persistAbortedPartials({
       context: params.context,
-      sessionKey: params.sessionKey,
+      sessionKey: params.persistSessionKey ?? params.sessionKey,
       snapshots,
     });
   }
@@ -2054,6 +2061,8 @@ export const chatHandlers: GatewayRequestHandlers = {
         context,
         ops: createChatAbortOps(context),
         sessionKey: rawSessionKey,
+        sessionKeyAliases: sessionKey === rawSessionKey ? undefined : [sessionKey],
+        persistSessionKey: sessionKey,
         abortOrigin: "stop-command",
         stopReason: "stop",
         requester: resolveChatAbortRequester(client),

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1585,6 +1585,7 @@ function canRequesterAbortChatRun(
 function resolveAuthorizedRunsForSessionKeys(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   sessionKeys: Iterable<string>;
+  sessionIds?: Iterable<string | undefined>;
   requester: ChatAbortRequester;
 }) {
   const sessionKeys = new Set(
@@ -1592,10 +1593,15 @@ function resolveAuthorizedRunsForSessionKeys(params: {
       (sessionKey): sessionKey is string => Boolean(sessionKey),
     ),
   );
+  const sessionIds = new Set(
+    Array.from(params.sessionIds ?? [], (sessionId) => normalizeOptionalText(sessionId)).filter(
+      (sessionId): sessionId is string => Boolean(sessionId),
+    ),
+  );
   const authorizedRuns: Array<{ runId: string; sessionKey: string }> = [];
   let matchedSessionRuns = 0;
   for (const [runId, active] of params.chatAbortControllers) {
-    if (!sessionKeys.has(active.sessionKey)) {
+    if (!sessionKeys.has(active.sessionKey) && !sessionIds.has(active.sessionId)) {
       continue;
     }
     matchedSessionRuns += 1;
@@ -1614,6 +1620,7 @@ async function abortChatRunsForSessionKeyWithPartials(params: {
   ops: ChatAbortOps;
   sessionKey: string;
   sessionKeyAliases?: string[];
+  sessionId?: string;
   persistSessionKey?: string;
   abortOrigin: AbortOrigin;
   stopReason?: string;
@@ -1622,6 +1629,7 @@ async function abortChatRunsForSessionKeyWithPartials(params: {
   const { matchedSessionRuns, authorizedRuns } = resolveAuthorizedRunsForSessionKeys({
     chatAbortControllers: params.context.chatAbortControllers,
     sessionKeys: [params.sessionKey, ...(params.sessionKeyAliases ?? [])],
+    sessionIds: [params.sessionId],
     requester: params.requester,
   });
   if (authorizedRuns.length === 0) {
@@ -2062,6 +2070,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         ops: createChatAbortOps(context),
         sessionKey: rawSessionKey,
         sessionKeyAliases: sessionKey === rawSessionKey ? undefined : [sessionKey],
+        sessionId: entry?.sessionId,
         persistSessionKey: sessionKey,
         abortOrigin: "stop-command",
         stopReason: "stop",


### PR DESCRIPTION
## Summary
- Rebase onto current `origin/main` (`1dac68c0bb`) and drop the auto-reply active-run stop work that upstream already landed in `8d3b5c2d19`.
- Make gateway `chat.send` stop handling abort active runs registered under either the raw requested session key or the canonical session key, and persist aborted partials under the canonical session key.
- Route Telegram targeted `/stop@bot` messages onto the isolated-ingress control lane even when cached `getMe()` bot metadata is unavailable, so they can bypass a busy same-topic turn.
- Add focused regression coverage for canonical/raw gateway session-key stop behavior and Telegram forum-topic `/stop@bot` spool bypass.

## Root Cause
- Upstream `origin/main` already fixes the core auto-reply active text stop path in `8d3b5c2d19` (`fix(auto-reply): abort active text stop runs`), so this PR no longer carries that duplicate work.
- Gateway stop handling still matched active chat abort controllers only by the exact requested session key. If the client requested a raw/alias key while the active run was registered under the canonical key, the running turn could remain alive.
- Telegram isolated ingress chooses an on-disk spool lane before the update reaches the shared abort handler. A targeted Telegram command like `/stop@vacs_tars_bot` only normalized to `/stop` when bot username metadata was available. When isolated spool replay lacked that metadata, `/stop@bot` stayed on the normal topic lane and queued behind the active turn it was meant to stop.

## Duplicate / Upstream Audit
- `git grep` on `origin/main` found no Telegram `/stop@bot` control-lane fallback in `extensions/telegram/src/sequential-key.ts` or the isolated polling tests.
- `gh search prs` for Telegram stop/control-lane terms returned no open PR carrying the same fix.
- `gitcrawl search` for `Telegram stop bot control lane isolated ingress /stop@bot` returned no hits.
- The only related upstreamed work found was `8d3b5c2d19`, and the duplicate auto-reply files were removed during the rebase. Final PR diff is five files: three Telegram lane/test files and two gateway canonical-session abort files.

## Real behavior proof
Behavior addressed: Telegram `/stop@bot` can reach the control lane while a same-topic turn is active, and gateway `stop` can abort active chat runs registered under a canonical session key.
Real environment tested: local OpenClaw source checkout rebased onto `origin/main` `1dac68c0bb`; the actual Telegram lane resolver loaded through Node/tsx from `extensions/telegram/src/sequential-key.ts`; user workstation live gateway log/spool inspection for topic `5907`.
Exact steps or command run after this patch: `timeout 9999 node --import tsx --input-type=module` with a live-shaped Telegram forum-topic update containing `/stop@vacs_tars_bot`, `message_thread_id: 5907`, and no `botInfo`; then focused regression commands listed in Verification.
Evidence after fix: Terminal output from the patched OpenClaw Telegram lane resolver:
```text
$ timeout 9999 node --import tsx --input-type=module
input.text=/stop@vacs_tars_bot
input.topic=5907
input.botInfo=absent
resolvedLane=telegram:-100:control
```
Observed result after fix: The same live-shaped `/stop@vacs_tars_bot` forum-topic update that previously sat on the active topic lane now resolves to the Telegram control lane before dispatch, so isolated ingress can run it while the regular topic turn remains active. Slash command authorization is unchanged; this only prevents targeted stop commands from being trapped behind the turn they are intended to cancel.
Before evidence: Live Telegram spool update `498455594` / message `94030` had text `/stop@vacs_tars_bot`, `message_thread_id: 5907`, and timestamp `2026-05-15 19:47:55 -0400`. The gateway did not log it as dispatched at that time and continued sending active-turn messages `94031` through `94041` from `2026-05-15 19:48:11 -0400` to `19:48:48 -0400`. Code inspection showed `extensions/telegram/src/polling-session.ts` lane selection called `getTelegramSequentialKey(...)` without `me` when `botInfo` was absent, and `extensions/telegram/src/sequential-key.ts` only treated `/stop@bot` as abort text when that bot username was available.
What was not tested: captured live transcript/log proof of a redeployed real Telegram `/stop@bot` after this targeted-lane patch; full `pnpm check`, cross-OS, and Crabbox/Testbox lanes.

## Verification
- `timeout 9999 pnpm install`: refreshed rebased worktree dependencies after `origin/main` introduced/updated Proxyline exports; lockfile was already up to date.
- `timeout 9999 node --import tsx --input-type=module`: live-shaped Telegram lane resolver output shown above.
- `timeout 9999 node scripts/run-vitest.mjs extensions/telegram/src/sequential-key.test.ts extensions/telegram/src/polling-session.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts`: 4 files, 72 tests passed after the final rebase onto `1dac68c0bb`.
- `timeout 9999 git diff --check origin/main...HEAD`: passed.

## What was not tested
- Captured live transcript/log proof of a redeployed real Telegram `/stop@bot` after this targeted-lane patch.
- Full `pnpm check`, cross-OS, and Crabbox/Testbox lanes.
