### PR TITLE
fix(skills): refresh snapshots after skill exposure config changes

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { INTERNAL_RUNTIME_CONTEXT_BEGIN, INTERNAL_RUNTIME_CONTEXT_END } from "./internal-events.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
+import { fingerprintSkillSnapshotConfig } from "./skills/snapshot-fingerprint.js";
 
 const state = vi.hoisted(() => ({
   defaultRuntimeConfig: {
@@ -1088,6 +1089,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       prompt: "persisted prompt",
       skills: [{ name: "cli-skill" }],
       skillFilter: ["cli-skill"],
+      configFingerprint: fingerprintSkillSnapshotConfig(state.defaultRuntimeConfig),
       version: 0,
     };
     const rebuiltSkills = [

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -79,6 +79,7 @@ import {
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-codex-routing.js";
 import { classifyEmbeddedPiRunResultForModelFallback } from "./pi-embedded-runner/result-fallback-classifier.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
+import { fingerprintSkillSnapshotConfig } from "./skills/snapshot-fingerprint.js";
 import { hydrateResolvedSkillsAsync } from "./skills/snapshot-hydration.js";
 import { normalizeSpawnedRunMetadata } from "./spawned-context.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
@@ -642,11 +643,13 @@ async function agentCommandInternal(
       await Promise.all([loadSkillsRefreshStateRuntime(), loadSkillsFilterRuntime()]);
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
+    const configFingerprint = fingerprintSkillSnapshotConfig(cfg);
     const currentSkillsSnapshot = sessionEntry?.skillsSnapshot;
     const shouldRefreshSkillsSnapshot =
       !currentSkillsSnapshot ||
       shouldRefreshSnapshotForVersion(currentSkillsSnapshot.version, skillsSnapshotVersion) ||
-      !matchesSkillFilter(currentSkillsSnapshot.skillFilter, skillFilter);
+      !matchesSkillFilter(currentSkillsSnapshot.skillFilter, skillFilter) ||
+      currentSkillsSnapshot.configFingerprint !== configFingerprint;
     const needsSkillsSnapshot = isNewSession || shouldRefreshSkillsSnapshot;
     const buildSkillsSnapshot = async () => {
       const [

--- a/src/agents/skills.buildworkspaceskillsnapshot.test.ts
+++ b/src/agents/skills.buildworkspaceskillsnapshot.test.ts
@@ -108,6 +108,43 @@ describe("buildWorkspaceSkillSnapshot", () => {
     expect(snapshot.skills).toStrictEqual([]);
   });
 
+  it("exposes shared x-post-analysis to HQ agent workspaces through skills.load.extraDirs", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("HQ Agents/tom");
+    const sharedSkillsDir = await fixtureSuite.createCaseDir("shared-skills");
+
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "xurl"),
+      name: "xurl",
+      description: "Generic X API access",
+    });
+    await writeSkill({
+      dir: path.join(sharedSkillsDir, "x-post-analysis"),
+      name: "x-post-analysis",
+      description: "Deterministic X post analysis workflow",
+    });
+
+    const withoutShared = buildSnapshot(workspaceDir);
+    expectSnapshotNamesAndPrompt(withoutShared, {
+      contains: ["xurl"],
+      omits: ["x-post-analysis"],
+    });
+
+    const withShared = buildSnapshot(workspaceDir, {
+      config: {
+        skills: {
+          load: {
+            extraDirs: [sharedSkillsDir],
+          },
+        },
+      },
+    });
+
+    expectSnapshotNamesAndPrompt(withShared, {
+      contains: ["x-post-analysis", "xurl"],
+    });
+    expect(withShared.configFingerprint).toEqual(expect.any(String));
+  });
+
   it("omits disable-model-invocation skills from the prompt", async () => {
     const workspaceDir = await fixtureSuite.createCaseDir("workspace");
     await writeSkill({

--- a/src/agents/skills/snapshot-fingerprint.ts
+++ b/src/agents/skills/snapshot-fingerprint.ts
@@ -1,0 +1,70 @@
+import crypto from "node:crypto";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { stableStringify } from "../stable-stringify.js";
+
+function isSensitiveConfigKey(key: string): boolean {
+  const normalized = key.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
+  return (
+    normalized.endsWith("apikey") ||
+    normalized.endsWith("token") ||
+    normalized.endsWith("secret") ||
+    normalized.endsWith("password") ||
+    normalized.endsWith("privatekey") ||
+    normalized.endsWith("clientsecret")
+  );
+}
+
+function redactSensitiveConfigValue(value: unknown): unknown {
+  if (value === undefined || value === null || value === false || value === "") {
+    return value;
+  }
+  if (typeof value === "string") {
+    return value.trim() ? "[redacted:string]" : "";
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value !== 0 ? "[redacted:number]" : value;
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0 ? [] : "[redacted:array]";
+  }
+  return "[redacted:object]";
+}
+
+function redactConfigForSkillSnapshot(value: unknown, stack = new WeakSet<object>()): unknown {
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  if (stack.has(value)) {
+    return "[Circular]";
+  }
+  stack.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((entry) => redactConfigForSkillSnapshot(entry, stack));
+    }
+    const redacted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).toSorted()) {
+      const field = (value as Record<string, unknown>)[key];
+      redacted[key] = isSensitiveConfigKey(key)
+        ? redactSensitiveConfigValue(field)
+        : redactConfigForSkillSnapshot(field, stack);
+    }
+    return redacted;
+  } finally {
+    stack.delete(value);
+  }
+}
+
+// Skill frontmatter `requires.config`, configured skill env, filters, and
+// skills.load.extraDirs all read the OpenClaw config. Persisting a redacted
+// fingerprint with the session snapshot makes config-driven skill exposure
+// changes deterministic across gateway restarts without storing secrets.
+export function fingerprintSkillSnapshotConfig(config?: OpenClawConfig): string {
+  return crypto
+    .createHash("sha256")
+    .update(stableStringify(redactConfigForSkillSnapshot(config ?? {})))
+    .digest("hex");
+}

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -99,6 +99,8 @@ export type SkillSnapshot = {
   skills: Array<{ name: string; primaryEnv?: string; requiredEnv?: string[] }>;
   /** Normalized agent-level filter used to build this snapshot; undefined means unrestricted. */
   skillFilter?: string[];
+  /** Redacted config fingerprint used to invalidate stale persisted snapshots after config-driven skill exposure changes. */
+  configFingerprint?: string;
   resolvedSkills?: Skill[];
   version?: number;
 };

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -21,6 +21,7 @@ import { loadSkillsFromDirSafe, readSkillFrontmatterSafe } from "./local-loader.
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
 import { formatSkillsForPrompt, type Skill } from "./skill-contract.js";
+import { fingerprintSkillSnapshotConfig } from "./snapshot-fingerprint.js";
 import type {
   ParsedSkillFrontmatter,
   SkillEligibilityContext,
@@ -1053,6 +1054,7 @@ export function buildWorkspaceSkillSnapshot(
       requiredEnv: entry.metadata?.requires?.env?.slice(),
     })),
     ...(skillFilter === undefined ? {} : { skillFilter }),
+    configFingerprint: fingerprintSkillSnapshotConfig(opts?.config),
     resolvedSkills,
     version: opts?.snapshotVersion,
   };

--- a/src/auto-reply/reply/session-updates.test.ts
+++ b/src/auto-reply/reply/session-updates.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fingerprintSkillSnapshotConfig } from "../../agents/skills/snapshot-fingerprint.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 const TEST_WORKSPACE_DIR = "/tmp/workspace";
 type TestSkillSnapshot = NonNullable<SessionEntry["skillsSnapshot"]>;
 
-function strippedSnapshot(skillName = "test"): TestSkillSnapshot {
+function strippedSnapshot(skillName = "test", config: OpenClawConfig = {}): TestSkillSnapshot {
   return {
     prompt: "skills prompt",
     skills: [{ name: skillName }],
+    configFingerprint: fingerprintSkillSnapshotConfig(config),
     version: 0,
   };
 }
@@ -236,6 +239,42 @@ describe("ensureSkillSnapshot", () => {
     expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledTimes(2);
   });
 
+  it("refreshes a stale persisted snapshot after config-driven shared skill exposure changes", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+
+    buildWorkspaceSkillSnapshotMock.mockImplementation((_workspaceDir, opts) => {
+      const config = (opts as { config?: OpenClawConfig }).config;
+      return {
+        prompt: "x-post-analysis prompt",
+        skills: [{ name: "x-post-analysis" }, { name: "xurl" }],
+        configFingerprint: fingerprintSkillSnapshotConfig(config),
+        resolvedSkills: [{ name: "x-post-analysis" }, { name: "xurl" }],
+        version: 0,
+      };
+    });
+
+    const staleSnapshot: TestSkillSnapshot = {
+      prompt: "old xurl-only prompt",
+      skills: [{ name: "xurl" }],
+      version: 0,
+    };
+
+    const result = await ensureSkillSnapshot({
+      sessionEntry: testSessionEntry("sess-1", staleSnapshot),
+      sessionStore: {},
+      sessionKey: "agent:tom:telegram:direct:123",
+      isFirstTurnInSession: false,
+      workspaceDir: TEST_WORKSPACE_DIR,
+      cfg: { skills: { load: { extraDirs: ["/root/clawd/skills"] } } },
+    });
+
+    expect(result.skillsSnapshot?.skills.map((skill) => skill.name)).toEqual([
+      "x-post-analysis",
+      "xurl",
+    ]);
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
   it("redacts secret values in the cache key while preserving eligibility presence", async () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "0");
 
@@ -245,7 +284,8 @@ describe("ensureSkillSnapshot", () => {
       resolvedSkills: [{ name: "discord" }],
     });
 
-    const snapshot = strippedSnapshot("discord");
+    const firstConfig = { channels: { discord: { token: "first-secret" } } };
+    const snapshot = strippedSnapshot("discord", firstConfig);
 
     await ensureSkillSnapshot({
       sessionEntry: testSessionEntry("sess-1", snapshot),
@@ -253,7 +293,7 @@ describe("ensureSkillSnapshot", () => {
       sessionKey: "main",
       isFirstTurnInSession: true,
       workspaceDir: TEST_WORKSPACE_DIR,
-      cfg: { channels: { discord: { token: "first-secret" } } },
+      cfg: firstConfig,
     });
 
     await ensureSkillSnapshot({

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
@@ -10,8 +9,8 @@ import {
   shouldRefreshSnapshotForVersion,
 } from "../../agents/skills/refresh-state.js";
 import { ensureSkillsWatcher } from "../../agents/skills/refresh.js";
+import { fingerprintSkillSnapshotConfig } from "../../agents/skills/snapshot-fingerprint.js";
 import { hydrateResolvedSkills } from "../../agents/skills/snapshot-hydration.js";
-import { stableStringify } from "../../agents/stable-stringify.js";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
@@ -40,71 +39,6 @@ const RESOLVED_SKILLS_CACHE_MAX = 10;
 
 export function __testing_resetResolvedSkillsCache(): void {
   resolvedSkillsCache.clear();
-}
-
-function isSensitiveConfigKey(key: string): boolean {
-  const normalized = key.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
-  return (
-    normalized.endsWith("apikey") ||
-    normalized.endsWith("token") ||
-    normalized.endsWith("secret") ||
-    normalized.endsWith("password") ||
-    normalized.endsWith("privatekey") ||
-    normalized.endsWith("clientsecret")
-  );
-}
-
-function redactSensitiveConfigValue(value: unknown): unknown {
-  if (value === undefined || value === null || value === false || value === "") {
-    return value;
-  }
-  if (typeof value === "string") {
-    return value.trim() ? "[redacted:string]" : "";
-  }
-  if (typeof value === "number") {
-    return Number.isFinite(value) && value !== 0 ? "[redacted:number]" : value;
-  }
-  if (typeof value === "boolean") {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value.length === 0 ? [] : "[redacted:array]";
-  }
-  return "[redacted:object]";
-}
-
-function redactConfigForSkillSnapshotCache(value: unknown, stack = new WeakSet<object>()): unknown {
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-  if (stack.has(value)) {
-    return "[Circular]";
-  }
-  stack.add(value);
-  try {
-    if (Array.isArray(value)) {
-      return value.map((entry) => redactConfigForSkillSnapshotCache(entry, stack));
-    }
-    const redacted: Record<string, unknown> = {};
-    for (const key of Object.keys(value as Record<string, unknown>).toSorted()) {
-      const field = (value as Record<string, unknown>)[key];
-      redacted[key] = isSensitiveConfigKey(key)
-        ? redactSensitiveConfigValue(field)
-        : redactConfigForSkillSnapshotCache(field, stack);
-    }
-    return redacted;
-  } finally {
-    stack.delete(value);
-  }
-}
-
-// Skill frontmatter `requires.config` reads the full OpenClaw config, so cache
-// reuse must follow the same boundary without putting raw secrets in Map keys.
-function fingerprintSkillSnapshotConfig(config: OpenClawConfig): string {
-  return crypto
-    .createHash("sha256")
-    .update(stableStringify(redactConfigForSkillSnapshotCache(config)))
-    .digest("hex");
 }
 
 function cacheResolvedSkills(cacheKey: string, snapshot: SkillSnapshot): SkillSnapshot {
@@ -261,9 +195,11 @@ export async function ensureSkillSnapshot(params: {
   const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   const existingSnapshot = nextEntry?.skillsSnapshot;
   ensureSkillsWatcher({ workspaceDir, config: cfg });
+  const configFingerprint = fingerprintSkillSnapshotConfig(cfg);
   const shouldRefreshSnapshot =
     shouldRefreshSnapshotForVersion(existingSnapshot?.version, snapshotVersion) ||
-    !matchesSkillFilter(existingSnapshot?.skillFilter, skillFilter);
+    !matchesSkillFilter(existingSnapshot?.skillFilter, skillFilter) ||
+    existingSnapshot?.configFingerprint !== configFingerprint;
   const buildSnapshot = () => {
     return buildWorkspaceSkillSnapshot(workspaceDir, {
       config: cfg,
@@ -274,7 +210,6 @@ export async function ensureSkillSnapshot(params: {
     });
   };
 
-  const configFingerprint = fingerprintSkillSnapshotConfig(cfg);
   const snapshotCacheKey = JSON.stringify([
     workspaceDir,
     snapshotVersion,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -574,6 +574,8 @@ export type SessionSkillSnapshot = {
   skills: Array<{ name: string; primaryEnv?: string; requiredEnv?: string[] }>;
   /** Normalized agent-level filter used to build this snapshot; undefined means unrestricted. */
   skillFilter?: string[];
+  /** Redacted config fingerprint used to invalidate stale persisted snapshots after config-driven skill exposure changes. */
+  configFingerprint?: string;
   /**
    * Runtime-only, never persisted. Carries the full parsed Skill[] (including
    * each SKILL.md body) so the embedded runner can skip a workspace skill


### PR DESCRIPTION
## Summary
- add a redacted skill snapshot config fingerprint so persisted `skillsSnapshot` entries refresh after skill exposure config changes, including `skills.load.extraDirs`
- persist the fingerprint on built skill snapshots and compare it in auto-reply/session update and agent-command paths
- add regression coverage for Tom/HQ-style shared skill exposure where `xurl` is local but `x-post-analysis` appears only via shared config

## Context
This is Lane A for GB-P12-W4 x-post-analysis deterministic workflow. It fixes the runtime side of the incident where Tom's persistent session had `xurl` but not `x-post-analysis`, so it could not load the built X-post workflow.

## Real behavior proof
- **Behavior or issue addressed:** persisted agent `skillsSnapshot` entries now refresh when the runtime skill exposure config changes, including `skills.load.extraDirs`, instead of keeping a stale snapshot that has `xurl` but not `x-post-analysis`.
- **Real environment tested:** Clawdbot-1 Ubuntu OpenClaw checkout at `/root/clawd/.worktrees/dan-xpost-snapshot-runtime`, Node v22.22.2, using real local skill directories and `/root/clawd/skills/x-post-analysis/SKILL.md` as the shared skill exposed through `skills.load.extraDirs`.
- **Exact steps or command run after this patch:**
  ```bash
  cd /root/clawd/.worktrees/dan-xpost-snapshot-runtime
  node --import tsx ./.tmp-xpost-real-behavior-proof.ts
  ```
- **Evidence after fix:** terminal output from the real OpenClaw checkout:
  ```json
  {
    "setup": {
      "workspace": "/tmp/openclaw-xpost-proof-eaZ0Io/workspace",
      "managedSkillsDir": "/tmp/openclaw-xpost-proof-eaZ0Io/managed-skills",
      "bundledSkillsDir": "/tmp/openclaw-xpost-proof-eaZ0Io/bundled-skills-empty",
      "sharedSkillsExtraDir": "/root/clawd/skills",
      "agentId": "tom",
      "skillFilter": ["xurl", "x-post-analysis"]
    },
    "before": {
      "extraDirs": [],
      "skills": ["browser-automation", "xurl"],
      "hasXurl": true,
      "hasXPost": false,
      "configFingerprint": "de6316be2f21..."
    },
    "after": {
      "extraDirs": ["/root/clawd/skills"],
      "skills": ["brave-search", "browser-automation", "coding-agent", "elevenlabs-voices", "github", "notion", "phone-agent", "planning-with-files", "video-transcript-downloader", "weather", "x-post-analysis", "xurl"],
      "hasXurl": true,
      "hasXPost": true,
      "xpostResolved": "/root/clawd/skills/x-post-analysis/SKILL.md",
      "configFingerprint": "3f0f7ab04b1c..."
    },
    "fingerprintChanged": true
  }
  ```
- **Observed result after fix:** after adding `/root/clawd/skills` to `skills.load.extraDirs`, the real snapshot builder exposes `x-post-analysis` and records a changed redacted `configFingerprint`, which is the persisted signal used by the patch to refresh stale `skillsSnapshot` data.
- **What was not tested:** no live gateway restart, no live Tom session mutation, no production config edit, and no deploy in this PR.

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs --maxWorkers=1 src/agents/skills.buildworkspaceskillsnapshot.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs --maxWorkers=1 src/auto-reply/reply/session-updates.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs --maxWorkers=1 src/agents/agent-command.live-model-switch.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ...`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json ...`
- Riley independent review: APPROVED

## Deployment
No live runtime/config/session mutation in this PR. Deployment/config exposure remains separate and must include backups, health checks, Tom `hasXPost=true` proof, and rollback.
