### PR TITLE
fix(telegram): drop expired approval callbacks

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -27,6 +27,7 @@ import {
   parsePluginBindingApprovalCustomId,
   resolvePluginConversationBindingApproval,
 } from "openclaw/plugin-sdk/conversation-runtime";
+import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import { applyModelOverrideToSessionEntry } from "openclaw/plugin-sdk/model-session-runtime";
 import { formatModelsAvailableHeader } from "openclaw/plugin-sdk/models-provider-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
@@ -2076,6 +2077,17 @@ export const registerTelegramHandlers = ({
           logVerbose(
             `telegram: failed to resolve approval callback ${approvalCallback.approvalId}: ${errStr}`,
           );
+          if (isApprovalNotFoundError(resolveErr)) {
+            logVerbose(
+              `telegram: ignoring expired approval callback ${approvalCallback.approvalId}`,
+            );
+            await clearCallbackButtons().catch((editErr) => {
+              logVerbose(
+                `telegram: failed to clear expired approval callback buttons: ${String(editErr)}`,
+              );
+            });
+            return;
+          }
           throw new TelegramRetryableCallbackError(resolveErr);
         }
         try {

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -866,7 +866,7 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-target");
   });
 
-  it("keeps legacy plugin fallback approval failures retryable for target-only recipients", async () => {
+  it("treats expired approval callbacks as handled for target-only recipients", async () => {
     onSpy.mockClear();
     editMessageReplyMarkupSpy.mockClear();
     editMessageTextSpy.mockClear();
@@ -898,23 +898,21 @@ describe("createTelegramBot", () => {
       throw new Error("Expected Telegram callback_query handler");
     }
 
-    await expect(
-      callbackHandler({
-        callbackQuery: {
-          id: "cbq-legacy-plugin-fallback-blocked",
-          data: "/approve 138e9b8c allow-once",
-          from: { id: 9, first_name: "Ada", username: "ada_bot" },
-          message: {
-            chat: { id: 1234, type: "private" },
-            date: 1736380800,
-            message_id: 25,
-            text: "Legacy plugin approval required.",
-          },
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-expired-approval",
+        data: "/approve 138e9b8c allow-once",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 25,
+          text: "Legacy plugin approval required.",
         },
-        me: { username: "openclaw_bot" },
-        getFile: async () => ({ download: async () => new Uint8Array() }),
-      }),
-    ).rejects.toThrow("unknown or expired approval id");
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
 
     const approvalCall = execApprovalCall();
     const execApprovals = execApprovalTargetConfig(approvalCall);
@@ -924,10 +922,13 @@ describe("createTelegramBot", () => {
     expect(approvalCall.decision).toBe("allow-once");
     expect(approvalCall.allowPluginFallback).toBe(false);
     expect(approvalCall.senderId).toBe("9");
-    expect(editMessageReplyMarkupSpy).not.toHaveBeenCalled();
+    expect(editMessageReplyMarkupSpy).toHaveBeenCalledTimes(1);
+    expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 25, {
+      reply_markup: { inline_keyboard: [] },
+    });
     expect(replySpy).not.toHaveBeenCalled();
     expect(sendMessageSpy).not.toHaveBeenCalled();
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-legacy-plugin-fallback-blocked");
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-expired-approval");
   });
 
   it("keeps plugin approval callback buttons for target-only recipients", async () => {


### PR DESCRIPTION
## Summary
- Treat stale Telegram exec approval callback resolutions as handled, non-retryable callbacks.
- Clear the inline keyboard for expired approval buttons when possible so persisted spooled updates can drain.
- Preserve retry behavior for generic approval resolver failures and other transient callback failures.

## Root cause
Telegram approval callbacks currently wrap every approval resolver failure in the retryable callback error. When the resolver returns `unknown or expired approval id`, polling-mode isolated ingress keeps the persisted spooled update for retry, so the same expired callback can be replayed forever across gateway restarts.

## Linked issue
Fixes #82347.

## Why this is safe
The fix reuses the existing runtime-enforced `isApprovalNotFoundError` classifier that other channel approval paths use for expired approvals. It only changes the already-failed stale approval-id path from retryable to handled; transient resolver errors still throw and retry as before.

## Security/runtime controls unchanged
Telegram sender authorization, exec approval target checks, plugin fallback authorization, approval decisions, and approval resolver policy are unchanged. This does not rely on prompt text; the behavior is gated by the structured/runtime approval-not-found error classifier.

## Real behavior proof
Behavior addressed: expired Telegram approval callbacks no longer bubble a retryable handler error after the approval id is gone.

Real environment tested: local OpenClaw source checkout with Telegram plugin unit harness.

Exact steps or command run after this patch: `npm_config_manage_package_manager_versions=false pnpm test extensions/telegram/src/bot.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts -- --reporter=verbose -t "expired approval callbacks|retries exec approval callbacks"`

Evidence after fix: the focused Telegram shard passed with 2 matching tests, including the new expired approval callback regression and the existing generic resolver retry regression.

Observed result after fix: stale approval callbacks resolve without throwing, acknowledge the callback, clear the inline keyboard, and do not send Telegram chat error messages; generic resolver failures still retry.

What was not tested: live Telegram polling with real credentials was not run in this local pass.

## Verification
- `git diff --check origin/main...HEAD`
- `npm_config_manage_package_manager_versions=false pnpm test extensions/telegram/src/bot.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts -- --reporter=verbose -t "expired approval callbacks|retries exec approval callbacks"`
- `npm_config_manage_package_manager_versions=false pnpm check:changed` (fails on unrelated pre-existing lint in `extensions/openrouter/image-generation-provider.ts`: `typescript(no-redundant-type-constituents)` for `OpenRouterChatCompletionResponse | unknown`; changed-file guards and extension typechecks passed before that lint failure)

## Out of scope
- Live Telegram credentialed E2E/package QA.
- Broader callback retry policy changes outside stale approval ids.
- Unrelated OpenRouter lint cleanup.

## AI-assisted
Yes.

Made with [Cursor](https://cursor.com)