### PR TITLE
fix(memory-core): retry disabled dreaming cron cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI/config: add `--dry-run` support to `openclaw config unset`, with `--json` output and allow-exec validation parity with `config set`/`config patch` dry-run handling. (#81895) Thanks @giodl73-repo.
+- Memory-core: retry disabled dreaming cron cleanup until cron is available after startup, so persisted managed dreaming jobs are removed after restart. Fixes #82383. (#82389) Thanks @neeravmakwana.
 - Gateway/diagnostics: redact credential-bearing gateway target URLs and client diagnostics while preserving raw connection URLs for programmatic use, so connect-failure logs no longer surface embedded tokens.
 - Logs: redact raw Basic auth and named security headers from `logs.tail` output before returning lines to read-scoped clients. Fixes #66832. Thanks @Magicray1217.
 - CLI/gateway: emit structured JSON for gateway transport close/timeout failures when `--json` is requested by health, gateway health, and devices list commands. Fixes #79108. Thanks @TurboTheTurtle.

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -1535,7 +1535,70 @@ describe("gateway startup reconciliation", () => {
     }
   });
 
-  it("does not reschedule startup cron retry from stale enabled config after runtime config disables dreaming", async () => {
+  it("retries disabled startup cleanup until cron is available", async () => {
+    vi.useFakeTimers();
+    clearInternalHooks();
+    const logger = createLogger();
+    const managedJob: CronJobLike = {
+      id: "job-managed",
+      name: constants.MANAGED_DREAMING_CRON_NAME,
+      description: `${constants.MANAGED_DREAMING_CRON_TAG} test`,
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 3 * * *" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: constants.DREAMING_SYSTEM_EVENT_TEXT },
+      createdAtMs: 10,
+    };
+    const harness = createCronHarness([managedJob]);
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: false,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      let cronAvailable = false;
+      await triggerGatewayStart(onMock, {
+        config: api.config,
+        getCron: () => (cronAvailable ? harness.cron : undefined),
+      });
+
+      await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
+      expect(harness.removeCalls).toHaveLength(0);
+
+      cronAvailable = true;
+      await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
+
+      expect(harness.removeCalls).toEqual(["job-managed"]);
+      expect(harness.jobs).toHaveLength(0);
+      expect(harness.addCalls).toHaveLength(0);
+      expectLogContains(logger.info, "removed 1 managed dreaming cron job");
+    } finally {
+      vi.useRealTimers();
+      clearInternalHooks();
+    }
+  });
+
+  it("does not recreate startup cron from stale enabled config after runtime config disables dreaming", async () => {
     vi.useFakeTimers();
     clearInternalHooks();
     const logger = createLogger();

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -694,14 +694,6 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
   const resolveCurrentConfig = (): OpenClawConfig =>
     (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
 
-  const resolveCurrentDreamingConfig = (): ShortTermPromotionDreamingConfig => {
-    const cfg = resolveCurrentConfig();
-    return resolveShortTermPromotionDreamingConfig({
-      pluginConfig: resolveMemoryCorePluginConfig(cfg),
-      cfg,
-    });
-  };
-
   const clearStartupCronRetry = (): void => {
     if (startupCronRetryTimer) {
       clearTimeout(startupCronRetryTimer);
@@ -823,8 +815,8 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
     return config;
   };
 
-  const scheduleStartupCronRetry = (config: ShortTermPromotionDreamingConfig): void => {
-    if (disposed || !config.enabled || hasStartupCron()) {
+  const scheduleStartupCronRetry = (): void => {
+    if (disposed || hasStartupCron()) {
       clearStartupCronRetry();
       return;
     }
@@ -838,12 +830,12 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
       }
       startupCronRetryAttempts += 1;
       void reconcileManagedDreamingCron({ reason: "runtime" })
-        .then((latestConfig) => {
-          if (disposed || !latestConfig.enabled || hasStartupCron()) {
+        .then(() => {
+          if (disposed || hasStartupCron()) {
             clearStartupCronRetry();
             return;
           }
-          scheduleStartupCronRetry(latestConfig);
+          scheduleStartupCronRetry();
         })
         .catch((err) => {
           if (disposed) {
@@ -852,13 +844,7 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
           api.logger.error(
             `memory-core: deferred dreaming cron retry failed: ${formatErrorMessage(err)}`,
           );
-          try {
-            scheduleStartupCronRetry(resolveCurrentDreamingConfig());
-          } catch (configErr) {
-            api.logger.error(
-              `memory-core: deferred dreaming cron retry config refresh failed: ${formatErrorMessage(configErr)}`,
-            );
-          }
+          scheduleStartupCronRetry();
         });
     }, STARTUP_CRON_RETRY_DELAY_MS);
   };
@@ -868,12 +854,12 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
     // Store the gateway context for runtime cron resolution retries.
     gatewayContext = ctx as unknown as { getCron?: () => CronServiceLike | null };
     try {
-      const config = await reconcileManagedDreamingCron({
+      await reconcileManagedDreamingCron({
         reason: "startup",
         startupConfig: ctx.config,
         startupCron: () => resolveCronServiceFromGatewayContext(ctx),
       });
-      scheduleStartupCronRetry(config);
+      scheduleStartupCronRetry();
     } catch (err) {
       api.logger.error(
         `memory-core: dreaming startup reconciliation failed: ${formatErrorMessage(err)}`,


### PR DESCRIPTION
## Summary

- Problem: memory-core skipped startup cron retry whenever dreaming resolved as disabled, so an existing managed dreaming cron job could survive if cron was unavailable during `gateway_start`.
- Why it matters: changing `plugins.entries.memory-core.config.dreaming.enabled` to `false` should reliably remove the managed `Memory Dreaming Promotion` job after restart.
- What changed: startup retry now waits for cron availability regardless of dreaming enablement, and the disabled reconciliation removes the persisted managed job once cron is available.
- What did NOT change (scope boundary): cron job shape, dreaming defaults, cron execution, prompt text, and memory promotion behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82383
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: disabled memory-core dreaming cleanup now retries after startup when cron was initially unavailable.
- Real environment tested: direct AWS Crabbox cbx_81c1368fd0cf on Linux, OpenClaw source checkout synced from the rebased PR branch, Node 22.22.2, pnpm 11.1.0, real CronService plus memory-core gateway_start and gateway_stop hooks.
- Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider aws --timing-json --script-stdin` with a script that installed deps, created a persisted real CronService job named `Memory Dreaming Promotion`, fired memory-core `gateway_start` while `getCron()` returned `undefined`, waited one startup retry, then made `getCron()` return the real CronService and waited the next retry.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): direct AWS Crabbox copied live terminal output from run `run_482e82c54972` / lease `cbx_81c1368fd0cf`:

  ```text
  setup: created persisted managed job b8b56b83-3f35-4ad6-bf23-7d630eea152d
  startup: cron unavailable, jobs=["Memory Dreaming Promotion"]
  first retry: cron still unavailable, jobs=1
  second retry: cron available, managed job removed
  observed result: disabled memory-core dreaming cleanup removes persisted managed cron job after delayed cron availability
  log proof: info memory-core: removed 1 managed dreaming cron job(s).
  {"provider":"aws","leaseId":"cbx_81c1368fd0cf","slug":"crimson-crayfish","commandPhases":[{"name":"user-command","ms":339},{"name":"bootstrap-node","ms":15166},{"name":"install","ms":8314},{"name":"e2e","ms":13218}],"totalMs":46025,"exitCode":0}
  ```
- Observed result after fix: The persisted managed dreaming cron job remained while cron was unavailable at startup, then the same memory-core startup retry path removed it after the real CronService became available; no replacement job was added.
- What was not tested: Full Docker/package restart lane; the exact cron-unavailable-to-available gateway hook condition was reproduced in direct AWS Crabbox with real CronService persistence.
- Before evidence (optional but encouraged): source review showed `scheduleStartupCronRetry` returned on disabled config before cron could become available for cleanup.

## Root Cause (if applicable)

- Root cause: `scheduleStartupCronRetry` treated `!config.enabled` as a terminal state, so disabled config stopped retry scheduling even though disabled reconciliation still needs a cron service to remove existing managed jobs.
- Missing detection / guardrail: tests covered enabled startup retry and direct disabled cleanup, but not disabled cleanup when cron is missing at startup and appears later.
- Contributing context (if known): the startup retry was originally optimized around creating enabled managed cron jobs, but cleanup needs the same deferred cron-resolution path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/dreaming.test.ts`
- Scenario the test should lock in: disabled dreaming with an existing managed cron job and cron unavailable during `gateway_start` removes the job when cron becomes available later.
- Why this is the smallest reliable guardrail: the bug is in plugin startup retry scheduling, and the test exercises that hook with controlled cron availability without broad gateway setup.
- Existing test that already covers this (if any): direct disabled reconciliation already removes managed jobs, but it did not cover startup retry.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

When memory-core dreaming is disabled, a persisted managed dreaming cron job is now cleaned up after startup even if cron was not available at the first gateway_start reconciliation.

## Diagram (if applicable)

```text
Before:
dreaming disabled + cron unavailable at startup -> retry skipped -> old managed job remains

After:
dreaming disabled + cron unavailable at startup -> retry waits for cron -> old managed job removed
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

Security/runtime controls unchanged: this remains runtime-enforced through cron reconciliation and managed-job ownership markers; it does not rely on prompt text or model behavior.

## Repro + Verification

### Environment

- OS: macOS local source checkout
- Runtime/container: Node 22, Vitest via `node scripts/run-vitest.mjs`
- Model/provider: N/A
- Integration/channel (if any): memory-core managed cron
- Relevant config (redacted): `plugins.entries.memory-core.config.dreaming.enabled: false`

### Steps

1. Register memory-core dreaming hooks with disabled dreaming config and an existing managed dreaming cron job.
2. Trigger `gateway_start` while cron resolution returns unavailable.
3. Advance startup retry once with cron still unavailable, then make cron available and advance retry again.

### Expected

- The managed dreaming cron job is removed once cron becomes available, and no replacement job is added.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: disabled startup cleanup after delayed cron availability; enabled startup retry still creates a managed job; stale enabled config does not recreate a job after runtime config disables dreaming.
- Edge cases checked: cron remains unavailable for an initial retry; disabled cleanup logs the removal side effect; no cron add occurs during disabled cleanup.
- What I did **not** verify: full live gateway/Docker restart timing.
- Assistance disclosure: AI-assisted.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: startup retry now also runs while dreaming is disabled if cron is unavailable.
  - Mitigation: disabled reconciliation only removes managed memory-core dreaming jobs and the retry still stops once cron is resolved or the existing retry attempt cap is reached.

## Verification

- `git diff --check`
- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming.test.ts -t "startup cron|disabled startup cleanup|stale enabled config"`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-core/src/dreaming.ts extensions/memory-core/src/dreaming.test.ts`
- `node /Users/neeravmakwana/.cache/node/corepack/v1/pnpm/11.1.0/bin/pnpm.cjs check:changed` (extension typechecks passed; extension-wide lint failed on existing `extensions/openrouter/image-generation-provider.ts` `typescript(no-redundant-type-constituents)`, outside this PR's files)

## Out of scope

- Adding a broader config-change listener for memory-core dreaming.
- Changing cron job payloads, schedules, or execution mode.
- Full live/Docker gateway restart proof for this timing race.

Made with [Cursor](https://cursor.com)
