### PR TITLE
fix(cron): bootstrap external channel delivery targets

### DIFF
--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -467,6 +467,7 @@ describe("resolveDeliveryTarget", () => {
       accountId: undefined,
       mode: "explicit",
       allowFrom: undefined,
+      allowBootstrap: true,
     });
   });
 

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -52,7 +52,7 @@ async function resolveOutboundTargetWithRuntime(
       return loaded;
     }
     const { resolveOutboundTarget } = await loadTargetsRuntime();
-    return resolveOutboundTarget(params);
+    return resolveOutboundTarget({ ...params, allowBootstrap: true });
   } catch (err) {
     return {
       ok: false as const,

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -79,6 +79,27 @@ describe("resolveOutboundTarget defaultTo config fallback", () => {
     expect(res).toEqual({ ok: true, to: "default-room" });
   });
 
+  it("passes bootstrap opt-in to channel plugin resolution", () => {
+    const cfg: OpenClawConfig = {
+      channels: { alpha: { defaultTo: "Alpha:Room One" } },
+    };
+
+    const res = resolveOutboundTarget({
+      channel: "alpha",
+      to: "Alpha:Override Room",
+      cfg,
+      mode: "explicit",
+      allowBootstrap: true,
+    });
+
+    expect(res).toEqual({ ok: true, to: "override-room" });
+    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenCalledWith({
+      channel: "alpha",
+      cfg,
+      allowBootstrap: true,
+    });
+  });
+
   it("explicit --reply-to overrides defaultTo", () => {
     const res = resolveOutboundTarget({
       channel: "alpha",

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -56,6 +56,7 @@ export function resolveOutboundTarget(params: {
   channel: GatewayMessageChannel;
   to?: string;
   allowFrom?: string[];
+  allowBootstrap?: boolean;
   cfg?: OpenClawConfig;
   accountId?: string | null;
   mode?: ChannelOutboundTargetMode;
@@ -65,6 +66,7 @@ export function resolveOutboundTarget(params: {
       plugin: resolveOutboundChannelPlugin({
         channel: params.channel,
         cfg: params.cfg,
+        allowBootstrap: params.allowBootstrap,
       }),
       target: params,
       onMissingPlugin: () =>


### PR DESCRIPTION
## Summary

Fixes #82360.

- Let isolated cron delivery target resolution opt into outbound channel plugin bootstrap when the loaded-plugin fast path misses.
- Thread the explicit allowBootstrap option through resolveOutboundTarget to resolveOutboundChannelPlugin.
- Keep default outbound target resolution behavior unchanged unless a caller explicitly opts in.

## Real behavior proof

**Behavior or issue addressed:** Isolated cron announce delivery can resolve a configured externalized Slack channel target instead of failing with "Unsupported channel: slack" when the Slack plugin has not already been loaded in the process.

**Real environment tested:** WSL Ubuntu-24.04 source checkout at this branch, plus a Crabbox AWS Linux lease running the synced dirty checkout. The runtime proof used the real OpenClaw isolated cron delivery target resolver and the real Slack plugin configuration path; it did not use Slack credentials and did not send a Slack message.

**Exact steps or command run after the patch:**

```bash
OPENCLAW_STATE_DIR=/tmp/openclaw82360-state-after CI=1 \
  node --import tsx --input-type=module - <<"JS"
import { resolveDeliveryTarget } from "./src/cron/isolated-agent/delivery-target.ts";
import { resetPluginRuntimeStateForTest } from "./src/plugins/runtime.ts";
resetPluginRuntimeStateForTest();
const cfg = {
  plugins: { allow: ["slack"], entries: { slack: { enabled: true } } },
  channels: { slack: { enabled: true } },
};
const result = await resolveDeliveryTarget(cfg, "agent:proof", {
  channel: "slack",
  to: "C1234567890",
});
console.log(JSON.stringify({ ok: result.ok, channel: result.channel, to: result.to, error: result.ok ? undefined : result.error.message }, null, 2));
if (!result.ok) process.exit(2);
JS
```

**Evidence after fix:** Copied live terminal output from the runtime command:

```json
{
  "ok": true,
  "channel": "slack",
  "to": "C1234567890"
}
```

Crabbox before/after proof also ran on synced checkout `run_99097f3350a1`:

- Logs: https://crabbox.openclaw.ai/v1/runs/run_99097f3350a1/logs

```text
before_status=1
FAIL src/cron/isolated-agent/delivery-target.test.ts > resolveDeliveryTarget > falls back to the runtime target resolver when the channel plugin is not already loaded
-     "allowBootstrap": true,
FAIL src/infra/outbound/targets.test.ts > resolveOutboundTarget defaultTo config fallback > passes bootstrap opt-in to channel plugin resolution
-     "allowBootstrap": true,
Test Files 2 failed | 1 passed (3)

after_status=0
Test Files 3 passed (3)
Tests 107 passed (107)
```

**Observed result after fix:** The isolated cron delivery target resolver returned `{ "ok": true, "channel": "slack", "to": "C1234567890" }`, proving the configured Slack channel target is reachable after the bootstrap opt-in. The WSL and Crabbox regression proof both fail on origin/main because allowBootstrap is absent and pass on this branch with 107 focused tests.

**What was not tested:** Actual Slack message delivery was not tested because Crabbox should not receive live workspace Slack tokens. This change only affects framework-level target resolution/bootstrap before sending.

## Validation

- CI=1 node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-target.test.ts src/infra/outbound/targets.test.ts src/infra/outbound/channel-resolution.test.ts
- CI=1 node scripts/run-vitest.mjs src/cron/delivery.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
- pnpm oxfmt --check src/cron/isolated-agent/delivery-target.ts src/cron/isolated-agent/delivery-target.test.ts src/infra/outbound/targets.ts src/infra/outbound/targets.test.ts
- git diff --check
- pnpm check:changed
