### PR TITLE
fix(openai-completions): skip non-JSON thinkingSignature provenance tags (#82335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 - Update/installers: override npm `min-release-age` quarantine for OpenClaw-managed package installs, so `openclaw update`, plugin updates, and hosted installer scripts can install the requested latest release immediately.
 - Agents/sessions: preserve fresh post-compaction token snapshots across stale usage updates, preventing repeated auto-compaction after every message. Fixes #82576. (#82578) Thanks @njuboy11.
 - Agents/OpenAI Responses: log redacted diagnostics for detail-less `response.failed` events while preserving failed response ids, so operators can correlate provider-side failures. Fixes #82558.
+- Agents/OpenRouter: strip non-replayable Anthropic/xAI reasoning provenance tags from follow-up requests, preventing poisoned thinking signatures from breaking second turns. Fixes #82335. (#82380) Thanks @hclsys.
 - Agents/auth: redact OAuth refresh failure causes against in-memory, attempted, and reloaded credentials before generic token masking while ensuring failed ACP dispatch cleanup closes initialized runtimes.
 - Google/Gemini CLI OAuth: add provider-owned refresh support for `google-gemini-cli` so expired Gemini CLI tokens refresh in OpenClaw instead of falling through to the generic unknown-provider path. Fixes #42541. Thanks @jason-allen-oneal.
 - Telegram: cache successful startup bot identity by account and token fingerprint for up to 24 hours, so restarts can skip redundant `getMe` probes during Telegram API slow periods without permanently pinning renamed bots. Refs #82525.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5839,6 +5839,18 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
     maxTokens: 8192,
   } satisfies Model<"openai-completions">;
 
+  const openRouterAnthropicModel = {
+    ...openRouterModel,
+    id: "anthropic/claude-sonnet-4.6",
+    name: "Claude Sonnet 4.6",
+  } satisfies Model<"openai-completions">;
+
+  const openRouterXaiModel = {
+    ...openRouterModel,
+    id: "x-ai/grok-4.3",
+    name: "Grok 4.3",
+  } satisfies Model<"openai-completions">;
+
   const openAIModel = {
     id: "gpt-5.4-mini",
     name: "GPT-5.4 Mini",
@@ -5974,6 +5986,25 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
 
     expect(assistant).not.toHaveProperty("reasoning_details");
     expect(assistant.reasoning).toBe("Need to answer politely.");
+  });
+
+  it.each([
+    ["Anthropic", openRouterAnthropicModel],
+    ["xAI", openRouterXaiModel],
+  ] as const)("strips OpenRouter %s non-replayable reasoning fields", (_label, model) => {
+    for (const thinkingSignature of [
+      "reasoning_details",
+      "reasoning_content",
+      "reasoning",
+      "reasoning_text",
+    ]) {
+      const assistant = getAssistantMessage(buildReplayParams(model, thinkingSignature));
+
+      expect(assistant).not.toHaveProperty("reasoning_details");
+      expect(assistant).not.toHaveProperty("reasoning_content");
+      expect(assistant).not.toHaveProperty("reasoning");
+      expect(assistant).not.toHaveProperty("reasoning_text");
+    }
   });
 
   it.each(["reasoning", "reasoning_content"])(

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -840,7 +840,16 @@ function convertResponsesMessages(
         msg.model !== model.id && msg.provider === model.provider && msg.api === model.api;
       for (const block of msg.content) {
         if (block.type === "thinking") {
-          if (shouldReplayReasoningItems && block.thinkingSignature) {
+          if (
+            shouldReplayReasoningItems &&
+            block.thinkingSignature &&
+            block.thinkingSignature.startsWith("{")
+          ) {
+            // openai-completions plain-text reasoning paths persist a
+            // provenance tag (e.g. "reasoning", "reasoning_details", "content")
+            // as thinkingSignature rather than a JSON-encoded reasoning item.
+            // Replaying those values would corrupt the next request payload
+            // (OpenRouter returns HTTP 500), so skip non-JSON signatures.
             const reasoningItem = JSON.parse(
               block.thinkingSignature,
             ) as ReplayableResponseReasoningItem;
@@ -2878,6 +2887,14 @@ function shouldPreserveReasoningContentReplay(
   );
 }
 
+function shouldPreserveOpenRouterReasoningReplay(model: OpenAIModeModel): boolean {
+  if (model.provider !== "openrouter") {
+    return true;
+  }
+  const normalizedModelId = model.id.trim().toLowerCase();
+  return !(normalizedModelId.startsWith("anthropic/") || normalizedModelId.startsWith("x-ai/"));
+}
+
 // OpenAI Chat Completions assistant-message input does not define reasoning
 // replay fields, while OpenRouter and DeepSeek-style providers document
 // compatible pass-back contracts. Keep valid provider-owned replay fields, but
@@ -2923,7 +2940,8 @@ export function buildOpenAICompletionsParams(
   let messages = convertMessages(model as never, completionsContext, compat as never);
   injectToolCallThoughtSignatures(messages as unknown[], context, model);
   sanitizeCompletionsReasoningReplayFields(messages, {
-    preserveOpenRouterReasoning: compat.thinkingFormat === "openrouter",
+    preserveOpenRouterReasoning:
+      compat.thinkingFormat === "openrouter" && shouldPreserveOpenRouterReasoningReplay(model),
     preserveReasoningContent: shouldPreserveReasoningContentReplay(model, compat),
   });
   if (compat.strictMessageKeys) {


### PR DESCRIPTION
## Summary
- keep provider-owned OpenAI-completions reasoning replay for OpenRouter/DeepSeek/Z.AI/MiMo/Kimi routes
- strip OpenRouter Anthropic/xAI non-replayable reasoning provenance fields before follow-up requests
- add regression coverage for the Anthropic/xAI OpenRouter second-turn sanitizer path

Fixes #82335.

## Real behavior proof

- **Behavior addressed:** OpenRouter passthrough (`api: "openai-completions"`) can persist response field names such as `"reasoning"`, `"reasoning_details"`, `"reasoning_content"`, and `"reasoning_text"` as assistant `thinkingSignature` values. Those field names are valid replay markers for some OpenAI-compatible providers, but they are not replayable for OpenRouter Anthropic/xAI routes and can poison the second turn.
- **Real environment tested:** Local OpenClaw source checkout on Linux, branch `fix-openrouter-thinking-signature`, using the real exported `buildOpenAICompletionsParams` implementation from `src/agents/openai-transport-stream.ts` through `pnpm exec tsx --input-type=module`.
- **Exact steps or command run after the patch:** Ran a direct `tsx` command that imports `buildOpenAICompletionsParams`, builds second-turn `api: "openai-completions"` payloads for `anthropic/claude-sonnet-4.6`, `x-ai/grok-4.3`, and `deepseek/deepseek-v4-flash`, and prints whether replay fields survive in the outgoing assistant message.
- **Evidence after fix:** Terminal output from the direct command:

```json
[
  {
    "modelId": "anthropic/claude-sonnet-4.6",
    "sig": "reasoning_details",
    "hasReasoning": false,
    "hasReasoningDetails": false,
    "hasReasoningContent": false,
    "hasReasoningText": false
  },
  {
    "modelId": "x-ai/grok-4.3",
    "sig": "reasoning",
    "hasReasoning": false,
    "hasReasoningDetails": false,
    "hasReasoningContent": false,
    "hasReasoningText": false
  },
  {
    "modelId": "deepseek/deepseek-v4-flash",
    "sig": "reasoning_content",
    "hasReasoning": false,
    "hasReasoningDetails": false,
    "hasReasoningContent": true,
    "hasReasoningText": false,
    "reasoning_content": "Need to answer."
  }
]
```

- **Observed result after fix:** OpenRouter Anthropic and xAI follow-up payloads contain no `reasoning*` replay fields, while the OpenRouter DeepSeek route still preserves `reasoning_content`. This targets the `buildOpenAICompletionsParams` path used by `api: "openai-completions"` second turns and preserves provider-owned replay for compatible routes.
- **What was not tested:** No live OpenRouter network call was run in this cycle. Supplemental local checks run: `pnpm exec oxfmt --check --threads=1 src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`; `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts` (`Test Files 2 passed (2)`, `Tests 298 passed (298)`); `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`; `git diff --check`.