### PR TITLE
fix(cron): honor subagent model fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Release tooling: align the published launcher Node floor, `npm start`, package script checks, sharded lint locking, Vitest root project coverage, and plugin-SDK declaration build cache metadata so release/package validation does not silently skip or ship stale surfaces.
+- Cron/agents: honor configured subagent model fallbacks for isolated scheduled runs and forward that fallback policy into embedded agent timeout failover. Fixes #74985. Thanks @chrisgwynne.
 - Codex app-server/MCP: scope user MCP servers to specific OpenClaw agent ids through an optional `mcp.servers.<name>.codex.agents` list and accept `codex.defaultToolsApprovalMode` (`auto`/`prompt`/`approve`) for native Codex approval defaults; OpenClaw strips the `codex` block before handing `mcp_servers` config to Codex. (#82180) Thanks @sercada.
 - Agents/OpenAI Responses: clamp `input_tokens - cached_tokens` at zero and reconstruct `totalTokens` from input + output + cached components so Responses-API streams report consistent usage when providers under-report `input_tokens` relative to `cached_tokens`.
 - Plugins: reject malformed `package.json` `openclaw.extensions` metadata during install, discovery, and post-update payload smoke instead of silently dropping invalid entries.

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -154,6 +154,10 @@ export function resolveAgentModelFallbacksOverride(
   agentId: string,
 ): string[] | undefined {
   const raw = resolveAgentConfig(cfg, agentId)?.model;
+  return resolveModelFallbacksOverride(raw);
+}
+
+function resolveModelFallbacksOverride(raw: AgentModelConfig | undefined): string[] | undefined {
   if (!raw) {
     return undefined;
   }
@@ -165,6 +169,17 @@ export function resolveAgentModelFallbacksOverride(
     return Object.hasOwn(raw, "primary") && resolvePrimaryStringValue(raw) ? [] : undefined;
   }
   return Array.isArray(raw.fallbacks) ? raw.fallbacks : undefined;
+}
+
+export function resolveSubagentModelFallbacksOverride(
+  cfg: OpenClawConfig,
+  agentId: string,
+): string[] | undefined {
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  return (
+    resolveModelFallbacksOverride(agentConfig?.subagents?.model) ??
+    resolveModelFallbacksOverride(cfg.agents?.defaults?.subagents?.model)
+  );
 }
 
 export function resolveFallbackAgentId(params: {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -22,7 +22,6 @@ import { sanitizeForLog } from "../../terminal/ansi.js";
 import { resolveUserPath } from "../../utils.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import {
-  hasConfiguredModelFallbacks,
   resolveAgentExecutionContract,
   resolveAgentDir,
   resolveSessionAgentIds,
@@ -120,6 +119,7 @@ import { resolveAuthProfileFailureReason } from "./run/auth-profile-failure-poli
 import { runEmbeddedAttemptWithBackend } from "./run/backend.js";
 import { createFailoverDecisionLogger } from "./run/failover-observation.js";
 import { mergeRetryFailoverReason, resolveRunFailoverDecision } from "./run/failover-policy.js";
+import { hasEmbeddedRunConfiguredModelFallbacks } from "./run/fallbacks.js";
 import {
   buildErrorAgentMeta,
   buildUsageAgentMetaFields,
@@ -479,10 +479,11 @@ export async function runEmbeddedPiAgent(
       const agentDir =
         params.agentDir ?? resolveAgentDir(params.config ?? {}, workspaceResolution.agentId);
       const normalizedSessionKey = params.sessionKey?.trim();
-      const fallbackConfigured = hasConfiguredModelFallbacks({
+      const fallbackConfigured = hasEmbeddedRunConfiguredModelFallbacks({
         cfg: params.config,
         agentId: params.agentId,
         sessionKey: normalizedSessionKey,
+        modelFallbacksOverride: params.modelFallbacksOverride,
       });
       const resolvedSessionKey = normalizedSessionKey;
       const hookRunner = getGlobalHookRunner();

--- a/src/agents/pi-embedded-runner/run/fallbacks.test.ts
+++ b/src/agents/pi-embedded-runner/run/fallbacks.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { hasEmbeddedRunConfiguredModelFallbacks } from "./fallbacks.js";
+
+describe("hasEmbeddedRunConfiguredModelFallbacks", () => {
+  it("uses explicit non-empty modelFallbacksOverride as configured", () => {
+    expect(
+      hasEmbeddedRunConfiguredModelFallbacks({
+        cfg: {},
+        modelFallbacksOverride: ["openai/gpt-5.4"],
+      }),
+    ).toBe(true);
+  });
+
+  it("treats explicit empty modelFallbacksOverride as disabling fallbacks", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            fallbacks: ["openai/gpt-5.4"],
+          },
+        },
+      },
+    };
+    expect(
+      hasEmbeddedRunConfiguredModelFallbacks({
+        cfg,
+        modelFallbacksOverride: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to normal agent/default model fallback config when no override is provided", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            fallbacks: ["openai/gpt-5.4"],
+          },
+        },
+      },
+    };
+    expect(hasEmbeddedRunConfiguredModelFallbacks({ cfg, agentId: "main" })).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/fallbacks.ts
+++ b/src/agents/pi-embedded-runner/run/fallbacks.ts
@@ -1,0 +1,18 @@
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { hasConfiguredModelFallbacks } from "../../agent-scope.js";
+
+export function hasEmbeddedRunConfiguredModelFallbacks(params: {
+  cfg: OpenClawConfig | undefined;
+  agentId?: string | null;
+  sessionKey?: string | null;
+  modelFallbacksOverride?: string[];
+}): boolean {
+  if (params.modelFallbacksOverride !== undefined) {
+    return params.modelFallbacksOverride.length > 0;
+  }
+  return hasConfiguredModelFallbacks({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
+}

--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -136,7 +136,7 @@ async function expectSelectedModel(
   expected: { provider: string; model: string },
 ) {
   const result = await selectModel(options);
-  expect(result).toEqual({ ok: true, ...expected });
+  expect(result).toMatchObject({ ok: true, ...expected });
 }
 
 async function expectDefaultSelectedModel(options: SelectModelOptions = {}) {

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -16,6 +16,8 @@ type CronSessionModelOverrides = {
   providerOverride?: string;
 };
 
+type CronModelSelectionSource = "default" | "subagent" | "agent" | "hook" | "payload" | "session";
+
 export type ResolveCronModelSelectionParams = {
   cfg: OpenClawConfig;
   cfgWithAgentDefaults: OpenClawConfig;
@@ -36,6 +38,7 @@ export type ResolveCronModelSelectionResult =
       ok: true;
       provider: string;
       model: string;
+      modelSource: CronModelSelectionSource;
     }
   | {
       ok: false;
@@ -73,6 +76,7 @@ export async function resolveCronModelSelection(
   });
   let provider = resolvedDefault.provider;
   let model = resolvedDefault.model;
+  let modelSource: CronModelSelectionSource = "default";
 
   let catalog: Awaited<ReturnType<typeof loadModelCatalog>> | undefined;
   const loadCatalogOnce = async () => {
@@ -82,10 +86,14 @@ export async function resolveCronModelSelection(
     return catalog;
   };
 
-  const subagentModelRaw =
-    normalizeModelSelection(params.agentConfigOverride?.subagents?.model) ??
-    normalizeModelSelection(params.agentConfigOverride?.model) ??
-    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model);
+  const agentSubagentModel = normalizeModelSelection(params.agentConfigOverride?.subagents?.model);
+  const agentModel = normalizeModelSelection(params.agentConfigOverride?.model);
+  const defaultSubagentModel = normalizeModelSelection(
+    params.cfg.agents?.defaults?.subagents?.model,
+  );
+  const subagentModelRaw = agentSubagentModel ?? agentModel ?? defaultSubagentModel;
+  const subagentModelSource: CronModelSelectionSource =
+    agentSubagentModel !== undefined ? "subagent" : agentModel !== undefined ? "agent" : "subagent";
   if (subagentModelRaw) {
     const resolvedSubagent = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,
@@ -97,6 +105,7 @@ export async function resolveCronModelSelection(
     if (!("error" in resolvedSubagent)) {
       provider = resolvedSubagent.ref.provider;
       model = resolvedSubagent.ref.model;
+      modelSource = subagentModelSource;
     }
   }
 
@@ -119,6 +128,7 @@ export async function resolveCronModelSelection(
       provider = hooksGmailModelRef.provider;
       model = hooksGmailModelRef.model;
       hooksGmailModelApplied = true;
+      modelSource = "hook";
     }
   }
 
@@ -144,6 +154,7 @@ export async function resolveCronModelSelection(
     }
     provider = resolvedOverride.ref.provider;
     model = resolvedOverride.ref.model;
+    modelSource = "payload";
   }
 
   if (!modelOverride && !hooksGmailModelApplied) {
@@ -161,9 +172,10 @@ export async function resolveCronModelSelection(
       if (!("error" in resolvedSessionOverride)) {
         provider = resolvedSessionOverride.ref.provider;
         model = resolvedSessionOverride.ref.model;
+        modelSource = "session";
       }
     }
   }
 
-  return { ok: true, provider, model };
+  return { ok: true, provider, model, modelSource };
 }

--- a/src/cron/isolated-agent/run-execution.runtime.ts
+++ b/src/cron/isolated-agent/run-execution.runtime.ts
@@ -1,4 +1,7 @@
-export { resolveEffectiveModelFallbacks } from "../../agents/agent-scope.js";
+export {
+  resolveEffectiveModelFallbacks,
+  resolveSubagentModelFallbacksOverride,
+} from "../../agents/agent-scope.js";
 export { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 export { resolveCronAgentLane } from "../../agents/lanes.js";
 export { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -123,6 +123,7 @@ export function createCronPromptExecutor(params: {
   };
   skillsSnapshot: SkillSnapshot;
   agentPayload: AgentTurnPayload;
+  useSubagentFallbacks: boolean;
   liveSelection: CronLiveSelection;
   cronSession: MutableCronSession;
   abortSignal?: AbortSignal;
@@ -144,6 +145,7 @@ export function createCronPromptExecutor(params: {
     cfg: params.cfg,
     job: params.job,
     agentId: params.agentId,
+    useSubagentFallbacks: params.useSubagentFallbacks,
   });
   let runResult: CronPromptRunResult | undefined;
   let fallbackProvider = params.liveSelection.provider;
@@ -246,6 +248,7 @@ export function createCronPromptExecutor(params: {
           lane: resolveCronAgentLane(params.lane),
           provider: providerOverride,
           model: modelOverride,
+          modelFallbacksOverride: cronFallbacksOverride,
           authProfileId: params.liveSelection.authProfileId,
           authProfileIdSource: params.liveSelection.authProfileId
             ? params.liveSelection.authProfileIdSource
@@ -330,6 +333,7 @@ export async function executeCronRun(params: {
   };
   skillsSnapshot: SkillSnapshot;
   agentPayload: AgentTurnPayload;
+  useSubagentFallbacks: boolean;
   agentVerboseDefault: AgentDefaultsConfig["verboseDefault"];
   liveSelection: CronLiveSelection;
   cronSession: MutableCronSession;
@@ -379,6 +383,7 @@ export async function executeCronRun(params: {
     toolPolicy: params.toolPolicy,
     skillsSnapshot: params.skillsSnapshot,
     agentPayload: params.agentPayload,
+    useSubagentFallbacks: params.useSubagentFallbacks,
     liveSelection: params.liveSelection,
     cronSession: params.cronSession,
     abortSignal: params.abortSignal,

--- a/src/cron/isolated-agent/run-fallback-policy.test.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.test.ts
@@ -71,6 +71,125 @@ describe("resolveCronFallbacksOverride", () => {
     ).toStrictEqual([]);
   });
 
+  it("uses subagent model fallbacks when cron selects the configured subagent model", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-opus-4-6",
+                fallbacks: ["openai/gpt-5.4"],
+              },
+              subagents: {
+                model: {
+                  primary: "kimi/kimi-code",
+                  fallbacks: ["openai-codex/gpt-5.2", "zai/glm-5"],
+                },
+              },
+            },
+          },
+        },
+        agentId: "main",
+        useSubagentFallbacks: true,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toEqual(["openai-codex/gpt-5.2", "zai/glm-5"]);
+  });
+
+  it("keeps default subagent fallbacks ahead of the agent primary fallback policy", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              subagents: {
+                model: {
+                  primary: "kimi/kimi-code",
+                  fallbacks: ["openai-codex/gpt-5.2"],
+                },
+              },
+            },
+            list: [
+              {
+                id: "research",
+                model: {
+                  primary: "anthropic/claude-opus-4-6",
+                },
+              },
+            ],
+          },
+        },
+        agentId: "research",
+        useSubagentFallbacks: true,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toEqual(["openai-codex/gpt-5.2"]);
+  });
+
+  it("keeps explicit empty subagent fallbacks as a fallback override", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-opus-4-6",
+                fallbacks: ["openai/gpt-5.4"],
+              },
+              subagents: {
+                model: {
+                  primary: "kimi/kimi-code",
+                  fallbacks: [],
+                },
+              },
+            },
+          },
+        },
+        agentId: "main",
+        useSubagentFallbacks: true,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("ignores subagent fallbacks when cron did not select the subagent model", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-opus-4-6",
+              },
+              subagents: {
+                model: {
+                  primary: "kimi/kimi-code",
+                  fallbacks: ["openai-codex/gpt-5.2"],
+                },
+              },
+            },
+          },
+        },
+        agentId: "main",
+        useSubagentFallbacks: false,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toBeUndefined();
+  });
+
   it("leaves the default model path to the fallback runner when no payload model is set", () => {
     expect(
       resolveCronFallbacksOverride({

--- a/src/cron/isolated-agent/run-fallback-policy.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.ts
@@ -1,23 +1,36 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
-import { resolveEffectiveModelFallbacks } from "./run-execution.runtime.js";
+import {
+  resolveEffectiveModelFallbacks,
+  resolveSubagentModelFallbacksOverride,
+} from "./run-execution.runtime.js";
 
 export function resolveCronFallbacksOverride(params: {
   cfg: OpenClawConfig;
   job: CronJob;
   agentId: string;
+  useSubagentFallbacks?: boolean;
 }): string[] | undefined {
   const payload = params.job.payload.kind === "agentTurn" ? params.job.payload : undefined;
   const payloadFallbacks = Array.isArray(payload?.fallbacks) ? payload.fallbacks : undefined;
   const hasCronPayloadModelOverride =
     typeof payload?.model === "string" && payload.model.trim().length > 0;
-  return (
-    payloadFallbacks ??
-    resolveEffectiveModelFallbacks({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      hasSessionModelOverride: hasCronPayloadModelOverride,
-      modelOverrideSource: hasCronPayloadModelOverride ? "auto" : undefined,
-    })
-  );
+  if (payloadFallbacks !== undefined) {
+    return payloadFallbacks;
+  }
+  if (params.useSubagentFallbacks === true && !hasCronPayloadModelOverride) {
+    const subagentFallbacksOverride = resolveSubagentModelFallbacksOverride(
+      params.cfg,
+      params.agentId,
+    );
+    if (subagentFallbacksOverride !== undefined) {
+      return subagentFallbacksOverride;
+    }
+  }
+  return resolveEffectiveModelFallbacks({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    hasSessionModelOverride: hasCronPayloadModelOverride,
+    modelOverrideSource: hasCronPayloadModelOverride ? "auto" : undefined,
+  });
 }

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -329,6 +329,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       },
       skillsSnapshot: emptySkillsSnapshot,
       agentPayload: null,
+      useSubagentFallbacks: false,
       liveSelection: {
         provider: "openai",
         model: "gpt-5.4",

--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -7,9 +7,11 @@ import {
 import {
   isCliProviderMock,
   loadRunCronIsolatedAgentTurn,
+  mockRunCronFallbackPassthrough,
   resolveConfiguredModelRefMock,
   resolveAgentModelFallbacksOverrideMock,
   runCliAgentMock,
+  runEmbeddedPiAgentMock,
   runWithModelFallbackMock,
 } from "./run.test-harness.js";
 
@@ -123,5 +125,40 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
       ["claude-cli", "claude-opus-4-6"],
       ["claude-cli", "claude-sonnet-4-6"],
     ]);
+  });
+
+  it("forwards subagent fallbacks into the embedded runner for internal failover decisions", async () => {
+    mockRunCronFallbackPassthrough();
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-opus-4-6",
+                fallbacks: ["openai/gpt-5.4"],
+              },
+              subagents: {
+                model: {
+                  primary: "kimi/kimi-code",
+                  fallbacks: ["openai-codex/gpt-5.2", "zai/glm-5"],
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(requireModelFallbackRequest().fallbacksOverride).toEqual([
+      "openai-codex/gpt-5.2",
+      "zai/glm-5",
+    ]);
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      modelFallbacksOverride: ["openai-codex/gpt-5.2", "zai/glm-5"],
+    });
   });
 });

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -41,6 +41,7 @@ function normalizeModelSelectionForTest(value: unknown): string | undefined {
 export const buildWorkspaceSkillSnapshotMock = createMock();
 export const resolveAgentConfigMock = createMock();
 export const resolveEffectiveModelFallbacksMock = createMock();
+export const resolveSubagentModelFallbacksOverrideMock = createMock();
 export const resolveAgentModelFallbacksOverrideMock = createMock();
 export const resolveAgentSkillsFilterMock = createMock();
 export const getModelRefStatusMock = createMock();
@@ -167,6 +168,7 @@ vi.mock("./run-model-selection.runtime.js", () => ({
 
 vi.mock("./run-execution.runtime.js", () => ({
   resolveEffectiveModelFallbacks: resolveEffectiveModelFallbacksMock,
+  resolveSubagentModelFallbacksOverride: resolveSubagentModelFallbacksOverrideMock,
   resolveBootstrapWarningSignaturesSeen: resolveBootstrapWarningSignaturesSeenMock,
   getCliSessionId: getCliSessionIdMock,
   runCliAgent: runCliAgentMock,
@@ -317,6 +319,38 @@ function resetRunConfigMocks(): void {
       return agentFallbacksOverride ?? defaultFallbacks;
     },
   );
+  resolveSubagentModelFallbacksOverrideMock.mockReset();
+  resolveSubagentModelFallbacksOverrideMock.mockImplementation((cfg, agentId) => {
+    const agentConfig = resolveAgentConfigMock(cfg, agentId) as
+      | { model?: unknown; subagents?: { model?: unknown } }
+      | undefined;
+    const resolveOverride = (raw: unknown): string[] | undefined => {
+      const primary = normalizeModelSelectionForTest(raw);
+      if (!raw) {
+        return undefined;
+      }
+      if (typeof raw === "string") {
+        return primary ? [] : undefined;
+      }
+      if (typeof raw !== "object" || Array.isArray(raw)) {
+        return undefined;
+      }
+      if (!Object.hasOwn(raw, "fallbacks")) {
+        return Object.hasOwn(raw, "primary") && primary ? [] : undefined;
+      }
+      const fallbacks = (raw as { fallbacks?: unknown }).fallbacks;
+      return Array.isArray(fallbacks)
+        ? fallbacks.filter((entry) => typeof entry === "string")
+        : undefined;
+    };
+    return (
+      resolveOverride(agentConfig?.subagents?.model) ??
+      resolveOverride(
+        (cfg as { agents?: { defaults?: { subagents?: { model?: unknown } } } })?.agents?.defaults
+          ?.subagents?.model,
+      )
+    );
+  });
   resolveAgentModelFallbacksOverrideMock.mockReturnValue(undefined);
   resolveAgentSkillsFilterMock.mockReturnValue(undefined);
   resolveConfiguredModelRefMock.mockReturnValue({ provider: "openai", model: "gpt-5.4" });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -474,6 +474,7 @@ type PreparedCronRunContext = {
   toolPolicy: ReturnType<typeof resolveCronToolPolicy>;
   skillsSnapshot: SkillSnapshot;
   liveSelection: CronLiveSelection;
+  useSubagentFallbacks: boolean;
   thinkLevel: ThinkLevel | undefined;
   timeoutMs: number;
   /**
@@ -616,6 +617,7 @@ async function prepareCronRunContext(params: {
   }
   let provider = resolvedModelSelection.provider;
   let model = resolvedModelSelection.model;
+  const useSubagentFallbacks = resolvedModelSelection.modelSource === "subagent";
 
   const preflight = await (
     await loadCronModelPreflightRuntime()
@@ -832,6 +834,7 @@ async function prepareCronRunContext(params: {
       toolPolicy,
       skillsSnapshot,
       liveSelection,
+      useSubagentFallbacks,
       thinkLevel,
       timeoutMs,
       runTimeoutOverrideMs,
@@ -1175,6 +1178,7 @@ export async function runCronIsolatedAgentTurn(params: {
       toolPolicy: prepared.context.toolPolicy,
       skillsSnapshot: prepared.context.skillsSnapshot,
       agentPayload: prepared.context.agentPayload,
+      useSubagentFallbacks: prepared.context.useSubagentFallbacks,
       agentVerboseDefault: prepared.context.agentCfg?.verboseDefault,
       liveSelection: prepared.context.liveSelection,
       cronSession: prepared.context.cronSession,


### PR DESCRIPTION
Fixes #74985.

Summary:
- Track whether isolated cron model selection actually came from subagent model config, so hook, payload, session, and agent-primary model paths keep their existing fallback behavior.
- Resolve and forward `agents.*.subagents.model.fallbacks` into both `runWithModelFallback` and the embedded runner's internal `fallbackConfigured` checks.
- Add regression coverage for configured subagent fallbacks, explicit empty fallback overrides, embedded-runner passthrough, and the direct executor test caller.

Verification:
- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/agents/pi-embedded-runner/run/fallbacks.test.ts src/agents/agent-scope.test.ts src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts src/agents/pi-embedded-runner/run/failover-observation.test.ts src/agents/pi-embedded-runner/run/failover-policy.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/agent-scope.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/fallbacks.ts src/agents/pi-embedded-runner/run/fallbacks.test.ts src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/model-selection.ts src/cron/isolated-agent/run-execution.runtime.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run-fallback-policy.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/cron/isolated-agent/run.test-harness.ts src/cron/isolated-agent/run.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`
- `node scripts/run-oxlint.mjs CHANGELOG.md src/agents/agent-scope.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/fallbacks.ts src/agents/pi-embedded-runner/run/fallbacks.test.ts src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/model-selection.ts src/cron/isolated-agent/run-execution.runtime.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run-fallback-policy.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/cron/isolated-agent/run.test-harness.ts src/cron/isolated-agent/run.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local`

Behavior addressed: isolated cron `agentTurn` runs that select `agents.defaults.subagents.model` or per-agent `subagents.model` now use that model config's fallback list instead of silently falling back to the main agent model policy.
Real environment tested: local OpenClaw checkout with mocked cron/embedded-runner regression tests.
Exact steps or command run after this patch: focused Vitest command above, oxfmt check, oxlint, git diff check, and codex-review local pass.
Evidence after fix: regression tests assert subagent fallback lists reach `runWithModelFallback` and `runEmbeddedPiAgent.modelFallbacksOverride`, while hook/payload/session/agent-primary paths stay isolated.
Observed result after fix: focused suite passed with 11 test files and 179 tests; codex-review finished clean with no accepted/actionable findings.
What was not tested: live scheduled cron run against a real provider timeout; this PR covers the model/fallback routing contract through focused regression tests.
