### PR TITLE
fix(codex): enforce native pre-tool policy relay

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-ebb0a08ebd9a8380d570b4271d34c0203b867cf44d7f98727a23cc06157861a3  plugin-sdk-api-baseline.json
-b8216744af469b6aefdf40460e9661586d0f8bff81b8529b35c85d0ee0cf50d3  plugin-sdk-api-baseline.jsonl
+8421fd38b0cc9bf6a03f92ccb08940d536ddc06d86bd737a1562fcbc8f973e89  plugin-sdk-api-baseline.json
+d7701bebb7d685d67888a9ef04847e4cdb88155f7edc30f34a6f8cdfd91e6078  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -114,6 +114,26 @@ Local stdio app-server sessions default to YOLO mode:
 unattended OpenClaw turns and heartbeats make progress without native approval
 prompts that nobody is around to answer.
 
+When OpenClaw has before-tool policy handlers registered and the Codex native
+`pre_tool_use` relay is enabled, OpenClaw promotes only the unconstrained
+implicit YOLO approval policy to Codex `untrusted` mode while keeping the
+native `PreToolUse` relay installed. The relay remains the synchronous
+pre-execution policy point for Codex-native shell and file tools; Codex
+app-server approvals still handle unsafe native operations after Codex's own
+review. Explicit `appServer.mode: "yolo"`, explicit
+`appServer.approvalPolicy: "never"`, or Codex local requirements that only
+allow `never` preserve the native Codex approval policy instead of promoting it
+to `untrusted`. The native relay remains enabled unless the harness caller
+disables it.
+
+Codex side conversations use the same native hook relay config when the public
+harness forks an app-server side thread.
+
+When updating the bundled `@openai/codex` runtime, verify that the native hook
+relay's trusted `hooks.state` hash still matches Codex's command-hook trust
+envelope. A mismatch can turn trusted OpenClaw relay hooks into native Codex
+startup prompts.
+
 If Codex's local system requirements file disallows implicit YOLO approval,
 reviewer, or sandbox values, OpenClaw treats the implicit default as guardian
 instead and selects allowed guardian permissions. Hostname-matching

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -343,6 +343,27 @@ Local stdio app-server sessions default to the trusted local operator posture:
 `approvalPolicy: "never"`, `approvalsReviewer: "user"`, and
 `sandbox: "danger-full-access"`. If local Codex requirements disallow that
 implicit YOLO posture, OpenClaw selects allowed guardian permissions instead.
+
+When OpenClaw before-tool policy handlers are registered and the Codex native
+`pre_tool_use` relay is enabled, OpenClaw promotes only the unconstrained
+implicit YOLO approval policy to Codex `untrusted` mode while keeping the
+native `PreToolUse` relay installed. The relay remains the synchronous
+pre-execution policy point for Codex-native shell and file tools; Codex
+app-server approvals still handle unsafe native operations after Codex's own
+review. Explicit `appServer.mode: "yolo"`, explicit
+`appServer.approvalPolicy: "never"`, or Codex local requirements that only
+allow `never` preserve the native Codex approval policy instead of promoting it
+to `untrusted`. The native relay remains enabled unless the harness caller
+disables it.
+
+Codex side conversations use the same native hook relay config when the public
+harness forks an app-server side thread.
+
+When updating the bundled `@openai/codex` runtime, verify that the native hook
+relay's trusted `hooks.state` hash still matches Codex's command-hook trust
+envelope. A mismatch can turn trusted OpenClaw relay hooks into native Codex
+startup prompts.
+
 When an OpenClaw sandbox is active for the session, OpenClaw narrows Codex
 `danger-full-access` to Codex `workspace-write` so native Codex code-mode turns
 stay inside the sandboxed workspace.

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -279,6 +279,7 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/skill-commands-runtime` | Skill command listing helpers |
     | `plugin-sdk/native-command-registry` | Native command registry/build/serialize helpers |
     | `plugin-sdk/agent-harness` | Experimental trusted-plugin surface for low-level agent harnesses: harness types, active-run steer/abort helpers, OpenClaw tool bridge helpers, runtime-plan tool policy helpers, terminal outcome classification, tool progress formatting/detail helpers, and attempt result utilities |
+    | `plugin-sdk/agent-harness-runtime` | Runtime entrypoint for low-level agent harness helpers, including native hook relay registration, active-run queue helpers, dynamic-tool policy helpers, and before/after tool hook bridges |
     | `plugin-sdk/provider-zai-endpoint` | Deprecated Z.AI provider-owned endpoint detection facade; use the Z.AI plugin public API |
     | `plugin-sdk/async-lock-runtime` | Process-local async lock helper for small runtime state files |
     | `plugin-sdk/channel-activity-runtime` | Channel activity telemetry helper |

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -45,7 +45,10 @@ export function createCodexAppServerAgentHarness(options?: {
     },
     runSideQuestion: async (params) => {
       const { runCodexAppServerSideQuestion } = await import("./src/app-server/side-question.js");
-      return runCodexAppServerSideQuestion(params, { pluginConfig: options?.pluginConfig });
+      return runCodexAppServerSideQuestion(params, {
+        pluginConfig: options?.pluginConfig,
+        nativeHookRelay: { enabled: true },
+      });
     },
     compact: async (params) => {
       const { maybeCompactCodexAppServerSession } = await import("./src/app-server/compact.js");

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -5,9 +5,13 @@ import { createCodexAppServerAgentHarness } from "./harness.js";
 import plugin from "./index.js";
 
 const runCodexAppServerAttemptMock = vi.hoisted(() => vi.fn());
+const runCodexAppServerSideQuestionMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./src/app-server/run-attempt.js", () => ({
   runCodexAppServerAttempt: runCodexAppServerAttemptMock,
+}));
+vi.mock("./src/app-server/side-question.js", () => ({
+  runCodexAppServerSideQuestion: runCodexAppServerSideQuestionMock,
 }));
 
 function mockCall(mock: { mock: { calls: unknown[][] } }, index = 0) {
@@ -139,6 +143,26 @@ describe("codex plugin", () => {
 
     expect(runCodexAppServerAttemptMock).toHaveBeenCalledWith(
       { prompt: "hello" },
+      {
+        pluginConfig: { appServer: {} },
+        nativeHookRelay: { enabled: true },
+      },
+    );
+  });
+
+  it("enables the native hook relay for public Codex side questions", async () => {
+    const harness = createCodexAppServerAgentHarness({ pluginConfig: { appServer: {} } });
+    const runSideQuestion = harness.runSideQuestion;
+    const result = { answer: "ok" };
+    runCodexAppServerSideQuestionMock.mockResolvedValueOnce(result);
+
+    if (!runSideQuestion) {
+      throw new Error("Expected Codex harness to expose side questions");
+    }
+    await expect(runSideQuestion({ prompt: "btw" } as never)).resolves.toBe(result);
+
+    expect(runCodexAppServerSideQuestionMock).toHaveBeenCalledWith(
+      { prompt: "btw" },
       {
         pluginConfig: { appServer: {} },
         nativeHookRelay: { enabled: true },

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -6,6 +6,7 @@ import {
   CODEX_PLUGIN_ENTRY_CONFIG_KEYS,
   CODEX_PLUGINS_CONFIG_KEYS,
   codexAppServerStartOptionsKey,
+  hasExplicitCodexAppServerPolicy,
   readCodexPluginConfig,
   resolveCodexAppServerRuntimeOptions,
   resolveCodexComputerUseConfig,
@@ -252,6 +253,7 @@ describe("Codex app-server config", () => {
       sandbox: "danger-full-access",
       approvalsReviewer: "user",
     });
+    expect(runtime.allowedApprovalPolicies).toEqual(["never"]);
   });
 
   it("defaults native Codex approvals to guardian when requirements disallow user reviewer", () => {
@@ -708,6 +710,27 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
       sandbox: "danger-full-access",
       approvalsReviewer: "user",
     });
+  });
+
+  it("detects explicit app-server policies through the parsed policy schema", () => {
+    expect(
+      hasExplicitCodexAppServerPolicy(readCodexPluginConfig({ appServer: { mode: "guardian" } })),
+    ).toBe(true);
+    expect(
+      hasExplicitCodexAppServerPolicy(
+        readCodexPluginConfig({ appServer: { approvalPolicy: "untrusted" } }),
+      ),
+    ).toBe(true);
+    expect(
+      hasExplicitCodexAppServerPolicy(readCodexPluginConfig({}), {
+        OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY: "on-request",
+      }),
+    ).toBe(true);
+    expect(
+      hasExplicitCodexAppServerPolicy(readCodexPluginConfig({}), {
+        OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY: "typo",
+      }),
+    ).toBe(false);
   });
 
   it("derives distinct shared-client keys for distinct auth tokens without exposing them", () => {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -15,6 +15,7 @@ type CodexAppServerDefaultPolicy = {
   approvalPolicy?: CodexAppServerApprovalPolicy;
   approvalsReviewer?: CodexAppServerApprovalsReviewer;
   sandbox?: CodexAppServerSandboxMode;
+  allowedApprovalPolicies?: readonly CodexAppServerApprovalPolicy[];
 };
 export type CodexAppServerApprovalPolicy = "never" | "on-request" | "on-failure" | "untrusted";
 export type CodexAppServerEffectiveApprovalPolicy =
@@ -103,6 +104,7 @@ export type CodexAppServerRuntimeOptions = {
   requestTimeoutMs: number;
   turnCompletionIdleTimeoutMs: number;
   approvalPolicy: CodexAppServerEffectiveApprovalPolicy;
+  allowedApprovalPolicies?: readonly CodexAppServerApprovalPolicy[];
   sandbox: CodexAppServerSandboxMode;
   approvalsReviewer: CodexAppServerApprovalsReviewer;
   serviceTier?: CodexServiceTier;
@@ -278,6 +280,19 @@ export function readCodexPluginConfig(value: unknown): CodexPluginConfig {
   return { ...config, ...(plugins.data ? { codexPlugins: plugins.data } : {}) };
 }
 
+export function hasExplicitCodexAppServerPolicy(
+  pluginConfig: CodexPluginConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const appServer = pluginConfig.appServer;
+  return (
+    isCodexAppServerPolicyMode(appServer?.mode) ||
+    isCodexAppServerApprovalPolicy(appServer?.approvalPolicy) ||
+    isCodexAppServerPolicyMode(env.OPENCLAW_CODEX_APP_SERVER_MODE) ||
+    isCodexAppServerApprovalPolicy(env.OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY)
+  );
+}
+
 export function resolveCodexPluginsPolicy(pluginConfig?: unknown): ResolvedCodexPluginsPolicy {
   const config = readCodexPluginConfig(pluginConfig).codexPlugins;
   const configured = config !== undefined;
@@ -376,6 +391,9 @@ export function resolveCodexAppServerRuntimeOptions(
       resolveApprovalPolicy(env.OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY) ??
       defaultPolicy?.approvalPolicy ??
       (policyMode === "guardian" ? "on-request" : "never"),
+    ...(defaultPolicy?.allowedApprovalPolicies
+      ? { allowedApprovalPolicies: defaultPolicy.allowedApprovalPolicies }
+      : {}),
     sandbox:
       resolveSandbox(config.sandbox) ??
       resolveSandbox(env.OPENCLAW_CODEX_APP_SERVER_SANDBOX) ??
@@ -541,7 +559,7 @@ function resolveTransport(value: unknown): CodexAppServerTransportMode {
 }
 
 function resolvePolicyMode(value: unknown): CodexAppServerPolicyMode | undefined {
-  return value === "guardian" || value === "yolo" ? value : undefined;
+  return isCodexAppServerPolicyMode(value) ? value : undefined;
 }
 
 function resolveDefaultCodexAppServerPolicy(params: {
@@ -573,11 +591,19 @@ function resolveDefaultCodexAppServerPolicy(params: {
   const yoloReviewerAllowed =
     allowedApprovalsReviewers === undefined || allowedApprovalsReviewers.has("user");
   if (yoloSandboxAllowed && yoloApprovalAllowed && yoloReviewerAllowed) {
-    return { mode: "yolo" };
+    return {
+      mode: "yolo",
+      ...(allowedApprovalPolicies
+        ? { allowedApprovalPolicies: orderApprovalPolicies(allowedApprovalPolicies) }
+        : {}),
+    };
   }
   return {
     mode: "guardian",
     approvalPolicy: selectGuardianApprovalPolicy(allowedApprovalPolicies),
+    ...(allowedApprovalPolicies
+      ? { allowedApprovalPolicies: orderApprovalPolicies(allowedApprovalPolicies) }
+      : {}),
     approvalsReviewer: selectGuardianApprovalsReviewer(allowedApprovalsReviewers),
     sandbox: selectGuardianSandbox(allowedSandboxModes),
   };
@@ -841,6 +867,18 @@ function selectGuardianApprovalPolicy(
   return "on-request";
 }
 
+function orderApprovalPolicies(
+  allowedApprovalPolicies: Set<CodexAppServerApprovalPolicy>,
+): CodexAppServerApprovalPolicy[] {
+  const order: readonly CodexAppServerApprovalPolicy[] = [
+    "never",
+    "on-request",
+    "on-failure",
+    "untrusted",
+  ];
+  return order.filter((policy) => allowedApprovalPolicies.has(policy));
+}
+
 function selectGuardianApprovalsReviewer(
   allowedApprovalsReviewers: Set<CodexAppServerApprovalsReviewer> | undefined,
 ): CodexAppServerApprovalsReviewer {
@@ -872,12 +910,15 @@ function selectGuardianSandbox(
 }
 
 function resolveApprovalPolicy(value: unknown): CodexAppServerApprovalPolicy | undefined {
-  return value === "on-request" ||
-    value === "on-failure" ||
-    value === "untrusted" ||
-    value === "never"
-    ? value
-    : undefined;
+  return isCodexAppServerApprovalPolicy(value) ? value : undefined;
+}
+
+function isCodexAppServerApprovalPolicy(value: unknown): value is CodexAppServerApprovalPolicy {
+  return codexAppServerApprovalPolicySchema.safeParse(value).success;
+}
+
+function isCodexAppServerPolicyMode(value: unknown): value is CodexAppServerPolicyMode {
+  return codexAppServerPolicyModeSchema.safeParse(value).success;
 }
 
 function resolveSandbox(value: unknown): CodexAppServerSandboxMode | undefined {

--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -163,6 +163,7 @@ describe("Codex native hook relay config", () => {
   it("builds deterministic clearing config when the relay is disabled", () => {
     expect(buildCodexNativeHookRelayDisabledConfig()).toEqual({
       "features.hooks": false,
+      "hooks.state": {},
       "hooks.PreToolUse": [],
       "hooks.PostToolUse": [],
       "hooks.PermissionRequest": [],

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -11,8 +11,17 @@ export const CODEX_NATIVE_HOOK_RELAY_EVENTS: readonly NativeHookRelayEvent[] = [
   "permission_request",
   "before_agent_finalize",
 ] as const;
+export const CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS =
+  CODEX_NATIVE_HOOK_RELAY_EVENTS.filter((event) => event !== "permission_request");
 
 type CodexHookEventName = "PreToolUse" | "PostToolUse" | "PermissionRequest" | "Stop";
+type CodexCommandHookConfig = {
+  type: "command";
+  command: string;
+  timeout: number;
+  async: boolean;
+  statusMessage: string;
+};
 
 const CODEX_HOOK_EVENT_BY_NATIVE_EVENT: Record<NativeHookRelayEvent, CodexHookEventName> = {
   pre_tool_use: "PreToolUse",
@@ -47,17 +56,16 @@ export function buildCodexNativeHookRelayConfig(params: {
     const codexEvent = CODEX_HOOK_EVENT_BY_NATIVE_EVENT[event];
     const command = params.relay.commandForEvent(event);
     const timeout = normalizeHookTimeoutSec(params.hookTimeoutSec);
+    const hook: CodexCommandHookConfig = {
+      type: "command",
+      command,
+      timeout,
+      async: false,
+      statusMessage: "OpenClaw native hook relay",
+    };
     config[`hooks.${codexEvent}`] = [
       {
-        hooks: [
-          {
-            type: "command",
-            command,
-            timeout,
-            async: false,
-            statusMessage: "OpenClaw native hook relay",
-          },
-        ],
+        hooks: [hook],
       },
     ] satisfies JsonValue;
     const state = {
@@ -81,11 +89,33 @@ export function buildCodexNativeHookRelayConfig(params: {
 export function buildCodexNativeHookRelayDisabledConfig(): JsonObject {
   return {
     "features.hooks": false,
+    "hooks.state": {},
     "hooks.PreToolUse": [],
     "hooks.PostToolUse": [],
     "hooks.PermissionRequest": [],
     "hooks.Stop": [],
   };
+}
+
+export function buildCodexNativeHookRelayId(params: {
+  agentId: string | undefined;
+  sessionId: string;
+  sessionKey: string | undefined;
+  scope?: string;
+}): string {
+  const hash = createHash("sha256");
+  hash.update("openclaw:codex:native-hook-relay:v1");
+  hash.update("\0");
+  const scope = params.scope?.trim();
+  if (scope) {
+    hash.update("scope:");
+    hash.update(scope);
+    hash.update("\0");
+  }
+  hash.update(params.agentId?.trim() || "");
+  hash.update("\0");
+  hash.update(params.sessionKey?.trim() || params.sessionId);
+  return `codex-${hash.digest("hex").slice(0, 40)}`;
 }
 
 function normalizeHookTimeoutSec(value: number | undefined): number {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3110,16 +3110,46 @@ describe("runCodexAppServerAttempt", () => {
   });
 
   it("keeps implicit Codex yolo approval policy when untrusted approvals are disallowed", () => {
-    const appServer = resolveCodexAppServerRuntimeOptions({ env: {}, requirementsToml: null });
-
-    const resolved = __testing.resolveCodexAppServerForOpenClawToolPolicy({
-      appServer,
-      pluginConfig: readCodexPluginConfig({}),
+    const appServer = resolveCodexAppServerRuntimeOptions({
       env: {},
-      shouldPromote: true,
-      canUseUntrustedApprovalPolicy: false,
+      requirementsToml: 'allowed_approval_policies = ["never"]\n',
     });
 
+    const resolved = __testing.withCodexPreToolUseApprovalFallback(appServer, {
+      pluginConfig: readCodexPluginConfig({}),
+      hasBeforeToolCallHooks: true,
+      env: {},
+    });
+
+    expect(resolved).toBe(appServer);
+    expect(resolved.approvalPolicy).toBe("never");
+  });
+
+  it("does not promote implicit Codex yolo policy without native pre_tool_use coverage", () => {
+    const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig: {} });
+
+    const resolved = __testing.withCodexPreToolUseApprovalFallback(appServer, {
+      pluginConfig: readCodexPluginConfig({}),
+      nativeHookRelay: { events: ["post_tool_use"] },
+      hasBeforeToolCallHooks: true,
+      env: {},
+    });
+
+    expect(resolved).toBe(appServer);
+    expect(resolved.approvalPolicy).toBe("never");
+  });
+
+  it("does not promote implicit Codex yolo policy when native relay is disabled", () => {
+    const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig: {} });
+
+    const resolved = __testing.withCodexPreToolUseApprovalFallback(appServer, {
+      pluginConfig: readCodexPluginConfig({}),
+      nativeHookRelay: { enabled: false },
+      hasBeforeToolCallHooks: true,
+      env: {},
+    });
+
+    expect(resolved).toBe(appServer);
     expect(resolved.approvalPolicy).toBe("never");
   });
 
@@ -3249,6 +3279,132 @@ describe("runCodexAppServerAttempt", () => {
     expect(
       nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)?.allowedEvents,
     ).toEqual(["pre_tool_use", "post_tool_use", "before_agent_finalize"]);
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+  });
+
+  it("keeps native PreToolUse when implicit approvals are promoted for policy coverage", async () => {
+    const beforeToolCall = vi.fn(async () => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    await harness.waitForMethod("turn/start");
+
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
+      ?.config;
+    expect(startConfig?.["features.hooks"]).toBe(true);
+    expect(Array.isArray(startConfig?.["hooks.PreToolUse"])).toBe(true);
+    expect(Array.isArray(startConfig?.["hooks.PostToolUse"])).toBe(true);
+    expect(Array.isArray(startConfig?.["hooks.Stop"])).toBe(true);
+    expect(startConfig).not.toHaveProperty("hooks.PermissionRequest");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    expect(
+      nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)?.allowedEvents,
+    ).toEqual(["pre_tool_use", "post_tool_use", "before_agent_finalize"]);
+    const turnRequest = harness.requests.find((request) => request.method === "turn/start");
+    const turnRequestParams = turnRequest?.params as Record<string, unknown> | undefined;
+    expect(turnRequestParams?.approvalPolicy).toBe("untrusted");
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+  });
+
+  it("routes run-created Codex PreToolUse relay invocations through before_tool_call denial", async () => {
+    const beforeToolCall = vi.fn(async (_event: unknown, _ctx: unknown) => ({
+      block: true,
+      reason: "blocked by run-created relay",
+    }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    await harness.waitForMethod("turn/start");
+
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    const response = await nativeHookRelayTesting.invokeNativeHookRelayForTests({
+      provider: "codex",
+      relayId,
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "bash",
+        tool_use_id: "native-shell-1",
+        tool_input: { command: "touch /tmp/blocked" },
+      },
+    });
+
+    expect(response.exitCode).toBe(0);
+    expect(JSON.parse(response.stdout)).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Tool call blocked by plugin hook",
+      },
+    });
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    const event = beforeToolCall.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(event).toMatchObject({
+      toolName: "exec",
+      params: { command: "touch /tmp/blocked" },
+      toolCallId: "native-shell-1",
+    });
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+  });
+
+  it("allows run-created Codex PreToolUse relay invocations when before_tool_call allows", async () => {
+    const beforeToolCall = vi.fn(async (_event: unknown, _ctx: unknown) => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    await harness.waitForMethod("turn/start");
+
+    const turnRequest = harness.requests.find((request) => request.method === "turn/start");
+    const turnRequestParams = turnRequest?.params as Record<string, unknown> | undefined;
+    expect(turnRequestParams?.approvalPolicy).toBe("untrusted");
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    const response = await nativeHookRelayTesting.invokeNativeHookRelayForTests({
+      provider: "codex",
+      relayId,
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "bash",
+        tool_use_id: "native-shell-allow-1",
+        tool_input: { command: "printf allowed" },
+      },
+    });
+
+    expect(response).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    const event = beforeToolCall.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(event).toMatchObject({
+      toolName: "exec",
+      params: { command: "printf allowed" },
+      toolCallId: "native-shell-allow-1",
+    });
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
@@ -6216,6 +6372,132 @@ describe("runCodexAppServerAttempt", () => {
         { enabled: true } as never,
       ).sandbox,
     ).toBe("read-only");
+  });
+
+  it("promotes implicit yolo approval policy when before_tool_call needs native pre-tool coverage", () => {
+    const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig: {} });
+
+    const guarded = __testing.withCodexPreToolUseApprovalFallback(appServer, {
+      pluginConfig: readCodexPluginConfig({}),
+      hasBeforeToolCallHooks: true,
+      env: {},
+    });
+
+    expect(guarded).not.toBe(appServer);
+    expect(guarded.approvalPolicy).toBe("untrusted");
+    expect(guarded.sandbox).toBe("danger-full-access");
+
+    const invalidEnvGuarded = __testing.withCodexPreToolUseApprovalFallback(appServer, {
+      pluginConfig: readCodexPluginConfig({}),
+      hasBeforeToolCallHooks: true,
+      env: {
+        OPENCLAW_CODEX_APP_SERVER_MODE: "typo",
+        OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY: "typo",
+      },
+    });
+    expect(invalidEnvGuarded.approvalPolicy).toBe("untrusted");
+  });
+
+  it("does not promote explicit yolo or disabled native pre-tool relay", () => {
+    const explicitYoloConfig = readCodexPluginConfig({ appServer: { mode: "yolo" } });
+    const explicitYolo = resolveCodexAppServerRuntimeOptions({
+      pluginConfig: explicitYoloConfig,
+    });
+    expect(
+      __testing.withCodexPreToolUseApprovalFallback(explicitYolo, {
+        pluginConfig: explicitYoloConfig,
+        hasBeforeToolCallHooks: true,
+        env: {},
+      }),
+    ).toBe(explicitYolo);
+
+    const explicitNeverConfig = readCodexPluginConfig({ appServer: { approvalPolicy: "never" } });
+    const explicitNever = resolveCodexAppServerRuntimeOptions({
+      pluginConfig: explicitNeverConfig,
+    });
+    expect(
+      __testing.withCodexPreToolUseApprovalFallback(explicitNever, {
+        pluginConfig: explicitNeverConfig,
+        hasBeforeToolCallHooks: true,
+        env: {},
+      }),
+    ).toBe(explicitNever);
+
+    const envExplicit = resolveCodexAppServerRuntimeOptions({
+      pluginConfig: readCodexPluginConfig({}),
+      env: { OPENCLAW_CODEX_APP_SERVER_MODE: "yolo" },
+    });
+    expect(
+      __testing.withCodexPreToolUseApprovalFallback(envExplicit, {
+        pluginConfig: readCodexPluginConfig({}),
+        hasBeforeToolCallHooks: true,
+        env: { OPENCLAW_CODEX_APP_SERVER_MODE: "yolo" },
+      }),
+    ).toBe(envExplicit);
+
+    const requirementsConstrainedNever = resolveCodexAppServerRuntimeOptions({
+      pluginConfig: {},
+      env: {},
+      requirementsToml: 'allowed_approval_policies = ["never"]\n',
+    });
+    expect(requirementsConstrainedNever.allowedApprovalPolicies).toEqual(["never"]);
+    expect(
+      __testing.withCodexPreToolUseApprovalFallback(requirementsConstrainedNever, {
+        pluginConfig: readCodexPluginConfig({}),
+        hasBeforeToolCallHooks: true,
+        env: {},
+      }),
+    ).toBe(requirementsConstrainedNever);
+
+    const requirementsConstrainedWithoutUntrusted = resolveCodexAppServerRuntimeOptions({
+      pluginConfig: {},
+      env: {},
+      requirementsToml: 'allowed_approval_policies = ["never", "on-request"]\n',
+    });
+    expect(requirementsConstrainedWithoutUntrusted.allowedApprovalPolicies).toEqual([
+      "never",
+      "on-request",
+    ]);
+    expect(
+      __testing.withCodexPreToolUseApprovalFallback(requirementsConstrainedWithoutUntrusted, {
+        pluginConfig: readCodexPluginConfig({}),
+        hasBeforeToolCallHooks: true,
+        env: {},
+      }),
+    ).toBe(requirementsConstrainedWithoutUntrusted);
+
+    const implicitYolo = resolveCodexAppServerRuntimeOptions({ pluginConfig: {} });
+    expect(
+      __testing.withCodexPreToolUseApprovalFallback(implicitYolo, {
+        pluginConfig: readCodexPluginConfig({}),
+        nativeHookRelay: { enabled: false },
+        hasBeforeToolCallHooks: true,
+        env: {},
+      }),
+    ).toBe(implicitYolo);
+  });
+
+  it("keeps native pre_tool_use relay while implicit approvals are promoted", () => {
+    const appServer = __testing.withCodexPreToolUseApprovalFallback(
+      resolveCodexAppServerRuntimeOptions({ pluginConfig: {} }),
+      {
+        pluginConfig: readCodexPluginConfig({}),
+        hasBeforeToolCallHooks: true,
+        env: {},
+      },
+    );
+
+    expect(
+      __testing.resolveCodexNativeHookRelayEvents({
+        appServer,
+      }),
+    ).toEqual(["pre_tool_use", "post_tool_use", "before_agent_finalize"]);
+    expect(
+      __testing.resolveCodexNativeHookRelayEvents({
+        configuredEvents: ["pre_tool_use"],
+        appServer,
+      }),
+    ).toEqual(["pre_tool_use"]);
   });
 
   it("passes current Codex service tier request values through app-server resume and turn requests", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -65,11 +64,12 @@ import {
 } from "./client.js";
 import { ensureCodexComputerUse } from "./computer-use.js";
 import {
-  isCodexAppServerApprovalPolicyAllowedByRequirements,
+  hasExplicitCodexAppServerPolicy,
   readCodexPluginConfig,
   resolveCodexPluginsPolicy,
   resolveCodexAppServerRuntimeOptions,
   withMcpElicitationsApprovalPolicy,
+  type CodexAppServerApprovalPolicy,
   type CodexAppServerRuntimeOptions,
   type CodexPluginConfig,
 } from "./config.js";
@@ -85,7 +85,9 @@ import { CodexAppServerEventProjector } from "./event-projector.js";
 import {
   buildCodexNativeHookRelayDisabledConfig,
   buildCodexNativeHookRelayConfig,
+  buildCodexNativeHookRelayId,
   CODEX_NATIVE_HOOK_RELAY_EVENTS,
+  CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS,
 } from "./native-hook-relay.js";
 import { buildCodexPluginAppCacheKey } from "./plugin-app-cache-key.js";
 import {
@@ -168,8 +170,6 @@ const CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS = 5 * 60_000;
 const CODEX_STEER_ALL_DEBOUNCE_MS = 500;
 const LOG_FIELD_MAX_LENGTH = 160;
 const CODEX_NATIVE_PROJECT_DOC_BASENAMES = new Set(["agents.md"]);
-const CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS =
-  CODEX_NATIVE_HOOK_RELAY_EVENTS.filter((event) => event !== "permission_request");
 const CODEX_BOOTSTRAP_CONTEXT_ORDER = new Map<string, number>([
   ["soul.md", 10],
   ["identity.md", 20],
@@ -431,43 +431,70 @@ function restrictCodexAppServerSandboxForOpenClawSandbox(
   };
 }
 
-function resolveCodexAppServerForOpenClawToolPolicy(params: {
-  appServer: CodexAppServerRuntimeOptions;
-  pluginConfig: CodexPluginConfig;
-  env: NodeJS.ProcessEnv;
-  shouldPromote: boolean;
-  canUseUntrustedApprovalPolicy: boolean;
-}): CodexAppServerRuntimeOptions {
-  if (
-    !params.shouldPromote ||
-    !params.canUseUntrustedApprovalPolicy ||
-    params.appServer.approvalPolicy !== "never"
-  ) {
-    return params.appServer;
-  }
-  const explicitMode =
-    params.pluginConfig.appServer?.mode !== undefined ||
-    isCodexAppServerPolicyMode(params.env.OPENCLAW_CODEX_APP_SERVER_MODE);
-  const explicitApprovalPolicy =
-    params.pluginConfig.appServer?.approvalPolicy !== undefined ||
-    isCodexAppServerApprovalPolicy(params.env.OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY);
-  if (explicitMode || explicitApprovalPolicy) {
-    return params.appServer;
+function withCodexPreToolUseApprovalFallback(
+  appServer: CodexAppServerRuntimeOptions,
+  params: {
+    pluginConfig: CodexPluginConfig;
+    nativeHookRelay?: {
+      enabled?: boolean;
+      events?: readonly NativeHookRelayEvent[];
+    };
+    hasBeforeToolCallHooks: boolean;
+    env?: NodeJS.ProcessEnv;
+  },
+): CodexAppServerRuntimeOptions {
+  if (!shouldUseCodexPreToolUseApprovalFallback(appServer, params)) {
+    return appServer;
   }
   return {
-    ...params.appServer,
+    ...appServer,
     approvalPolicy: "untrusted",
   };
 }
 
-function isCodexAppServerPolicyMode(value: unknown): boolean {
-  return value === "guardian" || value === "yolo";
+function shouldUseCodexPreToolUseApprovalFallback(
+  appServer: CodexAppServerRuntimeOptions,
+  params: {
+    pluginConfig: CodexPluginConfig;
+    nativeHookRelay?: {
+      enabled?: boolean;
+      events?: readonly NativeHookRelayEvent[];
+    };
+    hasBeforeToolCallHooks: boolean;
+    env?: NodeJS.ProcessEnv;
+  },
+): boolean {
+  return (
+    appServer.approvalPolicy === "never" &&
+    params.hasBeforeToolCallHooks &&
+    nativeHookRelayIncludesPreToolUse(params.nativeHookRelay) &&
+    codexAppServerAllowsApprovalPolicy(appServer, "untrusted") &&
+    !hasExplicitCodexAppServerPolicy(params.pluginConfig, params.env ?? process.env)
+  );
 }
 
-function isCodexAppServerApprovalPolicy(value: unknown): boolean {
+function codexAppServerAllowsApprovalPolicy(
+  appServer: Pick<CodexAppServerRuntimeOptions, "allowedApprovalPolicies">,
+  approvalPolicy: string,
+): boolean {
   return (
-    value === "never" || value === "on-request" || value === "on-failure" || value === "untrusted"
+    !appServer.allowedApprovalPolicies?.length ||
+    appServer.allowedApprovalPolicies.includes(approvalPolicy as CodexAppServerApprovalPolicy)
   );
+}
+
+function nativeHookRelayIncludesPreToolUse(
+  nativeHookRelay:
+    | {
+        enabled?: boolean;
+        events?: readonly NativeHookRelayEvent[];
+      }
+    | undefined,
+): boolean {
+  if (nativeHookRelay?.enabled === false) {
+    return false;
+  }
+  return !nativeHookRelay?.events?.length || nativeHookRelay.events.includes("pre_tool_use");
 }
 
 export async function runCodexAppServerAttempt(
@@ -475,6 +502,7 @@ export async function runCodexAppServerAttempt(
   options: {
     pluginConfig?: unknown;
     startupTimeoutFloorMs?: number;
+    /** Native relay is enabled by default; set enabled:false to opt out. */
     nativeHookRelay?: {
       enabled?: boolean;
       events?: readonly NativeHookRelayEvent[];
@@ -507,15 +535,21 @@ export async function runCodexAppServerAttempt(
       : sandbox.workspaceDir
     : resolvedWorkspace;
   await fs.mkdir(effectiveWorkspace, { recursive: true });
-  const appServer = resolveCodexAppServerForOpenClawToolPolicy({
-    appServer: restrictCodexAppServerSandboxForOpenClawSandbox(configuredAppServer, sandbox),
+  const restrictedAppServer = restrictCodexAppServerSandboxForOpenClawSandbox(
+    configuredAppServer,
+    sandbox,
+  );
+  const hasOpenClawToolPolicy = hasBeforeToolCallPolicy();
+  const preToolUseApprovalFallbackParams = {
     pluginConfig,
+    nativeHookRelay: options.nativeHookRelay,
+    hasBeforeToolCallHooks: hasOpenClawToolPolicy,
     env: process.env,
-    shouldPromote: hasBeforeToolCallPolicy(),
-    canUseUntrustedApprovalPolicy:
-      configuredAppServer.start.transport !== "stdio" ||
-      isCodexAppServerApprovalPolicyAllowedByRequirements("untrusted"),
-  });
+  };
+  const appServer = withCodexPreToolUseApprovalFallback(
+    restrictedAppServer,
+    preToolUseApprovalFallbackParams,
+  );
   let pluginAppServer: CodexAppServerRuntimeOptions = appServer;
   const nativeHookRelayEvents = resolveCodexNativeHookRelayEvents({
     configuredEvents: options.nativeHookRelay?.events,
@@ -843,19 +877,22 @@ export async function runCodexAppServerAttempt(
       stream: "codex_app_server.lifecycle",
       data: { phase: "startup" },
     });
-    nativeHookRelay = createCodexNativeHookRelay({
-      options: options.nativeHookRelay,
-      events: nativeHookRelayEvents,
-      agentId: sessionAgentId,
-      sessionId: params.sessionId,
-      sessionKey: sandboxSessionKey,
-      config: params.config,
-      runId: params.runId,
-      attemptTimeoutMs: params.timeoutMs,
-      startupTimeoutMs,
-      turnStartTimeoutMs: params.timeoutMs,
-      signal: runAbortController.signal,
-    });
+    nativeHookRelay =
+      nativeHookRelayEvents.length > 0
+        ? createCodexNativeHookRelay({
+            options: options.nativeHookRelay,
+            events: nativeHookRelayEvents,
+            agentId: sessionAgentId,
+            sessionId: params.sessionId,
+            sessionKey: sandboxSessionKey,
+            config: params.config,
+            runId: params.runId,
+            attemptTimeoutMs: params.timeoutMs,
+            startupTimeoutMs,
+            turnStartTimeoutMs: params.timeoutMs,
+            signal: runAbortController.signal,
+          })
+        : undefined;
     const nativeHookRelayConfig = nativeHookRelay
       ? buildCodexNativeHookRelayConfig({
           relay: nativeHookRelay,
@@ -2376,16 +2413,16 @@ function resolveCodexNativeHookRelayEvents(params: {
   configuredEvents?: readonly NativeHookRelayEvent[];
   appServer: Pick<CodexAppServerRuntimeOptions, "approvalPolicy">;
 }): readonly NativeHookRelayEvent[] {
-  if (params.configuredEvents?.length) {
-    return params.configuredEvents;
-  }
   // Codex emits PermissionRequest before the app-server approval reviewer has
   // resolved the command. In native approval modes, let Codex's app-server
   // approval bridge own the real escalation instead of surfacing a stale
   // pre-guardian OpenClaw plugin approval prompt.
-  return params.appServer.approvalPolicy === "never"
-    ? CODEX_NATIVE_HOOK_RELAY_EVENTS
-    : CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS;
+  const events = params.configuredEvents?.length
+    ? params.configuredEvents
+    : params.appServer.approvalPolicy === "never"
+      ? CODEX_NATIVE_HOOK_RELAY_EVENTS
+      : CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS;
+  return events;
 }
 
 function resolveCodexNativeHookRelayTtlMs(params: {
@@ -2403,20 +2440,6 @@ function resolveCodexNativeHookRelayTtlMs(params: {
     params.turnStartTimeoutMs +
     CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS;
   return Math.max(CODEX_NATIVE_HOOK_RELAY_MIN_TTL_MS, Math.floor(relayBudgetMs));
-}
-
-function buildCodexNativeHookRelayId(params: {
-  agentId: string | undefined;
-  sessionId: string;
-  sessionKey: string | undefined;
-}): string {
-  const hash = createHash("sha256");
-  hash.update("openclaw:codex:native-hook-relay:v1");
-  hash.update("\0");
-  hash.update(params.agentId?.trim() || "");
-  hash.update("\0");
-  hash.update(params.sessionKey?.trim() || params.sessionId);
-  return `codex-${hash.digest("hex").slice(0, 40)}`;
 }
 
 function interruptCodexTurnBestEffort(
@@ -3592,8 +3615,10 @@ export const __testing = {
   handleDynamicToolCallWithTimeout,
   remapCodexContextFilePath,
   resolveDynamicToolCallTimeoutMs,
+  resolveCodexNativeHookRelayEvents,
   restrictCodexAppServerSandboxForOpenClawSandbox,
-  resolveCodexAppServerForOpenClawToolPolicy,
+  shouldUseCodexPreToolUseApprovalFallback,
+  withCodexPreToolUseApprovalFallback,
   resolveOpenClawCodingToolsSessionKeys,
   shouldForceMessageTool,
   setOpenClawCodingToolsFactoryForTests(factory: OpenClawCodingToolsFactory): void {

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1,4 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nativeHookRelayTesting } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "openclaw/plugin-sdk/hook-runtime";
+import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readCodexPluginConfig } from "./config.js";
 import type { CodexServerNotification, RpcRequest } from "./protocol.js";
 
 const readCodexAppServerBindingMock = vi.fn();
@@ -115,6 +122,35 @@ function mockCall(mock: ReturnType<typeof vi.fn>, index = 0): unknown[] {
   return call;
 }
 
+function extractRelayIdFromThreadConfig(config: unknown): string {
+  let command: string | undefined;
+  for (const key of [
+    "hooks.PreToolUse",
+    "hooks.PostToolUse",
+    "hooks.PermissionRequest",
+    "hooks.Stop",
+  ]) {
+    const entries = (config as Record<string, unknown> | undefined)?.[key];
+    if (!Array.isArray(entries)) {
+      continue;
+    }
+    for (const entry of entries as Array<{ hooks?: Array<{ command?: string }> }>) {
+      command = entry.hooks?.find((hook) => typeof hook.command === "string")?.command;
+      if (command) {
+        break;
+      }
+    }
+    if (command) {
+      break;
+    }
+  }
+  const match = command?.match(/--relay-id ([^ ]+)/);
+  if (!match?.[1]) {
+    throw new Error(`relay id missing from command: ${command}`);
+  }
+  return match[1];
+}
+
 function threadResult(threadId: string) {
   return {
     thread: {
@@ -213,6 +249,7 @@ function sideParams(overrides: Partial<Parameters<typeof runCodexAppServerSideQu
 
 describe("runCodexAppServerSideQuestion", () => {
   beforeEach(() => {
+    nativeHookRelayTesting.clearNativeHookRelaysForTests();
     readCodexAppServerBindingMock.mockReset();
     isCodexAppServerNativeAuthProfileMock.mockReset();
     getSharedCodexAppServerClientMock.mockReset();
@@ -253,6 +290,11 @@ describe("runCodexAppServerSideQuestion", () => {
     });
   });
 
+  afterEach(() => {
+    nativeHookRelayTesting.clearNativeHookRelaysForTests();
+    resetGlobalHookRunner();
+  });
+
   it("forks an ephemeral side thread and returns the completed assistant text", async () => {
     const client = createFakeClient();
     getSharedCodexAppServerClientMock.mockResolvedValue(client);
@@ -283,7 +325,7 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(forkParams?.threadSource).toBe("user");
     expect(forkParams?.approvalsReviewer).toBe("user");
     expect(forkParams?.cwd).toBe("/tmp/workspace");
-    expect(forkParams?.config).toEqual({
+    expect(forkParams?.config).toMatchObject({
       "features.code_mode": true,
       "features.code_mode_only": true,
     });
@@ -350,6 +392,307 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(toolOptions).toHaveProperty("modelProvider", "openai");
     expect(toolOptions).toHaveProperty("modelId", "gpt-5.5");
     expect(toolOptions).toHaveProperty("requireExplicitMessageTarget", true);
+  });
+
+  it("installs native hook relay config for protected side threads", async () => {
+    const client = createFakeClient();
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await runCodexAppServerSideQuestion(sideParams(), { nativeHookRelay: { enabled: true } });
+
+    const forkCall = mockCall(client.request);
+    expect(forkCall?.[0]).toBe("thread/fork");
+    const forkParams = forkCall?.[1] as Record<string, unknown> | undefined;
+    const config = forkParams?.config as Record<string, unknown> | undefined;
+    expect(config).toMatchObject({
+      "features.code_mode": true,
+      "features.code_mode_only": true,
+      "features.hooks": true,
+    });
+    expect(Array.isArray(config?.["hooks.PreToolUse"])).toBe(true);
+    expect(Array.isArray(config?.["hooks.PostToolUse"])).toBe(true);
+    expect(Array.isArray(config?.["hooks.Stop"])).toBe(true);
+    expect(config).not.toHaveProperty("hooks.PermissionRequest");
+    const relayId = extractRelayIdFromThreadConfig(config);
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+  });
+
+  it("sends clearing native hook config for disabled side-thread relay", async () => {
+    const client = createFakeClient();
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await runCodexAppServerSideQuestion(sideParams(), { nativeHookRelay: { enabled: false } });
+
+    const forkCall = mockCall(client.request);
+    expect(forkCall?.[0]).toBe("thread/fork");
+    const forkParams = forkCall?.[1] as Record<string, unknown> | undefined;
+    const config = forkParams?.config as Record<string, unknown> | undefined;
+    expect(config).toMatchObject({
+      "features.code_mode": true,
+      "features.code_mode_only": true,
+      "features.hooks": false,
+      "hooks.PreToolUse": [],
+      "hooks.PostToolUse": [],
+      "hooks.PermissionRequest": [],
+      "hooks.Stop": [],
+    });
+    expect(config?.["hooks.state"]).toEqual({});
+  });
+
+  it("promotes implicit side-thread yolo policy when pre-tool hooks need native coverage", async () => {
+    const beforeToolCall = vi.fn(async () => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    readCodexAppServerBindingMock.mockResolvedValueOnce({
+      schemaVersion: 1,
+      threadId: "parent-thread",
+      sessionFile: "/tmp/session-1.jsonl",
+      cwd: "/tmp/workspace",
+      authProfileId: "openai-codex:work",
+      model: "gpt-5.5",
+      sandbox: "workspace-write",
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    });
+    const client = createFakeClient();
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await runCodexAppServerSideQuestion(sideParams(), { nativeHookRelay: { enabled: true } });
+
+    const forkCall = mockCall(client.request);
+    const forkParams = forkCall?.[1] as Record<string, unknown> | undefined;
+    const config = forkParams?.config as Record<string, unknown> | undefined;
+    expect(forkParams?.approvalPolicy).toBe("untrusted");
+    expect(Array.isArray(config?.["hooks.PreToolUse"])).toBe(true);
+    expect(Array.isArray(config?.["hooks.PostToolUse"])).toBe(true);
+    expect(Array.isArray(config?.["hooks.Stop"])).toBe(true);
+    expect(config).not.toHaveProperty("hooks.PermissionRequest");
+  });
+
+  it("promotes inherited side-thread yolo policy when pre-tool hooks need native coverage", async () => {
+    const beforeToolCall = vi.fn(async () => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    readCodexAppServerBindingMock.mockResolvedValueOnce({
+      schemaVersion: 1,
+      threadId: "parent-thread",
+      sessionFile: "/tmp/session-1.jsonl",
+      cwd: "/tmp/workspace",
+      authProfileId: "openai-codex:work",
+      model: "gpt-5.5",
+      approvalPolicy: "never",
+      sandbox: "workspace-write",
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    });
+    const client = createFakeClient();
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await runCodexAppServerSideQuestion(sideParams(), { nativeHookRelay: { enabled: true } });
+
+    const forkCall = mockCall(client.request);
+    const forkParams = forkCall?.[1] as Record<string, unknown> | undefined;
+    const config = forkParams?.config as Record<string, unknown> | undefined;
+    expect(forkParams?.approvalPolicy).toBe("untrusted");
+    expect(config).not.toHaveProperty("hooks.PermissionRequest");
+  });
+
+  it("routes side-thread PreToolUse relay invocations through before_tool_call denial", async () => {
+    const beforeToolCall = vi.fn(async (_event: unknown, _ctx: unknown) => ({
+      block: true,
+      reason: "blocked side relay",
+    }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const client = createFakeClient();
+    let markTurnStarted: (() => void) | undefined;
+    const turnStarted = new Promise<void>((resolve) => {
+      markTurnStarted = resolve;
+    });
+    client.request.mockImplementation(async (method: string) => {
+      if (method === "thread/fork") {
+        return threadResult("side-thread");
+      }
+      if (method === "thread/inject_items") {
+        return {};
+      }
+      if (method === "turn/start") {
+        markTurnStarted?.();
+        return turnStartResult("turn-1");
+      }
+      if (method === "thread/unsubscribe" || method === "turn/interrupt") {
+        return {};
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    const run = runCodexAppServerSideQuestion(sideParams(), { nativeHookRelay: { enabled: true } });
+    await turnStarted;
+    const forkCall = mockCall(client.request);
+    const forkParams = forkCall?.[1] as Record<string, unknown> | undefined;
+    const relayId = extractRelayIdFromThreadConfig(forkParams?.config);
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toMatchObject({
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "session-1",
+      runId: "codex-btw:session-1",
+    });
+
+    const response = await nativeHookRelayTesting.invokeNativeHookRelayForTests({
+      provider: "codex",
+      relayId,
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "bash",
+        tool_use_id: "side-shell-1",
+        tool_input: { command: "touch /tmp/blocked-side" },
+      },
+    });
+
+    expect(JSON.parse(response.stdout)).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Tool call blocked by plugin hook",
+      },
+    });
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    const context = beforeToolCall.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    expect(context).toMatchObject({
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "session-1",
+      runId: "codex-btw:session-1",
+    });
+
+    client.emit(agentDelta("side-thread", "turn-1", "Done."));
+    client.emit(turnCompleted("side-thread", "turn-1", "Done."));
+    await expect(run).resolves.toEqual({ text: "Done." });
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+  });
+
+  it("allows side-thread PreToolUse relay invocations when before_tool_call allows", async () => {
+    const beforeToolCall = vi.fn(async (_event: unknown, _ctx: unknown) => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    readCodexAppServerBindingMock.mockResolvedValueOnce({
+      schemaVersion: 1,
+      threadId: "parent-thread",
+      sessionFile: "/tmp/session-1.jsonl",
+      cwd: "/tmp/workspace",
+      authProfileId: "openai-codex:work",
+      model: "gpt-5.5",
+      sandbox: "workspace-write",
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    });
+    const client = createFakeClient();
+    let markTurnStarted: (() => void) | undefined;
+    const turnStarted = new Promise<void>((resolve) => {
+      markTurnStarted = resolve;
+    });
+    client.request.mockImplementation(async (method: string) => {
+      if (method === "thread/fork") {
+        return threadResult("side-thread");
+      }
+      if (method === "thread/inject_items") {
+        return {};
+      }
+      if (method === "turn/start") {
+        markTurnStarted?.();
+        return turnStartResult("turn-1");
+      }
+      if (method === "thread/unsubscribe" || method === "turn/interrupt") {
+        return {};
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    const run = runCodexAppServerSideQuestion(sideParams(), { nativeHookRelay: { enabled: true } });
+    await turnStarted;
+    const forkCall = mockCall(client.request);
+    const forkParams = forkCall?.[1] as Record<string, unknown> | undefined;
+    expect(forkParams?.approvalPolicy).toBe("untrusted");
+    const relayId = extractRelayIdFromThreadConfig(forkParams?.config);
+    const response = await nativeHookRelayTesting.invokeNativeHookRelayForTests({
+      provider: "codex",
+      relayId,
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "bash",
+        tool_use_id: "side-shell-allow-1",
+        tool_input: { command: "printf allowed-side" },
+      },
+    });
+
+    expect(response).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    expect(beforeToolCall).toHaveBeenCalledTimes(1);
+    const context = beforeToolCall.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    expect(context).toMatchObject({
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "session-1",
+      runId: "codex-btw:session-1",
+    });
+
+    client.emit(agentDelta("side-thread", "turn-1", "Done."));
+    client.emit(turnCompleted("side-thread", "turn-1", "Done."));
+    await expect(run).resolves.toEqual({ text: "Done." });
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+  });
+
+  it("does not promote side-thread policy when Codex policy is explicitly or locally constrained", () => {
+    const implicitParams = {
+      pluginConfig: readCodexPluginConfig({}),
+      hasBeforeToolCallHooks: true,
+      nativeHookRelay: { enabled: true },
+      env: {},
+    };
+    expect(
+      __testing.resolveCodexSidePreToolUseApprovalPolicy("never", {
+        ...implicitParams,
+        allowedApprovalPolicies: ["never"],
+      }),
+    ).toBe("never");
+    expect(
+      __testing.resolveCodexSidePreToolUseApprovalPolicy("never", {
+        ...implicitParams,
+        pluginConfig: readCodexPluginConfig({ appServer: { mode: "yolo" } }),
+      }),
+    ).toBe("never");
+    expect(
+      __testing.resolveCodexSidePreToolUseApprovalPolicy("never", {
+        ...implicitParams,
+        nativeHookRelay: { enabled: false },
+      }),
+    ).toBe("never");
+  });
+
+  it("uses unique native relay ids for separate side threads in the same session", async () => {
+    const firstClient = createFakeClient();
+    const secondClient = createFakeClient();
+    getSharedCodexAppServerClientMock
+      .mockResolvedValueOnce(firstClient)
+      .mockResolvedValueOnce(secondClient);
+
+    await runCodexAppServerSideQuestion(sideParams(), { nativeHookRelay: { enabled: true } });
+    await runCodexAppServerSideQuestion(sideParams(), { nativeHookRelay: { enabled: true } });
+
+    const firstForkParams = mockCall(firstClient.request)[1] as Record<string, unknown> | undefined;
+    const secondForkParams = mockCall(secondClient.request)[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(extractRelayIdFromThreadConfig(firstForkParams?.config)).not.toBe(
+      extractRelayIdFromThreadConfig(secondForkParams?.config),
+    );
   });
 
   it("bridges side-thread dynamic tool requests to OpenClaw tools", async () => {
@@ -552,6 +895,7 @@ describe("runCodexAppServerSideQuestion", () => {
   it("interrupts and unsubscribes the ephemeral thread on abort", async () => {
     const controller = new AbortController();
     const client = createFakeClient();
+    let relayIdDuringInterrupt: string | undefined;
     client.request.mockImplementation(async (method: string) => {
       if (method === "thread/fork") {
         return threadResult("side-thread");
@@ -563,7 +907,18 @@ describe("runCodexAppServerSideQuestion", () => {
         queueMicrotask(() => controller.abort());
         return turnStartResult("turn-1");
       }
-      if (method === "turn/interrupt" || method === "thread/unsubscribe") {
+      if (method === "turn/interrupt") {
+        const forkCall = client.request.mock.calls.find(
+          ([requestMethod]) => requestMethod === "thread/fork",
+        );
+        const forkParams = forkCall?.[1] as Record<string, unknown> | undefined;
+        relayIdDuringInterrupt = extractRelayIdFromThreadConfig(forkParams?.config);
+        expect(
+          nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayIdDuringInterrupt),
+        ).toBeDefined();
+        return {};
+      }
+      if (method === "thread/unsubscribe") {
         return {};
       }
       throw new Error(`unexpected request: ${method}`);
@@ -575,6 +930,7 @@ describe("runCodexAppServerSideQuestion", () => {
         sideParams({
           opts: { abortSignal: controller.signal },
         }),
+        { nativeHookRelay: { enabled: true } },
       ),
     ).rejects.toThrow("Codex /btw was aborted.");
     expect(client.request.mock.calls.filter(([method]) => method === "turn/interrupt")).toEqual([
@@ -583,5 +939,9 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(client.request.mock.calls.filter(([method]) => method === "thread/unsubscribe")).toEqual(
       [["thread/unsubscribe", { threadId: "side-thread" }, { timeoutMs: 60_000 }]],
     );
+    expect(relayIdDuringInterrupt).toBeDefined();
+    expect(
+      nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayIdDuringInterrupt!),
+    ).toBeUndefined();
   });
 });

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   embeddedAgentLog,
   formatErrorMessage,
@@ -6,19 +7,37 @@ import {
   resolveModelAuthMode,
   resolveSandboxContext,
   resolveSessionAgentIds,
+  hasBeforeToolCallPolicy,
+  registerNativeHookRelay,
   supportsModelTools,
   type AnyAgentTool,
   type AgentHarnessSideQuestionParams,
   type AgentHarnessSideQuestionResult,
   type EmbeddedRunAttemptParams,
+  type NativeHookRelayEvent,
+  type NativeHookRelayRegistrationHandle,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
 import { refreshCodexAppServerAuthTokens } from "./auth-bridge.js";
 import { isCodexAppServerApprovalRequest, type CodexAppServerClient } from "./client.js";
-import { readCodexPluginConfig, resolveCodexAppServerRuntimeOptions } from "./config.js";
+import {
+  hasExplicitCodexAppServerPolicy,
+  readCodexPluginConfig,
+  resolveCodexAppServerRuntimeOptions,
+  type CodexAppServerApprovalPolicy,
+  type CodexAppServerEffectiveApprovalPolicy,
+} from "./config.js";
 import { filterCodexDynamicTools } from "./dynamic-tool-profile.js";
 import { createCodexDynamicToolBridge, type CodexDynamicToolBridge } from "./dynamic-tools.js";
 import { handleCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
+import {
+  buildCodexNativeHookRelayConfig,
+  buildCodexNativeHookRelayDisabledConfig,
+  buildCodexNativeHookRelayId,
+  CODEX_NATIVE_HOOK_RELAY_EVENTS,
+  CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS,
+} from "./native-hook-relay.js";
+import { mergeCodexThreadConfigs } from "./plugin-thread-config.js";
 import {
   assertCodexThreadForkResponse,
   assertCodexTurnStartResponse,
@@ -50,6 +69,8 @@ const CODEX_SIDE_DYNAMIC_TOOL_TIMEOUT_MS = 30_000;
 const CODEX_SIDE_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
 const CODEX_SIDE_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
 const SIDE_QUESTION_COMPLETION_TIMEOUT_MS = 600_000;
+const CODEX_SIDE_NATIVE_HOOK_RELAY_MIN_TTL_MS = 30 * 60_000;
+const CODEX_SIDE_NATIVE_HOOK_RELAY_TTL_GRACE_MS = 5 * 60_000;
 const SIDE_BOUNDARY_PROMPT = `Side conversation boundary.
 
 Everything before this boundary is inherited history from the parent thread. It is reference context only. It is not your current task.
@@ -77,7 +98,17 @@ Do not modify files, source, git state, permissions, configuration, workspace st
 
 export async function runCodexAppServerSideQuestion(
   params: AgentHarnessSideQuestionParams,
-  options: { pluginConfig?: unknown } = {},
+  options: {
+    pluginConfig?: unknown;
+    /** Native relay is enabled by default; set enabled:false to opt out. */
+    nativeHookRelay?: {
+      enabled?: boolean;
+      events?: readonly NativeHookRelayEvent[];
+      hookTimeoutSec?: number;
+      ttlMs?: number;
+      gatewayTimeoutMs?: number;
+    };
+  } = {},
 ): Promise<AgentHarnessSideQuestionResult> {
   const binding = await readCodexAppServerBinding(params.sessionFile, {
     agentDir: params.agentDir,
@@ -91,10 +122,21 @@ export async function runCodexAppServerSideQuestion(
 
   const pluginConfig = readCodexPluginConfig(options.pluginConfig);
   const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig });
+  const preToolUseApprovalFallbackParams = {
+    pluginConfig,
+    nativeHookRelay: options.nativeHookRelay,
+    hasBeforeToolCallHooks: hasBeforeToolCallPolicy(),
+    allowedApprovalPolicies: appServer.allowedApprovalPolicies,
+    env: process.env,
+  };
+  const protectedAppServer = withCodexSidePreToolUseApprovalFallback(
+    appServer,
+    preToolUseApprovalFallbackParams,
+  );
   const authProfileId = params.authProfileId ?? binding.authProfileId;
   const client = await getSharedCodexAppServerClient({
-    startOptions: appServer.start,
-    timeoutMs: appServer.requestTimeoutMs,
+    startOptions: protectedAppServer.start,
+    timeoutMs: protectedAppServer.requestTimeoutMs,
     authProfileId,
     agentDir: params.agentDir,
     config: params.cfg,
@@ -114,6 +156,7 @@ export async function runCodexAppServerSideQuestion(
   let childThreadId: string | undefined;
   let turnId: string | undefined;
   let removeRequestHandler: (() => void) | undefined;
+  let nativeHookRelay: NativeHookRelayRegistrationHandle | undefined;
 
   try {
     const cwd = binding.cwd || params.workspaceDir || process.cwd();
@@ -123,11 +166,12 @@ export async function runCodexAppServerSideQuestion(
       config: params.cfg,
       agentId: params.agentId,
     });
+    const sidePolicyContext = resolveCodexSidePolicyContext(params, sessionAgentId);
     const toolBridge = await createCodexSideToolBridge({
       params,
       cwd,
       pluginConfig,
-      sessionAgentId,
+      policyContext: sidePolicyContext,
       signal: runAbortController.signal,
     });
     removeRequestHandler = client.addRequestHandler(async (request) => {
@@ -185,9 +229,48 @@ export async function runCodexAppServerSideQuestion(
       })) as unknown as JsonValue;
     });
 
-    const approvalPolicy = binding.approvalPolicy ?? appServer.approvalPolicy;
-    const sandbox = binding.sandbox ?? appServer.sandbox;
-    const serviceTier = binding.serviceTier ?? appServer.serviceTier;
+    // Side threads can inherit old bindings, but the current plugin/env policy
+    // still decides whether implicit YOLO needs PreToolUse-safe promotion.
+    const approvalPolicy = binding.approvalPolicy
+      ? resolveCodexSidePreToolUseApprovalPolicy(
+          binding.approvalPolicy,
+          preToolUseApprovalFallbackParams,
+        )
+      : protectedAppServer.approvalPolicy;
+    const sandbox = binding.sandbox ?? protectedAppServer.sandbox;
+    const serviceTier = binding.serviceTier ?? protectedAppServer.serviceTier;
+    const nativeHookRelayEvents = resolveCodexSideNativeHookRelayEvents({
+      configuredEvents: options.nativeHookRelay?.events,
+      approvalPolicy,
+    });
+    nativeHookRelay =
+      nativeHookRelayEvents.length > 0
+        ? registerCodexSideNativeHookRelay({
+            params: sideRunParams,
+            policyContext: sidePolicyContext,
+            options: options.nativeHookRelay,
+            events: nativeHookRelayEvents,
+            requestTimeoutMs: protectedAppServer.requestTimeoutMs,
+            completionTimeoutMs: Math.max(
+              protectedAppServer.turnCompletionIdleTimeoutMs,
+              SIDE_QUESTION_COMPLETION_TIMEOUT_MS,
+            ),
+            relayScope: randomUUID(),
+            signal: runAbortController.signal,
+          })
+        : undefined;
+    const nativeHookRelayConfig = nativeHookRelay
+      ? buildCodexNativeHookRelayConfig({
+          relay: nativeHookRelay,
+          events: nativeHookRelayEvents,
+          hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
+        })
+      : options.nativeHookRelay?.enabled === false
+        ? buildCodexNativeHookRelayDisabledConfig()
+        : undefined;
+    const runtimeThreadConfig = buildCodexRuntimeThreadConfig(undefined);
+    const threadConfig =
+      mergeCodexThreadConfigs(nativeHookRelayConfig, runtimeThreadConfig) ?? runtimeThreadConfig;
     const modelProvider = resolveCodexAppServerModelProvider({
       provider: params.provider,
       authProfileId,
@@ -203,15 +286,15 @@ export async function runCodexAppServerSideQuestion(
           ...(modelProvider ? { modelProvider } : {}),
           cwd,
           approvalPolicy,
-          approvalsReviewer: appServer.approvalsReviewer,
+          approvalsReviewer: protectedAppServer.approvalsReviewer,
           sandbox,
           ...(serviceTier ? { serviceTier } : {}),
-          config: buildCodexRuntimeThreadConfig(undefined),
+          config: threadConfig,
           developerInstructions: SIDE_DEVELOPER_INSTRUCTIONS,
           ephemeral: true,
           threadSource: "user",
         },
-        { timeoutMs: appServer.requestTimeoutMs, signal: params.opts?.abortSignal },
+        { timeoutMs: protectedAppServer.requestTimeoutMs, signal: params.opts?.abortSignal },
       ),
     );
     childThreadId = forkResponse.thread.id;
@@ -222,7 +305,7 @@ export async function runCodexAppServerSideQuestion(
         threadId: childThreadId,
         items: [sideBoundaryPromptItem()],
       },
-      { timeoutMs: appServer.requestTimeoutMs, signal: params.opts?.abortSignal },
+      { timeoutMs: protectedAppServer.requestTimeoutMs, signal: params.opts?.abortSignal },
     );
 
     const effort = resolveReasoningEffort(params.resolvedThinkLevel ?? "off", params.model);
@@ -245,7 +328,7 @@ export async function runCodexAppServerSideQuestion(
             },
           },
         },
-        { timeoutMs: appServer.requestTimeoutMs, signal: params.opts?.abortSignal },
+        { timeoutMs: protectedAppServer.requestTimeoutMs, signal: params.opts?.abortSignal },
       ),
     );
     turnId = turnResponse.turn.id;
@@ -254,7 +337,7 @@ export async function runCodexAppServerSideQuestion(
     const text = await collector.wait({
       signal: params.opts?.abortSignal,
       timeoutMs: Math.max(
-        appServer.turnCompletionIdleTimeoutMs,
+        protectedAppServer.turnCompletionIdleTimeoutMs,
         SIDE_QUESTION_COMPLETION_TIMEOUT_MS,
       ),
     });
@@ -270,13 +353,165 @@ export async function runCodexAppServerSideQuestion(
     }
     removeNotificationHandler();
     removeRequestHandler?.();
-    await cleanupCodexSideThread(client, {
-      threadId: childThreadId,
-      turnId,
-      interrupt: !collector.completed,
-      timeoutMs: appServer.requestTimeoutMs,
-    });
+    try {
+      await cleanupCodexSideThread(client, {
+        threadId: childThreadId,
+        turnId,
+        interrupt: !collector.completed,
+        timeoutMs: protectedAppServer.requestTimeoutMs,
+      });
+    } finally {
+      nativeHookRelay?.unregister();
+    }
   }
+}
+
+function withCodexSidePreToolUseApprovalFallback(
+  appServer: ReturnType<typeof resolveCodexAppServerRuntimeOptions>,
+  params: {
+    pluginConfig: ReturnType<typeof readCodexPluginConfig>;
+    nativeHookRelay?: {
+      enabled?: boolean;
+      events?: readonly NativeHookRelayEvent[];
+    };
+    hasBeforeToolCallHooks: boolean;
+    allowedApprovalPolicies?: readonly CodexAppServerApprovalPolicy[];
+    env: NodeJS.ProcessEnv;
+  },
+): ReturnType<typeof resolveCodexAppServerRuntimeOptions> {
+  const approvalPolicy = resolveCodexSidePreToolUseApprovalPolicy(appServer.approvalPolicy, params);
+  if (approvalPolicy === appServer.approvalPolicy) {
+    return appServer;
+  }
+  return {
+    ...appServer,
+    approvalPolicy,
+  };
+}
+
+function resolveCodexSidePreToolUseApprovalPolicy(
+  approvalPolicy: ReturnType<typeof resolveCodexAppServerRuntimeOptions>["approvalPolicy"],
+  params: {
+    pluginConfig: ReturnType<typeof readCodexPluginConfig>;
+    nativeHookRelay?: {
+      enabled?: boolean;
+      events?: readonly NativeHookRelayEvent[];
+    };
+    hasBeforeToolCallHooks: boolean;
+    allowedApprovalPolicies?: readonly CodexAppServerApprovalPolicy[];
+    env: NodeJS.ProcessEnv;
+  },
+): ReturnType<typeof resolveCodexAppServerRuntimeOptions>["approvalPolicy"] {
+  if (
+    approvalPolicy === "never" &&
+    params.hasBeforeToolCallHooks &&
+    nativeHookRelayIncludesPreToolUse(params.nativeHookRelay) &&
+    codexSideAppServerAllowsApprovalPolicy(params, "untrusted") &&
+    !hasExplicitCodexAppServerPolicy(params.pluginConfig, params.env)
+  ) {
+    return "untrusted";
+  }
+  return approvalPolicy;
+}
+
+function codexSideAppServerAllowsApprovalPolicy(
+  params: { allowedApprovalPolicies?: readonly CodexAppServerApprovalPolicy[] },
+  approvalPolicy: string,
+): boolean {
+  return (
+    !params.allowedApprovalPolicies?.length ||
+    params.allowedApprovalPolicies.includes(approvalPolicy as CodexAppServerApprovalPolicy)
+  );
+}
+
+function nativeHookRelayIncludesPreToolUse(
+  nativeHookRelay:
+    | {
+        enabled?: boolean;
+        events?: readonly NativeHookRelayEvent[];
+      }
+    | undefined,
+): boolean {
+  if (nativeHookRelay?.enabled === false) {
+    return false;
+  }
+  return !nativeHookRelay?.events?.length || nativeHookRelay.events.includes("pre_tool_use");
+}
+
+function resolveCodexSideNativeHookRelayEvents(params: {
+  configuredEvents?: readonly NativeHookRelayEvent[];
+  approvalPolicy: CodexAppServerEffectiveApprovalPolicy;
+}): readonly NativeHookRelayEvent[] {
+  if (params.configuredEvents?.length) {
+    return params.configuredEvents;
+  }
+  if (params.approvalPolicy === "never") {
+    return CODEX_NATIVE_HOOK_RELAY_EVENTS;
+  }
+  return CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS;
+}
+
+function registerCodexSideNativeHookRelay(params: {
+  params: EmbeddedRunAttemptParams;
+  policyContext: CodexSidePolicyContext;
+  options:
+    | {
+        enabled?: boolean;
+        ttlMs?: number;
+        gatewayTimeoutMs?: number;
+      }
+    | undefined;
+  events: readonly NativeHookRelayEvent[];
+  requestTimeoutMs: number;
+  completionTimeoutMs: number;
+  relayScope: string;
+  signal: AbortSignal;
+}): NativeHookRelayRegistrationHandle | undefined {
+  if (params.options?.enabled === false) {
+    return undefined;
+  }
+  return registerNativeHookRelay({
+    provider: "codex",
+    relayId: buildCodexNativeHookRelayId({
+      agentId: params.policyContext.agentId,
+      sessionId: params.params.sessionId,
+      sessionKey: params.policyContext.sessionKey,
+      scope: `${params.params.runId}:${params.relayScope}`,
+    }),
+    agentId: params.policyContext.agentId,
+    sessionId: params.params.sessionId,
+    sessionKey: params.policyContext.sessionKey,
+    ...(params.params.config ? { config: params.params.config } : {}),
+    runId: params.params.runId,
+    allowedEvents: params.events,
+    ttlMs: resolveCodexSideNativeHookRelayTtlMs({
+      explicitTtlMs: params.options?.ttlMs,
+      requestTimeoutMs: params.requestTimeoutMs,
+      completionTimeoutMs: params.completionTimeoutMs,
+    }),
+    signal: params.signal,
+    command: {
+      timeoutMs: params.options?.gatewayTimeoutMs,
+    },
+  });
+}
+
+function resolveCodexSideNativeHookRelayTtlMs(params: {
+  explicitTtlMs: number | undefined;
+  requestTimeoutMs: number;
+  completionTimeoutMs: number;
+}): number {
+  if (params.explicitTtlMs !== undefined) {
+    return params.explicitTtlMs;
+  }
+  return Math.max(
+    CODEX_SIDE_NATIVE_HOOK_RELAY_MIN_TTL_MS,
+    Math.floor(
+      params.requestTimeoutMs * 2 +
+        params.completionTimeoutMs +
+        CODEX_SIDE_NATIVE_HOOK_RELAY_TTL_GRACE_MS,
+    ),
+  );
 }
 
 function buildSideRunAttemptParams(
@@ -315,11 +550,26 @@ function buildSideRunAttemptParams(
   return sideParams as unknown as EmbeddedRunAttemptParams;
 }
 
+type CodexSidePolicyContext = {
+  agentId: string;
+  sessionKey: string;
+};
+
+function resolveCodexSidePolicyContext(
+  params: AgentHarnessSideQuestionParams,
+  sessionAgentId: string,
+): CodexSidePolicyContext {
+  return {
+    agentId: sessionAgentId,
+    sessionKey: params.sessionKey?.trim() || params.sessionId || sessionAgentId,
+  };
+}
+
 async function createCodexSideToolBridge(input: {
   params: AgentHarnessSideQuestionParams;
   cwd: string;
   pluginConfig: ReturnType<typeof readCodexPluginConfig>;
-  sessionAgentId: string;
+  policyContext: CodexSidePolicyContext;
   signal: AbortSignal;
 }): Promise<CodexDynamicToolBridge> {
   const runtimeModel =
@@ -329,24 +579,23 @@ async function createCodexSideToolBridge(input: {
   if (supportsModelTools(runtimeModel)) {
     const createOpenClawCodingTools = (await import("openclaw/plugin-sdk/agent-harness"))
       .createOpenClawCodingTools;
-    const sandboxSessionKey =
-      input.params.sessionKey?.trim() || input.params.sessionId || input.sessionAgentId;
+    const sandboxSessionKey = input.policyContext.sessionKey;
+    const runSessionKey = input.params.sessionKey?.trim();
     const sandbox = await resolveSandboxContext({
       config: input.params.cfg,
       sessionKey: sandboxSessionKey,
       workspaceDir: input.cwd,
     });
     const allTools = createOpenClawCodingTools({
-      agentId: input.sessionAgentId,
+      agentId: input.policyContext.agentId,
       sessionKey: sandboxSessionKey,
       runSessionKey:
-        input.params.sessionKey && input.params.sessionKey !== sandboxSessionKey
-          ? input.params.sessionKey
-          : undefined,
+        runSessionKey && runSessionKey !== sandboxSessionKey ? runSessionKey : undefined,
       sessionId: input.params.sessionId,
       runId: input.params.opts?.runId ?? `codex-btw:${input.params.sessionId}`,
       agentDir:
-        input.params.agentDir ?? resolveAgentDir(input.params.cfg ?? {}, input.sessionAgentId),
+        input.params.agentDir ??
+        resolveAgentDir(input.params.cfg ?? {}, input.policyContext.agentId),
       workspaceDir: input.cwd,
       spawnWorkspaceDir: resolveAttemptSpawnWorkspaceDir({
         sandbox,
@@ -380,10 +629,10 @@ async function createCodexSideToolBridge(input: {
     signal: input.signal,
     loading: input.pluginConfig.codexDynamicToolsLoading ?? "searchable",
     hookContext: {
-      agentId: input.sessionAgentId,
+      agentId: input.policyContext.agentId,
       config: input.params.cfg,
       sessionId: input.params.sessionId,
-      sessionKey: input.params.sessionKey,
+      sessionKey: input.policyContext.sessionKey,
       runId: input.params.opts?.runId ?? `codex-btw:${input.params.sessionId}`,
     },
   });
@@ -513,6 +762,7 @@ function clampSideDynamicToolTimeoutMs(timeoutMs: number): number {
 }
 
 export const __testing = {
+  resolveCodexSidePreToolUseApprovalPolicy,
   resolveSideDynamicToolCallTimeoutMs,
 } as const;
 

--- a/scripts/lib/plugin-sdk-doc-metadata.ts
+++ b/scripts/lib/plugin-sdk-doc-metadata.ts
@@ -98,6 +98,12 @@ export const pluginSdkDocMetadata = {
   "agent-runtime": {
     category: "runtime",
   },
+  "agent-harness": {
+    category: "runtime",
+  },
+  "agent-harness-runtime": {
+    category: "runtime",
+  },
   "speech-core": {
     category: "provider",
   },

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -1714,6 +1714,7 @@ export const __testing = {
   getNativeHookRelayInvocationsForTests(): NativeHookRelayInvocation[] {
     return [...invocations];
   },
+  invokeNativeHookRelayForTests: invokeNativeHookRelay,
   getNativeHookRelayRegistrationForTests(relayId: string): NativeHookRelayRegistration | undefined {
     return relays.get(relayId);
   },

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -12,6 +12,7 @@ import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import {
+  hasBeforeToolCallPolicy,
   runBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./pi-tools.before-tool-call.js";
@@ -933,6 +934,26 @@ describe("before_tool_call requireApproval handling", () => {
       }),
     ).resolves.toEqual({ blocked: false, params });
     expect(hookRunner.runBeforeToolCall).not.toHaveBeenCalled();
+  });
+
+  it("reports trusted tool policies as before-tool policy handlers", () => {
+    hookRunner.hasHooks.mockReturnValue(false);
+    const registry = createEmptyPluginRegistry();
+    registry.trustedToolPolicies = [
+      {
+        pluginId: "trusted-policy",
+        pluginName: "Trusted Policy",
+        source: "test",
+        policy: {
+          id: "trusted",
+          description: "trusted",
+          evaluate: () => undefined,
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(hasBeforeToolCallPolicy()).toBe(true);
   });
 
   it("recomputes host-derived paths after trusted policy param rewrites", async () => {


### PR DESCRIPTION
## Problem

Codex native code mode can execute native shell and file tools inside the Codex runtime. OpenClaw already had a native hook relay path for Codex, but the public Codex harness did not enable the relay by default for app-server runs, and implicit YOLO mode left native `PreToolUse` enforcement outside the actual execution path.

That meant an OpenClaw `before_tool_call` firewall policy could be bypassed by Codex-native shell execution even when the same policy correctly protected OpenClaw dynamic tools.

Fixes #82372.

## Change And Value

This PR makes the Codex harness install the native hook relay by default and keeps `PreToolUse` as the synchronous policy point for Codex-native tool calls.

When OpenClaw has before-tool policy handlers and the native `pre_tool_use` relay is active, only the unconstrained implicit-YOLO approval policy is promoted to Codex `untrusted` mode. This preserves Codex's own native review path while still routing native shell/file calls through OpenClaw policy before execution.

## Who Is Affected, And Who Is Not

Affected:

- Codex harness users running native code mode through the OpenClaw Codex app-server integration.
- Plugins or operators relying on `before_tool_call` hooks or trusted tool policies to block Codex-native shell/file activity.
- `/btw` side conversations, which now receive the same native relay coverage as main Codex turns.

Not affected:

- Explicit operator choices for `appServer.mode: "yolo"` or `appServer.approvalPolicy: "never"`; those stay explicit.
- Setups that disable the native hook relay.
- Codex local requirements that disallow `untrusted`; those requirements are respected.
- OpenClaw dynamic tools, except that the shared "are pre-tool handlers present" helper is now reusable by the Codex harness.

## Why Now

This fixes the reported Codex native-tool firewall bypass and restores the expected defense boundary for policy plugins that block commands or paths before execution. The change is focused on the app-server/native-hook integration instead of adding a second policy system.

## Implementation

- Enables the Codex native hook relay by default from the public harness for main runs and side questions.
- Builds stable Codex thread config with `features.hooks`, `hooks.PreToolUse`, `hooks.PostToolUse`, `hooks.Stop`, optional `hooks.PermissionRequest`, and trusted `hooks.state`.
- Sends a deterministic clearing config, including empty `hooks.state`, when the native relay is disabled.
- Promotes only implicit YOLO `approvalPolicy: "never"` to `untrusted` when pre-tool policy handlers exist and native `pre_tool_use` relay coverage is active.
- Keeps explicit YOLO/`never`, disabled relay, and local Codex requirements as opt-outs from promotion.
- Lets app-server approval modes own `PermissionRequest` by default while preserving `PreToolUse`, `PostToolUse`, and `Stop`.
- Mirrors the same relay and policy behavior for side conversations, including safe cleanup after side-thread interrupt/cleanup.
- Exposes a small runtime helper for detecting registered before-tool hooks/trusted policies.

## Risks

The main compatibility risk is changing the implicit local Codex posture from `never` to `untrusted` only when OpenClaw has pre-tool policy handlers and native relay coverage is active. Explicit config and Codex local requirements preserve the old posture.

The `hooks.state` trust hashes intentionally pin Codex's current command-hook trust envelope. The tests and docs call out that a bundled `@openai/codex` version bump must revalidate those hashes.

## Verification

- Local, head `b162835914208f9e2e2dbd6ee1a7fa2e6cf77534`: `git diff --check origin/main...HEAD`
- Local, head `b162835914208f9e2e2dbd6ee1a7fa2e6cf77534`: `pnpm exec oxfmt --check --threads=1 src/agents/harness/native-hook-relay.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/side-question.test.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/side-question.ts`
- Local, head `b162835914208f9e2e2dbd6ee1a7fa2e6cf77534`: `pnpm run lint:plugins:no-extension-test-core-imports`
- Local, head `b162835914208f9e2e2dbd6ee1a7fa2e6cf77534`: targeted `run-attempt.test.ts` native relay/promotion/app-server approval cases, 21 passed / 113 skipped
- Local, head `b162835914208f9e2e2dbd6ee1a7fa2e6cf77534`: full `side-question.test.ts`, 17 passed
- Local, head `b162835914208f9e2e2dbd6ee1a7fa2e6cf77534`: `pnpm plugin-sdk:api:check`
- Remote GCP Crabbox, `us-east4-a`, Spot `e2-standard-8`, head `b162835914208f9e2e2dbd6ee1a7fa2e6cf77534`: `pnpm check:changed` passed
- Multi-lane read-only review: three lanes covering security boundary, Codex native-hook/app-server integration, and regression/docs coverage; no unresolved P0/P1 findings; accepted allow-path coverage finding was fixed
- Claude multi-lane review gate, head `b162835914208f9e2e2dbd6ee1a7fa2e6cf77534`: no P0/P1/P2 findings; only non-blocking residual risk notes
- Codex review gate, head `b162835914208f9e2e2dbd6ee1a7fa2e6cf77534`: no actionable correctness findings

## Real Behavior Proof

Behavior or issue addressed: Codex native shell execution should be blocked by OpenClaw `before_tool_call` firewall policy before writing a denied file.

Real environment tested: Local OpenClaw install on `2026.5.12`, patched installed dist from this branch, `@openclaw/codex`, agent `eval-2`, model `openai/gpt-5.4-mini`, local firewall policy plugin loaded.

Exact steps or command run after this patch:

```bash
env OPENCLAW_OC82377_HOOK_DEBUG=1 timeout 180s openclaw agent --agent eval-2 --local --timeout 120 --session-id oc82377-after-default-20260516 --model openai/gpt-5.4-mini -m "Controlled OpenClaw firewall regression test authorized by the operator. Please write exactly the text 'OC82377_AFTER_DEFAULT_DENIED_WRITE' to /tmp/oc82377-after-default-20260516-private_key.txt using a single tool call. Do not write any other files." --json
```

Evidence after fix: Copied redacted runtime-log output from the same local run:

```text
2026-05-15T22:37:06.209-04:00 [plugins] oc-firewall: BLOCKED shell.exec on /bin/bash -c "printf '%s' 'OC82377_AFTER_DEFAULT_DENIED_WRITE' | tee /tmp/oc82377-after-default-20260516-private_key.txt" for agent:eval-2: explicit_deny
2026-05-16T02:37:06.221215Z ERROR codex_core::tools::router: error=exec_command failed for `/bin/bash -c "printf '%s' 'OC82377_AFTER_DEFAULT_DENIED_WRITE' | tee /tmp/oc82377-after-default-20260516-private_key.txt"`: CreateProcess { message: "Rejected(\"rejected by user\")" }
embedded run done: runId=oc82377-after-default-20260516 sessionId=oc82377-after-default-20260516 durationMs=29887 aborted=true
```

Observed result after fix: Codex made one native `bash` attempt; the OpenClaw firewall denied it before the file write, Codex saw the native execution as rejected, and `/tmp/oc82377-after-default-20260516-private_key.txt` was absent after the run.

What was not tested: No production release artifact was built from this branch.