### PR TITLE
Fix denied Codex app-server tool policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 - Mac app: align the Sessions settings pane with the standard Settings page gutter and row spacing.
 - Codex app-server: preserve streamed native command output in mirrored transcripts and trajectory exports when final snapshots omit aggregated output. (#83200) Thanks @rozmiarD.
+- Codex app-server: fail closed when chat or sender policy denies tools, disabling native code, app, environment, and user MCP surfaces for restricted turns. (#82374) Thanks @VACInc.
 - Feishu: return bound subagent delivery origins from session thread setup so Feishu subagent completions route back to the same DM or topic. (#83190) Thanks @100menotu001.
 - CLI/update: tailor post-update Gateway recovery hints by platform, showing systemd, LaunchAgent, Scheduled Task, or generic service-manager guidance instead of macOS-only recovery text. (#83096) Thanks @rubencu.
 - Plugins: apply a default 15-second timeout to legacy `before_agent_start` hooks so hung plugin handlers no longer block agent startup. Fixes #48534. (#83136) Thanks @therahul-yo.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1119,6 +1119,7 @@ describe("runCodexAppServerAttempt", () => {
     params.disableTools = false;
     params.runtimePlan = createCodexRuntimePlanFixture();
     params.toolsAllow = [];
+    params.extraSystemPrompt = "Tool and file actions are disabled for this sender by chat policy.";
 
     const run = runCodexAppServerAttempt(params, {
       pluginConfig: {
@@ -1142,18 +1143,75 @@ describe("runCodexAppServerAttempt", () => {
     const startParams = startRequest?.params as
       | {
           dynamicTools?: Array<{ name?: string }>;
+          environments?: unknown[];
+          developerInstructions?: string;
           config?: {
             "features.code_mode"?: boolean;
             "features.code_mode_only"?: boolean;
-            apps?: Record<string, { enabled?: boolean }>;
+            apps?: Record<
+              string,
+              { enabled?: boolean; destructive_enabled?: boolean; open_world_enabled?: boolean }
+            >;
           };
         }
       | undefined;
 
     expect(startParams?.dynamicTools).toEqual([]);
+    expect(startParams?.environments).toEqual([]);
+    expect(startParams?.developerInstructions).toContain(
+      "Tool and file actions are disabled for this sender by chat policy.",
+    );
     expect(startParams?.config?.["features.code_mode"]).toBe(false);
     expect(startParams?.config?.["features.code_mode_only"]).toBe(false);
+    expect(startParams?.config?.apps?._default).toEqual({
+      enabled: false,
+      destructive_enabled: false,
+      open_world_enabled: false,
+    });
     expect(startParams?.config?.apps?.["google-calendar-app"]?.enabled).toBeUndefined();
+    expect(harness.requests.map((entry) => entry.method)).not.toContain("app/list");
+  });
+
+  it("fails closed for Codex app defaults when restricted native tools have no plugin config", async () => {
+    __testing.setOpenClawCodingToolsFactoryForTests(() => [createRuntimeDynamicTool("message")]);
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "app/list") {
+        throw new Error("app/list should not run when runtime toolsAllow is empty.");
+      }
+      return undefined;
+    });
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = [];
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await harness.waitForMethod("turn/start", 120_000);
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const startRequest = harness.requests.find((entry) => entry.method === "thread/start");
+    const startParams = startRequest?.params as
+      | {
+          config?: {
+            apps?: Record<
+              string,
+              { enabled?: boolean; destructive_enabled?: boolean; open_world_enabled?: boolean }
+            >;
+          };
+        }
+      | undefined;
+
+    expect(startParams?.config?.apps?._default).toEqual({
+      enabled: false,
+      destructive_enabled: false,
+      open_world_enabled: false,
+    });
     expect(harness.requests.map((entry) => entry.method)).not.toContain("app/list");
   });
 
@@ -7054,6 +7112,105 @@ describe("runCodexAppServerAttempt", () => {
       "thread/start",
       "thread/resume",
     ]);
+  });
+
+  it("keeps plugin app bindings across transient native-tool-disabled turns", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const pluginAppPolicyContext = createPluginAppPolicyContext();
+    await writeExistingBinding(sessionFile, workspaceDir, {
+      pluginAppsFingerprint: "plugin-apps-config-1",
+      pluginAppsInputFingerprint: "plugin-apps-input-1",
+      pluginAppPolicyContext,
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    const appServer = createThreadLifecycleAppServerOptions();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-transient");
+      }
+      if (method === "thread/resume") {
+        return threadStartResult("thread-existing");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const buildDenyAllPluginThreadConfig = vi.fn(async () => ({
+      enabled: true,
+      configPatch: {
+        apps: {
+          _default: {
+            enabled: false,
+            destructive_enabled: false,
+            open_world_enabled: false,
+          },
+        },
+      },
+      fingerprint: "plugin-apps-deny-all",
+      inputFingerprint: "plugin-apps-input-deny-all",
+      policyContext: { fingerprint: "plugin-policy-deny-all", apps: {}, pluginAppIds: {} },
+      diagnostics: [],
+    }));
+    const buildEnabledPluginThreadConfig = vi.fn(async () => ({
+      enabled: true,
+      configPatch: createPluginAppConfigPatch(),
+      fingerprint: "plugin-apps-config-1",
+      inputFingerprint: "plugin-apps-input-1",
+      policyContext: pluginAppPolicyContext,
+      diagnostics: [],
+    }));
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer,
+      nativeCodeModeEnabled: false,
+      pluginThreadConfig: {
+        enabled: true,
+        inputFingerprint: "plugin-apps-input-deny-all",
+        enabledPluginConfigKeys: [],
+        build: buildDenyAllPluginThreadConfig,
+      },
+    });
+    const savedAfterDeny = await readCodexAppServerBinding(sessionFile);
+
+    expect(savedAfterDeny?.threadId).toBe("thread-existing");
+    expect(savedAfterDeny?.pluginAppsFingerprint).toBe("plugin-apps-config-1");
+    expect(savedAfterDeny?.pluginAppsInputFingerprint).toBe("plugin-apps-input-1");
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer,
+      pluginThreadConfig: {
+        enabled: true,
+        inputFingerprint: "plugin-apps-input-1",
+        enabledPluginConfigKeys: ["google-calendar"],
+        build: buildEnabledPluginThreadConfig,
+      },
+    });
+
+    expect(buildDenyAllPluginThreadConfig).toHaveBeenCalledTimes(1);
+    expect(buildEnabledPluginThreadConfig).toHaveBeenCalledTimes(1);
+    const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
+    expect(requestCalls.map(([method]) => method)).toEqual(["thread/start", "thread/resume"]);
+    expect(requestCalls[0]?.[1].config).toMatchObject({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+      },
+    });
+    const savedAfterAllowed = await readCodexAppServerBinding(sessionFile);
+    expect(savedAfterAllowed?.threadId).toBe("thread-existing");
+    expect(savedAfterAllowed?.pluginAppsFingerprint).toBe("plugin-apps-config-1");
+    expect(savedAfterAllowed?.pluginAppsInputFingerprint).toBe("plugin-apps-input-1");
+    expect(savedAfterAllowed?.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
   });
 
   it("preserves the binding when the app-server closes during thread resume", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -953,6 +953,35 @@ describe("runCodexAppServerAttempt", () => {
     ).toEqual(["exec", "apply_patch", "read"]);
   });
 
+  it("treats an explicit empty Codex dynamic toolsAllow as no tools", () => {
+    const tools = ["message", "web_search"].map((name) => ({ name }));
+
+    expect(__testing.filterCodexDynamicToolsForAllowlist(tools, [])).toEqual([]);
+  });
+
+  it("treats wildcard Codex dynamic toolsAllow as unrestricted", () => {
+    const tools = ["message", "web_search"].map((name) => ({ name }));
+
+    expect(__testing.filterCodexDynamicToolsForAllowlist(tools, [" * "])).toEqual(tools);
+  });
+
+  it("disables Codex native tool surfaces for restricted runtime allowlists", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+
+    expect(__testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    params.toolsAllow = ["*"];
+    expect(__testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    params.toolsAllow = [];
+    expect(__testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+
+    params.toolsAllow = ["message"];
+    expect(__testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
   it("forces the message dynamic tool for message-tool-only source replies", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
@@ -1070,6 +1099,62 @@ describe("runCodexAppServerAttempt", () => {
     expect(webSearch?.deferLoading).toBe(true);
     expect(heartbeat?.namespace).toBe(CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE);
     expect(heartbeat?.deferLoading).toBe(true);
+  });
+
+  it("disables Codex native tool surfaces when runtime toolsAllow is empty", async () => {
+    __testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("message"),
+      createRuntimeDynamicTool("web_search"),
+    ]);
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "app/list") {
+        throw new Error("app/list should not run when runtime toolsAllow is empty.");
+      }
+      return undefined;
+    });
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = [];
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: {
+        appServer: { mode: "yolo" },
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              marketplaceName: "openai-curated",
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+    });
+    await harness.waitForMethod("turn/start", 120_000);
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const startRequest = harness.requests.find((entry) => entry.method === "thread/start");
+    const startParams = startRequest?.params as
+      | {
+          dynamicTools?: Array<{ name?: string }>;
+          config?: {
+            "features.code_mode"?: boolean;
+            "features.code_mode_only"?: boolean;
+            apps?: Record<string, { enabled?: boolean }>;
+          };
+        }
+      | undefined;
+
+    expect(startParams?.dynamicTools).toEqual([]);
+    expect(startParams?.config?.["features.code_mode"]).toBe(false);
+    expect(startParams?.config?.["features.code_mode_only"]).toBe(false);
+    expect(startParams?.config?.apps?.["google-calendar-app"]?.enabled).toBeUndefined();
+    expect(harness.requests.map((entry) => entry.method)).not.toContain("app/list");
   });
 
   it("returns a run context report without deferred Codex dynamic tool schemas", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1137,8 +1137,14 @@ export async function runCodexAppServerAttempt(
     const threadConfig = mergeCodexThreadConfigs(
       bundleMcpThreadConfig?.configPatch as JsonObject | undefined,
     );
-    const pluginThreadConfigEnabled =
-      nativeToolSurfaceEnabled && shouldBuildCodexPluginThreadConfig(pluginConfig);
+    const nativeToolSurfaceRestricted = !nativeToolSurfaceEnabled;
+    const pluginThreadConfigRequired =
+      nativeToolSurfaceRestricted || shouldBuildCodexPluginThreadConfig(pluginConfig);
+    // Restricted runs still need a plugin thread config so thread/start
+    // carries the explicit apps._default denial patch without app/list.
+    const pluginThreadConfigPluginConfig = nativeToolSurfaceEnabled
+      ? pluginConfig
+      : disableCodexPluginThreadConfig(pluginConfig);
     const pluginAppCacheKey = buildCodexPluginAppCacheKey({
       appServer,
       agentDir,
@@ -1146,14 +1152,14 @@ export async function runCodexAppServerAttempt(
       accountId: startupAuthAccountCacheKey,
       envApiKeyFingerprint: startupEnvApiKeyCacheKey,
     });
-    const pluginThreadConfigInputFingerprint = pluginThreadConfigEnabled
+    const pluginThreadConfigInputFingerprint = pluginThreadConfigRequired
       ? buildCodexPluginThreadConfigInputFingerprint({
-          pluginConfig,
+          pluginConfig: pluginThreadConfigPluginConfig,
           appCacheKey: pluginAppCacheKey,
         })
       : undefined;
-    const resolvedPluginPolicy = pluginThreadConfigEnabled
-      ? resolveCodexPluginsPolicy(pluginConfig)
+    const resolvedPluginPolicy = pluginThreadConfigRequired
+      ? resolveCodexPluginsPolicy(pluginThreadConfigPluginConfig)
       : undefined;
     const enabledPluginConfigKeys = resolvedPluginPolicy
       ? resolvedPluginPolicy.pluginPolicies
@@ -1200,17 +1206,18 @@ export async function runCodexAppServerAttempt(
               config: threadConfig,
               finalConfigPatch: nativeHookRelayConfig,
               nativeCodeModeEnabled: nativeToolSurfaceEnabled,
+              userMcpServersEnabled: nativeToolSurfaceEnabled,
               mcpServersFingerprint: bundleMcpThreadConfig.fingerprint,
               mcpServersFingerprintEvaluated: bundleMcpThreadConfig.evaluated,
               contextEngineProjection,
-              pluginThreadConfig: pluginThreadConfigEnabled
+              pluginThreadConfig: pluginThreadConfigRequired
                 ? {
                     enabled: true,
                     inputFingerprint: pluginThreadConfigInputFingerprint,
                     enabledPluginConfigKeys,
                     build: () =>
                       buildCodexPluginThreadConfig({
-                        pluginConfig,
+                        pluginConfig: pluginThreadConfigPluginConfig,
                         request: (method, requestParams) =>
                           startupClient.request(method, requestParams, {
                             timeoutMs: appServer.requestTimeoutMs,
@@ -3135,6 +3142,17 @@ function shouldEnableCodexAppServerNativeToolSurface(params: EmbeddedRunAttemptP
   // capability, so narrow OpenClaw allowlists must fail closed rather than
   // widening `message` or `web_search` into shell access.
   return hasWildcardCodexToolsAllow(toolsAllow);
+}
+
+function disableCodexPluginThreadConfig(pluginConfig?: unknown): CodexPluginConfig {
+  const config = readCodexPluginConfig(pluginConfig);
+  return {
+    ...config,
+    codexPlugins: {
+      ...config.codexPlugins,
+      enabled: false,
+    },
+  };
 }
 
 function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -859,6 +859,7 @@ export async function runCodexAppServerAttempt(
     disableTools: params.disableTools,
     toolsAllow: params.toolsAllow,
   });
+  const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(params);
   for (const diagnostic of bundleMcpThreadConfig.diagnostics) {
     embeddedAgentLog.warn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);
   }
@@ -1136,7 +1137,8 @@ export async function runCodexAppServerAttempt(
     const threadConfig = mergeCodexThreadConfigs(
       bundleMcpThreadConfig?.configPatch as JsonObject | undefined,
     );
-    const pluginThreadConfigEnabled = shouldBuildCodexPluginThreadConfig(pluginConfig);
+    const pluginThreadConfigEnabled =
+      nativeToolSurfaceEnabled && shouldBuildCodexPluginThreadConfig(pluginConfig);
     const pluginAppCacheKey = buildCodexPluginAppCacheKey({
       appServer,
       agentDir,
@@ -1197,6 +1199,7 @@ export async function runCodexAppServerAttempt(
               developerInstructions: promptBuild.developerInstructions,
               config: threadConfig,
               finalConfigPatch: nativeHookRelayConfig,
+              nativeCodeModeEnabled: nativeToolSurfaceEnabled,
               mcpServersFingerprint: bundleMcpThreadConfig.fingerprint,
               mcpServersFingerprintEvaluated: bundleMcpThreadConfig.evaluated,
               contextEngineProjection,
@@ -3109,10 +3112,11 @@ function includeForcedMessageToolAllow(
   toolsAllow: string[] | undefined,
   params: EmbeddedRunAttemptParams,
 ): string[] | undefined {
-  if (!shouldForceMessageTool(params)) {
-    return toolsAllow;
-  }
-  if (toolsAllow === undefined) {
+  if (
+    !shouldForceMessageTool(params) ||
+    toolsAllow === undefined ||
+    hasWildcardCodexToolsAllow(toolsAllow)
+  ) {
     return toolsAllow;
   }
   if (toolsAllow.length === 0) {
@@ -3122,17 +3126,38 @@ function includeForcedMessageToolAllow(
   return normalized.has("message") ? toolsAllow : [...toolsAllow, "message"];
 }
 
+function shouldEnableCodexAppServerNativeToolSurface(params: EmbeddedRunAttemptParams): boolean {
+  const toolsAllow = includeForcedMessageToolAllow(params.toolsAllow, params);
+  if (toolsAllow === undefined) {
+    return true;
+  }
+  // Codex native code mode exposes its shell/file surface as one app-server
+  // capability, so narrow OpenClaw allowlists must fail closed rather than
+  // widening `message` or `web_search` into shell access.
+  return hasWildcardCodexToolsAllow(toolsAllow);
+}
+
 function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(
   tools: T[],
   toolsAllow?: string[],
 ): T[] {
-  if (!toolsAllow || toolsAllow.length === 0) {
+  if (!toolsAllow) {
+    return tools;
+  }
+  if (toolsAllow.length === 0) {
+    return [];
+  }
+  if (hasWildcardCodexToolsAllow(toolsAllow)) {
     return tools;
   }
   const allowSet = new Set(
     toolsAllow.map((name) => normalizeCodexDynamicToolName(name)).filter(Boolean),
   );
   return tools.filter((tool) => allowSet.has(normalizeCodexDynamicToolName(tool.name)));
+}
+
+function hasWildcardCodexToolsAllow(toolsAllow: string[]): boolean {
+  return toolsAllow.some((name) => normalizeCodexDynamicToolName(name) === "*");
 }
 
 function shouldForceMessageTool(params: EmbeddedRunAttemptParams): boolean {
@@ -4221,6 +4246,7 @@ export const __testing = {
   buildDynamicTools,
   filterCodexDynamicToolsForAllowlist,
   filterToolsForVisionInputs,
+  hasWildcardCodexToolsAllow,
   handleDynamicToolCallWithTimeout,
   isInvalidCodexImagePayloadError,
   remapCodexContextFilePath,
@@ -4230,6 +4256,7 @@ export const __testing = {
   restrictCodexAppServerSandboxForOpenClawSandbox,
   resolveCodexAppServerForOpenClawToolPolicy,
   resolveOpenClawCodingToolsSessionKeys,
+  shouldEnableCodexAppServerNativeToolSurface,
   shouldForceMessageTool,
   setOpenClawCodingToolsFactoryForTests(factory: OpenClawCodingToolsFactory): void {
     openClawCodingToolsFactoryForTests = factory;

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -91,6 +91,39 @@ describe("Codex app-server native code mode config", () => {
     });
   });
 
+  it("disables Codex native code mode on thread/start when runtime policy denies it", () => {
+    const request = buildThreadStartParams(createAttemptParams({ provider: "openai" }), {
+      cwd: "/repo",
+      dynamicTools: [],
+      appServer: createAppServerOptions() as never,
+      developerInstructions: "test instructions",
+      nativeCodeModeEnabled: false,
+      config: {
+        "features.code_mode": true,
+        "features.code_mode_only": true,
+      },
+    });
+
+    expect(request.config).toEqual({
+      "features.code_mode": false,
+      "features.code_mode_only": false,
+    });
+  });
+
+  it("disables Codex native code mode on thread/resume when runtime policy denies it", () => {
+    const request = buildThreadResumeParams(createAttemptParams({ provider: "openai" }), {
+      threadId: "thread-1",
+      appServer: createAppServerOptions() as never,
+      developerInstructions: "test instructions",
+      nativeCodeModeEnabled: false,
+    });
+
+    expect(request.config).toEqual({
+      "features.code_mode": false,
+      "features.code_mode_only": false,
+    });
+  });
+
   it("disables native Codex project docs for lightweight context threads", () => {
     const request = buildThreadStartParams(
       createAttemptParams({

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -93,6 +93,7 @@ export async function startOrResumeThread(params: {
   config?: JsonObject;
   finalConfigPatch?: JsonObject;
   nativeCodeModeEnabled?: boolean;
+  userMcpServersEnabled?: boolean;
   mcpServersFingerprint?: string;
   mcpServersFingerprintEvaluated?: boolean;
   pluginThreadConfig?: CodexPluginThreadConfigProvider;
@@ -103,12 +104,12 @@ export async function startOrResumeThread(params: {
     params.params,
     params.contextEngineProjection,
   );
-  const userMcpServersConfigPatch = buildCodexUserMcpServersThreadConfigPatch(
-    params.params.config,
-    {
-      agentId: params.agentId ?? params.params.agentId,
-    },
-  );
+  const userMcpServersConfigPatch =
+    params.userMcpServersEnabled === false
+      ? undefined
+      : buildCodexUserMcpServersThreadConfigPatch(params.params.config, {
+          agentId: params.agentId ?? params.params.agentId,
+        });
   const userMcpServersFingerprint = fingerprintUserMcpServersConfigPatch(userMcpServersConfigPatch);
   let binding = await readCodexAppServerBinding(params.params.sessionFile, {
     authProfileStore: params.params.authProfileStore,
@@ -118,6 +119,16 @@ export async function startOrResumeThread(params: {
   let preserveExistingBinding = false;
   let rotatedContextEngineBinding = false;
   let prebuiltPluginThreadConfig: CodexPluginThreadConfig | undefined;
+  if (binding?.threadId && params.nativeCodeModeEnabled === false) {
+    embeddedAgentLog.debug(
+      "codex app-server native tool surface disabled for turn; starting transient thread",
+      {
+        threadId: binding.threadId,
+      },
+    );
+    preserveExistingBinding = true;
+    binding = undefined;
+  }
   if (binding?.threadId && (binding.contextEngine || contextEngineBinding)) {
     if (
       !contextEngineBinding ||
@@ -569,6 +580,7 @@ export function buildThreadStartParams(
     config: buildCodexRuntimeThreadConfigForRun(params, options.config, {
       nativeCodeModeEnabled: options.nativeCodeModeEnabled,
     }),
+    ...(options.nativeCodeModeEnabled === false ? { environments: [] } : {}),
     developerInstructions: options.developerInstructions ?? buildDeveloperInstructions(params),
     dynamicTools: options.dynamicTools,
     experimentalRawEvents: true,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -73,6 +73,11 @@ export const CODEX_CODE_MODE_THREAD_CONFIG: JsonObject = {
   "features.code_mode_only": true,
 };
 
+export const CODEX_CODE_MODE_DISABLED_THREAD_CONFIG: JsonObject = {
+  "features.code_mode": false,
+  "features.code_mode_only": false,
+};
+
 const CODEX_LIGHTWEIGHT_CONTEXT_THREAD_CONFIG: JsonObject = {
   project_doc_max_bytes: 0,
 };
@@ -87,6 +92,7 @@ export async function startOrResumeThread(params: {
   developerInstructions?: string;
   config?: JsonObject;
   finalConfigPatch?: JsonObject;
+  nativeCodeModeEnabled?: boolean;
   mcpServersFingerprint?: string;
   mcpServersFingerprintEvaluated?: boolean;
   pluginThreadConfig?: CodexPluginThreadConfigProvider;
@@ -246,6 +252,7 @@ export async function startOrResumeThread(params: {
               appServer: params.appServer,
               developerInstructions: params.developerInstructions,
               config: resumeConfig,
+              nativeCodeModeEnabled: params.nativeCodeModeEnabled,
             }),
           ),
         );
@@ -341,6 +348,7 @@ export async function startOrResumeThread(params: {
         appServer: params.appServer,
         developerInstructions: params.developerInstructions,
         config,
+        nativeCodeModeEnabled: params.nativeCodeModeEnabled,
       }),
     ),
   );
@@ -539,6 +547,7 @@ export function buildThreadStartParams(
     appServer: CodexAppServerRuntimeOptions;
     developerInstructions?: string;
     config?: JsonObject;
+    nativeCodeModeEnabled?: boolean;
   },
 ): CodexThreadStartParams {
   const modelProvider = resolveCodexAppServerModelProvider({
@@ -557,7 +566,9 @@ export function buildThreadStartParams(
     sandbox: options.appServer.sandbox,
     ...(options.appServer.serviceTier ? { serviceTier: options.appServer.serviceTier } : {}),
     serviceName: "OpenClaw",
-    config: buildCodexRuntimeThreadConfigForRun(params, options.config),
+    config: buildCodexRuntimeThreadConfigForRun(params, options.config, {
+      nativeCodeModeEnabled: options.nativeCodeModeEnabled,
+    }),
     developerInstructions: options.developerInstructions ?? buildDeveloperInstructions(params),
     dynamicTools: options.dynamicTools,
     experimentalRawEvents: true,
@@ -573,6 +584,7 @@ export function buildThreadResumeParams(
     appServer: CodexAppServerRuntimeOptions;
     developerInstructions?: string;
     config?: JsonObject;
+    nativeCodeModeEnabled?: boolean;
   },
 ): CodexThreadResumeParams {
   const modelProvider = resolveCodexAppServerModelProvider({
@@ -590,15 +602,24 @@ export function buildThreadResumeParams(
     approvalsReviewer: options.appServer.approvalsReviewer,
     sandbox: options.appServer.sandbox,
     ...(options.appServer.serviceTier ? { serviceTier: options.appServer.serviceTier } : {}),
-    config: buildCodexRuntimeThreadConfigForRun(params, options.config),
+    config: buildCodexRuntimeThreadConfigForRun(params, options.config, {
+      nativeCodeModeEnabled: options.nativeCodeModeEnabled,
+    }),
     developerInstructions: options.developerInstructions ?? buildDeveloperInstructions(params),
     persistExtendedHistory: true,
   };
 }
 
-export function buildCodexRuntimeThreadConfig(config: JsonObject | undefined): JsonObject {
-  const runtimeConfig = mergeCodexThreadConfigs(config, CODEX_CODE_MODE_THREAD_CONFIG) ?? {
-    ...CODEX_CODE_MODE_THREAD_CONFIG,
+export function buildCodexRuntimeThreadConfig(
+  config: JsonObject | undefined,
+  options: { nativeCodeModeEnabled?: boolean } = {},
+): JsonObject {
+  const codeModeConfig =
+    options.nativeCodeModeEnabled === false
+      ? CODEX_CODE_MODE_DISABLED_THREAD_CONFIG
+      : CODEX_CODE_MODE_THREAD_CONFIG;
+  const runtimeConfig = mergeCodexThreadConfigs(config, codeModeConfig) ?? {
+    ...codeModeConfig,
   };
   return runtimeConfig;
 }
@@ -606,8 +627,9 @@ export function buildCodexRuntimeThreadConfig(config: JsonObject | undefined): J
 function buildCodexRuntimeThreadConfigForRun(
   params: EmbeddedRunAttemptParams,
   config: JsonObject | undefined,
+  options: { nativeCodeModeEnabled?: boolean } = {},
 ): JsonObject {
-  const runtimeConfig = buildCodexRuntimeThreadConfig(config);
+  const runtimeConfig = buildCodexRuntimeThreadConfig(config, options);
   if (params.bootstrapContextMode !== "lightweight") {
     return runtimeConfig;
   }

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodexAppServerRuntimeOptions } from "./config.js";
-import { writeCodexAppServerBinding } from "./session-binding.js";
+import { readCodexAppServerBinding, writeCodexAppServerBinding } from "./session-binding.js";
 import { startOrResumeThread } from "./thread-lifecycle.js";
 
 function threadStartResult(threadId = "thread-1"): Record<string, unknown> {
@@ -208,6 +208,41 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     expect(startParams?.config?.mcp_servers).toBeUndefined();
   });
 
+  it("omits user MCP servers when runtime policy disables native tool surfaces", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir, {
+        mcp: {
+          servers: {
+            notes: {
+              transport: "stdio",
+              command: "node",
+              args: ["/opt/notes-mcp/dist/index.js"],
+            },
+          },
+        },
+      } as unknown as EmbeddedRunAttemptParams["config"]),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+      nativeCodeModeEnabled: false,
+      userMcpServersEnabled: false,
+    });
+
+    const startCall = request.mock.calls.find(([method]) => method === "thread/start");
+    const startParams = startCall?.[1] as { config?: { mcp_servers?: Record<string, unknown> } };
+    expect(startParams?.config?.mcp_servers).toBeUndefined();
+  });
+
   it("starts a new thread when an existing binding lacks the matching user MCP fingerprint", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
@@ -253,6 +288,103 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     expect(startParams.config!.mcp_servers).toMatchObject({
       notes: { command: "node", args: ["/opt/notes-mcp/dist/index.js"] },
     });
+  });
+
+  it("does not resume an existing native thread when runtime policy disables native tools", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-native",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+    });
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-restricted");
+      }
+      if (method === "thread/resume") {
+        return threadResumeResult("thread-native");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+      nativeCodeModeEnabled: false,
+      userMcpServersEnabled: false,
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start"]);
+    const startParams = request.mock.calls[0]?.[1] as {
+      environments?: unknown[];
+      config?: {
+        "features.code_mode"?: boolean;
+        "features.code_mode_only"?: boolean;
+        mcp_servers?: Record<string, unknown>;
+      };
+    };
+    expect(startParams?.environments).toEqual([]);
+    expect(startParams?.config?.["features.code_mode"]).toBe(false);
+    expect(startParams?.config?.["features.code_mode_only"]).toBe(false);
+    expect(startParams?.config?.mcp_servers).toBeUndefined();
+    const preservedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(preservedBinding?.threadId).toBe("thread-native");
+  });
+
+  it("starts a new thread without user MCP servers when runtime policy disables them", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const config = {
+      mcp: {
+        servers: {
+          notes: {
+            transport: "stdio",
+            command: "node",
+            args: ["/opt/notes-mcp/dist/index.js"],
+          },
+        },
+      },
+    } as unknown as EmbeddedRunAttemptParams["config"];
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-started");
+      }
+      if (method === "thread/resume") {
+        return threadResumeResult("thread-existing");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir, config),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+    });
+
+    request.mockClear();
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir, config),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+      nativeCodeModeEnabled: false,
+      userMcpServersEnabled: false,
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start"]);
+    const startParams = request.mock.calls[0]?.[1] as {
+      config?: { mcp_servers?: Record<string, unknown> };
+    };
+    expect(startParams?.config?.mcp_servers).toBeUndefined();
   });
 
   it("resends user MCP config when resuming a thread with the matching fingerprint", async () => {

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./selection.js";
 import type { AgentHarness } from "./types.js";
 
-const piRunAttempt = vi.fn(async () => createAttemptResult("pi"));
+const piRunAttempt = vi.fn<AgentHarness["runAttempt"]>(async () => createAttemptResult("pi"));
 
 vi.mock("./builtin-pi.js", () => ({
   createPiAgentHarness: (): AgentHarness => ({
@@ -314,7 +314,7 @@ describe("runAgentHarnessAttempt", () => {
   });
 
   it("collapses channel group sender deny-all to empty toolsAllow for plugin harnesses", async () => {
-    const runAttempt = vi.fn(async () => createAttemptResult("codex"));
+    const runAttempt = vi.fn<AgentHarness["runAttempt"]>(async () => createAttemptResult("codex"));
     registerAgentHarness(
       {
         id: "codex",
@@ -343,7 +343,7 @@ describe("runAgentHarnessAttempt", () => {
   });
 
   it("adds chat policy wording for plugin harness group deny-all", async () => {
-    const runAttempt = vi.fn(async () => createAttemptResult("codex"));
+    const runAttempt = vi.fn<AgentHarness["runAttempt"]>(async () => createAttemptResult("codex"));
     registerAgentHarness(
       {
         id: "codex",

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -116,6 +116,36 @@ function registerSuccessfulCodexHarness(): void {
   );
 }
 
+function groupSenderDenyAllConfig(): OpenClawConfig {
+  return {
+    channels: {
+      telegram: {
+        groups: {
+          "test-deny-room": {
+            toolsBySender: {
+              "id:test-denied-sender": { deny: ["*"] },
+            },
+          },
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function groupDenyAllConfig(): OpenClawConfig {
+  return {
+    channels: {
+      telegram: {
+        groups: {
+          "test-deny-room": {
+            tools: { deny: ["*"] },
+          },
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
 function providerRuntimeConfig(provider: string, runtime: string): OpenClawConfig {
   return {
     models: {
@@ -281,6 +311,75 @@ describe("runAgentHarnessAttempt", () => {
     expect(classifyCall?.[1]).toBe(params);
     expect(result.agentHarnessId).toBe("codex");
     expect(result.agentHarnessResultClassification).toBe("empty");
+  });
+
+  it("collapses channel group sender deny-all to empty toolsAllow for plugin harnesses", async () => {
+    const runAttempt = vi.fn(async () => createAttemptResult("codex"));
+    registerAgentHarness(
+      {
+        id: "codex",
+        label: "Codex",
+        supports: (ctx) =>
+          ctx.provider === "codex" ? { supported: true, priority: 100 } : { supported: false },
+        runAttempt,
+      },
+      { ownerPluginId: "codex" },
+    );
+
+    await runAgentHarnessAttempt({
+      ...createAttemptParams(groupSenderDenyAllConfig()),
+      sessionKey: "agent:main:telegram:group:test-deny-room",
+      messageProvider: "telegram",
+      groupId: "test-deny-room",
+      senderId: "test-denied-sender",
+      extraSystemPrompt: "Existing operator note.",
+    });
+
+    expect(runAttempt).toHaveBeenCalledTimes(1);
+    const attempt = runAttempt.mock.calls[0]?.[0];
+    expect(attempt?.toolsAllow).toEqual([]);
+    expect(attempt?.extraSystemPrompt).toContain("Existing operator note.");
+    expect(attempt?.extraSystemPrompt).toContain("this sender is not allowed by policy");
+  });
+
+  it("adds chat policy wording for plugin harness group deny-all", async () => {
+    const runAttempt = vi.fn(async () => createAttemptResult("codex"));
+    registerAgentHarness(
+      {
+        id: "codex",
+        label: "Codex",
+        supports: (ctx) =>
+          ctx.provider === "codex" ? { supported: true, priority: 100 } : { supported: false },
+        runAttempt,
+      },
+      { ownerPluginId: "codex" },
+    );
+
+    await runAgentHarnessAttempt({
+      ...createAttemptParams(groupDenyAllConfig()),
+      sessionKey: "agent:main:telegram:group:test-deny-room",
+      messageProvider: "telegram",
+      groupId: "test-deny-room",
+      senderId: "test-denied-sender",
+    });
+
+    expect(runAttempt).toHaveBeenCalledTimes(1);
+    const attempt = runAttempt.mock.calls[0]?.[0];
+    expect(attempt?.toolsAllow).toEqual([]);
+    expect(attempt?.extraSystemPrompt).toContain("this chat is not allowed by policy");
+  });
+
+  it("leaves PI harness params unchanged for channel group sender deny-all policy", async () => {
+    await runAgentHarnessAttempt({
+      ...createAttemptParams(groupSenderDenyAllConfig()),
+      sessionKey: "agent:main:telegram:group:test-deny-room",
+      messageProvider: "telegram",
+      groupId: "test-deny-room",
+      senderId: "test-denied-sender",
+    });
+
+    expect(piRunAttempt).toHaveBeenCalledTimes(1);
+    expect(piRunAttempt.mock.calls[0]?.[0].toolsAllow).toBeUndefined();
   });
 
   it("fails for config-forced plugin harnesses when fallback is omitted", async () => {

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -7,6 +7,19 @@ import type {
   EmbeddedRunAttemptResult,
 } from "../pi-embedded-runner/run/types.js";
 import type { EmbeddedPiCompactResult } from "../pi-embedded-runner/types.js";
+import {
+  resolveEffectiveToolPolicy,
+  resolveGroupToolPolicy,
+  resolveInheritedToolPolicyForSession,
+  resolveSubagentToolPolicyForSession,
+} from "../pi-tools.policy.js";
+import { resolveSandboxRuntimeStatus } from "../sandbox/runtime-status.js";
+import { resolveSenderToolPolicy } from "../sender-tool-policy.js";
+import {
+  isSubagentEnvelopeSession,
+  resolveSubagentCapabilityStore,
+} from "../subagent-capabilities.js";
+import { expandToolGroups, normalizeToolName } from "../tool-policy.js";
 import { createPiAgentHarness } from "./builtin-pi.js";
 import {
   resolveAgentHarnessPolicy as resolveConfiguredAgentHarnessPolicy,
@@ -19,6 +32,13 @@ import { adaptAgentHarnessToV2, runAgentHarnessV2LifecycleAttempt } from "./v2.j
 const log = createSubsystemLogger("agents/harness");
 export { resolveAgentHarnessPolicy } from "./policy.js";
 export type { AgentHarnessPolicy };
+
+const PLUGIN_HARNESS_SENDER_DENY_ALL_PROMPT =
+  "Tool and file actions are disabled for this sender by chat policy. If asked to edit files or use tools, say this sender is not allowed by policy; do not imply retrying will help.";
+const PLUGIN_HARNESS_GROUP_DENY_ALL_PROMPT =
+  "Tool and file actions are disabled for this chat by policy. If asked to edit files or use tools, say this chat is not allowed by policy.";
+const PLUGIN_HARNESS_RUNTIME_DENY_ALL_PROMPT =
+  "Tool and file actions are disabled by runtime policy. If asked to edit files or use tools, say tools are disabled by policy.";
 
 type AgentHarnessSelectionCandidate = {
   id: string;
@@ -202,6 +222,7 @@ export async function runAgentHarnessAttempt(
     agentHarnessRuntimeOverride: params.agentHarnessRuntimeOverride,
   });
   const harness = selection.harness;
+  const attemptParams = harness.id === "pi" ? params : applyPluginHarnessDenyAllToolPolicy(params);
   logAgentHarnessSelection(selection, {
     provider: params.provider,
     modelId: params.modelId,
@@ -210,11 +231,11 @@ export async function runAgentHarnessAttempt(
   });
   const v2Harness = adaptAgentHarnessToV2(harness);
   if (harness.id === "pi") {
-    return await runAgentHarnessV2LifecycleAttempt(v2Harness, params);
+    return await runAgentHarnessV2LifecycleAttempt(v2Harness, attemptParams);
   }
 
   try {
-    return await runAgentHarnessV2LifecycleAttempt(v2Harness, params);
+    return await runAgentHarnessV2LifecycleAttempt(v2Harness, attemptParams);
   } catch (error) {
     log.warn(`${harness.label} failed; not falling back to embedded PI backend`, {
       harnessId: harness.id,
@@ -224,6 +245,141 @@ export async function runAgentHarnessAttempt(
     });
     throw error;
   }
+}
+
+function applyPluginHarnessDenyAllToolPolicy(
+  params: EmbeddedRunAttemptParams,
+): EmbeddedRunAttemptParams {
+  const prompt = resolvePluginHarnessDenyAllToolPolicyPrompt(params);
+  if (!prompt) {
+    return params;
+  }
+  return {
+    ...params,
+    toolsAllow: [],
+    extraSystemPrompt: appendPluginHarnessToolPolicyPrompt(params.extraSystemPrompt, prompt),
+  };
+}
+
+function resolvePluginHarnessDenyAllToolPolicyPrompt(
+  params: EmbeddedRunAttemptParams,
+): string | undefined {
+  const { globalPolicy, globalProviderPolicy, agentPolicy, agentProviderPolicy } =
+    resolveEffectiveToolPolicy({
+      config: params.config,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      modelProvider: params.provider,
+      modelId: params.modelId,
+    });
+  const messageProvider = params.messageProvider ?? params.messageChannel;
+  const groupPolicyParams = {
+    config: params.config,
+    sessionKey: params.sessionKey,
+    spawnedBy: params.spawnedBy,
+    messageProvider,
+    groupId: params.groupId,
+    groupChannel: params.groupChannel,
+    groupSpace: params.groupSpace,
+    accountId: params.agentAccountId,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
+  };
+  const groupPolicy = resolveGroupToolPolicy(groupPolicyParams);
+  const senderPolicy = resolveSenderToolPolicy({
+    config: params.config,
+    agentId: params.agentId,
+    messageProvider,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
+  });
+  if (
+    policyDeniesAllTools(senderPolicy) ||
+    policyDeniesAllTools(resolveSenderScopedGroupToolPolicy(params, groupPolicyParams, groupPolicy))
+  ) {
+    return PLUGIN_HARNESS_SENDER_DENY_ALL_PROMPT;
+  }
+  if (policyDeniesAllTools(groupPolicy)) {
+    return PLUGIN_HARNESS_GROUP_DENY_ALL_PROMPT;
+  }
+  const sandboxSessionKey = params.sandboxSessionKey ?? params.sessionKey;
+  const sandboxRuntime = resolveSandboxRuntimeStatus({
+    cfg: params.config,
+    sessionKey: sandboxSessionKey,
+  });
+  const sandboxPolicy = sandboxRuntime.sandboxed ? sandboxRuntime.toolPolicy : undefined;
+  const subagentStore = resolveSubagentCapabilityStore(sandboxSessionKey, { cfg: params.config });
+  const subagentPolicy =
+    sandboxSessionKey &&
+    isSubagentEnvelopeSession(sandboxSessionKey, {
+      cfg: params.config,
+      store: subagentStore,
+    })
+      ? resolveSubagentToolPolicyForSession(params.config, sandboxSessionKey, {
+          store: subagentStore,
+        })
+      : undefined;
+  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(
+    params.config,
+    sandboxSessionKey,
+    {
+      store: subagentStore,
+    },
+  );
+  return [
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    sandboxPolicy,
+    subagentPolicy,
+    inheritedToolPolicy,
+  ].some(policyDeniesAllTools)
+    ? PLUGIN_HARNESS_RUNTIME_DENY_ALL_PROMPT
+    : undefined;
+}
+
+function resolveSenderScopedGroupToolPolicy(
+  params: EmbeddedRunAttemptParams,
+  groupPolicyParams: Parameters<typeof resolveGroupToolPolicy>[0],
+  groupPolicy: { deny?: string[] } | undefined,
+): { deny?: string[] } | undefined {
+  if (!policyDeniesAllTools(groupPolicy) || !hasSenderIdentity(params)) {
+    return undefined;
+  }
+  const groupPolicyWithoutSender = resolveGroupToolPolicy({
+    ...groupPolicyParams,
+    senderId: undefined,
+    senderName: undefined,
+    senderUsername: undefined,
+    senderE164: undefined,
+  });
+  return policyDeniesAllTools(groupPolicyWithoutSender) ? undefined : groupPolicy;
+}
+
+function hasSenderIdentity(params: EmbeddedRunAttemptParams): boolean {
+  return Boolean(
+    params.senderId?.trim() ||
+    params.senderName?.trim() ||
+    params.senderUsername?.trim() ||
+    params.senderE164?.trim(),
+  );
+}
+
+function appendPluginHarnessToolPolicyPrompt(existing: string | undefined, prompt: string): string {
+  const trimmed = existing?.trim();
+  if (!trimmed) {
+    return prompt;
+  }
+  return trimmed.includes(prompt) ? trimmed : `${trimmed}\n\n${prompt}`;
+}
+
+function policyDeniesAllTools(policy?: { deny?: string[] }): boolean {
+  return expandToolGroups(policy?.deny ?? []).some((entry) => normalizeToolName(entry) === "*");
 }
 
 function listHarnessCandidates(harnesses: AgentHarness[]): AgentHarnessSelectionCandidate[] {


### PR DESCRIPTION
## Summary
- Honor deny-all (`deny: ["*"]`) and restricted runtime tool policies in the Codex app-server path by disabling native code mode, built-in environments, user MCP projection, dynamic tools, and Codex app defaults for restricted runs.
- Collapse plugin-harness deny-all policy into `toolsAllow: []` at runtime, matching PI behavior while preserving the config/source-of-truth shape as `deny: ["*"]`.
- Add sender/chat-specific refusal wording for denied users and keep restricted Codex turns transient so an allowed sender's existing tool-capable thread binding is preserved.

## Root Cause
Channel sender/chat deny-all policy is configured as `deny: ["*"]` and was reproduced through Telegram. Plugin harnesses did not consistently collapse that deny-all policy into an empty runtime allowlist before invoking Codex. In the Codex app-server path, an explicit empty allowlist still left native app-server surfaces available: code mode could remain enabled, built-in environments could still register shell/file tools, user MCP servers could still project, and Codex app defaults were not always explicitly disabled. That let a denied sender appear to have `toolCount: 0` while native Codex tool surfaces could still run.

## Real behavior proof
Behavior addressed: A sender/chat/runtime `deny: ["*"]` policy now produces a restricted Codex run that has no OpenClaw dynamic tools, no Codex native code-mode shell/file environment, no user MCP projection, and explicit Codex app default denial.

Real environment tested: Local temp worktree from current `origin/main`, plus the live gateway container rebuilt from this branch. The live proof below verifies the patched code is installed and healthy in the deployed OpenClaw gateway; the unit/runtime tests verify the exact restricted-turn request payload.

Before proof: In the pre-patch live gateway behavior, a denied-sender request under `deny: ["*"]` could still result in Codex-native shell/file tool calls and a completed edit even though policy intended a no-tool run. The pre-patch code also treated `toolsAllow: []` as an unrestricted dynamic-tool catalog, kept Codex code mode enabled, did not send `environments: []`, and did not always send an explicit `apps._default` denial.

Exact steps or command run after this patch: `docker ps --filter name=jackie-openclaw-gateway --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}' && docker exec jackie-openclaw-gateway sh -lc "grep -R -n -E 'this sender is not allowed by policy|nativeToolSurfaceRestricted|apps._default denial patch|environments: \[\]' /app/dist /app/extensions 2>/dev/null | head -20"`

Evidence after fix: Copied live output from the rebuilt gateway container:

```text
NAMES                     IMAGE                STATUS
jackie-openclaw-gateway   openclaw-eve:local   Up 23 minutes (healthy)
/app/dist/selection-CRZITzTC.js:15231:const PLUGIN_HARNESS_SENDER_DENY_ALL_PROMPT = "Tool and file actions are disabled for this sender by chat policy. If asked to edit files or use tools, say this sender is not allowed by policy; do not imply retrying will help.";
/app/dist/thread-lifecycle-BnrqCSE8.js:1300:		...options.nativeCodeModeEnabled === false ? { environments: [] } : {},
/app/extensions/codex/src/app-server/thread-lifecycle.ts:583:    ...(options.nativeCodeModeEnabled === false ? { environments: [] } : {}),
/app/extensions/codex/src/app-server/run-attempt.ts:1137:    const nativeToolSurfaceRestricted = !nativeToolSurfaceEnabled;
/app/extensions/codex/src/app-server/run-attempt.ts:1139:      nativeToolSurfaceRestricted || shouldBuildCodexPluginThreadConfig(pluginConfig);
/app/extensions/codex/src/app-server/run-attempt.ts:1141:    // carries the explicit apps._default denial patch without app/list.
```

Observed result after fix: The live gateway is running the patched build with the sender-policy refusal prompt, native-tool restriction branch, built-in environment denial, and Codex app-default denial present. Focused regression tests also verify sender-specific `deny: ["*"]` becomes `toolsAllow: []`, PI harness params remain unchanged, restricted Codex `thread/start` receives `dynamicTools: []`, `environments: []`, `features.code_mode: false`, `features.code_mode_only: false`, `apps._default` disabled, no `app/list`, no user MCP servers, and transient restricted turns do not overwrite an existing plugin-enabled thread binding.

What was not tested: A post-patch live Telegram roundtrip through the deployed gateway was not completed. Broad `pnpm check` / full CI was not run locally.

## Verification
- `git diff --check`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-vitest.mjs src/agents/harness/selection.test.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts`
- `~/.codex/skills/codex-review/scripts/codex-review --mode local` (`codex-review clean: no accepted/actionable findings reported`)
- Live gateway container rebuilt/recreated from this branch and verified healthy with patched code present.

## What was not tested
- Post-patch live Telegram roundtrip through the deployed gateway.
- Broad `pnpm check` / full CI locally.
