### PR TITLE
Start configured web search providers at gateway startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 - TTS: preserve channel-derived voice-note delivery for `/tts audio` replies even when the provider output is not natively voice-compatible. (#82174) Thanks @xuruiray.
 - Codex app-server: preserve inbound sender metadata and source-channel provenance on mirrored user prompts, including failure snapshots, so channel history keeps the original sender identity. (#82184) Thanks @zknicker.
 - Codex app-server: yield projector work to the event loop between embedded-run notifications while preserving pre-turn rate-limit capture, reducing gateway stalls from account and MCP status notifications. Fixes #81936. (#82333) Thanks @joshavant.
+- Plugins/web search: start the configured web_search provider plugin during gateway startup, including auto-enabled external providers behind allowlists. Fixes #82313. (#82376) Thanks @joshavant.
 - Codex account/status: treat metadata-only rate-limit buckets as returned but empty so `/codex status` and `/codex account` report `none returned` instead of counting phantom limits.
 - Codex/Lossless: keep Codex explicit compaction on native app-server threads while allowing Lossless through the context-engine slot; `openclaw doctor --fix` now migrates legacy `compaction.provider: "lossless-claw"` config to `plugins.slots.contextEngine`.
 - Cron/doctor: report scheduled jobs with explicit `payload.model` overrides, including provider namespace counts and default-model mismatches, so stale cron model pins are visible during auth or billing investigations. Fixes #82151. Thanks @mgonto.

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -184,6 +184,17 @@ function createManifestRegistryFixture(): PluginManifestRegistry {
         },
       },
       {
+        id: "brave",
+        channels: [],
+        origin: "global",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
+        contracts: {
+          webSearchProviders: ["brave"],
+        },
+      },
+      {
         id: "codex",
         channels: [],
         activation: {
@@ -820,6 +831,75 @@ describe("resolveGatewayStartupPluginIds", () => {
       ["browser", "memory-core"],
     ],
     [
+      "includes explicitly selected external web search providers at startup",
+      {
+        channels: {},
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+              provider: "brave",
+            },
+          },
+        },
+        plugins: {
+          allow: ["brave"],
+          entries: {
+            brave: {
+              enabled: true,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      ["brave"],
+    ],
+    [
+      "honors disabled web search when selecting startup providers",
+      {
+        channels: {},
+        tools: {
+          web: {
+            search: {
+              enabled: false,
+              provider: "brave",
+            },
+          },
+        },
+        plugins: {
+          allow: ["brave"],
+          entries: {
+            brave: {
+              enabled: true,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      [],
+    ],
+    [
+      "honors explicit plugin disablement for configured web search providers",
+      {
+        channels: {},
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+              provider: "brave",
+            },
+          },
+        },
+        plugins: {
+          allow: ["brave"],
+          entries: {
+            brave: {
+              enabled: false,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      [],
+    ],
+    [
       "keeps configured generation providers behind restrictive allowlists",
       {
         channels: {},
@@ -881,6 +961,40 @@ describe("resolveGatewayStartupPluginIds", () => {
       config: effectiveConfig,
       activationSourceConfig: rawConfig,
       expected: ["browser"],
+    });
+  });
+
+  it("includes auto-enabled external web search providers at startup", () => {
+    const rawConfig = {
+      channels: {},
+      tools: {
+        web: {
+          search: {
+            enabled: true,
+            provider: "brave",
+          },
+        },
+      },
+      plugins: {
+        allow: ["browser"],
+      },
+    } as OpenClawConfig;
+    const effectiveConfig = {
+      ...rawConfig,
+      plugins: {
+        allow: ["browser", "brave"],
+        entries: {
+          brave: {
+            enabled: true,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expectStartupPluginIdsCase({
+      config: effectiveConfig,
+      activationSourceConfig: rawConfig,
+      expected: ["browser", "brave"],
     });
   });
 

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -214,6 +214,28 @@ function manifestOwnsConfiguredSpeechProvider(params: {
   });
 }
 
+function collectConfiguredWebSearchProviderIds(config: OpenClawConfig): ReadonlySet<string> {
+  const search = config.tools?.web?.search;
+  if (search?.enabled === false || typeof search?.provider !== "string") {
+    return new Set();
+  }
+  const providerId = normalizeOptionalLowercaseString(search.provider);
+  return providerId ? new Set([providerId]) : new Set();
+}
+
+function manifestOwnsConfiguredWebSearchProvider(params: {
+  manifest: PluginManifestRecord | undefined;
+  configuredWebSearchProviderIds: ReadonlySet<string>;
+}): boolean {
+  if (params.configuredWebSearchProviderIds.size === 0) {
+    return false;
+  }
+  return (params.manifest?.contracts?.webSearchProviders ?? []).some((providerId) => {
+    const normalized = normalizeOptionalLowercaseString(providerId);
+    return normalized ? params.configuredWebSearchProviderIds.has(normalized) : false;
+  });
+}
+
 function listModelProviderRefs(value: unknown): string[] {
   if (typeof value === "string") {
     return [value];
@@ -431,6 +453,52 @@ function canStartConfiguredSpeechProviderPlugin(params: {
     activationSource: params.activationSource,
   });
   return activationState.enabled && activationState.explicitlyEnabled;
+}
+
+function canStartConfiguredWebSearchProviderPlugin(params: {
+  plugin: InstalledPluginIndexRecord;
+  manifest: PluginManifestRecord | undefined;
+  config: OpenClawConfig;
+  pluginsConfig: ReturnType<typeof normalizePluginsConfigWithRegistry>;
+  activationSource: {
+    plugins: ReturnType<typeof normalizePluginsConfigWithRegistry>;
+    rootConfig?: OpenClawConfig;
+  };
+  configuredWebSearchProviderIds: ReadonlySet<string>;
+  platform?: NodeJS.Platform;
+}): boolean {
+  if (
+    !manifestOwnsConfiguredWebSearchProvider({
+      manifest: params.manifest,
+      configuredWebSearchProviderIds: params.configuredWebSearchProviderIds,
+    })
+  ) {
+    return false;
+  }
+  if (!params.pluginsConfig.enabled || !params.activationSource.plugins.enabled) {
+    return false;
+  }
+  if (
+    params.pluginsConfig.deny.includes(params.plugin.pluginId) ||
+    params.activationSource.plugins.deny.includes(params.plugin.pluginId)
+  ) {
+    return false;
+  }
+  if (
+    params.pluginsConfig.entries[params.plugin.pluginId]?.enabled === false ||
+    params.activationSource.plugins.entries[params.plugin.pluginId]?.enabled === false
+  ) {
+    return false;
+  }
+  const activationState = resolveEffectivePluginActivationState({
+    id: params.plugin.pluginId,
+    origin: params.plugin.origin,
+    config: params.pluginsConfig,
+    rootConfig: params.config,
+    enabledByDefault: isPluginEnabledByDefaultForPlatform(params.plugin, params.platform),
+    activationSource: params.activationSource,
+  });
+  return activationState.enabled;
 }
 
 function canStartConfiguredRootPlugin(params: {
@@ -693,6 +761,8 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
   const startupDreamingPluginIds = resolveGatewayStartupDreamingPluginIds(params.config);
   const manifestLookup = createManifestRegistryLookup(params.manifestRegistry);
   const configuredSpeechProviderIds = collectConfiguredSpeechProviderIds(activationSourceConfig);
+  const configuredWebSearchProviderIds =
+    collectConfiguredWebSearchProviderIds(activationSourceConfig);
   const configuredGenerationProviderIds =
     collectConfiguredGenerationProviderIds(activationSourceConfig);
   const normalizePluginId = createPluginRegistryIdNormalizer(params.index, {
@@ -758,6 +828,19 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
           pluginsConfig,
           activationSource,
           configuredSpeechProviderIds,
+          platform: params.platform,
+        })
+      ) {
+        return true;
+      }
+      if (
+        canStartConfiguredWebSearchProviderPlugin({
+          plugin,
+          manifest,
+          config: params.config,
+          pluginsConfig,
+          activationSource,
+          configuredWebSearchProviderIds,
           platform: params.platform,
         })
       ) {


### PR DESCRIPTION
## Summary
- Start the plugin that owns the configured `tools.web.search.provider` during gateway startup.
- Preserve existing startup gates for disabled web search, plugin deny/disable config, and auto-enabled effective config.
- Add startup-planning coverage for explicit, disabled, and auto-enabled external web-search providers.

## Verification
- `node scripts/run-vitest.mjs src/plugins/channel-plugin-ids.test.ts src/config/config.web-search-provider.test.ts`
- Crabbox `run_37dfedccc966`: Linux AWS run validated the auto-enable gateway path and reached `http server listening (2 plugins: brave, browser; 3.9s)` with `gateway_brave_startup_plugin=true`.

## Real behavior proof
Behavior addressed: configured external web_search providers are loaded into gateway startup instead of being omitted from startup plugin ids.
Real environment tested: Crabbox AWS Linux lease `cbx_1578471cf1a4`, run `run_37dfedccc966`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/channel-plugin-ids.test.ts`, then temp gateway config with raw `plugins.allow: ["browser"]`, `tools.web.search.provider: "brave"`, and Brave plugin config, followed by `pnpm openclaw config validate --json` and `timeout 180s pnpm openclaw gateway run --bind loopback --port 19823 --force`.
Evidence after fix: runtime log excerpt printed `auto-enabled plugins for this runtime without writing config: brave web search provider selected, enabled automatically.` and `http server listening (2 plugins: brave, browser; 3.9s)`.
Observed result after fix: `gateway_brave_startup_plugin=true`; no `web_search provider is not available: brave` validation failure.
What was not tested: full repository check suite and live Brave API search execution.

## Links

Fixes #82313
