### PR TITLE
refactor(agents): share subagent cron fallback selection

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -16,6 +16,7 @@ import {
   resolveAgentModelFallbacksOverride,
   resolveAgentModelPrimary,
   resolveRunModelFallbacksOverride,
+  resolveSubagentModelConfigSelection,
   resolveSubagentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
   resolveAgentIdByWorkspacePath,
@@ -548,6 +549,16 @@ describe("resolveAgentConfig", () => {
             },
           },
           {
+            id: "metadata-only-subagent",
+            model: {
+              primary: "anthropic/claude-sonnet-4-6",
+              fallbacks: ["google/gemini-3-pro"],
+            },
+            subagents: {
+              model: { timeoutMs: 1_000 },
+            },
+          },
+          {
             id: "default-subagent",
           },
           {
@@ -567,11 +578,65 @@ describe("resolveAgentConfig", () => {
     expect(resolveSubagentModelFallbacksOverride(cfg, "agent-model")).toEqual([
       "google/gemini-3-pro",
     ]);
+    expect(resolveSubagentModelFallbacksOverride(cfg, "metadata-only-subagent")).toEqual([
+      "google/gemini-3-pro",
+    ]);
     expect(resolveSubagentModelFallbacksOverride(cfg, "default-subagent")).toEqual([
       "openai-codex/gpt-5.4",
       "zai/glm-5",
     ]);
     expect(resolveSubagentModelFallbacksOverride(cfg, "strict")).toStrictEqual([]);
+  });
+
+  it("resolves the subagent model config selected for isolated runs", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          subagents: { model: "openai/gpt-5.4" },
+        },
+        list: [
+          {
+            id: "agent-model",
+            model: {
+              primary: "anthropic/claude-sonnet-4-6",
+              fallbacks: ["google/gemini-3-pro"],
+            },
+          },
+          {
+            id: "subagent-model",
+            model: "anthropic/claude-sonnet-4-6",
+            subagents: {
+              model: {
+                primary: "kimi/kimi-code",
+                fallbacks: ["openai-codex/gpt-5.4"],
+              },
+            },
+          },
+          {
+            id: "metadata-only-subagent",
+            model: "anthropic/claude-sonnet-4-6",
+            subagents: {
+              model: { timeoutMs: 1_000 },
+            },
+          },
+        ],
+      },
+    };
+
+    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "agent-model" })).toEqual({
+      primary: "anthropic/claude-sonnet-4-6",
+      fallbacks: ["google/gemini-3-pro"],
+    });
+    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "subagent-model" })).toEqual({
+      primary: "kimi/kimi-code",
+      fallbacks: ["openai-codex/gpt-5.4"],
+    });
+    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "metadata-only-subagent" })).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
+    expect(resolveSubagentModelConfigSelection({ cfg, agentId: "default-subagent" })).toBe(
+      "openai/gpt-5.4",
+    );
   });
 
   it("should return agent-specific sandbox config", () => {

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -16,6 +16,7 @@ import {
   resolveAgentModelFallbacksOverride,
   resolveAgentModelPrimary,
   resolveRunModelFallbacksOverride,
+  resolveSubagentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
   resolveAgentIdByWorkspacePath,
   resolveAgentIdsByWorkspacePath,
@@ -512,6 +513,65 @@ describe("resolveAgentConfig", () => {
         sessionKey: "agent:main:session",
       }),
     ).toBe(false);
+  });
+
+  it("resolves subagent model fallbacks from the selected subagent model source", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["openai/gpt-5.4"],
+          },
+          subagents: {
+            model: {
+              primary: "kimi/kimi-code",
+              fallbacks: ["openai-codex/gpt-5.4", "zai/glm-5"],
+            },
+          },
+        },
+        list: [
+          {
+            id: "research",
+            subagents: {
+              model: {
+                primary: "kimi/kimi-code",
+                fallbacks: ["openai-codex/gpt-5.4", "zai/glm-5"],
+              },
+            },
+          },
+          {
+            id: "agent-model",
+            model: {
+              primary: "anthropic/claude-sonnet-4-6",
+              fallbacks: ["google/gemini-3-pro"],
+            },
+          },
+          {
+            id: "default-subagent",
+          },
+          {
+            id: "strict",
+            subagents: {
+              model: "kimi/kimi-code",
+            },
+          },
+        ],
+      },
+    };
+
+    expect(resolveSubagentModelFallbacksOverride(cfg, "research")).toEqual([
+      "openai-codex/gpt-5.4",
+      "zai/glm-5",
+    ]);
+    expect(resolveSubagentModelFallbacksOverride(cfg, "agent-model")).toEqual([
+      "google/gemini-3-pro",
+    ]);
+    expect(resolveSubagentModelFallbacksOverride(cfg, "default-subagent")).toEqual([
+      "openai-codex/gpt-5.4",
+      "zai/glm-5",
+    ]);
+    expect(resolveSubagentModelFallbacksOverride(cfg, "strict")).toStrictEqual([]);
   });
 
   it("should return agent-specific sandbox config", () => {

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -565,6 +565,14 @@ describe("resolveAgentConfig", () => {
             },
           },
           {
+            id: "fallback-only-subagent-model",
+            subagents: {
+              model: {
+                fallbacks: [],
+              },
+            },
+          },
+          {
             id: "default-subagent",
           },
           {
@@ -591,6 +599,9 @@ describe("resolveAgentConfig", () => {
       "openai-codex/gpt-5.4",
       "zai/glm-5",
     ]);
+    expect(
+      resolveSubagentModelFallbacksOverride(cfg, "fallback-only-subagent-model"),
+    ).toStrictEqual([]);
     expect(resolveSubagentModelFallbacksOverride(cfg, "default-subagent")).toEqual([
       "openai-codex/gpt-5.4",
       "zai/glm-5",

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -559,6 +559,12 @@ describe("resolveAgentConfig", () => {
             },
           },
           {
+            id: "fallback-only-agent-model",
+            model: {
+              fallbacks: ["google/gemini-3-pro"],
+            },
+          },
+          {
             id: "default-subagent",
           },
           {
@@ -580,6 +586,10 @@ describe("resolveAgentConfig", () => {
     ]);
     expect(resolveSubagentModelFallbacksOverride(cfg, "metadata-only-subagent")).toEqual([
       "google/gemini-3-pro",
+    ]);
+    expect(resolveSubagentModelFallbacksOverride(cfg, "fallback-only-agent-model")).toEqual([
+      "openai-codex/gpt-5.4",
+      "zai/glm-5",
     ]);
     expect(resolveSubagentModelFallbacksOverride(cfg, "default-subagent")).toEqual([
       "openai-codex/gpt-5.4",

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -153,11 +153,12 @@ export function resolveAgentModelFallbacksOverride(
   cfg: OpenClawConfig,
   agentId: string,
 ): string[] | undefined {
-  const raw = resolveAgentConfig(cfg, agentId)?.model;
-  return resolveModelFallbacksOverride(raw);
+  return resolveSelectedModelFallbacksOverride(resolveAgentConfig(cfg, agentId)?.model);
 }
 
-function resolveModelFallbacksOverride(raw: AgentModelConfig | undefined): string[] | undefined {
+function resolveSelectedModelFallbacksOverride(
+  raw: AgentModelConfig | undefined,
+): string[] | undefined {
   if (!raw) {
     return undefined;
   }
@@ -177,8 +178,9 @@ export function resolveSubagentModelFallbacksOverride(
 ): string[] | undefined {
   const agentConfig = resolveAgentConfig(cfg, agentId);
   return (
-    resolveModelFallbacksOverride(agentConfig?.subagents?.model) ??
-    resolveModelFallbacksOverride(cfg.agents?.defaults?.subagents?.model)
+    resolveSelectedModelFallbacksOverride(agentConfig?.subagents?.model) ??
+    resolveAgentModelFallbacksOverride(cfg, agentId) ??
+    resolveSelectedModelFallbacksOverride(cfg.agents?.defaults?.subagents?.model)
   );
 }
 

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -172,16 +172,48 @@ function resolveSelectedModelFallbacksOverride(
   return Array.isArray(raw.fallbacks) ? raw.fallbacks : undefined;
 }
 
+export function resolveSubagentModelConfigSelection(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
+}): AgentModelConfig | undefined {
+  return resolveSubagentModelConfigValue({
+    ...params,
+    select: (raw) => (resolvePrimaryStringValue(raw) ? raw : undefined),
+  });
+}
+
+function resolveSubagentModelConfigValue<T>(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
+  select: (raw: AgentModelConfig | undefined) => T | undefined;
+}): T | undefined {
+  const agentConfig =
+    params.agentConfigOverride ??
+    (params.agentId ? resolveAgentConfig(params.cfg, params.agentId) : undefined);
+  for (const raw of [
+    agentConfig?.subagents?.model,
+    agentConfig?.model,
+    params.cfg.agents?.defaults?.subagents?.model,
+  ]) {
+    const selected = params.select(raw);
+    if (selected !== undefined) {
+      return selected;
+    }
+  }
+  return undefined;
+}
+
 export function resolveSubagentModelFallbacksOverride(
   cfg: OpenClawConfig,
   agentId: string,
 ): string[] | undefined {
-  const agentConfig = resolveAgentConfig(cfg, agentId);
-  return (
-    resolveSelectedModelFallbacksOverride(agentConfig?.subagents?.model) ??
-    resolveAgentModelFallbacksOverride(cfg, agentId) ??
-    resolveSelectedModelFallbacksOverride(cfg.agents?.defaults?.subagents?.model)
-  );
+  return resolveSubagentModelConfigValue({
+    cfg,
+    agentId,
+    select: resolveSelectedModelFallbacksOverride,
+  });
 }
 
 export function resolveFallbackAgentId(params: {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -177,18 +177,6 @@ export function resolveSubagentModelConfigSelection(params: {
   agentId?: string;
   agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
 }): AgentModelConfig | undefined {
-  return resolveSubagentModelConfigValue({
-    ...params,
-    select: (raw) => (resolvePrimaryStringValue(raw) ? raw : undefined),
-  });
-}
-
-function resolveSubagentModelConfigValue<T>(params: {
-  cfg: OpenClawConfig;
-  agentId?: string;
-  agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
-  select: (raw: AgentModelConfig | undefined) => T | undefined;
-}): T | undefined {
   const agentConfig =
     params.agentConfigOverride ??
     (params.agentId ? resolveAgentConfig(params.cfg, params.agentId) : undefined);
@@ -197,9 +185,8 @@ function resolveSubagentModelConfigValue<T>(params: {
     agentConfig?.model,
     params.cfg.agents?.defaults?.subagents?.model,
   ]) {
-    const selected = params.select(raw);
-    if (selected !== undefined) {
-      return selected;
+    if (resolvePrimaryStringValue(raw)) {
+      return raw;
     }
   }
   return undefined;
@@ -209,11 +196,9 @@ export function resolveSubagentModelFallbacksOverride(
   cfg: OpenClawConfig,
   agentId: string,
 ): string[] | undefined {
-  return resolveSubagentModelConfigValue({
-    cfg,
-    agentId,
-    select: resolveSelectedModelFallbacksOverride,
-  });
+  return resolveSelectedModelFallbacksOverride(
+    resolveSubagentModelConfigSelection({ cfg, agentId }),
+  );
 }
 
 export function resolveFallbackAgentId(params: {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -172,33 +172,63 @@ function resolveSelectedModelFallbacksOverride(
   return Array.isArray(raw.fallbacks) ? raw.fallbacks : undefined;
 }
 
+export type SubagentModelConfigSelectionSource = "subagent" | "agent" | "default-subagent";
+
+export type SubagentModelConfigSelectionResult = {
+  raw: AgentModelConfig;
+  source: SubagentModelConfigSelectionSource;
+};
+
+export function resolveSubagentModelConfigSelectionResult(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
+}): SubagentModelConfigSelectionResult | undefined {
+  const agentConfig =
+    params.agentConfigOverride ??
+    (params.agentId ? resolveAgentConfig(params.cfg, params.agentId) : undefined);
+  const candidates: SubagentModelConfigSelectionResult[] = [
+    ...(agentConfig?.subagents?.model
+      ? [{ raw: agentConfig.subagents.model, source: "subagent" as const }]
+      : []),
+    ...(agentConfig?.model ? [{ raw: agentConfig.model, source: "agent" as const }] : []),
+    ...(params.cfg.agents?.defaults?.subagents?.model
+      ? [
+          {
+            raw: params.cfg.agents.defaults.subagents.model,
+            source: "default-subagent" as const,
+          },
+        ]
+      : []),
+  ];
+  return candidates.find((candidate) => resolvePrimaryStringValue(candidate.raw));
+}
+
 export function resolveSubagentModelConfigSelection(params: {
   cfg: OpenClawConfig;
   agentId?: string;
   agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
 }): AgentModelConfig | undefined {
-  const agentConfig =
-    params.agentConfigOverride ??
-    (params.agentId ? resolveAgentConfig(params.cfg, params.agentId) : undefined);
-  for (const raw of [
-    agentConfig?.subagents?.model,
-    agentConfig?.model,
-    params.cfg.agents?.defaults?.subagents?.model,
-  ]) {
-    if (resolvePrimaryStringValue(raw)) {
-      return raw;
-    }
-  }
-  return undefined;
+  return resolveSubagentModelConfigSelectionResult(params)?.raw;
 }
 
 export function resolveSubagentModelFallbacksOverride(
   cfg: OpenClawConfig,
   agentId: string,
 ): string[] | undefined {
-  return resolveSelectedModelFallbacksOverride(
-    resolveSubagentModelConfigSelection({ cfg, agentId }),
-  );
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  const subagentFallbacks = resolveSelectedModelFallbacksOverride(agentConfig?.subagents?.model);
+  if (subagentFallbacks !== undefined) {
+    return subagentFallbacks;
+  }
+  const selection = resolveSubagentModelConfigSelectionResult({ cfg, agentId });
+  if (selection?.source === "agent") {
+    return resolveSelectedModelFallbacksOverride(agentConfig?.model);
+  }
+  if (selection?.source === "default-subagent") {
+    return resolveSelectedModelFallbacksOverride(cfg.agents?.defaults?.subagents?.model);
+  }
+  return undefined;
 }
 
 export function resolveFallbackAgentId(params: {

--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -39,20 +39,20 @@ vi.mock("./isolated-agent/run-model-selection.runtime.js", () => ({
   resolveAllowedModelRef: resolveAllowedModelRefMock,
   resolveConfiguredModelRef: resolveConfiguredModelRefMock,
   resolveHooksGmailModel: resolveHooksGmailModelMock,
-  resolveSubagentModelConfigSelection: ({
+  resolveSubagentModelConfigSelectionResult: ({
     cfg,
     agentConfigOverride,
   }: {
     cfg?: { agents?: { defaults?: { subagents?: { model?: unknown } } } };
     agentConfigOverride?: { model?: unknown; subagents?: { model?: unknown } };
   }) => {
-    for (const raw of [
-      agentConfigOverride?.subagents?.model,
-      agentConfigOverride?.model,
-      cfg?.agents?.defaults?.subagents?.model,
+    for (const candidate of [
+      { raw: agentConfigOverride?.subagents?.model, source: "subagent" as const },
+      { raw: agentConfigOverride?.model, source: "agent" as const },
+      { raw: cfg?.agents?.defaults?.subagents?.model, source: "default-subagent" as const },
     ]) {
-      if (normalizeModelSelectionMock(raw)) {
-        return raw;
+      if (normalizeModelSelectionMock(candidate.raw)) {
+        return candidate;
       }
     }
     return undefined;

--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -39,6 +39,24 @@ vi.mock("./isolated-agent/run-model-selection.runtime.js", () => ({
   resolveAllowedModelRef: resolveAllowedModelRefMock,
   resolveConfiguredModelRef: resolveConfiguredModelRefMock,
   resolveHooksGmailModel: resolveHooksGmailModelMock,
+  resolveSubagentModelConfigSelection: ({
+    cfg,
+    agentConfigOverride,
+  }: {
+    cfg?: { agents?: { defaults?: { subagents?: { model?: unknown } } } };
+    agentConfigOverride?: { model?: unknown; subagents?: { model?: unknown } };
+  }) => {
+    for (const raw of [
+      agentConfigOverride?.subagents?.model,
+      agentConfigOverride?.model,
+      cfg?.agents?.defaults?.subagents?.model,
+    ]) {
+      if (normalizeModelSelectionMock(raw)) {
+        return raw;
+      }
+    }
+    return undefined;
+  },
 }));
 
 import { resolveCronModelSelection } from "./isolated-agent/model-selection.js";
@@ -612,6 +630,26 @@ describe("cron model formatting and precedence edge cases", () => {
           },
         },
         { provider: "google", model: "gemini-2.5-flash" },
+      );
+    });
+
+    it("falls through metadata-only subagents.model to the agent model", async () => {
+      await expectSelectedModel(
+        {
+          cfg: {
+            agents: {
+              defaults: {
+                model: "anthropic/claude-sonnet-4-6",
+                subagents: { model: "ollama/llama3.2:3b" },
+              },
+            },
+          },
+          agentConfigOverride: {
+            model: { primary: "anthropic/claude-opus-4-6" },
+            subagents: { model: { timeoutMs: 1_000 } },
+          },
+        },
+        { provider: "anthropic", model: "claude-opus-4-6" },
       );
     });
 

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -10,7 +10,7 @@ import {
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
-  resolveSubagentModelConfigSelection,
+  resolveSubagentModelConfigSelectionResult,
 } from "./run-model-selection.runtime.js";
 
 type CronSessionModelOverrides = {
@@ -83,21 +83,14 @@ export async function resolveCronModelSelection(
     return catalog;
   };
 
-  const subagentModelConfigSelection = resolveSubagentModelConfigSelection({
+  const subagentModelConfigSelection = resolveSubagentModelConfigSelectionResult({
     cfg: params.cfg,
     agentId: params.agentId,
     agentConfigOverride: params.agentConfigOverride,
   });
-  const subagentModelRaw = normalizeModelSelection(subagentModelConfigSelection);
-  const agentSubagentModel = normalizeModelSelection(params.agentConfigOverride?.subagents?.model);
-  const agentModel = normalizeModelSelection(params.agentConfigOverride?.model);
+  const subagentModelRaw = normalizeModelSelection(subagentModelConfigSelection?.raw);
   const subagentModelSource: CronModelSelectionSource =
-    subagentModelRaw !== undefined &&
-    agentModel !== undefined &&
-    (agentSubagentModel === undefined || subagentModelRaw !== agentSubagentModel) &&
-    subagentModelRaw === agentModel
-      ? "agent"
-      : "subagent";
+    subagentModelConfigSelection?.source === "agent" ? "agent" : "subagent";
   if (subagentModelRaw) {
     const resolvedSubagent = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -1,3 +1,4 @@
+import type { AgentConfig } from "../../config/types.agents.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
 import {
@@ -9,6 +10,7 @@ import {
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
+  resolveSubagentModelConfigSelection,
 } from "./run-model-selection.runtime.js";
 
 type CronSessionModelOverrides = {
@@ -21,12 +23,7 @@ type CronModelSelectionSource = "default" | "subagent" | "agent" | "hook" | "pay
 export type ResolveCronModelSelectionParams = {
   cfg: OpenClawConfig;
   cfgWithAgentDefaults: OpenClawConfig;
-  agentConfigOverride?: {
-    model?: unknown;
-    subagents?: {
-      model?: unknown;
-    };
-  };
+  agentConfigOverride?: Pick<AgentConfig, "model" | "subagents">;
   sessionEntry: CronSessionModelOverrides;
   payload: CronJob["payload"];
   isGmailHook: boolean;
@@ -86,14 +83,21 @@ export async function resolveCronModelSelection(
     return catalog;
   };
 
+  const subagentModelConfigSelection = resolveSubagentModelConfigSelection({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    agentConfigOverride: params.agentConfigOverride,
+  });
+  const subagentModelRaw = normalizeModelSelection(subagentModelConfigSelection);
   const agentSubagentModel = normalizeModelSelection(params.agentConfigOverride?.subagents?.model);
   const agentModel = normalizeModelSelection(params.agentConfigOverride?.model);
-  const defaultSubagentModel = normalizeModelSelection(
-    params.cfg.agents?.defaults?.subagents?.model,
-  );
-  const subagentModelRaw = agentSubagentModel ?? agentModel ?? defaultSubagentModel;
   const subagentModelSource: CronModelSelectionSource =
-    agentSubagentModel !== undefined ? "subagent" : agentModel !== undefined ? "agent" : "subagent";
+    subagentModelRaw !== undefined &&
+    agentModel !== undefined &&
+    (agentSubagentModel === undefined || subagentModelRaw !== agentSubagentModel) &&
+    subagentModelRaw === agentModel
+      ? "agent"
+      : "subagent";
   if (subagentModelRaw) {
     const resolvedSubagent = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,

--- a/src/cron/isolated-agent/run-fallback-policy.test.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.test.ts
@@ -100,7 +100,7 @@ describe("resolveCronFallbacksOverride", () => {
     ).toEqual(["openai-codex/gpt-5.2", "zai/glm-5"]);
   });
 
-  it("keeps default subagent fallbacks ahead of the agent primary fallback policy", () => {
+  it("keeps a selected agent primary model strict ahead of default subagent fallbacks", () => {
     expect(
       resolveCronFallbacksOverride({
         cfg: {
@@ -130,7 +130,7 @@ describe("resolveCronFallbacksOverride", () => {
           message: "summarize",
         }),
       }),
-    ).toEqual(["openai-codex/gpt-5.2"]);
+    ).toStrictEqual([]);
   });
 
   it("keeps explicit empty subagent fallbacks as a fallback override", () => {

--- a/src/cron/isolated-agent/run-fallback-policy.test.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.test.ts
@@ -190,6 +190,61 @@ describe("resolveCronFallbacksOverride", () => {
     ).toBeUndefined();
   });
 
+  it("treats string subagent model selection as strict when no fallbacks are configured", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-opus-4-6",
+                fallbacks: ["openai/gpt-5.4"],
+              },
+              subagents: {
+                model: "kimi/kimi-code",
+              },
+            },
+          },
+        },
+        agentId: "main",
+        useSubagentFallbacks: true,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps payload model overrides on the configured model fallback policy", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-opus-4-6",
+                fallbacks: ["openai/gpt-5.4"],
+              },
+              subagents: {
+                model: {
+                  primary: "kimi/kimi-code",
+                  fallbacks: ["openai-codex/gpt-5.4", "zai/glm-5"],
+                },
+              },
+            },
+          },
+        },
+        agentId: "main",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+          model: "google/gemini-3-pro",
+        }),
+      }),
+    ).toEqual(["openai/gpt-5.4"]);
+  });
+
   it("leaves the default model path to the fallback runner when no payload model is set", () => {
     expect(
       resolveCronFallbacksOverride({

--- a/src/cron/isolated-agent/run-model-selection.runtime.ts
+++ b/src/cron/isolated-agent/run-model-selection.runtime.ts
@@ -1,5 +1,5 @@
 export { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
-export { resolveSubagentModelConfigSelection } from "../../agents/agent-scope.js";
+export { resolveSubagentModelConfigSelectionResult } from "../../agents/agent-scope.js";
 export { loadModelCatalog } from "../../agents/model-catalog.js";
 export {
   getModelRefStatus,

--- a/src/cron/isolated-agent/run-model-selection.runtime.ts
+++ b/src/cron/isolated-agent/run-model-selection.runtime.ts
@@ -1,4 +1,5 @@
 export { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
+export { resolveSubagentModelConfigSelection } from "../../agents/agent-scope.js";
 export { loadModelCatalog } from "../../agents/model-catalog.js";
 export {
   getModelRefStatus,

--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -35,6 +35,20 @@ function requireModelFallbackRequest(): {
   return request;
 }
 
+function requireEmbeddedRunRequest(): {
+  modelFallbacksOverride?: string[];
+} {
+  const request = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as
+    | {
+        modelFallbacksOverride?: string[];
+      }
+    | undefined;
+  if (!request) {
+    throw new Error("Expected embedded run request");
+  }
+  return request;
+}
+
 describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
   setupRunCronIsolatedAgentTurnSuite();
 

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -164,6 +164,24 @@ vi.mock("./run-model-selection.runtime.js", () => ({
   resolveAllowedModelRef: resolveAllowedModelRefMock,
   resolveConfiguredModelRef: resolveConfiguredModelRefMock,
   resolveHooksGmailModel: resolveHooksGmailModelMock,
+  resolveSubagentModelConfigSelection: ({
+    cfg,
+    agentConfigOverride,
+  }: {
+    cfg?: { agents?: { defaults?: { subagents?: { model?: unknown } } } };
+    agentConfigOverride?: { model?: unknown; subagents?: { model?: unknown } };
+  }) => {
+    for (const raw of [
+      agentConfigOverride?.subagents?.model,
+      agentConfigOverride?.model,
+      cfg?.agents?.defaults?.subagents?.model,
+    ]) {
+      if (normalizeModelSelectionForTest(raw)) {
+        return raw;
+      }
+    }
+    return undefined;
+  },
 }));
 
 vi.mock("./run-execution.runtime.js", () => ({

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -345,6 +345,7 @@ function resetRunConfigMocks(): void {
     };
     return (
       resolveOverride(agentConfig?.subagents?.model) ??
+      resolveOverride(agentConfig?.model) ??
       resolveOverride(
         (cfg as { agents?: { defaults?: { subagents?: { model?: unknown } } } })?.agents?.defaults
           ?.subagents?.model,

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -164,20 +164,20 @@ vi.mock("./run-model-selection.runtime.js", () => ({
   resolveAllowedModelRef: resolveAllowedModelRefMock,
   resolveConfiguredModelRef: resolveConfiguredModelRefMock,
   resolveHooksGmailModel: resolveHooksGmailModelMock,
-  resolveSubagentModelConfigSelection: ({
+  resolveSubagentModelConfigSelectionResult: ({
     cfg,
     agentConfigOverride,
   }: {
     cfg?: { agents?: { defaults?: { subagents?: { model?: unknown } } } };
     agentConfigOverride?: { model?: unknown; subagents?: { model?: unknown } };
   }) => {
-    for (const raw of [
-      agentConfigOverride?.subagents?.model,
-      agentConfigOverride?.model,
-      cfg?.agents?.defaults?.subagents?.model,
+    for (const candidate of [
+      { raw: agentConfigOverride?.subagents?.model, source: "subagent" as const },
+      { raw: agentConfigOverride?.model, source: "agent" as const },
+      { raw: cfg?.agents?.defaults?.subagents?.model, source: "default-subagent" as const },
     ]) {
-      if (normalizeModelSelectionForTest(raw)) {
-        return raw;
+      if (normalizeModelSelectionForTest(candidate.raw)) {
+        return candidate;
       }
     }
     return undefined;
@@ -361,6 +361,10 @@ function resetRunConfigMocks(): void {
         ? fallbacks.filter((entry) => typeof entry === "string")
         : undefined;
     };
+    const subagentFallbacks = resolveOverride(agentConfig?.subagents?.model);
+    if (subagentFallbacks !== undefined) {
+      return subagentFallbacks;
+    }
     const selectedConfig = [
       agentConfig?.subagents?.model,
       agentConfig?.model,

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -361,14 +361,13 @@ function resetRunConfigMocks(): void {
         ? fallbacks.filter((entry) => typeof entry === "string")
         : undefined;
     };
-    return (
-      resolveOverride(agentConfig?.subagents?.model) ??
-      resolveOverride(agentConfig?.model) ??
-      resolveOverride(
-        (cfg as { agents?: { defaults?: { subagents?: { model?: unknown } } } })?.agents?.defaults
-          ?.subagents?.model,
-      )
-    );
+    const selectedConfig = [
+      agentConfig?.subagents?.model,
+      agentConfig?.model,
+      (cfg as { agents?: { defaults?: { subagents?: { model?: unknown } } } })?.agents?.defaults
+        ?.subagents?.model,
+    ].find((raw) => normalizeModelSelectionForTest(raw));
+    return resolveOverride(selectedConfig);
   });
   resolveAgentModelFallbacksOverrideMock.mockReturnValue(undefined);
   resolveAgentSkillsFilterMock.mockReturnValue(undefined);


### PR DESCRIPTION
Summary
- Refactor isolated cron subagent model selection so the primary model and fallback policy use one shared precedence helper.
- Preserve subagent-specific fallback overrides, including fallback-only configs, without letting parent agent fallback policy shadow selected subagent defaults.
- Add regression coverage for metadata-only fallthrough, fallback-only overrides, and payload model override precedence.

Replaces closed PR #82295. Builds on the #74985 fix already present on main.

## Real behavior proof
Behavior addressed: Isolated cron subagent fallback policy now follows the same selected model config as cron subagent primary selection, while payload model overrides keep the default model fallback policy.
Real environment tested: local checkout, importing the real OpenClaw cron fallback resolver through the TS runtime loader after rebase onto origin/main.
Exact steps or command run after this patch: node --import tsx with a cron isolated agentTurn fixture that configures agents.defaults.subagents.model.fallbacks, then the same fixture with payload.model override; node scripts/run-vitest.mjs src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/model-selection.test.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/agents/agent-scope.test.ts src/agents/pi-embedded-runner/run/failover-policy.test.ts src/agents/pi-embedded-runner/run/fallbacks.test.ts; pnpm exec oxfmt --check --threads=1 src/agents/agent-scope.ts src/agents/agent-scope.test.ts src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/model-selection.ts src/cron/isolated-agent/run-model-selection.runtime.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/cron/isolated-agent/run.test-harness.ts; git diff --check; codex-review --full-access.
Evidence after fix: Terminal output from the runtime resolver probe:
```json
{
  "isolated": [
    "openai-codex/gpt-5.4",
    "zai/glm-5"
  ],
  "payloadOverride": [
    "openai/gpt-5.4"
  ]
}
```
Focused Vitest passed 7 files / 140 tests after rebase onto origin/main; oxfmt passed; git diff --check passed; codex-review clean after accepted fixups.
Observed result after fix: isolated cron agent turns resolve to the configured subagent fallback chain, payload model overrides use the configured default model fallback policy instead of subagent fallbacks, explicit subagent fallback-only overrides are preserved, and metadata-only subagents.model falls through to the next selected model config.
What was not tested: live Kimi/provider timeout E2E.
