### PR TITLE
fix(doctor): repair configured plugins despite web search config errors

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -307,6 +307,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     path: snapshot.path ?? CONFIG_PATH,
     shouldWriteConfig: finalized.shouldWriteConfig,
     sourceConfigValid: snapshot.valid,
+    sourceConfigIssues: snapshot.issues,
     ...(sourceLastTouchedVersion ? { sourceLastTouchedVersion } : {}),
     ...(legacyMigrationPartiallyValid ? { skipPluginValidationOnWrite: true } : {}),
   };

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -142,6 +142,66 @@ describe("doctor health contributions", () => {
     expect(ctx.cfg.meta?.lastTouchedVersion).toBe("2026.5.2-test");
   });
 
+  it("runs release configured plugin installs when installable web search config blocks validation", async () => {
+    mocks.maybeRunConfiguredPluginInstallReleaseStep.mockResolvedValue({
+      changes: ['Installed missing configured plugin "brave".'],
+      warnings: [],
+      touchedConfig: true,
+    });
+    const contribution = requireDoctorContribution("doctor:release-configured-plugin-installs");
+    const cfg = { tools: { web: { search: { provider: "brave" } } } };
+    const ctx = {
+      cfg,
+      configResult: {
+        cfg,
+        sourceLastTouchedVersion: "2026.4.29",
+        sourceConfigIssues: [
+          {
+            path: "tools.web.search.provider",
+            message:
+              'web_search provider is not available: brave (install or enable plugin "brave", then run openclaw doctor --fix)',
+          },
+        ],
+      },
+      sourceConfigValid: false,
+      prompter: buildDoctorPrompter(true),
+      env: {},
+    } as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(mocks.maybeRunConfiguredPluginInstallReleaseStep).toHaveBeenCalledWith({
+      cfg,
+      env: {},
+      touchedVersion: "2026.4.29",
+    });
+    expect(mocks.note).toHaveBeenCalledWith(
+      'Installed missing configured plugin "brave".',
+      "Doctor changes",
+    );
+    expect(ctx.cfg.meta?.lastTouchedVersion).toBe("2026.5.2-test");
+  });
+
+  it("does not run release configured plugin installs for unrelated invalid config", async () => {
+    const contribution = requireDoctorContribution("doctor:release-configured-plugin-installs");
+    const ctx = {
+      cfg: {},
+      configResult: {
+        cfg: {},
+        sourceLastTouchedVersion: "2026.4.29",
+        sourceConfigIssues: [{ path: "gateway.mode", message: "Expected local or remote" }],
+      },
+      sourceConfigValid: false,
+      prompter: buildDoctorPrompter(true),
+      env: {},
+    } as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(mocks.maybeRunConfiguredPluginInstallReleaseStep).not.toHaveBeenCalled();
+    expect(mocks.note).not.toHaveBeenCalled();
+  });
+
   it("checks command owner configuration before final config writes", () => {
     const ids = resolveDoctorHealthContributions().map((entry) => entry.id);
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import type { probeGatewayMemoryStatus } from "../commands/doctor-gateway-health.js";
 import type { DoctorOptions, DoctorPrompter } from "../commands/doctor-prompter.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ConfigValidationIssue, OpenClawConfig } from "../config/types.openclaw.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { FlowContribution } from "./types.js";
@@ -13,6 +13,7 @@ type DoctorConfigResult = {
   path?: string;
   shouldWriteConfig?: boolean;
   sourceConfigValid?: boolean;
+  sourceConfigIssues?: ConfigValidationIssue[];
   sourceLastTouchedVersion?: string;
   skipPluginValidationOnWrite?: boolean;
 };
@@ -69,6 +70,22 @@ export function shouldSkipLegacyUpdateDoctorConfigWrite(params: {
     return false;
   }
   return true;
+}
+
+function isConfiguredPluginInstallRepairableIssue(issue: ConfigValidationIssue): boolean {
+  return (
+    issue.path.trim() === "tools.web.search.provider" &&
+    issue.message.trim().startsWith("web_search provider is not available:") &&
+    issue.message.includes("install or enable plugin")
+  );
+}
+
+function shouldRunReleaseConfiguredPluginInstallsHealth(ctx: DoctorHealthFlowContext): boolean {
+  if (ctx.sourceConfigValid) {
+    return true;
+  }
+  const issues = ctx.configResult.sourceConfigIssues ?? [];
+  return issues.length > 0 && issues.every(isConfiguredPluginInstallRepairableIssue);
 }
 
 function createDoctorHealthContribution(params: {
@@ -279,7 +296,7 @@ async function runPluginRegistryHealth(ctx: DoctorHealthFlowContext): Promise<vo
 async function runReleaseConfiguredPluginInstallsHealth(
   ctx: DoctorHealthFlowContext,
 ): Promise<void> {
-  if (!ctx.sourceConfigValid) {
+  if (!shouldRunReleaseConfiguredPluginInstallsHealth(ctx)) {
     return;
   }
   if (!ctx.prompter.shouldRepair) {


### PR DESCRIPTION
## Summary

Fixes #82301.

`openclaw doctor --fix` now runs the configured-plugin install repair when the source config is invalid only because `tools.web.search.provider` names an installable provider whose plugin is not active yet. That is the exact stock-to-externalized `brave` upgrade deadlock: validation tells the user to run doctor, but doctor previously skipped the repair because `sourceConfigValid=false`.

The gate remains narrow: unrelated invalid config still skips this repair path.

## Real behavior proof

Behavior or issue addressed:
`doctor:release-configured-plugin-installs` no longer early-returns when the only source-config validation issue is the installable web search provider error that the release repair is designed to fix.

Real environment tested:
WSL Ubuntu-24.04 source checkout with a temporary real OpenClaw state/config directory, plus Crabbox AWS Linux before/after proof against current `origin/main`.

Exact steps or command run after this patch:
```bash
state_dir=$(mktemp -d)
cat > "$state_dir/openclaw.json" <<'JSON'
{
  "meta": { "lastTouchedVersion": "2026.4.29" },
  "gateway": { "mode": "local" },
  "tools": { "web": { "search": { "provider": "brave" } } }
}
JSON
OPENCLAW_STATE_DIR="$state_dir" \
OPENCLAW_CONFIG_PATH="$state_dir/openclaw.json" \
CI=1 node --import tsx src/entry.ts doctor --fix --non-interactive
```

Crabbox before/after proof also applied the new regression test to `origin/main`, then ran the focused after suite on this branch.

Evidence after fix:
- Runtime doctor proof summary: https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82361/openclaw82301-real-proof/20260515-234120-626469581/summary.txt
- Runtime doctor log: https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82361/openclaw82301-real-proof/20260515-234120-626469581/doctor-after.log
- Crabbox before/after summary: https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82361/openclaw82301-artifacts/20260515-233611-577858748/summary.txt
- Crabbox log artifact: https://artifacts.openclaw.ai/crabbox-artifacts/giodl73%40gmail.com/pr-82361/openclaw82301-artifacts/20260515-233611-577858748/crabbox-run_20a574e79f3e.log
- Crabbox run: https://crabbox.openclaw.ai/v1/runs/run_20a574e79f3e/logs

The real doctor run exited with `doctor_status=0`, printed `brave web search provider selected, enabled automatically.`, wrote the config, and the resulting config contained:
```json
{
  "lastTouchedVersion": "2026.5.16",
  "provider": "brave",
  "pluginEntries": {
    "brave": {
      "enabled": true
    }
  }
}
```

Observed result after fix:
The configured-plugin install repair is called for the installable `brave` web search provider validation failure, the real doctor command completes, and the config is updated with an enabled `plugins.entries.brave` record while preserving `tools.web.search.provider = "brave"`.

What was not tested:
A live npm download of `@openclaw/brave-plugin` against a production user config was not performed; this proof uses the current source checkout and temp state. `pnpm check:changed` is currently blocked by an unrelated current-main test type error in `src/cron/isolated-agent.model-formatting.test.ts` introduced before this branch; the changed files and focused suites pass locally.