### PR TITLE
feat: add xAI Grok OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Providers/xAI: add xAI Grok OAuth login for SuperGrok subscribers, letting `xai/*` models and xAI media/tool providers authenticate without `XAI_API_KEY`.
 - Maintainer tooling: route Crabbox skill defaults through the repo brokered AWS config, leaving Blacksmith Testbox as an explicit opt-in instead of the broad-proof default.
 - CLI/onboarding: localize the setup wizard and bundled channel setup flows for English, Simplified Chinese, and Traditional Chinese. (#80645) Thanks @GaosCode.
 - Agents/skills: cache hydrated `resolvedSkills` across warm gateway turns while keying reuse by the redacted effective config, reducing redundant skill snapshot rebuilds without crossing config-gated skill boundaries. (#81451) Thanks @solodmd.

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -38,9 +38,9 @@ OpenClaw ships a bundled `xai` provider plugin for Grok models.
 OpenClaw uses the xAI Responses API as the bundled xAI transport. The same
 credential from `openclaw onboard --auth-choice xai-api-key` or
 `openclaw onboard --auth-choice xai-oauth` can also power first-class
-`x_search`, remote `code_execution`, xAI media generation, speech, and
-transcription. `XAI_API_KEY` or plugin web-search config can power
-Grok-backed `web_search` too.
+`x_search`, remote `code_execution`, and xAI image/video generation.
+Speech and transcription currently require `XAI_API_KEY` or provider config.
+`XAI_API_KEY` or plugin web-search config can power Grok-backed `web_search` too.
 If you store an xAI key under `plugins.entries.xai.config.webSearch.apiKey`,
 the bundled xAI model provider reuses that key as a fallback too.
 Set `plugins.entries.xai.config.webSearch.baseUrl` to route Grok `web_search`

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -11,14 +11,17 @@ OpenClaw ships a bundled `xai` provider plugin for Grok models.
 ## Getting started
 
 <Steps>
-  <Step title="Create an API key">
-    Create an API key in the [xAI console](https://console.x.ai/).
+  <Step title="Choose auth">
+    Use either an API key from the [xAI console](https://console.x.ai/) or
+    xAI Grok OAuth with a SuperGrok subscription.
   </Step>
-  <Step title="Set your API key">
-    Set `XAI_API_KEY`, or run:
+  <Step title="Sign in">
+    Set `XAI_API_KEY`, run the API-key wizard, or start the OAuth flow:
 
     ```bash
     openclaw onboard --auth-choice xai-api-key
+    openclaw onboard --auth-choice xai-oauth
+    openclaw models auth login --provider xai --method oauth
     ```
 
   </Step>
@@ -33,9 +36,11 @@ OpenClaw ships a bundled `xai` provider plugin for Grok models.
 
 <Note>
 OpenClaw uses the xAI Responses API as the bundled xAI transport. The same
-API key from `openclaw onboard --auth-choice xai-api-key` can also power
-first-class `x_search` and remote `code_execution`; `XAI_API_KEY` or plugin
-web-search config can power Grok-backed `web_search` too.
+credential from `openclaw onboard --auth-choice xai-api-key` or
+`openclaw onboard --auth-choice xai-oauth` can also power first-class
+`x_search`, remote `code_execution`, xAI media generation, speech, and
+transcription. `XAI_API_KEY` or plugin web-search config can power
+Grok-backed `web_search` too.
 If you store an xAI key under `plugins.entries.xai.config.webSearch.apiKey`,
 the bundled xAI model provider reuses that key as a fallback too.
 Set `plugins.entries.xai.config.webSearch.baseUrl` to route Grok `web_search`
@@ -411,9 +416,10 @@ Legacy aliases still normalize to the canonical bundled ids:
   </Accordion>
 
   <Accordion title="Known limits">
-    - Auth is API-key only today. The API key may be stored in an xAI auth
-      profile, environment variable, or plugin config; there is no xAI OAuth or
-      device-code flow in OpenClaw yet.
+    - xAI auth can use an API key, environment variable, plugin config fallback,
+      or xAI Grok OAuth with a SuperGrok subscription. OAuth uses a local
+      callback on `127.0.0.1:56121`; for remote hosts, forward that port before
+      opening the sign-in URL.
     - `grok-4.20-multi-agent-experimental-beta-0304` is not supported on the
       normal xAI provider path because it requires a different upstream API
       surface than the standard OpenClaw xAI transport.

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -31,6 +31,7 @@ import {
   buildMissingXSearchApiKeyPayload,
   createXSearchToolDefinition,
 } from "./x-search-tool-shared.js";
+import { createXaiOAuthAuthMethod, refreshXaiOAuthCredential } from "./xai-oauth.js";
 
 const PROVIDER_ID = "xai";
 type CodeExecutionModule = typeof import("./code-execution.js");
@@ -182,6 +183,7 @@ export default defineSingleProviderPluginEntry({
         },
       },
     ],
+    extraAuth: [createXaiOAuthAuthMethod()],
     catalog: {
       buildProvider: buildXaiProvider,
     },
@@ -210,6 +212,7 @@ export default defineSingleProviderPluginEntry({
       shouldContributeXaiCompat({ modelId, model }) ? resolveXaiModelCompatPatch() : undefined,
     normalizeModelId: ({ modelId }) => normalizeXaiModelId(modelId),
     resolveDynamicModel: (ctx) => resolveXaiForwardCompatModel({ providerId: PROVIDER_ID, ctx }),
+    refreshOAuth: refreshXaiOAuthCredential,
     resolveThinkingProfile,
     isModernModelRef: ({ modelId }) => isModernXaiModel(modelId),
   },

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -45,12 +45,23 @@
       "choiceLabel": "xAI API key",
       "groupId": "xai",
       "groupLabel": "xAI (Grok)",
-      "groupHint": "API key",
+      "groupHint": "API key or SuperGrok OAuth",
       "onboardingFeatured": true,
       "optionKey": "xaiApiKey",
       "cliFlag": "--xai-api-key",
       "cliOption": "--xai-api-key <key>",
       "cliDescription": "xAI API key"
+    },
+    {
+      "provider": "xai",
+      "method": "oauth",
+      "choiceId": "xai-oauth",
+      "choiceLabel": "xAI Grok OAuth",
+      "choiceHint": "SuperGrok subscription",
+      "groupId": "xai",
+      "groupLabel": "xAI (Grok)",
+      "groupHint": "API key or SuperGrok OAuth",
+      "onboardingFeatured": true
     }
   ],
   "uiHints": {

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  type OAuthCredential,
   buildXaiOAuthAuthorizeUrl,
   fetchXaiOAuthDiscovery,
   isTrustedXaiOAuthEndpoint,
@@ -80,7 +79,8 @@ describe("xAI OAuth", () => {
   it("refreshes with the cached token endpoint and preserves refresh fallback", async () => {
     const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       expect(init?.method).toBe("POST");
-      const body = String(init?.body);
+      expect(typeof init?.body).toBe("string");
+      const body = init?.body as string;
       expect(body).toContain("grant_type=refresh_token");
       expect(body).toContain(`client_id=${encodeURIComponent(XAI_OAUTH_CLIENT_ID)}`);
       expect(body).toContain("refresh_token=refresh-1");
@@ -98,7 +98,7 @@ describe("xAI OAuth", () => {
         refresh: "refresh-1",
         expires: 100,
         tokenEndpoint: "https://auth.x.ai/oauth2/token",
-      } as OAuthCredential & { tokenEndpoint: string },
+      } as unknown as Parameters<typeof refreshXaiOAuthCredential>[0],
       { fetchImpl, now: () => 1_000 },
     );
 

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type OAuthCredential,
+  buildXaiOAuthAuthorizeUrl,
+  fetchXaiOAuthDiscovery,
+  isTrustedXaiOAuthEndpoint,
+  refreshXaiOAuthCredential,
+  XAI_OAUTH_CALLBACK_PORT,
+  XAI_OAUTH_CLIENT_ID,
+  XAI_OAUTH_REDIRECT_URI,
+  XAI_OAUTH_SCOPE,
+} from "./xai-oauth.js";
+
+function jsonResponse(value: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+describe("xAI OAuth", () => {
+  it("accepts only trusted xAI OAuth endpoints", () => {
+    expect(isTrustedXaiOAuthEndpoint("https://auth.x.ai/oauth2/token")).toBe(true);
+    expect(isTrustedXaiOAuthEndpoint("https://accounts.x.ai/oauth2/token")).toBe(true);
+    expect(isTrustedXaiOAuthEndpoint("http://auth.x.ai/oauth2/token")).toBe(false);
+    expect(isTrustedXaiOAuthEndpoint("https://x.ai.evil.test/oauth2/token")).toBe(false);
+    expect(isTrustedXaiOAuthEndpoint("not a url")).toBe(false);
+  });
+
+  it("builds the Hermes-compatible authorize URL for OpenClaw", () => {
+    const url = new URL(
+      buildXaiOAuthAuthorizeUrl({
+        authorizationEndpoint: "https://auth.x.ai/oauth2/authorize",
+        state: "state-1",
+        nonce: "nonce-1",
+        challenge: "challenge-1",
+      }),
+    );
+
+    expect(url.origin + url.pathname).toBe("https://auth.x.ai/oauth2/authorize");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBe(XAI_OAUTH_CLIENT_ID);
+    expect(url.searchParams.get("redirect_uri")).toBe(XAI_OAUTH_REDIRECT_URI);
+    expect(url.searchParams.get("scope")).toBe(XAI_OAUTH_SCOPE);
+    expect(url.searchParams.get("code_challenge")).toBe("challenge-1");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("state")).toBe("state-1");
+    expect(url.searchParams.get("nonce")).toBe("nonce-1");
+    expect(url.searchParams.get("plan")).toBe("generic");
+    expect(url.searchParams.get("referrer")).toBe("openclaw");
+    expect(XAI_OAUTH_REDIRECT_URI).toContain(`:${XAI_OAUTH_CALLBACK_PORT}/`);
+  });
+
+  it("validates discovered endpoints before using them", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
+        token_endpoint: "https://auth.x.ai/oauth2/token",
+      }),
+    ) as unknown as typeof fetch;
+
+    await expect(fetchXaiOAuthDiscovery({ fetchImpl })).resolves.toEqual({
+      authorizationEndpoint: "https://auth.x.ai/oauth2/authorize",
+      tokenEndpoint: "https://auth.x.ai/oauth2/token",
+    });
+
+    const poisonedFetch = vi.fn(async () =>
+      jsonResponse({
+        authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
+        token_endpoint: "https://evil.test/oauth2/token",
+      }),
+    ) as unknown as typeof fetch;
+
+    await expect(fetchXaiOAuthDiscovery({ fetchImpl: poisonedFetch })).rejects.toThrow(
+      "untrusted token endpoint",
+    );
+  });
+
+  it("refreshes with the cached token endpoint and preserves refresh fallback", async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(init?.method).toBe("POST");
+      const body = String(init?.body);
+      expect(body).toContain("grant_type=refresh_token");
+      expect(body).toContain(`client_id=${encodeURIComponent(XAI_OAUTH_CLIENT_ID)}`);
+      expect(body).toContain("refresh_token=refresh-1");
+      return jsonResponse({
+        access_token: "access-2",
+        expires_in: 120,
+      });
+    }) as unknown as typeof fetch;
+
+    const refreshed = await refreshXaiOAuthCredential(
+      {
+        type: "oauth",
+        provider: "xai",
+        access: "access-1",
+        refresh: "refresh-1",
+        expires: 100,
+        tokenEndpoint: "https://auth.x.ai/oauth2/token",
+      } as OAuthCredential & { tokenEndpoint: string },
+      { fetchImpl, now: () => 1_000 },
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith("https://auth.x.ai/oauth2/token", expect.any(Object));
+    expect(refreshed.access).toBe("access-2");
+    expect(refreshed.refresh).toBe("refresh-1");
+    expect(refreshed.expires).toBe(121_000);
+  });
+});

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -251,12 +251,8 @@ export async function loginXaiOAuth(ctx: ProviderAuthContext): Promise<ProviderA
       nonce,
       challenge: pkce.challenge,
     });
-    await noteXaiOAuthUrl(ctx, authorizeUrl);
-    if (!ctx.isRemote) {
-      await ctx.openUrl(authorizeUrl);
-    }
     progress.update(`Waiting for xAI OAuth callback on ${XAI_OAUTH_REDIRECT_URI}...`);
-    const callback = await waitForLocalOAuthCallback({
+    const callbackPromise = waitForLocalOAuthCallback({
       expectedState: state,
       timeoutMs: XAI_OAUTH_TIMEOUT_MS,
       port: XAI_OAUTH_CALLBACK_PORT,
@@ -264,7 +260,14 @@ export async function loginXaiOAuth(ctx: ProviderAuthContext): Promise<ProviderA
       redirectUri: XAI_OAUTH_REDIRECT_URI,
       hostname: XAI_OAUTH_CALLBACK_HOST,
       successTitle: "xAI OAuth complete",
+      onProgress: (message) => progress.update(message),
     });
+    void callbackPromise.catch(() => undefined);
+    await noteXaiOAuthUrl(ctx, authorizeUrl);
+    if (!ctx.isRemote) {
+      await ctx.openUrl(authorizeUrl);
+    }
+    const callback = await callbackPromise;
     const tokens = await exchangeXaiOAuthToken({
       tokenEndpoint: discovery.tokenEndpoint,
       context: "xAI OAuth token exchange",

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -298,7 +298,7 @@ export async function loginXaiOAuth(ctx: ProviderAuthContext): Promise<ProviderA
     });
   } catch (err) {
     progress.stop("xAI OAuth failed");
-    throw new Error(`xAI OAuth failed: ${formatErrorMessage(err)}`);
+    throw new Error(`xAI OAuth failed: ${formatErrorMessage(err)}`, { cause: err });
   }
 }
 

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -1,0 +1,360 @@
+import { randomBytes } from "node:crypto";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import type { ProviderAuthContext, ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  buildOauthProviderAuthResult,
+  generateHexPkceVerifierChallenge,
+  toFormUrlEncoded,
+  type OAuthCredential,
+  type ProviderAuthResult,
+} from "openclaw/plugin-sdk/provider-auth";
+import { waitForLocalOAuthCallback } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { applyXaiConfig, XAI_DEFAULT_MODEL_REF } from "./onboard.js";
+
+const PROVIDER_ID = "xai";
+export const XAI_OAUTH_METHOD_ID = "oauth";
+export const XAI_OAUTH_CHOICE_ID = "xai-oauth";
+export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+export const XAI_OAUTH_ISSUER = "https://auth.x.ai";
+export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
+export const XAI_OAUTH_CALLBACK_HOST = "127.0.0.1";
+export const XAI_OAUTH_CALLBACK_PORT = 56121;
+export const XAI_OAUTH_CALLBACK_PATH = "/callback";
+export const XAI_OAUTH_REDIRECT_URI = `http://${XAI_OAUTH_CALLBACK_HOST}:${XAI_OAUTH_CALLBACK_PORT}${XAI_OAUTH_CALLBACK_PATH}`;
+
+const XAI_OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
+const XAI_OAUTH_FETCH_TIMEOUT_MS = 30 * 1000;
+
+type XaiOAuthDiscovery = {
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+};
+
+type XaiOAuthTokenResponse = {
+  accessToken: string;
+  refreshToken?: string;
+  expires?: number;
+  idToken?: string;
+};
+
+type XaiOAuthIdentity = {
+  email?: string;
+  displayName?: string;
+  accountId?: string;
+};
+
+type XaiOAuthFetchOptions = {
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+};
+
+function getFetchImpl(fetchImpl?: typeof fetch): typeof fetch {
+  return fetchImpl ?? fetch;
+}
+
+export function isTrustedXaiOAuthEndpoint(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint);
+    if (url.protocol !== "https:") {
+      return false;
+    }
+    return url.hostname === "x.ai" || url.hostname.endsWith(".x.ai");
+  } catch {
+    return false;
+  }
+}
+
+function requireTrustedXaiOAuthEndpoint(endpoint: string, label: string): string {
+  if (!isTrustedXaiOAuthEndpoint(endpoint)) {
+    throw new Error(`xAI OAuth discovery returned untrusted ${label}`);
+  }
+  return endpoint;
+}
+
+function readStringRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+async function readJsonResponse(response: Response, context: string): Promise<unknown> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  if (!response.ok) {
+    const errorText = readStringRecord(body).error_description ?? readStringRecord(body).error;
+    throw new Error(
+      `${context} failed (${response.status})${typeof errorText === "string" ? `: ${errorText}` : ""}`,
+    );
+  }
+  return body;
+}
+
+export async function fetchXaiOAuthDiscovery(
+  options: XaiOAuthFetchOptions = {},
+): Promise<XaiOAuthDiscovery> {
+  const response = await getFetchImpl(options.fetchImpl)(XAI_OAUTH_DISCOVERY_URL, {
+    signal: AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
+  });
+  const json = readStringRecord(await readJsonResponse(response, "xAI OAuth discovery"));
+  const authorizationEndpoint = json.authorization_endpoint;
+  const tokenEndpoint = json.token_endpoint;
+  if (typeof authorizationEndpoint !== "string" || typeof tokenEndpoint !== "string") {
+    throw new Error("xAI OAuth discovery response is missing endpoints");
+  }
+  return {
+    authorizationEndpoint: requireTrustedXaiOAuthEndpoint(
+      authorizationEndpoint,
+      "authorization endpoint",
+    ),
+    tokenEndpoint: requireTrustedXaiOAuthEndpoint(tokenEndpoint, "token endpoint"),
+  };
+}
+
+export function buildXaiOAuthAuthorizeUrl(params: {
+  authorizationEndpoint: string;
+  state: string;
+  nonce: string;
+  challenge: string;
+}): string {
+  const url = new URL(
+    requireTrustedXaiOAuthEndpoint(params.authorizationEndpoint, "authorization endpoint"),
+  );
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", XAI_OAUTH_CLIENT_ID);
+  url.searchParams.set("redirect_uri", XAI_OAUTH_REDIRECT_URI);
+  url.searchParams.set("scope", XAI_OAUTH_SCOPE);
+  url.searchParams.set("state", params.state);
+  url.searchParams.set("nonce", params.nonce);
+  url.searchParams.set("code_challenge", params.challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("plan", "generic");
+  url.searchParams.set("referrer", "openclaw");
+  return url.toString();
+}
+
+function normalizeExpires(value: unknown, now: () => number): number | undefined {
+  const seconds =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number.parseFloat(value)
+        : Number.NaN;
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return undefined;
+  }
+  return now() + seconds * 1000;
+}
+
+function parseXaiOAuthTokenResponse(value: unknown, now: () => number): XaiOAuthTokenResponse {
+  const json = readStringRecord(value);
+  const accessToken = json.access_token;
+  if (typeof accessToken !== "string" || accessToken.trim().length === 0) {
+    throw new Error("xAI OAuth token response is missing access_token");
+  }
+  const expires = normalizeExpires(json.expires_in, now);
+  return {
+    accessToken,
+    ...(typeof json.refresh_token === "string" && json.refresh_token.trim().length > 0
+      ? { refreshToken: json.refresh_token }
+      : {}),
+    ...(typeof json.id_token === "string" && json.id_token.trim().length > 0
+      ? { idToken: json.id_token }
+      : {}),
+    ...(expires ? { expires } : {}),
+  };
+}
+
+async function exchangeXaiOAuthToken(
+  params: {
+    tokenEndpoint: string;
+    body: Record<string, string>;
+    context: string;
+  } & XaiOAuthFetchOptions,
+): Promise<XaiOAuthTokenResponse> {
+  const response = await getFetchImpl(params.fetchImpl)(
+    requireTrustedXaiOAuthEndpoint(params.tokenEndpoint, "token endpoint"),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: toFormUrlEncoded(params.body),
+      signal: AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
+    },
+  );
+  return parseXaiOAuthTokenResponse(
+    await readJsonResponse(response, params.context),
+    params.now ?? Date.now,
+  );
+}
+
+function decodeJwtPayload(token: string | undefined): Record<string, unknown> {
+  if (!token) {
+    return {};
+  }
+  const part = token.split(".")[1];
+  if (!part) {
+    return {};
+  }
+  try {
+    return readStringRecord(JSON.parse(Buffer.from(part, "base64url").toString("utf8")));
+  } catch {
+    return {};
+  }
+}
+
+function resolveXaiOAuthIdentity(tokens: XaiOAuthTokenResponse): XaiOAuthIdentity {
+  const payload = decodeJwtPayload(tokens.idToken ?? tokens.accessToken);
+  const email = typeof payload.email === "string" ? payload.email : undefined;
+  const name = typeof payload.name === "string" ? payload.name : undefined;
+  const sub = typeof payload.sub === "string" ? payload.sub : undefined;
+  return {
+    ...(email ? { email } : {}),
+    ...(name ? { displayName: name } : {}),
+    ...(sub ? { accountId: sub } : {}),
+  };
+}
+
+function readCredentialString(credential: OAuthCredential, key: string): string | undefined {
+  const value = (credential as unknown as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+async function noteXaiOAuthUrl(ctx: ProviderAuthContext, authorizeUrl: string): Promise<void> {
+  const lines = ["Open this xAI OAuth URL in your browser:", authorizeUrl];
+  if (ctx.isRemote) {
+    lines.push(
+      "",
+      "Remote host: forward the callback before signing in:",
+      `ssh -N -L ${XAI_OAUTH_CALLBACK_PORT}:${XAI_OAUTH_CALLBACK_HOST}:${XAI_OAUTH_CALLBACK_PORT} <host>`,
+    );
+  }
+  await ctx.prompter.note(lines.join("\n"), "xAI OAuth");
+}
+
+export async function loginXaiOAuth(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
+  const progress = ctx.prompter.progress("Starting xAI OAuth...");
+  try {
+    const discovery = await fetchXaiOAuthDiscovery();
+    const pkce = generateHexPkceVerifierChallenge();
+    const state = randomBytes(32).toString("hex");
+    const nonce = randomBytes(16).toString("hex");
+    const authorizeUrl = buildXaiOAuthAuthorizeUrl({
+      authorizationEndpoint: discovery.authorizationEndpoint,
+      state,
+      nonce,
+      challenge: pkce.challenge,
+    });
+    await noteXaiOAuthUrl(ctx, authorizeUrl);
+    if (!ctx.isRemote) {
+      await ctx.openUrl(authorizeUrl);
+    }
+    progress.update(`Waiting for xAI OAuth callback on ${XAI_OAUTH_REDIRECT_URI}...`);
+    const callback = await waitForLocalOAuthCallback({
+      expectedState: state,
+      timeoutMs: XAI_OAUTH_TIMEOUT_MS,
+      port: XAI_OAUTH_CALLBACK_PORT,
+      callbackPath: XAI_OAUTH_CALLBACK_PATH,
+      redirectUri: XAI_OAUTH_REDIRECT_URI,
+      hostname: XAI_OAUTH_CALLBACK_HOST,
+      successTitle: "xAI OAuth complete",
+    });
+    const tokens = await exchangeXaiOAuthToken({
+      tokenEndpoint: discovery.tokenEndpoint,
+      context: "xAI OAuth token exchange",
+      body: {
+        grant_type: "authorization_code",
+        code: callback.code,
+        redirect_uri: XAI_OAUTH_REDIRECT_URI,
+        client_id: XAI_OAUTH_CLIENT_ID,
+        code_verifier: pkce.verifier,
+      },
+    });
+    const identity = resolveXaiOAuthIdentity(tokens);
+    progress.stop("xAI OAuth complete");
+    return buildOauthProviderAuthResult({
+      providerId: PROVIDER_ID,
+      defaultModel: XAI_DEFAULT_MODEL_REF,
+      access: tokens.accessToken,
+      refresh: tokens.refreshToken,
+      expires: tokens.expires,
+      email: identity.email,
+      displayName: identity.displayName,
+      profileName: identity.email ?? identity.accountId,
+      configPatch: applyXaiConfig(ctx.config),
+      credentialExtra: {
+        tokenEndpoint: discovery.tokenEndpoint,
+        issuer: XAI_OAUTH_ISSUER,
+        ...(tokens.idToken ? { idToken: tokens.idToken } : {}),
+        ...(identity.accountId ? { accountId: identity.accountId } : {}),
+      },
+      notes: ["xAI OAuth uses your SuperGrok subscription; xAI API keys still work."],
+    });
+  } catch (err) {
+    progress.stop("xAI OAuth failed");
+    throw new Error(`xAI OAuth failed: ${formatErrorMessage(err)}`);
+  }
+}
+
+export async function refreshXaiOAuthCredential(
+  credential: OAuthCredential,
+  options: XaiOAuthFetchOptions = {},
+): Promise<OAuthCredential> {
+  const refreshToken = credential.refresh;
+  if (!refreshToken) {
+    throw new Error("xAI OAuth credential is missing refresh token");
+  }
+  const tokenEndpoint =
+    readCredentialString(credential, "tokenEndpoint") ??
+    (await fetchXaiOAuthDiscovery(options)).tokenEndpoint;
+  const tokens = await exchangeXaiOAuthToken({
+    ...options,
+    tokenEndpoint,
+    context: "xAI OAuth refresh",
+    body: {
+      grant_type: "refresh_token",
+      client_id: XAI_OAUTH_CLIENT_ID,
+      refresh_token: refreshToken,
+    },
+  });
+  const identity = resolveXaiOAuthIdentity(tokens);
+  return {
+    ...credential,
+    type: "oauth",
+    provider: PROVIDER_ID,
+    access: tokens.accessToken,
+    refresh: tokens.refreshToken ?? refreshToken,
+    ...(tokens.expires ? { expires: tokens.expires } : {}),
+    ...(tokens.idToken ? { idToken: tokens.idToken } : {}),
+    ...(identity.email ? { email: identity.email } : {}),
+    ...(identity.displayName ? { displayName: identity.displayName } : {}),
+    ...(identity.accountId ? { accountId: identity.accountId } : {}),
+    tokenEndpoint,
+    issuer: XAI_OAUTH_ISSUER,
+  } as OAuthCredential;
+}
+
+export function createXaiOAuthAuthMethod(): ProviderAuthMethod {
+  return {
+    id: XAI_OAUTH_METHOD_ID,
+    label: "xAI Grok OAuth",
+    hint: "SuperGrok subscription",
+    kind: "oauth",
+    wizard: {
+      choiceId: XAI_OAUTH_CHOICE_ID,
+      choiceLabel: "xAI Grok OAuth",
+      choiceHint: "SuperGrok subscription",
+      groupId: PROVIDER_ID,
+      groupLabel: "xAI (Grok)",
+      groupHint: "API key or SuperGrok OAuth",
+      methodId: XAI_OAUTH_METHOD_ID,
+    },
+    run: async (ctx) => loginXaiOAuth(ctx),
+  };
+}

--- a/src/plugin-sdk/provider-entry.test.ts
+++ b/src/plugin-sdk/provider-entry.test.ts
@@ -237,4 +237,55 @@ describe("defineSingleProviderPluginEntry", () => {
       },
     });
   });
+
+  it("registers extra non-api-key auth methods", async () => {
+    const entry = defineSingleProviderPluginEntry({
+      id: "demo",
+      name: "Demo Provider",
+      description: "Demo provider plugin",
+      provider: {
+        label: "Demo",
+        docsPath: "/providers/demo",
+        auth: [
+          {
+            methodId: "api-key",
+            label: "Demo API key",
+            hint: "Shared key",
+            optionKey: "demoApiKey",
+            flagName: "--demo-api-key",
+            envVar: "DEMO_API_KEY",
+            promptMessage: "Enter Demo API key",
+            defaultModel: "demo/default",
+          },
+        ],
+        extraAuth: [
+          {
+            id: "oauth",
+            label: "Demo OAuth",
+            hint: "OAuth",
+            kind: "oauth",
+            wizard: {
+              choiceId: "demo-oauth",
+              choiceLabel: "Demo OAuth",
+              groupId: "demo",
+              groupLabel: "Demo",
+              methodId: "oauth",
+            },
+            run: async () => ({ profiles: [] }),
+          },
+        ],
+        catalog: {
+          buildProvider: () => ({
+            api: "openai-completions",
+            baseUrl: "https://api.demo.test/v1",
+            models: [createModel("default", "Default")],
+          }),
+        },
+      },
+    });
+
+    const { provider } = await captureProviderEntry({ entry });
+    expect(provider?.auth.map((method) => method.id)).toEqual(["api-key", "oauth"]);
+    expect(provider?.auth[1]?.wizard?.choiceId).toBe("demo-oauth");
+  });
 });

--- a/src/plugin-sdk/provider-entry.ts
+++ b/src/plugin-sdk/provider-entry.ts
@@ -4,6 +4,7 @@ import type {
   ProviderPlugin,
   ProviderCatalogContext,
   ProviderCatalogResult,
+  ProviderAuthMethod,
   ProviderPluginCatalog,
   UnifiedModelCatalogProviderContext,
   ProviderPluginWizardSetup,
@@ -62,6 +63,7 @@ export type SingleProviderPluginOptions = {
     aliases?: string[];
     envVars?: string[];
     auth?: SingleProviderPluginApiKeyAuthOptions[];
+    extraAuth?: ProviderAuthMethod[];
     catalog: SingleProviderPluginCatalogOptions;
   } & Omit<
     ProviderPlugin,
@@ -178,6 +180,7 @@ export function defineSingleProviderPluginEntry(options: SingleProviderPluginOpt
             ...(wizard ? { wizard } : {}),
           });
         });
+        auth.push(...(provider.extraAuth ?? []));
         let catalog: ProviderPluginCatalog;
         if ("run" in provider.catalog) {
           const catalogRun = provider.catalog.run;
@@ -233,6 +236,7 @@ export function defineSingleProviderPluginEntry(options: SingleProviderPluginOpt
                   "aliases",
                   "envVars",
                   "auth",
+                  "extraAuth",
                   "catalog",
                   "staticCatalog",
                 ].includes(key),


### PR DESCRIPTION
## Summary

- add xAI Grok OAuth as `xai-oauth` for SuperGrok subscription-backed login while keeping the runtime provider id as `xai`
- wire OAuth token refresh through the xAI provider so `xai/*` models and xAI media/tool providers reuse the same profile token
- document API key vs OAuth setup and add changelog coverage

## Verification

- `curl -fsSL https://auth.x.ai/.well-known/openid-configuration` confirmed live xAI discovery returns trusted xAI auth/token endpoints and supports authorization-code + refresh-token PKCE flow
- `pnpm openclaw onboard --help` after this patch shows `xai-oauth` in the generated auth-choice list from the real CLI/plugin registry
- `pnpm test extensions/xai/xai-oauth.test.ts src/plugin-sdk/provider-entry.test.ts`
- `pnpm test extensions/xai`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental false`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental false`
- `pnpm lint:extensions`
- `git diff --check`
- `pnpm check:changed` via Testbox `tbx_01krpzs4wtncfewxad4zyzcwkp` reached core-test typecheck and failed on existing unchanged `src/cron/isolated-agent.model-formatting.test.ts:144`; that file is not touched here and the same snippet is present on `origin/main`

## Real behavior proof

Behavior addressed: OpenClaw can offer xAI Grok OAuth for SuperGrok subscribers without changing existing `xai/*` model refs or xAI media/tool provider ids.
Real environment tested: local macOS checkout running OpenClaw CLI from this branch at `61bd40d`, plus live xAI OAuth discovery over HTTPS.
Exact steps or command run after this patch: `pnpm openclaw onboard --help`; `curl -fsSL https://auth.x.ai/.well-known/openid-configuration`.
Evidence after fix: copied live terminal output from the patched OpenClaw CLI and live xAI discovery:

```text
$ pnpm openclaw onboard --help
🦞 OpenClaw 2026.5.16 (61bd40d) — All your chats, one OpenClaw.
Usage: openclaw onboard [options]
--auth-choice <choice> Auth: ...|xai-api-key|xai-oauth|xiaomi-api-key|zai-api-key
--xai-api-key <key> xAI API key

$ curl -fsSL https://auth.x.ai/.well-known/openid-configuration
issuer: https://auth.x.ai
authorization_endpoint: https://auth.x.ai/oauth2/authorize
token_endpoint: https://auth.x.ai/oauth2/token
grant_types_supported: authorization_code, refresh_token
code_challenge_methods_supported: S256
```

Observed result after fix: the real OpenClaw CLI advertises the new `xai-oauth` auth choice from plugin metadata, while live xAI discovery exposes the authorization and token endpoints this implementation validates and uses.
What was not tested: interactive browser OAuth completion against a real SuperGrok account.
