### PR TITLE
fix(sessions): estimate local transcript usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - TUI: update the displayed model in real time when an auto-fallback resolution swaps in a different model mid-turn, so the status line reflects the actual model handling the run. Fixes #82296. Thanks @giodl73-repo.
+- Gateway/sessions: estimate context usage from local/OpenAI-compatible transcripts when provider usage telemetry is missing, so status no longer shows empty usage for real local-model sessions. Fixes #73990. (#82317) Thanks @giodl73-repo.
 - Agents/sessions: preserve fresh post-compaction token snapshots across stale usage updates, preventing repeated auto-compaction after every message. Fixes #82576. (#82578) Thanks @njuboy11.
 - Agents/OpenAI Responses: log redacted diagnostics for detail-less `response.failed` events while preserving failed response ids, so operators can correlate provider-side failures. Fixes #82558.
 - Gateway/sessions: discard stale metadata when recreating dead main session rows, so replacement sessions do not inherit old labels or transcript paths.

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import { estimateStringChars, estimateTokensFromChars } from "../utils/cjk-chars.js";
 import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
 import { clearSessionTranscriptIndexCache } from "./session-transcript-index.fs.js";
 import {
@@ -1810,6 +1811,44 @@ describe("readLatestSessionUsageFromTranscript", () => {
     } finally {
       readFileSpy.mockRestore();
     }
+  });
+
+  test("estimates transcript context when local model usage telemetry is missing", () => {
+    const sessionId = "usage-local-missing-telemetry";
+    const userText = "local prompt ".repeat(200);
+    const assistantText = "local response ".repeat(120);
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      { message: { role: "user", content: userText } },
+      {
+        message: {
+          role: "assistant",
+          provider: "openai-completions",
+          model: "local-llama",
+          content: [{ type: "text", text: assistantText }],
+        },
+      },
+    ]);
+
+    const expectedTotalTokens = estimateTokensFromChars(
+      estimateStringChars(userText) + estimateStringChars(assistantText),
+    );
+
+    expectUsageFields(readLatestSessionUsageFromTranscript(sessionId, storePath), {
+      modelProvider: "openai-completions",
+      model: "local-llama",
+      totalTokens: expectedTotalTokens,
+      totalTokensFresh: true,
+    });
+    expectUsageFields(
+      readRecentSessionUsageFromTranscript(sessionId, storePath, undefined, undefined, 64 * 1024),
+      {
+        modelProvider: "openai-completions",
+        model: "local-llama",
+        totalTokens: expectedTotalTokens,
+        totalTokensFresh: true,
+      },
+    );
   });
 
   test("returns null when the transcript has no assistant usage snapshot", () => {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -5,6 +5,7 @@ import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { hasInterSessionUserProvenance } from "../sessions/input-provenance.js";
 import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { estimateStringChars, estimateTokensFromChars } from "../utils/cjk-chars.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 import { extractToolCallNames, hasToolCall } from "../utils/transcript-tools.js";
 import { stripEnvelope } from "./chat-sanitize.js";
@@ -1159,6 +1160,85 @@ function resolvePositiveUsageNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
+function extractTranscriptContentEstimatedChars(content: unknown): number {
+  if (typeof content === "string") {
+    const normalized = stripInlineDirectiveTagsForDisplay(content).text.trim();
+    return normalized ? estimateStringChars(normalized) : 0;
+  }
+  if (!Array.isArray(content)) {
+    return 0;
+  }
+  let chars = 0;
+  for (const part of content) {
+    if (!part || typeof part !== "object" || Array.isArray(part)) {
+      continue;
+    }
+    const record = part as Record<string, unknown>;
+    if (typeof record.text !== "string") {
+      continue;
+    }
+    const type = typeof record.type === "string" ? record.type : "text";
+    if (type !== "text" && type !== "output_text" && type !== "input_text") {
+      continue;
+    }
+    const normalized = stripInlineDirectiveTagsForDisplay(record.text).text.trim();
+    if (normalized) {
+      chars += estimateStringChars(normalized);
+    }
+  }
+  return chars;
+}
+
+function extractTranscriptTokenEstimateFromLine(line: string): {
+  estimatedChars: number;
+  hasModelIdentity: boolean;
+} | null {
+  if (isOversizedTranscriptLine(line)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    const message =
+      parsed.message && typeof parsed.message === "object" && !Array.isArray(parsed.message)
+        ? (parsed.message as Record<string, unknown>)
+        : undefined;
+    if (!message) {
+      return null;
+    }
+    const role = typeof message.role === "string" ? message.role : undefined;
+    if (role !== "user" && role !== "assistant") {
+      return null;
+    }
+    const modelProvider =
+      typeof message.provider === "string"
+        ? message.provider.trim()
+        : typeof parsed.provider === "string"
+          ? parsed.provider.trim()
+          : undefined;
+    const model =
+      typeof message.model === "string"
+        ? message.model.trim()
+        : typeof parsed.model === "string"
+          ? parsed.model.trim()
+          : undefined;
+    const isDeliveryMirror =
+      role === "assistant" && modelProvider === "openclaw" && model === "delivery-mirror";
+    if (isDeliveryMirror) {
+      return null;
+    }
+    const contentChars = extractTranscriptContentEstimatedChars(message.content);
+    if (contentChars <= 0) {
+      return null;
+    }
+    return {
+      estimatedChars: contentChars,
+      hasModelIdentity: role === "assistant" && Boolean(modelProvider || model),
+    };
+  } catch {
+    return null;
+  }
+}
+
 function extractUsageSnapshotFromTranscriptLine(
   line: string,
 ): SessionTranscriptUsageSnapshot | null {
@@ -1261,8 +1341,17 @@ function extractAggregateUsageFromTranscriptLines(
   let sawCacheWrite = false;
   let costUsdTotal = 0;
   let sawCost = false;
+  let estimatedTranscriptChars = 0;
+  let sawEstimatedTranscriptContent = false;
+  let sawEstimateModelIdentity = false;
 
   for (const line of lines) {
+    const estimate = extractTranscriptTokenEstimateFromLine(line);
+    if (estimate) {
+      estimatedTranscriptChars += estimate.estimatedChars;
+      sawEstimatedTranscriptContent = true;
+      sawEstimateModelIdentity ||= estimate.hasModelIdentity;
+    }
     const current = extractUsageSnapshotFromTranscriptLine(line);
     if (!current) {
       continue;
@@ -1317,6 +1406,17 @@ function extractAggregateUsageFromTranscriptLines(
   }
   if (sawCost) {
     snapshot.costUsd = costUsdTotal;
+  }
+  if (
+    typeof snapshot.totalTokens !== "number" &&
+    sawEstimatedTranscriptContent &&
+    sawEstimateModelIdentity
+  ) {
+    const estimatedTotalTokens = estimateTokensFromChars(estimatedTranscriptChars);
+    if (estimatedTotalTokens > 0) {
+      snapshot.totalTokens = estimatedTotalTokens;
+      snapshot.totalTokensFresh = true;
+    }
   }
   return snapshot;
 }


### PR DESCRIPTION
## Summary

Fixes local/OpenAI-compatible transcript usage fallback so sessions with real transcript content but missing provider usage telemetry get a conservative transcript-derived context estimate instead of staying at unknown/empty usage.

The fallback keeps provider-reported usage when available, requires assistant model identity before estimating, skips delivery mirrors and oversized lines, and reuses the existing CJK-aware character/token estimator.

Fixes #73990.

## Validation

- Current PR CI: https://github.com/openclaw/openclaw/actions/runs/25964649916 (`success` on `a72e11e98ba7052a8d5c9898a1a5bbaa40b6f78b`)
- Real behavior proof check: artifact-backed proof supplied below
- Azure Crabbox clean-clone proof:

```bash
pnpm test src/gateway/session-utils.fs.test.ts src/status/status-message.test.ts
pnpm check:changed
pnpm exec tsx /tmp/openclaw-transcript-proof.mts
git diff --check origin/main...HEAD
```

Observed Crabbox proof:

```text
[test] passed 2 Vitest shards in 7.24s
[check:changed] lanes=core, coreTests
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).
RESULT_TRANSCRIPT_USAGE_FALLBACK=provider=openai-completions model=local-llama totalTokens=1100 fresh=true
CRABBOX_PHASE:done
```

## Real behavior proof

Behavior addressed: Local/OpenAI-compatible model sessions with transcript text but no provider usage telemetry can show missing or effectively empty context usage.

Real environment tested: Local WSL OpenClaw checkout on this branch with transcript JSONL fixtures matching local/OpenAI-compatible assistant entries that include provider/model identity but no usage telemetry; Azure Crabbox clean-clone validation of the same persisted transcript reader path.

Exact steps or command run after this patch:

```bash
CI=1 node scripts/run-vitest.mjs src/gateway/session-utils.fs.test.ts src/gateway/session-utils.test.ts src/status/status-message.test.ts src/agents/model-runtime-policy.test.ts
pnpm exec oxfmt --check --threads=1 src/gateway/session-utils.fs.ts src/gateway/session-utils.fs.test.ts src/agents/model-runtime-policy.test.ts
pnpm check:changed
```

Evidence after fix:

- Before/after proof image: https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82317/20260515-203850-2678238874/20260515-204136-647795704/local-transcript-usage-before-after-proof.png
- Before log, `origin/main` plus regression test: https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82317/20260515-203850-2678238874/20260515-204136-647795704/before-origin-main-with-regression-test.log
- After log, PR branch: https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82317/20260515-203850-2678238874/20260515-204136-647795704/after-pr-82317.log
- Regression test patch: https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82317/20260515-203850-2678238874/20260515-204136-647795704/regression-test.patch
- Current clean-clone proof result: `RESULT_TRANSCRIPT_USAGE_FALLBACK=provider=openai-completions model=local-llama totalTokens=1100 fresh=true`

Observed result after fix: The transcript usage fallback returns a fresh transcript-derived total token estimate for local/OpenAI-compatible transcript content without provider usage telemetry, while transcripts without assistant model identity remain unknown. The before log shows the regression test fails on `origin/main` when only the test is applied; the after log shows the same focused test passes on this PR branch. Current PR CI run `25964649916` is fully green on head `a72e11e98ba7052a8d5c9898a1a5bbaa40b6f78b`.

What was not tested: Live paid-provider or local llama.cpp process was not run; this PR validates the real local transcript reader/status fallback path using persisted session transcript JSONL.
