### PR TITLE
fix(auto-reply): abort active text stop runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: let authorized text `/stop` commands use the fast-abort path before queued agent work, so active turns stop immediately instead of processing the abort after the turn finishes. Fixes #82162. Thanks @civiltox.
 - Release tooling: align the published launcher Node floor, `npm start`, package script checks, sharded lint locking, Vitest root project coverage, and plugin-SDK declaration build cache metadata so release/package validation does not silently skip or ship stale surfaces.
 - Cron/agents: honor configured subagent model fallbacks for isolated scheduled runs and forward that fallback policy into embedded agent timeout failover. Fixes #74985. Thanks @chrisgwynne.
 - Codex app-server/MCP: scope user MCP servers to specific OpenClaw agent ids through an optional `mcp.servers.<name>.codex.agents` list and accept `codex.defaultToolsApprovalMode` (`auto`/`prompt`/`approve`) for native Codex approval defaults; OpenClaw strips the `codex` block before handing `mcp_servers` config to Codex. (#82180) Thanks @sercada.

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -64,6 +64,11 @@ const acpManagerMocks = vi.hoisted(() => ({
   cancelSession: vi.fn(async () => {}),
 }));
 
+const runtimeAbortMocks = vi.hoisted(() => ({
+  abortEmbeddedPiRun: vi.fn(() => true),
+  resolveActiveEmbeddedRunSessionId: vi.fn(() => undefined as string | undefined),
+}));
+
 vi.mock("../../acp/control-plane/manager.js", () => ({
   getAcpSessionManager: () => ({
     resolveSession: acpManagerMocks.resolveSession,
@@ -110,6 +115,8 @@ describe("abort detection", () => {
     sessionKey: string;
     from: string;
     to: string;
+    senderId?: string;
+    commandSource?: "native" | "text";
     targetSessionKey?: string;
     messageSid?: string;
     timestamp?: number;
@@ -124,6 +131,8 @@ describe("abort detection", () => {
         Surface: "telegram",
         From: params.from,
         To: params.to,
+        ...(params.senderId ? { SenderId: params.senderId } : {}),
+        ...(params.commandSource ? { CommandSource: params.commandSource } : {}),
         ...(params.targetSessionKey ? { CommandTargetSessionKey: params.targetSessionKey } : {}),
         ...(params.messageSid ? { MessageSid: params.messageSid } : {}),
         ...(typeof params.timestamp === "number" ? { Timestamp: params.timestamp } : {}),
@@ -176,7 +185,8 @@ describe("abort detection", () => {
           resolveSession: acpManagerMocks.resolveSession,
           cancelSession: acpManagerMocks.cancelSession,
         }) as never) as never,
-      abortEmbeddedPiRun: () => true,
+      abortEmbeddedPiRun: runtimeAbortMocks.abortEmbeddedPiRun,
+      resolveActiveEmbeddedRunSessionId: runtimeAbortMocks.resolveActiveEmbeddedRunSessionId,
       getLatestSubagentRunByChildSessionKey:
         subagentRegistryMocks.getLatestSubagentRunByChildSessionKey,
       listSubagentRunsForController: subagentRegistryMocks.listSubagentRunsForRequester,
@@ -196,6 +206,8 @@ describe("abort detection", () => {
     commandQueueMocks.clearCommandLane.mockClear().mockReturnValue(1);
     acpManagerMocks.resolveSession.mockReset().mockReturnValue({ kind: "none" });
     acpManagerMocks.cancelSession.mockReset().mockResolvedValue(undefined);
+    runtimeAbortMocks.abortEmbeddedPiRun.mockReset().mockReturnValue(true);
+    runtimeAbortMocks.resolveActiveEmbeddedRunSessionId.mockReset().mockReturnValue(undefined);
     subagentRegistryMocks.getLatestSubagentRunByChildSessionKey.mockReset().mockReturnValue(null);
   });
 
@@ -391,6 +403,37 @@ describe("abort detection", () => {
     });
 
     expect(result.handled).toBe(true);
+  });
+
+  it("fast-aborts authorized text slash stop commands before they queue", async () => {
+    const sessionKey = "telegram:123";
+    const sessionId = "session-123";
+    const activeSessionId = "session-active";
+    const { root, cfg } = await createAbortConfig({
+      sessionIdsByKey: { [sessionKey]: sessionId },
+    });
+    cfg.commands = {
+      ...cfg.commands,
+      ownerAllowFrom: ["telegram:123"],
+    };
+    runtimeAbortMocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(activeSessionId);
+    enqueueQueuedFollowupRun({ root, cfg, sessionId, sessionKey });
+    expect(getFollowupQueueDepth(sessionKey)).toBe(1);
+
+    const result = await runStopCommand({
+      cfg,
+      sessionKey,
+      from: "telegram:123",
+      to: "telegram:123",
+      senderId: "123",
+      commandSource: "text",
+    });
+
+    expect(result.handled).toBe(true);
+    expect(runtimeAbortMocks.resolveActiveEmbeddedRunSessionId).toHaveBeenCalledWith(sessionKey);
+    expect(runtimeAbortMocks.abortEmbeddedPiRun).toHaveBeenCalledWith(activeSessionId);
+    expect(getFollowupQueueDepth(sessionKey)).toBe(0);
+    expectSessionLaneCleared(sessionKey);
   });
 
   it("fast-abort clears queued followups and session lane", async () => {

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -1,6 +1,9 @@
 import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { abortEmbeddedPiRun } from "../../agents/pi-embedded-runner/runs.js";
+import {
+  abortEmbeddedPiRun,
+  resolveActiveEmbeddedRunSessionId,
+} from "../../agents/pi-embedded-runner/runs.js";
 import {
   getLatestSubagentRunByChildSessionKey,
   listSubagentRunsForController,
@@ -58,6 +61,7 @@ export {
 const defaultAbortDeps = {
   getAcpSessionManager,
   abortEmbeddedPiRun,
+  resolveActiveEmbeddedRunSessionId,
   getLatestSubagentRunByChildSessionKey,
   listSubagentRunsForController,
   markSubagentRunTerminated,
@@ -72,6 +76,8 @@ export const __testing = {
     abortDeps.getAcpSessionManager =
       deps?.getAcpSessionManager ?? defaultAbortDeps.getAcpSessionManager;
     abortDeps.abortEmbeddedPiRun = deps?.abortEmbeddedPiRun ?? defaultAbortDeps.abortEmbeddedPiRun;
+    abortDeps.resolveActiveEmbeddedRunSessionId =
+      deps?.resolveActiveEmbeddedRunSessionId ?? defaultAbortDeps.resolveActiveEmbeddedRunSessionId;
     abortDeps.getLatestSubagentRunByChildSessionKey =
       deps?.getLatestSubagentRunByChildSessionKey ??
       defaultAbortDeps.getLatestSubagentRunByChildSessionKey;
@@ -83,12 +89,35 @@ export const __testing = {
   resetDepsForTests(): void {
     abortDeps.getAcpSessionManager = defaultAbortDeps.getAcpSessionManager;
     abortDeps.abortEmbeddedPiRun = defaultAbortDeps.abortEmbeddedPiRun;
+    abortDeps.resolveActiveEmbeddedRunSessionId =
+      defaultAbortDeps.resolveActiveEmbeddedRunSessionId;
     abortDeps.getLatestSubagentRunByChildSessionKey =
       defaultAbortDeps.getLatestSubagentRunByChildSessionKey;
     abortDeps.listSubagentRunsForController = defaultAbortDeps.listSubagentRunsForController;
     abortDeps.markSubagentRunTerminated = defaultAbortDeps.markSubagentRunTerminated;
   },
 };
+
+export function abortSessionRunTarget(params: { key?: string; sessionId?: string }): boolean {
+  const sessionIds = new Set<string>();
+  const key = normalizeOptionalString(params.key);
+  if (key) {
+    const activeSessionId = abortDeps.resolveActiveEmbeddedRunSessionId(key);
+    if (activeSessionId) {
+      sessionIds.add(activeSessionId);
+    }
+  }
+  const explicitSessionId = normalizeOptionalString(params.sessionId);
+  if (explicitSessionId) {
+    sessionIds.add(explicitSessionId);
+  }
+
+  let aborted = key ? replyRunRegistry.abort(key) : false;
+  for (const sessionId of sessionIds) {
+    aborted = abortDeps.abortEmbeddedPiRun(sessionId) || aborted;
+  }
+  return aborted;
+}
 
 export function formatAbortReplyText(stoppedSubagents?: number): string {
   if (typeof stoppedSubagents !== "number" || stoppedSubagents <= 0) {
@@ -193,9 +222,7 @@ export function stopSubagentsForRequester(params: {
       }
       const entry = store[childKey];
       const sessionId = replyRunRegistry.resolveSessionId(childKey) ?? entry?.sessionId;
-      const aborted =
-        (childKey ? replyRunRegistry.abort(childKey) : false) ||
-        (sessionId ? abortDeps.abortEmbeddedPiRun(sessionId) : false);
+      const aborted = abortSessionRunTarget({ key: childKey, sessionId });
       const markedTerminated =
         abortDeps.markSubagentRunTerminated({
           runId: run.runId,
@@ -289,9 +316,7 @@ export async function tryFastAbortFromMessage(params: {
       }
     }
     const sessionId = replyRunRegistry.resolveSessionId(resolvedTargetKey) ?? entry?.sessionId;
-    const aborted =
-      replyRunRegistry.abort(resolvedTargetKey) ||
-      (sessionId ? abortDeps.abortEmbeddedPiRun(sessionId) : false);
+    const aborted = abortSessionRunTarget({ key: resolvedTargetKey, sessionId });
     const cleared = clearSessionQueues([resolvedTargetKey, sessionId]);
     if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
       logVerbose(

--- a/src/auto-reply/reply/commands-abort-trigger.test.ts
+++ b/src/auto-reply/reply/commands-abort-trigger.test.ts
@@ -7,6 +7,7 @@ import type { HandleCommandsParams } from "./commands-types.js";
 const abortEmbeddedPiRunMock = vi.hoisted(() => vi.fn());
 const persistAbortTargetEntryMock = vi.hoisted(() => vi.fn());
 const setAbortMemoryMock = vi.hoisted(() => vi.fn());
+const abortSessionRunTargetMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../agents/pi-embedded.js", () => ({
   abortEmbeddedPiRun: abortEmbeddedPiRunMock,
@@ -27,6 +28,7 @@ vi.mock("./abort-cutoff.js", () => ({
 }));
 
 vi.mock("./abort.js", () => ({
+  abortSessionRunTarget: abortSessionRunTargetMock,
   formatAbortReplyText: vi.fn(() => "⚙️ Agent was aborted."),
   isAbortTrigger: vi.fn((raw: string) => raw === "stop"),
   resolveSessionEntryForKey: vi.fn(() => ({ entry: undefined, key: "agent:main:main" })),
@@ -93,6 +95,7 @@ describe("handleAbortTrigger", () => {
   it("rejects unauthorized natural-language abort triggers", async () => {
     const result = await handleAbortTrigger(buildAbortParams(), true);
     expect(result).toEqual({ shouldContinue: false });
+    expect(abortSessionRunTargetMock).not.toHaveBeenCalled();
     expect(abortEmbeddedPiRunMock).not.toHaveBeenCalled();
     expect(persistAbortTargetEntryMock).not.toHaveBeenCalled();
     expect(setAbortMemoryMock).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -8,6 +8,7 @@ import {
   type AbortCutoff,
 } from "./abort-cutoff.js";
 import {
+  abortSessionRunTarget,
   formatAbortReplyText,
   isAbortTrigger,
   resolveSessionEntryForKey,
@@ -25,11 +26,6 @@ type AbortTarget = {
   key?: string;
   sessionId?: string;
 };
-
-async function abortEmbeddedPiRunForSession(sessionId: string): Promise<void> {
-  const { abortEmbeddedPiRun } = await import("../../agents/pi-embedded-runner/runs.js");
-  abortEmbeddedPiRun(sessionId);
-}
 
 function resolveAbortTarget(params: {
   ctx: { CommandTargetSessionKey?: string | null };
@@ -90,12 +86,7 @@ async function applyAbortTarget(params: {
   abortCutoff?: AbortCutoff;
 }) {
   const { abortTarget } = params;
-  if (abortTarget.key) {
-    replyRunRegistry.abort(abortTarget.key);
-  }
-  if (abortTarget.sessionId) {
-    await abortEmbeddedPiRunForSession(abortTarget.sessionId);
-  }
+  abortSessionRunTarget({ key: abortTarget.key, sessionId: abortTarget.sessionId });
 
   const persisted = await persistAbortTargetEntry({
     entry: abortTarget.entry,

--- a/src/auto-reply/reply/commands-stop-target.test.ts
+++ b/src/auto-reply/reply/commands-stop-target.test.ts
@@ -15,9 +15,9 @@ import type { HandleCommandsParams } from "./commands-types.js";
 const abortEmbeddedPiRunMock = vi.hoisted(() => vi.fn());
 const createInternalHookEventMock = vi.hoisted(() => vi.fn(() => ({})));
 const persistAbortTargetEntryMock = vi.hoisted(() => vi.fn(async () => true));
-const replyRunAbortMock = vi.hoisted(() => vi.fn());
 const resolveSessionIdMock = vi.hoisted(() => vi.fn(() => undefined));
 const stopSubagentsForRequesterMock = vi.hoisted(() => vi.fn(() => ({ stopped: 0 })));
+const abortSessionRunTargetMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../agents/pi-embedded.js", () => ({
   abortEmbeddedPiRun: abortEmbeddedPiRunMock,
@@ -38,6 +38,7 @@ vi.mock("./abort-cutoff.js", () => ({
 }));
 
 vi.mock("./abort.js", () => ({
+  abortSessionRunTarget: abortSessionRunTargetMock,
   formatAbortReplyText: vi.fn(() => "⚙️ Agent was aborted."),
   isAbortTrigger: vi.fn(() => false),
   resolveSessionEntryForKey: vi.fn(() => ({ entry: undefined, key: undefined })),
@@ -51,7 +52,6 @@ vi.mock("./commands-session-store.js", () => ({
 
 vi.mock("./reply-run-registry.js", () => ({
   replyRunRegistry: {
-    abort: replyRunAbortMock,
     resolveSessionId: resolveSessionIdMock,
   },
 }));
@@ -152,7 +152,10 @@ describe("handleStopCommand target fallback", () => {
       shouldContinue: false,
       reply: { text: "⚙️ Agent was aborted." },
     });
-    expect(replyRunAbortMock).toHaveBeenCalledWith("agent:target:telegram:direct:123");
+    expect(abortSessionRunTargetMock).toHaveBeenCalledWith({
+      key: "agent:target:telegram:direct:123",
+      sessionId: undefined,
+    });
     expect(abortEmbeddedPiRunMock).not.toHaveBeenCalledWith("wrapper-session-id");
     const [[persistAbortTargetParams]] = persistAbortTargetEntryMock.mock.calls as unknown as Array<
       [
@@ -223,7 +226,7 @@ describe("handleStopCommand target fallback", () => {
       shouldContinue: false,
       reply: { text: "You are not authorized to use this command." },
     });
-    expect(replyRunAbortMock).not.toHaveBeenCalled();
+    expect(abortSessionRunTargetMock).not.toHaveBeenCalled();
     expect(persistAbortTargetEntryMock).not.toHaveBeenCalled();
     expect(createInternalHookEventMock).not.toHaveBeenCalled();
     expect(stopSubagentsForRequesterMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- route `/stop` through the active embedded-run session registry before falling back to the stored session id
- share the same abort target helper across fast text aborts, normal `/stop`, and subagent stop cleanup
- keep command authorization intact, including Telegram owner allowlist normalization, and cover the text `/stop` path with regression tests

Fixes #82162.

## Real behavior proof
Behavior addressed: authorized Telegram text `/stop` reaches the active Codex embedded run registered for the session key and aborts it immediately, instead of only marking the stored session/queue state.
Real environment tested: local OpenClaw source checkout with production auto-reply abort code, production active embedded-run registry, and the real Telegram config adapter registered in the loaded channel registry.
Exact steps or command run after this patch: `node --import tsx --input-type=module` runtime probe importing `tryFastAbortFromMessage`, `setActiveEmbeddedRun`, `resolveActiveEmbeddedRunHandleSessionId`, `PLUGIN_REGISTRY_STATE`, and `telegramConfigAdapter`, then sending a finalized Telegram text `/stop` context with `CommandAuthorized: true`, `CommandSource: "text"`, `SessionKey: "telegram:123"`, `SenderId: "123"`, and `commands.ownerAllowFrom: ["telegram:123"]`.
Evidence after fix: terminal output from the runtime probe:
```json
{
  "before": "codex-active-session",
  "result": {
    "handled": true,
    "aborted": true,
    "stoppedSubagents": 0
  },
  "abortCalls": 1,
  "after": "codex-active-session"
}
```
Observed result after fix: the real Telegram adapter normalizes `telegram:123` to sender `123`; the text `/stop` command is authorized, resolves the active embedded run session id for `telegram:123`, and invokes the active run abort handle once.
What was not tested: live Telegram Bot API roundtrip against an external bot account; the runtime proof uses the production Telegram adapter and local OpenClaw registries without sending a real Telegram message.

## Verification
- `node --import tsx --input-type=module` runtime probe above
- `node scripts/run-vitest.mjs src/auto-reply/reply/abort.test.ts src/auto-reply/reply/commands-stop-target.test.ts src/auto-reply/reply/commands-abort-trigger.test.ts`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --parallel-tests "node scripts/run-vitest.mjs src/auto-reply/reply/abort.test.ts src/auto-reply/reply/commands-stop-target.test.ts src/auto-reply/reply/commands-abort-trigger.test.ts"`

Note: the Vitest shard and Codex review passed before this PR-body rewrite. A repeat local Vitest run in this checkout was stopped after several minutes of Rolldown transform timing output and no test result; no code changed after the earlier green run.
