### PR TITLE
Fix streamed chat completions dropping leading less-than

### DIFF
--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
@@ -119,6 +119,28 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payloads.some((payload) => payload.replace)).toBe(false);
   });
 
+  it("preserves literal custom XML tag openers split after a bare <", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    for (const delta of ["<", "xiaohai-banli>milk tea</xiaohai-banli>"]) {
+      emitAssistantTextDelta({ emit, delta });
+    }
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads.map((payload) => payload.delta).join("")).toBe(
+      "<xiaohai-banli>milk tea</xiaohai-banli>",
+    );
+  });
+
   it("strips self-closing and attributed final tags from streamed deltas", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -1622,6 +1622,41 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
 
       {
         agentCommand.mockClear();
+        agentCommand.mockImplementationOnce(((opts: unknown) => {
+          const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+          emitAgentEvent({
+            runId,
+            stream: "assistant",
+            data: {
+              text: "<xiaohai-banli>milk tea</xiaohai-banli>",
+              delta: "xiaohai-banli>milk tea</xiaohai-banli>",
+            },
+          });
+          return Promise.resolve({
+            payloads: [{ text: "<xiaohai-banli>milk tea</xiaohai-banli>" }],
+          });
+        }) as never);
+
+        const cumulativeRes = await postChatCompletions(port, {
+          stream: true,
+          model: "openclaw",
+          messages: [{ role: "user", content: "hi" }],
+        });
+        expect(cumulativeRes.status).toBe(200);
+        const cumulativeData = parseSseDataLines(await cumulativeRes.text());
+        const cumulativeChunks = cumulativeData
+          .filter((d) => d !== "[DONE]")
+          .map((d) => JSON.parse(d) as Record<string, unknown>);
+        const cumulativeContent = cumulativeChunks
+          .flatMap((c) => (c.choices as Array<Record<string, unknown>> | undefined) ?? [])
+          .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+          .filter((v): v is string => typeof v === "string")
+          .join("");
+        expect(cumulativeContent).toBe("<xiaohai-banli>milk tea</xiaohai-banli>");
+      }
+
+      {
+        agentCommand.mockClear();
         agentCommand.mockResolvedValueOnce({
           payloads: [{ text: "hello" }],
         } as never);
@@ -1635,6 +1670,40 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         const fallbackText = await fallbackRes.text();
         expect(fallbackText).toContain("[DONE]");
         expect(fallbackText).toContain("hello");
+      }
+
+      {
+        agentCommand.mockClear();
+        agentCommand.mockImplementationOnce(((opts: unknown) => {
+          const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+          emitAgentEvent({ runId, stream: "assistant", data: { delta: "start " } });
+          const result = Promise.resolve({ payloads: [{ text: "start finish" }] });
+          void result.then(() => {
+            emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+            void Promise.resolve().then(() => {
+              emitAgentEvent({ runId, stream: "assistant", data: { delta: "finish" } });
+            });
+          });
+          return result;
+        }) as never);
+
+        const microtaskFlushRes = await postChatCompletions(port, {
+          stream: true,
+          model: "openclaw",
+          messages: [{ role: "user", content: "hi" }],
+        });
+        expect(microtaskFlushRes.status).toBe(200);
+        const microtaskFlushData = parseSseDataLines(await microtaskFlushRes.text());
+        expect(microtaskFlushData[microtaskFlushData.length - 1]).toBe("[DONE]");
+        const microtaskFlushChunks = microtaskFlushData
+          .filter((d) => d !== "[DONE]")
+          .map((d) => JSON.parse(d) as Record<string, unknown>);
+        const microtaskFlushContent = microtaskFlushChunks
+          .flatMap((c) => (c.choices as Array<Record<string, unknown>> | undefined) ?? [])
+          .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+          .filter((v): v is string => typeof v === "string")
+          .join("");
+        expect(microtaskFlushContent).toBe("start finish");
       }
 
       {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -12,7 +12,7 @@ import {
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import type { GatewayHttpChatCompletionsConfig } from "../config/types.gateway.js";
-import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
+import { emitAgentEvent, onAgentEvent, type AgentEventPayload } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
 import { estimateBase64DecodedBytes } from "../media/base64.js";
 import {
@@ -99,6 +99,18 @@ type ResolvedOpenAiChatCompletionsLimits = {
   maxTotalImageBytes: number;
   images: InputImageLimits;
 };
+
+function resolveAssistantStreamDeltaTextAfter(
+  evt: AgentEventPayload,
+  previousText: string,
+): { content: string; nextText: string } {
+  const text = evt.data.text;
+  if (typeof text === "string" && text.startsWith(previousText)) {
+    return { content: text.slice(previousText.length), nextText: text };
+  }
+  const content = resolveAssistantStreamDeltaText(evt);
+  return { content, nextText: `${previousText}${content}` };
+}
 
 function resolveOpenAiChatCompletionsLimits(
   config: GatewayHttpChatCompletionsConfig | undefined,
@@ -1056,6 +1068,7 @@ export async function handleOpenAiHttpRequest(
   let wroteRole = false;
   let wroteStopChunk = false;
   let sawAssistantDelta = false;
+  let streamedAssistantText = "";
   let finalUsage:
     | {
         prompt_tokens: number;
@@ -1064,13 +1077,14 @@ export async function handleOpenAiHttpRequest(
       }
     | undefined;
   let finalizeRequested = false;
+  let finalizeScheduled = false;
   let finalizeFinishReason: "stop" | "tool_calls" = "stop";
   let resultResolved = false;
   let closed = false;
   let stopWatchingDisconnect = () => {};
 
   const maybeFinalize = () => {
-    if (closed || !finalizeRequested) {
+    if (closed || finalizeScheduled || !finalizeRequested) {
       return;
     }
     if (!resultResolved) {
@@ -1079,22 +1093,30 @@ export async function handleOpenAiHttpRequest(
     if (streamIncludeUsage && !finalUsage) {
       return;
     }
-    closed = true;
-    stopWatchingDisconnect();
-    unsubscribe();
-    if (!wroteStopChunk) {
-      writeAssistantFinishChunk(res, { runId, model, finishReason: finalizeFinishReason });
-      wroteStopChunk = true;
-    }
-    if (streamIncludeUsage && finalUsage) {
-      writeUsageChunk(res, { runId, model, usage: finalUsage });
-    }
-    writeDone(res);
-    res.end();
+    finalizeScheduled = true;
+    void Promise.resolve().then(() => {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      stopWatchingDisconnect();
+      unsubscribe();
+      if (!wroteStopChunk) {
+        writeAssistantFinishChunk(res, { runId, model, finishReason: finalizeFinishReason });
+        wroteStopChunk = true;
+      }
+      if (streamIncludeUsage && finalUsage) {
+        writeUsageChunk(res, { runId, model, usage: finalUsage });
+      }
+      writeDone(res);
+      res.end();
+    });
   };
 
   const requestFinalize = (finishReason: "stop" | "tool_calls" = "stop") => {
-    finalizeFinishReason = finishReason;
+    if (!finalizeRequested || finishReason === "tool_calls") {
+      finalizeFinishReason = finishReason;
+    }
     finalizeRequested = true;
     maybeFinalize();
   };
@@ -1108,7 +1130,8 @@ export async function handleOpenAiHttpRequest(
     }
 
     if (evt.stream === "assistant") {
-      const content = resolveAssistantStreamDeltaText(evt) ?? "";
+      const resolved = resolveAssistantStreamDeltaTextAfter(evt, streamedAssistantText);
+      const content = resolved.content;
       if (!content) {
         return;
       }
@@ -1119,6 +1142,7 @@ export async function handleOpenAiHttpRequest(
       }
 
       sawAssistantDelta = true;
+      streamedAssistantText = resolved.nextText;
       writeAssistantContentChunk(res, {
         runId,
         model,


### PR DESCRIPTION
## Summary
- Preserve cumulative assistant `text` payloads when translating agent events into OpenAI-compatible SSE deltas, so leading `<` characters are not dropped when `delta` starts after a buffered tag prefix.
- Defer chat-completion stream finalization by one microtask after lifecycle end/result resolution so same-turn assistant deltas are flushed before `[DONE]`.
- Add regression coverage for split literal XML openers and chat-completions SSE final-fragment flushing.

Fixes #81991

## Real behavior proof
- **Behavior or issue addressed:** `/v1/chat/completions` streaming responses now keep a literal leading `<` in assistant content and flush the last assistant text fragment before the OpenAI-compatible SSE `[DONE]` frame.
- **Real environment tested:** Local OpenClaw source checkout on macOS with Node `v23.11.0` and pnpm `11.1.0`, rebased on current `origin/main` (`3156d94bca`), exercising the repository's OpenAI-compatible HTTP SSE e2e harness for both `gateway-server` and `gateway-client` projects plus the embedded subscribe stream filter path.
- **Exact steps or command run after this patch:** `pnpm exec node --no-maglev node_modules/vitest/vitest.mjs run src/gateway/openai-http.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts --reporter=dot`
- **Evidence after fix:** Terminal output captured after the refreshed patch:

  ```text
  RUN  v4.1.6 /private/tmp/openclaw-sse-refresh

  Test Files  4 passed (4)
       Tests  70 passed (70)
    Duration  52.38s (transform 25.88s, setup 1.41s, import 16.87s, tests 33.71s, environment 0ms)
  ```
- **Observed result after fix:** The OpenAI-compatible HTTP SSE e2e path emitted the full streamed assistant content in both gateway modes, including the leading `<` case and the final `finish` fragment before stream completion; the embedded subscribe path preserved `<xiaohai-banli>...` when the literal tag opener was split after a bare `<`.
- **What was not tested:** A live external OpenAI/Codex provider call was not used; the proof exercises OpenClaw's local HTTP SSE gateway behavior and stream filtering path without sending provider credentials.

## Tests
- `git diff --cached --check && git diff --check`
- `node scripts/run-vitest.mjs run src/gateway/openai-http.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts --reporter=dot`
- `pnpm exec node --no-maglev node_modules/vitest/vitest.mjs run src/gateway/openai-http.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts --reporter=dot` — 4 files / 70 tests passed
- `pnpm check:test-types`
