### PR TITLE
fix(doctor): materialize group allowFrom fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Config persistence: ignore malformed array/scalar auth profile, cron job state, and session store entries instead of hydrating them into numeric profile ids, crashed cron rows, or invalid session records.
 - Providers: reject malformed successful Runway, BytePlus, and Ollama embedding responses with provider-owned errors instead of raw parser/type failures, silent bad vectors, or long bogus polling.
 - Trajectory export: skip and report malformed session/runtime JSONL rows in `manifest.json` instead of letting wrong-shaped session rows crash support bundle export.
+- Config/doctor: copy fallback-enabled channel `allowFrom` entries into explicit `groupAllowFrom` allowlists during `openclaw doctor --fix`, preserving current group access without adding runtime fallback-transition flags.
 - Hooks: raise bounded gateway lifecycle hook wait budgets to 5 seconds for shutdown and 10 seconds for pre-restart, giving short restart notification handlers time to finish before shutdown continues. (#82273) Thanks @bryanbaer.
 - Plugin releases: require external package compatibility metadata in the npm plugin publish plan, matching the ClawHub package contract before packages ship.
 - Agents/OpenAI-compatible: honor per-model `max_completion_tokens`/`max_tokens` params in embedded OpenAI-completions runs so high-token Kimi-style routes keep their configured completion cap. Fixes #82230. Thanks @albert-zen.

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -48,7 +48,7 @@
       "doctorCapabilities": {
         "dmAllowFromMode": "topOnly",
         "groupModel": "hybrid",
-        "groupAllowFromFallbackToAllowFrom": false,
+        "groupAllowFromFallbackToAllowFrom": true,
         "warnOnEmptyGroupSenderAllowlist": true
       }
     },

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -491,7 +491,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
       doctor: {
         dmAllowFromMode: "topOnly",
         groupModel: "hybrid",
-        groupAllowFromFallbackToAllowFrom: false,
+        groupAllowFromFallbackToAllowFrom: true,
         warnOnEmptyGroupSenderAllowlist: true,
         collectMutableAllowlistWarnings: collectMSTeamsMutableAllowlistWarnings,
       },

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -654,7 +654,7 @@ vi.mock("./doctor/channel-capabilities.js", () => {
     msteams: {
       dmAllowFromMode: "topOnly",
       groupModel: "hybrid",
-      groupAllowFromFallbackToAllowFrom: false,
+      groupAllowFromFallbackToAllowFrom: true,
       warnOnEmptyGroupSenderAllowlist: true,
     },
     zalouser: {

--- a/src/commands/doctor/channel-capabilities.test.ts
+++ b/src/commands/doctor/channel-capabilities.test.ts
@@ -33,7 +33,7 @@ describe("doctor channel capabilities", () => {
     expect(getDoctorChannelCapabilities("msteams")).toEqual({
       dmAllowFromMode: "topOnly",
       groupModel: "hybrid",
-      groupAllowFromFallbackToAllowFrom: false,
+      groupAllowFromFallbackToAllowFrom: true,
       warnOnEmptyGroupSenderAllowlist: true,
     });
   });

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -9,7 +9,9 @@ const mocks = vi.hoisted(() => ({
   getInstalledPluginRecord: vi.fn(),
   isInstalledPluginEnabled: vi.fn(),
   loadInstalledPluginIndex: vi.fn(),
+  maybeRepairGroupAllowFromFallback: vi.fn(),
   maybeRepairManagedNpmOpenClawPeerLinks: vi.fn(),
+  maybeRepairOpenPolicyAllowFrom: vi.fn(),
   maybeRepairStaleManagedNpmBundledPlugins: vi.fn(),
   maybeRepairStalePluginConfig: vi.fn(),
   repairStaleOAuthProfileShadows: vi.fn(),
@@ -101,6 +103,10 @@ vi.mock("./shared/allowlist-policy-repair.js", () => ({
   }),
 }));
 
+vi.mock("./shared/allowfrom-fallback-migration.js", () => ({
+  maybeRepairGroupAllowFromFallback: mocks.maybeRepairGroupAllowFromFallback,
+}));
+
 vi.mock("./shared/bundled-plugin-load-paths.js", () => ({
   maybeRepairBundledPluginLoadPaths: (cfg: OpenClawConfig) => ({
     config: cfg,
@@ -109,10 +115,7 @@ vi.mock("./shared/bundled-plugin-load-paths.js", () => ({
 }));
 
 vi.mock("./shared/open-policy-allowfrom.js", () => ({
-  maybeRepairOpenPolicyAllowFrom: (cfg: OpenClawConfig) => ({
-    config: cfg,
-    changes: [],
-  }),
+  maybeRepairOpenPolicyAllowFrom: mocks.maybeRepairOpenPolicyAllowFrom,
 }));
 
 vi.mock("./shared/stale-plugin-config.js", () => ({
@@ -174,6 +177,13 @@ vi.mock("./shared/exec-safe-bins.js", () => ({
   }),
 }));
 
+vi.mock("./shared/plugin-dependency-cleanup.js", () => ({
+  cleanupLegacyPluginDependencyState: async () => ({
+    changes: [],
+    warnings: [],
+  }),
+}));
+
 describe("doctor repair sequencing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -192,7 +202,15 @@ describe("doctor repair sequencing", () => {
     mocks.getInstalledPluginRecord.mockReturnValue(undefined);
     mocks.isInstalledPluginEnabled.mockReturnValue(false);
     mocks.loadInstalledPluginIndex.mockReturnValue({ plugins: [] });
+    mocks.maybeRepairGroupAllowFromFallback.mockImplementation((cfg: OpenClawConfig) => ({
+      config: cfg,
+      changes: [],
+    }));
     mocks.maybeRepairManagedNpmOpenClawPeerLinks.mockResolvedValue(false);
+    mocks.maybeRepairOpenPolicyAllowFrom.mockImplementation((cfg: OpenClawConfig) => ({
+      config: cfg,
+      changes: [],
+    }));
     mocks.maybeRepairStaleManagedNpmBundledPlugins.mockReturnValue(false);
     mocks.repairMissingConfiguredPluginInstalls.mockResolvedValue({
       changes: [],
@@ -442,6 +460,72 @@ describe("doctor repair sequencing", () => {
     expect(result.changeNotes).toStrictEqual([
       'Repaired Codex model routes:- agents.defaults.model: openai-codex/gpt-5.5 -> openai/gpt-5.5.\nSet agents.defaults.models.openai/gpt-5.5.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
     ]);
+  });
+
+  it("runs group allowFrom fallback migration after open-policy allowFrom repair", async () => {
+    const events: string[] = [];
+    mocks.maybeRepairOpenPolicyAllowFrom.mockImplementationOnce((cfg: OpenClawConfig) => {
+      events.push("open-policy");
+      return {
+        config: {
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            signal: {
+              ...cfg.channels?.signal,
+              allowFrom: ["*"],
+            },
+          },
+        },
+        changes: ['channels.signal.allowFrom: set to ["*"]'],
+      };
+    });
+    mocks.maybeRepairGroupAllowFromFallback.mockImplementationOnce((cfg: OpenClawConfig) => {
+      events.push("group-fallback");
+      expect(cfg.channels?.signal?.allowFrom).toEqual(["*"]);
+      return {
+        config: {
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            signal: {
+              ...cfg.channels?.signal,
+              groupAllowFrom: ["*"],
+            },
+          },
+        },
+        changes: ["channels.signal.groupAllowFrom: copied 1 sender entry from allowFrom"],
+      };
+    });
+
+    const result = await runDoctorRepairSequence({
+      state: {
+        cfg: {
+          channels: {
+            signal: {
+              dmPolicy: "open",
+            },
+          },
+        } as OpenClawConfig,
+        candidate: {
+          channels: {
+            signal: {
+              dmPolicy: "open",
+            },
+          },
+        } as OpenClawConfig,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(events).toEqual(["open-policy", "group-fallback"]);
+    expect(result.state.candidate.channels?.signal?.groupAllowFrom).toEqual(["*"]);
+    expect(result.changeNotes).toContain('channels.signal.allowFrom: set to ["*"]');
+    expect(result.changeNotes).toContain(
+      "channels.signal.groupAllowFrom: copied 1 sender entry from allowFrom",
+    );
   });
 
   it("does not remove deferred configured plugins during the package update doctor pass", async () => {

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -4,6 +4,7 @@ import {
   maybeRepairManagedNpmOpenClawPeerLinks,
   maybeRepairStaleManagedNpmBundledPlugins,
 } from "../doctor-plugin-registry.js";
+import { maybeRepairGroupAllowFromFallback } from "./shared/allowfrom-fallback-migration.js";
 import { maybeRepairAllowlistPolicyAllowFrom } from "./shared/allowlist-policy-repair.js";
 import { maybeRepairBundledPluginLoadPaths } from "./shared/bundled-plugin-load-paths.js";
 import {
@@ -66,7 +67,6 @@ export async function runDoctorRepairSequence(params: {
   })) {
     applyMutation(mutation);
   }
-  applyMutation(maybeRepairOpenPolicyAllowFrom(state.candidate));
   applyMutation(maybeRepairBundledPluginLoadPaths(state.candidate, env));
   maybeRepairStaleManagedNpmBundledPlugins({
     config: state.candidate,
@@ -106,6 +106,8 @@ export async function runDoctorRepairSequence(params: {
   }
   applyMutation(maybeRepairInvalidPluginConfig(state.candidate));
   applyMutation(await maybeRepairAllowlistPolicyAllowFrom(state.candidate));
+  applyMutation(maybeRepairOpenPolicyAllowFrom(state.candidate));
+  applyMutation(maybeRepairGroupAllowFromFallback(state.candidate));
 
   const emptyAllowlistWarnings = scanEmptyAllowlistPolicyWarnings(state.candidate, {
     doctorFixCommand: params.doctorFixCommand,

--- a/src/commands/doctor/shared/allowfrom-fallback-migration.test.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import { maybeRepairGroupAllowFromFallback } from "./allowfrom-fallback-migration.js";
+
+vi.mock("../channel-capabilities.js", () => ({
+  getDoctorChannelCapabilities: (channelName?: string) => ({
+    dmAllowFromMode: channelName === "matrix" ? "nestedOnly" : "topOnly",
+    groupModel: "sender",
+    groupAllowFromFallbackToAllowFrom: channelName !== "discord",
+    warnOnEmptyGroupSenderAllowlist: true,
+  }),
+}));
+
+describe("doctor group allowFrom fallback migration", () => {
+  it("copies fallback allowFrom into explicit groupAllowFrom", () => {
+    const result = maybeRepairGroupAllowFromFallback({
+      channels: {
+        telegram: {
+          allowFrom: [123, "accessGroup:ops", "123"],
+          groupPolicy: "allowlist",
+        },
+      },
+    });
+
+    expect(result.changes).toEqual([
+      "channels.telegram.groupAllowFrom: copied 2 sender entries from allowFrom for explicit group allowlist.",
+    ]);
+    expect(result.config.channels?.telegram?.groupAllowFrom).toEqual(["123", "accessGroup:ops"]);
+  });
+
+  it("uses canonical nested dm allowFrom for nested channels", () => {
+    const result = maybeRepairGroupAllowFromFallback({
+      channels: {
+        matrix: {
+          allowFrom: ["@legacy:example.org"],
+          dm: {
+            allowFrom: ["@alice:example.org"],
+          },
+        },
+      },
+    });
+
+    expect(result.changes).toEqual([
+      "channels.matrix.groupAllowFrom: copied 1 sender entry from allowFrom for explicit group allowlist.",
+    ]);
+    expect(result.config.channels?.matrix?.groupAllowFrom).toEqual(["@alice:example.org"]);
+  });
+
+  it("preserves account-scoped fallback without broadening to the channel", () => {
+    const result = maybeRepairGroupAllowFromFallback({
+      channels: {
+        signal: {
+          allowFrom: ["parent"],
+          accounts: {
+            work: { allowFrom: ["work-user"] },
+            personal: { groupAllowFrom: ["personal-user"], allowFrom: ["ignored"] },
+          },
+        },
+      },
+    });
+
+    expect(result.changes).toEqual([
+      "channels.signal.groupAllowFrom: copied 1 sender entry from allowFrom for explicit group allowlist.",
+      "channels.signal.accounts.work.groupAllowFrom: copied 1 sender entry from allowFrom for explicit group allowlist.",
+    ]);
+    expect(result.config.channels?.signal?.groupAllowFrom).toEqual(["parent"]);
+    expect(result.config.channels?.signal?.accounts?.work?.groupAllowFrom).toEqual(["work-user"]);
+    expect(result.config.channels?.signal?.accounts?.personal?.groupAllowFrom).toEqual([
+      "personal-user",
+    ]);
+  });
+
+  it("does not shadow an inherited channel group allowlist for accounts", () => {
+    const result = maybeRepairGroupAllowFromFallback({
+      channels: {
+        telegram: {
+          allowFrom: ["dm-user"],
+          groupAllowFrom: ["group-user"],
+          accounts: {
+            work: { allowFrom: ["work-dm-user"] },
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      config: {
+        channels: {
+          telegram: {
+            allowFrom: ["dm-user"],
+            groupAllowFrom: ["group-user"],
+            accounts: {
+              work: { allowFrom: ["work-dm-user"] },
+            },
+          },
+        },
+      },
+      changes: [],
+    });
+  });
+
+  it("skips disabled channels, disabled accounts, and channels without fallback", () => {
+    const cfg = {
+      channels: {
+        disabled: { enabled: false, allowFrom: ["user"] },
+        telegram: {
+          accounts: {
+            disabled: { enabled: false, allowFrom: ["user"] },
+          },
+        },
+        discord: { allowFrom: ["user"] },
+        tools: { allowFrom: ["user"] },
+      },
+    };
+
+    expect(maybeRepairGroupAllowFromFallback(cfg)).toEqual({ config: cfg, changes: [] });
+  });
+});

--- a/src/commands/doctor/shared/allowfrom-fallback-migration.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.ts
@@ -1,0 +1,135 @@
+import { resolveChannelDmAllowFrom } from "../../../channels/plugins/dm-access.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { normalizeStringEntries } from "../../../shared/string-normalization.js";
+import { getDoctorChannelCapabilities } from "../channel-capabilities.js";
+import { asObjectRecord } from "./object.js";
+
+const PSEUDO_CHANNEL_KEYS = new Set(["defaults", "modelByChannel", "tools"]);
+
+type ChannelRecord = Record<string, unknown>;
+
+function isDisabled(record: ChannelRecord): boolean {
+  return record.enabled === false;
+}
+
+function normalizeAllowFrom(raw: unknown): string[] {
+  return Array.from(new Set(normalizeStringEntries(Array.isArray(raw) ? raw : [])));
+}
+
+function readGroupAllowFrom(record: ChannelRecord): string[] {
+  return normalizeAllowFrom(record.groupAllowFrom);
+}
+
+function readDmAllowFrom(params: {
+  channelName: string;
+  account: ChannelRecord;
+  parent?: ChannelRecord;
+}): string[] {
+  return normalizeAllowFrom(
+    resolveChannelDmAllowFrom({
+      account: params.account,
+      parent: params.parent,
+      mode: getDoctorChannelCapabilities(params.channelName).dmAllowFromMode,
+    }),
+  );
+}
+
+function readOwnDmAllowFrom(params: { channelName: string; account: ChannelRecord }): string[] {
+  return normalizeAllowFrom(
+    resolveChannelDmAllowFrom({
+      account: params.account,
+      mode: getDoctorChannelCapabilities(params.channelName).dmAllowFromMode,
+    }),
+  );
+}
+
+function migrateRecord(params: {
+  account: ChannelRecord;
+  channelName: string;
+  changes: string[];
+  parent?: ChannelRecord;
+  parentHadGroupAllowFrom?: boolean;
+  prefix: string;
+}): boolean {
+  if (readGroupAllowFrom(params.account).length > 0) {
+    return false;
+  }
+  if (params.parent && params.parentHadGroupAllowFrom) {
+    return false;
+  }
+  const ownAllowFrom = readOwnDmAllowFrom(params);
+  if (params.parent && ownAllowFrom.length === 0 && readGroupAllowFrom(params.parent).length > 0) {
+    return false;
+  }
+  const allowFrom = readDmAllowFrom(params);
+  if (allowFrom.length === 0) {
+    return false;
+  }
+  params.account.groupAllowFrom = allowFrom;
+  const noun = allowFrom.length === 1 ? "entry" : "entries";
+  params.changes.push(
+    `${params.prefix}.groupAllowFrom: copied ${allowFrom.length} sender ${noun} from allowFrom for explicit group allowlist.`,
+  );
+  return true;
+}
+
+export function maybeRepairGroupAllowFromFallback(cfg: OpenClawConfig): {
+  config: OpenClawConfig;
+  changes: string[];
+} {
+  const channels = asObjectRecord(cfg.channels);
+  if (!channels) {
+    return { config: cfg, changes: [] };
+  }
+
+  const next = structuredClone(cfg);
+  const nextChannels = next.channels as Record<string, ChannelRecord>;
+  const changes: string[] = [];
+
+  for (const [channelName, channelConfig] of Object.entries(nextChannels)) {
+    if (
+      PSEUDO_CHANNEL_KEYS.has(channelName) ||
+      !channelConfig ||
+      typeof channelConfig !== "object"
+    ) {
+      continue;
+    }
+    if (isDisabled(channelConfig)) {
+      continue;
+    }
+    if (!getDoctorChannelCapabilities(channelName).groupAllowFromFallbackToAllowFrom) {
+      continue;
+    }
+
+    const hadGroupAllowFrom = readGroupAllowFrom(channelConfig).length > 0;
+    migrateRecord({
+      account: channelConfig,
+      channelName,
+      changes,
+      prefix: `channels.${channelName}`,
+    });
+
+    const accounts = asObjectRecord(channelConfig.accounts);
+    if (!accounts) {
+      continue;
+    }
+    for (const [accountId, accountConfig] of Object.entries(accounts)) {
+      if (!accountConfig || typeof accountConfig !== "object" || isDisabled(accountConfig)) {
+        continue;
+      }
+      migrateRecord({
+        account: accountConfig,
+        channelName,
+        changes,
+        parent: channelConfig,
+        parentHadGroupAllowFrom: hadGroupAllowFrom,
+        prefix: `channels.${channelName}.accounts.${accountId}`,
+      });
+    }
+  }
+
+  if (changes.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+  return { config: next, changes };
+}

--- a/src/commands/doctor/shared/allowfrom-fallback-migration.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.ts
@@ -114,11 +114,12 @@ export function maybeRepairGroupAllowFromFallback(cfg: OpenClawConfig): {
       continue;
     }
     for (const [accountId, accountConfig] of Object.entries(accounts)) {
-      if (!accountConfig || typeof accountConfig !== "object" || isDisabled(accountConfig)) {
+      const account = asObjectRecord(accountConfig);
+      if (!account || isDisabled(account)) {
         continue;
       }
       migrateRecord({
-        account: accountConfig,
+        account,
         channelName,
         changes,
         parent: channelConfig,


### PR DESCRIPTION
Summary
- Add a doctor repair that materializes fallback-enabled channel `allowFrom` entries into explicit `groupAllowFrom` allowlists.
- Run the migration after allowlist/open-policy repairs so recovered and `dmPolicy="open"` sources are preserved.
- Align MS Teams doctor metadata with runtime fallback behavior and cover sequencing/capability edge cases.

Verification
- `git diff --check origin/main...HEAD`
- `OPENCLAW_BUNDLED_PLUGINS_DIR=/Users/steipete/Projects/clawdbot6/extensions OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/commands/doctor/shared/allowfrom-fallback-migration.test.ts src/commands/doctor/repair-sequencing.test.ts src/commands/doctor/channel-capabilities.test.ts src/commands/doctor-config-flow.test.ts -- --reporter=verbose`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local --full-access --parallel-tests "OPENCLAW_BUNDLED_PLUGINS_DIR=/Users/steipete/Projects/clawdbot6/extensions OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/commands/doctor/shared/allowfrom-fallback-migration.test.ts src/commands/doctor/repair-sequencing.test.ts src/commands/doctor/channel-capabilities.test.ts src/commands/doctor-config-flow.test.ts -- --reporter=verbose"`

Behavior addressed: `openclaw doctor --fix` preserves existing group sender access for channels whose runtime currently falls back from `groupAllowFrom` to `allowFrom`, without adding runtime fallback-transition flags.
Real environment tested: Local OpenClaw source checkout with source plugin metadata forced through `OPENCLAW_BUNDLED_PLUGINS_DIR=/Users/steipete/Projects/clawdbot6/extensions`.
Exact steps or command run after this patch: `OPENCLAW_BUNDLED_PLUGINS_DIR=/Users/steipete/Projects/clawdbot6/extensions OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/commands/doctor/shared/allowfrom-fallback-migration.test.ts src/commands/doctor/repair-sequencing.test.ts src/commands/doctor/channel-capabilities.test.ts src/commands/doctor-config-flow.test.ts -- --reporter=verbose`
Evidence after fix: 47 focused Vitest tests passed; `git diff --check origin/main...HEAD` passed; Codex review reported no accepted/actionable findings.
Observed result after fix: Doctor copies normalized/deduped `allowFrom` entries to `groupAllowFrom`, respects nested DM mode, account scope, disabled entries, non-fallback channels, inherited channel group allowlists, and MS Teams fallback metadata.
What was not tested: Full `pnpm check`, live gateway, and real channel inbound flows.

Replaces and closes #81259.
