### PR TITLE
fix(whatsapp): improve reconnect stability for long-running sessions

### DIFF
--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -71,18 +71,18 @@ describe("web auto-reply connection", () => {
     expect(() => formatEnvelopeTimestamp(d, " America/Los_Angeles ")).not.toThrow();
   });
 
-  it("handles reconnect progress and max-attempt stop behavior", async () => {
+  it("handles reconnect progress and max-attempt degraded-mode behavior", async () => {
     for (const scenario of [
       {
         reconnect: { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1 },
         expectedCallsAfterFirstClose: 2,
-        closeTwiceAndFinish: false,
+        triggerDegradedMode: false,
         expectedError: "Retry 1",
       },
       {
         reconnect: { initialMs: 5, maxMs: 5, maxAttempts: 2, factor: 1.1 },
         expectedCallsAfterFirstClose: 2,
-        closeTwiceAndFinish: true,
+        triggerDegradedMode: true,
         expectedError: "max attempts reached",
       },
     ]) {
@@ -106,8 +106,22 @@ describe("web auto-reply connection", () => {
         { timeout: 250, interval: 2 },
       );
 
-      if (scenario.closeTwiceAndFinish) {
+      if (scenario.triggerDegradedMode) {
+        // After max attempts, monitor enters degraded slow-poll mode instead of stopping.
+        // Close the second listener to trigger the degraded retry, then abort.
         scripted.resolveClose(1);
+        await vi.waitFor(
+          () => {
+            expect(scripted.getListenerCount()).toBeGreaterThanOrEqual(3);
+          },
+          { timeout: 250, interval: 2 },
+        );
+        controller.abort();
+        scripted.resolveClose(scripted.getListenerCount() - 1, {
+          status: 499,
+          isLoggedOut: false,
+          error: "aborted",
+        });
         await run;
       } else {
         controller.abort();
@@ -223,6 +237,82 @@ describe("web auto-reply connection", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("forces reconnect on transport timeout for quiet accounts", async () => {
+    vi.useFakeTimers();
+    try {
+      const sleep = vi.fn(async () => {});
+      const scripted = createScriptedWebListenerFactory();
+      const { controller, run } = startWebAutoReplyMonitor({
+        monitorWebChannelFn: monitorWebChannel as never,
+        listenerFactory: scripted.listenerFactory,
+        sleep,
+        heartbeatSeconds: 60,
+        messageTimeoutMs: 60_000,
+        watchdogCheckMs: 5,
+      });
+
+      await Promise.resolve();
+      expect(scripted.getListenerCount()).toBe(1);
+
+      // Advance past transport timeout (10m default) without any messages or
+      // transport activity — the watchdog should detect the stale transport.
+      await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+      await Promise.resolve();
+      await vi.waitFor(
+        () => {
+          expect(scripted.getListenerCount()).toBeGreaterThanOrEqual(2);
+        },
+        { timeout: 250, interval: 2 },
+      );
+
+      controller.abort();
+      scripted.resolveClose(scripted.getListenerCount() - 1, {
+        status: 499,
+        isLoggedOut: false,
+        error: "aborted",
+      });
+      await Promise.resolve();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("enters degraded slow-poll mode after max reconnect attempts and recovers", async () => {
+    const sleep = vi.fn(async () => {});
+    const scripted = createScriptedWebListenerFactory();
+    const { runtime, controller, run } = startWebAutoReplyMonitor({
+      monitorWebChannelFn: monitorWebChannel as never,
+      listenerFactory: scripted.listenerFactory,
+      sleep,
+      reconnect: { initialMs: 5, maxMs: 5, maxAttempts: 1, factor: 1.1 },
+    });
+
+    await Promise.resolve();
+    expect(scripted.getListenerCount()).toBe(1);
+
+    // First close exhausts maxAttempts (1), entering degraded mode.
+    scripted.resolveClose(0);
+    await vi.waitFor(
+      () => {
+        expect(scripted.getListenerCount()).toBeGreaterThanOrEqual(2);
+      },
+      { timeout: 250, interval: 2 },
+    );
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("max attempts reached"));
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Retrying every"));
+
+    // The monitor continues — a third listener was created after degraded sleep.
+    controller.abort();
+    scripted.resolveClose(scripted.getListenerCount() - 1, {
+      status: 499,
+      isLoggedOut: false,
+      error: "aborted",
+    });
+    await Promise.resolve();
+    await run;
   });
 
   it("processes inbound messages without batching and preserves timestamps", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -165,7 +165,10 @@ export async function monitorWebChannel(
     // Watchdog to detect stuck message processing (e.g., event emitter died).
     // Tuning overrides are test-oriented; production defaults remain unchanged.
     const MESSAGE_TIMEOUT_MS = tuning.messageTimeoutMs ?? 30 * 60 * 1000; // 30m default
+    const TRANSPORT_TIMEOUT_MS = tuning.transportTimeoutMs ?? 10 * 60 * 1000; // 10m default
     const WATCHDOG_CHECK_MS = tuning.watchdogCheckMs ?? 60 * 1000; // 1m default
+    const HEALTHY_UPTIME_RESET_MS = tuning.healthyUptimeResetMs ?? 5 * 60 * 1000; // 5m default
+    let lastTransportActivityAt = Date.now();
 
     const onMessage = createWebOnMessageHandler({
       cfg,
@@ -212,6 +215,12 @@ export async function monitorWebChannel(
         await onMessage(msg);
       },
     });
+
+    if (typeof listener.onTransportActivity === "function") {
+      listener.onTransportActivity((at: number) => {
+        lastTransportActivityAt = at;
+      });
+    }
 
     statusController.noteConnected();
 
@@ -294,10 +303,42 @@ export async function monitorWebChannel(
       }, heartbeatSeconds * 1000);
 
       active.watchdogTimer = setInterval(() => {
+        const now = Date.now();
+
+        // Transport-level staleness: no socket activity at all (covers quiet accounts
+        // that never receive app-level messages but should still see transport frames).
+        const timeSinceTransport = now - lastTransportActivityAt;
+        if (timeSinceTransport > TRANSPORT_TIMEOUT_MS) {
+          const minutesSinceTransport = Math.floor(timeSinceTransport / 60000);
+          statusController.noteWatchdogStale();
+          heartbeatLogger.warn(
+            {
+              connectionId: active.connectionId,
+              minutesSinceTransport,
+              lastTransportActivityAt: new Date(lastTransportActivityAt),
+              messagesHandled: active.handledMessages,
+            },
+            "Transport timeout detected - forcing reconnect",
+          );
+          whatsappHeartbeatLog.warn(
+            `No transport activity in ${minutesSinceTransport}m - restarting connection`,
+          );
+          void closeListener().catch((err) => {
+            logVerbose(`Close listener failed: ${formatError(err)}`);
+          });
+          listener.signalClose?.({
+            status: 499,
+            isLoggedOut: false,
+            error: "watchdog-transport-timeout",
+          });
+          return;
+        }
+
+        // App-level staleness: messages were flowing but stopped.
         if (!active.lastInboundAt) {
           return;
         }
-        const timeSinceLastMessage = Date.now() - active.lastInboundAt;
+        const timeSinceLastMessage = now - active.lastInboundAt;
         if (timeSinceLastMessage <= MESSAGE_TIMEOUT_MS) {
           return;
         }
@@ -346,8 +387,8 @@ export async function monitorWebChannel(
     ]);
 
     const uptimeMs = Date.now() - active.startedAt;
-    if (uptimeMs > heartbeatSeconds * 1000) {
-      reconnectAttempts = 0; // Healthy stretch; reset the backoff.
+    if (uptimeMs > HEALTHY_UPTIME_RESET_MS) {
+      reconnectAttempts = 0;
     }
     statusController.noteReconnectAttempts(reconnectAttempts);
 
@@ -423,11 +464,12 @@ export async function monitorWebChannel(
 
     reconnectAttempts += 1;
     if (reconnectPolicy.maxAttempts > 0 && reconnectAttempts >= reconnectPolicy.maxAttempts) {
+      const DEGRADED_RETRY_MS = tuning.degradedRetryMs ?? 5 * 60 * 1000; // 5m slow-poll
       statusController.noteClose({
         statusCode: numericStatusCode,
         error: errorStr,
         reconnectAttempts,
-        healthState: "stopped",
+        healthState: "reconnecting",
       });
       reconnectLogger.warn(
         {
@@ -435,14 +477,20 @@ export async function monitorWebChannel(
           status: statusCode,
           reconnectAttempts,
           maxAttempts: reconnectPolicy.maxAttempts,
+          degradedRetryMs: DEGRADED_RETRY_MS,
         },
-        "web reconnect: max attempts reached; continuing in degraded mode",
+        "web reconnect: max attempts reached; entering degraded slow-poll mode",
       );
       runtime.error(
-        `WhatsApp Web reconnect: max attempts reached (${reconnectAttempts}/${reconnectPolicy.maxAttempts}). Stopping web monitoring.`,
+        `WhatsApp Web reconnect: max attempts reached (${reconnectAttempts}/${reconnectPolicy.maxAttempts}). Retrying every ${formatDurationPrecise(DEGRADED_RETRY_MS)}…`,
       );
       await closeListener();
-      break;
+      try {
+        await sleep(DEGRADED_RETRY_MS, abortSignal);
+      } catch {
+        break;
+      }
+      continue;
     }
 
     statusController.noteClose({

--- a/extensions/whatsapp/src/auto-reply/types.ts
+++ b/extensions/whatsapp/src/auto-reply/types.ts
@@ -38,7 +38,13 @@ export type WebMonitorTuning = {
   reconnect?: Partial<ReconnectPolicy>;
   heartbeatSeconds?: number;
   messageTimeoutMs?: number;
+  /** Transport-level silence threshold before the watchdog forces a reconnect (ms). */
+  transportTimeoutMs?: number;
   watchdogCheckMs?: number;
+  /** Minimum uptime (ms) before the reconnect backoff counter resets. */
+  healthyUptimeResetMs?: number;
+  /** Slow-poll interval (ms) used after exponential backoff is exhausted. */
+  degradedRetryMs?: number;
   sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
   statusSink?: (status: WebChannelStatus) => void;
   /** WhatsApp account id. Default: "default". */

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -55,6 +55,13 @@ export async function monitorWebInbox(options: {
   await waitForWaConnection(sock);
   const connectedAtMs = Date.now();
 
+  let lastTransportActivityAt = Date.now();
+  let onTransportActivityCallback: ((at: number) => void) | null = null;
+  const noteTransportActivity = () => {
+    lastTransportActivityAt = Date.now();
+    onTransportActivityCallback?.(lastTransportActivityAt);
+  };
+
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;
   const onClose = new Promise<WebListenerCloseReason>((resolve) => {
     onCloseResolve = resolve;
@@ -460,6 +467,7 @@ export async function monitorWebInbox(options: {
   };
 
   const handleMessagesUpsert = async (upsert: { type?: string; messages?: Array<WAMessage> }) => {
+    noteTransportActivity();
     if (upsert.type !== "notify" && upsert.type !== "append") {
       return;
     }
@@ -499,6 +507,7 @@ export async function monitorWebInbox(options: {
     update: Partial<import("@whiskeysockets/baileys").ConnectionState>,
   ) => {
     try {
+      noteTransportActivity();
       if (update.connection === "close") {
         const status = getStatusCode(update.lastDisconnect?.error);
         resolveClose({
@@ -556,6 +565,7 @@ export async function monitorWebInbox(options: {
   return {
     close: async () => {
       try {
+        onTransportActivityCallback = null;
         detachMessagesUpsert();
         detachConnectionUpdate();
         closeInboundMonitorSocket(sock);
@@ -566,6 +576,12 @@ export async function monitorWebInbox(options: {
     onClose,
     signalClose: (reason?: WebListenerCloseReason) => {
       resolveClose(reason ?? { status: undefined, isLoggedOut: false, error: "closed" });
+    },
+    get lastTransportActivityAt() {
+      return lastTransportActivityAt;
+    },
+    onTransportActivity(cb: (at: number) => void) {
+      onTransportActivityCallback = cb;
     },
     // IPC surface (sendMessage/sendPoll/sendReaction/sendComposingTo)
     ...sendApi,


### PR DESCRIPTION
## Summary

- **Transport-level watchdog**: Track Baileys socket events (`connection.update`, `messages.upsert`) so the watchdog detects dead sockets even on quiet accounts that never receive app-level messages. Previously, `lastInboundAt` stayed null on quiet accounts and the watchdog was a no-op.
- **Backoff reset threshold**: Raise the minimum healthy uptime from 60s to 5 minutes before resetting the reconnect counter, preventing rapid reconnect storms from connections that die shortly after connecting.
- **Degraded slow-poll mode**: Instead of permanently stopping monitoring after exhausting max reconnect attempts (12), fall back to retrying every 5 minutes indefinitely, so transient network outages self-heal without manual gateway restarts.

Fixes #17475
Fixes #11871

## Files changed

| File | Change |
|---|---|
| `extensions/whatsapp/src/inbound/monitor.ts` | Track transport activity from Baileys socket events, expose `lastTransportActivityAt` and `onTransportActivity` callback |
| `extensions/whatsapp/src/auto-reply/monitor.ts` | Add transport timeout watchdog, raise backoff reset threshold, replace hard stop with degraded slow-poll `continue` |
| `extensions/whatsapp/src/auto-reply/types.ts` | Add `transportTimeoutMs`, `healthyUptimeResetMs`, `degradedRetryMs` tuning params |
| `extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts` | 2 new tests (transport timeout, degraded mode recovery) + updated existing max-attempt test |

## Test plan

- [x] Existing reconnect unit tests pass (4/4)
- [x] Existing WhatsApp unit tests pass (9/9 across 3 files)
- [x] Existing e2e connection tests pass (9/9 original + 2 new)
- [ ] Manual: run gateway with WhatsApp linked for 12+ hours, verify no silent disconnects
- [ ] Manual: simulate network interruption, verify reconnect with backoff then recovery
- [ ] Manual: kill WhatsApp Web session externally, verify degraded mode kicks in and recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)