### PR TITLE
feat(skills-setup): add skill setup hook plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -284,6 +284,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/open-prose/**"
+"extensions: skills-setup":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/skills-setup/**"
 "extensions: tokenjuice":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/skills-setup/index.js
+++ b/extensions/skills-setup/index.js
@@ -1,4 +1,4 @@
-import { access, readFile, readdir, realpath } from "node:fs/promises";
+import { access, readFile, readdir, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import { ErrorCodes, errorShape } from "openclaw/plugin-sdk/gateway-runtime";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
@@ -77,6 +77,24 @@ async function resolveRealSkillDirCandidate({ skillsDirReal, candidateDir }) {
   if (!isPathInside(skillsDirReal, candidateDirReal)) {
     throw new Error("skill directory escapes skills root");
   }
+
+  let skillMarkdownReal;
+  try {
+    skillMarkdownReal = await realpath(path.join(candidateDirReal, "SKILL.md"));
+    const skillMarkdownStat = await stat(skillMarkdownReal);
+    if (!skillMarkdownStat.isFile()) {
+      return undefined;
+    }
+  } catch (error) {
+    if (error?.code === "ENOENT" || error?.code === "ENOTDIR") {
+      return undefined;
+    }
+    throw error;
+  }
+  if (!isPathInside(candidateDirReal, skillMarkdownReal)) {
+    throw new Error("skill manifest escapes skill directory");
+  }
+
   return candidateDirReal;
 }
 

--- a/extensions/skills-setup/index.js
+++ b/extensions/skills-setup/index.js
@@ -1,0 +1,337 @@
+import { access, readFile, realpath } from "node:fs/promises";
+import path from "node:path";
+import { ErrorCodes, errorShape } from "openclaw/plugin-sdk/gateway-runtime";
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/sandbox";
+import { isPathInside } from "openclaw/plugin-sdk/security-runtime";
+
+// SDK gap: at openclaw@2026.5.5 the plugin SDK does not re-export the skills-
+// registry helpers (loadWorkspaceSkillEntries, parseSkillFrontmatter,
+// resolveOpenClawMetadata). Those live under src/agents/skills/* but the
+// published package's `exports` map limits plugin imports to ./plugin-sdk/*.
+// Until upstream surfaces them via ./plugin-sdk/skills-runtime (or similar),
+// this plugin resolves skill directories and parses frontmatter directly.
+
+const METHOD_NAME = "skills.setup";
+const PLUGIN_ID = "skills-setup";
+const DEFAULT_AGENT_ID = "main";
+const DEFAULT_TIMEOUT_MS = 120_000;
+const MAX_TIMEOUT_MS = 600_000;
+const MIN_TIMEOUT_MS = 1_000;
+const VALID_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i;
+const RESERVED_ENV_KEYS = new Set([
+  "HOME",
+  "PATH",
+  "SKILL_DIR",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+]);
+
+// #region Basic request/config normalization
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeSlug(value) {
+  const slug = normalizeString(value);
+  if (!slug || slug.includes("/") || slug.includes("\\") || slug.includes("..")) {
+    throw new Error("invalid skill slug");
+  }
+  if (!VALID_SLUG_PATTERN.test(slug) || /[^\x00-\x7F]/.test(slug)) {
+    throw new Error("invalid skill slug");
+  }
+  return slug;
+}
+
+function normalizeAgentId(value) {
+  return normalizeString(value) || DEFAULT_AGENT_ID;
+}
+
+// #endregion
+
+// #region Installed skill path resolution
+
+const ERR_SKILL_NOT_FOUND = "SKILL_NOT_FOUND";
+
+function skillNotFound(message) {
+  const err = new Error(message);
+  err.code = ERR_SKILL_NOT_FOUND;
+  return err;
+}
+
+async function resolveInstalledSkillDir({ workspaceDir, slug }) {
+  const skillsDir = path.join(path.resolve(workspaceDir), "skills");
+  const targetDir = path.resolve(skillsDir, slug);
+  if (!isPathInside(skillsDir, targetDir)) {
+    throw new Error("invalid skill target path");
+  }
+  let skillsDirReal;
+  let targetDirReal;
+  try {
+    [skillsDirReal, targetDirReal] = await Promise.all([realpath(skillsDir), realpath(targetDir)]);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw skillNotFound(`skill "${slug}" not installed`);
+    }
+    throw error;
+  }
+  if (!isPathInside(skillsDirReal, targetDirReal)) {
+    throw new Error("skill directory escapes skills root");
+  }
+  return targetDirReal;
+}
+
+// #endregion
+
+// #region SDK gap: setup script metadata parsing
+
+// SDK gap: OpenClaw has internal SKILL.md frontmatter helpers, but they are not
+// exported through `openclaw/plugin-sdk/*`.
+// Needed public surface: `parseSkillFrontmatter()` + `resolveOpenClawMetadata()`
+// or a narrower `resolveSkillSetupScript()` helper. That would replace
+// normalizeScalar(), extractFrontmatterBlock(), parseIndentedSetupScript(), and
+// parseSetupScriptFromSkillMarkdown().
+function normalizeScalar(raw) {
+  const value = raw.trim();
+  if (!value) {
+    return "";
+  }
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1).trim();
+  }
+  const commentIndex = value.indexOf(" #");
+  return (commentIndex >= 0 ? value.slice(0, commentIndex) : value).trim();
+}
+
+function extractFrontmatterBlock(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  if (lines[0]?.trim() !== "---") {
+    return undefined;
+  }
+  const endIndex = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+  return endIndex > 0 ? lines.slice(1, endIndex).join("\n") : undefined;
+}
+
+function parseIndentedSetupScript(frontmatter) {
+  const lines = frontmatter.split(/\r?\n/);
+  const stack = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (!line.trim() || line.trimStart().startsWith("#")) {
+      continue;
+    }
+    const match = /^(\s*)([A-Za-z0-9_-]+):(?:\s*(.*))?$/.exec(line);
+    if (!match) {
+      continue;
+    }
+    const indent = match[1].length;
+    const key = match[2];
+    const rawValue = match[3] ?? "";
+    while (stack.length > 0 && stack[stack.length - 1].indent >= indent) {
+      stack.pop();
+    }
+    const pathKeys = [...stack.map((entry) => entry.key), key];
+    if (pathKeys.join(".") === "metadata.openclaw.setup.script" && rawValue.trim()) {
+      return normalizeScalar(rawValue);
+    }
+    if (!rawValue.trim()) {
+      stack.push({ indent, key });
+    }
+  }
+  return undefined;
+}
+
+function parseSetupScriptFromSkillMarkdown(markdown) {
+  const frontmatter = extractFrontmatterBlock(markdown);
+  return frontmatter ? parseIndentedSetupScript(frontmatter) : undefined;
+}
+
+// #endregion
+
+// #region SDK gap: setup script path resolution
+
+// SDK gap: OpenClaw does not expose a public resolver for an installed skill's
+// setup script. Needed public surface: `resolveSkillSetupScriptPath(skillDir)`
+// that reads the supported metadata shape and enforces the same path boundary.
+async function resolveSetupScriptPath(skillDir) {
+  const skillMarkdown = await readFile(path.join(skillDir, "SKILL.md"), "utf8");
+  const script = parseSetupScriptFromSkillMarkdown(skillMarkdown);
+  if (!script) {
+    return undefined;
+  }
+  if (path.isAbsolute(script) || script.includes("\0")) {
+    throw new Error("setup.script must be a relative path inside the skill directory");
+  }
+  const scriptPath = path.resolve(skillDir, script);
+  if (!isPathInside(skillDir, scriptPath)) {
+    throw new Error("setup.script escapes the skill directory");
+  }
+  const scriptPathReal = await realpath(scriptPath);
+  if (!isPathInside(skillDir, scriptPathReal)) {
+    throw new Error("setup.script resolves outside the skill directory");
+  }
+  await access(scriptPathReal);
+  return scriptPathReal;
+}
+
+// #endregion
+
+// #region SDK gap: setup env overlay
+
+// SDK gap: OpenClaw does not expose a setup-env sanitizer that allows
+// operator-provided credential vars while blocking only execution-context
+// overrides. The generic sandbox sanitizer blocks token-like keys, which is
+// wrong for this setup hook. Needed public surface: `sanitizeSetupEnvOverlay()`.
+function normalizeEnvMap(value) {
+  const env = {};
+  if (!isRecord(value)) {
+    return env;
+  }
+  for (const [rawKey, rawValue] of Object.entries(value)) {
+    if (typeof rawValue !== "string") {
+      continue;
+    }
+    const key = rawKey.trim();
+    if (!key || RESERVED_ENV_KEYS.has(key.toUpperCase())) {
+      continue;
+    }
+    env[key] = rawValue;
+  }
+  return env;
+}
+
+function readSkillConfigEnv(config, slug) {
+  if (!isRecord(config?.skills) || !isRecord(config.skills.entries)) {
+    return {};
+  }
+  const entry = config.skills.entries[slug];
+  return isRecord(entry) ? normalizeEnvMap(entry.env) : {};
+}
+
+function buildSetupEnv({ configEnv, overlayEnv, skillDir }) {
+  const env = {};
+  Object.assign(env, configEnv, overlayEnv);
+  env.SKILL_DIR = skillDir;
+  return env;
+}
+
+// #endregion
+
+// #region Timeout resolution
+
+function clampTimeoutMs(candidate, fallback) {
+  if (typeof candidate !== "number" || !Number.isFinite(candidate)) {
+    return fallback;
+  }
+  const rounded = Math.floor(candidate);
+  if (rounded < MIN_TIMEOUT_MS) {
+    return MIN_TIMEOUT_MS;
+  }
+  if (rounded > MAX_TIMEOUT_MS) {
+    return MAX_TIMEOUT_MS;
+  }
+  return rounded;
+}
+
+function readPluginConfigTimeoutMs(config) {
+  if (!isRecord(config?.plugins) || !isRecord(config.plugins.entries)) {
+    return undefined;
+  }
+  const entry = config.plugins.entries[PLUGIN_ID];
+  // OpenClaw plugin config schema lives at plugins.entries.<id>.config.* — see
+  // openclaw/src/plugin-sdk/plugin-config-runtime.ts resolvePluginConfigObject.
+  // Reading entry.timeoutMs directly would silently ignore the operator setting.
+  if (!isRecord(entry) || !isRecord(entry.config)) {
+    return undefined;
+  }
+  return entry.config.timeoutMs;
+}
+
+function resolveTimeoutMs({ config, params }) {
+  const configured = clampTimeoutMs(readPluginConfigTimeoutMs(config), DEFAULT_TIMEOUT_MS);
+  return clampTimeoutMs(params?.timeoutMs, configured);
+}
+
+// #endregion
+
+// #region Gateway RPC registration
+
+function respondError(respond, code, message) {
+  respond(false, { error: message }, errorShape(code, message));
+}
+
+export default definePluginEntry({
+  id: "skills-setup",
+  register(api) {
+    api.registerGatewayMethod(
+      METHOD_NAME,
+      async ({ params, respond, context }) => {
+        const startedAt = Date.now();
+        let slugForLog = "?";
+        let agentIdForLog = "?";
+        try {
+          const slug = normalizeSlug(params?.slug);
+          const agentId = normalizeAgentId(params?.agentId);
+          slugForLog = slug;
+          agentIdForLog = agentId;
+          const config = context.getRuntimeConfig();
+          const workspaceDir = api.runtime.agent.resolveAgentWorkspaceDir(config, agentId);
+          const skillDir = await resolveInstalledSkillDir({ workspaceDir, slug });
+          const scriptPath = await resolveSetupScriptPath(skillDir);
+          if (!scriptPath) {
+            api.logger.debug(
+              `skills.setup ${slug} (agent=${agentId}) skipped: no setup script declared`,
+            );
+            respond(true, { code: 0, stdout: "", stderr: "" });
+            return;
+          }
+
+          const timeoutMs = resolveTimeoutMs({ config, params });
+          api.logger.debug(
+            `skills.setup ${slug} (agent=${agentId}) started: script=${path.relative(skillDir, scriptPath)} timeoutMs=${timeoutMs}`,
+          );
+
+          const result = await runPluginCommandWithTimeout({
+            argv: ["bash", scriptPath],
+            cwd: skillDir,
+            env: buildSetupEnv({
+              configEnv: readSkillConfigEnv(config, slug),
+              overlayEnv: normalizeEnvMap(params?.env),
+              skillDir,
+            }),
+            timeoutMs,
+          });
+          api.logger.debug(
+            `skills.setup ${slug} (agent=${agentId}) completed: code=${result.code} durationMs=${Date.now() - startedAt}`,
+          );
+          respond(true, result);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "skill setup failed";
+          // INVALID_REQUEST when the caller-supplied slug doesn't resolve to an
+          // installed skill on this agent — no generic NOT_FOUND code at v2026.5.5
+          // (see openclaw src/gateway/protocol/schema/error-codes.ts). Reserve
+          // UNAVAILABLE for transient / server-side execution failures.
+          const code =
+            error?.code === ERR_SKILL_NOT_FOUND
+              ? ErrorCodes.INVALID_REQUEST
+              : ErrorCodes.UNAVAILABLE;
+          api.logger.warn(
+            `skills.setup ${slugForLog} (agent=${agentIdForLog}) failed: ${message} durationMs=${Date.now() - startedAt}`,
+          );
+          respondError(respond, code, message);
+        }
+      },
+      { scope: "operator.admin" },
+    );
+  },
+});
+
+// #endregion

--- a/extensions/skills-setup/index.js
+++ b/extensions/skills-setup/index.js
@@ -175,27 +175,49 @@ function stripWrappingQuotes(raw) {
   return value;
 }
 
-function readSetupScriptFromObject(value) {
+function mergeSetupMetadata(...items) {
+  const merged = {};
+  for (const item of items) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    if (typeof item.script === "string" && item.script) {
+      merged.script = item.script;
+    }
+    if (typeof item.skillKey === "string" && item.skillKey) {
+      merged.skillKey = item.skillKey;
+    }
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function readSetupMetadataFromObject(value) {
   if (!isRecord(value)) {
     return undefined;
   }
   const openclaw = value.openclaw;
-  if (!isRecord(openclaw) || !isRecord(openclaw.setup)) {
+  if (!isRecord(openclaw)) {
     return undefined;
   }
-  return typeof openclaw.setup.script === "string" ? openclaw.setup.script.trim() : undefined;
+  return mergeSetupMetadata({
+    script:
+      isRecord(openclaw.setup) && typeof openclaw.setup.script === "string"
+        ? openclaw.setup.script.trim()
+        : undefined,
+    skillKey: typeof openclaw.skillKey === "string" ? openclaw.skillKey.trim() : undefined,
+  });
 }
 
-function parseSetupScriptFromManifestText(raw) {
+function parseSetupMetadataFromManifestText(raw) {
   const value = stripWrappingQuotes(raw);
   if (!value) {
     return undefined;
   }
   try {
     const parsed = JSON.parse(value);
-    const script = readSetupScriptFromObject(parsed);
-    if (script) {
-      return script;
+    const metadata = readSetupMetadataFromObject(parsed);
+    if (metadata) {
+      return metadata;
     }
   } catch {
     // Existing skill metadata is JSON-shaped but historically parsed as JSON5.
@@ -206,11 +228,22 @@ function parseSetupScriptFromManifestText(raw) {
     return undefined;
   }
   const openclawText = value.slice(openclawMatch.index);
-  const match =
+  const scriptMatch =
     /(?:^|[,{]\s*)["']?setup["']?\s*:\s*\{[\s\S]*?["']?script["']?\s*:\s*(?:"([^"]+)"|'([^']+)'|([^\s,}]+))/u.exec(
       openclawText,
     );
-  return match ? normalizeScalar(match[1] ?? match[2] ?? match[3] ?? "") : undefined;
+  const skillKeyMatch =
+    /(?:^|[,{]\s*)["']?skillKey["']?\s*:\s*(?:"([^"]+)"|'([^']+)'|([^\s,}]+))/u.exec(
+      openclawText,
+    );
+  return mergeSetupMetadata({
+    script: scriptMatch
+      ? normalizeScalar(scriptMatch[1] ?? scriptMatch[2] ?? scriptMatch[3] ?? "")
+      : undefined,
+    skillKey: skillKeyMatch
+      ? normalizeScalar(skillKeyMatch[1] ?? skillKeyMatch[2] ?? skillKeyMatch[3] ?? "")
+      : undefined,
+  });
 }
 
 function extractFrontmatterBlock(markdown) {
@@ -222,9 +255,10 @@ function extractFrontmatterBlock(markdown) {
   return endIndex > 0 ? lines.slice(1, endIndex).join("\n") : undefined;
 }
 
-function parseIndentedSetupScript(frontmatter) {
+function parseIndentedSetupMetadata(frontmatter) {
   const lines = frontmatter.split(/\r?\n/);
   const stack = [];
+  const metadata = {};
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
     if (!line.trim() || line.trimStart().startsWith("#")) {
@@ -241,21 +275,25 @@ function parseIndentedSetupScript(frontmatter) {
       stack.pop();
     }
     const pathKeys = [...stack.map((entry) => entry.key), key];
-    if (pathKeys.join(".") === "metadata.openclaw.setup.script" && rawValue.trim()) {
-      return normalizeScalar(rawValue);
+    const pathKey = pathKeys.join(".");
+    if (pathKey === "metadata.openclaw.setup.script" && rawValue.trim()) {
+      metadata.script = normalizeScalar(rawValue);
+    }
+    if (pathKey === "metadata.openclaw.skillKey" && rawValue.trim()) {
+      metadata.skillKey = normalizeScalar(rawValue);
     }
     if (!rawValue.trim()) {
       stack.push({ indent, key });
     }
   }
-  return undefined;
+  return mergeSetupMetadata(metadata);
 }
 
 function isYamlBlockScalarIndicator(value) {
   return /^[|>][+-]?(\d+)?[+-]?$/u.test(value.trim());
 }
 
-function parseMetadataValueSetupScript(frontmatter) {
+function parseMetadataValueSetupMetadata(frontmatter) {
   const lines = frontmatter.split(/\r?\n/);
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
@@ -265,7 +303,7 @@ function parseMetadataValueSetupScript(frontmatter) {
     }
     const rawValue = match[1] ?? "";
     if (rawValue.trim() && !isYamlBlockScalarIndicator(rawValue)) {
-      return parseSetupScriptFromManifestText(rawValue);
+      return parseSetupMetadataFromManifestText(rawValue);
     }
 
     const valueLines = [];
@@ -276,17 +314,20 @@ function parseMetadataValueSetupScript(frontmatter) {
       }
       valueLines.push(nextLine.trim());
     }
-    return parseSetupScriptFromManifestText(valueLines.join("\n"));
+    return parseSetupMetadataFromManifestText(valueLines.join("\n"));
   }
   return undefined;
 }
 
-function parseSetupScriptFromSkillMarkdown(markdown) {
+function parseSetupMetadataFromSkillMarkdown(markdown) {
   const frontmatter = extractFrontmatterBlock(markdown);
   if (!frontmatter) {
     return undefined;
   }
-  return parseIndentedSetupScript(frontmatter) ?? parseMetadataValueSetupScript(frontmatter);
+  return mergeSetupMetadata(
+    parseMetadataValueSetupMetadata(frontmatter),
+    parseIndentedSetupMetadata(frontmatter),
+  );
 }
 
 // #endregion
@@ -298,7 +339,8 @@ function parseSetupScriptFromSkillMarkdown(markdown) {
 // that reads the supported metadata shape and enforces the same path boundary.
 async function resolveSetupScriptPath(skillDir) {
   const skillMarkdown = await readFile(path.join(skillDir, "SKILL.md"), "utf8");
-  const script = parseSetupScriptFromSkillMarkdown(skillMarkdown);
+  const metadata = parseSetupMetadataFromSkillMarkdown(skillMarkdown);
+  const script = metadata?.script;
   if (!script) {
     return undefined;
   }
@@ -314,7 +356,7 @@ async function resolveSetupScriptPath(skillDir) {
     throw new Error("setup.script resolves outside the skill directory");
   }
   await access(scriptPathReal);
-  return scriptPathReal;
+  return { scriptPath: scriptPathReal, skillKey: metadata.skillKey };
 }
 
 // #endregion
@@ -343,11 +385,11 @@ function normalizeEnvMap(value) {
   return env;
 }
 
-function readSkillConfigEnv(config, slug) {
+function readSkillConfigEnv(config, skillKey) {
   if (!isRecord(config?.skills) || !isRecord(config.skills.entries)) {
     return {};
   }
-  const entry = config.skills.entries[slug];
+  const entry = config.skills.entries[skillKey];
   return isRecord(entry) ? normalizeEnvMap(entry.env) : {};
 }
 
@@ -420,8 +462,8 @@ export default definePluginEntry({
           const config = context.getRuntimeConfig();
           const workspaceDir = api.runtime.agent.resolveAgentWorkspaceDir(config, agentId);
           const skillDir = await resolveInstalledSkillDir({ workspaceDir, slug });
-          const scriptPath = await resolveSetupScriptPath(skillDir);
-          if (!scriptPath) {
+          const setupScript = await resolveSetupScriptPath(skillDir);
+          if (!setupScript) {
             api.logger.debug(
               `skills.setup ${slug} (agent=${agentId}) skipped: no setup script declared`,
             );
@@ -429,6 +471,7 @@ export default definePluginEntry({
             return;
           }
 
+          const { scriptPath, skillKey = slug } = setupScript;
           const timeoutMs = resolveTimeoutMs({ config, params });
           api.logger.debug(
             `skills.setup ${slug} (agent=${agentId}) started: script=${path.relative(skillDir, scriptPath)} timeoutMs=${timeoutMs}`,
@@ -438,7 +481,7 @@ export default definePluginEntry({
             argv: ["bash", scriptPath],
             cwd: skillDir,
             env: buildSetupEnv({
-              configEnv: readSkillConfigEnv(config, slug),
+              configEnv: readSkillConfigEnv(config, skillKey),
               overlayEnv: normalizeEnvMap(params?.env),
               skillDir,
             }),

--- a/extensions/skills-setup/index.js
+++ b/extensions/skills-setup/index.js
@@ -1,4 +1,4 @@
-import { access, readFile, realpath } from "node:fs/promises";
+import { access, readFile, readdir, realpath } from "node:fs/promises";
 import path from "node:path";
 import { ErrorCodes, errorShape } from "openclaw/plugin-sdk/gateway-runtime";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
@@ -64,6 +64,22 @@ function skillNotFound(message) {
   return err;
 }
 
+async function resolveRealSkillDirCandidate({ skillsDirReal, candidateDir }) {
+  let candidateDirReal;
+  try {
+    candidateDirReal = await realpath(candidateDir);
+  } catch (error) {
+    if (error?.code === "ENOENT" || error?.code === "ENOTDIR") {
+      return undefined;
+    }
+    throw error;
+  }
+  if (!isPathInside(skillsDirReal, candidateDirReal)) {
+    throw new Error("skill directory escapes skills root");
+  }
+  return candidateDirReal;
+}
+
 async function resolveInstalledSkillDir({ workspaceDir, slug }) {
   const skillsDir = path.join(path.resolve(workspaceDir), "skills");
   const targetDir = path.resolve(skillsDir, slug);
@@ -71,19 +87,38 @@ async function resolveInstalledSkillDir({ workspaceDir, slug }) {
     throw new Error("invalid skill target path");
   }
   let skillsDirReal;
-  let targetDirReal;
   try {
-    [skillsDirReal, targetDirReal] = await Promise.all([realpath(skillsDir), realpath(targetDir)]);
+    skillsDirReal = await realpath(skillsDir);
   } catch (error) {
     if (error?.code === "ENOENT") {
       throw skillNotFound(`skill "${slug}" not installed`);
     }
     throw error;
   }
-  if (!isPathInside(skillsDirReal, targetDirReal)) {
-    throw new Error("skill directory escapes skills root");
+
+  const directDir = await resolveRealSkillDirCandidate({ skillsDirReal, candidateDir: targetDir });
+  if (directDir) {
+    return directDir;
   }
-  return targetDirReal;
+
+  const groupEntries = await readdir(skillsDirReal, { withFileTypes: true });
+  for (const entry of groupEntries
+    .filter((candidate) => !candidate.name.startsWith(".") && candidate.name !== "node_modules")
+    .toSorted((left, right) => left.name.localeCompare(right.name, "en"))) {
+    const groupedTargetDir = path.resolve(skillsDirReal, entry.name, slug);
+    if (!isPathInside(skillsDirReal, groupedTargetDir)) {
+      throw new Error("invalid grouped skill target path");
+    }
+    const groupedDir = await resolveRealSkillDirCandidate({
+      skillsDirReal,
+      candidateDir: groupedTargetDir,
+    });
+    if (groupedDir) {
+      return groupedDir;
+    }
+  }
+
+  throw skillNotFound(`skill "${slug}" not installed`);
 }
 
 // #endregion
@@ -109,6 +144,55 @@ function normalizeScalar(raw) {
   }
   const commentIndex = value.indexOf(" #");
   return (commentIndex >= 0 ? value.slice(0, commentIndex) : value).trim();
+}
+
+function stripWrappingQuotes(raw) {
+  const value = raw.trim();
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1).trim();
+  }
+  return value;
+}
+
+function readSetupScriptFromObject(value) {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const openclaw = value.openclaw;
+  if (!isRecord(openclaw) || !isRecord(openclaw.setup)) {
+    return undefined;
+  }
+  return typeof openclaw.setup.script === "string" ? openclaw.setup.script.trim() : undefined;
+}
+
+function parseSetupScriptFromManifestText(raw) {
+  const value = stripWrappingQuotes(raw);
+  if (!value) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    const script = readSetupScriptFromObject(parsed);
+    if (script) {
+      return script;
+    }
+  } catch {
+    // Existing skill metadata is JSON-shaped but historically parsed as JSON5.
+  }
+
+  const openclawMatch = /(?:^|[,{]\s*)["']?openclaw["']?\s*:/u.exec(value);
+  if (!openclawMatch) {
+    return undefined;
+  }
+  const openclawText = value.slice(openclawMatch.index);
+  const match =
+    /(?:^|[,{]\s*)["']?setup["']?\s*:\s*\{[\s\S]*?["']?script["']?\s*:\s*(?:"([^"]+)"|'([^']+)'|([^\s,}]+))/u.exec(
+      openclawText,
+    );
+  return match ? normalizeScalar(match[1] ?? match[2] ?? match[3] ?? "") : undefined;
 }
 
 function extractFrontmatterBlock(markdown) {
@@ -149,9 +233,42 @@ function parseIndentedSetupScript(frontmatter) {
   return undefined;
 }
 
+function isYamlBlockScalarIndicator(value) {
+  return /^[|>][+-]?(\d+)?[+-]?$/u.test(value.trim());
+}
+
+function parseMetadataValueSetupScript(frontmatter) {
+  const lines = frontmatter.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const match = /^metadata:(?:\s*(.*))?$/.exec(line);
+    if (!match) {
+      continue;
+    }
+    const rawValue = match[1] ?? "";
+    if (rawValue.trim() && !isYamlBlockScalarIndicator(rawValue)) {
+      return parseSetupScriptFromManifestText(rawValue);
+    }
+
+    const valueLines = [];
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const nextLine = lines[cursor] ?? "";
+      if (nextLine.trim() && !nextLine.startsWith(" ") && !nextLine.startsWith("\t")) {
+        break;
+      }
+      valueLines.push(nextLine.trim());
+    }
+    return parseSetupScriptFromManifestText(valueLines.join("\n"));
+  }
+  return undefined;
+}
+
 function parseSetupScriptFromSkillMarkdown(markdown) {
   const frontmatter = extractFrontmatterBlock(markdown);
-  return frontmatter ? parseIndentedSetupScript(frontmatter) : undefined;
+  if (!frontmatter) {
+    return undefined;
+  }
+  return parseIndentedSetupScript(frontmatter) ?? parseMetadataValueSetupScript(frontmatter);
 }
 
 // #endregion

--- a/extensions/skills-setup/index.test.ts
+++ b/extensions/skills-setup/index.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { ErrorCodes } from "openclaw/plugin-sdk/gateway-runtime";
 import type { GatewayRequestHandlerOptions } from "openclaw/plugin-sdk/gateway-runtime";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -276,6 +277,29 @@ metadata:
     expect(respond.mock.calls[0]?.[0]).toBe(false);
     expect(respond.mock.calls[0]?.[1]).toEqual({
       error: "setup.script escapes the skill directory",
+    });
+    expect(respond.mock.calls[0]?.[2]).toMatchObject({
+      code: ErrorCodes.INVALID_REQUEST,
+    });
+  });
+
+  it("reports invalid slugs as invalid requests", async () => {
+    const workspaceDir = await makeTempDir();
+    const { handler } = registerSkillsSetupPlugin({ workspaceDir, config: {} });
+
+    const respond = await callGatewayMethod({
+      handler,
+      config: {},
+      requestParams: { slug: "../bad" },
+    });
+
+    expect(commandMocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(respond.mock.calls[0]?.[0]).toBe(false);
+    expect(respond.mock.calls[0]?.[1]).toEqual({
+      error: "invalid skill slug",
+    });
+    expect(respond.mock.calls[0]?.[2]).toMatchObject({
+      code: ErrorCodes.INVALID_REQUEST,
     });
   });
 });

--- a/extensions/skills-setup/index.test.ts
+++ b/extensions/skills-setup/index.test.ts
@@ -186,7 +186,7 @@ metadata:
       handler,
       config,
       requestParams: {
-        slug: "demo",
+        slug: "Demo",
         env: {
           API_TOKEN: "from-request",
           CUSTOM: "from-request",

--- a/extensions/skills-setup/index.test.ts
+++ b/extensions/skills-setup/index.test.ts
@@ -1,0 +1,281 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { GatewayRequestHandlerOptions } from "openclaw/plugin-sdk/gateway-runtime";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+type TestPluginApi = ReturnType<typeof createTestPluginApi>;
+type GatewayHandler = Parameters<TestPluginApi["registerGatewayMethod"]>[1];
+type GatewayMethodOptions = Parameters<TestPluginApi["registerGatewayMethod"]>[2];
+
+const commandMocks = vi.hoisted(() => ({
+  runPluginCommandWithTimeout: vi.fn(async () => ({
+    code: 0,
+    stdout: "setup ok",
+    stderr: "",
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/sandbox", () => ({
+  runPluginCommandWithTimeout: commandMocks.runPluginCommandWithTimeout,
+}));
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-setup-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeSkill({
+  workspaceDir,
+  relativeDir,
+  frontmatter,
+  scriptPath = "scripts/setup.sh",
+}: {
+  workspaceDir: string;
+  relativeDir: string;
+  frontmatter: string;
+  scriptPath?: string;
+}): Promise<{ skillDir: string; skillDirReal: string; scriptPathReal: string }> {
+  const skillDir = path.join(workspaceDir, "skills", relativeDir);
+  await fs.mkdir(path.dirname(path.join(skillDir, scriptPath)), { recursive: true });
+  await fs.writeFile(
+    path.join(skillDir, "SKILL.md"),
+    `---\n${frontmatter.trim()}\n---\n# ${path.basename(relativeDir)}\n`,
+    "utf8",
+  );
+  await fs.writeFile(path.join(skillDir, scriptPath), "#!/usr/bin/env bash\n", "utf8");
+  return {
+    skillDir,
+    skillDirReal: await fs.realpath(skillDir),
+    scriptPathReal: await fs.realpath(path.join(skillDir, scriptPath)),
+  };
+}
+
+function registerSkillsSetupPlugin({
+  config,
+  workspaceDir,
+}: {
+  config: Record<string, unknown>;
+  workspaceDir: string;
+}): {
+  handler: GatewayHandler;
+  options: GatewayMethodOptions;
+  registerGatewayMethod: ReturnType<typeof vi.fn>;
+} {
+  void config;
+  let handler: GatewayHandler | undefined;
+  let options: GatewayMethodOptions;
+  const registerGatewayMethod = vi.fn(
+    (method: string, nextHandler: GatewayHandler, nextOptions: GatewayMethodOptions) => {
+    expect(method).toBe("skills.setup");
+    handler = nextHandler;
+    options = nextOptions;
+    },
+  );
+  const api = createTestPluginApi({
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    runtime: {
+      agent: {
+        resolveAgentWorkspaceDir: vi.fn(() => workspaceDir),
+      },
+    } as unknown as TestPluginApi["runtime"],
+    registerGatewayMethod,
+  });
+
+  plugin.register(api);
+  if (!handler) {
+    throw new Error("skills-setup did not register skills.setup");
+  }
+  return { handler, options, registerGatewayMethod };
+}
+
+async function callGatewayMethod({
+  handler,
+  config,
+  requestParams,
+}: {
+  handler: GatewayHandler;
+  config: Record<string, unknown>;
+  requestParams: Record<string, unknown>;
+}) {
+  const respond = vi.fn();
+  await handler({
+    params: requestParams,
+    respond,
+    context: {
+      getRuntimeConfig: () => config,
+    },
+  } as unknown as GatewayRequestHandlerOptions);
+  return respond;
+}
+
+beforeEach(() => {
+  commandMocks.runPluginCommandWithTimeout.mockClear();
+  commandMocks.runPluginCommandWithTimeout.mockResolvedValue({
+    code: 0,
+    stdout: "setup ok",
+    stderr: "",
+  });
+});
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("skills-setup plugin", () => {
+  it("registers the admin-only skills.setup gateway method", async () => {
+    const workspaceDir = await makeTempDir();
+    const { options, registerGatewayMethod } = registerSkillsSetupPlugin({
+      workspaceDir,
+      config: {},
+    });
+
+    expect(registerGatewayMethod).toHaveBeenCalledTimes(1);
+    expect(options).toEqual({ scope: "operator.admin" });
+  });
+
+  it("runs grouped skills and passes sanitized setup env", async () => {
+    const workspaceDir = await makeTempDir();
+    await fs.mkdir(path.join(workspaceDir, "skills", "demo"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "skills", "demo", "README.md"), "not a skill\n");
+    const skill = await writeSkill({
+      workspaceDir,
+      relativeDir: "team/demo",
+      frontmatter: `
+metadata:
+  openclaw:
+    skillKey: team/demo
+    setup:
+      script: scripts/setup.sh
+`,
+    });
+    const config = {
+      plugins: {
+        entries: {
+          "skills-setup": {
+            config: { timeoutMs: 5_000 },
+          },
+        },
+      },
+      skills: {
+        entries: {
+          "team/demo": {
+            env: {
+              API_TOKEN: "from-config",
+              EXTRA: "from-config",
+              HOME: "/should/not/pass",
+              PATH: "/should/not/pass",
+            },
+          },
+        },
+      },
+    };
+    const { handler } = registerSkillsSetupPlugin({ workspaceDir, config });
+
+    const respond = await callGatewayMethod({
+      handler,
+      config,
+      requestParams: {
+        slug: "demo",
+        env: {
+          API_TOKEN: "from-request",
+          CUSTOM: "from-request",
+          PATH: "/request/path",
+          SKILL_DIR: "/request/skill",
+        },
+        timeoutMs: 999_999,
+      },
+    });
+
+    expect(respond).toHaveBeenCalledWith(true, { code: 0, stdout: "setup ok", stderr: "" });
+    expect(commandMocks.runPluginCommandWithTimeout).toHaveBeenCalledWith({
+      argv: ["bash", skill.scriptPathReal],
+      cwd: skill.skillDirReal,
+      env: {
+        API_TOKEN: "from-request",
+        EXTRA: "from-config",
+        CUSTOM: "from-request",
+        SKILL_DIR: skill.skillDirReal,
+      },
+      timeoutMs: 600_000,
+    });
+  });
+
+  it("reads JSON-shaped skill metadata", async () => {
+    const workspaceDir = await makeTempDir();
+    const skill = await writeSkill({
+      workspaceDir,
+      relativeDir: "json-skill",
+      scriptPath: "setup.sh",
+      frontmatter: `
+metadata: '{"openclaw":{"skillKey":"json-skill-key","setup":{"script":"setup.sh"}}}'
+`,
+    });
+    const config = {
+      skills: {
+        entries: {
+          "json-skill-key": {
+            env: {
+              JSON_SKILL_ENV: "enabled",
+            },
+          },
+        },
+      },
+    };
+    const { handler } = registerSkillsSetupPlugin({ workspaceDir, config });
+
+    const respond = await callGatewayMethod({
+      handler,
+      config,
+      requestParams: { slug: "json-skill" },
+    });
+
+    expect(respond).toHaveBeenCalledWith(true, { code: 0, stdout: "setup ok", stderr: "" });
+    expect(commandMocks.runPluginCommandWithTimeout).toHaveBeenCalledWith({
+      argv: ["bash", skill.scriptPathReal],
+      cwd: skill.skillDirReal,
+      env: {
+        JSON_SKILL_ENV: "enabled",
+        SKILL_DIR: skill.skillDirReal,
+      },
+      timeoutMs: 120_000,
+    });
+  });
+
+  it("rejects setup scripts outside the skill directory", async () => {
+    const workspaceDir = await makeTempDir();
+    await writeSkill({
+      workspaceDir,
+      relativeDir: "escape",
+      frontmatter: `
+metadata:
+  openclaw:
+    setup:
+      script: ../outside.sh
+`,
+    });
+    const { handler } = registerSkillsSetupPlugin({ workspaceDir, config: {} });
+
+    const respond = await callGatewayMethod({
+      handler,
+      config: {},
+      requestParams: { slug: "escape" },
+    });
+
+    expect(commandMocks.runPluginCommandWithTimeout).not.toHaveBeenCalled();
+    expect(respond.mock.calls[0]?.[0]).toBe(false);
+    expect(respond.mock.calls[0]?.[1]).toEqual({
+      error: "setup.script escapes the skill directory",
+    });
+  });
+});

--- a/extensions/skills-setup/index.ts
+++ b/extensions/skills-setup/index.ts
@@ -60,7 +60,7 @@ function normalizeString(value: unknown): string {
 }
 
 function normalizeSlug(value: unknown): string {
-  const slug = normalizeString(value);
+  const slug = normalizeString(value).toLowerCase();
   if (!slug || slug.includes("/") || slug.includes("\\") || slug.includes("..")) {
     throw new Error("invalid skill slug");
   }

--- a/extensions/skills-setup/index.ts
+++ b/extensions/skills-setup/index.ts
@@ -62,10 +62,10 @@ function normalizeString(value: unknown): string {
 function normalizeSlug(value: unknown): string {
   const slug = normalizeString(value).toLowerCase();
   if (!slug || slug.includes("/") || slug.includes("\\") || slug.includes("..")) {
-    throw new Error("invalid skill slug");
+    throw invalidRequest("invalid skill slug");
   }
   if (!VALID_SLUG_PATTERN.test(slug)) {
-    throw new Error("invalid skill slug");
+    throw invalidRequest("invalid skill slug");
   }
   return slug;
 }
@@ -79,11 +79,22 @@ function normalizeAgentId(value: unknown): string {
 // #region Installed skill path resolution
 
 const ERR_SKILL_NOT_FOUND = "SKILL_NOT_FOUND";
+const ERR_INVALID_REQUEST = "INVALID_REQUEST";
+
+function invalidRequest(message: string): Error & { code: typeof ERR_INVALID_REQUEST } {
+  const err = new Error(message) as Error & { code: typeof ERR_INVALID_REQUEST };
+  err.code = ERR_INVALID_REQUEST;
+  return err;
+}
 
 function skillNotFound(message: string): Error & { code: typeof ERR_SKILL_NOT_FOUND } {
   const err = new Error(message) as Error & { code: typeof ERR_SKILL_NOT_FOUND };
   err.code = ERR_SKILL_NOT_FOUND;
   return err;
+}
+
+function isInvalidRequestError(error: unknown): boolean {
+  return hasErrorCode(error, ERR_SKILL_NOT_FOUND) || hasErrorCode(error, ERR_INVALID_REQUEST);
 }
 
 async function resolveRealSkillDirCandidate({
@@ -103,7 +114,7 @@ async function resolveRealSkillDirCandidate({
     throw error;
   }
   if (!isPathInside(skillsDirReal, candidateDirReal)) {
-    throw new Error("skill directory escapes skills root");
+    throw invalidRequest("skill directory escapes skills root");
   }
 
   let skillMarkdownReal;
@@ -120,7 +131,7 @@ async function resolveRealSkillDirCandidate({
     throw error;
   }
   if (!isPathInside(candidateDirReal, skillMarkdownReal)) {
-    throw new Error("skill manifest escapes skill directory");
+    throw invalidRequest("skill manifest escapes skill directory");
   }
 
   return candidateDirReal;
@@ -136,7 +147,7 @@ async function resolveInstalledSkillDir({
   const skillsDir = path.join(path.resolve(workspaceDir), "skills");
   const targetDir = path.resolve(skillsDir, slug);
   if (!isPathInside(skillsDir, targetDir)) {
-    throw new Error("invalid skill target path");
+    throw invalidRequest("invalid skill target path");
   }
   let skillsDirReal;
   try {
@@ -159,7 +170,7 @@ async function resolveInstalledSkillDir({
     .toSorted((left, right) => left.name.localeCompare(right.name, "en"))) {
     const groupedTargetDir = path.resolve(skillsDirReal, entry.name, slug);
     if (!isPathInside(skillsDirReal, groupedTargetDir)) {
-      throw new Error("invalid grouped skill target path");
+      throw invalidRequest("invalid grouped skill target path");
     }
     const groupedDir = await resolveRealSkillDirCandidate({
       skillsDirReal,
@@ -379,15 +390,15 @@ async function resolveSetupScriptPath(skillDir: string): Promise<SetupScriptReso
     return undefined;
   }
   if (path.isAbsolute(script) || script.includes("\0")) {
-    throw new Error("setup.script must be a relative path inside the skill directory");
+    throw invalidRequest("setup.script must be a relative path inside the skill directory");
   }
   const scriptPath = path.resolve(skillDir, script);
   if (!isPathInside(skillDir, scriptPath)) {
-    throw new Error("setup.script escapes the skill directory");
+    throw invalidRequest("setup.script escapes the skill directory");
   }
   const scriptPathReal = await realpath(scriptPath);
   if (!isPathInside(skillDir, scriptPathReal)) {
-    throw new Error("setup.script resolves outside the skill directory");
+    throw invalidRequest("setup.script resolves outside the skill directory");
   }
   await access(scriptPathReal);
   return { scriptPath: scriptPathReal, skillKey: metadata.skillKey };
@@ -559,10 +570,9 @@ export default definePluginEntry({
           // installed skill on this agent — no generic NOT_FOUND code at v2026.5.5
           // (see openclaw src/gateway/protocol/schema/error-codes.ts). Reserve
           // UNAVAILABLE for transient / server-side execution failures.
-          const code =
-            hasErrorCode(error, ERR_SKILL_NOT_FOUND)
-              ? ErrorCodes.INVALID_REQUEST
-              : ErrorCodes.UNAVAILABLE;
+          const code = isInvalidRequestError(error)
+            ? ErrorCodes.INVALID_REQUEST
+            : ErrorCodes.UNAVAILABLE;
           api.logger.warn(
             `skills.setup ${slugForLog} (agent=${agentIdForLog}) failed: ${message} durationMs=${Date.now() - startedAt}`,
           );

--- a/extensions/skills-setup/index.ts
+++ b/extensions/skills-setup/index.ts
@@ -1,6 +1,7 @@
 import { access, readFile, readdir, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import { ErrorCodes, errorShape } from "openclaw/plugin-sdk/gateway-runtime";
+import type { GatewayRequestHandlerOptions } from "openclaw/plugin-sdk/gateway-runtime";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/sandbox";
 import { isPathInside } from "openclaw/plugin-sdk/security-runtime";
@@ -27,28 +28,49 @@ const RESERVED_ENV_KEYS = new Set([
   "XDG_DATA_HOME",
 ]);
 
+type EnvMap = Record<string, string>;
+
+type SetupMetadata = {
+  script?: string;
+  skillKey?: string;
+};
+
+type SetupScriptResolution = {
+  scriptPath: string;
+  skillKey?: string;
+};
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code?: unknown }).code === code,
+  );
+}
+
 // #region Basic request/config normalization
 
-function isRecord(value) {
+function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function normalizeString(value) {
+function normalizeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function normalizeSlug(value) {
+function normalizeSlug(value: unknown): string {
   const slug = normalizeString(value);
   if (!slug || slug.includes("/") || slug.includes("\\") || slug.includes("..")) {
     throw new Error("invalid skill slug");
   }
-  if (!VALID_SLUG_PATTERN.test(slug) || /[^\x00-\x7F]/.test(slug)) {
+  if (!VALID_SLUG_PATTERN.test(slug)) {
     throw new Error("invalid skill slug");
   }
   return slug;
 }
 
-function normalizeAgentId(value) {
+function normalizeAgentId(value: unknown): string {
   return normalizeString(value) || DEFAULT_AGENT_ID;
 }
 
@@ -58,18 +80,24 @@ function normalizeAgentId(value) {
 
 const ERR_SKILL_NOT_FOUND = "SKILL_NOT_FOUND";
 
-function skillNotFound(message) {
-  const err = new Error(message);
+function skillNotFound(message: string): Error & { code: typeof ERR_SKILL_NOT_FOUND } {
+  const err = new Error(message) as Error & { code: typeof ERR_SKILL_NOT_FOUND };
   err.code = ERR_SKILL_NOT_FOUND;
   return err;
 }
 
-async function resolveRealSkillDirCandidate({ skillsDirReal, candidateDir }) {
+async function resolveRealSkillDirCandidate({
+  skillsDirReal,
+  candidateDir,
+}: {
+  skillsDirReal: string;
+  candidateDir: string;
+}): Promise<string | undefined> {
   let candidateDirReal;
   try {
     candidateDirReal = await realpath(candidateDir);
   } catch (error) {
-    if (error?.code === "ENOENT" || error?.code === "ENOTDIR") {
+    if (hasErrorCode(error, "ENOENT") || hasErrorCode(error, "ENOTDIR")) {
       return undefined;
     }
     throw error;
@@ -86,7 +114,7 @@ async function resolveRealSkillDirCandidate({ skillsDirReal, candidateDir }) {
       return undefined;
     }
   } catch (error) {
-    if (error?.code === "ENOENT" || error?.code === "ENOTDIR") {
+    if (hasErrorCode(error, "ENOENT") || hasErrorCode(error, "ENOTDIR")) {
       return undefined;
     }
     throw error;
@@ -98,7 +126,13 @@ async function resolveRealSkillDirCandidate({ skillsDirReal, candidateDir }) {
   return candidateDirReal;
 }
 
-async function resolveInstalledSkillDir({ workspaceDir, slug }) {
+async function resolveInstalledSkillDir({
+  workspaceDir,
+  slug,
+}: {
+  workspaceDir: string;
+  slug: string;
+}): Promise<string> {
   const skillsDir = path.join(path.resolve(workspaceDir), "skills");
   const targetDir = path.resolve(skillsDir, slug);
   if (!isPathInside(skillsDir, targetDir)) {
@@ -108,7 +142,7 @@ async function resolveInstalledSkillDir({ workspaceDir, slug }) {
   try {
     skillsDirReal = await realpath(skillsDir);
   } catch (error) {
-    if (error?.code === "ENOENT") {
+    if (hasErrorCode(error, "ENOENT")) {
       throw skillNotFound(`skill "${slug}" not installed`);
     }
     throw error;
@@ -149,7 +183,7 @@ async function resolveInstalledSkillDir({ workspaceDir, slug }) {
 // or a narrower `resolveSkillSetupScript()` helper. That would replace
 // normalizeScalar(), extractFrontmatterBlock(), parseIndentedSetupScript(), and
 // parseSetupScriptFromSkillMarkdown().
-function normalizeScalar(raw) {
+function normalizeScalar(raw: string): string {
   const value = raw.trim();
   if (!value) {
     return "";
@@ -164,7 +198,7 @@ function normalizeScalar(raw) {
   return (commentIndex >= 0 ? value.slice(0, commentIndex) : value).trim();
 }
 
-function stripWrappingQuotes(raw) {
+function stripWrappingQuotes(raw: string): string {
   const value = raw.trim();
   if (
     (value.startsWith('"') && value.endsWith('"')) ||
@@ -175,8 +209,8 @@ function stripWrappingQuotes(raw) {
   return value;
 }
 
-function mergeSetupMetadata(...items) {
-  const merged = {};
+function mergeSetupMetadata(...items: Array<Partial<SetupMetadata> | undefined>): SetupMetadata | undefined {
+  const merged: SetupMetadata = {};
   for (const item of items) {
     if (!isRecord(item)) {
       continue;
@@ -191,7 +225,7 @@ function mergeSetupMetadata(...items) {
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
-function readSetupMetadataFromObject(value) {
+function readSetupMetadataFromObject(value: unknown): SetupMetadata | undefined {
   if (!isRecord(value)) {
     return undefined;
   }
@@ -208,7 +242,7 @@ function readSetupMetadataFromObject(value) {
   });
 }
 
-function parseSetupMetadataFromManifestText(raw) {
+function parseSetupMetadataFromManifestText(raw: string): SetupMetadata | undefined {
   const value = stripWrappingQuotes(raw);
   if (!value) {
     return undefined;
@@ -246,7 +280,7 @@ function parseSetupMetadataFromManifestText(raw) {
   });
 }
 
-function extractFrontmatterBlock(markdown) {
+function extractFrontmatterBlock(markdown: string): string | undefined {
   const lines = markdown.split(/\r?\n/);
   if (lines[0]?.trim() !== "---") {
     return undefined;
@@ -255,10 +289,10 @@ function extractFrontmatterBlock(markdown) {
   return endIndex > 0 ? lines.slice(1, endIndex).join("\n") : undefined;
 }
 
-function parseIndentedSetupMetadata(frontmatter) {
+function parseIndentedSetupMetadata(frontmatter: string): SetupMetadata | undefined {
   const lines = frontmatter.split(/\r?\n/);
-  const stack = [];
-  const metadata = {};
+  const stack: Array<{ indent: number; key: string }> = [];
+  const metadata: SetupMetadata = {};
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
     if (!line.trim() || line.trimStart().startsWith("#")) {
@@ -289,11 +323,11 @@ function parseIndentedSetupMetadata(frontmatter) {
   return mergeSetupMetadata(metadata);
 }
 
-function isYamlBlockScalarIndicator(value) {
+function isYamlBlockScalarIndicator(value: string): boolean {
   return /^[|>][+-]?(\d+)?[+-]?$/u.test(value.trim());
 }
 
-function parseMetadataValueSetupMetadata(frontmatter) {
+function parseMetadataValueSetupMetadata(frontmatter: string): SetupMetadata | undefined {
   const lines = frontmatter.split(/\r?\n/);
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
@@ -306,7 +340,7 @@ function parseMetadataValueSetupMetadata(frontmatter) {
       return parseSetupMetadataFromManifestText(rawValue);
     }
 
-    const valueLines = [];
+    const valueLines: string[] = [];
     for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
       const nextLine = lines[cursor] ?? "";
       if (nextLine.trim() && !nextLine.startsWith(" ") && !nextLine.startsWith("\t")) {
@@ -319,7 +353,7 @@ function parseMetadataValueSetupMetadata(frontmatter) {
   return undefined;
 }
 
-function parseSetupMetadataFromSkillMarkdown(markdown) {
+function parseSetupMetadataFromSkillMarkdown(markdown: string): SetupMetadata | undefined {
   const frontmatter = extractFrontmatterBlock(markdown);
   if (!frontmatter) {
     return undefined;
@@ -337,7 +371,7 @@ function parseSetupMetadataFromSkillMarkdown(markdown) {
 // SDK gap: OpenClaw does not expose a public resolver for an installed skill's
 // setup script. Needed public surface: `resolveSkillSetupScriptPath(skillDir)`
 // that reads the supported metadata shape and enforces the same path boundary.
-async function resolveSetupScriptPath(skillDir) {
+async function resolveSetupScriptPath(skillDir: string): Promise<SetupScriptResolution | undefined> {
   const skillMarkdown = await readFile(path.join(skillDir, "SKILL.md"), "utf8");
   const metadata = parseSetupMetadataFromSkillMarkdown(skillMarkdown);
   const script = metadata?.script;
@@ -367,8 +401,8 @@ async function resolveSetupScriptPath(skillDir) {
 // operator-provided credential vars while blocking only execution-context
 // overrides. The generic sandbox sanitizer blocks token-like keys, which is
 // wrong for this setup hook. Needed public surface: `sanitizeSetupEnvOverlay()`.
-function normalizeEnvMap(value) {
-  const env = {};
+function normalizeEnvMap(value: unknown): EnvMap {
+  const env: EnvMap = {};
   if (!isRecord(value)) {
     return env;
   }
@@ -385,16 +419,28 @@ function normalizeEnvMap(value) {
   return env;
 }
 
-function readSkillConfigEnv(config, skillKey) {
-  if (!isRecord(config?.skills) || !isRecord(config.skills.entries)) {
+function readSkillConfigEnv(config: unknown, skillKey: string): EnvMap {
+  if (!isRecord(config)) {
     return {};
   }
-  const entry = config.skills.entries[skillKey];
+  const skills = config.skills;
+  if (!isRecord(skills) || !isRecord(skills.entries)) {
+    return {};
+  }
+  const entry = skills.entries[skillKey];
   return isRecord(entry) ? normalizeEnvMap(entry.env) : {};
 }
 
-function buildSetupEnv({ configEnv, overlayEnv, skillDir }) {
-  const env = {};
+function buildSetupEnv({
+  configEnv,
+  overlayEnv,
+  skillDir,
+}: {
+  configEnv: EnvMap;
+  overlayEnv: EnvMap;
+  skillDir: string;
+}): EnvMap {
+  const env: EnvMap = {};
   Object.assign(env, configEnv, overlayEnv);
   env.SKILL_DIR = skillDir;
   return env;
@@ -404,7 +450,7 @@ function buildSetupEnv({ configEnv, overlayEnv, skillDir }) {
 
 // #region Timeout resolution
 
-function clampTimeoutMs(candidate, fallback) {
+function clampTimeoutMs(candidate: unknown, fallback: number): number {
   if (typeof candidate !== "number" || !Number.isFinite(candidate)) {
     return fallback;
   }
@@ -418,11 +464,15 @@ function clampTimeoutMs(candidate, fallback) {
   return rounded;
 }
 
-function readPluginConfigTimeoutMs(config) {
-  if (!isRecord(config?.plugins) || !isRecord(config.plugins.entries)) {
+function readPluginConfigTimeoutMs(config: unknown): unknown {
+  if (!isRecord(config)) {
     return undefined;
   }
-  const entry = config.plugins.entries[PLUGIN_ID];
+  const plugins = config.plugins;
+  if (!isRecord(plugins) || !isRecord(plugins.entries)) {
+    return undefined;
+  }
+  const entry = plugins.entries[PLUGIN_ID];
   // OpenClaw plugin config schema lives at plugins.entries.<id>.config.* — see
   // openclaw/src/plugin-sdk/plugin-config-runtime.ts resolvePluginConfigObject.
   // Reading entry.timeoutMs directly would silently ignore the operator setting.
@@ -432,7 +482,13 @@ function readPluginConfigTimeoutMs(config) {
   return entry.config.timeoutMs;
 }
 
-function resolveTimeoutMs({ config, params }) {
+function resolveTimeoutMs({
+  config,
+  params,
+}: {
+  config: unknown;
+  params?: Record<string, unknown>;
+}): number {
   const configured = clampTimeoutMs(readPluginConfigTimeoutMs(config), DEFAULT_TIMEOUT_MS);
   return clampTimeoutMs(params?.timeoutMs, configured);
 }
@@ -441,12 +497,18 @@ function resolveTimeoutMs({ config, params }) {
 
 // #region Gateway RPC registration
 
-function respondError(respond, code, message) {
+function respondError(
+  respond: GatewayRequestHandlerOptions["respond"],
+  code: Parameters<typeof errorShape>[0],
+  message: string,
+): void {
   respond(false, { error: message }, errorShape(code, message));
 }
 
 export default definePluginEntry({
   id: "skills-setup",
+  name: "Skills Setup",
+  description: "Runs installed skill setup scripts through the admin-only skills.setup gateway RPC.",
   register(api) {
     api.registerGatewayMethod(
       METHOD_NAME,
@@ -464,7 +526,7 @@ export default definePluginEntry({
           const skillDir = await resolveInstalledSkillDir({ workspaceDir, slug });
           const setupScript = await resolveSetupScriptPath(skillDir);
           if (!setupScript) {
-            api.logger.debug(
+            api.logger.debug?.(
               `skills.setup ${slug} (agent=${agentId}) skipped: no setup script declared`,
             );
             respond(true, { code: 0, stdout: "", stderr: "" });
@@ -473,7 +535,7 @@ export default definePluginEntry({
 
           const { scriptPath, skillKey = slug } = setupScript;
           const timeoutMs = resolveTimeoutMs({ config, params });
-          api.logger.debug(
+          api.logger.debug?.(
             `skills.setup ${slug} (agent=${agentId}) started: script=${path.relative(skillDir, scriptPath)} timeoutMs=${timeoutMs}`,
           );
 
@@ -487,7 +549,7 @@ export default definePluginEntry({
             }),
             timeoutMs,
           });
-          api.logger.debug(
+          api.logger.debug?.(
             `skills.setup ${slug} (agent=${agentId}) completed: code=${result.code} durationMs=${Date.now() - startedAt}`,
           );
           respond(true, result);
@@ -498,7 +560,7 @@ export default definePluginEntry({
           // (see openclaw src/gateway/protocol/schema/error-codes.ts). Reserve
           // UNAVAILABLE for transient / server-side execution failures.
           const code =
-            error?.code === ERR_SKILL_NOT_FOUND
+            hasErrorCode(error, ERR_SKILL_NOT_FOUND)
               ? ErrorCodes.INVALID_REQUEST
               : ErrorCodes.UNAVAILABLE;
           api.logger.warn(

--- a/extensions/skills-setup/openclaw.plugin.json
+++ b/extensions/skills-setup/openclaw.plugin.json
@@ -1,0 +1,21 @@
+{
+  "id": "skills-setup",
+  "activation": {
+    "onStartup": true
+  },
+  "name": "Skills Setup",
+  "description": "Runs installed skill setup scripts through the admin-only skills.setup gateway RPC. Setup scripts must be idempotent — the plugin does not track completion state, so each call re-runs the script.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "timeoutMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 600000,
+        "default": 120000,
+        "description": "Default setup-script timeout in milliseconds. Callers may override per-request via params.timeoutMs; the maximum is always enforced."
+      }
+    }
+  }
+}

--- a/extensions/skills-setup/package.json
+++ b/extensions/skills-setup/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "openclaw": {
     "extensions": [
-      "./index.js"
+      "./index.ts"
     ]
   }
 }

--- a/extensions/skills-setup/package.json
+++ b/extensions/skills-setup/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/skills-setup",
+  "version": "2026.5.12-beta.1",
+  "private": true,
+  "description": "OpenClaw plugin for running skill setup scripts.",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1412,6 +1412,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/skills-setup: {}
+
   extensions/slack:
     dependencies:
       '@slack/bolt':


### PR DESCRIPTION
## Summary

- Problem: OpenClaw issue #80213 asks for skill author-defined setup hooks; this PR implements the behavior as a bundled plugin instead of adding setup execution directly to core.
- Why it matters: skills that need local setup need a controlled, admin-only execution path with path validation, timeout bounds, and scoped environment overlays.
- What changed: added the `skills-setup` plugin with the `skills.setup` gateway RPC, setup metadata parsing, grouped skill directory resolution, env sanitization, and focused tests.
- What did NOT change (scope boundary): this does not track setup completion state, does not auto-run setup on skill install/update, and does not expose non-admin setup execution. The maintainability follow-up is tracked in #81913 for exposing shared skill registry/frontmatter/env sanitizer helpers through `openclaw/plugin-sdk/*`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #80213
- Related #81913
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: adds an admin-only `skills.setup` gateway RPC for running an installed skill’s declared setup script.
- Real environment tested: local OpenClaw checkout on macOS using the repo `pnpm` test/check wrappers.
- Exact steps or command run after this patch:
  - `pnpm test extensions/skills-setup/index.test.ts -- --reporter=verbose`
  - `pnpm check:changed`
- Evidence after fix: `extensions/skills-setup/index.test.ts` passed 5 tests; `pnpm check:changed` passed typecheck, lint, guard checks, and runtime import cycle check.
- Observed result after fix: grouped skills resolve correctly, JSON-shaped metadata is parsed, unsafe env overrides are blocked, invalid slugs/path escapes return `INVALID_REQUEST`, and the setup runner receives the expected script path, cwd, env, and bounded timeout.
- What was not tested: live gateway invocation against a running packaged OpenClaw gateway.
- Before evidence: N/A, new plugin surface.

## Root Cause (if applicable)

N/A

This is a feature implementation for #80213. The plugin currently duplicates some skill registry/frontmatter/env-sanitizer behavior because those helpers are not exposed through the plugin SDK yet; #81913 tracks the maintainability improvement to move those shared contracts into `openclaw/plugin-sdk/*`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/skills-setup/index.test.ts`
- Scenario the test should lock in: gateway method registration, grouped skill resolution, metadata parsing, setup env construction, timeout clamping, and invalid request classification.
- Why this is the smallest reliable guardrail: the test exercises the plugin entry through the registered gateway handler while mocking only command execution.
- Existing test that already covers this: N/A, new plugin.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Adds a bundled `skills-setup` plugin that registers an admin-only `skills.setup` gateway RPC. The plugin can run an installed skill’s declared `metadata.openclaw.setup.script` with a default timeout of 120000ms and a maximum of 600000ms.

## Diagram (if applicable)

```text
Before:
[installed skill with setup script] -> [no bundled setup RPC]

After:
[operator/admin calls skills.setup] -> [resolve installed skill] -> [validate setup script path] -> [run script with sanitized env]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation: setup scripts can execute local commands, so the RPC is registered with `operator.admin`, validates the skill directory and script path with realpath boundary checks, blocks execution-context env overrides like `HOME`, `PATH`, `SKILL_DIR`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME`, and clamps timeout values.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: repo `pnpm` wrappers, Node 22-compatible project tooling
- Model/provider: N/A
- Integration/channel: plugin gateway RPC
- Relevant config: test config uses `plugins.entries.skills-setup.config.timeoutMs` and `skills.entries.<skillKey>.env`

### Steps

1. Run `pnpm test extensions/skills-setup/index.test.ts -- --reporter=verbose`.
2. Run `pnpm check:changed`.
3. Confirm the new plugin package metadata points to `./index.ts`.

### Expected

- The skills-setup tests pass.
- Changed checks pass.
- No runtime import cycles are introduced.

### Actual

- `pnpm test extensions/skills-setup/index.test.ts -- --reporter=verbose` passed.
- `pnpm check:changed` passed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: grouped skill lookup, mixed-case slug normalization, JSON-shaped metadata parsing, env overlay sanitization, timeout clamping, setup path escape rejection, invalid slug error mapping.
- Edge cases checked: direct non-skill directory skipped, grouped skill selected, reserved env keys ignored, unsafe setup path returns `INVALID_REQUEST`.
- What you did **not** verify: live packaged gateway invocation.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: no migration needed; optional plugin config may set `plugins.entries.skills-setup.config.timeoutMs`.

## Risks and Mitigations

- Risk: setup scripts execute local commands.
  - Mitigation: RPC requires `operator.admin`, validates realpaths, confines scripts to the skill directory, sanitizes execution-context env overrides, and enforces timeout bounds.